### PR TITLE
Improve detection of the Eigen3 library

### DIFF
--- a/cmake/Modules/FindEigen3.cmake
+++ b/cmake/Modules/FindEigen3.cmake
@@ -99,10 +99,15 @@ if (NOT EIGEN3_INCLUDE_DIR)
 	  NO_DEFAULT_PATH
 	  )
   else (EIGEN3_ROOT)
-    find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
-      PATHS
-      ${CMAKE_INSTALL_PREFIX}/include
-      ${KDE4_INCLUDE_DIR}
+	# assume that if there is a sibling directory to our project which
+	# is called eigen3, there is a newer version located there, or that
+	# it may have been checked out next to the build directory
+	find_path(EIGEN3_INCLUDE_DIR
+	  NAMES signature_of_eigen3_matrix_library
+	  HINTS ${CMAKE_SOURCE_DIR}/../
+	        ${PROJECT_SOURCE_DIR}/../
+	        ${CMAKE_INSTALL_PREFIX}/include
+	        ${KDE4_INCLUDE_DIR}
       PATH_SUFFIXES eigen3 eigen
     )
   endif (EIGEN3_ROOT)


### PR DESCRIPTION
Two new scenarios are now supported:
1. You have an `eigen3` source tree checked out next to the `opm-autodiff` source tree.
2. You give the location to an `eigen3` "build" tree (meaning a directory where you have run `cmake «path-to-eigen3-source»`) in the variable `EIGEN3_ROOT`.
