### PR TITLE
Include <config.h> to fix build on GCC 4.8

### DIFF
--- a/examples/opm_init_check.cpp
+++ b/examples/opm_init_check.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
 
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
GCC 4.8 provides `nullptr` in C++11 mode.  That capability is detected at configuration time and stored in `<config.h>` and we need it when targeting Dune 2.2.1 to avoid diagnostics of the form

```
[...]/dune/common/nullptr.hh:27:1:
error: expected ‘;’ after class definition
 } nullptr = {};              // and whose name is nullptr
  ^

[...]/dune/common/nullptr.hh:27:1:
error: qualifiers can only be specified for objects and functions
[...]/dune/common/nullptr.hh:27:3:
error: expected unqualified-id before ‘nullptr’
 } nullptr = {};              // and whose name is nullptr
```
