### PR TITLE
Correctly parallelize computeFluidInPlace

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -251,6 +251,9 @@ namespace Opm {
                          ReservoirState& reservoir_state,
                          WellState& well_state);
 
+        /// Return true if this is a parallel run.
+        bool isParallel() const;
+
         /// Return true if output to cout is wanted.
         bool terminalOutputEnabled() const;
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -2369,8 +2369,8 @@ namespace detail {
 
         // compute PAV and PORV for every regions.
         const V hydrocarbon = saturation[Oil].value() + saturation[Gas].value();
-        V hcpv = V::Zero(nc);
-        V pres = V::Zero(nc);
+        V hcpv = V::Zero(dims);
+        V pres = V::Zero(dims);
         for (int c = 0; c < nc; ++c) {
             if (fipnum[c] != 0) {
                 hcpv[fipnum[c]-1] += pv[c] * hydrocarbon[c];


### PR DESCRIPTION
Its first implementation computed wrong results in parallel. With this commit we now have completely parallelized the computations and the results seem correct for parallel runs with norne.

Closes #807.

Includes and closes #828