### PR TITLE
TransMult, Init, and SimConfig are references, applyModifierDeck take…

### DIFF
--- a/examples/opm_init_check.cpp
+++ b/examples/opm_init_check.cpp
@@ -349,7 +349,7 @@ int main(int argc, char** argv) {
     ParseContext parseContext;
     std::cout << "Parsing input file ............: " << input_file << std::endl;
     DeckConstPtr deck = parser->parseFile(input_file, parseContext);
-    std::shared_ptr<EclipseState> state = std::make_shared<EclipseState>( deck , parseContext );
+    std::shared_ptr<EclipseState> state = std::make_shared<EclipseState>( *deck , parseContext );
     
     std::cout << "Loading eclipse INIT file .....: " << init_file << std::endl;
     ecl_file_type * ecl_init = ecl_file_open( init_file.c_str() , 0 );

--- a/examples/sim_2p_comp_reorder.cpp
+++ b/examples/sim_2p_comp_reorder.cpp
@@ -103,7 +103,7 @@ try
         ParseContext parseContext;
         std::string deck_filename = param.get<std::string>("deck_filename");
         deck = parser->parseFile(deck_filename , parseContext);
-        eclipseState.reset(new EclipseState(deck, parseContext));
+        eclipseState.reset(new EclipseState(*deck, parseContext));
 
         // Grid init
         grid.reset(new GridManager(eclipseState->getInputGrid()));

--- a/examples/sim_2p_incomp.cpp
+++ b/examples/sim_2p_incomp.cpp
@@ -115,7 +115,7 @@ try
 
         std::string deck_filename = param.get<std::string>("deck_filename");
         deck = parser->parseFile(deck_filename , parseContext);
-        eclipseState.reset( new EclipseState(deck, parseContext));
+        eclipseState.reset( new EclipseState(*deck, parseContext));
         // Grid init
         grid.reset(new GridManager(eclipseState->getInputGrid()));
         {

--- a/examples/sim_2p_incomp_ad.cpp
+++ b/examples/sim_2p_incomp_ad.cpp
@@ -115,7 +115,7 @@ try
         std::string deck_filename = param.get<std::string>("deck_filename");
         Opm::ParseContext parseContext;
         deck = parser->parseFile(deck_filename, parseContext);
-        eclipseState.reset(new EclipseState(deck , parseContext));
+        eclipseState.reset(new EclipseState(*deck , parseContext));
 
         // Grid init
         grid.reset(new GridManager(eclipseState->getInputGrid()));

--- a/examples/sim_poly2p_comp_reorder.cpp
+++ b/examples/sim_poly2p_comp_reorder.cpp
@@ -102,7 +102,7 @@ try
         ParserPtr parser(new Opm::Parser());
         Opm::ParseContext parseContext({{ ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE }});
         deck = parser->parseFile(deck_filename , parseContext);
-        eclipseState.reset(new Opm::EclipseState(deck , parseContext));
+        eclipseState.reset(new Opm::EclipseState(*deck , parseContext));
 
         // Grid init
         grid.reset(new GridManager(eclipseState->getInputGrid()));

--- a/examples/sim_poly2p_incomp_reorder.cpp
+++ b/examples/sim_poly2p_incomp_reorder.cpp
@@ -102,7 +102,8 @@ try
         Opm::ParseContext parseContext({{ ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE }});
         ParserPtr parser(new Opm::Parser());
         deck = parser->parseFile(deck_filename , parseContext);
-        eclipseState.reset(new Opm::EclipseState(deck , parseContext));
+
+        eclipseState.reset(new Opm::EclipseState(*deck , parseContext));
 
         // Grid init
         grid.reset(new GridManager(eclipseState->getInputGrid()));

--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -156,7 +156,7 @@ try
     try {
         deck = parser->parseFile(deck_filename , parseContext);
         Opm::checkDeck(deck, parser);
-        eclipseState.reset(new Opm::EclipseState(deck , parseContext));
+        eclipseState.reset(new Opm::EclipseState(*deck , parseContext));
     }
     catch (const std::invalid_argument& e) {
         std::cerr << "Failed to create valid ECLIPSESTATE object. See logfile: " << logFile << std::endl;

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -414,7 +414,7 @@ namespace Opm
                 deck_ = parser->parseFile(deck_filename, parseContext);
                 checkDeck(deck_, parser);
                 MissingFeatures::checkKeywords(*deck_);
-                eclipse_state_.reset(new EclipseState(deck_, parseContext));
+                eclipse_state_.reset(new EclipseState(*deck_, parseContext));
                 auto ioConfig = eclipse_state_->getIOConfig();
                 ioConfig->setOutputDir(output_dir_);
             }
@@ -684,7 +684,7 @@ namespace Opm
             std::string flowDefaultSolver = interleavedSolver;
 
             if (!param_.has("solver_approach")) {
-                if (eclipse_state_->getSimulationConfig()->useCPR()) {
+                if (eclipse_state_->getSimulationConfig().useCPR()) {
                     flowDefaultSolver = cprSolver;
                 }
             }
@@ -716,8 +716,8 @@ namespace Opm
             SimulatorTimer simtimer;
 
             // initialize variables
-            const auto initConfig = eclipse_state_->getInitConfig();
-            simtimer.init(timeMap, (size_t)initConfig->getRestartStep());
+            const auto& initConfig = eclipse_state_->getInitConfig();
+            simtimer.init(timeMap, (size_t)initConfig.getRestartStep());
 
             if (!ioConfig->initOnly()) {
                 if (output_cout_) {

--- a/opm/autodiff/FlowMainPolymer.hpp
+++ b/opm/autodiff/FlowMainPolymer.hpp
@@ -104,13 +104,13 @@ namespace Opm
             const std::string directSolver = "direct";
             const std::string flowDefaultSolver = interleavedSolver;
 
-            std::shared_ptr<const Opm::SimulationConfig> simCfg = eclipse_state_->getSimulationConfig();
+            const Opm::SimulationConfig& simCfg = eclipse_state_->getSimulationConfig();
             std::string solver_approach = flowDefaultSolver;
 
             if (param_.has("solver_approach")) {
                 solver_approach = param_.template get<std::string>("solver_approach");
             }  else {
-                if (simCfg->useCPR()) {
+                if (simCfg.useCPR()) {
                     solver_approach = cprSolver;
                 }
             }

--- a/opm/autodiff/FlowMainSequential.hpp
+++ b/opm/autodiff/FlowMainSequential.hpp
@@ -81,7 +81,7 @@ namespace Opm
             std::string flowDefaultSolver = interleavedSolver;
 
             if (!param_.has("solver_approach")) {
-                if (eclipse_state_->getSimulationConfig()->useCPR()) {
+                if (eclipse_state_->getSimulationConfig().useCPR()) {
                     flowDefaultSolver = cprSolver;
                 }
             }

--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -432,12 +432,12 @@ namespace Opm
         std::vector<int> actnum;
         eclgrid->exportACTNUM(actnum);
 
-        auto transMult = eclState.getTransMult();
+        const auto& transMult = eclState.getTransMult();
         std::vector<double> multz(numCells, 0.0);
         const int* global_cell = Opm::UgGridHelpers::globalCell(grid);
 
         for (int i = 0; i < numCells; ++i) {
-            multz[i] = transMult->getMultiplier(global_cell[i], Opm::FaceDir::ZPlus);
+            multz[i] = transMult.getMultiplier(global_cell[i], Opm::FaceDir::ZPlus);
         }
 
         // Note the pore volume from eclState is used and not the pvol_ calculated above
@@ -461,7 +461,7 @@ namespace Opm
         intersectionTransMult.resize(numIntersections);
         std::fill(intersectionTransMult.begin(), intersectionTransMult.end(), 1.0);
 
-        std::shared_ptr<const Opm::TransMult> multipliers = eclState->getTransMult();
+        const TransMult& multipliers = eclState->getTransMult();
         auto cell2Faces = Opm::UgGridHelpers::cell2Faces(grid);
         auto faceCells  = Opm::AutoDiffGrid::faceCells(grid);
         const int* global_cell = Opm::UgGridHelpers::globalCell(grid);
@@ -515,7 +515,7 @@ namespace Opm
 
                 // Multiplier contribution on this face for MULT[XYZ] logical cartesian multipliers
                 intersectionTransMult[faceIdx] *=
-                    multipliers->getMultiplier(cartesianCellIdx, faceDirection);
+                    multipliers.getMultiplier(cartesianCellIdx, faceDirection);
 
                 // Multiplier contribution on this fase for region multipliers
                 const int cellIdxInside  = faceCells(faceIdx, 0);
@@ -529,7 +529,7 @@ namespace Opm
                 const int cartesianCellIdxOutside = global_cell[cellIdxOutside];
                 //  Only apply the region multipliers from the inside
                 if (cartesianCellIdx == cartesianCellIdxInside) {
-                    intersectionTransMult[faceIdx] *= multipliers->getRegionMultiplier(cartesianCellIdxInside,cartesianCellIdxOutside,faceDirection);
+                    intersectionTransMult[faceIdx] *= multipliers.getRegionMultiplier(cartesianCellIdxInside,cartesianCellIdxOutside,faceDirection);
                 }
 
 

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -234,7 +234,7 @@ namespace Opm
                 //
                 // TODO (?): handle the parallel case (maybe this works out of the box)
                 DeckConstPtr miniDeck = schedule->getModifierDeck(nextTimeStepIdx);
-                eclipse_state_->applyModifierDeck(miniDeck);
+                eclipse_state_->applyModifierDeck(*miniDeck);
                 geo_.update(grid_, props_, eclipse_state_, gravity_);
             }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -340,8 +340,8 @@ namespace Opm
         // ECL output
         if ( eclWriter_ )
         {
-            const auto initConfig = eclipseState_->getInitConfig();
-            if (initConfig->restartRequested() && ((initConfig->getRestartStep()) == (timer.currentStepNum()))) {
+            const auto& initConfig = eclipseState_->getInitConfig();
+            if (initConfig.restartRequested() && ((initConfig.getRestartStep()) == (timer.currentStepNum()))) {
                 std::cout << "Skipping restart write in start of step " << timer.currentStepNum() << std::endl;
             } else {
                  eclWriter_->writeTimeStep(timer.currentStepNum(),
@@ -453,7 +453,7 @@ namespace Opm
 
 
     bool BlackoilOutputWriter::isRestart() const {
-        const auto initconfig = eclipseState_->getInitConfig();
-        return initconfig->restartRequested();
+        const auto& initconfig = eclipseState_->getInitConfig();
+        return initconfig.restartRequested();
     }
 }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -356,7 +356,7 @@ namespace Opm
         // gives a dummy dynamic_list_econ_limited
         DynamicListEconLimited dummy_list_econ_limited;
         WellsManager wellsmanager(eclipseState_,
-                                  eclipseState_->getInitConfig()->getRestartStep(),
+                                  eclipseState_->getInitConfig().getRestartStep(),
                                   Opm::UgGridHelpers::numCells(grid),
                                   Opm::UgGridHelpers::globalCell(grid),
                                   Opm::UgGridHelpers::cartDims(grid),

--- a/opm/simulators/thresholdPressures.hpp
+++ b/opm/simulators/thresholdPressures.hpp
@@ -324,10 +324,10 @@ void computeMaxDp(std::map<std::pair<int, int>, double>& maxDp,
                                            const Grid& grid,
                                            const std::map<std::pair<int, int>, double>& maxDp)
     {
-        SimulationConfigConstPtr simulationConfig = eclipseState->getSimulationConfig();
+        const SimulationConfig& simulationConfig = eclipseState->getSimulationConfig();
         std::vector<double> thpres_vals;
-        if (simulationConfig->hasThresholdPressure()) {
-            std::shared_ptr<const ThresholdPressure> thresholdPressure = simulationConfig->getThresholdPressure();
+        if (simulationConfig.hasThresholdPressure()) {
+            std::shared_ptr<const ThresholdPressure> thresholdPressure = simulationConfig.getThresholdPressure();
             const auto& eqlnum = eclipseState->get3DProperties().getIntGridProperty("EQLNUM");
             const auto& eqlnumData = eqlnum.getData();
 
@@ -382,10 +382,10 @@ void computeMaxDp(std::map<std::pair<int, int>, double>& maxDp,
                                                const NNC& nnc,
                                                const std::map<std::pair<int, int>, double>& maxDp)
     {
-        SimulationConfigConstPtr simulationConfig = eclipseState->getSimulationConfig();
+        const SimulationConfig& simulationConfig = eclipseState->getSimulationConfig();
         std::vector<double> thpres_vals;
-        if (simulationConfig->hasThresholdPressure()) {
-            std::shared_ptr<const ThresholdPressure> thresholdPressure = simulationConfig->getThresholdPressure();
+        if (simulationConfig.hasThresholdPressure()) {
+            std::shared_ptr<const ThresholdPressure> thresholdPressure = simulationConfig.getThresholdPressure();
             const auto& eqlnum = eclipseState->get3DProperties().getIntGridProperty("EQLNUM");
             const auto& eqlnumData = eqlnum.getData();
 

--- a/tests/test_boprops_ad.cpp
+++ b/tests/test_boprops_ad.cpp
@@ -51,7 +51,7 @@ struct SetupSimple {
         Opm::ParseContext parseContext;
         Opm::ParserPtr parser(new Opm::Parser());
         deck = parser->parseFile("fluid.data", parseContext);
-        eclState.reset(new Opm::EclipseState(deck , parseContext));
+        eclState.reset(new Opm::EclipseState(*deck , parseContext));
 
         param.disableOutput();
         param.insertParameter("init_rock"       , "false" );

--- a/tests/test_multisegmentwells.cpp
+++ b/tests/test_multisegmentwells.cpp
@@ -72,7 +72,7 @@ struct SetupMSW {
         Opm::ParseContext parse_context;
         Opm::ParserPtr parser(new Opm::Parser());
         Opm::DeckConstPtr deck = parser->parseFile("msw.data", parse_context);
-        Opm::EclipseStateConstPtr ecl_state(new Opm::EclipseState(deck , parse_context));
+        Opm::EclipseStateConstPtr ecl_state(new Opm::EclipseState(*deck , parse_context));
 
         // Create grid.
         const std::vector<double>& porv =

--- a/tests/test_rateconverter.cpp
+++ b/tests/test_rateconverter.cpp
@@ -51,7 +51,7 @@ struct SetupSimple {
         Opm::ParserPtr parser(new Opm::Parser());
         Opm::ParseContext parseContext;
         deck = parser->parseFile("fluid.data" , parseContext);
-        eclState.reset(new Opm::EclipseState(deck , parseContext));
+        eclState.reset(new Opm::EclipseState(*deck , parseContext));
 
         param.disableOutput();
         param.insertParameter("init_rock"       , "false" );

--- a/tests/test_solventprops_ad.cpp
+++ b/tests/test_solventprops_ad.cpp
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(Construction)
         Opm::ParserPtr parser(new Opm::Parser());
         Opm::DeckPtr deck =  parser->parseString(deckData + solventData, parseContext);
         Opm::EclipseStateConstPtr eclState;
-        eclState.reset(new Opm::EclipseState(deck , parseContext));
+        eclState.reset(new Opm::EclipseState(*deck , parseContext));
         std::vector<int> global_ind = {0 , 1 , 2};
         Opm::SolventPropsAdFromDeck solventprops(deck, eclState, 3, global_ind.data());
 }
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(SolventData)
         Opm::ParserPtr parser(new Opm::Parser());
         Opm::DeckPtr deck =  parser->parseString(deckData + solventData, parseContext);
         Opm::EclipseStateConstPtr eclState;
-        eclState.reset(new Opm::EclipseState(deck , parseContext));
+        eclState.reset(new Opm::EclipseState(*deck , parseContext));
         std::vector<int> global_ind = {0 , 1 , 2};
         Opm::SolventPropsAdFromDeck solventprops(deck, eclState, 3, global_ind.data());
 
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(PMISC)
         Opm::ParserPtr parser(new Opm::Parser());
         Opm::DeckPtr deck =  parser->parseString(deckData + solventData + pmiscData, parseContext);
         Opm::EclipseStateConstPtr eclState;
-        eclState.reset(new Opm::EclipseState(deck , parseContext));
+        eclState.reset(new Opm::EclipseState(*deck , parseContext));
         const Opm::SolventPropsAdFromDeck::Cells cells(3, 0);
         typedef Opm::SolventPropsAdFromDeck::V V;
         std::vector<int> global_ind = {0 , 1 , 2};
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(TLPMIXPA)
         Opm::ParserPtr parser(new Opm::Parser());
         Opm::DeckPtr deck =  parser->parseString(deckData + solventData + tlpmixpaData, parseContext);
         Opm::EclipseStateConstPtr eclState;
-        eclState.reset(new Opm::EclipseState(deck , parseContext));
+        eclState.reset(new Opm::EclipseState(*deck , parseContext));
         const Opm::SolventPropsAdFromDeck::Cells cells(3, 0);
         typedef Opm::SolventPropsAdFromDeck::V V;
         const int* global_ind = new int[3] {0 , 1 , 2};
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(TLPMIXPA_NOT_SPECIFIED)
     // no pmisc data and default tlpmixdata i.e it should throw
     Opm::DeckPtr deck =  parser->parseString(deckData + solventData, parseContext);
     Opm::EclipseStateConstPtr eclState;
-    eclState.reset(new Opm::EclipseState(deck , parseContext));
+    eclState.reset(new Opm::EclipseState(*deck , parseContext));
     const Opm::SolventPropsAdFromDeck::Cells cells(3, 0);
     const int* global_ind = new int[3] {0 , 1 , 2};
     Opm::SolventPropsAdFromDeck solventprops(deck, eclState, 3, global_ind);
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(TLPMIXPA_DEFAULT)
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckPtr deck =  parser->parseString(deckData + solventData + pmiscData + tlpmixpaDataDefault, parseContext);
     Opm::EclipseStateConstPtr eclState;
-    eclState.reset(new Opm::EclipseState(deck , parseContext));
+    eclState.reset(new Opm::EclipseState(*deck , parseContext));
     const Opm::SolventPropsAdFromDeck::Cells cells(3, 0);
     typedef Opm::SolventPropsAdFromDeck::V V;
     const int* global_ind = new int[3] {0 , 1 , 2};
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(TLPMIXPA_DEFAULT_NOPMISC)
     // no pmisc data and default tlpmixdata i.e it should throw
     Opm::DeckPtr deck =  parser->parseString(deckData + solventData + tlpmixpaDataDefault, parseContext);
     Opm::EclipseStateConstPtr eclState;
-    eclState.reset(new Opm::EclipseState(deck , parseContext));
+    eclState.reset(new Opm::EclipseState(*deck , parseContext));
     const Opm::SolventPropsAdFromDeck::Cells cells(3, 0);
     const int* global_ind = new int[3] {0 , 1 , 2};
     BOOST_CHECK_THROW(Opm::SolventPropsAdFromDeck solventprops(deck, eclState, 3, global_ind), std::invalid_argument);

--- a/tests/test_thresholdpressure.cpp
+++ b/tests/test_thresholdpressure.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(CreateSimulationConfig) {
     ParseContext parseContext;
     typedef UnstructuredGrid  Grid;
     DeckPtr deck = createDeckSimConfig();
-    EclipseState state(deck, parseContext);
+    EclipseState state(*deck, parseContext);
     EclipseGridConstPtr eclipseGrid = state.getInputGrid();
     std::vector<double> porv = eclipseState->getDoubleGridProperty("PORV")->getData();
     GridManager gridManager( eclipseState->getInputGrid(), porv );

--- a/tests/test_transmissibilitymultipliers.cpp
+++ b/tests/test_transmissibilitymultipliers.cpp
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersLegacyGridInterface)
     /////
     // create a DerivedGeology object without any multipliers involved
     Opm::DeckConstPtr origDeck = parser->parseString(origDeckString, parseContext);
-    Opm::EclipseStateConstPtr origEclipseState(new Opm::EclipseState(origDeck , parseContext));
+    Opm::EclipseStateConstPtr origEclipseState(new Opm::EclipseState(*origDeck , parseContext));
 
     auto origGridManager = std::make_shared<Opm::GridManager>(origEclipseState->getInputGrid());
     auto origProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(origDeck, origEclipseState, *(origGridManager->c_grid()));
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersLegacyGridInterface)
     /////
     // create a DerivedGeology object _with_ transmissibility multipliers involved
     Opm::DeckConstPtr multDeck = parser->parseString(multDeckString, parseContext);
-    Opm::EclipseStateConstPtr multEclipseState(new Opm::EclipseState(multDeck, parseContext));
+    Opm::EclipseStateConstPtr multEclipseState(new Opm::EclipseState(*multDeck, parseContext));
 
     auto multGridManager = std::make_shared<Opm::GridManager>(multEclipseState->getInputGrid());
     auto multProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(multDeck, multEclipseState, *(multGridManager->c_grid()));
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersLegacyGridInterface)
     // create a DerivedGeology object _with_ transmissibility multipliers involved for
     // the negative faces
     Opm::DeckConstPtr multMinusDeck = parser->parseString(multMinusDeckString, parseContext);
-    Opm::EclipseStateConstPtr multMinusEclipseState(new Opm::EclipseState(multMinusDeck , parseContext));
+    Opm::EclipseStateConstPtr multMinusEclipseState(new Opm::EclipseState(*multMinusDeck , parseContext));
 
     auto multMinusGridManager = std::make_shared<Opm::GridManager>(multMinusEclipseState->getInputGrid());
     auto multMinusProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(multMinusDeck, multMinusEclipseState, *(multMinusGridManager->c_grid()));
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersLegacyGridInterface)
     /////
     // create a DerivedGeology object with the NTG keyword involved
     Opm::DeckConstPtr ntgDeck = parser->parseString(ntgDeckString, parseContext);
-    Opm::EclipseStateConstPtr ntgEclipseState(new Opm::EclipseState(ntgDeck, parseContext));
+    Opm::EclipseStateConstPtr ntgEclipseState(new Opm::EclipseState(*ntgDeck, parseContext));
 
     auto ntgGridManager = std::make_shared<Opm::GridManager>(ntgEclipseState->getInputGrid());
     auto ntgProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(ntgDeck, ntgEclipseState, *(ntgGridManager->c_grid()));
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersCpGrid)
     /////
     // create a DerivedGeology object without any multipliers involved
     Opm::DeckConstPtr origDeck = parser->parseString(origDeckString , parseContext);
-    Opm::EclipseStateConstPtr origEclipseState(new Opm::EclipseState(origDeck , parseContext));
+    Opm::EclipseStateConstPtr origEclipseState(new Opm::EclipseState(*origDeck , parseContext));
 
     auto origGrid = std::make_shared<Dune::CpGrid>();
     origGrid->processEclipseFormat(origEclipseState->getInputGrid(), 0.0, false);
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersCpGrid)
     /////
     // create a DerivedGeology object _with_ transmissibility multipliers involved
     Opm::DeckConstPtr multDeck = parser->parseString(multDeckString,parseContext);
-    Opm::EclipseStateConstPtr multEclipseState(new Opm::EclipseState(multDeck, parseContext));
+    Opm::EclipseStateConstPtr multEclipseState(new Opm::EclipseState(*multDeck, parseContext));
 
     auto multGrid = std::make_shared<Dune::CpGrid>();
     multGrid->processEclipseFormat(multEclipseState->getInputGrid(), 0.0, false);
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersCpGrid)
     // create a DerivedGeology object _with_ transmissibility multipliers involved for
     // the negative faces
     Opm::DeckConstPtr multMinusDeck = parser->parseString(multMinusDeckString , parseContext);
-    Opm::EclipseStateConstPtr multMinusEclipseState(new Opm::EclipseState(multMinusDeck, parseContext));
+    Opm::EclipseStateConstPtr multMinusEclipseState(new Opm::EclipseState(*multMinusDeck, parseContext));
 
     auto multMinusGrid = std::make_shared<Dune::CpGrid>();
     multMinusGrid->processEclipseFormat(multMinusEclipseState->getInputGrid(), 0.0, false);
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersCpGrid)
     /////
     // create a DerivedGeology object with the NTG keyword involved
     Opm::DeckConstPtr ntgDeck = parser->parseString(ntgDeckString, parseContext);
-    Opm::EclipseStateConstPtr ntgEclipseState(new Opm::EclipseState(ntgDeck, parseContext));
+    Opm::EclipseStateConstPtr ntgEclipseState(new Opm::EclipseState(*ntgDeck, parseContext));
 
     auto ntgGrid = std::make_shared<Dune::CpGrid>();
     ntgGrid->processEclipseFormat(ntgEclipseState->getInputGrid(), 0.0, false);


### PR DESCRIPTION
Reflect API change in parser:

* TransMult, InitConfig and SimulationConfig are returned as references
* applyModifierDeck takes a reference, not a shared_ptr
* use the correct EclipseState constructor, the old one will be deprecated in the future

Downstream of OPM/opm-parser#890.