### PR TITLE
Set timesteps after events

### DIFF
--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -105,9 +105,9 @@ namespace Opm
         std::ofstream tstep_os(tstep_filename.c_str());
 
         const auto& schedule = eclipse_state_->getSchedule();
-        const auto& events = schedule.getEvents();
 
         // adaptive time stepping
+        const auto& events = schedule.getEvents();
         std::unique_ptr< AdaptiveTimeStepping > adaptiveTimeStepping;
         if( param_.getDefault("timestep.adaptive", true ) )
         {
@@ -234,8 +234,12 @@ namespace Opm
             //
             // \Note: The report steps are met in any case
             // \Note: The sub stepping will require a copy of the state variables
-            if( adaptiveTimeStepping ) {
-                report += adaptiveTimeStepping->step( timer, *solver, state, well_state, output_writer_, 
+            if( adaptiveTimeStepping ) {  
+                bool event = events.hasEvent(ScheduleEvents::NEW_WELL, timer.currentStepNum()) ||
+                        events.hasEvent(ScheduleEvents::PRODUCTION_UPDATE, timer.currentStepNum()) ||
+                        events.hasEvent(ScheduleEvents::INJECTION_UPDATE, timer.currentStepNum()) ||
+                        events.hasEvent(ScheduleEvents::WELL_STATUS_CHANGE, timer.currentStepNum());
+                report += adaptiveTimeStepping->step( timer, *solver, state, well_state, event, output_writer_,
                                                      output_writer_.requireFIPNUM() ? &fipnum : nullptr );
             }
             else {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -162,6 +162,7 @@ public:
         const auto& schedule = eclState().getSchedule();
 
         // adaptive time stepping
+        const auto& events = schedule.getEvents();
         std::unique_ptr< AdaptiveTimeStepping > adaptiveTimeStepping;
         if( param_.getDefault("timestep.adaptive", true ) )
         {
@@ -293,7 +294,11 @@ public:
             // \Note: The report steps are met in any case
             // \Note: The sub stepping will require a copy of the state variables
             if( adaptiveTimeStepping ) {
-                report += adaptiveTimeStepping->step( timer, *solver, state, well_state, output_writer_,
+                bool event = events.hasEvent(ScheduleEvents::NEW_WELL, timer.currentStepNum()) ||
+                        events.hasEvent(ScheduleEvents::PRODUCTION_UPDATE, timer.currentStepNum()) ||
+                        events.hasEvent(ScheduleEvents::INJECTION_UPDATE, timer.currentStepNum()) ||
+                        events.hasEvent(ScheduleEvents::WELL_STATUS_CHANGE, timer.currentStepNum());
+                report += adaptiveTimeStepping->step( timer, *solver, state, well_state, event, output_writer_,
                                                       output_writer_.requireFIPNUM() ? &fipnum : nullptr );
             }
             else {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -66,6 +66,7 @@ namespace Opm
         std::ofstream tstep_os(tstep_filename.c_str());
 
         // adaptive time stepping
+        const auto& events = eclipse_state_->getSchedule().getEvents();
         std::unique_ptr< AdaptiveTimeStepping > adaptiveTimeStepping;
         if( param_.getDefault("timestep.adaptive", true ) )
         {
@@ -173,7 +174,11 @@ namespace Opm
             // \Note: The report steps are met in any case
             // \Note: The sub stepping will require a copy of the state variables
             if( adaptiveTimeStepping ) {
-                adaptiveTimeStepping->step( timer, *solver, state, well_state, output_writer_ );
+                bool event = events.hasEvent(ScheduleEvents::NEW_WELL, timer.currentStepNum()) ||
+                        events.hasEvent(ScheduleEvents::PRODUCTION_UPDATE, timer.currentStepNum()) ||
+                        events.hasEvent(ScheduleEvents::INJECTION_UPDATE, timer.currentStepNum()) ||
+                        events.hasEvent(ScheduleEvents::WELL_STATUS_CHANGE, timer.currentStepNum());
+                adaptiveTimeStepping->step( timer, *solver, state, well_state, event, output_writer_);
             }
             else {
                 // solve for complete report step

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -63,10 +63,12 @@ namespace Opm {
             \param  solver      solver object that must implement a method step( dt, state, well_state )
             \param  state       current state of the solution variables
             \param  well_state  additional well state object
+            \param  event        event status for possible tuning
         */
         template <class Solver, class State, class WellState>
         SimulatorReport step( const SimulatorTimer& timer,
-                              Solver& solver, State& state, WellState& well_state );
+                              Solver& solver, State& state, WellState& well_state, 
+                              const bool event);
 
         /** \brief  step method that acts like the solver::step method
                     in a sub cycle of time steps
@@ -76,11 +78,13 @@ namespace Opm {
             \param  solver       solver object that must implement a method step( dt, state, well_state )
             \param  state        current state of the solution variables
             \param  well_state   additional well state object
+            \param  event        event status for possible tuning
             \param  outputWriter writer object to write sub steps
         */
         template <class Solver, class State, class WellState, class Output>
         SimulatorReport step( const SimulatorTimer& timer,
                               Solver& solver, State& state, WellState& well_state,
+                              const bool event,
                               Output& outputWriter,
                               const std::vector<int>* fipnum = nullptr);
 
@@ -92,6 +96,7 @@ namespace Opm {
         template <class Solver, class State, class WellState, class Output>
         SimulatorReport stepImpl( const SimulatorTimer& timer,
                                   Solver& solver, State& state, WellState& well_state,
+                                  const bool event,
                                   Output* outputWriter,
                                   const std::vector<int>* fipnum);
 
@@ -109,6 +114,8 @@ namespace Opm {
         const bool timestep_verbose_;         //!< timestep verbosity
         double suggested_next_timestep_;      //!< suggested size of next timestep
         bool full_timestep_initially_;        //!< beginning with the size of the time step from data file
+        const double timestep_after_event_;   //!< suggested size of timestep after an event
+        bool use_newton_iteration_;           //!< use newton iteration count for adaptive time step control
     };
 }
 


### PR DESCRIPTION
1) The time step after an event can either be set using
timestep_in_days_after_event 
or using the TUNING keyword in the deck.

2) A timestep control pid+newtoniteration that adjust the timestep based on number of Newton iterations is made available. 

Default is to not use any of this. So this should not effect any results. 