### PR TITLE
Fix missing template keyword.

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -1661,9 +1661,8 @@ namespace {
 
         bool converged_CNV = (CNVW < tol_cnv) && (CNVO < tol_cnv) && (CNVG < tol_cnv);
 
-
-        double residualWellFlux = residual_.well_flux_eq.value().matrix().lpNorm<Eigen::Infinity>();
-        double residualWell = residual_.well_eq.value().matrix().lpNorm<Eigen::Infinity>();
+        double residualWellFlux = residual_.well_flux_eq.value().matrix().template lpNorm<Eigen::Infinity>();
+        double residualWell = residual_.well_eq.value().matrix().template lpNorm<Eigen::Infinity>();
 
         bool converged_Well = (residualWellFlux < 1./Opm::unit::day) && (residualWell < Opm::unit::barsa);
 


### PR DESCRIPTION
When invoking a member template in a template function one must in most
cases use the template keyword as a qualifier to indicate that the member
is a template.

I do not understand why this did not trigger a compiler error for the
original author though.
