### PR TITLE
use the depth of the centroid as the cell depth

### DIFF
--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -175,7 +175,7 @@ namespace Opm
 
             // Compute z coordinates
             for (int c = 0; c<numCells; ++c){
-                z_[c] = Opm::UgGridHelpers::cellCenterDepth(grid, c);
+                z_[c] = AutoDiffGrid::cellCentroid(grid, c)[2];
             }
 
 


### PR DESCRIPTION
this fixes an annoying inconsistency: a few lines below the centroid
depth is used to calculate the depth difference between the cell and
the face. Note that I do not really care what is used (using the grid
is more convenient, though) but it should be done consistently.

From my testing with Norne, the summary results stay the same (or get slightly better):

![perf-n_linear1](https://cloud.githubusercontent.com/assets/1837735/16338194/6dbc896e-3a1b-11e6-95c8-092f9dd0b3c5.png)

![perf-n_linear1](https://cloud.githubusercontent.com/assets/1837735/16338221/9001e406-3a1b-11e6-91d4-8a2851ed4800.png)

For Norne, performance also stays basically unchanged (old: 1212.38 seconds, 1632 Newton iterations, 25022 linear iterations; new:  1263.03 seconds,  1615 Newton iterations,  24969 linear iterations; estimated timing variance: 5 to 10%)

I have not tested Model 2 or the SPEs, but I don't expect their results to be qualitatively different from the Norne ones.