### PR TITLE
Redo existing tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,6 @@ endif (NOT EIGEN3_FOUND)
 
 
 if (HAVE_OPM_DATA)
-    add_test( NAME flow_SPE1CASE2 COMMAND flow_legacy ${OPM_DATA_ROOT}/spe1/SPE1CASE2.DATA )
     add_test( NAME flow_sequential_SPE1 COMMAND flow_sequential ${OPM_DATA_ROOT}/spe1/SPE1CASE1.DATA )
     add_test( NAME flow_MSW2DH__ COMMAND flow_multisegment ${OPM_DATA_ROOT}/wells_test_suite/MSW/2D_H__/2D_H__.DATA)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,6 @@ endif (NOT EIGEN3_FOUND)
 
 
 if (HAVE_OPM_DATA)
-    add_test( NAME flow_sequential_SPE1 COMMAND flow_sequential ${OPM_DATA_ROOT}/spe1/SPE1CASE1.DATA )
     add_test( NAME flow_MSW2DH__ COMMAND flow_multisegment ${OPM_DATA_ROOT}/wells_test_suite/MSW/2D_H__/2D_H__.DATA)
 
     include (${CMAKE_CURRENT_SOURCE_DIR}/compareECLFiles.cmake)

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -58,6 +58,7 @@ endif()
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-regressionTest.sh "")
 
 add_test_compareECLFiles(spe1 SPE1CASE2 flow)
+add_test_compareECLFiles(spe1 SPE1CASE1 flow_sequential)
 add_test_compareECLFiles(spe3 SPE3CASE1 flow)
 add_test_compareECLFiles(spe9 SPE9_CP_SHORT flow)
 

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -12,12 +12,12 @@ set(BASE_RESULT_PATH ${PROJECT_BINARY_DIR}/tests/results)
 # Input:
 #   - casename: basename (no extension)
 #
-macro (add_test_compareECLFiles casename filename)
+macro (add_test_compareECLFiles casename filename simulator)
 
-  set(RESULT_PATH ${BASE_RESULT_PATH}/${casename})
+  set(RESULT_PATH ${BASE_RESULT_PATH}/${casename}+${simulator})
   # Add test that runs flow and outputs the results to file
-  opm_add_test(compareECLFiles_${filename} NO_COMPILE
-               EXE_NAME flow
+  opm_add_test(compareECLFiles_${simulator}+${filename} NO_COMPILE
+               EXE_NAME ${simulator}
                DRIVER_ARGS ${OPM_DATA_ROOT}/${casename} ${RESULT_PATH}
                            ${CMAKE_BINARY_DIR}/bin
                            ${filename}
@@ -34,12 +34,12 @@ endmacro (add_test_compareECLFiles)
 # Input:
 #   - casename: basename (no extension)
 #
-macro (add_test_compareECLRestartFiles casename filename)
+macro (add_test_compareECLRestartFiles casename filename simulator)
 
   set(RESULT_PATH ${BASE_RESULT_PATH}/restart/${casename})
   # Add test that runs flow and outputs the results to file
-  opm_add_test(compareECLRestartFiles_${filename} NO_COMPILE
-               EXE_NAME flow
+  opm_add_test(compareECLRestartFiles_${simulator}+${filename} NO_COMPILE
+               EXE_NAME ${simulator}
                DRIVER_ARGS ${OPM_DATA_ROOT}/${casename} ${RESULT_PATH}
                            ${CMAKE_BINARY_DIR}/bin
                            ${filename}
@@ -54,14 +54,15 @@ if(NOT TARGET test-suite)
   add_custom_target(test-suite)
 endif()
 
+# Regression tests
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-regressionTest.sh "")
 
-add_test_compareECLFiles(spe1 SPE1CASE2)
-add_test_compareECLFiles(spe3 SPE3CASE1)
-add_test_compareECLFiles(spe9 SPE9_CP_SHORT)
+add_test_compareECLFiles(spe1 SPE1CASE2 flow)
+add_test_compareECLFiles(spe3 SPE3CASE1 flow)
+add_test_compareECLFiles(spe9 SPE9_CP_SHORT flow)
 
 # Restart tests
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-restart-regressionTest.sh "")
 
-add_test_compareECLRestartFiles(spe9 SPE9_CP_SHORT)
-add_test_compareECLRestartFiles(spe1 SPE1CASE2_ACTNUM)
+add_test_compareECLRestartFiles(spe1 SPE1CASE2_ACTNUM flow)
+add_test_compareECLRestartFiles(spe9 SPE9_CP_SHORT flow)


### PR DESCRIPTION
- add ability to test simulators other than 'flow'
- remove old SPE1CASE2 test that only executed and did no comparison
- move the SPE1CASE1 flow_sequential test to an actual regression test

data update: https://github.com/OPM/opm-data/pull/142

please process ASAP to avoid duplicated work