### PR TITLE
Apply threshold pressure for all dp

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -1642,13 +1642,12 @@ namespace {
         // Create a sparse vector that nullifies the low potential elements.
         const M keep_high_potential = spdiag(high_potential);
 
-        // The threshold modification must have the sign that reduces the
-        // absolute value of the potential.
-        const V sign_for_mod = (dp.value() < 0).template cast<double>();
-        const V threshold_modification = sign_for_mod * threshold_pressures_by_interior_face_;
+        // Find the current sign for the threshold modification
+        const V sign_dp = sign(dp.value());
+        const V threshold_modification = sign_dp * threshold_pressures_by_interior_face_;
 
         // Modify potential and nullify where appropriate.
-        dp = keep_high_potential * (dp + threshold_modification);
+        dp = keep_high_potential * (dp - threshold_modification);
     }
 
 


### PR DESCRIPTION
The threshold pressure is applied for all dp.
The sign of the threshold pressure is given by the sign of the dp.

This fix makes a modified SPE 1 where thpress is added match Eclipse results. 
This fix also get rids of oscillations in the newton for the Norne model that where introduced when the thpress keyword was added.   
