### PR TITLE
Fix parallel output

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -66,6 +66,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/polymer/fullyimplicit/PolymerPropsAd.cpp
   opm/simulators/SimulatorCompressibleTwophase.cpp
   opm/simulators/SimulatorIncompTwophase.cpp
+	opm/simulators/WellSwitchingLogger.cpp
   )
 
 
@@ -87,6 +88,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_solventprops_ad.cpp
 	tests/test_multisegmentwells.cpp
 	# tests/test_thresholdpressure.cpp
+	tests/test_wellswitchlogger.cpp
   )
 
 list (APPEND TEST_DATA_FILES
@@ -240,5 +242,6 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/polymer/fullyimplicit/WellStateFullyImplicitBlackoilPolymer.hpp
   opm/simulators/SimulatorCompressibleTwophase.hpp
   opm/simulators/SimulatorIncompTwophase.hpp
+	opm/simulators/WellSwitchingLogger.hpp
   )
 

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -240,6 +240,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer.hpp
   opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer_impl.hpp
   opm/polymer/fullyimplicit/WellStateFullyImplicitBlackoilPolymer.hpp
+  opm/simulators/ParallelFileMerger.hpp
   opm/simulators/SimulatorCompressibleTwophase.hpp
   opm/simulators/SimulatorIncompTwophase.hpp
 	opm/simulators/WellSwitchingLogger.hpp

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1082,7 +1082,11 @@ namespace detail {
         } while (it < 15);
 
         if (converged) {
-            OpmLog::note("well converged iter: " + std::to_string(it));
+            if (terminalOutputEnabled())
+            {
+                OpmLog::note("well converged iter: " + std::to_string(it));
+            }
+
             const int nw = wells().number_of_wells;
             {
                 // We will set the bhp primary variable to the new ones,

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -382,11 +382,11 @@ namespace Opm
                 logFile_ = baseName + ".PRT";
                 debugFile = "." + baseName + ".DEBUG";
             }
-            std::shared_ptr<EclipsePRTLog> prtLog = std::make_shared<EclipsePRTLog>(logFile_ , Log::NoDebugMessageTypes);
+            std::shared_ptr<EclipsePRTLog> prtLog = std::make_shared<EclipsePRTLog>(logFile_ , Log::NoDebugMessageTypes, false, output_cout_);
             std::shared_ptr<StreamLog> streamLog = std::make_shared<StreamLog>(std::cout, Log::StdoutMessageTypes);
             OpmLog::addBackend( "ECLIPSEPRTLOG" , prtLog );
             OpmLog::addBackend( "STREAMLOG", streamLog);
-            std::shared_ptr<StreamLog> debugLog = std::make_shared<EclipsePRTLog>(debugFile, Log::DefaultMessageTypes);
+            std::shared_ptr<StreamLog> debugLog = std::make_shared<EclipsePRTLog>(debugFile, Log::DefaultMessageTypes, false, output_cout_);
             OpmLog::addBackend( "DEBUGLOG" ,  debugLog);
             prtLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(false));
             streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10));

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -396,7 +396,10 @@ namespace Opm
             streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10));
             streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(true));
             // Read parameters.
-            OpmLog::debug("\n---------------    Reading parameters     ---------------\n");
+            if ( output_cout_ )
+            {
+                OpmLog::debug("\n---------------    Reading parameters     ---------------\n");
+            }
         }
 
 

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -40,6 +40,7 @@
 #include <opm/autodiff/GridHelpers.hpp>
 #include <opm/autodiff/createGlobalCellArray.hpp>
 #include <opm/autodiff/GridInit.hpp>
+#include <opm/simulators/ParallelFileMerger.hpp       >
 
 #include <opm/core/wells.h>
 #include <opm/core/wells/WellsManager.hpp>
@@ -84,8 +85,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/regex.hpp>
+
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -111,101 +111,6 @@ namespace Opm
     {
         boost::filesystem::path simulationCaseName( const std::string& casename );
         int64_t convertMessageType(const Message::type& mtype);
-
-        namespace fs = boost::filesystem;
-
-    /// \brief A functor that merges multiple files of a parallel run to one file.
-    ///
-    /// Without care multiple processes might log messages in a parallel run.
-    /// Non-root processes will do that to seperate files
-    /// <basename>.<rank>.<extension. This functor will append those file
-    /// to usual ones and delete the other files.
-    class ParallelFileMerger
-    {
-    public:
-        /// \brief Constructor
-        /// \param output_dir The output directory to use for reading/Writing.
-        /// \param deckanme The name of the deck.
-        ParallelFileMerger(fs::path output_dir,
-                           const std::string& deckname)
-            : debugFileRegex_("\\."+deckname+"\\.\\d+\\.DEBUG"),
-              logFileRegex_(deckname+"\\.\\d+\\.PRT")
-        {
-            auto debugPath = output_dir;
-            debugPath /= (std::string(".") + deckname + ".DEBUG");
-            debugStream_.reset(new fs::ofstream(debugPath,
-                                                std::ofstream::app));
-            auto logPath = output_dir;
-            logPath /= ( deckname + ".PRT");
-            logStream_.reset(new fs::ofstream(logPath,
-                                              std::ofstream::app));
-        }
-
-        void operator()(const fs::path& file)
-        {
-            const static boost::regex regex(".+\\.(\\d+)\\..+");
-            boost::smatch matches;
-            std::string filename = file.filename().native();
-
-            if ( boost::regex_match(filename, matches, regex) )
-            {
-                std::string rank = boost::regex_replace(filename, regex, "\\1");
-
-
-                if( boost::regex_match(filename, logFileRegex_) )
-                {
-                    appendFile(*logStream_, file, rank);
-                }
-                else
-                {
-                    if (boost::regex_match(filename, debugFileRegex_)  )
-                    {
-                        appendFile(*debugStream_, file, rank);
-                    }
-                    else
-                    {
-                        OPM_THROW(std::runtime_error,
-                                  "Unrecognized file with name "
-                                  << filename
-                                  << " from parallel run.");
-                    }
-                }
-            }
-        }
-    private:
-        /// \brief Append contents of a file to a stream
-        /// \brief of The output stream to use.
-        /// \brief file The file whose content to append.
-        /// \brief rank The rank that wrote the file.
-        void appendFile(fs::ofstream& of, const fs::path& file, const std::string& rank)
-        {
-            if( fs::file_size(file) )
-            {
-                std::cerr<<"WARNING: There has been logging out by non-root process "
-                         <<rank<<std::endl<<"Please report this in the issue tracker!"
-                         <<std::endl;
-                fs::ifstream in(file);
-                of<<std::endl<< std::endl;
-                of<<"=======================================================";
-                of<<std::endl<<std::endl;
-                of<<" Output written by rank "<<rank<<" to file "<<file.string()<<":"<<std::endl<<std::endl;
-                of<<in.rdbuf()<<std::endl<<std::endl;
-                of<<"======================== end output =====================";
-                of<<std::endl;
-                in.close();
-            }
-            fs::remove(file);
-        }
-
-        /// \brief Regex to capture .*.DEBUG
-        boost::regex debugFileRegex_;
-        /// \brief Regex to capture  *.PRT
-        boost::regex logFileRegex_;
-        /// \brief Stream to *.DEBUG file
-        std::unique_ptr<fs::ofstream> debugStream_;
-        /// \brief Stream to *.PRT file
-        std::unique_ptr<fs::ofstream> logStream_;
-    };
     }
 
 

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -40,7 +40,7 @@
 #include <opm/autodiff/GridHelpers.hpp>
 #include <opm/autodiff/createGlobalCellArray.hpp>
 #include <opm/autodiff/GridInit.hpp>
-#include <opm/simulators/ParallelFileMerger.hpp       >
+#include <opm/simulators/ParallelFileMerger.hpp>
 
 #include <opm/core/wells.h>
 #include <opm/core/wells/WellsManager.hpp>
@@ -426,12 +426,17 @@ namespace Opm
             prtLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(false));
             streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10));
             streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(true));
+
             // Read parameters.
             if ( output_cout_ )
             {
                 OpmLog::debug("\n---------------    Reading parameters     ---------------\n");
             }
         }
+
+
+
+
 
         void mergeParallelLogFiles()
         {
@@ -681,7 +686,9 @@ namespace Opm
         void extractMessages()
         {
             if ( !output_cout_ )
+            {
                 return;
+            }
 
             auto extractMessage = [](const Message& msg) {
                 auto log_type = detail::convertMessageType(msg.mtype);

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -150,12 +150,19 @@ namespace Opm
             asImpl().setupOutputWriter();
             asImpl().setupLinearSolver();
             asImpl().createSimulator();
-
+            
             // Run.
             return asImpl().runSimulator();
         }
         catch (const std::exception &e) {
-            std::cerr << "Program threw an exception: " << e.what() << "\n";
+            std::ostringstream message;
+            message  << "Program threw an exception: " << e.what();
+
+            if( output_cout_ )
+            {
+                OpmLog::error(message.str());
+            }
+
             return EXIT_FAILURE;
         }
 
@@ -389,7 +396,6 @@ namespace Opm
                 logFileStream << baseName << ".PRT";
                 debugFileStream << "." << baseName << ".DEBUG";
             }
-            if ( must_distribute_ && mpi_rank_ != 0 )
             {
                 // Added rank to log file for non-zero ranks.
                 // This prevents message loss.

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -618,6 +618,9 @@ namespace Opm
         //    OpmLog singleton.
         void extractMessages()
         {
+            if ( !output_cout_ )
+                return;
+
             auto extractMessage = [](const Message& msg) {
                 auto log_type = detail::convertMessageType(msg.mtype);
                 const auto& location = msg.location;

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -339,10 +339,14 @@ namespace Opm
         {
             // Write parameters used for later reference. (only if rank is zero)
             output_to_files_ = output_cout_ && param_.getDefault("output", true);
+            // Always read output_dir as it will be set unconditionally later.
+            // Not doing this might cause files to be created in the current
+            // directory.
+            output_dir_ =
+                param_.getDefault("output_dir", std::string("."));
+
             if (output_to_files_) {
                 // Create output directory if needed.
-                output_dir_ =
-                    param_.getDefault("output_dir", std::string("."));
                 boost::filesystem::path fpath(output_dir_);
                 if (!is_directory(fpath)) {
                     try {

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -656,6 +656,11 @@ namespace Opm
         //   OpmLog singleton.
         void runDiagnostics()
         {
+            if( ! output_cout_ )
+            {
+                return;
+            }
+
             // Run relperm diagnostics
             RelpermDiagnostics diagnostic;
             diagnostic.diagnosis(eclipse_state_, deck_, grid_init_->grid());

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -417,7 +417,12 @@ namespace Opm
                 ParseContext parseContext({{ ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE }});
                 deck_ = parser->parseFile(deck_filename, parseContext);
                 checkDeck(deck_, parser);
-                MissingFeatures::checkKeywords(*deck_);
+
+                if ( output_cout_)
+                {
+                    MissingFeatures::checkKeywords(*deck_);
+                }
+
                 eclipse_state_.reset(new EclipseState(*deck_, parseContext));
                 auto ioConfig = eclipse_state_->getIOConfig();
                 ioConfig->setOutputDir(output_dir_);

--- a/opm/autodiff/MultisegmentWells.cpp
+++ b/opm/autodiff/MultisegmentWells.cpp
@@ -142,7 +142,7 @@ namespace Opm {
     MultisegmentWells::
     MultisegmentWells(const Wells* wells_arg,
                       const std::vector< const Well* >& wells_ecl,
-                      const int time_step)
+                      const int time_step, const Communication& comm)
       : wells_multisegment_( createMSWellVector(wells_arg, wells_ecl, time_step) )
       , wops_ms_(wells_multisegment_)
       , num_phases_(wells_arg ? wells_arg->number_of_phases : 0)
@@ -158,6 +158,7 @@ namespace Opm {
       , segment_comp_surf_volume_current_(num_phases_, ADB::null())
       , segment_mass_flow_rates_(ADB::null())
       , segment_viscosities_(ADB::null())
+      , comm_(comm)
     {
         const int nw = wells_multisegment_.size();
         int nperf_total = 0;

--- a/opm/autodiff/MultisegmentWells.hpp
+++ b/opm/autodiff/MultisegmentWells.hpp
@@ -22,6 +22,8 @@
 #ifndef OPM_MULTISEGMENTWELLS_HEADER_INCLUDED
 #define OPM_MULTISEGMENTWELLS_HEADER_INCLUDED
 
+#include <dune/common/parallel/mpihelper.hh>
+
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <Eigen/Eigen>
 #include <Eigen/Sparse>
@@ -41,6 +43,7 @@
 
 #include <opm/autodiff/WellMultiSegment.hpp>
 #include <opm/autodiff/WellDensitySegmented.hpp>
+#include <opm/simulators/WellSwitchingLogger.hpp>
 
 
 
@@ -78,13 +81,17 @@ namespace Opm {
                                             Eigen::Dynamic,
                                             Eigen::Dynamic,
                                             Eigen::RowMajor>;
+            using Communication =
+                Dune::CollectiveCommunication<typename Dune::MPIHelper
+                                              ::MPICommunicator>;
 
             // ---------  Public methods  ---------
             // TODO: using a vector of WellMultiSegmentConstPtr for now
             // TODO: it should use const Wells or something else later.
             MultisegmentWells(const Wells* wells_arg,
                               const std::vector< const Well* >& wells_ecl,
-                              const int time_step);
+                              const int time_step,
+                              const Communication& comm=Communication());
 
             std::vector<WellMultiSegmentConstPtr> createMSWellVector(const Wells* wells_arg,
                                                                      const std::vector< const Well* >& wells_ecl,
@@ -305,6 +312,7 @@ namespace Opm {
         Vector well_perforation_densities_;
         Vector well_perforation_pressure_diffs_;
 
+        Communication comm_;
     };
 
 } // namespace Opm

--- a/opm/autodiff/MultisegmentWells_impl.hpp
+++ b/opm/autodiff/MultisegmentWells_impl.hpp
@@ -824,6 +824,8 @@ namespace Opm
     MultisegmentWells::
     updateWellControls(WellState& xw) const
     {
+        wellhelpers::WellSwitchingLogger logger(comm_);
+
         if( msWells().empty() ) return ;
 
         std::string modestring[4] = { "BHP", "THP", "RESERVOIR_RATE", "SURFACE_RATE" };
@@ -860,9 +862,9 @@ namespace Opm
             if (ctrl_index != nwc) {
                 // Constraint number ctrl_index was broken, switch to it.
                 // Each well is only active on one process. Therefore we always print the sitch info.
-                std::cout << "Switching control mode for well " << msWells()[w]->name()
-                          << " from " << modestring[well_controls_iget_type(wc, current)]
-                          << " to " << modestring[well_controls_iget_type(wc, ctrl_index)] << std::endl;
+                logger.wellSwitched(msWells()[w]->name(),
+                                    well_controls_iget_type(wc, current),
+                                    well_controls_iget_type(wc, ctrl_index));
                 xw.currentControls()[w] = ctrl_index;
                 current = xw.currentControls()[w];
             }

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -280,11 +280,14 @@ namespace Opm
             FIPUnitConvert(eclipse_state_->getUnits(), COIP);
             V OOIP_totals = FIPTotals(OOIP, state);
             V COIP_totals = FIPTotals(COIP, state);
-            outputFluidInPlace(OOIP_totals, COIP_totals,eclipse_state_->getUnits(), 0);
-            for (size_t reg = 0; reg < OOIP.size(); ++reg) {
-                outputFluidInPlace(OOIP[reg], COIP[reg], eclipse_state_->getUnits(), reg+1);
-            }
 
+            if ( terminal_output_ )
+            {
+                outputFluidInPlace(OOIP_totals, COIP_totals,eclipse_state_->getUnits(), 0);
+                for (size_t reg = 0; reg < OOIP.size(); ++reg) {
+                    outputFluidInPlace(OOIP[reg], COIP[reg], eclipse_state_->getUnits(), reg+1);
+                }
+            }
 
             // accumulate total time
             stime += st;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -437,7 +437,8 @@ namespace Opm
                 const Opm::PhaseUsage& phaseUsage,
                 const Model& model,
                 const RestartConfig& restartConfig,
-                const int reportStepNum) {
+                const int reportStepNum,
+                const bool output) {
 
 
             std::vector<data::CellData> simProps;
@@ -547,8 +548,11 @@ namespace Opm
                             std::move(adbToDoubleVector(sd.rq[aqua_idx].kr))});
                 }
                 else {
-                    Opm::OpmLog::warning("Empty:WATKR",
-                                         "Not emitting empty Water Rel-Perm");
+                    if ( output )
+                    {
+                        Opm::OpmLog::warning("Empty:WATKR",
+                                             "Not emitting empty Water Rel-Perm");
+                    }
                 }
             }
             if (liquid_active && outKeywords["KRO"] > 0) {
@@ -560,8 +564,11 @@ namespace Opm
                              std::move(adbToDoubleVector(sd.rq[liquid_idx].kr))});
                 }
                 else {
-                    Opm::OpmLog::warning("Empty:OILKR",
-                                         "Not emitting empty Oil Rel-Perm");
+                    if ( output )
+                    {
+                        Opm::OpmLog::warning("Empty:OILKR",
+                                             "Not emitting empty Oil Rel-Perm");
+                    }
                 }
             }
             if (vapour_active && outKeywords["KRG"] > 0) {
@@ -573,8 +580,11 @@ namespace Opm
                              std::move(adbToDoubleVector(sd.rq[vapour_idx].kr))});
                 }
                 else {
-                    Opm::OpmLog::warning("Empty:GASKR",
-                                         "Not emitting empty Gas Rel-Perm");
+                    if ( output )
+                    {
+                        Opm::OpmLog::warning("Empty:GASKR",
+                                             "Not emitting empty Gas Rel-Perm");
+                    }
                 }
             }
 
@@ -600,7 +610,8 @@ namespace Opm
             /**
              * Bubble point and dew point pressures
              */
-            if (vapour_active && liquid_active && outKeywords["PBPD"] > 0) {
+            if (output && vapour_active &&
+                liquid_active && outKeywords["PBPD"] > 0) {
                 outKeywords["PBPD"] = 0;
                 Opm::OpmLog::warning("Bubble/dew point pressure output unsupported",
                         "Writing bubble points and dew points (PBPD) to file is unsupported, "
@@ -608,12 +619,15 @@ namespace Opm
             }
 
             //Warn for any unhandled keyword
-            for (auto& keyValue : outKeywords) {
-                if (keyValue.second > 0) {
-                    std::string logstring = "Keyword '";
-                    logstring.append(keyValue.first);
-                    logstring.append("' is unhandled for output to file.");
-                    Opm::OpmLog::warning("Unhandled output keyword", logstring);
+            if (output)
+            {
+                for (auto& keyValue : outKeywords) {
+                    if (keyValue.second > 0) {
+                        std::string logstring = "Keyword '";
+                        logstring.append(keyValue.first);
+                        logstring.append("' is unhandled for output to file.");
+                        Opm::OpmLog::warning("Unhandled output keyword", logstring);
+                    }
                 }
             }
 
@@ -636,7 +650,7 @@ namespace Opm
     {
         const RestartConfig& restartConfig = eclipseState_->getRestartConfig();
         const int reportStepNum = timer.reportStepNum();
-        std::vector<data::CellData> cellData = detail::getCellData( phaseUsage_, physicalModel, restartConfig, reportStepNum );
+        std::vector<data::CellData> cellData = detail::getCellData( phaseUsage_, physicalModel, restartConfig, reportStepNum,  parallelOutput_->isIORank() );
         writeTimeStepWithCellProperties(timer, localState, localWellState, cellData, substep);
     }
 }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -438,7 +438,7 @@ namespace Opm
                 const Model& model,
                 const RestartConfig& restartConfig,
                 const int reportStepNum,
-                const bool output) {
+                const bool log) {
 
 
             std::vector<data::CellData> simProps;
@@ -548,7 +548,7 @@ namespace Opm
                             std::move(adbToDoubleVector(sd.rq[aqua_idx].kr))});
                 }
                 else {
-                    if ( output )
+                    if ( log )
                     {
                         Opm::OpmLog::warning("Empty:WATKR",
                                              "Not emitting empty Water Rel-Perm");
@@ -564,7 +564,7 @@ namespace Opm
                              std::move(adbToDoubleVector(sd.rq[liquid_idx].kr))});
                 }
                 else {
-                    if ( output )
+                    if ( log )
                     {
                         Opm::OpmLog::warning("Empty:OILKR",
                                              "Not emitting empty Oil Rel-Perm");
@@ -580,7 +580,7 @@ namespace Opm
                              std::move(adbToDoubleVector(sd.rq[vapour_idx].kr))});
                 }
                 else {
-                    if ( output )
+                    if ( log )
                     {
                         Opm::OpmLog::warning("Empty:GASKR",
                                              "Not emitting empty Gas Rel-Perm");
@@ -610,7 +610,7 @@ namespace Opm
             /**
              * Bubble point and dew point pressures
              */
-            if (output && vapour_active &&
+            if (log && vapour_active &&
                 liquid_active && outKeywords["PBPD"] > 0) {
                 outKeywords["PBPD"] = 0;
                 Opm::OpmLog::warning("Bubble/dew point pressure output unsupported",
@@ -619,7 +619,7 @@ namespace Opm
             }
 
             //Warn for any unhandled keyword
-            if (output)
+            if (log)
             {
                 for (auto& keyValue : outKeywords) {
                     if (keyValue.second > 0) {
@@ -650,8 +650,10 @@ namespace Opm
     {
         const RestartConfig& restartConfig = eclipseState_->getRestartConfig();
         const int reportStepNum = timer.reportStepNum();
-        std::vector<data::CellData> cellData = detail::getCellData( phaseUsage_, physicalModel, restartConfig, reportStepNum,
-                                                                    output_ && parallelOutput_->isIORank() );
+        bool logMessages = output_ && parallelOutput_->isIORank();
+        std::vector<data::CellData> cellData =
+            detail::getCellData( phaseUsage_,physicalModel, restartConfig,
+                                 reportStepNum, logMessages );
         writeTimeStepWithCellProperties(timer, localState, localWellState, cellData, substep);
     }
 }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -650,7 +650,8 @@ namespace Opm
     {
         const RestartConfig& restartConfig = eclipseState_->getRestartConfig();
         const int reportStepNum = timer.reportStepNum();
-        std::vector<data::CellData> cellData = detail::getCellData( phaseUsage_, physicalModel, restartConfig, reportStepNum,  parallelOutput_->isIORank() );
+        std::vector<data::CellData> cellData = detail::getCellData( phaseUsage_, physicalModel, restartConfig, reportStepNum,
+                                                                    output_ && parallelOutput_->isIORank() );
         writeTimeStepWithCellProperties(timer, localState, localWellState, cellData, substep);
     }
 }

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -22,6 +22,8 @@
 #ifndef OPM_STANDARDWELLS_HEADER_INCLUDED
 #define OPM_STANDARDWELLS_HEADER_INCLUDED
 
+#include <dune/common/parallel/mpihelper.hh>
+
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
@@ -39,7 +41,7 @@
 #include <opm/autodiff/AutoDiffBlock.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
 #include <opm/autodiff/BlackoilPropsAdInterface.hpp>
-
+#include <opm/simulators/WellSwitchingLogger.hpp>
 
 namespace Opm {
 
@@ -57,6 +59,9 @@ namespace Opm {
             // ---------      Types      ---------
             using ADB = AutoDiffBlock<double>;
             using Vector = ADB::V;
+            using Communication =
+                Dune::CollectiveCommunication<typename Dune::MPIHelper
+                                              ::MPICommunicator>;
 
             // copied from BlackoilModelBase
             // should put to somewhere better
@@ -65,7 +70,8 @@ namespace Opm {
                                             Eigen::Dynamic,
                                             Eigen::RowMajor>;
             // ---------  Public methods  ---------
-            explicit StandardWells(const Wells* wells_arg);
+            explicit StandardWells(const Wells* wells_arg,
+                                   const Communication& comm=Communication());
 
             void init(const BlackoilPropsAdInterface* fluid_arg,
                       const std::vector<bool>* active_arg,
@@ -204,6 +210,8 @@ namespace Opm {
 
             bool store_well_perforation_fluxes_;
             Vector well_perforation_fluxes_;
+
+            Communication comm_;
 
             // protected methods
             template <class SolutionState, class WellState>

--- a/opm/autodiff/WellHelpers.hpp
+++ b/opm/autodiff/WellHelpers.hpp
@@ -35,6 +35,8 @@ namespace Opm {
 
     namespace wellhelpers
     {
+
+    
         inline
         double rateToCompare(const std::vector<double>& well_phase_flow_rate,
                              const int well,

--- a/opm/simulators/ParallelFileMerger.hpp
+++ b/opm/simulators/ParallelFileMerger.hpp
@@ -1,0 +1,132 @@
+/*
+  Copyright 2016 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2016 STATOIL AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PARALLELFILEMERGER_HEADER_INCLUDED
+#define OPM_PARALLELFILEMERGER_HEADER_INCLUDED
+
+#include <memory>
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/regex.hpp>
+
+namespace Opm
+{
+namespace detail
+{
+
+namespace fs = boost::filesystem;
+
+/// \brief A functor that merges multiple files of a parallel run to one file.
+///
+/// Without care multiple processes might log messages in a parallel run.
+/// Non-root processes will do that to seperate files
+/// <basename>.<rank>.<extension. This functor will append those file
+/// to usual ones and delete the other files.
+class ParallelFileMerger
+{
+public:
+    /// \brief Constructor
+    /// \param output_dir The output directory to use for reading/Writing.
+    /// \param deckanme The name of the deck.
+    ParallelFileMerger(fs::path output_dir,
+                       const std::string& deckname)
+        : debugFileRegex_("\\."+deckname+"\\.\\d+\\.DEBUG"),
+          logFileRegex_(deckname+"\\.\\d+\\.PRT")
+    {
+        auto debugPath = output_dir;
+        debugPath /= (std::string(".") + deckname + ".DEBUG");
+        debugStream_.reset(new fs::ofstream(debugPath,
+                                            std::ofstream::app));
+        auto logPath = output_dir;
+        logPath /= ( deckname + ".PRT");
+        logStream_.reset(new fs::ofstream(logPath,
+                                          std::ofstream::app));
+    }
+
+    void operator()(const fs::path& file)
+    {
+        const static boost::regex regex(".+\\.(\\d+)\\..+");
+        boost::smatch matches;
+        std::string filename = file.filename().native();
+
+        if ( boost::regex_match(filename, matches, regex) )
+        {
+            std::string rank = boost::regex_replace(filename, regex, "\\1");
+
+
+            if( boost::regex_match(filename, logFileRegex_) )
+            {
+                appendFile(*logStream_, file, rank);
+            }
+            else
+            {
+                if (boost::regex_match(filename, debugFileRegex_)  )
+                {
+                    appendFile(*debugStream_, file, rank);
+                }
+                else
+                {
+                    OPM_THROW(std::runtime_error,
+                              "Unrecognized file with name "
+                              << filename
+                              << " from parallel run.");
+                }
+            }
+        }
+    }
+private:
+    /// \brief Append contents of a file to a stream
+    /// \brief of The output stream to use.
+    /// \brief file The file whose content to append.
+    /// \brief rank The rank that wrote the file.
+    void appendFile(fs::ofstream& of, const fs::path& file, const std::string& rank)
+    {
+        if( fs::file_size(file) )
+        {
+            std::cerr<<"WARNING: There has been logging out by non-root process "
+                     <<rank<<std::endl<<"Please report this in the issue tracker!"
+                     <<std::endl;
+            fs::ifstream in(file);
+            of<<std::endl<< std::endl;
+            of<<"=======================================================";
+            of<<std::endl<<std::endl;
+            of << " Output written by rank " << rank << " to file " << file.string();
+            of << ":" << std::endl << std::endl;
+            of << in.rdbuf() << std::endl << std::endl;
+            of << "======================== end output =====================";
+            of << std::endl;
+            in.close();
+        }
+        fs::remove(file);
+    }
+
+    /// \brief Regex to capture .*.DEBUG
+    boost::regex debugFileRegex_;
+    /// \brief Regex to capture  *.PRT
+    boost::regex logFileRegex_;
+    /// \brief Stream to *.DEBUG file
+    std::unique_ptr<fs::ofstream> debugStream_;
+    /// \brief Stream to *.PRT file
+    std::unique_ptr<fs::ofstream> logStream_;
+};
+} // end namespace detail
+} // end namespace OPM
+#endif // end header guard

--- a/opm/simulators/ParallelFileMerger.hpp
+++ b/opm/simulators/ParallelFileMerger.hpp
@@ -46,7 +46,7 @@ public:
     /// \brief Constructor
     /// \param output_dir The output directory to use for reading/Writing.
     /// \param deckanme The name of the deck.
-    ParallelFileMerger(fs::path output_dir,
+    ParallelFileMerger(const fs::path& output_dir,
                        const std::string& deckname)
         : debugFileRegex_("\\."+deckname+"\\.\\d+\\.DEBUG"),
           logFileRegex_(deckname+"\\.\\d+\\.PRT")

--- a/opm/simulators/ParallelFileMerger.hpp
+++ b/opm/simulators/ParallelFileMerger.hpp
@@ -71,7 +71,6 @@ public:
         {
             std::string rank = boost::regex_replace(filename, regex, "\\1");
 
-
             if( boost::regex_match(filename, logFileRegex_) )
             {
                 appendFile(*logStream_, file, rank);
@@ -101,9 +100,9 @@ private:
     {
         if( fs::file_size(file) )
         {
-            std::cerr<<"WARNING: There has been logging out by non-root process "
-                     <<rank<<std::endl<<"Please report this in the issue tracker!"
-                     <<std::endl;
+            std::cerr << "WARNING: There has been logging out by non-root process "
+                      << rank << std::endl<<"Please report this in the issue tracker!"
+                     << std::endl;
             fs::ifstream in(file);
             of<<std::endl<< std::endl;
             of<<"=======================================================";

--- a/opm/simulators/WellSwitchingLogger.cpp
+++ b/opm/simulators/WellSwitchingLogger.cpp
@@ -1,0 +1,206 @@
+/*
+  Copyright 2016 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2016 Statoil AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
+#include <opm/simulators/WellSwitchingLogger.hpp>
+
+namespace Opm
+{
+namespace wellhelpers
+{
+
+#if HAVE_MPI
+int WellSwitchingLogger::calculateMessageSize(std::vector<int>& well_name_length)
+{
+
+    // Each process will send a message to the root process with
+    // the following data:
+    // total number of switches, for each switch the length of the
+    // well name, for each switch the well name and the two controls.
+    well_name_length.reserve(switchMap_.size());
+
+    for(const auto& switchEntry : switchMap_)
+    {
+        int length = switchEntry.first.size() +1;  //we write an additional \0
+        well_name_length.push_back(length);
+    }
+
+    // compute the message size
+    int message_size = 0;
+    int increment = 0;
+    // number of switches
+    MPI_Pack_size(1, MPI_INT, MPI_COMM_WORLD, &message_size);
+    message_size += increment;
+    // const char* length include delimiter for each switch
+    MPI_Pack_size(switchMap_.size(), MPI_INT, MPI_COMM_WORLD, &increment);
+    message_size += increment;
+    // for each well the name + two controls in one write
+    auto length = well_name_length.begin();
+
+    for(const auto& switchEntry : switchMap_)
+    {
+        // well name
+        MPI_Pack_size(*length, MPI_CHAR, MPI_COMM_WORLD, &increment);
+        message_size += increment;
+        // controls
+        MPI_Pack_size(2, MPI_CHAR, MPI_COMM_WORLD, &increment);
+        message_size += increment;
+        ++length;
+    }
+    return message_size;
+}
+
+void WellSwitchingLogger::packData(std::vector<int>& well_name_length,
+                                   std::vector<char>& buffer)
+{
+    // Pack the data
+    // number of switches
+    int offset = 0;
+    int no_switches = switchMap_.size();
+    MPI_Pack(&no_switches, 1, MPI_INT, buffer.data(), buffer.size(),
+             &offset, MPI_COMM_WORLD);
+    MPI_Pack(well_name_length.data(), well_name_length.size(),
+             MPI_INT, buffer.data(), buffer.size(),
+             &offset, MPI_COMM_WORLD);
+
+    for(const auto& switchEntry : switchMap_)
+    {
+        // well name
+        auto& well_name = switchEntry.first;
+        MPI_Pack(const_cast<char*>(well_name.c_str()), well_name.size()+1,
+                 MPI_CHAR, buffer.data(), buffer.size(),
+                 &offset, MPI_COMM_WORLD);
+
+        // controls
+        MPI_Pack(const_cast<char*>(switchEntry.second.data()), 2 , MPI_CHAR,
+                 buffer.data(), buffer.size(), &offset, MPI_COMM_WORLD);
+    }
+}
+
+void WellSwitchingLogger::unpackDataAndLog(std::vector<char>& recv_buffer,
+                                           const std::vector<int>& displ)
+{
+    for(int p=1; p < cc_.size(); ++p)
+    {
+        int offset = displ[p];
+        int no_switches = 0;
+        MPI_Unpack(recv_buffer.data(), recv_buffer.size(), &offset,
+                   &no_switches, 1, MPI_INT, MPI_COMM_WORLD);
+
+        if ( no_switches == 0 )
+        {
+            continue;
+        }
+
+        std::vector<int> well_name_length(no_switches);
+
+        MPI_Unpack(recv_buffer.data(), recv_buffer.size(), &offset,
+                   well_name_length.data(), well_name_length.size(),
+                   MPI_INT, MPI_COMM_WORLD);
+
+        for ( int i = 0; i < no_switches; ++i )
+        {
+            char well_name[well_name_length[i]] = {};
+            MPI_Unpack(recv_buffer.data(), recv_buffer.size(), &offset,
+                       well_name, well_name_length[i], MPI_CHAR,
+                       MPI_COMM_WORLD);
+
+            std::array<char,2> fromto{{}};
+            MPI_Unpack(recv_buffer.data(), recv_buffer.size(), &offset,
+                       fromto.data(), 2, MPI_CHAR, MPI_COMM_WORLD);
+
+            logSwitch(well_name, fromto, p);
+        }
+    }
+}
+
+void WellSwitchingLogger::logSwitch(const char* name, std::array<char,2> fromto,
+                                    int rank)
+{
+            std::ostringstream ss;
+            ss << "Switching control mode for well " << name
+               << " from " << modestring[WellControlType(fromto[0])]
+               << " to " <<  modestring[WellControlType(fromto[1])]
+               << " on rank " << rank << std::endl;
+            OpmLog::info(ss.str());
+}
+#endif
+
+void WellSwitchingLogger::gatherDataAndLog()
+{
+
+#if HAVE_MPI
+    if(cc_.size() == 1)
+    {
+        return;
+    }
+
+    std::vector<int> message_sizes;
+    std::vector<int> well_name_length;
+    int message_size = calculateMessageSize(well_name_length);
+
+    if ( cc_.rank() == 0 ){
+        for(const auto& entry : switchMap_)
+        {
+            logSwitch(entry.first.c_str(), entry.second,0);
+        }
+
+        message_sizes.resize(cc_.size());
+    }
+
+    MPI_Gather(&message_size, 1, MPI_INT, message_sizes.data(),
+               1, MPI_INT, 0, MPI_COMM_WORLD);
+
+    std::vector<char> buffer(message_size);
+    packData(well_name_length, buffer);
+
+    std::vector<int> displ;
+
+    if ( cc_.rank() == 0){
+        // last entry will be total size of
+        displ.resize(cc_.size() + 1, 0);
+        std::partial_sum(message_sizes.begin(), message_sizes.end(),
+                         displ.begin()+1);
+    }
+    std::vector<char> recv_buffer;
+    if ( cc_.rank() == 0 ){
+        recv_buffer.resize(displ[cc_.size()]);
+    }
+
+    MPI_Gatherv(buffer.data(), buffer.size(), MPI_PACKED,
+                recv_buffer.data(), message_sizes.data(),
+                displ.data(), MPI_PACKED, 0, MPI_COMM_WORLD);
+    if ( cc_.rank() == 0 )
+    {
+        unpackDataAndLog(recv_buffer, displ);
+    }
+#endif
+}
+
+
+WellSwitchingLogger::~WellSwitchingLogger()
+{
+    gatherDataAndLog();
+}
+} // end namespace wellhelpers
+} // end namespace Opm

--- a/opm/simulators/WellSwitchingLogger.cpp
+++ b/opm/simulators/WellSwitchingLogger.cpp
@@ -53,18 +53,16 @@ int WellSwitchingLogger::calculateMessageSize(std::vector<int>& well_name_length
     // const char* length include delimiter for each switch
     MPI_Pack_size(switchMap_.size(), MPI_INT, MPI_COMM_WORLD, &increment);
     message_size += increment;
-    // for each well the name + two controls in one write
-    auto length_iter = well_name_lengths.begin();
 
-    for(const auto& switchEntry : switchMap_)
+    // for each well the name + two controls in one write
+    for(const auto& length : well_name_lengths)
     {
         // well name
-        MPI_Pack_size(*length_iter, MPI_CHAR, MPI_COMM_WORLD, &increment);
+        MPI_Pack_size(length, MPI_CHAR, MPI_COMM_WORLD, &increment);
         message_size += increment;
         // controls
         MPI_Pack_size(2, MPI_CHAR, MPI_COMM_WORLD, &increment);
         message_size += increment;
-        ++length_iter;
     }
     return message_size;
 }

--- a/opm/simulators/WellSwitchingLogger.hpp
+++ b/opm/simulators/WellSwitchingLogger.hpp
@@ -1,0 +1,112 @@
+/*
+  Copyright 2016 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2016 Statoil AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_WELLSWITCHINGLOGGER_HEADER_INCLUDED
+#define OPM_WELLSWITCHINGLOGGER_HEADER_INCLUDED
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <dune/common/parallel/mpihelper.hh>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+
+#include <opm/core/well_controls.h>
+
+namespace Opm
+{
+namespace wellhelpers
+{
+
+/// \brief Utility class to handle the log messages about well switching.
+///
+/// In parallel all the messages will be send to a root processor
+/// and logged there.
+class WellSwitchingLogger
+{
+    typedef std::map<std::string, std::array<char,2> > SwitchMap;
+
+public:
+    /// \brief The type of the collective communication used.
+    typedef Dune::CollectiveCommunication<typename Dune::MPIHelper::MPICommunicator>
+    Communication;
+
+    /// \brief Constructor.
+    ///
+    /// \param cc The collective communication to use.
+    explicit WellSwitchingLogger(const Communication& cc=Communication())
+        : cc_(cc)
+    {}
+
+    /// \brief Log that a well switched.
+    /// \param name The name of the well.
+    /// \param from The control of the well before the switch.
+    /// \param to The control of the well after the switch.
+    void wellSwitched(std::string name,
+                      WellControlType from,
+                      WellControlType to)
+    {
+        if( cc_.size() > 1 )
+        {
+            using Pair = typename SwitchMap::value_type;
+            switchMap_.insert(Pair(name, {char(from), char(to)}));
+        }
+        else
+        {
+            std::ostringstream ss;
+            ss << "Switching control mode for well " << name
+               << " from " << modestring[from]
+               << " to " <<  modestring[to] << std::endl;
+            OpmLog::info(ss.str());
+        }
+    }
+
+    /// \brief Destructor send does the actual logging.
+    ~WellSwitchingLogger();
+
+private:
+
+#if HAVE_MPI
+    void unpackDataAndLog(std::vector<char>& recv_buffer,
+                          const std::vector<int>& displ);
+
+    void packData(std::vector<int>& well_name_length,
+                  std::vector<char>& buffer);
+
+    int calculateMessageSize(std::vector<int>& well_name_length);
+
+    void logSwitch(const char* name, std::array<char,2> fromto,
+                   int rank);
+
+#endif // HAVE_MPI
+
+    void gatherDataAndLog();
+    
+    /// \brief A map containing the local switches
+    SwitchMap switchMap_;
+    /// \brief Collective communication object.
+    Communication cc_;
+    /// \brief The strings for printing.
+    const std::string modestring[4] = { "BHP", "THP", "RESERVOIR_RATE", "SURFACE_RATE" };
+};
+} // end namespace wellhelpers
+} // end namespace Opm
+#endif

--- a/tests/test_multisegmentwells.cpp
+++ b/tests/test_multisegmentwells.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #define BOOST_TEST_MODULE MultisegmentWellsTest
+#define BOOST_TEST_NO_MAIN
 
 #include <vector>
 #include <unordered_set>
@@ -166,4 +167,17 @@ BOOST_AUTO_TEST_CASE(testStructure)
     BOOST_CHECK_EQUAL(nw, ms_wells->msWells().size());
     BOOST_CHECK_EQUAL(0, ms_wells->topWellSegments()[0]);
     BOOST_CHECK_EQUAL(1, ms_wells->topWellSegments()[1]);
+}
+
+bool
+init_unit_test_func()
+{
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+    boost::unit_test::unit_test_main(&init_unit_test_func,
+                                     argc, argv);
 }

--- a/tests/test_wellswitchlogger.cpp
+++ b/tests/test_wellswitchlogger.cpp
@@ -1,0 +1,65 @@
+#include <config.h>
+#include <dune/common/version.hh>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+#define BOOST_TEST_MODULE DistributedCpGridTests
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/WellSwitchingLogger.hpp>
+
+#if HAVE_MPI
+class MPIError {
+public:
+  /** @brief Constructor. */
+  MPIError(std::string s, int e) : errorstring(s), errorcode(e){}
+  /** @brief The error string. */
+  std::string errorstring;
+  /** @brief The mpi error code. */
+  int errorcode;
+};
+
+void MPI_err_handler(MPI_Comm *, int *err_code, ...){
+  char *err_string=new char[MPI_MAX_ERROR_STRING];
+  int err_length;
+  MPI_Error_string(*err_code, err_string, &err_length);
+  std::string s(err_string, err_length);
+  std::cerr << "An MPI Error ocurred:"<<std::endl<<s<<std::endl;
+  delete[] err_string;
+  throw MPIError(s, *err_code);
+}
+#endif
+
+bool
+init_unit_test_func()
+{
+    return true;
+}
+BOOST_AUTO_TEST_CASE(wellswitchlog)
+{
+    auto cc = Dune::MPIHelper::getCollectiveCommunication();
+
+    Opm::wellhelpers::WellSwitchingLogger logger(cc);
+    std::ostringstream name;
+    name <<"Well on rank "<<cc.rank()<<std::flush;
+
+    logger.wellSwitched(name.str(), BHP, THP);
+
+}
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+#if HAVE_MPI
+    // register a throwing error handler to allow for
+    // debugging with "catch throw" in gdb
+    MPI_Errhandler handler;
+    MPI_Comm_create_errhandler(MPI_err_handler, &handler);
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, handler);
+#endif
+    boost::unit_test::unit_test_main(&init_unit_test_func,
+                                     argc, argv);
+}


### PR DESCRIPTION
Before this PR logging was done  regardless whether it was a sequential or a parallel run. Leading to  multiple processes logging simultaneously to the same file and causing message loss.

This PR fixes this in the following ways:
- If possible log only on one process.That is the case if all processes have the same information.
- Gather all messages about well switching on a root process and log there. (This might cost us some runtime, though)
- To prevent losses and surprises (if the above does either not suffice or we missed some parts): Each process now logs to its own file and after the simulation is finished the log of non-root processes are 
append to the default log files.

Closes #830 in most parts. One exception is the logging within OPM_THROW which will still happen on all processes.