### PR TITLE
Fixed apparent bug in outputting PDPB

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -728,8 +728,7 @@ namespace Opm
             /**
              * Bubble point and dew point pressures
              */
-            if (log && vapour_active &&
-                liquid_active && rstKeywords["PBPD"] > 0) {
+            if (vapour_active && liquid_active && rstKeywords["PBPD"] > 0) {
                 rstKeywords["PBPD"] = 0;
                 output.insert("PBUB",
                         Opm::UnitSystem::measure::pressure,


### PR DESCRIPTION
I cannot see why log should be required in the if-test, and I think this is a bug which would not output PDPB if log is set to false