### PR TITLE
Use const reference parameters for prepareStep()

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -164,8 +164,8 @@ namespace Opm {
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         void prepareStep(const double dt,
-                         ReservoirState& reservoir_state,
-                         WellState& well_state);
+                         const ReservoirState& reservoir_state,
+                         const WellState& well_state);
 
         /// Called once per nonlinear iteration.
         /// This model will perform a Newton-Raphson update, changing reservoir_state

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -258,8 +258,8 @@ namespace detail {
     void
     BlackoilModelBase<Grid, WellModel, Implementation>::
     prepareStep(const double dt,
-                ReservoirState& reservoir_state,
-                WellState& /* well_state */)
+                const ReservoirState& reservoir_state,
+                const WellState& /* well_state */)
     {
         pvdt_ = geo_.poreVolume() / dt;
         if (active_[Gas]) {

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -97,8 +97,8 @@ namespace Opm {
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         void prepareStep(const double dt,
-                         ReservoirState& reservoir_state,
-                         WellState& well_state);
+                         const ReservoirState& reservoir_state,
+                         const WellState& well_state);
 
 
         /// Assemble the residual and Jacobian of the nonlinear system.

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -81,8 +81,8 @@ namespace Opm {
     void
     BlackoilMultiSegmentModel<Grid>::
     prepareStep(const double dt,
-                ReservoirState& reservoir_state,
-                WellState& well_state)
+                const ReservoirState& reservoir_state,
+                const WellState& well_state)
     {
         pvdt_ = geo_.poreVolume() / dt;
         if (active_[Gas]) {

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -97,8 +97,8 @@ namespace Opm {
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         void prepareStep(const double dt,
-                         ReservoirState& reservoir_state,
-                         WellState& well_state);
+                         const ReservoirState& reservoir_state,
+                         const WellState& well_state);
 
         /// Called once after each time step.
         /// \param[in] dt                     time step size

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -122,8 +122,8 @@ namespace Opm {
     void
     BlackoilPolymerModel<Grid>::
     prepareStep(const double dt,
-                ReservoirState& reservoir_state,
-                WellState& well_state)
+                const ReservoirState& reservoir_state,
+                const WellState& well_state)
     {
         Base::prepareStep(dt, reservoir_state, well_state);
         auto& max_concentration = reservoir_state.getCellData( reservoir_state.CMAX );


### PR DESCRIPTION
A minor fix with no changes to behavior. Will self-merge when tests are green unless someone objects.