### PR TITLE
Allow restarting without OPMEXTRA field in restart file.

### DIFF
--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -118,7 +118,9 @@ namespace Opm
                 adaptiveTimeStepping.reset( new AdaptiveTimeStepping( param_, terminal_output_ ) );
             }
             if (output_writer_.isRestart()) {
-                adaptiveTimeStepping->setSuggestedNextStep(extra.suggested_step);
+                if (extra.suggested_step > 0.0) {
+                    adaptiveTimeStepping->setSuggestedNextStep(extra.suggested_step);
+                }
             }
         }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -174,7 +174,9 @@ public:
             }
 
             if (output_writer_.isRestart()) {
-                adaptiveTimeStepping->setSuggestedNextStep(extra.suggested_step);
+                if (extra.suggested_step > 0.0) {
+                    adaptiveTimeStepping->setSuggestedNextStep(extra.suggested_step);
+                }
             }
         }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -467,7 +467,8 @@ namespace Opm
             assert(opmextra.size() == 1);
             extra.suggested_step = opmextra[0];
         } else {
-            OPM_THROW(std::runtime_error, "Cannot restart, restart data is missing OPMEXTRA field.");
+            OpmLog::warning("Restart data is missing OPMEXTRA field, restart run may deviate from original run.");
+            extra.suggested_step = -1.0;
         }
     }
 


### PR DESCRIPTION
This increases the lifespan of restart files in the sense that old restart files (from before OPMEXTRA was added) can now be used for restarting (although initial timestep will often be different from the original run, since that is what is saved in OPMEXTRA).

I have tested that this works correctly using old and new restart data for the SPE1CASE2(_RESTART) case in opm-data.

@dr-robertk Hope this makes things easier for your testing!