### PR TITLE
flow*: reset the locale settings on startup

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -82,6 +82,7 @@
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
+#include <opm/common/ResetLocale.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
@@ -133,6 +134,10 @@ namespace Opm
         /// flow.cpp.
         int execute(int argc, char** argv)
         try {
+            // we always want to use the default locale, and thus spare us the trouble
+            // with incorrect locale settings.
+            resetLocale();
+
             // Setup.
             asImpl().setupParallelism(argc, argv);
             asImpl().printStartupMessage();

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -39,6 +39,7 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/EclipsePRTLog.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/ResetLocale.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
@@ -74,6 +75,10 @@ namespace Opm
         int execute(int argc, char** argv)
         {
             try {
+                // we always want to use the default locale, and thus spare us the trouble
+                // with incorrect locale settings.
+                resetLocale();
+
                 setupParallelism(argc, argv);
                 printStartupMessage();
                 const bool ok = setupParameters(argc, argv);


### PR DESCRIPTION
this makes use of the `resetLocale()` function introduced by OPM/opm-common#221.