### PR TITLE
extend and clean up the SimulatorReport

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -37,6 +37,7 @@
 #include <opm/autodiff/DefaultBlackoilSolutionState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/core/simulator/SimulatorTimerInterface.hpp>
+#include <opm/core/simulator/SimulatorReport.hpp>
 
 #include <array>
 
@@ -175,7 +176,7 @@ namespace Opm {
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         template <class NonlinearSolverType>
-        IterationReport nonlinearIteration(const int iteration,
+        SimulatorReport nonlinearIteration(const int iteration,
                                            const SimulatorTimerInterface& timer,
                                            NonlinearSolverType& nonlinear_solver,
                                            ReservoirState& reservoir_state,
@@ -194,8 +195,7 @@ namespace Opm {
         /// \param[in]      reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         /// \param[in]      initial_assembly  pass true if this is the first call to assemble() in this timestep
-        /// \return well iterations.
-        IterationReport
+        SimulatorReport
         assemble(const ReservoirState& reservoir_state,
                  WellState& well_state,
                  const bool initial_assembly);
@@ -396,7 +396,7 @@ namespace Opm {
         assembleMassBalanceEq(const SolutionState& state);
 
 
-        IterationReport
+        SimulatorReport
         solveWellEq(const std::vector<ADB>& mob_perfcells,
                     const std::vector<ADB>& b_perfcells,
                     const ReservoirState& reservoir_state,

--- a/opm/autodiff/BlackoilMultiSegmentModel.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel.hpp
@@ -106,7 +106,7 @@ namespace Opm {
         /// \param[in]      reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         /// \param[in]      initial_assembly  pass true if this is the first call to assemble() in this timestep
-        IterationReport
+        SimulatorReport
         assemble(const ReservoirState& reservoir_state,
                  WellState& well_state,
                  const bool initial_assembly);
@@ -166,7 +166,7 @@ namespace Opm {
 
         const MultisegmentWells::MultisegmentWellOps& msWellOps() const { return well_model_.wellOps(); }
 
-        IterationReport
+        SimulatorReport
         solveWellEq(const std::vector<ADB>& mob_perfcells,
                     const std::vector<ADB>& b_perfcells,
                     const ReservoirState& reservoir_state,

--- a/opm/autodiff/BlackoilPressureModel.hpp
+++ b/opm/autodiff/BlackoilPressureModel.hpp
@@ -149,13 +149,14 @@ namespace Opm {
 
 
 
-        IterationReport
+        SimulatorReport
         assemble(const ReservoirState& reservoir_state,
                  WellState& well_state,
                  const bool initial_assembly)
         {
-            IterationReport iter_report = Base::assemble(reservoir_state, well_state, initial_assembly);
+            SimulatorReport report;
 
+            report += Base::assemble(reservoir_state, well_state, initial_assembly);
             if (initial_assembly) {
             }
 
@@ -186,7 +187,8 @@ namespace Opm {
                 assert(int(well_state.perfRates().size()) == wflux.size());
                 std::copy_n(wflux.data(), wflux.size(), well_state.perfRates().begin());
             }
-            return iter_report;
+
+            return report;
         }
 
 

--- a/opm/autodiff/BlackoilTransportModel.hpp
+++ b/opm/autodiff/BlackoilTransportModel.hpp
@@ -83,13 +83,14 @@ namespace Opm {
             asImpl().makeConstantState(state0_);
         }
 
-        IterationReport
+        SimulatorReport
         assemble(const ReservoirState& reservoir_state,
                  WellState& well_state,
                  const bool initial_assembly)
         {
-
             using namespace Opm::AutoDiffGrid;
+
+            SimulatorReport report;
 
             // If we have VFP tables, we need the well connection
             // pressures for the "simple" hydrostatic correction
@@ -125,9 +126,8 @@ namespace Opm {
             asImpl().assembleMassBalanceEq(state);
 
             // -------- Well equations ----------
-            IterationReport iter_report = {false, false, 0, 0};
             if ( ! wellsActive() ) {
-                return iter_report;
+                return report;
             }
 
             std::vector<ADB> mob_perfcells;
@@ -135,7 +135,7 @@ namespace Opm {
             asImpl().wellModel().extractWellPerfProperties(state, sd_.rq, mob_perfcells, b_perfcells);
             if (param_.solve_welleq_initially_ && initial_assembly) {
                 // solve the well equations as a pre-processing step
-                iter_report = asImpl().solveWellEq(mob_perfcells, b_perfcells, reservoir_state, state, well_state);
+                report += asImpl().solveWellEq(mob_perfcells, b_perfcells, reservoir_state, state, well_state);
             }
             V aliveWells;
             std::vector<ADB> cq_s;
@@ -154,7 +154,8 @@ namespace Opm {
                 asImpl().makeConstantState(state0);
                 asImpl().wellModel().computeWellPotentials(mob_perfcells, b_perfcells, state0, well_state);
             }
-            return iter_report;
+
+            return report;
         }
 
 

--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -22,6 +22,7 @@
 #define OPM_NONLINEARSOLVER_HEADER_INCLUDED
 
 #include <opm/autodiff/AutoDiffBlock.hpp>
+#include <opm/core/simulator/SimulatorReport.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/core/simulator/SimulatorTimerInterface.hpp>
 #include <opm/autodiff/DuneMatrix.hpp>
@@ -87,8 +88,7 @@ namespace Opm {
         /// \param[in] timer                  simulation timer
         /// \param[in, out] reservoir_state     reservoir state variables
         /// \param[in, out] well_state          well state variables
-        /// \return                             number of linear iterations used
-        int
+        SimulatorReport
         step(const SimulatorTimerInterface& timer,
              ReservoirState& reservoir_state,
              WellState& well_state);
@@ -103,7 +103,7 @@ namespace Opm {
         /// \param[in, out] reservoir_state     reservoir state variables
         /// \param[in, out] well_state          well state variables
         /// \return                             number of linear iterations used
-        int
+        SimulatorReport
         step(const SimulatorTimerInterface& timer,
              const ReservoirState& initial_reservoir_state,
              const WellState& initial_well_state,
@@ -178,7 +178,7 @@ namespace Opm {
         double relaxRelTol() const       { return param_.relax_rel_tol_; }
 
         /// The maximum number of nonlinear iterations allowed.
-        double maxIter() const           { return param_.max_iter_; }
+        int maxIter() const           { return param_.max_iter_; }
 
         /// The minimum number of nonlinear iterations allowed.
         double minIter() const           { return param_.min_iter_; }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -161,7 +161,6 @@ public:
 
         // Create timers and file for writing timing info.
         Opm::time::StopWatch solver_timer;
-        double stime = 0.0;
         Opm::time::StopWatch step_timer;
         Opm::time::StopWatch total_timer;
         total_timer.start();
@@ -188,12 +187,11 @@ public:
             //                                    desiredRestoreStep );
         }
 
-        unsigned int totalLinearizations = 0;
-        unsigned int totalNonlinearIterations = 0;
-        unsigned int totalLinearIterations = 0;
         bool is_well_potentials_computed = param_.getDefault("compute_well_potentials", false );
         std::vector<double> well_potentials;
         DynamicListEconLimited dynamic_list_econ_limited;
+        SimulatorReport report;
+        SimulatorReport stepReport;
 
         bool ooip_computed = false;
         std::vector<int> fipnum_global = eclState().get3DProperties().getIntGridProperty("FIPNUM").getData();
@@ -253,22 +251,25 @@ public:
 
             // write the inital state at the report stage
             if (timer.initialStep()) {
+                Dune::Timer perfTimer;
+                perfTimer.start();
 
-                // calculate Intensive Quantities
+                // make sure that the Intensive Quantities cache is up to date
                 const auto& gridManager = ebosSimulator_.gridManager();
                 const auto& gridView = gridManager.gridView();
                 auto elemIt = gridView.template begin<0>();
                 auto elemEndIt = gridView.template end<0>();
                 ElementContext elemCtx(ebosSimulator_);
                 for (; elemIt != elemEndIt; ++ elemIt) {
-                    // this is convenient, but slightly inefficient: one only needs to update
-                    // the primary intensive quantities
-                    elemCtx.updateAll(*elemIt);
+                    elemCtx.updatePrimaryStencil(*elemIt);
+                    elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
                 }
 
                 // No per cell data is written for initial step, but will be
                 // for subsequent steps, when we have started simulating
                 output_writer_.writeTimeStepWithoutCellProperties( timer, state, well_state );
+
+                report.output_write_time += perfTimer.stop();
             }
 
             // Compute orignal FIP;
@@ -283,11 +284,12 @@ public:
                 std::ostringstream step_msg;
                 boost::posix_time::time_facet* facet = new boost::posix_time::time_facet("%d-%b-%Y");
                 step_msg.imbue(std::locale(std::locale::classic(), facet));
-                step_msg << "\nTime step " << std::setw(4) <<timer.currentStepNum()
+                step_msg << "\n"
+                         << "Time step " << std::setw(4) <<timer.currentStepNum()
                          << " at day " << (double)unit::convert::to(timer.simulationTimeElapsed(), unit::day)
                          << "/" << (double)unit::convert::to(timer.totalTime(), unit::day)
                          << ", date = " << timer.currentDateTime()
-                         << "\n";
+                         << ", size = " << (double)unit::convert::to(timer.currentStepLength(), unit::day) << " days";
                 OpmLog::info(step_msg.str());
             }
 
@@ -299,14 +301,16 @@ public:
             // \Note: The report steps are met in any case
             // \Note: The sub stepping will require a copy of the state variables
             if( adaptiveTimeStepping ) {
-                adaptiveTimeStepping->step( timer, *solver, state, well_state, output_writer_ );
+                report += adaptiveTimeStepping->step( timer, *solver, state, well_state, output_writer_ );
             }
             else {
                 // solve for complete report step
-                solver->step(timer, state, well_state);
+                stepReport = solver->step(timer, state, well_state);
+                report += stepReport;
 
                 if( terminal_output_ )
                 {
+                    //stepReport.briefReport();
                     std::ostringstream iter_msg;
                     iter_msg << "Stepsize " << (double)unit::convert::to(timer.currentStepLength(), unit::day);
                     if (solver->wellIterations() != 0) {
@@ -324,13 +328,8 @@ public:
             // take time that was used to solve system for this reportStep
             solver_timer.stop();
 
-            // accumulate the number of nonlinear and linear Iterations
-            totalLinearizations += solver->linearizations();
-            totalNonlinearIterations += solver->nonlinearIterations();
-            totalLinearIterations += solver->linearIterations();
-
-            // Report timing.
-            const double st = solver_timer.secsSinceStart();
+            // update timing.
+            report.solver_time += solver_timer.secsSinceStart();
 
             // Compute current FIP.
             std::vector<std::vector<double>> COIP;
@@ -345,30 +344,22 @@ public:
                 for (size_t reg = 0; reg < OOIP.size(); ++reg) {
                     outputFluidInPlace(OOIP[reg], COIP[reg], eclState().getUnits(), reg+1);
                 }
-            }
 
-            // accumulate total time
-            stime += st;
-
-            if ( terminal_output_ )
-            {
                 std::string msg;
-                msg = "Fully implicit solver took: " + std::to_string(st) + " seconds. Total solver time taken: " + std::to_string(stime) + " seconds.";
+                msg =
+                    "Time step took " + std::to_string(stepReport.solver_time) + " seconds; "
+                    "total solver time " + std::to_string(report.solver_time) + " seconds.";
                 OpmLog::note(msg);
-            }
-
-            if ( output_writer_.output() ) {
-                SimulatorReport step_report;
-                step_report.pressure_time = st;
-                step_report.total_time =  step_timer.secsSinceStart();
-                step_report.reportParam(tstep_os);
             }
 
             // Increment timer, remember well state.
             ++timer;
 
             // write simulation state at the report stage
+            Dune::Timer perfTimer;
+            perfTimer.start();
             output_writer_.writeTimeStep( timer, state, well_state, solver->model() );
+            report.output_write_time += perfTimer.stop();
 
             prev_well_state = well_state;
             // The well potentials are only computed if they are needed
@@ -383,13 +374,8 @@ public:
 
         // Stop timer and create timing report
         total_timer.stop();
-        SimulatorReport report;
-        report.pressure_time = stime;
-        report.transport_time = 0.0;
         report.total_time = total_timer.secsSinceStart();
-        report.total_linearizations = totalLinearizations;
-        report.total_newton_iterations = totalNonlinearIterations;
-        report.total_linear_iterations = totalLinearIterations;
+        report.converged = true;
         return report;
     }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -179,7 +179,7 @@ namespace Opm
             stime += st;
             if ( output_writer_.output() ) {
                 SimulatorReport step_report;
-                step_report.pressure_time = st;
+                step_report.solver_time = st;
                 step_report.total_time =  step_timer.secsSinceStart();
                 step_report.reportParam(tstep_os);
             }
@@ -198,9 +198,8 @@ namespace Opm
         // Stop timer and create timing report
         total_timer.stop();
         SimulatorReport report;
-        report.pressure_time = stime;
-        report.transport_time = 0.0;
         report.total_time = total_timer.secsSinceStart();
+        report.solver_time = stime;
         report.total_newton_iterations = totalNonlinearIterations;
         report.total_linear_iterations = totalLinearIterations;
         return report;

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -160,14 +160,14 @@ namespace Opm {
 
 
             template <typename Simulator>
-            IterationReport assemble(Simulator& ebosSimulator,
+            SimulatorReport assemble(Simulator& ebosSimulator,
                                      const int iterationIdx,
                                      const double dt,
                                      WellState& well_state) {
 
-                IterationReport iter_report = {false, false, 0, 0};
+                SimulatorReport report;
                 if ( ! localWellsActive() ) {
-                    return iter_report;
+                    return report;
                 }
 
                 resetWellControlFromState(well_state);
@@ -182,7 +182,7 @@ namespace Opm {
 
                 if (param_.solve_welleq_initially_ && iterationIdx == 0) {
                     // solve the well equations as a pre-processing step
-                    iter_report = solveWellEq(ebosSimulator, dt, well_state);
+                    report = solveWellEq(ebosSimulator, dt, well_state);
                 }
                 assembleWellEq(ebosSimulator, dt, well_state, false);
 
@@ -190,7 +190,8 @@ namespace Opm {
                 if (param_.compute_well_potentials_) {
                     //wellModel().computeWellPotentials(mob_perfcells, b_perfcells, state0, well_state);
                 }
-                return iter_report;
+                report.converged = true;
+                return report;
             }
 
             template <typename Simulator>
@@ -637,9 +638,8 @@ namespace Opm {
                 }
             }
 
-
             template <typename Simulator>
-            IterationReport solveWellEq(Simulator& ebosSimulator,
+            SimulatorReport solveWellEq(Simulator& ebosSimulator,
                                         const double dt,
                                         WellState& well_state)
             {
@@ -672,9 +672,10 @@ namespace Opm {
                     well_state = well_state0;
                 }
 
-                const bool failed = false; // Not needed in this method.
-                const int linear_iters = 0; // Not needed in this method
-                return IterationReport{failed, converged, linear_iters, it};
+                SimulatorReport report;
+                report.converged = converged;
+                report.total_well_iterations = it;
+                return report;
             }
 
             void printIf(int c, double x, double y, double eps, std::string type) {
@@ -1114,9 +1115,9 @@ namespace Opm {
                         // We disregard terminal_ouput here as with it only messages
                         // for wells on one process will be printed.
                         std::ostringstream ss;
-                        ss << "Switching control mode for well " << wells().name[w]
-                              << " from " << modestring[well_controls_iget_type(wc, current)]
-                              << " to " << modestring[well_controls_iget_type(wc, ctrl_index)] << std::endl;
+                        ss << "    Switching control mode for well " << wells().name[w]
+                           << " from " << modestring[well_controls_iget_type(wc, current)]
+                           << " to " << modestring[well_controls_iget_type(wc, ctrl_index)];
                         OpmLog::info(ss.str());
                         xw.currentControls()[w] = ctrl_index;
                         current = xw.currentControls()[w];

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -121,7 +121,7 @@ namespace Opm {
         /// \param[in]      reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         /// \param[in]      initial_assembly  pass true if this is the first call to assemble() in this timestep
-        IterationReport 
+        SimulatorReport
         assemble(const ReservoirState& reservoir_state,
                  WellState& well_state,
                  const bool initial_assembly);

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -494,12 +494,14 @@ namespace Opm {
 
 
     template <class Grid>
-    IterationReport
+    SimulatorReport
     BlackoilPolymerModel<Grid>::assemble(const ReservoirState& reservoir_state,
                                          WellState& well_state,
                                          const bool initial_assembly)
     {
         using namespace Opm::AutoDiffGrid;
+
+        SimulatorReport report;
 
         // Possibly switch well controls and updating well state to
         // get reasonable initial conditions for the wells
@@ -531,10 +533,9 @@ namespace Opm {
 
         // -------- Mass balance equations --------
         assembleMassBalanceEq(state);
-        IterationReport iter_report = {false, false, 0, 0};
         // -------- Well equations ----------
         if ( ! wellsActive() ) {
-            return iter_report;
+            return report;
         }
 
         std::vector<ADB> mob_perfcells;
@@ -572,7 +573,9 @@ namespace Opm {
         wellModel().addWellFluxEq(cq_s, state, residual_);
         addWellContributionToMassBalanceEq(cq_s, state, well_state);
         wellModel().addWellControlEq(state, well_state, aliveWells, residual_);
-        return iter_report;
+
+        report.converged = true;
+        return report;
     }
 
 

--- a/opm/simulators/WellSwitchingLogger.cpp
+++ b/opm/simulators/WellSwitchingLogger.cpp
@@ -137,7 +137,7 @@ void WellSwitchingLogger::logSwitch(const char* name, std::array<char,2> fromto,
                                     int rank)
 {
             std::ostringstream ss;
-            ss << "Switching control mode for well " << name
+            ss << "    Switching control mode for well " << name
                << " from " << modestring[WellControlType(fromto[0])]
                << " to " <<  modestring[WellControlType(fromto[1])]
                << " on rank " << rank << std::endl;

--- a/opm/simulators/WellSwitchingLogger.hpp
+++ b/opm/simulators/WellSwitchingLogger.hpp
@@ -74,7 +74,7 @@ public:
         else
         {
             std::ostringstream ss;
-            ss << "Switching control mode for well " << name
+            ss << "    Switching control mode for well " << name
                << " from " << modestring[from]
                << " to " <<  modestring[to] << std::endl;
             OpmLog::info(ss.str());


### PR DESCRIPTION
this is the compagnion PR to OPM/opm-core#1112. I've made sure that everything still compiles and that no additional unit tests fail. I've also checked that `flow_legacy` and `flow_ebos` work as expected for the Norne deck:

```
# tail -n 20 flow_ebos.log flow_legacy.log 
==> flow_ebos.log <==
[...]
Total time taken (seconds):   761.545
Solver time (seconds):        745.516
 Assembly time (seconds):     355.981
 Linear solve time (seconds): 319.673
 Update time time (seconds):  2.69076
 Output write time (seconds): 16.9406
Overall Linearizations:       1964
Overall Newton Iterations:    1621
Overall Linear Iterations:    24638


==> flow_legacy.log <==
[...]
Total time taken (seconds):   1259.69
Solver time (seconds):        1253.5
 Assembly time (seconds):     701.505
 Linear solve time (seconds): 352.299
 Update time time (seconds):  35.5654
 Output write time (seconds): 1.1171
Overall Linearizations:       1973
Overall Newton Iterations:    1610
Overall Linear Iterations:    25265
```

these results indicate that the linearization in `flow_ebos` is about twice as fast as that of `flow_legacy` and that the linear solver is approximately the same once the results have been adjusted for the different number of linar solves.