### PR TITLE
Call writeInit with global grid and properties.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -145,6 +145,7 @@ namespace Opm
             asImpl().extractMessages();
             asImpl().runDiagnostics();
             asImpl().setupState();
+            asImpl().writeInit();
             asImpl().distributeData();
             asImpl().setupOutputWriter();
             asImpl().setupLinearSolver();
@@ -650,7 +651,20 @@ namespace Opm
         }
 
 
-
+        void writeInit()
+        {
+            bool output      = param_.getDefault("output", true);
+            bool output_ecl  = param_.getDefault("output_ecl", true);
+            const Grid& grid = grid_init_->grid();
+            if( output && output_ecl && output_cout_)
+            {
+                EclipseWriter writer(eclipse_state_,
+                                     Opm::UgGridHelpers::numCells(grid),
+                                     Opm::UgGridHelpers::globalCell(grid));
+                writer.writeInitAndEgrid(geoprops_->simProps(grid),
+                                         geoprops_->nonCartesianConnections());
+            }
+        }
 
 
         // Setup output writer.
@@ -748,7 +762,6 @@ namespace Opm
                     fullReport.reportParam(tot_os);
                 }
             } else {
-                output_writer_->writeInit(geoprops_->simProps(grid_init_->grid()) , geoprops_->nonCartesianConnections( ));
                 if (output_cout_) {
                     std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;
                 }

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -111,10 +111,6 @@ namespace Opm
             adaptiveTimeStepping.reset( new AdaptiveTimeStepping( param_, terminal_output_ ) );
         }
 
-
-
-        output_writer_.writeInit( geo_.simProps(grid_) , geo_.nonCartesianConnections( ) );
-
         std::string restorefilename = param_.getDefault("restorefile", std::string("") );
         if( ! restorefilename.empty() )
         {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -72,9 +72,6 @@ namespace Opm
             adaptiveTimeStepping.reset( new AdaptiveTimeStepping( param_, terminal_output_ ) );
         }
 
-        // init output writer
-        output_writer_.writeInit( geo_.simProps(grid_) , geo_.nonCartesianConnections( ) );
-
         std::string restorefilename = param_.getDefault("restorefile", std::string("") );
         if( ! restorefilename.empty() )
         {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -245,15 +245,6 @@ namespace Opm
     }
 #endif
 
-    void
-    BlackoilOutputWriter::
-    writeInit(const std::vector<data::CellData>& simProps,  const NNC& nnc)
-    {
-        if( eclWriter_ ) {
-            eclWriter_->writeInitAndEgrid(simProps, nnc);
-        }
-    }
-
 
 
     namespace detail {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -216,9 +216,6 @@ namespace Opm
                              const Opm::PhaseUsage &phaseUsage,
                              const double* permeability );
 
-        /** \copydoc Opm::OutputWriter::writeInit */
-        void writeInit(const std::vector<data::CellData>& simProps, const NNC& nnc);
-
         /** \copydoc Opm::OutputWriter::writeTimeStep */
         void writeTimeStep(const SimulatorTimerInterface& timer,
                            const SimulationDataContainer& reservoirState,


### PR DESCRIPTION
Previously, the call was made after the grid was distributed.
This means that each process wrote it, but only with his cells
active which was just a part of the whole domain.

With this PR we make the writeInit call before distributing the
grid and make sure that only one process calls it.

Closes #765.