### PR TITLE
apply SWATINIT after computing the hydrocarbon state

### DIFF
--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -418,7 +418,6 @@ namespace Opm
         // Initialise the reservoir state. Updated fluid props for SWATINIT.
         // Writes to:
         //   state_
-        //   threshold_pressures_
         //   fluidprops_ (if SWATINIT is used)
         void setupState()
         {
@@ -488,16 +487,9 @@ namespace Opm
                                           props, deck(), gravity_[2], *state_);
             }
 
-            // The capillary pressure is scaled in fluidprops_ to match the scaled capillary pressure in props.
-            if (deck().hasKeyword("SWATINIT")) {
-                const int numCells = Opm::UgGridHelpers::numCells(grid);
-                std::vector<int> cells(numCells);
-                for (int c = 0; c < numCells; ++c) { cells[c] = c; }
-                std::vector<double> pc = state_->saturation();
-                props.capPress(numCells, state_->saturation().data(), cells.data(), pc.data(), nullptr);
-                fluidprops_->setSwatInitScaling(state_->saturation(), pc);
-            }
             initHydroCarbonState(*state_, pu, Opm::UgGridHelpers::numCells(grid), deck().hasKeyword("DISGAS"), deck().hasKeyword("VAPOIL"));
+
+            ebosSimulator_->problem().applySwatinit();
         }
 
         // Extract messages from parser.


### PR DESCRIPTION
this moves the application of SWATINIT after the creation of the hydrocarbon state in an attempt to match the values computed by E100.

@totto82: does this make the threshold pressures more similar to E100? if no: are the threshold pressures of E100for Model 2 different depending on whether SWATINIT is present or not?
