### PR TITLE
Print all well switching in parallel.

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -745,7 +745,7 @@ namespace detail {
 
         // Possibly switch well controls and updating well state to
         // get reasonable initial conditions for the wells
-        asImpl().wellModel().updateWellControls(terminal_output_, well_state);
+        asImpl().wellModel().updateWellControls(well_state);
 
         // Create the primary variables.
         SolutionState state = asImpl().variableState(reservoir_state, well_state);
@@ -1034,7 +1034,7 @@ namespace detail {
                 const Eigen::VectorXd& dx = solver.solve(total_residual_v.matrix());
                 assert(dx.size() == total_residual_v.size());
                 asImpl().wellModel().updateWellState(dx.array(), dpMaxRel(), well_state);
-                asImpl().wellModel().updateWellControls(terminal_output_, well_state);
+                asImpl().wellModel().updateWellControls(well_state);
             }
         } while (it < 15);
 

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -147,7 +147,7 @@ namespace Opm {
 
         // Possibly switch well controls and updating well state to
         // get reasonable initial conditions for the wells
-        wellModel().updateWellControls(terminal_output_, well_state);
+        wellModel().updateWellControls(well_state);
 
         // Create the primary variables.
         SolutionState state = asImpl().variableState(reservoir_state, well_state);

--- a/opm/autodiff/MultisegmentWells.hpp
+++ b/opm/autodiff/MultisegmentWells.hpp
@@ -193,8 +193,7 @@ namespace Opm {
 
             template <class WellState>
             void
-            updateWellControls(const bool terminal_output,
-                               WellState& xw) const;
+            updateWellControls(WellState& xw) const;
 
             // TODO: these code are same with the StandardWells
             // to find a better solution later.

--- a/opm/autodiff/MultisegmentWells_impl.hpp
+++ b/opm/autodiff/MultisegmentWells_impl.hpp
@@ -822,8 +822,7 @@ namespace Opm
     template <class WellState>
     void
     MultisegmentWells::
-    updateWellControls(const bool terminal_output,
-                       WellState& xw) const
+    updateWellControls(WellState& xw) const
     {
         if( msWells().empty() ) return ;
 
@@ -860,12 +859,10 @@ namespace Opm
 
             if (ctrl_index != nwc) {
                 // Constraint number ctrl_index was broken, switch to it.
-                if (terminal_output)
-                {
-                    std::cout << "Switching control mode for well " << msWells()[w]->name()
-                              << " from " << modestring[well_controls_iget_type(wc, current)]
-                              << " to " << modestring[well_controls_iget_type(wc, ctrl_index)] << std::endl;
-                }
+                // Each well is only active on one process. Therefore we always print the sitch info.
+                std::cout << "Switching control mode for well " << msWells()[w]->name()
+                          << " from " << modestring[well_controls_iget_type(wc, current)]
+                          << " to " << modestring[well_controls_iget_type(wc, ctrl_index)] << std::endl;
                 xw.currentControls()[w] = ctrl_index;
                 current = xw.currentControls()[w];
             }

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -115,8 +115,7 @@ namespace Opm {
                                  WellState& well_state);
 
             template <class WellState>
-            void updateWellControls(const bool terminal_output,
-                                    WellState& xw) const;
+            void updateWellControls(WellState& xw) const;
 
             // TODO: should LinearisedBlackoilResidual also be a template class?
             template <class SolutionState>

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -682,8 +682,7 @@ namespace Opm
     template <class WellState>
     void
     StandardWells::
-    updateWellControls(const bool terminal_output,
-                       WellState& xw) const
+    updateWellControls(WellState& xw) const
     {
         if( !localWellsActive() ) return ;
 
@@ -720,14 +719,13 @@ namespace Opm
             }
             if (ctrl_index != nwc) {
                 // Constraint number ctrl_index was broken, switch to it.
-                if (terminal_output)
-                {
-                    std::ostringstream ss;
-                    ss << "Switching control mode for well " << wells().name[w]
-                       << " from " << modestring[well_controls_iget_type(wc, current)]
-                       << " to " << modestring[well_controls_iget_type(wc, ctrl_index)] << std::endl;
-                    OpmLog::info(ss.str());
-                }
+                // We disregard terminal_ouput here as with it only messages
+                // for wells on one process will be printed.
+                std::ostringstream ss;
+                ss << "Switching control mode for well " << wells().name[w]
+                   << " from " << modestring[well_controls_iget_type(wc, current)]
+                   << " to " << modestring[well_controls_iget_type(wc, ctrl_index)] << std::endl;
+                OpmLog::info(ss.str());
                 xw.currentControls()[w] = ctrl_index;
                 current = xw.currentControls()[w];
             }

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -499,7 +499,7 @@ namespace Opm {
         // Possibly switch well controls and updating well state to
         // get reasonable initial conditions for the wells
         // updateWellControls(well_state);
-        wellModel().updateWellControls(terminal_output_, well_state);
+        wellModel().updateWellControls(well_state);
 
         // Create the primary variables.
         SolutionState state = variableState(reservoir_state, well_state);


### PR DESCRIPTION
As for each well only one process is responsible, the output process
does not see all wells. Ergo some well switching information was never
printed in a parallel run.

Therefore with this commit the well switching
message is printed regardless on which process it appears.