### PR TITLE
fixed: calculate FIP in substeps for summary output

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -1005,6 +1005,14 @@ namespace Opm {
             return fluid_.numPhases();
         }
 
+        /// Wrapper required due to not following generic API
+        template<class T>
+        std::vector<std::vector<double> >
+        computeFluidInPlace(const T&, const std::vector<int>& fipnum) const
+        {
+            return computeFluidInPlace(fipnum);
+        }
+
         std::vector<std::vector<double> >
         computeFluidInPlace(const std::vector<int>& fipnum) const
         {

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -232,7 +232,8 @@ namespace Opm
             // \Note: The report steps are met in any case
             // \Note: The sub stepping will require a copy of the state variables
             if( adaptiveTimeStepping ) {
-                report += adaptiveTimeStepping->step( timer, *solver, state, well_state, output_writer_ );
+                report += adaptiveTimeStepping->step( timer, *solver, state, well_state, output_writer_, 
+                                                     output_writer_.requireFIPNUM() ? &fipnum : nullptr );
             }
             else {
                 // solve for complete report step

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -282,7 +282,8 @@ public:
             // \Note: The report steps are met in any case
             // \Note: The sub stepping will require a copy of the state variables
             if( adaptiveTimeStepping ) {
-                report += adaptiveTimeStepping->step( timer, *solver, state, well_state, output_writer_ );
+                report += adaptiveTimeStepping->step( timer, *solver, state, well_state, output_writer_,
+                                                      output_writer_.requireFIPNUM() ? &fipnum : nullptr );
             }
             else {
                 // solve for complete report step

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -459,4 +459,9 @@ namespace Opm
         const auto& initconfig = eclipseState_.getInitConfig();
         return initconfig.restartRequested();
     }
+
+
+    bool BlackoilOutputWriter::requireFIPNUM() const {
+        return eclipseState_.getSummaryConfig().requireFIPNUM();
+    }
 }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -288,6 +288,8 @@ namespace Opm
 
         bool isRestart() const;
 
+        bool requireFIPNUM() const;
+
     protected:
         const bool output_;
         std::unique_ptr< ParallelDebugOutputInterface > parallelOutput_;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.cpp
@@ -132,6 +132,8 @@ namespace Opm
         const WellStateFullyImplicitBlackoil& wellState  = (parallelOutput_ && parallelOutput_->isParallel() ) ? parallelOutput_->globalWellState() : localWellState;
 
         // serial output is only done on I/O rank
+        int err = 0;
+        std::string emsg;
         if( isIORank )
         {
             if( asyncOutput_ ) {
@@ -140,7 +142,25 @@ namespace Opm
             }
             else {
                 // just write the data to disk
-                writeTimeStepSerial( timer, state, wellState, sol, substep );
+                try {
+                    writeTimeStepSerial( timer, state, wellState, sol, substep );
+                } catch (std::runtime_error& msg) {
+                    err = 1;
+                    emsg = msg.what();
+                }
+            }
+        }
+
+        if (!asyncOutput_) {
+#if HAVE_MPI
+            MPI_Bcast(&err, 1, MPI_INT, 0, MPI_COMM_WORLD);
+#endif
+            if (err) {
+                if (isIORank) {
+                    throw std::runtime_error(emsg);
+                } else {
+                    throw std::runtime_error("I/O process encountered problems.");
+                }
             }
         }
     }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.cpp
@@ -299,4 +299,9 @@ namespace Opm
         const auto& initconfig = eclipseState_.getInitConfig();
         return initconfig.restartRequested();
     }
+
+
+    bool BlackoilOutputWriterEbos::requireFIPNUM() const {
+        return eclipseState_.getSummaryConfig().requireFIPNUM();
+    }
 }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.hpp
@@ -602,7 +602,7 @@ namespace Opm
                 const std::vector<double>& oipg = vapour_active ? fip.fip[Model::FIPData::FIP_VAPORIZED_OIL] : std::vector<double>(size,0.0);
                 std::vector<double> oip = oipl;
                 if (vapour_active) {
-                    oip.insert(oip.end(), oipg.begin(), oipg.end());
+                    std::transform(oip.begin(), oip.end(), oipg.begin(), oip.begin(), std::plus<double>());
                 }
 
                 //Oil in place (liquid phase only)
@@ -638,7 +638,7 @@ namespace Opm
                 const std::vector<double>& gipl= liquid_active ? fip.fip[Model::FIPData::FIP_DISSOLVED_GAS] : std::vector<double>(size,0.0);
                 std::vector<double> gip = gipg;
                 if (liquid_active) {
-                    gip.insert(gip.end(), gipl.begin(), gipl.end());
+                    std::transform(gip.begin(), gip.end(), gipl.begin(), gip.begin(), std::plus<double>());
                 }
 
                 // Gas in place (gas phase only)

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutputEbos.hpp
@@ -147,6 +147,8 @@ namespace Opm
 
         bool isRestart() const;
 
+        bool requireFIPNUM() const;
+
     protected:
         const bool output_;
         std::unique_ptr< ParallelDebugOutputInterface > parallelOutput_;


### PR DESCRIPTION
Causes a crash in opm-output, as it seems to expect data has been correctly sized by caller. Ref https://github.com/OPM/opm-output/pull/162