### PR TITLE
Fixes in updateState

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -60,7 +60,7 @@ namespace Opm {
         {
             double                          dp_max_rel_;
             double                          ds_max_;
-            double                          drs_max_rel_;
+            double                          dr_max_rel_;
             enum RelaxType                  relax_type_;
             double                          relax_max_;
             double                          relax_increment_;
@@ -338,7 +338,7 @@ namespace Opm {
 
         double dpMaxRel() const { return param_.dp_max_rel_; }
         double dsMax() const { return param_.ds_max_; }
-        double drsMaxRel() const { return param_.drs_max_rel_; }
+        double drMaxRel() const { return param_.dr_max_rel_; }
         enum RelaxType relaxType() const { return param_.relax_type_; }
         double relaxMax() const { return param_.relax_max_; };
         double relaxIncrement() const { return param_.relax_increment_; };

--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -163,7 +163,7 @@ namespace {
         // default values for the solver parameters
         dp_max_rel_      = 1.0e9;
         ds_max_          = 0.2;
-        drs_max_rel_     = 1.0e9;
+        dr_max_rel_      = 1.0e9;
         relax_type_      = DAMPEN;
         relax_max_       = 0.5;
         relax_increment_ = 0.1;
@@ -189,7 +189,7 @@ namespace {
         // overload with given parameters
         dp_max_rel_  = param.getDefault("dp_max_rel", dp_max_rel_);
         ds_max_      = param.getDefault("ds_max", ds_max_);
-        drs_max_rel_ = param.getDefault("drs_max_rel", drs_max_rel_);
+        dr_max_rel_  = param.getDefault("dr_max_rel", dr_max_rel_);
         relax_max_   = param.getDefault("relax_max", relax_max_);
         max_iter_    = param.getDefault("max_iter", max_iter_);
 
@@ -1403,20 +1403,19 @@ namespace {
         }
 
         // Update rs and rv
-        const double drsmaxrel = drsMaxRel();
-        const double drvmax = 1e9;//% same as in Mrst
+        const double drmaxrel = drMaxRel();
         V rs;
         if (has_disgas_) {
             const V rs_old = Eigen::Map<const V>(&state.gasoilratio()[0], nc);
             const V drs = isRs * dxvar;
-            const V drs_limited = sign(drs) * drs.abs().min(rs_old.abs()*drsmaxrel);
+            const V drs_limited = sign(drs) * drs.abs().min(rs_old.abs()*drmaxrel);
             rs = rs_old - drs_limited;
         }
         V rv;
         if (has_vapoil_) {
             const V rv_old = Eigen::Map<const V>(&state.rv()[0], nc);
             const V drv = isRv * dxvar;
-            const V drv_limited = sign(drv) * drv.abs().min(drvmax);
+            const V drv_limited = sign(drv) * drv.abs().min(rv_old.abs()*drmaxrel);
             rv = rv_old - drv_limited;
         }
 


### PR DESCRIPTION
This PR address 3 things in updateState. 

1) The update of rs and rv is moved after they are used in the phase-transition calculations. 
2) The oil/gas is kept saturated (Sg is used as variable) for cases that hadGas/hadOil, respectively. 
3) The same relative threshold is used for the drv update and drs. 

Tested on SPE 1, SPE 3 and SPE 9.
For SPE 1 the total number of non-linear equations goes up with fix 1), but 1) is a bug and should be fixed anyway. 

For SPE 3 the newly merged change in the data file is needed in order for the simulator to converge. 

For SPE9, fix 2) is needed in order for it to converge. The hadGas/hadOil criteria is a copy from MRST, there the condition for hadOil is: hadOil = so < 0 and so_old>threshold. But as so earlier is fixed for negative value the first condition is never true. In earlier versions of OPM the conditions for hadOil was so < 0 and so_old > threshold, but this was changed to so <= 0, when so was hard-coded to be non-negative.

The results for all the SPEs matches in the eyeball norm. I have only looked at the well results. 

The test for Norne is running right now.  With two more fixes that address the partial copying and the crossflow the norne is currently running smoothly until 1152 days. I will add a comment on how far the Norne model runs when it is finished. 
