### PR TITLE
[bugfix][output_dir] Fix output_dir creation failure. 

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -381,7 +381,9 @@ namespace Opm
                     create_directories(fpath);
                 }
                 catch (...) {
-                    OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
+                    if( fpath != "." ) {
+                        OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath << " " << outputDir_);
+                    }
                 }
 
                 // create output thread if enabled and rank is I/O rank


### PR DESCRIPTION
Recently a patch was introduced that make the opm-simulators/flow* tools fail when the simulator is called from the directory containing the deck. The failure message reads that the directory "." cannot be created. Seems like the previous patch was not very carefully tested. This PR contains a suggestions on  how to fix this problem. 

