### PR TITLE
Use phase pressures for the fluid properties

### DIFF
--- a/opm/autodiff/FullyImplicitBlackoilSolver.hpp
+++ b/opm/autodiff/FullyImplicitBlackoilSolver.hpp
@@ -236,6 +236,12 @@ namespace Opm {
         computePressures(const SolutionState& state) const;
 
         std::vector<ADB>
+        computePressures(const ADB& po,
+                         const ADB& sw,
+                         const ADB& so,
+                         const ADB& sg) const;
+
+        std::vector<ADB>
         computeRelPerm(const SolutionState& state) const;
 
         std::vector<ADB>


### PR DESCRIPTION
There has been an inconsitancy in which pressure to use in the
evaluation of the fluid properties.
With this commit the phase pressure is used for all the evaluation of
the fluid properties.

Tested on SPE3 and SPE9. Even thought this PR do not change the results significantly, it improves the convergence on Norne. (And with the current simulator it is nesseary in order for the model to run through the deck) 
