### PR TITLE
Handle partially supported options manually.

### DIFF
--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -57,7 +57,7 @@ namespace MissingFeatures {
                 std::string msg = "For keyword '" + it->first + "' only value " + boost::lexical_cast<std::string>(it->second.item_value)
                     + " in item " + it->second.item + " is supported by flow.\n"
                     + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n";
-                OpmLog::error(msg);
+                OpmLog::warning(msg);
             }
         }
     }
@@ -106,7 +106,7 @@ namespace MissingFeatures {
             if (it != unsupported_keywords.end()) {
                 std::string msg = "Keyword '" + keyword.name() + "' is not supported by flow.\n"
                     + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n";
-                OpmLog::error(msg);
+                OpmLog::warning(msg);
             }
             checkOptions<std::string>(keyword, string_options);
             checkOptions<int>(keyword, int_options);

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -66,6 +66,61 @@ namespace MissingFeatures {
                     + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n";
                 OpmLog::error(msg);
             }
+
+            // check for partially supported options.
+            if (keyword.name() == "COMPORD") {
+                for (unsigned recordIdx = 0; recordIdx < keyword.size(); ++recordIdx) {
+                    const auto& record = keyword.getRecord(recordIdx);
+                    if (record.getItem("ORDER_TYPE").getTrimmedString(0) != "TRACK") {
+                        std::string msg = std::string("For keyword 'COMPORD' only 'TRACK' in second item is supported by flow.\n")
+                            + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n";
+                        OpmLog::error(msg);
+                    }
+                }
+            }
+
+            if (keyword.name() == "EHYSTR") {
+                for (unsigned recordIdx = 0; recordIdx < keyword.size(); ++recordIdx) {
+                    const auto& record = keyword.getRecord(recordIdx);
+                    if (record.getItem(1).get<int>(0) != 0) {
+                        std::string msg = std::string("For keyword 'EHYSTR' only Carlson kr hystersis model is supported by flow.\n")
+                            + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n";
+                        OpmLog::error(msg);
+                    }
+                }
+            }
+
+            if (keyword.name() == "ENDSCALE") {
+                for (unsigned recordIdx = 0; recordIdx < keyword.size(); ++recordIdx) {
+                    const auto& record = keyword.getRecord(recordIdx);
+                    if (record.getItem(0).getTrimmedString(0) == "DIRECT") {
+                        std::string msg = std::string("For keyword 'ENDSCALE', 'DIRECT' in first item is not supported by flow.\n")
+                            + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n";
+                        OpmLog::error(msg);
+                    }
+                    if (record.getItem(1).getTrimmedString(0) == "IRREVERS") {
+                        std::string msg = std::string("For keyword 'ENDSCALE', 'IRREVERS' in second item is not supported by flow.\n")
+                            + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n";
+                        OpmLog::error(msg);
+                    }
+                }
+            }
+
+            if (keyword.name() == "PINCH") {
+                for (unsigned recordIdx = 0; recordIdx < keyword.size(); ++recordIdx) {
+                    const auto& record = keyword.getRecord(recordIdx);
+                    if (record.getItem(1).getTrimmedString(0) != "GAP") {
+                        std::string msg = std::string("For keyword 'PINCH' only 'GAP' in second item is supported by flow.\n")
+                            + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n";
+                        OpmLog::error(msg);
+                    }
+                    if (record.getItem(3).getTrimmedString(0) != "TOPBOT") {
+                        std::string msg = std::string("For keyword 'PINCH' only 'TOPBOT' in fourth item is supported by flow.\n")
+                            + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n";
+                        OpmLog::error(msg);
+                    }
+                }
+            }
         }
     }
 } // namespace MissingFeatures

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -37,7 +37,7 @@ namespace MissingFeatures {
 
 
     template <typename Keyword, typename Item, typename T>
-    void addUnsupported(std::multimap<std::string, PartiallySupported<T> >& map, T itemValue)
+    void addSupported(std::multimap<std::string, PartiallySupported<T> >& map, T itemValue)
     {
         std::pair<std::string,PartiallySupported<T> > pair({Keyword::keywordName, PartiallySupported<T>{Item::itemName , itemValue}});
         map.insert(pair);
@@ -91,12 +91,12 @@ namespace MissingFeatures {
             "WTEST", "WTRACER", "ZIPPY2" };
         std::multimap<std::string, PartiallySupported<std::string> > string_options;
         std::multimap<std::string, PartiallySupported<int> > int_options;
-        addUnsupported<ParserKeywords::COMPORD, ParserKeywords::COMPORD::ORDER_TYPE, std::string>(string_options , "TRACK");
-        addUnsupported<ParserKeywords::ENDSCALE, ParserKeywords::ENDSCALE::DIRECT, std::string>(string_options, "NODIR");
-        addUnsupported<ParserKeywords::ENDSCALE, ParserKeywords::ENDSCALE::IRREVERS, std::string>(string_options, "REVER");
-        addUnsupported<ParserKeywords::PINCH, ParserKeywords::PINCH::CONTROL_OPTION, std::string>(string_options, "GAP");
-        addUnsupported<ParserKeywords::PINCH, ParserKeywords::PINCH::PINCHOUT_OPTION, std::string>(string_options, "TOPBOT");
-        addUnsupported<ParserKeywords::EHYSTR, ParserKeywords::EHYSTR::relative_perm_hyst, int>(int_options , 0);
+        addSupported<ParserKeywords::COMPORD, ParserKeywords::COMPORD::ORDER_TYPE, std::string>(string_options , "DEPTH");
+        addSupported<ParserKeywords::ENDSCALE, ParserKeywords::ENDSCALE::DIRECT, std::string>(string_options, "NODIR");
+        addSupported<ParserKeywords::ENDSCALE, ParserKeywords::ENDSCALE::IRREVERS, std::string>(string_options, "REVER");
+        addSupported<ParserKeywords::PINCH, ParserKeywords::PINCH::CONTROL_OPTION, std::string>(string_options, "GAP");
+        addSupported<ParserKeywords::PINCH, ParserKeywords::PINCH::PINCHOUT_OPTION, std::string>(string_options, "TOPBOT");
+        addSupported<ParserKeywords::EHYSTR, ParserKeywords::EHYSTR::relative_perm_hyst, int>(int_options , 0);
 
         // check deck and keyword for flow and parser.
         for (size_t idx = 0; idx < deck.size(); ++idx) {

--- a/opm/autodiff/MissingFeatures.hpp
+++ b/opm/autodiff/MissingFeatures.hpp
@@ -31,7 +31,7 @@ namespace MissingFeatures {
     };
 
     template <typename Keyword, typename Item, typename T>
-    void addUnsupported(std::multimap<std::string, PartiallySupported<T> >& map, T itemValue);
+    void addSupported(std::multimap<std::string, PartiallySupported<T> >& map, T itemValue);
 
     template <typename T>
     void checkOptions(const DeckKeyword& keyword, std::multimap<std::string , PartiallySupported<T> >& map);

--- a/opm/autodiff/MissingFeatures.hpp
+++ b/opm/autodiff/MissingFeatures.hpp
@@ -24,6 +24,18 @@ namespace Opm {
 
 namespace MissingFeatures {
 
+    template <typename T>
+    struct PartiallySupported {
+        std::string item;
+        T item_value;
+    };
+
+    template <typename Keyword, typename Item, typename T>
+    void addUnsupported(std::multimap<std::string, PartiallySupported<T> >& map, T itemValue);
+
+    template <typename T>
+    void checkOptions(const DeckKeyword& keyword, std::multimap<std::string , PartiallySupported<T> >& map);
+
     void checkKeywords(const Deck& deck);
 
 }


### PR DESCRIPTION
There are some options of the keywords only partially supported by flow, handle them automatically is not that easy, so we decided to handle them manually, the lucky thing is that the number of these kind of keywords is limited. 
Any feedback and suggestions are welcome.