### PR TITLE
added: generate a plot without ecl reference for norne runs

### DIFF
--- a/jenkins/run-norne.sh
+++ b/jenkins/run-norne.sh
@@ -9,6 +9,7 @@ cd norne
 mkdir $SIM
 $WORKSPACE/$configuration/build-opm-simulators/bin/$SIM deck_filename=NORNE_ATW2013.DATA output_dir=$SIM
 test $? -eq 0 || exit 1
-./plotwells.sh $WORKSPACE/$configuration/install/bin
+./plotwells.sh $WORKSPACE/$configuration/install/bin "ECL.2014.2 opm-simulation-reference" norne-wells
+./plotwells.sh $WORKSPACE/$configuration/install/bin "opm-simulation-reference" norne-wells-noecl
 
 popd


### PR DESCRIPTION
sometimes it is easier to compare without the extra data in the graphs

@atgeirr as requested