### PR TITLE
StandardWellsDense: fix two assertations

### DIFF
--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -135,7 +135,7 @@ enum WellVariablePositions {
 
                 // assumes the gas fractions are stored after water fractions
                 // WellVariablePositions needs to be changed for 2p runs
-                assert (np == 3 || np == 2 && !pu.phase_used[Gas] );
+                assert (np == 3 || (np == 2 && !pu.phase_used[Gas]) );
 #endif
 
                 // set invDuneD

--- a/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
@@ -124,7 +124,7 @@ namespace Opm
                 const int waterpos = pu.phase_pos[Water];
                 const int gaspos = pu.phase_pos[Gas];
 
-                assert (np == 3 || np == 2 && !pu.phase_used[Gas] );
+                assert(np == 3 || (np == 2 && !pu.phase_used[Gas]));
                 // assumes the gas fractions are stored after water fractions
                 if(std::abs(total_rates) > 0) {
                     if( pu.phase_used[Water] ) {


### PR DESCRIPTION
the compiler suggested braces around the conditions, and by look of
it, it was right: these asserts most likely want express that only the
threephase case or the twophase case without gas are handled...

I stumbled over this while doing #957.