### PR TITLE
checking the residual for the well control equations.

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1840,6 +1840,7 @@ namespace detail {
         const double tol_mb    = param_.tolerance_mb_;
         const double tol_cnv   = param_.tolerance_cnv_;
         const double tol_wells = param_.tolerance_wells_;
+        const double tol_well_control = param_.tolerance_well_control_;
 
         const int nc = Opm::AutoDiffGrid::numCells(grid_);
         const int np = asImpl().numPhases();
@@ -1893,7 +1894,7 @@ namespace detail {
 
         const double residualWell     = detail::infinityNormWell(residual_.well_eq,
                                                                  linsolver_.parallelInformation());
-        converged_Well = converged_Well && (residualWell < Opm::unit::barsa);
+        converged_Well = converged_Well && (residualWell < tol_well_control);
         const bool converged = converged_MB && converged_CNV && converged_Well;
 
         // Residual in Pascal can have high values and still be ok.
@@ -1913,6 +1914,7 @@ namespace detail {
                 for (int idx = 0; idx < np; ++idx) {
                     msg += "  W-FLUX(" + materialName(idx).substr(0, 1) + ")";
                 }
+                msg += "  WELL-CONT";
                 // std::cout << "  WELL-CONT ";
                 OpmLog::note(msg);
             }
@@ -1929,6 +1931,7 @@ namespace detail {
             for (int idx = 0; idx < np; ++idx) {
                 ss << std::setw(11) << well_flux_residual[idx];
             }
+            ss << std::setw(11) << residualWell;
             // std::cout << std::setw(11) << residualWell;
             ss.precision(oprec);
             ss.flags(oflags);
@@ -1976,6 +1979,7 @@ namespace detail {
     getWellConvergence(const int iteration)
     {
         const double tol_wells = param_.tolerance_wells_;
+        const double tol_well_control = param_.tolerance_well_control_;
 
         const int nc = Opm::AutoDiffGrid::numCells(grid_);
         const int np = asImpl().numPhases();
@@ -2010,7 +2014,7 @@ namespace detail {
 
         const double residualWell     = detail::infinityNormWell(residual_.well_eq,
                                                                  linsolver_.parallelInformation());
-        converged_Well = converged_Well && (residualWell < Opm::unit::barsa);
+        converged_Well = converged_Well && (residualWell < tol_well_control);
         const bool converged = converged_Well;
 
         // if one of the residuals is NaN, throw exception, so that the solver can be restarted
@@ -2040,6 +2044,7 @@ namespace detail {
                 for (int idx = 0; idx < np; ++idx) {
                     msg += "  W-FLUX(" + materialName(idx).substr(0, 1) + ")";
                 }
+                msg += "  WELL-CONT";
                 OpmLog::note(msg);
             }
             std::ostringstream ss;
@@ -2049,6 +2054,7 @@ namespace detail {
             for (int idx = 0; idx < np; ++idx) {
                 ss << std::setw(11) << well_flux_residual[idx];
             }
+            ss << std::setw(11) << residualWell;
             ss.precision(oprec);
             ss.flags(oflags);
             OpmLog::note(ss.str());

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -46,6 +46,7 @@ namespace Opm
         tolerance_mb_    = param.getDefault("tolerance_mb", tolerance_mb_);
         tolerance_cnv_   = param.getDefault("tolerance_cnv", tolerance_cnv_);
         tolerance_wells_ = param.getDefault("tolerance_wells", tolerance_wells_ );
+        tolerance_well_control_ = param.getDefault("tolerance_well_control", tolerance_well_control_);
         solve_welleq_initially_ = param.getDefault("solve_welleq_initially",solve_welleq_initially_);
         update_equations_scaling_ = param.getDefault("update_equations_scaling", update_equations_scaling_);
         compute_well_potentials_ = param.getDefault("compute_well_potentials", compute_well_potentials_);
@@ -65,6 +66,7 @@ namespace Opm
         tolerance_mb_    = 1.0e-5;
         tolerance_cnv_   = 1.0e-2;
         tolerance_wells_ = 1.0e-3;
+        tolerance_well_control_ = 1.0e-7;
         solve_welleq_initially_ = true;
         update_equations_scaling_ = false;
         compute_well_potentials_ = false;

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -42,6 +42,9 @@ namespace Opm
         double tolerance_cnv_;
         /// Well convergence tolerance.
         double tolerance_wells_;
+        /// Tolerance for the well control equations
+        //  TODO: it might need to distinguish between rate control and pressure control later
+        double tolerance_well_control_;
 
         /// Solve well equation initially
         bool solve_welleq_initially_;


### PR DESCRIPTION
When the targets like, BHP or WRAT or ORAT, we are able to set the `WellState` to match the target value. As a result, we can get almost always zero residual for the well control equations, which is also why we do not care much about this residual and even not outputting them. 

When come to some types of combined control, like RESV, LRAT, REIN, VREP, and so on, we can not set the `WellState` based on the targets, then we get some non-zero residuals. The current tolerance is set to be `barsa`, which is 1e5, make the checking not working actually. 

With this PR, we set the tolerance for 1.e-7 by default and also we output the evolution of the residual of the well control equations. 

It is tested on Norne, it does not change the well curves. It reduced the non-linear iteration and linear iteration a little, which results from the better convergence from the previous step (resulting in less iteration failures.). 

The following is my testing results with Norne. 
With master branch
```
90483 Total time taken (seconds):  2154.89
90484 Solver time (seconds):       2143.85
90485 Overall Linearizations:      2005
90486 Overall Newton Iterations:   1639
90487 Overall Linear Iterations:   25440
```

With this PR
```
90163 Total time taken (seconds):  2107.52
90164 Solver time (seconds):       2096.43
90165 Overall Linearizations:      1980
90166 Overall Newton Iterations:   1624
90167 Overall Linear Iterations:   25222
```