### PR TITLE
replace all version checks for DUNE_ISTL by ones for DUNE_COMMON

### DIFF
--- a/opm/autodiff/DuneMatrix.hpp
+++ b/opm/autodiff/DuneMatrix.hpp
@@ -33,7 +33,7 @@
 #include <dune/common/fmatrix.hh>
 #include <dune/common/version.hh>
 
-#if DUNE_VERSION_NEWER(DUNE_ISTL,2,4)
+#if DUNE_VERSION_NEWER(DUNE_COMMON,2,4)
 #include <dune/istl/bcrsmatrix.hh>
 #else
 // Include matrix header with hackery to make it possible to inherit.
@@ -80,7 +80,7 @@ namespace Opm
             this->m = cols;
 
             typedef Super::size_type size_type ;
-#if DUNE_VERSION_NEWER_REV(DUNE_ISTL, 2, 4, 1)
+#if DUNE_VERSION_NEWER_REV(DUNE_COMMON, 2, 4, 1)
             size_type& nnz = this->nnz_;
             std::shared_ptr<size_type>& j = this->j_;
 #else
@@ -90,8 +90,8 @@ namespace Opm
 
             nnz = ia[rows];
 
-#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 3)
-    #if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 5)
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+    #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 5)
             this->allocationSize_ = nnz;
     #else
             this->allocationSize = nnz;


### PR DESCRIPTION
this is a work around for the build system bug that DUNE_ISTL_VERSION* macros are not generated under some circumstances if dunecontrol is used. (For some reason, the HAVE_DUNE_ISTL macro is correctly set, though.) Since issue gets *really* annoying for me because it reliably breaks my build (I've got to hand-edit config.h to fix it), and since it is unlikely that dune-istl and dune-common exhibit a different version, I hereby propose this "fix" again.

I know that this patch is a bad kludge and a proper build system fix is appreciated, but it solves a problem encountered in the wild. I've also verified that these occurrences are the only places within the opm-simulators module where the DUNE_ISTL_VERSION macros are needed.