### PR TITLE
Fix output writer setup

### DIFF
--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -623,11 +623,6 @@ namespace Opm
         //   output_writer_
         void setupOutputWriter()
         {
-            output_writer_.reset(new OutputWriter(grid(),
-                                                  param_,
-                                                  eclState(),
-                                                  std::move( eclIO_ ),
-                                                  Opm::phaseUsageFromDeck(deck())) );
             // create output writer after grid is distributed, otherwise the parallel output
             // won't work correctly since we need to create a mapping from the distributed to
             // the global view

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -66,12 +66,14 @@ namespace Opm
                                          const ConstIter& local_begin,
                                          const Iter& global_begin)
     {
+#if HAVE_MPI
         FixedSizeIterCopyHandle<ConstIter,Iter> handle(local_begin,
                                                    global_begin);
         const auto& gatherScatterInf = grid.cellScatterGatherInterface();
         Dune::VariableSizeCommunicator<> comm(grid.comm(),
                                               gatherScatterInf);
         comm.backward(handle);
+#endif
     }
 
 

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -372,6 +372,10 @@ namespace Opm
             ebosSimulator_.reset(new EbosSimulator(/*verbose=*/false));
             ebosSimulator_->model().applyInitialSolution();
 
+            // Create a grid with a global view.
+            globalGrid_.reset(new Grid(grid()));
+            globalGrid_->switchToGlobalView();
+
             try {
                 if (output_cout_) {
                     MissingFeatures::checkKeywords(deck());
@@ -766,7 +770,7 @@ namespace Opm
         { return ebosSimulator_->gridManager().grid(); }
 
         const Grid& globalGrid()
-        { return ebosSimulator_->gridManager().equilGrid(); }
+        { return *globalGrid_; }
 
         Problem& ebosProblem()
         { return ebosSimulator_->problem(); }
@@ -799,6 +803,8 @@ namespace Opm
         std::unique_ptr<NewtonIterationBlackoilInterface> fis_solver_;
         std::unique_ptr<Simulator> simulator_;
         std::string logFile_;
+        // Needs to be shared pointer because it gets initialzed before MPI_Init.
+        std::shared_ptr<Grid> globalGrid_;
     };
 } // namespace Opm
 

--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -241,6 +241,11 @@ namespace Opm
 
         enum { ioRank = 0 };
 
+        /// \brief Constructor
+        /// \param otherGrid The grid with the distributed(!) view  activated.
+        /// \param eclipseState The eclipse file parser output
+        /// \param numPhases The number of active phases.
+        /// \param permeability The permeabilities  for the global(!) view.
         ParallelDebugOutput( const Dune::CpGrid& otherGrid,
                              const EclipseState& eclipseState,
                              const int numPhases,

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -29,6 +29,7 @@
 
 #include <opm/autodiff/BlackoilPropsAdFromDeck.hpp>
 #include <opm/autodiff/ExtractParallelGridInformationToISTL.hpp>
+#include <opm/autodiff/createGlobalCellArray.hpp>
 
 #include<boost/any.hpp>
 


### PR DESCRIPTION
Before this PR the output writer was  never initialized with the global grid in parallel. Therefore only the active cells of process 0 were honored as active cells. With this PR this is changed and at least the grid and the transmissibilties are writen for the whole domain.

Beware: Dynamic data is still somehow missing in parallel output for ebos.
Needs OPM/opm-grid#263