### PR TITLE
Alternative fix for Eigen versions lacking pow(Eigen::Array).

### DIFF
--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -234,7 +234,7 @@ namespace Opm
             typedef Eigen::DiagonalMatrix<Scalar, Eigen::Dynamic> D;
             D D1 = val_.matrix().asDiagonal();
             D D2 = rhs.val_.matrix().asDiagonal();
-            D D3 = std::pow(rhs.val_, -2).matrix().asDiagonal();
+            D D3 = (1.0/(rhs.val_*rhs.val_)).matrix().asDiagonal();
             for (int block = 0; block < num_blocks; ++block) {
                 assert(jac_[block].rows() == rhs.jac_[block].rows());
                 assert(jac_[block].cols() == rhs.jac_[block].cols());


### PR DESCRIPTION
This is suggested as a minimal fix (replacing a single line with a different single line) for the problem building on ubuntu with slightly too old Eigen.

Another fix was proposed in #45, this fix should be a little simpler.

Anyway, do not merge until someone can confirm that it solves the problem. Could you check that, @andlaus?
