### PR TITLE
Switch PVT Evaluators to Use Explicit External Condition Interface

### DIFF
--- a/opm/autodiff/BlackoilPropsAd.cpp
+++ b/opm/autodiff/BlackoilPropsAd.cpp
@@ -121,12 +121,12 @@ namespace Opm
     /// Oil viscosity.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
-    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+    /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     V BlackoilPropsAd::muOil(const V& po,
                              const V& rs,
-                             const bool* /*isSat*/,
+                             const std::vector<PhasePresence>& /*cond*/,
                              const Cells& cells) const
     {
         if (!pu_.phase_used[Oil]) {
@@ -199,16 +199,16 @@ namespace Opm
     /// Oil viscosity.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
-    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+    /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     ADB BlackoilPropsAd::muOil(const ADB& po,
                                const ADB& rs,
-                               const bool* isSat,
+                               const std::vector<PhasePresence>& cond,
                                const Cells& cells) const
     {
 #if 1
-        return ADB::constant(muOil(po.value(), rs.value(), isSat,cells), po.blockPattern());
+        return ADB::constant(muOil(po.value(), rs.value(), cond, cells), po.blockPattern());
 #else
         if (!pu_.phase_used[Oil]) {
             OPM_THROW(std::runtime_error, "Cannot call muOil(): oil phase not present.");
@@ -310,12 +310,12 @@ namespace Opm
     /// Oil formation volume factor.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
-    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+    /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     V BlackoilPropsAd::bOil(const V& po,
                             const V& rs,
-                            const bool* /*isSat*/,
+                            const std::vector<PhasePresence>& /*cond*/,
                             const Cells& cells) const
     {
         if (!pu_.phase_used[Oil]) {
@@ -388,12 +388,12 @@ namespace Opm
     /// Oil formation volume factor.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
-    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+    /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     ADB BlackoilPropsAd::bOil(const ADB& po,
                               const ADB& rs,
-                              const bool* /*isSat*/,
+                              const std::vector<PhasePresence>& /*cond*/,
                               const Cells& cells) const
     {
         if (!pu_.phase_used[Oil]) {

--- a/opm/autodiff/BlackoilPropsAd.hpp
+++ b/opm/autodiff/BlackoilPropsAd.hpp
@@ -109,12 +109,12 @@ namespace Opm
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+        /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         V muOil(const V& po,
                 const V& rs,
-                const bool* isSat,
+                const std::vector<PhasePresence>& cond,
                 const Cells& cells) const;
 
         /// Gas viscosity.
@@ -134,12 +134,12 @@ namespace Opm
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+        /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muOil(const ADB& po,
                   const ADB& rs,
-                  const bool* isSat,
+                  const std::vector<PhasePresence>& cond,
                   const Cells& cells) const;
 
         /// Gas viscosity.
@@ -162,12 +162,12 @@ namespace Opm
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+        /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         V bOil(const V& po,
                const V& rs,
-               const bool* isSat,
+               const std::vector<PhasePresence>& cond,
                const Cells& cells) const;
 
         /// Gas formation volume factor.
@@ -187,12 +187,12 @@ namespace Opm
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+        /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bOil(const ADB& po,
                  const ADB& rs,
-                 const bool* isSat,
+                 const std::vector<PhasePresence>& cond,
                  const Cells& cells) const;
 
         /// Gas formation volume factor.

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -212,12 +212,12 @@ namespace Opm
     /// Oil viscosity.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
-    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+    /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     V BlackoilPropsAdFromDeck::muOil(const V& po,
                                      const V& rs,
-                                     const bool* isSat,
+                                     const std::vector<PhasePresence>& cond,
                                      const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Oil]) {
@@ -229,7 +229,7 @@ namespace Opm
         V dmudp(n);
         V dmudr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->mu(n, po.data(), rs.data(),isSat,
+        props_[phase_usage_.phase_pos[Oil]]->mu(n, po.data(), rs.data(), &cond[0],
                                                 mu.data(), dmudp.data(), dmudr.data());
         return mu;
     }
@@ -287,12 +287,12 @@ namespace Opm
     /// Oil viscosity.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
-    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+    /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     ADB BlackoilPropsAdFromDeck::muOil(const ADB& po,
                                        const ADB& rs,
-                                       const bool* isSat,
+                                       const std::vector<PhasePresence>& cond,
                                        const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Oil]) {
@@ -304,8 +304,8 @@ namespace Opm
         V dmudp(n);
         V dmudr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->mu(n, po.value().data(), rs.value().data(), isSat,
-                                                mu.data(), dmudp.data(), dmudr.data());
+        props_[phase_usage_.phase_pos[Oil]]->mu(n, po.value().data(), rs.value().data(),
+                                                &cond[0], mu.data(), dmudp.data(), dmudr.data());
 
         ADB::M dmudp_diag = spdiag(dmudp);
         ADB::M dmudr_diag = spdiag(dmudr);
@@ -391,11 +391,12 @@ namespace Opm
     /// Oil formation volume factor.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
+    /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     V BlackoilPropsAdFromDeck::bOil(const V& po,
                                     const V& rs,
-                                    const bool* isSat,
+                                    const std::vector<PhasePresence>& cond,
                                     const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Oil]) {
@@ -408,7 +409,7 @@ namespace Opm
         V dbdp(n);
         V dbdr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->b(n, po.data(), rs.data(),isSat,
+        props_[phase_usage_.phase_pos[Oil]]->b(n, po.data(), rs.data(), &cond[0],
                                                b.data(), dbdp.data(), dbdr.data());
 
         return b;
@@ -471,12 +472,12 @@ namespace Opm
     /// Oil formation volume factor.
     /// \param[in]  po     Array of n oil pressure values.
     /// \param[in]  rs     Array of n gas solution factor values.
-    /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+    /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     ADB BlackoilPropsAdFromDeck::bOil(const ADB& po,
                                       const ADB& rs,
-                                      const bool* isSat,
+                                      const std::vector<PhasePresence>& cond,
                                       const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Oil]) {
@@ -489,8 +490,8 @@ namespace Opm
         V dbdp(n);
         V dbdr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->b(n, po.value().data(), rs.value().data(),isSat,
-                                               b.data(), dbdp.data(), dbdr.data());
+        props_[phase_usage_.phase_pos[Oil]]->b(n, po.value().data(), rs.value().data(),
+                                               &cond[0], b.data(), dbdp.data(), dbdr.data());
 
         ADB::M dbdp_diag = spdiag(dbdp);
         ADB::M dbdr_diag = spdiag(dbdr);

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -110,12 +110,12 @@ namespace Opm
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+        /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         V muOil(const V& po,
                 const V& rs,
-                const bool* isSat,
+                const std::vector<PhasePresence>& cond,
                 const Cells& cells) const;
 
         /// Gas viscosity.
@@ -135,12 +135,12 @@ namespace Opm
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+        /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muOil(const ADB& po,
                   const ADB& rs,
-                  const bool* isSat,
+                  const std::vector<PhasePresence>& cond,
                   const Cells& cells) const;
 
         /// Gas viscosity.
@@ -163,12 +163,12 @@ namespace Opm
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+        /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         V bOil(const V& po,
                const V& rs,
-               const bool* isSat,
+               const std::vector<PhasePresence>& cond,
                const Cells& cells) const;
 
         /// Gas formation volume factor.
@@ -188,12 +188,12 @@ namespace Opm
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+        /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bOil(const ADB& po,
                  const ADB& rs,
-                 const bool* isSat,
+                 const std::vector<PhasePresence>& cond,
                  const Cells& cells) const;
 
         /// Gas formation volume factor.

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -100,13 +100,13 @@ namespace Opm
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+        /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
         V muOil(const V& po,
                 const V& rs,
-                const bool* isSat,
+                const std::vector<PhasePresence>& cond,
                 const Cells& cells) const = 0;
 
         /// Gas viscosity.
@@ -128,13 +128,13 @@ namespace Opm
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+        /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
         ADB muOil(const ADB& po,
                   const ADB& rs,
-                  const bool* isSat,
+                  const std::vector<PhasePresence>& cond,
                   const Cells& cells) const = 0;
 
         /// Gas viscosity.
@@ -159,13 +159,13 @@ namespace Opm
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+        /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         V bOil(const V& po,
                const V& rs,
-               const bool* isSat,
+               const std::vector<PhasePresence>& cond,
                const Cells& cells) const = 0;
 
         /// Gas formation volume factor.
@@ -187,13 +187,13 @@ namespace Opm
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
         /// \param[in]  rs     Array of n gas solution factor values.
-        /// \param[in]  isSat  Array of n booleans telling whether the fluid is saturated or not.
+        /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         ADB bOil(const ADB& po,
                  const ADB& rs,
-                 const bool* isSat,
+                 const std::vector<PhasePresence>& cond,
                  const Cells& cells) const = 0;
 
         /// Gas formation volume factor.

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -189,21 +189,21 @@ namespace Opm {
         fluidViscosity(const int               phase,
                        const ADB&              p    ,
                        const ADB&              rs   ,
-                       const bool*             isSat,
+                       const std::vector<PhasePresence>& cond,
                        const std::vector<int>& cells) const;
 
         ADB
         fluidReciprocFVF(const int               phase,
                          const ADB&              p    ,
                          const ADB&              rs   ,
-                         const bool*             isSat,
+                         const std::vector<PhasePresence>& cond,
                          const std::vector<int>& cells) const;
 
         ADB
         fluidDensity(const int               phase,
                      const ADB&              p    ,
                      const ADB&              rs   ,
-                     const bool*             isSat,
+                     const std::vector<PhasePresence>& cond,
                      const std::vector<int>& cells) const;
 
         V
@@ -221,7 +221,8 @@ namespace Opm {
         transMult(const ADB& p) const;
 
         void
-        getSaturatedCells(const SolutionState& state, bool* isSat) const;
+        classifyCondition(const SolutionState&        state,
+                          std::vector<PhasePresence>& cond ) const;
     };
 } // namespace Opm
 

--- a/opm/autodiff/ImpesTPFAAD.cpp
+++ b/opm/autodiff/ImpesTPFAAD.cpp
@@ -533,8 +533,9 @@ namespace {
             return fluid_.muWat(p, cells);
         case Oil: {
             V dummy_rs = V::Zero(p.size(), 1) * p;
-            bool dummy_isSat[p.size()];
-            return fluid_.muOil(p, dummy_rs, dummy_isSat, cells);
+            std::vector<PhasePresence> cond(dummy_rs.size());
+
+            return fluid_.muOil(p, dummy_rs, cond, cells);
         }
         case Gas:
             return fluid_.muGas(p, cells);
@@ -554,8 +555,9 @@ namespace {
             return fluid_.muWat(p, cells);
         case Oil: {
             ADB dummy_rs = V::Zero(p.size(), 1) * p;
-            bool dummy_isSat[p.size()];
-            return fluid_.muOil(p, dummy_rs, dummy_isSat, cells);
+            std::vector<PhasePresence> cond(dummy_rs.size());
+
+            return fluid_.muOil(p, dummy_rs, cond, cells);
         }
         case Gas:
             return fluid_.muGas(p, cells);
@@ -575,8 +577,9 @@ namespace {
             return fluid_.bWat(p, cells);
         case Oil: {
             V dummy_rs = V::Zero(p.size(), 1) * p;
-            bool dummy_isSat[p.size()];
-            return fluid_.bOil(p, dummy_rs, dummy_isSat,cells);
+            std::vector<PhasePresence> cond(dummy_rs.size());
+
+            return fluid_.bOil(p, dummy_rs, cond, cells);
         }
         case Gas:
             return fluid_.bGas(p, cells);
@@ -596,8 +599,9 @@ namespace {
             return fluid_.bWat(p, cells);
         case Oil: {
             ADB dummy_rs = V::Zero(p.size(), 1) * p;
-            bool dummy_isSat[p.size()];
-            return fluid_.bOil(p, dummy_rs, dummy_isSat,cells);
+            std::vector<PhasePresence> cond(dummy_rs.size());
+
+            return fluid_.bOil(p, dummy_rs, cond, cells);
         }
         case Gas:
             return fluid_.bGas(p, cells);


### PR DESCRIPTION
The criteria for whether the fluid is saturated or not is moved from the within the pvt calculations to the solver, and passed to the pvt calculations as arrays of opm-core's `PhasePresence` values.

The new criteria is set to `Sg > 0`, previously `rs >= rsBbp`. With this criteria the convergences problems 
is gone for the SPE9 simple case and moreover the overall number of iterations is reduced.

This update depends on OPM/opm-core#442.

This change incorporates, supersedes and closes #68.
