### PR TITLE
Add a generic (throwing) tpfa_loc_trans_compute_().

### DIFF
--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -280,10 +280,18 @@ namespace Opm
         }
     }
 
+    template <class GridType>
+    inline void DerivedGeology::tpfa_loc_trans_compute_(const GridType& /* grid */,
+                                                        const double* /* perm */,
+                                                        Vector& /* hTrans */)
+    {
+        OPM_THROW(std::logic_error, "No generic implementation exists for tpfa_loc_trans_compute_().");
+    }
+
     template <>
-    inline void DerivedGeology::tpfa_loc_trans_compute_<UnstructuredGrid>(const UnstructuredGrid &grid,
+    inline void DerivedGeology::tpfa_loc_trans_compute_<UnstructuredGrid>(const UnstructuredGrid& grid,
                                                                          const double* perm,
-                                                                         Vector &hTrans){
+                                                                         Vector& hTrans){
 
         // Using Local coordinate system for the transmissibility calculations
         // hTrans(cellFaceIdx) = K(cellNo,j) * sum( C(:,i) .* N(:,j), 2) / sum(C.*C, 2)


### PR DESCRIPTION
Without this, we may have link errors with CpGrid, since only an UnstructuredGrid specialization was provided.

On my system, this strangely only affected debug mode, release mode linked without errors.
