### PR TITLE
Added output of dew and bubble point pressures

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -1271,6 +1271,13 @@ namespace Opm {
             VectorType& RsSat = simData.getCellData( "RSSAT" );
             VectorType& RvSat = simData.getCellData( "RVSAT" );
 
+            simData.registerCellData( "PBUB", 1 );
+            simData.registerCellData( "PDEW", 1 );
+
+            VectorType& Pb = simData.getCellData( "PBUB" );
+            VectorType& Pd = simData.getCellData( "PDEW" );
+
+
             for (int cellIdx = 0; cellIdx < numCells; ++cellIdx) {
                 const auto& intQuants = *ebosModel.cachedIntensiveQuantities(cellIdx, /*timeIdx=*/0);
                 const auto& fs = intQuants.fluidState();
@@ -1304,6 +1311,8 @@ namespace Opm {
                                                                              FluidSystem::gasPhaseIdx,
                                                                              intQuants.pvtRegionIndex(),
                                                                              /*maxOilSaturation=*/1.0).value();
+                    Pb[cellIdx] = FluidSystem::bubblePointPressure(fs, intQuants.pvtRegionIndex()).value();
+                    Pd[cellIdx] = FluidSystem::dewPointPressure(fs, intQuants.pvtRegionIndex()).value();
                 }
                 if( liquid_active )
                 {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -726,11 +726,11 @@ namespace Opm
                 output.insert("PBUB",
                         Opm::UnitSystem::measure::pressure,
                         std::move( sd.getCellData("PBUB") ),
-                        data::TargetType::RESTART_AUXILLARY);
+                        data::TargetType::RESTART_AUXILIARY);
                 output.insert("PDEW",
                         Opm::UnitSystem::measure::pressure,
                         std::move( sd.getCellData("PDEW") ),
-                        data::TargetType::RESTART_AUXILLARY);
+                        data::TargetType::RESTART_AUXILIARY);
             }
 
             //Warn for any unhandled keyword

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -723,9 +723,14 @@ namespace Opm
             if (log && vapour_active &&
                 liquid_active && rstKeywords["PBPD"] > 0) {
                 rstKeywords["PBPD"] = 0;
-                Opm::OpmLog::warning("Bubble/dew point pressure output unsupported",
-                        "Writing bubble points and dew points (PBPD) to file is unsupported, "
-                        "as the simulator does not use these internally.");
+                output.insert("PBUB",
+                        Opm::UnitSystem::measure::pressure,
+                        std::move( sd.getCellData("PBUB") ),
+                        data::TargetType::RESTART_AUXILLARY);
+                output.insert("PDEW",
+                        Opm::UnitSystem::measure::pressure,
+                        std::move( sd.getCellData("PDEW") ),
+                        data::TargetType::RESTART_AUXILLARY);
             }
 
             //Warn for any unhandled keyword


### PR DESCRIPTION
This enables output of bubble point and dew point pressures to a restart file. 

This PR requires that OPM/opm-material#204 is merged.

This will fail with an exception if we are unable to find the dew point / bubble point pressure. See 
opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp:571
and
opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp:540
I'm not entirely sure how to best handle this situation, and I'm open to ideas. 