### PR TITLE
Update perfPhaseRates() field of well state object.

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -170,6 +170,7 @@ namespace Opm {
 
         void
         addWellEq(const SolutionState& state,
+                  WellStateFullyImplicitBlackoil& xw,
                   V& aliveWells);
 
         void updateWellControls(ADB& bhp,


### PR DESCRIPTION
The field is used to compute new well perforation pressure differences at the start of every timestep, but was not updated. This patch will update it with every call to addWellEq(), since we have access to the necessary data in that function.
