### PR TITLE
Fix NaNs for well equations.

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.cpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.cpp
@@ -787,16 +787,17 @@ namespace {
 
         // check for dead wells
         V isNotDeadWells = V::Constant(nw,1.0);
-        for (int c = 0; c < nw; ++c){
-            if (wbqt.value()[c] == 0)
-                isNotDeadWells[c] = 0;
+        for (int w = 0; w < nw; ++w) {
+            if (wbqt.value()[w] == 0) {
+                isNotDeadWells[w] = 0;
+            }
         }
         // compute wellbore mixture at std conds
-        Selector<double> notDeadWells_selector(wbqt.value(),Selector<double>::Zero);
+        Selector<double> notDeadWells_selector(wbqt.value(), Selector<double>::Zero);
         std::vector<ADB> mix_s(np, ADB::null());
         for (int phase = 0; phase < np; ++phase) {
             const int pos = pu.phase_pos[phase];
-            mix_s[phase] = notDeadWells_selector.select(ADB::constant(compi.col(pos), state.bhp.blockPattern()),wbq[phase]/wbqt);
+            mix_s[phase] = notDeadWells_selector.select(ADB::constant(compi.col(pos)), wbq[phase]/wbqt);
         }
 
 
@@ -834,7 +835,7 @@ namespace {
                 const int oilpos = pu.phase_pos[Oil];
                 tmp = tmp - subset(state.rs,well_cells) * cmix_s[oilpos] / d;
             }
-           volRat += tmp / subset(rq_[phase].b,well_cells);
+            volRat += tmp / subset(rq_[phase].b,well_cells);
 
         }
 


### PR DESCRIPTION
This avoids a division by zero for wells that have zero flow rate (typically encountered as an initial state).

Taken together with OPM/opm-core#564, this avoid the NaNs previously encountered in the residuals.
