### PR TITLE
sim_fibo_ad*: change the default for the use_cpr parameter from false to...

### DIFF
--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -160,7 +160,7 @@ try
 
     // Solver for Newton iterations.
     std::unique_ptr<NewtonIterationBlackoilInterface> fis_solver;
-    if (param.getDefault("use_cpr", false)) {
+    if (param.getDefault("use_cpr", true)) {
         fis_solver.reset(new NewtonIterationBlackoilCPR(param));
     } else {
         fis_solver.reset(new NewtonIterationBlackoilSimple(param));

--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -195,7 +195,7 @@ try
 
     // Solver for Newton iterations.
     std::unique_ptr<NewtonIterationBlackoilInterface> fis_solver;
-    if (param.getDefault("use_cpr", false)) {
+    if (param.getDefault("use_cpr", true)) {
         fis_solver.reset(new NewtonIterationBlackoilCPR(param));
     } else {
         fis_solver.reset(new NewtonIterationBlackoilSimple(param));


### PR DESCRIPTION
... true

SPE9 and Norne are basically unusable if UMFPack is used as linear solver...
