### PR TITLE
Allow for 2 phase initialization using EQUIL

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -519,7 +519,7 @@ namespace Opm
                         gor[c] = surface_vol[ c * numPhases + pu.phase_pos[Gas]] / surface_vol[ c * numPhases + pu.phase_pos[Oil]];
                     }
                 }
-            } else if (deck_->hasKeyword("EQUIL") && props.numPhases() == 3) {
+            } else if (deck_->hasKeyword("EQUIL")) {
                 // Which state class are we really using - what a f... mess?
                 state_.reset( new ReservoirState( Opm::UgGridHelpers::numCells(grid),
                                                   Opm::UgGridHelpers::numFaces(grid),


### PR DESCRIPTION
Remove guard against 2 phase cases for EQUIL initialization. 

Depends on OPM/opm-core#1027 

