### PR TITLE
Adds has_disgas and has_vapoil flags to hydrocarbonstate initialization

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -552,7 +552,9 @@ namespace Opm
                 props.capPress(numCells, state_->saturation().data(), cells.data(), pc.data(), nullptr);
                 fluidprops_->setSwatInitScaling(state_->saturation(), pc);
             }
-            initHydroCarbonState(*state_, pu, Opm::UgGridHelpers::numCells(grid));
+            initHydroCarbonState(*state_, pu, Opm::UgGridHelpers::numCells(grid), deck_->hasKeyword("DISGAS"), deck_->hasKeyword("VAPOIL"));
+
+
         }
 
 

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -87,7 +87,7 @@ namespace Opm
         if (output_writer_.isRestart()) {
             // This is a restart, populate WellState and ReservoirState state objects from restart file
             output_writer_.initFromRestartFile(props_.phaseUsage(), props_.permeability(), grid_, state, prev_well_state);
-            initHydroCarbonState(state, props_.phaseUsage(), Opm::UgGridHelpers::numCells(grid_));
+            initHydroCarbonState(state, props_.phaseUsage(), Opm::UgGridHelpers::numCells(grid_), has_disgas_, has_vapoil_);
         }
 
         // Create timers and file for writing timing info.


### PR DESCRIPTION
Gas saturation is used as primal variable if DISGAS and VAPOIL is
not activated. 
Needs OPM/opm-core#1025

