### PR TITLE
add flow_ebos to the programs which are going to be installed

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -126,6 +126,7 @@ list (APPEND PROGRAM_SOURCE_FILES
   examples/sim_2p_incomp.cpp
   examples/sim_2p_incomp_ad.cpp
   examples/sim_2p_comp_reorder.cpp
+  examples/flow_ebos.cpp
   examples/flow_legacy.cpp
   examples/flow_sequential.cpp
   examples/flow_solvent.cpp


### PR DESCRIPTION
some fun with the build system: binaries that are supposed to be installed need to be added to PROGRAM_SOURCE_FILES in addition to EXAMPLE_SOURCE_FILES.  I guess I picked the wrong template (e.g. `flow_multisegment`) when I originally added `flow_ebos`. This hopefully fixes the `make install` problems reported by @nairr in #990.