### PR TITLE
Fix usage of result from computePressures().

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -589,7 +589,7 @@ namespace {
         for (int phase = 0; phase < maxnp; ++phase) {
             if (active_[ phase ]) {
                 const int pos = pu.phase_pos[ phase ];
-                rq_[pos].b = fluidReciprocFVF(phase, pressures[pos], rs, rv, cond, cells_);
+                rq_[pos].b = fluidReciprocFVF(phase, pressures[phase], rs, rv, cond, cells_);
                 rq_[pos].accum[aix] = pv_mult * rq_[pos].b * sat[pos];
                 // DUMP(rq_[pos].b);
                 // DUMP(rq_[pos].accum[aix]);


### PR DESCRIPTION
Since computePressures() always returns all canonical phase pressures, rather than just active ones.

Pointed out by @bska.
