### PR TITLE
DuneMatrix: use the version macros for dune-common instead of those of dune-istl

### DIFF
--- a/opm/autodiff/DuneMatrix.hpp
+++ b/opm/autodiff/DuneMatrix.hpp
@@ -80,7 +80,7 @@ namespace Opm
             this->m = cols;
 
             typedef Super::size_type size_type ;
-#if DUNE_VERSION_NEWER_REV(DUNE_ISTL, 2, 4, 1)
+#if DUNE_VERSION_NEWER_REV(DUNE_COMMON, 2, 4, 1)
             size_type& nnz = this->nnz_;
             std::shared_ptr<size_type>& j = this->j_;
 #else


### PR DESCRIPTION
for me, the macros for dune-istl insist on being undefined if I don't
do `git clean -fdx` before every recompile. on the other hand the
DUNE_COMMON_VERSION_* macros are reliably generated. Since I consider
it very unlikely that the version of dune-istl differs from that of
dune-common, let's just use the latter macros...