### PR TITLE
Support for saturation table for each well completion

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -163,7 +163,7 @@ namespace Opm {
                           const ModelParameters&          param,
                           const BlackoilPropsAdFromDeck& fluid,
                           const DerivedGeology&           geo  ,
-                          const StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>& well_model,
+                          const StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw>& well_model,
                           const NewtonIterationBlackoilInterface& linsolver,
                           const bool terminal_output)
         : ebosSimulator_(ebosSimulator)
@@ -1428,7 +1428,7 @@ namespace Opm {
         ModelParameters                 param_;
 
         // Well Model
-        StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext> well_model_;
+        StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw> well_model_;
 
         /// \brief Whether we print something to std::cout
         bool terminal_output_;
@@ -1446,9 +1446,9 @@ namespace Opm {
     public:
 
         /// return the StandardWells object
-        StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>&
+        StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw>&
         wellModel() { return well_model_; }
-        const StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>&
+        const StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw>&
         wellModel() const { return well_model_; }
 
         /// return the Well struct in the StandardWells

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -57,6 +57,8 @@ public:
     typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
     typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
     typedef typename GET_PROP_TYPE(TypeTag, Indices) BlackoilIndices;
+    typedef typename GET_PROP_TYPE(TypeTag, MaterialLaw) MaterialLaw;
+
 
     typedef WellStateFullyImplicitBlackoilDense WellState;
     typedef BlackoilState ReservoirState;
@@ -64,7 +66,7 @@ public:
     typedef BlackoilModelEbos Model;
     typedef BlackoilModelParameters ModelParameters;
     typedef NonlinearSolver<Model> Solver;
-    typedef StandardWellsDense<FluidSystem, BlackoilIndices,ElementContext> WellModel;
+    typedef StandardWellsDense<FluidSystem, BlackoilIndices,ElementContext,MaterialLaw> WellModel;
 
 
     /// Initialise from parameters and objects to observe.

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -67,7 +67,7 @@ enum WellVariablePositions {
 
 
         /// Class for handling the standard well model.
-        template<typename FluidSystem, typename BlackoilIndices, typename  ElementContext>
+        template<typename FluidSystem, typename BlackoilIndices, typename  ElementContext, typename MaterialLaw>
         class StandardWellsDense {
         public:
             // ---------      Types      ---------
@@ -113,6 +113,13 @@ enum WellVariablePositions {
                                 const double dt,
                                 WellState& well_state,
                                 bool only_wells);
+
+            template <typename Simulator>
+            void
+            getMobility(const Simulator& ebosSimulator,
+                        const int perf,
+                        const int cell_idx,
+                        std::vector<EvalWell>& mob) const;
 
             template <typename Simulator>
             bool allow_cross_flow(const int w, Simulator& ebosSimulator) const;
@@ -180,9 +187,9 @@ enum WellVariablePositions {
 
             void computeAccumWells();
 
-            template<typename intensiveQuants>
+            template<typename FluidState>
             void
-            computeWellFlux(const int& w, const double& Tw, const intensiveQuants& intQuants,
+            computeWellFlux(const int& w, const double& Tw, const FluidState& fs, const std::vector<EvalWell>& mob_perfcells_dense,
                             const EvalWell& bhp, const double& cdp, const bool& allow_cf, std::vector<EvalWell>& cq_s)  const;
 
             template <typename Simulator>

--- a/tests/test_vfpproperties.cpp
+++ b/tests/test_vfpproperties.cpp
@@ -448,7 +448,7 @@ BOOST_AUTO_TEST_CASE(GetTable)
     std::shared_ptr<Wells> wells(create_wells(nphases, nwells, nperfs),
                                 destroy_wells);
     const int cells[] = {5};
-    add_well(INJECTOR, 100, 1, NULL, cells, NULL, NULL, true, wells.get());
+    add_well(INJECTOR, 100, 1, NULL, cells, NULL, 0, NULL, true, wells.get());
 
     //Create interpolation points
     double aqua_d   = -0.15;
@@ -785,7 +785,7 @@ BOOST_AUTO_TEST_CASE(InterpolateADBAndQs)
         std::stringstream ss;
         ss << "WELL_" << i;
         const bool ok = add_well(INJECTOR, 0.0, 1, NULL, &cells,
-                                 NULL, ss.str().c_str(), true, wells.get());
+                                 NULL, 0, ss.str().c_str(), true, wells.get());
         BOOST_REQUIRE(ok);
     }
 

--- a/tests/test_welldensitysegmented.cpp
+++ b/tests/test_welldensitysegmented.cpp
@@ -52,9 +52,9 @@ BOOST_AUTO_TEST_CASE(TestPressureDeltas)
     const bool allow_crossflow = true;
     std::shared_ptr<Wells> wells(create_wells(np, 2, nperf), destroy_wells);
     BOOST_REQUIRE(wells);
-    int ok = add_well(INJECTOR, ref_depth, nperf/2, comp_frac_w, cells, WI, "INJ", allow_crossflow, wells.get());
+    int ok = add_well(INJECTOR, ref_depth, nperf/2, comp_frac_w, cells, WI, 0, "INJ", allow_crossflow, wells.get());
     BOOST_REQUIRE(ok);
-    ok = add_well(PRODUCER, ref_depth, nperf/2, comp_frac_o, cells, WI, "PROD", allow_crossflow, wells.get());
+    ok = add_well(PRODUCER, ref_depth, nperf/2, comp_frac_o, cells, WI, 0, "PROD", allow_crossflow, wells.get());
     BOOST_REQUIRE(ok);
     std::vector<double> rates = { 1.0, 0.0, 0.0,
                                   1.0, 0.0, 0.0,


### PR DESCRIPTION
Compute relperms for each well completion based on saturation table ids
(satnums)

Depends on  OPM/opm-parser#1045, OPM/opm-core#1145 and OPM/opm-material#??? 

This PR together with its parents implements support for specifying saturation table numbers for completions. Improves Model 2.2. results significantly. 

Does not work in combination with hysteresis and end-point scaling. I want to add a warning for this, but where/how should I add this warning? 
