### PR TITLE
Add use_update_stabilization parameter.

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -299,20 +299,22 @@ namespace detail {
             // Compute the nonlinear update.
             V dx = asImpl().solveJacobianSystem();
 
-            // Stabilize the nonlinear update.
-            bool isOscillate = false;
-            bool isStagnate = false;
-            nonlinear_solver.detectOscillations(residual_norms_history_, iteration, isOscillate, isStagnate);
-            if (isOscillate) {
-                current_relaxation_ -= nonlinear_solver.relaxIncrement();
-                current_relaxation_ = std::max(current_relaxation_, nonlinear_solver.relaxMax());
-                if (terminalOutputEnabled()) {
-                    std::string msg = " Oscillating behavior detected: Relaxation set to "
-                        + std::to_string(current_relaxation_);
-                    OpmLog::info(msg);
+            if (param_.use_update_stabilization_) {
+                // Stabilize the nonlinear update.
+                bool isOscillate = false;
+                bool isStagnate = false;
+                nonlinear_solver.detectOscillations(residual_norms_history_, iteration, isOscillate, isStagnate);
+                if (isOscillate) {
+                    current_relaxation_ -= nonlinear_solver.relaxIncrement();
+                    current_relaxation_ = std::max(current_relaxation_, nonlinear_solver.relaxMax());
+                    if (terminalOutputEnabled()) {
+                        std::string msg = " Oscillating behavior detected: Relaxation set to "
+                            + std::to_string(current_relaxation_);
+                        OpmLog::info(msg);
+                    }
                 }
+                nonlinear_solver.stabilizeNonlinearUpdate(dx, dx_old_, current_relaxation_);
             }
-            nonlinear_solver.stabilizeNonlinearUpdate(dx, dx_old_, current_relaxation_);
 
             // Apply the update, applying model-dependent
             // limitations and chopping of the update.

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -49,6 +49,7 @@ namespace Opm
         solve_welleq_initially_ = param.getDefault("solve_welleq_initially",solve_welleq_initially_);
         update_equations_scaling_ = param.getDefault("update_equations_scaling", update_equations_scaling_);
         compute_well_potentials_ = param.getDefault("compute_well_potentials", compute_well_potentials_);
+        use_update_stabilization_ = param.getDefault("use_update_stabilization", use_update_stabilization_);
     }
 
 
@@ -67,6 +68,7 @@ namespace Opm
         solve_welleq_initially_ = true;
         update_equations_scaling_ = false;
         compute_well_potentials_ = false;
+        use_update_stabilization_ = true;
     }
 
 

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -53,6 +53,9 @@ namespace Opm
         /// controlled wells
         bool compute_well_potentials_;
 
+        /// Try to detect oscillation or stagnation.
+        bool use_update_stabilization_;
+
         /// Construct from user parameters or defaults.
         explicit BlackoilModelParameters( const parameter::ParameterGroup& param );
 


### PR DESCRIPTION
This makes it easier to run without, for example for debugging. The default is 'true', preserving existing behaviour.

Again, unless objected to I intend to self-merge this fairly quickly after the tests are green.