### PR TITLE
Correctly distribute the hydro carbon state for parallel runs.

### DIFF
--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -451,7 +451,7 @@ void distributeGridAndData( Dune::CpGrid& grid,
     // construction does not resize surfacevol and hydroCarbonState. Do it manually.
     distributed_state.surfacevol().resize(grid.numCells()*state.numPhases(),
                                           std::numeric_limits<double>::max());
-    distributed_state.hydroCarbonState().resize(grid.numCells()*state.numPhases());
+    distributed_state.hydroCarbonState().resize(grid.numCells());
     BlackoilStateDataHandle state_handle(global_grid, grid,
                                          state, distributed_state);
     BlackoilPropsDataHandle props_handle(properties,

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -209,9 +209,9 @@ public:
         : sendGrid_(sendGrid), recvGrid_(recvGrid), sendState_(sendState), recvState_(recvState)
     {
         // construction does not resize surfacevol and hydroCarbonState. Do it manually.
-        recvState.surfacevol().resize(grid.numCells()*state.numPhases(),
+        recvState.surfacevol().resize(recvGrid.numCells()*sendState.numPhases(),
                                       std::numeric_limits<double>::max());
-        recvState.hydroCarbonState().resize(grid.numCells());
+        recvState.hydroCarbonState().resize(recvGrid.numCells());
     }
 
     bool fixedsize(int /*dim*/, int /*codim*/)

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -266,7 +266,7 @@ public:
     void scatter(B& buffer, const T& e, std::size_t size_arg)
     {
         assert( T::codimension == 0);
-        assert( size_arg == 2 * recvState_.numPhases() +4+2*recvGrid_.numCellFaces(e.index()));
+        assert( size_arg == 2 * recvState_.numPhases() + 5 +2*recvGrid_.numCellFaces(e.index()));
         static_cast<void>(size_arg);
 
         double val;

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -207,7 +207,12 @@ public:
                             const BlackoilState& sendState,
                             BlackoilState& recvState)
         : sendGrid_(sendGrid), recvGrid_(recvGrid), sendState_(sendState), recvState_(recvState)
-    {}
+    {
+        // construction does not resize surfacevol and hydroCarbonState. Do it manually.
+        recvState.surfacevol().resize(grid.numCells()*state.numPhases(),
+                                      std::numeric_limits<double>::max());
+        recvState.hydroCarbonState().resize(grid.numCells());
+    }
 
     bool fixedsize(int /*dim*/, int /*codim*/)
     {
@@ -448,10 +453,6 @@ void distributeGridAndData( Dune::CpGrid& grid,
                                               distributed_material_law_manager,
                                               grid.numCells());
     BlackoilState distributed_state(grid.numCells(), grid.numFaces(), state.numPhases());
-    // construction does not resize surfacevol and hydroCarbonState. Do it manually.
-    distributed_state.surfacevol().resize(grid.numCells()*state.numPhases(),
-                                          std::numeric_limits<double>::max());
-    distributed_state.hydroCarbonState().resize(grid.numCells());
     BlackoilStateDataHandle state_handle(global_grid, grid,
                                          state, distributed_state);
     BlackoilPropsDataHandle props_handle(properties,


### PR DESCRIPTION
This is needed since hydro carbon state is used to get the
primal variables in PR #687. Therefore we now distribute the
state along with rest of the black oil state variable at the
start of a parallel simulation.

This closes issue #695