### PR TITLE
Using new EclipseState API, made ->s into .s

### DIFF
--- a/examples/opm_init_check.cpp
+++ b/examples/opm_init_check.cpp
@@ -207,8 +207,9 @@ public:
 
 /*****************************************************************/
 
-void initOPMTrans(TransGraph& opmTrans , DeckConstPtr deck , std::shared_ptr<const EclipseState> eclipseState) {
-    std::shared_ptr<GridManager> grid = std::make_shared<GridManager>( eclipseState->getEclipseGrid(), eclipseState->getDoubleGridProperty("PORV")->getData());
+void initOPMTrans(TransGraph& opmTrans, DeckConstPtr deck, std::shared_ptr<const EclipseState> eclipseState) {
+    std::shared_ptr<GridManager> grid = std::make_shared<GridManager>( eclipseState->getEclipseGrid(),
+            eclipseState->getEclipseProperties().getDoubleGridProperty( "PORV" ).getData() );
     const struct UnstructuredGrid * cGrid = grid->c_grid();
     std::shared_ptr<BlackoilPropsAdInterface> props;
 

--- a/examples/opm_init_check.cpp
+++ b/examples/opm_init_check.cpp
@@ -209,7 +209,7 @@ public:
 
 void initOPMTrans(TransGraph& opmTrans, DeckConstPtr deck, std::shared_ptr<const EclipseState> eclipseState) {
     std::shared_ptr<GridManager> grid = std::make_shared<GridManager>( eclipseState->getEclipseGrid(),
-            eclipseState->getEclipseProperties().getDoubleGridProperty( "PORV" ).getData() );
+            eclipseState->get3DProperties().getDoubleGridProperty( "PORV" ).getData() );
     const struct UnstructuredGrid * cGrid = grid->c_grid();
     std::shared_ptr<BlackoilPropsAdInterface> props;
 

--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -165,11 +165,13 @@ try
     }
 
     // Grid init
-    std::vector<double> porv;
-    if (eclipseState->hasDeckDoubleGridProperty("PORV")) {
-        porv = eclipseState->getDoubleGridProperty("PORV")->getData();
+
+    if (eclipseState->getEclipseProperties().hasDeckDoubleGridProperty("PORV")) {
+        const auto& porv = eclipseState->getEclipseProperties().getDoubleGridProperty("PORV").getData();
+        grid.reset(new GridManager(eclipseState->getEclipseGrid(), porv));
+    } else {
+        grid.reset(new GridManager(eclipseState->getEclipseGrid()));
     }
-    grid.reset(new GridManager(eclipseState->getEclipseGrid(), porv));
     auto &cGrid = *grid->c_grid();
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);
 

--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -166,8 +166,8 @@ try
 
     // Grid init
 
-    if (eclipseState->getEclipseProperties().hasDeckDoubleGridProperty("PORV")) {
-        const auto& porv = eclipseState->getEclipseProperties().getDoubleGridProperty("PORV").getData();
+    if (eclipseState->get3DProperties().hasDeckDoubleGridProperty("PORV")) {
+        const auto& porv = eclipseState->get3DProperties().getDoubleGridProperty("PORV").getData();
         grid.reset(new GridManager(eclipseState->getEclipseGrid(), porv));
     } else {
         grid.reset(new GridManager(eclipseState->getEclipseGrid()));

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -160,7 +160,9 @@ namespace detail {
         , geo_   (geo)
         , rock_comp_props_(rock_comp_props)
         , std_wells_ (wells_arg)
-        , vfp_properties_(eclState->getTableManager()->getVFPInjTables(), eclState->getTableManager()->getVFPProdTables())
+        , vfp_properties_(
+                    eclState->getTableManager().getVFPInjTables(),
+                    eclState->getTableManager().getVFPProdTables())
         , linsolver_ (linsolver)
         , active_(detail::activePhases(fluid.phaseUsage()))
         , canph_ (detail::active2Canonical(fluid.phaseUsage()))

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -422,7 +422,8 @@ namespace Opm
         void setupGridAndProps()
         {
             // Create grid.
-            const std::vector<double>& porv = eclipse_state_->getDoubleGridProperty("PORV")->getData();
+            const std::vector<double>& porv =
+                    eclipse_state_->getEclipseProperties().getDoubleGridProperty("PORV").getData();
             grid_init_.reset(new GridInit<Grid>(deck_, eclipse_state_, porv));
             const Grid& grid = grid_init_->grid();
 

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -423,7 +423,7 @@ namespace Opm
         {
             // Create grid.
             const std::vector<double>& porv =
-                    eclipse_state_->getEclipseProperties().getDoubleGridProperty("PORV").getData();
+                    eclipse_state_->get3DProperties().getDoubleGridProperty("PORV").getData();
             grid_init_.reset(new GridInit<Grid>(deck_, eclipse_state_, porv));
             const Grid& grid = grid_init_->grid();
 

--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -95,14 +95,15 @@ namespace Opm
 
             // get the pore volume multipliers from the EclipseState
             std::vector<double> multpv(numCartesianCells, 1.0);
-            if (eclState->hasDeckDoubleGridProperty("MULTPV")) {
-                multpv = eclState->getDoubleGridProperty("MULTPV")->getData();
+            const auto& eclProps = eclState->getEclipseProperties();
+            if (eclProps.hasDeckDoubleGridProperty("MULTPV")) {
+                multpv = eclProps.getDoubleGridProperty("MULTPV").getData();
             }
 
             // get the net-to-gross cell thickness from the EclipseState
             std::vector<double> ntg(numCartesianCells, 1.0);
-            if (eclState->hasDeckDoubleGridProperty("NTG")) {
-                ntg = eclState->getDoubleGridProperty("NTG")->getData();
+            if (eclProps.hasDeckDoubleGridProperty("NTG")) {
+                ntg = eclProps.getDoubleGridProperty("NTG").getData();
             }
 
             // Get grid from parser.
@@ -177,7 +178,7 @@ namespace Opm
                 }
 
                 // Note the pore volume from eclState is used and not the pvol_ calculated above
-                std::vector<double> porv = eclState->getDoubleGridProperty("PORV")->getData();
+                const auto& porv = eclProps.getDoubleGridProperty("PORV").getData();
                 pinch.process(grid, htrans_copy, actnum, multz, porv, nnc_);
             }           
 
@@ -277,7 +278,7 @@ namespace Opm
         const int* global_cell = Opm::UgGridHelpers::globalCell(grid);
         const int* cartdims = Opm::UgGridHelpers::cartDims(grid);
         EclipseGridConstPtr eclgrid = eclState->getEclipseGrid();
-        std::vector<double> porv = eclState->getDoubleGridProperty("PORV")->getData();
+        const auto& porv = eclState->getEclipseProperties().getDoubleGridProperty("PORV").getData();
         for (int cellIdx = 0; cellIdx < numCells; ++cellIdx) {
             const int nx = cartdims[0];
             const int ny = cartdims[1];

--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -95,7 +95,7 @@ namespace Opm
 
             // get the pore volume multipliers from the EclipseState
             std::vector<double> multpv(numCartesianCells, 1.0);
-            const auto& eclProps = eclState->getEclipseProperties();
+            const auto& eclProps = eclState->get3DProperties();
             if (eclProps.hasDeckDoubleGridProperty("MULTPV")) {
                 multpv = eclProps.getDoubleGridProperty("MULTPV").getData();
             }
@@ -278,7 +278,7 @@ namespace Opm
         const int* global_cell = Opm::UgGridHelpers::globalCell(grid);
         const int* cartdims = Opm::UgGridHelpers::cartDims(grid);
         EclipseGridConstPtr eclgrid = eclState->getEclipseGrid();
-        const auto& porv = eclState->getEclipseProperties().getDoubleGridProperty("PORV").getData();
+        const auto& porv = eclState->get3DProperties().getDoubleGridProperty("PORV").getData();
         for (int cellIdx = 0; cellIdx < numCells; ++cellIdx) {
             const int nx = cartdims[0];
             const int ny = cartdims[1];

--- a/opm/autodiff/SolventPropsAdFromDeck.cpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.cpp
@@ -63,9 +63,9 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
             OPM_THROW(std::runtime_error, "SDENSITY must be specified in SOLVENT runs\n");
         }
 
-        auto tables = eclState->getTableManager();
+        const auto& tables = eclState->getTableManager();
         // pvt
-        const TableContainer& pvdsTables = tables->getPvdsTables();
+        const TableContainer& pvdsTables = tables.getPvdsTables();
         if (!pvdsTables.empty()) {
 
             int numRegions = pvdsTables.size();
@@ -97,7 +97,7 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
             OPM_THROW(std::runtime_error, "PVDS must be specified in SOLVENT runs\n");
         }
 
-        const TableContainer& ssfnTables = tables->getSsfnTables();
+        const TableContainer& ssfnTables = tables.getSsfnTables();
         // relative permeabilty multiplier
         if (!ssfnTables.empty()) {
 
@@ -131,7 +131,7 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
             extractTableIndex("MISCNUM", eclState, number_of_cells, global_cell, cellMiscRegionIdx_);
 
             // misicible hydrocabon relative permeability wrt water
-            const TableContainer& sof2Tables = tables->getSof2Tables();
+            const TableContainer& sof2Tables = tables.getSof2Tables();
             if (!sof2Tables.empty()) {
 
                 int numRegions = sof2Tables.size();
@@ -153,7 +153,7 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
                 OPM_THROW(std::runtime_error, "SOF2 must be specified in MISCIBLE (SOLVENT) runs\n");
             }
 
-            const TableContainer& miscTables = tables->getMiscTables();
+            const TableContainer& miscTables = tables.getMiscTables();
             if (!miscTables.empty()) {
 
                 int numRegions = miscTables.size();
@@ -175,7 +175,7 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
                 OPM_THROW(std::runtime_error, "MISC must be specified in MISCIBLE (SOLVENT) runs\n");
             }
 
-            const TableContainer& pmiscTables = tables->getPmiscTables();
+            const TableContainer& pmiscTables = tables.getPmiscTables();
             if (!pmiscTables.empty()) {
 
                 int numRegions = pmiscTables.size();
@@ -195,7 +195,7 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
             }
 
             // miscible relative permeability multipleiers
-            const TableContainer& msfnTables = tables->getMsfnTables();
+            const TableContainer& msfnTables = tables.getMsfnTables();
             if (!msfnTables.empty()) {
 
                 int numRegions = msfnTables.size();
@@ -218,7 +218,7 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
                 }
             }
 
-            const TableContainer& sorwmisTables = tables->getSorwmisTables();
+            const TableContainer& sorwmisTables = tables.getSorwmisTables();
             if (!sorwmisTables.empty()) {
 
                 int numRegions = sorwmisTables.size();
@@ -236,7 +236,7 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
                 }
             }
 
-            const TableContainer& sgcwmisTables = tables->getSgcwmisTables();
+            const TableContainer& sgcwmisTables = tables.getSgcwmisTables();
             if (!sgcwmisTables.empty()) {
 
                 int numRegions = sgcwmisTables.size();
@@ -497,7 +497,7 @@ void SolventPropsAdFromDeck::extractTableIndex(const std::string& keyword,
                                                const int* compressedToCartesianCellIdx,
                                                std::vector<int>& tableIdx) const {
     //Get the Region data
-    const std::vector<int>& regionData = eclState->getIntGridProperty(keyword)->getData();
+    const auto& regionData = eclState->getEclipseProperties().getIntGridProperty(keyword).getData();
     // Convert this into an array of compressed cells
     // Eclipse uses Fortran-style indices which start at 1
     // instead of 0, we subtract 1.

--- a/opm/autodiff/SolventPropsAdFromDeck.cpp
+++ b/opm/autodiff/SolventPropsAdFromDeck.cpp
@@ -277,7 +277,7 @@ SolventPropsAdFromDeck::SolventPropsAdFromDeck(DeckConstPtr deck,
             }
 
             if (deck->hasKeyword("TLPMIXPA")) {
-                const TableContainer& tlpmixparTables = tables->getTlpmixpaTables();
+                const TableContainer& tlpmixparTables = tables.getTlpmixpaTables();
                 if (!tlpmixparTables.empty()) {
 
                     int numRegions = tlpmixparTables.size();
@@ -497,7 +497,7 @@ void SolventPropsAdFromDeck::extractTableIndex(const std::string& keyword,
                                                const int* compressedToCartesianCellIdx,
                                                std::vector<int>& tableIdx) const {
     //Get the Region data
-    const auto& regionData = eclState->getEclipseProperties().getIntGridProperty(keyword).getData();
+    const auto& regionData = eclState->get3DProperties().getIntGridProperty(keyword).getData();
     // Convert this into an array of compressed cells
     // Eclipse uses Fortran-style indices which start at 1
     // instead of 0, we subtract 1.

--- a/opm/polymer/PolymerProperties.hpp
+++ b/opm/polymer/PolymerProperties.hpp
@@ -130,8 +130,8 @@ namespace Opm
         void readFromDeck(Opm::DeckConstPtr deck, Opm::EclipseStateConstPtr eclipseState)
         {
             // We assume NTMISC=1
-            auto tables = eclipseState->getTableManager();
-            const auto& plymaxTable = tables->getPlymaxTables().getTable<PlymaxTable>(0);
+            const auto& tables = eclipseState->getTableManager();
+            const auto& plymaxTable = tables.getPlymaxTables().getTable<PlymaxTable>(0);
             const auto& plmixparRecord = deck->getKeyword("PLMIXPAR").getRecord(0);
 
             // We also assume that each table has exactly one row...
@@ -141,7 +141,7 @@ namespace Opm
             mix_param_ = plmixparRecord.getItem("TODD_LONGSTAFF").getSIDouble(0);
 
             // We assume NTSFUN=1
-            const auto& plyrockTable = tables->getPlyrockTables().getTable<PlyrockTable>(0);
+            const auto& plyrockTable = tables.getPlyrockTables().getTable<PlyrockTable>(0);
 
             // We also assume that each table has exactly one row...
             assert(plyrockTable.numRows() == 1);
@@ -153,14 +153,14 @@ namespace Opm
             c_max_ads_ = plyrockTable.getMaxAdsorbtionColumn()[0];
 
             // We assume NTPVT=1
-            const auto& plyviscTable = tables->getPlyviscTables().getTable<PlyviscTable>(0);
+            const auto& plyviscTable = tables.getPlyviscTables().getTable<PlyviscTable>(0);
 
 
             c_vals_visc_ = plyviscTable.getPolymerConcentrationColumn().vectorCopy( );
             visc_mult_vals_ =  plyviscTable.getViscosityMultiplierColumn().vectorCopy( );
 
             // We assume NTSFUN=1
-            const auto& plyadsTable = tables->getPlyadsTables().getTable<PlyadsTable>(0);
+            const auto& plyadsTable = tables.getPlyadsTables().getTable<PlyadsTable>(0);
 
             c_vals_ads_ = plyadsTable.getPolymerConcentrationColumn().vectorCopy( );
             ads_vals_ = plyadsTable.getAdsorbedPolymerColumn().vectorCopy( );
@@ -170,7 +170,7 @@ namespace Opm
 
             if (has_plyshlog_) {
                 // Assuming NTPVT == 1 always
-                const auto& plyshlogTable = tables->getPlyshlogTables().getTable<PlyshlogTable>(0);
+                const auto& plyshlogTable = tables.getPlyshlogTables().getTable<PlyshlogTable>(0);
 
                 water_vel_vals_ = plyshlogTable.getWaterVelocityColumn().vectorCopy( );
                 shear_vrf_vals_ = plyshlogTable.getShearMultiplierColumn().vectorCopy( );


### PR DESCRIPTION
This PR changes the use of EclipseState's API in opm-parser, see PR [Introduce Eclipse3DProperties #751](https://github.com/OPM/opm-parser/pull/751) in other repo.

The only changes are from `->` to `.` and use `state.getEclipseProperties()`.  Also added some `const auto& x` where we previously copied.