### PR TITLE
[WIP] making the updateWellControls an iterative process for StandardWells

### DIFF
--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -276,6 +276,12 @@ namespace Opm {
                                                   const WellState& well_state,
                                                   const WellMapEntryType& map_entry) const;
 
+            template <class WellState>
+            void updateWellStateWithTarget(const WellControls* wc,
+                                           const int current,
+                                           const int well_index,
+                                           WellState& xw) const;
+
         };
 
 


### PR DESCRIPTION
Seperating the updateWellStateWithTarget from updateWellControls, will update the controls when any of the control constraints gets broken.

The reason is that the updated (once) well control can still break some of the other constraints. We need to choose one control to make sure all the constraints are honored.

It will be more important for the cases that the wells has more different controls (can be from the group controls) at the same time, and potentially it will reduce the number of the Newton iterations. 

A preliminary test show it does not change the results of Norne while reduces the iterations a little bit. 
Master branch (from the PR #906 )
```
90163 Total time taken (seconds):  2107.52
90164 Solver time (seconds):       2096.43
90165 Overall Linearizations:      1980
90166 Overall Newton Iterations:   1624
90167 Overall Linear Iterations:   25222
```
With this PR
```
Total time taken (seconds):  2092.98
Solver time (seconds):       2082.56
Overall Linearizations:      1968
Overall Newton Iterations:   1613
Overall Linear Iterations:   25114
```

There is something missing here still, like should we impose a maximum iteration number here for exiting. Although theoretically there should always be able to find one viable control. 