### PR TITLE
Use the shared_ptr<> from Boost.

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -26,6 +26,8 @@
 #include <opm/core/props/satfunc/SaturationPropsFromDeck.hpp>
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
 #include <opm/core/props/rock/RockFromDeck.hpp>
+
+#include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
 
 namespace Opm
@@ -241,7 +243,7 @@ namespace Opm
         RockFromDeck rock_;
         boost::scoped_ptr<SaturationPropsInterface> satprops_;
         PhaseUsage phase_usage_;
-        std::vector<std::tr1::shared_ptr<SinglePvtInterface> > props_;
+        std::vector<boost::shared_ptr<SinglePvtInterface> > props_;
         double densities_[BlackoilPhases::MaxNumPhases];
     };
 


### PR DESCRIPTION
Not all implementations support the TR1, and if they do, the type
might not be in a namespace called std::tr1 .  Favour the
implementation from Boost for reasons of portability.

This is inspired (and necessitated) by commit OPM/opm-core@68eb3fb
which, incidentally, cleaned up some header pollution on which we
inadvertently depended.
