### PR TITLE
don't pass the eclipsewriter to the simulator anymore

### DIFF
--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -242,16 +242,11 @@ try
                                                  rock_comp->isActive() ? rock_comp.get() : 0,
                                                  wells,
                                                  linsolver,
-                                                 grav,
-                                                 outputWriter);
+                                                 grav);
         SimulatorReport episodeReport = simulator.run(simtimer, state, well_state);
 
         outputWriter.writeTimeStep(simtimer, state, well_state.basicWellState());
         fullReport += episodeReport;
-
-        if (output) {
-            episodeReport.reportParam(outStream);
-        }
     }
 
     std::cout << "\n\n================    End of simulation     ===============\n\n";
@@ -318,8 +313,7 @@ try
                                                  rock_comp->isActive() ? rock_comp.get() : 0,
                                                  wells,
                                                  linsolver,
-                                                 grav,
-                                                 outputWriter);
+                                                 grav);
         outputWriter.writeTimeStep(simtimer, state, well_state.basicWellState());
 
         if (epoch == 0) {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil.cpp
@@ -38,7 +38,6 @@
 #include <opm/core/simulator/SimulatorReport.hpp>
 #include <opm/core/simulator/SimulatorTimer.hpp>
 #include <opm/core/utility/StopWatch.hpp>
-#include <opm/core/io/eclipse/EclipseWriter.hpp>
 #include <opm/core/io/vtk/writeVtkData.hpp>
 #include <opm/core/utility/miscUtilities.hpp>
 #include <opm/core/utility/miscUtilitiesBlackoil.hpp>
@@ -72,8 +71,7 @@ namespace Opm
              const RockCompressibility* rock_comp_props,
              WellsManager& wells_manager,
              LinearSolverInterface& linsolver,
-             const double* gravity,
-             EclipseWriter &writer);
+             const double* gravity);
 
         SimulatorReport run(SimulatorTimer& timer,
                             BlackoilState& state,
@@ -102,7 +100,6 @@ namespace Opm
         FullyImplicitBlackoilSolver solver_;
         // Misc. data
         std::vector<int> allcells_;
-        EclipseWriter &eclipseWriter_;
     };
 
 
@@ -114,11 +111,10 @@ namespace Opm
                                                                    const RockCompressibility* rock_comp_props,
                                                                    WellsManager& wells_manager,
                                                                    LinearSolverInterface& linsolver,
-                                                                   const double* gravity,
-                                                                   EclipseWriter &eclipseWriter)
+                                                                   const double* gravity)
 
     {
-        pimpl_.reset(new Impl(param, grid, props, rock_comp_props, wells_manager, linsolver, gravity, eclipseWriter));
+        pimpl_.reset(new Impl(param, grid, props, rock_comp_props, wells_manager, linsolver, gravity));
     }
 
 
@@ -262,8 +258,7 @@ namespace Opm
                                                const RockCompressibility* rock_comp_props,
                                                WellsManager& wells_manager,
                                                LinearSolverInterface& linsolver,
-                                               const double* gravity,
-                                               EclipseWriter &eclipseWriter)
+                                               const double* gravity)
         : grid_(grid),
           props_(props),
           rock_comp_props_(rock_comp_props),
@@ -271,9 +266,7 @@ namespace Opm
           wells_(wells_manager.c_wells()),
           gravity_(gravity),
           geo_(grid_, props_, gravity_),
-          solver_(grid_, props_, geo_, rock_comp_props, *wells_manager.c_wells(), linsolver),
-          eclipseWriter_(eclipseWriter)
-
+          solver_(grid_, props_, geo_, rock_comp_props, *wells_manager.c_wells(), linsolver)
           /*                   param.getDefault("nl_pressure_residual_tolerance", 0.0),
                                param.getDefault("nl_pressure_change_tolerance", 1.0),
                                param.getDefault("nl_pressure_maxiter", 10),
@@ -419,11 +412,6 @@ namespace Opm
 
             // advance to next timestep before reporting at this location
             ++timer;
-
-            // write an output file for later inspection
-            if (output_) {
-                eclipseWriter_.writeTimeStep(timer, state, well_state.basicWellState());
-            }
         }
 
         total_timer.stop();

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
@@ -31,7 +31,6 @@ namespace Opm
 {
     namespace parameter { class ParameterGroup; }
     class BlackoilPropsAdInterface;
-    class EclipseWriter;
     class RockCompressibility;
     class WellsManager;
     class LinearSolverInterface;
@@ -72,8 +71,7 @@ namespace Opm
                                        const RockCompressibility* rock_comp_props,
                                        WellsManager& wells_manager,
                                        LinearSolverInterface& linsolver,
-                                       const double* gravity,
-                                       EclipseWriter &writer);
+                                       const double* gravity);
 
         /// Run the simulation.
         /// This will run succesive timesteps until timer.done() is true. It will


### PR DESCRIPTION
i.e., the simulator does not deal with any output operations
anymore. This makes sense because report steps are handled by
Opm::TimeMap and the constructor for the simulator already needs more
arguments than appropriate even without this...
