### PR TITLE
Well shared_ptr alias deprecated

### DIFF
--- a/opm/autodiff/MultisegmentWells.cpp
+++ b/opm/autodiff/MultisegmentWells.cpp
@@ -141,7 +141,7 @@ namespace Opm {
 
     MultisegmentWells::
     MultisegmentWells(const Wells* wells_arg,
-                      const std::vector<WellConstPtr>& wells_ecl,
+                      const std::vector< const Well* >& wells_ecl,
                       const int time_step)
       : wells_multisegment_( createMSWellVector(wells_arg, wells_ecl, time_step) )
       , wops_ms_(wells_multisegment_)
@@ -179,7 +179,7 @@ namespace Opm {
 
     std::vector<WellMultiSegmentConstPtr>
     MultisegmentWells::createMSWellVector(const Wells* wells_arg,
-                                          const std::vector<WellConstPtr>& wells_ecl,
+                                          const std::vector< const Well* >& wells_ecl,
                                           const int time_step)
     {
         std::vector<WellMultiSegmentConstPtr> wells_multisegment;

--- a/opm/autodiff/MultisegmentWells.hpp
+++ b/opm/autodiff/MultisegmentWells.hpp
@@ -83,11 +83,11 @@ namespace Opm {
             // TODO: using a vector of WellMultiSegmentConstPtr for now
             // TODO: it should use const Wells or something else later.
             MultisegmentWells(const Wells* wells_arg,
-                              const std::vector<WellConstPtr>& wells_ecl,
+                              const std::vector< const Well* >& wells_ecl,
                               const int time_step);
 
             std::vector<WellMultiSegmentConstPtr> createMSWellVector(const Wells* wells_arg,
-                                                                     const std::vector<WellConstPtr>& wells_ecl,
+                                                                     const std::vector< const Well* >& wells_ecl,
                                                                      const int time_step);
 
             void init(const BlackoilPropsAdInterface* fluid_arg,

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -257,14 +257,14 @@ namespace Opm
     }
 
     namespace SimFIBODetails {
-        typedef std::unordered_map<std::string, WellConstPtr> WellMap;
+        typedef std::unordered_map<std::string, const Well* > WellMap;
 
         inline WellMap
-        mapWells(const std::vector<WellConstPtr>& wells)
+        mapWells(const std::vector< const Well* >& wells)
         {
             WellMap wmap;
 
-            for (std::vector<WellConstPtr>::const_iterator
+            for (std::vector< const Well* >::const_iterator
                      w = wells.begin(), e = wells.end();
                  w != e; ++w)
             {
@@ -306,7 +306,7 @@ namespace Opm
             WellMap::const_iterator i = wmap.find(name);
 
             if (i != wmap.end()) {
-                WellConstPtr wp = i->second;
+                const Well* wp = i->second;
 
                 match = (wp->isProducer(step) &&
                          wp->getProductionProperties(step)
@@ -428,7 +428,7 @@ namespace Opm
     {
         typedef SimFIBODetails::WellMap WellMap;
 
-        const std::vector<WellConstPtr>& w_ecl = eclipse_state_->getSchedule()->getWells(step);
+        const auto w_ecl = eclipse_state_->getSchedule()->getWells(step);
         const WellMap& wmap = SimFIBODetails::mapWells(w_ecl);
 
         const std::vector<int>& resv_wells = SimFIBODetails::resvWells(wells, step, wmap);
@@ -506,7 +506,7 @@ namespace Opm
                     WellMap::const_iterator i = wmap.find(wells->name[*rp]);
 
                     if (i != wmap.end()) {
-                        WellConstPtr wp = i->second;
+                        const auto* wp = i->second;
 
                         const WellProductionProperties& p =
                             wp->getProductionProperties(step);
@@ -563,7 +563,7 @@ namespace Opm
                 if (!is_producer && wells->name[w] != 0) {
                     WellMap::const_iterator i = wmap.find(wells->name[w]);
                     if (i != wmap.end()) {
-                        WellConstPtr wp = i->second;
+                        const auto* wp = i->second;
                         const WellInjectionProperties& injector = wp->getInjectionProperties(step);
                         if (!injector.predictionMode) {
                             //History matching WCONINJEH

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -114,7 +114,7 @@ namespace Opm
             WellState well_state;
             // well_state.init(wells, state, prev_well_state);
 
-            const std::vector<WellConstPtr>& wells_ecl = eclipse_state_->getSchedule()->getWells(timer.currentStepNum());
+            const auto wells_ecl = eclipse_state_->getSchedule()->getWells(timer.currentStepNum());
             const int current_time_step = timer.currentStepNum();
 
             const WellModel well_model(wells, wells_ecl, current_time_step);

--- a/opm/autodiff/WellMultiSegment.cpp
+++ b/opm/autodiff/WellMultiSegment.cpp
@@ -26,7 +26,7 @@
 namespace Opm
 {
 
-    WellMultiSegment::WellMultiSegment(WellConstPtr well, size_t time_step, const Wells* wells) {
+    WellMultiSegment::WellMultiSegment(const Well* well, size_t time_step, const Wells* wells) {
         m_well_name_ = well->name();
         if (well->isMultiSegment(time_step)) {
             initMultiSegmentWell(well, time_step, wells);
@@ -36,7 +36,7 @@ namespace Opm
         updateWellOps();
     }
 
-    void WellMultiSegment::initMultiSegmentWell(WellConstPtr well, size_t time_step, const Wells* wells) {
+    void WellMultiSegment::initMultiSegmentWell(const Well* well, size_t time_step, const Wells* wells) {
 
         CompletionSetConstPtr completion_set = well->getCompletions(time_step);
 
@@ -169,7 +169,7 @@ namespace Opm
 
     }
 
-    void WellMultiSegment::initNonMultiSegmentWell(WellConstPtr well, size_t time_step, const Wells* wells) {
+    void WellMultiSegment::initNonMultiSegmentWell(const Well* well, size_t time_step, const Wells* wells) {
 
         CompletionSetConstPtr completion_set = well->getCompletions(time_step);
 

--- a/opm/autodiff/WellMultiSegment.hpp
+++ b/opm/autodiff/WellMultiSegment.hpp
@@ -54,7 +54,7 @@ namespace Opm
         /// \param[in]       well information from EclipseState
         /// \param[in]       current time step
         /// \param[in[       pointer to Wells structure, to be removed eventually
-        WellMultiSegment(WellConstPtr well, size_t time_step, const Wells* wells);
+        WellMultiSegment(const Well* well, size_t time_step, const Wells* wells);
 
         /// Well name.
         const std::string& name() const;
@@ -146,8 +146,8 @@ namespace Opm
     private:
         // for the moment, we use the information from wells.
         // TODO: remove the dependency on wells from opm-core.
-        void initMultiSegmentWell(WellConstPtr well, size_t time_step, const Wells* wells);
-        void initNonMultiSegmentWell(WellConstPtr well, size_t time_step, const Wells* wells);
+        void initMultiSegmentWell(const Well* well, size_t time_step, const Wells* wells);
+        void initNonMultiSegmentWell(const Well* well, size_t time_step, const Wells* wells);
         void updateWellOps();
 
     private:

--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer_impl.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer_impl.hpp
@@ -185,13 +185,13 @@ namespace Opm
         setupCompressedToCartesian(global_cell, number_of_cells,
                                    cartesian_to_compressed);
 
-        ScheduleConstPtr          schedule = eclipseState->getSchedule();
-        std::vector<WellConstPtr> wells    = schedule->getWells(timeStep);
+        ScheduleConstPtr schedule = eclipseState->getSchedule();
+        auto wells       = schedule->getWells(timeStep);
 
         int well_index = 0;
 
         for (auto wellIter= wells.begin(); wellIter != wells.end(); ++wellIter) {
-             WellConstPtr well = (*wellIter);
+             const auto* well = (*wellIter);
 
              if (well->getStatus(timeStep) == WellCommon::SHUT) {
                  continue;

--- a/tests/test_multisegmentwells.cpp
+++ b/tests/test_multisegmentwells.cpp
@@ -104,7 +104,7 @@ struct SetupMSW {
                                         false);
 
         const Wells* wells = wells_manager.c_wells();
-        const std::vector<Opm::WellConstPtr>& wells_ecl = ecl_state->getSchedule()->getWells(current_timestep);
+        const auto wells_ecl = ecl_state->getSchedule()->getWells(current_timestep);
 
         ms_wells.reset(new Opm::MultisegmentWells(wells, wells_ecl, current_timestep));
     };


### PR DESCRIPTION
The shared_ptr aliasing is deprecated, and in the Well case this has
been removed upstream.

Upstream. https://github.com/OPM/opm-parser/pull/849