### PR TITLE
Makes distinction between functions more clear. (#176)

### DIFF
--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -164,7 +164,7 @@ try
     if (param.has("init_saturation")) {
         initStateBasic(grid->numCells(), &(grid->globalCell())[0],
                        &(grid->logicalCartesianSize()[0]),
-                       grid->numFaces(), AutoDiffGrid::faceCells(*grid),
+                       grid->numFaces(), UgGridHelpers::faceCells(*grid),
                        grid->beginFaceCentroids(),
                        grid->beginCellCentroids(), Dune::CpGrid::dimension,
                        *props, param, gravity[2], state);
@@ -182,7 +182,7 @@ try
         OPM_THROW(std::logic_error, "sim_fibo_ad_cp does not support EQUIL initialization.");
     } else {
         initBlackoilStateFromDeck(grid->numCells(), &(grid->globalCell())[0],
-                                  grid->numFaces(), AutoDiffGrid::faceCells(*grid),
+                                  grid->numFaces(), UgGridHelpers::faceCells(*grid),
                                   grid->beginFaceCentroids(),
                                   grid->beginCellCentroids(), Dune::CpGrid::dimension,
                                   *props, deck, gravity[2], state);

--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -92,7 +92,7 @@ struct HelperOps
         div = ngrad.transpose();
         std::vector<Tri> fullngrad_tri;
         fullngrad_tri.reserve(2*nf);
-        typename ADFaceCellTraits<Grid>::Type nb=faceCells(grid);
+        typename ADFaceCellTraits<Grid>::Type nb=faceCellsToEigen(grid);
         for (int i = 0; i < nf; ++i) {
             if (nb(i,0) >= 0) {
                 fullngrad_tri.emplace_back(i, nb(i,0), 1.0);
@@ -126,7 +126,7 @@ struct HelperOps
             typedef HelperOps::IFaces::Index IFIndex;
             const IFIndex nif = h.internal_faces.size();
             typename ADFaceCellTraits<Grid>::Type
-                face_cells = faceCells(g);
+                face_cells = faceCellsToEigen(g);
             assert(nif == ifaceflux.size());
 
             // Define selector structure.

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -606,7 +606,7 @@ namespace {
         // b is row major, so can just copy data.
         std::vector<double> b_perf(b.data(), b.data() + nperf * pu.num_phases);
         // Extract well connection depths.
-        const V depth = cellCentroidsZ(grid_);
+        const V depth = cellCentroidsZToEigen(grid_);
         const V pdepth = subset(depth, well_cells);
         std::vector<double> perf_depth(pdepth.data(), pdepth.data() + nperf);
         // Surface density.

--- a/opm/autodiff/GridHelpers.cpp
+++ b/opm/autodiff/GridHelpers.cpp
@@ -43,14 +43,14 @@ int dimensions(const UnstructuredGrid& grid)
 }
 */
 Eigen::Array<int, Eigen::Dynamic, 2, Eigen::RowMajor>
-faceCells(const UnstructuredGrid& grid)
+faceCellsToEigen(const UnstructuredGrid& grid)
 {
     typedef Eigen::Array<int, Eigen::Dynamic, 2, Eigen::RowMajor> TwoColInt;
     return Eigen::Map<TwoColInt>(grid.face_cells, grid.number_of_faces, 2);
 }
 
 Eigen::Array<double, Eigen::Dynamic, 1>
-cellCentroidsZ(const UnstructuredGrid& grid)
+cellCentroidsZToEigen(const UnstructuredGrid& grid)
 {
     return Eigen::Map<Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> >
         (grid.cell_centroids, grid.number_of_cells, grid.dimensions).rightCols<1>();
@@ -93,7 +93,7 @@ void extractInternalFaces(const UnstructuredGrid& grid,
     typedef Eigen::Array<bool, Eigen::Dynamic, 1> OneColBool;
     typedef Eigen::Array<int, Eigen::Dynamic, 2, Eigen::RowMajor> TwoColInt;
     typedef Eigen::Array<bool, Eigen::Dynamic, 2, Eigen::RowMajor> TwoColBool;
-    TwoColInt nb = faceCells(grid);
+    TwoColInt nb = faceCellsToEigen(grid);
     // std::cout << "nb = \n" << nb << std::endl;
     // Extracts the internal faces of the grid.
     // These are stored in internal_faces.
@@ -201,9 +201,14 @@ double faceArea(const Dune::CpGrid& grid, int face_index)
 namespace AutoDiffGrid
 {
 
+ADFaceCellTraits<Dune::CpGrid>::Type
+faceCellsToEigen(const Dune::CpGrid& grid)
+{
+    return Opm::AutoDiffGrid::FaceCellsContainerProxy(&grid);
+}
 
 Eigen::Array<double, Eigen::Dynamic, 1>
-cellCentroidsZ(const Dune::CpGrid& grid)
+cellCentroidsZToEigen(const Dune::CpGrid& grid)
 {
     // Create an Eigen array of appropriate size
     int rows=numCells(grid);

--- a/opm/autodiff/GridHelpers.hpp
+++ b/opm/autodiff/GridHelpers.hpp
@@ -41,10 +41,6 @@
 namespace Opm
 {
 
-namespace UgGridHelpers
-{
-
-} //end namespace UgGridHelpers
 namespace AutoDiffGrid
 {
 
@@ -58,7 +54,7 @@ struct ADFaceCellTraits
 
 /// \brief Get the z coordinates of the cell centroids of a grid.
 Eigen::Array<double, Eigen::Dynamic, 1>
-cellCentroidsZ(const UnstructuredGrid& grid);
+cellCentroidsZToEigen(const UnstructuredGrid& grid);
 
 /// \brief Get the centroid of a cell.
 /// \param grid The grid whose cell centroid we query.
@@ -396,8 +392,9 @@ namespace AutoDiffGrid
 {
 
 /// \brief Get the z coordinates of the cell centroids of a grid.
+/// \return The z coordinates of the cell centroids in an Eigen array
 Eigen::Array<double, Eigen::Dynamic, 1>
-cellCentroidsZ(const  Dune::CpGrid& grid);
+cellCentroidsZToEigen(const  Dune::CpGrid& grid);
 
 /// \brief Get the centroid of a cell.
 /// \param grid The grid whose cell centroid we query.
@@ -491,11 +488,8 @@ struct ADFaceCellTraits<Dune::CpGrid>
     : public Opm::UgGridHelpers::FaceCellTraits<Dune::CpGrid>
 {};
 /// \brief Get the face to cell mapping of a grid.
-inline ADFaceCellTraits<Dune::CpGrid>::Type
-faceCells(const Dune::CpGrid& grid)
-{
-    return Opm::UgGridHelpers::faceCells(grid);
-}
+ADFaceCellTraits<Dune::CpGrid>::Type
+faceCellsToEigen(const Dune::CpGrid& grid);
 } // end namespace AutoDiffGrid
 } //end namespace OPM
 
@@ -507,6 +501,7 @@ namespace AutoDiffGrid
 
 using Opm::UgGridHelpers::SparseTableView;
 using Opm::UgGridHelpers::numCells;
+using Opm::UgGridHelpers::faceCells;
 using Opm::UgGridHelpers::numFaces;
 using Opm::UgGridHelpers::dimensions;
 using Opm::UgGridHelpers::cartDims;
@@ -526,9 +521,9 @@ struct ADFaceCellTraits<UnstructuredGrid>
 
 /// \brief Get the face to cell mapping of a grid.
 ADFaceCellTraits<UnstructuredGrid>::Type
-faceCells(const UnstructuredGrid& grid);
+faceCellsToEigen(const UnstructuredGrid& grid);
 
-}
-}
+} // end namespace AutoDiffGrid
+} //end namespace OPM
 
 #endif

--- a/opm/autodiff/ImpesTPFAAD.cpp
+++ b/opm/autodiff/ImpesTPFAAD.cpp
@@ -61,7 +61,7 @@ namespace {
 
         std::vector<int> f2hf(2 * numFaces(grid), -1);
         Eigen::Array<int, Eigen::Dynamic, 2, Eigen::RowMajor>
-            face_cells = faceCells(grid);
+            face_cells = faceCellsToEigen(grid);
         
         typedef typename Opm::UgGridHelpers::Cell2FacesTraits<UnstructuredGrid>::Type
             Cell2Faces;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -75,7 +75,7 @@ namespace Opm
         Opm::estimateCellVelocity(AutoDiffGrid::numCells(grid),
                                   AutoDiffGrid::numFaces(grid),
                                   AutoDiffGrid::beginFaceCentroids(grid),
-                                  AutoDiffGrid::faceCells(grid),
+                                  UgGridHelpers::faceCells(grid),
                                   AutoDiffGrid::beginCellCentroids(grid),
                                   AutoDiffGrid::beginCellVolumes(grid),
                                   AutoDiffGrid::dimensions(grid),

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -60,7 +60,7 @@ namespace Opm
         Opm::estimateCellVelocity(AutoDiffGrid::numCells(grid),
                                   AutoDiffGrid::numFaces(grid),
                                   AutoDiffGrid::beginFaceCentroids(grid),
-                                  AutoDiffGrid::faceCells(grid),
+                                  UgGridHelpers::faceCells(grid),
                                   AutoDiffGrid::beginCellCentroids(grid),
                                   AutoDiffGrid::beginCellVolumes(grid),
                                   AutoDiffGrid::dimensions(grid),

--- a/opm/autodiff/TransportSolverTwophaseAd.cpp
+++ b/opm/autodiff/TransportSolverTwophaseAd.cpp
@@ -185,7 +185,7 @@ namespace Opm
         // but for scalar lambda and using TPFA it holds.
         const V p1 = Vec(state.pressure().data(), nc, 1);
         const V ndp = (ops_.ngrad * p1.matrix()).array();
-        const V z = cellCentroidsZ(grid_);
+        const V z = cellCentroidsZToEigen(grid_);
         const V ndz = (ops_.ngrad * z.matrix()).array();
         assert(num_internal == ndp.size());
         const double* density = props_.density();


### PR DESCRIPTION
Currently, there are two abstract interface for the grids. One that
usually returns pods and arrays of them that also can be used by C
and is used also in opm-core, and one that returns Eigen datastructures
 needed within opm-autodiff.

This commit adds a postfix ToEigen to those functions (faceCells, and
cellCentroidsZ) one could imagine to also return pods and arrays of them.
This should at least resolve the confusion about the two faceCells functions.

The next step will be issue #192
Fixes #176
