### PR TITLE
Removed second implementation of matlab output.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -68,12 +68,6 @@ namespace Opm
                         const int step,
                         const std::string& output_dir);
 
-
-    void outputStateMatlab(const UnstructuredGrid& grid,
-                           const Opm::SimulationDataContainer& state,
-                           const int step,
-                           const std::string& output_dir);
-
     void outputWellStateMatlab(const Opm::WellState& well_state,
                                const int step,
                                const std::string& output_dir);


### PR DESCRIPTION
There is already a generic one with the Grid implementation
being the template parameter in the header file. The other
implementation using UnstructuredGrid does exactly the same.
Therefore we remove it with this commit.