### PR TITLE
Fix using local active cells for writing eclipse files in parallel.

### DIFF
--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -245,7 +245,7 @@ try
                                              ::createEclipseGrid( cGrid ,
                                                                   eclipseState->getInputGrid())));
     Opm::BlackoilOutputWriter
-        outputWriter(cGrid, param, *eclipseState, eclipseWriter, pu,
+        outputWriter(cGrid, param, *eclipseState, std::move(eclipseWriter), pu,
                      new_props->permeability() );
 
     SimulatorReport fullReport;

--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -239,8 +239,13 @@ try
     std::cout << "\n\n================    Starting main simulation loop     ===============\n"
               << std::flush;
 
+    std::unique_ptr<Opm::EclipseWriter>
+        eclipseWriter(new Opm::EclipseWriter(*eclipseState,
+                                             UgGridHelpers
+                                             ::createEclipseGrid( cGrid ,
+                                                                  eclipseState->getInputGrid())));
     Opm::BlackoilOutputWriter
-        outputWriter(cGrid, param, *eclipseState, pu,
+        outputWriter(cGrid, param, *eclipseState, eclipseWriter, pu,
                      new_props->permeability() );
 
     SimulatorReport fullReport;

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -773,7 +773,7 @@ namespace Opm
             output_writer_.reset(new BlackoilOutputWriter(grid_init_->grid(),
                                                           param_,
                                                           *eclipse_state_,
-                                                          eclipse_writer_,
+                                                          std::move(eclipse_writer_),
                                                           Opm::phaseUsageFromDeck(*deck_),
                                                           fluidprops_->permeability()));
         }

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -228,6 +228,7 @@ namespace Opm
         // distributeData()
         boost::any parallel_information_;
         // setupOutputWriter()
+        std::unique_ptr<EclipseWriter> eclipse_writer_;
         std::unique_ptr<BlackoilOutputWriter> output_writer_;
         // setupLinearSolver
         std::unique_ptr<NewtonIterationBlackoilInterface> fis_solver_;
@@ -754,9 +755,9 @@ namespace Opm
             if( output && output_ecl && output_cout_)
             {
                 const EclipseGrid& inputGrid = eclipse_state_->getInputGrid();
-                EclipseWriter writer(*eclipse_state_, UgGridHelpers::createEclipseGrid( grid , inputGrid ));
-                writer.writeInitAndEgrid(geoprops_->simProps(grid),
-                                         geoprops_->nonCartesianConnections());
+                eclipse_writer_.reset(new EclipseWriter(*eclipse_state_, UgGridHelpers::createEclipseGrid( grid , inputGrid )));
+                eclipse_writer_->writeInitAndEgrid(geoprops_->simProps(grid),
+                                                  geoprops_->nonCartesianConnections());
             }
         }
 
@@ -772,6 +773,7 @@ namespace Opm
             output_writer_.reset(new BlackoilOutputWriter(grid_init_->grid(),
                                                           param_,
                                                           *eclipse_state_,
+                                                          eclipse_writer_,
                                                           Opm::phaseUsageFromDeck(*deck_),
                                                           fluidprops_->permeability()));
         }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -214,7 +214,7 @@ namespace Opm
         BlackoilOutputWriter(const Grid& grid,
                              const parameter::ParameterGroup& param,
                              const Opm::EclipseState& eclipseState,
-                             std::unique_ptr<EclipseWriter>& eclWriter,
+                             std::unique_ptr<EclipseWriter>&& eclWriter,
                              const Opm::PhaseUsage &phaseUsage,
                              const double* permeability );
 
@@ -329,7 +329,7 @@ namespace Opm
     BlackoilOutputWriter(const Grid& grid,
                          const parameter::ParameterGroup& param,
                          const Opm::EclipseState& eclipseState,
-                         std::unique_ptr<EclipseWriter>& eclWriter,
+                         std::unique_ptr<EclipseWriter>&& eclWriter,
                          const Opm::PhaseUsage &phaseUsage,
                          const double* permeability )
       : output_( param.getDefault("output", true) ),
@@ -345,8 +345,8 @@ namespace Opm
                      new BlackoilMatlabWriter< Grid >( grid, outputDir_ ) : 0 ),
         eclWriter_( output_ && parallelOutput_->isIORank() &&
                     param.getDefault("output_ecl", true) ?
-                    eclWriter.release()
-                   : 0 ),
+                    std::move(eclWriter)
+                    : std::move(std::unique_ptr<EclipseWriter>()) ),
         eclipseState_(eclipseState),
         asyncOutput_()
     {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -214,6 +214,7 @@ namespace Opm
         BlackoilOutputWriter(const Grid& grid,
                              const parameter::ParameterGroup& param,
                              const Opm::EclipseState& eclipseState,
+                             std::unique_ptr<EclipseWriter>& eclWriter,
                              const Opm::PhaseUsage &phaseUsage,
                              const double* permeability );
 
@@ -328,6 +329,7 @@ namespace Opm
     BlackoilOutputWriter(const Grid& grid,
                          const parameter::ParameterGroup& param,
                          const Opm::EclipseState& eclipseState,
+                         std::unique_ptr<EclipseWriter>& eclWriter,
                          const Opm::PhaseUsage &phaseUsage,
                          const double* permeability )
       : output_( param.getDefault("output", true) ),
@@ -343,7 +345,7 @@ namespace Opm
                      new BlackoilMatlabWriter< Grid >( grid, outputDir_ ) : 0 ),
         eclWriter_( output_ && parallelOutput_->isIORank() &&
                     param.getDefault("output_ecl", true) ?
-                    new EclipseWriter(eclipseState,UgGridHelpers::createEclipseGrid( grid , eclipseState.getInputGrid()))
+                    eclWriter.release()
                    : 0 ),
         eclipseState_(eclipseState),
         asyncOutput_()


### PR DESCRIPTION
Previously, the eclipseGrid used by EclipseWriter was constructed from
the one in the EclipseState with the current CpGrid. Unfortunately the
latter was the distributed version resembling only the local part that
the processor works on. Therefore the information about the active cells
was wrong when writing results (which raised an exception in the writer).

With this commit we construct the EclipseWriter before distributing the grid
and use this writer later on in the OutputWriter.

Closes #892 