### PR TITLE
Frankenstein merge master v4

### DIFF
--- a/opm/autodiff/GeoProps.hpp
+++ b/opm/autodiff/GeoProps.hpp
@@ -33,7 +33,8 @@
 #include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
 #include <opm/core/grid/PinchProcessor.hpp>
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
-#include <opm/output/Cells.hpp>
+#include <opm/output/data/Cells.hpp>
+#include <opm/output/data/Solution.hpp>
 
 #include <Eigen/Eigen>
 
@@ -228,15 +229,15 @@ namespace Opm
         /// grid the whole TRAN keyword is quite meaningless.
 
         template <class Grid>
-        const std::vector<data::CellData> simProps( const Grid& grid ) const {
+        data::Solution simProps( const Grid& grid ) const {
             using namespace UgGridHelpers;
             const int* dims = cartDims( grid );
             const int globalSize = dims[0] * dims[1] * dims[2];
             const auto& trans = this->transmissibility( );
 
-            data::CellData tranx = {"TRANX" , UnitSystem::measure::transmissibility, std::vector<double>( globalSize )};
-            data::CellData trany = {"TRANY" , UnitSystem::measure::transmissibility, std::vector<double>( globalSize )};
-            data::CellData tranz = {"TRANZ" , UnitSystem::measure::transmissibility, std::vector<double>( globalSize )};
+            data::CellData tranx = {UnitSystem::measure::transmissibility, std::vector<double>( globalSize ), data::TargetType::INIT};
+            data::CellData trany = {UnitSystem::measure::transmissibility, std::vector<double>( globalSize ), data::TargetType::INIT};
+            data::CellData tranz = {UnitSystem::measure::transmissibility, std::vector<double>( globalSize ), data::TargetType::INIT};
 
             size_t num_faces = numFaces(grid);
             auto fc = faceCells(grid);
@@ -263,12 +264,9 @@ namespace Opm
                 }
             }
 
-            std::vector<data::CellData> tran;
-            tran.push_back( std::move( tranx ));
-            tran.push_back( std::move( trany ));
-            tran.push_back( std::move( tranz ));
-
-            return tran;
+            return { {"TRANX" , tranx},
+                     {"TRANY" , trany} ,
+                     {"TRANZ" , tranz } };
         }
 
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -166,7 +166,6 @@ public:
         std::ofstream tstep_os(tstep_filename.c_str());
 
         const auto& schedule = eclState()->getSchedule();
-        const auto& events = schedule->getEvents();
 
         // adaptive time stepping
         std::unique_ptr< AdaptiveTimeStepping > adaptiveTimeStepping;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -24,7 +24,7 @@
 #include <opm/common/data/SimulationDataContainer.hpp>
 
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
-#include <opm/output/Cells.hpp>
+#include <opm/output/data/Cells.hpp>
 #include <opm/core/simulator/BlackoilState.hpp>
 #include <opm/core/utility/DataMap.hpp>
 #include <opm/autodiff/Compat.hpp>
@@ -262,14 +262,14 @@ namespace Opm
             std::unique_ptr< SimulatorTimerInterface > timer_;
             const SimulationDataContainer state_;
             const WellState wellState_;
-            std::vector<data::CellData> simProps_;
+            data::Solution simProps_;
             const bool substep_;
 
             explicit WriterCall( BlackoilOutputWriter& writer,
                                  const SimulatorTimerInterface& timer,
                                  const SimulationDataContainer& state,
                                  const WellState& wellState,
-                                 const std::vector<data::CellData>& simProps,
+                                 const data::Solution& simProps,
                                  bool substep )
                 : writer_( writer ),
                   timer_( timer.clone() ),
@@ -300,8 +300,7 @@ namespace Opm
                   const WellState& localWellState,
                   bool substep)
     {
-        std::vector<data::CellData> noCellProperties;
-        writeTimeStepWithCellProperties(timer, localState, localWellState, noCellProperties, substep);
+        writeTimeStepWithCellProperties(timer, localState, localWellState, {} , substep);
     }
 
 
@@ -314,7 +313,7 @@ namespace Opm
                   const SimulatorTimerInterface& timer,
                   const SimulationDataContainer& localState,
                   const WellState& localWellState,
-                  const std::vector<data::CellData>& cellData,
+                  const data::Solution& cellData,
                   bool substep)
     {
         // VTK output (is parallel if grid is parallel)
@@ -360,7 +359,7 @@ namespace Opm
     writeTimeStepSerial(const SimulatorTimerInterface& timer,
                         const SimulationDataContainer& state,
                         const WellState& wellState,
-                        const std::vector<data::CellData>& simProps,
+                        const data::Solution& simProps,
                         bool substep)
     {
         // Matlab output
@@ -379,8 +378,7 @@ namespace Opm
                                           substep,
                                           timer.simulationTimeElapsed(),
                                           simToSolution( state, phaseUsage_ ),
-                                          wellState.report(phaseUsage_),
-                                          simProps);
+                                          wellState.report(phaseUsage_));
             }
         }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -31,7 +31,8 @@
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/core/wells/DynamicListEconLimited.hpp>
 
-#include <opm/output/Cells.hpp>
+#include <opm/output/data/Cells.hpp>
+#include <opm/output/data/Solution.hpp>
 #include <opm/output/eclipse/EclipseWriter.hpp>
 
 #include <opm/autodiff/GridHelpers.hpp>
@@ -217,7 +218,7 @@ namespace Opm
                              const double* permeability );
 
         /** \copydoc Opm::OutputWriter::writeInit */
-        void writeInit(const std::vector<data::CellData>& simProps, const NNC& nnc);
+        void writeInit(const data::Solution& simProps, const NNC& nnc);
 
         /*!
          * \brief Write a blackoil reservoir state to disk for later inspection with
@@ -242,7 +243,7 @@ namespace Opm
                            const SimulatorTimerInterface& timer,
                            const SimulationDataContainer& reservoirState,
                            const Opm::WellState& wellState,
-                           const std::vector<data::CellData>& simProps,
+                           const data::Solution& solution,
                            bool substep = false);
 
         /*!
@@ -264,7 +265,7 @@ namespace Opm
         void writeTimeStepSerial(const SimulatorTimerInterface& timer,
                                  const SimulationDataContainer& reservoirState,
                                  const Opm::WellState& wellState,
-                                 const std::vector<data::CellData>& simProps,
+                                 const data::Solution& cellData,
                                  bool substep);
 
         /** \brief return output directory */
@@ -449,18 +450,16 @@ namespace Opm
          * Returns the data requested in the restartConfig
          */
         template<class Model>
-        void getRestartData(
-                std::vector<data::CellData>& output,
-                const Opm::PhaseUsage& phaseUsage,
-                const Model& physicalModel,
-                const RestartConfig& restartConfig,
-                const int reportStepNum,
-                const bool log) {
+        void getRestartData(data::Solution& output,
+                            const Opm::PhaseUsage& phaseUsage,
+                            const Model& physicalModel,
+                            const RestartConfig& restartConfig,
+                            const int reportStepNum,
+                            const bool log) {
 
             typedef Opm::AutoDiffBlock<double> ADB;
 
             const typename Model::SimulatorData& sd = physicalModel.getSimulatorData();
-
             //Get the value of each of the keys for the restart keywords
             std::map<std::string, int> rstKeywords = restartConfig.getRestartKeywords(reportStepNum);
             for (auto& keyValue : rstKeywords) {
@@ -482,27 +481,24 @@ namespace Opm
              */
             if (aqua_active && rstKeywords["BW"] > 0) {
                 rstKeywords["BW"] = 0;
-                output.emplace_back(data::CellData{
-                        "1OVERBW",
-                        Opm::UnitSystem::measure::water_inverse_formation_volume_factor,
-                        adbToDoubleVector(sd.rq[aqua_idx].b),
-                        true});
+                output.insert("1OVERBW",
+                              Opm::UnitSystem::measure::water_inverse_formation_volume_factor,
+                              adbToDoubleVector(sd.rq[aqua_idx].b),
+                              data::TargetType::RESTART_AUXILLARY);
             }
             if (liquid_active && rstKeywords["BO"]  > 0) {
                 rstKeywords["BO"] = 0;
-                output.emplace_back(data::CellData{
-                        "1OVERBO",
-                        Opm::UnitSystem::measure::oil_inverse_formation_volume_factor,
-                        adbToDoubleVector(sd.rq[liquid_idx].b),
-                        true});
+                output.insert("1OVERBO",
+                              Opm::UnitSystem::measure::oil_inverse_formation_volume_factor,
+                              adbToDoubleVector(sd.rq[liquid_idx].b),
+                              data::TargetType::RESTART_AUXILLARY);
             }
             if (vapour_active && rstKeywords["BG"] > 0) {
                 rstKeywords["BG"] = 0;
-                output.emplace_back(data::CellData{
-                        "1OVERBG",
-                        Opm::UnitSystem::measure::gas_inverse_formation_volume_factor,
-                        adbToDoubleVector(sd.rq[vapour_idx].b),
-                        true});
+                output.insert("1OVERBG",
+                              Opm::UnitSystem::measure::gas_inverse_formation_volume_factor,
+                              adbToDoubleVector(sd.rq[vapour_idx].b),
+                              data::TargetType::RESTART_AUXILLARY);
             }
 
             /**
@@ -511,25 +507,22 @@ namespace Opm
             if (rstKeywords["DEN"] > 0) {
                 rstKeywords["DEN"] = 0;
                 if (aqua_active) {
-                    output.emplace_back(data::CellData{
-                            "WAT_DEN",
-                            Opm::UnitSystem::measure::density,
-                            adbToDoubleVector(sd.rq[aqua_idx].rho),
-                            true});
+                    output.insert("WAT_DEN",
+                                  Opm::UnitSystem::measure::density,
+                                  adbToDoubleVector(sd.rq[aqua_idx].rho),
+                                  data::TargetType::RESTART_AUXILLARY);
                 }
                 if (liquid_active) {
-                    output.emplace_back(data::CellData{
-                            "OIL_DEN",
-                            Opm::UnitSystem::measure::density,
-                            adbToDoubleVector(sd.rq[liquid_idx].rho),
-                            true});
+                    output.insert("OIL_DEN",
+                                  Opm::UnitSystem::measure::density,
+                                  adbToDoubleVector(sd.rq[liquid_idx].rho),
+                                  data::TargetType::RESTART_AUXILLARY);
                 }
                 if (vapour_active) {
-                    output.emplace_back(data::CellData{
-                            "GAS_DEN",
-                            Opm::UnitSystem::measure::density,
-                            adbToDoubleVector(sd.rq[vapour_idx].rho),
-                            true});
+                    output.insert("GAS_DEN",
+                                  Opm::UnitSystem::measure::density,
+                                  adbToDoubleVector(sd.rq[vapour_idx].rho),
+                                  data::TargetType::RESTART_AUXILLARY);
                 }
             }
 
@@ -539,25 +532,22 @@ namespace Opm
             if (rstKeywords["VISC"] > 0) {
                 rstKeywords["VISC"] = 0;
                 if (aqua_active) {
-                    output.emplace_back(data::CellData{
-                            "WAT_VISC",
-                            Opm::UnitSystem::measure::viscosity,
-                            adbToDoubleVector(sd.rq[aqua_idx].mu),
-                            true});
+                    output.insert("WAT_VISC",
+                                  Opm::UnitSystem::measure::viscosity,
+                                  adbToDoubleVector(sd.rq[aqua_idx].mu),
+                                  data::TargetType::RESTART_AUXILLARY);
                 }
                 if (liquid_active) {
-                    output.emplace_back(data::CellData{
-                            "OIL_VISC",
-                            Opm::UnitSystem::measure::viscosity,
-                            adbToDoubleVector(sd.rq[liquid_idx].mu),
-                            true});
+                    output.insert("OIL_VISC",
+                                  Opm::UnitSystem::measure::viscosity,
+                                  adbToDoubleVector(sd.rq[liquid_idx].mu),
+                                  data::TargetType::RESTART_AUXILLARY);
                 }
                 if (vapour_active) {
-                    output.emplace_back(data::CellData{
-                            "GAS_VISC",
-                            Opm::UnitSystem::measure::viscosity,
-                            adbToDoubleVector(sd.rq[vapour_idx].mu),
-                            true});
+                    output.insert("GAS_VISC",
+                                  Opm::UnitSystem::measure::viscosity,
+                                  adbToDoubleVector(sd.rq[vapour_idx].mu),
+                                  data::TargetType::RESTART_AUXILLARY);
                 }
             }
 
@@ -567,11 +557,10 @@ namespace Opm
             if (aqua_active && rstKeywords["KRW"] > 0) {
                 if (sd.rq[aqua_idx].kr.size() > 0) {
                     rstKeywords["KRW"] = 0;
-                    output.emplace_back(data::CellData{
-                            "WATKR",
-                            Opm::UnitSystem::measure::permeability,
-                            adbToDoubleVector(sd.rq[aqua_idx].kr),
-                            true});
+                    output.insert("WATKR",
+                                  Opm::UnitSystem::measure::permeability,
+                                  adbToDoubleVector(sd.rq[aqua_idx].kr),
+                                  data::TargetType::RESTART_AUXILLARY);
                 }
                 else {
                     if ( log )
@@ -584,11 +573,10 @@ namespace Opm
             if (liquid_active && rstKeywords["KRO"] > 0) {
                 if (sd.rq[liquid_idx].kr.size() > 0) {
                     rstKeywords["KRO"] = 0;
-                    output.emplace_back(data::CellData{
-                             "OILKR",
-                             Opm::UnitSystem::measure::permeability,
-                             adbToDoubleVector(sd.rq[liquid_idx].kr),
-                             true});
+                    output.insert("OILKR",
+                                  Opm::UnitSystem::measure::permeability,
+                                  adbToDoubleVector(sd.rq[liquid_idx].kr),
+                                  data::TargetType::RESTART_AUXILLARY);
                 }
                 else {
                     if ( log )
@@ -601,11 +589,10 @@ namespace Opm
             if (vapour_active && rstKeywords["KRG"] > 0) {
                 if (sd.rq[vapour_idx].kr.size() > 0) {
                     rstKeywords["KRG"] = 0;
-                    output.emplace_back(data::CellData{
-                             "GASKR",
-                             Opm::UnitSystem::measure::permeability,
-                             adbToDoubleVector(sd.rq[vapour_idx].kr),
-                             true});
+                    output.insert("GASKR",
+                                  Opm::UnitSystem::measure::permeability,
+                                  adbToDoubleVector(sd.rq[vapour_idx].kr),
+                                  data::TargetType::RESTART_AUXILLARY);
                 }
                 else {
                     if ( log )
@@ -621,19 +608,17 @@ namespace Opm
              */
             if (vapour_active && liquid_active && rstKeywords["RSSAT"] > 0) {
                 rstKeywords["RSSAT"] = 0;
-                output.emplace_back(data::CellData{
-                        "RSSAT",
-                        Opm::UnitSystem::measure::gas_oil_ratio,
-                        adbToDoubleVector(sd.rsSat),
-                        true});
+                output.insert("RSSAT",
+                              Opm::UnitSystem::measure::gas_oil_ratio,
+                              adbToDoubleVector(sd.rsSat),
+                              data::TargetType::RESTART_AUXILLARY);
             }
             if (vapour_active && liquid_active && rstKeywords["RVSAT"] > 0) {
                 rstKeywords["RVSAT"] = 0;
-                output.emplace_back(data::CellData{
-                        "RVSAT",
-                        Opm::UnitSystem::measure::oil_gas_ratio,
-                        adbToDoubleVector(sd.rvSat),
-                        true});
+                output.insert("RVSAT",
+                              Opm::UnitSystem::measure::oil_gas_ratio,
+                              adbToDoubleVector(sd.rvSat),
+                              data::TargetType::RESTART_AUXILLARY);
             }
 
 
@@ -681,11 +666,10 @@ namespace Opm
          * Returns the data as asked for in the summaryConfig
          */
         template<class Model>
-        void getSummaryData(
-                std::vector<data::CellData>& output,
-                const Opm::PhaseUsage& phaseUsage,
-                const Model& physicalModel,
-                const SummaryConfig& summaryConfig) {
+        void getSummaryData(data::Solution& output,
+                            const Opm::PhaseUsage& phaseUsage,
+                            const Model& physicalModel,
+                            const SummaryConfig& summaryConfig) {
 
             typedef Opm::AutoDiffBlock<double> ADB;
 
@@ -701,83 +685,74 @@ namespace Opm
              */
             // Water in place
             if (aqua_active && hasFRBKeyword(summaryConfig, "WIP")) {
-                output.emplace_back(data::CellData{
-                         "WIP",
-                         Opm::UnitSystem::measure::volume,
-                         adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_AQUA]),
-                         false});
+                output.insert("WIP",
+                              Opm::UnitSystem::measure::volume,
+                              adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_AQUA]),
+                              data::TargetType::SUMMARY );
             }
             if (liquid_active) {
                 //Oil in place (liquid phase only)
                 if (hasFRBKeyword(summaryConfig, "OIPL")) {
-                    output.emplace_back(data::CellData{
-                             "OIPL",
-                             Opm::UnitSystem::measure::volume,
-                             adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_LIQUID]),
-                             false});
+                    output.insert("OIPL",
+                                  Opm::UnitSystem::measure::volume,
+                                  adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_LIQUID]),
+                                  data::TargetType::SUMMARY );
                 }
                 //Oil in place (gas phase only)
                 if (hasFRBKeyword(summaryConfig, "OIPG")) {
-                    output.emplace_back(data::CellData{
-                             "OIPG",
-                             Opm::UnitSystem::measure::volume,
-                             adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_VAPORIZED_OIL]),
-                             false});
+                    output.insert("OIPG",
+                                  Opm::UnitSystem::measure::volume,
+                                  adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_VAPORIZED_OIL]),
+                                  data::TargetType::SUMMARY );
                 }
                 // Oil in place (in liquid and gas phases)
                 if (hasFRBKeyword(summaryConfig, "OIP")) {
                     ADB::V oip = sd.fip[Model::SimulatorData::FIP_LIQUID] +
                                  sd.fip[Model::SimulatorData::FIP_VAPORIZED_OIL];
-                    output.emplace_back(data::CellData{
-                             "OIP",
-                             Opm::UnitSystem::measure::volume,
-                             adbVToDoubleVector(oip),
-                             false});
+                    output.insert("OIP",
+                                  Opm::UnitSystem::measure::volume,
+                                  adbVToDoubleVector(oip),
+                                  data::TargetType::SUMMARY );
                 }
             }
             if (vapour_active) {
                 // Gas in place (gas phase only)
                 if (hasFRBKeyword(summaryConfig, "GIPG")) {
-                    output.emplace_back(data::CellData{
-                             "GIPG",
-                             Opm::UnitSystem::measure::volume,
-                             adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_VAPOUR]),
-                             false});
+                    output.insert("GIPG",
+                                  Opm::UnitSystem::measure::volume,
+                                  adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_VAPOUR]),
+                                  data::TargetType::SUMMARY );
                 }
                 // Gas in place (liquid phase only)
                 if (hasFRBKeyword(summaryConfig, "GIPL")) {
-                    output.emplace_back(data::CellData{
-                             "GIPL",
-                             Opm::UnitSystem::measure::volume,
-                             adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_DISSOLVED_GAS]),
-                             false});
+                    output.insert("GIPL",
+                                  Opm::UnitSystem::measure::volume,
+                                  adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_DISSOLVED_GAS]),
+                                  data::TargetType::SUMMARY );
                 }
                 // Gas in place (in both liquid and gas phases)
                 if (hasFRBKeyword(summaryConfig, "GIP")) {
                     ADB::V gip = sd.fip[Model::SimulatorData::FIP_VAPOUR] +
                                  sd.fip[Model::SimulatorData::FIP_DISSOLVED_GAS];
-                    output.emplace_back(data::CellData{
-                             "GIP",
-                             Opm::UnitSystem::measure::volume,
-                             adbVToDoubleVector(gip),
-                             false});
+                    output.insert("GIP",
+                                  Opm::UnitSystem::measure::volume,
+                                  adbVToDoubleVector(gip),
+                                  data::TargetType::SUMMARY );
                 }
             }
             // Cell pore volume in reservoir conditions
             if (hasFRBKeyword(summaryConfig, "RPV")) {
-                output.emplace_back(data::CellData{
-                         "RPV",
-                         Opm::UnitSystem::measure::volume,
-                         adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_PV]),
-                         false});
+                output.insert("RPV",
+                              Opm::UnitSystem::measure::volume,
+                              adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_PV]),
+                              data::TargetType::SUMMARY );
             }
             // Pressure averaged value (hydrocarbon pore volume weighted)
             if (summaryConfig.hasKeyword("FPRH") || summaryConfig.hasKeyword("RPRH")) {
-                output.emplace_back(data::CellData{
-                         "PRH",
-                         Opm::UnitSystem::measure::pressure,
-                         adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_WEIGHTED_PRESSURE]),
-                         false});
+                output.insert("PRH",
+                              Opm::UnitSystem::measure::pressure,
+                              adbVToDoubleVector(sd.fip[Model::SimulatorData::FIP_WEIGHTED_PRESSURE]),
+                              data::TargetType::SUMMARY );
             }
         }
 
@@ -800,8 +775,8 @@ namespace Opm
         const int reportStepNum = timer.reportStepNum();
         bool logMessages = output_ && parallelOutput_->isIORank();
 
-        std::vector<data::CellData> cellData;
-        detail::getRestartData( cellData, phaseUsage_, physicalModel, 
+        data::Solution cellData;
+        detail::getRestartData( cellData, phaseUsage_, physicalModel,
                                 restartConfig, reportStepNum, logMessages );
         detail::getSummaryData( cellData, phaseUsage_, physicalModel, summaryConfig );
 

--- a/opm/polymer/SimulatorPolymer.cpp
+++ b/opm/polymer/SimulatorPolymer.cpp
@@ -610,10 +610,9 @@ namespace Opm
                                const std::string& output_dir)
         {
 #ifdef HAVE_ERT
-            using ds = data::Solution::key;
             data::Solution sol;
-            sol.insert( ds::PRESSURE, state.pressure() );
-            sol.insert( ds::SWAT, destripe( state.saturation(), 0, 2 ) );
+            sol.insert( "PRESSURE", UnitSystem::measure::pressure , state.pressure() , data::TargetType::RESTART_SOLUTION );
+            sol.insert( "SWAT", UnitSystem::measure::identity, destripe( state.saturation(), 0, 2 ) , data::TargetType::RESTART_SOLUTION);
 
             writeECLData( grid.cartdims[ 0 ],
                           grid.cartdims[ 1 ],


### PR DESCRIPTION
this merges the latest master version and mobs up afterward in order to make flow_ebos compatible with the latest master versions of the other OPM modules.

once again, the culprit for the build breakage was an API change in opm-output. (which I think was a change for the better, BTW.) I suppose this means that the frankenstein branch should be merged soon after the release in order to avoid to continue breaking the flow_ebos build twice a week.