### PR TITLE
Fix conditional viscosity output

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -1351,7 +1351,7 @@ namespace Opm {
                 errlog << "Finding the dew point pressure failed for " << failed_cells_pb.size() << " cells [";
                 errlog << failed_cells_pb[0];
                 const int max_elems = std::min(max_num_cells_faillog, failed_cells_pb.size());
-                for (size_t i = 1; i < max_elems; ++i) {
+                for (int i = 1; i < max_elems; ++i) {
                     errlog << ", " << failed_cells_pb[i];
                 }
                 if (failed_cells_pb.size() > max_num_cells_faillog) {
@@ -1365,7 +1365,7 @@ namespace Opm {
                 errlog << "Finding the dew point pressure failed for " << failed_cells_pd.size() << " cells [";
                 errlog << failed_cells_pd[0];
                 const int max_elems = std::min(max_num_cells_faillog, failed_cells_pd.size());
-                for (size_t i = 1; i < max_elems; ++i) {
+                for (int i = 1; i < max_elems; ++i) {
                     errlog << ", " << failed_cells_pd[i];
                 }
                 if (failed_cells_pd.size() > max_num_cells_faillog) {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -628,21 +628,21 @@ namespace Opm
                 const bool has_voil = (rstKeywords["VISC"] > 0) || (rstKeywords["VOIL"] > 0);
                 const bool has_vgas = (rstKeywords["VISC"] > 0) || (rstKeywords["VGAS"] > 0);
                 rstKeywords["VISC"] = 0;
-                if (aqua_active) {
+                if (aqua_active && has_vwat) {
                     output.insert("WAT_VISC",
                                   Opm::UnitSystem::measure::viscosity,
                                   std::move( sd.getCellData("WAT_VISC") ),
                                   data::TargetType::RESTART_AUXILIARY);
                     rstKeywords["VWAT"] = 0;
                 }
-                if (liquid_active) {
+                if (liquid_active && has_voil) {
                     output.insert("OIL_VISC",
                                   Opm::UnitSystem::measure::viscosity,
                                   std::move( sd.getCellData("OIL_VISC") ),
                                   data::TargetType::RESTART_AUXILIARY);
                     rstKeywords["VOIL"] = 0;
                 }
-                if (vapour_active) {
+                if (vapour_active && has_vgas) {
                     output.insert("GAS_VISC",
                                   Opm::UnitSystem::measure::viscosity,
                                   std::move( sd.getCellData("GAS_VISC") ),


### PR DESCRIPTION
A few warnings have been silenced. One of the warnings pointed to a minor bug: the merged code for viscosity output does the output unconditionally.

Although quite trivial I'll wait on Jenkins before merging, since the bugfix might affect the files created.