### PR TITLE
Add MINPV support to grid creation for fully implicit sims.

### DIFF
--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -107,7 +107,11 @@ try
     std::shared_ptr<EclipseState> eclipseState(new EclipseState(deck));
 
     // Grid init
-    grid.reset(new GridManager(eclipseState->getEclipseGrid()));
+    std::vector<double> porv;
+    if (eclipseState->hasDoubleGridProperty("PORV")) {
+        porv = eclipseState->getDoubleGridProperty("PORV")->getData();
+    }
+    grid.reset(new GridManager(eclipseState->getEclipseGrid(), porv));
     auto &cGrid = *grid->c_grid();
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
     Opm::EclipseWriter outputWriter(param,

--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -137,7 +137,11 @@ try
 
     // Grid init
     grid.reset(new Dune::CpGrid());
-    grid->processEclipseFormat(deck, false, false, false);
+    std::vector<double> porv;
+    if (eclipseState->hasDoubleGridProperty("PORV")) {
+        porv = eclipseState->getDoubleGridProperty("PORV")->getData();
+    }
+    grid->processEclipseFormat(deck, false, false, false, porv);
 
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
     Opm::EclipseWriter outputWriter(param, eclipseState, pu,


### PR DESCRIPTION
This requires OPM/opm-core#637 and OPM/dune-cornerpoint#106.

Note that nothing will actually change in the running sim with this, since the EclipseState class does not yet support the PORV array property.
