### PR TITLE
Fix out-of-bounds indexing into PVT function table

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -752,7 +752,7 @@ namespace Opm
         assert(po.size() == n);
         V rbub(n);
         V drbubdp(n);
-        props_[Oil]->rsSat(n, &pvtTableIdx_[0], po.data(), rbub.data(), drbubdp.data());
+        props_[phase_usage_.phase_pos[Oil]]->rsSat(n, &pvtTableIdx_[0], po.data(), rbub.data(), drbubdp.data());
         return rbub;
     }
 
@@ -784,7 +784,7 @@ namespace Opm
         assert(po.size() == n);
         V rbub(n);
         V drbubdp(n);
-        props_[Oil]->rsSat(n, &pvtTableIdx_[0], po.value().data(), rbub.data(), drbubdp.data());
+        props_[phase_usage_.phase_pos[Oil]]->rsSat(n, &pvtTableIdx_[0], po.value().data(), rbub.data(), drbubdp.data());
         ADB::M drbubdp_diag = spdiag(drbubdp);
         const int num_blocks = po.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);
@@ -824,7 +824,7 @@ namespace Opm
         assert(po.size() == n);
         V rv(n);
         V drvdp(n);
-        props_[Gas]->rvSat(n, &pvtTableIdx_[0], po.data(), rv.data(), drvdp.data());
+        props_[phase_usage_.phase_pos[Gas]]->rvSat(n, &pvtTableIdx_[0], po.data(), rv.data(), drvdp.data());
         return rv;
     }
 
@@ -856,7 +856,7 @@ namespace Opm
         assert(po.size() == n);
         V rv(n);
         V drvdp(n);
-        props_[Gas]->rvSat(n, &pvtTableIdx_[0], po.value().data(), rv.data(), drvdp.data());
+        props_[phase_usage_.phase_pos[Gas]]->rvSat(n, &pvtTableIdx_[0], po.value().data(), rv.data(), drvdp.data());
         ADB::M drvdp_diag = spdiag(drvdp);
         const int num_blocks = po.numBlocks();
         std::vector<ADB::M> jacs(num_blocks);


### PR DESCRIPTION
The `props_` table of PVT functions has one entry for each active phase.  Fix four instances of indexing into the table using the canonical rather than active phase indices.

This is necessary, but probably not sufficient, to run two-phase problems without a "dummy" third phase.
