### PR TITLE
flow_ebos: only invalidate the intensive quantities after an iteration if necessary

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -253,6 +253,9 @@ namespace Opm {
                 updateState(x,reservoir_state);
                 wellModel().updateWellState(xw, well_state);
 
+                // since the solution was changed, the cache for the intensive quantities
+                // are invalid
+                ebosSimulator_.model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
             }
             const bool failed = false; // Not needed in this model.
             const int linear_iters = must_solve ? result.iterations : 0;
@@ -1012,7 +1015,6 @@ namespace Opm {
             ebosSimulator_.startNextEpisode( timer.currentStepLength() );
             ebosSimulator_.setEpisodeIndex( timer.reportStepNum() );
             ebosSimulator_.setTimeStepIndex( timer.reportStepNum() );
-            ebosSimulator_.model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
             ebosSimulator_.model().newtonMethod().setIterationIndex(iterationIdx);
 
             static int prevEpisodeIdx = 10000;


### PR DESCRIPTION
"if necessary" means that the solution has changed (which is the case
iff the linear solver needs to do some work...

On my machine the time required to solve the Norne deck went down from 1022.59 seconds to 993 seconds. Note that this there is some additional performance to be gained if the linearization is "short circuted", but that is also quite a bit more work...