### PR TITLE
Make StandardWellsDense support cases with no wells.

### DIFF
--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -1360,7 +1360,8 @@ enum WellVariablePositions {
                                   const WellState& well_state,
                                   DynamicListEconLimited& list_econ_limited) const
             {
-                const int nw = wells_struct->number_of_wells;
+                // With no wells (on process) wells_struct is a null pointer
+                const int nw = (wells_struct)? wells_struct->number_of_wells : 0;
 
                 for (int w = 0; w < nw; ++w) {
                     // flag to check if the mim oil/gas rate limit is violated


### PR DESCRIPTION
In that case `wells_manager.c_wells()` returns a null pointer
which made `updateListEconLimited` segfault. With this commit
we treat a null wells_struct as having zero wells.

With this this and #1001 opm-data/equilibrium at least runs
through in parallel. Results will be checked next.