### PR TITLE
Prevent dereferencing a null pointer during parallel output.

### DIFF
--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -269,6 +269,9 @@ namespace Opm
                 }
                 else // all other simply send to the I/O rank
                 {
+                    // globalReservoirState will be deferenced even if this rank is not outputting anything
+                    // To prevent dereferencing a nullptr we create an empty container
+                    globalReservoirState_.reset( new SimulationDataContainer( 0, 0, 0));
                     send.insert( ioRank );
                 }
 


### PR DESCRIPTION
ParallelDebugOutput will always dereference its member variable
globalReservoirState_ even if it will not be used for any output.
In g++ this throws when using -D_GLIBCXX_DEBUG -DDEBUG -DGLIBCXX_FORCE_NEW.
I any case we will have a dangling reference into Nirvana in
PackUnPackSimulationDataContainer. This commit fixes this by always
initializing the pointer globalReservoirState_. In the case where the rank
does not perform any output its size will be zero.
This closes #697.