### PR TITLE
Do not move when it would disable copy elision.

### DIFF
--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -699,7 +699,7 @@ namespace Opm
         SolutionVector dx = newtonIncrement.computeNewtonIncrement( residual );
         // get number of linear iterations
         iterations_ = newtonIncrement.iterations();
-        return std::move(dx);
+        return dx;
     }
 
     const boost::any& NewtonIterationBlackoilInterleaved::parallelInformation() const


### PR DESCRIPTION
Discovered by warnings from recent clang.

Trivial change, intend to self-merge when green.