### PR TITLE
Fixed missing unit conversion for total fluid in place

### DIFF
--- a/opm/autodiff/SimulatorBase.hpp
+++ b/opm/autodiff/SimulatorBase.hpp
@@ -159,6 +159,9 @@ namespace Opm
                     WellState& xw);
 
         void
+        FIPUnitConvert(const UnitSystem& units, V& fip);
+
+        void
         FIPUnitConvert(const UnitSystem& units,
                        std::vector<V>& fip);
         

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -693,6 +693,9 @@ namespace Opm
         else if (units.getType() == UnitSystem::UnitType::UNIT_TYPE_METRIC) {
             fip[6] = unit::convert::to(fip[6], unit::barsa);
         }
+        else {
+            OPM_THROW(std::runtime_error, "Unsupported unit type for fluid in place output.");
+        }
     }
 
 


### PR DESCRIPTION
This (hopefully) fixes the issue with SPE1CASE2, in which the field total fluid in place is reported in the wrong units. 