### PR TITLE
make the unit tests to explicitly use flow_legacy instead of flow

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -93,10 +93,10 @@ opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-regressionTest.sh "")
 set(abs_tol 2e-2)
 set(rel_tol 1e-5)
 
-add_test_compareECLFiles(spe1 SPE1CASE2 flow ${abs_tol} ${rel_tol} compareECLFiles "")
+add_test_compareECLFiles(spe1 SPE1CASE2 flow_legacy ${abs_tol} ${rel_tol} compareECLFiles "")
 add_test_compareECLFiles(spe1 SPE1CASE1 flow_sequential ${abs_tol} ${rel_tol} compareECLFiles "")
-add_test_compareECLFiles(spe3 SPE3CASE1 flow ${abs_tol} ${rel_tol} compareECLFiles "")
-add_test_compareECLFiles(spe9 SPE9_CP_SHORT flow ${abs_tol} ${rel_tol} compareECLFiles "")
+add_test_compareECLFiles(spe3 SPE3CASE1 flow_legacy ${abs_tol} ${rel_tol} compareECLFiles "")
+add_test_compareECLFiles(spe9 SPE9_CP_SHORT flow_legacy ${abs_tol} ${rel_tol} compareECLFiles "")
 add_test_compareECLFiles(msw_2d_h 2D_H__ flow_multisegment ${abs_tol} ${rel_tol} compareECLFiles "")
 
 # Restart tests
@@ -113,7 +113,7 @@ endforeach()
 # Init tests
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-init-regressionTest.sh "")
 
-foreach(sim flow flow_ebos)
+foreach(sim flow_legacy flow_ebos)
   add_test_compareECLFiles(norne NORNE_ATW2013 ${sim} ${abs_tol} ${rel_tol} compareECLInitFiles /init)
 endforeach()
 

--- a/jenkins/run-norne.sh
+++ b/jenkins/run-norne.sh
@@ -2,7 +2,7 @@
 
 pushd .
 cd deps/opm-data
-test -z $SIM && SIM=flow
+test -z $SIM && SIM=flow_legacy
 
 # Run the norne case
 cd norne

--- a/jenkins/run-spe.sh
+++ b/jenkins/run-spe.sh
@@ -14,15 +14,15 @@ cd deps/opm-data
 
 # Run the SPE1/3/9 cases
 cd spe1
-$WORKSPACE/$configuration/build-opm-simulators/bin/flow deck_filename=SPE1CASE2.DATA
+$WORKSPACE/$configuration/build-opm-simulators/bin/flow_legacy deck_filename=SPE1CASE2.DATA
 test $? -eq 0 || exit 1
 cd ..
 cd spe3
-$WORKSPACE/$configuration/build-opm-simulators/bin/flow max_iter=50 deck_filename=SPE3CASE1.DATA
+$WORKSPACE/$configuration/build-opm-simulators/bin/flow_legacy max_iter=50 deck_filename=SPE3CASE1.DATA
 test $? -eq 0 || exit 1
 cd ..
 cd spe9
-$WORKSPACE/$configuration/build-opm-simulators/bin/flow max_iter=50 deck_filename=SPE9_CP.DATA
+$WORKSPACE/$configuration/build-opm-simulators/bin/flow_legacy max_iter=50 deck_filename=SPE9_CP.DATA
 test $? -eq 0 || exit 1
 cd ..
 

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -311,7 +311,7 @@ namespace Opm
                 const std::string version = moduleVersionName();
                 std::cout << "**********************************************************************\n";
                 std::cout << "*                                                                    *\n";
-                std::cout << "*                   This is Flow (version " << version << ")"
+                std::cout << "*            This is flow_legacy (version " << version << ")"
                           << std::string(26 - version.size(), ' ') << "*\n";
                 std::cout << "*                                                                    *\n";
                 std::cout << "* Flow is a simulator for fully implicit three-phase black-oil flow, *\n";


### PR DESCRIPTION
the results of `flow_legacy` and `flow_ebos` are not bit-wise identical. The same tests using `flow_ebos`  should to be added when re-organizing the unit tests the next time.