### PR TITLE
Frankenstein fip output

### DIFF
--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -143,6 +143,12 @@ namespace Opm {
             return model_->computeFluidInPlace(x, fipnum);
         }
 
+        std::vector<std::vector<double>>
+        computeFluidInPlace(const std::vector<int>& fipnum) const
+        {
+            return model_->computeFluidInPlace(fipnum);
+        }
+
 
         /// Reference to physical model.
         const PhysicalModel& model() const;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.cpp
@@ -162,10 +162,12 @@ namespace Opm
             if (initConfig.restartRequested() && ((initConfig.getRestartStep()) == (timer.currentStepNum()))) {
                 std::cout << "Skipping restart write in start of step " << timer.currentStepNum() << std::endl;
             } else {
+                data::Solution combined_sol = simToSolution(state, phaseUsage_); // Get "normal" data (SWAT, PRESSURE, ...)
+                combined_sol.insert(sol.begin(), sol.end());           // ... insert "extra" data (KR, VISC, ...)
                 eclWriter_->writeTimeStep(timer.reportStepNum(),
                                           substep,
                                           timer.simulationTimeElapsed(),
-                                          simToSolution( state, phaseUsage_ ),
+                                          combined_sol,
                                           wellState.report(phaseUsage_));
             }
         }


### PR DESCRIPTION
Implements FIP for flow_ebos

Known issues
1) Not tested for 2p and in parallel. 
2) Original FIP is calculated after the first time step instead of before. 

@babrodtk There is slight mismatch between the FIP calculated with flow_ebos and flow. Could you test this PR and judge whether the mismatch is acceptable or not. 

When this PR is merged. Flow and flow_ebos is supposed to have the same ecl output capabilities.  