### PR TITLE
Add the option of computing the full sparity pattern based on all phases

### DIFF
--- a/opm/autodiff/FlowMainSolvent.hpp
+++ b/opm/autodiff/FlowMainSolvent.hpp
@@ -107,6 +107,15 @@ namespace Opm
                                                  Base::deck_->hasKeyword("SOLVENT")));
         }
 
+        void setupLinearSolver()
+        {
+            // require_full_sparsity_pattern as default for solvent runs
+            if (Base::deck_->hasKeyword("SOLVENT") && !Base::param_.has("require_full_sparsity_pattern") )  {
+                Base::param_.insertParameter("require_full_sparsity_pattern","true");
+            }
+            Base::setupLinearSolver();
+        }
+
     };
 
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -41,6 +41,7 @@ namespace Opm
         int    linear_solver_restart_;
         int    linear_solver_verbosity_;
         bool   newton_use_gmres_;
+        bool   require_full_sparsity_pattern_;
 
         NewtonIterationBlackoilInterleavedParameters() { reset(); }
         // read values from parameter class
@@ -55,6 +56,7 @@ namespace Opm
             linear_solver_maxiter_   = param.getDefault("linear_solver_maxiter", linear_solver_maxiter_);
             linear_solver_restart_   = param.getDefault("linear_solver_restart", linear_solver_restart_);
             linear_solver_verbosity_ = param.getDefault("linear_solver_verbosity", linear_solver_verbosity_);
+            require_full_sparsity_pattern_ = param.getDefault("require_full_sparsity_pattern", require_full_sparsity_pattern_);
         }
 
         // set default values
@@ -65,6 +67,7 @@ namespace Opm
             linear_solver_maxiter_   = 75;
             linear_solver_restart_   = 40;
             linear_solver_verbosity_ = 0;
+            require_full_sparsity_pattern_ = false;
         }
     };
 


### PR DESCRIPTION
- For some cases (for instance involving solvent flow) the reasoning for
only adding the pressure derivatives seems to fail. As getting the
sparsity pattern is non-trivial, in terms of work, the full sparsity
pattern is only added when specified by the parameter
"require_full_sparsity_pattern"
- For solvent runs "require_full_sparsity_pattern" defaults to true for
all other runs the default is to only extract the sparsity pattern from
the pressure derivatives.