### PR TITLE
Bugfix: pass both normal and extra data to output.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -374,10 +374,12 @@ namespace Opm
             if (initConfig.restartRequested() && ((initConfig.getRestartStep()) == (timer.currentStepNum()))) {
                 std::cout << "Skipping restart write in start of step " << timer.currentStepNum() << std::endl;
             } else {
+                data::Solution combined_sol = simToSolution(state, phaseUsage_); // Get "normal" data (SWAT, PRESSURE, ...)
+                combined_sol.insert(simProps.begin(), simProps.end());           // ... insert "extra" data (KR, VISC, ...)
                 eclWriter_->writeTimeStep(timer.reportStepNum(),
                                           substep,
                                           timer.simulationTimeElapsed(),
-                                          simToSolution( state, phaseUsage_ ),
+                                          combined_sol,
                                           wellState.report(phaseUsage_));
             }
         }


### PR DESCRIPTION
Normal meaning SWAT, PRESSURE, RS etc.
Extra meaning KR, VISC etc. as asked for in RPTRST.

Due to some error previously, we no longer actually passed the extra data to the output facility. Maybe a rebasing bug, in any case discovered by compiler warnings (unused argument).

I believe this should be the last PR for the release!