### PR TITLE
Get rid off temporary copies of depth and pore volume.

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -186,8 +186,6 @@ namespace Opm {
         , isBeginReportStep_(false)
         {
             const double gravity = detail::getGravity(geo_.gravity(), UgGridHelpers::dimensions(grid_));
-            const std::vector<double> pv(geo_.poreVolume().data(), geo_.poreVolume().data() + geo_.poreVolume().size());
-            const std::vector<double> depth(geo_.z().data(), geo_.z().data() + geo_.z().size());
             // Wells are active if they are active wells on at least
             // one process.
             int wellsActive = localWellsActive() ? 1 : 0;
@@ -195,7 +193,7 @@ namespace Opm {
             wellModel().setWellsActive( wellsActive );
             // compute global sum of number of cells
             global_nc_ = detail::countGlobalCells(grid_);
-            well_model_.init(fluid_.phaseUsage(), active_, &vfp_properties_, gravity, depth, pv, &rate_converter_, global_nc_);
+            well_model_.init(fluid_.phaseUsage(), active_, &vfp_properties_, gravity, geo_.z(), geo_.poreVolume(), &rate_converter_, global_nc_);
             if (!istlSolver_)
             {
                 OPM_THROW(std::logic_error,"solver down cast to ISTLSolver failed");

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -57,6 +57,8 @@
 
 #include <opm/simulators/WellSwitchingLogger.hpp>
 
+#include <Eigen/Eigen>
+
 namespace Opm {
 
 enum WellVariablePositions {
@@ -96,8 +98,8 @@ enum WellVariablePositions {
                       const std::vector<bool>& active_arg,
                       const VFPProperties*  vfp_properties_arg,
                       const double gravity_arg,
-                      const std::vector<double>& depth_arg,
-                      const std::vector<double>& pv_arg,
+                      const Eigen::ArrayXd& depth_arg,
+                      const Eigen::ArrayXd& pv_arg,
                       const RateConverterType* rate_converter,
                       long int global_nc);
 
@@ -142,7 +144,7 @@ enum WellVariablePositions {
             int ebosCompToFlowPhaseIdx( const int compIdx ) const;
 
             std::vector<double>
-            extractPerfData(const std::vector<double>& in) const;
+            extractPerfData(const Eigen::ArrayXd& in) const;
 
             int numPhases() const;
 

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -39,8 +39,8 @@ namespace Opm {
          const std::vector<bool>& active_arg,
          const VFPProperties*  vfp_properties_arg,
          const double gravity_arg,
-         const std::vector<double>& depth_arg,
-         const std::vector<double>& pv_arg,
+         const Eigen::ArrayXd& depth_arg,
+         const Eigen::ArrayXd& pv_arg,
          const RateConverterType* rate_converter,
          long int global_nc)
     {
@@ -56,7 +56,7 @@ namespace Opm {
         vfp_properties_ = vfp_properties_arg;
         gravity_ = gravity_arg;
         cell_depths_ = extractPerfData(depth_arg);
-        pv_ = pv_arg;
+        pv_.assign(pv_arg.data(), pv_arg.data()+pv_arg.size());
         rate_converter_ = rate_converter;
 
         calculateEfficiencyFactors();
@@ -463,7 +463,7 @@ namespace Opm {
     template<typename FluidSystem, typename BlackoilIndices, typename ElementContext>
     std::vector<double>
     StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext>::
-    extractPerfData(const std::vector<double>& in) const
+    extractPerfData(const Eigen::ArrayXd& in) const
     {
         const int nw   = wells().number_of_wells;
         const int nperf = wells().well_connpos[nw];


### PR DESCRIPTION
We can pass the Eigen array directly to WellModel::init where they
will either be copied anyway or the important data will be extracted.