### PR TITLE
Bump version number and label.

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -1,6 +1,6 @@
 Module: opm-autodiff
 Description: Utilities for automatic differentiation and simulators based on AD
-Version: 0.1
-Label: 2013.03
+Version: 1.0
+Label: 2013.10
 Maintainer: atgeirr@sintef.no
 Depends: opm-core


### PR DESCRIPTION
Set version number to 1.0 since core class AutoDiffBlock is quite well-tested and documented. Prototype solvers and simulators may not yet warrant that version number, but are stated to be experimental in the README.
