### PR TITLE
Separate non-neighbour and non-cartesian connections.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -724,7 +724,7 @@ namespace Opm
                     fullReport.reportParam(tot_os);
                 }
             } else {
-                output_writer_->writeInit( simtimer, geoprops_->nnc() );
+                output_writer_->writeInit( simtimer, geoprops_->nonCartesianConnections() );
                 if (output_cout_) {
                     std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;
                 }

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -110,7 +110,7 @@ namespace Opm
         }
 
         // init output writer
-        output_writer_.writeInit( timer, geo_.nnc() );
+        output_writer_.writeInit( timer, geo_.nonCartesianConnections() );
 
         std::string restorefilename = param_.getDefault("restorefile", std::string("") );
         if( ! restorefilename.empty() )

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -73,7 +73,7 @@ namespace Opm
         }
 
         // init output writer
-        output_writer_.writeInit( timer, geo_.nnc());
+        output_writer_.writeInit( timer, geo_.nonCartesianConnections());
 
         std::string restorefilename = param_.getDefault("restorefile", std::string("") );
         if( ! restorefilename.empty() )

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -246,10 +246,10 @@ namespace Opm
 
     void
     BlackoilOutputWriter::
-    writeInit(const SimulatorTimerInterface& timer, const NNC& nnc)
+    writeInit(const SimulatorTimerInterface& timer, const NNC& non_cartesian_connections)
     {
         if( eclWriter_ ) {
-            eclWriter_->writeInit(timer, nnc);
+            eclWriter_->writeInit(timer, non_cartesian_connections);
         }
     }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -153,7 +153,7 @@ namespace Opm
         {}
 
         /** \copydoc Opm::OutputWriter::writeInit */
-        void writeInit(const SimulatorTimerInterface& /* timer */, const NNC& nnc)
+        void writeInit(const SimulatorTimerInterface& /* timer */, const NNC& /* non_cartesian_connections */)
         {}
 
         /** \copydoc Opm::OutputWriter::writeTimeStep */
@@ -183,7 +183,7 @@ namespace Opm
         {}
 
         /** \copydoc Opm::OutputWriter::writeInit */
-        void writeInit(const SimulatorTimerInterface& /* timer */, const NNC& nnc)
+        void writeInit(const SimulatorTimerInterface& /* timer */, const NNC& /* non_cartesian_connections */)
         {}
 
         /** \copydoc Opm::OutputWriter::writeTimeStep */
@@ -214,7 +214,7 @@ namespace Opm
                              const double* permeability );
 
         /** \copydoc Opm::OutputWriter::writeInit */
-        void writeInit(const SimulatorTimerInterface &timer, const NNC& nnc);
+        void writeInit(const SimulatorTimerInterface &timer, const NNC& non_cartesian_connections);
 
         /** \copydoc Opm::OutputWriter::writeTimeStep */
         void writeTimeStep(const SimulatorTimerInterface& timer,


### PR DESCRIPTION
The non-cartesian connections are required by the output facilities, while the truly non-neighbour connections (meaning those not in the grid) should be used by all other code.

Test of Norne still running locally, seems ok so far, but this should be tested carefully for both results and performance.