### PR TITLE
If deck has keyword NOSIM, simulator should stop.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -494,6 +494,9 @@ namespace Opm
         //   fluidprops_ (if SWATINIT is used)
         void setupState()
         {
+            if (deck_->hasKeyword("NOSIM")) {
+                exit(0);
+            }
             const PhaseUsage pu = Opm::phaseUsageFromDeck(deck_);
             const Grid& grid = grid_init_->grid();
 


### PR DESCRIPTION
If ``exit()`` is not good, please make comment for a better solution.