### PR TITLE
Updated OutputWriter signature.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -657,9 +657,8 @@ namespace Opm
             const Grid& grid = grid_init_->grid();
             if( output && output_ecl && output_cout_)
             {
-                EclipseWriter writer(eclipse_state_,
-                                     Opm::UgGridHelpers::numCells(grid),
-                                     Opm::UgGridHelpers::globalCell(grid));
+                const EclipseGrid& inputGrid = *eclipse_state_->getInputGrid();
+                EclipseWriter writer(eclipse_state_, UgGridHelpers::createEclipseGrid( grid , inputGrid ));
                 writer.writeInitAndEgrid(geoprops_->simProps(grid),
                                          geoprops_->nonCartesianConnections());
             }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -336,9 +336,7 @@ namespace Opm
                      new BlackoilMatlabWriter< Grid >( grid, outputDir_ ) : 0 ),
         eclWriter_( output_ && parallelOutput_->isIORank() &&
                     param.getDefault("output_ecl", true) ?
-                    new EclipseWriter(eclipseState,
-                                      parallelOutput_->numCells(),
-                                      parallelOutput_->globalCell())
+                    new EclipseWriter(eclipseState,UgGridHelpers::createEclipseGrid( grid , *eclipseState->getInputGrid()))
                    : 0 ),
         eclipseState_(eclipseState),
         asyncOutput_()


### PR DESCRIPTION
Pass an `EclipseGrid` instance to the output writer instead of the `const int*` global/active mapping. Depends on:

Parser: https://github.com/OPM/opm-parser/pull/915
Output: https://github.com/OPM/opm-output/pull/87