### PR TITLE
fixing flow_polymer running cases without polymer.

### DIFF
--- a/opm/autodiff/FlowMainPolymer.hpp
+++ b/opm/autodiff/FlowMainPolymer.hpp
@@ -83,8 +83,10 @@ namespace Opm
         {
             Base::setupGridAndProps();
 
-            polymer_props_legacy_.reset(new PolymerProperties(Base::deck_, Base::eclipse_state_));
-            polymer_props_.reset(new PolymerPropsAd(*polymer_props_legacy_));
+            if (Base::deck_->hasKeyword("POLYMER")) {
+                polymer_props_legacy_.reset(new PolymerProperties(Base::deck_, Base::eclipse_state_));
+                polymer_props_.reset(new PolymerPropsAd(*polymer_props_legacy_));
+            }
         }
 
 


### PR DESCRIPTION
It is tested with `SPE1CASE2.DATA` and `SPE9.DATA` and polymer running. 