### PR TITLE
Implement two phase blackoil

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -622,99 +622,102 @@ namespace Opm {
                 double& so = reservoir_state.saturation()[cell_idx*np + pu.phase_pos[ Oil ]];
                 so -= step * dso;
 
-                // const double drmaxrel = drMaxRel();
-                // Update rs and rv
-                if (has_disgas_) {
-                    double& rs = reservoir_state.gasoilratio()[cell_idx];
-                    rs -= drs;
-                    rs = std::max(rs, 0.0);
-
-                }
-                if (has_vapoil_) {
-                    double& rv = reservoir_state.rv()[cell_idx];
-                    rv -= drv;
-                    rv = std::max(rv, 0.0);
-                }
-
-                // Sg is used as primal variable for water only cells.
-                const double epsilon = 1e-4; //std::sqrt(std::numeric_limits<double>::epsilon());
-                double& sw = reservoir_state.saturation()[cell_idx*np + pu.phase_pos[ Water ]];
-                double& sg = reservoir_state.saturation()[cell_idx*np + pu.phase_pos[ Gas ]];
-                double& rs = reservoir_state.gasoilratio()[cell_idx];
-                double& rv = reservoir_state.rv()[cell_idx];
-
-
-                // phase translation sg <-> rs
-                const HydroCarbonState hydroCarbonState = reservoir_state.hydroCarbonState()[cell_idx];
-                const auto& intQuants = *(ebosSimulator_.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
-                const auto& fs = intQuants.fluidState();
-                switch (hydroCarbonState) {
-                case HydroCarbonState::GasAndOil: {
-
-                    if (sw > (1.0 - epsilon)) // water only i.e. do nothing
-                        break;
-
-                    if (sg <= 0.0 && has_disgas_) {
-                        reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::OilOnly; // sg --> rs
-                        sg = 0;
-                        so = 1.0 - sw - sg;
-                        const double& rsSat = FluidSystem::oilPvt().saturatedGasDissolutionFactor(fs.pvtRegionIndex(), reservoir_state.temperature()[cell_idx], reservoir_state.pressure()[cell_idx]);
+                // phase for when oil and gas
+                if (active_[Gas] && active_[Oil] ) {
+                    // const double drmaxrel = drMaxRel();
+                    // Update rs and rv
+                    if (has_disgas_) {
                         double& rs = reservoir_state.gasoilratio()[cell_idx];
-                        rs = rsSat*(1-epsilon);
-                    } else if (so <= 0.0 && has_vapoil_) {
-                        reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::GasOnly; // sg --> rv
-                        so = 0;
-                        sg = 1.0 - sw - so;
+                        rs -= drs;
+                        rs = std::max(rs, 0.0);
+
+                    }
+                    if (has_vapoil_) {
                         double& rv = reservoir_state.rv()[cell_idx];
-                        // use gas pressure?
+                        rv -= drv;
+                        rv = std::max(rv, 0.0);
+                    }
+
+                    // Sg is used as primal variable for water only cells.
+                    const double epsilon = 1e-4; //std::sqrt(std::numeric_limits<double>::epsilon());
+                    double& sw = reservoir_state.saturation()[cell_idx*np + pu.phase_pos[ Water ]];
+                    double& sg = reservoir_state.saturation()[cell_idx*np + pu.phase_pos[ Gas ]];
+                    double& rs = reservoir_state.gasoilratio()[cell_idx];
+                    double& rv = reservoir_state.rv()[cell_idx];
+
+
+                    // phase translation sg <-> rs
+                    const HydroCarbonState hydroCarbonState = reservoir_state.hydroCarbonState()[cell_idx];
+                    const auto& intQuants = *(ebosSimulator_.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
+                    const auto& fs = intQuants.fluidState();
+                    switch (hydroCarbonState) {
+                    case HydroCarbonState::GasAndOil: {
+
+                        if (sw > (1.0 - epsilon)) // water only i.e. do nothing
+                            break;
+
+                        if (sg <= 0.0 && has_disgas_) {
+                            reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::OilOnly; // sg --> rs
+                            sg = 0;
+                            so = 1.0 - sw - sg;
+                            const double& rsSat = FluidSystem::oilPvt().saturatedGasDissolutionFactor(fs.pvtRegionIndex(), reservoir_state.temperature()[cell_idx], reservoir_state.pressure()[cell_idx]);
+                            double& rs = reservoir_state.gasoilratio()[cell_idx];
+                            rs = rsSat*(1-epsilon);
+                        } else if (so <= 0.0 && has_vapoil_) {
+                            reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::GasOnly; // sg --> rv
+                            so = 0;
+                            sg = 1.0 - sw - so;
+                            double& rv = reservoir_state.rv()[cell_idx];
+                            // use gas pressure?
+                            const double& rvSat = FluidSystem::gasPvt().saturatedOilVaporizationFactor(fs.pvtRegionIndex(), reservoir_state.temperature()[cell_idx], reservoir_state.pressure()[cell_idx]);
+                            rv = rvSat*(1-epsilon);
+                        }
+                        break;
+                    }
+                    case HydroCarbonState::OilOnly: {
+                        if (sw > (1.0 - epsilon)) {
+                            // water only change to Sg
+                            rs = 0;
+                            rv = 0;
+                            reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::GasAndOil;
+                            //std::cout << "watonly rv -> sg" << cell_idx << std::endl;
+                            break;
+                        }
+
+
+
+
+                        const double& rsSat = FluidSystem::oilPvt().saturatedGasDissolutionFactor(fs.pvtRegionIndex(), reservoir_state.temperature()[cell_idx], reservoir_state.pressure()[cell_idx]);
+                        if (rs > ( rsSat * (1+epsilon) ) ) {
+                            reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::GasAndOil;
+                            sg = epsilon;
+                            so -= epsilon;
+                            rs = rsSat;
+                        }
+                        break;
+                    }
+                    case HydroCarbonState::GasOnly: {
+                        if (sw > (1.0 - epsilon)) {
+                            // water only change to Sg
+                            rs = 0;
+                            rv = 0;
+                            reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::GasAndOil;
+                            //std::cout << "watonly rv -> sg" << cell_idx << std::endl;
+                            break;
+                        }
                         const double& rvSat = FluidSystem::gasPvt().saturatedOilVaporizationFactor(fs.pvtRegionIndex(), reservoir_state.temperature()[cell_idx], reservoir_state.pressure()[cell_idx]);
-                        rv = rvSat*(1-epsilon);
-                    }
-                    break;
-                }
-                case HydroCarbonState::OilOnly: {
-                    if (sw > (1.0 - epsilon)) {
-                        // water only change to Sg
-                        rs = 0;
-                        rv = 0;
-                        reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::GasAndOil;
-                        //std::cout << "watonly rv -> sg" << cell_idx << std::endl;
+                        if (rv > rvSat * (1+epsilon) ) {
+                            reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::GasAndOil;
+                            so = epsilon;
+                            rv = rvSat;
+                            sg -= epsilon;
+                        }
                         break;
                     }
 
-
-
-
-                    const double& rsSat = FluidSystem::oilPvt().saturatedGasDissolutionFactor(fs.pvtRegionIndex(), reservoir_state.temperature()[cell_idx], reservoir_state.pressure()[cell_idx]);
-                    if (rs > ( rsSat * (1+epsilon) ) ) {
-                        reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::GasAndOil;
-                        sg = epsilon;
-                        so -= epsilon;
-                        rs = rsSat;
+                    default:
+                        OPM_THROW(std::logic_error, "Unknown primary variable enum value in cell " << cell_idx << ": " << hydroCarbonState);
                     }
-                    break;
-                }
-                case HydroCarbonState::GasOnly: {
-                    if (sw > (1.0 - epsilon)) {
-                        // water only change to Sg
-                        rs = 0;
-                        rv = 0;
-                        reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::GasAndOil;
-                        //std::cout << "watonly rv -> sg" << cell_idx << std::endl;
-                        break;
-                    }
-                    const double& rvSat = FluidSystem::gasPvt().saturatedOilVaporizationFactor(fs.pvtRegionIndex(), reservoir_state.temperature()[cell_idx], reservoir_state.pressure()[cell_idx]);
-                    if (rv > rvSat * (1+epsilon) ) {
-                        reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::GasAndOil;
-                        so = epsilon;
-                        rv = rvSat;
-                        sg -= epsilon;
-                    }
-                    break;
-                }
-
-                default:
-                    OPM_THROW(std::logic_error, "Unknown primary variable enum value in cell " << cell_idx << ": " << hydroCarbonState);
                 }
             }
 
@@ -1237,56 +1240,61 @@ namespace Opm {
                 cellPv[BlackoilIndices::waterSaturationIdx] = saturations[cellIdx*numPhases + pu.phase_pos[Water]];
 
                 // set switching variable and interpretation
-                if( reservoirState.hydroCarbonState()[cellIdx] == HydroCarbonState::OilOnly && has_disgas_ )
-                {
-                    cellPv[BlackoilIndices::compositionSwitchIdx] = rs[cellIdx];
+                if (active_[Gas] ) {
+                    if( reservoirState.hydroCarbonState()[cellIdx] == HydroCarbonState::OilOnly && has_disgas_ )
+                    {
+                        cellPv[BlackoilIndices::compositionSwitchIdx] = rs[cellIdx];
+                        cellPv[BlackoilIndices::pressureSwitchIdx] = oilPressure[cellIdx];
+                        cellPv.setPrimaryVarsMeaning( PrimaryVariables::Sw_po_Rs );
+                    }
+                    else if( reservoirState.hydroCarbonState()[cellIdx] == HydroCarbonState::GasOnly && has_vapoil_ )
+                    {
+                        // this case (-> gas only with vaporized oil in the gas) is
+                        // relatively expensive as it requires to compute the capillary
+                        // pressure in order to get the gas phase pressure. (the reason why
+                        // ebos uses the gas pressure here is that it makes the common case
+                        // of the primary variable switching code fast because to determine
+                        // whether the oil phase appears one needs to compute the Rv value
+                        // for the saturated gas phase and if this is not available as a
+                        // primary variable, it needs to be computed.) luckily for here, the
+                        // gas-only case is not too common, so the performance impact of this
+                        // is limited.
+                        typedef Opm::SimpleModularFluidState<double,
+                                /*numPhases=*/3,
+                                /*numComponents=*/3,
+                                FluidSystem,
+                                /*storePressure=*/false,
+                                /*storeTemperature=*/false,
+                                /*storeComposition=*/false,
+                                /*storeFugacity=*/false,
+                                /*storeSaturation=*/true,
+                                /*storeDensity=*/false,
+                                /*storeViscosity=*/false,
+                                /*storeEnthalpy=*/false> SatOnlyFluidState;
+                        SatOnlyFluidState fluidState;
+                        fluidState.setSaturation(FluidSystem::waterPhaseIdx, saturations[cellIdx*numPhases + pu.phase_pos[Water]]);
+                        fluidState.setSaturation(FluidSystem::oilPhaseIdx, saturations[cellIdx*numPhases + pu.phase_pos[Oil]]);
+                        fluidState.setSaturation(FluidSystem::gasPhaseIdx, saturations[cellIdx*numPhases + pu.phase_pos[Gas]]);
+
+                        double pC[/*numPhases=*/3] = { 0.0, 0.0, 0.0 };
+                        const MaterialLawParams& matParams = simulator.problem().materialLawParams(cellIdx);
+                        MaterialLaw::capillaryPressures(pC, matParams, fluidState);
+                        double pg = oilPressure[cellIdx] + (pC[FluidSystem::gasPhaseIdx] - pC[FluidSystem::oilPhaseIdx]);
+
+                        cellPv[BlackoilIndices::compositionSwitchIdx] = rv[cellIdx];
+                        cellPv[BlackoilIndices::pressureSwitchIdx] = pg;
+                        cellPv.setPrimaryVarsMeaning( PrimaryVariables::Sw_pg_Rv );
+                    }
+                    else
+                    {
+                        assert( reservoirState.hydroCarbonState()[cellIdx] == HydroCarbonState::GasAndOil);
+                        cellPv[BlackoilIndices::compositionSwitchIdx] = saturations[cellIdx*numPhases + pu.phase_pos[Gas]];
+                        cellPv[BlackoilIndices::pressureSwitchIdx] = oilPressure[ cellIdx ];
+                        cellPv.setPrimaryVarsMeaning( PrimaryVariables::Sw_po_Sg );
+                    }
+                } else {
+                    // for oil-water case oil pressure should be used as primary variable
                     cellPv[BlackoilIndices::pressureSwitchIdx] = oilPressure[cellIdx];
-                    cellPv.setPrimaryVarsMeaning( PrimaryVariables::Sw_po_Rs );
-                }
-                else if( reservoirState.hydroCarbonState()[cellIdx] == HydroCarbonState::GasOnly && has_vapoil_ )
-                {
-                    // this case (-> gas only with vaporized oil in the gas) is
-                    // relatively expensive as it requires to compute the capillary
-                    // pressure in order to get the gas phase pressure. (the reason why
-                    // ebos uses the gas pressure here is that it makes the common case
-                    // of the primary variable switching code fast because to determine
-                    // whether the oil phase appears one needs to compute the Rv value
-                    // for the saturated gas phase and if this is not available as a
-                    // primary variable, it needs to be computed.) luckily for here, the
-                    // gas-only case is not too common, so the performance impact of this
-                    // is limited.
-                    typedef Opm::SimpleModularFluidState<double,
-                                                         /*numPhases=*/3,
-                                                         /*numComponents=*/3,
-                                                         FluidSystem,
-                                                         /*storePressure=*/false,
-                                                         /*storeTemperature=*/false,
-                                                         /*storeComposition=*/false,
-                                                         /*storeFugacity=*/false,
-                                                         /*storeSaturation=*/true,
-                                                         /*storeDensity=*/false,
-                                                         /*storeViscosity=*/false,
-                                                         /*storeEnthalpy=*/false> SatOnlyFluidState;
-                    SatOnlyFluidState fluidState;
-                    fluidState.setSaturation(FluidSystem::waterPhaseIdx, saturations[cellIdx*numPhases + pu.phase_pos[Water]]);
-                    fluidState.setSaturation(FluidSystem::oilPhaseIdx, saturations[cellIdx*numPhases + pu.phase_pos[Oil]]);
-                    fluidState.setSaturation(FluidSystem::gasPhaseIdx, saturations[cellIdx*numPhases + pu.phase_pos[Gas]]);
-
-                    double pC[/*numPhases=*/3] = { 0.0, 0.0, 0.0 };
-                    const MaterialLawParams& matParams = simulator.problem().materialLawParams(cellIdx);
-                    MaterialLaw::capillaryPressures(pC, matParams, fluidState);
-                    double pg = oilPressure[cellIdx] + (pC[FluidSystem::gasPhaseIdx] - pC[FluidSystem::oilPhaseIdx]);
-
-                    cellPv[BlackoilIndices::compositionSwitchIdx] = rv[cellIdx];
-                    cellPv[BlackoilIndices::pressureSwitchIdx] = pg;
-                    cellPv.setPrimaryVarsMeaning( PrimaryVariables::Sw_pg_Rv );
-                }
-                else
-                {
-                    assert( reservoirState.hydroCarbonState()[cellIdx] == HydroCarbonState::GasAndOil);
-                    cellPv[BlackoilIndices::compositionSwitchIdx] = saturations[cellIdx*numPhases + pu.phase_pos[Gas]];
-                    cellPv[BlackoilIndices::pressureSwitchIdx] = oilPressure[ cellIdx ];
-                    cellPv.setPrimaryVarsMeaning( PrimaryVariables::Sw_po_Sg );
                 }
             }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -233,7 +233,7 @@ public:
 
             const Wells* wells = wells_manager.c_wells();
             WellState well_state;
-            well_state.init(wells, state, prev_well_state);
+            well_state.init(wells, state, prev_well_state, props_.phaseUsage());
 
             // give the polymer and surfactant simulators the chance to do their stuff
             handleAdditionalWellInflow(timer, wells_manager, well_state, wells);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.hpp
@@ -254,7 +254,7 @@ namespace Opm
                                   std::unordered_set<std::string>());
 
         const Wells* wells = wellsmanager.c_wells();
-        wellstate.resize(wells, simulatorstate); //Resize for restart step
+        wellstate.resize(wells, simulatorstate, phaseusage ); //Resize for restart step
         auto restarted = Opm::init_from_restart_file(
                                 eclipseState_,
                                 Opm::UgGridHelpers::numCells(grid) );

--- a/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
@@ -115,7 +115,8 @@ namespace Opm
                 }
                     break;
                 }
-                assert(np == 3);
+#warning "HACK: that assert() was probably there for a reason!"
+                //assert(np == 3);
                 double total_rates = 0.0;
                 for (int p = 0; p < np; ++p)  {
                     total_rates += g[p] * wellRates()[np*w + p];

--- a/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
@@ -62,7 +62,7 @@ namespace Opm
         /// to give useful initial values to the bhp(), wellRates()
         /// and perfPhaseRates() fields, depending on controls
         template <class State, class PrevState>
-        void init(const Wells* wells, const State& state, const PrevState& prevState)
+        void init(const Wells* wells, const State& state, const PrevState& prevState, const PhaseUsage& pu)
         {
             // call init on base class
             BaseType :: init(wells, state, prevState);
@@ -115,19 +115,31 @@ namespace Opm
                 }
                     break;
                 }
-#warning "HACK: that assert() was probably there for a reason!"
-                //assert(np == 3);
+
                 double total_rates = 0.0;
                 for (int p = 0; p < np; ++p)  {
                     total_rates += g[p] * wellRates()[np*w + p];
                 }
 
+                const int waterpos = pu.phase_pos[Water];
+                const int gaspos = pu.phase_pos[Gas];
+
+                assert (np == 3 || np == 2 && !pu.phase_used[Gas] );
+                // assumes the gas fractions are stored after water fractions
                 if(std::abs(total_rates) > 0) {
-                    wellSolutions()[nw + w] = g[Water] * wellRates()[np*w + Water] / total_rates; //wells->comp_frac[np*w + Water]; // Water;
-                    wellSolutions()[2*nw + w] = g[Gas] * wellRates()[np*w + Gas] / total_rates ; //wells->comp_frac[np*w + Gas]; //Gas
+                    if( pu.phase_used[Water] ) {
+                        wellSolutions()[nw + w] = g[Water] * wellRates()[np*w + waterpos] / total_rates;
+                    }
+                    if( pu.phase_used[Gas] ) {
+                        wellSolutions()[2*nw + w] = g[Gas] * wellRates()[np*w + gaspos] / total_rates ;
+                    }
                 } else {
-                    wellSolutions()[nw + w] = wells->comp_frac[np*w + Water];
-                    wellSolutions()[2*nw + w] = wells->comp_frac[np*w + Gas];
+                    if( pu.phase_used[Water] ) {
+                        wellSolutions()[nw + w] = wells->comp_frac[np*w + waterpos];
+                    }
+                    if( pu.phase_used[Gas] ) {
+                        wellSolutions()[2*nw + w] = wells->comp_frac[np*w + gaspos];
+                    }
                 }
             }
 
@@ -159,9 +171,9 @@ namespace Opm
         }
 
         template <class State>
-        void resize(const Wells* wells, const State& state) {
+        void resize(const Wells* wells, const State& state, const PhaseUsage& pu ) {
             const WellStateFullyImplicitBlackoilDense dummy_state{}; // Init with an empty previous state only resizes
-            init(wells, state, dummy_state) ;
+            init(wells, state, dummy_state, pu) ;
         }
 
 


### PR DESCRIPTION
this PR adds the capability to run twophase simulations with flow_ebos (so far only the oil-water case has been tested. everything else will likely fail but it shouldn't be too much effort to fix this if there is interest in it.)

@totto82 verified that the results for flow_ebos and flow_legacy (and maybe Eclipse) are identical for the twophase version SPE-1 which is in opm-data and for the Brugge case. Also, model 2 and Norne both are unaffected when it comes to the results and to performance.

Be aware that this PR also requires changes in opm-material and ewoms.