### PR TITLE
flow_ebos.cpp: do not include DuneMatrix.hpp header

### DIFF
--- a/examples/flow_ebos.cpp
+++ b/examples/flow_ebos.cpp
@@ -25,7 +25,6 @@
 #endif // HAVE_CONFIG_H
 
 #include <opm/material/densead/Evaluation.hpp>
-#include <opm/autodiff/DuneMatrix.hpp>
 #include <dune/grid/CpGrid.hpp>
 #include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/autodiff/FlowMainEbos.hpp>


### PR DESCRIPTION
this one is not required by flow_ebos.