### PR TITLE
Fix timer usage.

### DIFF
--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -230,8 +230,10 @@ try
 
         simtimer.setCurrentStepNum(reportStepIdx);
 
-        if (reportStepIdx == 0)
+        if (reportStepIdx == 0) {
             outputWriter.writeInit(simtimer, state, well_state.basicWellState());
+            outputWriter.writeTimeStep(simtimer, state, well_state.basicWellState());
+        }
 
         // Create and run simulator.
         SimulatorFullyImplicitBlackoil simulator(param,
@@ -242,6 +244,8 @@ try
                                                  linsolver,
                                                  grav);
         SimulatorReport episodeReport = simulator.run(simtimer, state, well_state);
+
+        ++simtimer;
 
         outputWriter.writeTimeStep(simtimer, state, well_state.basicWellState());
         fullReport += episodeReport;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil.cpp
@@ -411,7 +411,7 @@ namespace Opm
             }
 
             // advance to next timestep before reporting at this location
-            ++timer;
+            // ++timer; // Commented out since this has temporarily moved to the main() function.
             break; // this is a temporary measure
         }
 


### PR DESCRIPTION
This makes the simulator produce proper summary output again.

Note that this PR goes against the direction I would like for timestep control (moves the last remaining shred of it to the main() function), but it does make the simulator consistent and produce correct output, which is more important.
