### PR TITLE
Save space in computeFluidAndSpace.

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -2369,8 +2369,8 @@ namespace detail {
 
         // compute PAV and PORV for every regions.
         const V hydrocarbon = saturation[Oil].value() + saturation[Gas].value();
-        V hcpv = V::Zero(nc);
-        V pres = V::Zero(nc);
+        V hcpv = V::Zero(dims);
+        V pres = V::Zero(dims);
         for (int c = 0; c < nc; ++c) {
             if (fipnum[c] != 0) {
                 hcpv[fipnum[c]-1] += pv[c] * hydrocarbon[c];


### PR DESCRIPTION
Both hcpv and res will be used to save only dims elements. As dims will most likely be much smaller than the number of cells, we only allocate containers of size dims with this commit.

I came across this during working on #807.