### PR TITLE
Fix handling of no wells in WellStateFullyImplicitBlackoil.hpp

### DIFF
--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -195,7 +195,9 @@ namespace Opm
             data::Wells res = WellState::report();
 
             const int nw = this->numWells();
-            const int np = this->numPhases();
+            // If there are now wells numPhases throws a floating point
+            // exception.
+            const int np = nw ? this->numPhases() : -1;
 
             /* this is a reference or example on **how** to convert from
              * WellState to something understood by opm-output. it is intended


### PR DESCRIPTION
In that case we cannot call numPhases() on the wells as it produces
a floating point exception. As we do not use that information in this case
anyway, we simply use -1 instead to prevent the call.

Closes #731