### PR TITLE
fix the build

### DIFF
--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -556,10 +556,12 @@ namespace Opm
         //   output_writer_
         void setupOutputWriter()
         {
+            const PhaseUsage pu = Opm::phaseUsageFromDeck(deck());
             output_writer_.reset(new OutputWriter(grid(),
                                                   param_,
                                                   eclState(),
-                                                  std::move(eclIO_));
+                                                  *eclIO_,
+                                                  pu));
         }
 
         // Run the simulator.

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.cpp
@@ -156,7 +156,7 @@ namespace Opm
                         bool substep)
     {
         // ECL output
-        if ( eclIO_ )
+        if (output())
         {
             const auto& initConfig = eclipseState_.getInitConfig();
             if (initConfig.restartRequested() && ((initConfig.getRestartStep()) == (timer.currentStepNum()))) {
@@ -164,11 +164,11 @@ namespace Opm
             } else {
                 data::Solution combined_sol = simToSolution(state, phaseUsage_); // Get "normal" data (SWAT, PRESSURE, ...)
                 combined_sol.insert(sol.begin(), sol.end());           // ... insert "extra" data (KR, VISC, ...)
-                eclIO_->writeTimeStep(timer.reportStepNum(),
-                                      substep,
-                                      timer.simulationTimeElapsed(),
-                                      combined_sol,
-                                      wellState.report(phaseUsage_));
+                eclIO_.writeTimeStep(timer.reportStepNum(),
+                                     substep,
+                                     timer.simulationTimeElapsed(),
+                                     combined_sol,
+                                     wellState.report(phaseUsage_));
             }
         }
 


### PR DESCRIPTION
seems like #1042 was a bit premature. sorry for this. this patch also does not `std::move` the  `unique_ptr` for `eclIO` anymore. (IMO, that's a semantically quite strange thing to do.)