### PR TITLE
do not explicitly pass the permeability to the well model anymore

### DIFF
--- a/examples/sim_2p_comp_reorder.cpp
+++ b/examples/sim_2p_comp_reorder.cpp
@@ -252,7 +252,7 @@ try
                       << simtimer.numSteps() - step << ")\n\n" << std::flush;
 
             // Create new wells, well_state
-            WellsManager wells(*eclipseState , reportStepIdx , *grid->c_grid(), props->permeability());
+            WellsManager wells(*eclipseState , reportStepIdx , *grid->c_grid());
             // @@@ HACK: we should really make a new well state and
             // properly transfer old well state to it every report step,
             // since number of wells may change etc.

--- a/examples/sim_2p_incomp.cpp
+++ b/examples/sim_2p_incomp.cpp
@@ -273,7 +273,7 @@ try
             //           << simtimer.numSteps() - step << ")\n\n" << std::flush;
 
             // Create new wells, well_state
-            WellsManager wells(*eclipseState , reportStepIdx , *grid->c_grid(), props->permeability());
+            WellsManager wells(*eclipseState , reportStepIdx , *grid->c_grid());
             // @@@ HACK: we should really make a new well state and
             // properly transfer old well state to it every report step,
             // since number of wells may change etc.

--- a/examples/sim_2p_incomp_ad.cpp
+++ b/examples/sim_2p_incomp_ad.cpp
@@ -262,7 +262,7 @@ try
                       << timeMap.numTimesteps() - reportStepIdx << ")\n\n" << std::flush;
 
             // Create new wells, well_state
-            WellsManager wells(*eclipseState , reportStepIdx , *grid->c_grid(), props->permeability());
+            WellsManager wells(*eclipseState , reportStepIdx , *grid->c_grid());
             // @@@ HACK: we should really make a new well state and
             // properly transfer old well state to it every report step,
             // since number of wells may change etc.

--- a/examples/sim_poly2p_comp_reorder.cpp
+++ b/examples/sim_poly2p_comp_reorder.cpp
@@ -286,7 +286,7 @@ try
 
             // Create new wells, polymer inflow controls.
             eclipseState.reset( new EclipseState( deck ) );
-            WellsManager wells(*eclipseState , reportStepIdx , *grid->c_grid(), props->permeability());
+            WellsManager wells(*eclipseState , reportStepIdx , *grid->c_grid());
             boost::scoped_ptr<PolymerInflowInterface> polymer_inflow;
             if (use_wpolymer) {
                 if (wells.c_wells() == 0) {

--- a/examples/sim_poly2p_incomp_reorder.cpp
+++ b/examples/sim_poly2p_incomp_reorder.cpp
@@ -320,7 +320,7 @@ try
                       << simtimer.numSteps() - step << ")\n\n" << std::flush;
 
             // Create new wells, polymer inflow controls.
-            WellsManager wells(*eclipseState , reportStepIdx , *grid->c_grid(), props->permeability());
+            WellsManager wells(*eclipseState , reportStepIdx , *grid->c_grid());
             boost::scoped_ptr<PolymerInflowInterface> polymer_inflow;
             if (use_wpolymer) {
                 if (wells.c_wells() == 0) {

--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -245,8 +245,7 @@ try
                                          ::createEclipseGrid( cGrid ,
                                                               eclipseState->getInputGrid())));
     Opm::BlackoilOutputWriter
-        outputWriter(cGrid, param, *eclipseState, std::move(eclipseWriter), pu,
-                     new_props->permeability() );
+        outputWriter(cGrid, param, *eclipseState, std::move(eclipseWriter), pu);
 
     SimulatorReport fullReport;
     // Create and run simulator.

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -781,8 +781,7 @@ namespace Opm
                                                   param_,
                                                   *eclipse_state_,
                                                   std::move(eclipse_writer_),
-                                                  Opm::phaseUsageFromDeck(*deck_),
-                                                  fluidprops_->permeability()));
+                                                  Opm::phaseUsageFromDeck(*deck_)));
         }
 
 

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -556,15 +556,10 @@ namespace Opm
         //   output_writer_
         void setupOutputWriter()
         {
-            // create output writer after grid is distributed, otherwise the parallel output
-            // won't work correctly since we need to create a mapping from the distributed to
-            // the global view
             output_writer_.reset(new OutputWriter(grid(),
                                                   param_,
                                                   eclState(),
-                                                  std::move(eclIO_),
-                                                  Opm::phaseUsageFromDeck(deck()),
-                                                  fluidprops_->permeability()));
+                                                  std::move(eclIO_));
         }
 
         // Run the simulator.

--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -82,7 +82,6 @@ namespace Opm
         ParallelDebugOutput ( const GridImpl& grid,
                               const EclipseState& /* eclipseState */,
                               const int,
-                              const double*,
                               const Opm::PhaseUsage& )
             : grid_( grid ) {}
 
@@ -245,11 +244,9 @@ namespace Opm
         ParallelDebugOutput( const Dune::CpGrid& otherGrid,
                              const EclipseState& eclipseState,
                              const int numPhases,
-                             const double* permeability,
                              const Opm::PhaseUsage& phaseUsage)
             : grid_(),
               eclipseState_( eclipseState ),
-              permeability_( permeability ),
               toIORankComm_( otherGrid.comm() ),
               globalCellData_(new data::Solution),
               isIORank_( otherGrid.comm().rank() == ioRank ),
@@ -628,16 +625,14 @@ namespace Opm
                                            Opm::UgGridHelpers::dimensions( globalGrid ),
                                            Opm::UgGridHelpers::cell2Faces( globalGrid ),
                                            Opm::UgGridHelpers::beginFaceCentroids( globalGrid ),
-                                           permeability_,
                                            dynamic_list_econ_limited,
-                                           false
+                                           false,
                                            // We need to pass the optionaly arguments
                                            // as we get the following error otherwise
                                            // with c++ (Debian 4.9.2-10) 4.9.2 and -std=c++11
                                            // converting to ‘const std::unordered_set<std::basic_string<char> >’ from initializer list would use explicit constructor
-                                           , std::vector<double>(),
-                                           std::unordered_set<std::string>()
-                                           );
+                                           std::vector<double>(),
+                                           std::unordered_set<std::string>());
 
                 const Wells* wells = wells_manager.c_wells();
                 globalWellState_.init(wells, *globalReservoirState_, globalWellState_ );
@@ -693,7 +688,6 @@ namespace Opm
     protected:
         std::unique_ptr< Dune::CpGrid >           grid_;
         const EclipseState&                       eclipseState_;
-        const double*                             permeability_;
         P2PCommunicatorType                       toIORankComm_;
         IndexMapType                              globalIndex_;
         IndexMapType                              localIndexMap_;

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -92,7 +92,7 @@ namespace Opm
 
         if (output_writer_.isRestart()) {
             // This is a restart, populate WellState and ReservoirState state objects from restart file
-            output_writer_.initFromRestartFile(props_.phaseUsage(), props_.permeability(), grid_, state, prev_well_state);
+            output_writer_.initFromRestartFile(props_.phaseUsage(), grid_, state, prev_well_state);
             initHydroCarbonState(state, props_.phaseUsage(), Opm::UgGridHelpers::numCells(grid_), has_disgas_, has_vapoil_);
         }
 
@@ -170,7 +170,6 @@ namespace Opm
                                        Opm::UgGridHelpers::dimensions(grid_),
                                        Opm::UgGridHelpers::cell2Faces(grid_),
                                        Opm::UgGridHelpers::beginFaceCentroids(grid_),
-                                       props_.permeability(),
                                        dynamic_list_econ_limited,
                                        is_parallel_run_,
                                        well_potentials,

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -145,7 +145,7 @@ public:
 
         if (output_writer_.isRestart()) {
             // This is a restart, populate WellState and ReservoirState state objects from restart file
-            output_writer_.initFromRestartFile(props_.phaseUsage(), props_.permeability(), grid(), state, prev_well_state);
+            output_writer_.initFromRestartFile(props_.phaseUsage(), grid(), state, prev_well_state);
             initHydroCarbonState(state, props_.phaseUsage(), Opm::UgGridHelpers::numCells(grid()), has_disgas_, has_vapoil_);
         }
 
@@ -222,7 +222,6 @@ public:
                                        Opm::UgGridHelpers::dimensions(grid()),
                                        Opm::UgGridHelpers::cell2Faces(grid()),
                                        Opm::UgGridHelpers::beginFaceCentroids(grid()),
-                                       props_.permeability(),
                                        dynamic_list_econ_limited,
                                        is_parallel_run_,
                                        well_potentials,

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -106,7 +106,6 @@ namespace Opm
                                        Opm::UgGridHelpers::dimensions(grid_),
                                        Opm::UgGridHelpers::cell2Faces(grid_),
                                        Opm::UgGridHelpers::beginFaceCentroids(grid_),
-                                       props_.permeability(),
                                        dynamic_list_econ_limited,
                                        is_parallel_run_,
                                        // We need to pass the optionaly arguments

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -208,8 +208,7 @@ namespace Opm
                              const parameter::ParameterGroup& param,
                              const Opm::EclipseState& eclipseState,
                              std::unique_ptr<EclipseIO>&& eclIO,
-                             const Opm::PhaseUsage &phaseUsage,
-                             const double* permeability );
+                             const Opm::PhaseUsage &phaseUsage);
 
         /** \copydoc Opm::OutputWriter::writeInit */
         void writeInit(const data::Solution& simProps, const NNC& nnc);
@@ -283,7 +282,6 @@ namespace Opm
 
         template <class Grid>
         void initFromRestartFile(const PhaseUsage& phaseusage,
-                                 const double* permeability,
                                  const Grid& grid,
                                  SimulationDataContainer& simulatorstate,
                                  WellStateFullyImplicitBlackoil& wellstate);
@@ -323,10 +321,9 @@ namespace Opm
                          const parameter::ParameterGroup& param,
                          const Opm::EclipseState& eclipseState,
                          std::unique_ptr<EclipseIO>&& eclIO,
-                         const Opm::PhaseUsage &phaseUsage,
-                         const double* permeability )
+                         const Opm::PhaseUsage &phaseUsage)
       : output_( param.getDefault("output", true) ),
-        parallelOutput_( output_ ? new ParallelDebugOutput< Grid >( grid, eclipseState, phaseUsage.num_phases, permeability, phaseUsage ) : 0 ),
+        parallelOutput_( output_ ? new ParallelDebugOutput< Grid >( grid, eclipseState, phaseUsage.num_phases, phaseUsage ) : 0 ),
         outputDir_( output_ ? param.getDefault("output_dir", std::string("output")) : "." ),
         output_interval_( output_ ? param.getDefault("output_interval", 1): 0 ),
         lastBackupReportStep_( -1 ),
@@ -400,7 +397,6 @@ namespace Opm
     inline void
     BlackoilOutputWriter::
     initFromRestartFile( const PhaseUsage& phaseusage,
-                         const double* permeability,
                          const Grid& grid,
                          SimulationDataContainer& simulatorstate,
                          WellStateFullyImplicitBlackoil& wellstate)
@@ -422,7 +418,6 @@ namespace Opm
                                   Opm::UgGridHelpers::dimensions(grid),
                                   Opm::UgGridHelpers::cell2Faces(grid),
                                   Opm::UgGridHelpers::beginFaceCentroids(grid),
-                                  permeability,
                                   dummy_list_econ_limited
                                   // We need to pass the optionaly arguments
                                   // as we get the following error otherwise

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.hpp
@@ -70,8 +70,7 @@ namespace Opm
                                  const parameter::ParameterGroup& param,
                                  const EclipseState& eclipseState,
                                  std::unique_ptr<EclipseIO>&& eclIO,
-                                 const Opm::PhaseUsage &phaseUsage,
-                                 const double* permeability );
+                                 const Opm::PhaseUsage &phaseUsage);
 
         /*!
          * \brief Write a blackoil reservoir state to disk for later inspection with
@@ -142,7 +141,6 @@ namespace Opm
 
         template <class Grid>
         void initFromRestartFile(const PhaseUsage& phaseusage,
-                                 const double* permeability,
                                  const Grid& grid,
                                  SimulationDataContainer& simulatorstate,
                                  WellStateFullyImplicitBlackoilDense& wellstate);
@@ -180,10 +178,9 @@ namespace Opm
                              const parameter::ParameterGroup& param,
                              const Opm::EclipseState& eclipseState,
                              std::unique_ptr<EclipseIO>&& eclIO,
-                             const Opm::PhaseUsage &phaseUsage,
-                             const double* permeability )
+                             const Opm::PhaseUsage &phaseUsage)
       : output_( param.getDefault("output", true) ),
-        parallelOutput_( output_ ? new ParallelDebugOutput< Grid >( grid, eclipseState, phaseUsage.num_phases, permeability, phaseUsage ) : 0 ),
+        parallelOutput_( output_ ? new ParallelDebugOutput< Grid >( grid, eclipseState, phaseUsage.num_phases, phaseUsage ) : 0 ),
         outputDir_( output_ ? param.getDefault("output_dir", std::string("output")) : "." ),
         output_interval_( output_ ? param.getDefault("output_interval", 1): 0 ),
         lastBackupReportStep_( -1 ),
@@ -233,7 +230,6 @@ namespace Opm
     inline void
     BlackoilOutputWriterEbos::
     initFromRestartFile( const PhaseUsage& phaseusage,
-                         const double* permeability,
                          const Grid& grid,
                          SimulationDataContainer& simulatorstate,
                          WellStateFullyImplicitBlackoilDense& wellstate)
@@ -255,7 +251,6 @@ namespace Opm
                                   Opm::UgGridHelpers::dimensions(grid),
                                   Opm::UgGridHelpers::cell2Faces(grid),
                                   Opm::UgGridHelpers::beginFaceCentroids(grid),
-                                  permeability,
                                   dummy_list_econ_limited
                                   // We need to pass the optionaly arguments
                                   // as we get the following error otherwise
@@ -278,13 +273,13 @@ namespace Opm
 
     namespace detail {
         template<class Model>
-    void getOutputDataEbos(data::Solution& output,
-                           const Opm::PhaseUsage& phaseUsage,
-                           const Model& model,
-                           const RestartConfig& restartConfig,
-                           const int reportStepNum,
-                           const bool log)
-    {
+        void getOutputDataEbos(data::Solution& output,
+                               const Opm::PhaseUsage& phaseUsage,
+                               const Model& model,
+                               const RestartConfig& restartConfig,
+                               const int reportStepNum,
+                               const bool log)
+        {
             typedef typename Model::FluidSystem FluidSystem;
 
             //Get the value of each of the keys

--- a/tests/test_multisegmentwells.cpp
+++ b/tests/test_multisegmentwells.cpp
@@ -106,7 +106,6 @@ struct SetupMSW {
                                         Opm::UgGridHelpers::dimensions(grid),
                                         Opm::UgGridHelpers::cell2Faces(grid),
                                         Opm::UgGridHelpers::beginFaceCentroids(grid),
-                                        fluidprops->permeability(),
                                         dummy_dynamic_list,
                                         false
                                         // We need to pass the optionaly arguments


### PR DESCRIPTION
this information is already part of the EclipseState. The reason why this should IMO be avoided is that this enforces an implementation detail (ordering of the permeability matrices) of the simulator on the well model. If this needs to be done for performance reasons, IMO it would be smarter to pass an array of matrices, instead of passing a raw array of doubles.  I doubt that this is necessary, though: completing the full Norne deck takes about 0.25 seconds longer on my machine, that's substantially less than 0.1% of the total runtime.