### PR TITLE
BlackoilModelEnums: don't use high-level classes

### DIFF
--- a/opm/autodiff/BlackoilModelEnums.hpp
+++ b/opm/autodiff/BlackoilModelEnums.hpp
@@ -20,16 +20,15 @@
 #ifndef OPM_BLACKOILMODELENUMS_HEADER_INCLUDED
 #define OPM_BLACKOILMODELENUMS_HEADER_INCLUDED
 
-#include <opm/autodiff/BlackoilPropsAdInterface.hpp>
-#include <opm/core/simulator/BlackoilState.hpp>
+#include <opm/core/props/BlackoilPhases.hpp>
 
 namespace Opm
 {
 
-    constexpr const auto Water        = BlackoilPropsAdInterface::Water;
-    constexpr const auto Oil          = BlackoilPropsAdInterface::Oil;
-    constexpr const auto Gas          = BlackoilPropsAdInterface::Gas;
-    constexpr const auto MaxNumPhases = BlackoilPropsAdInterface::MaxNumPhases;
+    constexpr const auto Water        = BlackoilPhases::Aqua;
+    constexpr const auto Oil          = BlackoilPhases::Liquid;
+    constexpr const auto Gas          = BlackoilPhases::Vapour;
+    constexpr const auto MaxNumPhases = BlackoilPhases::MaxNumPhases;
 
     enum PrimalVariables {
         Sg = 0,

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -22,6 +22,7 @@
 #include <config.h>
 
 #include <opm/autodiff/BlackoilPropsAdFromDeck.hpp>
+#include <opm/autodiff/BlackoilModelEnums.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
 
 #include <opm/core/props/BlackoilPropertiesInterface.hpp>

--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -177,16 +177,16 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
 
         surfaceDensity_.resize(numRegions);
         for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
-            if (phase_usage_.phase_used[Liquid]) {
-                surfaceDensity_[regionIdx][phase_usage_.phase_pos[Liquid]]
+            if (phase_usage_.phase_used[Oil]) {
+                surfaceDensity_[regionIdx][phase_usage_.phase_pos[Oil]]
                     = densityKeyword.getRecord(regionIdx).getItem("OIL").getSIDouble(0);
             }
-            if (phase_usage_.phase_used[Aqua]) {
-                surfaceDensity_[regionIdx][phase_usage_.phase_pos[Aqua]]
+            if (phase_usage_.phase_used[Water]) {
+                surfaceDensity_[regionIdx][phase_usage_.phase_pos[Water]]
                     = densityKeyword.getRecord(regionIdx).getItem("WATER").getSIDouble(0);
             }
-            if (phase_usage_.phase_used[Vapour]) {
-                surfaceDensity_[regionIdx][phase_usage_.phase_pos[Vapour]]
+            if (phase_usage_.phase_used[Gas]) {
+                surfaceDensity_[regionIdx][phase_usage_.phase_pos[Gas]]
                     = densityKeyword.getRecord(regionIdx).getItem("GAS").getSIDouble(0);
             }
         }

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -24,8 +24,8 @@
 
 #include <opm/autodiff/BlackoilPropsAdInterface.hpp>
 #include <opm/autodiff/AutoDiffBlock.hpp>
+#include <opm/autodiff/BlackoilModelEnums.hpp>
 
-#include <opm/core/props/BlackoilPhases.hpp>
 #include <opm/core/props/satfunc/SaturationPropsFromDeck.hpp>
 #include <opm/core/props/rock/RockFromDeck.hpp>
 

--- a/opm/autodiff/BlackoilPropsAdInterface.hpp
+++ b/opm/autodiff/BlackoilPropsAdInterface.hpp
@@ -21,7 +21,7 @@
 #define OPM_BLACKOILPROPSADINTERFACE_HEADER_INCLUDED
 
 #include <opm/autodiff/AutoDiffBlock.hpp>
-#include <opm/core/props/BlackoilPhases.hpp>
+#include <opm/autodiff/BlackoilModelEnums.hpp>
 
 namespace Opm
 {
@@ -74,16 +74,6 @@ namespace Opm
 
         /// \return   Object describing the active phases.
         virtual PhaseUsage phaseUsage() const = 0;
-
-        // ------ Canonical named indices for each phase ------
-
-        /// Canonical named indices for each phase.
-        enum PhaseIndex { Water = BlackoilPhases::Aqua, Oil = BlackoilPhases::Liquid,
-                          Gas = BlackoilPhases::Vapour,
-                          Aqua = BlackoilPhases::Aqua,
-                          Liquid = BlackoilPhases::Liquid,
-                          Vapour = BlackoilPhases::Vapour,
-                          MaxNumPhases = BlackoilPhases::MaxNumPhases};
 
         // ------ Density ------
 

--- a/opm/autodiff/ImpesTPFAAD.hpp
+++ b/opm/autodiff/ImpesTPFAAD.hpp
@@ -23,6 +23,7 @@
 
 #include <opm/autodiff/AutoDiffBlock.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
+#include <opm/autodiff/BlackoilModelEnums.hpp>
 #include <opm/autodiff/BlackoilPropsAdInterface.hpp>
 
 struct UnstructuredGrid;
@@ -70,9 +71,9 @@ namespace Opm {
                              Eigen::Dynamic,
                              Eigen::Dynamic,
                              Eigen::RowMajor> DataBlock;
-        enum { Water = BlackoilPropsAdInterface::Water,
-               Oil = BlackoilPropsAdInterface::Oil,
-               Gas = BlackoilPropsAdInterface::Gas };
+        enum { Water = Opm::Water,
+               Oil = Opm::Oil,
+               Gas = Opm::Gas };
 
         // Data
         const UnstructuredGrid&      grid_;

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
@@ -23,7 +23,8 @@
 
 #include <opm/autodiff/AutoDiffBlock.hpp>
 #include <opm/autodiff/AutoDiffHelpers.hpp>
-#include <opm/autodiff/BlackoilPropsAdInterface.hpp>
+#include <opm/autodiff/BlackoilModelEnums.hpp>
+#include <opm/autodiff/BlackoilPropsAdFromDeck.hpp>
 #include <opm/autodiff/NewtonIterationBlackoilInterface.hpp>
 #include <opm/autodiff/LinearisedBlackoilResidual.hpp>
 #include <opm/polymer/PolymerProperties.hpp>
@@ -85,9 +86,9 @@ namespace Opm {
             }
 
             enum FipId {
-                FIP_AQUA = BlackoilPropsAdInterface::Water,
-                FIP_LIQUID = BlackoilPropsAdInterface::Oil,
-                FIP_VAPOUR = BlackoilPropsAdInterface::Gas,
+                FIP_AQUA = Opm::Water,
+                FIP_LIQUID = Opm::Oil,
+                FIP_VAPOUR = Opm::Gas,
                 FIP_DISSOLVED_GAS = 3,
                 FIP_VAPORIZED_OIL = 4,
                 FIP_PV = 5,                    //< Pore volume
@@ -179,8 +180,8 @@ namespace Opm {
             Eigen::SparseMatrix<double> p2w;  // perf -> well (gather)
         };
 
-        enum { Water = BlackoilPropsAdInterface::Water,
-               Oil   = BlackoilPropsAdInterface::Oil  };
+        enum { Water = Opm::Water,
+               Oil   = Opm::Oil  };
 
         // Member data
         const UnstructuredGrid&         grid_;

--- a/tests/test_boprops_ad.cpp
+++ b/tests/test_boprops_ad.cpp
@@ -116,17 +116,17 @@ BOOST_FIXTURE_TEST_CASE(SurfaceDensity, TestFixture<SetupSimple>)
 
     typedef Opm::BlackoilPropsAdFromDeck::V V;
 
-    enum { Water = Opm::BlackoilPropsAdFromDeck::Water };
+    enum { Water = Opm::Water };
     V rho0AD_Water = boprops_ad.surfaceDensity(Water, cells);
     BOOST_REQUIRE_EQUAL(rho0AD_Water.size(), cells.size());
     BOOST_CHECK_EQUAL(rho0AD_Water[0], 1000.0);
 
-    enum { Oil = Opm::BlackoilPropsAdFromDeck::Oil };
+    enum { Oil = Opm::Oil };
     V rho0AD_Oil = boprops_ad.surfaceDensity(Oil, cells);
     BOOST_REQUIRE_EQUAL(rho0AD_Oil.size(), cells.size());
     BOOST_CHECK_EQUAL(rho0AD_Oil[0], 800.0);
 
-    enum { Gas = Opm::BlackoilPropsAdFromDeck::Gas };
+    enum { Gas = Opm::Gas };
     V rho0AD_Gas = boprops_ad.surfaceDensity(Gas, cells);
     BOOST_REQUIRE_EQUAL(rho0AD_Gas.size(), cells.size());
     BOOST_CHECK_EQUAL(rho0AD_Gas[0], 1.0);


### PR DESCRIPTION
I consider the blackoil model enums to be pretty low level while the "FluidProperties" code is IMO quite high level. this, using the latter to define the former constitutes a layering violation IMO. note that the fix is to simply use the enums from opm-core directly.