### PR TITLE
Warn instead of throw when missing DIMS keyword.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -498,7 +498,8 @@ namespace Opm
 
             // Create Deck and EclipseState.
             try {
-                ParseContext parseContext({{ ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE }});
+                ParseContext parseContext({ { ParseContext::PARSE_RANDOM_SLASH ,        InputError::IGNORE },
+                                            { ParseContext::PARSE_MISSING_DIMS_KEYWORD, InputError::WARN   } });
                 deck_ = std::make_shared< Deck >( parser.parseFile(deck_filename, parseContext) );
                 checkDeck(*deck_, parser);
 


### PR DESCRIPTION
This allows us to run some cases that apparently are generated without various DIMS keywords. I think it is probably quite safe, in the sense that the parser is not likely to fail reading such decks, become confused etc.