### PR TITLE
Use termininal_output_ to only print time step status once for parallel runs

### DIFF
--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -179,10 +179,10 @@ namespace Opm
             const WellModel well_model(wells);
 
             auto solver = asImpl().createSolver(well_model);
-            std::ostringstream step_msg;
 
             if( terminal_output_ )
             {
+                std::ostringstream step_msg;
                 boost::posix_time::time_facet* facet = new boost::posix_time::time_facet("%d-%b-%Y");
                 step_msg.imbue(std::locale(std::locale::classic(), facet));
                 step_msg << "\nTime step " << std::setw(4) <<timer.currentStepNum()


### PR DESCRIPTION
Previously each process printed this to the terminal