### PR TITLE
Read write perforation rates, pressure, phase reates, and control of wells.

### DIFF
--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -55,13 +55,13 @@ namespace Opm
         //!                            localReservoirState)
         //! \param wellStateStepNumber The step number of the well state.
         virtual bool collectToIORank( const SimulationDataContainer& localReservoirState,
-                                      const WellState& localWellState,
+                                      const WellStateFullyImplicitBlackoil& localWellState,
                                       const data::Solution& localCellData,
                                       const int wellStateStepNumber ) = 0;
 
         virtual const SimulationDataContainer& globalReservoirState() const = 0 ;
         virtual const data::Solution& globalCellData() const = 0 ;
-        virtual const WellState& globalWellState() const = 0 ;
+        virtual const WellStateFullyImplicitBlackoil& globalWellState() const = 0 ;
         virtual bool isIORank() const = 0;
         virtual bool isParallel() const = 0;
         virtual int numCells() const = 0 ;
@@ -74,9 +74,9 @@ namespace Opm
     protected:
         const GridImpl& grid_;
 
-        const SimulationDataContainer* globalState_;
-        const WellState*      wellState_;
-        const data::Solution* globalCellData_;
+        const SimulationDataContainer*        globalState_;
+        const WellStateFullyImplicitBlackoil* wellState_;
+        const data::Solution*                 globalCellData_;
 
     public:
         ParallelDebugOutput ( const GridImpl& grid,
@@ -88,7 +88,7 @@ namespace Opm
 
         // gather solution to rank 0 for EclipseWriter
         virtual bool collectToIORank( const SimulationDataContainer& localReservoirState,
-                                      const WellState& localWellState,
+                                      const WellStateFullyImplicitBlackoil& localWellState,
                                       const data::Solution& localCellData,
                                       const int /* wellStateStepNumber */)
         {
@@ -103,7 +103,7 @@ namespace Opm
         {
             return *globalCellData_;
         }
-        virtual const WellState& globalWellState() const { return *wellState_; }
+        virtual const WellStateFullyImplicitBlackoil& globalWellState() const { return *wellState_; }
         virtual bool isIORank () const { return true; }
         virtual bool isParallel () const { return false; }
         virtual int numCells() const { return grid_.number_of_cells; }
@@ -341,8 +341,8 @@ namespace Opm
             SimulationDataContainer& globalState_;
             const data::Solution& localCellData_;
             data::Solution& globalCellData_;
-            const WellState& localWellState_;
-            WellState& globalWellState_;
+            const WellStateFullyImplicitBlackoil& localWellState_;
+            WellStateFullyImplicitBlackoil& globalWellState_;
             const IndexMapType& localIndexMap_;
             const IndexMapStorageType& indexMaps_;
 
@@ -351,8 +351,8 @@ namespace Opm
                                                SimulationDataContainer& globalState,
                                                const data::Solution& localCellData,
                                                data::Solution& globalCellData,
-                                               const WellState& localWellState,
-                                               WellState& globalWellState,
+                                               const WellStateFullyImplicitBlackoil& localWellState,
+                                               WellStateFullyImplicitBlackoil& globalWellState,
                                                const IndexMapType& localIndexMap,
                                                const IndexMapStorageType& indexMaps,
                                                const bool isIORank )
@@ -536,6 +536,8 @@ namespace Opm
                     {
                         buffer.write( localWellState_.perfPress()[ con ] );
                     }
+
+                    // Write perfPhaseRate
                 }
             }
 
@@ -585,7 +587,7 @@ namespace Opm
 
         // gather solution to rank 0 for EclipseWriter
         bool collectToIORank( const SimulationDataContainer& localReservoirState,
-                              const WellState& localWellState,
+                              const WellStateFullyImplicitBlackoil& localWellState,
                               const data::Solution& localCellData,
                               const int wellStateStepNumber )
         {
@@ -648,7 +650,7 @@ namespace Opm
             return *globalCellData_;
         }
 
-        const WellState& globalWellState() const { return globalWellState_; }
+        const WellStateFullyImplicitBlackoil& globalWellState() const { return globalWellState_; }
 
         bool isIORank() const
         {

--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -538,6 +538,13 @@ namespace Opm
                     }
 
                     // Write perfPhaseRate
+                    const int np = localWellState_.perfPhaseRates().size() /
+                        localWellState_.perfRates().size();
+
+                    for( int con = it->second[1]*np; con < end_con*np; ++con )
+                    {
+                        buffer.write( localWellState_.perfPhaseRates()[ con ] );
+                    }
                 }
             }
 
@@ -581,6 +588,14 @@ namespace Opm
                         buffer.read( globalWellState_.perfPress()[ con ] );
                     }
 
+                    // Read perfPhaseRate
+                    const int np = globalWellState_.perfPhaseRates().size() /
+                        globalWellState_.perfRates().size();
+
+                    for( int con = it->second[1]*np; con < end_con*np; ++con )
+                    {
+                        buffer.read( globalWellState_.perfPhaseRates()[ con ] );
+                    }
                 }
             }
         };

--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -522,9 +522,20 @@ namespace Opm
                     const int wellRateIdx = wellIdx * localWellState_.numPhases();
                     for( int np=0; np<localWellState_.numPhases(); ++np )
                         buffer.write( localWellState_.wellRates()[ wellRateIdx + np ] );
+                    // Write perfRates and perfPress. No need to figure out the index
+                    // mapping there as the ordering of the perforations should
+                    // be the same for global and local state.
+                    const int end_con = it->second[1] + it->second[2];
 
-                    // TODO: perfRates and perfPress, need to figure out the index
-                    // mapping there.
+                    for( int con = it->second[1]; con < end_con; ++con )
+                    {
+                        buffer.write( localWellState_.perfRates()[ con ] );
+                    }
+
+                    for( int con = it->second[1]; con < end_con; ++con )
+                    {
+                        buffer.write( localWellState_.perfPress()[ con ] );
+                    }
                 }
             }
 
@@ -553,8 +564,21 @@ namespace Opm
                     for( int np=0; np<globalWellState_.numPhases(); ++np )
                         buffer.read( globalWellState_.wellRates()[ wellRateIdx + np ] );
 
-                    // TODO: perfRates and perfPress, need to figure out the index
-                    // mapping there.
+                    // Read perfRates and perfPress. No need to figure out the index
+                    // mapping there as the ordering of the perforations should
+                    // be the same for global and local state.
+                    const int end_con = it->second[1] + it->second[2];
+
+                    for( int con = it->second[1]; con < end_con; ++con )
+                    {
+                        buffer.read( globalWellState_.perfRates()[ con ] );
+                    }
+
+                    for( int con = it->second[1]; con < end_con; ++con )
+                    {
+                        buffer.read( globalWellState_.perfPress()[ con ] );
+                    }
+
                 }
             }
         };

--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -522,6 +522,10 @@ namespace Opm
                     const int wellRateIdx = wellIdx * localWellState_.numPhases();
                     for( int np=0; np<localWellState_.numPhases(); ++np )
                         buffer.write( localWellState_.wellRates()[ wellRateIdx + np ] );
+
+                    // Write well control
+                    buffer.write(localWellState_.currentControls()[ wellIdx ]);
+
                     // Write perfRates and perfPress. No need to figure out the index
                     // mapping there as the ordering of the perforations should
                     // be the same for global and local state.
@@ -572,6 +576,9 @@ namespace Opm
                     const int wellRateIdx = wellIdx * globalWellState_.numPhases();
                     for( int np=0; np<globalWellState_.numPhases(); ++np )
                         buffer.read( globalWellState_.wellRates()[ wellRateIdx + np ] );
+
+                    // Write well control
+                    buffer.read(globalWellState_.currentControls()[ wellIdx ]);
 
                     // Read perfRates and perfPress. No need to figure out the index
                     // mapping there as the ordering of the perforations should

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -201,14 +201,14 @@ namespace Opm
             BlackoilOutputWriter& writer_;
             std::unique_ptr< SimulatorTimerInterface > timer_;
             const SimulationDataContainer state_;
-            const WellState wellState_;
+            const WellStateFullyImplicitBlackoil wellState_;
             data::Solution simProps_;
             const bool substep_;
 
             explicit WriterCall( BlackoilOutputWriter& writer,
                                  const SimulatorTimerInterface& timer,
                                  const SimulationDataContainer& state,
-                                 const WellState& wellState,
+                                 const WellStateFullyImplicitBlackoil& wellState,
                                  const data::Solution& simProps,
                                  bool substep )
                 : writer_( writer ),
@@ -237,7 +237,7 @@ namespace Opm
     writeTimeStepWithoutCellProperties(
                   const SimulatorTimerInterface& timer,
                   const SimulationDataContainer& localState,
-                  const WellState& localWellState,
+                  const WellStateFullyImplicitBlackoil& localWellState,
                   bool substep)
     {
         data::Solution localCellData{};
@@ -259,7 +259,7 @@ namespace Opm
                   const SimulatorTimerInterface& timer,
                   const SimulationDataContainer& localState,
                   const data::Solution& localCellData,
-                  const WellState& localWellState,
+                  const WellStateFullyImplicitBlackoil& localWellState,
                   bool substep)
     {
         // VTK output (is parallel if grid is parallel)
@@ -285,7 +285,7 @@ namespace Opm
 
         const data::Solution& cellData = ( parallelOutput_ && parallelOutput_->isParallel() ) ? parallelOutput_->globalCellData() : localCellData;
         const SimulationDataContainer& state = (parallelOutput_ && parallelOutput_->isParallel() ) ? parallelOutput_->globalReservoirState() : localState;
-        const WellState& wellState  = (parallelOutput_ && parallelOutput_->isParallel() ) ? parallelOutput_->globalWellState() : localWellState;
+        const WellStateFullyImplicitBlackoil& wellState  = (parallelOutput_ && parallelOutput_->isParallel() ) ? parallelOutput_->globalWellState() : localWellState;
 
         // serial output is only done on I/O rank
         if( isIORank )
@@ -307,7 +307,7 @@ namespace Opm
     BlackoilOutputWriter::
     writeTimeStepSerial(const SimulatorTimerInterface& timer,
                         const SimulationDataContainer& state,
-                        const WellState& wellState,
+                        const WellStateFullyImplicitBlackoil& wellState,
                         const data::Solution& simProps,
                         bool substep)
     {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -148,7 +148,7 @@ namespace Opm
 
         virtual void writeTimeStep(const SimulatorTimerInterface& timer,
                            const SimulationDataContainer& state,
-                           const WellState&,
+                           const WellStateFullyImplicitBlackoil&,
                            bool /*substep*/ = false) = 0;
         protected:
             const std::string outputDir_;
@@ -165,7 +165,7 @@ namespace Opm
 
             void writeTimeStep(const SimulatorTimerInterface& timer,
                     const SimulationDataContainer& state,
-                    const WellState&,
+                    const WellStateFullyImplicitBlackoil&,
                     bool /*substep*/ = false) override
             {
                 outputStateVtk(grid_, state, timer.currentStepNum(), outputDir_);
@@ -187,7 +187,7 @@ namespace Opm
 
         void writeTimeStep(const SimulatorTimerInterface& timer,
                            const SimulationDataContainer& reservoirState,
-                           const WellState& wellState,
+                           const WellStateFullyImplicitBlackoil& wellState,
                            bool /*substep*/ = false) override
         {
             outputStateMatlab(grid_, reservoirState, timer.currentStepNum(), outputDir_);
@@ -224,7 +224,7 @@ namespace Opm
         template<class Model>
         void writeTimeStep(const SimulatorTimerInterface& timer,
                            const SimulationDataContainer& reservoirState,
-                           const Opm::WellState& wellState,
+                           const Opm::WellStateFullyImplicitBlackoil& wellState,
                            const Model& physicalModel,
                            bool substep = false);
 
@@ -238,7 +238,7 @@ namespace Opm
                            const SimulatorTimerInterface& timer,
                            const SimulationDataContainer& reservoirState,
                            const data::Solution& cellData,
-                           const Opm::WellState& wellState,
+                           const Opm::WellStateFullyImplicitBlackoil& wellState,
                            bool substep = false);
 
         /*!
@@ -249,7 +249,7 @@ namespace Opm
         void writeTimeStepWithoutCellProperties(
                            const SimulatorTimerInterface& timer,
                            const SimulationDataContainer& reservoirState,
-                           const Opm::WellState& wellState,
+                           const Opm::WellStateFullyImplicitBlackoil& wellState,
                            bool substep = false);
 
         /*!
@@ -259,7 +259,7 @@ namespace Opm
          */
         void writeTimeStepSerial(const SimulatorTimerInterface& timer,
                                  const SimulationDataContainer& reservoirState,
-                                 const Opm::WellState& wellState,
+                                 const Opm::WellStateFullyImplicitBlackoil& wellState,
                                  const data::Solution& simProps,
                                  bool substep);
 
@@ -781,7 +781,7 @@ namespace Opm
     BlackoilOutputWriter::
     writeTimeStep(const SimulatorTimerInterface& timer,
                   const SimulationDataContainer& localState,
-                  const WellState& localWellState,
+                  const WellStateFullyImplicitBlackoil& localWellState,
                   const Model& physicalModel,
                   bool substep)
     {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.cpp
@@ -61,14 +61,14 @@ namespace Opm
             BlackoilOutputWriterEbos& writer_;
             std::unique_ptr< SimulatorTimerInterface > timer_;
             const SimulationDataContainer state_;
-            const WellState wellState_;
+            const WellStateFullyImplicitBlackoil wellState_;
             data::Solution simProps_;
             const bool substep_;
 
             explicit WriterCallEbos( BlackoilOutputWriterEbos& writer,
                                  const SimulatorTimerInterface& timer,
                                  const SimulationDataContainer& state,
-                                 const WellState& wellState,
+                                 const WellStateFullyImplicitBlackoil& wellState,
                                  const data::Solution& simProps,
                                  bool substep )
                 : writer_( writer ),
@@ -94,7 +94,7 @@ namespace Opm
     writeTimeStepWithoutCellProperties(
                   const SimulatorTimerInterface& timer,
                   const SimulationDataContainer& localState,
-                  const WellState& localWellState,
+                  const WellStateFullyImplicitBlackoil& localWellState,
                   bool substep)
     {
         data::Solution noCellProperties;
@@ -110,7 +110,7 @@ namespace Opm
     writeTimeStepWithCellProperties(
                   const SimulatorTimerInterface& timer,
                   const SimulationDataContainer& localState,
-                  const WellState& localWellState,
+                  const WellStateFullyImplicitBlackoil& localWellState,
                   const data::Solution& sol,
                   bool substep)
     {
@@ -129,7 +129,7 @@ namespace Opm
         }
 
         const SimulationDataContainer& state = (parallelOutput_ && parallelOutput_->isParallel() ) ? parallelOutput_->globalReservoirState() : localState;
-        const WellState& wellState  = (parallelOutput_ && parallelOutput_->isParallel() ) ? parallelOutput_->globalWellState() : localWellState;
+        const WellStateFullyImplicitBlackoil& wellState  = (parallelOutput_ && parallelOutput_->isParallel() ) ? parallelOutput_->globalWellState() : localWellState;
 
         // serial output is only done on I/O rank
         if( isIORank )
@@ -151,7 +151,7 @@ namespace Opm
     BlackoilOutputWriterEbos::
     writeTimeStepSerial(const SimulatorTimerInterface& timer,
                         const SimulationDataContainer& state,
-                        const WellState& wellState,
+                        const WellStateFullyImplicitBlackoil& wellState,
                         const data::Solution& sol,
                         bool substep)
     {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.hpp
@@ -83,7 +83,7 @@ namespace Opm
         template<class Model>
         void writeTimeStep(const SimulatorTimerInterface& timer,
                            const SimulationDataContainer& reservoirState,
-                           const Opm::WellState& wellState,
+                           const Opm::WellStateFullyImplicitBlackoil& wellState,
                            const Model& physicalModel,
                            bool substep = false);
 
@@ -96,7 +96,7 @@ namespace Opm
         void writeTimeStepWithCellProperties(
                            const SimulatorTimerInterface& timer,
                            const SimulationDataContainer& reservoirState,
-                           const Opm::WellState& wellState,
+                           const Opm::WellStateFullyImplicitBlackoil& wellState,
                            const data::Solution& sol,
                            bool substep = false);
 
@@ -108,7 +108,7 @@ namespace Opm
         void writeTimeStepWithoutCellProperties(
                            const SimulatorTimerInterface& timer,
                            const SimulationDataContainer& reservoirState,
-                           const Opm::WellState& wellState,
+                           const Opm::WellStateFullyImplicitBlackoil& wellState,
                            bool substep = false);
 
         /*!
@@ -118,7 +118,7 @@ namespace Opm
          */
         void writeTimeStepSerial(const SimulatorTimerInterface& timer,
                                  const SimulationDataContainer& reservoirState,
-                                 const Opm::WellState& wellState,
+                                 const Opm::WellStateFullyImplicitBlackoil& wellState,
                                  const data::Solution& simProps,
                                  bool substep);
 
@@ -684,7 +684,7 @@ namespace Opm
     BlackoilOutputWriterEbos::
     writeTimeStep(const SimulatorTimerInterface& timer,
                   const SimulationDataContainer& localState,
-                  const WellState& localWellState,
+                  const WellStateFullyImplicitBlackoil& localWellState,
                   const Model& physicalModel,
                   bool substep)
     {


### PR DESCRIPTION
With this PR we should finally write all the data of the wells in a parallel run.

Still, we might want to use data::Wells for the gathering in the future. Currently this code in limited to Blackoil.