### PR TITLE
fixed: autodiff depends on opm-core

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -1,4 +1,4 @@
 Module: opm-autodiff
 Version: 0.1
 Maintainer: atgeirr@sintef.no
-Depends:
+Depends: opm-core


### PR DESCRIPTION
as in title. minor issue of course, but i just noticed it..
