### PR TITLE
FlowMain: use std::cout to print exceptions to the terminal

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -166,7 +166,14 @@ namespace Opm
 
             if( output_cout_ )
             {
-                OpmLog::error(message.str());
+                // in some cases exceptions are thrown before the logging system is set
+                // up.
+                if (OpmLog::hasBackend("STREAMLOG")) {
+                    OpmLog::error(message.str());
+                }
+                else {
+                    std::cout << message.str() << "\n";
+                }
             }
 
             return EXIT_FAILURE;


### PR DESCRIPTION
the reason for this is that otherwise there's a chicken-and-egg
problem: exceptions which are thrown before the logging system has
been initialized -- most prominently while parsing the deck -- cause
the simulator to silently abort without any user notification which
can be very confusing. On the other hand, initializing the logging
system requires a fully initialized EclipseState object,
i.e. currently to initialze the logging system the deck must be parsed
and in order to print the exceptions thrown while parsing the deck one
needs the logging system...