### PR TITLE
Do not assume ordering in an unordered_map when gathering data.

### DIFF
--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -382,9 +382,11 @@ namespace Opm
             void doUnpack( const IndexMapType& indexMap, MessageBufferType& buffer )
             {
                 // write all cell data registered in local state
-	        for (auto& pair : globalState_.cellData()) {
+                // we loop over the data of the local state as
+                // its order governs the order the data got received.
+                for (auto& pair : localState_.cellData()) {
                     const std::string& key = pair.first;
-		    auto& data = pair.second;
+                    auto& data = globalState_.getCellData(key);
                     const size_t stride = globalState_.numCellDataComponents( key );
 
                     for( size_t i=0; i<stride; ++i )


### PR DESCRIPTION
The order of an unordered_map is quite unpredictable. (The same order will only hold with the same hash function, comparison operator, and insertion order). Therefore we cannot assume that the global SimulationDataContainer uses the same order for the cell data as the local one (This was done before this commit). But we can assume that the local one uses the same order on every
process.

Before this PR data got mixed up (e.g. gasoilratio with surfacevol) when gathering local data for writing eclipse files on the master process. This PR fixes this.

Instead of iterating over the cell data of the global state when writing the data received, we again iterate over the cell data of the local state and simply use the key to request the correct data for writing from the global state.

Closes #772 