### PR TITLE
Let only one rank write to step_timing.txt

### DIFF
--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -306,7 +306,11 @@ namespace Opm
                 step_report.total_newton_iterations = solver->nonlinearIterations();
                 step_report.total_linear_iterations = solver->linearIterations();
                 step_report.total_linearizations = solver->linearizations();
-                step_report.reportParam(tstep_os);
+
+                if ( output_writer_.isIORank() )
+                {
+                    step_report.reportParam(tstep_os);
+                }
             }
 
             // Increment timer, remember well state.

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -273,6 +273,12 @@ namespace Opm
         /** \brief return true if output is enabled */
         bool output () const { return output_; }
 
+        /** \brief Whether this process does write to disk */
+        bool isIORank () const
+        {
+            parallelOutput_->isIORank();
+        }
+
         void restore(SimulatorTimerInterface& timer,
                      BlackoilState& state,
                      WellStateFullyImplicitBlackoil& wellState,


### PR DESCRIPTION
All ranks were still writing to step_timing.txt at the same time.
This made it unusable for parallel runs. With this commit only
one processes writes to this file.