### PR TITLE
Fix the parallel L-infinity norm calculation.

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1104,7 +1104,7 @@ namespace detail {
                 const ParallelISTLInformation& real_info =
                     boost::any_cast<const ParallelISTLInformation&>(pinfo);
                 double result=0;
-                real_info.computeReduction(a.value(), Reduction::makeGlobalMaxFunctor<double>(), result);
+                real_info.computeReduction(a.value(), Reduction::makeLInfinityNormFunctor<double>(), result);
                 return result;
             }
             else


### PR DESCRIPTION
It was computing a global maximum before, which obviously is not the same thing. Therefore this really fixes a bug that I probably should have noticed a long time ago. Well, better late than never.

This needs PR OPM/opm-core#1026 to be merged first!