### PR TITLE
glue in support for property modifiers

### DIFF
--- a/examples/sim_2p_comp_ad.cpp
+++ b/examples/sim_2p_comp_ad.cpp
@@ -110,7 +110,7 @@ try
         // Grid init
         grid.reset(new GridManager(deck));
         // Rock and fluid init
-        props.reset(new BlackoilPropertiesFromDeck(deck, *grid->c_grid(), param));
+        props.reset(new BlackoilPropertiesFromDeck(deck, eclipseState, *grid->c_grid(), param));
         // check_well_controls = param.getDefault("check_well_controls", false);
         // max_well_control_iterations = param.getDefault("max_well_control_iterations", 10);
         // Rock compressibility.

--- a/examples/sim_2p_incomp_ad.cpp
+++ b/examples/sim_2p_incomp_ad.cpp
@@ -117,7 +117,7 @@ try
         // Grid init
         grid.reset(new GridManager(deck));
         // Rock and fluid init
-        props.reset(new IncompPropertiesFromDeck(deck, *grid->c_grid()));
+        props.reset(new IncompPropertiesFromDeck(deck, eclipseState, *grid->c_grid()));
         // check_well_controls = param.getDefault("check_well_controls", false);
         // max_well_control_iterations = param.getDefault("max_well_control_iterations", 10);
         // Rock compressibility.

--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -110,8 +110,8 @@ try
     Opm::EclipseWriter outputWriter(param, deck, share_obj(*grid->c_grid()));
 
     // Rock and fluid init
-    props.reset(new BlackoilPropertiesFromDeck(deck, *grid->c_grid(), param));
-    new_props.reset(new BlackoilPropsAdFromDeck(deck, *grid->c_grid()));
+    props.reset(new BlackoilPropertiesFromDeck(deck, eclipseState, *grid->c_grid(), param));
+    new_props.reset(new BlackoilPropsAdFromDeck(deck, eclipseState, *grid->c_grid()));
 
     // check_well_controls = param.getDefault("check_well_controls", false);
     // max_well_control_iterations = param.getDefault("max_well_control_iterations", 10);

--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -131,6 +131,7 @@ try
 
     Opm::ParserPtr newParser(new Opm::Parser() );
     Opm::DeckConstPtr deck = newParser->parseFile( deck_filename );
+    Opm::EclipseStateConstPtr eclipseState(new EclipseState(deck));
 
     // Grid init
     grid.reset(new Dune::CpGrid());
@@ -151,12 +152,13 @@ try
                                     Opm::UgGridHelpers::dimensions(*grid));
 
     // Rock and fluid init
-    props.reset(new BlackoilPropertiesFromDeck(deck, Opm::UgGridHelpers::numCells(*grid),
+    props.reset(new BlackoilPropertiesFromDeck(deck, eclipseState,
+                                               Opm::UgGridHelpers::numCells(*grid),
                                                Opm::UgGridHelpers::globalCell(*grid),
                                                Opm::UgGridHelpers::cartDims(*grid),
                                                Opm::UgGridHelpers::beginCellCentroids(*grid),
                                                Opm::UgGridHelpers::dimensions(*grid), param));
-    new_props.reset(new BlackoilPropsAdFromDeck(deck, *grid));
+    new_props.reset(new BlackoilPropsAdFromDeck(deck, eclipseState, *grid));
     // check_well_controls = param.getDefault("check_well_controls", false);
     // max_well_control_iterations = param.getDefault("max_well_control_iterations", 10);
     // Rock compressibility.
@@ -232,7 +234,6 @@ try
     WellStateFullyImplicitBlackoil well_state;
     Opm::TimeMapPtr timeMap(new Opm::TimeMap(deck));
     SimulatorTimer simtimer;
-    std::shared_ptr<EclipseState> eclipseState(new EclipseState(deck));
 
     // initialize variables
     simtimer.init(timeMap);

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -33,6 +33,7 @@
 #include <opm/core/utility/Units.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/Utility/PvtoTable.hpp>
 #include <opm/parser/eclipse/Utility/PvtgTable.hpp>
 #include <opm/parser/eclipse/Utility/PvtwTable.hpp>
@@ -51,20 +52,22 @@ namespace Opm
 
     /// Constructor wrapping an opm-core black oil interface.
     BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(Opm::DeckConstPtr deck,
+                                                     Opm::EclipseStateConstPtr eclState,
                                                      const UnstructuredGrid& grid,
                                                      const bool init_rock)
     {
-        init(deck, grid.number_of_cells, grid.global_cell, grid.cartdims, 
+        init(deck, eclState, grid.number_of_cells, grid.global_cell, grid.cartdims, 
              grid.cell_centroids, grid.dimensions, init_rock);
     }
 
 #ifdef HAVE_DUNE_CORNERPOINT
     /// Constructor wrapping an opm-core black oil interface.
     BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(Opm::DeckConstPtr deck,
+                                                     Opm::EclipseStateConstPtr eclState,
                                                      const Dune::CpGrid& grid,
                                                      const bool init_rock )
     {
-        init(deck, grid.numCells(), static_cast<const int*>(&grid.globalCell()[0]),
+        init(deck, eclState, grid.numCells(), static_cast<const int*>(&grid.globalCell()[0]),
              static_cast<const int*>(&grid.logicalCartesianSize()[0]),
              grid.beginCellCentroids(), Dune::CpGrid::dimension, init_rock);
     }
@@ -73,6 +76,7 @@ namespace Opm
     /// Initializes the properties.
     template <class CentroidIterator>
     void BlackoilPropsAdFromDeck::init(Opm::DeckConstPtr deck,
+                                       Opm::EclipseStateConstPtr eclState,
                                        int number_of_cells,
                                        const int* global_cell,
                                        const int* cart_dims,
@@ -85,7 +89,7 @@ namespace Opm
         extractPvtTableIndex(cellPvtRegionIdx_, deck, number_of_cells, global_cell);
 
         if (init_rock){
-            rock_.init(deck, number_of_cells, global_cell, cart_dims);
+            rock_.init(eclState, number_of_cells, global_cell, cart_dims);
         }
 
         phase_usage_ = phaseUsageFromDeck(deck);

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -28,6 +28,7 @@
 #include <opm/core/props/rock/RockFromDeck.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
 #include <memory>
 #include <vector>
@@ -56,12 +57,14 @@ namespace Opm
     public:
         /// Constructor wrapping an opm-core black oil interface.
         BlackoilPropsAdFromDeck(Opm::DeckConstPtr deck,
+                                Opm::EclipseStateConstPtr eclState,
                                 const UnstructuredGrid& grid,
                                 const bool init_rock = true );
 
 #ifdef HAVE_DUNE_CORNERPOINT
         /// Constructor wrapping an opm-core black oil interface.
         BlackoilPropsAdFromDeck(Opm::DeckConstPtr deck,
+                                Opm::EclipseStateConstPtr eclState,
                                 const Dune::CpGrid& grid,
                                 const bool init_rock = true );
 #endif
@@ -344,6 +347,7 @@ namespace Opm
         /// Initializes the properties.
         template <class CentroidIterator>
         void init(Opm::DeckConstPtr deck,
+                  Opm::EclipseStateConstPtr eclState,
                   int number_of_cells,
                   const int* global_cell,
                   const int* cart_dims,

--- a/tests/fluid.data
+++ b/tests/fluid.data
@@ -1,13 +1,19 @@
+-- =====================================================================
 RUNSPEC
-
-DIMENS
-1 1 1
-/
 
 OIL
 WATER
 
 METRIC
+
+DIMENS
+1 1 1
+/
+
+TABDIMS
+-- use the default values for TABDIMS, but the keyword must be present
+-- if any tables ought to be specified...
+/
 
 -- =====================================================================
 GRID
@@ -28,29 +34,8 @@ DEPTHZ
 4*0
 /
 
-PERMX
-1.01325E15
-/
-
-PERMY
-1.01325E15
-/
-
-PERMZ
-1.01325E15
-/
-
-PORO
-1
-/
-
 -- =====================================================================
 PROPS
-
-TABDIMS
--- use the default values for TABDIMS, but the keyword must be present
--- if any tables ought to be specified...
-/
 
 PVTW
 -- Pw Bw(Pw) Cw muw  Cv
@@ -70,6 +55,14 @@ SWOF
 DENSITY
   800 1000 1
 /
+
+-- =====================================================================
+SOLUTION
+-- empty section
+
+-- =====================================================================
+SCHEDULE
+-- empty section
 
 -- =====================================================================
 END

--- a/tests/test_boprops_ad.cpp
+++ b/tests/test_boprops_ad.cpp
@@ -36,6 +36,7 @@
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
 #include <fstream>
@@ -47,6 +48,7 @@ struct SetupSimple {
     {
         Opm::ParserPtr parser(new Opm::Parser());
         deck = parser->parseFile("fluid.data");
+        eclState.reset(new Opm::EclipseState(deck));
 
         param.disableOutput();
         param.insertParameter("init_rock"       , "false" );
@@ -57,6 +59,7 @@ struct SetupSimple {
 
     Opm::parameter::ParameterGroup  param;
     Opm::DeckConstPtr               deck;
+    Opm::EclipseStateConstPtr       eclState;
 };
 
 
@@ -66,13 +69,14 @@ struct TestFixture : public Setup
     TestFixture()
         : Setup()
         , grid (deck)
-        , props(deck, *grid.c_grid(), param,
+        , props(deck, eclState, *grid.c_grid(), param,
                 param.getDefault("init_rock", false))
     {
     }
 
     using Setup::param;
     using Setup::deck;
+    using Setup::eclState;
 
     Opm::GridManager                grid;
     Opm::BlackoilPropertiesFromDeck props;


### PR DESCRIPTION
i.e. reading the grid properties from EclipseState instead of from the
raw deck. This requires that all deck files exhibit a GRID and a
SCHEDULE section or else EclipseState will throw in the constructor.
