### PR TITLE
Two phase bugfixes

### DIFF
--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -292,6 +292,7 @@ namespace Opm
         /// Elementwise operator -
         AutoDiffBlock operator-(const AutoDiffBlock& rhs) const
         {
+            /*
             assert(val_.rows() > 0 || rhs.val_.rows() > 0);
             if (val_.rows() == 0) {
                 return rhs*(-1.0);
@@ -299,6 +300,7 @@ namespace Opm
             if (rhs.val_.rows() == 0) {
                 return *this;
             }
+            */
 
             if (jac_.empty() && rhs.jac_.empty()) {
                 return constant(val_ - rhs.val_);

--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -292,16 +292,6 @@ namespace Opm
         /// Elementwise operator -
         AutoDiffBlock operator-(const AutoDiffBlock& rhs) const
         {
-            /*
-            assert(val_.rows() > 0 || rhs.val_.rows() > 0);
-            if (val_.rows() == 0) {
-                return rhs*(-1.0);
-            }
-            if (rhs.val_.rows() == 0) {
-                return *this;
-            }
-            */
-
             if (jac_.empty() && rhs.jac_.empty()) {
                 return constant(val_ - rhs.val_);
             }

--- a/opm/autodiff/AutoDiffBlock.hpp
+++ b/opm/autodiff/AutoDiffBlock.hpp
@@ -292,6 +292,14 @@ namespace Opm
         /// Elementwise operator -
         AutoDiffBlock operator-(const AutoDiffBlock& rhs) const
         {
+            assert(val_.rows() > 0 || rhs.val_.rows() > 0);
+            if (val_.rows() == 0) {
+                return rhs*(-1.0);
+            }
+            if (rhs.val_.rows() == 0) {
+                return *this;
+            }
+
             if (jac_.empty() && rhs.jac_.empty()) {
                 return constant(val_ - rhs.val_);
             }

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -536,7 +536,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
 
         typedef Opm::LocalAd::Evaluation<double, /*size=*/2> LadEval;
 
-        // FIXME: What is Lad?
         LadEval pLad = 0.0;
         LadEval TLad = 0.0;
         LadEval RsLad = 0.0;
@@ -556,7 +555,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             }
             else {
                 if (rs.size() == 0) {
-                    // If FIXME
                     RsLad.value = 0.0;
                 }
                 else {

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -550,18 +550,19 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             pLad.value = po.value()[i];
             TLad.value = T.value()[i];
 
-            if (phase_usage_.phase_used[Gas]) {
-                //RS/RV only makes sense when gas phase is active
-                if (cond[i].hasFreeGas()) {
-                    bLad = oilPvt_->saturatedInverseFormationVolumeFactor(pvtRegionIdx, TLad, pLad);
+            //RS/RV only makes sense when gas phase is active
+            if (cond[i].hasFreeGas()) {
+                bLad = oilPvt_->saturatedInverseFormationVolumeFactor(pvtRegionIdx, TLad, pLad);
+            }
+            else {
+                if (rs.size() == 0) {
+                    // If FIXME
+                    RsLad.value = 0.0;
                 }
                 else {
                     RsLad.value = rs.value()[i];
-                    bLad = oilPvt_->inverseFormationVolumeFactor(pvtRegionIdx, TLad, pLad, RsLad);
                 }
-            }
-            else {
-                bLad = 0.0;
+                bLad = oilPvt_->inverseFormationVolumeFactor(pvtRegionIdx, TLad, pLad, RsLad);
             }
 
             b[i] = bLad.value;
@@ -867,9 +868,6 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
         std::vector<ADB> adbCapPressures;
         adbCapPressures.reserve(3);
         const ADB* s[3] = { &sw, &so, &sg };
-        //const std::vector<int>& block_pattern = sw.blockPattern();
-        assert(sw.blockPattern() == so.blockPattern());
-        assert(sw.blockPattern() == sg.blockPattern());
         for (int phase1 = 0; phase1 < 3; ++phase1) {
             if (phase_usage_.phase_used[phase1]) {
                 const int phase1_pos = phase_usage_.phase_pos[phase1];

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -219,18 +219,20 @@ namespace Opm
         }
         assert(active[Oil]);
         const Vector perf_so =  subset(state.saturation[pu.phase_pos[Oil]].value(), well_cells);
-        if (pu.phase_used[BlackoilPhases::Liquid] && pu.phase_used[BlackoilPhases::Vapour]) {
-            const ADB perf_rs = subset(state.rs, well_cells);
+        if (pu.phase_used[BlackoilPhases::Liquid]) {
+            const ADB perf_rs = (state.rs.size() > 0) ? subset(state.rs, well_cells) : ADB::null();
             const Vector bo = fluid.bOil(avg_press_ad, perf_temp, perf_rs, perf_cond, well_cells).value();
             b.col(pu.phase_pos[BlackoilPhases::Liquid]) = bo;
-            // const V rssat = fluidRsSat(avg_press, perf_so, well_cells);
+        }
+        if (pu.phase_used[BlackoilPhases::Vapour]) {
+            const ADB perf_rv = (state.rv.size() > 0) ? subset(state.rv, well_cells) : ADB::null();
+            const Vector bg = fluid.bGas(avg_press_ad, perf_temp, perf_rv, perf_cond, well_cells).value();
+            b.col(pu.phase_pos[BlackoilPhases::Vapour]) = bg;
+        }
+        if (pu.phase_used[BlackoilPhases::Liquid] && pu.phase_used[BlackoilPhases::Vapour]) {
             const Vector rssat = fluid.rsSat(ADB::constant(avg_press), ADB::constant(perf_so), well_cells).value();
             rsmax_perf.assign(rssat.data(), rssat.data() + nperf);
 
-            const ADB perf_rv = subset(state.rv, well_cells);
-            const Vector bg = fluid.bGas(avg_press_ad, perf_temp, perf_rv, perf_cond, well_cells).value();
-            b.col(pu.phase_pos[BlackoilPhases::Vapour]) = bg;
-            // const V rvsat = fluidRvSat(avg_press, perf_so, well_cells);
             const Vector rvsat = fluid.rvSat(ADB::constant(avg_press), ADB::constant(perf_so), well_cells).value();
             rvmax_perf.assign(rvsat.data(), rvsat.data() + nperf);
         }

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -453,18 +453,11 @@ namespace Opm
             const int oilpos = pu.phase_pos[Oil];
             const int gaspos = pu.phase_pos[Gas];
 
+            const ADB tmp_oil = cmix_s[oilpos] - (rv_perfcells * cmix_s[gaspos] / d);
+            volumeRatio += tmp_oil / b_perfcells[oilpos];
 
-            // First compute for Oil
-            {
-                const ADB tmp = cmix_s[oilpos] - (rv_perfcells * cmix_s[gaspos] / d);
-                volumeRatio += tmp / b_perfcells[oilpos];
-            }
-
-            // Then compute for Gas
-            {
-                const ADB tmp = cmix_s[gaspos] - (rs_perfcells * cmix_s[oilpos] / d);
-                volumeRatio += tmp / b_perfcells[gaspos];
-            }
+            const ADB tmp_gas = cmix_s[gaspos] - (rs_perfcells * cmix_s[oilpos] / d);
+            volumeRatio += tmp_gas / b_perfcells[gaspos];
         }
         else {
             if (active[Oil]) {

--- a/opm/simulators/thresholdPressures.hpp
+++ b/opm/simulators/thresholdPressures.hpp
@@ -110,20 +110,25 @@ void computeMaxDp(std::map<std::pair<int, int>, double>& maxDp,
     // the inverse formation volume factors
     std::vector<PhasePresence> cond(numCells);
     for (int cellIdx = 0; cellIdx < numCells; ++cellIdx) {
-        const double sw = initialState.saturation()[numPhases*cellIdx + pu.phase_pos[BlackoilPhases::Aqua]];
-        const double so = initialState.saturation()[numPhases*cellIdx + pu.phase_pos[BlackoilPhases::Liquid]];
-        const double sg = initialState.saturation()[numPhases*cellIdx + pu.phase_pos[BlackoilPhases::Vapour]];
-
-        if (pu.phase_used[BlackoilPhases::Aqua] && sw > 0.0) {
-            cond[cellIdx].setFreeWater();
+        if (pu.phase_used[BlackoilPhases::Aqua]) {
+            const double sw = initialState.saturation()[numPhases*cellIdx + pu.phase_pos[BlackoilPhases::Aqua]];
+            if (sw > 0.0) {
+                cond[cellIdx].setFreeWater();
+            }
         }
 
-        if (pu.phase_used[BlackoilPhases::Liquid] && so > 0.0) {
-            cond[cellIdx].setFreeOil();
+        if (pu.phase_used[BlackoilPhases::Liquid]) {
+            const double so = initialState.saturation()[numPhases*cellIdx + pu.phase_pos[BlackoilPhases::Liquid]];
+            if (so > 0.0) {
+                cond[cellIdx].setFreeOil();
+            }
         }
 
-        if (pu.phase_used[BlackoilPhases::Vapour] && sg > 0.0) {
-            cond[cellIdx].setFreeGas();
+        if (pu.phase_used[BlackoilPhases::Vapour]) {
+            const double sg = initialState.saturation()[numPhases*cellIdx + pu.phase_pos[BlackoilPhases::Vapour]];
+            if (sg > 0.0) {
+                cond[cellIdx].setFreeGas();
+            }
         }
     }
 


### PR DESCRIPTION
This PR enables running a two phase test case with plausible results

This PR should have no side effects for running existing three phase simulations. See also the twin PR in opm-core which should be merged simultaneously with this one