### PR TITLE
Cater for variable name change in BCRSMatrix of DUNE 2.5

### DIFF
--- a/opm/autodiff/DuneMatrix.hpp
+++ b/opm/autodiff/DuneMatrix.hpp
@@ -91,11 +91,11 @@ namespace Opm
             nnz = ia[rows];
 
 #if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 3)
-#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 5)
+    #if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 5)
             this->allocationSize_ = nnz;
-#else
+    #else
             this->allocationSize = nnz;
-#endif
+    #endif
             this->avg = 0;
             this->overflowsize = -1.0;
 #endif

--- a/opm/autodiff/DuneMatrix.hpp
+++ b/opm/autodiff/DuneMatrix.hpp
@@ -91,7 +91,11 @@ namespace Opm
             nnz = ia[rows];
 
 #if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 3)
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 5)
+            this->allocationSize_ = nnz;
+#else
             this->allocationSize = nnz;
+#endif
             this->avg = 0;
             this->overflowsize = -1.0;
 #endif


### PR DESCRIPTION
One of the variables now has a trailing underline. With this PR we can use DUNE 2.5