### PR TITLE
Do not throw for unrecognized file when merging log files.

### DIFF
--- a/opm/simulators/ParallelFileMerger.hpp
+++ b/opm/simulators/ParallelFileMerger.hpp
@@ -83,10 +83,10 @@ public:
                 }
                 else
                 {
-                    OPM_THROW(std::runtime_error,
-                              "Unrecognized file with name "
+                    std::cerr << "WARNING: Unrecognized file with name "
                               << filename
-                              << " from parallel run.");
+                              << " that might stem from a  parallel run."
+                              << std::endl;
                 }
             }
         }


### PR DESCRIPTION
The regex we are using might also consider a file named bla.2.blub.
In that case it is not nice to throw an exception. Instead we print
a message to std::cerr.

Closes #897 