### PR TITLE
RateConverter: remove the unused averageTemperature() method

### DIFF
--- a/opm/autodiff/RateConverter.hpp
+++ b/opm/autodiff/RateConverter.hpp
@@ -286,6 +286,7 @@ namespace Opm {
             defineState(const BlackoilState& state)
             {
                 averagePressure(state);
+                averageTemperature(state);
                 calcRmax();
             }
 


### PR DESCRIPTION
probably I added it in analogy to averagePressure(), but it has been
unused, so it's better to remove it to avoid bitrot. Thanks to
[at] bska for noticing this.
