### PR TITLE
Use shared copy of opm-data when possible

### DIFF
--- a/jenkins/build-opm-simulators.sh
+++ b/jenkins/build-opm-simulators.sh
@@ -58,11 +58,14 @@ function build_opm_simulators {
   clone_and_build_module opm-output "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" $OPM_OUTPUT_REVISION $WORKSPACE/serial
   test $? -eq 0 || exit 1
 
+  # Setup opm-data
+  source $WORKSPACE/deps/opm-common/jenkins/setup-opm-data.sh
+
   # Build opm-simulators
   pushd .
   mkdir serial/build-opm-simulators
   cd serial/build-opm-simulators
-  build_module "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install" 1 $WORKSPACE
+  build_module "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DOPM_DATA_ROOT=$OPM_DATA_ROOT" 1 $WORKSPACE
   test $? -eq 0 || exit 1
   popd
 }

--- a/jenkins/run-norne.sh
+++ b/jenkins/run-norne.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-# Clone opm-data if necessary
-if ! test -d deps/opm-data
-then
-  OPM_DATA_REVISION="master"
-  if grep -q "opm-data=" <<< $ghprbCommentBody
-  then
-    OPM_DATA_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-data=([0-9]+).*/\1/g'`/merge
-  fi
-  source $WORKSPACE/deps/opm-common/jenkins/build-opm-module.sh
-  clone_module opm-data $OPM_DATA_REVISION
-fi
-
 pushd .
 cd deps/opm-data
 

--- a/jenkins/run-polymer.sh
+++ b/jenkins/run-polymer.sh
@@ -1,18 +1,5 @@
 #!/bin/bash
 
-# Clone opm-data if necessary
-if ! test -d deps/opm-data
-then
-  OPM_DATA_REVISION="master"
-  if grep -q "opm-data=" <<< $ghprbCommentBody
-  then
-    OPM_DATA_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-data=([0-9]+).*/\1/g'`/merge
-  fi
-  source $WORKSPACE/deps/opm-common/jenkins/build-opm-module.sh
-  echo "grabbing opm-data rev $OPM_DATA_REVISION"
-  clone_module opm-data $OPM_DATA_REVISION
-fi
-
 pushd .
 cd deps/opm-data
 

--- a/jenkins/run-spe.sh
+++ b/jenkins/run-spe.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-# Clone opm-data if necessary
-if ! test -d deps/opm-data
-then
-  OPM_DATA_REVISION="master"
-  if grep -q "opm-data=" <<< $ghprbCommentBody
-  then
-    OPM_DATA_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-data=([0-9]+).*/\1/g'`/merge
-  fi
-  source $WORKSPACE/deps/opm-common/jenkins/build-opm-module.sh
-  clone_module opm-data $OPM_DATA_REVISION
-fi
-
 pushd .
 cd deps/opm-data
 


### PR DESCRIPTION
Use shared copy of opm-data when possible
    
- The user can supply OPM_DATA_ROOT directly and this is used.
- The user can supply OPM_DATA_ROOT_PREDEFINED and this is used unless there is a PR against opm-data specified in the trigger.
    
This is used to minimize the network traffic on the jenkins resource. opm-data is updated nightly, and this nightly updated copy is used unless otherwise instructed.
    
This commit also enables the opm-data integration tests on all runs.