### PR TITLE
Make CPR preconditioner honor linear_solver_ignoreconvergencefailure

### DIFF
--- a/opm/autodiff/NewtonIterationBlackoilCPR.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -63,7 +63,7 @@ namespace Opm
         linear_solver_maxiter_( param.getDefault("linear_solver_maxiter", 50 ) ),
         linear_solver_restart_( param.getDefault("linear_solver_restart", 40 ) ),
         linear_solver_verbosity_( param.getDefault("linear_solver_verbosity", 0 )),
-	ignoreConvergenceFailure_(param.getDefault("linear_solver_ignoreconvergencefailure", ignoreConvergenceFailure_))
+        ignoreConvergenceFailure_(param.getDefault("linear_solver_ignoreconvergencefailure", ignoreConvergenceFailure_))
     {
     }
 

--- a/opm/autodiff/NewtonIterationBlackoilCPR.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -63,7 +63,7 @@ namespace Opm
         linear_solver_maxiter_( param.getDefault("linear_solver_maxiter", 50 ) ),
         linear_solver_restart_( param.getDefault("linear_solver_restart", 40 ) ),
         linear_solver_verbosity_( param.getDefault("linear_solver_verbosity", 0 )),
-        linear_solver_ignoreconvergencefailure_(param.getDefault("linear_solver_ignoreconvergencefailure", ignoreConvergenceFailure_))
+        linear_solver_ignoreconvergencefailure_(param.getDefault("linear_solver_ignoreconvergencefailure", false))
     {
     }
 

--- a/opm/autodiff/NewtonIterationBlackoilCPR.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -63,7 +63,7 @@ namespace Opm
         linear_solver_maxiter_( param.getDefault("linear_solver_maxiter", 50 ) ),
         linear_solver_restart_( param.getDefault("linear_solver_restart", 40 ) ),
         linear_solver_verbosity_( param.getDefault("linear_solver_verbosity", 0 )),
-        ignoreConvergenceFailure_(param.getDefault("linear_solver_ignoreconvergencefailure", ignoreConvergenceFailure_))
+        linear_solver_ignoreconvergencefailure_(param.getDefault("linear_solver_ignoreconvergencefailure", ignoreConvergenceFailure_))
     {
     }
 
@@ -168,7 +168,7 @@ namespace Opm
         iterations_ = result.iterations;
 
         // Check for failure of linear solver.
-        if (!result.converged && !ignoreConvergenceFailure_) {
+        if (!result.converged && !linear_solver_ignoreconvergencefailure_) {
             OPM_THROW(LinearSolverProblem, "Convergence failure for linear solver.");
         }
 

--- a/opm/autodiff/NewtonIterationBlackoilCPR.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -62,7 +62,8 @@ namespace Opm
         linear_solver_reduction_( param.getDefault("linear_solver_reduction", 1e-2 ) ),
         linear_solver_maxiter_( param.getDefault("linear_solver_maxiter", 50 ) ),
         linear_solver_restart_( param.getDefault("linear_solver_restart", 40 ) ),
-        linear_solver_verbosity_( param.getDefault("linear_solver_verbosity", 0 ))
+        linear_solver_verbosity_( param.getDefault("linear_solver_verbosity", 0 )),
+	ignoreConvergenceFailure_(param.getDefault("linear_solver_ignoreconvergencefailure", ignoreConvergenceFailure_))
     {
     }
 
@@ -167,7 +168,7 @@ namespace Opm
         iterations_ = result.iterations;
 
         // Check for failure of linear solver.
-        if (!result.converged) {
+        if (!result.converged && !ignoreConvergenceFailure_) {
             OPM_THROW(LinearSolverProblem, "Convergence failure for linear solver.");
         }
 

--- a/opm/autodiff/NewtonIterationBlackoilCPR.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.hpp
@@ -128,7 +128,7 @@ namespace Opm
         const int    linear_solver_maxiter_;
         const int    linear_solver_restart_;
         const int    linear_solver_verbosity_;
-        const bool   ignoreConvergenceFailure_;
+        const bool   linear_solver_ignoreconvergencefailure_;
     };
 
 } // namespace Opm

--- a/opm/autodiff/NewtonIterationBlackoilCPR.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilCPR.hpp
@@ -128,6 +128,7 @@ namespace Opm
         const int    linear_solver_maxiter_;
         const int    linear_solver_restart_;
         const int    linear_solver_verbosity_;
+        const bool   ignoreConvergenceFailure_;
     };
 
 } // namespace Opm


### PR DESCRIPTION
This is a follow up to PR #700 which only covered ILU as a preconditioner