### PR TITLE
register the transmissibilities at the EcliseWriter

### DIFF
--- a/examples/sim_fibo_ad.cpp
+++ b/examples/sim_fibo_ad.cpp
@@ -210,6 +210,12 @@ try
 
     Opm::DerivedGeology geology(*grid->c_grid(), *new_props, eclipseState, grav);
 
+    // TODO: also do this in sim_fibo_ad_cp
+    bool writeTrans = param.getDefault("write_transmissibilities", false);
+    if (writeTrans) {
+        outputWriter.setFaceTransmissibilities(*grid->c_grid(), geology.transmissibility().data());
+    }
+
     std::vector<double> threshold_pressures = thresholdPressures(deck, eclipseState, *grid->c_grid());
 
     SimulatorFullyImplicitBlackoil<UnstructuredGrid> simulator(param,


### PR DESCRIPTION
missing: the simulator using dune-cornerpoint. This is because for
Once again, this is because there is no reasonable way to convert an
intersection to a unique global index yet.

this PR needs to be merged after OPM/opm-core#689 but the build does not break if the core PR was merged.
