### PR TITLE
StandardWellsDense: fix assert for the 2p case

### DIFF
--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -264,7 +264,7 @@ enum WellVariablePositions {
 
                             // add trivial equation for 2p cases (Only support water + oil)
                             if (np == 2) {
-                                assert((*active_)[ Gas ]);
+                                assert(!(*active_)[ Gas ]);
                                 invDuneD_[w][w][flowPhaseToEbosCompIdx(Gas)][flowToEbosPvIdx(Gas)] = 1.0;
                             }
 


### PR DESCRIPTION
this wasn't noticed earlier because it only bites in the water-oil
case and only if NDEBUG is not defined.