### PR TITLE
Passing keys to the restart load function.

### DIFF
--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -37,7 +37,7 @@
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
-#include <opm/output/eclipse/EclipseWriter.hpp>
+#include <opm/output/eclipse/EclipseIO.hpp>
 #include <opm/core/props/BlackoilPropertiesBasic.hpp>
 #include <opm/core/props/BlackoilPropertiesFromDeck.hpp>
 #include <opm/core/props/rock/RockCompressibility.hpp>
@@ -239,11 +239,11 @@ try
     std::cout << "\n\n================    Starting main simulation loop     ===============\n"
               << std::flush;
 
-    std::unique_ptr<Opm::EclipseWriter>
-        eclipseWriter(new Opm::EclipseWriter(*eclipseState,
-                                             UgGridHelpers
-                                             ::createEclipseGrid( cGrid ,
-                                                                  eclipseState->getInputGrid())));
+    std::unique_ptr<Opm::EclipseIO>
+        eclipseWriter(new Opm::EclipseIO(*eclipseState,
+                                         UgGridHelpers
+                                         ::createEclipseGrid( cGrid ,
+                                                              eclipseState->getInputGrid())));
     Opm::BlackoilOutputWriter
         outputWriter(cGrid, param, *eclipseState, std::move(eclipseWriter), pu,
                      new_props->permeability() );

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -234,7 +234,7 @@ namespace Opm
         // distributeData()
         boost::any parallel_information_;
         // setupOutputWriter()
-        std::unique_ptr<EclipseWriter> eclipse_writer_;
+        std::unique_ptr<EclipseIO> eclipse_writer_;
         std::unique_ptr<OutputWriter> output_writer_;
         // setupLinearSolver
         std::unique_ptr<NewtonIterationBlackoilInterface> fis_solver_;
@@ -762,7 +762,7 @@ namespace Opm
             if( output && output_ecl && output_cout_)
             {
                 const EclipseGrid& inputGrid = eclipse_state_->getInputGrid();
-                eclipse_writer_.reset(new EclipseWriter(*eclipse_state_, UgGridHelpers::createEclipseGrid( grid , inputGrid )));
+                eclipse_writer_.reset(new EclipseIO(*eclipse_state_, UgGridHelpers::createEclipseGrid( grid , inputGrid )));
                 eclipse_writer_->writeInitial(geoprops_->simProps(grid),
                                               geoprops_->nonCartesianConnections());
             }

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -545,8 +545,8 @@ namespace Opm
             if( output && output_ecl && output_cout_)
             {
                 const EclipseGrid& inputGrid = eclState().getInputGrid();
-                eclipse_writer_.reset(new EclipseWriter(eclState(), UgGridHelpers::createEclipseGrid( grid , inputGrid )));
-                eclipse_writer_->writeInitial(geoprops_->simProps(grid),
+                eclIO_.reset(new EclipseIO(eclState(), UgGridHelpers::createEclipseGrid( grid , inputGrid )));
+                eclIO_->writeInitial(geoprops_->simProps(grid),
                                               geoprops_->nonCartesianConnections());
             }
         }
@@ -562,7 +562,7 @@ namespace Opm
             output_writer_.reset(new OutputWriter(grid(),
                                                   param_,
                                                   eclState(),
-                                                  std::move(eclipse_writer_),
+                                                  std::move(eclIO_),
                                                   Opm::phaseUsageFromDeck(deck()),
                                                   fluidprops_->permeability()));
         }
@@ -725,7 +725,7 @@ namespace Opm
         std::unique_ptr<BlackoilPropsAdFromDeck> fluidprops_;
         std::unique_ptr<DerivedGeology> geoprops_;
         std::unique_ptr<ReservoirState> state_;
-        std::unique_ptr<EclipseWriter> eclipse_writer_;
+        std::unique_ptr<EclipseIO> eclIO_;
         std::unique_ptr<OutputWriter> output_writer_;
         boost::any parallel_information_;
         std::unique_ptr<NewtonIterationBlackoilInterface> fis_solver_;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -317,18 +317,18 @@ namespace Opm
         }
 
         // ECL output
-        if ( eclWriter_ )
+        if ( eclIO_ )
         {
             const auto& initConfig = eclipseState_.getInitConfig();
             if (initConfig.restartRequested() && ((initConfig.getRestartStep()) == (timer.currentStepNum()))) {
                 std::cout << "Skipping restart write in start of step " << timer.currentStepNum() << std::endl;
             } else {
                 // ... insert "extra" data (KR, VISC, ...)
-                eclWriter_->writeTimeStep(timer.reportStepNum(),
-                                          substep,
-                                          timer.simulationTimeElapsed(),
-                                          simProps,
-                                          wellState.report(phaseUsage_));
+                eclIO_->writeTimeStep(timer.reportStepNum(),
+                                      substep,
+                                      timer.simulationTimeElapsed(),
+                                      simProps,
+                                      wellState.report(phaseUsage_));
             }
         }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.cpp
@@ -156,7 +156,7 @@ namespace Opm
                         bool substep)
     {
         // ECL output
-        if ( eclWriter_ )
+        if ( eclIO_ )
         {
             const auto& initConfig = eclipseState_.getInitConfig();
             if (initConfig.restartRequested() && ((initConfig.getRestartStep()) == (timer.currentStepNum()))) {
@@ -164,11 +164,11 @@ namespace Opm
             } else {
                 data::Solution combined_sol = simToSolution(state, phaseUsage_); // Get "normal" data (SWAT, PRESSURE, ...)
                 combined_sol.insert(sol.begin(), sol.end());           // ... insert "extra" data (KR, VISC, ...)
-                eclWriter_->writeTimeStep(timer.reportStepNum(),
-                                          substep,
-                                          timer.simulationTimeElapsed(),
-                                          combined_sol,
-                                          wellState.report(phaseUsage_));
+                eclIO_->writeTimeStep(timer.reportStepNum(),
+                                      substep,
+                                      timer.simulationTimeElapsed(),
+                                      combined_sol,
+                                      wellState.report(phaseUsage_));
             }
         }
 

--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer.hpp
@@ -38,7 +38,7 @@
 #include <opm/core/simulator/SimulatorReport.hpp>
 #include <opm/core/simulator/SimulatorTimer.hpp>
 #include <opm/core/utility/StopWatch.hpp>
-#include <opm/output/eclipse/EclipseWriter.hpp>
+#include <opm/output/eclipse/EclipseIO.hpp>
 #include <opm/core/utility/miscUtilities.hpp>
 #include <opm/core/utility/miscUtilitiesBlackoil.hpp>
 


### PR DESCRIPTION
Followup to: https://github.com/OPM/opm-output/pull/152

Previously the list of keywords to load from a restart file was hardcoded in the opm-output, now the `load_from_restart_file( )` takes a map of keys to load. With the current follow-up patch the hardcoding has just been moved into the opm-simulator.

The PR also contains some minor refactorings:

1. The `EclipseWriter` class has been renamed `EclipseIO`.
2. The functionality to load restart information is a method on the `EclipseIO` class.

In addition a namespace `RestartIO{ ... }` with functions `save()` and `load( )` has been created as part of:  https://github.com/OPM/opm-output/pull/152 - using these functions client scope (i.e. `flow_xxx`) can save and load restart files completely bypassing the IO configuration from the deck / EclipseState. 