### PR TITLE
Group controls for flow_ebos

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -268,6 +268,12 @@ namespace Opm {
             perfTimer.start();
             // the step is not considered converged until at least minIter iterations is done
             report.converged = getConvergence(timer, iteration,residual_norms) && iteration > nonlinear_solver.minIter();
+
+             // checking whether the group targets are converged
+             if (wellModel().wellCollection()->groupControlActive()) {
+                  report.converged = report.converged && wellModel().wellCollection()->groupTargetConverged(well_state.wellRates());
+             }
+
             report.update_time += perfTimer.stop();
             residual_norms_history_.push_back(residual_norms);
             if (!report.converged) {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -252,7 +252,7 @@ public:
             // Run a multiple steps of the solver depending on the time step control.
             solver_timer.start();
 
-            const WellModel well_model(wells, model_param_, terminal_output_);
+            const WellModel well_model(wells, &(wells_manager.wellCollection()), model_param_, terminal_output_);
 
             auto solver = createSolver(well_model);
 

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -90,9 +90,6 @@ enum WellVariablePositions {
                 , well_collection_(well_collection)
                 , param_(param)
                 , terminal_output_(terminal_output)
-                , fluid_(nullptr)
-                , active_(nullptr)
-                , vfp_properties_(nullptr)
                 , well_perforation_efficiency_factors_((wells_!=nullptr ? wells_->well_connpos[wells_->number_of_wells] : 0), 1.0)
                 , well_perforation_densities_( wells_ ? wells_arg->well_connpos[wells_arg->number_of_wells] : 0)
                 , well_perforation_pressure_diffs_( wells_ ? wells_arg->well_connpos[wells_arg->number_of_wells] : 0)
@@ -546,7 +543,7 @@ enum WellVariablePositions {
             void
             computeWellFlux(const int& w, const double& Tw, const intensiveQuants& intQuants, const EvalWell& bhp, const double& cdp, const bool& allow_cf, std::vector<EvalWell>& cq_s)  const
             {
-                const Opm::PhaseUsage& pu = fluid_->phaseUsage();
+                const Opm::PhaseUsage& pu = phase_usage_;
                 const int np = wells().number_of_phases;
                 std::vector<EvalWell> cmix_s(np,0.0);
                 for (int phase = 0; phase < np; ++phase) {
@@ -1551,15 +1548,15 @@ enum WellVariablePositions {
                             double liquid = 0.0;
                             double vapour = 0.0;
 
-                            const Opm::PhaseUsage& pu = fluid_->phaseUsage();
+                            const Opm::PhaseUsage& pu = phase_usage_;
 
-                            if ((*active_)[ Water ]) {
+                            if (active_[ Water ]) {
                                 aqua = well_state.wellRates()[w*np + pu.phase_pos[ Water ] ];
                             }
-                            if ((*active_)[ Oil ]) {
+                            if (active_[ Oil ]) {
                                 liquid = well_state.wellRates()[w*np + pu.phase_pos[ Oil ] ];
                             }
-                            if ((*active_)[ Gas ]) {
+                            if (active_[ Gas ]) {
                                 vapour = well_state.wellRates()[w*np + pu.phase_pos[ Gas ] ];
                             }
 

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -35,6 +35,7 @@
 
 #include <opm/core/wells.h>
 #include <opm/core/wells/DynamicListEconLimited.hpp>
+#include <opm/core/wells/WellCollection.hpp>
 #include <opm/autodiff/VFPProperties.hpp>
 #include <opm/autodiff/VFPInjProperties.hpp>
 #include <opm/autodiff/VFPProdProperties.hpp>
@@ -81,10 +82,12 @@ enum WellVariablePositions {
 
             // ---------  Public methods  ---------
             StandardWellsDense(const Wells* wells_arg,
+                               WellCollection* well_collection,
                                const ModelParameters& param,
                                const bool terminal_output)
                 : wells_active_(wells_arg!=nullptr)
                 , wells_(wells_arg)
+                , well_collection_(well_collection)
                 , param_(param)
                 , terminal_output_(terminal_output)
                 , well_perforation_densities_( wells_ ? wells_arg->well_connpos[wells_arg->number_of_wells] : 0)
@@ -1575,9 +1578,22 @@ enum WellVariablePositions {
             }
 
 
+
+
+
+            WellCollection* wellCollection() const
+            {
+                return well_collection_;
+            }
+
+
         protected:
             bool wells_active_;
             const Wells*   wells_;
+
+            // Well collection is used to enforce the group control
+            WellCollection* well_collection_;
+
             ModelParameters param_;
             bool terminal_output_;
 

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -235,7 +235,8 @@ enum WellVariablePositions {
                         const int cell_idx = wells().well_cells[perf];
                         const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
                         std::vector<EvalWell> cq_s(np,0.0);
-                        computeWellFlux(w, wells().WI[perf], intQuants, wellPerforationPressureDiffs()[perf], allow_cf, cq_s);
+                        const EvalWell bhp = getBhp(w);
+                        computeWellFlux(w, wells().WI[perf], intQuants, bhp, wellPerforationPressureDiffs()[perf], allow_cf, cq_s);
 
                         for (int p1 = 0; p1 < np; ++p1) {
 
@@ -531,10 +532,9 @@ enum WellVariablePositions {
 
             template<typename intensiveQuants>
             void
-            computeWellFlux(const int& w, const double& Tw, const intensiveQuants& intQuants, const double& cdp, const bool& allow_cf, std::vector<EvalWell>& cq_s)  const
+            computeWellFlux(const int& w, const double& Tw, const intensiveQuants& intQuants, const EvalWell& bhp, const double& cdp, const bool& allow_cf, std::vector<EvalWell>& cq_s)  const
             {
-                const Opm::PhaseUsage& pu = phase_usage_;
-                EvalWell bhp = getBhp(w);
+                const Opm::PhaseUsage& pu = fluid_->phaseUsage();
                 const int np = wells().number_of_phases;
                 std::vector<EvalWell> cmix_s(np,0.0);
                 for (int phase = 0; phase < np; ++phase) {

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -191,6 +191,10 @@ enum WellVariablePositions {
                     return report;
                 }
 
+                if (param_.compute_well_potentials_) {
+                    computeWellPotentials(ebosSimulator, well_state);
+                }
+
                 resetWellControlFromState(well_state);
                 updateWellControls(well_state);
                 // Set the primary variables for the wells
@@ -207,10 +211,6 @@ enum WellVariablePositions {
                 }
                 assembleWellEq(ebosSimulator, dt, well_state, false);
 
-                // Not sure we should calculate it during solveWellEq
-                if (param_.compute_well_potentials_) {
-                    computeWellPotentials(ebosSimulator, well_state);
-                }
                 report.converged = true;
                 return report;
             }

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -1197,7 +1197,6 @@ enum WellVariablePositions {
                         well_controls_set_current( wc, current);
 
 
-
                         // Updating well state and primary variables if constraint is broken
 
                         // Target values are used as initial conditions for BHP, THP, and SURFACE_RATE
@@ -1294,11 +1293,8 @@ enum WellVariablePositions {
                                 OPM_THROW(std::logic_error, "Expected PRODUCER or INJECTOR type of well");
                             }
 
-
                             break;
                         }
-
-
 
 
                         std::vector<double> g = {1,1,0.01};
@@ -1597,6 +1593,8 @@ enum WellVariablePositions {
                             }
                         }
                     }
+
+                    assert(bhp != 0.0);
 
                     // Should we consider crossflow when calculating well potentionals?
                     const bool allow_cf = allow_cross_flow(w, ebosSimulator);

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -682,6 +682,11 @@ enum WellVariablePositions {
                     assembleWellEq(ebosSimulator, dt, well_state, true);
                     converged = getWellConvergence(ebosSimulator, it);
 
+                    // checking whether the group targets are converged
+                    if (wellCollection()->groupControlActive()) {
+                        converged = converged && wellCollection()->groupTargetConverged(well_state.wellRates());
+                    }
+
                     if (converged) {
                         break;
                     }


### PR DESCRIPTION
Implementing the group controls for flow_ebos. VREP is a little special and possibly need to handle with other issues together, like OPM/opm-simulators#1011.  Will be proposed in another PR. 

This PR calculate the well potentials, and distribute the group target within different wells dynamically. GEFAC is also handled. The testing results are fine. 

This PR needs OPM/opm-core#1134 to get correct results, while not dependent on that PR in term of compiling. 