### PR TITLE
Restore gravity effects

### DIFF
--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -193,7 +193,7 @@ try
     // initialize variables
     simtimer.init(timeMap);
 
-    Opm::DerivedGeology geology(*grid->c_grid(), *new_props, eclipseState);
+    Opm::DerivedGeology geology(*grid->c_grid(), *new_props, eclipseState, grav);
 
     SimulatorReport fullReport;
     for (size_t reportStepIdx = 0; reportStepIdx < timeMap->numTimesteps(); ++reportStepIdx) {

--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -236,7 +236,7 @@ try
     // initialize variables
     simtimer.init(timeMap);
 
-    Opm::DerivedGeology geology(*grid, *new_props, eclipseState);
+    Opm::DerivedGeology geology(*grid, *new_props, eclipseState, grav);
 
     SimulatorReport fullReport;
     for (size_t reportStepIdx = 0; reportStepIdx < timeMap->numTimesteps(); ++reportStepIdx) {


### PR DESCRIPTION
The refactorisation of class `FullyImplicitBlackoilSolver<Grid>` to defer transmissibility and pore-volume calculation to the client in order to support multipliers (net-to-gross &c) accidentally ended up removing all effects of gravity.  This commit restores those effects.

This resolves #171.
