### PR TITLE
Added script to update opm-data references

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#Print commands as they execute
+#set -x
+
 declare -a upstreams
 upstreams=(opm-common
            ert

--- a/tests/update_helper.sh
+++ b/tests/update_helper.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+#Stop on first error
+set -e
+
+#Echo all commands to terminal
+#set -x
+
+
+getAbsPath() {
+  local MY_PATH=$1
+  local ORIG_PATH=`pwd`
+
+  MY_PATH="`( cd \"$MY_PATH\" && pwd )`" 
+  cd "$ORIG_PATH"
+
+  if [ -z "$MY_PATH" ] ; then
+    echo "Script path became something strange: '$SCRIPT_PATH'" 
+    exit 1  # fail
+  fi
+  echo "$MY_PATH"
+}
+
+
+#Print usage if requested
+usage() {
+  #Grep through this source file for the options
+  echo "$0 usage:" && grep "    .)\ # " $0
+  exit 1
+}
+
+
+
+#Get the script absolute path to reference other scripts
+SCRIPT_PATH="`dirname \"$0\"`"
+SCRIPT_PATH=`getAbsPath "$SCRIPT_PATH"`
+
+
+
+#Get options
+OPM_DATA=
+WORKSPACE="$SCRIPT_PATH/.."
+BUILDTHREADS=4 
+PULL_REQUESTS=
+[ $# -eq 0 ] && usage
+while getopts "d:w:p:t:h" arg; do
+  case $arg in
+    d) # OPM Data path to use
+      echo "OPM_DATA ${OPTARG}"
+      OPM_DATA=${OPTARG}
+      ;;
+    w) # Workspace directory to use for opm-simultors
+      echo "WORKSPACE ${OPTARG}"
+      WORKSPACE=${OPTARG}
+      ;;
+    t) # Build threads
+      echo "BUILDTHREADS ${OPTARG}"
+      BUILDTHREADS=${OPTARG}
+      ;;
+    p) # Select pull requests to build (e.g., opm-core=1100)
+      echo "PULL_REQUESTS ${OPTARG}"
+      PULL_REQUESTS=${OPTARG}
+      ;;
+    h) # Display help.
+      usage
+      exit 0
+      ;;
+  esac
+done
+
+
+if [ -z "$OPM_DATA" ]; then 
+  echo "No OPM_DATA dir, will clone using network (slow)"; 
+fi
+WORKSPACE=`getAbsPath "$WORKSPACE"`
+
+
+
+
+
+
+#The BUILD_SCRIPT uses environment variables, so let's expose some arguments
+export OPM_DATA_ROOT_PREDEFINED="$OPM_DATA"
+export OPM_DATA_ROOT="$OPM_DATA"
+export WORKSPACE
+export BUILDTHREADS
+export ghprbCommentBody="$PULL_REQUESTS"
+
+
+#Build the requested configuration
+$SCRIPT_PATH/../jenkins/build.sh
+
+
+#Now update reference data-command
+echo " "
+echo " "
+echo " "
+echo ">>> To update opm-data, please use the following command <<<"
+echo " "
+echo "configuration=serial WORKSPACE=$WORKSPACE $SCRIPT_PATH/update_reference_data.sh $WORKSPACE/deps/opm-data [spe1] [spe3] [spe9]"
+echo " "
+
+echo ">>> To plot difference between new and old data, usse the following <<<"
+echo "SUMMARY_X=<path-to-summary.x> deps/opm-data/norne/plothelper.sh -o compare_runs.pdf -d [deck_name] -r serial/build-opm/simulators/tests/results/<casename> -r $OPM_DATA_ROOT/<casename>/opm-simulation_reference/ -v WBHP -v WOPR -v WGFR -v WWPR -c"

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+OPM_DATA_ROOT=$1
+
+copyToReferenceDir () {
+  SRC_DIR=$1
+  DST_DIR=$2;
+  STEM=$3;
+  FILETYPES=${@:4};
+
+  for filetype in $FILETYPES; do
+    cp "$SRC_DIR$STEM.$filetype" $DST_DIR
+  done
+}
+
+for test_name in ${@:2}; do
+  if grep -q "spe1" <<< $test_name
+  then
+    copyToReferenceDir \
+      $configuration/build-opm-simulators/tests/results/flow_sequential+spe1/ \
+      $OPM_DATA_ROOT/spe1/opm-simulation-reference/ \
+      SPE1CASE1 \
+      EGRID INIT SMSPEC UNRST UNSMRY
+
+    copyToReferenceDir \
+      $configuration/build-opm-simulators/tests/results/flow_sequential+spe1/ \
+      $OPM_DATA_ROOT/spe1/opm-simulation-reference/ \
+      SPE1CASE2 \
+      EGRID INIT SMSPEC UNRST UNSMRY
+  fi
+
+  if grep -q "spe3" <<< $2
+  then
+    copyToReferenceDir \
+      $configuration/build-opm-simulators/tests/results/flow_sequential+spe3/ \
+      $OPM_DATA_ROOT/spe3/opm-simulation-reference/ \
+      SPE3CASE1 \
+      EGRID INIT PRT SMSPEC UNRST UNSMRY
+  fi
+
+  if grep -q "spe9" <<< $2
+  then
+    copyToReferenceDir \
+      $configuration/build-opm-simulators/tests/results/flow+spe9/ \
+      $OPM_DATA_ROOT/spe9/opm-simulation-reference/ \
+      SPE9_CP_SHORT \
+      EGRID INIT PRT SMSPEC UNRST UNSMRY
+  fi
+done
+
+
+
+
+
+echo -e "update reference data for $2\n" > /tmp/cmsg
+for dep in ert opm-common opm-core opm-grid opm-material opm-parser opm-output
+do
+  pushd $WORKSPACE/deps/$dep > /dev/null
+  name=`printf "%-14s" $dep`
+  rev=`git rev-parse HEAD`
+  echo -e "$name = $rev" >> /tmp/cmsg
+  popd > /dev/null
+done
+echo -e "opm-simulators = `git rev-parse HEAD`" >> /tmp/cmsg
+
+cd $OPM_DATA_ROOT
+git commit -a -t /tmp/cmsg


### PR DESCRIPTION
This PR adds a couple of scripts that aid in updating the opm-data repository. 

The script update_helper.sh can be run as 
```
tests/update_helper.sh -t <build-threads> -d <path-to-opm-data-checkout>
```
and is based on the script by @akva2 

The script then checks out fresh copies of the required repositories, builds, and finally prints out the commands you can run to update opm-data with the newly generated reference data, and how to compare them with the script in opm-data (see OPM/opm-data#157 )