### PR TITLE
fixed: running summary.x failed due to missing libraries

### DIFF
--- a/jenkins/run-norne.sh
+++ b/jenkins/run-norne.sh
@@ -7,6 +7,6 @@ cd deps/opm-data
 cd norne
 $WORKSPACE/$configuration/build-opm-simulators/bin/flow deck_filename=NORNE_ATW2013.DATA output_dir=OPM
 test $? -eq 0 || exit 1
-PATH=$WORKSPACE/$configuration/install/bin:$PATH ./plotwells.sh
+LD_LIBRARY_PATH=$WORKSPACE/$configuration/lib/x86_64-linux-gnu PATH=$WORKSPACE/$configuration/install/bin:$PATH ./plotwells.sh
 
 popd


### PR DESCRIPTION
ert has been changed to shared libraries. this sets the required
LD_LIBRARY_PATH value