### PR TITLE
fixing the calculation when polymer not fully mixed

### DIFF
--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel.hpp
@@ -228,6 +228,10 @@ namespace Opm {
                      const int            aix  );
 
         void
+        computeInjectionMobility(const SolutionState& state,
+                                 std::vector<ADB>& mob_perfcells);
+
+        void
         assembleMassBalanceEq(const SolutionState& state);
 
         void

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -539,7 +539,8 @@ namespace Opm {
         std::vector<ADB> mob_perfcells;
         std::vector<ADB> b_perfcells;
         wellModel().extractWellPerfProperties(state, sd_.rq, mob_perfcells, b_perfcells);
-        // get the concentration of the well cells
+
+        // Calculating the mobility for the polymer injection peforations
         if (has_polymer_ && wellModel().localWellsActive()) {
             const std::vector<int> well_cells = wellModel().wellOps().well_cells;
             const int nperf = well_cells.size();

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -463,14 +463,13 @@ namespace Opm {
             if (has_polymer_) {
                 const ADB tr_mult = transMult(state.pressure);
                 const ADB cmax = ADB::constant(cmax_, state.concentration.blockPattern());
-                const ADB mc = computeMc(state);
                 const ADB krw_eff = polymer_props_ad_.effectiveRelPerm(state.concentration, cmax, kr);
                 const ADB inv_wat_eff_visc = polymer_props_ad_.effectiveInvWaterVisc(state.concentration, mu.value());
                 // Reduce mobility of water phase by relperm reduction and effective viscosity increase.
                 sd_.rq[actph].mob = tr_mult * krw_eff * inv_wat_eff_visc;
                 // Compute polymer mobility.
                 const ADB inv_poly_eff_visc = polymer_props_ad_.effectiveInvPolymerVisc(state.concentration, mu.value());
-                sd_.rq[poly_pos_].mob = tr_mult * mc * krw_eff * inv_poly_eff_visc;
+                sd_.rq[poly_pos_].mob = tr_mult * krw_eff * state.concentration * inv_poly_eff_visc;
                 sd_.rq[poly_pos_].b = sd_.rq[actph].b;
                 sd_.rq[poly_pos_].dh = sd_.rq[actph].dh;
                 UpwindSelector<double> upwind(grid_, ops_, sd_.rq[poly_pos_].dh.value());
@@ -622,7 +621,6 @@ namespace Opm {
         UpwindSelector<double> upwind(grid_, ops_, dh.value());
 
         const ADB cmax = ADB::constant(cmax_, state.concentration.blockPattern());
-        const ADB mc = computeMc(state);
         ADB krw_eff = polymer_props_ad_.effectiveRelPerm(state.concentration,
                                                          cmax,
                                                          sd_.rq[phase].kr);

--- a/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
+++ b/opm/polymer/fullyimplicit/BlackoilPolymerModel_impl.hpp
@@ -565,9 +565,9 @@ namespace Opm {
             V shear_mult_wells_v = Eigen::Map<V>(shear_mult_wells_.data(), shear_mult_wells_.size());
             ADB shear_mult_wells_adb = ADB::constant(shear_mult_wells_v);
             mob_perfcells[water_pos] = mob_perfcells[water_pos] / shear_mult_wells_adb;
+            wellModel().computeWellFlux(state, mob_perfcells, b_perfcells, aliveWells, cq_s);
         }
 
-        wellModel().computeWellFlux(state, mob_perfcells, b_perfcells, aliveWells, cq_s);
         wellModel().updatePerfPhaseRatesAndPressures(cq_s, state, well_state);
         wellModel().addWellFluxEq(cq_s, state, residual_);
         addWellContributionToMassBalanceEq(cq_s, state, well_state);

--- a/opm/polymer/fullyimplicit/PolymerPropsAd.hpp
+++ b/opm/polymer/fullyimplicit/PolymerPropsAd.hpp
@@ -74,6 +74,9 @@ namespace Opm {
         /// \param[in] c        Array of n polymer concentraion values.
         /// \return             Array of n viscosity multiplier from PLVISC table.
 
+
+        ADB viscMult(const ADB& c) const;
+
         /// Constructor wrapping a polymer props.
         PolymerPropsAd(const PolymerProperties& polymer_props);
 


### PR DESCRIPTION
We corrected a bug in the polymer convection term and changed the formulation calculating the injection mobility (assuming polymer fully mixed in wellbore.)

The change basically only affects the results with non-fully mixed polymer. Good agreements are achieved for all the test examples we have and it is not well tested with shear calculation with non-fully mixed polymer (`omega != 1`, we include a suggestion in the PR, while not having an example to verify the suggestion.).