### PR TITLE
Refine nonlinear solver interface

### DIFF
--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -76,12 +76,29 @@ namespace Opm {
 
         /// Take a single forward step, after which the states will be modified
         /// according to the physical model.
-        /// \param[in] dt                time step size
-        /// \param[in] reservoir_state   reservoir state variables
-        /// \param[in] well_state        well state variables
-        /// \return                      number of linear iterations used
+        /// \param[in] dt                       time step size
+        /// \param[in, out] reservoir_state     reservoir state variables
+        /// \param[in, out] well_state          well state variables
+        /// \return                             number of linear iterations used
         int
         step(const double dt,
+             ReservoirState& reservoir_state,
+             WellState& well_state);
+
+        /// Take a single forward step, after which the states will be modified
+        /// according to the physical model. This version allows for the
+        /// states passed as in/out arguments to be different from the initial
+        /// states.
+        /// \param[in] dt                       time step size
+        /// \param[in] initial_reservoir_state  reservoir state variables at start of timestep
+        /// \param[in] initial_well_state       well state variables at start of timestep
+        /// \param[in, out] reservoir_state     reservoir state variables
+        /// \param[in, out] well_state          well state variables
+        /// \return                             number of linear iterations used
+        int
+        step(const double dt,
+             const ReservoirState& initial_reservoir_state,
+             const WellState& initial_well_state,
              ReservoirState& reservoir_state,
              WellState& well_state);
 

--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -100,6 +100,9 @@ namespace Opm {
         /// Reference to physical model.
         const PhysicalModel& model() const;
 
+        /// Mutable reference to physical model.
+        PhysicalModel& model();
+
         /// Detect oscillation or stagnation in a given residual history.
         void detectOscillations(const std::vector<std::vector<double>>& residual_history,
                                 const int it, bool& oscillate, bool& stagnate) const;

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -61,6 +61,12 @@ namespace Opm
     }
 
     template <class PhysicalModel>
+    PhysicalModel& NonlinearSolver<PhysicalModel>::model()
+    {
+        return *model_;
+    }
+
+    template <class PhysicalModel>
     unsigned int NonlinearSolver<PhysicalModel>::nonlinearIterationsLastStep() const
     {
         return nonlinearIterationsLast_;

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -86,8 +86,22 @@ namespace Opm
          ReservoirState& reservoir_state,
          WellState& well_state)
     {
+        return step(dt, reservoir_state, well_state, reservoir_state, well_state);
+    }
+
+
+
+    template <class PhysicalModel>
+    int
+    NonlinearSolver<PhysicalModel>::
+    step(const double dt,
+         const ReservoirState& initial_reservoir_state,
+         const WellState& initial_well_state,
+         ReservoirState& reservoir_state,
+         WellState& well_state)
+    {
         // Do model-specific once-per-step calculations.
-        model_->prepareStep(dt, reservoir_state, well_state);
+        model_->prepareStep(dt, initial_reservoir_state, initial_well_state);
 
         int iteration = 0;
 


### PR DESCRIPTION
Adds a mutable `model()` accessor and more importantly, a new `step()` method that allows us to separate the concepts of initial state (start of timestep) and starting state for iterations.

Will self-merge after tests are green unless objected to.