### PR TITLE
Remove unused grav_ member and function used to compute it.

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -145,7 +145,6 @@ namespace Opm {
         const std::vector<int>          cells_;  // All grid cells
         HelperOps                       ops_;
         const WellOps                   wops_;
-        const M                         grav_;
         const bool has_disgas_;
         const bool has_vapoil_;
         double                          dp_max_rel_;


### PR DESCRIPTION
This is a relic of the way we originally handled gravity. The member remained after the change, and is now a major time-consumption sink due to the unfortunate fact that it is computed every time step (unnecessary), and because the gravityOperator() function (now removed) was very unperformant after changing to use the faceCells() function.

This cuts time per step with about 20 seconds (!) for me on the Norne test case.
