### PR TITLE
Switch off non-owner entries during accumulation in getConvergence

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -787,11 +787,23 @@ namespace Opm {
             R_sum.resize(np);
             maxNormWell.resize(np);
 
+            const std::vector<double>* mask = nullptr;
+
+#if HAVE_MPI
+            if ( comm.size() > 1 )
+            {
+                // mask[c] is 1 if we need to compute something in parallel
+                const auto & pinfo =
+                        boost::any_cast<const ParallelISTLInformation&>(istlSolver().parallelInformation());
+                mask = &pinfo.updateOwnerMask( B[ 0 ] );
+            }
+#endif
+
             // computation
             for ( int idx = 0; idx < np; ++idx )
             {
-                B_avg[idx] = std::accumulate( B[ idx ].begin(), B[ idx ].end(), 0.0 ) / double(ncGlobal);
-                R_sum[idx] = std::accumulate( R[ idx ].begin(), R[ idx ].end(), 0.0 );
+                B_avg[idx] = accumulateMaskedValues(B[ idx ], mask) / double(ncGlobal);
+                R_sum[idx] = accumulateMaskedValues(R[ idx ], mask);
                 maxCoeff[idx] = *(std::max_element( tempV[ idx ].begin(), tempV[ idx ].end() ));
 
                 assert(np >= np);
@@ -803,8 +815,8 @@ namespace Opm {
                 }
             }
 
-            // Compute total pore volume
-            double pvSum = std::accumulate(pv.begin(), pv.end(), 0.0);
+            // Compute total pore volume (use only owned entries)
+            double pvSum = accumulateMaskedValues(pv, mask);
 
             if( comm.size() > 1 )
             {


### PR DESCRIPTION
Previously entries attached to cells that are present on multiply processes were acumulated several times.
This is currently untested since the parallel output of flow_ebos is broken. Therefore marked as work in progress