### PR TITLE
Don't use undocumented NOGRAV keyword and add the parser to the test fixture in botest

### DIFF
--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -119,7 +119,7 @@ try
     rock_comp.reset(new RockCompressibility(deck));
 
     // Gravity.
-    gravity[2] = deck->hasKeyword("NOGRAV") ? 0.0 : unit::gravity;
+    gravity[2] = unit::gravity;
 
     // Init state variables (saturation and pressure).
     if (param.has("init_saturation")) {

--- a/tests/test_boprops_ad.cpp
+++ b/tests/test_boprops_ad.cpp
@@ -45,7 +45,7 @@
 struct SetupSimple {
     SetupSimple()
     {
-        Opm::ParserPtr parser(new Opm::Parser());
+        parser.reset(new Opm::Parser());
         deck = parser->parseFile("fluid.data");
 
         param.disableOutput();
@@ -56,6 +56,7 @@ struct SetupSimple {
     }
 
     Opm::parameter::ParameterGroup  param;
+    Opm::ParserPtr                  parser;
     Opm::DeckConstPtr               deck;
 };
 


### PR DESCRIPTION
maybe NOGRAV is documented somewhere, but certainly not in my version of the Eclipse RM...
