### PR TITLE
[cmake,bugfix] Corrects required version and make Eigen3 download work.

### DIFF
--- a/cmake/Modules/opm-autodiff-prereqs.cmake
+++ b/cmake/Modules/opm-autodiff-prereqs.cmake
@@ -19,5 +19,5 @@ set (opm-autodiff_DEPS
 	dune-istl REQUIRED;
 	opm-core REQUIRED"
 	# Eigen
-	"Eigen3 3.1 REQUIRED"
+	"Eigen3 3.1.2 "
 	)


### PR DESCRIPTION
At least on Debian requiring version 3.1 of Eigen3 is not sufficient
according to issue #25 the minimum version is 3.1.2. This patch fixes
the required version. In addition it skips the REQUIRED option passed
to find_package(Eigen3) to make the git download work.

Fixes #25.
