### PR TITLE
Use templates to avoid hardcoded typedef

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -126,8 +126,9 @@ namespace Opm {
         typedef typename GET_PROP_TYPE(TypeTag, MaterialLawParams) MaterialLawParams;
 
         typedef double Scalar;
-        typedef Dune::FieldVector<Scalar, 3    >        VectorBlockType;
-        typedef Dune::FieldMatrix<Scalar, 3, 3 >        MatrixBlockType;
+        static const int blocksize = 3;
+        typedef Dune::FieldVector<Scalar, blocksize    >        VectorBlockType;
+        typedef Dune::FieldMatrix<Scalar, blocksize, blocksize >        MatrixBlockType;
         typedef Dune::BCRSMatrix <MatrixBlockType>      Mat;
         typedef Dune::BlockVector<VectorBlockType>      BVector;
 

--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -44,10 +44,6 @@ namespace Opm {
         typedef ADB::V V;
         typedef ADB::M M;
 
-        typedef double Scalar;
-        typedef Dune::FieldVector<Scalar, 3    >       VectorBlockType;
-        typedef Dune::BlockVector<VectorBlockType>      BVector;
-
         // Available relaxation scheme types.
         enum RelaxType { DAMPEN, SOR };
 
@@ -163,6 +159,9 @@ namespace Opm {
         /// Apply a stabilization to dx, depending on dxOld and relaxation parameters.
         void stabilizeNonlinearUpdate(V& dx, V& dxOld, const double omega) const;
 
+        /// Apply a stabilization to dx, depending on dxOld and relaxation parameters.
+        /// Implemention for Dune block vectors.
+        template <class BVector>
         void stabilizeNonlinearUpdate(BVector& dx, BVector& dxOld, const double omega) const;
 
         /// The greatest relaxation factor (i.e. smallest factor) allowed.

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -273,6 +273,7 @@ namespace Opm
     }
 
     template <class PhysicalModel>
+    template <class BVector>
     void
     NonlinearSolver<PhysicalModel>::stabilizeNonlinearUpdate(BVector& dx, BVector& dxOld, const double omega) const
     {

--- a/opm/autodiff/VFPHelpers.hpp
+++ b/opm/autodiff/VFPHelpers.hpp
@@ -36,7 +36,6 @@ namespace detail {
 
 
 typedef AutoDiffBlock<double> ADB;
-typedef DenseAd::Evaluation<double, /*size=*/6> EvalWell;
 
 
 /**
@@ -49,6 +48,7 @@ inline double zeroIfNan(const double& value) {
 /**
  * Returns zero if input value is NaN
  */
+template <class EvalWell>
 inline double zeroIfNan(const EvalWell& value) {
     return (std::isnan(value.value())) ? 0.0 : value.value();
 }

--- a/opm/autodiff/VFPInjProperties.cpp
+++ b/opm/autodiff/VFPInjProperties.cpp
@@ -89,38 +89,6 @@ VFPInjProperties::ADB VFPInjProperties::bhp(const std::vector<int>& table_id,
 
 
 
-VFPInjProperties::EvalWell VFPInjProperties::bhp(const int table_id,
-                                                   const EvalWell& aqua,
-                                                   const EvalWell& liquid,
-                                                   const EvalWell& vapour,
-                                                   const double& thp) const {
-
-    //Get the table
-    const VFPInjTable* table = detail::getTable(m_tables, table_id);
-    EvalWell bhp = 0.0;
-
-    //Find interpolation variables
-    EvalWell flo = detail::getFlo(aqua, liquid, vapour, table->getFloType());
-
-    //Compute the BHP for each well independently
-    if (table != nullptr) {
-        //First, find the values to interpolate between
-        //Value of FLO is negative in OPM for producers, but positive in VFP table
-        auto flo_i = detail::findInterpData(flo.value(), table->getFloAxis());
-        auto thp_i = detail::findInterpData( thp, table->getTHPAxis()); // assume constant
-
-        detail::VFPEvaluation bhp_val = detail::interpolate(table->getTable(), flo_i, thp_i);
-
-        bhp = bhp_val.dflo * flo;
-        bhp.setValue(bhp_val.value); // thp is assumed constant i.e.
-    }
-    else {
-        bhp.setValue(-1e100); //Signal that this value has not been calculated properly, due to "missing" table
-    }
-    return bhp;
-}
-
-
 
 VFPInjProperties::ADB VFPInjProperties::bhp(const std::vector<int>& table_id,
         const ADB& aqua,

--- a/opm/autodiff/VFPInjProperties.hpp
+++ b/opm/autodiff/VFPInjProperties.hpp
@@ -25,6 +25,7 @@
 #include <opm/autodiff/AutoDiffBlock.hpp>
 #include <opm/material/densead/Math.hpp>
 #include <opm/material/densead/Evaluation.hpp>
+#include <opm/autodiff/VFPHelpers.hpp>
 
 #include <vector>
 #include <map>
@@ -93,12 +94,53 @@ public:
             const ADB& vapour,
             const ADB& thp) const;
 
-    typedef DenseAd::Evaluation<double, /*size=*/6> EvalWell;
+    /**
+     * Linear interpolation of bhp as a function of the input parameters given as
+     * Evaluation
+     * Each entry corresponds typically to one well.
+     * @param table_id Table number to use. A negative entry (e.g., -1)
+     *                 will indicate that no table is used, and the corresponding
+     *                 BHP will be calculated as a constant -1e100.
+     * @param aqua Water phase
+     * @param liquid Oil phase
+     * @param vapour Gas phase
+     * @param thp Tubing head pressure
+     *
+     * @return The bottom hole pressure, interpolated/extrapolated linearly using
+     * the above parameters from the values in the input table, for each entry in the
+     * input ADB objects.
+     */
+    template <class EvalWell>
     EvalWell bhp(const int table_id,
-            const EvalWell& aqua,
-            const EvalWell& liquid,
-            const EvalWell& vapour,
-            const double& thp) const;
+                 const EvalWell& aqua,
+                 const EvalWell& liquid,
+                 const EvalWell& vapour,
+                 const double& thp) const {
+
+        //Get the table
+        const VFPInjTable* table = detail::getTable(m_tables, table_id);
+        EvalWell bhp = 0.0;
+
+        //Find interpolation variables
+        EvalWell flo = detail::getFlo(aqua, liquid, vapour, table->getFloType());
+
+        //Compute the BHP for each well independently
+        if (table != nullptr) {
+            //First, find the values to interpolate between
+            //Value of FLO is negative in OPM for producers, but positive in VFP table
+            auto flo_i = detail::findInterpData(flo.value(), table->getFloAxis());
+            auto thp_i = detail::findInterpData( thp, table->getTHPAxis()); // assume constant
+
+            detail::VFPEvaluation bhp_val = detail::interpolate(table->getTable(), flo_i, thp_i);
+
+            bhp = bhp_val.dflo * flo;
+            bhp.setValue(bhp_val.value); // thp is assumed constant i.e.
+        }
+        else {
+            bhp.setValue(-1e100); //Signal that this value has not been calculated properly, due to "missing" table
+        }
+        return bhp;
+    }
 
     /**
      * Linear interpolation of bhp as a function of the input parameters

--- a/opm/autodiff/VFPProdProperties.cpp
+++ b/opm/autodiff/VFPProdProperties.cpp
@@ -75,45 +75,6 @@ VFPProdProperties::ADB VFPProdProperties::bhp(const std::vector<int>& table_id,
 }
 
 
-VFPProdProperties::EvalWell VFPProdProperties::bhp(const int table_id,
-                                                   const EvalWell& aqua,
-                                                   const EvalWell& liquid,
-                                                   const EvalWell& vapour,
-                                                   const double& thp,
-                                                   const double& alq) const {
-
-    //Get the table
-    const VFPProdTable* table = detail::getTable(m_tables, table_id);
-    EvalWell bhp = 0.0;
-
-    //Find interpolation variables
-    EvalWell flo = detail::getFlo(aqua, liquid, vapour, table->getFloType());
-    EvalWell wfr = detail::getWFR(aqua, liquid, vapour, table->getWFRType());
-    EvalWell gfr = detail::getGFR(aqua, liquid, vapour, table->getGFRType());
-
-    //Compute the BHP for each well independently
-    if (table != nullptr) {
-        //First, find the values to interpolate between
-        //Value of FLO is negative in OPM for producers, but positive in VFP table
-        auto flo_i = detail::findInterpData(-flo.value(), table->getFloAxis());
-        auto thp_i = detail::findInterpData( thp, table->getTHPAxis()); // assume constant
-        auto wfr_i = detail::findInterpData( wfr.value(), table->getWFRAxis());
-        auto gfr_i = detail::findInterpData( gfr.value(), table->getGFRAxis());
-        auto alq_i = detail::findInterpData( alq, table->getALQAxis()); //assume constant
-
-        detail::VFPEvaluation bhp_val = detail::interpolate(table->getTable(), flo_i, thp_i, wfr_i, gfr_i, alq_i);
-
-        bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (bhp_val.dflo * flo);
-        bhp.setValue(bhp_val.value);
-    }
-    else {
-        bhp.setValue(-1e100); //Signal that this value has not been calculated properly, due to "missing" table
-    }
-    return bhp;
-}
-
-
-
 VFPProdProperties::ADB VFPProdProperties::bhp(const std::vector<int>& table_id,
         const ADB& aqua,
         const ADB& liquid,


### PR DESCRIPTION
Prepare for changing the size of the blocks by using template BVectors and
Evaluation. 

Shouldn't effect the simulators performance or results. 
