### PR TITLE
ParallelDebugOutput: remove unused variable and tabbing.

### DIFF
--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -368,10 +368,10 @@ namespace Opm
                 if( isIORank )
                 {
                     // add missing data to global state
-   		    for (const auto& pair : localState.cellData()) {
-		        const std::string& key = pair.first;
+                    for (const auto& pair : localState.cellData()) {
+                        const std::string& key = pair.first;
                         if (!globalState_.hasCellData( key )) {
-			    globalState_.registerCellData( key , localState.numCellDataComponents( key ));
+                            globalState_.registerCellData( key , localState.numCellDataComponents( key ));
                         }
                     }
 
@@ -404,7 +404,6 @@ namespace Opm
 
                 // write all cell data registered in local state
                 for (const auto& pair : localCellData_) {
-		    const std::string& key = pair.first;
                     const auto& data = pair.second.data;
                     const size_t stride = data.size()/localState_.numCells();
 
@@ -433,7 +432,7 @@ namespace Opm
                     for( size_t i=0; i<stride; ++i )
                     {
                         //write all data from local state to buffer
-		        read( buffer, indexMap, data, i, stride );
+                        read( buffer, indexMap, data, i, stride );
                     }
                 }
 


### PR DESCRIPTION
This PR simply removes an unused variable in ParallelDebugOutput.