### PR TITLE
fix the calculation of the derivatives of VAPPARS

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -979,9 +979,16 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             for (int i=0; i<n; ++i) {
                 if (satOilMax_[cells[i]] > vap_satmax_guard_ && so.value()[i] < satOilMax_[cells[i]]) {
                     // guard against too small saturation values.
-                    const double so_i= std::max(so.value()[i],eps_sqrt);
-                    factor[i] = std::pow(so_i/satOilMax_[cells[i]], vap);
-                    dfactor_dso[i] = vap*std::pow(so_i/satOilMax_[cells[i]], vap-1.0)/satOilMax_[cells[i]];
+                    if (so.value()[i] > eps_sqrt) {
+                        double so_i = so.value()[i];
+                        factor[i] = std::pow(so_i/satOilMax_[cells[i]], vap);
+                        dfactor_dso[i] = vap*std::pow(so_i/satOilMax_[cells[i]], vap-1.0)/satOilMax_[cells[i]];
+                    }
+                    else {
+                        double so_i = eps_sqrt;
+                        factor[i] = std::pow(so_i/satOilMax_[cells[i]], vap);
+                        dfactor_dso[i] = 0.0;
+                    }
                 }
             }
             ADB::M dfactor_dso_diag(dfactor_dso.matrix().asDiagonal());


### PR DESCRIPTION
the values of the scaling factor were correct but the derivatives were
not because the maximum of the oil saturation and some small constant
was taken. If the maximum was the constant, the derivative of the
scaling factor w.r.t. the oil saturation is zero, but this was
ignored. (Note: this is not the first time where this issue occurred
in opm-simulators; e.g. the old saturation functions implementation
also fell victim to this mistake, so it is very well possible that
this has not been the last remaining piece of code which is affected.)