### PR TITLE
Make StandardWells support cases with no wells.

### DIFF
--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -1210,7 +1210,8 @@ namespace Opm
                          const WellState& well_state,
                          DynamicListEconLimited& list_econ_limited) const
    {
-       const int nw = wells_struct->number_of_wells;
+       // wells_struct may be null pointer if there are no wells in process domain
+       const int nw = ( wells_struct ) ? wells_struct->number_of_wells : 0;
 
        for (int w = 0; w < nw; ++w) {
            // flag to check if the mim oil/gas rate limit is violated


### PR DESCRIPTION
Dense case was handled in PR #1002. I was not aware that the same
regression was in the legacy code. wells_manager.c_wells() might return
a null pointer if there are no wells in the domain of a process. In this case
we treat it as having zero wells.