### PR TITLE
FlowMainEbos: fix the output of the initial condition

### DIFF
--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -555,12 +555,8 @@ namespace Opm
             {
                 const EclipseGrid& inputGrid = eclState().getInputGrid();
                 eclipse_writer_.reset(new EclipseWriter(eclState(), UgGridHelpers::createEclipseGrid( grid , inputGrid )));
-
-#warning TODO
-#if 0
                 eclipse_writer_->writeInitial(geoprops_->simProps(grid),
                                               geoprops_->nonCartesianConnections());
-#endif
             }
         }
 


### PR DESCRIPTION
I probably did not see this warning when testing f7910af7d70 because I'm currently flooded by deprecation warnings stemming from Eigen. (these warnings are caused because I use Ubuntu 16.04 and an
old version of Eigen is cloned by the build system that is not system installed.)

@totto82: please merge if this fixes #976.