### PR TITLE
sim_fibo_ad: convert to the new-style wells manager

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoil.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil.cpp
@@ -314,9 +314,6 @@ namespace Opm
                                                               BlackoilState& state,
                                                               WellStateFullyImplicitBlackoil& well_state)
     {
-        eclipseWriter_.writeInit(timer, state, well_state.basicWellState());
-        eclipseWriter_.writeTimeStep(timer, state, well_state.basicWellState());
-
         // Initialisation.
         std::vector<double> porevol;
         if (rock_comp_props_ && rock_comp_props_->isActive()) {


### PR DESCRIPTION
i.e. it now uses Opm::EclipseState. This change required to re-add the
the epoch concept in some sense, but the loop variables now call it
"episode" which sounds less ethernal IMO.
