### PR TITLE
Make non-strict parsing the default.

### DIFF
--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -102,7 +102,7 @@ try
     std::string deck_filename = param.get<std::string>("deck_filename");
 
     Opm::ParserPtr newParser(new Opm::Parser() );
-    bool strict_parsing = param.getDefault("strict_parsing", false);
+    bool strict_parsing = param.getDefault("strict_parsing", true);
     Opm::DeckConstPtr deck = newParser->parseFile(deck_filename, strict_parsing);
     std::shared_ptr<EclipseState> eclipseState(new EclipseState(deck));
 


### PR DESCRIPTION
It can be argued whether strict or non-strict should be the default.  The essential thing  is the option to do non-strict parsing ... 
