### PR TITLE
Compare additional keywords in Norne flow-eclipse.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,8 @@ if (HAVE_OPM_DATA)
 
         opm_add_python_test( check_INIT_SPE1 ${PROJECT_SOURCE_DIR}/tests/compare_INIT.py $<TARGET_FILE:flow> ${OPM_DATA_ROOT}/spe1/SPE1CASE1.DATA ${OPM_DATA_ROOT}/spe1/eclipse-simulation/SPE1CASE1.INIT
                              TRANX TRANY TRANZ PORO PORV PERMX DX DY DZ DEPTH PVTNUM SATNUM EQLNUM FIPNUM )
-        opm_add_python_test( check_INIT_NORNE ${PROJECT_SOURCE_DIR}/tests/compare_INIT.py $<TARGET_FILE:flow> ${OPM_DATA_ROOT}/norne/NORNE_ATW2013.DATA ${OPM_DATA_ROOT}/norne/ECL.2014.2/NORNE_ATW2013.INIT PORO PORV PERMX )
+        opm_add_python_test( check_INIT_NORNE ${PROJECT_SOURCE_DIR}/tests/compare_INIT.py $<TARGET_FILE:flow> ${OPM_DATA_ROOT}/norne/NORNE_ATW2013.DATA ${OPM_DATA_ROOT}/norne/ECL.2014.2/NORNE_ATW2013.INIT
+                             PORO PORV PERMX DX DY DZ DEPTH PVTNUM SATNUM EQLNUM FIPNUM )
 
         opm_add_python_test( check_RESTART_SPE1CASE2
                              ${PROJECT_SOURCE_DIR}/tests/check_RESTART.py


### PR DESCRIPTION
Added more keywords in the OPM - Eclipse comparison of the Norne INIT file.

Requires: https://github.com/Ensembles/ert/pull/1172 to get the `DY` keyword correct.
