### PR TITLE
Added writing initial timestep data to restart

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -235,18 +235,6 @@ public:
             // give the polymer and surfactant simulators the chance to do their stuff
             handleAdditionalWellInflow(timer, wells_manager, well_state, wells);
 
-            // write the inital state at the report stage
-            if (timer.initialStep()) {
-                Dune::Timer perfTimer;
-                perfTimer.start();
-
-                // No per cell data is written for initial step, but will be
-                // for subsequent steps, when we have started simulating
-                output_writer_.writeTimeStepWithoutCellProperties( timer, state, well_state );
-
-                report.output_write_time += perfTimer.stop();
-            }
-
             // Compute reservoir volumes for RESV controls.
             computeRESV(timer.currentStepNum(), wells, state, well_state);
 
@@ -256,6 +244,18 @@ public:
             const WellModel well_model(wells, &(wells_manager.wellCollection()), model_param_, terminal_output_);
 
             auto solver = createSolver(well_model);
+
+            // write the inital state at the report stage
+            if (timer.initialStep()) {
+                Dune::Timer perfTimer;
+                perfTimer.start();
+
+                // No per cell data is written for initial step, but will be
+                // for subsequent steps, when we have started simulating
+                output_writer_.writeTimeStep( timer, state, well_state, solver->model() );
+
+                report.output_write_time += perfTimer.stop();
+            }
 
             // Compute orignal fluid in place if this has not been done yet
             if (originalFluidInPlace.empty()) {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -532,6 +532,8 @@ namespace Opm
 
         /**
          * Returns the data requested in the restartConfig
+         * NOTE: Since this function steals data from the SimulationDataContainer (std::move),
+         * the variable sd becomes "invalid" after calling this function.
          */
         template<class Model>
         void getRestartData(data::Solution& output,


### PR DESCRIPTION
This enables writing the internal flow_ebos simulator state to the restart file for the initial conditions. 

This essentially dumps the internal state of the simulator before starting the simulation instead of dumping the initial conditions used to construct the simulator.

For the Norne case, it addes missing variables for the first report step (e.g., such as GAS_KR, WAT_KR, ...)

It also changes some of the existing output *for the first output step* (all subsequent steps are identical):
- 330 cells have a slightly different PRESSURE (e.g., 0.2764*4662*E+03 vs 0.2764*7656*E+03. I've been unable to track down the cause of this difference. Any ideas?
- The same cells appear to also have a different RS (e.g., 0.1*0677000*E+03 vs 0.1*2498261*E+03) and RV (e.g., 0.627*09332*E-04 vs 0.627*26634*E-04)
- SGAS, SWAT is different for virtually all cells
- TEMP is different for all cells (20 C for master, 15.56 C for this PR). The next report steps all cells are 15.56 C for both master and this PR.