### PR TITLE
Ignore linear solver convergence failure.

### DIFF
--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -486,7 +486,7 @@ namespace Opm
             iterations_ = result.iterations;
 
             // Check for failure of linear solver.
-            if (!result.converged) {
+            if (!parameters_.ignoreConvergenceFailure_ && !result.converged) {
                 OPM_THROW(LinearSolverProblem, "Convergence failure for linear solver.");
             }
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -42,6 +42,7 @@ namespace Opm
         int    linear_solver_verbosity_;
         bool   newton_use_gmres_;
         bool   require_full_sparsity_pattern_;
+        bool   ignoreConvergenceFailure_;
 
         NewtonIterationBlackoilInterleavedParameters() { reset(); }
         // read values from parameter class
@@ -57,6 +58,7 @@ namespace Opm
             linear_solver_restart_   = param.getDefault("linear_solver_restart", linear_solver_restart_);
             linear_solver_verbosity_ = param.getDefault("linear_solver_verbosity", linear_solver_verbosity_);
             require_full_sparsity_pattern_ = param.getDefault("require_full_sparsity_pattern", require_full_sparsity_pattern_);
+            ignoreConvergenceFailure_ = param.getDefault("linear_solver_ignoreconvergencefailure", ignoreConvergenceFailure_);
         }
 
         // set default values
@@ -68,6 +70,7 @@ namespace Opm
             linear_solver_restart_   = 40;
             linear_solver_verbosity_ = 0;
             require_full_sparsity_pattern_ = false;
+            ignoreConvergenceFailure_ = false;
         }
     };
 


### PR DESCRIPTION
This PR adds a user flag to allow to ignore the convergence failure of the linear solver. 
For Model 2 this gives a speedup according to totto82.

The default behavior remains unchanged.