### PR TITLE
Allow output for user requested data in parallel runs.

### DIFF
--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -594,6 +594,7 @@ namespace Opm
 
                 const Wells* wells = wells_manager.c_wells();
                 globalWellState_.init(wells, *globalReservoirState_, globalWellState_ );
+                globalCellData_->clear();
             }
 
             PackUnPackSimulationDataContainer packUnpack( localReservoirState, *globalReservoirState_,

--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -380,9 +380,11 @@ namespace Opm
                         const std::string& key = pair.first;
                         std::size_t container_size = globalState_.numCells() *
                             pair.second.data.size() / localState_.numCells();
-                        globalCellData_.insert(key, pair.second.dim,
+                        auto ret = globalCellData_.insert(key, pair.second.dim,
                                                 std::vector<double>(container_size),
                                                 pair.second.target);
+                        assert(ret.second);
+                        DUNE_UNUSED_PARAMETER(ret.second); //dummy op to prevent warning with -DNDEBUG
                     }
 
                     MessageBufferType buffer;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -344,9 +344,17 @@ namespace Opm
                     .reset(new BlackoilVTKWriter< Grid >( grid, outputDir_ ));
             }
 
+            auto output_matlab = param.getDefault("output_matlab", false );
+
+            if ( parallelOutput_->isParallel() && output_matlab )
+            {
+                Opm::OpmLog::warning("Parallel Output Config",
+                                     "Velocity output for matlab is broken in parallel.");
+            }
+                
             if( parallelOutput_->isIORank() ) {
 
-                if ( param.getDefault("output_matlab", false ) )
+                if ( output_matlab )
                 {
                     matlabWriter_
                         .reset(new BlackoilMatlabWriter< Grid >( grid, outputDir_ ));
@@ -824,7 +832,7 @@ namespace Opm
 
                 if ( no_kw )
                 {
-                    Opm::OpmLog::warning("Unhandled output request in parallel", str.str());
+                    Opm::OpmLog::warning("Unhandled ouput request", str.str());
                 }
             }
         }        


### PR DESCRIPTION
This PR further aligns parallel output with the one done in a serial. Previously outputting data in addition to the cell data registered with in `SimulationDataContainer` was not possible in a parallel run. Now we use the `data::Solution` map when gathering data. As this also gets the user requested cell data, we output this in parallel now, too.

Norne seems to run fine. Will test with Model 2 also.