### PR TITLE
Change method name -> IOConfig::restart()

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -339,7 +339,7 @@ namespace Opm
         if ( eclWriter_ )
         {
             const auto initConfig = eclipseState_->getInitConfig();
-            if (initConfig->getRestartInitiated() && ((initConfig->getRestartStep()) == (timer.currentStepNum()))) {
+            if (initConfig->restartRequested() && ((initConfig->getRestartStep()) == (timer.currentStepNum()))) {
                 std::cout << "Skipping restart write in start of step " << timer.currentStepNum() << std::endl;
             } else {
                  eclWriter_->writeTimeStep(timer, state, wellState, substep );
@@ -448,6 +448,6 @@ namespace Opm
 
     bool BlackoilOutputWriter::isRestart() const {
         const auto initconfig = eclipseState_->getInitConfig();
-        return initconfig->getRestartInitiated();
+        return initconfig->restartRequested();
     }
 }


### PR DESCRIPTION
This is a followup to: https://github.com/OPM/opm-parser/pull/777.

I started out with an intention of fixing: https://github.com/OPM/opm-parser/issues/773 - however as mentioned here: https://github.com/OPM/opm-parser/issues/773#issuecomment-214395099 I got cold feet and backed off from any substantial changes. 

The end result is that this PR is extremely trivial.