### PR TITLE
flow_ebos: remove the legacy geologic properties object

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -83,6 +83,7 @@ namespace Properties {
 NEW_TYPE_TAG(EclFlowProblem, INHERITS_FROM(BlackOilModel, EclBaseProblem));
 SET_BOOL_PROP(EclFlowProblem, DisableWells, true);
 SET_BOOL_PROP(EclFlowProblem, EnableDebuggingChecks, false);
+SET_BOOL_PROP(EclFlowProblem, ExportGlobalTransmissibility, true);
 
 // SWATINIT is done by the flow part of flow_ebos. this can be removed once the legacy
 // code for fluid and satfunc handling gets fully retired.


### PR DESCRIPTION
it was already almost unused (except for output). this may even imply a small performance improvement because the transmissibilities do not need to be calculated twice.