### PR TITLE
a few warning fixing.

### DIFF
--- a/opm/autodiff/BlackoilSolventState.cpp
+++ b/opm/autodiff/BlackoilSolventState.cpp
@@ -28,7 +28,7 @@ namespace Opm
         : BlackoilState( number_of_cells , number_of_faces , number_of_phases)
     {
         registerCellData( SSOL , 1 );
-    };
+    }
 
 } // namespace Opm
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.cpp
@@ -581,7 +581,6 @@ namespace Opm
         computePressureIncrement(const LinearisedBlackoilResidual& residual)
         {
             typedef LinearisedBlackoilResidual::ADB ADB;
-            typedef ADB::V V;
 
             // Build the vector of equations (should be just a single material balance equation
             // in which the pressure equation is stored).

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -468,8 +468,6 @@ namespace Opm
                             const int reportStepNum,
                             const bool log) {
 
-            typedef Opm::AutoDiffBlock<double> ADB;
-
             const typename Model::SimulatorData& sd = physicalModel.getSimulatorData();
             //Get the value of each of the keys for the restart keywords
             std::map<std::string, int> rstKeywords = restartConfig.getRestartKeywords(reportStepNum);


### PR DESCRIPTION
Silencing a few warnings.

The warnings related to shadowing global declaration of `Oil`, `Water` and `Gas` in `BlackoilModelEnums.hpp` remains, and also the shadowing of global declaration of `M`, `V` and `DataBlock` through `BlackoilModeBase_impl.hpp`. 