### PR TITLE
distinguish between the number of non linear iterations and the number of linearizations

### DIFF
--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -103,7 +103,11 @@ namespace Opm {
              ReservoirState& reservoir_state,
              WellState& well_state);
 
-        /// Number of nonlinear solver iterations used in all calls to step().
+
+        /// Number of linearizations used in all calls to step().
+        int linearizations() const;
+
+        /// Number of full nonlinear solver iterations used in all calls to step().
         int nonlinearIterations() const;
 
         /// Number of linear solver iterations used in all calls to step().
@@ -156,6 +160,7 @@ namespace Opm {
         // ---------  Data members  ---------
         SolverParameters param_;
         std::unique_ptr<PhysicalModel> model_;
+        int linearizations_;
         int nonlinearIterations_;
         int linearIterations_;
         int wellIterations_;

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -32,6 +32,7 @@ namespace Opm
                                                     std::unique_ptr<PhysicalModel> model_arg)
         : param_(param),
           model_(std::move(model_arg)),
+          linearizations_(0),
           nonlinearIterations_(0),
           linearIterations_(0),
           wellIterations_(0),
@@ -42,6 +43,12 @@ namespace Opm
         if (!model_) {
             OPM_THROW(std::logic_error, "Must provide a non-null model argument for NonlinearSolver.");
         }
+    }
+
+    template <class PhysicalModel>
+    int NonlinearSolver<PhysicalModel>::linearizations() const
+    {
+        return linearizations_;
     }
 
     template <class PhysicalModel>
@@ -149,6 +156,7 @@ namespace Opm
 
         linearIterations_ += linIters;
         nonlinearIterations_ += iteration - 1; // Since the last one will always be trivial.
+        linearizations_ += iteration;
         wellIterations_ += wellIters;
         linearIterationsLast_ = linIters;
         nonlinearIterationsLast_ = iteration;

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -128,6 +128,7 @@ namespace Opm
                                     desiredRestoreStep );
         }
 
+        unsigned int totalLinearizations = 0;
         unsigned int totalNonlinearIterations = 0;
         unsigned int totalLinearIterations = 0;
         bool is_well_potentials_computed = param_.getDefault("compute_well_potentials", false );
@@ -241,6 +242,7 @@ namespace Opm
             solver_timer.stop();
 
             // accumulate the number of nonlinear and linear Iterations
+            totalLinearizations += solver->linearizations();
             totalNonlinearIterations += solver->nonlinearIterations();
             totalLinearIterations += solver->linearIterations();
 
@@ -287,6 +289,7 @@ namespace Opm
         report.pressure_time = stime;
         report.transport_time = 0.0;
         report.total_time = total_timer.secsSinceStart();
+        report.total_linearizations = totalLinearizations;
         report.total_newton_iterations = totalNonlinearIterations;
         report.total_linear_iterations = totalLinearIterations;
         return report;

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
@@ -191,6 +191,7 @@ namespace {
                         ADB::null(),
                         { 1.1169, 1.0031, 0.0031, 1.0 },
                         false } ) // default scaling
+        , linearizations_(0)
     {
     }
 
@@ -243,6 +244,7 @@ namespace {
             resTooLarge = (r > atol) && (r > rtol*r0);
 
             it += 1;
+            linearizations_ += 1;
             newtonIterations_ += 1;
             std::cout << std::setw(9) << it << std::setprecision(9)
                       << std::setw(18) << r << std::setprecision(9)
@@ -259,6 +261,11 @@ namespace {
         computeCmax(x);
 
         return it;
+    }
+
+    int FullyImplicitCompressiblePolymerSolver::linearizations() const
+    {
+        return linearizations_;
     }
 
     int FullyImplicitCompressiblePolymerSolver::nonlinearIterations() const

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
@@ -87,6 +87,7 @@ namespace Opm {
              PolymerBlackoilState& 		state ,
              WellStateFullyImplicitBlackoilPolymer& wstate);
 
+        int linearizations() const;
         int nonlinearIterations() const;
         int linearIterations() const;
         int wellIterations() const;
@@ -159,6 +160,7 @@ namespace Opm {
         // The well_eq has size equal to the number of wells.
         LinearisedBlackoilResidual  residual_;
 
+        unsigned int linearizations_;
         unsigned int newtonIterations_;
         unsigned int linearIterations_;
         unsigned int wellIterations_;


### PR DESCRIPTION
while the printed number of "Non linear iterations" was correct in a
strict sense, it was very confusing if one was working on the
linearization code because the last Newton iteration of each time step
was linearized but not solved for (and the solution was thus not
updated hence it does not count as a "non linear iteration"). This
makes sense for large problems were the total runtime is completely
dominated by the performance of the linear solver, but smaller
problems exhibit the opposite behavior (i.e., for them, runtime is
typically dominated by the linearization proceedure), so one is more
interested in the number of linearizations, not the number of linear
solves.

note that this PR needs a (small) companion  in opm-core.