### PR TITLE
Fix convergence failure exception message

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.cpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.cpp
@@ -778,7 +778,9 @@ namespace {
                                matr.outerIndexPtr(), matr.innerIndexPtr(), matr.valuePtr(),
                                total_residual.value().data(), dx.data());
         if (!rep.converged) {
-            OPM_THROW(std::runtime_error, "ImpesTPFAAD::solve(): Linear solver convergence failure.");
+            OPM_THROW(std::runtime_error,
+                      "FullyImplicitBlackoilSolver::solveJacobianSystem(): "
+                      "Linear solver convergence failure.");
         }
         return dx;
     }


### PR DESCRIPTION
The message was a leftover from the ImpesTPFA solver and should reflect the actual location.

Noticed by: @qilicun (Liu Ming)
Fixes: Issue #50
