### PR TITLE
Output well rates for present phases

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -379,7 +379,7 @@ namespace Opm
                                           substep,
                                           timer.simulationTimeElapsed(),
                                           simToSolution( state, phaseUsage_ ),
-                                          wellState.report(),
+                                          wellState.report(phaseUsage_),
                                           simProps);
             }
         }

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -24,6 +24,7 @@
 #include <opm/core/wells.h>
 #include <opm/core/well_controls.h>
 #include <opm/core/simulator/WellState.hpp>
+#include <opm/core/props/BlackoilPhases.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <vector>
 #include <cassert>
@@ -191,8 +192,8 @@ namespace Opm
         std::vector<double>& wellPotentials() { return well_potentials_; }
         const std::vector<double>& wellPotentials() const { return well_potentials_; }
 
-        data::Wells report() const override {
-            data::Wells res = WellState::report();
+        data::Wells report(const PhaseUsage &pu) const override {
+            data::Wells res = WellState::report(pu);
 
             const int nw = this->numWells();
             // If there are now wells numPhases throws a floating point
@@ -230,16 +231,16 @@ namespace Opm
                 const auto& wv = this->wellRates();
 
                 data::Rates wellrates;
-                if( np > 0 ) {
-                    wellrates.set( rt::wat, wv[ wellrate_index + 0 ] );
+                if( pu.phase_used[BlackoilPhases::Aqua] ) {
+                    wellrates.set( rt::wat, wv[ wellrate_index + pu.phase_pos[BlackoilPhases::Aqua] ] );
                 }
 
-                if( np > 1 ) {
-                    wellrates.set( rt::oil, wv[ wellrate_index + 1 ] );
+                if( pu.phase_used[BlackoilPhases::Liquid] ) {
+                    wellrates.set( rt::oil, wv[ wellrate_index + pu.phase_pos[BlackoilPhases::Liquid] ] );
                 }
 
-                if( np > 2 ) {
-                    wellrates.set( rt::gas, wv[ wellrate_index + 2 ] );
+                if( pu.phase_used[BlackoilPhases::Vapour] ) {
+                    wellrates.set( rt::wat, wv[ wellrate_index + pu.phase_pos[BlackoilPhases::Vapour] ] );
                 }
 
                 const double bhp  = this->bhp()[ w ];

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -230,10 +230,15 @@ namespace Opm
                 const auto& wv = this->wellRates();
 
                 data::Rates wellrates;
-                if( np == 3 ) {
-                    /* only write if 3-phase solution */
+                if( np > 0 ) {
                     wellrates.set( rt::wat, wv[ wellrate_index + 0 ] );
+                }
+
+                if( np > 1 ) {
                     wellrates.set( rt::oil, wv[ wellrate_index + 1 ] );
+                }
+
+                if( np > 2 ) {
                     wellrates.set( rt::gas, wv[ wellrate_index + 2 ] );
                 }
 


### PR DESCRIPTION
Output well rates for all present phases, not just for three phase flow.

Not sure if there's a reason this was done in the first place, but the patch seems to work well for my two phase case.