### PR TITLE
Update well data output integration.

### DIFF
--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -227,16 +227,17 @@ namespace Opm
                 well.control = this->currentControls()[ w ];
 
                 int local_comp_index = 0;
-                for( auto& cpair : well.completions ) {
+                for( auto& comp : well.completions ) {
                     const auto rates = this->perfPhaseRates().begin()
                                      + (np * wt.second[ 1 ])
                                      + (np * local_comp_index);
                     ++local_comp_index;
 
                     for( int i = 0; i < np; ++i ) {
-                        cpair.second.rates.set( phs[ i ], *(rates + i) );
+                        comp.rates.set( phs[ i ], *(rates + i) );
                     }
                 }
+                assert(local_comp_index == this->wells_->well_connpos[ w + 1 ] - this->wells_->well_connpos[ w ]);
             }
 
             return res;


### PR DESCRIPTION
Includes the following changes:
 - update to match API change in opm-output (vector not map for data::Wells::completions),
 - restore WellStateFullyImplicitBlackoil::perfPhaseRates() from output,
 - restore WellStateFullyImplicitBlackoil::currentControls() from output.

Remaining non-restored well-related data are:
 - well potentials,
 - the dynamic list of econ-limited completions.

Requires OPM/opm-data#116 and OPM/opm-core#1094.

@totto82 can you test restart with these three commits?