### PR TITLE
Only log messages about failed timesteps on one processes.

### DIFF
--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -150,7 +150,13 @@ namespace Opm
         } while ( (!converged && (iteration <= maxIter())) || (iteration < minIter()));
 
         if (!converged) {
-            OPM_THROW(Opm::NumericalProblem, "Failed to complete a time step within "+std::to_string(maxIter())+" iterations.");
+            if (model_->terminalOutputEnabled()) {
+                OPM_THROW(Opm::NumericalProblem, "Failed to complete a time step within "+std::to_string(maxIter())+" iterations.");
+            }
+            else
+            {
+                OPM_THROW_NOLOG(Opm::NumericalProblem, "Failed to complete a time step within "+std::to_string(maxIter())+" iterations.");
+            }
         }
 
         // Do model-specific post-step actions.


### PR DESCRIPTION
This OPM_THROW was introduced lately and results in all processes
logging the failure. With this commit the message is logged only once.