### PR TITLE
Fix unit conversion of fip totals (pav) again.

### DIFF
--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -737,7 +737,7 @@ namespace Opm
                 tmp2 += geo_.poreVolume()[i] * hydrocarbon[i];
             }
             totals[5] = geo_.poreVolume().sum();
-            totals[6] = unit::convert::to(tmp/tmp2, unit::barsa); 
+            totals[6] = tmp/tmp2;
        }
         else
         {


### PR DESCRIPTION
This was (accidentally?) introduced in c880efae5be (labelled
"mostly eliminate Eigen in the FIP and VFP code"). As it is neither
present in flow_ebos nor in flow_mpi and was previously removed in
ccec17f8 (labelled "Fixed missing unit conversion for total fluid in place")
I assume that this is a bug.