### PR TITLE
Bugfix for output writer

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -132,8 +132,8 @@ namespace Opm {
         struct SimulatorData {
             SimulatorData(int num_phases);
             std::vector<ReservoirResidualQuant> rq;
-            ADB rs;
-            ADB rv;
+            ADB rsSat;
+            ADB rvSat;
         };
 
         typedef typename ModelTraits<Implementation>::ReservoirState ReservoirState;
@@ -323,7 +323,7 @@ namespace Opm {
         bool use_threshold_pressure_;
         V threshold_pressures_by_connection_;
 
-        SimulatorData sd_;
+        mutable SimulatorData sd_;
         std::vector<PhasePresence> phaseCondition_;
 
         // Well Model

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -469,8 +469,8 @@ namespace detail {
     BlackoilModelBase<Grid, WellModel, Implementation>::
     SimulatorData::SimulatorData(int num_phases)
         : rq(num_phases)
-        , rs(ADB::null())
-        , rv(ADB::null())
+        , rsSat(ADB::null())
+        , rvSat(ADB::null())
     {
     }
 
@@ -657,17 +657,17 @@ namespace detail {
 
                 if (active_[ Oil ]) {
                     // RS and RV is only defined if both oil and gas phase are active.
-                    const ADB rsSat = fluidRsSat(state.canonical_phase_pressures[ Oil ], so , cells_);
+                    sd_.rsSat = fluidRsSat(state.canonical_phase_pressures[ Oil ], so , cells_);
                     if (has_disgas_) {
-                        state.rs = (1-isRs_)*rsSat + isRs_*xvar;
+                        state.rs = (1-isRs_)*sd_.rsSat + isRs_*xvar;
                     } else {
-                        state.rs = rsSat;
+                        state.rs = sd_.rsSat;
                     }
-                    const ADB rvSat = fluidRvSat(state.canonical_phase_pressures[ Gas ], so , cells_);
+                    sd_.rvSat = fluidRvSat(state.canonical_phase_pressures[ Gas ], so , cells_);
                     if (has_vapoil_) {
-                        state.rv = (1-isRv_)*rvSat + isRv_*xvar;
+                        state.rv = (1-isRv_)*sd_.rvSat + isRv_*xvar;
                     } else {
-                        state.rv = rvSat;
+                        state.rv = sd_.rvSat;
                     }
                 }
             }
@@ -1414,6 +1414,7 @@ namespace detail {
         if (has_disgas_) {
             const V rsSat0 = fluidRsSat(p_old, s_old.col(pu.phase_pos[Oil]), cells_);
             const V rsSat = fluidRsSat(p, so, cells_);
+            sd_.rsSat = ADB::constant(rsSat);
             // The obvious case
             auto hasGas = (sg > 0 && isRs_ == 0);
 
@@ -1439,6 +1440,7 @@ namespace detail {
             const V gaspress = computeGasPressure(p, sw, so, sg);
             const V rvSat0 = fluidRvSat(gaspress_old, s_old.col(pu.phase_pos[Oil]), cells_);
             const V rvSat = fluidRvSat(gaspress, so, cells_);
+            sd_.rvSat = ADB::constant(rvSat);
 
             // The obvious case
             auto hasOil = (so > 0 && isRv_ == 0);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -579,14 +579,14 @@ namespace Opm
                 simProps.emplace_back(data::CellData{
                         "RSSAT",
                         Opm::UnitSystem::measure::gas_oil_ratio,
-                        std::move(adbToDoubleVector(sd.rs))});
+                        std::move(adbToDoubleVector(sd.rsSat))});
             }
             if (vapour_active && liquid_active && outKeywords["RVSAT"] > 0) {
                 outKeywords["RVSAT"] = 0;
                 simProps.emplace_back(data::CellData{
                         "RVSAT",
                         Opm::UnitSystem::measure::oil_gas_ratio,
-                        std::move(adbToDoubleVector(sd.rv))});
+                        std::move(adbToDoubleVector(sd.rvSat))});
             }
 
 

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
@@ -78,13 +78,13 @@ namespace Opm {
         struct SimulatorData {
             SimulatorData(int num_phases)
                 : rq(num_phases)
-                , rs(ADB::null())
-                , rv(ADB::null())
+                , rsSat(ADB::null())
+                , rvSat(ADB::null())
             {
             }
             std::vector<ReservoirResidualQuant> rq;
-            ADB rs;
-            ADB rv;
+            ADB rsSat;
+            ADB rvSat;
         };
 
         /// Construct a solver. It will retain references to the


### PR DESCRIPTION
Somehow rsSat/rvSat were never set in original PR, and this should fix that issue. 

Related to issue OPM/opm-output#88