### PR TITLE
Wells refactoring_adding WellModel as template class

### DIFF
--- a/opm/autodiff/BlackoilModel.hpp
+++ b/opm/autodiff/BlackoilModel.hpp
@@ -41,10 +41,10 @@ namespace Opm {
     /// It uses automatic differentiation via the class AutoDiffBlock
     /// to simplify assembly of the jacobian matrix.
     template<class Grid>
-    class BlackoilModel : public BlackoilModelBase<Grid, BlackoilModel<Grid>, StandardWells>
+    class BlackoilModel : public BlackoilModelBase<Grid, StandardWells, BlackoilModel<Grid> >
     {
     public:
-        typedef BlackoilModelBase<Grid, BlackoilModel<Grid>, StandardWells> Base;
+        typedef BlackoilModelBase<Grid, StandardWells, BlackoilModel<Grid> > Base;
 
         /// Construct the model. It will retain references to the
         /// arguments of this functions, and they are expected to

--- a/opm/autodiff/BlackoilModel.hpp
+++ b/opm/autodiff/BlackoilModel.hpp
@@ -26,6 +26,7 @@
 #include <opm/autodiff/BlackoilModelBase.hpp>
 #include <opm/core/simulator/BlackoilState.hpp>
 #include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/autodiff/StandardWells.hpp>
 #include <opm/autodiff/BlackoilModelParameters.hpp>
 
 namespace Opm {
@@ -40,10 +41,10 @@ namespace Opm {
     /// It uses automatic differentiation via the class AutoDiffBlock
     /// to simplify assembly of the jacobian matrix.
     template<class Grid>
-    class BlackoilModel : public BlackoilModelBase<Grid, BlackoilModel<Grid> >
+    class BlackoilModel : public BlackoilModelBase<Grid, BlackoilModel<Grid>, StandardWells>
     {
     public:
-        typedef BlackoilModelBase<Grid, BlackoilModel<Grid> > Base;
+        typedef BlackoilModelBase<Grid, BlackoilModel<Grid>, StandardWells> Base;
 
         /// Construct the model. It will retain references to the
         /// arguments of this functions, and they are expected to

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -104,6 +104,7 @@ namespace Opm {
     /// It uses automatic differentiation via the class AutoDiffBlock
     /// to simplify assembly of the jacobian matrix.
     /// \tparam  Grid            UnstructuredGrid or CpGrid.
+    /// \tparam  WellModel       WellModel employed.
     /// \tparam  Implementation  Provides concrete state types.
     template<class Grid, class WellModel, class Implementation>
     class BlackoilModelBase

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -105,7 +105,7 @@ namespace Opm {
     /// to simplify assembly of the jacobian matrix.
     /// \tparam  Grid            UnstructuredGrid or CpGrid.
     /// \tparam  Implementation  Provides concrete state types.
-    template<class Grid, class Implementation, class WellModel>
+    template<class Grid, class WellModel, class Implementation>
     class BlackoilModelBase
     {
     public:

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -32,7 +32,6 @@
 #include <opm/autodiff/NewtonIterationBlackoilInterface.hpp>
 #include <opm/autodiff/BlackoilModelEnums.hpp>
 #include <opm/autodiff/VFPProperties.hpp>
-#include <opm/autodiff/StandardWells.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 
 #include <array>
@@ -106,7 +105,7 @@ namespace Opm {
     /// to simplify assembly of the jacobian matrix.
     /// \tparam  Grid            UnstructuredGrid or CpGrid.
     /// \tparam  Implementation  Provides concrete state types.
-    template<class Grid, class Implementation>
+    template<class Grid, class Implementation, class WellModel>
     class BlackoilModelBase
     {
     public:
@@ -276,7 +275,7 @@ namespace Opm {
         const BlackoilPropsAdInterface& fluid_;
         const DerivedGeology&           geo_;
         const RockCompressibility*      rock_comp_props_;
-        StandardWells                   std_wells_;
+        WellModel                       std_wells_;
         VFPProperties                   vfp_properties_;
         const NewtonIterationBlackoilInterface&    linsolver_;
         // For each canonical phase -> true if active
@@ -328,11 +327,11 @@ namespace Opm {
             return static_cast<const Implementation&>(*this);
         }
 
-        /// return the StandardWells object
-        StandardWells& stdWells() { return std_wells_; }
-        const StandardWells& stdWells() const { return std_wells_; }
+        /// return the WellModel object
+        WellModel& stdWells() { return std_wells_; }
+        const WellModel& stdWells() const { return std_wells_; }
 
-        /// return the Well struct in the StandardWells
+        /// return the Well struct in the WellModel
         const Wells& wells() const { return std_wells_.wells(); }
 
         /// return true if wells are available in the reservoir

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1723,9 +1723,12 @@ namespace detail {
     }
 
 
-    template <class Grid, class Implementation>
+
+
+
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     computeWellPotentials(const SolutionState& state,
                           const std::vector<ADB>& mob_perfcells,
                           const std::vector<ADB>& b_perfcells,

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -143,8 +143,8 @@ namespace detail {
 } // namespace detail
 
 
-    template <class Grid, class Implementation, class WellModel>
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    template <class Grid, class WellModel, class Implementation>
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     BlackoilModelBase(const ModelParameters&          param,
                   const Grid&                     grid ,
                   const BlackoilPropsAdInterface& fluid,
@@ -217,9 +217,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     prepareStep(const double dt,
                 ReservoirState& reservoir_state,
                 WellState& /* well_state */)
@@ -234,10 +234,10 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     template <class NonlinearSolverType>
     IterationReport
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     nonlinearIteration(const int iteration,
                        const double dt,
                        NonlinearSolverType& nonlinear_solver,
@@ -289,9 +289,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     afterStep(const double /* dt */,
               ReservoirState& /* reservoir_state */,
               WellState& /* well_state */)
@@ -303,9 +303,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     int
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     sizeNonLinear() const
     {
         return residual_.sizeNonLinear();
@@ -315,9 +315,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     int
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     linearIterationsLastSolve() const
     {
         return linsolver_.iterations();
@@ -327,9 +327,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     bool
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     terminalOutputEnabled() const
     {
         return terminal_output_;
@@ -339,9 +339,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     int
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     numPhases() const
     {
         return fluid_.numPhases();
@@ -351,9 +351,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     int
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     numMaterials() const
     {
         return material_name_.size();
@@ -363,9 +363,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     const std::string&
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     materialName(int material_index) const
     {
         assert(material_index < numMaterials());
@@ -376,9 +376,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     setThresholdPressures(const std::vector<double>& threshold_pressures)
     {
         const int num_faces = AutoDiffGrid::numFaces(grid_);
@@ -407,8 +407,8 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    template <class Grid, class WellModel, class Implementation>
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     ReservoirResidualQuant::ReservoirResidualQuant()
         : accum(2, ADB::null())
         , mflux(   ADB::null())
@@ -422,9 +422,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     int
-    BlackoilModelBase<Grid, Implementation, WellModel>::numWellVars() const
+    BlackoilModelBase<Grid, WellModel, Implementation>::numWellVars() const
     {
         // For each well, we have a bhp variable, and one flux per phase.
         const int nw = stdWells().localWellsActive() ? wells().number_of_wells : 0;
@@ -435,9 +435,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     makeConstantState(SolutionState& state) const
     {
         // HACK: throw away the derivatives. this may not be the most
@@ -465,9 +465,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
-    typename BlackoilModelBase<Grid, Implementation, WellModel>::SolutionState
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    template <class Grid, class WellModel, class Implementation>
+    typename BlackoilModelBase<Grid, WellModel, Implementation>::SolutionState
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     variableState(const ReservoirState& x,
                   const WellState&     xw) const
     {
@@ -480,9 +480,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     std::vector<V>
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     variableStateInitials(const ReservoirState& x,
                           const WellState&     xw) const
     {
@@ -503,9 +503,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     variableReservoirStateInitials(const ReservoirState& x, std::vector<V>& vars0) const
     {
         using namespace Opm::AutoDiffGrid;
@@ -542,10 +542,10 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
-    variableWellStateInitials(const WellState&     xw, std::vector<V>& vars0) const
+    BlackoilModelBase<Grid, WellModel, Implementation>::
+    variableWellStateInitials(const WellState& xw, std::vector<V>& vars0) const
     {
         // Initial well rates.
         if ( stdWells().localWellsActive() )
@@ -577,9 +577,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     std::vector<int>
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     variableStateIndices() const
     {
         assert(active_[Oil]);
@@ -601,9 +601,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     std::vector<int>
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     variableWellStateIndices() const
     {
         // Black oil model standard is 5 equation.
@@ -620,9 +620,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
-    typename BlackoilModelBase<Grid, Implementation, WellModel>::SolutionState
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    template <class Grid, class WellModel, class Implementation>
+    typename BlackoilModelBase<Grid, WellModel, Implementation>::SolutionState
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     variableStateExtractVars(const ReservoirState& x,
                              const std::vector<int>& indices,
                              std::vector<ADB>& vars) const
@@ -693,9 +693,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     variableStateExtractWellsVars(const std::vector<int>& indices,
                                   std::vector<ADB>& vars,
                                   SolutionState& state) const
@@ -711,9 +711,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     computeAccum(const SolutionState& state,
                  const int            aix  )
     {
@@ -774,8 +774,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
-    void BlackoilModelBase<Grid, Implementation, WellModel>::
+    template <class Grid, class WellModel, class Implementation>
+    void 
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     computeWellConnectionPressures(const SolutionState& state,
                                    const WellState& xw)
     {
@@ -808,9 +809,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     assemble(const ReservoirState& reservoir_state,
              WellState& well_state,
              const bool initial_assembly)
@@ -886,9 +887,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     assembleMassBalanceEq(const SolutionState& state)
     {
         // Compute b_p and the accumulation term b_p*s_p for each phase,
@@ -954,9 +955,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     updateEquationsScaling() {
         ADB::V B;
         const Opm::PhaseUsage& pu = fluid_.phaseUsage();
@@ -988,9 +989,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     addWellContributionToMassBalanceEq(const std::vector<ADB>& cq_s,
                                        const SolutionState&,
                                        const WellState&)
@@ -1015,9 +1016,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     extractWellPerfProperties(const SolutionState&,
                               std::vector<ADB>& mob_perfcells,
                               std::vector<ADB>& b_perfcells) const
@@ -1044,9 +1045,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     addWellFluxEq(const std::vector<ADB>& cq_s,
                   const SolutionState& state)
     {
@@ -1072,8 +1073,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
-    bool BlackoilModelBase<Grid, Implementation, WellModel>::
+    template <class Grid, class WellModel, class Implementation>
+    bool
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     isVFPActive() const
     {
         if( ! localWellsActive() ) {
@@ -1107,8 +1109,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
-    bool BlackoilModelBase<Grid, Implementation, WellModel>::
+    template <class Grid, class WellModel, class Implementation>
+    bool
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     solveWellEq(const std::vector<ADB>& mob_perfcells,
                 const std::vector<ADB>& b_perfcells,
                 SolutionState& state,
@@ -1215,8 +1218,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
-    void BlackoilModelBase<Grid, Implementation, WellModel>::
+    template <class Grid, class WellModel, class Implementation>
+    void
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     addWellControlEq(const SolutionState& state,
                      const WellState& xw,
                      const V& aliveWells)
@@ -1382,9 +1386,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     V
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     solveJacobianSystem() const
     {
         return linsolver_.computeNewtonIncrement(residual_);
@@ -1495,9 +1499,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     updateState(const V& dx,
                 ReservoirState& reservoir_state,
                 WellState& well_state)
@@ -1824,9 +1828,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     std::vector<ADB>
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     computeRelPerm(const SolutionState& state) const
     {
         using namespace Opm::AutoDiffGrid;
@@ -1854,9 +1858,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     std::vector<ADB>
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     computePressures(const ADB& po,
                      const ADB& sw,
                      const ADB& so,
@@ -1891,9 +1895,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     V
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     computeGasPressure(const V& po,
                        const V& sw,
                        const V& so,
@@ -1909,16 +1913,16 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     computeMassFlux(const int               actph ,
                     const V&                transi,
                     const ADB&              kr    ,
                     const ADB&              mu    ,
                     const ADB&              rho   ,
                     const ADB&              phasePressure,
-                   const SolutionState&    state)
+                    const SolutionState&    state)
     {
         // Compute and store mobilities.
         const ADB tr_mult = transMult(state.pressure);
@@ -1943,9 +1947,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     applyThresholdPressures(ADB& dp)
     {
         // We support reversible threshold pressures only.
@@ -1976,9 +1980,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     std::vector<double>
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     computeResidualNorms() const
     {
         std::vector<double> residualNorms;
@@ -2017,9 +2021,9 @@ namespace detail {
     }
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     double
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     relativeChange(const SimulationDataContainer& previous,
                    const SimulationDataContainer& current ) const
     {
@@ -2058,9 +2062,9 @@ namespace detail {
         }
     }
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     double
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     convergenceReduction(const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>& B,
                          const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>& tempV,
                          const Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>& R,
@@ -2145,9 +2149,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     bool
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     getConvergence(const double dt, const int iteration)
     {
         const double tol_mb    = param_.tolerance_mb_;
@@ -2270,9 +2274,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     bool
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     getWellConvergence(const int iteration)
     {
         const double tol_wells = param_.tolerance_wells_;
@@ -2350,9 +2354,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     ADB
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     fluidViscosity(const int               phase,
                    const ADB&              p    ,
                    const ADB&              temp ,
@@ -2376,9 +2380,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     ADB
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     fluidReciprocFVF(const int               phase,
                      const ADB&              p    ,
                      const ADB&              temp ,
@@ -2402,9 +2406,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     ADB
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     fluidDensity(const int  phase,
                  const ADB& b,
                  const ADB& rs,
@@ -2426,9 +2430,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     V
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     fluidRsSat(const V&                p,
                const V&                satOil,
                const std::vector<int>& cells) const
@@ -2440,9 +2444,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     ADB
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     fluidRsSat(const ADB&              p,
                const ADB&              satOil,
                const std::vector<int>& cells) const
@@ -2454,9 +2458,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     V
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     fluidRvSat(const V&                p,
                const V&              satOil,
                const std::vector<int>& cells) const
@@ -2468,9 +2472,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     ADB
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     fluidRvSat(const ADB&              p,
                const ADB&              satOil,
                const std::vector<int>& cells) const
@@ -2482,9 +2486,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     ADB
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     poroMult(const ADB& p) const
     {
         const int n = p.size();
@@ -2513,9 +2517,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     ADB
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     transMult(const ADB& p) const
     {
         const int n = p.size();
@@ -2544,9 +2548,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     classifyCondition(const ReservoirState& state)
     {
         using namespace Opm::AutoDiffGrid;
@@ -2585,9 +2589,9 @@ namespace detail {
 
 
 
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     updatePrimalVariableFromState(const ReservoirState& state)
     {
         using namespace Opm::AutoDiffGrid;
@@ -2636,9 +2640,9 @@ namespace detail {
 
 
     /// Update the phaseCondition_ member based on the primalVariable_ member.
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     updatePhaseCondFromPrimalVariable()
     {
         if (! active_[Gas]) {
@@ -2677,9 +2681,9 @@ namespace detail {
 
     // TODO: only kept for now due to flow_multisegment
     // will be removed soon
-    template <class Grid, class Implementation, class WellModel>
+    template <class Grid, class WellModel, class Implementation>
     void
-    BlackoilModelBase<Grid, Implementation, WellModel>::
+    BlackoilModelBase<Grid, WellModel, Implementation>::
     updateWellState(const V& dwells,
                     WellState& well_state)
     {

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -25,6 +25,7 @@
 #include <opm/autodiff/BlackoilModelParameters.hpp>
 #include <opm/autodiff/WellStateMultiSegment.hpp>
 #include <opm/autodiff/WellMultiSegment.hpp>
+#include <opm/autodiff/StandardWells.hpp>
 
 namespace Opm {
 
@@ -48,11 +49,11 @@ namespace Opm {
     /// \tparam  Grid            UnstructuredGrid or CpGrid.
     /// \tparam  Implementation  Provides concrete state types.
     template<class Grid>
-    class BlackoilMultiSegmentModel : public BlackoilModelBase<Grid, BlackoilMultiSegmentModel<Grid>>
+    class BlackoilMultiSegmentModel : public BlackoilModelBase<Grid, StandardWells, BlackoilMultiSegmentModel<Grid> >
     {
     public:
 
-        typedef BlackoilModelBase<Grid, BlackoilMultiSegmentModel<Grid> > Base; // base class
+        typedef BlackoilModelBase<Grid, StandardWells, BlackoilMultiSegmentModel<Grid> > Base; // base class
         typedef typename Base::ReservoirState ReservoirState;
         typedef typename Base::WellState WellState;
         typedef BlackoilMultiSegmentSolutionState SolutionState;

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -36,18 +36,18 @@ namespace Opm {
     /// It uses automatic differentiation via the class AutoDiffBlock
     /// to simplify assembly of the jacobian matrix.
     template<class Grid>
-    class BlackoilSolventModel : public BlackoilModelBase<Grid, BlackoilSolventModel<Grid> >
+    class BlackoilSolventModel : public BlackoilModelBase<Grid, BlackoilSolventModel<Grid>, StandardWellsSolvent>
     {
     public:
 
         // ---------  Types and enums  ---------
 
-        typedef BlackoilModelBase<Grid, BlackoilSolventModel<Grid> > Base;
+        typedef BlackoilModelBase<Grid, BlackoilSolventModel<Grid>, StandardWellsSolvent> Base;
         typedef typename Base::ReservoirState ReservoirState;
         typedef typename Base::WellState WellState;
         // The next line requires C++11 support available in g++ 4.7.
         // friend Base;
-        friend class BlackoilModelBase<Grid, BlackoilSolventModel<Grid> >;
+        friend class BlackoilModelBase<Grid, BlackoilSolventModel<Grid>, StandardWellsSolvent>;
 
         /// Construct the model. It will retain references to the
         /// arguments of this functions, and they are expected to
@@ -104,10 +104,6 @@ namespace Opm {
         const bool is_miscible_;
         std::vector<ADB> mu_eff_;
         std::vector<ADB> b_eff_;
-        StandardWellsSolvent std_wells_;
-        const StandardWellsSolvent& stdWells() const { return std_wells_; }
-        StandardWellsSolvent& stdWells() { return std_wells_; }
-
 
         // Need to declare Base members we want to use here.
         using Base::grid_;
@@ -134,7 +130,7 @@ namespace Opm {
         // ---------  Protected methods  ---------
 
         // Need to declare Base members we want to use here.
-        // using Base::stdWells;
+        using Base::stdWells;
         using Base::wells;
         using Base::variableState;
         using Base::computeGasPressure;

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -36,18 +36,18 @@ namespace Opm {
     /// It uses automatic differentiation via the class AutoDiffBlock
     /// to simplify assembly of the jacobian matrix.
     template<class Grid>
-    class BlackoilSolventModel : public BlackoilModelBase<Grid, BlackoilSolventModel<Grid>, StandardWellsSolvent>
+    class BlackoilSolventModel : public BlackoilModelBase<Grid, StandardWellsSolvent, BlackoilSolventModel<Grid> >
     {
     public:
 
         // ---------  Types and enums  ---------
 
-        typedef BlackoilModelBase<Grid, BlackoilSolventModel<Grid>, StandardWellsSolvent> Base;
+        typedef BlackoilModelBase<Grid, StandardWellsSolvent, BlackoilSolventModel<Grid> > Base;
         typedef typename Base::ReservoirState ReservoirState;
         typedef typename Base::WellState WellState;
         // The next line requires C++11 support available in g++ 4.7.
         // friend Base;
-        friend class BlackoilModelBase<Grid, BlackoilSolventModel<Grid>, StandardWellsSolvent>;
+        friend class BlackoilModelBase<Grid, StandardWellsSolvent, BlackoilSolventModel<Grid> >;
 
         /// Construct the model. It will retain references to the
         /// arguments of this functions, and they are expected to

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -89,8 +89,7 @@ namespace Opm {
           has_solvent_(has_solvent),
           solvent_pos_(detail::solventPos(fluid.phaseUsage())),
           solvent_props_(solvent_props),
-          is_miscible_(is_miscible),
-          std_wells_(wells_arg, solvent_props, solvent_pos_)
+          is_miscible_(is_miscible)
 
     {
         if (has_solvent_) {
@@ -105,6 +104,8 @@ namespace Opm {
             }
 
             residual_.matbalscale.resize(fluid_.numPhases() + 1, 0.0031); // use the same as gas
+
+            stdWells().initilazeSolvent(&solvent_props_, solvent_pos_);
         }
         if (is_miscible_) {
             mu_eff_.resize(fluid_.numPhases() + 1, ADB::null());

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -105,7 +105,7 @@ namespace Opm {
 
             residual_.matbalscale.resize(fluid_.numPhases() + 1, 0.0031); // use the same as gas
 
-            stdWells().initilazeSolvent(&solvent_props_, solvent_pos_);
+            stdWells().initSolvent(&solvent_props_, solvent_pos_);
         }
         if (is_miscible_) {
             mu_eff_.resize(fluid_.numPhases() + 1, ADB::null());

--- a/opm/autodiff/StandardWellsSolvent.hpp
+++ b/opm/autodiff/StandardWellsSolvent.hpp
@@ -36,7 +36,11 @@ namespace Opm {
             using Base = StandardWells;
 
             // ---------  Public methods  ---------
-            explicit StandardWellsSolvent(const Wells* wells, const SolventPropsAdFromDeck& solvent_props, const int solvent_pos);
+            explicit StandardWellsSolvent(const Wells* wells);
+
+            // added the Solvent related
+            // TODO: Should add interface in StandardWells, so this can be put in the constructor
+            void initilazeSolvent(const SolventPropsAdFromDeck* solvent_props, const int solvent_pos);
 
             template <class SolutionState, class WellState>
             void computePropertiesForWellConnectionPressures(const SolutionState& state,
@@ -59,8 +63,8 @@ namespace Opm {
                                            std::vector<ADB>& mob_perfcells,
                                            std::vector<ADB>& b_perfcells) const;
         protected:
-            const SolventPropsAdFromDeck& solvent_props_;
-            const int solvent_pos_;
+            const SolventPropsAdFromDeck* solvent_props_;
+            int solvent_pos_;
 
         };
 

--- a/opm/autodiff/StandardWellsSolvent.hpp
+++ b/opm/autodiff/StandardWellsSolvent.hpp
@@ -39,8 +39,7 @@ namespace Opm {
             explicit StandardWellsSolvent(const Wells* wells);
 
             // added the Solvent related
-            // TODO: Should add interface in StandardWells, so this can be put in the constructor
-            void initilazeSolvent(const SolventPropsAdFromDeck* solvent_props, const int solvent_pos);
+            void initSolvent(const SolventPropsAdFromDeck* solvent_props, const int solvent_pos);
 
             template <class SolutionState, class WellState>
             void computePropertiesForWellConnectionPressures(const SolutionState& state,

--- a/opm/autodiff/StandardWellsSolvent_impl.hpp
+++ b/opm/autodiff/StandardWellsSolvent_impl.hpp
@@ -34,6 +34,8 @@ namespace Opm
 
     StandardWellsSolvent::StandardWellsSolvent(const Wells* wells_arg)
         : Base(wells_arg)
+        , solvent_props_(nullptr)
+        , solvent_pos_(-1)
     {
     }
 
@@ -41,7 +43,7 @@ namespace Opm
 
 
 
-    void StandardWellsSolvent::initilazeSolvent(const SolventPropsAdFromDeck* solvent_props, const int solvent_pos)
+    void StandardWellsSolvent::initSolvent(const SolventPropsAdFromDeck* solvent_props, const int solvent_pos)
     {
         solvent_props_ = solvent_props;
         solvent_pos_ = solvent_pos;

--- a/opm/autodiff/StandardWellsSolvent_impl.hpp
+++ b/opm/autodiff/StandardWellsSolvent_impl.hpp
@@ -32,13 +32,19 @@ namespace Opm
 
 
 
-    StandardWellsSolvent::StandardWellsSolvent(const Wells* wells_arg,
-                                               const SolventPropsAdFromDeck& solvent_props,
-                                               const int solvent_pos)
+    StandardWellsSolvent::StandardWellsSolvent(const Wells* wells_arg)
         : Base(wells_arg)
-        , solvent_props_(solvent_props)
-        , solvent_pos_(solvent_pos)
     {
+    }
+
+
+
+
+
+    void StandardWellsSolvent::initilazeSolvent(const SolventPropsAdFromDeck* solvent_props, const int solvent_pos)
+    {
+        solvent_props_ = solvent_props;
+        solvent_pos_ = solvent_pos;
     }
 
 
@@ -129,7 +135,7 @@ namespace Opm
             // to handle solvent related
             {
 
-                const Vector bs = solvent_props_.bSolvent(avg_press_ad,well_cells).value();
+                const Vector bs = solvent_props_->bSolvent(avg_press_ad,well_cells).value();
                 //const V bs_eff = subset(rq_[solvent_pos_].b,well_cells).value();
 
                 // number of cells
@@ -161,7 +167,7 @@ namespace Opm
                 bg = bg * (ones - F_solvent);
                 bg = bg + F_solvent * bs;
 
-                const Vector& rhos = solvent_props_.solventSurfaceDensity(well_cells);
+                const Vector& rhos = solvent_props_->solventSurfaceDensity(well_cells);
                 rhog = ( (ones - F_solvent) * rhog ) + (F_solvent * rhos);
             }
             b.col(pu.phase_pos[BlackoilPhases::Vapour]) = bg;

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -27,6 +27,7 @@
 #include <opm/polymer/fullyimplicit/PolymerPropsAd.hpp>
 #include <opm/polymer/PolymerBlackoilState.hpp>
 #include <opm/polymer/fullyimplicit/WellStateFullyImplicitBlackoilPolymer.hpp>
+#include <opm/autodiff/StandardWells.hpp>
 
 namespace Opm {
 
@@ -40,18 +41,18 @@ namespace Opm {
     /// It uses automatic differentiation via the class AutoDiffBlock
     /// to simplify assembly of the jacobian matrix.
     template<class Grid>
-    class BlackoilPolymerModel : public BlackoilModelBase<Grid, BlackoilPolymerModel<Grid> >
+    class BlackoilPolymerModel : public BlackoilModelBase<Grid, StandardWells, BlackoilPolymerModel<Grid> >
     {
     public:
 
         // ---------  Types and enums  ---------
 
-        typedef BlackoilModelBase<Grid, BlackoilPolymerModel<Grid> > Base;
+        typedef BlackoilModelBase<Grid, StandardWells, BlackoilPolymerModel<Grid> > Base;
         typedef typename Base::ReservoirState ReservoirState;
         typedef typename Base::WellState WellState;
         // The next line requires C++11 support available in g++ 4.7.
         // friend Base;
-        friend class BlackoilModelBase<Grid, BlackoilPolymerModel<Grid> >;
+        friend class BlackoilModelBase<Grid, StandardWells, BlackoilPolymerModel<Grid> >;
 
         /// Construct the model. It will retain references to the
         /// arguments of this functions, and they are expected to


### PR DESCRIPTION
Adding the WellModel as a template Class for `BlackoilModelBase`. 

The previous implementation will  cause two std_wells_ with different types in the BlackoilSolventModel, which is actually buggy. 

Not result change for `flow`, `flow_solvent`, `flow_polymer` and `flow_multisegment` is observed. 