### PR TITLE
simplify euclidianNormSquared()

### DIFF
--- a/opm/autodiff/BlackoilDetails.hpp
+++ b/opm/autodiff/BlackoilDetails.hpp
@@ -92,68 +92,20 @@ namespace detail {
 
 
         /// \brief Compute the Euclidian norm of a vector
-        /// \warning In the case that num_components is greater than 1
-        ///          an interleaved ordering is assumed. E.g. for each cell
-        ///          all phases of that cell are stored consecutively. First
-        ///          the ones for cell 0, then the ones for cell 1, ... .
         /// \param it              begin iterator for the given vector
         /// \param end             end iterator for the given vector
-        /// \param num_components  number of components (i.e. phases) in the vector
         /// \param pinfo           In a parallel this holds the information about the data distribution.
-        template <class Iterator>
+        template <class Iterator, class Communicator>
         inline
-        double euclidianNormSquared( Iterator it, const Iterator end, int num_components, const boost::any& pinfo = boost::any() )
+        double euclidianNormSquared(Iterator it,
+                                    const Iterator end,
+                                    const Communicator& comm)
         {
-            static_cast<void>(num_components); // Suppress warning in the serial case.
-            static_cast<void>(pinfo); // Suppress warning in non-MPI case.
-#if HAVE_MPI
-            if ( pinfo.type() == typeid(ParallelISTLInformation) )
-            {
-                const ParallelISTLInformation& info =
-                    boost::any_cast<const ParallelISTLInformation&>(pinfo);
-                typedef typename Iterator::value_type Scalar;
-                Scalar product = 0.0;
-                int size_per_component = (end - it);
-                size_per_component /= num_components; // two lines to supresse unused warning.
-                assert((end - it) == num_components * size_per_component);
-
-                if( num_components == 1 )
-                {
-                    auto component_container =
-                        boost::make_iterator_range(it, end);
-                    info.computeReduction(component_container,
-                                           Opm::Reduction::makeInnerProductFunctor<double>(),
-                                           product);
-                }
-                else
-                {
-                    auto& maskContainer = info.getOwnerMask();
-                    auto mask = maskContainer.begin();
-                    assert(static_cast<int>(maskContainer.size()) == size_per_component);
-
-                    for(int cell = 0; cell < size_per_component; ++cell, ++mask)
-                    {
-                        Scalar cell_product = (*it) * (*it);
-                        ++it;
-                        for(int component=1; component < num_components;
-                            ++component, ++it)
-                        {
-                            cell_product += (*it) * (*it);
-                        }
-                        product += cell_product * (*mask);
-                    }
-                }
-                return info.communicator().sum(product);
+            double product = 0.0 ;
+            for( ; it != end; ++it ) {
+                product += ( *it * *it );
             }
-            else
-#endif
-            {
-                double product = 0.0 ;
-                for( ; it != end; ++it ) {
-                    product += ( *it * *it );
-                }
-                return product;
-            }
+            return comm.sum(product);
         }
 
         template <class Scalar>

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1596,16 +1596,14 @@ typedef Eigen::Array<double,
         }
 
         // compute || u^n - u^n+1 ||
-        const double stateOld  = detail::euclidianNormSquared( p0.begin(),   p0.end(), 1, linsolver_.parallelInformation() ) +
+        const double stateOld  = detail::euclidianNormSquared( p0.begin(),   p0.end(), AutoDiffGrid::communicator(grid_) ) +
                                  detail::euclidianNormSquared( sat0.begin(), sat0.end(),
-                                                               current.numPhases(),
-                                                               linsolver_.parallelInformation() );
+                                                               AutoDiffGrid::communicator(grid_));
 
         // compute || u^n+1 ||
-        const double stateNew  = detail::euclidianNormSquared( current.pressure().begin(),   current.pressure().end(), 1, linsolver_.parallelInformation() ) +
+        const double stateNew  = detail::euclidianNormSquared( current.pressure().begin(),   current.pressure().end(), AutoDiffGrid::communicator(grid_) ) +
                                  detail::euclidianNormSquared( current.saturation().begin(), current.saturation().end(),
-                                                               current.numPhases(),
-                                                               linsolver_.parallelInformation() );
+                                                               AutoDiffGrid::communicator(grid_) );
 
         if( stateNew > 0.0 ) {
             return stateOld / stateNew ;

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -401,16 +401,24 @@ namespace Opm {
             }
 
             // compute || u^n - u^n+1 ||
-            const double stateOld  = detail::euclidianNormSquared( p0.begin(),   p0.end(), 1, istlSolver().parallelInformation() ) +
-                detail::euclidianNormSquared( sat0.begin(), sat0.end(),
-                                              current.numPhases(),
-                                              istlSolver().parallelInformation() );
+            const double stateOld  =
+                detail::euclidianNormSquared( p0.begin(),
+                                              p0.end(),
+                                              grid_.comm() )
+                +
+                detail::euclidianNormSquared( sat0.begin(),
+                                              sat0.end(),
+                                              grid_.comm() );
 
             // compute || u^n+1 ||
-            const double stateNew  = detail::euclidianNormSquared( current.pressure().begin(),   current.pressure().end(), 1, istlSolver().parallelInformation() ) +
-                detail::euclidianNormSquared( current.saturation().begin(), current.saturation().end(),
-                                              current.numPhases(),
-                                              istlSolver().parallelInformation() );
+            const double stateNew  =
+                detail::euclidianNormSquared( current.pressure().begin(),
+                                              current.pressure().end(),
+                                              grid_.comm() )
+                +
+                detail::euclidianNormSquared( current.saturation().begin(),
+                                              current.saturation().end(),
+                                              grid_.comm() );
 
             if( stateNew > 0.0 ) {
                 return stateOld / stateNew ;

--- a/opm/autodiff/GridHelpers.hpp
+++ b/opm/autodiff/GridHelpers.hpp
@@ -158,6 +158,16 @@ struct ADFaceCellTraits< Dune::PolyhedralGrid< dim, dimworld > >
 ADFaceCellTraits<UnstructuredGrid>::Type
 faceCellsToEigen(const UnstructuredGrid& grid);
 
+inline
+Dune::CollectiveCommunication<Dune::No_Comm>
+communicator(const UnstructuredGrid& grid)
+{ return Dune::CollectiveCommunication<Dune::No_Comm>(); }
+
+template <class Grid>
+auto communicator(const Grid& grid)
+    -> decltype(grid.comm())
+{ return grid.comm(); }
+
 } // end namespace AutoDiffGrid
 } //end namespace OPM
 


### PR DESCRIPTION
this sheds a few lines of code, but more importantly there's now no distinction between the parallel and the sequential cases anymore. Also note that the `AutoDiffGrid::communicator(grid)` function is introduced to make this easier.