### PR TITLE
support MESSAGES keyword.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -141,12 +141,12 @@ namespace Opm
                 return EXIT_FAILURE;
             }
             asImpl().setupOutput();
-            asImpl().setupLogging();
             asImpl().readDeckInput();
             asImpl().setupGridAndProps();
+            asImpl().setupState();
+            asImpl().setupLogging();
             asImpl().extractMessages();
             asImpl().runDiagnostics();
-            asImpl().setupState();
             asImpl().writeInit();
             asImpl().distributeData();
             asImpl().setupOutputWriter();
@@ -423,8 +423,16 @@ namespace Opm
             OpmLog::addBackend( "STREAMLOG", streamLog);
             std::shared_ptr<StreamLog> debugLog = std::make_shared<EclipsePRTLog>(debugFile, Log::DefaultMessageTypes, false, output_cout_);
             OpmLog::addBackend( "DEBUGLOG" ,  debugLog);
+            const auto& msgLimits = eclipse_state_->getSchedule()->getMessageLimits();
+            const std::map<int64_t, int>limits = {{Log::MessageType::Note, msgLimits.getMessagePrintLimit(0)},
+                                                  {Log::MessageType::Info, msgLimits.getMessagePrintLimit(0)},
+                                                  {Log::MessageType::Warning, msgLimits.getWarningPrintLimit(0)},
+                                                  {Log::MessageType::Error, msgLimits.getErrorPrintLimit(0)},
+                                                  {Log::MessageType::Problem, msgLimits.getProblemPrintLimit(0)},
+                                                  {Log::MessageType::Bug, msgLimits.getBugPrintLimit(0)}};
+            prtLog->setMessageLimiter(std::make_shared<MessageLimiter>(-1, limits));
             prtLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(false));
-            streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10));
+            streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10, limits));
             streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(true));
 
             // Read parameters.

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -424,13 +424,13 @@ namespace Opm
             std::shared_ptr<StreamLog> debugLog = std::make_shared<EclipsePRTLog>(debugFile, Log::DefaultMessageTypes, false, output_cout_);
             OpmLog::addBackend( "DEBUGLOG" ,  debugLog);
             const auto& msgLimits = eclipse_state_->getSchedule()->getMessageLimits();
-            const std::map<int64_t, int> limits = {{Log::MessageType::Note, msgLimits.getMessagePrintLimit(0)},
+            const std::map<int64_t, int> limits = {{Log::MessageType::Note, msgLimits.getCommentPrintLimit(0)},
                                                    {Log::MessageType::Info, msgLimits.getMessagePrintLimit(0)},
                                                    {Log::MessageType::Warning, msgLimits.getWarningPrintLimit(0)},
                                                    {Log::MessageType::Error, msgLimits.getErrorPrintLimit(0)},
                                                    {Log::MessageType::Problem, msgLimits.getProblemPrintLimit(0)},
                                                    {Log::MessageType::Bug, msgLimits.getBugPrintLimit(0)}};
-            prtLog->setMessageLimiter(std::make_shared<MessageLimiter>(-1, limits));
+            prtLog->setMessageLimiter(std::make_shared<MessageLimiter>());
             prtLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(false));
             streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10, limits));
             streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(true));

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -142,11 +142,11 @@ namespace Opm
             }
             asImpl().setupOutput();
             asImpl().readDeckInput();
-            asImpl().setupGridAndProps();
-            asImpl().setupState();
             asImpl().setupLogging();
             asImpl().extractMessages();
+            asImpl().setupGridAndProps();
             asImpl().runDiagnostics();
+            asImpl().setupState();
             asImpl().writeInit();
             asImpl().distributeData();
             asImpl().setupOutputWriter();
@@ -424,12 +424,12 @@ namespace Opm
             std::shared_ptr<StreamLog> debugLog = std::make_shared<EclipsePRTLog>(debugFile, Log::DefaultMessageTypes, false, output_cout_);
             OpmLog::addBackend( "DEBUGLOG" ,  debugLog);
             const auto& msgLimits = eclipse_state_->getSchedule()->getMessageLimits();
-            const std::map<int64_t, int>limits = {{Log::MessageType::Note, msgLimits.getMessagePrintLimit(0)},
-                                                  {Log::MessageType::Info, msgLimits.getMessagePrintLimit(0)},
-                                                  {Log::MessageType::Warning, msgLimits.getWarningPrintLimit(0)},
-                                                  {Log::MessageType::Error, msgLimits.getErrorPrintLimit(0)},
-                                                  {Log::MessageType::Problem, msgLimits.getProblemPrintLimit(0)},
-                                                  {Log::MessageType::Bug, msgLimits.getBugPrintLimit(0)}};
+            const std::map<int64_t, int> limits = {{Log::MessageType::Note, msgLimits.getMessagePrintLimit(0)},
+                                                   {Log::MessageType::Info, msgLimits.getMessagePrintLimit(0)},
+                                                   {Log::MessageType::Warning, msgLimits.getWarningPrintLimit(0)},
+                                                   {Log::MessageType::Error, msgLimits.getErrorPrintLimit(0)},
+                                                   {Log::MessageType::Problem, msgLimits.getProblemPrintLimit(0)},
+                                                   {Log::MessageType::Bug, msgLimits.getBugPrintLimit(0)}};
             prtLog->setMessageLimiter(std::make_shared<MessageLimiter>(-1, limits));
             prtLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(false));
             streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10, limits));


### PR DESCRIPTION
With this PR, MESSAGES keyword is supported now. Depends on https://github.com/OPM/opm-parser/pull/921 and https://github.com/OPM/opm-common/pull/173