### PR TITLE
[Discussion] using smaller tolerance_wells for StandardWellsDense

### DIFF
--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -73,7 +73,7 @@ namespace Opm
         max_residual_allowed_ = 1e7;
         tolerance_mb_    = 1.0e-5;
         tolerance_cnv_   = 1.0e-2;
-        tolerance_wells_ = 1.0e-3;
+        tolerance_wells_ = 1.0e-4;
         tolerance_well_control_ = 1.0e-7;
         maxSinglePrecisionTimeStep_ = unit::convert::from( 20.0, unit::day );
         solve_welleq_initially_ = true;


### PR DESCRIPTION
Some tests require smaller `tolerance_wells` when running with flow_ebos to make the well curves convergent. I specifies with 1.e-4, which is a tenth of the defaulted one. 

It helps the test get the converged results. In the below link, the blue line is the result from flow_ebos with default tolerance_wells, the yellow line is the result with flow_ebos with smaller tolerance_wells from this PR.

https://www.dropbox.com/s/4am5g3rn1scgolv/comparison_with_different_tolerance.png?dl=0

However, it also increases the running time of Norne by 1%-2%. 

Norne with current master branch. 
```
89350 Total time taken (seconds):   1482.55
89351 Solver time (seconds):        1457.5
89352  Assembly time (seconds):     797.135
89353  Linear solve time (seconds): 566.846
89354  Update time (seconds):       16.399
89355  Output write time (seconds): 25.4629
89356 Overall Well Iterations:      884
89357 Overall Linearizations:       1985
89358 Overall Newton Iterations:    1646
89359 Overall Linear Iterations:    25019
```

Norne with smaller tolerance_wells in this PR
```
89672 Total time taken (seconds):   1511.59
89673 Solver time (seconds):        1485.99
89674  Assembly time (seconds):     810.8
89675  Linear solve time (seconds): 576.447
89676  Update time (seconds):       16.8977
89677  Output write time (seconds): 26.0421
89678 Overall Well Iterations:      1190
89679 Overall Linearizations:       2009
89680 Overall Newton Iterations:    1670
89681 Overall Linear Iterations:    25171
```

I have not explored the equation system to pursue possible reason and tested different tolerances between 1.e-3 and 1.e-4, while I just created this PR for discussions and opinions. 

Thanks. 
