### PR TITLE
BUGFIX Pass solution from flowEbos to ebos initially

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -1467,8 +1467,8 @@ namespace Opm {
                 ebosSimulator_.problem().beginTimeStep();
             }
             // if the last time step failed we need to update the solution varables in ebos
-            // and recalculate the IntesiveQuantities.
-            if ( timer.lastStepFailed() && iterationIdx == 0 ) {
+            // and recalculate the IntesiveQuantities. Also pass the solution initially.
+            if ( (timer.lastStepFailed() || timer.reportStepNum()==0) && iterationIdx == 0  ) {
                 convertInput( iterationIdx, reservoirState, ebosSimulator_ );
                 ebosSimulator_.model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
             }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -256,11 +256,6 @@ public:
 
             auto solver = createSolver(well_model);
 
-            // make sure that the ebos side of the model is consistent with the reservoir
-            // state object.
-            solver->model().convertInput(/*iterationIdx=*/0, state, ebosSimulator_);
-            ebosSimulator_.model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
-
             // Compute orignal FIP;
             if (!ooip_computed) {
                 OOIP = solver->computeFluidInPlace(fipnum);


### PR DESCRIPTION
The initial solution in ebos and  in flowEbos are different in cases where
SWATINIT is present. Pass the initial solution and recalculate the
intensive quantities to make sure that the flowEbos initial solution is
used.