### PR TITLE
Changes needed to run Model 2 with co2

### DIFF
--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -532,7 +532,8 @@ namespace Opm {
         auto watOnly = sw >  (1 - epsilon);
 
         // phase translation sg <-> rs
-        std::fill(primalVariable_.begin(), primalVariable_.end(), PrimalVariables::Sg);
+        std::vector<HydroCarbonState>& hydroCarbonState = reservoir_state.hydroCarbonState();
+        std::fill(hydroCarbonState.begin(), hydroCarbonState.end(), HydroCarbonState::GasAndOil);
 
         if (has_disgas_) {
             const V rsSat0 = fluidRsSat(p_old, s_old.col(pu.phase_pos[Oil]), cells_);
@@ -548,7 +549,7 @@ namespace Opm {
                 if (useSg[c]) {
                     rs[c] = rsSat[c];
                 } else {
-                    primalVariable_[c] = PrimalVariables::RS;
+                    hydroCarbonState[c] = HydroCarbonState::OilOnly;
                 }
             }
 
@@ -574,7 +575,7 @@ namespace Opm {
                 if (useSg[c]) {
                     rv[c] = rvSat[c];
                 } else {
-                    primalVariable_[c] = PrimalVariables::RV;
+                    hydroCarbonState[c] = HydroCarbonState::GasOnly;
                 }
             }
         }
@@ -615,7 +616,7 @@ namespace Opm {
         Base::updateWellState(dwells,well_state);
 
         // Update phase conditions used for property calculations.
-        updatePhaseCondFromPrimalVariable();
+        updatePhaseCondFromPrimalVariable(reservoir_state);
     }
 
 

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -384,6 +384,11 @@ namespace Opm {
                 ReservoirState& reservoir_state,
                 WellState& well_state)
     {
+        //TODO:
+        // This is basicly a copy of updateState in the Base class
+        // The convergence is very sensitive to details in the appelyard process
+        // and the hydrocarbonstate detection. Further changes may occur, refactoring
+        // to reuse more of the base class is planned when the code mature a bit more.
         using namespace Opm::AutoDiffGrid;
         const int np = fluid_.numPhases();
         const int nc = numCells(grid_);
@@ -425,13 +430,13 @@ namespace Opm {
 
         // initialize with zeros
         // if the phase is active the saturation are overwritten.
-        V so = zero;
+        V so;
         V sw = zero;
         V sg = zero;
         V ss = zero;
 
         // Appleyard chop process.
-        // We chop to large updates in saturations
+        // We chop too large updates in the saturations
         {
             V maxVal = zero;
             V dso = zero;
@@ -507,7 +512,7 @@ namespace Opm {
         // The oil saturation is defined to
         // fill the rest of the pore space.
         // For convergence reasons oil saturations
-        // must be included in the appelyard copping
+        // is included in the appelyard chopping.
         so = V::Constant(nc,1.0) - sw - sg - ss;
 
         // Update rs and rv

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -365,7 +365,7 @@ namespace Opm {
             int oil_pos = fluid_.phaseUsage().phase_pos[Oil];
 
             // remove contribution from the dissolved gas.
-            const ADB cq_s_solvent = (isProducer * F_solvent + (ones - isProducer) * injectedSolventFraction) * (cq_s[gas_pos] - (rs_perfcells * cq_s[oil_pos] / (ones - rs_perfcells * rv_perfcells)));
+            const ADB cq_s_solvent = (isProducer * F_solvent + (ones - isProducer) * injectedSolventFraction) * (cq_s[gas_pos] - rs_perfcells * cq_s[oil_pos]) / (ones - rs_perfcells * rv_perfcells);
 
             // Solvent contribution to the mass balance equation is given as a fraction
             // of the gas contribution.


### PR DESCRIPTION
Includes: 
- fixes to make liveoil and solvent work together 
- some convergence fixes in the TL model. 
- changes in how the sparsity pattern is determined 

Note: The last point effects the standard blackoil model, the two first ones only the solvent model. 
Note2: With this PR the updatestate in the solvent model no longer uses updatestate in the base model. I plan to restructure this part later to avoid code copying, but would like to wait until this part of the code matures. 

