### PR TITLE
Dunematrix uses wrong allocation.

### DIFF
--- a/opm/autodiff/NewtonIterationBlackoilCPR.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -168,10 +168,10 @@ namespace Opm
         SolutionVector dx(SolutionVector::Zero(b.size()));
 
         // Create ISTL matrix.
-        Mat istlA = makeIstlMatrix(A);
+        DuneMatrix istlA( A );
 
         // Create ISTL matrix for elliptic part.
-        Mat istlAe = makeIstlMatrix(A.topLeftCorner(nc, nc));
+        DuneMatrix istlAe( A.topLeftCorner(nc, nc) );
 
         // Construct operator, scalar product and vectors needed.
         typedef Dune::MatrixAdapter<Mat,Vector,Vector> Operator;
@@ -456,22 +456,6 @@ namespace Opm
             A = L * total_residual.derivative()[0];
             b = L * total_residual.value().matrix();
         }
-
-
-
-
-
-        Mat makeIstlMatrix(const Eigen::SparseMatrix<double, Eigen::RowMajor>& matrix)
-        {
-            // Create ISTL matrix.
-            const int size = matrix.rows();
-            const int* ia = matrix.outerIndexPtr();
-            const int* ja = matrix.innerIndexPtr();
-            const double* sa = matrix.valuePtr();
-            return Opm::DuneMatrix(size, size, ia, ja, sa);
-        }
-
-
 
     } // anonymous namespace
 


### PR DESCRIPTION
This PR fixes wrongly used allocation in DuneMatrix. This might not have been a problem on Linux systems but it might fail on WIN OS or Macdows. 

Also, the matrix can now be directly created from an Eigen SparseMatrix and thus avoiding the makeIstlMatrix method completely. 
