### PR TITLE
explicitly include <array>

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -30,6 +30,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
 #include <memory>
+#include <array>
 #include <vector>
 
 #ifdef HAVE_DUNE_CORNERPOINT


### PR DESCRIPTION
it _seems_ like this causes the build  failures of the RHEL 5 build at
statoil: http://opm-project.org/CDash/viewBuildError.php?buildid=18933
