### PR TITLE
Support of Keyword WECON. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if (HAVE_OPM_DATA)
     add_test( NAME flow_SPE1CASE2 COMMAND flow ${OPM_DATA_ROOT}/spe1/SPE1CASE2.DATA )
     add_test( NAME flow_SPE1CASE2_restart COMMAND flow ${OPM_DATA_ROOT}/spe1/SPE1CASE2_RESTART.DATA )
 
-    add_test( NAME flow_MSW2DH__ COMMAND flow_multisegment ${OPM_DATA_ROOT}/multisegment_wells_test_suite/2D_H__/2D_H__.DATA)
+    add_test( NAME flow_MSW2DH__ COMMAND flow_multisegment ${OPM_DATA_ROOT}/wells_test_suite/MSW/2D_H__/2D_H__.DATA)
 
     set_tests_properties(flow_SPE1CASE2_restart PROPERTIES DEPENDS flow_SPE1CASE2) # Dependes on the restart file from test flow_SPE1CASE2
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -255,6 +255,10 @@ namespace Opm {
         /// Update the scaling factors for mass balance equations
         void updateEquationsScaling();
 
+        /// return the WellModel object
+        WellModel& wellModel() { return well_model_; }
+        const WellModel& wellModel() const { return well_model_; }
+
     protected:
 
         // ---------  Types and enums  ---------
@@ -332,10 +336,6 @@ namespace Opm {
         {
             return static_cast<const Implementation&>(*this);
         }
-
-        /// return the WellModel object
-        WellModel& wellModel() { return well_model_; }
-        const WellModel& wellModel() const { return well_model_; }
 
         /// return the Well struct in the WellModel
         const Wells& wells() const { return well_model_.wells(); }

--- a/opm/autodiff/BlackoilPressureModel.hpp
+++ b/opm/autodiff/BlackoilPressureModel.hpp
@@ -129,6 +129,7 @@ namespace Opm {
 
         using Base::numPhases;
         using Base::numMaterials;
+        using Base::wellModel;
 
     protected:
         using Base::asImpl;

--- a/opm/autodiff/BlackoilSequentialModel.hpp
+++ b/opm/autodiff/BlackoilSequentialModel.hpp
@@ -239,6 +239,13 @@ namespace Opm {
                             transport_solver_.model().relativeChange(previous, current));
         }
 
+        /// Return the well model
+        const WellModel& wellModel() const
+        {
+            return pressure_model_->wellModel();
+        }
+
+
 
 
 

--- a/opm/autodiff/BlackoilSolventModel.hpp
+++ b/opm/autodiff/BlackoilSolventModel.hpp
@@ -88,6 +88,8 @@ namespace Opm {
                          ReservoirState& reservoir_state,
                          WellState& well_state);
 
+        using Base::wellModel;
+
 
     protected:
 
@@ -129,7 +131,6 @@ namespace Opm {
         // ---------  Protected methods  ---------
 
         // Need to declare Base members we want to use here.
-        using Base::wellModel;
         using Base::wells;
         using Base::variableState;
         using Base::computeGasPressure;

--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -28,6 +28,7 @@
 
 #include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
 #include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/core/wells/DynamicListEconLimited.hpp>
 
 #if HAVE_OPM_GRID
 #include <dune/grid/common/p2pcommunicator.hh>
@@ -523,6 +524,10 @@ namespace Opm
             if( isIORank() )
             {
                 Dune::CpGrid& globalGrid = *grid_;
+                // TODO: make a dummy DynamicListEconLimited here for NOW for compilation and development
+                // TODO: NOT SURE whether it will cause problem for parallel running
+                // TODO: TO BE TESTED AND IMPROVED
+                const DynamicListEconLimited dynamic_list_econ_limited;
                 // Create wells and well state.
                 WellsManager wells_manager(eclipseState_,
                                            reportStep,
@@ -533,6 +538,7 @@ namespace Opm
                                            Opm::UgGridHelpers::cell2Faces( globalGrid ),
                                            Opm::UgGridHelpers::beginFaceCentroids( globalGrid ),
                                            permeability_,
+                                           dynamic_list_econ_limited,
                                            false);
 
                 const Wells* wells = wells_manager.c_wells();

--- a/opm/autodiff/SimulatorBase.hpp
+++ b/opm/autodiff/SimulatorBase.hpp
@@ -162,6 +162,13 @@ namespace Opm
                                    const WellState& xw,
                                    std::vector<double>& well_potentials);
 
+        void updateListEconLimited(const std::unique_ptr<Solver>& solver,
+                                   ScheduleConstPtr schedule,
+                                   const int current_step,
+                                   const Wells* wells,
+                                   const WellState& well_state,
+                                   DynamicListEconLimited& list_econ_limited) const;
+
 
         // Data.
         typedef RateConverter::

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -165,9 +165,10 @@ namespace Opm
             // give the polymer and surfactant simulators the chance to do their stuff
             asImpl().handleAdditionalWellInflow(timer, wells_manager, well_state, wells);
 
-            // write simulation state at the report stage
-            output_writer_.writeTimeStep( timer, state, well_state );
-
+            // write the inital state at the report stage
+            if (timer.initialStep()) {
+                output_writer_.writeTimeStep( timer, state, well_state );
+            }
 
             // Max oil saturation (for VPPARS), hysteresis update.
             props_.updateSatOilMax(state.saturation());
@@ -265,6 +266,10 @@ namespace Opm
 
             // Increment timer, remember well state.
             ++timer;
+
+            // write simulation state at the report stage
+            output_writer_.writeTimeStep( timer, state, well_state );
+
             prev_well_state = well_state;
             // The well potentials are only computed if they are needed
             // For now thay are only used to determine default guide rates for group controlled wells
@@ -275,8 +280,6 @@ namespace Opm
             asImpl().updateListEconLimited(solver, eclipse_state_->getSchedule(), timer.currentStepNum(), wells,
                                            well_state, dynamic_list_econ_limited);
         }
-        // Write final simulation state.
-        output_writer_.writeTimeStep( timer, state, prev_well_state );
 
         // Stop timer and create timing report
         total_timer.stop();

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -272,8 +272,8 @@ namespace Opm
                 asImpl().computeWellPotentials(wells, well_state, well_potentials);
             }
 
-            solver->model().wellModel().updateListEconLimited(eclipse_state_->getSchedule(), timer.currentStepNum(), wells,
-                                                              well_state, dynamic_list_econ_limited);
+            asImpl().updateListEconLimited(solver, eclipse_state_->getSchedule(), timer.currentStepNum(), wells,
+                                           well_state, dynamic_list_econ_limited);
         }
         // Write final simulation state.
         output_writer_.writeTimeStep( timer, state, prev_well_state );
@@ -618,4 +618,24 @@ namespace Opm
             }
         }
     }
+
+
+
+
+
+    template <class Implementation>
+    void
+    SimulatorBase<Implementation>::
+    updateListEconLimited(const std::unique_ptr<Solver>& solver,
+                          ScheduleConstPtr schedule,
+                          const int current_step,
+                          const Wells* wells,
+                          const WellState& well_state,
+                          DynamicListEconLimited& list_econ_limited) const
+    {
+
+        solver->model().wellModel().updateListEconLimited(schedule, current_step, wells,
+                                                          well_state, list_econ_limited);
+    }
+
 } // namespace Opm

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -25,6 +25,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
 #include <opm/core/utility/initHydroCarbonState.hpp>
 #include <opm/core/well_controls.h>
+#include <opm/core/wells/DynamicListEconLimited.hpp>
 
 namespace Opm
 {
@@ -131,6 +132,7 @@ namespace Opm
         unsigned int totalLinearIterations = 0;
         bool is_well_potentials_computed = param_.getDefault("compute_well_potentials", false );
         std::vector<double> well_potentials;
+        DynamicListEconLimited dynamic_list_econ_limited;
 
         // Main simulation loop.
         while (!timer.done()) {
@@ -153,6 +155,7 @@ namespace Opm
                                        Opm::UgGridHelpers::cell2Faces(grid_),
                                        Opm::UgGridHelpers::beginFaceCentroids(grid_),
                                        props_.permeability(),
+                                       dynamic_list_econ_limited,
                                        is_parallel_run_,
                                        well_potentials);
             const Wells* wells = wells_manager.c_wells();

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -272,6 +272,8 @@ namespace Opm
                 asImpl().computeWellPotentials(wells, well_state, well_potentials);
             }
 
+            solver->model().wellModel().updateListEconLimited(eclipse_state_->getSchedule(), timer.currentStepNum(), wells,
+                                                              well_state, dynamic_list_econ_limited);
         }
         // Write final simulation state.
         output_writer_.writeTimeStep( timer, state, prev_well_state );

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -89,6 +89,7 @@ namespace Opm
 
         unsigned int totalNonlinearIterations = 0;
         unsigned int totalLinearIterations = 0;
+        DynamicListEconLimited dynamic_list_econ_limited;
 
         // Main simulation loop.
         while (!timer.done()) {
@@ -109,6 +110,7 @@ namespace Opm
                                        Opm::UgGridHelpers::cell2Faces(grid_),
                                        Opm::UgGridHelpers::beginFaceCentroids(grid_),
                                        props_.permeability(),
+                                       dynamic_list_econ_limited,
                                        is_parallel_run_);
             const Wells* wells = wells_manager.c_wells();
             WellState well_state;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -126,8 +126,10 @@ namespace Opm
             // give the polymer and surfactant simulators the chance to do their stuff
             Base::asImpl().handleAdditionalWellInflow(timer, wells_manager, well_state, wells);
 
-            // write simulation state at the report stage
-            output_writer_.writeTimeStep( timer, state, well_state );
+            // write the inital state at the report stage
+            if (timer.initialStep()) {
+                output_writer_.writeTimeStep( timer, state, well_state );
+            }
 
             // Max oil saturation (for VPPARS), hysteresis update.
             props_.updateSatOilMax(state.saturation());
@@ -179,11 +181,12 @@ namespace Opm
 
             // Increment timer, remember well state.
             ++timer;
+
+            // write simulation state at the report stage
+            output_writer_.writeTimeStep( timer, state, well_state );
+
             prev_well_state = well_state;
         }
-
-        // Write final simulation state.
-        output_writer_.writeTimeStep( timer, state, prev_well_state );
 
         // Stop timer and create timing report
         total_timer.stop();

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -28,6 +28,7 @@
 #include <opm/output/eclipse/EclipseReader.hpp>
 #include <opm/core/utility/miscUtilities.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
+#include <opm/core/wells/DynamicListEconLimited.hpp>
 
 #include <opm/output/Cells.hpp>
 #include <opm/output/OutputWriter.hpp>
@@ -352,6 +353,8 @@ namespace Opm
                          SimulationDataContainer& simulatorstate,
                          WellStateFullyImplicitBlackoil& wellstate)
     {
+        // gives a dummy dynamic_list_econ_limited
+        DynamicListEconLimited dummy_list_econ_limited;
         WellsManager wellsmanager(eclipseState_,
                                   eclipseState_->getInitConfig()->getRestartStep(),
                                   Opm::UgGridHelpers::numCells(grid),
@@ -360,7 +363,8 @@ namespace Opm
                                   Opm::UgGridHelpers::dimensions(grid),
                                   Opm::UgGridHelpers::cell2Faces(grid),
                                   Opm::UgGridHelpers::beginFaceCentroids(grid),
-                                  permeability);
+                                  permeability,
+                                  dummy_list_econ_limited);
 
         const Wells* wells = wellsmanager.c_wells();
         wellstate.resize(wells, simulatorstate); //Resize for restart step

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -22,6 +22,8 @@
 #ifndef OPM_STANDARDWELLS_HEADER_INCLUDED
 #define OPM_STANDARDWELLS_HEADER_INCLUDED
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <Eigen/Eigen>
 #include <Eigen/Sparse>

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -230,6 +230,7 @@ namespace Opm {
                                      const int well_number) const;
 
             using WellMapType = typename WellState::WellMapType;
+            using WellMapEntryType = typename WellState::mapentry_t;
 
             // a tuple type for ratio limit check.
             // first value indicates whether ratio limit is violated, when the ratio limit is not violated, the following three
@@ -248,12 +249,12 @@ namespace Opm {
             template <class WellState>
             RatioCheckTuple checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
                                                  const WellState& well_state,
-                                                 const typename WellMapType::const_iterator& i_well) const;
+                                                 const WellMapEntryType& map_entry) const;
 
             template <class WellState>
             RatioCheckTuple checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
                                                   const WellState& well_state,
-                                                  const typename WellMapType::const_iterator& i_well) const;
+                                                  const WellMapEntryType& map_entry) const;
 
         };
 

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -220,6 +220,12 @@ namespace Opm {
                                                         const std::vector<double>& depth_perf,
                                                         const double grav);
 
+
+            template <class WellState>
+            bool checkRateEconLimits(const WellEconProductionLimits& econ_production_limits,
+                                     const WellState& well_state,
+                                     const int well_number) const;
+
         };
 
 

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -29,7 +29,10 @@
 
 #include <cassert>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+
 #include <opm/core/wells.h>
+#include <opm/core/wells/DynamicListEconLimited.hpp>
 #include <opm/autodiff/AutoDiffBlock.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
 #include <opm/autodiff/BlackoilPropsAdInterface.hpp>
@@ -169,6 +172,15 @@ namespace Opm {
             /// unless setStoreWellPerforationFluxesFlag(true) has been
             /// called.
             const Vector& getStoredWellPerforationFluxes() const;
+
+            /// upate the dynamic lists related to economic limits
+            template<class WellState>
+            void
+            updateListEconLimited(ScheduleConstPtr schedule,
+                                  const int current_step,
+                                  const Wells* wells,
+                                  const WellState& well_state,
+                                  DynamicListEconLimited& list_econ_limited) const;
 
         protected:
             bool wells_active_;

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -226,6 +226,17 @@ namespace Opm {
                                      const WellState& well_state,
                                      const int well_number) const;
 
+            using WellMapType = typename WellState::WellMapType;
+
+
+            template <class WellState>
+            bool checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
+                                       const WellState& well_state,
+                                       const typename WellMapType::const_iterator& i_well,
+                                       int& worst_offending_connection,
+                                       double& violation_extent,
+                                       bool& last_connection) const;
+
         };
 
 

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -235,7 +235,8 @@ namespace Opm {
             bool checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
                                       const WellState& well_state,
                                       const typename WellMapType::const_iterator& i_well,
-                                      int& worst_offending_connection) const;
+                                      int& worst_offending_connection,
+                                      bool& last_connection) const;
 
             template <class WellState>
             bool checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -230,6 +230,12 @@ namespace Opm {
 
 
             template <class WellState>
+            bool checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
+                                      const WellState& well_state,
+                                      const typename WellMapType::const_iterator& i_well,
+                                      int& worst_offending_connection) const;
+
+            template <class WellState>
             bool checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
                                        const WellState& well_state,
                                        const typename WellMapType::const_iterator& i_well,

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -30,6 +30,7 @@
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <cassert>
+#include <tuple>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
@@ -230,21 +231,29 @@ namespace Opm {
 
             using WellMapType = typename WellState::WellMapType;
 
+            // a tuple type for ratio limit check.
+            // first value indicates whether ratio limit is violated, when the ratio limit is not violated, the following three
+            // values should not be used.
+            // second value indicates whehter there is only one connection left.
+            // third value indicates the indx of the worst-offending connection.
+            // the last value indicates the extent of the violation for the worst-offending connection, which is defined by
+            // the ratio of the actual value to the value of the violated limit.
+            using RatioCheckTuple = std::tuple<bool, bool, int, double>;
+
+            enum ConnectionIndex {
+                INVALIDCONNECTION = -10000
+            };
+
 
             template <class WellState>
-            bool checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
-                                      const WellState& well_state,
-                                      const typename WellMapType::const_iterator& i_well,
-                                      int& worst_offending_connection,
-                                      bool& last_connection) const;
+            RatioCheckTuple checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
+                                                 const WellState& well_state,
+                                                 const typename WellMapType::const_iterator& i_well) const;
 
             template <class WellState>
-            bool checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
-                                       const WellState& well_state,
-                                       const typename WellMapType::const_iterator& i_well,
-                                       int& worst_offending_connection,
-                                       double& violation_extent,
-                                       bool& last_connection) const;
+            RatioCheckTuple checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
+                                                  const WellState& well_state,
+                                                  const typename WellMapType::const_iterator& i_well) const;
 
         };
 

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -1307,8 +1307,8 @@ namespace Opm
                }
 
                if (well_ecl->getAutomaticShutIn()) {
-                   list_econ_limited.addShuttedWell(well_name);
-                   const std::string msg = std::string("well ") + well_name + std::string(" will be shutted in due to economic limit");
+                   list_econ_limited.addShutWell(well_name);
+                   const std::string msg = std::string("well ") + well_name + std::string(" will be shut in due to economic limit");
                    OpmLog::info(msg);
                } else {
                    list_econ_limited.addStoppedWell(well_name);
@@ -1341,8 +1341,8 @@ namespace Opm
                OpmLog::info(msg);
 
                if (last_connection) {
-                   list_econ_limited.addShuttedWell(well_name);
-                   const std::string msg2 = well_name + std::string(" will be shutted due to the last connection closed");
+                   list_econ_limited.addShutWell(well_name);
+                   const std::string msg2 = well_name + std::string(" will be shut due to the last connection closed");
                    OpmLog::info(msg2);
                }
            }

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -1320,6 +1320,11 @@ namespace Opm
                              << std::endl
                              << "the program will keep running after " << well_name << " is closed " << std::endl;
                }
+
+               if (econ_production_limits.validFollowonWell()) {
+                   std::cerr << "WARNING: opening following on well after well closed is not supported yet" << std::endl;
+               }
+
                list_econ_limited.addShuttedWell(well_name);
            }
        }

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -1382,6 +1382,67 @@ namespace Opm
 
 
 
+    template <class WellState>
+    bool
+    StandardWells::
+    checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
+                         const WellState& well_state,
+                         const typename WellMapType::const_iterator& i_well,
+                         int& worst_offending_connection) const
+    {
+        // TODO: not sure how to define the worst-offending connection when more than one
+        //       ratio related limit is violated.
+        //       The defintion used here is that we define the violation extent based on the
+        //       ratio between the value and the corresopoding limit.
+        //       For each violated limit, we decide the worst-offending connection separately.
+        //       Among the worst-offending connections, we use the one has the biggest violation
+        //       extent.
+
+
+        bool any_limit_violated = false;
+        // should handle last_connection here instead of in any following check Function.
+        bool last_connection = false;
+        double violation_extent = 0.0;
+        worst_offending_connection = -1;
+
+        if (econ_production_limits.onMaxWaterCut()) {
+            int worst_offending_connection_water_cut = -1;
+            double violation_extent_water_cut = 0.0;
+            const bool water_cut_violated = checkMaxWaterCutLimit(econ_production_limits, well_state, i_well,
+                                                                  worst_offending_connection_water_cut,
+                                                                  violation_extent_water_cut,
+                                                                  last_connection);
+            if (water_cut_violated) {
+                any_limit_violated = true;
+                if (violation_extent_water_cut > violation_extent) {
+                    violation_extent = violation_extent_water_cut;
+                    worst_offending_connection = worst_offending_connection_water_cut;
+                }
+            }
+        }
+
+        if (econ_production_limits.onMaxGasOilRatio()) {
+            OPM_MESSAGE("WARNING: the support for max Gas-Oil ratio is not implemented yet!");
+        }
+
+        if (econ_production_limits.onMaxWaterGasRatio()) {
+            OPM_MESSAGE("WARNING: the support for max Water-Gas ratio is not implemented yet!");
+        }
+
+        if (econ_production_limits.onMaxGasLiquidRatio()) {
+            OPM_MESSAGE("WARNING: the support for max Gas-Liquid ratio is not implemented yet!");
+        }
+
+        if (any_limit_violated) {
+            assert(worst_offending_connection >=0);
+            assert(violation_extent > 1.);
+        }
+
+        return any_limit_violated;
+    }
+
+
+
 
 
     template <class WellState>

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -1292,13 +1292,13 @@ namespace Opm
 
            if (rate_limit_violated) {
                if (econ_production_limits.endRun()) {
-                   std::cerr << "WARNING: ending run after well closed due to economic limits is not supported yet"
-                             << std::endl
-                             << "the program will keep running after " << well_name << " is closed " << std::endl;
+                   const std::string warning_message = std::string("WARNING: ending run after well closed due to economic limits is not supported yet \n")
+                                                     + std::string("the program will keep running after ") + well_name + std::string(" is closed");
+                   OpmLog::warning(warning_message);
                }
 
                if (econ_production_limits.validFollowonWell()) {
-                   std::cerr << "WARNING: opening following on well after well closed is not supported yet" << std::endl;
+                   OpmLog::warning("WARNING: opening following on well after well closed is not supported yet");
                }
 
                list_econ_limited.addShuttedWell(well_name);
@@ -1372,7 +1372,7 @@ namespace Opm
         }
 
         if (econ_production_limits.onMinReservoirFluidRate()) {
-            std::cerr << "WARNING: Minimum reservoir fluid production rate limit is not supported yet" << std::endl;
+            OpmLog::warning("WARNING: Minimum reservoir fluid production rate limit is not supported yet");
         }
 
         return false;
@@ -1422,15 +1422,15 @@ namespace Opm
         }
 
         if (econ_production_limits.onMaxGasOilRatio()) {
-            OPM_MESSAGE("WARNING: the support for max Gas-Oil ratio is not implemented yet!");
+            OpmLog::warning("WARNING: the support for max Gas-Oil ratio is not implemented yet!");
         }
 
         if (econ_production_limits.onMaxWaterGasRatio()) {
-            OPM_MESSAGE("WARNING: the support for max Water-Gas ratio is not implemented yet!");
+            OpmLog::warning("WARNING: the support for max Water-Gas ratio is not implemented yet!");
         }
 
         if (econ_production_limits.onMaxGasLiquidRatio()) {
-            OPM_MESSAGE("WARNING: the support for max Gas-Liquid ratio is not implemented yet!");
+            OpmLog::warning("WARNING: the support for max Gas-Liquid ratio is not implemented yet!");
         }
 
         if (any_limit_violated) {

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -1283,7 +1283,9 @@ namespace Opm
            // the potential limits should not be difficult to add
            const WellEcon::QuantityLimitEnum& quantity_limit = econ_production_limits.quantityLimit();
            if (quantity_limit == WellEcon::POTN) {
-               OPM_THROW(std::logic_error, "Only RATE limit is supported for the moment");
+               const std::string msg = std::string("POTN limit for well ") + well_name + std::string(" is not supported for the moment. \n")
+                                     + std::string("All the limits will be evaluated based on RATE. ");
+               OpmLog::warning(msg);
            }
 
            const WellMapType& well_map = well_state.wellMap();
@@ -1297,13 +1299,13 @@ namespace Opm
 
            if (rate_limit_violated) {
                if (econ_production_limits.endRun()) {
-                   const std::string warning_message = std::string("WARNING: ending run after well closed due to economic limits is not supported yet \n")
+                   const std::string warning_message = std::string("ending run after well closed due to economic limits is not supported yet \n")
                                                      + std::string("the program will keep running after ") + well_name + std::string(" is closed");
                    OpmLog::warning(warning_message);
                }
 
                if (econ_production_limits.validFollowonWell()) {
-                   OpmLog::warning("WARNING: opening following on well after well closed is not supported yet");
+                   OpmLog::warning("opening following on well after well closed is not supported yet");
                }
 
                if (well_ecl->getAutomaticShutIn()) {
@@ -1395,7 +1397,7 @@ namespace Opm
         }
 
         if (econ_production_limits.onMinReservoirFluidRate()) {
-            OpmLog::warning("WARNING: Minimum reservoir fluid production rate limit is not supported yet");
+            OpmLog::warning("Minimum reservoir fluid production rate limit is not supported yet");
         }
 
         return false;
@@ -1444,15 +1446,15 @@ namespace Opm
         }
 
         if (econ_production_limits.onMaxGasOilRatio()) {
-            OpmLog::warning("WARNING: the support for max Gas-Oil ratio is not implemented yet!");
+            OpmLog::warning("the support for max Gas-Oil ratio is not implemented yet!");
         }
 
         if (econ_production_limits.onMaxWaterGasRatio()) {
-            OpmLog::warning("WARNING: the support for max Water-Gas ratio is not implemented yet!");
+            OpmLog::warning("the support for max Water-Gas ratio is not implemented yet!");
         }
 
         if (econ_production_limits.onMaxGasLiquidRatio()) {
-            OpmLog::warning("WARNING: the support for max Gas-Liquid ratio is not implemented yet!");
+            OpmLog::warning("the support for max Gas-Liquid ratio is not implemented yet!");
         }
 
         if (any_limit_violated) {

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -1285,7 +1285,7 @@ namespace Opm
            if (quantity_limit == WellEcon::POTN) {
                const std::string msg = std::string("POTN limit for well ") + well_name + std::string(" is not supported for the moment. \n")
                                      + std::string("All the limits will be evaluated based on RATE. ");
-               OpmLog::warning(msg);
+               OpmLog::warning("NOT_SUPPORTING_POTN", msg);
            }
 
            const WellMapType& well_map = well_state.wellMap();
@@ -1301,11 +1301,11 @@ namespace Opm
                if (econ_production_limits.endRun()) {
                    const std::string warning_message = std::string("ending run after well closed due to economic limits is not supported yet \n")
                                                      + std::string("the program will keep running after ") + well_name + std::string(" is closed");
-                   OpmLog::warning(warning_message);
+                   OpmLog::warning("NOT_SUPPORTING_ENDRUN", warning_message);
                }
 
                if (econ_production_limits.validFollowonWell()) {
-                   OpmLog::warning("opening following on well after well closed is not supported yet");
+                   OpmLog::warning("NOT_SUPPORTING_FOLLOWONWELL", "opening following on well after well closed is not supported yet");
                }
 
                if (well_ecl->getAutomaticShutIn()) {
@@ -1397,7 +1397,7 @@ namespace Opm
         }
 
         if (econ_production_limits.onMinReservoirFluidRate()) {
-            OpmLog::warning("Minimum reservoir fluid production rate limit is not supported yet");
+            OpmLog::warning("NOT_SUPPORTING_MIN_RESERVOIR_FLUID_RATE", "Minimum reservoir fluid production rate limit is not supported yet");
         }
 
         return false;
@@ -1446,15 +1446,15 @@ namespace Opm
         }
 
         if (econ_production_limits.onMaxGasOilRatio()) {
-            OpmLog::warning("the support for max Gas-Oil ratio is not implemented yet!");
+            OpmLog::warning("NOT_SUPPORTING_MAX_GOR", "the support for max Gas-Oil ratio is not implemented yet!");
         }
 
         if (econ_production_limits.onMaxWaterGasRatio()) {
-            OpmLog::warning("the support for max Water-Gas ratio is not implemented yet!");
+            OpmLog::warning("NOT_SUPPORTING_MAX_WGR", "the support for max Water-Gas ratio is not implemented yet!");
         }
 
         if (econ_production_limits.onMaxGasLiquidRatio()) {
-            OpmLog::warning("the support for max Gas-Liquid ratio is not implemented yet!");
+            OpmLog::warning("NOT_SUPPORTING_MAX_GLR", "the support for max Gas-Liquid ratio is not implemented yet!");
         }
 
         if (any_limit_violated) {

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -1315,6 +1315,11 @@ namespace Opm
            }
 
            if (rate_limit_violated) {
+               if (econ_production_limits.endRun()) {
+                   std::cerr << "WARNING: ending run after well closed due to economic limits is not supported yet"
+                             << std::endl
+                             << "the program will keep running after " << well_name << " is closed " << std::endl;
+               }
                list_econ_limited.addShuttedWell(well_name);
            }
        }

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -125,6 +125,7 @@ namespace Opm {
                  WellState& well_state,
                  const bool initial_assembly);
 
+        using Base::wellModel;
 
     protected:
 
@@ -180,7 +181,6 @@ namespace Opm {
         // ---------  Protected methods  ---------
 
         // Need to declare Base members we want to use here.
-        using Base::wellModel;
         using Base::wells;
         using Base::wellsActive;
         using Base::variableState;

--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer.hpp
@@ -119,9 +119,17 @@ namespace Opm
                                         WellsManager& wells_manager,
                                         typename BaseType::WellState& well_state,
                                         const Wells* wells);
+
+        void updateListEconLimited(const std::unique_ptr<Solver>& solver,
+                                   ScheduleConstPtr schedule,
+                                   const int current_step,
+                                   const Wells* wells,
+                                   const WellState& well_state,
+                                   DynamicListEconLimited& list_econ_limited) const;
 private:
         Opm::DeckConstPtr deck_;
         const PolymerPropsAd& polymer_props_;
+
     };
 
 } // namespace Opm

--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer_impl.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer_impl.hpp
@@ -98,6 +98,23 @@ handleAdditionalWellInflow(SimulatorTimer& timer,
 }
 
 
+
+
+
+template <class GridT>
+void
+SimulatorFullyImplicitCompressiblePolymer<GridT>::
+updateListEconLimited(const std::unique_ptr<Solver>& /*solver*/,
+                      ScheduleConstPtr /*schedule*/,
+                      const int /*current_step*/,
+                      const Wells* /*wells*/,
+                      const WellState& /*well_state*/,
+                      DynamicListEconLimited& /*list_econ_limited*/) const
+{
+
+}
+
+
 } // namespace Opm
 
 #endif // OPM_SIMULATORFULLYIMPLICITCOMPRESSIBLEPOLYMER_HEADER_INCLUDED

--- a/tests/test_multisegmentwells.cpp
+++ b/tests/test_multisegmentwells.cpp
@@ -48,6 +48,7 @@
 #include <opm/core/utility/Units.hpp>
 #include <opm/core/wells/WellsManager.hpp>
 #include <opm/core/wells.h>
+#include <opm/core/wells/DynamicListEconLimited.hpp>
 
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
 #include <opm/autodiff/GridHelpers.hpp>
@@ -91,6 +92,9 @@ struct SetupMSW {
 
         const size_t current_timestep = 0;
 
+        // dummy_dynamic_list_econ_lmited
+        const Opm::DynamicListEconLimited dummy_dynamic_list;
+
         // Create wells.
         Opm::WellsManager wells_manager(ecl_state,
                                         current_timestep,
@@ -101,6 +105,7 @@ struct SetupMSW {
                                         Opm::UgGridHelpers::cell2Faces(grid),
                                         Opm::UgGridHelpers::beginFaceCentroids(grid),
                                         fluidprops->permeability(),
+                                        dummy_dynamic_list,
                                         false);
 
         const Wells* wells = wells_manager.c_wells();


### PR DESCRIPTION
 Based on the current requirement, it supports the economic limit related to minimum oil rate, minimum gas rate, and water cut. 

Other limits like gas-oil ratio, water-gas ratio, minimum liquid rate, are relatively easy to add. Will add them when having time. 

Ending the running after some well is closed is not supported. 

Secondary water-cut limit treatment, which is related to how to handle when it is about to remove the last connection of the well due to water-cut limit, is not supported yet. 

The workover on exceeding water-cut, GOR, WGR or GLR limit only support closing the worst-offending connection. 

It is dependent on the PR OPM/opm-core#1051