### PR TITLE
Moving more well related functions to StandardWells

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -131,7 +131,7 @@ list (APPEND PROGRAM_SOURCE_FILES
 # originally generated with the command:
 # find opm -name '*.h*' -a ! -name '*-pch.hpp' -printf '\t%p\n' | sort
 list (APPEND PUBLIC_HEADER_FILES
-<<<<<<< HEAD
+
   opm/autodiff/AdditionalObjectDeleter.hpp
   opm/autodiff/AutoDiffBlock.hpp
   opm/autodiff/AutoDiffHelpers.hpp
@@ -197,7 +197,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/autodiff/WellStateMultiSegment.hpp
   opm/autodiff/WellMultiSegment.hpp
   opm/autodiff/StandardWells.hpp
-  opm/autodiff/StandardWells_impl.hpp
+  opm/autodiff/StandardWellsSolvent.hpp
   opm/polymer/CompressibleTpfaPolymer.hpp
   opm/polymer/GravityColumnSolverPolymer.hpp
   opm/polymer/GravityColumnSolverPolymer_impl.hpp
@@ -226,4 +226,5 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/SimulatorCompressibleTwophase.hpp
   opm/simulators/SimulatorIncompTwophase.hpp
   )
+
 

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -196,6 +196,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/autodiff/VFPInjProperties.hpp
   opm/autodiff/WellStateMultiSegment.hpp
   opm/autodiff/WellMultiSegment.hpp
+  opm/autodiff/WellHelpers.hpp
   opm/autodiff/StandardWells.hpp
   opm/autodiff/StandardWellsSolvent.hpp
   opm/polymer/CompressibleTpfaPolymer.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -26,7 +26,6 @@
 # originally generated with the command:
 # find opm -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND MAIN_SOURCE_FILES
-
   opm/autodiff/BlackoilPropsAdInterface.cpp
   opm/autodiff/ExtractParallelGridInformationToISTL.cpp
   opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -66,7 +65,6 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/SimulatorCompressibleTwophase.cpp
   opm/simulators/SimulatorIncompTwophase.cpp
   )
-
 
 
 # originally generated with the command:
@@ -131,7 +129,6 @@ list (APPEND PROGRAM_SOURCE_FILES
 # originally generated with the command:
 # find opm -name '*.h*' -a ! -name '*-pch.hpp' -printf '\t%p\n' | sort
 list (APPEND PUBLIC_HEADER_FILES
-
   opm/autodiff/AdditionalObjectDeleter.hpp
   opm/autodiff/AutoDiffBlock.hpp
   opm/autodiff/AutoDiffHelpers.hpp
@@ -227,5 +224,4 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/SimulatorCompressibleTwophase.hpp
   opm/simulators/SimulatorIncompTwophase.hpp
   )
-
 

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -26,6 +26,7 @@
 # originally generated with the command:
 # find opm -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND MAIN_SOURCE_FILES
+
   opm/autodiff/BlackoilPropsAdInterface.cpp
   opm/autodiff/ExtractParallelGridInformationToISTL.cpp
   opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -47,7 +48,6 @@ list (APPEND MAIN_SOURCE_FILES
   opm/autodiff/VFPProdProperties.cpp
   opm/autodiff/VFPInjProperties.cpp
   opm/autodiff/WellMultiSegment.cpp
-  opm/autodiff/StandardWells.cpp
   opm/autodiff/BlackoilSolventState.cpp
   opm/autodiff/ThreadHandle.hpp
   opm/polymer/PolymerState.cpp
@@ -66,6 +66,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/SimulatorCompressibleTwophase.cpp
   opm/simulators/SimulatorIncompTwophase.cpp
   )
+
 
 
 # originally generated with the command:
@@ -130,6 +131,7 @@ list (APPEND PROGRAM_SOURCE_FILES
 # originally generated with the command:
 # find opm -name '*.h*' -a ! -name '*-pch.hpp' -printf '\t%p\n' | sort
 list (APPEND PUBLIC_HEADER_FILES
+<<<<<<< HEAD
   opm/autodiff/AdditionalObjectDeleter.hpp
   opm/autodiff/AutoDiffBlock.hpp
   opm/autodiff/AutoDiffHelpers.hpp
@@ -195,6 +197,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/autodiff/WellStateMultiSegment.hpp
   opm/autodiff/WellMultiSegment.hpp
   opm/autodiff/StandardWells.hpp
+  opm/autodiff/StandardWells_impl.hpp
   opm/polymer/CompressibleTpfaPolymer.hpp
   opm/polymer/GravityColumnSolverPolymer.hpp
   opm/polymer/GravityColumnSolverPolymer_impl.hpp

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -398,13 +398,6 @@ namespace Opm {
                     WellState& well_state);
 
         void
-        computeWellFlux(const SolutionState& state,
-                        const std::vector<ADB>& mob_perfcells,
-                        const std::vector<ADB>& b_perfcells,
-                        V& aliveWells,
-                        std::vector<ADB>& cq_s) const;
-
-        void
         updatePerfPhaseRatesAndPressures(const std::vector<ADB>& cq_s,
                                          const SolutionState& state,
                                          WellState& xw) const;

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -276,7 +276,7 @@ namespace Opm {
         const BlackoilPropsAdInterface& fluid_;
         const DerivedGeology&           geo_;
         const RockCompressibility*      rock_comp_props_;
-        StandardWells                   std_wells_;
+        StandardWells<SolutionState, WellState> std_wells_;
         VFPProperties                   vfp_properties_;
         const NewtonIterationBlackoilInterface&    linsolver_;
         // For each canonical phase -> true if active
@@ -329,8 +329,8 @@ namespace Opm {
         }
 
         /// return the StandardWells object
-        StandardWells& stdWells() { return std_wells_; }
-        const StandardWells& stdWells() const { return std_wells_; }
+        StandardWells<SolutionState, WellState>& stdWells() { return std_wells_; }
+        const StandardWells<SolutionState, WellState>& stdWells() const { return std_wells_; }
 
         /// return the Well struct in the StandardWells
         const Wells& wells() const { return std_wells_.wells(); }

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -393,6 +393,12 @@ namespace Opm {
                                   std::vector<ADB>& mob_perfcells,
                                   std::vector<ADB>& b_perfcells) const;
 
+        // TODO: only kept for now due to flow_multisegment
+        // will be removed soon
+        void updateWellState(const V& dwells,
+                             WellState& well_state);
+
+
         bool
         solveWellEq(const std::vector<ADB>& mob_perfcells,
                     const std::vector<ADB>& b_perfcells,

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -276,7 +276,7 @@ namespace Opm {
         const BlackoilPropsAdInterface& fluid_;
         const DerivedGeology&           geo_;
         const RockCompressibility*      rock_comp_props_;
-        StandardWells<SolutionState, WellState> std_wells_;
+        StandardWells                   std_wells_;
         VFPProperties                   vfp_properties_;
         const NewtonIterationBlackoilInterface&    linsolver_;
         // For each canonical phase -> true if active
@@ -329,8 +329,8 @@ namespace Opm {
         }
 
         /// return the StandardWells object
-        StandardWells<SolutionState, WellState>& stdWells() { return std_wells_; }
-        const StandardWells<SolutionState, WellState>& stdWells() const { return std_wells_; }
+        StandardWells& stdWells() { return std_wells_; }
+        const StandardWells& stdWells() const { return std_wells_; }
 
         /// return the Well struct in the StandardWells
         const Wells& wells() const { return std_wells_.wells(); }

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -411,11 +411,6 @@ namespace Opm {
                          const WellState& xw,
                          const V& aliveWells);
 
-        void updateWellControls(WellState& xw) const;
-
-        void updateWellState(const V& dwells,
-                             WellState& well_state);
-
         bool getWellConvergence(const int iteration);
 
         bool isVFPActive() const;

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -398,11 +398,6 @@ namespace Opm {
                     WellState& well_state);
 
         void
-        updatePerfPhaseRatesAndPressures(const std::vector<ADB>& cq_s,
-                                         const SolutionState& state,
-                                         WellState& xw) const;
-
-        void
         addWellFluxEq(const std::vector<ADB>& cq_s,
                       const SolutionState& state);
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -386,6 +386,8 @@ namespace Opm {
         void
         assembleMassBalanceEq(const SolutionState& state);
 
+        // TODO: only kept for now due to flow_multisegment
+        // will be removed soon
         void
         extractWellPerfProperties(const SolutionState& state,
                                   std::vector<ADB>& mob_perfcells,

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -383,13 +383,6 @@ namespace Opm {
         void computeWellConnectionPressures(const SolutionState& state,
                                             const WellState& xw);
 
-        void computePropertiesForWellConnectionPressures(const SolutionState& state,
-                                                         const WellState& xw,
-                                                         std::vector<double>& b_perf,
-                                                         std::vector<double>& rsmax_perf,
-                                                         std::vector<double>& rvmax_perf,
-                                                         std::vector<double>& surf_dens_perf);
-
         void
         assembleMassBalanceEq(const SolutionState& state);
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -849,7 +849,7 @@ namespace detail {
         std::vector<double> rsmax_perf;
         std::vector<double> rvmax_perf;
         std::vector<double> surf_dens_perf;
-        asImpl().computePropertiesForWellConnectionPressures(state, xw, b_perf, rsmax_perf, rvmax_perf, surf_dens_perf);
+        asImpl().stdWells().computePropertiesForWellConnectionPressures(state, xw, fluid_, active_, phaseCondition_, b_perf, rsmax_perf, rvmax_perf, surf_dens_perf);
 
         // 2. Compute densities
         std::vector<double> cd =

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -855,7 +855,7 @@ namespace detail {
 
         std::vector<ADB> mob_perfcells;
         std::vector<ADB> b_perfcells;
-        asImpl().stdWells().extractWellPerfProperties(rq_, fluid_.numPhases(), mob_perfcells, b_perfcells);
+        asImpl().stdWells().extractWellPerfProperties(state, rq_, fluid_.numPhases(), fluid_, active_, mob_perfcells, b_perfcells);
         if (param_.solve_welleq_initially_ && initial_assembly) {
             // solve the well equations as a pre-processing step
             asImpl().solveWellEq(mob_perfcells, b_perfcells, state, well_state);

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -780,8 +780,8 @@ namespace detail {
         asImpl().stdWells().computePropertiesForWellConnectionPressures(state, xw, fluid_, active_, phaseCondition_, b_perf, rsmax_perf, rvmax_perf, surf_dens_perf);
 
         // Extract well connection depths.
-        const Vector depth = cellCentroidsZToEigen(grid_);
-        const Vector pdepth = subset(depth, asImpl().stdWells().wellOps().well_cells);
+        const StandardWells::Vector depth = cellCentroidsZToEigen(grid_);
+        const StandardWells::Vector pdepth = subset(depth, asImpl().stdWells().wellOps().well_cells);
         const int nperf = wells().well_connpos[wells().number_of_wells];
         const std::vector<double> depth_perf(pdepth.data(), pdepth.data() + nperf);
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1685,9 +1685,9 @@ namespace detail {
 
 
         // TODO: gravity should be stored as a member
-        const double gravity = detail::getGravity(geo_.gravity(), UgGridHelpers::dimensions(grid_));
-        // asImpl().updateWellState(dwells,well_state);
-        asImpl().stdWells().updateWellState(dwells, gravity, dpMaxRel(), fluid_.phaseUsage(), active_, vfp_properties_, well_state);
+        // const double gravity = detail::getGravity(geo_.gravity(), UgGridHelpers::dimensions(grid_));
+        // asImpl().stdWells().updateWellState(dwells, gravity, dpMaxRel(), fluid_.phaseUsage(), active_, vfp_properties_, well_state);
+        asImpl().updateWellState(dwells,well_state);
 
         // Update phase conditions used for property calculations.
         updatePhaseCondFromPrimalVariable();
@@ -2523,6 +2523,24 @@ namespace detail {
             }
         }
     }
+
+
+
+
+
+    // TODO: only kept for now due to flow_multisegment
+    // will be removed soon
+    template <class Grid, class Implementation>
+    void
+    BlackoilModelBase<Grid, Implementation>::updateWellState(const V& dwells,
+                                                             WellState& well_state)
+    {
+        const double gravity = detail::getGravity(geo_.gravity(), UgGridHelpers::dimensions(grid_));
+        asImpl().stdWells().updateWellState(dwells, gravity, dpMaxRel(), fluid_.phaseUsage(),
+                                            active_, vfp_properties_, well_state);
+
+    }
+
 
 
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -851,7 +851,7 @@ namespace detail {
 
         std::vector<ADB> mob_perfcells;
         std::vector<ADB> b_perfcells;
-        asImpl().extractWellPerfProperties(state, mob_perfcells, b_perfcells);
+        asImpl().stdWells().extractWellPerfProperties(rq_, fluid_.numPhases(), mob_perfcells, b_perfcells);
         if (param_.solve_welleq_initially_ && initial_assembly) {
             // solve the well equations as a pre-processing step
             asImpl().solveWellEq(mob_perfcells, b_perfcells, state, well_state);

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -222,6 +222,7 @@ namespace Opm {
         using Base::convergenceReduction;
         using Base::maxResidualAllowed;
         using Base::variableState;
+        using Base::variableWellStateIndices;
         using Base::asImpl;
 
         const std::vector<WellMultiSegmentConstPtr>& wellsMultiSegment() const { return wells_multisegment_; }
@@ -238,6 +239,13 @@ namespace Opm {
 
         void computeWellConnectionPressures(const SolutionState& state,
                                             const WellState& xw);
+
+        /// added to fixing the flow_multisegment running
+        bool
+        baseSolveWellEq(const std::vector<ADB>& mob_perfcells,
+                        const std::vector<ADB>& b_perfcells,
+                        SolutionState& state,
+                        WellState& well_state);
 
         bool
         solveWellEq(const std::vector<ADB>& mob_perfcells,

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -964,7 +964,7 @@ namespace Opm {
                     // inequality constraint, and therefore skipped.
                     continue;
                 }
-                if (detail::constraintBroken(
+                if (wellhelpers::constraintBroken(
                         xw.bhp(), xw.thp(), xw.wellRates(),
                         w, np, wellsMultiSegment()[w]->wellType(), wc, ctrl_index)) {
                     // ctrl_index will be the index of the broken constraint after the loop.

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -1033,7 +1033,7 @@ namespace Opm {
                                                       SolutionState& state,
                                                       WellState& well_state)
     {
-        const bool converged = Base::solveWellEq(mob_perfcells, b_perfcells, state, well_state);
+        const bool converged = baseSolveWellEq(mob_perfcells, b_perfcells, state, well_state);
 
         if (converged) {
             // We must now update the state.segp and state.segqs members,
@@ -1546,6 +1546,112 @@ namespace Opm {
         well_segment_perforation_pressure_diffs_ = grav * well_segment_perforation_depth_diffs_ * well_segment_perforation_densities;
 
     }
+
+
+
+        /// added to fixing the flow_multisegment running
+    template <class Grid>
+    bool
+    BlackoilMultiSegmentModel<Grid>::baseSolveWellEq(const std::vector<ADB>& mob_perfcells,
+                                                     const std::vector<ADB>& b_perfcells,
+                                                     SolutionState& state,
+                                                     WellState& well_state) {
+        V aliveWells;
+        const int np = wells().number_of_phases;
+        std::vector<ADB> cq_s(np, ADB::null());
+        std::vector<int> indices = variableWellStateIndices();
+        SolutionState state0 = state;
+        WellState well_state0 = well_state;
+        makeConstantState(state0);
+
+        std::vector<ADB> mob_perfcells_const(np, ADB::null());
+        std::vector<ADB> b_perfcells_const(np, ADB::null());
+
+        if ( Base::localWellsActive() ){
+            // If there are non well in the sudomain of the process
+            // thene mob_perfcells_const and b_perfcells_const would be empty
+            for (int phase = 0; phase < np; ++phase) {
+                mob_perfcells_const[phase] = ADB::constant(mob_perfcells[phase].value());
+                b_perfcells_const[phase] = ADB::constant(b_perfcells[phase].value());
+            }
+        }
+
+        int it  = 0;
+        bool converged;
+        do {
+            // bhp and Q for the wells
+            std::vector<V> vars0;
+            vars0.reserve(2);
+            variableWellStateInitials(well_state, vars0);
+            std::vector<ADB> vars = ADB::variables(vars0);
+
+            SolutionState wellSolutionState = state0;
+            variableStateExtractWellsVars(indices, vars, wellSolutionState);
+            computeWellFlux(wellSolutionState, mob_perfcells_const, b_perfcells_const, aliveWells, cq_s);
+            updatePerfPhaseRatesAndPressures(cq_s, wellSolutionState, well_state);
+            addWellFluxEq(cq_s, wellSolutionState);
+            addWellControlEq(wellSolutionState, well_state, aliveWells);
+            converged = Base::getWellConvergence(it);
+
+            if (converged) {
+                break;
+            }
+
+            ++it;
+            if( Base::localWellsActive() )
+            {
+                std::vector<ADB> eqs;
+                eqs.reserve(2);
+                eqs.push_back(residual_.well_flux_eq);
+                eqs.push_back(residual_.well_eq);
+                ADB total_residual = vertcatCollapseJacs(eqs);
+                const std::vector<M>& Jn = total_residual.derivative();
+                typedef Eigen::SparseMatrix<double> Sp;
+                Sp Jn0;
+                Jn[0].toSparse(Jn0);
+                const Eigen::SparseLU< Sp > solver(Jn0);
+                ADB::V total_residual_v = total_residual.value();
+                const Eigen::VectorXd& dx = solver.solve(total_residual_v.matrix());
+                assert(dx.size() == total_residual_v.size());
+                // asImpl().updateWellState(dx.array(), well_state);
+                updateWellState(dx.array(), well_state);
+                updateWellControls(well_state);
+            }
+        } while (it < 15);
+
+        if (converged) {
+            if ( terminal_output_ ) {
+                std::cout << "well converged iter: " << it << std::endl;
+            }
+            const int nw = wells().number_of_wells;
+            {
+                // We will set the bhp primary variable to the new ones,
+                // but we do not change the derivatives here.
+                ADB::V new_bhp = Eigen::Map<ADB::V>(well_state.bhp().data(), nw);
+                // Avoiding the copy below would require a value setter method
+                // in AutoDiffBlock.
+                std::vector<ADB::M> old_derivs = state.bhp.derivative();
+                state.bhp = ADB::function(std::move(new_bhp), std::move(old_derivs));
+            }
+            {
+                // Need to reshuffle well rates, from phase running fastest
+                // to wells running fastest.
+                // The transpose() below switches the ordering.
+                const DataBlock wrates = Eigen::Map<const DataBlock>(well_state.wellRates().data(), nw, np).transpose();
+                ADB::V new_qs = Eigen::Map<const V>(wrates.data(), nw*np);
+                std::vector<ADB::M> old_derivs = state.qs.derivative();
+                state.qs = ADB::function(std::move(new_qs), std::move(old_derivs));
+            }
+            computeWellConnectionPressures(state, well_state);
+        }
+
+        if (!converged) {
+            well_state = well_state0;
+        }
+
+        return converged;
+    }
+
 
 } // namespace Opm
 

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -25,6 +25,7 @@
 #include <opm/autodiff/BlackoilSolventState.hpp>
 #include <opm/autodiff/WellStateFullyImplicitBlackoilSolvent.hpp>
 #include <opm/autodiff/SolventPropsAdFromDeck.hpp>
+#include <opm/autodiff/StandardWellsSolvent.hpp>
 
 namespace Opm {
 
@@ -103,6 +104,9 @@ namespace Opm {
         const bool is_miscible_;
         std::vector<ADB> mu_eff_;
         std::vector<ADB> b_eff_;
+        StandardWellsSolvent std_wells_;
+        const StandardWellsSolvent& stdWells() const { return std_wells_; }
+        StandardWellsSolvent& stdWells() { return std_wells_; }
 
 
         // Need to declare Base members we want to use here.
@@ -130,7 +134,7 @@ namespace Opm {
         // ---------  Protected methods  ---------
 
         // Need to declare Base members we want to use here.
-        using Base::stdWells;
+        // using Base::stdWells;
         using Base::wells;
         using Base::variableState;
         using Base::computeGasPressure;
@@ -148,7 +152,7 @@ namespace Opm {
         using Base::updateWellControls;
         using Base::computeWellConnectionPressures;
         using Base::addWellControlEq;
-        using Base::computePropertiesForWellConnectionPressures;
+        // using Base::computePropertiesForWellConnectionPressures;
 
         std::vector<ADB>
         computeRelPerm(const SolutionState& state) const;
@@ -201,13 +205,6 @@ namespace Opm {
         addWellContributionToMassBalanceEq(const std::vector<ADB>& cq_s,
                                            const SolutionState& state,
                                            WellState& xw);
-
-        void computePropertiesForWellConnectionPressures(const SolutionState& state,
-                                                         const WellState& xw,
-                                                         std::vector<double>& b_perf,
-                                                         std::vector<double>& rsmax_perf,
-                                                         std::vector<double>& rvmax_perf,
-                                                         std::vector<double>& surf_dens_perf);
 
         void updateEquationsScaling();
 

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -149,7 +149,7 @@ namespace Opm {
         using Base::dsMax;
         using Base::drMaxRel;
         using Base::maxResidualAllowed;
-        using Base::updateWellControls;
+        // using Base::updateWellControls;
         using Base::computeWellConnectionPressures;
         using Base::addWellControlEq;
         // using Base::computePropertiesForWellConnectionPressures;

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -90,7 +90,7 @@ namespace Opm {
           solvent_pos_(detail::solventPos(fluid.phaseUsage())),
           solvent_props_(solvent_props),
           is_miscible_(is_miscible),
-          std_wells_(wells_arg, solvent_props)
+          std_wells_(wells_arg, solvent_props, solvent_pos_)
 
     {
         if (has_solvent_) {

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -121,6 +121,22 @@ namespace Opm {
                                                   const SolutionState& state,
                                                   WellState& xw) const;
 
+            template <class WellState>
+            void updateWellState(const Vector& dwells,
+                                 const double gravity,
+                                 const double dpmaxrel,
+                                 const Opm::PhaseUsage& pu,
+                                 const std::vector<bool>& active,
+                                 const VFPProperties& vfp_properties,
+                                 WellState& well_state);
+
+           template <class WellState>
+           void updateWellControls(const Opm::PhaseUsage& pu,
+                                   const double gravity,
+                                   const VFPProperties& vfp_properties,
+                                   const bool terminal_output,
+                                   const std::vector<bool>& active,
+                                   WellState& xw) const;
 
 
         protected:

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -40,6 +40,7 @@ namespace Opm {
         typedef ADB::V Vector;
 
         /// Class for handling the standard well model.
+        template <class SolutionState, class WellState>
         class StandardWells {
         protected:
             struct WellOps {
@@ -81,4 +82,7 @@ namespace Opm {
 
 
 } // namespace Opm
+
+#include "StandardWells_impl.hpp"
+
 #endif

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -37,16 +37,6 @@
 
 namespace Opm {
 
-        // ---------      Types      ---------
-        typedef AutoDiffBlock<double> ADB;
-        typedef ADB::V Vector;
-
-        // copied from BlackoilModelBase
-        // should put to somewhere better
-        typedef Eigen::Array<double,
-                     Eigen::Dynamic,
-                     Eigen::Dynamic,
-                     Eigen::RowMajor> DataBlock;
 
         /// Class for handling the standard well model.
         class StandardWells {
@@ -59,6 +49,16 @@ namespace Opm {
             };
 
         public:
+            // ---------      Types      ---------
+            using ADB = AutoDiffBlock<double>;
+            using Vector = ADB::V;
+
+            // copied from BlackoilModelBase
+            // should put to somewhere better
+            using DataBlock =  Eigen::Array<double,
+                                            Eigen::Dynamic,
+                                            Eigen::Dynamic,
+                                            Eigen::RowMajor>;
             // ---------  Public methods  ---------
             explicit StandardWells(const Wells* wells);
 
@@ -73,11 +73,11 @@ namespace Opm {
             const WellOps& wellOps() const;
 
             /// Density of each well perforation
-            Vector& wellPerforationDensities();
+            Vector& wellPerforationDensities(); // mutable version kept for BlackoilMultisegmentModel
             const Vector& wellPerforationDensities() const;
 
             /// Diff to bhp for each well perforation.
-            Vector& wellPerforationPressureDiffs();
+            Vector& wellPerforationPressureDiffs(); // mutable version kept for BlackoilMultisegmentModel
             const Vector& wellPerforationPressureDiffs() const;
 
             template <class SolutionState, class WellState>

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -107,6 +107,16 @@ namespace Opm {
                                            std::vector<ADB>& mob_perfcells,
                                            std::vector<ADB>& b_perfcells) const;
 
+            template <class SolutionState>
+            void computeWellFlux(const SolutionState& state,
+                                 const Opm::PhaseUsage& phase_usage,
+                                 const std::vector<bool>& active,
+                                 const std::vector<ADB>& mob_perfcells,
+                                 const std::vector<ADB>& b_perfcells,
+                                 Vector& aliveWells,
+                                 std::vector<ADB>& cq_s) const;
+
+
 
         protected:
             bool wells_active_;

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -101,6 +101,12 @@ namespace Opm {
                                                         const std::vector<double>& depth_perf,
                                                         const double grav);
 
+            template <class ReservoirResidualQuant>
+            void extractWellPerfProperties(const std::vector<ReservoirResidualQuant>& rq,
+                                           const int np,
+                                           std::vector<ADB>& mob_perfcells,
+                                           std::vector<ADB>& b_perfcells) const;
+
 
         protected:
             bool wells_active_;

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -116,6 +116,11 @@ namespace Opm {
                                  Vector& aliveWells,
                                  std::vector<ADB>& cq_s) const;
 
+            template <class SolutionState, class WellState>
+            void updatePerfPhaseRatesAndPressures(const std::vector<ADB>& cq_s,
+                                                  const SolutionState& state,
+                                                  WellState& xw) const;
+
 
 
         protected:

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -31,6 +31,8 @@
 
 #include <opm/core/wells.h>
 #include <opm/autodiff/AutoDiffBlock.hpp>
+#include <opm/autodiff/AutoDiffHelpers.hpp>
+#include <opm/autodiff/BlackoilPropsAdInterface.hpp>
 
 
 namespace Opm {
@@ -38,6 +40,13 @@ namespace Opm {
         // ---------      Types      ---------
         typedef AutoDiffBlock<double> ADB;
         typedef ADB::V Vector;
+
+        // copied from BlackoilModelBase
+        // should put to somewhere better
+        typedef Eigen::Array<double,
+                     Eigen::Dynamic,
+                     Eigen::Dynamic,
+                     Eigen::RowMajor> DataBlock;
 
         /// Class for handling the standard well model.
         template <class SolutionState, class WellState>
@@ -71,6 +80,17 @@ namespace Opm {
             /// Diff to bhp for each well perforation.
             Vector& wellPerforationPressureDiffs();
             const Vector& wellPerforationPressureDiffs() const;
+
+            void computePropertiesForWellConnectionPressures(const SolutionState& state,
+                                                             const WellState& xw,
+                                                             const BlackoilPropsAdInterface& fluid,
+                                                             const std::vector<bool>& active,
+                                                             const std::vector<PhasePresence>& pc,
+                                                             std::vector<double>& b_perf,
+                                                             std::vector<double>& rsmax_perf,
+                                                             std::vector<double>& rvmax_perf,
+                                                             std::vector<double>& surf_dens_perf);
+
 
         protected:
             bool wells_active_;

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -91,6 +91,16 @@ namespace Opm {
                                                              std::vector<double>& rvmax_perf,
                                                              std::vector<double>& surf_dens_perf);
 
+            template <class WellState>
+            void computeWellConnectionDensitesPressures(const WellState& xw,
+                                                        const BlackoilPropsAdInterface& fluid,
+                                                        const std::vector<double>& b_perf,
+                                                        const std::vector<double>& rsmax_perf,
+                                                        const std::vector<double>& rvmax_perf,
+                                                        const std::vector<double>& surf_dens_perf,
+                                                        const std::vector<double>& depth_perf,
+                                                        const double grav);
+
 
         protected:
             bool wells_active_;

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -49,7 +49,6 @@ namespace Opm {
                      Eigen::RowMajor> DataBlock;
 
         /// Class for handling the standard well model.
-        template <class SolutionState, class WellState>
         class StandardWells {
         protected:
             struct WellOps {
@@ -81,6 +80,7 @@ namespace Opm {
             Vector& wellPerforationPressureDiffs();
             const Vector& wellPerforationPressureDiffs() const;
 
+            template <class SolutionState, class WellState>
             void computePropertiesForWellConnectionPressures(const SolutionState& state,
                                                              const WellState& xw,
                                                              const BlackoilPropsAdInterface& fluid,

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -101,9 +101,12 @@ namespace Opm {
                                                         const std::vector<double>& depth_perf,
                                                         const double grav);
 
-            template <class ReservoirResidualQuant>
-            void extractWellPerfProperties(const std::vector<ReservoirResidualQuant>& rq,
+            template <class ReservoirResidualQuant, class SolutionState>
+            void extractWellPerfProperties(const SolutionState& state,
+                                           const std::vector<ReservoirResidualQuant>& rq,
                                            const int np,
+                                           const BlackoilPropsAdInterface& fluid,
+                                           const std::vector<bool>& active,
                                            std::vector<ADB>& mob_perfcells,
                                            std::vector<ADB>& b_perfcells) const;
 

--- a/opm/autodiff/StandardWellsSolvent.hpp
+++ b/opm/autodiff/StandardWellsSolvent.hpp
@@ -1,0 +1,61 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef OPM_STANDARDWELLSSOLVENT_HEADER_INCLUDED
+#define OPM_STANDARDWELLSSOLVENT_HEADER_INCLUDED
+
+#include <opm/autodiff/StandardWells.hpp>
+#include <opm/autodiff/SolventPropsAdFromDeck.hpp>
+
+namespace Opm {
+
+
+        /// Class for handling the standard well model for solvent model
+        class StandardWellsSolvent : public StandardWells
+        {
+        public:
+
+            using Base = StandardWells;
+
+            // ---------  Public methods  ---------
+            explicit StandardWellsSolvent(const Wells* wells, const SolventPropsAdFromDeck& solvent_props);
+
+            template <class SolutionState, class WellState>
+            void computePropertiesForWellConnectionPressures(const SolutionState& state,
+                                                             const WellState& xw,
+                                                             const BlackoilPropsAdInterface& fluid,
+                                                             const std::vector<bool>& active,
+                                                             const std::vector<PhasePresence>& pc,
+                                                             std::vector<double>& b_perf,
+                                                             std::vector<double>& rsmax_perf,
+                                                             std::vector<double>& rvmax_perf,
+                                                             std::vector<double>& surf_dens_perf);
+        protected:
+            const SolventPropsAdFromDeck& solvent_props_;
+
+        };
+
+
+} // namespace Opm
+
+#include "StandardWellsSolvent_impl.hpp"
+
+#endif

--- a/opm/autodiff/StandardWellsSolvent.hpp
+++ b/opm/autodiff/StandardWellsSolvent.hpp
@@ -36,7 +36,7 @@ namespace Opm {
             using Base = StandardWells;
 
             // ---------  Public methods  ---------
-            explicit StandardWellsSolvent(const Wells* wells, const SolventPropsAdFromDeck& solvent_props);
+            explicit StandardWellsSolvent(const Wells* wells, const SolventPropsAdFromDeck& solvent_props, const int solvent_pos);
 
             template <class SolutionState, class WellState>
             void computePropertiesForWellConnectionPressures(const SolutionState& state,
@@ -48,8 +48,19 @@ namespace Opm {
                                                              std::vector<double>& rsmax_perf,
                                                              std::vector<double>& rvmax_perf,
                                                              std::vector<double>& surf_dens_perf);
+
+            // TODO: fluid and active may be can put in the member list
+            template <class ReservoirResidualQuant, class SolutionState>
+            void extractWellPerfProperties(const SolutionState& state,
+                                           const std::vector<ReservoirResidualQuant>& rq,
+                                           const int np,
+                                           const BlackoilPropsAdInterface& fluid,
+                                           const std::vector<bool>& active,
+                                           std::vector<ADB>& mob_perfcells,
+                                           std::vector<ADB>& b_perfcells) const;
         protected:
             const SolventPropsAdFromDeck& solvent_props_;
+            const int solvent_pos_;
 
         };
 

--- a/opm/autodiff/StandardWellsSolvent_impl.hpp
+++ b/opm/autodiff/StandardWellsSolvent_impl.hpp
@@ -1,0 +1,181 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <opm/autodiff/StandardWellsSolvent.hpp>
+
+
+
+
+namespace Opm
+{
+
+
+
+
+
+
+    StandardWellsSolvent::StandardWellsSolvent(const Wells* wells_arg,
+                                               const SolventPropsAdFromDeck& solvent_props)
+        : Base(wells_arg)
+        , solvent_props_(solvent_props)
+    {
+    }
+
+
+
+
+
+    template<class SolutionState, class WellState>
+    void
+    StandardWellsSolvent::
+    computePropertiesForWellConnectionPressures(const SolutionState& state,
+                                                const WellState& xw,
+                                                const BlackoilPropsAdInterface& fluid,
+                                                const std::vector<bool>& active,
+                                                const std::vector<PhasePresence>& pc,
+                                                std::vector<double>& b_perf,
+                                                std::vector<double>& rsmax_perf,
+                                                std::vector<double>& rvmax_perf,
+                                                std::vector<double>& surf_dens_perf)
+    {
+        // 1. Compute properties required by computeConnectionPressureDelta().
+        //    Note that some of the complexity of this part is due to the function
+        //    taking std::vector<double> arguments, and not Eigen objects.
+        const int nperf = wells().well_connpos[wells().number_of_wells];
+        const int nw = wells().number_of_wells;
+
+        // Compute the average pressure in each well block
+        const Vector perf_press = Eigen::Map<const V>(xw.perfPress().data(), nperf);
+        Vector avg_press = perf_press*0;
+        for (int w = 0; w < nw; ++w) {
+            for (int perf = wells().well_connpos[w]; perf < wells().well_connpos[w+1]; ++perf) {
+                const double p_above = perf == wells().well_connpos[w] ? state.bhp.value()[w] : perf_press[perf - 1];
+                const double p_avg = (perf_press[perf] + p_above)/2;
+                avg_press[perf] = p_avg;
+            }
+        }
+
+        const std::vector<int>& well_cells = wellOps().well_cells;
+
+        // Use cell values for the temperature as the wells don't knows its temperature yet.
+        const ADB perf_temp = subset(state.temperature, well_cells);
+
+        // Compute b, rsmax, rvmax values for perforations.
+        // Evaluate the properties using average well block pressures
+        // and cell values for rs, rv, phase condition and temperature.
+        const ADB avg_press_ad = ADB::constant(avg_press);
+        std::vector<PhasePresence> perf_cond(nperf);
+        for (int perf = 0; perf < nperf; ++perf) {
+            perf_cond[perf] = pc[well_cells[perf]];
+        }
+
+        const PhaseUsage& pu = fluid.phaseUsage();
+        DataBlock b(nperf, pu.num_phases);
+
+        const Vector bw = fluid.bWat(avg_press_ad, perf_temp, well_cells).value();
+        if (pu.phase_used[BlackoilPhases::Aqua]) {
+            b.col(pu.phase_pos[BlackoilPhases::Aqua]) = bw;
+        }
+
+        assert(active[Oil]);
+        assert(active[Gas]);
+        const ADB perf_rv = subset(state.rv, well_cells);
+        const ADB perf_rs = subset(state.rs, well_cells);
+        const Vector perf_so =  subset(state.saturation[pu.phase_pos[Oil]].value(), well_cells);
+        if (pu.phase_used[BlackoilPhases::Liquid]) {
+            const Vector bo = fluid.bOil(avg_press_ad, perf_temp, perf_rs, perf_cond, well_cells).value();
+            //const V bo_eff = subset(rq_[pu.phase_pos[Oil] ].b , well_cells).value();
+            b.col(pu.phase_pos[BlackoilPhases::Liquid]) = bo;
+            // const Vector rssat = fluidRsSat(avg_press, perf_so, well_cells);
+            const Vector rssat = fluid.rsSat(ADB::constant(avg_press), ADB::constant(perf_so), well_cells).value();
+            rsmax_perf.assign(rssat.data(), rssat.data() + nperf);
+        } else {
+            rsmax_perf.assign(0.0, nperf);
+        }
+        V surf_dens_copy = superset(fluid.surfaceDensity(0, well_cells), Span(nperf, pu.num_phases, 0), nperf*pu.num_phases);
+        for (int phase = 1; phase < pu.num_phases; ++phase) {
+            if ( phase == pu.phase_pos[BlackoilPhases::Vapour]) {
+                continue; // the gas surface density is added after the solvent is accounted for.
+            }
+            surf_dens_copy += superset(fluid.surfaceDensity(phase, well_cells), Span(nperf, pu.num_phases, phase), nperf*pu.num_phases);
+        }
+
+        if (pu.phase_used[BlackoilPhases::Vapour]) {
+            // Unclear wether the effective or the pure values should be used for the wells
+            // the current usage of unmodified properties values gives best match.
+            //V bg_eff = subset(rq_[pu.phase_pos[Gas]].b,well_cells).value();
+            Vector bg = fluid.bGas(avg_press_ad, perf_temp, perf_rv, perf_cond, well_cells).value();
+            Vector rhog = fluid.surfaceDensity(pu.phase_pos[BlackoilPhases::Vapour], well_cells);
+            // to handle solvent related
+            {
+
+                const Vector bs = solvent_props_.bSolvent(avg_press_ad,well_cells).value();
+                //const V bs_eff = subset(rq_[solvent_pos_].b,well_cells).value();
+
+                // number of cells
+                const int nc = state.pressure.size();
+
+                const ADB zero = ADB::constant(Vector::Zero(nc));
+                const ADB& ss = state.solvent_saturation;
+                const ADB& sg = (active[ Gas ]
+                                 ? state.saturation[ pu.phase_pos[ Gas ] ]
+                                 : zero);
+
+                Selector<double> zero_selector(ss.value() + sg.value(), Selector<double>::Zero);
+                Vector F_solvent = subset(zero_selector.select(ss, ss / (ss + sg)),well_cells).value();
+
+                Vector injectedSolventFraction = Eigen::Map<const Vector>(&xw.solventFraction()[0], nperf);
+
+                Vector isProducer = Vector::Zero(nperf);
+                Vector ones = Vector::Constant(nperf,1.0);
+                for (int w = 0; w < nw; ++w) {
+                    if(wells().type[w] == PRODUCER) {
+                        for (int perf = wells().well_connpos[w]; perf < wells().well_connpos[w+1]; ++perf) {
+                            isProducer[perf] = 1;
+                        }
+                    }
+                }
+
+                F_solvent = isProducer * F_solvent + (ones - isProducer) * injectedSolventFraction;
+
+                bg = bg * (ones - F_solvent);
+                bg = bg + F_solvent * bs;
+
+                const Vector& rhos = solvent_props_.solventSurfaceDensity(well_cells);
+                rhog = ( (ones - F_solvent) * rhog ) + (F_solvent * rhos);
+            }
+            b.col(pu.phase_pos[BlackoilPhases::Vapour]) = bg;
+            surf_dens_copy += superset(rhog, Span(nperf, pu.num_phases, pu.phase_pos[BlackoilPhases::Vapour]), nperf*pu.num_phases);
+
+            // const Vector rvsat = fluidRvSat(avg_press, perf_so, well_cells);
+            const Vector rvsat = fluid.rvSat(ADB::constant(avg_press), ADB::constant(perf_so), well_cells).value();
+            rvmax_perf.assign(rvsat.data(), rvsat.data() + nperf);
+        } else {
+            rvmax_perf.assign(0.0, nperf);
+        }
+
+        // b and surf_dens_perf is row major, so can just copy data.
+        b_perf.assign(b.data(), b.data() + nperf * pu.num_phases);
+        surf_dens_perf.assign(surf_dens_copy.data(), surf_dens_copy.data() + nperf * pu.num_phases);
+    }
+
+
+}

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -130,7 +130,7 @@ namespace Opm
 
 
 
-    Vector& StandardWells::wellPerforationDensities()
+    StandardWells::Vector& StandardWells::wellPerforationDensities()
     {
         return well_perforation_densities_;
     }
@@ -139,7 +139,7 @@ namespace Opm
 
 
 
-    const Vector&
+    const StandardWells::Vector&
     StandardWells::wellPerforationDensities() const
     {
         return well_perforation_densities_;
@@ -149,7 +149,7 @@ namespace Opm
 
 
 
-    Vector&
+    StandardWells::Vector&
     StandardWells::wellPerforationPressureDiffs()
     {
         return well_perforation_pressure_diffs_;
@@ -159,7 +159,7 @@ namespace Opm
 
 
 
-    const Vector&
+    const StandardWells::Vector&
     StandardWells::wellPerforationPressureDiffs() const
     {
         return well_perforation_pressure_diffs_;

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -289,11 +289,14 @@ namespace Opm
 
 
 
-    template <class ReservoirResidualQuant>
+    template <class ReservoirResidualQuant, class SolutionState>
     void
     StandardWells::
-    extractWellPerfProperties(const std::vector<ReservoirResidualQuant>& rq,
+    extractWellPerfProperties(const SolutionState& /* state */,
+                              const std::vector<ReservoirResidualQuant>& rq,
                               const int np,
+                              const BlackoilPropsAdInterface& /* fluid */,
+                              const std::vector<bool>& /* active */,
                               std::vector<ADB>& mob_perfcells,
                               std::vector<ADB>& b_perfcells) const
     {

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -247,6 +247,10 @@ namespace Opm
 
     }
 
+
+
+
+
     template <class WellState>
     void
     StandardWells::
@@ -275,6 +279,35 @@ namespace Opm
         // Store the results
         well_perforation_densities_ = Eigen::Map<const Vector>(cd.data(), nperf);
         well_perforation_pressure_diffs_ = Eigen::Map<const Vector>(cdp.data(), nperf);
+    }
+
+
+
+
+
+    template <class ReservoirResidualQuant>
+    void
+    StandardWells::
+    extractWellPerfProperties(const std::vector<ReservoirResidualQuant>& rq,
+                              const int np,
+                              std::vector<ADB>& mob_perfcells,
+                              std::vector<ADB>& b_perfcells) const
+    {
+        // If we have wells, extract the mobilities and b-factors for
+        // the well-perforated cells.
+        if ( !localWellsActive() ) {
+            mob_perfcells.clear();
+            b_perfcells.clear();
+            return;
+        } else {
+            const std::vector<int>& well_cells = wellOps().well_cells;
+            mob_perfcells.resize(np, ADB::null());
+            b_perfcells.resize(np, ADB::null());
+            for (int phase = 0; phase < np; ++phase) {
+                mob_perfcells[phase] = subset(rq[phase].mob, well_cells);
+                b_perfcells[phase] = subset(rq[phase].b, well_cells);
+            }
+        }
     }
 
 }

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -23,6 +23,7 @@
 
 
 
+
 namespace Opm
 {
 
@@ -184,5 +185,92 @@ namespace Opm
     {
         return well_perforation_pressure_diffs_;
     }
+
+
+
+
+    template<class SolutionState, class WellState>
+    void
+    StandardWells<SolutionState, WellState>::
+    computePropertiesForWellConnectionPressures(const SolutionState& state,
+                                                const WellState& xw,
+                                                const BlackoilPropsAdInterface& fluid,
+                                                const std::vector<bool>& active,
+                                                const std::vector<PhasePresence>& pc,
+                                                std::vector<double>& b_perf,
+                                                std::vector<double>& rsmax_perf,
+                                                std::vector<double>& rvmax_perf,
+                                                std::vector<double>& surf_dens_perf)
+    {
+        const int nperf = wells().well_connpos[wells().number_of_wells];
+        const int nw = wells().number_of_wells;
+
+        // Compute the average pressure in each well block
+        const Vector perf_press = Eigen::Map<const Vector>(xw.perfPress().data(), nperf);
+        Vector avg_press = perf_press*0;
+        for (int w = 0; w < nw; ++w) {
+            for (int perf = wells().well_connpos[w]; perf < wells().well_connpos[w+1]; ++perf) {
+                const double p_above = perf == wells().well_connpos[w] ? state.bhp.value()[w] : perf_press[perf - 1];
+                const double p_avg = (perf_press[perf] + p_above)/2;
+                avg_press[perf] = p_avg;
+            }
+        }
+
+        const std::vector<int>& well_cells = wellOps().well_cells;
+
+        // Use cell values for the temperature as the wells don't knows its temperature yet.
+        const ADB perf_temp = subset(state.temperature, well_cells);
+
+        // Compute b, rsmax, rvmax values for perforations.
+        // Evaluate the properties using average well block pressures
+        // and cell values for rs, rv, phase condition and temperature.
+        const ADB avg_press_ad = ADB::constant(avg_press);
+        std::vector<PhasePresence> perf_cond(nperf);
+        // const std::vector<PhasePresence>& pc = phaseCondition();
+        for (int perf = 0; perf < nperf; ++perf) {
+            perf_cond[perf] = pc[well_cells[perf]];
+        }
+        const PhaseUsage& pu = fluid.phaseUsage();
+        DataBlock b(nperf, pu.num_phases);
+        if (pu.phase_used[BlackoilPhases::Aqua]) {
+            const Vector bw = fluid.bWat(avg_press_ad, perf_temp, well_cells).value();
+            b.col(pu.phase_pos[BlackoilPhases::Aqua]) = bw;
+        }
+        assert(active[Oil]);
+        const Vector perf_so =  subset(state.saturation[pu.phase_pos[Oil]].value(), well_cells);
+        if (pu.phase_used[BlackoilPhases::Liquid]) {
+            const ADB perf_rs = subset(state.rs, well_cells);
+            const Vector bo = fluid.bOil(avg_press_ad, perf_temp, perf_rs, perf_cond, well_cells).value();
+            b.col(pu.phase_pos[BlackoilPhases::Liquid]) = bo;
+            // const V rssat = fluidRsSat(avg_press, perf_so, well_cells);
+            const Vector rssat = fluid.rsSat(ADB::constant(avg_press), ADB::constant(perf_so), well_cells).value();
+            rsmax_perf.assign(rssat.data(), rssat.data() + nperf);
+        } else {
+            rsmax_perf.assign(nperf, 0.0);
+        }
+        if (pu.phase_used[BlackoilPhases::Vapour]) {
+            const ADB perf_rv = subset(state.rv, well_cells);
+            const Vector bg = fluid.bGas(avg_press_ad, perf_temp, perf_rv, perf_cond, well_cells).value();
+            b.col(pu.phase_pos[BlackoilPhases::Vapour]) = bg;
+            // const V rvsat = fluidRvSat(avg_press, perf_so, well_cells);
+            const Vector rvsat = fluid.rvSat(ADB::constant(avg_press), ADB::constant(perf_so), well_cells).value();
+            rvmax_perf.assign(rvsat.data(), rvsat.data() + nperf);
+        } else {
+            rvmax_perf.assign(nperf, 0.0);
+        }
+        // b is row major, so can just copy data.
+        b_perf.assign(b.data(), b.data() + nperf * pu.num_phases);
+
+        // Surface density.
+        // The compute density segment wants the surface densities as
+        // an np * number of wells cells array
+        Vector rho = superset(fluid.surfaceDensity(0 , well_cells), Span(nperf, pu.num_phases, 0), nperf*pu.num_phases);
+        for (int phase = 1; phase < pu.num_phases; ++phase) {
+            rho += superset(fluid.surfaceDensity(phase , well_cells), Span(nperf, pu.num_phases, phase), nperf*pu.num_phases);
+        }
+        surf_dens_perf.assign(rho.data(), rho.data() + nperf * pu.num_phases);
+
+    }
+
 
 }

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -28,8 +28,7 @@ namespace Opm
 {
 
 
-    template <class SolutionState, class WellState>
-    StandardWells<SolutionState, WellState>::
+    StandardWells::
     WellOps::WellOps(const Wells* wells)
       : w2p(),
         p2w(),
@@ -67,9 +66,7 @@ namespace Opm
 
 
 
-    template <class SolutionState, class WellState>
-    StandardWells<SolutionState, WellState>::
-    StandardWells(const Wells* wells_arg)
+    StandardWells::StandardWells(const Wells* wells_arg)
       : wells_(wells_arg)
       , wops_(wells_arg)
       , well_perforation_densities_(Vector())
@@ -81,10 +78,7 @@ namespace Opm
 
 
 
-    template <class SolutionState, class WellState>
-    const Wells&
-    StandardWells<SolutionState, WellState>::
-    wells() const
+    const Wells& StandardWells::wells() const
     {
         assert(wells_ != 0);
         return *(wells_);
@@ -94,10 +88,7 @@ namespace Opm
 
 
 
-    template <class SolutionState, class WellState>
-    bool
-    StandardWells<SolutionState, WellState>::
-    wellsActive() const
+    bool StandardWells::wellsActive() const
     {
         return wells_active_;
     }
@@ -106,10 +97,7 @@ namespace Opm
 
 
 
-    template <class SolutionState, class WellState>
-    void
-    StandardWells<SolutionState, WellState>::
-    setWellsActive(const bool wells_active)
+    void StandardWells::setWellsActive(const bool wells_active)
     {
         wells_active_ = wells_active;
     }
@@ -118,10 +106,7 @@ namespace Opm
 
 
 
-    template <class SolutionState, class WellState>
-    bool
-    StandardWells<SolutionState, WellState>::
-    localWellsActive() const
+    bool StandardWells::localWellsActive() const
     {
         return wells_ ? (wells_->number_of_wells > 0 ) : false;
     }
@@ -130,10 +115,8 @@ namespace Opm
 
 
 
-    template <class SolutionState, class WellState>
-    const typename StandardWells<SolutionState, WellState>::WellOps&
-    StandardWells<SolutionState, WellState>::
-    wellOps() const
+    const StandardWells::WellOps&
+    StandardWells::wellOps() const
     {
         return wops_;
     }
@@ -142,10 +125,7 @@ namespace Opm
 
 
 
-    template <class SolutionState, class WellState>
-    Vector&
-    StandardWells<SolutionState, WellState>::
-    wellPerforationDensities()
+    Vector& StandardWells::wellPerforationDensities()
     {
         return well_perforation_densities_;
     }
@@ -154,10 +134,8 @@ namespace Opm
 
 
 
-    template <class SolutionState, class WellState>
     const Vector&
-    StandardWells<SolutionState, WellState>::
-    wellPerforationDensities() const
+    StandardWells::wellPerforationDensities() const
     {
         return well_perforation_densities_;
     }
@@ -166,10 +144,8 @@ namespace Opm
 
 
 
-    template <class SolutionState, class WellState>
     Vector&
-    StandardWells<SolutionState, WellState>::
-    wellPerforationPressureDiffs()
+    StandardWells::wellPerforationPressureDiffs()
     {
         return well_perforation_pressure_diffs_;
     }
@@ -178,10 +154,8 @@ namespace Opm
 
 
 
-    template <class SolutionState, class WellState>
     const Vector&
-    StandardWells<SolutionState, WellState>::
-    wellPerforationPressureDiffs() const
+    StandardWells::wellPerforationPressureDiffs() const
     {
         return well_perforation_pressure_diffs_;
     }
@@ -191,7 +165,7 @@ namespace Opm
 
     template<class SolutionState, class WellState>
     void
-    StandardWells<SolutionState, WellState>::
+    StandardWells::
     computePropertiesForWellConnectionPressures(const SolutionState& state,
                                                 const WellState& xw,
                                                 const BlackoilPropsAdInterface& fluid,

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -27,7 +27,8 @@ namespace Opm
 {
 
 
-    StandardWells::
+    template <class SolutionState, class WellState>
+    StandardWells<SolutionState, WellState>::
     WellOps::WellOps(const Wells* wells)
       : w2p(),
         p2w(),
@@ -65,7 +66,9 @@ namespace Opm
 
 
 
-    StandardWells::StandardWells(const Wells* wells_arg)
+    template <class SolutionState, class WellState>
+    StandardWells<SolutionState, WellState>::
+    StandardWells(const Wells* wells_arg)
       : wells_(wells_arg)
       , wops_(wells_arg)
       , well_perforation_densities_(Vector())
@@ -77,7 +80,10 @@ namespace Opm
 
 
 
-    const Wells& StandardWells::wells() const
+    template <class SolutionState, class WellState>
+    const Wells&
+    StandardWells<SolutionState, WellState>::
+    wells() const
     {
         assert(wells_ != 0);
         return *(wells_);
@@ -87,7 +93,10 @@ namespace Opm
 
 
 
-    bool StandardWells::wellsActive() const
+    template <class SolutionState, class WellState>
+    bool
+    StandardWells<SolutionState, WellState>::
+    wellsActive() const
     {
         return wells_active_;
     }
@@ -96,7 +105,10 @@ namespace Opm
 
 
 
-    void StandardWells::setWellsActive(const bool wells_active)
+    template <class SolutionState, class WellState>
+    void
+    StandardWells<SolutionState, WellState>::
+    setWellsActive(const bool wells_active)
     {
         wells_active_ = wells_active;
     }
@@ -105,7 +117,10 @@ namespace Opm
 
 
 
-    bool StandardWells::localWellsActive() const
+    template <class SolutionState, class WellState>
+    bool
+    StandardWells<SolutionState, WellState>::
+    localWellsActive() const
     {
         return wells_ ? (wells_->number_of_wells > 0 ) : false;
     }
@@ -114,8 +129,10 @@ namespace Opm
 
 
 
-    const StandardWells::WellOps&
-    StandardWells::wellOps() const
+    template <class SolutionState, class WellState>
+    const typename StandardWells<SolutionState, WellState>::WellOps&
+    StandardWells<SolutionState, WellState>::
+    wellOps() const
     {
         return wops_;
     }
@@ -124,7 +141,10 @@ namespace Opm
 
 
 
-    Vector& StandardWells::wellPerforationDensities()
+    template <class SolutionState, class WellState>
+    Vector&
+    StandardWells<SolutionState, WellState>::
+    wellPerforationDensities()
     {
         return well_perforation_densities_;
     }
@@ -133,7 +153,10 @@ namespace Opm
 
 
 
-    const Vector& StandardWells::wellPerforationDensities() const
+    template <class SolutionState, class WellState>
+    const Vector&
+    StandardWells<SolutionState, WellState>::
+    wellPerforationDensities() const
     {
         return well_perforation_densities_;
     }
@@ -142,7 +165,10 @@ namespace Opm
 
 
 
-    Vector& StandardWells::wellPerforationPressureDiffs()
+    template <class SolutionState, class WellState>
+    Vector&
+    StandardWells<SolutionState, WellState>::
+    wellPerforationPressureDiffs()
     {
         return well_perforation_pressure_diffs_;
     }
@@ -151,7 +177,10 @@ namespace Opm
 
 
 
-    const Vector& StandardWells::wellPerforationPressureDiffs() const
+    template <class SolutionState, class WellState>
+    const Vector&
+    StandardWells<SolutionState, WellState>::
+    wellPerforationPressureDiffs() const
     {
         return well_perforation_pressure_diffs_;
     }

--- a/opm/autodiff/WellHelpers.hpp
+++ b/opm/autodiff/WellHelpers.hpp
@@ -1,0 +1,169 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef OPM_WELLHELPERS_HEADER_INCLUDED
+#define OPM_WELLHELPERS_HEADER_INCLUDED
+
+#include <opm/core/wells.h>
+#include <opm/autodiff/AutoDiffBlock.hpp>
+// #include <opm/autodiff/AutoDiffHelpers.hpp>
+
+#include <vector>
+
+namespace Opm {
+
+
+    // ---------      Types      ---------
+    typedef AutoDiffBlock<double> ADB;
+    typedef ADB::V Vector;
+
+
+    namespace wellhelpers
+    {
+        inline
+        double rateToCompare(const std::vector<double>& well_phase_flow_rate,
+                             const int well,
+                             const int num_phases,
+                             const double* distr)
+        {
+            double rate = 0.0;
+            for (int phase = 0; phase < num_phases; ++phase) {
+                // Important: well_phase_flow_rate is ordered with all phase rates for first
+                // well first, then all phase rates for second well etc.
+                rate += well_phase_flow_rate[well*num_phases + phase] * distr[phase];
+            }
+            return rate;
+        }
+
+        inline
+        bool constraintBroken(const std::vector<double>& bhp,
+                              const std::vector<double>& thp,
+                              const std::vector<double>& well_phase_flow_rate,
+                              const int well,
+                              const int num_phases,
+                              const WellType& well_type,
+                              const WellControls* wc,
+                              const int ctrl_index)
+        {
+            const WellControlType ctrl_type = well_controls_iget_type(wc, ctrl_index);
+            const double target = well_controls_iget_target(wc, ctrl_index);
+            const double* distr = well_controls_iget_distr(wc, ctrl_index);
+
+            bool broken = false;
+
+            switch (well_type) {
+            case INJECTOR:
+            {
+                switch (ctrl_type) {
+                case BHP:
+                    broken = bhp[well] > target;
+                    break;
+
+                case THP:
+                    broken = thp[well] > target;
+                    break;
+
+                case RESERVOIR_RATE: // Intentional fall-through
+                case SURFACE_RATE:
+                    broken = rateToCompare(well_phase_flow_rate,
+                                           well, num_phases, distr) > target;
+                    break;
+                }
+            }
+            break;
+
+            case PRODUCER:
+            {
+                switch (ctrl_type) {
+                case BHP:
+                    broken = bhp[well] < target;
+                    break;
+
+                case THP:
+                    broken = thp[well] < target;
+                    break;
+
+                case RESERVOIR_RATE: // Intentional fall-through
+                case SURFACE_RATE:
+                    // Note that the rates compared below are negative,
+                    // so breaking the constraints means: too high flow rate
+                    // (as for injection).
+                    broken = rateToCompare(well_phase_flow_rate,
+                                           well, num_phases, distr) < target;
+                    break;
+                }
+            }
+            break;
+
+            default:
+                OPM_THROW(std::logic_error, "Can only handle INJECTOR and PRODUCER wells.");
+            }
+
+            return broken;
+        }
+
+        /**
+         * Simple hydrostatic correction for VFP table
+         * @param wells - wells struct
+         * @param w Well number
+         * @param vfp_table VFP table
+         * @param well_perforation_densities Densities at well perforations
+         * @param gravity Gravitational constant (e.g., 9.81...)
+         */
+        inline
+        double computeHydrostaticCorrection(const Wells& wells, const int w, double vfp_ref_depth,
+                                            const Vector& well_perforation_densities, const double gravity) {
+            if ( wells.well_connpos[w] == wells.well_connpos[w+1] )
+            {
+                // This is a well with no perforations.
+                // If this is the last well we would subscript over the
+                // bounds below.
+                // we assume well_perforation_densities to be 0
+                return 0;
+            }
+            const double well_ref_depth = wells.depth_ref[w];
+            const double dh = vfp_ref_depth - well_ref_depth;
+            const int perf = wells.well_connpos[w];
+            const double rho = well_perforation_densities[perf];
+            const double dp = rho*gravity*dh;
+
+            return dp;
+        }
+
+        inline
+        Vector computeHydrostaticCorrection(const Wells& wells, const Vector vfp_ref_depth,
+                const Vector& well_perforation_densities, const double gravity) {
+            const int nw = wells.number_of_wells;
+            Vector retval = Vector::Zero(nw);
+
+#pragma omp parallel for schedule(static)
+            for (int i=0; i<nw; ++i) {
+                retval[i] = computeHydrostaticCorrection(wells, i, vfp_ref_depth[i], well_perforation_densities, gravity);
+            }
+
+            return retval;
+        }
+
+    } // namespace wellhelpers
+
+}
+
+#endif

--- a/opm/autodiff/WellHelpers.hpp
+++ b/opm/autodiff/WellHelpers.hpp
@@ -31,9 +31,6 @@
 namespace Opm {
 
 
-    // ---------      Types      ---------
-    typedef AutoDiffBlock<double> ADB;
-    typedef ADB::V Vector;
 
 
     namespace wellhelpers
@@ -119,6 +116,10 @@ namespace Opm {
 
             return broken;
         }
+
+
+        // ---------      Types      ---------
+        using Vector = AutoDiffBlock<double>::V;
 
         /**
          * Simple hydrostatic correction for VFP table

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -174,6 +174,7 @@ namespace Opm {
         using Base::terminal_output_;
         using Base::primalVariable_;
         using Base::pvdt_;
+        using Base::vfp_properties_;
 
         // ---------  Protected methods  ---------
 
@@ -199,7 +200,7 @@ namespace Opm {
         using Base::drMaxRel;
         using Base::maxResidualAllowed;
 
-        using Base::updateWellControls;
+        // using Base::updateWellControls;
         using Base::computeWellConnectionPressures;
         using Base::addWellControlEq;
         using Base::computeRelPerm;

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -570,7 +570,7 @@ namespace Opm {
         }
 
         stdWells().computeWellFlux(state, fluid_.phaseUsage(), active_, mob_perfcells, b_perfcells, aliveWells, cq_s);
-        Base::updatePerfPhaseRatesAndPressures(cq_s, state, well_state);
+        stdWells().updatePerfPhaseRatesAndPressures(cq_s, state, well_state);
         Base::addWellFluxEq(cq_s, state);
         addWellContributionToMassBalanceEq(cq_s, state, well_state);
         addWellControlEq(state, well_state, aliveWells);

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -550,7 +550,7 @@ namespace Opm {
             Base::solveWellEq(mob_perfcells, b_perfcells, state, well_state);
         }
 
-        Base::computeWellFlux(state, mob_perfcells, b_perfcells, aliveWells, cq_s);
+        stdWells().computeWellFlux(state, fluid_.phaseUsage(), active_, mob_perfcells, b_perfcells, aliveWells, cq_s);
 
         if (has_plyshlog_) {
             std::vector<double> water_vel_wells;
@@ -569,7 +569,7 @@ namespace Opm {
             mob_perfcells[water_pos] = mob_perfcells[water_pos] / shear_mult_wells_adb;
         }
 
-        Base::computeWellFlux(state, mob_perfcells, b_perfcells, aliveWells, cq_s);
+        stdWells().computeWellFlux(state, fluid_.phaseUsage(), active_, mob_perfcells, b_perfcells, aliveWells, cq_s);
         Base::updatePerfPhaseRatesAndPressures(cq_s, state, well_state);
         Base::addWellFluxEq(cq_s, state);
         addWellContributionToMassBalanceEq(cq_s, state, well_state);

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -498,7 +498,9 @@ namespace Opm {
 
         // Possibly switch well controls and updating well state to
         // get reasonable initial conditions for the wells
-        updateWellControls(well_state);
+        const double gravity = detail::getGravity(geo_.gravity(), UgGridHelpers::dimensions(grid_));
+        // updateWellControls(well_state);
+        stdWells().updateWellControls(fluid_.phaseUsage(), gravity, vfp_properties_, terminal_output_, active_, well_state);
 
         // Create the primary variables.
         SolutionState state = variableState(reservoir_state, well_state);


### PR DESCRIPTION

Moving the following functions related to Wells from `BlackoilModelBase` to `StandardWells`. 
  . `computePropertiesForWellConnectionPressures`
  . `computeWellConnectionDensitesPressures`
  . `extractWellPerfProperties` 
  . `computeWellFlux`
  . `updatePerfPhaseRatesAndPressures`
  . `updateWellState`
  . `updateWellControls`

A derived class `StandardWellsSolvent` is introduced to handle the solvent related well stuff. 

Some temporary interfaces such as `extractWellPerfProperties` and `updateWellState` are kept for `BlackoilModeBase` for recovering the running of `flow_multisegment`. They will be removed when we get the point to remove `BlackoilMultisegmentModel`. 

The PR is tested for `flow` with SPE9 and Norne. `flow_polymer` with one 3D polymer case. `flow_solvent` with `SPE1CASE2_SOLVENT.DATA`. (Not sure which is the most sophisticated solvent test CASE) and `flow_multisegment` with a benchmark case I have. No change of results and performance against the current master branch. 

Further refactoring is on-going. It is a good point now to open a PR to avoid too huge PR in the near future. 

