### PR TITLE
Fix output of rs and rv. 

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -258,7 +258,7 @@ namespace Opm {
         const WellModel& wellModel() const { return well_model_; }
 
         /// Return reservoir simulation data (for output functionality)
-        const SimulatorData& getSimulatorData() const {
+        const SimulatorData& getSimulatorData(const SimulationDataContainer&) const {
             return sd_;
         }
 

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -677,6 +677,11 @@ namespace Opm {
                     switch (hydroCarbonState) {
                     case HydroCarbonState::GasAndOil: {
 
+                        // for the Gas and Oil case rs=rsSat and rv=rvSat
+                        rs = FluidSystem::oilPvt().saturatedGasDissolutionFactor(fs.pvtRegionIndex(), reservoir_state.temperature()[cell_idx], reservoir_state.pressure()[cell_idx]);
+                        // use gas pressure?
+                        rv = FluidSystem::gasPvt().saturatedOilVaporizationFactor(fs.pvtRegionIndex(), reservoir_state.temperature()[cell_idx], reservoir_state.pressure()[cell_idx]);
+
                         if (sw > (1.0 - epsilon)) // water only i.e. do nothing
                             break;
 
@@ -684,15 +689,12 @@ namespace Opm {
                             reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::OilOnly; // sg --> rs
                             sg = 0;
                             so = 1.0 - sw - sg;
-                            const double& rsSat = FluidSystem::oilPvt().saturatedGasDissolutionFactor(fs.pvtRegionIndex(), reservoir_state.temperature()[cell_idx], reservoir_state.pressure()[cell_idx]);
-                            rs = rsSat*(1-epsilon);
+                            rs *= (1-epsilon);
                         } else if (so <= 0.0 && has_vapoil_) {
                             reservoir_state.hydroCarbonState()[cell_idx] = HydroCarbonState::GasOnly; // sg --> rv
                             so = 0;
                             sg = 1.0 - sw - so;
-                            // use gas pressure?
-                            const double& rvSat = FluidSystem::gasPvt().saturatedOilVaporizationFactor(fs.pvtRegionIndex(), reservoir_state.temperature()[cell_idx], reservoir_state.pressure()[cell_idx]);
-                            rv = rvSat*(1-epsilon);
+                            rv *= (1-epsilon);
                         }
                         break;
                     }

--- a/opm/autodiff/BlackoilSequentialModel.hpp
+++ b/opm/autodiff/BlackoilSequentialModel.hpp
@@ -273,8 +273,8 @@ namespace Opm {
 
 
         /// Return reservoir simulation data (for output functionality)
-        const SimulatorData& getSimulatorData() const {
-            return transport_solver_.model().getSimulatorData();
+        const SimulatorData& getSimulatorData(const SimulationDataContainer& localState) const {
+            return transport_solver_.model().getSimulatorData(localState);
         }
 
         /// Return fluid-in-place data (for output functionality)

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -29,6 +29,7 @@
 #include <opm/core/utility/miscUtilities.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/core/wells/DynamicListEconLimited.hpp>
+#include <opm/core/simulator/BlackoilState.hpp>
 
 #include <opm/output/data/Cells.hpp>
 #include <opm/output/data/Solution.hpp>
@@ -952,7 +953,7 @@ namespace Opm
                 // while for flow_ebos a SimulationDataContainer is returned
                 // this is addressed in the above specialized methods
                 SimulationDataContainer sd =
-                    detail::convertToSimulationDataContainer( physicalModel.getSimulatorData(), localState, phaseUsage_ );
+                    detail::convertToSimulationDataContainer( physicalModel.getSimulatorData(localState), localState, phaseUsage_ );
 
                 localCellData = simToSolution( sd, restart_double_si_, phaseUsage_); // Get "normal" data (SWAT, PRESSURE, ...);
 

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
@@ -32,6 +32,7 @@
 #include <opm/polymer/fullyimplicit/PolymerPropsAd.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/simulators/timestepping/SimulatorTimerInterface.hpp>
+#include <opm/common/data/SimulationDataContainer.hpp>
 
 struct UnstructuredGrid;
 struct Wells;
@@ -146,7 +147,7 @@ namespace Opm {
                               const PolymerBlackoilState& current ) const;
 
         /// Return reservoir simulation data (for output functionality)
-        const SimulatorData& getSimulatorData() const {
+        const SimulatorData& getSimulatorData(const SimulationDataContainer&) const {
             return sd_;
         }
 


### PR DESCRIPTION
This PR is only targeted at output and should not effect the simulations at all. 

1) Fixes output of rs and rv for the free gas and free oil case, and the water only case. 
2) Makes the initial output of rs, rv, bo, bg, rho_o and rho_g Ecl compatible. 

