### PR TITLE
only calculating representative radius when having PLYSHLOG.

### DIFF
--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer_impl.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer_impl.hpp
@@ -123,7 +123,9 @@ namespace Opm
                                             polymer_inflow_c);
         well_state.polymerInflow() = polymer_inflow_c;
 
-        computeRepRadiusPerfLength(BaseType::eclipse_state_, timer.currentStepNum(), BaseType::grid_, wells_rep_radius_, wells_perf_length_, wells_bore_diameter_);
+        if (has_plyshlog_) {
+            computeRepRadiusPerfLength(BaseType::eclipse_state_, timer.currentStepNum(), BaseType::grid_, wells_rep_radius_, wells_perf_length_, wells_bore_diameter_);
+        }
     }
 
 


### PR DESCRIPTION
When we do not use PLYSHLOG shear model, the diameter of the well-bore does not need to be specified explicitly, which is required for the calculation of the representative radius. 