### PR TITLE
Suppress warnings of various kinds.

### DIFF
--- a/opm/autodiff/BlackoilPropsAd.cpp
+++ b/opm/autodiff/BlackoilPropsAd.cpp
@@ -898,7 +898,7 @@ namespace Opm
     }
     
     /// Update for max oil saturation.
-    void BlackoilPropsAd::updateSatOilMax(const std::vector<double>& saturation)
+    void BlackoilPropsAd::updateSatOilMax(const std::vector<double>& /*saturation*/)
     {
         OPM_THROW(std::logic_error, "BlackoilPropsAd class does not support this functionality.");
     }

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -410,8 +410,8 @@ namespace Opm
         std::unique_ptr<SaturationPropsInterface> satprops_;
 
         PhaseUsage phase_usage_;
-        bool has_vapoil_;
-        bool has_disgas_;
+        // bool has_vapoil_;
+        // bool has_disgas_;
 
         // The PVT region which is to be used for each cell
         std::vector<int> cellPvtRegionIdx_;

--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -32,13 +32,13 @@
 
 #include <Eigen/Eigen>
 
-#include "reenable_warning_pragmas.h"
-
 #ifdef HAVE_DUNE_CORNERPOINT
 #include <dune/common/version.hh>
 #include <dune/grid/CpGrid.hpp>
 #include <dune/grid/common/mcmgmapper.hh>
 #endif
+
+#include "reenable_warning_pragmas.h"
 
 #include <cstddef>
 


### PR DESCRIPTION
Some unused variables and dune includes added outside the suppression zone.
