### PR TITLE
Do not copy the wellSolution() member from previous state.

### DIFF
--- a/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
@@ -69,48 +69,6 @@ namespace Opm
             BaseType :: init(wells, state, prevState);
 
             setWellSolutions(pu);
-            setWellSolutionsFromPrevState(prevState);
-        }
-
-
-        template <class PrevState>
-        void setWellSolutionsFromPrevState(const PrevState& prevState)
-        {
-            // Set nw and np, or return if no wells.
-            if (wells_.get() == nullptr) {
-                return;
-            }
-            const int nw = wells_->number_of_wells;
-            if (nw == 0) {
-                return;
-            }
-            const int np = wells_->number_of_phases;
-
-            // intialize wells that have been there before
-            // order may change so the mapping is based on the well name
-            // if there are no well, do nothing in init
-            if( ! prevState.wellMap().empty() )
-            {
-                typedef typename WellMapType :: const_iterator const_iterator;
-                const_iterator end = prevState.wellMap().end();
-                int nw_old = prevState.bhp().size();
-                for (int w = 0; w < nw; ++w) {
-                    std::string name( wells_->name[ w ] );
-                    const_iterator it = prevState.wellMap().find( name );
-                    if( it != end )
-                    {
-                        const int oldIndex = (*it).second[ 0 ];
-                        const int newIndex = w;
-
-                        // wellSolutions
-                        for( int i = 0;  i < np; ++i)
-                        {
-                            wellSolutions()[ i*nw + newIndex ] = prevState.wellSolutions()[i * nw_old + oldIndex ];
-                        }
-
-                    }
-                }
-            }
         }
 
 


### PR DESCRIPTION
Instead, we let this member always be initialized from the other data members.

In addition to simplifying the code, this is necessary for perfect restarting. Before this, the restarted state would be initialized from the other data members while the not-restarted state (at the same timestep) would be copied from the previous state. This caused floating-point roundoff differences that would eventually creep into all state variables. Although insignificant, it would prevent bitwise-perfect restarting.

With this, I get perfect (bitwise identical) restarts on SPE1CASE2 and SPE9.

Note: that the differences are insignificant is borne out by the fact that no regression tests fail, even though all the restart files are slightly different (I suggest we let the next PR that requires data updates deal with this).