### PR TITLE
[WIP] Restarting improvements

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -243,6 +243,8 @@ namespace Opm {
                 residual_norms_history_.clear();
                 current_relaxation_ = 1.0;
                 dx_old_ = 0.0;
+                convertInput( iteration, reservoir_state, ebosSimulator_ );
+                ebosSimulator_.model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
             }
 
             report.total_linearizations = 1;

--- a/opm/autodiff/Compat.cpp
+++ b/opm/autodiff/Compat.cpp
@@ -75,10 +75,18 @@ std::vector< double >& stripe( const std::vector< double >& v,
 
 
 data::Solution simToSolution( const SimulationDataContainer& reservoir,
+                              const bool use_si_units,
                               PhaseUsage phases ) {
+
+    // Set up unit system to use to suppress conversion if use_si_units is true.
+    const UnitSystem::measure press_unit = use_si_units ? UnitSystem::measure::identity : UnitSystem::measure::pressure;
+    const UnitSystem::measure temp_unit = use_si_units ? UnitSystem::measure::identity : UnitSystem::measure::temperature;
+    const UnitSystem::measure rs_unit = use_si_units ? UnitSystem::measure::identity : UnitSystem::measure::gas_oil_ratio;
+    const UnitSystem::measure rv_unit = use_si_units ? UnitSystem::measure::identity : UnitSystem::measure::oil_gas_ratio;
+
     data::Solution sol;
-    sol.insert( "PRESSURE", UnitSystem::measure::pressure, reservoir.pressure() , data::TargetType::RESTART_SOLUTION);
-    sol.insert( "TEMP"    , UnitSystem::measure::temperature, reservoir.temperature() , data::TargetType::RESTART_SOLUTION );
+    sol.insert( "PRESSURE", press_unit, reservoir.pressure() , data::TargetType::RESTART_SOLUTION);
+    sol.insert( "TEMP"    , temp_unit, reservoir.temperature() , data::TargetType::RESTART_SOLUTION );
 
     const auto ph = reservoir.numPhases();
     const auto& sat = reservoir.saturation();
@@ -95,11 +103,11 @@ data::Solution simToSolution( const SimulationDataContainer& reservoir,
     }
 
     if( reservoir.hasCellData( BlackoilState::GASOILRATIO ) ) {
-        sol.insert( "RS", UnitSystem::measure::gas_oil_ratio, reservoir.getCellData( BlackoilState::GASOILRATIO ) , data::TargetType::RESTART_SOLUTION );
+        sol.insert( "RS", rs_unit, reservoir.getCellData( BlackoilState::GASOILRATIO ) , data::TargetType::RESTART_SOLUTION );
     }
 
     if( reservoir.hasCellData( BlackoilState::RV ) ) {
-        sol.insert( "RV", UnitSystem::measure::oil_gas_ratio, reservoir.getCellData( BlackoilState::RV ) , data::TargetType::RESTART_SOLUTION );
+        sol.insert( "RV", rv_unit, reservoir.getCellData( BlackoilState::RV ) , data::TargetType::RESTART_SOLUTION );
     }
 
     if (reservoir.hasCellData( BlackoilSolventState::SSOL)) {

--- a/opm/autodiff/Compat.hpp
+++ b/opm/autodiff/Compat.hpp
@@ -51,7 +51,10 @@ namespace Opm {
     /// Returns Solution with the following fields:
     ///   PRESSURE, TEMP (unconditionally)
     ///   SWAT, SGAS, RS, RV, SSOL (if appropriate fields present in input)
+    /// If use_si_units is true, the fields will have the measure UnitSystem::measure::identity,
+    /// and therefore *not* be converted to customary units (depending on family) upon output.
     data::Solution simToSolution( const SimulationDataContainer& reservoir,
+                                  const bool use_si_units,
                                   PhaseUsage phases );
 
     /// Copies the following fields from sol into state (all conditionally):

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -89,10 +89,10 @@ namespace Opm
     {
         WellState prev_well_state;
 
-
+        ExtraData extra;
         if (output_writer_.isRestart()) {
             // This is a restart, populate WellState and ReservoirState state objects from restart file
-            output_writer_.initFromRestartFile(props_.phaseUsage(), grid_, state, prev_well_state);
+            output_writer_.initFromRestartFile(props_.phaseUsage(), grid_, state, prev_well_state, extra);
             initHydroCarbonState(state, props_.phaseUsage(), Opm::UgGridHelpers::numCells(grid_), has_disgas_, has_vapoil_);
         }
 
@@ -116,6 +116,9 @@ namespace Opm
                 adaptiveTimeStepping.reset( new AdaptiveTimeStepping( schedule.getTuning(), timer.currentStepNum(), param_, terminal_output_ ) );
             } else {
                 adaptiveTimeStepping.reset( new AdaptiveTimeStepping( param_, terminal_output_ ) );
+            }
+            if (output_writer_.isRestart()) {
+                adaptiveTimeStepping->setSuggestedNextStep(extra.suggested_step);
             }
         }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -243,7 +243,7 @@ namespace Opm
         data::Solution localCellData{};
         if( output_ )
         {
-            localCellData = simToSolution(localState, phaseUsage_); // Get "normal" data (SWAT, PRESSURE, ...);
+            localCellData = simToSolution(localState, restart_double_si_, phaseUsage_); // Get "normal" data (SWAT, PRESSURE, ...);
         }
         writeTimeStepWithCellProperties(timer, localState, localCellData ,
                                         localWellState, substep);
@@ -348,7 +348,8 @@ namespace Opm
                                       substep,
                                       timer.simulationTimeElapsed(),
                                       simProps,
-                                      wellState.report(phaseUsage_));
+                                      wellState.report(phaseUsage_),
+                                      restart_double_si_);
             }
         }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -198,6 +198,7 @@ namespace Opm
     };
 
 
+    /// Extra data to read/write for OPM restarting
     struct ExtraData
     {
         double suggested_step;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -197,6 +197,13 @@ namespace Opm
             const Grid& grid_;
     };
 
+
+    struct ExtraData
+    {
+        double suggested_step;
+    };
+
+
     /** \brief Wrapper class for VTK, Matlab, and ECL output. */
     class BlackoilOutputWriter
     {
@@ -224,7 +231,8 @@ namespace Opm
                            const SimulationDataContainer& reservoirState,
                            const Opm::WellStateFullyImplicitBlackoil& wellState,
                            const Model& physicalModel,
-                           bool substep = false);
+                           bool substep = false,
+                           const double nextstep = -1.0);
 
 
         /*!
@@ -280,11 +288,12 @@ namespace Opm
                      const int desiredReportStep);
 
 
-        template <class Grid, class WellStateFullyImplicitBlackOel>
+        template <class Grid, class WellState>
         void initFromRestartFile(const PhaseUsage& phaseUsage,
                                  const Grid& grid,
                                  SimulationDataContainer& simulatorstate,
-                                 WellStateFullyImplicitBlackOel& wellstate);
+                                 WellState& wellstate,
+                                 ExtraData& extra);
 
         bool isRestart() const;
 
@@ -401,14 +410,16 @@ namespace Opm
     initFromRestartFile( const PhaseUsage& phaseUsage,
                          const Grid& grid,
                          SimulationDataContainer& simulatorstate,
-                         WellState& wellstate)
+                         WellState& wellstate,
+                         ExtraData& extra )
     {
         std::map<std::string, UnitSystem::measure> solution_keys {{"PRESSURE" , UnitSystem::measure::pressure},
                                                                   {"SWAT" , UnitSystem::measure::identity},
                                                                   {"SGAS" , UnitSystem::measure::identity},
                                                                   {"TEMP" , UnitSystem::measure::temperature},
                                                                   {"RS" , UnitSystem::measure::gas_oil_ratio},
-                                                                  {"RV" , UnitSystem::measure::oil_gas_ratio}};
+                                                                  {"RV" , UnitSystem::measure::oil_gas_ratio},
+                                                                  {"OPMEXTRA" , UnitSystem::measure::identity}};
 
         // gives a dummy dynamic_list_econ_limited
         DynamicListEconLimited dummy_list_econ_limited;
@@ -435,6 +446,12 @@ namespace Opm
 
         solutionToSim( state.first, phaseUsage, simulatorstate );
         wellsToState( state.second, phaseUsage, wellstate );
+
+        if (state.first.has( "OPMEXTRA" ) ) {
+            std::vector<double> opmextra = state.first.data( "OPMEXTRA" );
+            assert(opmextra.size() == 1);
+            extra.suggested_step = opmextra[0];
+        }
     }
 
 
@@ -900,7 +917,8 @@ namespace Opm
                   const SimulationDataContainer& localState,
                   const WellStateFullyImplicitBlackoil& localWellState,
                   const Model& physicalModel,
-                  bool substep)
+                  bool substep,
+                  const double nextstep)
     {
         data::Solution localCellData{};
         const RestartConfig& restartConfig = eclipseState_.getRestartConfig();
@@ -925,6 +943,13 @@ namespace Opm
                 // sd will be invalid after getRestartData has been called
             }
             detail::getSummaryData( localCellData, phaseUsage_, physicalModel, summaryConfig );
+
+            // Hack: add suggested next timestep.
+            assert(!localCellData.empty());
+            localCellData.insert("OPMEXTRA",
+                                 UnitSystem::measure::identity,
+                                 std::vector<double>(1, nextstep),
+                                 data::TargetType::RESTART_SOLUTION);
         }
 
         writeTimeStepWithCellProperties(timer, localState, localCellData, localWellState, substep);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -307,6 +307,7 @@ namespace Opm
         // Parameters for output.
         const std::string outputDir_;
         const int output_interval_;
+        const bool restart_double_si_;
 
         int lastBackupReportStep_;
 
@@ -338,6 +339,7 @@ namespace Opm
         parallelOutput_( output_ ? new ParallelDebugOutput< Grid >( grid, eclipseState, phaseUsage.num_phases, phaseUsage ) : 0 ),
         outputDir_( output_ ? param.getDefault("output_dir", std::string("output")) : "." ),
         output_interval_( output_ ? param.getDefault("output_interval", 1): 0 ),
+        restart_double_si_( output_ ? param.getDefault("restart_double_si", false) : false ),
         lastBackupReportStep_( -1 ),
         phaseUsage_( phaseUsage ),
         eclipseState_(eclipseState),
@@ -415,12 +417,19 @@ namespace Opm
                          ExtraData& extra )
     {
         std::map<std::string, UnitSystem::measure> solution_keys {{"PRESSURE" , UnitSystem::measure::pressure},
-                                                                  {"SWAT" , UnitSystem::measure::identity},
-                                                                  {"SGAS" , UnitSystem::measure::identity},
-                                                                  {"TEMP" , UnitSystem::measure::temperature},
-                                                                  {"RS" , UnitSystem::measure::gas_oil_ratio},
-                                                                  {"RV" , UnitSystem::measure::oil_gas_ratio},
+                                                                  {"SWAT"     , UnitSystem::measure::identity},
+                                                                  {"SGAS"     , UnitSystem::measure::identity},
+                                                                  {"TEMP"     , UnitSystem::measure::temperature},
+                                                                  {"RS"       , UnitSystem::measure::gas_oil_ratio},
+                                                                  {"RV"       , UnitSystem::measure::oil_gas_ratio},
                                                                   {"OPMEXTRA" , UnitSystem::measure::identity}};
+
+        if (restart_double_si_) {
+            // Avoid any unit conversions, treat restart input as SI units.
+            for (auto& elem : solution_keys) {
+                elem.second = UnitSystem::measure::identity;
+            }
+        }
 
         // gives a dummy dynamic_list_econ_limited
         DynamicListEconLimited dummy_list_econ_limited;
@@ -937,7 +946,7 @@ namespace Opm
                 SimulationDataContainer sd =
                     detail::convertToSimulationDataContainer( physicalModel.getSimulatorData(), localState, phaseUsage_ );
 
-                localCellData = simToSolution( sd, phaseUsage_); // Get "normal" data (SWAT, PRESSURE, ...);
+                localCellData = simToSolution( sd, restart_double_si_, phaseUsage_); // Get "normal" data (SWAT, PRESSURE, ...);
 
                 detail::getRestartData( localCellData, std::move(sd), phaseUsage_, physicalModel,
                                         restartConfig, reportStepNum, logMessages );

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -84,6 +84,10 @@ namespace Opm {
                               Output& outputWriter,
                               const std::vector<int>* fipnum = nullptr);
 
+        double suggestedNextStep() const { return suggested_next_timestep_; }
+
+        void setSuggestedNextStep(const double x) { suggested_next_timestep_ = x; }
+
     protected:
         template <class Solver, class State, class WellState, class Output>
         SimulatorReport stepImpl( const SimulatorTimer& timer,


### PR DESCRIPTION
This is work in progress, do not merge yet.

Together with OPM/opm-output#171, this makes perfect restarting (in the sense of making a restarted simulator run reproduce the exact same results as the original run) possible for the SPE1CASE2(_RESTART).DATA test case.

First, it includes #1074, so that should be tested and merged first, and then I'll rebase this.
To that it adds the following:
 - Read and write the adaptive timestepper's suggested next time step (through a new field "OPMEXTRA"), this requires OPM/opm-output#171, or equivalent functionality.
 - Add a feature to preserve SI units (avoiding unit conversions) and write data as doubles. This is triggered by setting "restart_double_si=true" (default is false) on the command line or in the parameter file. This only requires existing opm-output features.

We know that for perfect restarting of other cases we will (at least) also need saturation history (for VAPPARS and hysteresis).
