### PR TITLE
local -> cartesian active to writeInit, not ctor

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -250,7 +250,11 @@ namespace Opm
     writeInit(const NNC& nnc)
     {
         if( eclWriter_ ) {
-            eclWriter_->writeInit( nnc );
+
+            auto cells = parallelOutput_ ? parallelOutput_->numCells() : 0;
+            auto* activeCells = parallelOutput_ ? parallelOutput_->globalCell() : nullptr;
+
+            eclWriter_->writeInit( nnc, cells, activeCells );
         }
     }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -29,7 +29,6 @@
 #include <opm/core/utility/miscUtilities.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 
-#include <opm/output/OutputWriter.hpp>
 #include <opm/output/eclipse/EclipseWriter.hpp>
 
 #include <opm/autodiff/GridHelpers.hpp>
@@ -297,9 +296,7 @@ namespace Opm
                      new BlackoilMatlabWriter< Grid >( grid, outputDir_ ) : 0 ),
         eclWriter_( output_ && parallelOutput_->isIORank() &&
                     param.getDefault("output_ecl", true) ?
-                    new EclipseWriter(eclipseState,
-                                      parallelOutput_->numCells(),
-                                      parallelOutput_->globalCell() )
+                    new EclipseWriter(eclipseState)
                    : 0 ),
         eclipseState_(eclipseState),
         asyncOutput_()


### PR DESCRIPTION
A change in opm-output's interface mandates that this information is
passed to writeInit, not to the EclipseWriter constructor.

See https://github.com/OPM/opm-output/pull/39