### PR TITLE
fix build on kubuntu 13.10

### DIFF
--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -23,6 +23,7 @@
 #include <Eigen/Eigen>
 #include <Eigen/Sparse>
 #include <vector>
+#include <cmath>
 #include <cassert>
 
 namespace Opm
@@ -234,7 +235,10 @@ namespace Opm
             typedef Eigen::DiagonalMatrix<Scalar, Eigen::Dynamic> D;
             D D1 = val_.matrix().asDiagonal();
             D D2 = rhs.val_.matrix().asDiagonal();
-            D D3 = std::pow(rhs.val_, -2).matrix().asDiagonal();
+            D D3;
+            D3.diagonal().resize(rhs.val_.size());
+            for (int i = 0; i < rhs.val_.size(); ++i)
+                D3.diagonal()[i] = std::pow(rhs.val_[i], -2);
             for (int block = 0; block < num_blocks; ++block) {
                 assert(jac_[block].rows() == rhs.jac_[block].rows());
                 assert(jac_[block].cols() == rhs.jac_[block].cols());
@@ -449,3 +453,4 @@ namespace Opm
 
 
 #endif // OPM_AUTODIFFBLOCK_HEADER_INCLUDED
+


### PR DESCRIPTION
I used CLang as the compiler, but I guess the issue is that the
version of Eigen shipping with 13.10 does not provide a std::pow
function for matrices.

I'm not completely sure whether this change is correct, so please 
review thoroughly. (what's the power of a vector?)
