### PR TITLE
update the dune.module file

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -10,4 +10,4 @@ Label: 2017.04-pre
 Maintainer: atgeirr@sintef.no
 MaintainerName: Atgeirr F. Rasmussen
 Url: http://opm-project.org
-Depends: opm-common opm-parser opm-output opm-material opm-core opm-grid dune-istl (>=2.2) ewoms
+Depends: dune-istl (>= 2.3) opm-common opm-parser opm-output opm-material opm-core opm-grid ewoms


### PR DESCRIPTION
this explicitly sets the minimum dune version to 2.3 in the `dune.module` file.