### PR TITLE
Unconditionally include "config.h"

### DIFF
--- a/examples/sim_2p_comp_ad.cpp
+++ b/examples/sim_2p_comp_ad.cpp
@@ -18,9 +18,7 @@
 */
 
 
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif // HAVE_CONFIG_H
 
 #include <opm/core/pressure/FlowBCManager.hpp>
 

--- a/examples/sim_2p_incomp_adfi.cpp
+++ b/examples/sim_2p_incomp_adfi.cpp
@@ -18,10 +18,7 @@
 */
 
 
-
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif // HAVE_CONFIG_H
 
 #include <opm/core/pressure/FlowBCManager.hpp>
 

--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -18,9 +18,7 @@
 */
 
 
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif // HAVE_CONFIG_H
 
 #include <opm/core/pressure/FlowBCManager.hpp>
 

--- a/opm/autodiff/SimulatorCompressibleAd.cpp
+++ b/opm/autodiff/SimulatorCompressibleAd.cpp
@@ -17,9 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
+
 #include "config.h"
-#endif // HAVE_CONFIG_H
 
 #include <opm/autodiff/SimulatorCompressibleAd.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil.cpp
@@ -18,9 +18,7 @@
 */
 
 
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif // HAVE_CONFIG_H
 
 #include <opm/autodiff/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>

--- a/opm/autodiff/SimulatorIncompTwophaseAdfi.cpp
+++ b/opm/autodiff/SimulatorIncompTwophaseAdfi.cpp
@@ -18,9 +18,7 @@
 */
 
 
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif // HAVE_CONFIG_H
 
 #include <opm/autodiff/SimulatorIncompTwophaseAdfi.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>


### PR DESCRIPTION
Our build system no longer defines HAVE_CONFIG_H, so the construct

  #if HAVE_CONFIG_H
  #include "config.h"
  #endif

leads to not including "config.h" at all.
