### PR TITLE
updating rates of multi phases with updateWellStateWithTargets

### DIFF
--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -2397,29 +2397,30 @@ namespace Opm {
             // break;
 
         case SURFACE_RATE:
-            // assign target value as initial guess for injectors and
-            // single phase producers (orat, grat, wrat)
+            // checking the number of the phases under control
+            int numPhasesWithTargetsUnderThisControl = 0;
+            for (int phase = 0; phase < np; ++phase) {
+                if (distr[phase] > 0.0) {
+                    numPhasesWithTargetsUnderThisControl += 1;
+                }
+            }
+
+            assert(numPhasesWithTargetsUnderThisControl > 0);
+
             const WellType& well_type = wells().type[well_index];
             if (well_type == INJECTOR) {
+                // assign target value as initial guess for injectors
+                // only handles single phase control at the moment
+                assert(numPhasesWithTargetsUnderThisControl == 1);
+
                 for (int phase = 0; phase < np; ++phase) {
-                    const double& compi = wells().comp_frac[np * well_index + phase];
-                    if (compi > 0.0) {
-                        assert(distr[phase] > 0.);
-                        xw.wellRates()[np*well_index + phase] = target * compi / distr[phase];
+                    if (distr[phase] > 0.) {
+                        xw.wellRates()[np*well_index + phase] = target / distr[phase];
                     } else {
-                        xw.wellRates()[np * well_index + phase] = target * compi;
+                        xw.wellRates()[np * well_index + phase] = 0.;
                     }
                 }
             } else if (well_type == PRODUCER) {
-                // checking the number of the phases under control
-                int numPhasesWithTargetsUnderThisControl = 0;
-                for (int phase = 0; phase < np; ++phase) {
-                    if (distr[phase] > 0.0) {
-                        numPhasesWithTargetsUnderThisControl += 1;
-                    }
-                }
-
-                assert(numPhasesWithTargetsUnderThisControl > 0);
 
                 // update the rates of phases under control based on the target,
                 // and also update rates of phases not under control to keep the rate ratio,
@@ -2438,17 +2439,17 @@ namespace Opm {
                         xw.wellRates()[np * well_index + phase] *= scaling_factor;
                     }
                 } else { // scaling factor is not well defied when orignal_rates_under_phase_control is zero
-                    if (orignal_rates_under_phase_control == 0.0) {
-                        // only handle single-phase control
-                        if (numPhasesWithTargetsUnderThisControl == 1) {
-                            for (int phase = 0; phase < np; ++phase) {
-                                if (distr[phase] > 0.0) {
-                                    xw.wellRates()[np * well_index + phase] = target;
-                                }
-                            }
+                    // separating targets equally between phases under control
+                    const double target_rate_devided = target / numPhasesWithTargetsUnderThisControl;
+                    for (int phase = 0; phase < np; ++phase) {
+                        if (distr[phase] > 0.0) {
+                            xw.wellRates()[np * well_index + phase] = target_rate_devided / distr[phase];
+                        } else {
+                            // this only happens for SURFACE_RATE control
+                            xw.wellRates()[np * well_index + phase] = target_rate_devided;
                         }
                     }
-               }
+                }
             } else {
                 OPM_THROW(std::logic_error, "Expected PRODUCER or INJECTOR type of well");
             }
@@ -2501,12 +2502,37 @@ namespace Opm {
                 xw.wellSolutions()[GFrac*nw + well_index] = g[Gas] * xw.wellRates()[np*well_index + Gas] / tot_well_rate ;
             }
         } else {
-            if (active_[ Water ]) {
-                xw.wellSolutions()[WFrac*nw + well_index] =  wells().comp_frac[np*well_index + Water];
-            }
+            const WellType& well_type = wells().type[well_index];
+            if (well_type == INJECTOR) {
+                // only single phase injection handled
+                if (active_[Water]) {
+                    if (distr[Water] > 0.0) {
+                        xw.wellSolutions()[WFrac * nw + well_index] = 1.0;
+                    } else {
+                        xw.wellSolutions()[WFrac * nw + well_index] = 0.0;
+                    }
+                }
 
-            if (active_[ Gas ]) {
-                xw.wellSolutions()[GFrac*nw + well_index] =  wells().comp_frac[np*well_index + Gas];
+                if (active_[Gas]) {
+                    if (distr[Gas] > 0.0) {
+                        xw.wellSolutions()[GFrac * nw + well_index] = 1.0;
+                    } else {
+                        xw.wellSolutions()[GFrac * nw + well_index] = 0.0;
+                    }
+                }
+
+                // TODO: it is possible to leave injector as a oil well,
+                // when F_w and F_g both equals to zero, not sure under what kind of circumstance
+                // this will happen.
+            } else if (well_type == PRODUCER) { // producers
+                if (active_[Water]) {
+                    xw.wellSolutions()[WFrac * nw + well_index] = 1.0 / np;
+                }
+                if (active_[Gas]) {
+                    xw.wellSolutions()[GFrac * nw + well_index] = 1.0 / np;
+                }
+            } else {
+                OPM_THROW(std::logic_error, "Expected PRODUCER or INJECTOR type of well");
             }
         }
 


### PR DESCRIPTION
When we have the distr coefficients, we should be able update the rates of all the phases under SURFACE_RATE and RESEVOIR_RATE. The main principle is that the ratio between the rates of different phases should be kept for production wells when we updating one or more than one of the rates, assuming the mobility ratio is the same.  For the injection well, still only single-phase injection is handled. 

It is developed during the efforts to correcting the usage of well potentials, while this part impacts running of all the examples with `flow_ebos`. So a separate PR is created for testing. It should be tested not to break running of any current successful examples before merging. 