### PR TITLE
Fixes in the Appelyard in updateState and updateWellState

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -540,6 +540,7 @@ namespace Opm {
                              int nc) const;
 
         double dpMaxRel() const { return param_.dp_max_rel_; }
+        double dbhpMaxRel() const {return param_.dbhp_max_rel_; }
         double dsMax() const { return param_.ds_max_; }
         double drMaxRel() const { return param_.dr_max_rel_; }
         double maxResidualAllowed() const { return param_.max_residual_allowed_; }

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1304,7 +1304,7 @@ typedef Eigen::Array<double,
                     hydroCarbonState[c] = HydroCarbonState::OilOnly;
                 }
             }
-            rs = rs.min(rsSat);
+            //rs = rs.min(rsSat);
         }
 
         // phase transitions so <-> rv
@@ -1336,7 +1336,7 @@ typedef Eigen::Array<double,
                     hydroCarbonState[c] = HydroCarbonState::GasOnly;
                 }
             }
-            rv = rv.min(rvSat);
+            //rv = rv.min(rvSat);
         }
 
         // Update the reservoir_state

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1260,7 +1260,7 @@ typedef Eigen::Array<double,
         if (has_disgas_) {
             const V rs_old = Eigen::Map<const V>(&reservoir_state.gasoilratio()[0], nc);
             const V drs = isRs_ * dxvar;
-            const V drs_limited = sign(drs) * drs.abs().min( (rs_old.abs()*drmaxrel).max( ones*1e-6));
+            const V drs_limited = sign(drs) * drs.abs().min( (rs_old.abs()*drmaxrel).max( ones*1.0));
             rs = rs_old - drs_limited;
             rs = rs.max(zero);
         }
@@ -1268,7 +1268,7 @@ typedef Eigen::Array<double,
         if (has_vapoil_) {
             const V rv_old = Eigen::Map<const V>(&reservoir_state.rv()[0], nc);
             const V drv = isRv_ * dxvar;
-            const V drv_limited = sign(drv) * drv.abs().min( (rv_old.abs()*drmaxrel).max( ones*1e-6));
+            const V drv_limited = sign(drv) * drv.abs().min( (rv_old.abs()*drmaxrel).max( ones*1e-3));
             rv = rv_old - drv_limited;
             rv = rv.max(zero);
         }

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -19,8 +19,6 @@
 
 #include <opm/autodiff/BlackoilModelParameters.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
-#include <opm/parser/eclipse/Units/Units.hpp>
-
 
 namespace Opm
 {
@@ -44,6 +42,7 @@ namespace Opm
         dp_max_rel_  = param.getDefault("dp_max_rel", dp_max_rel_);
         ds_max_      = param.getDefault("ds_max", ds_max_);
         dr_max_rel_  = param.getDefault("dr_max_rel", dr_max_rel_);
+        dbhp_max_rel_=  param.getDefault("dbhp_max_rel", dbhp_max_rel_);
         max_residual_allowed_ = param.getDefault("max_residual_allowed", max_residual_allowed_);
         tolerance_mb_    = param.getDefault("tolerance_mb", tolerance_mb_);
         tolerance_cnv_   = param.getDefault("tolerance_cnv", tolerance_cnv_);
@@ -64,9 +63,10 @@ namespace Opm
     void BlackoilModelParameters::reset()
     {
         // default values for the solver parameters
-        dp_max_rel_      = 1.0e9;
+        dp_max_rel_      = 0.2;
         ds_max_          = 0.2;
         dr_max_rel_      = 1.0e9;
+        dbhp_max_rel_    = 1.0;
         max_residual_allowed_ = 1e7;
         tolerance_mb_    = 1.0e-5;
         tolerance_cnv_   = 1.0e-2;

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -19,6 +19,7 @@
 
 #include <opm/autodiff/BlackoilModelParameters.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 namespace Opm
 {
@@ -43,6 +44,7 @@ namespace Opm
         ds_max_      = param.getDefault("ds_max", ds_max_);
         dr_max_rel_  = param.getDefault("dr_max_rel", dr_max_rel_);
         dbhp_max_rel_=  param.getDefault("dbhp_max_rel", dbhp_max_rel_);
+        dwell_fraction_max_ = param.getDefault("dwell_fraction_max", dwell_fraction_max_);
         max_residual_allowed_ = param.getDefault("max_residual_allowed", max_residual_allowed_);
         tolerance_mb_    = param.getDefault("tolerance_mb", tolerance_mb_);
         tolerance_cnv_   = param.getDefault("tolerance_cnv", tolerance_cnv_);
@@ -63,10 +65,11 @@ namespace Opm
     void BlackoilModelParameters::reset()
     {
         // default values for the solver parameters
-        dp_max_rel_      = 0.2;
+        dp_max_rel_      = 1.0;
         ds_max_          = 0.2;
         dr_max_rel_      = 1.0e9;
         dbhp_max_rel_    = 1.0;
+        dwell_fraction_max_ = 0.2;
         max_residual_allowed_ = 1e7;
         tolerance_mb_    = 1.0e-5;
         tolerance_cnv_   = 1.0e-2;

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -36,6 +36,8 @@ namespace Opm
         double ds_max_;
         /// Max relative change in gas-oil or oil-gas ratio in single iteration.
         double dr_max_rel_;
+        /// Max relative change in bhp in single iteration.
+        double dbhp_max_rel_;
         /// Absolute max limit for residuals.
         double max_residual_allowed_;
         /// Relative mass balance tolerance (total mass balance error).

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -38,6 +38,8 @@ namespace Opm
         double dr_max_rel_;
         /// Max relative change in bhp in single iteration.
         double dbhp_max_rel_;
+        /// Max absolute change in well volume fraction in single iteration.
+        double dwell_fraction_max_;
         /// Absolute max limit for residuals.
         double max_residual_allowed_;
         /// Relative mass balance tolerance (total mass balance error).

--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -548,7 +548,7 @@ namespace Opm {
         if (has_vapoil_) {
             const V rv_old = Eigen::Map<const V>(&reservoir_state.rv()[0], nc);
             const V drv = Base::isRv_ * dxvar;
-            const V drv_limited = sign(drv) * drv.abs().min( (rv_old.abs()*drmaxrel).max( ones*1e-6));
+            const V drv_limited = sign(drv) * drv.abs().min( (rv_old.abs()*drmaxrel).max( ones*1e-3));
             rv = rv_old - drv_limited;
             rv = rv.max(zero);
         }

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -935,8 +935,8 @@ enum WellVariablePositions {
                     const int np = wells().number_of_phases;
                     const int nw = wells().number_of_wells;
 
-                    double dFLimit = 0.2;
-                    double dBHPLimit = 2.0;
+                    double dFLimit = dWellFractionMax();
+                    double dBHPLimit = dbhpMaxRel();
                     std::vector<double> xvar_well_old = well_state.wellSolutions();
 
                     for (int w = 0; w < nw; ++w) {
@@ -1502,6 +1502,9 @@ enum WellVariablePositions {
             mutable BVector Cx_;
             mutable BVector invDrw_;
             mutable BVector scaleAddRes_;
+
+            double dbhpMaxRel() const {return param_.dbhp_max_rel_; }
+            double dWellFractionMax() const {return param_.dwell_fraction_max_; }
 
             // protected methods
             EvalWell getBhp(const int wellIdx) const {


### PR DESCRIPTION
This is work done by @osae. 
1) changes dp_max_rel default to 0.2
2) introduces a dbhp_max_rel parameter to restrict the bhp update in the
updateWellState() (instead of using the dp_max_rel) Default is set to
1.0
3) Restrict rs and rv between 0 and the saturated value
4) Set rs and rv to zero for the water only cases
5) Guard against zero rs and rv when calculating the maximum allowed rs
and rv change.

Tested on Norne, Model 2 and Model 2.2

Number of problems for the different models with and without this fix

Case this PR master 
Norne       10       45
Model 2    21       78
Model 2.2 200   248
