### PR TITLE
Exclude examples/sim_simple.cpp if UMFPACK is unavailable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ set (${project}_DEPS
 	opm-core REQUIRED"
 	# Eigen
 	"Eigen3 3.1"
+	# Tim Davis' SuiteSparse package (UMFPACK component)
+	"SuiteSparse COMPONENTS umfpack"
 	)
 
 # Additional search modules


### PR DESCRIPTION
Not all systems provide UMFPACK so even if Eigen provides the required
bindings, we should not assume that the underlying library and/or
headers are available.  Currently, only examples/sim_simple.cpp uses
UMFPACK unconditionally, so the simplest solution is to exclude that
example unless UMFPACK is available.
