### PR TITLE
Make WellSwitchingLogger work with DUNE 2.3

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1077,8 +1077,11 @@ namespace detail {
                 const Eigen::VectorXd& dx = solver.solve(total_residual_v.matrix());
                 assert(dx.size() == total_residual_v.size());
                 asImpl().wellModel().updateWellState(dx.array(), dpMaxRel(), well_state);
-                asImpl().wellModel().updateWellControls(well_state);
             }
+            // We have to update the well controls regardless whether there are local
+            // wells active or not as parallel logging will take place that needs to
+            // communicate with all processes.
+            asImpl().wellModel().updateWellControls(well_state);
         } while (it < 15);
 
         if (converged) {

--- a/opm/autodiff/MultisegmentWells.cpp
+++ b/opm/autodiff/MultisegmentWells.cpp
@@ -142,7 +142,7 @@ namespace Opm {
     MultisegmentWells::
     MultisegmentWells(const Wells* wells_arg,
                       const std::vector< const Well* >& wells_ecl,
-                      const int time_step, const Communication& comm)
+                      const int time_step)
       : wells_multisegment_( createMSWellVector(wells_arg, wells_ecl, time_step) )
       , wops_ms_(wells_multisegment_)
       , num_phases_(wells_arg ? wells_arg->number_of_phases : 0)
@@ -158,7 +158,6 @@ namespace Opm {
       , segment_comp_surf_volume_current_(num_phases_, ADB::null())
       , segment_mass_flow_rates_(ADB::null())
       , segment_viscosities_(ADB::null())
-      , comm_(comm)
     {
         const int nw = wells_multisegment_.size();
         int nperf_total = 0;

--- a/opm/autodiff/MultisegmentWells.hpp
+++ b/opm/autodiff/MultisegmentWells.hpp
@@ -90,8 +90,7 @@ namespace Opm {
             // TODO: it should use const Wells or something else later.
             MultisegmentWells(const Wells* wells_arg,
                               const std::vector< const Well* >& wells_ecl,
-                              const int time_step,
-                              const Communication& comm=Communication());
+                              const int time_step);
 
             std::vector<WellMultiSegmentConstPtr> createMSWellVector(const Wells* wells_arg,
                                                                      const std::vector< const Well* >& wells_ecl,
@@ -312,7 +311,6 @@ namespace Opm {
         Vector well_perforation_densities_;
         Vector well_perforation_pressure_diffs_;
 
-        Communication comm_;
     };
 
 } // namespace Opm

--- a/opm/autodiff/MultisegmentWells_impl.hpp
+++ b/opm/autodiff/MultisegmentWells_impl.hpp
@@ -824,7 +824,7 @@ namespace Opm
     MultisegmentWells::
     updateWellControls(WellState& xw) const
     {
-        wellhelpers::WellSwitchingLogger logger(comm_);
+        wellhelpers::WellSwitchingLogger logger;
 
         if( msWells().empty() ) return ;
 

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -70,8 +70,7 @@ namespace Opm {
                                             Eigen::Dynamic,
                                             Eigen::RowMajor>;
             // ---------  Public methods  ---------
-            explicit StandardWells(const Wells* wells_arg,
-                                   const Communication& comm=Communication());
+            explicit StandardWells(const Wells* wells_arg);
 
             void init(const BlackoilPropsAdInterface* fluid_arg,
                       const std::vector<bool>* active_arg,
@@ -210,8 +209,6 @@ namespace Opm {
 
             bool store_well_perforation_fluxes_;
             Vector well_perforation_fluxes_;
-
-            Communication comm_;
 
             // protected methods
             template <class SolutionState, class WellState>

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -71,8 +71,7 @@ namespace Opm
 
 
 
-StandardWells::StandardWells(const Wells* wells_arg,
-                             const Communication& comm)
+StandardWells::StandardWells(const Wells* wells_arg)
       : wells_active_(wells_arg!=nullptr)
       , wells_(wells_arg)
       , wops_(wells_arg)
@@ -83,7 +82,6 @@ StandardWells::StandardWells(const Wells* wells_arg,
       , well_perforation_densities_(Vector())
       , well_perforation_pressure_diffs_(Vector())
       , store_well_perforation_fluxes_(false)
-      , comm_(comm)
     {
     }
 
@@ -708,7 +706,7 @@ StandardWells::StandardWells(const Wells* wells_arg,
     StandardWells::
     updateWellControls(WellState& xw) const
     {
-        wellhelpers::WellSwitchingLogger logger(comm_);
+        wellhelpers::WellSwitchingLogger logger;
 
         if( !localWellsActive() ) return ;
 

--- a/opm/simulators/WellSwitchingLogger.hpp
+++ b/opm/simulators/WellSwitchingLogger.hpp
@@ -52,7 +52,8 @@ public:
     /// \brief Constructor.
     ///
     /// \param cc The collective communication to use.
-    explicit WellSwitchingLogger(const Communication& cc=Communication())
+    explicit WellSwitchingLogger(const Communication& cc =
+                                 Dune::MPIHelper::getCollectiveCommunication())
         : cc_(cc)
     {}
 


### PR DESCRIPTION
That version does not provide a default constructor for
CollectiveCommunication, Therefore we now use
MPIHelper::getCollectiveCommunication() for the default
constructor argument.

Discovered by build error in jenkins. http://80.240.129.131:8080/job/opm-simulators/139