### PR TITLE
frankenstein: fix some valgrind complaints

### DIFF
--- a/opm/autodiff/BlackoilDetails.hpp
+++ b/opm/autodiff/BlackoilDetails.hpp
@@ -275,7 +275,7 @@ namespace detail {
                 for ( int idx = 0; idx < np; ++idx )
                 {
                     B_avg[idx] = B.col(idx).sum()/nc;
-                    //maxCoeff[idx] = tempV.col(idx).maxCoeff();
+                    maxCoeff[idx] = tempV.col(idx).maxCoeff();
                     R_sum[idx] = R.col(idx).sum();
 
                     assert(np >= np);

--- a/opm/autodiff/BlackoilDetails.hpp
+++ b/opm/autodiff/BlackoilDetails.hpp
@@ -226,8 +226,7 @@ namespace detail {
             assert(nw * np == int(residual_well.size()));
 
             // Do the global reductions
-#if 0
-            HAVE_MPI
+#if 0 // HAVE_MPI
             if ( linsolver_.parallelInformation().type() == typeid(ParallelISTLInformation) )
             {
                 const ParallelISTLInformation& info =
@@ -276,7 +275,7 @@ namespace detail {
                 for ( int idx = 0; idx < np; ++idx )
                 {
                     B_avg[idx] = B.col(idx).sum()/nc;
-                    maxCoeff[idx] = tempV.col(idx).maxCoeff();
+                    //maxCoeff[idx] = tempV.col(idx).maxCoeff();
                     R_sum[idx] = R.col(idx).sum();
 
                     assert(np >= np);

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -168,8 +168,8 @@ namespace Opm {
         , well_model_ (well_model)
         , terminal_output_ (terminal_output)
         , current_relaxation_(1.0)
-        , isBeginReportStep_(false)
         , dx_old_(AutoDiffGrid::numCells(grid_))
+        , isBeginReportStep_(false)
         {
             const double gravity = detail::getGravity(geo_.gravity(), UgGridHelpers::dimensions(grid_));
             const std::vector<double> pv(geo_.poreVolume().data(), geo_.poreVolume().data() + geo_.poreVolume().size());

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -829,13 +829,14 @@ namespace Opm {
 
                         if (pu.phase_used[BlackoilPhases::Vapour]) {
                             int gaspos = pu.phase_pos[BlackoilPhases::Vapour] + perf * pu.num_phases;
+                            int gaspos_well = pu.phase_pos[BlackoilPhases::Vapour] + w * pu.num_phases;
 
                             if (pu.phase_used[BlackoilPhases::Liquid]) {
-                                int oilpos = pu.phase_pos[BlackoilPhases::Liquid] + perf * pu.num_phases;
-                                const double oilrate = std::abs(xw.wellRates()[oilpos]); //in order to handle negative rates in producers
+                                int oilpos_well = pu.phase_pos[BlackoilPhases::Liquid] + w * pu.num_phases;
+                                const double oilrate = std::abs(xw.wellRates()[oilpos_well]); //in order to handle negative rates in producers
                                 rvmax_perf[perf] = FluidSystem::gasPvt().saturatedOilVaporizationFactor(fs.pvtRegionIndex(), temperature, p_avg);
                                 if (oilrate > 0) {
-                                    const double gasrate = std::abs(xw.wellRates()[gaspos]);
+                                    const double gasrate = std::abs(xw.wellRates()[gaspos_well]);
                                     double rv = 0.0;
                                     if (gasrate > 0) {
                                         rv = oilrate / gasrate;
@@ -855,12 +856,13 @@ namespace Opm {
 
                         if (pu.phase_used[BlackoilPhases::Liquid]) {
                             int oilpos = pu.phase_pos[BlackoilPhases::Liquid] + perf * pu.num_phases;
+                            int oilpos_well = pu.phase_pos[BlackoilPhases::Liquid] + w * pu.num_phases;
                             if (pu.phase_used[BlackoilPhases::Vapour]) {
                                 rsmax_perf[perf] = FluidSystem::oilPvt().saturatedGasDissolutionFactor(fs.pvtRegionIndex(), temperature, p_avg);
-                                int gaspos = pu.phase_pos[BlackoilPhases::Vapour] + perf * pu.num_phases;
-                                const double gasrate = std::abs(xw.wellRates()[gaspos]);
+                                int gaspos_well = pu.phase_pos[BlackoilPhases::Vapour] + w * pu.num_phases;
+                                const double gasrate = std::abs(xw.wellRates()[gaspos_well]);
                                 if (gasrate > 0) {
-                                    const double oilrate = std::abs(xw.wellRates()[oilpos]);
+                                    const double oilrate = std::abs(xw.wellRates()[oilpos_well]);
                                     double rs = 0.0;
                                     if (oilrate > 0) {
                                         rs = gasrate / oilrate;


### PR DESCRIPTION
note that I don't know if these changes are semantically correct (I
doubt it), but this patch fixes the valgrind complaints I saw for
SPE9_CP and on Norne.

Also, this makes the timing of flow_ebos for SPE9 determinisic between
runs: without this, I got some random time steps fail in a given run
and in the next run a completely different set of timesteps
failed. Since this was on the same same machine, without any
recompiles and no changes to the deck or any other input parameters, I
initially attributed the behavior to cosmic rays ;)

@totto82: could you have a thorough look on this?