### PR TITLE
Remove weak enum Opm::Phase; replace with constexpr

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -133,9 +133,9 @@ namespace Opm {
             SimulatorData(int num_phases);
 
             enum FipId {
-                FIP_AQUA = Opm::Phases::Water,
-                FIP_LIQUID = Opm::Phases::Oil,
-                FIP_VAPOUR = Opm::Phases::Gas,
+                FIP_AQUA = Opm::Water,
+                FIP_LIQUID = Opm::Oil,
+                FIP_VAPOUR = Opm::Gas,
                 FIP_DISSOLVED_GAS = 3,
                 FIP_VAPORIZED_OIL = 4,
                 FIP_PV = 5,                    //< Pore volume

--- a/opm/autodiff/BlackoilModelEnums.hpp
+++ b/opm/autodiff/BlackoilModelEnums.hpp
@@ -26,12 +26,10 @@
 namespace Opm
 {
 
-    enum Phases {
-        Water        = BlackoilPropsAdInterface::Water,
-        Oil          = BlackoilPropsAdInterface::Oil  ,
-        Gas          = BlackoilPropsAdInterface::Gas  ,
-        MaxNumPhases = BlackoilPropsAdInterface::MaxNumPhases
-    };
+    constexpr const auto Water        = BlackoilPropsAdInterface::Water;
+    constexpr const auto Oil          = BlackoilPropsAdInterface::Oil;
+    constexpr const auto Gas          = BlackoilPropsAdInterface::Gas;
+    constexpr const auto MaxNumPhases = BlackoilPropsAdInterface::MaxNumPhases;
 
     enum PrimalVariables {
         Sg = 0,


### PR DESCRIPTION
This weak enum is really just an alias for four other constants which in
turn alias another enum. Since they're mostly used for indexing they're
relaxed to constexpr ints.