### PR TITLE
Revert som changes in default values

### DIFF
--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -59,7 +59,7 @@ namespace Opm
     void BlackoilModelParameters::reset()
     {
         // default values for the solver parameters
-        dp_max_rel_      = 1.0;
+        dp_max_rel_      = 1.0e9;
         ds_max_          = 0.2;
         dr_max_rel_      = 1.0e9;
         max_residual_allowed_ = 1e7;

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -248,7 +248,7 @@ namespace Opm
             stagnate = (stagnate && !(std::abs((F1[p] - F2[p]) / F2[p]) > 1.0e-3));
         }
 
-        oscillate = (oscillatePhase > 0);
+        oscillate = (oscillatePhase > 1);
     }
 
 


### PR DESCRIPTION
Make sure flow in Frankenstein and flow in master uses the same default
values

This PR revert changes effecting flow that was merged in #916. I plan to add these changes to #880 instead. In this way the results and performance of flow stays unchanged when Frankenstein is merged into master. 