### PR TITLE
make the default flow point to flow_ebos instead of flow_legacy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,5 +133,5 @@ endif()
 
  # create a symbolic link from flow to flow_legacy
 ADD_CUSTOM_TARGET(flow ALL
-	                COMMAND ${CMAKE_COMMAND} -E create_symlink "flow_legacy" "${CMAKE_BINARY_DIR}/bin/flow")
+	                COMMAND ${CMAKE_COMMAND} -E create_symlink "flow_ebos" "${CMAKE_BINARY_DIR}/bin/flow")
 


### PR DESCRIPTION
`flow_ebos` should be now capable of doing everything that `flow_legacy` can and recently all testing seems to have been centered on `flow_ebos`. note that `flow_ebos` does not yet support some more
advanced/exotic features like MPI, solvents, polymer, etc., but neither does the plain `flow_legacy` binary. until `flow_ebos` supports these features, the specialized simulators thus continue to use the legacy code paths.