### PR TITLE
fixed: [WAT|OIL|GAS)KR are ratios and thus dimensionless

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -569,7 +569,7 @@ namespace Opm
                 if (sd.rq[aqua_idx].kr.size() > 0) {
                     rstKeywords["KRW"] = 0;
                     output.insert("WATKR",
-                                  Opm::UnitSystem::measure::permeability,
+                                  Opm::UnitSystem::measure::identity,
                                   adbToDoubleVector(sd.rq[aqua_idx].kr),
                                   data::TargetType::RESTART_AUXILLARY);
                 }
@@ -585,7 +585,7 @@ namespace Opm
                 if (sd.rq[liquid_idx].kr.size() > 0) {
                     rstKeywords["KRO"] = 0;
                     output.insert("OILKR",
-                                  Opm::UnitSystem::measure::permeability,
+                                  Opm::UnitSystem::measure::identity,
                                   adbToDoubleVector(sd.rq[liquid_idx].kr),
                                   data::TargetType::RESTART_AUXILLARY);
                 }
@@ -601,7 +601,7 @@ namespace Opm
                 if (sd.rq[vapour_idx].kr.size() > 0) {
                     rstKeywords["KRG"] = 0;
                     output.insert("GASKR",
-                                  Opm::UnitSystem::measure::permeability,
+                                  Opm::UnitSystem::measure::identity,
                                   adbToDoubleVector(sd.rq[vapour_idx].kr),
                                   data::TargetType::RESTART_AUXILLARY);
                 }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.hpp
@@ -489,21 +489,21 @@ namespace Opm
             if (aqua_active && outKeywords["KRW"] > 0) {
                 outKeywords["KRW"] = 0;
                 output.insert("WATKR",
-                           Opm::UnitSystem::measure::permeability,
+                           Opm::UnitSystem::measure::identity,
                            std::move(krWater),
                            data::TargetType::RESTART_AUXILLARY);
             }
             if (liquid_active && outKeywords["KRO"] > 0) {
                 outKeywords["KRO"] = 0;
                 output.insert("OILKR",
-                           Opm::UnitSystem::measure::permeability,
+                           Opm::UnitSystem::measure::identity,
                            std::move(krOil),
                            data::TargetType::RESTART_AUXILLARY);
             }
             if (vapour_active && outKeywords["KRG"] > 0) {
                 outKeywords["KRG"] = 0;
                 output.insert("GASKR",
-                           Opm::UnitSystem::measure::permeability,
+                           Opm::UnitSystem::measure::identity,
                            std::move(krGas),
                            data::TargetType::RESTART_AUXILLARY);
             }


### PR DESCRIPTION
This (or some variant) should take care of https://github.com/OPM/opm-output/issues/145