### PR TITLE
Remove rs_or_sg_eq from the residual.

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.cpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.cpp
@@ -211,7 +211,6 @@ namespace {
         , phaseCondition_(grid.number_of_cells)
         , residual_ ( { std::vector<ADB>(fluid.numPhases(), ADB::null()),
                         ADB::null(),
-                        ADB::null(),
                         ADB::null() } )
     {
     }
@@ -1274,9 +1273,6 @@ namespace {
              b != e; ++b)
         {
             r = std::max(r, (*b).value().matrix().norm());
-        }
-        if (active_[Oil] && active_[Gas]) {
-            r = std::max(r, residual_.rs_or_sg_eq.value().matrix().norm());
         }
         r = std::max(r, residual_.well_flux_eq.value().matrix().norm());
         r = std::max(r, residual_.well_eq.value().matrix().norm());

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -141,7 +141,6 @@ namespace Opm {
         // The well_eq has size equal to the number of wells.
         struct {
             std::vector<ADB> mass_balance;
-            ADB rs_or_sg_eq; // Only used if both gas and oil present
             ADB well_flux_eq;
             ADB well_eq;
         } residual_;


### PR DESCRIPTION
This has not been used since the introduction of live gas changed the treatment of rs (and rv) values to make a more compact system.
