### PR TITLE
adding the has_solvent_ flag to StandardWellsSolvent

### DIFF
--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -105,7 +105,7 @@ namespace Opm {
 
             residual_.matbalscale.resize(fluid_.numPhases() + 1, 0.0031); // use the same as gas
 
-            stdWells().initSolvent(&solvent_props_, solvent_pos_);
+            stdWells().initSolvent(&solvent_props_, solvent_pos_, has_solvent_);
         }
         if (is_miscible_) {
             mu_eff_.resize(fluid_.numPhases() + 1, ADB::null());

--- a/opm/autodiff/StandardWellsSolvent.hpp
+++ b/opm/autodiff/StandardWellsSolvent.hpp
@@ -39,7 +39,9 @@ namespace Opm {
             explicit StandardWellsSolvent(const Wells* wells);
 
             // added the Solvent related
-            void initSolvent(const SolventPropsAdFromDeck* solvent_props, const int solvent_pos);
+            void initSolvent(const SolventPropsAdFromDeck* solvent_props,
+                             const int solvent_pos,
+                             const bool has_solvent);
 
             template <class SolutionState, class WellState>
             void computePropertiesForWellConnectionPressures(const SolutionState& state,
@@ -64,6 +66,7 @@ namespace Opm {
         protected:
             const SolventPropsAdFromDeck* solvent_props_;
             int solvent_pos_;
+            bool has_solvent_;
 
         };
 

--- a/opm/autodiff/StandardWellsSolvent_impl.hpp
+++ b/opm/autodiff/StandardWellsSolvent_impl.hpp
@@ -36,6 +36,7 @@ namespace Opm
         : Base(wells_arg)
         , solvent_props_(nullptr)
         , solvent_pos_(-1)
+        , has_solvent_(false)
     {
     }
 
@@ -43,10 +44,14 @@ namespace Opm
 
 
 
-    void StandardWellsSolvent::initSolvent(const SolventPropsAdFromDeck* solvent_props, const int solvent_pos)
+    void
+    StandardWellsSolvent::initSolvent(const SolventPropsAdFromDeck* solvent_props,
+                                      const int solvent_pos,
+                                      const bool has_solvent)
     {
         solvent_props_ = solvent_props;
         solvent_pos_ = solvent_pos;
+        has_solvent_ = has_solvent;
     }
 
 
@@ -135,7 +140,7 @@ namespace Opm
             Vector bg = fluid.bGas(avg_press_ad, perf_temp, perf_rv, perf_cond, well_cells).value();
             Vector rhog = fluid.surfaceDensity(pu.phase_pos[BlackoilPhases::Vapour], well_cells);
             // to handle solvent related
-            {
+            if (has_solvent_) {
 
                 const Vector bs = solvent_props_->bSolvent(avg_press_ad,well_cells).value();
                 //const V bs_eff = subset(rq_[solvent_pos_].b,well_cells).value();
@@ -205,7 +210,7 @@ namespace Opm
     {
         Base::extractWellPerfProperties(state, rq, np, fluid, active, mob_perfcells, b_perfcells);
         // handle the solvent related
-        {
+        if (has_solvent_) {
             int gas_pos = fluid.phaseUsage().phase_pos[Gas];
             const std::vector<int>& well_cells = wellOps().well_cells;
             const int nperf = well_cells.size();


### PR DESCRIPTION
Adding the bool flag `has_solvent_` to `StandardWellsSolvent`, so that the running with `flow_solvent` with cases without solvent can be recovered. 

It is tested with `SPE1CASE2.DATA` and `SPE9.DATA`.