### PR TITLE
pass the simulation timer object instead of the time step size

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -33,6 +33,7 @@
 #include <opm/autodiff/BlackoilModelEnums.hpp>
 #include <opm/autodiff/VFPProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 #include <array>
 
@@ -161,10 +162,10 @@ namespace Opm {
         void setThresholdPressures(const std::vector<double>& threshold_pressures_by_face);
 
         /// Called once before each time step.
-        /// \param[in] dt                     time step size
+        /// \param[in] timer                  simulation timer
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
-        void prepareStep(const double dt,
+        void prepareStep(const SimulatorTimerInterface& timer,
                          const ReservoirState& reservoir_state,
                          const WellState& well_state);
 
@@ -173,23 +174,23 @@ namespace Opm {
         /// and well_state. It will also use the nonlinear_solver to do relaxation of
         /// updates if necessary.
         /// \param[in] iteration              should be 0 for the first call of a new timestep
-        /// \param[in] dt                     time step size
+        /// \param[in] timer                  simulation timer
         /// \param[in] nonlinear_solver       nonlinear solver used (for oscillation/relaxation control)
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         template <class NonlinearSolverType>
         IterationReport nonlinearIteration(const int iteration,
-                                           const double dt,
+                                           const SimulatorTimerInterface& timer,
                                            NonlinearSolverType& nonlinear_solver,
                                            ReservoirState& reservoir_state,
                                            WellState& well_state);
 
         /// Called once after each time step.
         /// In this class, this function does nothing.
-        /// \param[in] dt                     time step size
+        /// \param[in] timer                  simulation timer
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
-        void afterStep(const double dt,
+        void afterStep(const SimulatorTimerInterface& timer,
                        ReservoirState& reservoir_state,
                        WellState& well_state);
 
@@ -236,9 +237,9 @@ namespace Opm {
 
         /// Compute convergence based on total mass balance (tol_mb) and maximum
         /// residual mass balance (tol_cnv).
-        /// \param[in]   dt          timestep length
+        /// \param[in]   timer       simulation timer
         /// \param[in]   iteration   current iteration number
-        bool getConvergence(const double dt, const int iteration);
+        bool getConvergence(const SimulatorTimerInterface& timer, const int iteration);
 
         /// The number of active fluid phases in the model.
         int numPhases() const;

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -26,6 +26,7 @@
 #include <opm/autodiff/WellStateMultiSegment.hpp>
 #include <opm/autodiff/WellMultiSegment.hpp>
 #include <opm/autodiff/StandardWells.hpp>
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 #include <opm/autodiff/MultisegmentWells.hpp>
 
@@ -93,10 +94,10 @@ namespace Opm {
                           const bool terminal_output);
 
         /// Called once before each time step.
-        /// \param[in] dt                     time step size
+        /// \param[in]      timer             simulation timer
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
-        void prepareStep(const double dt,
+        void prepareStep(const SimulatorTimerInterface& timer,
                          const ReservoirState& reservoir_state,
                          const WellState& well_state);
 

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -80,10 +80,11 @@ namespace Opm {
     template <class Grid>
     void
     BlackoilMultiSegmentModel<Grid>::
-    prepareStep(const double dt,
+    prepareStep(const SimulatorTimerInterface& timer,
                 const ReservoirState& reservoir_state,
                 const WellState& well_state)
     {
+        const double dt = timer.currentStepLength();
         pvdt_ = geo_.poreVolume() / dt;
         if (active_[Gas]) {
             updatePrimalVariableFromState(reservoir_state);

--- a/opm/autodiff/BlackoilPressureModel.hpp
+++ b/opm/autodiff/BlackoilPressureModel.hpp
@@ -26,6 +26,7 @@
 #include <opm/core/simulator/BlackoilState.hpp>
 #include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
 #include <opm/autodiff/BlackoilModelParameters.hpp>
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 #include <algorithm>
 
@@ -83,12 +84,12 @@ namespace Opm {
         }
 
         /// Called once per timestep.
-        void prepareStep(const double dt,
+        void prepareStep(const SimulatorTimerInterface& timer,
                          const ReservoirState& reservoir_state,
                          const WellState& well_state)
         {
             asImpl().wellModel().setStoreWellPerforationFluxesFlag(true);
-            Base::prepareStep(dt, reservoir_state, well_state);
+            Base::prepareStep(timer, reservoir_state, well_state);
             max_dp_rel_ = std::numeric_limits<double>::infinity();
             state0_ = asImpl().variableState(reservoir_state, well_state);
             asImpl().makeConstantState(state0_);
@@ -289,7 +290,7 @@ namespace Opm {
 
 
 
-        bool getConvergence(const double /* dt */, const int iteration)
+        bool getConvergence(const SimulatorTimerInterface& /* timer */, const int iteration)
         {
             const double tol_p = 1e-11;
             const double resmax = residual_.material_balance_eq[0].value().abs().maxCoeff();

--- a/opm/autodiff/BlackoilSequentialModel.hpp
+++ b/opm/autodiff/BlackoilSequentialModel.hpp
@@ -28,6 +28,7 @@
 #include <opm/core/simulator/BlackoilState.hpp>
 #include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
 #include <opm/autodiff/BlackoilModelParameters.hpp>
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 namespace Opm {
 
@@ -94,10 +95,10 @@ namespace Opm {
 
 
         /// Called once before each time step.
-        /// \param[in] dt                time step size
+        /// \param[in] timer             simulation timer
         /// \param[in] reservoir_state   reservoir state variables
         /// \param[in] well_state        well state variables
-        void prepareStep(const double /* dt */,
+        void prepareStep(const SimulatorTimerInterface& /*timer*/,
                          const ReservoirState& reservoir_state,
                          const WellState& well_state)
         {
@@ -113,13 +114,13 @@ namespace Opm {
         /// This model will first solve the pressure model to convergence, then the
         /// transport model.
         /// \param[in] iteration              should be 0 for the first call of a new timestep
-        /// \param[in] dt                     time step size
+        /// \param[in] timer             simulation timer
         /// \param[in] nonlinear_solver       nonlinear solver used (for oscillation/relaxation control)
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         template <class NonlinearSolverType>
         IterationReport nonlinearIteration(const int iteration,
-                                           const double dt,
+                                           const SimulatorTimerInterface& timer,
                                            NonlinearSolverType& /* nonlinear_solver */,
                                            ReservoirState& reservoir_state,
                                            WellState& well_state)
@@ -135,7 +136,7 @@ namespace Opm {
                     OpmLog::info("Solving the pressure equation.");
                 }
                 ReservoirState initial_state = reservoir_state;
-                const int pressure_liniter = pressure_solver_.step(dt, reservoir_state, well_state);
+                const int pressure_liniter = pressure_solver_.step(timer, reservoir_state, well_state);
                 if (pressure_liniter == -1) {
                     OPM_THROW(std::runtime_error, "Pressure solver failed to converge.");
                 }
@@ -144,7 +145,7 @@ namespace Opm {
                 if (terminalOutputEnabled()) {
                     OpmLog::info("Solving the transport equations.");
                 }
-                const int transport_liniter = transport_solver_.step(dt, initial_state, well_state, reservoir_state, well_state);
+                const int transport_liniter = transport_solver_.step(timer, initial_state, well_state, reservoir_state, well_state);
                 if (transport_liniter == -1) {
                     OPM_THROW(std::runtime_error, "Transport solver failed to converge.");
                 }
@@ -163,7 +164,7 @@ namespace Opm {
                 if (terminalOutputEnabled()) {
                     OpmLog::info("Solving the pressure equation.");
                 }
-                const int pressure_liniter = pressure_solver_.step(dt, initial_reservoir_state_, initial_well_state_, reservoir_state, well_state);
+                const int pressure_liniter = pressure_solver_.step(timer, initial_reservoir_state_, initial_well_state_, reservoir_state, well_state);
                 if (pressure_liniter == -1) {
                     OPM_THROW(std::runtime_error, "Pressure solver failed to converge.");
                 }
@@ -172,7 +173,7 @@ namespace Opm {
                 if (terminalOutputEnabled()) {
                     OpmLog::info("Solving the transport equations.");
                 }
-                const int transport_liniter = transport_solver_.step(dt, initial_reservoir_state_, initial_well_state_, reservoir_state, well_state);
+                const int transport_liniter = transport_solver_.step(timer, initial_reservoir_state_, initial_well_state_, reservoir_state, well_state);
                 if (transport_liniter == -1) {
                     OPM_THROW(std::runtime_error, "Transport solver failed to converge.");
                 }
@@ -189,10 +190,10 @@ namespace Opm {
 
         /// Called once after each time step.
         /// In this class, this function does nothing.
-        /// \param[in] dt                     time step size
+        /// \param[in] timer                  simulation timer
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
-        void afterStep(const double /* dt */,
+        void afterStep(const SimulatorTimerInterface& /* timer */,
                        ReservoirState& /* reservoir_state */,
                        WellState& /* well_state */)
         {

--- a/opm/autodiff/BlackoilTransportModel.hpp
+++ b/opm/autodiff/BlackoilTransportModel.hpp
@@ -25,6 +25,7 @@
 #include <opm/core/simulator/BlackoilState.hpp>
 #include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
 #include <opm/autodiff/BlackoilModelParameters.hpp>
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 namespace Opm {
 
@@ -72,11 +73,11 @@ namespace Opm {
         {
         }
 
-        void prepareStep(const double dt,
+        void prepareStep(const SimulatorTimerInterface& timer,
                          const ReservoirState& reservoir_state,
                          const WellState& well_state)
         {
-            Base::prepareStep(dt, reservoir_state, well_state);
+            Base::prepareStep(timer, reservoir_state, well_state);
             Base::param_.solve_welleq_initially_ = false;
             state0_ = variableState(reservoir_state, well_state);
             asImpl().makeConstantState(state0_);
@@ -530,8 +531,9 @@ namespace Opm {
 
 
 
-        bool getConvergence(const double dt, const int iteration)
+        bool getConvergence(const SimulatorTimerInterface& timer, const int iteration)
         {
+            const double dt = timer.currentStepLength();
             const double tol_mb    = param_.tolerance_mb_;
             const double tol_cnv   = param_.tolerance_cnv_;
 

--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -23,6 +23,7 @@
 
 #include <opm/autodiff/AutoDiffBlock.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
 #include <memory>
 
 namespace Opm {
@@ -76,12 +77,12 @@ namespace Opm {
 
         /// Take a single forward step, after which the states will be modified
         /// according to the physical model.
-        /// \param[in] dt                       time step size
+        /// \param[in] timer                  simulation timer
         /// \param[in, out] reservoir_state     reservoir state variables
         /// \param[in, out] well_state          well state variables
         /// \return                             number of linear iterations used
         int
-        step(const double dt,
+        step(const SimulatorTimerInterface& timer,
              ReservoirState& reservoir_state,
              WellState& well_state);
 
@@ -89,14 +90,14 @@ namespace Opm {
         /// according to the physical model. This version allows for the
         /// states passed as in/out arguments to be different from the initial
         /// states.
-        /// \param[in] dt                       time step size
+        /// \param[in] timer                  simulation timer
         /// \param[in] initial_reservoir_state  reservoir state variables at start of timestep
         /// \param[in] initial_well_state       well state variables at start of timestep
         /// \param[in, out] reservoir_state     reservoir state variables
         /// \param[in, out] well_state          well state variables
         /// \return                             number of linear iterations used
         int
-        step(const double dt,
+        step(const SimulatorTimerInterface& timer,
              const ReservoirState& initial_reservoir_state,
              const WellState& initial_well_state,
              ReservoirState& reservoir_state,

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -96,11 +96,11 @@ namespace Opm
     template <class PhysicalModel>
     int
     NonlinearSolver<PhysicalModel>::
-    step(const double dt,
+    step(const SimulatorTimerInterface& timer,
          ReservoirState& reservoir_state,
          WellState& well_state)
     {
-        return step(dt, reservoir_state, well_state, reservoir_state, well_state);
+        return step(timer, reservoir_state, well_state, reservoir_state, well_state);
     }
 
 
@@ -108,14 +108,14 @@ namespace Opm
     template <class PhysicalModel>
     int
     NonlinearSolver<PhysicalModel>::
-    step(const double dt,
+    step(const SimulatorTimerInterface& timer,
          const ReservoirState& initial_reservoir_state,
          const WellState& initial_well_state,
          ReservoirState& reservoir_state,
          WellState& well_state)
     {
         // Do model-specific once-per-step calculations.
-        model_->prepareStep(dt, initial_reservoir_state, initial_well_state);
+        model_->prepareStep(timer, initial_reservoir_state, initial_well_state);
 
         int iteration = 0;
 
@@ -131,7 +131,7 @@ namespace Opm
             // Do the nonlinear step. If we are in a converged state, the
             // model will usually do an early return without an expensive
             // solve, unless the minIter() count has not been reached yet.
-            IterationReport report = model_->nonlinearIteration(iteration, dt, *this, reservoir_state, well_state);
+            IterationReport report = model_->nonlinearIteration(iteration, timer, *this, reservoir_state, well_state);
             if (report.failed) {
                 OPM_THROW(Opm::NumericalProblem, "Failed to complete a nonlinear iteration.");
             }
@@ -156,7 +156,7 @@ namespace Opm
         wellIterationsLast_ = wellIters;
 
         // Do model-specific post-step actions.
-        model_->afterStep(dt, reservoir_state, well_state);
+        model_->afterStep(timer, reservoir_state, well_state);
 
         return linIters;
     }

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -207,7 +207,7 @@ namespace Opm
             }
             else {
                 // solve for complete report step
-                solver->step(timer.currentStepLength(), state, well_state);
+                solver->step(timer, state, well_state);
 
                 if( terminal_output_ )
                 {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -153,7 +153,7 @@ namespace Opm
             }
             else {
                 // solve for complete report step
-                solver->step(timer.currentStepLength(), state, well_state);
+                solver->step(timer, state, well_state);
             }
 
             // take time that was used to solve system for this reportStep

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -28,6 +28,7 @@
 #include <opm/polymer/PolymerBlackoilState.hpp>
 #include <opm/polymer/fullyimplicit/WellStateFullyImplicitBlackoilPolymer.hpp>
 #include <opm/autodiff/StandardWells.hpp>
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 namespace Opm {
 
@@ -93,18 +94,18 @@ namespace Opm {
                              const bool                              terminal_output);
 
         /// Called once before each time step.
-        /// \param[in] dt                     time step size
+        /// \param[in] timer                  simulation timer
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
-        void prepareStep(const double dt,
+        void prepareStep(const SimulatorTimerInterface& timer,
                          const ReservoirState& reservoir_state,
                          const WellState& well_state);
 
         /// Called once after each time step.
-        /// \param[in] dt                     time step size
+        /// \param[in] timer                  simulation timer
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
-        void afterStep(const double dt,
+        void afterStep(const SimulatorTimerInterface& timer,
                        ReservoirState& reservoir_state,
                        WellState& well_state);
 

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -121,11 +121,11 @@ namespace Opm {
     template <class Grid>
     void
     BlackoilPolymerModel<Grid>::
-    prepareStep(const double dt,
+    prepareStep(const SimulatorTimerInterface& timer,
                 const ReservoirState& reservoir_state,
                 const WellState& well_state)
     {
-        Base::prepareStep(dt, reservoir_state, well_state);
+        Base::prepareStep(timer, reservoir_state, well_state);
         auto& max_concentration = reservoir_state.getCellData( reservoir_state.CMAX );
         // Initial max concentration of this time step from PolymerBlackoilState.
 
@@ -138,7 +138,7 @@ namespace Opm {
     template <class Grid>
     void
     BlackoilPolymerModel<Grid>::
-    afterStep(const double /* dt */,
+    afterStep(const SimulatorTimerInterface& /* timer */,
               ReservoirState& reservoir_state,
               WellState& /* well_state */)
     {

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
@@ -32,6 +32,7 @@
 #include <opm/core/grid.h>
 #include <opm/core/linalg/LinearSolverInterface.hpp>
 #include <opm/core/props/rock/RockCompressibility.hpp>
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
 #include <opm/polymer/PolymerBlackoilState.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/well_controls.h>
@@ -199,11 +200,12 @@ namespace {
 
     int
     FullyImplicitCompressiblePolymerSolver::
-    step(const double          dt,
+    step(const SimulatorTimerInterface& timer,
          PolymerBlackoilState& x ,
          WellStateFullyImplicitBlackoilPolymer& xw)
     {
         const std::vector<double>& polymer_inflow = xw.polymerInflow();
+        const double dt = timer.currentStepLength();
 
         // Initial max concentration of this time step from PolymerBlackoilState.
         cmax_ = Eigen::Map<V>(&x.getCellData( x.CMAX )[0], Opm::AutoDiffGrid::numCells(grid_));

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
@@ -30,6 +30,7 @@
 #include <opm/polymer/fullyimplicit/WellStateFullyImplicitBlackoilPolymer.hpp>
 #include <opm/polymer/fullyimplicit/PolymerPropsAd.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
+#include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
 struct UnstructuredGrid;
 struct Wells;
@@ -82,7 +83,7 @@ namespace Opm {
         /// \param[in] wstate    well state
         /// \param[in] polymer_inflow	polymer influx
         int
-        step(const double   			dt,
+        step(const SimulatorTimerInterface& timer,
              PolymerBlackoilState& 		state ,
              WellStateFullyImplicitBlackoilPolymer& wstate);
 


### PR DESCRIPTION
models may need a more detailed picture of where they are in the
simulation. Note that since the timer objects are available at every
call site, this is also not a very deep change.

this PR has a cyclic depency with  OPM/opm-core#1052 and must thus merged synchronously.