### PR TITLE
fix well iterations counting bugs.

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -775,7 +775,7 @@ namespace detail {
         asImpl().assembleMassBalanceEq(state);
 
         // -------- Well equations ----------
-        IterationReport iter_report = {false, false, 0, std::numeric_limits<int>::min()};
+        IterationReport iter_report = {false, false, 0, 0};
         if ( ! wellsActive() ) {
             return iter_report;
         }

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -182,7 +182,7 @@ namespace Opm {
         asImpl().assembleMassBalanceEq(state);
 
         // -------- Well equations ----------
-        IterationReport iter_report = {false, false, 0, std::numeric_limits<int>::min()};
+        IterationReport iter_report = {false, false, 0, 0};
         if ( ! wellsActive() ) {
             return iter_report;
         }

--- a/opm/autodiff/BlackoilTransportModel.hpp
+++ b/opm/autodiff/BlackoilTransportModel.hpp
@@ -124,7 +124,7 @@ namespace Opm {
             asImpl().assembleMassBalanceEq(state);
 
             // -------- Well equations ----------
-            IterationReport iter_report = {false, false, 0, std::numeric_limits<int>::min()};
+            IterationReport iter_report = {false, false, 0, 0};
             if ( ! wellsActive() ) {
                 return iter_report;
             }

--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -117,9 +117,6 @@ namespace Opm {
         /// Number of linear solver iterations used in the last call to step().
         int linearIterationsLastStep() const;
 
-        /// Number of well iterations used in the last call to step().
-        int wellIterationsLastStep() const;
-
         /// Reference to physical model.
         const PhysicalModel& model() const;
 
@@ -160,7 +157,6 @@ namespace Opm {
         int wellIterations_;
         int nonlinearIterationsLast_;
         int linearIterationsLast_;
-        int wellIterationsLast_;
     };
 } // namespace Opm
 

--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -117,6 +117,9 @@ namespace Opm {
         /// Number of linear solver iterations used in the last call to step().
         int linearIterationsLastStep() const;
 
+        /// Number of well iterations used in all calls to step().
+        int wellIterationsLastStep() const;
+
         /// Reference to physical model.
         const PhysicalModel& model() const;
 
@@ -157,6 +160,7 @@ namespace Opm {
         int wellIterations_;
         int nonlinearIterationsLast_;
         int linearIterationsLast_;
+        int wellIterationsLast_;
     };
 } // namespace Opm
 

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -36,7 +36,8 @@ namespace Opm
           linearIterations_(0),
           wellIterations_(0),
           nonlinearIterationsLast_(0),
-          linearIterationsLast_(0)
+          linearIterationsLast_(0),
+          wellIterationsLast_(0)
     {
         if (!model_) {
             OPM_THROW(std::logic_error, "Must provide a non-null model argument for NonlinearSolver.");
@@ -85,6 +86,11 @@ namespace Opm
         return linearIterationsLast_;
     }
 
+    template <class PhysicalModel>
+    int NonlinearSolver<PhysicalModel>::wellIterationsLastStep() const
+    {
+        return wellIterationsLast_;
+    }
 
     template <class PhysicalModel>
     int
@@ -143,9 +149,10 @@ namespace Opm
 
         linearIterations_ += linIters;
         nonlinearIterations_ += iteration - 1; // Since the last one will always be trivial.
-        wellIterations_ = wellIters;
+        wellIterations_ += wellIters;
         linearIterationsLast_ = linIters;
         nonlinearIterationsLast_ = iteration;
+        wellIterationsLast_ = wellIters;
 
         // Do model-specific post-step actions.
         model_->afterStep(dt, reservoir_state, well_state);

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -137,9 +137,7 @@ namespace Opm
             }
             converged = report.converged;
             linIters += report.linear_iterations;
-            if (report.well_iterations != std::numeric_limits<int>::min()) {
-                wellIters += report.well_iterations;
-            }
+            wellIters += report.well_iterations;
             ++iteration;
         } while ( (!converged && (iteration <= maxIter())) || (iteration <= minIter()));
 
@@ -152,14 +150,8 @@ namespace Opm
 
         linearIterations_ += linIters;
         nonlinearIterations_ += iteration - 1; // Since the last one will always be trivial.
-        if (wellIters != 0) {
-            wellIterations_ += wellIters;
-            wellIterationsLast_ = wellIters;
-        }
-        if (wellIters == 0) {
-            wellIterations_ = std::numeric_limits<int>::min();
-            wellIterationsLast_ = std::numeric_limits<int>::min();
-        }
+        wellIterations_ = wellIters;
+        wellIterationsLast_ = wellIters;
         linearIterationsLast_ = linIters;
         nonlinearIterationsLast_ = iteration;
 

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -137,7 +137,11 @@ namespace Opm
             }
             converged = report.converged;
             linIters += report.linear_iterations;
-            wellIters += report.well_iterations;
+            if (report.well_iterations != std::numeric_limits<int>::min()) {
+                wellIters += report.well_iterations;
+            } else {
+                wellIters = report.well_iterations;
+            }
             ++iteration;
         } while ( (!converged && (iteration <= maxIter())) || (iteration <= minIter()));
 

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -139,8 +139,6 @@ namespace Opm
             linIters += report.linear_iterations;
             if (report.well_iterations != std::numeric_limits<int>::min()) {
                 wellIters += report.well_iterations;
-            } else {
-                wellIters = report.well_iterations;
             }
             ++iteration;
         } while ( (!converged && (iteration <= maxIter())) || (iteration <= minIter()));
@@ -154,10 +152,16 @@ namespace Opm
 
         linearIterations_ += linIters;
         nonlinearIterations_ += iteration - 1; // Since the last one will always be trivial.
-        wellIterations_ += wellIters; 
+        if (wellIters != 0) {
+            wellIterations_ += wellIters;
+            wellIterationsLast_ = wellIters;
+        }
+        if (wellIters == 0) {
+            wellIterations_ = std::numeric_limits<int>::min();
+            wellIterationsLast_ = std::numeric_limits<int>::min();
+        }
         linearIterationsLast_ = linIters;
         nonlinearIterationsLast_ = iteration;
-        wellIterationsLast_ = wellIters;
 
         // Do model-specific post-step actions.
         model_->afterStep(dt, reservoir_state, well_state);

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -36,8 +36,7 @@ namespace Opm
           linearIterations_(0),
           wellIterations_(0),
           nonlinearIterationsLast_(0),
-          linearIterationsLast_(0),
-          wellIterationsLast_(0)
+          linearIterationsLast_(0)
     {
         if (!model_) {
             OPM_THROW(std::logic_error, "Must provide a non-null model argument for NonlinearSolver.");
@@ -84,12 +83,6 @@ namespace Opm
     int NonlinearSolver<PhysicalModel>::linearIterationsLastStep() const
     {
         return linearIterationsLast_;
-    }
-
-    template <class PhysicalModel>
-    int NonlinearSolver<PhysicalModel>::wellIterationsLastStep() const
-    {
-        return wellIterationsLast_;
     }
 
 
@@ -151,7 +144,6 @@ namespace Opm
         linearIterations_ += linIters;
         nonlinearIterations_ += iteration - 1; // Since the last one will always be trivial.
         wellIterations_ = wellIters;
-        wellIterationsLast_ = wellIters;
         linearIterationsLast_ = linIters;
         nonlinearIterationsLast_ = iteration;
 

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -213,7 +213,7 @@ namespace Opm
                 {
                     std::ostringstream iter_msg;
                     iter_msg << "Stepsize " << (double)unit::convert::to(timer.currentStepLength(), unit::day);
-                    if (solver->wellIterations() != std::numeric_limits<int>::min()) {
+                    if (solver->wellIterations() != 0) {
                         iter_msg << " days well iterations = " << solver->wellIterations() << ", ";
                     }
                     iter_msg << "non-linear iterations = " << solver->nonlinearIterations()


### PR DESCRIPTION
If the well iterations is ``std::numeric_limits<int>::min()``, it should not do the counting.