### PR TITLE
[WIP] Changes to improve the StandardWellsDense

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -558,6 +558,11 @@ namespace Opm {
                              std::vector<double>& maxNormWell,
                              int nc) const;
 
+        /// Set up the group control related at the beginning of each time step
+        void
+        setupGroupControl(const ReservoirState& reservoir_state,
+                          WellState& well_state);
+
         double dpMaxRel() const { return param_.dp_max_rel_; }
         double dbhpMaxRel() const {return param_.dbhp_max_rel_; }
         double dsMax() const { return param_.ds_max_; }

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -2585,14 +2585,14 @@ typedef Eigen::Array<double,
 
             for (int phase = 0; phase < np; ++phase) {
                 if (active_[phase]) {
-                const std::vector<int>& well_cells = asImpl().wellModel().wellOps().well_cells;
-                const ADB mu = asImpl().fluidViscosity(canph_[phase], state.canonical_phase_pressures[canph_[phase]],
+                    const std::vector<int>& well_cells = asImpl().wellModel().wellOps().well_cells;
+                    const ADB mu = asImpl().fluidViscosity(canph_[phase], state.canonical_phase_pressures[canph_[phase]],
                                                        temp, rs, rv, cond);
-                mob[phase] = tr_mult * kr[canph_[phase]] / mu;
-                mob_perfcells[phase] = subset(mob[phase], well_cells);
+                    mob[phase] = tr_mult * kr[canph_[phase]] / mu;
+                    mob_perfcells[phase] = subset(mob[phase], well_cells);
 
-                b[phase] = asImpl().fluidReciprocFVF(phase, state.canonical_phase_pressures[phase], temp, rs, rv, cond);
-                b_perfcells[phase] = subset(b[phase], well_cells);
+                    b[phase] = asImpl().fluidReciprocFVF(phase, state.canonical_phase_pressures[phase], temp, rs, rv, cond);
+                    b_perfcells[phase] = subset(b[phase], well_cells);
                 }
             }
 

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -764,6 +764,11 @@ typedef Eigen::Array<double,
             asImpl().wellModel().computeWellConnectionPressures(state0, well_state);
         }
 
+        // set up the guide rate and group control
+        if (asImpl().wellModel().wellCollection()->groupControlActive() && initial_assembly) {
+            setupGroupControl(reservoir_state, well_state);
+        }
+
         // Possibly switch well controls and updating well state to
         // get reasonable initial conditions for the wells
         asImpl().wellModel().updateWellControls(well_state);
@@ -2543,6 +2548,77 @@ typedef Eigen::Array<double,
                 }
             }
         }
+    }
+
+
+
+
+
+    template <class Grid, class WellModel, class Implementation>
+    void
+    BlackoilModelBase<Grid, WellModel, Implementation>::
+    setupGroupControl(const ReservoirState& reservoir_state,
+                      WellState& well_state)
+    {
+        if (param_.compute_well_potentials_) {
+            SolutionState state = asImpl().variableState(reservoir_state, well_state);
+            asImpl().makeConstantState(state);
+            asImpl().wellModel().computeWellConnectionPressures(state, well_state);
+
+            const int np = numPhases();
+            std::vector<ADB> b(np, ADB::null());
+            std::vector<ADB> mob(np, ADB::null());
+
+            const ADB&              press = state.pressure;
+            const ADB&              temp  = state.temperature;
+            const ADB&              rs    = state.rs;
+            const ADB&              rv    = state.rv;
+
+            const std::vector<PhasePresence> cond = phaseCondition();
+
+            const ADB pv_mult = poroMult(press);
+            const ADB tr_mult = transMult(press);
+            const std::vector<ADB> kr = asImpl().computeRelPerm(state);
+
+            std::vector<ADB> mob_perfcells(np, ADB::null());
+            std::vector<ADB> b_perfcells(np, ADB::null());
+
+            for (int phase = 0; phase < np; ++phase) {
+                if (active_[phase]) {
+                const std::vector<int>& well_cells = asImpl().wellModel().wellOps().well_cells;
+                const ADB mu = asImpl().fluidViscosity(canph_[phase], state.canonical_phase_pressures[canph_[phase]],
+                                                       temp, rs, rv, cond);
+                mob[phase] = tr_mult * kr[canph_[phase]] / mu;
+                mob_perfcells[phase] = subset(mob[phase], well_cells);
+
+                b[phase] = asImpl().fluidReciprocFVF(phase, state.canonical_phase_pressures[phase], temp, rs, rv, cond);
+                b_perfcells[phase] = subset(b[phase], well_cells);
+                }
+            }
+
+            // well potentials for each well
+            std::vector<double> well_potentials;
+            asImpl().wellModel().computeWellPotentials(mob_perfcells, b_perfcells, well_state, state, well_potentials);
+            asImpl().wellModel().wellCollection()->setGuideRatesWithPotentials(asImpl().wellModel().wellsPointer(),
+                                                                               fluid_.phaseUsage(), well_potentials);
+            applyVREPGroupControl(reservoir_state, well_state);
+
+            if (asImpl().wellModel().wellCollection()->groupControlApplied()) {
+                asImpl().wellModel().wellCollection()->updateWellTargets(well_state.wellRates());
+            } else {
+                asImpl().wellModel().wellCollection()->applyGroupControls();
+
+                // the well collections do not have access to Well State, so the currentControls() of Well State need to
+                // be updated based on the group control setup
+                const int nw = wells().number_of_wells;
+                for (int w = 0; w < nw; ++w) {
+                    const WellNode& well_node = asImpl().wellModel().wellCollection()->findWellNode(wells().name[w]);
+                    if (!well_node.individualControl()) {
+                        well_state.currentControls()[w] = well_node.groupControlIndex();
+                    }
+                }
+            } // end of else
+        } // end of if (param_.compute_well_potentials_)
     }
 
 } // namespace Opm

--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -820,12 +820,6 @@ typedef Eigen::Array<double,
         asImpl().addWellContributionToMassBalanceEq(cq_s, state, well_state);
         asImpl().wellModel().addWellControlEq(state, well_state, aliveWells, residual_);
 
-        if (param_.compute_well_potentials_) {
-            SolutionState state0 = state;
-            asImpl().makeConstantState(state0);
-            asImpl().wellModel().computeWellPotentials(mob_perfcells, b_perfcells, state0, well_state);
-        }
-
         return report;
     }
 

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -212,9 +212,13 @@ namespace Opm {
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         void prepareStep(const SimulatorTimerInterface& /*timer*/,
-                         const ReservoirState& /*reservoir_state*/,
+                         const ReservoirState& reservoir_state,
                          WellState& well_state)
         {
+            if ( wellModel().wellCollection()->havingVREPGroups() ) {
+                updateRateConverter(reservoir_state);
+            }
+
             well_model_.prepareTimeStep(ebosSimulator_, well_state);
         }
 

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -213,13 +213,11 @@ namespace Opm {
         /// \param[in, out] well_state        well state variables
         void prepareStep(const SimulatorTimerInterface& /*timer*/,
                          const ReservoirState& reservoir_state,
-                         WellState& well_state)
+                         const WellState& /* well_state */)
         {
             if ( wellModel().wellCollection()->havingVREPGroups() ) {
                 updateRateConverter(reservoir_state);
             }
-
-            well_model_.prepareTimeStep(ebosSimulator_, well_state);
         }
 
 

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -213,8 +213,9 @@ namespace Opm {
         /// \param[in, out] well_state        well state variables
         void prepareStep(const SimulatorTimerInterface& /*timer*/,
                          const ReservoirState& /*reservoir_state*/,
-                         const WellState& /* well_state */)
+                         WellState& well_state)
         {
+            well_model_.prepareTimeStep(ebosSimulator_, well_state);
         }
 
 

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -54,7 +54,6 @@ namespace Opm
                 param.getDefault("max_single_precision_days", unit::convert::to( maxSinglePrecisionTimeStep_, unit::day) ), unit::day );
         solve_welleq_initially_ = param.getDefault("solve_welleq_initially",solve_welleq_initially_);
         update_equations_scaling_ = param.getDefault("update_equations_scaling", update_equations_scaling_);
-        compute_well_potentials_ = param.getDefault("compute_well_potentials", compute_well_potentials_);
         use_update_stabilization_ = param.getDefault("use_update_stabilization", use_update_stabilization_);
         deck_file_name_ = param.template get<std::string>("deck_filename");
     }
@@ -78,7 +77,6 @@ namespace Opm
         maxSinglePrecisionTimeStep_ = unit::convert::from( 20.0, unit::day );
         solve_welleq_initially_ = true;
         update_equations_scaling_ = false;
-        compute_well_potentials_ = false;
         use_update_stabilization_ = true;
     }
 

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -62,10 +62,6 @@ namespace Opm
         /// Update scaling factors for mass balance equations
         bool update_equations_scaling_;
 
-        /// Compute well potentials, needed to calculate default guide rates for group
-        /// controlled wells
-        bool compute_well_potentials_;
-
         /// Try to detect oscillation or stagnation.
         bool use_update_stabilization_;
 

--- a/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+++ b/opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
@@ -150,10 +150,13 @@ namespace Opm {
         // get reasonable initial conditions for the wells
         wellModel().updateWellControls(well_state);
 
-        // enforce VREP control when necessary.
-        Base::applyVREPGroupControl(reservoir_state, well_state);
+        // TODO: I do not think the multi_segment well can handle group control yet
+        if (asImpl().wellModel().wellCollection()->groupControlActive()) {
+            // enforce VREP control when necessary.
+            Base::applyVREPGroupControl(reservoir_state, well_state);
 
-        asImpl().wellModel().wellCollection()->updateWellTargets(well_state.wellRates());
+            asImpl().wellModel().wellCollection()->updateWellTargets(well_state.wellRates());
+        }
 
         // Create the primary variables.
         SolutionState state = asImpl().variableState(reservoir_state, well_state);

--- a/opm/autodiff/BlackoilTransportModel.hpp
+++ b/opm/autodiff/BlackoilTransportModel.hpp
@@ -149,12 +149,6 @@ namespace Opm {
             asImpl().addWellContributionToMassBalanceEq(cq_s, state, well_state);
             asImpl().wellModel().addWellControlEq(state, well_state, aliveWells, residual_);
 
-            if (param_.compute_well_potentials_) {
-                SolutionState state0 = state;
-                asImpl().makeConstantState(state0);
-                asImpl().wellModel().computeWellPotentials(mob_perfcells, b_perfcells, state0, well_state);
-            }
-
             return report;
         }
 

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -127,9 +127,6 @@ namespace Opm
         failureReport_ = SimulatorReport();
 
         // Do model-specific once-per-step calculations.
-        // TODO: this is not the correct fix, possibly breaking the sequential solver
-        // TODO: the only reason to do this is that the wellPotentials() is part of the well_state, which will be modified
-        // during the well_potential calculation
         model_->prepareStep(timer, initial_reservoir_state, initial_well_state);
 
         int iteration = 0;

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -130,8 +130,7 @@ namespace Opm
         // TODO: this is not the correct fix, possibly breaking the sequential solver
         // TODO: the only reason to do this is that the wellPotentials() is part of the well_state, which will be modified
         // during the well_potential calculation
-        model_->prepareStep(timer, initial_reservoir_state, well_state);
-        // model_->prepareStep(timer, initial_reservoir_state, initial_reservoir_state);
+        model_->prepareStep(timer, initial_reservoir_state, initial_well_state);
 
         int iteration = 0;
 

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -127,7 +127,11 @@ namespace Opm
         failureReport_ = SimulatorReport();
 
         // Do model-specific once-per-step calculations.
-        model_->prepareStep(timer, initial_reservoir_state, initial_well_state);
+        // TODO: this is not the correct fix, possibly breaking the sequential solver
+        // TODO: the only reason to do this is that the wellPotentials() is part of the well_state, which will be modified
+        // during the well_potential calculation
+        model_->prepareStep(timer, initial_reservoir_state, well_state);
+        // model_->prepareStep(timer, initial_reservoir_state, initial_reservoir_state);
 
         int iteration = 0;
 

--- a/opm/autodiff/ParallelDebugOutput.hpp
+++ b/opm/autodiff/ParallelDebugOutput.hpp
@@ -642,7 +642,6 @@ namespace Opm
                                            // as we get the following error otherwise
                                            // with c++ (Debian 4.9.2-10) 4.9.2 and -std=c++11
                                            // converting to ‘const std::unordered_set<std::basic_string<char> >’ from initializer list would use explicit constructor
-                                           std::vector<double>(),
                                            std::unordered_set<std::string>());
 
                 const Wells* wells = wells_manager.c_wells();

--- a/opm/autodiff/SimulatorBase.hpp
+++ b/opm/autodiff/SimulatorBase.hpp
@@ -175,9 +175,6 @@ namespace Opm
         void
         outputFluidInPlace(const std::vector<double>& oip, const std::vector<double>& cip, const UnitSystem& units, const int reg);
 
-        void computeWellPotentials(const Wells*                    wells,
-                                   const WellState& xw,
-                                   std::vector<double>& well_potentials);
 
         void updateListEconLimited(const std::unique_ptr<Solver>& solver,
                                    const Schedule& schedule,

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -227,9 +227,6 @@ public:
                 OpmLog::note(ss.str());
             }
 
-            // TODO: not used at all, keeping it for interface purpose.
-
-            std::vector<double> well_potentials;
             // Create wells and well state.
             WellsManager wells_manager(eclState(),
                                        timer.currentStepNum(),
@@ -241,7 +238,6 @@ public:
                                        Opm::UgGridHelpers::beginFaceCentroids(grid()),
                                        dynamic_list_econ_limited,
                                        is_parallel_run_,
-                                       well_potentials,
                                        defunct_well_names_ );
             const Wells* wells = wells_manager.c_wells();
             WellState well_state;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -199,8 +199,6 @@ public:
                                     desiredRestoreStep );
         }
 
-        bool is_well_potentials_computed = param_.getDefault("compute_well_potentials", false );
-        std::vector<double> well_potentials;
         DynamicListEconLimited dynamic_list_econ_limited;
         SimulatorReport report;
         SimulatorReport stepReport;
@@ -229,6 +227,9 @@ public:
                 OpmLog::note(ss.str());
             }
 
+            // TODO: not used at all, keeping it for interface purpose.
+
+            std::vector<double> well_potentials;
             // Create wells and well state.
             WellsManager wells_manager(eclState(),
                                        timer.currentStepNum(),
@@ -395,11 +396,6 @@ public:
             report.output_write_time += perfTimer.stop();
 
             prev_well_state = well_state;
-            // The well potentials are only computed if they are needed
-            // For now thay are only used to determine default guide rates for group controlled wells
-            if ( is_well_potentials_computed ) {
-                computeWellPotentials(wells, well_state, well_potentials);
-            }
 
             updateListEconLimited(solver, eclState().getSchedule(), timer.currentStepNum(), wells,
                                   well_state, dynamic_list_econ_limited);
@@ -604,23 +600,6 @@ protected:
         }
     }
 
-
-    void computeWellPotentials(const Wells*                    wells,
-                               const WellState& xw,
-                               std::vector<double>& well_potentials)
-    {
-        const int nw = wells->number_of_wells;
-        const int np = wells->number_of_phases;
-        well_potentials.clear();
-        well_potentials.resize(nw*np,0.0);
-        for (int w = 0; w < nw; ++w) {
-            for (int perf = wells->well_connpos[w]; perf < wells->well_connpos[w + 1]; ++perf) {
-                for (int phase = 0; phase < np; ++phase) {
-                    well_potentials[w*np + phase] += xw.wellPotentials()[perf*np + phase];
-                }
-            }
-        }
-    }
 
 
     void updateListEconLimited(const std::unique_ptr<Solver>& solver,

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -126,7 +126,6 @@ namespace Opm
                                        // as we get the following error otherwise
                                        // with c++ (Debian 4.9.2-10) 4.9.2 and -std=c++11
                                        // converting to ‘const std::unordered_set<std::basic_string<char> >’ from initializer list would use explicit constructor
-                                       std::vector<double>(), // null well_potentials
                                        Base::defunct_well_names_);
             const Wells* wells = wells_manager.c_wells();
             WellState well_state;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -445,7 +445,6 @@ namespace Opm
                                   // with c++ (Debian 4.9.2-10) 4.9.2 and -std=c++11
                                   // converting to ‘const std::unordered_set<std::basic_string<char> >’ from initializer list would use explicit constructo
                                   , false,
-                                  std::vector<double>(),
                                   std::unordered_set<std::string>());
 
         const Wells* wells = wellsmanager.c_wells();

--- a/opm/autodiff/StandardWells.hpp
+++ b/opm/autodiff/StandardWells.hpp
@@ -152,8 +152,9 @@ namespace Opm {
             void
             computeWellPotentials(const std::vector<ADB>& mob_perfcells,
                                   const std::vector<ADB>& b_perfcells,
+                                  const WellState& well_state,
                                   SolutionState& state0,
-                                  WellState& well_state);
+                                  std::vector<double>& well_potentials) const;
 
             template <class SolutionState>
             void

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -243,17 +243,13 @@ enum WellVariablePositions {
                                                         const double grav);
 
 
-            // TODO: Later we might want to change the function to only handle one well,
-            // the requirement for well potential calculation can be based on individual wells.
-            // getBhp() will be refactored to reduce the duplication of the code calculating the bhp from THP.
+            // Calculating well potentials for each well
+            // TODO: getBhp() will be refactored to reduce the duplication of the code calculating the bhp from THP.
             template<typename Simulator>
             void
             computeWellPotentials(const Simulator& ebosSimulator,
-                                  WellState& well_state)  const;
-
-            // TODO: temporary function name for now before changing the simulator and also WellsMananger
-            void computeWellPotentials(const WellState& well_state,
-                                       std::vector<double>& well_potentials) const;
+                                  const WellState& well_state,
+                                  std::vector<double>& well_potentials)  const;
 
             // TODO: some preparation work, mostly related to group control and RESV,
             // at the beginning of each time step (Not report step)

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -374,7 +374,7 @@ enum WellVariablePositions {
                                     const int well_index,
                                     std::vector<double>& well_flux) const;
 
-            double leastStrictBhpFromBhpLimits(const int well_index) const;
+            double mostStrictBhpFromBhpLimits(const int well_index) const;
 
             // TODO: maybe it should be improved to be calculate general rates for THP control later
             template<typename Simulator>

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -363,6 +363,8 @@ enum WellVariablePositions {
                                            const int well_index,
                                            WellState& xw) const;
 
+            bool wellHasTHPConstraints(const int well_index) const;
+
         };
 
 

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -249,7 +249,7 @@ enum WellVariablePositions {
             void
             computeWellPotentials(const Simulator& ebosSimulator,
                                   const WellState& well_state,
-                                  std::vector<double>& well_potentials)  const;
+                                  std::vector<double>& well_potentials) const;
 
             // TODO: some preparation work, mostly related to group control and RESV,
             // at the beginning of each time step (Not report step)

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -375,6 +375,14 @@ enum WellVariablePositions {
                                     std::vector<double>& well_flux) const;
 
             double leastStrictBhpFromBhpLimits(const int well_index) const;
+
+            // TODO: maybe it should be improved to be calculate general rates for THP control later
+            template<typename Simulator>
+            std::vector<double>
+            computeWellPotentialWithTHP(const Simulator& ebosSimulator,
+                                        const int well_index,
+                                        const double initial_bhp, // bhp from BHP constraints
+                                        const std::vector<double>& initial_potential) const;
         };
 
 

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -374,6 +374,7 @@ enum WellVariablePositions {
                                     const int well_index,
                                     std::vector<double>& well_flux) const;
 
+            double leastStrictBhpFromBhpLimits(const int well_index) const;
         };
 
 

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -155,7 +155,7 @@ enum WellVariablePositions {
 
             int numCells() const;
 
-            void resetWellControlFromState(WellState xw) const;
+            void resetWellControlFromState(const WellState& xw) const;
 
             const Wells& wells() const;
 

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -251,10 +251,15 @@ enum WellVariablePositions {
             computeWellPotentials(const Simulator& ebosSimulator,
                                   WellState& well_state)  const;
 
-
             // TODO: temporary function name for now before changing the simulator and also WellsMananger
             void computeWellPotentials(const WellState& well_state,
                                        std::vector<double>& well_potentials) const;
+
+            // TODO: some preparation work, mostly related to group control and RESV,
+            // at the beginning of each time step (Not report step)
+            template<typename Simulator>
+            void prepareTimeStep(const Simulator& ebos_simulator,
+                                 WellState& well_state);
 
             WellCollection* wellCollection() const;
 

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -365,6 +365,15 @@ enum WellVariablePositions {
 
             bool wellHasTHPConstraints(const int well_index) const;
 
+            // TODO: maybe we should provide a light version of computeWellFlux, which does not include the
+            // calculation of the derivatives
+            template<typename Simulator>
+            void
+            computeWellRatesWithBhp(const Simulator& ebosSimulator,
+                                    const EvalWell& bhp,
+                                    const int well_index,
+                                    std::vector<double>& well_flux) const;
+
         };
 
 

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -251,6 +251,11 @@ enum WellVariablePositions {
             computeWellPotentials(const Simulator& ebosSimulator,
                                   WellState& well_state)  const;
 
+
+            // TODO: temporary function name for now before changing the simulator and also WellsMananger
+            void computeWellPotentials(const WellState& well_state,
+                                       std::vector<double>& well_potentials) const;
+
             WellCollection* wellCollection() const;
 
             const std::vector<double>&

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -2481,9 +2481,13 @@ namespace Opm {
         switch (well_controls_iget_type(wc, current)) {
         case BHP:
             xw.bhp()[well_index] = target;
+            // TODO: similar to the way below to handle THP
+            // we should not something related to thp here when there is thp constraint
             break;
 
         case THP: {
+            xw.thp()[well_index] = target;
+
             double aqua = 0.0;
             double liquid = 0.0;
             double vapour = 0.0;

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -130,6 +130,10 @@ namespace Opm {
              WellState& well_state)
     {
 
+        if (iterationIdx == 0) {
+            prepareTimeStep(ebosSimulator, well_state);
+        }
+
         // after restarting, the well_controls can be modified while
         // the well_state still uses the old control index
         // we need to synchronize these two.

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -1739,6 +1739,11 @@ namespace Opm {
         well_potentials.resize(nw * np, 0.0);
 
         for (int w = 0; w < nw; ++w) {
+
+            bool is_thp_determined = wellHasTHPConstraints(w);
+
+            if (!is_thp_determined) {
+
             // bhp needs to be determined for the well potential calculation
             // There can be more than one BHP/THP constraints.
             // TODO: there is an option to ignore the THP limit when calculating well potentials,
@@ -2750,5 +2755,24 @@ namespace Opm {
 
     }
 
+
+
+
+
+    template<typename FluidSystem, typename BlackoilIndices>
+    bool
+    StandardWellsDense<FluidSystem, BlackoilIndices>::
+    wellHasTHPConstraints(const int well_index) const
+    {
+        const WellType& well_type = wells().type[well_index];
+        const WellControls* well_control = wells().ctrls[well_index];
+        const int nwc = well_controls_get_num(well_control);
+        for (int ctrl_index = 0; ctrl_index < nwc; ++ctrl_index) {
+            if (well_controls_iget_type(well_control, ctrl_index) == THP) {
+                return true;
+            }
+        }
+        return false;
+    }
 
 } // namespace Opm

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -1835,26 +1835,24 @@ namespace Opm {
 
                 // update/setup guide rates for each well based on the well_potentials
                 well_collection_->setGuideRatesWithPotentials(wellsPointer(), phase_usage_, well_potentials);
-
-                // handling the situation that wells does not have a valid control
-                // it happens the well specified with GRUP and restarting due to non-convergencing
-                // putting the well under group control for this situation
-                if (wellCollection()->groupControlActive()) {
-                    for (int w = 0; w < nw; ++w) {
-                        WellControls* wc = wells().ctrls[w];
-                        const int ctrl_index = well_controls_get_current(wc);
-                        WellNode& well_node = well_collection_->findWellNode(std::string(wells().name[w]));
-
-                        const int group_control_index = well_node.groupControlIndex();
-                        if (group_control_index >= 0 && ctrl_index < 0) {
-                            well_controls_set_current(wc, group_control_index);
-                            well_state.currentControls()[w] = group_control_index;
-                            well_node.setIndividualControl(false);
-                        }
-                    }
-                }
-
             }
+
+            // handling the situation that wells do not have a valid control
+            // it happens the well specified with GRUP and restarting due to non-convergencing
+            // putting the well under group control for this situation
+            for (int w = 0; w < nw; ++w) {
+                WellControls* wc = wells().ctrls[w];
+                const int ctrl_index = well_controls_get_current(wc);
+                WellNode& well_node = well_collection_->findWellNode(std::string(wells().name[w]));
+
+                const int group_control_index = well_node.groupControlIndex();
+                if (group_control_index >= 0 && ctrl_index < 0) {
+                    well_controls_set_current(wc, group_control_index);
+                    well_state.currentControls()[w] = group_control_index;
+                    well_node.setIndividualControl(false);
+                }
+            }
+
             applyVREPGroupControl(well_state);
 
             if (!wellCollection()->groupControlApplied()) {

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -898,6 +898,11 @@ namespace Opm {
 
         if (!converged) {
             well_state = well_state0;
+            // also recover the old well controls
+            for (int w = 0; w < nw; ++w) {
+                WellControls* wc = wells().ctrls[w];
+                well_controls_set_current(wc, well_state.currentControls()[w]);
+            }
         }
 
         SimulatorReport report;

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -148,7 +148,7 @@ namespace Opm {
             return report;
         }
 
-        resetWellControlFromState(well_state);
+        // resetWellControlFromState(well_state);
         updateWellControls(well_state);
         // Set the primary variables for the wells
         setWellVariables(well_state);

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -262,7 +262,7 @@ namespace Opm {
     {
 
         const int np = wells().number_of_phases;
-        assert (mob.size() == np);
+        assert (int(mob.size()) == np);
         const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
         const auto& materialLawManager = ebosSimulator.problem().materialLawManager();
 
@@ -2664,7 +2664,6 @@ namespace Opm {
     StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw>::
     wellHasTHPConstraints(const int well_index) const
     {
-        const WellType& well_type = wells().type[well_index];
         const WellControls* well_control = wells().ctrls[well_index];
         const int nwc = well_controls_get_num(well_control);
         for (int ctrl_index = 0; ctrl_index < nwc; ++ctrl_index) {

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -1786,10 +1786,10 @@ namespace Opm {
 
 
 
-    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext>
+    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext, typename MaterialLaw>
     template<typename Simulator>
     void
-    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>::
+    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw>::
     prepareTimeStep(const Simulator& ebos_simulator,
                     WellState& well_state)
     {
@@ -1881,7 +1881,7 @@ namespace Opm {
 
 
 
-    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext>
+    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext, typename MaterialLaw>
     WellCollection*
     StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw>::
     wellCollection() const
@@ -2659,9 +2659,9 @@ namespace Opm {
 
 
 
-    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext>
+    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext, typename MaterialLaw>
     bool
-    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>::
+    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw>::
     wellHasTHPConstraints(const int well_index) const
     {
         const WellType& well_type = wells().type[well_index];
@@ -2679,10 +2679,10 @@ namespace Opm {
 
 
 
-    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext>
+    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext, typename MaterialLaw>
     template <typename Simulator>
     void
-    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>::
+    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw>::
     computeWellRatesWithBhp(const Simulator& ebosSimulator,
                             const EvalWell& bhp,
                             const int well_index,
@@ -2697,7 +2697,9 @@ namespace Opm {
             const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_index, /*timeIdx=*/ 0));
             // flux for each perforation
             std::vector<EvalWell> cq_s(np, 0.0);
-            computeWellFlux(well_index, wells().WI[perf], intQuants, bhp,
+            std::vector<EvalWell> mob(np, 0.0);
+            getMobility(ebosSimulator, perf, cell_index, mob);
+            computeWellFlux(well_index, wells().WI[perf], intQuants.fluidState(), mob, bhp,
                             wellPerforationPressureDiffs()[perf], allow_cf, cq_s);
 
             for(int p = 0; p < np; ++p) {
@@ -2711,9 +2713,9 @@ namespace Opm {
 
 
 
-    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext>
+    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext, typename MaterialLaw>
     double
-    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>::
+    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw>::
     mostStrictBhpFromBhpLimits(const int well_index) const
     {
         double bhp;
@@ -2767,10 +2769,10 @@ namespace Opm {
 
 
 
-    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext>
+    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext, typename MaterialLaw>
     template <typename Simulator>
     std::vector<double>
-    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>::
+    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw>::
     computeWellPotentialWithTHP(const Simulator& ebosSimulator,
                                 const int well_index,
                                 const double initial_bhp, // bhp from BHP constraints

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -1282,7 +1282,11 @@ namespace Opm {
             if (well_controls_iget_type(wc, current) == RESERVOIR_RATE) {
                 const double* distr = well_controls_iget_distr(wc, current);
                 for (int p = 0; p < np; ++p) {
-                    F[p] /= distr[p];
+                    if (distr[p] > 0.) { // For injection wells, there only one non-zero distr value
+                        F[p] /= distr[p];
+                    } else {
+                        F[p] = 0.;
+                    }
                 }
             } else {
                 for (int p = 0; p < np; ++p) {
@@ -2201,7 +2205,13 @@ namespace Opm {
         const WellControls* wc = wells().ctrls[wellIdx];
         if (well_controls_get_current_type(wc) == RESERVOIR_RATE) {
             const double* distr = well_controls_get_current_distr(wc);
-            return wellVolumeFraction(wellIdx, phaseIdx) / distr[phaseIdx];
+            if (distr[phaseIdx] > 0.) {
+                return wellVolumeFraction(wellIdx, phaseIdx) / distr[phaseIdx];
+            } else {
+                // TODO: not sure why return EvalWell(0.) causing problem here
+                // Probably due to the wrong Jacobians.
+                return wellVolumeFraction(wellIdx, phaseIdx);
+            }
         }
         std::vector<double> g = {1,1,0.01};
         return (wellVolumeFraction(wellIdx, phaseIdx) / g[phaseIdx]);

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -1823,7 +1823,7 @@ namespace Opm {
 
         if (well_collection_->groupControlActive()) {
             // calculate the well potentials
-            if (param_.compute_well_potentials_) {
+            if (well_collection_->requireWellPotentials()) {
 
                 setWellVariables(well_state);
                 computeWellConnectionPressures(ebos_simulator, well_state);

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -545,7 +545,7 @@ namespace Opm {
     template<typename FluidSystem, typename BlackoilIndices, typename ElementContext, typename MaterialLaw>
     void
     StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw>::
-    resetWellControlFromState(WellState xw) const
+    resetWellControlFromState(const WellState& xw) const
     {
         const int        nw   = wells_->number_of_wells;
         for (int w = 0; w < nw; ++w) {

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -2850,7 +2850,7 @@ namespace Opm {
                 }
             }
 
-            // there should be always some avaible bhp/thp constraints there
+            // there should be always some available bhp/thp constraints there
             if (std::isinf(bhp) || std::isnan(bhp)) {
                 OPM_THROW(std::runtime_error, "Unvalid bhp value obtained during the potential calculation for well " << wells().name[well_index]);
             }
@@ -2858,6 +2858,13 @@ namespace Opm {
             converged = std::abs(old_bhp - bhp) < bhp_tolerance;
 
             computeWellRatesWithBhp(ebosSimulator, bhp, well_index, potentials);
+
+            // checking whether the potentials have valid values
+            for (const double value : potentials) {
+                if (std::isinf(value) || std::isnan(value)) {
+                    OPM_THROW(std::runtime_error, "Unvalid potential value obtained during the potential calculation for well " << wells().name[well_index]);
+                }
+            }
 
             if (!converged) {
                 old_bhp = bhp;

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -1741,7 +1741,7 @@ namespace Opm {
         for (int w = 0; w < nw; ++w) {
 
             // get the bhp value based on the bhp constraints
-            double bhp = mostStrictBhpFromBhpLimits(w);
+            const double bhp = mostStrictBhpFromBhpLimits(w);
 
             // does the well have a THP related constraint?
             bool is_thp_determined = wellHasTHPConstraints(w);
@@ -1789,7 +1789,7 @@ namespace Opm {
     template<typename FluidSystem, typename BlackoilIndices, typename ElementContext>
     template<typename Simulator>
     void
-    StandardWellsDense<FluidSystem, BlackoilIndices>::
+    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>::
     prepareTimeStep(const Simulator& ebos_simulator,
                     WellState& well_state)
     {
@@ -2662,9 +2662,9 @@ namespace Opm {
 
 
 
-    template<typename FluidSystem, typename BlackoilIndices>
+    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext>
     bool
-    StandardWellsDense<FluidSystem, BlackoilIndices>::
+    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>::
     wellHasTHPConstraints(const int well_index) const
     {
         const WellType& well_type = wells().type[well_index];
@@ -2682,10 +2682,10 @@ namespace Opm {
 
 
 
-    template<typename FluidSystem, typename BlackoilIndices>
+    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext>
     template <typename Simulator>
     void
-    StandardWellsDense<FluidSystem, BlackoilIndices>::
+    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>::
     computeWellRatesWithBhp(const Simulator& ebosSimulator,
                             const EvalWell& bhp,
                             const int well_index,
@@ -2714,9 +2714,9 @@ namespace Opm {
 
 
 
-    template<typename FluidSystem, typename BlackoilIndices>
+    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext>
     double
-    StandardWellsDense<FluidSystem, BlackoilIndices>::
+    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>::
     mostStrictBhpFromBhpLimits(const int well_index) const
     {
         double bhp;
@@ -2770,10 +2770,10 @@ namespace Opm {
 
 
 
-    template<typename FluidSystem, typename BlackoilIndices>
+    template<typename FluidSystem, typename BlackoilIndices, typename ElementContext>
     template <typename Simulator>
     std::vector<double>
-    StandardWellsDense<FluidSystem, BlackoilIndices>::
+    StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>::
     computeWellPotentialWithTHP(const Simulator& ebosSimulator,
                                 const int well_index,
                                 const double initial_bhp, // bhp from BHP constraints

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -2499,29 +2499,30 @@ namespace Opm {
             // break;
 
         case SURFACE_RATE:
-            // assign target value as initial guess for injectors and
-            // single phase producers (orat, grat, wrat)
+            // checking the number of the phases under control
+            int numPhasesWithTargetsUnderThisControl = 0;
+            for (int phase = 0; phase < np; ++phase) {
+                if (distr[phase] > 0.0) {
+                    numPhasesWithTargetsUnderThisControl += 1;
+                }
+            }
+
+            assert(numPhasesWithTargetsUnderThisControl > 0);
+
             const WellType& well_type = wells().type[well_index];
             if (well_type == INJECTOR) {
+                // assign target value as initial guess for injectors
+                // only handles single phase control at the moment
+                assert(numPhasesWithTargetsUnderThisControl == 1);
+
                 for (int phase = 0; phase < np; ++phase) {
-                    const double& compi = wells().comp_frac[np * well_index + phase];
-                    if (compi > 0.0) {
-                        assert(distr[phase] > 0.);
-                        xw.wellRates()[np*well_index + phase] = target * compi / distr[phase];
+                    if (distr[phase] > 0.) {
+                        xw.wellRates()[np*well_index + phase] = target / distr[phase];
                     } else {
-                        xw.wellRates()[np * well_index + phase] = target * compi;
+                        xw.wellRates()[np * well_index + phase] = 0.;
                     }
                 }
             } else if (well_type == PRODUCER) {
-                // checking the number of the phases under control
-                int numPhasesWithTargetsUnderThisControl = 0;
-                for (int phase = 0; phase < np; ++phase) {
-                    if (distr[phase] > 0.0) {
-                        numPhasesWithTargetsUnderThisControl += 1;
-                    }
-                }
-
-                assert(numPhasesWithTargetsUnderThisControl > 0);
 
                 // update the rates of phases under control based on the target,
                 // and also update rates of phases not under control to keep the rate ratio,
@@ -2540,17 +2541,17 @@ namespace Opm {
                         xw.wellRates()[np * well_index + phase] *= scaling_factor;
                     }
                 } else { // scaling factor is not well defied when orignal_rates_under_phase_control is zero
-                    if (orignal_rates_under_phase_control == 0.0) {
-                        // only handle single-phase control
-                        if (numPhasesWithTargetsUnderThisControl == 1) {
-                            for (int phase = 0; phase < np; ++phase) {
-                                if (distr[phase] > 0.0) {
-                                    xw.wellRates()[np * well_index + phase] = target;
-                                }
-                            }
+                    // separating targets equally between phases under control
+                    const double target_rate_devided = target / numPhasesWithTargetsUnderThisControl;
+                    for (int phase = 0; phase < np; ++phase) {
+                        if (distr[phase] > 0.0) {
+                            xw.wellRates()[np * well_index + phase] = target_rate_devided / distr[phase];
+                        } else {
+                            // this only happens for SURFACE_RATE control
+                            xw.wellRates()[np * well_index + phase] = target_rate_devided;
                         }
                     }
-               }
+                }
             } else {
                 OPM_THROW(std::logic_error, "Expected PRODUCER or INJECTOR type of well");
             }
@@ -2603,12 +2604,37 @@ namespace Opm {
                 xw.wellSolutions()[GFrac*nw + well_index] = g[Gas] * xw.wellRates()[np*well_index + Gas] / tot_well_rate ;
             }
         } else {
-            if (active_[ Water ]) {
-                xw.wellSolutions()[WFrac*nw + well_index] =  wells().comp_frac[np*well_index + Water];
-            }
+            const WellType& well_type = wells().type[well_index];
+            if (well_type == INJECTOR) {
+                // only single phase injection handled
+                if (active_[Water]) {
+                    if (distr[Water] > 0.0) {
+                        xw.wellSolutions()[WFrac * nw + well_index] = 1.0;
+                    } else {
+                        xw.wellSolutions()[WFrac * nw + well_index] = 0.0;
+                    }
+                }
 
-            if (active_[ Gas ]) {
-                xw.wellSolutions()[GFrac*nw + well_index] =  wells().comp_frac[np*well_index + Gas];
+                if (active_[Gas]) {
+                    if (distr[Gas] > 0.0) {
+                        xw.wellSolutions()[GFrac * nw + well_index] = 1.0;
+                    } else {
+                        xw.wellSolutions()[GFrac * nw + well_index] = 0.0;
+                    }
+                }
+
+                // TODO: it is possible to leave injector as a oil well,
+                // when F_w and F_g both equals to zero, not sure under what kind of circumstance
+                // this will happen.
+            } else if (well_type == PRODUCER) { // producers
+                if (active_[Water]) {
+                    xw.wellSolutions()[WFrac * nw + well_index] = 1.0 / np;
+                }
+                if (active_[Gas]) {
+                    xw.wellSolutions()[GFrac * nw + well_index] = 1.0 / np;
+                }
+            } else {
+                OPM_THROW(std::logic_error, "Expected PRODUCER or INJECTOR type of well");
             }
         }
 

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -1549,11 +1549,14 @@ namespace Opm {
         // checking whether control changed
         wellhelpers::WellSwitchingLogger logger;
         for (int w = 0; w < nw; ++w) {
+            const WellControls* wc = wells().ctrls[w];
             if (updated_control_index[w] != old_control_index[w]) {
-                WellControls* wc = wells().ctrls[w];
                 logger.wellSwitched(wells().name[w],
                                     well_controls_iget_type(wc, old_control_index[w]),
                                     well_controls_iget_type(wc, updated_control_index[w]));
+            }
+
+            if (updated_control_index[w] != old_control_index[w] || well_collection_->groupControlActive()) {
                 updateWellStateWithTarget(wc, updated_control_index[w], w, xw);
             }
         }

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -1768,7 +1768,7 @@ namespace Opm {
                     for (double& value : potentials) {
                         // make the value a little safer in case the BHP limits are default ones
                         // TODO: a better way should be a better rescaling based on the investigation of the VFP table.
-                        value *= 0.001;
+                        value *= 0.00001;
                     }
                 }
 
@@ -2866,8 +2866,9 @@ namespace Opm {
             if (!converged) {
                 old_bhp = bhp;
                 for (int p = 0; p < np; ++p) {
-                    // TODO: improve the interpolation, will it always be valid with the way below
-                    potentials[p] = 0.01 * potentials[p] + 0.99 * old_potentials[p];
+                    // TODO: improve the interpolation, will it always be valid with the way below?
+                    // TODO: finding better paramters, better iteration strategy for better convergence rate.
+                    potentials[p] = 0.001 * potentials[p] + 0.999 * old_potentials[p];
                     old_potentials[p] = potentials[p];
                 }
             }

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -2048,11 +2048,14 @@ namespace Opm {
             computeWellVoidageRates(well_state, well_voidage_rates, voidage_conversion_coeffs);
             wellCollection()->applyVREPGroupControls(well_voidage_rates, voidage_conversion_coeffs);
 
-            // for the wells under group control, update the currentControls for the well_state
+            // for the wells under group control, update the control index for the well_state and well_controls
             for (const WellNode* well_node : wellCollection()->getLeafNodes()) {
                 if (well_node->isInjector() && !well_node->individualControl()) {
                     const int well_index = well_node->selfIndex();
                     well_state.currentControls()[well_index] = well_node->groupControlIndex();
+
+                    WellControls* wc = wells().ctrls[well_index];
+                    well_controls_set_current(wc, well_node->groupControlIndex());
                 }
             }
         }

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -775,7 +775,7 @@ namespace Opm {
         EvalWell well_pressure = bhp + cdp;
         EvalWell drawdown = pressure - well_pressure;
 
-        // injection perforations
+        // producing perforations
         if ( drawdown.value() > 0 )  {
             //Do nothing if crossflow is not allowed
             if (!allow_cf && wells().type[w] == INJECTOR) {

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -129,6 +129,20 @@ namespace Opm {
              const double dt,
              WellState& well_state)
     {
+
+        // after restarting, the well_controls can be modified while
+        // the well_state still uses the old control index
+        // we need to synchronize these two.
+        const int nw = wells().number_of_wells;
+        for (int w = 0; w < nw; ++w) {
+            const int ctrl_index = well_state.currentControls()[w];
+            WellControls* wc = wells().ctrls[w];
+            const int ctrl_index_2 = well_controls_get_current(wc);
+            if (ctrl_index_2 != ctrl_index) {
+                well_controls_set_current(wc, ctrl_index);
+            }
+        }
+
         SimulatorReport report;
         if ( ! localWellsActive() ) {
             return report;

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -2496,7 +2496,7 @@ namespace Opm {
             // surface condition.  In this case, use existing
             // flow rates as initial conditions as reservoir
             // rate acts only in aggregate.
-            break;
+            // break;
 
         case SURFACE_RATE:
             // assign target value as initial guess for injectors and
@@ -2505,26 +2505,52 @@ namespace Opm {
             if (well_type == INJECTOR) {
                 for (int phase = 0; phase < np; ++phase) {
                     const double& compi = wells().comp_frac[np * well_index + phase];
-                    // TODO: it was commented out from the master branch already.
-                    //if (compi > 0.0) {
-                    xw.wellRates()[np*well_index + phase] = target * compi;
-                    //}
+                    if (compi > 0.0) {
+                        assert(distr[phase] > 0.);
+                        xw.wellRates()[np*well_index + phase] = target * compi / distr[phase];
+                    } else {
+                        xw.wellRates()[np * well_index + phase] = target * compi;
+                    }
                 }
             } else if (well_type == PRODUCER) {
-                // only set target as initial rates for single phase
-                // producers. (orat, grat and wrat, and not lrat)
-                // lrat will result in numPhasesWithTargetsUnderThisControl == 2
+                // checking the number of the phases under control
                 int numPhasesWithTargetsUnderThisControl = 0;
                 for (int phase = 0; phase < np; ++phase) {
                     if (distr[phase] > 0.0) {
                         numPhasesWithTargetsUnderThisControl += 1;
                     }
                 }
+
+                assert(numPhasesWithTargetsUnderThisControl > 0);
+
+                // update the rates of phases under control based on the target,
+                // and also update rates of phases not under control to keep the rate ratio,
+                // assuming the mobility ratio does not change for the production wells
+                double orignal_rates_under_phase_control = 0.0;
                 for (int phase = 0; phase < np; ++phase) {
-                    if (distr[phase] > 0.0 && numPhasesWithTargetsUnderThisControl < 2 ) {
-                        xw.wellRates()[np*well_index + phase] = target * distr[phase];
+                    if (distr[phase] > 0.0) {
+                        orignal_rates_under_phase_control += xw.wellRates()[np * well_index + phase] * distr[phase];
                     }
                 }
+
+                if (orignal_rates_under_phase_control != 0.0 ) {
+                    double scaling_factor = target / orignal_rates_under_phase_control;
+
+                    for (int phase = 0; phase < np; ++phase) {
+                        xw.wellRates()[np * well_index + phase] *= scaling_factor;
+                    }
+                } else { // scaling factor is not well defied when orignal_rates_under_phase_control is zero
+                    if (orignal_rates_under_phase_control == 0.0) {
+                        // only handle single-phase control
+                        if (numPhasesWithTargetsUnderThisControl == 1) {
+                            for (int phase = 0; phase < np; ++phase) {
+                                if (distr[phase] > 0.0) {
+                                    xw.wellRates()[np * well_index + phase] = target;
+                                }
+                            }
+                        }
+                    }
+               }
             } else {
                 OPM_THROW(std::logic_error, "Expected PRODUCER or INJECTOR type of well");
             }

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -1426,7 +1426,8 @@ namespace Opm {
             const WellControls* wc = wells().ctrls[w];
             const int nwc = well_controls_get_num(wc);
             // Looping over all controls until we find a THP constraint
-            for (int ctrl_index = 0; ctrl_index < nwc; ++ctrl_index) {
+            int ctrl_index = 0;
+            for ( ; ctrl_index < nwc; ++ctrl_index) {
                 if (well_controls_iget_type(wc, ctrl_index) == THP) {
                     // the current control
                     const int current = well_state.currentControls()[w];
@@ -1479,6 +1480,11 @@ namespace Opm {
                     break;
                 }
             }  // end of for loop for seaching THP constraints
+
+            // no THP constraint found
+            if (ctrl_index == nwc) { // not finding a THP contstraints
+                well_state.thp()[w] = 0.0;
+            }
         } // end of for (int w = 0; w < nw; ++w)
     }
 

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -106,6 +106,8 @@ namespace Opm
             well_potentials_.clear();
             well_potentials_.resize(nperf * np, 0.0);
 
+            is_new_well_.resize(nw, true);
+
             // intialize wells that have been there before
             // order may change so the mapping is based on the well name
             if( ! prevState.wellMap().empty() )
@@ -117,6 +119,9 @@ namespace Opm
                     const_iterator it = prevState.wellMap().find( name );
                     if( it != end )
                     {
+                        // this is not a new added well
+                        is_new_well_[w] = false;
+
                         const int oldIndex = (*it).second[ 0 ];
                         const int newIndex = w;
 
@@ -273,10 +278,26 @@ namespace Opm
             return res;
         }
 
+
+        bool isNewWell(const int w) const {
+            return is_new_well_[w];
+        }
+
+
+        void setNewWell(const int w, const bool is_new_well) {
+            is_new_well_[w] = is_new_well;
+        }
+
     private:
         std::vector<double> perfphaserates_;
         std::vector<int> current_controls_;
         std::vector<double> well_potentials_;
+
+        // marking whether the well is just added
+        // for newly added well, the current initialized rates from WellState
+        // will have very wrong compsitions for productions wells, will mostly cause
+        // problem with VFP interpolation
+        std::vector<bool> is_new_well_;
     };
 
 } // namespace Opm

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -123,6 +123,9 @@ namespace Opm
                         // bhp
                         bhp()[ newIndex ] = prevState.bhp()[ oldIndex ];
 
+                        // thp
+                        thp()[ newIndex ] = prevState.thp()[ oldIndex ];
+
                         // wellrates
                         for( int i=0, idx=newIndex*np, oldidx=oldIndex*np; i<np; ++i, ++idx, ++oldidx )
                         {

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -271,7 +271,7 @@ namespace Opm
 
         // marking whether the well is just added
         // for newly added well, the current initialized rates from WellState
-        // will have very wrong compsitions for productions wells, will mostly cause
+        // will have very wrong compositions for production wells, will mostly cause
         // problem with VFP interpolation
         std::vector<bool> is_new_well_;
     };

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -167,22 +167,6 @@ namespace Opm
                                 perfPress()[ perf ] = prevState.perfPress()[ oldPerf_idx ];
                             }
                         }
-
-                        // currentControls
-                        // TODO: copying the control index from the previous state can provide better guess of the inital control
-                        // while it can cause problem when the combination of the controls/constraints change. In that situation, coying
-                        // the control index means specifying a rather random control. The VFP table provides some damaging values for
-                        // situatioin not desirable, entering with a random control will possibly crash the whole simulation. Restarting with smaller
-                        // time step might not help.
-                        /* const int old_control_index = prevState.currentControls()[ oldIndex ];
-                        if (old_control_index < well_controls_get_num(wells->ctrls[w])) {
-                            // If the set of controls have changed, this may not be identical
-                            // to the last control, but it must be a valid control.
-                            currentControls()[ newIndex ] = old_control_index;
-                        } else {
-                            assert(well_controls_get_num(wells->ctrls[w]) > 0);
-                            currentControls()[ newIndex ] = 0;
-                        } */
                     }
 
 

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -161,7 +161,12 @@ namespace Opm
                         }
 
                         // currentControls
-                        const int old_control_index = prevState.currentControls()[ oldIndex ];
+                        // TODO: copying the control index from the previous state can provide better guess of the inital control
+                        // while it can cause problem when the combination of the controls/constraints change. In that situation, coying
+                        // the control index means specifying a rather random control. The VFP table provides some damaging values for
+                        // situatioin not desirable, entering with a random control will possibly crash the whole simulation. Restarting with smaller
+                        // time step might not help.
+                        /* const int old_control_index = prevState.currentControls()[ oldIndex ];
                         if (old_control_index < well_controls_get_num(wells->ctrls[w])) {
                             // If the set of controls have changed, this may not be identical
                             // to the last control, but it must be a valid control.
@@ -169,7 +174,7 @@ namespace Opm
                         } else {
                             assert(well_controls_get_num(wells->ctrls[w]) > 0);
                             currentControls()[ newIndex ] = 0;
-                        }
+                        } */
                     }
 
 

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -103,9 +103,6 @@ namespace Opm
                 current_controls_[w] = well_controls_get_current(wells->ctrls[w]);
             }
 
-            well_potentials_.clear();
-            well_potentials_.resize(nperf * np, 0.0);
-
             is_new_well_.resize(nw, true);
 
             // intialize wells that have been there before
@@ -207,10 +204,6 @@ namespace Opm
         std::vector<int>& currentControls() { return current_controls_; }
         const std::vector<int>& currentControls() const { return current_controls_; }
 
-        /// One rate per phase and well connection.
-        std::vector<double>& wellPotentials() { return well_potentials_; }
-        const std::vector<double>& wellPotentials() const { return well_potentials_; }
-
         data::Wells report(const PhaseUsage &pu) const override {
             data::Wells res = WellState::report(pu);
 
@@ -275,7 +268,6 @@ namespace Opm
     private:
         std::vector<double> perfphaserates_;
         std::vector<int> current_controls_;
-        std::vector<double> well_potentials_;
 
         // marking whether the well is just added
         // for newly added well, the current initialized rates from WellState

--- a/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
@@ -57,7 +57,6 @@ namespace Opm
         using BaseType :: numPhases;
         using BaseType :: perfPhaseRates;
         using BaseType :: currentControls;
-        using BaseType :: wellPotentials;
 
         /// Allocate and initialize if wells is non-null.  Also tries
         /// to give useful initial values to the bhp(), wellRates()

--- a/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
@@ -68,8 +68,13 @@ namespace Opm
             // call init on base class
             BaseType :: init(wells, state, prevState);
 
+            // TODO: the reason to keep this is to avoid getting defaulted value BHP
+            // some facilities needed from opm-parser or opm-core
+            // It is a little tricky, since sometimes before applying group control, the only
+            // available constraints in the well_controls is the defaulted BHP value, and it
+            // is really not desirable to use this value to enter the Newton iterations.
             setWellSolutions(pu);
-            setWellSolutionsFromPrevState(prevState);
+            // setWellSolutionsFromPrevState(prevState);
         }
 
 

--- a/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
@@ -74,49 +74,8 @@ namespace Opm
             // available constraints in the well_controls is the defaulted BHP value, and it
             // is really not desirable to use this value to enter the Newton iterations.
             setWellSolutions(pu);
-            // setWellSolutionsFromPrevState(prevState);
         }
 
-
-        template <class PrevState>
-        void setWellSolutionsFromPrevState(const PrevState& prevState)
-        {
-            // Set nw and np, or return if no wells.
-            if (wells_.get() == nullptr) {
-                return;
-            }
-            const int nw = wells_->number_of_wells;
-            if (nw == 0) {
-                return;
-            }
-            const int np = wells_->number_of_phases;
-
-            // intialize wells that have been there before
-            // order may change so the mapping is based on the well name
-            // if there are no well, do nothing in init
-            if( ! prevState.wellMap().empty() )
-            {
-                typedef typename WellMapType :: const_iterator const_iterator;
-                const_iterator end = prevState.wellMap().end();
-                int nw_old = prevState.bhp().size();
-                for (int w = 0; w < nw; ++w) {
-                    std::string name( wells_->name[ w ] );
-                    const_iterator it = prevState.wellMap().find( name );
-                    if( it != end )
-                    {
-                        const int oldIndex = (*it).second[ 0 ];
-                        const int newIndex = w;
-
-                        // wellSolutions
-                        for( int i = 0;  i < np; ++i)
-                        {
-                            wellSolutions()[ i*nw + newIndex ] = prevState.wellSolutions()[i * nw_old + oldIndex ];
-                        }
-
-                    }
-                }
-            }
-        }
 
 
         /// Set wellSolutions() based on the base class members.

--- a/tests/test_multisegmentwells.cpp
+++ b/tests/test_multisegmentwells.cpp
@@ -107,12 +107,11 @@ struct SetupMSW {
                                         Opm::UgGridHelpers::cell2Faces(grid),
                                         Opm::UgGridHelpers::beginFaceCentroids(grid),
                                         dummy_dynamic_list,
-                                        false
+                                        false,
                                         // We need to pass the optionaly arguments
                                         // as we get the following error otherwise
                                         // with c++ (Debian 4.9.2-10) 4.9.2 and -std=c++11
                                         // converting to ‘const std::unordered_set<std::basic_string<char> >’ from initializer list would use explicit constructor
-                                        , std::vector<double>(), // null well_potentials
                                         std::unordered_set<std::string>());
 
         const Wells* wells = wells_manager.c_wells();


### PR DESCRIPTION
The PR includes mostly the following revisions

1. Moving the calculation of well potentials at the beginning of each `time step` instead of the end of previous `report step`, which is the better and more correct thing to do.

    In the old way, we always use the well potentials from the end of the last `report step`. For many cases, it will be fine. The well potentials will be invalid when a new well is newly added, since we do not have this well yet in the last report step. 
And also, there are some decks, the size of the report step is pretty big, half year / 1 year. For some period, the well potentials will change significantly during the report step, updating the well potentials during the report step is also more desirable.  
When THP is involved, the well potentials are closely related to the well rates and also the composition of the rates (water cut, GOR, and so on). Updating the well potential during the report step is also more desirable.

TODO: computeRESV() should probably be done in `time step` basis too, while it will be interfering with the current way to handle RESV controls, and will be done after the addressing OPM/opm-parser#1032 .

2. Better way to initialize / update WellState with the well controls. Based on the old composition of the rates, we update the rates for multi-phase targets.  The old implementation is that we only update single phase target. 

TODO: We should never update WellState based on the defaulted BHP value, which will gives a disastrous rates. We need some support from the parser side to achieve this. 

3. Not copying the old control index, always using the the control mode the deck asks for.

    The reason is that when the control sets changed due to new well control keywords enter, the same control index can mean rather random control mode. It only cause problem when new control keyword is entered, which will result in a random control mode. Most of the time, due to the fully implicit nature of our implementation, a sensible result is likely to be obtained eventually. While when THP control is involved, a random control will result in a non-desirable region in VFP table which will make the simulation fail immediately.  

    The old way make senses when no new control keyword is entered. As a result, the current PR might slow down the simulation for some / many cases a little bit.  

TODO: A better way is that for each well, if there is some control keywords enters, we should use the control index that deck ask for, otherwise, it should be pretty safe to use the old control index, which is potentially a better / safe initial guess for the time step. To achieve this, we need some support from the opm-parser side. 

4. An iterative way to calculate the well potentials is introduced when the THP control is involved.  
    Due to the coupling between the rates (potentials are rates) and BHP through VFP table when THP control is involved, we have to calculate the well potentials iteratively to find an consistent matching between potentials and BHP.  It raises problems when a well is newly added. We did not have a reasonable initial guess for the iteration process. In this PR, we calculate a initial value assuming small rates will always be in safe regions in the VFP table.

TODO: We need more knowledge from the VFP tables to do all the VFP related things better, including the keyword WVFPEXP, which detect the unstable region in VFP so that we can overcome difficulties in THP control related calculation. 

5. Considering the injection phase of the INJECTORS. 
   The comp_frac from the `Wells` struct only show the preferred phase of the injection wells, it has nothing to do with the actual injection phase. Using comp_frac in most place in well control related is wrong. This PR makes the `distr` in `well_controls` recognize the injection phase and make use of it. 


There are quite a few other changes following the above several relatively major ones.

1.  Not copying the wellSolutions() from the old well state. The reason is that the content of the first element of wellSolutions() depends on the control type, copying the old values is dangerous when control type changes. It is the culprit of the many of `too large residual for water phase`. This makes this PR cover the PR OPM/opm-simulators#1086

2. Better treatment of the THP control.  When no THP constraint is involved, we do not calculate the THP related at all, and the thp value will be zero. 

3. When the wells are all under individual control, their group targets will be updated for each iteration.  

There are many changes in this PR will affect all the simulations, should be tested thoroughly. And the group control of the legacy `flow` is broken. Will update `flow` after the review of `flow_ebos` is done. 

This PR requires the PR OPM/opm-core#1152 . 
