### PR TITLE
hack: work around a segmentation fault in flow

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -382,7 +382,7 @@ namespace Opm
                 logFile_ = baseName + ".PRT";
             }
             // Create Parser
-            ParserPtr parser(new Parser());
+            static ParserPtr parser(new Parser());
             {
                 std::shared_ptr<EclipsePRTLog> prtLog = std::make_shared<EclipsePRTLog>(logFile_ , Log::DefaultMessageTypes);
                 std::shared_ptr<StreamLog> streamLog = std::make_shared<StreamLog>(std::cout, Log::DefaultMessageTypes);


### PR DESCRIPTION
this is related to deleting the Opm::Parser object when the shared_ptr
which points to it runs out of scope. On my machine, the segfault only
happened after I pulled the latest master versions of this afternoon
(27th of May, 2016), so the issue seems to be new. I'm aware that this
patch only papers over the symptom of a deeper cause, so I don't
consider it to be a "good" solution in any way. Without it, I get the
following segmentation fault, though:

```
and@heuristix:~/src/opm-simulators|master > ./bin/flow /home/and/src/opm-data/norne/NORNE_ATW2013.DATA
**********************************************************************
*                                                                    *
*                   This is Flow (version 2016.10-pre)               *
*                                                                    *
* Flow is a simulator for fully implicit three-phase black-oil flow, *
*            and is part of OPM. For more information see:           *
*                       http://opm-project.org                       *
*                                                                    *
**********************************************************************

---------------    Reading parameters     ---------------
VFPPROD bhp versus thp not monotonic increasing: 7/4224(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 9/3168(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 1/7296(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 6/15200(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 5/13300(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 11/13300(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 8/13300(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 10/13300(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 15/13680(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 3/15200(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 73/3360(2%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 335/6804(4%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 32/6804(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 54/6804(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 282/6912(4%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 87/6804(1%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 337/6048(5%) elements failed test
ERROR when handling keyword for well C-4H: Cannot open a well where all completions are shut
ERROR when handling keyword for well D-1H: Cannot open a well where all completions are shut
ERROR when handling keyword for well D-1H: Cannot open a well where all completions are shut
ERROR when handling keyword for well E-3AH: Cannot open a well where all completions are shut
ERROR when handling keyword for well D-3AH: Cannot open a well where all completions are shut
ERROR when handling keyword for well E-2H: Cannot open a well where all completions are shut
[heuristix:04932] *** Process received signal ***
[heuristix:04932] Signal: Segmentation fault (11)
[heuristix:04932] Signal code: Address not mapped (1)
[heuristix:04932] Failing at address: 0xfffffffffffffff9
[heuristix:04932] [ 0] /lib/x86_64-linux-gnu/libpthread.so.0(+0x10d10) [0x7fe10babbd10]
[heuristix:04932] [ 1] /lib/x86_64-linux-gnu/libc.so.6(cfree+0x22) [0x7fe109cf17c2]
[heuristix:04932] [ 2] ./bin/flow(_ZN3Opm13ParserKeywordD1Ev+0x1e) [0x1029c78]
[heuristix:04932] [ 3] ./bin/flow(_ZNKSt14default_deleteIKN3Opm13ParserKeywordEEclEPS2_+0x22) [0x1029d12]
[heuristix:04932] [ 4] ./bin/flow(_ZNSt10unique_ptrIKN3Opm13ParserKeywordESt14default_deleteIS2_EED1Ev+0x47) [0x101cfc1]
[heuristix:04932] [ 5] ./bin/flow(_ZSt8_DestroyISt10unique_ptrIKN3Opm13ParserKeywordESt14default_deleteIS3_EEEvPT_+0x18) [0x100fb81]
[heuristix:04932] [ 6] ./bin/flow(_ZNSt12_Destroy_auxILb0EE9__destroyIPSt10unique_ptrIKN3Opm13ParserKeywordESt14default_deleteIS5_EEEEvT_SA_+0x2e) [0x100284f]
[heuristix:04932] [ 7] ./bin/flow(_ZSt8_DestroyIPSt10unique_ptrIKN3Opm13ParserKeywordESt14default_deleteIS3_EEEvT_S8_+0x23) [0xfec926]
[heuristix:04932] [ 8] ./bin/flow(_ZSt8_DestroyIPSt10unique_ptrIKN3Opm13ParserKeywordESt14default_deleteIS3_EES6_EvT_S8_RSaIT0_E+0x27) [0xfd2fa9]
[heuristix:04932] [ 9] ./bin/flow(_ZNSt6vectorISt10unique_ptrIKN3Opm13ParserKeywordESt14default_deleteIS3_EESaIS6_EED1Ev+0x35) [0xfbb72f]
[heuristix:04932] [10] ./bin/flow(_ZN3Opm6ParserD1Ev+0x38) [0xfa6fe6]
[heuristix:04932] [11] ./bin/flow(_ZNSt15_Sp_counted_ptrIPN3Opm6ParserELN9__gnu_cxx12_Lock_policyE2EE10_M_disposeEv+0x22) [0x106dcee]
[heuristix:04932] [12] ./bin/flow(_ZNSt16_Sp_counted_baseILN9__gnu_cxx12_Lock_policyE2EE10_M_releaseEv+0x42) [0xf54080]
[heuristix:04932] [13] ./bin/flow(_ZNSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EED1Ev+0x27) [0xf49901]
[heuristix:04932] [14] ./bin/flow(_ZNSt12__shared_ptrIN3Opm6ParserELN9__gnu_cxx12_Lock_policyE2EED1Ev+0x1c) [0xf63438]
[heuristix:04932] [15] ./bin/flow(_ZNSt10shared_ptrIN3Opm6ParserEED1Ev+0x18) [0xf63454]
[heuristix:04932] [16] ./bin/flow(_ZN3Opm12FlowMainBaseINS_8FlowMainI16UnstructuredGridNS_30SimulatorFullyImplicitBlackoilIS2_EEEES2_S4_E13readDeckInputEv+0xa2b) [0xf6412f]
[heuristix:04932] [17] ./bin/flow(_ZN3Opm12FlowMainBaseINS_8FlowMainI16UnstructuredGridNS_30SimulatorFullyImplicitBlackoilIS2_EEEES2_S4_E7executeEiPPc+0xa8) [0xf51848]
[heuristix:04932] [18] ./bin/flow(main+0x55) [0xf2a921]
[heuristix:04932] [19] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0) [0x7fe109c8dac0]
[heuristix:04932] [20] ./bin/flow(_start+0x29) [0xf27ee9]
[heuristix:04932] *** End of error message ***
Segmentation fault (core dumped)
```

(this happens with both, debug and optimized compiler flags on GCC
5.2.1, kubuntu 15.10)