### PR TITLE
shared_ptr<EclipseGrid> -> const EclipseGrid&

### DIFF
--- a/examples/opm_init_check.cpp
+++ b/examples/opm_init_check.cpp
@@ -208,7 +208,7 @@ public:
 /*****************************************************************/
 
 void initOPMTrans(TransGraph& opmTrans, DeckConstPtr deck, std::shared_ptr<const EclipseState> eclipseState) {
-    std::shared_ptr<GridManager> grid = std::make_shared<GridManager>( eclipseState->getInputGrid(),
+    std::shared_ptr<GridManager> grid = std::make_shared<GridManager>( *eclipseState->getInputGrid(),
             eclipseState->get3DProperties().getDoubleGridProperty( "PORV" ).getData() );
     const struct UnstructuredGrid * cGrid = grid->c_grid();
     std::shared_ptr<BlackoilPropsAdInterface> props;

--- a/examples/sim_2p_comp_reorder.cpp
+++ b/examples/sim_2p_comp_reorder.cpp
@@ -106,7 +106,7 @@ try
         eclipseState.reset(new EclipseState(*deck, parseContext));
 
         // Grid init
-        grid.reset(new GridManager(eclipseState->getInputGrid()));
+        grid.reset(new GridManager(*eclipseState->getInputGrid()));
         {
             const UnstructuredGrid& ug_grid = *(grid->c_grid());
             state.reset( new BlackoilState( UgGridHelpers::numCells( ug_grid ) , UgGridHelpers::numFaces( ug_grid ) ,2));

--- a/examples/sim_2p_incomp.cpp
+++ b/examples/sim_2p_incomp.cpp
@@ -117,7 +117,7 @@ try
         deck = parser->parseFile(deck_filename , parseContext);
         eclipseState.reset( new EclipseState(*deck, parseContext));
         // Grid init
-        grid.reset(new GridManager(eclipseState->getInputGrid()));
+        grid.reset(new GridManager(*eclipseState->getInputGrid()));
         {
             const UnstructuredGrid& ug_grid = *(grid->c_grid());
             // Rock and fluid init

--- a/examples/sim_2p_incomp_ad.cpp
+++ b/examples/sim_2p_incomp_ad.cpp
@@ -118,7 +118,7 @@ try
         eclipseState.reset(new EclipseState(*deck , parseContext));
 
         // Grid init
-        grid.reset(new GridManager(eclipseState->getInputGrid()));
+        grid.reset(new GridManager(*eclipseState->getInputGrid()));
         {
             const UnstructuredGrid& ug_grid = *(grid->c_grid());
 

--- a/examples/sim_poly2p_comp_reorder.cpp
+++ b/examples/sim_poly2p_comp_reorder.cpp
@@ -105,7 +105,7 @@ try
         eclipseState.reset(new Opm::EclipseState(*deck , parseContext));
 
         // Grid init
-        grid.reset(new GridManager(eclipseState->getInputGrid()));
+        grid.reset(new GridManager(*eclipseState->getInputGrid()));
         {
             const UnstructuredGrid& ug_grid = *(grid->c_grid());
 

--- a/examples/sim_poly2p_incomp_reorder.cpp
+++ b/examples/sim_poly2p_incomp_reorder.cpp
@@ -106,7 +106,7 @@ try
         eclipseState.reset(new Opm::EclipseState(*deck , parseContext));
 
         // Grid init
-        grid.reset(new GridManager(eclipseState->getInputGrid()));
+        grid.reset(new GridManager(*eclipseState->getInputGrid()));
         {
             const UnstructuredGrid& ug_grid = *(grid->c_grid());
             // Rock and fluid init

--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -168,9 +168,9 @@ try
 
     if (eclipseState->get3DProperties().hasDeckDoubleGridProperty("PORV")) {
         const auto& porv = eclipseState->get3DProperties().getDoubleGridProperty("PORV").getData();
-        grid.reset(new GridManager(eclipseState->getInputGrid(), porv));
+        grid.reset(new GridManager(*eclipseState->getInputGrid(), porv));
     } else {
-        grid.reset(new GridManager(eclipseState->getInputGrid()));
+        grid.reset(new GridManager(*eclipseState->getInputGrid()));
     }
     auto &cGrid = *grid->c_grid();
     const PhaseUsage pu = Opm::phaseUsageFromDeck(deck);

--- a/opm/autodiff/GridInit.hpp
+++ b/opm/autodiff/GridInit.hpp
@@ -54,7 +54,7 @@ namespace Opm
     public:
         /// Initialize from a deck and/or an eclipse state and (logical cartesian) specified pore volumes.
         GridInit(EclipseStateConstPtr eclipse_state, const std::vector<double>& porv)
-            : grid_manager_(eclipse_state->getInputGrid(), porv)
+            : grid_manager_(*eclipse_state->getInputGrid(), porv)
         {
         }
         /// Access the created grid.
@@ -76,7 +76,7 @@ namespace Opm
         /// Initialize from a deck and/or an eclipse state and (logical cartesian) specified pore volumes.
         GridInit(EclipseStateConstPtr eclipse_state, const std::vector<double>& porv)
         {
-            grid_.processEclipseFormat(eclipse_state->getInputGrid(), false, false, false, porv);
+            grid_.processEclipseFormat(*eclipse_state->getInputGrid(), false, false, false, porv);
         }
         /// Access the created grid. Note that mutable access may be required for load balancing.
         Dune::CpGrid& grid()

--- a/tests/test_boprops_ad.cpp
+++ b/tests/test_boprops_ad.cpp
@@ -71,7 +71,7 @@ struct TestFixture : public Setup
 {
     TestFixture()
         : Setup()
-        , grid (eclState->getInputGrid())
+        , grid (*eclState->getInputGrid())
         , boprops_ad(deck, eclState, *grid.c_grid(), param.getDefault("init_rock", false))
     {
     }
@@ -89,7 +89,7 @@ struct TestFixtureAd : public Setup
 {
     TestFixtureAd()
         : Setup()
-        , grid (eclState->getInputGrid())
+        , grid (*eclState->getInputGrid())
         , props(deck, eclState, *grid.c_grid(),
                 param.getDefault("init_rock", false))
     {

--- a/tests/test_rateconverter.cpp
+++ b/tests/test_rateconverter.cpp
@@ -71,7 +71,7 @@ struct TestFixture : public Setup
 {
     TestFixture()
         : Setup()
-        , grid (eclState->getInputGrid())
+        , grid (*eclState->getInputGrid())
         , ad_props(deck, eclState, *grid.c_grid(), param.getDefault("init_rock", false))
     {
     }

--- a/tests/test_transmissibilitymultipliers.cpp
+++ b/tests/test_transmissibilitymultipliers.cpp
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersLegacyGridInterface)
     Opm::DeckConstPtr origDeck = parser->parseString(origDeckString, parseContext);
     Opm::EclipseStateConstPtr origEclipseState(new Opm::EclipseState(*origDeck , parseContext));
 
-    auto origGridManager = std::make_shared<Opm::GridManager>(origEclipseState->getInputGrid());
+    auto origGridManager = std::make_shared<Opm::GridManager>(*origEclipseState->getInputGrid());
     auto origProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(origDeck, origEclipseState, *(origGridManager->c_grid()));
 
     Opm::DerivedGeology origGeology(*(origGridManager->c_grid()), *origProps, origEclipseState, false);
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersLegacyGridInterface)
     Opm::DeckConstPtr multDeck = parser->parseString(multDeckString, parseContext);
     Opm::EclipseStateConstPtr multEclipseState(new Opm::EclipseState(*multDeck, parseContext));
 
-    auto multGridManager = std::make_shared<Opm::GridManager>(multEclipseState->getInputGrid());
+    auto multGridManager = std::make_shared<Opm::GridManager>(*multEclipseState->getInputGrid());
     auto multProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(multDeck, multEclipseState, *(multGridManager->c_grid()));
 
     Opm::DerivedGeology multGeology(*(multGridManager->c_grid()), *multProps, multEclipseState, false);
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersLegacyGridInterface)
     Opm::DeckConstPtr multMinusDeck = parser->parseString(multMinusDeckString, parseContext);
     Opm::EclipseStateConstPtr multMinusEclipseState(new Opm::EclipseState(*multMinusDeck , parseContext));
 
-    auto multMinusGridManager = std::make_shared<Opm::GridManager>(multMinusEclipseState->getInputGrid());
+    auto multMinusGridManager = std::make_shared<Opm::GridManager>(*multMinusEclipseState->getInputGrid());
     auto multMinusProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(multMinusDeck, multMinusEclipseState, *(multMinusGridManager->c_grid()));
 
     Opm::DerivedGeology multMinusGeology(*(multMinusGridManager->c_grid()), *multMinusProps, multMinusEclipseState, false);
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersLegacyGridInterface)
     Opm::DeckConstPtr ntgDeck = parser->parseString(ntgDeckString, parseContext);
     Opm::EclipseStateConstPtr ntgEclipseState(new Opm::EclipseState(*ntgDeck, parseContext));
 
-    auto ntgGridManager = std::make_shared<Opm::GridManager>(ntgEclipseState->getInputGrid());
+    auto ntgGridManager = std::make_shared<Opm::GridManager>(*ntgEclipseState->getInputGrid());
     auto ntgProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(ntgDeck, ntgEclipseState, *(ntgGridManager->c_grid()));
 
     Opm::DerivedGeology ntgGeology(*(ntgGridManager->c_grid()), *ntgProps, ntgEclipseState, false);
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersCpGrid)
     Opm::EclipseStateConstPtr origEclipseState(new Opm::EclipseState(*origDeck , parseContext));
 
     auto origGrid = std::make_shared<Dune::CpGrid>();
-    origGrid->processEclipseFormat(origEclipseState->getInputGrid(), 0.0, false);
+    origGrid->processEclipseFormat(*origEclipseState->getInputGrid(), 0.0, false);
 
     auto origProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(origDeck,
                                                                     origEclipseState,
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersCpGrid)
     Opm::EclipseStateConstPtr multEclipseState(new Opm::EclipseState(*multDeck, parseContext));
 
     auto multGrid = std::make_shared<Dune::CpGrid>();
-    multGrid->processEclipseFormat(multEclipseState->getInputGrid(), 0.0, false);
+    multGrid->processEclipseFormat(*multEclipseState->getInputGrid(), 0.0, false);
 
     auto multProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(multDeck, multEclipseState, *multGrid);
 
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersCpGrid)
     Opm::EclipseStateConstPtr multMinusEclipseState(new Opm::EclipseState(*multMinusDeck, parseContext));
 
     auto multMinusGrid = std::make_shared<Dune::CpGrid>();
-    multMinusGrid->processEclipseFormat(multMinusEclipseState->getInputGrid(), 0.0, false);
+    multMinusGrid->processEclipseFormat(*multMinusEclipseState->getInputGrid(), 0.0, false);
 
     auto multMinusProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(multMinusDeck, multMinusEclipseState, *multMinusGrid);
 
@@ -324,7 +324,7 @@ BOOST_AUTO_TEST_CASE(TransmissibilityMultipliersCpGrid)
     Opm::EclipseStateConstPtr ntgEclipseState(new Opm::EclipseState(*ntgDeck, parseContext));
 
     auto ntgGrid = std::make_shared<Dune::CpGrid>();
-    ntgGrid->processEclipseFormat(ntgEclipseState->getInputGrid(), 0.0, false);
+    ntgGrid->processEclipseFormat(*ntgEclipseState->getInputGrid(), 0.0, false);
 
     auto ntgProps = std::make_shared<Opm::BlackoilPropsAdFromDeck>(ntgDeck, ntgEclipseState, *ntgGrid);
 


### PR DESCRIPTION
This is a followup to: 

parser: https://github.com/OPM/opm-parser/pull/905 
core: https://github.com/OPM/opm-core/pull/1059 
grid: https://github.com/OPM/opm-grid/pull/230

This will not actually use any new functionality; only ensure that things compile.