### PR TITLE
White spcae change.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -984,7 +984,6 @@ namespace Opm
     } // namespace detail
 
 
-
 } // namespace Opm
 
 #endif // OPM_FLOWMAIN_HEADER_INCLUDED


### PR DESCRIPTION
The sole purpose of this PR is to trigger the functionality to update reference data; it must be merged though to get a valid sha in the opm-data commit messages.