### PR TITLE
Ensure ebos variables are converted for the first iteration.

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -243,6 +243,8 @@ namespace Opm {
                 residual_norms_history_.clear();
                 current_relaxation_ = 1.0;
                 dx_old_ = 0.0;
+                convertInput( iteration, reservoir_state, ebosSimulator_ );
+                ebosSimulator_.model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
             }
 
             report.total_linearizations = 1;


### PR DESCRIPTION
This is the second part of PR #1071, that was split in two.

As discussed in #1071 this changes initial values before the first well solve, which should be the right thing to do, but changes the solution path right off the bat. Therefore this should be tested extensively before merging.

@totto82 if you have trouble restarting, you could try adding this patch and see if it works better (it should, but it might not be sufficient for any particular restart-related problem).