### PR TITLE
Change default output dir

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -310,7 +310,6 @@ namespace Opm
 
         // Parameters for output.
         const std::string outputDir_;
-        const int output_interval_;
         const bool restart_double_si_;
 
         int lastBackupReportStep_;
@@ -341,8 +340,7 @@ namespace Opm
                          const Opm::PhaseUsage &phaseUsage)
       : output_( param.getDefault("output", true) ),
         parallelOutput_( output_ ? new ParallelDebugOutput< Grid >( grid, eclipseState, phaseUsage.num_phases, phaseUsage ) : 0 ),
-        outputDir_( output_ ? param.getDefault("output_dir", std::string("output")) : "." ),
-        output_interval_( output_ ? param.getDefault("output_interval", 1): 0 ),
+        outputDir_( eclipseState.getIOConfig().getOutputDir() ),
         restart_double_si_( output_ ? param.getDefault("restart_double_si", false) : false ),
         lastBackupReportStep_( -1 ),
         phaseUsage_( phaseUsage ),

--- a/tests/run-init-regressionTest.sh
+++ b/tests/run-init-regressionTest.sh
@@ -21,7 +21,7 @@ TEST_ARGS="$@"
 rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS} nosim=true
+${BINPATH}/${EXE_NAME} ${TEST_ARGS} nosim=true output_dir=${RESULT_PATH}
 cd ..
 
 ecode=0

--- a/tests/run-parallel-regressionTest.sh
+++ b/tests/run-parallel-regressionTest.sh
@@ -19,11 +19,11 @@ TEST_ARGS="$@"
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA linear_solver_reduction=1e-7 tolerance_cnv=5e-6 tolerance_mb=1e-8
+${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA linear_solver_reduction=1e-7 tolerance_cnv=5e-6 tolerance_mb=1e-8 output_dir=${RESULT_PATH}
 test $? -eq 0 || exit 1
 mkdir mpi
 cd mpi
-mpirun -np 4 ${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA linear_solver_reduction=1e-7 tolerance_cnv=5e-6 tolerance_mb=1e-8
+mpirun -np 4 ${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA linear_solver_reduction=1e-7 tolerance_cnv=5e-6 tolerance_mb=1e-8 output_dir=${RESULT_PATH}/mpi
 test $? -eq 0 || exit 1
 cd ..
 

--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -18,7 +18,7 @@ TEST_ARGS="$@"
 rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS}
+${BINPATH}/${EXE_NAME} ${TEST_ARGS} output_dir=${RESULT_PATH}
 cd ..
 
 ecode=0

--- a/tests/run-restart-regressionTest.sh
+++ b/tests/run-restart-regressionTest.sh
@@ -19,9 +19,9 @@ TEST_ARGS="$@"
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA timestep.adaptive=false
+${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA timestep.adaptive=false output_dir=${RESULT_PATH}
 test $? -eq 0 || exit 1
-${BINPATH}/${EXE_NAME} ${TEST_ARGS}_RESTART.DATA timestep.adaptive=false
+${BINPATH}/${EXE_NAME} ${TEST_ARGS}_RESTART.DATA timestep.adaptive=false output_dir=${RESULT_PATH}
 test $? -eq 0 || exit 1
 
 ecode=0


### PR DESCRIPTION
This changes the default output directory of flow_legacy and flow_ebos. Currently we default to the current directory, with this PR we will default to the directory where the data deck is found. According to @nairr and @alfbr this is what engineers would expect. Behaviour when specifying output_dir is as before: everything is written to the specified directory.

At the same time, I have taken the opportunity to clean up a little. One minor change is that before, some things would default to be written to the `output` directory instead of the current dir. This has now been unified.

There might be Jenkins or Travis failures because of this. I have only fixed the in-module tests. Hopefully @akva2 can assist if necessary.