### PR TITLE
Correct number of (nonlineat) iterations/linearizations in step_timing.txt

### DIFF
--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -295,6 +295,9 @@ namespace Opm
                 SimulatorReport step_report;
                 step_report.pressure_time = st;
                 step_report.total_time =  step_timer.secsSinceStart();
+                step_report.total_newton_iterations = solver->nonlinearIterations();
+                step_report.total_linear_iterations = solver->linearIterations();
+                step_report.total_linearizations = solver->linearizations();
                 step_report.reportParam(tstep_os);
             }
 


### PR DESCRIPTION

Previously, for all steps zero was reported. With this commit
we set these numbers in the SimulatorReport and now they end
up correctly in step_timings.txt