### PR TITLE
[WIP] Fixing restart for flow_ebos

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -26,6 +26,7 @@
 # originally generated with the command:
 # find opm -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND MAIN_SOURCE_FILES
+  opm/autodiff/Compat.cpp
   opm/autodiff/ExtractParallelGridInformationToISTL.cpp
   opm/autodiff/NewtonIterationBlackoilCPR.cpp
   opm/autodiff/NewtonIterationBlackoilInterleaved.cpp

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -243,6 +243,8 @@ namespace Opm {
                 residual_norms_history_.clear();
                 current_relaxation_ = 1.0;
                 dx_old_ = 0.0;
+                convertInput( iteration, reservoir_state, ebosSimulator_ );
+                ebosSimulator_.model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
             }
 
             report.total_linearizations = 1;

--- a/opm/autodiff/Compat.cpp
+++ b/opm/autodiff/Compat.cpp
@@ -28,6 +28,7 @@
 #include <opm/core/props/BlackoilPhases.hpp>
 #include <opm/core/simulator/BlackoilState.hpp>
 #include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp>
 #include <opm/autodiff/BlackoilSolventState.hpp>
 #include <opm/output/data/Cells.hpp>
 #include <opm/output/data/Solution.hpp>
@@ -236,6 +237,21 @@ void wellsToState( const data::Wells& wells,
     }
 }
 
+
+
+
+
+
+void wellsToState( const data::Wells& wells,
+                   PhaseUsage phases,
+                   WellStateFullyImplicitBlackoilDense& state )
+{
+    // Set base class variables.
+    wellsToState(wells, phases, static_cast<WellStateFullyImplicitBlackoil&>(state));
+
+    // Set wellSolution() variable.
+    state.setWellSolutions(phases);
+}
 
 
 } // namespace Opm

--- a/opm/autodiff/Compat.cpp
+++ b/opm/autodiff/Compat.cpp
@@ -1,0 +1,241 @@
+/*
+  Copyright 2016 Statoil ASA
+  Copyright 2016 IRIS
+  Copyright 2017 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/autodiff/Compat.hpp>
+
+#include <algorithm>
+#include <cassert>
+
+#include <opm/common/data/SimulationDataContainer.hpp>
+#include <opm/core/props/BlackoilPhases.hpp>
+#include <opm/core/simulator/BlackoilState.hpp>
+#include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/autodiff/BlackoilSolventState.hpp>
+#include <opm/output/data/Cells.hpp>
+#include <opm/output/data/Solution.hpp>
+#include <opm/output/data/Wells.hpp>
+
+namespace Opm {
+
+std::vector< double > destripe( const std::vector< double >& v,
+                                size_t stride,
+                                size_t offset ) {
+
+    std::vector< double > dst( v.size() / stride );
+
+    size_t di = 0;
+    for( size_t i = offset; i < v.size(); i += stride ) {
+        dst[ di++ ] = v[ i ];
+    }
+
+    return dst;
+}
+
+
+
+
+
+
+std::vector< double >& stripe( const std::vector< double >& v,
+                               size_t stride,
+                               size_t offset,
+                               std::vector< double >& dst ) {
+
+    /* does little range checking etc; for future revisions */
+    size_t vi = 0;
+    for( size_t i = offset; i < dst.size(); i += stride ) {
+        dst[ i ] = v[ vi++ ];
+    }
+
+    return dst;
+}
+
+
+
+
+
+
+data::Solution simToSolution( const SimulationDataContainer& reservoir,
+                              PhaseUsage phases ) {
+    data::Solution sol;
+    sol.insert( "PRESSURE", UnitSystem::measure::pressure, reservoir.pressure() , data::TargetType::RESTART_SOLUTION);
+    sol.insert( "TEMP"    , UnitSystem::measure::temperature, reservoir.temperature() , data::TargetType::RESTART_SOLUTION );
+
+    const auto ph = reservoir.numPhases();
+    const auto& sat = reservoir.saturation();
+
+    const auto aqua = BlackoilPhases::Aqua;
+    const auto vapour = BlackoilPhases::Vapour;
+
+    if( phases.phase_used[ aqua ] ) {
+        sol.insert( "SWAT", UnitSystem::measure::identity, destripe( sat, ph, phases.phase_pos[ aqua ] ) , data::TargetType::RESTART_SOLUTION );
+    }
+
+    if( phases.phase_used[ vapour ] ) {
+        sol.insert( "SGAS", UnitSystem::measure::identity, destripe( sat, ph, phases.phase_pos[ vapour ] ) , data::TargetType::RESTART_SOLUTION );
+    }
+
+    if( reservoir.hasCellData( BlackoilState::GASOILRATIO ) ) {
+        sol.insert( "RS", UnitSystem::measure::gas_oil_ratio, reservoir.getCellData( BlackoilState::GASOILRATIO ) , data::TargetType::RESTART_SOLUTION );
+    }
+
+    if( reservoir.hasCellData( BlackoilState::RV ) ) {
+        sol.insert( "RV", UnitSystem::measure::oil_gas_ratio, reservoir.getCellData( BlackoilState::RV ) , data::TargetType::RESTART_SOLUTION );
+    }
+
+    if (reservoir.hasCellData( BlackoilSolventState::SSOL)) {
+        sol.insert( "SSOL", UnitSystem::measure::identity, reservoir.getCellData( BlackoilSolventState::SSOL ) , data::TargetType::RESTART_SOLUTION );
+    }
+
+    return sol;
+}
+
+
+
+
+
+
+void solutionToSim( const data::Solution& sol,
+                    PhaseUsage phases,
+                    SimulationDataContainer& state ) {
+
+    const auto stride = phases.num_phases;
+
+    if( sol.has( "SWAT" ) ) {
+        stripe( sol.data( "SWAT" ),
+                stride,
+                phases.phase_pos[ BlackoilPhases::Aqua ],
+                state.saturation() );
+    }
+
+    if( sol.has( "SGAS" ) ) {
+        stripe( sol.data( "SGAS" ),
+                stride,
+                phases.phase_pos[ BlackoilPhases::Vapour ],
+                state.saturation() );
+    }
+
+    for (size_t c = 0; c < state.numCells(); ++c) {
+        double& so = state.saturation()[phases.num_phases*c + phases.phase_pos[ BlackoilPhases::Liquid ]];
+        so = 1.0;
+        if (phases.phase_used[ BlackoilPhases::Aqua]) {
+            so -= state.saturation()[phases.num_phases*c + phases.phase_pos[ BlackoilPhases::Aqua ]];
+        }
+        if (phases.phase_used[ BlackoilPhases::Vapour]) {
+            so -= state.saturation()[phases.num_phases*c + phases.phase_pos[ BlackoilPhases::Vapour ]];
+        }
+    }
+
+
+    if( sol.has( "PRESSURE" ) ) {
+        state.pressure() = sol.data( "PRESSURE" );
+    }
+
+    if( sol.has( "TEMP" ) ) {
+        state.temperature() = sol.data( "TEMP" );
+    }
+
+    if( sol.has( "RS" ) ) {
+        state.getCellData( "GASOILRATIO" ) = sol.data( "RS" );
+    }
+
+    if( sol.has( "RV" ) ) {
+        state.getCellData( "RV" ) = sol.data( "RV" );
+    }
+
+    if (sol.has( "SSOL" ) ) {
+        state.getCellData("SSOL") = sol.data("SSOL");
+    }
+
+}
+
+
+
+
+
+
+void wellsToState( const data::Wells& wells,
+                   PhaseUsage phases,
+                   WellStateFullyImplicitBlackoil& state ) {
+
+    using rt = data::Rates::opt;
+
+    const auto np = phases.num_phases;
+
+    std::vector< rt > phs( np );
+    if( phases.phase_used[BlackoilPhases::Aqua] ) {
+        phs.at( phases.phase_pos[BlackoilPhases::Aqua] ) = rt::wat;
+    }
+
+    if( phases.phase_used[BlackoilPhases::Liquid] ) {
+        phs.at( phases.phase_pos[BlackoilPhases::Liquid] ) = rt::oil;
+    }
+
+    if( phases.phase_used[BlackoilPhases::Vapour] ) {
+        phs.at( phases.phase_pos[BlackoilPhases::Vapour] ) = rt::gas;
+    }
+
+    for( const auto& wm : state.wellMap() ) {
+        const auto well_index = wm.second[ 0 ];
+        const auto& well = wells.at( wm.first );
+
+        state.bhp()[ well_index ] = well.bhp;
+        state.temperature()[ well_index ] = well.temperature;
+        state.currentControls()[ well_index ] = well.control;
+
+        const auto wellrate_index = well_index * np;
+        for( size_t i = 0; i < phs.size(); ++i ) {
+            assert( well.rates.has( phs[ i ] ) );
+            state.wellRates()[ wellrate_index + i ] = well.rates.get( phs[ i ] );
+        }
+
+        const auto perforation_pressure = []( const data::Completion& comp ) {
+            return comp.pressure;
+        };
+
+        const auto perforation_reservoir_rate = []( const data::Completion& comp ) {
+            return comp.reservoir_rate;
+        };
+
+        std::transform( well.completions.begin(),
+                        well.completions.end(),
+                        state.perfPress().begin() + wm.second[ 1 ],
+                        perforation_pressure );
+
+        std::transform( well.completions.begin(),
+                        well.completions.end(),
+                        state.perfRates().begin() + wm.second[ 1 ],
+                        perforation_reservoir_rate );
+
+        int local_comp_index = 0;
+        for (const data::Completion& comp : well.completions) {
+            const int global_comp_index = wm.second[1] + local_comp_index;
+            for (int phase_index = 0; phase_index < np; ++phase_index) {
+                state.perfPhaseRates()[global_comp_index*np + phase_index] = comp.rates.get(phs[phase_index]);
+            }
+            ++local_comp_index;
+        }
+    }
+}
+
+
+
+} // namespace Opm

--- a/opm/autodiff/Compat.hpp
+++ b/opm/autodiff/Compat.hpp
@@ -31,6 +31,7 @@ namespace Opm {
     // Forward declarations
     class SimulationDataContainer;
     class WellStateFullyImplicitBlackoil;
+    class WellStateFullyImplicitBlackoilDense;
 
     std::vector< double > destripe( const std::vector< double >& v,
                                     size_t stride,
@@ -51,6 +52,10 @@ namespace Opm {
     void wellsToState( const data::Wells& wells,
                        PhaseUsage phases,
                        WellStateFullyImplicitBlackoil& state );
+
+    void wellsToState( const data::Wells& wells,
+                       PhaseUsage phases,
+                       WellStateFullyImplicitBlackoilDense& state );
 
 }
 

--- a/opm/autodiff/Compat.hpp
+++ b/opm/autodiff/Compat.hpp
@@ -21,229 +21,36 @@
 #ifndef OPM_SIMULATORS_COMPAT_HPP
 #define OPM_SIMULATORS_COMPAT_HPP
 
-#include <algorithm>
-#include <cassert>
-
-#include <opm/common/data/SimulationDataContainer.hpp>
-#include <opm/core/props/BlackoilPhases.hpp>
-#include <opm/core/simulator/BlackoilState.hpp>
-#include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
-#include <opm/autodiff/BlackoilSolventState.hpp>
-#include <opm/output/data/Cells.hpp>
 #include <opm/output/data/Solution.hpp>
 #include <opm/output/data/Wells.hpp>
+#include <opm/core/props/BlackoilPhases.hpp>
+#include <vector>
 
 namespace Opm {
 
-inline std::vector< double > destripe( const std::vector< double >& v,
-                                       size_t stride,
-                                       size_t offset ) {
-
-    std::vector< double > dst( v.size() / stride );
-
-    size_t di = 0;
-    for( size_t i = offset; i < v.size(); i += stride ) {
-        dst[ di++ ] = v[ i ];
-    }
-
-    return dst;
-}
-
-
-
-
-
-inline std::vector< double >& stripe( const std::vector< double >& v,
-                                      size_t stride,
-                                      size_t offset,
-                                      std::vector< double >& dst ) {
-
-    /* does little range checking etc; for future revisions */
-    size_t vi = 0;
-    for( size_t i = offset; i < dst.size(); i += stride ) {
-        dst[ i ] = v[ vi++ ];
-    }
-
-    return dst;
-}
-
-
-
-
-
-
-
-    inline data::Solution simToSolution( const SimulationDataContainer& reservoir,
-                                         PhaseUsage phases ) {
-    data::Solution sol;
-    sol.insert( "PRESSURE", UnitSystem::measure::pressure, reservoir.pressure() , data::TargetType::RESTART_SOLUTION);
-    sol.insert( "TEMP"    , UnitSystem::measure::temperature, reservoir.temperature() , data::TargetType::RESTART_SOLUTION );
-
-    const auto ph = reservoir.numPhases();
-    const auto& sat = reservoir.saturation();
-
-    const auto aqua = BlackoilPhases::Aqua;
-    const auto vapour = BlackoilPhases::Vapour;
-
-    if( phases.phase_used[ aqua ] ) {
-        sol.insert( "SWAT", UnitSystem::measure::identity, destripe( sat, ph, phases.phase_pos[ aqua ] ) , data::TargetType::RESTART_SOLUTION );
-    }
-
-    if( phases.phase_used[ vapour ] ) {
-        sol.insert( "SGAS", UnitSystem::measure::identity, destripe( sat, ph, phases.phase_pos[ vapour ] ) , data::TargetType::RESTART_SOLUTION );
-    }
-
-    if( reservoir.hasCellData( BlackoilState::GASOILRATIO ) ) {
-        sol.insert( "RS", UnitSystem::measure::gas_oil_ratio, reservoir.getCellData( BlackoilState::GASOILRATIO ) , data::TargetType::RESTART_SOLUTION );
-    }
-
-    if( reservoir.hasCellData( BlackoilState::RV ) ) {
-        sol.insert( "RV", UnitSystem::measure::oil_gas_ratio, reservoir.getCellData( BlackoilState::RV ) , data::TargetType::RESTART_SOLUTION );
-    }
-
-    if (reservoir.hasCellData( BlackoilSolventState::SSOL)) {
-        sol.insert( "SSOL", UnitSystem::measure::identity, reservoir.getCellData( BlackoilSolventState::SSOL ) , data::TargetType::RESTART_SOLUTION );
-    }
-
-    return sol;
-}
-
-
-
-
-
-
-
-
-inline void solutionToSim( const data::Solution& sol,
-                          PhaseUsage phases,
-                          SimulationDataContainer& state ) {
-
-    const auto stride = phases.num_phases;
-
-    if( sol.has( "SWAT" ) ) {
-        stripe( sol.data( "SWAT" ),
-                stride,
-                phases.phase_pos[ BlackoilPhases::Aqua ],
-                state.saturation() );
-    }
-
-    if( sol.has( "SGAS" ) ) {
-        stripe( sol.data( "SGAS" ),
-                stride,
-                phases.phase_pos[ BlackoilPhases::Vapour ],
-                state.saturation() );
-    }
-
-    for (size_t c = 0; c < state.numCells(); ++c) {
-        double& so = state.saturation()[phases.num_phases*c + phases.phase_pos[ BlackoilPhases::Liquid ]];
-        so = 1.0;
-        if (phases.phase_used[ BlackoilPhases::Aqua]) {
-            so -= state.saturation()[phases.num_phases*c + phases.phase_pos[ BlackoilPhases::Aqua ]];
-        }
-        if (phases.phase_used[ BlackoilPhases::Vapour]) {
-            so -= state.saturation()[phases.num_phases*c + phases.phase_pos[ BlackoilPhases::Vapour ]];
-        }
-    }
-
-
-    if( sol.has( "PRESSURE" ) ) {
-        state.pressure() = sol.data( "PRESSURE" );
-    }
-
-    if( sol.has( "TEMP" ) ) {
-        state.temperature() = sol.data( "TEMP" );
-    }
-
-    if( sol.has( "RS" ) ) {
-        state.getCellData( "GASOILRATIO" ) = sol.data( "RS" );
-    }
-
-    if( sol.has( "RV" ) ) {
-        state.getCellData( "RV" ) = sol.data( "RV" );
-    }
-
-    if (sol.has( "SSOL" ) ) {
-        state.getCellData("SSOL") = sol.data("SSOL");
-    }
-
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-inline void wellsToState( const data::Wells& wells,
-                          PhaseUsage phases,
-                          WellStateFullyImplicitBlackoil& state ) {
-
-    using rt = data::Rates::opt;
-
-    const auto np = phases.num_phases;
-
-    std::vector< rt > phs( np );
-    if( phases.phase_used[BlackoilPhases::Aqua] ) {
-        phs.at( phases.phase_pos[BlackoilPhases::Aqua] ) = rt::wat;
-    }
-
-    if( phases.phase_used[BlackoilPhases::Liquid] ) {
-        phs.at( phases.phase_pos[BlackoilPhases::Liquid] ) = rt::oil;
-    }
-
-    if( phases.phase_used[BlackoilPhases::Vapour] ) {
-        phs.at( phases.phase_pos[BlackoilPhases::Vapour] ) = rt::gas;
-    }
-
-    for( const auto& wm : state.wellMap() ) {
-        const auto well_index = wm.second[ 0 ];
-        const auto& well = wells.at( wm.first );
-
-        state.bhp()[ well_index ] = well.bhp;
-        state.temperature()[ well_index ] = well.temperature;
-        state.currentControls()[ well_index ] = well.control;
-
-        const auto wellrate_index = well_index * np;
-        for( size_t i = 0; i < phs.size(); ++i ) {
-            assert( well.rates.has( phs[ i ] ) );
-            state.wellRates()[ wellrate_index + i ] = well.rates.get( phs[ i ] );
-        }
-
-        const auto perforation_pressure = []( const data::Completion& comp ) {
-            return comp.pressure;
-        };
-
-        const auto perforation_reservoir_rate = []( const data::Completion& comp ) {
-            return comp.reservoir_rate;
-        };
-
-        std::transform( well.completions.begin(),
-                        well.completions.end(),
-                        state.perfPress().begin() + wm.second[ 1 ],
-                        perforation_pressure );
-
-        std::transform( well.completions.begin(),
-                        well.completions.end(),
-                        state.perfRates().begin() + wm.second[ 1 ],
-                        perforation_reservoir_rate );
-
-        int local_comp_index = 0;
-        for (const data::Completion& comp : well.completions) {
-            const int global_comp_index = wm.second[1] + local_comp_index;
-            for (int phase_index = 0; phase_index < np; ++phase_index) {
-                state.perfPhaseRates()[global_comp_index*np + phase_index] = comp.rates.get(phs[phase_index]);
-            }
-            ++local_comp_index;
-        }
-    }
-}
+    // Forward declarations
+    class SimulationDataContainer;
+    class WellStateFullyImplicitBlackoil;
+
+    std::vector< double > destripe( const std::vector< double >& v,
+                                    size_t stride,
+                                    size_t offset );
+
+    std::vector< double >& stripe( const std::vector< double >& v,
+                                   size_t stride,
+                                   size_t offset,
+                                   std::vector< double >& dst );
+
+    data::Solution simToSolution( const SimulationDataContainer& reservoir,
+                                  PhaseUsage phases );
+
+    void solutionToSim( const data::Solution& sol,
+                        PhaseUsage phases,
+                        SimulationDataContainer& state );
+
+    void wellsToState( const data::Wells& wells,
+                       PhaseUsage phases,
+                       WellStateFullyImplicitBlackoil& state );
 
 }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -395,13 +395,13 @@ namespace Opm
     }
 
 
-    template <class Grid, class WellStateFullyImplicitBlackOel>
+    template <class Grid, class WellState>
     inline void
     BlackoilOutputWriter::
     initFromRestartFile( const PhaseUsage& phaseUsage,
                          const Grid& grid,
                          SimulationDataContainer& simulatorstate,
-                         WellStateFullyImplicitBlackOel& wellstate)
+                         WellState& wellstate)
     {
         std::map<std::string, UnitSystem::measure> solution_keys {{"PRESSURE" , UnitSystem::measure::pressure},
                                                                   {"SWAT" , UnitSystem::measure::identity},

--- a/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
@@ -68,23 +68,23 @@ namespace Opm
             // call init on base class
             BaseType :: init(wells, state, prevState);
 
-            setWellSolutions(wells, pu);
-            setWellSolutionsFromPrevState(wells, prevState);
+            setWellSolutions(pu);
+            setWellSolutionsFromPrevState(prevState);
         }
 
 
         template <class PrevState>
-        void setWellSolutionsFromPrevState(const Wells* wells, const PrevState& prevState)
+        void setWellSolutionsFromPrevState(const PrevState& prevState)
         {
             // Set nw and np, or return if no wells.
-            if (wells == 0) {
+            if (wells_.get() == nullptr) {
                 return;
             }
-            const int nw = wells->number_of_wells;
+            const int nw = wells_->number_of_wells;
             if (nw == 0) {
                 return;
             }
-            const int np = wells->number_of_phases;
+            const int np = wells_->number_of_phases;
 
             // intialize wells that have been there before
             // order may change so the mapping is based on the well name
@@ -95,7 +95,7 @@ namespace Opm
                 const_iterator end = prevState.wellMap().end();
                 int nw_old = prevState.bhp().size();
                 for (int w = 0; w < nw; ++w) {
-                    std::string name( wells->name[ w ] );
+                    std::string name( wells_->name[ w ] );
                     const_iterator it = prevState.wellMap().find( name );
                     if( it != end )
                     {
@@ -115,37 +115,37 @@ namespace Opm
 
 
         /// Set wellSolutions() based on the base class members.
-        void setWellSolutions(const Wells* wells, const PhaseUsage& pu)
+        void setWellSolutions(const PhaseUsage& pu)
         {
             // Set nw and np, or return if no wells.
-            if (wells == 0) {
+            if (wells_.get() == nullptr) {
                 return;
             }
-            const int nw = wells->number_of_wells;
+            const int nw = wells_->number_of_wells;
             if (nw == 0) {
                 return;
             }
-            const int np = wells->number_of_phases;
+            const int np = wells_->number_of_phases;
 
             well_solutions_.clear();
             well_solutions_.resize(nw * np, 0.0);
             std::vector<double> g = {1.0,1.0,0.01};
             for (int w = 0; w < nw; ++w) {
-                WellControls* wc = wells->ctrls[w];
+                WellControls* wc = wells_->ctrls[w];
 
                 // The current control in the well state overrides
                 // the current control set in the Wells struct, which
                 // is instead treated as a default.
                 const int current = currentControls()[w];
                 well_controls_set_current( wc, current);
-                const WellType& well_type = wells->type[w];
+                const WellType& well_type = wells_->type[w];
 
                 switch (well_controls_iget_type(wc, current)) {
                 case THP: // Intentional fall-through
                 case BHP:
                     if (well_type == INJECTOR) {
                         for (int p = 0; p < np; ++p)  {
-                            well_solutions_[w] += wellRates()[np*w + p] * wells->comp_frac[np*w + p];
+                            well_solutions_[w] += wellRates()[np*w + p] * wells_->comp_frac[np*w + p];
                         }
                     } else {
                         for (int p = 0; p < np; ++p) {
@@ -178,10 +178,10 @@ namespace Opm
                     }
                 } else {
                     if( pu.phase_used[Water] ) {
-                        wellSolutions()[nw + w] = wells->comp_frac[np*w + waterpos];
+                        wellSolutions()[nw + w] = wells_->comp_frac[np*w + waterpos];
                     }
                     if( pu.phase_used[Gas] ) {
-                        wellSolutions()[2*nw + w] = wells->comp_frac[np*w + gaspos];
+                        wellSolutions()[2*nw + w] = wells_->comp_frac[np*w + gaspos];
                     }
                 }
             }

--- a/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
@@ -35,6 +35,7 @@
 #include <map>
 #include <algorithm>
 #include <array>
+#include <cmath>
 
 namespace Opm
 {


### PR DESCRIPTION
This PR contains refactoring and fixes relating to *some* problems with restarting for flow_ebos:
 - the well state object is properly initialized from restart data,
 - for the first iteration, the input data (from the init routines) are converted to the ebos sim *before* the initial well solve.

The first fix is sufficient to make the SPE1CASE2_RESTART test work. Upon restarting the well iteration are completely bogus, which is fixed by the second point above, but the simulator recovers in this particular case.

The reason this is tagged as work in progress is the second fix (which is commit 5ac3b37). It changes the results of the very first timestep, sufficiently to perturb the solution path significantly. For me that meant increased runtime for the Norne case, in addition to the extra time taken to convert the data one more time per timestep (I guess it is only required for the very first step, but not sure if this is a significant time sink).

@andlaus, please take a look at the performance implications. @totto82 and @GitPaean, please test if this helps you with restarting.

There are at this point no changes to the content of restart files, so you should be able to restart better from those you already have.