### PR TITLE
Update perfPressure

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -170,6 +170,7 @@ namespace Opm {
 
         void
         addWellEq(const SolutionState& state,
+                  WellStateFullyImplicitBlackoil& xw,
                   V& aliveWells);
 
         void updateWellControls(ADB& bhp,


### PR DESCRIPTION
The secondary variable perfpressure is updated when the well
equation is assembled. The perfpressure is used to calculate the
well density.
