### PR TITLE
Write TRAN? to the INIT file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,5 +149,11 @@ if (HAVE_OPM_DATA)
     set_tests_properties(compare_restart_files PROPERTIES DEPENDS flow_SPE1CASE2_restart) # Compares the restart files from tests flow_SPE1CASE2_restart and flow_SPE1CASE2
 
     add_test( NAME flow_sequential_SPE1 COMMAND flow_sequential ${OPM_DATA_ROOT}/spe1/SPE1CASE1.DATA )
+    if (ERT_PYTHON_PATH)
+        include(OpmPythonTest)
+
+        opm_add_python_test( check_INIT_SPE1 ${PROJECT_SOURCE_DIR}/tests/compare_INIT.py $<TARGET_FILE:flow> ${OPM_DATA_ROOT}/spe1/SPE1CASE1.DATA ${OPM_DATA_ROOT}/spe1/eclipse-simulation/SPE1CASE1.INIT TRANX TRANY TRANZ PORO PORV PERMX )
+        opm_add_python_test( check_INIT_NORNE ${PROJECT_SOURCE_DIR}/tests/compare_INIT.py $<TARGET_FILE:flow> ${OPM_DATA_ROOT}/norne/NORNE_ATW2013.DATA ${OPM_DATA_ROOT}/norne/ECL.2014.2/NORNE_ATW2013.INIT PORO PORV PERMX )
+    endif()
 
 endif()

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -746,7 +746,7 @@ namespace Opm
                     fullReport.reportParam(tot_os);
                 }
             } else {
-                output_writer_->writeInit();
+                output_writer_->writeInit(geoprops_->simProps(grid_init_->grid()) , geoprops_->nonCartesianConnections( ));
                 if (output_cout_) {
                     std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;
                 }

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -111,59 +111,8 @@ namespace Opm
         }
 
 
-        /// This code block is used to initialize grid properties TRANX, TRANY
-        /// and TRANZ which will be written to the INIT file. These properties
-        /// should be interpreted with a 'the-grid-is-nearly-cartesian'
-        /// mindset:
-        ///
-        ///   TRANX[i,j,k] = T on face between cells (i,j,k) and (i+1,j  ,k  )
-        ///   TRANY[i,j,k] = T on face between cells (i,j,k) and (i  ,j+1,k  )
-        ///   TRANZ[i,j,k] = T on face between cells (i,j,k) and (i  ,j  ,k+1)
-        ///
-        /// If the grid structure has no resemblance to a cartesian grid the
-        /// whole TRAN keyword is quite meaningless.
 
-        {
-            using namespace UgGridHelpers;
-            const int* dims = cartDims( grid_ );
-            const int globalSize = dims[0] * dims[1] * dims[2];
-            const auto& trans = geo_.transmissibility( );
-
-            data::CellData tranx = {"TRANX" , UnitSystem::measure::transmissibility, std::vector<double>( globalSize )};
-            data::CellData trany = {"TRANY" , UnitSystem::measure::transmissibility, std::vector<double>( globalSize )};
-            data::CellData tranz = {"TRANZ" , UnitSystem::measure::transmissibility, std::vector<double>( globalSize )};
-
-            size_t num_faces = numFaces(grid_);
-            auto fc = faceCells(grid_);
-            for (size_t i = 0; i < num_faces; ++i) {
-                auto c1 = std::min( fc(i,0) , fc(i,1));
-                auto c2 = std::max( fc(i,0) , fc(i,1));
-
-                if (c1 == -1 || c2 == -1)
-                    continue;
-
-                c1 = globalCell(grid_) ? globalCell(grid_)[c1] : c1;
-                c2 = globalCell(grid_) ? globalCell(grid_)[c2] : c2;
-
-                if ((c2 - c1) == 1) {
-                    tranx.data[c1] = trans[i];
-                }
-
-                if ((c2 - c1) == dims[0]) {
-                    trany.data[c1] = trans[i];
-                }
-
-                if ((c2 - c1) == dims[0]*dims[1]) {
-                    tranz.data[c1] = trans[i];
-                }
-            }
-
-            std::vector<data::CellData> tran;
-            tran.push_back( std::move( tranx ));
-            tran.push_back( std::move( trany ));
-            tran.push_back( std::move( tranz ));
-            output_writer_.writeInit( tran , geo_.nonCartesianConnections( ));
-        }
+        output_writer_.writeInit( geo_.simProps(grid_) , geo_.nonCartesianConnections( ) );
 
         std::string restorefilename = param_.getDefault("restorefile", std::string("") );
         if( ! restorefilename.empty() )

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -73,7 +73,7 @@ namespace Opm
         }
 
         // init output writer
-        output_writer_.writeInit();
+        output_writer_.writeInit( geo_.simProps(grid_) , geo_.nonCartesianConnections( ) );
 
         std::string restorefilename = param_.getDefault("restorefile", std::string("") );
         if( ! restorefilename.empty() )

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -247,12 +247,13 @@ namespace Opm
 
     void
     BlackoilOutputWriter::
-    writeInit()
+    writeInit(const std::vector<data::CellData>& simProps,  const NNC& nnc)
     {
         if( eclWriter_ ) {
-            eclWriter_->writeInit();
+            eclWriter_->writeInit(simProps, nnc);
         }
     }
+
 
 
     namespace detail {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -250,7 +250,7 @@ namespace Opm
     writeInit(const std::vector<data::CellData>& simProps,  const NNC& nnc)
     {
         if( eclWriter_ ) {
-            eclWriter_->writeInit(simProps, nnc);
+            eclWriter_->writeInitAndEgrid(simProps, nnc);
         }
     }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -29,6 +29,7 @@
 #include <opm/core/utility/miscUtilities.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 
+#include <opm/output/Cells.hpp>
 #include <opm/output/OutputWriter.hpp>
 #include <opm/output/eclipse/EclipseWriter.hpp>
 
@@ -215,7 +216,7 @@ namespace Opm
                              const double* permeability );
 
         /** \copydoc Opm::OutputWriter::writeInit */
-        void writeInit();
+        void writeInit(const std::vector<data::CellData>& simProps = {} , const NNC& = NNC());
 
         /** \copydoc Opm::OutputWriter::writeTimeStep */
         void writeTimeStep(const SimulatorTimerInterface& timer,

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -216,7 +216,7 @@ namespace Opm
                              const double* permeability );
 
         /** \copydoc Opm::OutputWriter::writeInit */
-        void writeInit(const std::vector<data::CellData>& simProps = {} , const NNC& = NNC());
+        void writeInit(const std::vector<data::CellData>& simProps, const NNC& nnc);
 
         /** \copydoc Opm::OutputWriter::writeTimeStep */
         void writeTimeStep(const SimulatorTimerInterface& timer,

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -302,8 +302,7 @@ namespace Opm
                     param.getDefault("output_ecl", true) ?
                     new EclipseWriter(eclipseState,
                                       parallelOutput_->numCells(),
-                                      parallelOutput_->globalCell(),
-                                      nnc )
+                                      parallelOutput_->globalCell())
                    : 0 ),
         eclipseState_(eclipseState),
         asyncOutput_()

--- a/tests/compare_INIT.py
+++ b/tests/compare_INIT.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+import subprocess
+import sys
+import os.path
+
+from ert.ecl import EclFile
+from ert.test import TestAreaContext
+
+
+def compare_files( flow_file , ref_file , kw_list):
+    flow = EclFile( flow_file )
+    ref = EclFile( ref_file )
+
+    for kw in kw_list:
+        flow_kw = flow[kw][0]
+        ref_kw = ref[kw][0]
+
+        if not flow_kw.equal_numeric( ref_kw , epsilon = 1e-3 ):
+            sys.exit("Keyword:%s was different in flow simulation and reference")
+            
+
+        
+
+
+
+
+flow = sys.argv[1]
+data_file = sys.argv[2]
+ref_init_file = sys.argv[3]
+kw_list = sys.argv[4:]
+
+with TestAreaContext("flow_init") as ta:
+    subprocess.check_call( [flow , "nosim=true" , data_file ] )
+
+    compare_files( os.path.splitext( os.path.basename( data_file ) )[0] + ".INIT" , ref_init_file , kw_list)
+
+


### PR DESCRIPTION
Warning: This is work in progress, but it is posted here for early review and discussion, in case I am on the wrong track entirely.

Further plans:

1. These must be merged: https://github.com/OPM/opm-output/pull/51 :  https://github.com/OPM/opm-common/pull/149
2. ~~The method `EclipseWriter::writeInit( )` writes the `CASE.INIT` *and* `CASE.EGRID` files - i.e. the files which are written *before* the actual simulation starts. I wish to rename that to e.g. `EclipseWriter::writeStatic( )`.~~ Update: have renamed to `EclipseWriter::writeInitAndEgrid( )`.
3. ~~The `NNC` argument should be removed from the `EclipseWriter` constructor, it should rather be passed to the `EclipseWriter::writeStatic( )` method - where it will be dispatched to the `EclipseWriter::writeEGRID()` and `EclipseWriter::writeINITFile()` methods respectively.~~
4. ~~Add integration testing - based on data from opm-data.~~ Update: have added a Python based integration test in the last commit: see https://github.com/OPM/opm-common/pull/149 for an explanation.