### PR TITLE
loosen tolerance a bit to avoid failing tests on certain archs

### DIFF
--- a/tests/test_syntax.cpp
+++ b/tests/test_syntax.cpp
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(SquareRoot)
 {
     typedef Opm::AutoDiff<double> AdFW;
 
-    const double atol = 1.0e-14;
+    const double atol = 1.0e-13;
 
     const AdFW x = AdFW::variable(1.234e-5);
 


### PR DESCRIPTION
in particular, this was discovered building i386 precise packages on launchpad.
