### PR TITLE
fixing application of rs and rv to the volumeRatio calculation.

### DIFF
--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -489,10 +489,10 @@ namespace Opm
             const int oilpos = pu.phase_pos[Oil];
             const int gaspos = pu.phase_pos[Gas];
 
-            const ADB tmp_oil = cmix_s[oilpos] - (rv_perfcells * cmix_s[gaspos] / d);
+            const ADB tmp_oil = (cmix_s[oilpos] - rv_perfcells * cmix_s[gaspos]) / d;
             volumeRatio += tmp_oil / b_perfcells[oilpos];
 
-            const ADB tmp_gas = cmix_s[gaspos] - (rs_perfcells * cmix_s[oilpos] / d);
+            const ADB tmp_gas = (cmix_s[gaspos] - rs_perfcells * cmix_s[oilpos]) / d;
             volumeRatio += tmp_gas / b_perfcells[gaspos];
         }
         else {


### PR DESCRIPTION
The use of parenthesis is wrong according to Cramer's rule. 

It is a bug pointed out by @totto82 in OPM/opm-simulators#684 . 

It should not change the results significantly, while thorough tests need to be done before merging. 