### PR TITLE
Hysteresis.

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -905,6 +905,15 @@ namespace Opm
         }
         return adbCapPressures;
     }
+                                  
+    /// Saturation update for hysteresis behavior.
+    /// \param[in]  cells       Array of n cell indices to be associated with the saturation values.
+    void BlackoilPropsAdFromDeck::updateSatHyst(const std::vector<double>& saturation,
+                                                const std::vector<int>& cells)
+    {
+        const int n = cells.size();
+        satprops_->updateSatHyst(n, cells.data(), saturation.data());
+    }
 
 } // namespace Opm
 

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -314,6 +314,11 @@ namespace Opm
                                   const ADB& so,
                                   const ADB& sg,
                                   const Cells& cells) const;
+                                  
+        /// Saturation update for hysteresis behavior.
+        /// \param[in]  cells       Array of n cell indices to be associated with the saturation values.
+        void updateSatHyst(const std::vector<double>& saturation,
+                           const std::vector<int>& cells);
 
     private:
         RockFromDeck rock_;

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -315,6 +315,12 @@ namespace Opm
                                   const ADB& so,
                                   const ADB& sg,
                                   const Cells& cells) const = 0;
+                                  
+        /// Saturation update for hysteresis behavior.
+        /// \param[in]  cells       Array of n cell indices to be associated with the saturation values.
+        virtual
+        void updateSatHyst(const std::vector<double>& saturation,
+                           const std::vector<int>& cells) {assert(false); } // Please implement me ...
     };
 
 } // namespace Opm

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil.cpp
@@ -68,7 +68,7 @@ namespace Opm
     public:
         Impl(const parameter::ParameterGroup& param,
              const UnstructuredGrid& grid,
-             const BlackoilPropsAdInterface& props,
+             BlackoilPropsAdInterface& props,
              const RockCompressibility* rock_comp_props,
              WellsManager& wells_manager,
              LinearSolverInterface& linsolver,
@@ -92,7 +92,7 @@ namespace Opm
         int max_well_control_iterations_;
         // Observed objects.
         const UnstructuredGrid& grid_;
-        const BlackoilPropsAdInterface& props_;
+        BlackoilPropsAdInterface& props_;
         const RockCompressibility* rock_comp_props_;
         WellsManager& wells_manager_;
         const Wells* wells_;
@@ -110,7 +110,7 @@ namespace Opm
 
     SimulatorFullyImplicitBlackoil::SimulatorFullyImplicitBlackoil(const parameter::ParameterGroup& param,
                                                                    const UnstructuredGrid& grid,
-                                                                   const BlackoilPropsAdInterface& props,
+                                                                   BlackoilPropsAdInterface& props,
                                                                    const RockCompressibility* rock_comp_props,
                                                                    WellsManager& wells_manager,
                                                                    LinearSolverInterface& linsolver,
@@ -258,7 +258,7 @@ namespace Opm
     // \TODO: Treat bcs.
     SimulatorFullyImplicitBlackoil::Impl::Impl(const parameter::ParameterGroup& param,
                                                const UnstructuredGrid& grid,
-                                               const BlackoilPropsAdInterface& props,
+                                               BlackoilPropsAdInterface& props,
                                                const RockCompressibility* rock_comp_props,
                                                WellsManager& wells_manager,
                                                LinearSolverInterface& linsolver,
@@ -407,6 +407,9 @@ namespace Opm
                 initial_porevol = porevol;
                 computePorevolume(grid_, props_.porosity(), *rock_comp_props_, state.pressure(), porevol);
             }
+
+            // Hysteresis
+            props_.updateSatHyst(state.saturation(), allcells_);
 
             sreport.total_time =  step_timer.secsSinceStart();
             if (output_) {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
@@ -68,7 +68,7 @@ namespace Opm
         /// \param[in] gravity       if non-null, gravity vector
         SimulatorFullyImplicitBlackoil(const parameter::ParameterGroup& param,
                                        const UnstructuredGrid& grid,
-                                       const BlackoilPropsAdInterface& props,
+                                       BlackoilPropsAdInterface& props,
                                        const RockCompressibility* rock_comp_props,
                                        WellsManager& wells_manager,
                                        LinearSolverInterface& linsolver,


### PR DESCRIPTION
SimulatorFullyImplicitBlackoil reports saturation values at each
completed time-step, allowing detection of hysteresis behavior.

This PR requires functionality consistent with PR #495, opm-core.
