### PR TITLE
sim_fibo_ad*: print the log messages from the parser/EclipseState

### DIFF
--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -113,12 +113,12 @@ try
         eclipseState.reset(new EclipseState(deck, parserLog));
     }
     catch (const std::invalid_argument& e) {
-        std::cerr << "error while parsing the deck file: " << e.what() << "\n";
         if (parserLog->size() > 0) {
             std::cerr << "Issues found while parsing the deck file:\n";
             parserLog->printAll(std::cerr);
         }
-        return 1;
+        std::cerr << "error while parsing the deck file: " << e.what() << "\n";
+        return EXIT_FAILURE;
     }
 
     if (parserLog->size() > 0) {

--- a/examples/sim_fibo_ad_cp.cpp
+++ b/examples/sim_fibo_ad_cp.cpp
@@ -139,12 +139,12 @@ try
         eclipseState.reset(new EclipseState(deck, parserLog));
     }
     catch (const std::invalid_argument& e) {
-        std::cerr << "error while parsing the deck file: " << e.what() << "\n";
         if (parserLog->size() > 0) {
             std::cerr << "Issues found while parsing the deck file:\n";
             parserLog->printAll(std::cerr);
         }
-        return 1;
+        std::cerr << "error while parsing the deck file: " << e.what() << "\n";
+        return EXIT_FAILURE;
     }
 
     if (parserLog->size() > 0) {


### PR DESCRIPTION
this prints any issues of the deck found by the opm-parser. it requires https://github.com/OPM/opm-parser/pull/310 to be merged first, but once OPM/opm-parser#310 is in, merging this PR here is optional...
