### PR TITLE
pass a reference to the UnstructuredGrid to EclipseWriter instead of a shared_ptr

### DIFF
--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -108,11 +108,12 @@ try
     // Grid init
     grid.reset(new GridManager(eclipseState->getEclipseGrid()));
     auto &cGrid = *grid->c_grid();
+    const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
     Opm::EclipseWriter outputWriter(param,
-                                    deck,
+                                    eclipseState,
+                                    pu,
                                     cGrid.number_of_cells,
-                                    cGrid.global_cell,
-                                    cGrid.cartdims);
+                                    cGrid.global_cell);
 
     // Rock and fluid init
     props.reset(new BlackoilPropertiesFromDeck(deck, eclipseState, *grid->c_grid(), param));
@@ -131,7 +132,6 @@ try
         initStateBasic(*grid->c_grid(), *props, param, gravity[2], state);
         initBlackoilSurfvol(*grid->c_grid(), *props, state);
         enum { Oil = BlackoilPhases::Liquid, Gas = BlackoilPhases::Vapour };
-        const PhaseUsage pu = props->phaseUsage();
         if (pu.phase_used[Oil] && pu.phase_used[Gas]) {
             const int np = props->numPhases();
             const int nc = grid->c_grid()->number_of_cells;

--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -145,10 +145,10 @@ try
     }
 
 
-    Opm::EclipseWriter outputWriter(param, deck,
+    const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
+    Opm::EclipseWriter outputWriter(param, eclipseState, pu,
                                     Opm::UgGridHelpers::numCells(*grid),
-                                    Opm::UgGridHelpers::globalCell(*grid),
-                                    Opm::UgGridHelpers::cartDims(*grid));
+                                    Opm::UgGridHelpers::globalCell(*grid));
 
     // Rock and fluid init
     props.reset(new BlackoilPropertiesFromDeck(deck, eclipseState,
@@ -176,7 +176,6 @@ try
                        *props, param, gravity[2], state);
         initBlackoilSurfvol(grid->numCells(), *props, state);
         enum { Oil = BlackoilPhases::Liquid, Gas = BlackoilPhases::Vapour };
-        const PhaseUsage pu = props->phaseUsage();
         if (pu.phase_used[Oil] && pu.phase_used[Gas]) {
             const int np = props->numPhases();
             const int nc = grid->numCells();


### PR DESCRIPTION
a shared_ptr might delete the grid object as soon as the shared_ptr
thinks that the object is unused. This happens as soon as there are no
other shared_ptr which were derived from the original one
anymore. Since this is a C object with plenty of raw pointers to it,
potentially deleting it is not a good idea...

(the current code works as well because the OPM 'share_obj' utility
function actually works around this by explicitly instructing
'shared_ptr' not to delete the object, but IMHO using this function
only makes it more complicated than neccessary.)

Note that this patch requires OPM/opm-core#560
