### PR TITLE
Use direct deck-using version of grid construction method.

### DIFF
--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -137,15 +137,7 @@ try
 
     // Grid init
     grid.reset(new Dune::CpGrid());
-    {
-        grdecl g = {};
-        GridManager::createGrdecl(deck, g);
-
-        grid->processEclipseFormat(g, 2e-12, false);
-
-        std::free(const_cast<double*>(g.mapaxes));
-    }
-
+    grid->processEclipseFormat(deck, false, false, false);
 
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
     Opm::EclipseWriter outputWriter(param, eclipseState, pu,


### PR DESCRIPTION
A simplification that also allow new PINCH functionality.

Requires OPM/opm-parser#284 and OPM/dune-cornerpoint#104.
