### PR TITLE
Do not assign to dereferenced null pointers.

### DIFF
--- a/examples/sim_poly2p_incomp_reorder.cpp
+++ b/examples/sim_poly2p_incomp_reorder.cpp
@@ -87,7 +87,7 @@ try
 
     // If we have a "deck_filename", grid and props will be read from that.
     bool use_deck = param.has("deck_filename");
-    std::shared_ptr< Deck > deck;
+    Deck deck;
     boost::scoped_ptr<GridManager> grid;
     boost::scoped_ptr<IncompPropertiesInterface> props;
     boost::scoped_ptr<RockCompressibility> rock_comp;
@@ -101,32 +101,32 @@ try
         std::string deck_filename = param.get<std::string>("deck_filename");
         Opm::ParseContext parseContext({{ ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE }});
         Parser parser;
-        *deck = parser.parseFile(deck_filename , parseContext);
+        deck = parser.parseFile(deck_filename , parseContext);
 
-        eclipseState.reset(new Opm::EclipseState(*deck , parseContext));
+        eclipseState.reset(new Opm::EclipseState(deck , parseContext));
 
         // Grid init
         grid.reset(new GridManager(eclipseState->getInputGrid()));
         {
             const UnstructuredGrid& ug_grid = *(grid->c_grid());
             // Rock and fluid init
-            props.reset(new IncompPropertiesFromDeck(*deck, *eclipseState, ug_grid ));
+            props.reset(new IncompPropertiesFromDeck(deck, *eclipseState, ug_grid ));
             // check_well_controls = param.getDefault("check_well_controls", false);
             // max_well_control_iterations = param.getDefault("max_well_control_iterations", 10);
             state.reset( new PolymerState(  UgGridHelpers::numCells( ug_grid ) , UgGridHelpers::numFaces( ug_grid ), 2));
 
             // Rock compressibility.
-            rock_comp.reset(new RockCompressibility(*deck, *eclipseState));
+            rock_comp.reset(new RockCompressibility(deck, *eclipseState));
             // Gravity.
-            gravity[2] = deck->hasKeyword("NOGRAV") ? 0.0 : unit::gravity;
+            gravity[2] = deck.hasKeyword("NOGRAV") ? 0.0 : unit::gravity;
             // Init state variables (saturation and pressure).
             if (param.has("init_saturation")) {
                 initStateBasic(ug_grid, *props, param, gravity[2], *state);
             } else {
-                initStateFromDeck(ug_grid, *props, *deck, gravity[2], *state);
+                initStateFromDeck(ug_grid, *props, deck, gravity[2], *state);
             }
             // Init polymer properties.
-            poly_props.readFromDeck(*deck, *eclipseState);
+            poly_props.readFromDeck(deck, *eclipseState);
         }
     } else {
         // Grid init.
@@ -299,12 +299,12 @@ try
 
         WellState well_state;
         int step = 0;
-        TimeMap timeMap(*deck);
+        const auto& timeMap = eclipseState->getSchedule().getTimeMap();
         SimulatorTimer simtimer;
         simtimer.init(timeMap);
         // Check for WPOLYMER presence in last epoch to decide
         // polymer injection control type.
-        const bool use_wpolymer = deck->hasKeyword("WPOLYMER");
+        const bool use_wpolymer = deck.hasKeyword("WPOLYMER");
         if (use_wpolymer) {
             if (param.has("poly_start_days")) {
                 OPM_MESSAGE("Warning: Using WPOLYMER to control injection since it was found in deck. "

--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer.hpp
@@ -109,7 +109,7 @@ namespace Opm
                                                   const RockCompressibility* rock_comp_props,
                                                   std::shared_ptr<EclipseState> eclipse_state,
                                                   BlackoilOutputWriter& output_writer,
-                                                  std::shared_ptr< const Deck > deck,
+                                                  const Deck& deck,
                                                   NewtonIterationBlackoilInterface& linsolver,
                                                   const double* gravity);
 
@@ -127,7 +127,7 @@ namespace Opm
                                    const WellState& well_state,
                                    DynamicListEconLimited& list_econ_limited) const;
 private:
-        std::shared_ptr< const Deck > deck_;
+        const Deck& deck_;
         const PolymerPropsAd& polymer_props_;
 
     };

--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer_impl.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer_impl.hpp
@@ -34,7 +34,7 @@ SimulatorFullyImplicitCompressiblePolymer(const parameter::ParameterGroup& param
                                           const RockCompressibility* rock_comp_props,
                                           std::shared_ptr<EclipseState> eclipse_state,
                                           BlackoilOutputWriter& output_writer,
-                                          std::shared_ptr< const Deck > deck,
+                                          const Deck& deck,
                                           NewtonIterationBlackoilInterface& linsolver,
                                           const double* gravity)
 : BaseType(param,
@@ -82,7 +82,7 @@ handleAdditionalWellInflow(SimulatorTimer& timer,
 {
     // compute polymer inflow
     std::unique_ptr<PolymerInflowInterface> polymer_inflow_ptr;
-    if (deck_->hasKeyword("WPOLYMER")) {
+    if (deck_.hasKeyword("WPOLYMER")) {
         if (wells_manager.c_wells() == 0) {
             OPM_THROW(std::runtime_error, "Cannot control polymer injection via WPOLYMER without wells.");
         }


### PR DESCRIPTION
This fixes a bug introduced when `Opm::Parser::parseFile()` started returning `Deck` directly instead of shared pointers. Basically,
```C++
*deck = ...
```
is always an error for a default-constructed shared (or unique) pointer.