### PR TITLE
Fix step number used by parallel io and OutputWriter::writeTimeStep

### DIFF
--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -45,10 +45,12 @@ namespace Opm
     public:
         virtual ~ParallelDebugOutputInterface() {}
 
-        // gather solution to rank 0 for EclipseWriter
+        //! \brief gather solution to rank 0 for EclipseWriter
+        //! \param localWellState      The well state
+        //! \param wellStateStepNumber The step number of the well state.
         virtual bool collectToIORank( const SimulationDataContainer& localReservoirState,
                                       const WellState& localWellState,
-                                      const int reportStep ) = 0;
+                                      const int wellStateStepNumber ) = 0;
 
         virtual const SimulationDataContainer& globalReservoirState() const = 0 ;
         virtual const WellState& globalWellState() const = 0 ;
@@ -77,7 +79,7 @@ namespace Opm
         // gather solution to rank 0 for EclipseWriter
         virtual bool collectToIORank( const SimulationDataContainer& localReservoirState,
                                       const WellState& localWellState,
-                                      const int /* reportStep */)
+                                      const int /* wellStateStepNumber */)
         {
             globalState_ = &localReservoirState;
             wellState_   = &localWellState;
@@ -519,7 +521,7 @@ namespace Opm
         // gather solution to rank 0 for EclipseWriter
         bool collectToIORank( const SimulationDataContainer& localReservoirState,
                               const WellState& localWellState,
-                              const int reportStep )
+                              const int wellStateStepNumber )
         {
             if( isIORank() )
             {
@@ -530,7 +532,7 @@ namespace Opm
                 const DynamicListEconLimited dynamic_list_econ_limited;
                 // Create wells and well state.
                 WellsManager wells_manager(eclipseState_,
-                                           reportStep,
+                                           wellStateStepNumber,
                                            Opm::UgGridHelpers::numCells( globalGrid ),
                                            Opm::UgGridHelpers::globalCell( globalGrid ),
                                            Opm::UgGridHelpers::cartDims( globalGrid ),

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -304,8 +304,15 @@ namespace Opm
         bool isIORank = output_ ;
         if( parallelOutput_ && parallelOutput_->isParallel() )
         {
+            // If this is not the initial write and no substep, then the well
+            // state used in the computation is actually the one of the last
+            // step. We need that well state for the gathering. Otherwise
+            // It an exception with a message like "global state does not
+            // contain well ..." might be thrown.
+            int wellStateStepNumber = ( ! substep && timer.reportStepNum() > 0) ?
+                (timer.reportStepNum() - 1) : timer.reportStepNum();
             // collect all solutions to I/O rank
-            isIORank = parallelOutput_->collectToIORank( localState, localWellState, timer.reportStepNum() );
+            isIORank = parallelOutput_->collectToIORank( localState, localWellState, wellStateStepNumber );
         }
 
         const SimulationDataContainer& state = (parallelOutput_ && parallelOutput_->isParallel() ) ? parallelOutput_->globalReservoirState() : localState;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -370,7 +370,7 @@ namespace Opm
 
                 */
 
-                eclWriter_->writeTimeStep(timer.currentStepNum(),
+                eclWriter_->writeTimeStep(timer.reportStepNum(),
                                           substep,
                                           timer.simulationTimeElapsed(),
                                           simToSolution( state, phaseUsage_ ),


### PR DESCRIPTION
When running in parallel a well state object with the well information of the whole grid needs to constructed to gather the information from all processes. Previously, this was done with the report step exported by thetimer. This was wrong for the following reason:
The output occurs after solving the time step and the timer is already incremented. This means that we constructed the well state for gathering the data for the next report step, already. Unfortunately, at that step some wells that we have computed results for might have been shut. In that case an exception with message "global state does not contain well ..." was thrown.

This problem occured for Model number 2 and might have been due to shut wells because of banned cross flow. With this PR Model number 2 runs through again with 2 processes.

With this PR we use the last report step if this is not an initial write and not a substep. In addition we pass the report step (instead of the substep number) to OutputWriter::writeTimeStep as that is needed according to the documentation.