### PR TITLE
Make BlackoilPropsAdInterface pure virtual again.

### DIFF
--- a/opm/autodiff/BlackoilPropsAd.cpp
+++ b/opm/autodiff/BlackoilPropsAd.cpp
@@ -817,5 +817,16 @@ namespace Opm
         return adbCapPressures;
     }
 
+
+
+    /// Saturation update for hysteresis behavior.
+    /// \param[in]  cells       Array of n cell indices to be associated with the saturation values.
+    void BlackoilPropsAd::updateSatHyst(const std::vector<double>& /* saturation */,
+                                        const std::vector<int>& /* cells */)
+    {
+        OPM_THROW(std::logic_error, "BlackoilPropsAd class does not support hysteresis.");
+    }
+
+
 } // namespace Opm
 

--- a/opm/autodiff/BlackoilPropsAd.hpp
+++ b/opm/autodiff/BlackoilPropsAd.hpp
@@ -316,6 +316,10 @@ namespace Opm
                                   const ADB& sg,
                                   const Cells& cells) const;
 
+        /// Saturation update for hysteresis behavior.
+        /// \param[in]  cells       Array of n cell indices to be associated with the saturation values.
+        void updateSatHyst(const std::vector<double>& saturation,
+                           const std::vector<int>& cells);
     private:
         const BlackoilPropertiesInterface& props_;
         PhaseUsage pu_;

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -320,7 +320,7 @@ namespace Opm
         /// \param[in]  cells       Array of n cell indices to be associated with the saturation values.
         virtual
         void updateSatHyst(const std::vector<double>& saturation,
-                           const std::vector<int>& cells) {assert(false); } // Please implement me ...
+                           const std::vector<int>& cells) = 0;
     };
 
 } // namespace Opm


### PR DESCRIPTION
Done by adding (throwing) implementation to BlackoilPropsAd class, instead of assert(false) in superclass.
