### PR TITLE
Check if dir already exists before creating.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -328,11 +328,13 @@ namespace Opm
                 output_dir_ =
                     param_.getDefault("output_dir", std::string("."));
                 boost::filesystem::path fpath(output_dir_);
-                try {
-                    create_directories(fpath);
-                }
-                catch (...) {
-                    OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
+                if (!is_directory(fpath)) {
+                    try {
+                        create_directories(fpath);
+                    }
+                    catch (...) {
+                        OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
+                    }
                 }
                 // Write simulation parameters.
                 param_.writeParam(output_dir_ + "/simulation.param");


### PR DESCRIPTION
May be necessary on some platforms for the current dir (".").

Please check, @qilicun, if this fixes issue #682.