### PR TITLE
Add an option for using values from TUNING in the timestepping.

### DIFF
--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -111,7 +111,12 @@ namespace Opm
         std::unique_ptr< AdaptiveTimeStepping > adaptiveTimeStepping;
         if( param_.getDefault("timestep.adaptive", true ) )
         {
-            adaptiveTimeStepping.reset( new AdaptiveTimeStepping( param_, terminal_output_ ) );
+
+            if (param_.getDefault("use_TUNING", false)) {
+                adaptiveTimeStepping.reset( new AdaptiveTimeStepping( *schedule->getTuning(), timer.currentStepNum(), param_, terminal_output_ ) );
+            } else {
+                adaptiveTimeStepping.reset( new AdaptiveTimeStepping( param_, terminal_output_ ) );
+            }
         }
 
         std::string restorefilename = param_.getDefault("restorefile", std::string("") );


### PR DESCRIPTION
if the paramter use_TUNING=true, the adaptive time-stepper will
initialize with relevant values from the TUNING keywords.

Default is set to false. So this should not change the behavior of the current simulations. 

Depends on OPM/opm-core#1076
