### PR TITLE
Using SPE1 testcase with ACTNUM for restart.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ if (HAVE_OPM_DATA)
 
         opm_add_python_test( check_RESTART_SPE1CASE2
                              ${PROJECT_SOURCE_DIR}/tests/check_RESTART.py
-                             $<TARGET_FILE:flow> ${OPM_DATA_ROOT}/spe1/SPE1CASE2.DATA ${OPM_DATA_ROOT}/spe1/SPE1CASE2_RESTART.DATA )
+                             $<TARGET_FILE:flow> ${OPM_DATA_ROOT}/spe1/SPE1CASE2_ACTNUM.DATA ${OPM_DATA_ROOT}/spe1/SPE1CASE2_ACTNUM_RESTART.DATA )
     endif()
 
     include (${CMAKE_CURRENT_SOURCE_DIR}/compareECLFiles.cmake)

--- a/tests/check_RESTART.py
+++ b/tests/check_RESTART.py
@@ -15,8 +15,8 @@ def compare_files( flow_file , ref_file):
         flow_kw = flow[kw][-1]
         ref_kw = ref[kw][-1]
 
-        if not flow_kw.equal_numeric( ref_kw , abs_epsilon = 0, rel_epsilon = 1e-3 ):
-            first_different = flow_kw.firstDifferent( ref_kw , abs_epsilon = 0, rel_epsilon = 1e-3 )
+        if not flow_kw.equal_numeric( ref_kw , abs_epsilon = 0, rel_epsilon = 2.5e-2 ):
+            first_different = flow_kw.firstDifferent( ref_kw , abs_epsilon = 0, rel_epsilon = 2.5e-2 )
             sys.exit("Keyword:%s was different in flow simulation and reference. First difference in index:%d" % (kw , first_different))
 
 


### PR DESCRIPTION
With this PR we change the SPE case used in the restart case to a case where some cells are not active. With this in place we should have been able to catch: https://github.com/OPM/opm-output/issues/88 in the normal Travis based pre-merge build testing.

This was originally attempted here: #764 - but then precision problems led me to hold back on the change. The precision problems have since then better understood, and I again attempt to add this test. The main purpose of this test to protect against quite typical active <-> global cell bugs in the output layer. 

It was necessary to increase the epsilon value used in the comparison script to the not-very-small epsilon value of 0.025; but I feel the concept of numerical precision in restart is _reasonably well understood_ anyway, so I think this should be merged to protect against future mishaps like: https://github.com/OPM/opm-output/issues/88
