### PR TITLE
Improve convergence output.

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver_impl.hpp
@@ -1887,7 +1887,7 @@ namespace {
         bool converged = converged_MB && converged_CNV && converged_Well;
 
         if (iteration == 0) {
-            std::cout << "\nIter    MB(OIL)  MB(WATER)    MB(GAS)       CNVW       CNVO       CNVW  WELL-FLOW WELL-CNTRL\n";
+            std::cout << "\nIter    MB(OIL)  MB(WATER)    MB(GAS)       CNVW       CNVO       CNVG  WELL-FLOW WELL-CNTRL\n";
         }
         const std::streamsize oprec = std::cout.precision(3);
         const std::ios::fmtflags oflags = std::cout.setf(std::ios::scientific);


### PR DESCRIPTION
This minor modification refines the convergence output a little:
- Add CNV{W,O,G} to output.
- Make output a bit tighter.
- Avoid printing extra newline and header for each iteration.
