### PR TITLE
Only try to merge files from a parallel run if ouptput requested.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -465,7 +465,7 @@ namespace Opm
             // force closing of all log files.
             OpmLog::removeAllBackends();
 
-            if( mpi_rank_ != 0 || !must_distribute_ )
+            if( mpi_rank_ != 0 || !must_distribute_ || !output_to_files_ )
             {
                 return;
             }

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -315,7 +315,7 @@ namespace Opm
             // force closing of all log files.
             OpmLog::removeAllBackends();
 
-            if( mpi_rank_ != 0 || !must_distribute_ )
+            if( mpi_rank_ != 0 || !must_distribute_ || !output_to_files_ )
             {
                 return;
             }


### PR DESCRIPTION
If it is not requested then output_dir is not created and boost
will throw an exception if we try to read from a non existing
directory.