### PR TITLE
add new regression test class: parallel

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -14,7 +14,7 @@ set(BASE_RESULT_PATH ${PROJECT_BINARY_DIR}/tests/results)
 #
 macro (add_test_compareECLFiles casename filename simulator)
 
-  set(RESULT_PATH ${BASE_RESULT_PATH}/${casename}+${simulator})
+  set(RESULT_PATH ${BASE_RESULT_PATH}/${simulator}+${casename})
   # Add test that runs flow and outputs the results to file
   opm_add_test(compareECLFiles_${simulator}+${filename} NO_COMPILE
                EXE_NAME ${simulator}
@@ -36,7 +36,7 @@ endmacro (add_test_compareECLFiles)
 #
 macro (add_test_compareECLRestartFiles casename filename simulator)
 
-  set(RESULT_PATH ${BASE_RESULT_PATH}/restart/${casename})
+  set(RESULT_PATH ${BASE_RESULT_PATH}/restart/${simulator}+${casename})
   # Add test that runs flow and outputs the results to file
   opm_add_test(compareECLRestartFiles_${simulator}+${filename} NO_COMPILE
                EXE_NAME ${simulator}
@@ -49,6 +49,29 @@ macro (add_test_compareECLRestartFiles casename filename simulator)
                TEST_ARGS ${OPM_DATA_ROOT}/${casename}/${filename})
 endmacro (add_test_compareECLRestartFiles)
 
+###########################################################################
+# TEST: parallelECLFiles
+###########################################################################
+
+# Input:
+#   - casename: basename (no extension)
+#
+macro (add_test_parallelECLFiles casename filename simulator)
+  set(abs_tol 0.02)
+  set(rel_tol 1e-5)
+  set(RESULT_PATH ${BASE_RESULT_PATH}/parallel/${simulator}+${casename})
+
+  # Add test that runs flow_mpi and outputs the results to file
+  opm_add_test(parallelECLFiles_${simulator}+${filename} NO_COMPILE
+               EXE_NAME ${simulator}
+               DRIVER_ARGS ${OPM_DATA_ROOT}/${casename} ${RESULT_PATH}
+                           ${CMAKE_BINARY_DIR}/bin
+                           ${filename}
+                           ${abs_tol} ${rel_tol}
+                           ${COMPARE_SUMMARY_COMMAND}
+                           ${COMPARE_ECL_COMMAND}
+               TEST_ARGS ${OPM_DATA_ROOT}/${casename}/${filename})
+endmacro (add_test_parallelECLFiles)
 
 if(NOT TARGET test-suite)
   add_custom_target(test-suite)
@@ -67,3 +90,12 @@ opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-restart-regressionTest.sh ""
 
 add_test_compareECLRestartFiles(spe1 SPE1CASE2_ACTNUM flow)
 add_test_compareECLRestartFiles(spe9 SPE9_CP_SHORT flow)
+
+# Parallel tests
+if(MPI_FOUND)
+  opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-parallel-regressionTest.sh "")
+
+  add_test_parallelECLFiles(spe1 SPE1CASE2 flow_mpi)
+  add_test_parallelECLFiles(spe3 SPE3CASE1 flow_mpi)
+  add_test_parallelECLFiles(spe9 SPE9_CP_SHORT flow_mpi)
+endif()

--- a/tests/run-parallel-regressionTest.sh
+++ b/tests/run-parallel-regressionTest.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+INPUT_DATA_PATH="$1"
+RESULT_PATH="$2"
+BINPATH="$3"
+FILENAME="$4"
+ABS_TOL="$5"
+REL_TOL="$6"
+COMPARE_SUMMARY_COMMAND="$7"
+COMPARE_ECL_COMMAND="$8"
+EXE_NAME="${9}"
+shift 9
+TEST_ARGS="$@"
+
+rm -Rf ${RESULT_PATH}
+mkdir -p ${RESULT_PATH}
+cd ${RESULT_PATH}
+${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA linear_solver_reduction=1e-7 tolerance_cnv=5e-6 tolerance_mb=1e-8
+mkdir mpi
+cd mpi
+mpirun -np 4 ${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA linear_solver_reduction=1e-7 tolerance_cnv=5e-6 tolerance_mb=1e-8
+cd ..
+
+${COMPARE_SUMMARY_COMMAND} -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+${COMPARE_ECL_COMMAND} -l ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}


### PR DESCRIPTION
this compares the output of a serial and a parallel run for a simulation.

note this is just a draft. the tests all currently fail.the number of processes is hardcoded to 4 and my choice of models was just because those were the examples used earlier.

do you agree this is a good idea and if so, which models, which processes? 

in any case these models should pass i imagine. i have set very slack tolerances for the tests to point out that eventually we have differing values in integer fields. so i assume my understanding of the io is broken; i thought it was all based on serialization so ultimately we write the same data in the same order (up to rounding) from one process in either runs.