### PR TITLE
Forward declare PhaseUsage as struct, not class.

### DIFF
--- a/opm/autodiff/WellDensitySegmented.hpp
+++ b/opm/autodiff/WellDensitySegmented.hpp
@@ -28,7 +28,7 @@ namespace Opm
 {
 
     class WellState;
-    class PhaseUsage;
+    struct PhaseUsage;
 
 
     /// A class giving a well model, by which we mean a way to compute


### PR DESCRIPTION
This avoids a warning from clang.
