### PR TITLE
The getNNC API in Parser changed; remove *

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -198,7 +198,7 @@ namespace Opm
         parameter::ParameterGroup param_;
         // setupOutput()
         bool output_to_files_ = false;
-        std::string output_dir_ = std::string("output");
+        std::string output_dir_ = std::string(".");
         // readDeckInput()
         std::shared_ptr<const Deck> deck_;
         std::shared_ptr<EclipseState> eclipse_state_;
@@ -339,7 +339,7 @@ namespace Opm
             if (output_to_files_) {
                 // Create output directory if needed.
                 output_dir_ =
-                    param_.getDefault("output_dir", std::string("output"));
+                    param_.getDefault("output_dir", std::string("."));
                 boost::filesystem::path fpath(output_dir_);
                 try {
                     create_directories(fpath);

--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -152,7 +152,7 @@ namespace Opm
 
             // Handle NNCs
             if (eclState) {
-                nnc_ = *(eclState->getNNC());
+                nnc_ = eclState->getNNC();
             }
 
             // opmfil is hardcoded to be true. i.e the pinch processor is never used


### PR DESCRIPTION
* Changed default output directory in FlowMain to be "." instead of "output".  This is consistent with Eclipse
* Removed one * to reflect changes in Parser API.  This depends on OPM/opm-parser#791