### PR TITLE
Whether the fluid is saturated or not is explicitly passed to the pvts

### DIFF
--- a/opm/autodiff/BlackoilPropsAd.cpp
+++ b/opm/autodiff/BlackoilPropsAd.cpp
@@ -121,10 +121,12 @@ namespace Opm
     /// Oil viscosity.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
+    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     V BlackoilPropsAd::muOil(const V& po,
                              const V& rs,
+                             const bool* /*isSat*/,
                              const Cells& cells) const
     {
         if (!pu_.phase_used[Oil]) {
@@ -197,14 +199,16 @@ namespace Opm
     /// Oil viscosity.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
+    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     ADB BlackoilPropsAd::muOil(const ADB& po,
                                const ADB& rs,
+                               const bool* isSat,
                                const Cells& cells) const
     {
 #if 1
-        return ADB::constant(muOil(po.value(), rs.value(), cells), po.blockPattern());
+        return ADB::constant(muOil(po.value(), rs.value(), isSat,cells), po.blockPattern());
 #else
         if (!pu_.phase_used[Oil]) {
             OPM_THROW(std::runtime_error, "Cannot call muOil(): oil phase not present.");
@@ -306,10 +310,12 @@ namespace Opm
     /// Oil formation volume factor.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
+    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     V BlackoilPropsAd::bOil(const V& po,
                             const V& rs,
+                            const bool* /*isSat*/,
                             const Cells& cells) const
     {
         if (!pu_.phase_used[Oil]) {
@@ -382,10 +388,12 @@ namespace Opm
     /// Oil formation volume factor.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
+    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     ADB BlackoilPropsAd::bOil(const ADB& po,
                               const ADB& rs,
+                              const bool* /*isSat*/,
                               const Cells& cells) const
     {
         if (!pu_.phase_used[Oil]) {

--- a/opm/autodiff/BlackoilPropsAd.hpp
+++ b/opm/autodiff/BlackoilPropsAd.hpp
@@ -109,10 +109,12 @@ namespace Opm
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         V muOil(const V& po,
                 const V& rs,
+                const bool* isSat,
                 const Cells& cells) const;
 
         /// Gas viscosity.
@@ -132,10 +134,12 @@ namespace Opm
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muOil(const ADB& po,
                   const ADB& rs,
+                  const bool* isSat,
                   const Cells& cells) const;
 
         /// Gas viscosity.
@@ -158,10 +162,12 @@ namespace Opm
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         V bOil(const V& po,
                const V& rs,
+               const bool* isSat,
                const Cells& cells) const;
 
         /// Gas formation volume factor.
@@ -181,10 +187,12 @@ namespace Opm
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bOil(const ADB& po,
                  const ADB& rs,
+                 const bool* isSat,
                  const Cells& cells) const;
 
         /// Gas formation volume factor.

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -212,10 +212,12 @@ namespace Opm
     /// Oil viscosity.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
+    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     V BlackoilPropsAdFromDeck::muOil(const V& po,
                                      const V& rs,
+                                     const bool* isSat,
                                      const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Oil]) {
@@ -227,7 +229,7 @@ namespace Opm
         V dmudp(n);
         V dmudr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->mu(n, po.data(), rs.data(),
+        props_[phase_usage_.phase_pos[Oil]]->mu(n, po.data(), rs.data(),isSat,
                                                 mu.data(), dmudp.data(), dmudr.data());
         return mu;
     }
@@ -285,10 +287,12 @@ namespace Opm
     /// Oil viscosity.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
+    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     ADB BlackoilPropsAdFromDeck::muOil(const ADB& po,
                                        const ADB& rs,
+                                       const bool* isSat,
                                        const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Oil]) {
@@ -300,7 +304,7 @@ namespace Opm
         V dmudp(n);
         V dmudr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->mu(n, po.value().data(), rs.value().data(),
+        props_[phase_usage_.phase_pos[Oil]]->mu(n, po.value().data(), rs.value().data(), isSat,
                                                 mu.data(), dmudp.data(), dmudr.data());
 
         ADB::M dmudp_diag = spdiag(dmudp);
@@ -391,6 +395,7 @@ namespace Opm
     /// \return            Array of n formation volume factor values.
     V BlackoilPropsAdFromDeck::bOil(const V& po,
                                     const V& rs,
+                                    const bool* isSat,
                                     const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Oil]) {
@@ -403,7 +408,7 @@ namespace Opm
         V dbdp(n);
         V dbdr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->b(n, po.data(), rs.data(),
+        props_[phase_usage_.phase_pos[Oil]]->b(n, po.data(), rs.data(),isSat,
                                                b.data(), dbdp.data(), dbdr.data());
 
         return b;
@@ -466,10 +471,12 @@ namespace Opm
     /// Oil formation volume factor.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
+    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     ADB BlackoilPropsAdFromDeck::bOil(const ADB& po,
                                       const ADB& rs,
+                                      const bool* isSat,
                                       const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Oil]) {
@@ -482,7 +489,7 @@ namespace Opm
         V dbdp(n);
         V dbdr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->b(n, po.value().data(), rs.value().data(),
+        props_[phase_usage_.phase_pos[Oil]]->b(n, po.value().data(), rs.value().data(),isSat,
                                                b.data(), dbdp.data(), dbdr.data());
 
         ADB::M dbdp_diag = spdiag(dbdp);

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -110,10 +110,12 @@ namespace Opm
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         V muOil(const V& po,
                 const V& rs,
+                const bool* isSat,
                 const Cells& cells) const;
 
         /// Gas viscosity.
@@ -133,10 +135,12 @@ namespace Opm
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muOil(const ADB& po,
                   const ADB& rs,
+                  const bool* isSat,
                   const Cells& cells) const;
 
         /// Gas viscosity.
@@ -159,10 +163,12 @@ namespace Opm
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         V bOil(const V& po,
                const V& rs,
+               const bool* isSat,
                const Cells& cells) const;
 
         /// Gas formation volume factor.
@@ -182,10 +188,12 @@ namespace Opm
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bOil(const ADB& po,
                  const ADB& rs,
+                 const bool* isSat,
                  const Cells& cells) const;
 
         /// Gas formation volume factor.

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -100,11 +100,13 @@ namespace Opm
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
         V muOil(const V& po,
                 const V& rs,
+                const bool* isSat,
                 const Cells& cells) const = 0;
 
         /// Gas viscosity.
@@ -126,11 +128,13 @@ namespace Opm
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
         ADB muOil(const ADB& po,
                   const ADB& rs,
+                  const bool* isSat,
                   const Cells& cells) const = 0;
 
         /// Gas viscosity.
@@ -155,11 +159,13 @@ namespace Opm
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         V bOil(const V& po,
                const V& rs,
+               const bool* isSat,
                const Cells& cells) const = 0;
 
         /// Gas formation volume factor.
@@ -181,11 +187,13 @@ namespace Opm
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
+        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         ADB bOil(const ADB& po,
                  const ADB& rs,
+                 const bool* isSat,
                  const Cells& cells) const = 0;
 
         /// Gas formation volume factor.

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -189,18 +189,21 @@ namespace Opm {
         fluidViscosity(const int               phase,
                        const ADB&              p    ,
                        const ADB&              rs   ,
+                       const bool*             isSat,
                        const std::vector<int>& cells) const;
 
         ADB
         fluidReciprocFVF(const int               phase,
                          const ADB&              p    ,
                          const ADB&              rs   ,
+                         const bool*             isSat,
                          const std::vector<int>& cells) const;
 
         ADB
         fluidDensity(const int               phase,
                      const ADB&              p    ,
                      const ADB&              rs   ,
+                     const bool*             isSat,
                      const std::vector<int>& cells) const;
 
         V
@@ -216,6 +219,9 @@ namespace Opm {
 
         ADB
         transMult(const ADB& p) const;
+
+        void
+        getSaturatedCells(const SolutionState& state, bool* isSat) const;
     };
 } // namespace Opm
 

--- a/opm/autodiff/ImpesTPFAAD.cpp
+++ b/opm/autodiff/ImpesTPFAAD.cpp
@@ -533,7 +533,8 @@ namespace {
             return fluid_.muWat(p, cells);
         case Oil: {
             V dummy_rs = V::Zero(p.size(), 1) * p;
-            return fluid_.muOil(p, dummy_rs, cells);
+            bool dummy_isSat[p.size()];
+            return fluid_.muOil(p, dummy_rs, dummy_isSat, cells);
         }
         case Gas:
             return fluid_.muGas(p, cells);
@@ -553,7 +554,8 @@ namespace {
             return fluid_.muWat(p, cells);
         case Oil: {
             ADB dummy_rs = V::Zero(p.size(), 1) * p;
-            return fluid_.muOil(p, dummy_rs, cells);
+            bool dummy_isSat[p.size()];
+            return fluid_.muOil(p, dummy_rs, dummy_isSat, cells);
         }
         case Gas:
             return fluid_.muGas(p, cells);
@@ -573,7 +575,8 @@ namespace {
             return fluid_.bWat(p, cells);
         case Oil: {
             V dummy_rs = V::Zero(p.size(), 1) * p;
-            return fluid_.bOil(p, dummy_rs, cells);
+            bool dummy_isSat[p.size()];
+            return fluid_.bOil(p, dummy_rs, dummy_isSat,cells);
         }
         case Gas:
             return fluid_.bGas(p, cells);
@@ -593,7 +596,8 @@ namespace {
             return fluid_.bWat(p, cells);
         case Oil: {
             ADB dummy_rs = V::Zero(p.size(), 1) * p;
-            return fluid_.bOil(p, dummy_rs, cells);
+            bool dummy_isSat[p.size()];
+            return fluid_.bOil(p, dummy_rs, dummy_isSat,cells);
         }
         case Gas:
             return fluid_.bGas(p, cells);


### PR DESCRIPTION
The criteria for whether the fluid is saturated or not is moved from the
within the pvt calculations to the solver, and passed to the pvt
calculations as a array of Boolean values.

The new criteria is set to Sg>0. (From rs >= rsBbp).  With this criteria the convergences problems 
is gone for the SPE9 simple case and moreover the overall number of iterations is reduced.  

This update depends on OPM/opm-core#434 
