### PR TITLE
PVT properties: allow them to be temperature dependent

### DIFF
--- a/opm/autodiff/BlackoilPropsAd.hpp
+++ b/opm/autodiff/BlackoilPropsAd.hpp
@@ -101,72 +101,88 @@ namespace Opm
 
         /// Water viscosity.
         /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         V muWat(const V& pw,
+                const V& T,
                 const Cells& cells) const;
 
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rs     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         V muOil(const V& po,
+                const V& T,
                 const V& rs,
                 const std::vector<PhasePresence>& cond,
                 const Cells& cells) const;
 
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         V muGas(const V& pg,
+                const V& T,
                 const Cells& cells) const;
 
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rv     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         V muGas(const V& pg,
+                const V& T,
                   const V& rv,
                   const std::vector<PhasePresence>& cond,
                   const Cells& cells) const;
 
         /// Water viscosity.
         /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muWat(const ADB& pw,
+                  const ADB& T,
                   const Cells& cells) const;
 
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rs     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muOil(const ADB& po,
+                  const ADB& T,
                   const ADB& rs,
                   const std::vector<PhasePresence>& cond,
                   const Cells& cells) const;
 
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muGas(const ADB& pg,
+                  const ADB& T,
                   const Cells& cells) const;
 
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rv     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muGas(const ADB& pg,
+                  const ADB& T,
                   const ADB& rv,
                   const std::vector<PhasePresence>& cond,
                   const Cells& cells) const;
@@ -175,73 +191,89 @@ namespace Opm
 
         /// Water formation volume factor.
         /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         V bWat(const V& pw,
+               const V& T,
                const Cells& cells) const;
 
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rs     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         V bOil(const V& po,
+               const V& T,
                const V& rs,
                const std::vector<PhasePresence>& cond,
                const Cells& cells) const;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         V bGas(const V& pg,
+               const V& T,
                const Cells& cells) const;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rv     Array of n vapor oil/gas ratio
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         V bGas(const V& pg,
+               const V& T,
                const V& rv,
                const std::vector<PhasePresence>& cond,
                const Cells& cells) const;
 
         /// Water formation volume factor.
         /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bWat(const ADB& pw,
+                 const ADB& T,
                  const Cells& cells) const;
 
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rs     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bOil(const ADB& po,
+                 const ADB& T,
                  const ADB& rs,
                  const std::vector<PhasePresence>& cond,
                  const Cells& cells) const;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bGas(const ADB& pg,
+                 const ADB& T,
                  const Cells& cells) const;
 
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rv     Array of n vapor oil/gas ratio
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bGas(const ADB& pg,
+                 const ADB& T,
                const ADB& rv,
                const std::vector<PhasePresence>& cond,
                const Cells& cells) const;

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -269,9 +269,11 @@ namespace Opm
 
     /// Water viscosity.
     /// \param[in]  pw     Array of n water pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     V BlackoilPropsAdFromDeck::muWat(const V& pw,
+                                     const V& T,
                                      const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Water]) {
@@ -284,18 +286,20 @@ namespace Opm
         V dmudr(n);
         const double* rs = 0;
 
-        props_[phase_usage_.phase_pos[Water]]->mu(n, &pvtTableIdx_[0], pw.data(), rs,
+        props_[phase_usage_.phase_pos[Water]]->mu(n, &pvtTableIdx_[0], pw.data(), T.data(), rs,
                                                   mu.data(), dmudp.data(), dmudr.data());
         return mu;
     }
 
     /// Oil viscosity.
     /// \param[in]  po     Array of n oil pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  rs     Array of n gas solution factor values.
     /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     V BlackoilPropsAdFromDeck::muOil(const V& po,
+                                     const V& T,
                                      const V& rs,
                                      const std::vector<PhasePresence>& cond,
                                      const Cells& cells) const
@@ -309,16 +313,18 @@ namespace Opm
         V dmudp(n);
         V dmudr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->mu(n, &pvtTableIdx_[0], po.data(), rs.data(), &cond[0],
+        props_[phase_usage_.phase_pos[Oil]]->mu(n, &pvtTableIdx_[0], po.data(), T.data(), rs.data(), &cond[0],
                                                 mu.data(), dmudp.data(), dmudr.data());
         return mu;
     }
 
     /// Gas viscosity.
     /// \param[in]  pg     Array of n gas pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     V BlackoilPropsAdFromDeck::muGas(const V& pg,
+                                     const V& T,
                                      const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Gas]) {
@@ -331,16 +337,18 @@ namespace Opm
         V dmudr(n);
         const double* rs = 0;
 
-        props_[phase_usage_.phase_pos[Gas]]->mu(n, &pvtTableIdx_[0], pg.data(), rs,
+        props_[phase_usage_.phase_pos[Gas]]->mu(n, &pvtTableIdx_[0], pg.data(), T.data(), rs,
                                                 mu.data(), dmudp.data(), dmudr.data());
         return mu;
     }
 
     /// Gas viscosity.
     /// \param[in]  pg     Array of n gas pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     V BlackoilPropsAdFromDeck::muGas(const V& pg,
+                                     const V& T,
                                      const V& rv,
                                      const std::vector<PhasePresence>& cond,
                                      const Cells& cells) const
@@ -354,16 +362,18 @@ namespace Opm
         V dmudp(n);
         V dmudr(n);
 
-        props_[phase_usage_.phase_pos[Gas]]->mu(n, &pvtTableIdx_[0], pg.data(), rv.data(),&cond[0],
+        props_[phase_usage_.phase_pos[Gas]]->mu(n, &pvtTableIdx_[0], pg.data(), T.data(), rv.data(),&cond[0],
                                                 mu.data(), dmudp.data(), dmudr.data());
         return mu;
     }
 
     /// Water viscosity.
     /// \param[in]  pw     Array of n water pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     ADB BlackoilPropsAdFromDeck::muWat(const ADB& pw,
+                                       const ADB& T,
                                        const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Water]) {
@@ -376,7 +386,7 @@ namespace Opm
         V dmudr(n);
         const double* rs = 0;
 
-        props_[phase_usage_.phase_pos[Water]]->mu(n, &pvtTableIdx_[0], pw.value().data(), rs,
+        props_[phase_usage_.phase_pos[Water]]->mu(n, &pvtTableIdx_[0], pw.value().data(), T.value().data(), rs,
                                                   mu.data(), dmudp.data(), dmudr.data());
         ADB::M dmudp_diag = spdiag(dmudp);
         const int num_blocks = pw.numBlocks();
@@ -389,11 +399,13 @@ namespace Opm
 
     /// Oil viscosity.
     /// \param[in]  po     Array of n oil pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  rs     Array of n gas solution factor values.
     /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     ADB BlackoilPropsAdFromDeck::muOil(const ADB& po,
+                                       const ADB& T,
                                        const ADB& rs,
                                        const std::vector<PhasePresence>& cond,
                                        const Cells& cells) const
@@ -407,7 +419,7 @@ namespace Opm
         V dmudp(n);
         V dmudr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->mu(n, &pvtTableIdx_[0], po.value().data(), rs.value().data(),
+        props_[phase_usage_.phase_pos[Oil]]->mu(n, &pvtTableIdx_[0], po.value().data(), T.value().data(), rs.value().data(),
                                                 &cond[0], mu.data(), dmudp.data(), dmudr.data());
 
         ADB::M dmudp_diag = spdiag(dmudp);
@@ -422,9 +434,11 @@ namespace Opm
 
     /// Gas viscosity.
     /// \param[in]  pg     Array of n gas pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     ADB BlackoilPropsAdFromDeck::muGas(const ADB& pg,
+                                       const ADB& T,
                                        const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Gas]) {
@@ -437,7 +451,7 @@ namespace Opm
         V dmudr(n);
         const double* rv = 0;
 
-        props_[phase_usage_.phase_pos[Gas]]->mu(n, &pvtTableIdx_[0], pg.value().data(), rv,
+        props_[phase_usage_.phase_pos[Gas]]->mu(n, &pvtTableIdx_[0], pg.value().data(), T.value().data(), rv,
                                                   mu.data(), dmudp.data(), dmudr.data());
 
         ADB::M dmudp_diag = spdiag(dmudp);
@@ -451,11 +465,13 @@ namespace Opm
 
     /// Gas viscosity.
     /// \param[in]  pg     Array of n gas pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  rv     Array of n vapor oil/gas ratio
     /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n viscosity values.
     ADB BlackoilPropsAdFromDeck::muGas(const ADB& pg,
+                                       const ADB& T,
                                        const ADB& rv,
                                        const std::vector<PhasePresence>& cond,
                                        const Cells& cells) const
@@ -469,7 +485,7 @@ namespace Opm
         V dmudp(n);
         V dmudr(n);
 
-        props_[phase_usage_.phase_pos[Gas]]->mu(n, &pvtTableIdx_[0], pg.value().data(), rv.value().data(),&cond[0],
+        props_[phase_usage_.phase_pos[Gas]]->mu(n, &pvtTableIdx_[0], pg.value().data(), T.value().data(), rv.value().data(),&cond[0],
                                                   mu.data(), dmudp.data(), dmudr.data());
 
         ADB::M dmudp_diag = spdiag(dmudp);
@@ -502,9 +518,11 @@ namespace Opm
 
     /// Water formation volume factor.
     /// \param[in]  pw     Array of n water pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     V BlackoilPropsAdFromDeck::bWat(const V& pw,
+                                    const V& T,
                                     const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Water]) {
@@ -518,7 +536,7 @@ namespace Opm
         V dbdr(n);
         const double* rs = 0;
 
-        props_[phase_usage_.phase_pos[Water]]->b(n, &pvtTableIdx_[0], pw.data(), rs,
+        props_[phase_usage_.phase_pos[Water]]->b(n, &pvtTableIdx_[0], pw.data(), T.data(), rs,
                                                  b.data(), dbdp.data(), dbdr.data());
 
         return b;
@@ -526,11 +544,13 @@ namespace Opm
 
     /// Oil formation volume factor.
     /// \param[in]  po     Array of n oil pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  rs     Array of n gas solution factor values.
     /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     V BlackoilPropsAdFromDeck::bOil(const V& po,
+                                    const V& T,
                                     const V& rs,
                                     const std::vector<PhasePresence>& cond,
                                     const Cells& cells) const
@@ -545,7 +565,7 @@ namespace Opm
         V dbdp(n);
         V dbdr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->b(n, &pvtTableIdx_[0], po.data(), rs.data(), &cond[0],
+        props_[phase_usage_.phase_pos[Oil]]->b(n, &pvtTableIdx_[0], po.data(), T.data(), rs.data(), &cond[0],
                                                b.data(), dbdp.data(), dbdr.data());
 
         return b;
@@ -553,9 +573,11 @@ namespace Opm
 
     /// Gas formation volume factor.
     /// \param[in]  pg     Array of n gas pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     V BlackoilPropsAdFromDeck::bGas(const V& pg,
+                                    const V& T,
                                     const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Gas]) {
@@ -569,7 +591,7 @@ namespace Opm
         V dbdr(n);
         const double* rs = 0;
 
-        props_[phase_usage_.phase_pos[Gas]]->b(n, &pvtTableIdx_[0], pg.data(), rs,
+        props_[phase_usage_.phase_pos[Gas]]->b(n, &pvtTableIdx_[0], pg.data(), T.data(), rs,
                                                b.data(), dbdp.data(), dbdr.data());
 
         return b;
@@ -577,11 +599,13 @@ namespace Opm
 
     /// Gas formation volume factor.
     /// \param[in]  pg     Array of n gas pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  rv     Array of n vapor oil/gas ratio
     /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     V BlackoilPropsAdFromDeck::bGas(const V& pg,
+                                    const V& T,
            const V& rv,
            const std::vector<PhasePresence>& cond,
            const Cells& cells) const
@@ -596,7 +620,7 @@ namespace Opm
         V dbdp(n);
         V dbdr(n);
 
-        props_[phase_usage_.phase_pos[Gas]]->b(n, &pvtTableIdx_[0], pg.data(), rv.data(), &cond[0],
+        props_[phase_usage_.phase_pos[Gas]]->b(n, &pvtTableIdx_[0], pg.data(), T.data(), rv.data(), &cond[0],
                                                b.data(), dbdp.data(), dbdr.data());
 
         return b;
@@ -604,9 +628,11 @@ namespace Opm
 
     /// Water formation volume factor.
     /// \param[in]  pw     Array of n water pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     ADB BlackoilPropsAdFromDeck::bWat(const ADB& pw,
+                                      const ADB& T,
                                       const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Water]) {
@@ -620,7 +646,7 @@ namespace Opm
         V dbdr(n);
         const double* rs = 0;
 
-        props_[phase_usage_.phase_pos[Water]]->b(n, &pvtTableIdx_[0], pw.value().data(), rs,
+        props_[phase_usage_.phase_pos[Water]]->b(n, &pvtTableIdx_[0], pw.value().data(), T.value().data(), rs,
                                                  b.data(), dbdp.data(), dbdr.data());
 
         ADB::M dbdp_diag = spdiag(dbdp);
@@ -634,11 +660,13 @@ namespace Opm
 
     /// Oil formation volume factor.
     /// \param[in]  po     Array of n oil pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  rs     Array of n gas solution factor values.
     /// \param[in]  cond   Array of n taxonomies classifying fluid condition.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     ADB BlackoilPropsAdFromDeck::bOil(const ADB& po,
+                                      const ADB& T,
                                       const ADB& rs,
                                       const std::vector<PhasePresence>& cond,
                                       const Cells& cells) const
@@ -653,7 +681,7 @@ namespace Opm
         V dbdp(n);
         V dbdr(n);
 
-        props_[phase_usage_.phase_pos[Oil]]->b(n, &pvtTableIdx_[0], po.value().data(), rs.value().data(),
+        props_[phase_usage_.phase_pos[Oil]]->b(n, &pvtTableIdx_[0], po.value().data(), T.value().data(), rs.value().data(),
                                                &cond[0], b.data(), dbdp.data(), dbdr.data());
 
         ADB::M dbdp_diag = spdiag(dbdp);
@@ -668,9 +696,11 @@ namespace Opm
 
     /// Gas formation volume factor.
     /// \param[in]  pg     Array of n gas pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     ADB BlackoilPropsAdFromDeck::bGas(const ADB& pg,
+                                      const ADB& T,
                                       const Cells& cells) const
     {
         if (!phase_usage_.phase_used[Gas]) {
@@ -684,7 +714,7 @@ namespace Opm
         V dbdr(n);
         const double* rv = 0;
 
-        props_[phase_usage_.phase_pos[Gas]]->b(n, &pvtTableIdx_[0], pg.value().data(), rv,
+        props_[phase_usage_.phase_pos[Gas]]->b(n, &pvtTableIdx_[0], pg.value().data(), T.value().data(), rv,
                                                b.data(), dbdp.data(), dbdr.data());
 
         ADB::M dbdp_diag = spdiag(dbdp);
@@ -698,11 +728,13 @@ namespace Opm
 
     /// Gas formation volume factor.
     /// \param[in]  pg     Array of n gas pressure values.
+    /// \param[in]  T      Array of n temperature values.
     /// \param[in]  rv     Array of n vapor oil/gas ratio
     /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
     /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
     /// \return            Array of n formation volume factor values.
     ADB BlackoilPropsAdFromDeck::bGas(const ADB& pg,
+                                      const ADB& T,
            const ADB& rv,
            const std::vector<PhasePresence>& cond,
            const Cells& cells) const
@@ -717,7 +749,7 @@ namespace Opm
         V dbdp(n);
         V dbdr(n);
 
-        props_[phase_usage_.phase_pos[Gas]]->b(n, &pvtTableIdx_[0], pg.value().data(), rv.value().data(), &cond[0],
+        props_[phase_usage_.phase_pos[Gas]]->b(n, &pvtTableIdx_[0], pg.value().data(), T.value().data(), rv.value().data(), &cond[0],
                                                b.data(), dbdp.data(), dbdr.data());
 
         ADB::M dbdp_diag = spdiag(dbdp);

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -126,70 +126,86 @@ namespace Opm
 
         /// Water viscosity.
         /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         V muWat(const V& pw,
+                const V& T,
                 const Cells& cells) const;
 
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rs     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         V muOil(const V& po,
+                const V& T,
                 const V& rs,
                 const std::vector<PhasePresence>& cond,
                 const Cells& cells) const;
 
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         V muGas(const V& pg,
+                const V& T,
                 const Cells& cells) const;
 
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rv     Array of n vapor oil/gas ratio
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         V muGas(const V& po,
+                const V& T,
                 const V& rv,
                 const std::vector<PhasePresence>& cond,
                 const Cells& cells) const;
 
         /// Water viscosity.
         /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muWat(const ADB& pw,
+                  const ADB& T,
                   const Cells& cells) const;
 
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rs     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muOil(const ADB& po,
+                  const ADB& T,
                   const ADB& rs,
                   const std::vector<PhasePresence>& cond,
                   const Cells& cells) const;
 
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muGas(const ADB& pg,
+                  const ADB& T,
                   const Cells& cells) const;
 
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         ADB muGas(const ADB& pg,
+                  const ADB& T,
                   const ADB& rv,
                   const std::vector<PhasePresence>& cond,
                   const Cells& cells) const;
@@ -198,72 +214,88 @@ namespace Opm
 
         /// Water formation volume factor.
         /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         V bWat(const V& pw,
+               const V& T,
                const Cells& cells) const;
 
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rs     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         V bOil(const V& po,
+               const V& T,
                const V& rs,
                const std::vector<PhasePresence>& cond,
                const Cells& cells) const;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         V bGas(const V& pg,
+               const V& T,
                const Cells& cells) const;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rv     Array of n vapor oil/gas ratio
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         V bGas(const V& pg,
+               const V& T,
                const V& rv,
                const std::vector<PhasePresence>& cond,
                const Cells& cells) const;
 
         /// Water formation volume factor.
         /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bWat(const ADB& pw,
+                 const ADB& T,
                  const Cells& cells) const;
 
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rs     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bOil(const ADB& po,
+                 const ADB& T,
                  const ADB& rs,
                  const std::vector<PhasePresence>& cond,
                  const Cells& cells) const;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bGas(const ADB& pg,
+                 const ADB& T,
                  const Cells& cells) const;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rv     Array of n vapor oil/gas ratio
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         ADB bGas(const ADB& pg,
+                 const ADB& T,
                const ADB& rv,
                const std::vector<PhasePresence>& cond,
                const Cells& cells) const;

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -91,66 +91,80 @@ namespace Opm
 
         /// Water viscosity.
         /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
         V muWat(const V& pw,
+                const V& T,
                 const Cells& cells) const = 0;
 
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rs     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
         V muOil(const V& po,
+                const V& T,
                 const V& rs,
                 const std::vector<PhasePresence>& cond,
                 const Cells& cells) const = 0;
 
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
         V muGas(const V& pg,
+                const V& T,
                 const Cells& cells) const = 0;
 
         /// Water viscosity.
         /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
         ADB muWat(const ADB& pw,
+                  const ADB& T,
                   const Cells& cells) const = 0;
 
         /// Oil viscosity.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rs     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
         ADB muOil(const ADB& po,
+                  const ADB& T,
                   const ADB& rs,
                   const std::vector<PhasePresence>& cond,
                   const Cells& cells) const = 0;
 
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
         ADB muGas(const ADB& pg,
+                  const ADB& T,
                   const Cells& cells) const = 0;
 
         /// Gas viscosity.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n viscosity values.
         virtual
         ADB muGas(const ADB& pg,
+                  const ADB& T,
                   const ADB& rv,
                   const std::vector<PhasePresence>& cond,
                   const Cells& cells) const = 0;
@@ -159,80 +173,96 @@ namespace Opm
 
         /// Water formation volume factor.
         /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         V bWat(const V& pw,
+               const V& T,
                const Cells& cells) const = 0;
 
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rs     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         V bOil(const V& po,
+               const V& T,
                const V& rs,
                const std::vector<PhasePresence>& cond,
                const Cells& cells) const = 0;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         V bGas(const V& pg,
+               const V& T,
                const Cells& cells) const = 0;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rv     Array of n vapor oil/gas ratio
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         V bGas(const V& pg,
+               const V& T,
                const V& rv,
                const std::vector<PhasePresence>& cond,
                const Cells& cells) const = 0;
 
         /// Water formation volume factor.
         /// \param[in]  pw     Array of n water pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         ADB bWat(const ADB& pw,
+                 const ADB& T,
                  const Cells& cells) const = 0;
 
         /// Oil formation volume factor.
         /// \param[in]  po     Array of n oil pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rs     Array of n gas solution factor values.
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         ADB bOil(const ADB& po,
+                 const ADB& T,
                  const ADB& rs,
                  const std::vector<PhasePresence>& cond,
                  const Cells& cells) const = 0;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         ADB bGas(const ADB& pg,
+                 const ADB& T,
                  const Cells& cells) const = 0;
 
         /// Gas formation volume factor.
         /// \param[in]  pg     Array of n gas pressure values.
+        /// \param[in]  T      Array of n temperature values.
         /// \param[in]  rv     Array of n vapor oil/gas ratio
         /// \param[in]  cond   Array of n objects, each specifying which phases are present with non-zero saturation in a cell.
         /// \param[in]  cells  Array of n cell indices to be associated with the pressure values.
         /// \return            Array of n formation volume factor values.
         virtual
         ADB bGas(const ADB& pg,
+                 const ADB& T,
                const ADB& rv,
                const std::vector<PhasePresence>& cond,
                const Cells& cells) const = 0;

--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -142,6 +142,7 @@ namespace Opm {
         struct SolutionState {
             SolutionState(const int np);
             ADB              pressure;
+            ADB              temperature;
             std::vector<ADB> saturation;
             ADB              rs;
             ADB              rv;
@@ -259,6 +260,7 @@ namespace Opm {
         ADB
         fluidViscosity(const int               phase,
                        const ADB&              p    ,
+                       const ADB&              temp ,
                        const ADB&              rs   ,
                        const ADB&              rv   ,
                        const std::vector<PhasePresence>& cond,
@@ -267,6 +269,7 @@ namespace Opm {
         ADB
         fluidReciprocFVF(const int               phase,
                          const ADB&              p    ,
+                         const ADB&              temp ,
                          const ADB&              rs   ,
                          const ADB&              rv   ,
                          const std::vector<PhasePresence>& cond,
@@ -275,6 +278,7 @@ namespace Opm {
         ADB
         fluidDensity(const int               phase,
                      const ADB&              p    ,
+                     const ADB&              temp ,
                      const ADB&              rs   ,
                      const ADB&              rv   ,
                      const std::vector<PhasePresence>& cond,

--- a/opm/autodiff/ImpesTPFAAD.hpp
+++ b/opm/autodiff/ImpesTPFAAD.hpp
@@ -104,12 +104,12 @@ namespace Opm {
         void computeFluxes(BlackoilState& state, WellState& well_state) const;
 
         // Fluid interface forwarding calls to correct methods of fluid_.
-        V fluidMu(const int phase, const V& p, const std::vector<int>& cells) const;
-        ADB fluidMu(const int phase, const ADB& p, const std::vector<int>& cells) const;
-        V fluidFvf(const int phase, const V& p, const std::vector<int>& cells) const;
-        ADB fluidFvf(const int phase, const ADB& p, const std::vector<int>& cells) const;
-        V fluidRho(const int phase, const V& p, const std::vector<int>& cells) const;
-        ADB fluidRho(const int phase, const ADB& p, const std::vector<int>& cells) const;
+        V fluidMu(const int phase, const V& p, const V& T, const std::vector<int>& cells) const;
+        ADB fluidMu(const int phase, const ADB& p, const ADB& T, const std::vector<int>& cells) const;
+        V fluidFvf(const int phase, const V& p, const V& T, const std::vector<int>& cells) const;
+        ADB fluidFvf(const int phase, const ADB& p, const ADB& T, const std::vector<int>& cells) const;
+        V fluidRho(const int phase, const V& p, const V& T, const std::vector<int>& cells) const;
+        ADB fluidRho(const int phase, const ADB& p, const ADB& T, const std::vector<int>& cells) const;
         V fluidKr(const int phase) const;
         V fluidKrWell(const int phase) const;
     };

--- a/opm/autodiff/SimulatorCompressibleAd.cpp
+++ b/opm/autodiff/SimulatorCompressibleAd.cpp
@@ -357,7 +357,7 @@ namespace Opm
             // Solve pressure equation.
             if (check_well_controls_) {
                 computeFractionalFlow(props_, allcells_,
-                                      state.pressure(), state.surfacevol(), state.saturation(),
+                                      state.pressure(), state.temperature(), state.surfacevol(), state.saturation(),
                                       fractional_flows);
                 wells_manager_.applyExplicitReinjectionControls(well_resflows_phase, well_resflows_phase);
             }
@@ -446,7 +446,7 @@ namespace Opm
             double injected[2] = { 0.0 };
             double produced[2] = { 0.0 };
             for (int tr_substep = 0; tr_substep < num_transport_substeps_; ++tr_substep) {
-                tsolver_.solve(&state.faceflux()[0], &state.pressure()[0],
+                tsolver_.solve(&state.faceflux()[0], &state.pressure()[0], &state.temperature()[0],
                                &initial_porevol[0], &porevol[0], &transport_src[0], stepsize,
                                state.saturation(), state.surfacevol());
                 double substep_injected[2] = { 0.0 };

--- a/tests/test_boprops_ad.cpp
+++ b/tests/test_boprops_ad.cpp
@@ -124,7 +124,11 @@ BOOST_FIXTURE_TEST_CASE(ViscosityValue, TestFixture<SetupSimple>)
     Vpw[3] =  8*Opm::unit::barsa;
     Vpw[4] = 16*Opm::unit::barsa;
 
-    const Opm::BlackoilPropsAd::V VmuWat = boprops_ad.muWat(Vpw, cells);
+    // standard temperature
+    V T;
+    T.resize(cells.size(), 273.15+20);
+
+    const Opm::BlackoilPropsAd::V VmuWat = boprops_ad.muWat(Vpw, T, cells);
 
     // Zero pressure dependence in water viscosity
     for (V::Index i = 0, n = VmuWat.size(); i < n; ++i) {
@@ -149,16 +153,21 @@ BOOST_FIXTURE_TEST_CASE(ViscosityAD, TestFixture<SetupSimple>)
     Vpw[3] =  8*Opm::unit::barsa;
     Vpw[4] = 16*Opm::unit::barsa;
 
+    // standard temperature
+    V T;
+    T.resize(cells.size(), 273.15+20);
+
     typedef Opm::BlackoilPropsAd::ADB ADB;
 
-    const V VmuWat = boprops_ad.muWat(Vpw, cells);
+    const V VmuWat = boprops_ad.muWat(Vpw, T, cells);
     for (V::Index i = 0, n = Vpw.size(); i < n; ++i) {
         const std::vector<int> bp(1, grid.c_grid()->number_of_cells);
 
         const Opm::BlackoilPropsAd::Cells c(1, 0);
         const V   pw     = V(1, 1) * Vpw[i];
         const ADB Apw    = ADB::variable(0, pw, bp);
-        const ADB AmuWat = boprops_ad.muWat(Apw, c);
+        const ADB AT     = ADB::constant(T);
+        const ADB AmuWat = boprops_ad.muWat(Apw, AT, c);
 
         BOOST_CHECK_EQUAL(AmuWat.value()[0], VmuWat[i]);
     }


### PR DESCRIPTION
Note that this patch does not introduce any real temperature
dependence but only changes the APIs for the viscosity and for the
density related methods. Note that I also don't like the fact that
this requires so many changes to so many files, but with the current
design of the property classes I cannot see a way to avoid this...

this PR must be merged synchronously with OPM/opm-core#688...
