### PR TITLE
Use names of defunct wells from loadbalancer for wellsmanager

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -214,6 +214,9 @@ namespace Opm
         std::unique_ptr<Simulator> simulator_;
         // create log file
         std::string logFile_;
+        // The names of wells that are artifically defunct in parallel runs.
+        // Those wells are handled on a another process.
+        std::unordered_set<std::string> defunct_well_names_;
         // ------------   Methods   ------------
 
 
@@ -598,10 +601,11 @@ namespace Opm
             // If there are more than one processors involved, we now repartition the grid
             // and initilialize new properties and states for it.
             if (must_distribute_) {
-                distributeGridAndData(grid_init_->grid(), deck_, eclipse_state_,
-                                      *state_, *fluidprops_, *geoprops_,
-                                      material_law_manager_, threshold_pressures_,
-                                      parallel_information_, use_local_perm_);
+                defunct_well_names_ =
+                    distributeGridAndData(grid_init_->grid(), deck_, eclipse_state_,
+                                          *state_, *fluidprops_, *geoprops_,
+                                          material_law_manager_, threshold_pressures_,
+                                          parallel_information_, use_local_perm_);
             }
         }
 
@@ -811,7 +815,8 @@ namespace Opm
                                                  Base::deck_->hasKeyword("VAPOIL"),
                                                  Base::eclipse_state_,
                                                  *Base::output_writer_,
-                                                 Base::threshold_pressures_));
+                                                 Base::threshold_pressures_,
+                                                 Base::defunct_well_names_));
         }
     };
 

--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -19,6 +19,8 @@
 #ifndef OPM_PARALLELDEBUGOUTPUT_HEADER_INCLUDED
 #define OPM_PARALLELDEBUGOUTPUT_HEADER_INCLUDED
 
+#include <unordered_set>
+
 #include <opm/common/data/SimulationDataContainer.hpp>
 
 

--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -543,7 +543,14 @@ namespace Opm
                                            Opm::UgGridHelpers::beginFaceCentroids( globalGrid ),
                                            permeability_,
                                            dynamic_list_econ_limited,
-                                           false);
+                                           false
+                                           // We need to pass the optionaly arguments
+                                           // as we get the following error otherwise
+                                           // with c++ (Debian 4.9.2-10) 4.9.2 and -std=c++11
+                                           // converting to ‘const std::unordered_set<std::basic_string<char> >’ from initializer list would use explicit constructor
+                                           , std::vector<double>(),
+                                           std::unordered_set<std::string>()
+                                           );
 
                 const Wells* wells = wells_manager.c_wells();
                 globalWellState_.init(wells, *globalReservoirState_, globalWellState_ );

--- a/opm/autodiff/SimulatorBase.hpp
+++ b/opm/autodiff/SimulatorBase.hpp
@@ -130,7 +130,8 @@ namespace Opm
                       const bool vapoil,
                       std::shared_ptr<EclipseState> eclipse_state,
                       OutputWriter& output_writer,
-                      const std::vector<double>& threshold_pressures_by_face);
+                      const std::vector<double>& threshold_pressures_by_face,
+                      const std::unordered_set<std::string>& defunct_well_names);
 
         /// Run the simulation.
         /// This will run succesive timesteps until timer.done() is true. It will
@@ -214,6 +215,10 @@ namespace Opm
         std::vector<double> threshold_pressures_by_face_;
         // Whether this a parallel simulation or not
         bool is_parallel_run_;
+        // The names of wells that should be defunct
+        // (e.g. in a parallel run when they are handeled by
+        // a different process)
+        std::unordered_set<std::string> defunct_well_names_;
     };
 
 } // namespace Opm

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -42,7 +42,8 @@ namespace Opm
                                                  const bool has_vapoil,
                                                  std::shared_ptr<EclipseState> eclipse_state,
                                                  OutputWriter& output_writer,
-                                                 const std::vector<double>& threshold_pressures_by_face)
+                                                 const std::vector<double>& threshold_pressures_by_face,
+                                                 const std::unordered_set<std::string>& defunct_well_names)
         : param_(param),
           model_param_(param),
           solver_param_(param),
@@ -59,7 +60,8 @@ namespace Opm
           output_writer_(output_writer),
           rateConverter_(props_, std::vector<int>(AutoDiffGrid::numCells(grid_), 0)),
           threshold_pressures_by_face_(threshold_pressures_by_face),
-          is_parallel_run_( false )
+          is_parallel_run_( false ),
+          defunct_well_names_(defunct_well_names)
     {
         // Misc init.
         const int num_cells = AutoDiffGrid::numCells(grid);
@@ -166,7 +168,8 @@ namespace Opm
                                        props_.permeability(),
                                        dynamic_list_econ_limited,
                                        is_parallel_run_,
-                                       well_potentials);
+                                       well_potentials,
+                                       defunct_well_names_);
             const Wells* wells = wells_manager.c_wells();
             WellState well_state;
             well_state.init(wells, state, prev_well_state);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoil.hpp
@@ -61,9 +61,10 @@ public:
                                    const bool vapoil,
                                    std::shared_ptr<EclipseState> eclipse_state,
                                    BlackoilOutputWriter& output_writer,
-                                   const std::vector<double>& threshold_pressures_by_face)
+                                   const std::vector<double>& threshold_pressures_by_face,
+                                   const std::unordered_set<std::string>& defunct_well_names)
     : Base(param, grid, geo, props, rock_comp_props, linsolver, gravity, disgas, vapoil,
-           eclipse_state, output_writer, threshold_pressures_by_face)
+           eclipse_state, output_writer, threshold_pressures_by_face, defunct_well_names)
     {}
 };
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment.hpp
@@ -73,9 +73,10 @@ public:
                                    const bool vapoil,
                                    std::shared_ptr<EclipseState> eclipse_state,
                                    BlackoilOutputWriter& output_writer,
-                                   const std::vector<double>& threshold_pressures_by_face)
+                                   const std::vector<double>& threshold_pressures_by_face,
+                                   const std::unordered_set<std::string>& defunct_well_names)
     : Base(param, grid, geo, props, rock_comp_props, linsolver, gravity, disgas, vapoil,
-           eclipse_state, output_writer, threshold_pressures_by_face)
+           eclipse_state, output_writer, threshold_pressures_by_face, defunct_well_names)
     {}
 
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -108,7 +108,13 @@ namespace Opm
                                        Opm::UgGridHelpers::beginFaceCentroids(grid_),
                                        props_.permeability(),
                                        dynamic_list_econ_limited,
-                                       is_parallel_run_);
+                                       is_parallel_run_,
+                                       // We need to pass the optionaly arguments
+                                       // as we get the following error otherwise
+                                       // with c++ (Debian 4.9.2-10) 4.9.2 and -std=c++11
+                                       // converting to ‘const std::unordered_set<std::basic_string<char> >’ from initializer list would use explicit constructor
+                                       std::vector<double>(), // null well_potentials
+                                       Base::defunct_well_names_);
             const Wells* wells = wells_manager.c_wells();
             WellState well_state;
             // well_state.init(wells, state, prev_well_state);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -397,7 +397,14 @@ namespace Opm
                                   Opm::UgGridHelpers::cell2Faces(grid),
                                   Opm::UgGridHelpers::beginFaceCentroids(grid),
                                   permeability,
-                                  dummy_list_econ_limited);
+                                  dummy_list_econ_limited
+                                  // We need to pass the optionaly arguments
+                                  // as we get the following error otherwise
+                                  // with c++ (Debian 4.9.2-10) 4.9.2 and -std=c++11
+                                  // converting to ‘const std::unordered_set<std::basic_string<char> >’ from initializer list would use explicit constructo
+                                  , false,
+                                  std::vector<double>(),
+                                  std::unordered_set<std::string>());
 
         const Wells* wells = wellsmanager.c_wells();
         wellstate.resize(wells, simulatorstate); //Resize for restart step

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilSolvent_impl.hpp
@@ -50,7 +50,9 @@ namespace Opm
                has_vapoil,
                eclipse_state,
                output_writer,
-               threshold_pressures_by_face)
+               threshold_pressures_by_face,
+               // names of deactivated wells in parallel run
+               std::unordered_set<std::string>())
     , has_solvent_(has_solvent)
     , deck_(deck)
     , solvent_props_(solvent_props)

--- a/opm/autodiff/SimulatorSequentialBlackoil.hpp
+++ b/opm/autodiff/SimulatorSequentialBlackoil.hpp
@@ -65,7 +65,9 @@ public:
                                 BlackoilOutputWriter& output_writer,
                                 const std::vector<double>& threshold_pressures_by_face)
     : Base(param, grid, geo, props, rock_comp_props, linsolver, gravity, disgas, vapoil,
-           eclipse_state, output_writer, threshold_pressures_by_face)
+           eclipse_state, output_writer, threshold_pressures_by_face,
+           // names of deactivated wells in parallel run
+           std::unordered_set<std::string>())
     {}
 };
 

--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer_impl.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer_impl.hpp
@@ -51,7 +51,9 @@ namespace Opm
                has_vapoil,
                eclipse_state,
                output_writer,
-               threshold_pressures_by_face)
+               threshold_pressures_by_face,
+               // names of deactivated wells in parallel run
+               std::unordered_set<std::string>())
         , polymer_props_(polymer_props)
         , has_polymer_(has_polymer)
         , has_plyshlog_(has_plyshlog)

--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer_impl.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer_impl.hpp
@@ -48,7 +48,9 @@ SimulatorFullyImplicitCompressiblePolymer(const parameter::ParameterGroup& param
            /*vapoil=*/false,
            eclipse_state,
            output_writer,
-           /*threshold_pressures_by_face=*/std::vector<double>())
+           /*threshold_pressures_by_face=*/std::vector<double>(),
+           // names of deactivated wells in parallel run
+           std::unordered_set<std::string>())
     , deck_(deck)
     , polymer_props_(polymer_props)
 

--- a/tests/test_multisegmentwells.cpp
+++ b/tests/test_multisegmentwells.cpp
@@ -28,6 +28,7 @@
 #define BOOST_TEST_MODULE MultisegmentWellsTest
 
 #include <vector>
+#include <unordered_set>
 #include <memory>
 #include <array>
 
@@ -106,7 +107,13 @@ struct SetupMSW {
                                         Opm::UgGridHelpers::beginFaceCentroids(grid),
                                         fluidprops->permeability(),
                                         dummy_dynamic_list,
-                                        false);
+                                        false
+                                        // We need to pass the optionaly arguments
+                                        // as we get the following error otherwise
+                                        // with c++ (Debian 4.9.2-10) 4.9.2 and -std=c++11
+                                        // converting to ‘const std::unordered_set<std::basic_string<char> >’ from initializer list would use explicit constructor
+                                        , std::vector<double>(), // null well_potentials
+                                        std::unordered_set<std::string>());
 
         const Wells* wells = wells_manager.c_wells();
         const auto wells_ecl = ecl_state->getSchedule()->getWells(current_timestep);


### PR DESCRIPTION
 Instead of the WellsManager guessing which wells are handled by other processes we now use the output of the load balancer to compute wells that are handled by other processes.

With the previous approach it was not possible to calculate this information correctly. Wells with only one completion next to the border of the processes' partition were represented on multiple processes. In addition wells that the eclipse schedule section defined with completions on non-active cells in sequential runs were not at all calculated in parallel runs.

With the new approach the CpGrid::loadBalance routine returns the set names of wells that are not handled by this process when setting up the simulation. This information is then used throughout the simulation.

This PR needs OPM/opm-core#1062 and OPM/opm-grid#232.

There are to downsides to this and its accompanying PRs:
1. We use and unordered_set and that is buggy in C++11. As a result we can use default initialized default arguments for the added function parameters. Ergo this is not backwards compatible.
2. As we changed the constructor for SimulatorBase all downstream simulators need to be changed.
3. It seems like well names are the only persistent way to identify wells across different steps. Therefore in each step there additional string comparisons. I would really love to see some cheap ids for identifying wells. But that is for another day/task

