### PR TITLE
Fix incomplete type error for std::ofstream in examples

### DIFF
--- a/examples/sim_2p_comp_reorder.cpp
+++ b/examples/sim_2p_comp_reorder.cpp
@@ -57,7 +57,7 @@
 #include <iostream>
 #include <vector>
 #include <numeric>
-
+#include <fstream>
 
 namespace
 {

--- a/examples/sim_2p_incomp.cpp
+++ b/examples/sim_2p_incomp.cpp
@@ -57,7 +57,7 @@
 #include <iostream>
 #include <vector>
 #include <numeric>
-
+#include <fstream>
 
 namespace
 {

--- a/examples/sim_2p_incomp_ad.cpp
+++ b/examples/sim_2p_incomp_ad.cpp
@@ -57,7 +57,7 @@
 #include <iostream>
 #include <vector>
 #include <numeric>
-
+#include <fstream>
 
 namespace
 {

--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -78,7 +78,7 @@
 #include <iostream>
 #include <vector>
 #include <numeric>
-
+#include <fstream>
 
 namespace
 {


### PR DESCRIPTION
On my system I got
```c++
error: variable ‘std::ofstream file’ has initializer but incomplete type
         std::ofstream file(fname.str().c_str());
```
This is fixed with this commit by including fstream. Previously, this include might have happened implicitely.