### PR TITLE
WIP/RFC report function for well-related output

### DIFF
--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -21,6 +21,7 @@
 #define OPM_WELLSTATEFULLYIMPLICITBLACKOIL_HEADER_INCLUDED
 
 
+#include <opm/output/Wells.hpp>
 #include <opm/core/wells.h>
 #include <opm/core/well_controls.h>
 #include <opm/core/simulator/WellState.hpp>
@@ -188,6 +189,53 @@ namespace Opm
         std::vector<double> perfphaserates_;
         std::vector<int> current_controls_;
     };
+
+    static inline data::Wells report( const WellStateFullyImplicitBlackoil& state,
+                                      const Wells* wells,
+                                      double step_len ) {
+
+        using rt = data::Rates::opt;
+
+        std::map< std::string, data::Well > res;
+
+        const int nw = state.numWells();
+        const int np = state.numPhases();
+
+        for( auto w = 0; w < nw; ++w ) {
+
+            std::map< size_t, data::Completion > completions;
+            const auto* begin = wells->well_connpos + w;
+            const auto* end = wells->well_connpos + w + 1;
+            for( auto* i = begin; i != end; ++i ) {
+
+                const auto perfrate = state.perfPhaseRates().begin() + *i;
+                data::Rates perfrates;
+                perfrates.set( rt::wat, *(perfrate + 0 ) );
+                perfrates.set( rt::oil, *(perfrate + 1 ) );
+                perfrates.set( rt::gas, *(perfrate + 2 ) );
+                /* needs conversion to logical cartesian index */
+                const size_t globalindex = wells->well_cells[ *i ];
+
+                completions.emplace( globalindex,
+                    data::Completion{ globalindex, perfrates } );
+            }
+
+            const auto wellrate_index = np * w;
+            const auto& wv = state.wellRates();
+
+            data::Rates wellrates;
+            wellrates.set( rt::wat, wv[ wellrate_index + 0 ] );
+            wellrates.set( rt::oil, wv[ wellrate_index + 1 ] );
+            wellrates.set( rt::gas, wv[ wellrate_index + 2 ] );
+
+            const double bhp  = state.bhp()[ w ];
+
+            res.emplace( wells->name[ w ],
+                data::Well { wellrates, bhp, std::move( completions ) } );
+        }
+
+        return { step_len, std::move( res ) };
+    }
 
 } // namespace Opm
 


### PR DESCRIPTION
A function that can generate a well-specified report object defined by
opm-common for data exchange (in particular for co-op with opm-output).
Populates the result::Wells object and intended to be called on a
per-timestep basis from flow.

--

This is an opm-output related effort.

A quick write-up of a function that creates an instance of the opm-common specified well data object. It's a simple data aggregate which essentially dumps the simulator well-related data into a common (shared with other modules) format.

Thoughts/opinions/discussions? I would especially like feedback w.r.t. correctness from people knowing the internals of the simulators better than me.

related to the opm-common PR https://github.com/OPM/opm-common/pull/105