### PR TITLE
Improvments in convergence for flow_ebos

### DIFF
--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -59,7 +59,7 @@ namespace Opm
     void BlackoilModelParameters::reset()
     {
         // default values for the solver parameters
-        dp_max_rel_      = 1.0e9;
+        dp_max_rel_      = 1.0;
         ds_max_          = 0.2;
         dr_max_rel_      = 1.0e9;
         max_residual_allowed_ = 1e7;

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -66,7 +66,7 @@ namespace Opm
         {
             newton_use_gmres_        = false;
             linear_solver_reduction_ = 1e-2;
-            linear_solver_maxiter_   = 75;
+            linear_solver_maxiter_   = 150;
             linear_solver_restart_   = 40;
             linear_solver_verbosity_ = 0;
             require_full_sparsity_pattern_ = false;

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -248,7 +248,7 @@ namespace Opm
             stagnate = (stagnate && !(std::abs((F1[p] - F2[p]) / F2[p]) > 1.0e-3));
         }
 
-        oscillate = (oscillatePhase > 1);
+        oscillate = (oscillatePhase > 0);
     }
 
 

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -1502,7 +1502,8 @@ namespace Opm {
                         currentControlIdx += wells().comp_frac[np*wellIdx + i] * i;
                     }
 
-                    if (wellVolumeFractionScaled(wellIdx,currentControlIdx) == 0) {
+                    const double eps = 1e-6;
+                    if (wellVolumeFractionScaled(wellIdx,currentControlIdx) < eps) {
                         return qs;
                     }
                     return (target_rate * wellVolumeFractionScaled(wellIdx,phaseIdx) / wellVolumeFractionScaled(wellIdx,currentControlIdx));


### PR DESCRIPTION
1. restrict pressure changes. Set default to 1.0 (this also effects flow)
2. change default number of linear iterations to 150
3. tell stabilized newton that the residual oscillates even if it oscillates in
only one phase (this also effects flow)
4. avoid problems related to division on small numbers

Tested on SPE9, norne and Model 2. 
Note that number of non-linear and linear iterations is not counted if not converged. So even if the number of linear and non-linear iterations increases in the table below, this does not mean that the actual number of non-linear and linear iterations increases. 

| |SPE9|SPE9 this PR|Norne |Norne this PR| Model 2 | Model 2 this PR |
|-|-|-|-|-|-|-|
|Problems| 3 |0 | 10 | 4 | 88 |29|  
|Linear #|1305|1340|24239|25356|47245|50576|
|Non lin. #|314|235|1620|1611|1884|1870|
|time s| 11.4|10|749|711|3156|3048|

Since this PR also effects flow it is maybe beneficial to wait mering this to after Frankenstein is merged in to master. An alternative solution is to revert the changes that effects flow (number 1 and 3) and make a new PR with only these changes.  