### PR TITLE
Use stored hydrocarbonstate to get primal variables

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -305,7 +305,6 @@ namespace Opm {
         /// \brief The number of cells of the global grid.
         int global_nc_;
 
-        std::vector<int>         primalVariable_;
         V pvdt_;
         std::vector<std::string> material_name_;
         std::vector<std::vector<double>> residual_norms_history_;
@@ -494,7 +493,7 @@ namespace Opm {
         /// Update the phaseCondition_ member based on the primalVariable_ member.
         /// Also updates isRs_, isRv_ and isSg_;
         void
-        updatePhaseCondFromPrimalVariable();
+        updatePhaseCondFromPrimalVariable(const ReservoirState& state);
 
         /// \brief Compute the reduction within the convergence check.
         /// \param[in] B     A matrix with MaxNumPhases columns and the same number rows

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1485,6 +1485,7 @@ namespace detail {
             std::copy(&rv[0], &rv[0] + nc, reservoir_state.rv().begin());
         }
 
+        reservoir_state.hydroCarbonState() = primalVariable_;
 
         // TODO: gravity should be stored as a member
         // const double gravity = detail::getGravity(geo_.gravity(), UgGridHelpers::dimensions(grid_));
@@ -2269,42 +2270,48 @@ namespace detail {
     BlackoilModelBase<Grid, WellModel, Implementation>::
     updatePrimalVariableFromState(const ReservoirState& state)
     {
-        using namespace Opm::AutoDiffGrid;
-        const int nc = numCells(grid_);
-        const int np = state.numPhases();
+        if (state.hydroCarbonState().size() > 0) {
+            primalVariable_ = state.hydroCarbonState();
+        } else {
+            // if not provided by the state, the primalVariables are computed based
+            // on the saturations
+            using namespace Opm::AutoDiffGrid;
+            const int nc = numCells(grid_);
+            const int np = state.numPhases();
 
-        const PhaseUsage& pu = fluid_.phaseUsage();
-        const DataBlock s = Eigen::Map<const DataBlock>(& state.saturation()[0], nc, np);
+            const PhaseUsage& pu = fluid_.phaseUsage();
+            const DataBlock s = Eigen::Map<const DataBlock>(& state.saturation()[0], nc, np);
 
-        // Water/Oil/Gas system
-        assert (active_[ Gas ]);
+            // Water/Oil/Gas system
+            assert (active_[ Gas ]);
 
-        // reset the primary variables if RV and RS is not set Sg is used as primary variable.
-        primalVariable_.resize(nc);
-        std::fill(primalVariable_.begin(), primalVariable_.end(), PrimalVariables::Sg);
+            // reset the primary variables if RV and RS is not set Sg is used as primary variable.
+            primalVariable_.resize(nc);
+            std::fill(primalVariable_.begin(), primalVariable_.end(), PrimalVariables::Sg);
 
-        const V sg = s.col(pu.phase_pos[ Gas ]);
-        const V so = s.col(pu.phase_pos[ Oil ]);
-        const V sw = s.col(pu.phase_pos[ Water ]);
+            const V sg = s.col(pu.phase_pos[ Gas ]);
+            const V so = s.col(pu.phase_pos[ Oil ]);
+            const V sw = s.col(pu.phase_pos[ Water ]);
 
-        const double epsilon = std::sqrt(std::numeric_limits<double>::epsilon());
-        auto watOnly = sw >  (1 - epsilon);
-        auto hasOil = so > 0;
-        auto hasGas = sg > 0;
+            const double epsilon = std::sqrt(std::numeric_limits<double>::epsilon());
+            auto watOnly = sw >  (1 - epsilon);
+            auto hasOil = so > 0;
+            auto hasGas = sg > 0;
 
-        // For oil only cells Rs is used as primal variable. For cells almost full of water
-        // the default primal variable (Sg) is used.
-        if (has_disgas_) {
-            for (V::Index c = 0, e = sg.size(); c != e; ++c) {
-                if ( !watOnly[c] && hasOil[c] && !hasGas[c] ) {primalVariable_[c] = PrimalVariables::RS; }
+            // For oil only cells Rs is used as primal variable. For cells almost full of water
+            // the default primal variable (Sg) is used.
+            if (has_disgas_) {
+                for (V::Index c = 0, e = sg.size(); c != e; ++c) {
+                    if ( !watOnly[c] && hasOil[c] && !hasGas[c] ) {primalVariable_[c] = PrimalVariables::RS; }
+                }
             }
-        }
 
-        // For gas only cells Rv is used as primal variable. For cells almost full of water
-        // the default primal variable (Sg) is used.
-        if (has_vapoil_) {
-            for (V::Index c = 0, e = so.size(); c != e; ++c) {
-                if ( !watOnly[c] && hasGas[c] && !hasOil[c] ) {primalVariable_[c] = PrimalVariables::RV; }
+            // For gas only cells Rv is used as primal variable. For cells almost full of water
+            // the default primal variable (Sg) is used.
+            if (has_vapoil_) {
+                for (V::Index c = 0, e = so.size(); c != e; ++c) {
+                    if ( !watOnly[c] && hasGas[c] && !hasOil[c] ) {primalVariable_[c] = PrimalVariables::RV; }
+                }
             }
         }
         updatePhaseCondFromPrimalVariable();

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1428,7 +1428,7 @@ namespace detail {
         auto watOnly = sw >  (1 - epsilon);
 
         // phase translation sg <-> rs
-        std::vector<int>& hydroCarbonState = reservoir_state.hydroCarbonState();
+        std::vector<HydroCarbonState>& hydroCarbonState = reservoir_state.hydroCarbonState();
         std::fill(hydroCarbonState.begin(), hydroCarbonState.end(), HydroCarbonState::GasAndOil);
 
         if (has_disgas_) {

--- a/opm/autodiff/BlackoilModelEnums.hpp
+++ b/opm/autodiff/BlackoilModelEnums.hpp
@@ -21,6 +21,7 @@
 #define OPM_BLACKOILMODELENUMS_HEADER_INCLUDED
 
 #include <opm/autodiff/BlackoilPropsAdInterface.hpp>
+#include <opm/core/simulator/BlackoilState.hpp>
 
 namespace Opm
 {
@@ -37,7 +38,6 @@ namespace Opm
         RS = 1,
         RV = 2
     };
-
 
     enum CanonicalVariablePositions {
         Pressure = 0,

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -133,7 +133,6 @@ namespace Opm {
         using Base::isRv_;
         using Base::has_disgas_;
         using Base::has_vapoil_;
-        using Base::primalVariable_;
         using Base::cells_;
         using Base::param_;
         using Base::linsolver_;

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -124,7 +124,6 @@ namespace Opm {
         using Base::phaseCondition_;
         using Base::residual_;
         using Base::terminal_output_;
-        using Base::primalVariable_;
         using Base::pvdt_;
 
         // ---------  Protected methods  ---------

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -69,7 +69,7 @@
 #include <opm/autodiff/moduleVersion.hpp>
 
 #include <opm/core/utility/share_obj.hpp>
-
+#include <opm/core/utility/initHydroCarbonState.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/EclipsePRTLog.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
@@ -533,6 +533,7 @@ namespace Opm
                 props.capPress(numCells, state_->saturation().data(), cells.data(), pc.data(), nullptr);
                 fluidprops_->setSwatInitScaling(state_->saturation(), pc);
             }
+            initHydroCarbonState(*state_, pu, Opm::UgGridHelpers::numCells(grid));
         }
 
 

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
+#include <opm/core/utility/initHydroCarbonState.hpp>
 #include <opm/core/well_controls.h>
 
 namespace Opm
@@ -83,10 +84,11 @@ namespace Opm
         WellState prev_well_state;
 
 
-		if (output_writer_.isRestart()) {
-			// This is a restart, populate WellState and ReservoirState state objects from restart file
-			output_writer_.initFromRestartFile(props_.phaseUsage(), props_.permeability(), grid_, state, prev_well_state);
-		}
+        if (output_writer_.isRestart()) {
+            // This is a restart, populate WellState and ReservoirState state objects from restart file
+            output_writer_.initFromRestartFile(props_.phaseUsage(), props_.permeability(), grid_, state, prev_well_state);
+            initHydroCarbonState(state, props_.phaseUsage(), Opm::UgGridHelpers::numCells(grid_));
+        }
 
         // Create timers and file for writing timing info.
         Opm::time::StopWatch solver_timer;

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -173,7 +173,6 @@ namespace Opm {
         using Base::phaseCondition_;
         using Base::residual_;
         using Base::terminal_output_;
-        using Base::primalVariable_;
         using Base::pvdt_;
         using Base::vfp_properties_;
 


### PR DESCRIPTION
If hydrocarbonstate is not provided by the state fall back to
the old behavior of computing the hydrocarbonstate from the saturations

Depends on OPM/opm-core#1015 

Tested on various cases

case  |This PR | | Master | |
--------|-----|-----|-----|-----
 | Newton | Linear | Newton | Linear
SPE1CASE1 | 224 | 1279 | 222 |1251| 
SPE3CASE1 | 323 |2652 | 323| 2653|
SPE9_CP | 224 |1257 | 222| 1251 |
norne | 1631| 25173 | 1625| 25216|
simple2D (polymer) | 904 |3849 | 905| 3844 |
SPE5CASE1 (solvent) | 812 |3953 | 813 |3963 |

Based on this teste, it is a somewhat inconclusive whether this improves the convergence 
My motivation for providing this PR is 
1. It is more consistent. The hydrocarbon state is determined in updatestate except for the initialization before the frist timestep. It doesn't change between timesteps. 
2. It helps convergence for the Model 2 CO2 case. 

I will provide results for Model2 tomorrow. 

This PR should not be merged before the following issues are discussed / solved
1. Model 2 results are ready
2. Currently state.hydroCarbonState() is assumed to be equivalent with primalVariable_ . I suggest removing primalVariable_ and only use state.hydroCarbonState(). 
3. Now the initialization happens in BlackoilModel_impl.hpp . Should this be moved to blackoilstate?. And blackoil state moved to opm-simulators?
