### PR TITLE
avoid relying on undefined behaviour

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -158,7 +158,7 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
 
         phase_usage_ = phaseUsageFromDeck(deck);
 
-        if (! (&FluidSystem::oilPvt()) ) {
+        if (!FluidSystem::isInitialized()) {
             // make sure that we don't initialize the fluid system twice
             FluidSystem::initFromDeck(deck, eclState);
         }

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -260,24 +260,28 @@ namespace Opm
         dxOld = dx;
 
         switch (relaxType()) {
-            case DAMPEN:
+            case DAMPEN: {
                 if (omega == 1.) {
                     return;
                 }
-                for (size_t i = 0; i < dx.size(); ++i) {
+                auto i = dx.size();
+                for (i = 0; i < dx.size(); ++i) {
                     dx[i] *= omega;
                 }
                 return;
-            case SOR:
+            }
+            case SOR: {
                 if (omega == 1.) {
                     return;
                 }
-                for (size_t i = 0; i < dx.size(); ++i) {
+                auto i = dx.size();
+                for (i = 0; i < dx.size(); ++i) {
                     dx[i] *= omega;
                     tempDxOld[i] *= (1.-omega);
                     dx[i] += tempDxOld[i];
                 }
                 return;
+            }
             default:
                 OPM_THROW(std::runtime_error, "Can only handle DAMPEN and SOR relaxation type.");
         }


### PR DESCRIPTION
in C++ references may be assumed to be non-null. thanks to @atgeirr for pointing this out.

(note: this PR also fixes a harmless sign comparison warning in the non-linear solver.)
