### PR TITLE
Fix "make install" in opm-autodiff

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -98,7 +98,7 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/autodiff/BlackoilPropsAdFromDeck.hpp
 	opm/autodiff/BlackoilPropsAdInterface.hpp
 	opm/autodiff/CPRPreconditioner.hpp
-	opm/autodiff/fastSparseProduct.h
+	opm/autodiff/fastSparseProduct.hpp
 	opm/autodiff/DuneMatrix.hpp
 	opm/autodiff/GeoProps.hpp
 	opm/autodiff/GridHelpers.hpp


### PR DESCRIPTION
This fixes `make install` which would otherwise fail with a diagnostic message of the form

```
CMake Error at cmake_install.cmake:64 (FILE):
  file INSTALL cannot find
  opm/autodiff/ConservativeSparseSparseProduct.h
```

Thanks to `HudsonBuildServer` for highlighting the issue.
