### PR TITLE
when no THP control/limit, thp value will be set to zero.

### DIFF
--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -171,6 +171,22 @@ namespace Opm
                             currentControls()[ newIndex ] = 0;
                         }
                     }
+
+
+                    // If in the new step, there is no THP related target/limit anymore, its thp value should be
+                    // set to zero.
+                    const WellControls* ctrl = wells->ctrls[w];
+                    const int nwc = well_controls_get_num(ctrl);
+                    int ctrl_index = 0;
+                    for (; ctrl_index < nwc; ++ctrl_index) {
+                        if (well_controls_iget_type(ctrl, ctrl_index) == THP) {
+                            break;
+                        }
+                    }
+                    // not finding any thp related control/limits
+                    if (ctrl_index == nwc) {
+                        thp()[w] = 0.;
+                    }
                 }
             }
         }


### PR DESCRIPTION
It provides a strategy to reset the zero thp value when no thp control is involved anymore.

It should not change any running results of all the current examples, while trying to avoid outputting distracting thp values. 

Compared with OPM/opm-core#1143, it provides a strategy to recover the zero THP output when no THP control/limit is involved anymore.  Maybe it should just go ahead to the end of `init()` function. 