### PR TITLE
Fix spelling in warning about unhandled parallel ouput.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -830,7 +830,7 @@ namespace Opm
 
                 if ( no_kw )
                 {
-                    Opm::OpmLog::warning("Unhandled ouput request", str.str());
+                    Opm::OpmLog::warning("Unhandled output request in parallel", str.str());
                 }
             }
         }        


### PR DESCRIPTION
Fixes spelling fallout introduced in #900