### PR TITLE
Bug fix for reusing cached intensive quantities.

### DIFF
--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -336,6 +336,22 @@ namespace Opm {
                 duneB_.mmtv(invDCx,Ax);
             }
 
+            // apply well model with scaling of alpha
+            void applyScaleAdd(const Scalar alpha, const BVector& x, BVector& Ax)
+            {
+                if ( ! localWellsActive() ) {
+                    return;
+                }
+
+                if( scaleAddRes_.size() != Ax.size() ) {
+                    scaleAddRes_.resize( Ax.size() );
+                }
+
+                scaleAddRes_ = 0.0;
+                apply( x, scaleAddRes_ );
+                Ax.axpy( alpha, scaleAddRes_ );
+            }
+
             // xw = inv(D)*(rw - C*x)
             void recoverVariable(const BVector& x, BVector& xw) const {
                 if ( ! localWellsActive() ) {
@@ -1418,6 +1434,7 @@ namespace Opm {
 
             mutable BVector Cx_;
             mutable BVector invDrw_;
+            mutable BVector scaleAddRes_;
 
             // protected methods
             EvalWell getBhp(const int wellIdx) const {


### PR DESCRIPTION
This bug was introduced by unification of the linear solvers due to a throw for non-convergent solves. 
This PR also fixed the applyscaleadd method in the overloaded linear operator. 