### PR TITLE
Do not refer users to issue tracker if multiple procs log.

### DIFF
--- a/opm/simulators/ParallelFileMerger.hpp
+++ b/opm/simulators/ParallelFileMerger.hpp
@@ -100,9 +100,10 @@ private:
     {
         if( fs::file_size(file) )
         {
-            std::cerr << "WARNING: There has been logging out by non-root process "
-                      << rank << std::endl<<"Please report this in the issue tracker!"
-                     << std::endl;
+            std::cerr << "WARNING: There has been logging to file "
+                      << file.string() <<" by process "
+                      << rank << std::endl;
+
             fs::ifstream in(file);
             of<<std::endl<< std::endl;
             of<<"=======================================================";


### PR DESCRIPTION
This is currently still happening due to the implementation of OPM_THROW whenever the linear solver does not converge. This happens quite often and we might not want to get overwhelmed by the issue tracker.