### PR TITLE
fixed: do not deref empty well vector

### DIFF
--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -211,10 +211,12 @@ namespace Opm {
         V aliveWells;
         std::vector<ADB> cq_s;
         wellModel().computeWellFlux(state, mob_perfcells, b_perfcells, aliveWells, cq_s);
-        wellModel().updatePerfPhaseRatesAndPressures(cq_s, state, well_state);
-        wellModel().addWellFluxEq(cq_s, state, residual_);
-        asImpl().addWellContributionToMassBalanceEq(cq_s, state, well_state);
-        wellModel().addWellControlEq(state, well_state, aliveWells, residual_);
+        if (!cq_s.empty()) {
+            wellModel().updatePerfPhaseRatesAndPressures(cq_s, state, well_state);
+            wellModel().addWellFluxEq(cq_s, state, residual_);
+            asImpl().addWellContributionToMassBalanceEq(cq_s, state, well_state);
+            wellModel().addWellControlEq(state, well_state, aliveWells, residual_);
+        }
         return iter_report;
     }
 


### PR DESCRIPTION
we may end up with no local wells in parallel runs. i think this is an acceptable fix.

easy to reproduce, a parallel run on MSW_2D_H__ test case with 2 processes (for instance) will expose the problem.