### PR TITLE
Guard against null-pointer dereference.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoil.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil.cpp
@@ -280,7 +280,7 @@ namespace Opm
                                gravity,  */
     {
         // Intercept usage of bcs, since we do not handle it.
-        if (bcs->nbc != 0) {
+        if (bcs && bcs->nbc != 0) {
             OPM_THROW(std::runtime_error, "SimulatorFullyImplicitBlackoil cannot handle boundary conditions other than no-flow. Not implemented yet.");
         }
         // For output.


### PR DESCRIPTION
This restores the check that was lost in commit 79562ca (PR #39).
