### PR TITLE
Removed unused variable / compilation fix Eigen 3.3.1

### DIFF
--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
@@ -697,8 +697,6 @@ namespace {
 
         const ADB& bhp = state.bhp;
 
-        const DataBlock well_s = wops_.w2p * Eigen::Map<const DataBlock>(wells_.comp_frac, nw, np).matrix();
-
         // Extract variables for perforation cell pressures
         // and corresponding perforation well pressures.
         const ADB p_perfcell = subset(state.pressure, well_cells);


### PR DESCRIPTION
Removed well_s, which appears to me to be unused?

The line in question gave me compilation errors with the most recent Eigen release (complaining about operator+= being private, did not dig any further)

