### PR TITLE
group control_updating well production targets within a group

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -312,6 +312,14 @@ namespace Opm {
         computeFluidInPlace(const ReservoirState& x,
                             const std::vector<int>& fipnum);
 
+        /// Function to compute the resevoir voidage for the production wells.
+        /// TODO: it is just prototyping, and not sure where is the best place to
+        /// put this function yet.
+        void computeWellVoidageRates(const ReservoirState& reservoir_state,
+                                     const WellState& well_state,
+                                     std::vector<double>& well_voidage_rates,
+                                     std::vector<double>& voidage_conversion_coeffs);
+
     protected:
 
         // ---------  Types and enums  ---------
@@ -427,6 +435,7 @@ namespace Opm {
         IterationReport
         solveWellEq(const std::vector<ADB>& mob_perfcells,
                     const std::vector<ADB>& b_perfcells,
+                    const ReservoirState& reservoir_state,
                     SolutionState& state,
                     WellState& well_state);
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -32,6 +32,7 @@
 #include <opm/autodiff/NewtonIterationBlackoilInterface.hpp>
 #include <opm/autodiff/BlackoilModelEnums.hpp>
 #include <opm/autodiff/VFPProperties.hpp>
+#include <opm/autodiff/RateConverter.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/core/simulator/SimulatorTimerInterface.hpp>
 
@@ -151,6 +152,11 @@ namespace Opm {
         typedef typename ModelTraits<Implementation>::WellState WellState;
         typedef typename ModelTraits<Implementation>::ModelParameters ModelParameters;
         typedef typename ModelTraits<Implementation>::SolutionState SolutionState;
+
+        // for the conversion between the surface volume rate and resrevoir voidage rate
+        // Due to the requirement of the grid information, put the converter in the model.
+        using RateConverterType = RateConverter::
+                                  SurfaceToReservoirVoidage<BlackoilPropsAdInterface, std::vector<int> >;
 
         // ---------  Public methods  ---------
 
@@ -359,6 +365,9 @@ namespace Opm {
         std::vector<std::vector<double>> residual_norms_history_;
         double current_relaxation_;
         V dx_old_;
+
+        // rate converter between the surface volume rates and reservoir voidage rates
+        RateConverterType rate_converter_;
 
         // ---------  Protected methods  ---------
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -153,8 +153,7 @@ namespace Opm {
         typedef typename ModelTraits<Implementation>::ModelParameters ModelParameters;
         typedef typename ModelTraits<Implementation>::SolutionState SolutionState;
 
-        // for the conversion between the surface volume rate and resrevoir voidage rate
-        // Due to the requirement of the grid information, put the converter in the model.
+        // For the conversion between the surface volume rate and resrevoir voidage rate
         using RateConverterType = RateConverter::
                                   SurfaceToReservoirVoidage<BlackoilPropsAdInterface, std::vector<int> >;
 
@@ -313,8 +312,8 @@ namespace Opm {
                             const std::vector<int>& fipnum);
 
         /// Function to compute the resevoir voidage for the production wells.
-        /// TODO: it is just prototyping, and not sure where is the best place to
-        /// put this function yet.
+        /// TODO: Probably should go to well model, while we then have duplications there.
+        /// With time, it looks like probably the time to introduce a base class for Well Models.
         void computeWellVoidageRates(const ReservoirState& reservoir_state,
                                      const WellState& well_state,
                                      std::vector<double>& well_voidage_rates,

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -321,7 +321,7 @@ namespace Opm {
 
 
         void applyVREPGroupControl(const ReservoirState& reservoir_state,
-                                   const WellState& well_state);
+                                   WellState& well_state);
 
     protected:
 

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -312,8 +312,8 @@ namespace Opm {
                             const std::vector<int>& fipnum);
 
         /// Function to compute the resevoir voidage for the production wells.
-        /// TODO: Probably should go to well model, while we then have duplications there.
-        /// With time, it looks like probably the time to introduce a base class for Well Models.
+        /// TODO: Probably should go to well model, while we then have duplications there for two Well Models.
+        /// With time, it looks like probably we will introduce a base class for Well Models.
         void computeWellVoidageRates(const ReservoirState& reservoir_state,
                                      const WellState& well_state,
                                      std::vector<double>& well_voidage_rates,

--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -319,6 +319,10 @@ namespace Opm {
                                      std::vector<double>& well_voidage_rates,
                                      std::vector<double>& voidage_conversion_coeffs);
 
+
+        void applyVREPGroupControl(const ReservoirState& reservoir_state,
+                                   const WellState& well_state);
+
     protected:
 
         // ---------  Types and enums  ---------

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -2034,7 +2034,13 @@ namespace detail {
 
         const double residualWell     = detail::infinityNormWell(residual_.well_eq,
                                                                  linsolver_.parallelInformation());
+<<<<<<< 002439c5b12c64e112f06d48c747da47031c3852
         converged_Well = converged_Well && (residualWell < tol_well_control);
+=======
+        // Hard-coded residual for well control equations.
+        converged_Well = converged_Well && (residualWell < 1.e-7);
+        // converged_Well = converged_Well && (residualWell < Opm::unit::barsa);
+>>>>>>> checking and outputing the residuals for the well equations.
         const bool converged = converged_Well;
 
         // if one of the residuals is NaN, throw exception, so that the solver can be restarted

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1058,12 +1058,12 @@ namespace detail {
             converged = getWellConvergence(it);
 
             // When the well targets are just updated or need to be updated, we need at least one more iteration.
-            if (asImpl().wellModel().justUpdateWellTargets()) {
+            if (asImpl().wellModel().wellCollection()->justUpdateWellTargets()) {
                 converged = false;
-                asImpl().wellModel().setJustUpdateWellTargets(false);
+                asImpl().wellModel().wellCollection()->setJustUpdateWellTargets(false);
             }
 
-            if (converged && asImpl().wellModel().needUpdateWellTargets()) {
+            if (converged && asImpl().wellModel().wellCollection()->needUpdateWellTargets()) {
                 converged = false;
             }
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -203,7 +203,11 @@ namespace detail {
         , terminal_output_ (terminal_output)
         , material_name_(0)
         , current_relaxation_(1.0)
-        , rate_converter_(fluid_, std::vector<int>(std::vector<int>(AutoDiffGrid::numCells(grid_),0)))
+        // only one region 0 used, which means average reservoir hydrocarbon conditions in
+        // the field will be calculated.
+        // TODO: more delicate implementation will be required if we want to handle different
+        // FIP regions specified from the well specifications.
+        , rate_converter_(fluid_, std::vector<int>(AutoDiffGrid::numCells(grid_),0))
     {
         if (active_[Water]) {
             material_name_.push_back("Water");
@@ -2645,6 +2649,7 @@ namespace detail {
                                    well_state.wellRates().begin() + np * (w + 1),
                                    well_rates.begin(), std::negate<double>());
 
+                    // the average hydrocarbon conditions of the whole field will be used
                     const int fipreg = 0; // Not considering FIP for the moment.
 
                     rate_converter_.calcCoeff(well_rates, fipreg, convert_coeff);
@@ -2656,6 +2661,7 @@ namespace detail {
                     std::copy(well_state.wellRates().begin() + np * w,
                               well_state.wellRates().begin() + np * (w + 1),
                               well_rates.begin());
+                    // the average hydrocarbon conditions of the whole field will be used
                     const int fipreg = 0; // Not considering FIP for the moment.
                     rate_converter_.calcCoeff(well_rates, fipreg, convert_coeff);
                     std::copy(convert_coeff.begin(), convert_coeff.end(),

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -2608,6 +2608,7 @@ namespace detail {
     {
         // TODO: for now, we store the voidage rates for all the production wells.
         // For injection wells, the rates are stored as zero.
+        // We only store the conversion coefficients for all the injection wells.
         // Later, more delicate model will be implemented here.
         // And for the moment, group control can only work for serial running.
         const int nw = well_state.numWells();

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1071,8 +1071,6 @@ namespace detail {
             asImpl().wellModel().addWellControlEq(wellSolutionState, well_state, aliveWells, residual_);
             converged = getWellConvergence(it);
 
-            // When the well targets are just updated or need to be updated, we need at least one more iteration.
-
             if (converged) {
                 break;
             }

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -967,8 +967,10 @@ namespace detail {
         // Add well contributions to mass balance equations
         const int nc = Opm::AutoDiffGrid::numCells(grid_);
         const int np = asImpl().numPhases();
+        const V& efficiency_factors = wellModel().wellPerfEfficiencyFactors();
         for (int phase = 0; phase < np; ++phase) {
-            residual_.material_balance_eq[phase] -= superset(cq_s[phase], wellModel().wellOps().well_cells, nc);
+            residual_.material_balance_eq[phase] -= superset(efficiency_factors * cq_s[phase],
+                                                             wellModel().wellOps().well_cells, nc);
         }
     }
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1057,14 +1057,13 @@ namespace detail {
             asImpl().wellModel().addWellControlEq(wellSolutionState, well_state, aliveWells, residual_);
             converged = getWellConvergence(it);
 
+            // When the well targets are just updated or need to be updated, we need at least one more iteration.
             if (asImpl().wellModel().justUpdateWellTargets()) {
-                std::cout << "converged changed to false due to justUpdateWellTargets " << std::endl;
                 converged = false;
                 asImpl().wellModel().setJustUpdateWellTargets(false);
             }
 
             if (converged && asImpl().wellModel().needUpdateWellTargets()) {
-                std::cout << "converged changed to false due to needUpdateWellTargets " << std::endl;
                 converged = false;
             }
 
@@ -1089,9 +1088,7 @@ namespace detail {
                 const Eigen::VectorXd& dx = solver.solve(total_residual_v.matrix());
                 assert(dx.size() == total_residual_v.size());
                 asImpl().wellModel().updateWellState(dx.array(), dpMaxRel(), well_state);
-                std::cout << "after updateWellState " << std::endl;
                 asImpl().wellModel().updateWellControls(well_state);
-                std::cout << " justUpdateWellTargets " << asImpl().wellModel().justUpdateWellTargets() << std::endl;
             }
             // We have to update the well controls regardless whether there are local
             // wells active or not as parallel logging will take place that needs to

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1043,7 +1043,6 @@ namespace detail {
         int it  = 0;
         bool converged;
         do {
-            std::cout << "in solveWellEq " << std::endl;
             // bhp and Q for the wells
             std::vector<V> vars0;
             vars0.reserve(2);
@@ -1133,7 +1132,6 @@ namespace detail {
         }
         const bool failed = false; // Not needed in this method.
         const int linear_iters = 0; // Not needed in this method
-        std::cout << " end of solveWellEq " << std::endl;
         return IterationReport{failed, converged, linear_iters, it};
     }
 
@@ -1911,6 +1909,7 @@ namespace detail {
         const double residualWell     = detail::infinityNormWell(residual_.well_eq,
                                                                  linsolver_.parallelInformation());
         converged_Well = converged_Well && (residualWell < tol_well_control);
+
         const bool converged = converged_MB && converged_CNV && converged_Well;
 
         // Residual in Pascal can have high values and still be ok.

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -790,10 +790,12 @@ namespace detail {
         // get reasonable initial conditions for the wells
         asImpl().wellModel().updateWellControls(well_state);
 
-        // enforce VREP control when necessary.
-        applyVREPGroupControl(reservoir_state, well_state);
+        if (asImpl().wellModel().wellCollection()->groupControlActive()) {
+            // enforce VREP control when necessary.
+            applyVREPGroupControl(reservoir_state, well_state);
 
-        asImpl().wellModel().wellCollection()->updateWellTargets(well_state.wellRates());
+            asImpl().wellModel().wellCollection()->updateWellTargets(well_state.wellRates());
+        }
 
         // Create the primary variables.
         SolutionState state = asImpl().variableState(reservoir_state, well_state);
@@ -1097,9 +1099,12 @@ namespace detail {
             // wells active or not as parallel logging will take place that needs to
             // communicate with all processes.
             asImpl().wellModel().updateWellControls(well_state);
-            // Enforce the VREP control
-            applyVREPGroupControl(reservoir_state, well_state);
-            asImpl().wellModel().wellCollection()->updateWellTargets(well_state.wellRates());
+
+            if (asImpl().wellModel().wellCollection()->groupControlActive()) {
+                // Enforce the VREP control
+                applyVREPGroupControl(reservoir_state, well_state);
+                asImpl().wellModel().wellCollection()->updateWellTargets(well_state.wellRates());
+            }
         } while (it < 15);
 
         if (converged) {

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -2032,13 +2032,8 @@ namespace detail {
 
         const double residualWell     = detail::infinityNormWell(residual_.well_eq,
                                                                  linsolver_.parallelInformation());
-<<<<<<< 002439c5b12c64e112f06d48c747da47031c3852
         converged_Well = converged_Well && (residualWell < tol_well_control);
-=======
-        // Hard-coded residual for well control equations.
-        converged_Well = converged_Well && (residualWell < 1.e-7);
-        // converged_Well = converged_Well && (residualWell < Opm::unit::barsa);
->>>>>>> checking and outputing the residuals for the well equations.
+
         const bool converged = converged_Well;
 
         // if one of the residuals is NaN, throw exception, so that the solver can be restarted
@@ -2681,9 +2676,7 @@ namespace detail {
             asImpl().wellModel().wellCollection()->applyVREPGroupControls(well_voidage_rates, voidage_conversion_coeffs);
 
             // for the wells under group control, update the currentControls for the well_state
-            const size_t number_node = asImpl().wellModel().wellCollection()->numNode();
-            for (size_t w = 0; w < number_node; ++w) {
-                const WellNode* well_node = asImpl().wellModel().wellCollection()->getNode(w);
+            for (const WellNode* well_node : asImpl().wellModel().wellCollection()->getLeafNodes()) {
                 if (well_node->isInjector() && !well_node->individualControl()) {
                     const int well_index = well_node->selfIndex();
                     well_state.currentControls()[well_index] = well_node->groupControlIndex();

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1088,7 +1088,6 @@ namespace detail {
                 const Eigen::VectorXd& dx = solver.solve(total_residual_v.matrix());
                 assert(dx.size() == total_residual_v.size());
                 asImpl().wellModel().updateWellState(dx.array(), dpMaxRel(), well_state);
-                asImpl().wellModel().updateWellControls(well_state);
             }
             // We have to update the well controls regardless whether there are local
             // wells active or not as parallel logging will take place that needs to

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -203,6 +203,7 @@ namespace detail {
         , terminal_output_ (terminal_output)
         , material_name_(0)
         , current_relaxation_(1.0)
+        , rate_converter_(fluid_, std::vector<int>(std::vector<int>(AutoDiffGrid::numCells(grid_),0)))
     {
         if (active_[Water]) {
             material_name_.push_back("Water");

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -169,6 +169,7 @@ namespace Opm {
         IterationReport
         solveWellEq(const std::vector<ADB>& mob_perfcells,
                     const std::vector<ADB>& b_perfcells,
+                    const ReservoirState& reservoir_state,
                     SolutionState& state,
                     WellState& well_state);
 

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -198,7 +198,7 @@ namespace Opm {
         wellModel().extractWellPerfProperties(state, sd_.rq, mob_perfcells, b_perfcells);
         if (param_.solve_welleq_initially_ && initial_assembly) {
             // solve the well equations as a pre-processing step
-            iter_report = asImpl().solveWellEq(mob_perfcells, b_perfcells, state, well_state);
+            iter_report = asImpl().solveWellEq(mob_perfcells, b_perfcells, reservoir_state, state, well_state);
         }
 
         // the perforation flux here are different
@@ -221,10 +221,11 @@ namespace Opm {
     IterationReport
     BlackoilMultiSegmentModel<Grid>::solveWellEq(const std::vector<ADB>& mob_perfcells,
                                                  const std::vector<ADB>& b_perfcells,
+                                                 const ReservoirState& reservoir_state,
                                                  SolutionState& state,
                                                  WellState& well_state)
     {
-        IterationReport iter_report = Base::solveWellEq(mob_perfcells, b_perfcells, state, well_state);
+        IterationReport iter_report = Base::solveWellEq(mob_perfcells, b_perfcells, reservoir_state, state, well_state);
 
         if (iter_report.converged) {
             // We must now update the state.segp and state.segqs members,

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -150,6 +150,11 @@ namespace Opm {
         // get reasonable initial conditions for the wells
         wellModel().updateWellControls(well_state);
 
+        // enforce VREP control when necessary.
+        Base::applyVREPGroupControl(reservoir_state, well_state);
+
+        asImpl().wellModel().wellCollection()->updateWellTargets(well_state.wellRates());
+
         // Create the primary variables.
         SolutionState state = asImpl().variableState(reservoir_state, well_state);
 

--- a/opm/autodiff/BlackoilTransportModel.hpp
+++ b/opm/autodiff/BlackoilTransportModel.hpp
@@ -135,7 +135,7 @@ namespace Opm {
             asImpl().wellModel().extractWellPerfProperties(state, sd_.rq, mob_perfcells, b_perfcells);
             if (param_.solve_welleq_initially_ && initial_assembly) {
                 // solve the well equations as a pre-processing step
-                iter_report = asImpl().solveWellEq(mob_perfcells, b_perfcells, state, well_state);
+                iter_report = asImpl().solveWellEq(mob_perfcells, b_perfcells, reservoir_state, state, well_state);
             }
             V aliveWells;
             std::vector<ADB> cq_s;

--- a/opm/autodiff/MultisegmentWells.cpp
+++ b/opm/autodiff/MultisegmentWells.cpp
@@ -272,6 +272,8 @@ namespace Opm {
         }
 
         assert(start_perforation == nperf_total_);
+
+        calculateEfficiencyFactors();
     }
 
 
@@ -392,6 +394,45 @@ namespace Opm {
     wellCollection() const {
         return well_collection_;
     }
+
+
+
+
+
+    void
+    MultisegmentWells::
+    calculateEfficiencyFactors()
+    {
+        if ( !localWellsActive() ) {
+            return;
+        }
+        // get efficiency factor for each well first
+        const int nw = wells_->number_of_wells;
+
+        Vector well_efficiency_factors = Vector::Ones(nw);
+
+        for (int w = 0; w < nw; ++w) {
+            const std::string well_name = wells_->name[w];
+            const WellNode* well_node = dynamic_cast<const WellNode *>(well_collection_->findNode(well_name));
+            well_efficiency_factors(w) = well_node->getAccumulativeEfficiencyFactor();
+        }
+
+        // map them to the perforation.
+        well_perforation_efficiency_factors_ = wellOps().w2p * well_efficiency_factors.matrix();
+    }
+
+
+
+
+
+    const
+    MultisegmentWells::Vector&
+    MultisegmentWells::
+    wellPerfEfficiencyFactors() const
+    {
+        return well_perforation_efficiency_factors_;
+    }
+
 
 } // end of namespace Opm
 

--- a/opm/autodiff/MultisegmentWells.cpp
+++ b/opm/autodiff/MultisegmentWells.cpp
@@ -141,10 +141,12 @@ namespace Opm {
 
     MultisegmentWells::
     MultisegmentWells(const Wells* wells_arg,
+                      WellCollection* well_collection,
                       const std::vector< const Well* >& wells_ecl,
                       const int time_step)
       : wells_multisegment_( createMSWellVector(wells_arg, wells_ecl, time_step) )
       , wops_ms_(wells_multisegment_)
+      , well_collection_(well_collection)
       , num_phases_(wells_arg ? wells_arg->number_of_phases : 0)
       , wells_(wells_arg)
       , fluid_(nullptr)
@@ -379,6 +381,16 @@ namespace Opm {
 
         assert(next == 2);
         return indices;
+    }
+
+
+
+
+
+    WellCollection*
+    MultisegmentWells::
+    wellCollection() const {
+        return well_collection_;
     }
 
 } // end of namespace Opm

--- a/opm/autodiff/MultisegmentWells.cpp
+++ b/opm/autodiff/MultisegmentWells.cpp
@@ -413,13 +413,9 @@ namespace Opm {
 
         for (int w = 0; w < nw; ++w) {
             const std::string well_name = wells_->name[w];
-            // get the pointer to the well node in the well collection
-            WellNode* well_node = well_collection_->findWellNode(std::string(wells().name[w]));
-            // maybe should put this if in function findWellNode()
-            if (well_node == nullptr) {
-                 OPM_THROW(std::runtime_error, "Could not find well " << std::string(wells().name[w]) << " in the well collection!\n");
-            }
-            well_efficiency_factors(w) = well_node->getAccumulativeEfficiencyFactor();
+            // get the well node in the well collection
+            WellNode& well_node = well_collection_->findWellNode(std::string(wells().name[w]));
+            well_efficiency_factors(w) = well_node.getAccumulativeEfficiencyFactor();
         }
 
         // map them to the perforation.

--- a/opm/autodiff/MultisegmentWells.cpp
+++ b/opm/autodiff/MultisegmentWells.cpp
@@ -413,7 +413,12 @@ namespace Opm {
 
         for (int w = 0; w < nw; ++w) {
             const std::string well_name = wells_->name[w];
-            const WellNode* well_node = dynamic_cast<const WellNode *>(well_collection_->findNode(well_name));
+            // get the pointer to the well node in the well collection
+            WellNode* well_node = well_collection_->findWellNode(std::string(wells().name[w]));
+            // maybe should put this if in function findWellNode()
+            if (well_node == nullptr) {
+                 OPM_THROW(std::runtime_error, "Could not find well " << std::string(wells().name[w]) << " in the well collection!\n");
+            }
             well_efficiency_factors(w) = well_node->getAccumulativeEfficiencyFactor();
         }
 

--- a/opm/autodiff/MultisegmentWells.cpp
+++ b/opm/autodiff/MultisegmentWells.cpp
@@ -147,6 +147,7 @@ namespace Opm {
       : wells_multisegment_( createMSWellVector(wells_arg, wells_ecl, time_step) )
       , wops_ms_(wells_multisegment_)
       , well_collection_(well_collection)
+      , well_perforation_efficiency_factors_(Vector::Ones(numWells()))
       , num_phases_(wells_arg ? wells_arg->number_of_phases : 0)
       , wells_(wells_arg)
       , fluid_(nullptr)

--- a/opm/autodiff/MultisegmentWells.hpp
+++ b/opm/autodiff/MultisegmentWells.hpp
@@ -32,6 +32,7 @@
 #include <cassert>
 
 #include <opm/core/props/BlackoilPhases.hpp>
+#include <opm/core/wells/WellCollection.hpp>
 
 #include <opm/autodiff/AutoDiffBlock.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
@@ -89,6 +90,7 @@ namespace Opm {
             // TODO: using a vector of WellMultiSegmentConstPtr for now
             // TODO: it should use const Wells or something else later.
             MultisegmentWells(const Wells* wells_arg,
+                              WellCollection* well_collection,
                               const std::vector< const Well* >& wells_ecl,
                               const int time_step);
 
@@ -229,11 +231,16 @@ namespace Opm {
                                                 const std::vector<ADB>& kr_adb,
                                                 const std::vector<ADB>& fluid_density);
 
+            WellCollection* wellCollection() const;
+
     protected:
         // TODO: probably a wells_active_ will be required here.
         bool wells_active_;
         std::vector<WellMultiSegmentConstPtr> wells_multisegment_;
         MultisegmentWellOps wops_ms_;
+        // It will probably need to be updated during running time.
+        WellCollection* well_collection_;
+
         const int num_phases_;
         int nseg_total_;
         int nperf_total_;

--- a/opm/autodiff/MultisegmentWells.hpp
+++ b/opm/autodiff/MultisegmentWells.hpp
@@ -233,6 +233,11 @@ namespace Opm {
 
             WellCollection* wellCollection() const;
 
+            void calculateEfficiencyFactors();
+
+            const Vector& wellPerfEfficiencyFactors() const;
+
+
     protected:
         // TODO: probably a wells_active_ will be required here.
         bool wells_active_;
@@ -240,6 +245,11 @@ namespace Opm {
         MultisegmentWellOps wops_ms_;
         // It will probably need to be updated during running time.
         WellCollection* well_collection_;
+
+        // The efficiency factor for each connection
+        // It is specified based on wells and groups
+        // By default, they should all be one.
+        Vector well_perforation_efficiency_factors_;
 
         const int num_phases_;
         int nseg_total_;

--- a/opm/autodiff/MultisegmentWells_impl.hpp
+++ b/opm/autodiff/MultisegmentWells_impl.hpp
@@ -878,9 +878,10 @@ namespace Opm
                 xw.currentControls()[w] = ctrl_index;
                 current = xw.currentControls()[w];
 
-                // not good practice, not easy to put groupControlIndex to WellsGroup.
-                // revising the interface for the better implementation later.
-                WellNode* well_node =  dynamic_cast<Opm::WellNode *>(well_collection_->findNode(std::string(wells().name[w])));
+                WellNode* well_node =  well_collection_->findWellNode(std::string(wells().name[w]));
+                if (well_node == nullptr) {
+                    OPM_THROW(std::runtime_error, "Could not find well " << std::string(wells().name[w]) << " in the well collection!\n");
+                }
 
                 // When the wells swtiching back and forwards between individual control and group control
                 // The targets of the wells should be updated.

--- a/opm/autodiff/MultisegmentWells_impl.hpp
+++ b/opm/autodiff/MultisegmentWells_impl.hpp
@@ -904,20 +904,16 @@ namespace Opm
                 break;
             }
 
-            // get the pointer to the well node in the well collection
-            WellNode* well_node = well_collection_->findWellNode(std::string(wells().name[w]));
-            // maybe should put this if in function findWellNode()
-            if (well_node == nullptr) {
-                 OPM_THROW(std::runtime_error, "Could not find well " << std::string(wells().name[w]) << " in the well collection!\n");
-            }
+            // get the well node in the well collection
+            WellNode& well_node = well_collection_->findWellNode(std::string(wells().name[w]));
 
             // update whehter the well is under group control or individual control
-            if (well_node->groupControlIndex() >= 0 && current == well_node->groupControlIndex()) {
+            if (well_node.groupControlIndex() >= 0 && current == well_node.groupControlIndex()) {
                 // under group control
-                well_node->setIndividualControl(false);
+                well_node.setIndividualControl(false);
             } else {
                 // individual control
-                well_node->setIndividualControl(true);
+                well_node.setIndividualControl(true);
             }
 
         }

--- a/opm/autodiff/MultisegmentWells_impl.hpp
+++ b/opm/autodiff/MultisegmentWells_impl.hpp
@@ -904,16 +904,18 @@ namespace Opm
                 break;
             }
 
-            // get the well node in the well collection
-            WellNode& well_node = well_collection_->findWellNode(std::string(wells().name[w]));
+            if (wellCollection()->groupControlActive()) {
+                // get the well node in the well collection
+                WellNode& well_node = well_collection_->findWellNode(std::string(wells().name[w]));
 
-            // update whehter the well is under group control or individual control
-            if (well_node.groupControlIndex() >= 0 && current == well_node.groupControlIndex()) {
-                // under group control
-                well_node.setIndividualControl(false);
-            } else {
-                // individual control
-                well_node.setIndividualControl(true);
+                // update whehter the well is under group control or individual control
+                if (well_node.groupControlIndex() >= 0 && current == well_node.groupControlIndex()) {
+                    // under group control
+                    well_node.setIndividualControl(false);
+                } else {
+                    // individual control
+                    well_node.setIndividualControl(true);
+                }
             }
 
         }

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -200,7 +200,7 @@ namespace Opm
             // Run a multiple steps of the solver depending on the time step control.
             solver_timer.start();
 
-            const WellModel well_model(wells);
+            const WellModel well_model(wells, &(wells_manager.wellCollection()));
 
             std::unique_ptr<Solver> solver = asImpl().createSolver(well_model);
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -122,7 +122,7 @@ namespace Opm
             const auto wells_ecl = eclipse_state_->getSchedule().getWells(timer.currentStepNum());
             const int current_time_step = timer.currentStepNum();
 
-            const WellModel well_model(wells, wells_ecl, current_time_step);
+            const WellModel well_model(wells, &(wells_manager.wellCollection()), wells_ecl, current_time_step);
 
             well_state.init(well_model, state, prev_well_state, wells);
 

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -38,6 +38,7 @@
 
 #include <opm/core/wells.h>
 #include <opm/core/wells/DynamicListEconLimited.hpp>
+#include <opm/core/wells/WellCollection.hpp>
 #include <opm/autodiff/AutoDiffBlock.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
 #include <opm/autodiff/BlackoilPropsAdInterface.hpp>
@@ -70,7 +71,7 @@ namespace Opm {
                                             Eigen::Dynamic,
                                             Eigen::RowMajor>;
             // ---------  Public methods  ---------
-            explicit StandardWells(const Wells* wells_arg);
+            StandardWells(const Wells* wells_arg, const WellCollection* well_collection);
 
             void init(const BlackoilPropsAdInterface* fluid_arg,
                       const std::vector<bool>* active_arg,
@@ -194,6 +195,8 @@ namespace Opm {
             bool wells_active_;
             const Wells*   wells_;
             const WellOps  wops_;
+            // TODO: It will probably need to be updated during running time.
+            const WellCollection* well_collection_;
 
             const BlackoilPropsAdInterface* fluid_;
             const std::vector<bool>*  active_;

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -194,7 +194,9 @@ namespace Opm {
 
             WellCollection* wellCollection() const;
 
-            void calculateEfficiencyFactor();
+            void calculateEfficiencyFactors();
+
+            const Vector& wellPerfEfficiencyFactors() const;
 
         protected:
             bool wells_active_;
@@ -206,7 +208,7 @@ namespace Opm {
             // The efficiency factor for each connection
             // It is specified based on wells and groups
             // By default, they should all be one.
-            Vector well_perforation_efficiency_factor_;
+            Vector well_perforation_efficiency_factors_;
 
             const BlackoilPropsAdInterface* fluid_;
             const std::vector<bool>*  active_;

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -191,23 +191,14 @@ namespace Opm {
                                   const WellState& well_state,
                                   DynamicListEconLimited& list_econ_limited) const;
 
-            bool justUpdateWellTargets() const {
-                return well_collection_->justUpdateWellTargets();
-            }
 
-            bool needUpdateWellTargets() const {
-                return well_collection_->needUpdateWellTargets();
-            }
-
-            void setJustUpdateWellTargets(const bool flag) const {
-                well_collection_->setJustUpdateWellTargets(flag);
-            }
+            WellCollection* wellCollection() const;
 
         protected:
             bool wells_active_;
             const Wells*   wells_;
             const WellOps  wops_;
-            // TODO: It will probably need to be updated during running time.
+            // It will probably need to be updated during running time.
             WellCollection* well_collection_;
 
             const BlackoilPropsAdInterface* fluid_;

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -71,7 +71,7 @@ namespace Opm {
                                             Eigen::Dynamic,
                                             Eigen::RowMajor>;
             // ---------  Public methods  ---------
-            StandardWells(const Wells* wells_arg, const WellCollection* well_collection);
+            StandardWells(const Wells* wells_arg, WellCollection* well_collection);
 
             void init(const BlackoilPropsAdInterface* fluid_arg,
                       const std::vector<bool>* active_arg,
@@ -196,7 +196,7 @@ namespace Opm {
             const Wells*   wells_;
             const WellOps  wops_;
             // TODO: It will probably need to be updated during running time.
-            const WellCollection* well_collection_;
+            WellCollection* well_collection_;
 
             const BlackoilPropsAdInterface* fluid_;
             const std::vector<bool>*  active_;

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -194,12 +194,19 @@ namespace Opm {
 
             WellCollection* wellCollection() const;
 
+            void calculateEfficiencyFactor();
+
         protected:
             bool wells_active_;
             const Wells*   wells_;
             const WellOps  wops_;
             // It will probably need to be updated during running time.
             WellCollection* well_collection_;
+
+            // The efficiency factor for each connection
+            // It is specified based on wells and groups
+            // By default, they should all be one.
+            Vector well_perforation_efficiency_factor_;
 
             const BlackoilPropsAdInterface* fluid_;
             const std::vector<bool>*  active_;

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -191,6 +191,18 @@ namespace Opm {
                                   const WellState& well_state,
                                   DynamicListEconLimited& list_econ_limited) const;
 
+            bool justUpdateWellTargets() const {
+                return well_collection_->justUpdateWellTargets();
+            }
+
+            bool needUpdateWellTargets() const {
+                return well_collection_->needUpdateWellTargets();
+            }
+
+            void setJustUpdateWellTargets(const bool flag) const {
+                well_collection_->setJustUpdateWellTargets(flag);
+            }
+
         protected:
             bool wells_active_;
             const Wells*   wells_;

--- a/opm/autodiff/StandardWellsSolvent.hpp
+++ b/opm/autodiff/StandardWellsSolvent.hpp
@@ -37,7 +37,7 @@ namespace Opm {
             using Base::computeWellConnectionDensitesPressures;
 
             // ---------  Public methods  ---------
-            StandardWellsSolvent(const Wells* wells_arg);
+            StandardWellsSolvent(const Wells* wells_arg, WellCollection* well_collection);
 
             // added the Solvent related
             void initSolvent(const SolventPropsAdFromDeck* solvent_props,

--- a/opm/autodiff/StandardWellsSolvent_impl.hpp
+++ b/opm/autodiff/StandardWellsSolvent_impl.hpp
@@ -32,8 +32,8 @@ namespace Opm
 
 
 
-    StandardWellsSolvent::StandardWellsSolvent(const Wells* wells_arg)
-        : Base(wells_arg)
+    StandardWellsSolvent::StandardWellsSolvent(const Wells* wells_arg, WellCollection* well_collection)
+        : Base(wells_arg, well_collection)
         , solvent_props_(nullptr)
         , solvent_pos_(-1)
         , has_solvent_(false)

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -779,7 +779,7 @@ namespace Opm
                 // revising the interface for the better implementation later.
                 WellNode* well_node =  dynamic_cast<Opm::WellNode *>(well_collection_->findNode(std::string(wells().name[w])));
 
-                // When the wells swtiching back and forwards between individual control and group control
+                // When the wells switching back and forwards between individual control and group control
                 // The targets of the wells should be updated.
                 if (well_node->individualControl()) {
                     if (ctrl_index == well_node->groupControlIndex()) {

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -1639,6 +1639,9 @@ namespace Opm
     }
 
 
+
+
+
     const StandardWells::Vector&
     StandardWells::wellPerfEfficiencyFactors() const
     {

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -71,10 +71,11 @@ namespace Opm
 
 
 
-StandardWells::StandardWells(const Wells* wells_arg)
+    StandardWells::StandardWells(const Wells* wells_arg, const WellCollection* well_collection)
       : wells_active_(wells_arg!=nullptr)
       , wells_(wells_arg)
       , wops_(wells_arg)
+      , well_collection_(well_collection)
       , fluid_(nullptr)
       , active_(nullptr)
       , phase_condition_(nullptr)
@@ -740,6 +741,15 @@ StandardWells::StandardWells(const Wells* wells_arg)
                     break;
                 }
             }
+            // TODO: when constraints got broken. For a well under group control, we need to change it to individual control
+            // We need to check the controls in the same group. If there is still some wells under group control,
+            // we need to update their group share targets. If no well is under group control, it means the group target
+            // will not be able to meet. We need to give a message there.
+            // It is better to wait until after the limit check loop. We need to record whose control status changed
+            // from group control to individual control here.
+            // Not sure exactly how the well go back from the individual control to group control.
+            // A guess is that the target is not updated. It works as a limit. When it got broken again, it switch back to
+            // group control. Then we also need to do something there.
             if (ctrl_index != nwc) {
                 // Constraint number ctrl_index was broken, switch to it.
                 // We disregard terminal_ouput here as with it only messages

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -771,12 +771,7 @@ namespace Opm
                 logger.wellSwitched(wells().name[w],
                                     well_controls_iget_type(wc, current),
                                     well_controls_iget_type(wc, ctrl_index));
-                std::ostringstream ss;
-                ss << "Switching control mode for well " << wells().name[w]
-                   << " from " << modestring[well_controls_iget_type(wc, current)]
-                   << " to " << modestring[well_controls_iget_type(wc, ctrl_index)] << std::endl;
 
-                OpmLog::info(ss.str());
                 xw.currentControls()[w] = ctrl_index;
                 current = xw.currentControls()[w];
 

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -711,10 +711,11 @@ namespace Opm
 
         if( !localWellsActive() ) return ;
 
+        std::cout << " StandardWells updateWellControls " << std::endl;
+
         if (well_collection_->needUpdateWellTargets() ) {
-            well_collection_->updateWellTargets(xw);
             std::cout << " well_collection_ need to update well targets " << std::endl;
-            std::cin.ignore();
+            well_collection_->updateWellTargets(xw);
             for (size_t i = 0; i < well_collection_->numNode(); ++i) {
                 well_collection_->getNode(i)->setShouldUpdateWellTargets(false);
             }
@@ -790,16 +791,27 @@ namespace Opm
                     if (ctrl_index == well_node->groupControlIndex()) {
                         std::cout << "well " << well_node->name() << " is switching from individual control to group control " << std::endl;
                         well_node->setIndividualControl(false);
-                        well_node->setShouldUpdateWellTargets(true);
+                        std::cout << "well_name " << well_node->name() << " should update well target? " << well_node->shouldUpdateWellTargets() << std::endl;
                     }
                 } else {
                     if (ctrl_index != well_node->groupControlIndex()) {
                         well_node->setIndividualControl(true);
                         std::cout << "well " << well_node->name() << " is switching from group control to individual control " << std::endl;
-                        well_node->setShouldUpdateWellTargets(true);
+                        std::cout << "well_name " << well_node->name() << " should update well target? " << well_node->shouldUpdateWellTargets() << std::endl;
+                    }
+                }
+                well_node->setShouldUpdateWellTargets(true);
+            } else {
+                // no constraints got broken
+                // the wells running under group control should set to be under group control
+                auto* well_node =  dynamic_cast<Opm::WellNode *>(well_collection_->findNode(std::string(wells().name[w])));
+                if (well_node->individualControl()) {
+                    if (current == well_node->groupControlIndex()) {
+                        well_node->setIndividualControl(false);
                     }
                 }
             }
+
 
             // Updating well state and primary variables.
             // Target values are used as initial conditions for BHP, THP, and SURFACE_RATE

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -76,7 +76,7 @@ namespace Opm
       , wells_(wells_arg)
       , wops_(wells_arg)
       , well_collection_(well_collection)
-      , well_perforation_efficiency_factors_(Vector())
+      , well_perforation_efficiency_factors_(Vector::Ones(wells_!=nullptr ? wells_->well_connpos[wells_->number_of_wells] : 0))
       , fluid_(nullptr)
       , active_(nullptr)
       , phase_condition_(nullptr)
@@ -852,16 +852,20 @@ namespace Opm
                 break;
             }
 
-            // get well node in the well collection
-            WellNode& well_node = well_collection_->findWellNode(std::string(wells().name[w]));
 
-            // update whehter the well is under group control or individual control
-            if (well_node.groupControlIndex() >= 0 && current == well_node.groupControlIndex()) {
-                // under group control
-                well_node.setIndividualControl(false);
-            } else {
-                // individual control
-                well_node.setIndividualControl(true);
+            if (wellCollection()->groupControlActive()) {
+
+                // get well node in the well collection
+                WellNode& well_node = well_collection_->findWellNode(std::string(wells().name[w]));
+
+                // update whehter the well is under group control or individual control
+                if (well_node.groupControlIndex() >= 0 && current == well_node.groupControlIndex()) {
+                    // under group control
+                    well_node.setIndividualControl(false);
+                } else {
+                    // individual control
+                    well_node.setIndividualControl(true);
+                }
             }
         }
 

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -76,7 +76,7 @@ namespace Opm
       , wells_(wells_arg)
       , wops_(wells_arg)
       , well_collection_(well_collection)
-      , well_perforation_efficiency_factor_(Vector())
+      , well_perforation_efficiency_factors_(Vector())
       , fluid_(nullptr)
       , active_(nullptr)
       , phase_condition_(nullptr)
@@ -106,7 +106,7 @@ namespace Opm
         gravity_ = gravity_arg;
         perf_cell_depth_ = subset(depth_arg, wellOps().well_cells);;
 
-        calculateEfficiencyFactor();
+        calculateEfficiencyFactors();
     }
 
 
@@ -1609,7 +1609,8 @@ namespace Opm
 
 
 
-    WellCollection* StandardWells::wellCollection() const {
+    WellCollection* StandardWells::wellCollection() const
+    {
         return well_collection_;
     }
 
@@ -1617,23 +1618,31 @@ namespace Opm
 
 
 
-    void StandardWells::calculateEfficiencyFactor() {
+    void StandardWells::calculateEfficiencyFactors()
+    {
         if ( !localWellsActive() ) {
             return;
         }
         // get efficiency factor for each well first
         const int nw = wells_->number_of_wells;
 
-        Vector well_efficiency_factor = Vector::Ones(nw);
+        Vector well_efficiency_factors = Vector::Ones(nw);
 
         for (int w = 0; w < nw; ++w) {
             const std::string well_name = wells_->name[w];
             const WellNode* well_node = dynamic_cast<const WellNode *>(well_collection_->findNode(well_name));
-            well_efficiency_factor(w) = well_node->getAccumulativeEfficiencyFactor();
+            well_efficiency_factors(w) = well_node->getAccumulativeEfficiencyFactor();
         }
 
         // map them to the perforation.
-        well_perforation_efficiency_factor_ = wellOps().w2p * well_efficiency_factor.matrix();
+        well_perforation_efficiency_factors_ = wellOps().w2p * well_efficiency_factors.matrix();
+    }
+
+
+    const StandardWells::Vector&
+    StandardWells::wellPerfEfficiencyFactors() const
+    {
+        return well_perforation_efficiency_factors_;
     }
 
 

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -1602,4 +1602,12 @@ namespace Opm
     }
 
 
+
+
+
+    WellCollection* StandardWells::wellCollection() const {
+        return well_collection_;
+    }
+
+
 } // namespace Opm

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -714,16 +714,6 @@ namespace Opm
 
         if( !localWellsActive() ) return ;
 
-        // if we need to update the well targets related to group control,
-        // we update them then re-run the simulation before updating the well control
-        /* if (well_collection_->needUpdateWellTargets() ) {
-            well_collection_->updateWellTargets(xw.wellRates());
-            for (size_t i = 0; i < well_collection_->numNode(); ++i) {
-                well_collection_->getNode(i)->setShouldUpdateWellTargets(false);
-            }
-            return;
-        } */
-
         // Find, for each well, if any constraints are broken. If so,
         // switch control to first broken constraint.
         const int np = wells().number_of_phases;
@@ -754,22 +744,6 @@ namespace Opm
                     break;
                 }
             }
-            // TODO: when constraints got broken. For a well under group control, we need to change it to individual control
-            // We need to check the controls in the same group. If there is still some wells under group control,
-            // we need to update their group share targets. If no well is under group control, it means the group target
-            // will not be able to meet. We need to give a message there.
-            // It is better to wait until after the limit check loop. We need to record whose control status changed
-            // from group control to individual control here.
-            // Not sure exactly how the well go back from the individual control to group control.
-            // A guess is that the target is not updated. It works as a limit. When it got broken again, it switch back to
-            // group control. Then we also need to do something there.
-
-            // get the pointer to the well node in the well collection
-            WellNode* well_node = well_collection_->findWellNode(std::string(wells().name[w]));
-            // maybe should put this if in function findWellNode()
-            if (well_node == nullptr) {
-                 OPM_THROW(std::runtime_error, "Could not find well " << std::string(wells().name[w]) << " in the well collection!\n");
-            }
 
             if (ctrl_index != nwc) {
                 // Constraint number ctrl_index was broken, switch to it.
@@ -781,9 +755,6 @@ namespace Opm
 
                 xw.currentControls()[w] = ctrl_index;
                 current = xw.currentControls()[w];
-
-                // TODO: double confirming the current strategy
-                well_node->setShouldUpdateWellTargets(true);
             }
 
             // Updating well state and primary variables.
@@ -879,6 +850,13 @@ namespace Opm
 
 
                 break;
+            }
+
+            // get the pointer to the well node in the well collection
+            WellNode* well_node = well_collection_->findWellNode(std::string(wells().name[w]));
+            // maybe should put this if in function findWellNode()
+            if (well_node == nullptr) {
+                 OPM_THROW(std::runtime_error, "Could not find well " << std::string(wells().name[w]) << " in the well collection!\n");
             }
 
             // update whehter the well is under group control or individual control

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -716,13 +716,13 @@ namespace Opm
 
         // if we need to update the well targets related to group control,
         // we update them then re-run the simulation before updating the well control
-        if (well_collection_->needUpdateWellTargets() ) {
+        /* if (well_collection_->needUpdateWellTargets() ) {
             well_collection_->updateWellTargets(xw.wellRates());
             for (size_t i = 0; i < well_collection_->numNode(); ++i) {
                 well_collection_->getNode(i)->setShouldUpdateWellTargets(false);
             }
             return;
-        }
+        } */
 
         // Find, for each well, if any constraints are broken. If so,
         // switch control to first broken constraint.

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -852,20 +852,16 @@ namespace Opm
                 break;
             }
 
-            // get the pointer to the well node in the well collection
-            WellNode* well_node = well_collection_->findWellNode(std::string(wells().name[w]));
-            // maybe should put this if in function findWellNode()
-            if (well_node == nullptr) {
-                 OPM_THROW(std::runtime_error, "Could not find well " << std::string(wells().name[w]) << " in the well collection!\n");
-            }
+            // get well node in the well collection
+            WellNode& well_node = well_collection_->findWellNode(std::string(wells().name[w]));
 
             // update whehter the well is under group control or individual control
-            if (well_node->groupControlIndex() >= 0 && current == well_node->groupControlIndex()) {
+            if (well_node.groupControlIndex() >= 0 && current == well_node.groupControlIndex()) {
                 // under group control
-                well_node->setIndividualControl(false);
+                well_node.setIndividualControl(false);
             } else {
                 // individual control
-                well_node->setIndividualControl(true);
+                well_node.setIndividualControl(true);
             }
         }
 
@@ -1590,12 +1586,9 @@ namespace Opm
 
         for (int w = 0; w < nw; ++w) {
             const std::string well_name = wells_->name[w];
-            const WellNode* well_node = well_collection_->findWellNode(well_name);
-            if (well_node == nullptr) {
-                OPM_THROW(std::runtime_error, "Could not find well " << std::string(wells().name[w]) << " in the well collection!\n");
-            }
+            const WellNode& well_node = well_collection_->findWellNode(well_name);
 
-            well_efficiency_factors(w) = well_node->getAccumulativeEfficiencyFactor();
+            well_efficiency_factors(w) = well_node.getAccumulativeEfficiencyFactor();
         }
 
         // map them to the perforation.

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -724,7 +724,6 @@ namespace Opm
             return;
         }
 
-        std::string modestring[4] = { "BHP", "THP", "RESERVOIR_RATE", "SURFACE_RATE" };
         // Find, for each well, if any constraints are broken. If so,
         // switch control to first broken constraint.
         const int np = wells().number_of_phases;
@@ -775,9 +774,11 @@ namespace Opm
                 xw.currentControls()[w] = ctrl_index;
                 current = xw.currentControls()[w];
 
-                // not good practice, not easy to put groupControlIndex to WellsGroup.
-                // revising the interface for the better implementation later.
-                WellNode* well_node =  dynamic_cast<Opm::WellNode *>(well_collection_->findNode(std::string(wells().name[w])));
+                WellNode* well_node = well_collection_->findWellNode(std::string(wells().name[w]));
+                // maybe should put this if in function findWellNode()
+                if (well_node == nullptr) {
+                    OPM_THROW(std::runtime_error, "Could not find well " << std::string(wells().name[w]) << " in the well collection!\n");
+                }
 
                 // When the wells switching back and forwards between individual control and group control
                 // The targets of the wells should be updated.
@@ -799,7 +800,11 @@ namespace Opm
                 // The wells have been running from last time step under group control, will be reset to be under individual control
                 // when rebuilding WellsManager. They need to set to be under group control (non-individual control) when they keep
                 // running under group control.
-                WellNode* well_node =  dynamic_cast<Opm::WellNode *>(well_collection_->findNode(std::string(wells().name[w])));
+                WellNode* well_node = well_collection_->findWellNode(std::string(wells().name[w]));
+                if (well_node == nullptr) {
+                    OPM_THROW(std::runtime_error, "Could not find well " << std::string(wells().name[w]) << " in the well collection!\n");
+                }
+
                 if (well_node->individualControl()) {
                     // the wells running under group control, meaning they are not under individual control
                     if (current == well_node->groupControlIndex()) {
@@ -1625,7 +1630,11 @@ namespace Opm
 
         for (int w = 0; w < nw; ++w) {
             const std::string well_name = wells_->name[w];
-            const WellNode* well_node = dynamic_cast<const WellNode *>(well_collection_->findNode(well_name));
+            const WellNode* well_node = well_collection_->findWellNode(well_name);
+            if (well_node == nullptr) {
+                OPM_THROW(std::runtime_error, "Could not find well " << std::string(wells().name[w]) << " in the well collection!\n");
+            }
+
             well_efficiency_factors(w) = well_node->getAccumulativeEfficiencyFactor();
         }
 

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -796,10 +796,11 @@ namespace Opm
                 well_node->setShouldUpdateWellTargets(true);
             } else {
                 // no constraints got broken
-                // the wells running under group control should set to be under group control
-                // it is based on the fact that we begin with setting all the wells be be under individual control
-                // The wells switch to be under group control after breaking one of the group target/limit.
-                // It is the same philosophy with the current srategy of the well control changing.
+                // The wells running under group control should set to be under group control
+                // It is based on the fact that we begin with setting all the wells be be under individual control.
+                // The wells have been running from last time step under group control, will be reset to be under individual control
+                // when rebuilding WellsManager. They need to set to be under group control (non-individual control) when they keep
+                // running under group control.
                 WellNode* well_node =  dynamic_cast<Opm::WellNode *>(well_collection_->findNode(std::string(wells().name[w])));
                 if (well_node->individualControl()) {
                     // the wells running under group control, meaning they are not under individual control

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -777,20 +777,19 @@ namespace Opm
                 xw.currentControls()[w] = ctrl_index;
                 current = xw.currentControls()[w];
 
-                // not good practice, revising the interface for the better implementation later.
-                auto* well_node =  dynamic_cast<Opm::WellNode *>(well_collection_->findNode(std::string(wells().name[w])));
+                // not good practice, not easy to put groupControlIndex to WellsGroup.
+                // revising the interface for the better implementation later.
+                WellNode* well_node =  dynamic_cast<Opm::WellNode *>(well_collection_->findNode(std::string(wells().name[w])));
 
                 // When the wells swtiching back and forwards between individual control and group control
                 // The targets of the wells should be updated.
                 if (well_node->individualControl()) {
                     if (ctrl_index == well_node->groupControlIndex()) {
-                        std::cout << "well " << well_node->name() << " is switching from individual control to group control " << std::endl;
                         well_node->setIndividualControl(false);
                     }
                 } else {
                     if (ctrl_index != well_node->groupControlIndex()) {
                         well_node->setIndividualControl(true);
-                        std::cout << "well " << well_node->name() << " is switching from group control to individual control " << std::endl;
                     }
                 }
                 // TODO: double confirming the current strategy
@@ -798,7 +797,10 @@ namespace Opm
             } else {
                 // no constraints got broken
                 // the wells running under group control should set to be under group control
-                auto* well_node =  dynamic_cast<Opm::WellNode *>(well_collection_->findNode(std::string(wells().name[w])));
+                // it is based on the fact that we begin with setting all the wells be be under individual control
+                // The wells switch to be under group control after breaking one of the group target/limit.
+                // It is the same philosophy with the current srategy of the well control changing.
+                WellNode* well_node =  dynamic_cast<Opm::WellNode *>(well_collection_->findNode(std::string(wells().name[w])));
                 if (well_node->individualControl()) {
                     // the wells running under group control, meaning they are not under individual control
                     if (current == well_node->groupControlIndex()) {

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -166,8 +166,10 @@ namespace Opm
                             // If the set of controls have changed, this may not be identical
                             // to the last control, but it must be a valid control.
                             currentControls()[ newIndex ] = old_control_index;
+                        } else {
+                            assert(well_controls_get_num(wells->ctrls[w]) > 0);
+                            currentControls()[ newIndex ] = 0;
                         }
-
                     }
                 }
             }

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -542,7 +542,7 @@ namespace Opm {
         wellModel().extractWellPerfProperties(state, sd_.rq, mob_perfcells, b_perfcells);
         if (param_.solve_welleq_initially_ && initial_assembly) {
             // solve the well equations as a pre-processing step
-            Base::solveWellEq(mob_perfcells, b_perfcells, state, well_state);
+            Base::solveWellEq(mob_perfcells, b_perfcells, reservoir_state, state, well_state);
         }
 
         V aliveWells;

--- a/tests/test_multisegmentwells.cpp
+++ b/tests/test_multisegmentwells.cpp
@@ -119,7 +119,7 @@ struct SetupMSW {
         const Wells* wells = wells_manager.c_wells();
         const auto wells_ecl = ecl_state.getSchedule().getWells(current_timestep);
 
-        ms_wells.reset(new Opm::MultisegmentWells(wells, wells_ecl, current_timestep));
+        ms_wells.reset(new Opm::MultisegmentWells(wells, &(wells_manager.wellCollection()), wells_ecl, current_timestep));
     };
 
     std::shared_ptr<const Opm::MultisegmentWells> ms_wells;


### PR DESCRIPTION
The updating of the well production targets within a group is designed based on our current way in handling schedule and well control, which means the WellsManager is always rebuilt at the beginning of the time step. 

The wells switch to group control when they violate the targets provided by the group control. 

When we need to update the well targets or we just update the well targets, we do not consider the current solution is converged. 

Updating targets during the time step is something new to the simulators. 

The wells are either under `individual control` due to their own limits or under `group control` under the targets provided through group control. They always begin with `individual control`, then switch to `group control` when they violate the group targets. 

The following two results are from two deck files modified from SPE9_CP_GROUP case for testing purpose. 

https://www.dropbox.com/s/y3lw2j0mnwc6br0/spe9-group2.pdf?dl=0

https://www.dropbox.com/s/ljcpk2fb6cbb0gm/spe9-group.pdf?dl=0

It depends on the PR OPM/opm-core#1088
