### PR TITLE
Use UMPACK only if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,12 +132,6 @@ opm_out_dirs ()
 # tests files in tests/, examples in examples/
 opm_sources (${project})
 
-if (NOT SuiteSparse_FOUND)
-	list(REMOVE_ITEM examples_SOURCES
-		${PROJECT_SOURCE_DIR}/examples/sim_simple.cpp
-	)
-endif (NOT SuiteSparse_FOUND)
-
 # Create configuration header which describes available features
 # necessary to compile this library. Singular version is the names that
 # is required by this project alone, plural version transitively

--- a/examples/sim_simple.cpp
+++ b/examples/sim_simple.cpp
@@ -27,7 +27,12 @@
 #include <opm/core/utility/Units.hpp>
 #include <opm/core/utility/StopWatch.hpp>
 #include <opm/core/pressure/tpfa/trans_tpfa.h>
+
+#if HAVE_SUITESPARSE_UMFPACK_H
+#include <Eigen/UmfPackSupport>
+#else
 #include <Eigen/IterativeLinearSolvers>
+#endif
 
 #include <iostream>
 #include <cstdlib>
@@ -202,7 +207,13 @@ int main()
     // Where R(p0) and J(p0) are contained in residual.value() and
     // residual.derived()[0].
 
-    Eigen::BiCGSTAB<M> solver;
+#if HAVE_SUITESPARSE_UMFPACK_H
+    typedef Eigen::UmfPackLU<M> LinSolver;
+#else
+    typedef Eigen::BiCGSTAB<M>  LinSolver;
+#endif  // HAVE_SUITESPARSE_UMFPACK_H
+
+    LinSolver solver;
     M pmatr = residual.derivative()[0];
     pmatr.coeffRef(0,0) *= 2.0;
     pmatr.makeCompressed();


### PR DESCRIPTION
Unconditionally build `examples/sim_simple.cpp`, but only use the UMFPACK-based solver if it is available on the build system.  @andlaus' suggestion of using `Eigen::BiCGSTAB` as a fall-back solver is a good one.
