### PR TITLE
BUGFIX. Store RsSat and RvSat in simulator container also in the Solvent model

### DIFF
--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -220,17 +220,17 @@ namespace Opm {
                 if (active_[ Oil ]) {
                     // RS and RV is only defined if both oil and gas phase are active.
                     state.canonical_phase_pressures = computePressures(state.pressure, state.saturation[pu.phase_pos[ Water ]], so, sg, state.solvent_saturation);
-                    const ADB rsSat = fluidRsSat(state.canonical_phase_pressures[ Oil ], so , cells_);
+                    sd_.rsSat = fluidRsSat(state.canonical_phase_pressures[ Oil ], so , cells_);
                     if (has_disgas_) {
-                        state.rs = (1-Base::isRs_)*rsSat + Base::isRs_*xvar;
+                        state.rs = (1-Base::isRs_)*sd_.rsSat + Base::isRs_*xvar;
                     } else {
-                        state.rs = rsSat;
+                        state.rs = sd_.rsSat;
                     }
-                    const ADB rvSat = fluidRvSat(state.canonical_phase_pressures[ Gas ], so , cells_);
+                    sd_.rvSat = fluidRvSat(state.canonical_phase_pressures[ Gas ], so , cells_);
                     if (has_vapoil_) {
-                        state.rv = (1-Base::isRv_)*rvSat + Base::isRv_*xvar;
+                        state.rv = (1-Base::isRv_)*sd_.rvSat + Base::isRv_*xvar;
                     } else {
-                        state.rv = rvSat;
+                        state.rv = sd_.rvSat;
                     }
                 }
             }
@@ -549,6 +549,7 @@ namespace Opm {
         if (has_disgas_) {
             const V rsSat0 = fluidRsSat(p_old, s_old.col(pu.phase_pos[Oil]), cells_);
             const V rsSat = fluidRsSat(p, so, cells_);
+            sd_.rsSat = ADB::constant(rsSat);
             // The obvious case
             auto hasGas = (sg > 0 && Base::isRs_ == 0);
 
@@ -574,6 +575,7 @@ namespace Opm {
             const V gaspress = computeGasPressure(p, sw, so, sg);
             const V rvSat0 = fluidRvSat(gaspress_old, s_old.col(pu.phase_pos[Oil]), cells_);
             const V rvSat = fluidRvSat(gaspress, so, cells_);
+            sd_.rvSat = ADB::constant(rvSat);
 
             // The obvious case
             auto hasOil = (so > 0 && Base::isRv_ == 0);


### PR DESCRIPTION
Updated solvent model similar as in #825
Store rsSat and rvSat in simulator container for output.
Fixes issue #831 
