### PR TITLE
fixed: build with g++ 5.3

### DIFF
--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -360,6 +360,7 @@ spdiag(const AutoDiffBlock<double>::V& d)
         Selector(const typename ADB::V& selection_basis,
                  CriterionForLeftElement crit = GreaterEqualZero)
         {
+            using std::isnan;
             // Define selector structure.
             const int n = selection_basis.size();
             // Over-reserving so we do not have to count.


### PR DESCRIPTION
this partially fixes the build on ubuntu xenial.
it also breaks due to an updated eigen, but with this
you can build with the old eigen instead of the distro
supplied eigen.