### PR TITLE
adapt to the rename of "applications/ebos" to "ebos" inside eWoms

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -24,7 +24,7 @@
 #ifndef OPM_BLACKOILMODELEBOS_HEADER_INCLUDED
 #define OPM_BLACKOILMODELEBOS_HEADER_INCLUDED
 
-#include <applications/ebos/eclproblem.hh>
+#include <ebos/eclproblem.hh>
 #include <ewoms/common/start.hh>
 
 #include <opm/autodiff/BlackoilModelParameters.hpp>


### PR DESCRIPTION
this is required once OPM/ewoms#85 goes in.