### PR TITLE
Implement parallel fip total computation.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -673,7 +673,7 @@ protected:
                 }
             }
 #else
-            OPM_THROW(std::logic_error, "Requested a parallel run with MPI available!");
+            OPM_THROW(std::logic_error, "Requested a parallel run without MPI available!");
 #endif
         }
         totals[6] = (p_pv_hydrocarbon_sum / pv_hydrocarbon_sum);


### PR DESCRIPTION
Up to now parallel runs aborted due to an exception with the message "FIP not yet implemented for MPI". With this commit we do the computation in parallel, too. And flow_ebos runs a bit longer in parallel ...