### PR TITLE
Fix warnings about "unused" parameters and typedefs.

### DIFF
--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -62,7 +62,6 @@ struct HelperOps
         const int nc = grid.number_of_cells;
         const int nf = grid.number_of_faces;
         // Define some neighbourhood-derived helper arrays.
-        typedef Eigen::Array<int, Eigen::Dynamic, 1> OneColInt;
         typedef Eigen::Array<bool, Eigen::Dynamic, 1> OneColBool;
         typedef Eigen::Array<int, Eigen::Dynamic, 2, Eigen::RowMajor> TwoColInt;
         typedef Eigen::Array<bool, Eigen::Dynamic, 2, Eigen::RowMajor> TwoColBool;

--- a/opm/autodiff/BlackoilPropsAd.cpp
+++ b/opm/autodiff/BlackoilPropsAd.cpp
@@ -456,6 +456,10 @@ namespace Opm
     V BlackoilPropsAd::rsMax(const V& po,
                              const Cells& cells) const
     {
+        // Suppress warning about "unused parameters".
+        static_cast<void>(po);
+        static_cast<void>(cells);
+
         OPM_THROW(std::runtime_error, "Method rsMax() not implemented.");
     }
 
@@ -466,6 +470,10 @@ namespace Opm
     ADB BlackoilPropsAd::rsMax(const ADB& po,
                                const Cells& cells) const
     {
+        // Suppress warning about "unused parameters".
+        static_cast<void>(po);
+        static_cast<void>(cells);
+
         OPM_THROW(std::runtime_error, "Method rsMax() not implemented.");
     }
 

--- a/opm/autodiff/ImpesTPFAAD.cpp
+++ b/opm/autodiff/ImpesTPFAAD.cpp
@@ -226,6 +226,10 @@ namespace {
                                      const BlackoilState& state,
                                      const WellState& well_state)
     {
+        // Suppress warnings about "unused parameters".
+        static_cast<void>(dt);
+        static_cast<void>(well_state);
+
         const int nc = grid_.number_of_cells;
         const int np = state.numPhases();
         const int nw = wells_.number_of_wells;


### PR DESCRIPTION
CLang and recent GCC warn about the "typedef" `OneColInt` in `AutoDiffHelpers.hpp` being unused.  Similarly, GCC warns about unused parameters in various place at level `-Wunused`.  This change-set either removes (`OneColInt`) or suppresses those messages.

This is a first step towards removing the most egregious transgressions at http://www.opm-project.org/CDash/viewBuildError.php?type=1&buildid=6039.
