### PR TITLE
fixed: install eigen3 as opm-autodiff might have downstreams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ if (NOT EIGEN3_FOUND)
 
 	include_directories(${CMAKE_BINARY_DIR}/eigen3-installed/include/eigen3)
 	add_dependencies(opmautodiff Eigen3)
+	install(DIRECTORY ${CMAKE_BINARY_DIR}/eigen3-installed/include/eigen3 DESTINATION include)
 endif (NOT EIGEN3_FOUND)
 
 


### PR DESCRIPTION
this solves an issue raised by @rolk on the mailing list.

we now install eigen3 as well. i thought opm-autodiff was an 'end point' module...
