### PR TITLE
Diagnostics keywords that not supported by flow.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -50,6 +50,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/autodiff/MultisegmentWells.cpp
   opm/autodiff/BlackoilSolventState.cpp
   opm/autodiff/ThreadHandle.hpp
+	opm/autodiff/MissingFeatures.cpp
   opm/polymer/PolymerState.cpp
   opm/polymer/PolymerBlackoilState.cpp
   opm/polymer/CompressibleTpfaPolymer.cpp
@@ -210,6 +211,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/autodiff/StandardWells_impl.hpp
   opm/autodiff/StandardWellsSolvent.hpp
   opm/autodiff/StandardWellsSolvent_impl.hpp
+	opm/autodiff/MissingFeatures.hpp
   opm/polymer/CompressibleTpfaPolymer.hpp
   opm/polymer/GravityColumnSolverPolymer.hpp
   opm/polymer/GravityColumnSolverPolymer_impl.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -50,7 +50,7 @@ list (APPEND MAIN_SOURCE_FILES
 	opm/autodiff/MultisegmentWells.cpp
   opm/autodiff/BlackoilSolventState.cpp
   opm/autodiff/ThreadHandle.hpp
-	opm/autodiff/MissingFeatures.cpp
+  opm/autodiff/MissingFeatures.cpp
   opm/polymer/PolymerState.cpp
   opm/polymer/PolymerBlackoilState.cpp
   opm/polymer/CompressibleTpfaPolymer.cpp
@@ -211,7 +211,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/autodiff/StandardWells_impl.hpp
   opm/autodiff/StandardWellsSolvent.hpp
   opm/autodiff/StandardWellsSolvent_impl.hpp
-	opm/autodiff/MissingFeatures.hpp
+  opm/autodiff/MissingFeatures.hpp
   opm/polymer/CompressibleTpfaPolymer.hpp
   opm/polymer/GravityColumnSolverPolymer.hpp
   opm/polymer/GravityColumnSolverPolymer_impl.hpp

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -413,7 +413,7 @@ namespace Opm
                 ParseContext parseContext({{ ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE }});
                 deck_ = parser->parseFile(deck_filename, parseContext);
                 checkDeck(deck_, parser);
-                MissingFeatures::checkKeywords(deck_);
+                MissingFeatures::checkKeywords(*deck_);
                 eclipse_state_.reset(new EclipseState(deck_, parseContext));
                 auto ioConfig = eclipse_state_->getIOConfig();
                 ioConfig->setOutputDir(output_dir_);

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -67,6 +67,7 @@
 #include <opm/autodiff/BlackoilPropsAdFromDeck.hpp>
 #include <opm/autodiff/RedistributeDataHandles.hpp>
 #include <opm/autodiff/moduleVersion.hpp>
+#include <opm/autodiff/MissingFeatures.hpp>
 
 #include <opm/core/utility/share_obj.hpp>
 #include <opm/core/utility/initHydroCarbonState.hpp>
@@ -76,7 +77,6 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
@@ -411,7 +411,7 @@ namespace Opm
             try {
                 ParseContext parseContext({{ ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE }});
                 deck_ = parser->parseFile(deck_filename, parseContext);
-                checkDeck(deck_, parser);
+                checkKeywords(deck_, parser);
                 eclipse_state_.reset(new EclipseState(deck_, parseContext));
                 auto ioConfig = eclipse_state_->getIOConfig();
                 ioConfig->setOutputDir(output_dir_);

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -413,7 +413,7 @@ namespace Opm
                 ParseContext parseContext({{ ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE }});
                 deck_ = parser->parseFile(deck_filename, parseContext);
                 checkDeck(deck_, parser);
-                MissingFeatures::checkKeywords(deck_, parser);
+                MissingFeatures::checkKeywords(deck_);
                 eclipse_state_.reset(new EclipseState(deck_, parseContext));
                 auto ioConfig = eclipse_state_->getIOConfig();
                 ioConfig->setOutputDir(output_dir_);

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -80,6 +80,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
@@ -411,7 +412,8 @@ namespace Opm
             try {
                 ParseContext parseContext({{ ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE }});
                 deck_ = parser->parseFile(deck_filename, parseContext);
-                checkKeywords(deck_, parser);
+                checkDeck(deck_, parser);
+                MissingFeatures::checkKeywords(deck_, parser);
                 eclipse_state_.reset(new EclipseState(deck_, parseContext));
                 auto ioConfig = eclipse_state_->getIOConfig();
                 ioConfig->setOutputDir(output_dir_);

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -1,0 +1,75 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
+#include <opm/autodiff/MissingFeatures.hpp>
+#include <vector>
+#include <string>
+
+
+namespace Opm {
+
+    
+    void checkKeywords(DeckConstPtr deck, ParserConstPtr parser)
+    {
+        // These keywords are supported by opm-parser, but are not supported
+        // by flow. For some of them, only part of the options are supported.
+        // The list is used to output messages only.
+        std::vector<std::string> unsupported_keywords = {
+            "ACTDIMS", "ADSALNOD", "API", "AQUCON", "AQUDIMS", "AQUNUM"
+            "BLOCK_PROBE", "COMPLUMP", "COMPSEGS", "CONNECTION", "CPR", 
+            "DATE", "ECHO", "EDITNNC", "ENDINC", "ENDNUM", "ENDPOINT_SPECIFIERS",
+            "ENDSKIP", "ENKSRVD", "ENPTVD", "EQLNUM", "EQUALREG",
+            "EXCEL", "EXTRAPMS", "FILED_PROBE", "FILLEPS", "FIPNUM", "FMTIN",
+            "FMTOUT", "FULLIMP", "GDORIENT", "GECON", "GEFAC", "GRIDUNIT", 
+            "GROUP_PROBE", "GRUPNET", "IMKRVD", "IMPES", "IMPTVD", "MAPUNITS",
+            "MAXVALUE", "MEMORY", "MESSAGES", "MINVALUE", "MONITOR", "MSGFILE",
+            "MULT_XYZ", "NETBALAN", "NEXTSTEP", "NOCASC", "NOECHO",
+            "NOGGF", "NOINSPEC", "NOMONITO", "NONNC", "NORSSPEC", "NOSIM",
+            "NSTACK", "NUMRES", "NUPCOL", "OILVISCT", "OLDTRAN", "OPTIONS", 
+            "PARALLEL", "PBVD", "PCG", "PERFORMACE_PROBE", "PERMXY", "PERMYZ", 
+            "PERMZX", "PIMTDIMS", "PIMULTAB", "PLMIXPAR", "PLYADSS", "PLYDHFLF",
+            "RADFIN4", "REGDIMS", "REGION_PROBE", "RKTRMDIR", "ROCKCOMP", "ROCKOPTS",
+            "ROCKTAB", "RPTGRID", "RPTONLY", "RPTONLYO", "RPTPROS", "PRTRST", "RPTRUNSP",
+            "RPTSCHED", "RPTSOL", "RTEMPVD", "RUNSUM", "SATOPTS", "SAVE", "SEPARATE",
+            "SKIP", "SKIP100", "SKIP300", "SKIPREST", "SMRYDIMS", "SPECGRID", "SSOL",
+            "SUMTHIN", "TEMP", "THCONR", "TRACER", "TRACERS", "UDADIMS", "UDQDIMS",
+            "UNIFIN", "UNIFOUT", "VAPPARS", "VISCREF", "WATVISCT", "WELL_PROBE",
+            "WPAVE", "WPIMULT", "WPITAB", "WRFT", "WRFTPLT", "WSEGDIMS", "WTEMP",
+            "WTEST", "WTRACER", "ZIPPY2" };
+        
+        // check deck and keyword for flow and parser.
+        if (checkDeck(deck, parser)) {
+            for (size_t idx = 0; idx < deck->size(); ++idx) {
+                const auto& keyword = deck->getKeyword(idx);
+                std::vector<std::string>::const_iterator it;
+                it = std::find(unsupported_keywords.begin(),
+                               unsupported_keywords.end(), 
+                               keyword.name());
+                if (it != unsupported_keywords.end()) {
+                    std::string msg = "Keyword '" + keyword.name() + "' is not supported by flow.\n"
+                        + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n"; 
+                    OpmLog::error(msg);
+                }
+            }
+        }
+    }
+} // namespace Opm

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -28,7 +28,7 @@ namespace Opm {
 
 namespace MissingFeatures {
 
-    void checkKeywords(DeckConstPtr deck, ParserConstPtr parser)
+    void checkKeywords(DeckConstPtr deck)
     {
         // These keywords are supported by opm-parser, but are not supported
         // by flow. For some of them, only part of the options are supported.

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -28,7 +28,7 @@ namespace Opm {
 
 namespace MissingFeatures {
 
-    void checkKeywords(DeckConstPtr deck)
+    void checkKeywords(const Deck& deck)
     {
         // These keywords are supported by opm-parser, but are not supported
         // by flow. For some of them, only part of the options are supported.
@@ -57,8 +57,8 @@ namespace MissingFeatures {
             "WTEST", "WTRACER", "ZIPPY2" };
         
         // check deck and keyword for flow and parser.
-        for (size_t idx = 0; idx < deck->size(); ++idx) {
-            const auto& keyword = deck->getKeyword(idx);
+        for (size_t idx = 0; idx < deck.size(); ++idx) {
+            const auto& keyword = deck.getKeyword(idx);
             std::unordered_set<std::string>::const_iterator it;
             it = unsupported_keywords.find(keyword.name());
             if (it != unsupported_keywords.end()) {

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -21,7 +21,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/autodiff/MissingFeatures.hpp>
-#include <vector>
+#include <unordered_set>
 #include <string>
 
 
@@ -33,7 +33,7 @@ namespace Opm {
         // These keywords are supported by opm-parser, but are not supported
         // by flow. For some of them, only part of the options are supported.
         // The list is used to output messages only.
-        std::vector<std::string> unsupported_keywords = {
+        std::unordered_set<std::string> unsupported_keywords = {
             "ACTDIMS", "ADSALNOD", "API", "AQUCON", "AQUDIMS", "AQUNUM"
             "BLOCK_PROBE", "COMPLUMP", "COMPSEGS", "CONNECTION", "CPR", 
             "DATE", "ECHO", "EDITNNC", "ENDINC", "ENDNUM", "ENDPOINT_SPECIFIERS",
@@ -60,10 +60,8 @@ namespace Opm {
         if (checkDeck(deck, parser)) {
             for (size_t idx = 0; idx < deck->size(); ++idx) {
                 const auto& keyword = deck->getKeyword(idx);
-                std::vector<std::string>::const_iterator it;
-                it = std::find(unsupported_keywords.begin(),
-                               unsupported_keywords.end(), 
-                               keyword.name());
+                std::unordered_set<std::string>::const_iterator it;
+                it = unsupported_keywords.find(keyword.name());
                 if (it != unsupported_keywords.end()) {
                     std::string msg = "Keyword '" + keyword.name() + "' is not supported by flow.\n"
                         + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n"; 

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -34,26 +34,26 @@ namespace MissingFeatures {
         // by flow. For some of them, only part of the options are supported.
         // The list is used to output messages only.
         std::unordered_set<std::string> unsupported_keywords = {
-            "ACTDIMS", "ADSALNOD", "API", "AQUCON", "AQUDIMS", "AQUNUM"
+            "ADSALNOD", "API", "AQUCON", "AQUNUM"
             "COMPLUMP", "COMPSEGS", "CONNECTION", "CPR", 
             "DATE", "ECHO", "EDITNNC", "ENDNUM",
             "ENDSKIP", "ENKSRVD", "ENPTVD", "EQLNUM", "EQUALREG",
-            "EXCEL", "EXTRAPMS", "FILLEPS", "FIPNUM", "FMTIN",
-            "FMTOUT", "FULLIMP", "GDORIENT", "GECON", "GEFAC", "GRIDUNIT", 
+            "EXCEL", "EXTRAPMS", "FILLEPS", "FIPNUM",
+            "FULLIMP", "GDORIENT", "GECON", "GEFAC", "GRIDUNIT", 
             "GRUPNET", "IMKRVD", "IMPES", "IMPTVD", "MAPUNITS",
             "MAXVALUE", "MESSAGES", "MINVALUE", "MONITOR", "MSGFILE",
             "MULT_XYZ", "NETBALAN", "NEXTSTEP", "NOCASC", "NOECHO",
             "NOGGF", "NOINSPEC", "NOMONITO", "NONNC", "NORSSPEC", "NOSIM",
             "NSTACK", "NUMRES", "NUPCOL", "OILVISCT", "OLDTRAN", "OPTIONS", 
             "PARALLEL", "PBVD", "PCG", "PERMXY", "PERMYZ", 
-            "PERMZX", "PIMTDIMS", "PIMULTAB", "PLMIXPAR", "PLYADSS", "PLYDHFLF",
-            "RADFIN4", "REGDIMS", "RKTRMDIR", "ROCKCOMP", "ROCKOPTS",
+            "PERMZX", "PIMULTAB", "PLMIXPAR", "PLYADSS", "PLYDHFLF",
+            "RADFIN4", "RKTRMDIR", "ROCKCOMP", "ROCKOPTS",
             "ROCKTAB", "RPTGRID", "RPTONLY", "RPTONLYO", "RPTPROS", "PRTRST", "RPTRUNSP",
             "RPTSCHED", "RPTSOL", "RTEMPVD", "RUNSUM", "SATOPTS", "SAVE", "SEPARATE",
-            "SKIP", "SKIP100", "SKIP300", "SKIPREST", "SMRYDIMS", "SPECGRID", "SSOL",
-            "SUMTHIN", "TEMP", "THCONR", "TRACER", "TRACERS", "UDADIMS", "UDQDIMS",
+            "SKIP", "SKIP100", "SKIP300", "SKIPREST", "SPECGRID", "SSOL",
+            "SUMTHIN", "TEMP", "THCONR", "TRACER", "TRACERS",
             "VAPPARS", "VISCREF", "WATVISCT",
-            "WPAVE", "WPIMULT", "WPITAB", "WSEGDIMS", "WTEMP",
+            "WPAVE", "WPIMULT", "WPITAB", "WTEMP",
             "WTEST", "WTRACER", "ZIPPY2" };
         
         // check deck and keyword for flow and parser.

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -19,7 +19,6 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/autodiff/MissingFeatures.hpp>
 #include <unordered_set>
 #include <string>
@@ -27,7 +26,8 @@
 
 namespace Opm {
 
-    
+namespace MissingFeatures {
+
     void checkKeywords(DeckConstPtr deck, ParserConstPtr parser)
     {
         // These keywords are supported by opm-parser, but are not supported
@@ -35,39 +35,38 @@ namespace Opm {
         // The list is used to output messages only.
         std::unordered_set<std::string> unsupported_keywords = {
             "ACTDIMS", "ADSALNOD", "API", "AQUCON", "AQUDIMS", "AQUNUM"
-            "BLOCK_PROBE", "COMPLUMP", "COMPSEGS", "CONNECTION", "CPR", 
-            "DATE", "ECHO", "EDITNNC", "ENDINC", "ENDNUM", "ENDPOINT_SPECIFIERS",
+            "COMPLUMP", "COMPSEGS", "CONNECTION", "CPR", 
+            "DATE", "ECHO", "EDITNNC", "ENDNUM",
             "ENDSKIP", "ENKSRVD", "ENPTVD", "EQLNUM", "EQUALREG",
-            "EXCEL", "EXTRAPMS", "FILED_PROBE", "FILLEPS", "FIPNUM", "FMTIN",
+            "EXCEL", "EXTRAPMS", "FILLEPS", "FIPNUM", "FMTIN",
             "FMTOUT", "FULLIMP", "GDORIENT", "GECON", "GEFAC", "GRIDUNIT", 
-            "GROUP_PROBE", "GRUPNET", "IMKRVD", "IMPES", "IMPTVD", "MAPUNITS",
-            "MAXVALUE", "MEMORY", "MESSAGES", "MINVALUE", "MONITOR", "MSGFILE",
+            "GRUPNET", "IMKRVD", "IMPES", "IMPTVD", "MAPUNITS",
+            "MAXVALUE", "MESSAGES", "MINVALUE", "MONITOR", "MSGFILE",
             "MULT_XYZ", "NETBALAN", "NEXTSTEP", "NOCASC", "NOECHO",
             "NOGGF", "NOINSPEC", "NOMONITO", "NONNC", "NORSSPEC", "NOSIM",
             "NSTACK", "NUMRES", "NUPCOL", "OILVISCT", "OLDTRAN", "OPTIONS", 
-            "PARALLEL", "PBVD", "PCG", "PERFORMACE_PROBE", "PERMXY", "PERMYZ", 
+            "PARALLEL", "PBVD", "PCG", "PERMXY", "PERMYZ", 
             "PERMZX", "PIMTDIMS", "PIMULTAB", "PLMIXPAR", "PLYADSS", "PLYDHFLF",
-            "RADFIN4", "REGDIMS", "REGION_PROBE", "RKTRMDIR", "ROCKCOMP", "ROCKOPTS",
+            "RADFIN4", "REGDIMS", "RKTRMDIR", "ROCKCOMP", "ROCKOPTS",
             "ROCKTAB", "RPTGRID", "RPTONLY", "RPTONLYO", "RPTPROS", "PRTRST", "RPTRUNSP",
             "RPTSCHED", "RPTSOL", "RTEMPVD", "RUNSUM", "SATOPTS", "SAVE", "SEPARATE",
             "SKIP", "SKIP100", "SKIP300", "SKIPREST", "SMRYDIMS", "SPECGRID", "SSOL",
             "SUMTHIN", "TEMP", "THCONR", "TRACER", "TRACERS", "UDADIMS", "UDQDIMS",
-            "UNIFIN", "UNIFOUT", "VAPPARS", "VISCREF", "WATVISCT", "WELL_PROBE",
-            "WPAVE", "WPIMULT", "WPITAB", "WRFT", "WRFTPLT", "WSEGDIMS", "WTEMP",
+            "VAPPARS", "VISCREF", "WATVISCT",
+            "WPAVE", "WPIMULT", "WPITAB", "WSEGDIMS", "WTEMP",
             "WTEST", "WTRACER", "ZIPPY2" };
         
         // check deck and keyword for flow and parser.
-        if (checkDeck(deck, parser)) {
-            for (size_t idx = 0; idx < deck->size(); ++idx) {
-                const auto& keyword = deck->getKeyword(idx);
-                std::unordered_set<std::string>::const_iterator it;
-                it = unsupported_keywords.find(keyword.name());
-                if (it != unsupported_keywords.end()) {
-                    std::string msg = "Keyword '" + keyword.name() + "' is not supported by flow.\n"
-                        + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n"; 
+        for (size_t idx = 0; idx < deck->size(); ++idx) {
+            const auto& keyword = deck->getKeyword(idx);
+            std::unordered_set<std::string>::const_iterator it;
+            it = unsupported_keywords.find(keyword.name());
+            if (it != unsupported_keywords.end()) {
+                std::string msg = "Keyword '" + keyword.name() + "' is not supported by flow.\n"
+                    + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n"; 
                     OpmLog::error(msg);
-                }
             }
         }
     }
+} // namespace MissingFeatures
 } // namespace Opm

--- a/opm/autodiff/MissingFeatures.hpp
+++ b/opm/autodiff/MissingFeatures.hpp
@@ -24,7 +24,7 @@ namespace Opm {
 
 namespace MissingFeatures {
 
-    void checkKeywords(std::shared_ptr<const Deck> deck);
+    void checkKeywords(const Deck& deck);
 
 }
 

--- a/opm/autodiff/MissingFeatures.hpp
+++ b/opm/autodiff/MissingFeatures.hpp
@@ -24,7 +24,7 @@ namespace Opm {
 
 namespace MissingFeatures {
 
-    void checkKeywords(std::shared_ptr<const Deck> deck, std::shared_ptr<const Parser> parser);
+    void checkKeywords(std::shared_ptr<const Deck> deck);
 
 }
 

--- a/opm/autodiff/MissingFeatures.hpp
+++ b/opm/autodiff/MissingFeatures.hpp
@@ -21,7 +21,13 @@
 #define OPM_MISSINGFEATURES_HEADER_INCLUDED
 
 namespace Opm {
+
+namespace MissingFeatures {
+
     void checkKeywords(std::shared_ptr<const Deck> deck, std::shared_ptr<const Parser> parser);
+
+}
+
 }
 
 

--- a/opm/autodiff/MissingFeatures.hpp
+++ b/opm/autodiff/MissingFeatures.hpp
@@ -1,0 +1,28 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_MISSINGFEATURES_HEADER_INCLUDED
+#define OPM_MISSINGFEATURES_HEADER_INCLUDED
+
+namespace Opm {
+    void checkKeywords(std::shared_ptr<const Deck> deck, std::shared_ptr<const Parser> parser);
+}
+
+
+#endif // OPM_MISSINGFEATURES_HEADER_INCLUDED


### PR DESCRIPTION
The intention of this PR is to output messages for the keywords which are supported by opm-parser but not by flow. 

This PR only deal with the unsupported keywords. For the case that partially supported keywords and partially supported options, that are much more complicated and need more consideration.

The keywords listed in this PR may not include all the unsupported keywords or some of them probably have been already supported but I did aware. In any of these two case, please feel free to make comments.