### PR TITLE
Refactor directory creation

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -63,6 +63,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/polymer/TransportSolverTwophasePolymer.cpp
   opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.cpp
   opm/polymer/fullyimplicit/PolymerPropsAd.cpp
+  opm/simulators/ensureDirectoryExists.cpp
   opm/simulators/SimulatorCompressibleTwophase.cpp
   opm/simulators/SimulatorIncompTwophase.cpp
   opm/simulators/WellSwitchingLogger.cpp
@@ -258,6 +259,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer.hpp
   opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer_impl.hpp
   opm/polymer/fullyimplicit/WellStateFullyImplicitBlackoilPolymer.hpp
+  opm/simulators/ensureDirectoryExists.hpp
   opm/simulators/ParallelFileMerger.hpp
   opm/simulators/SimulatorCompressibleTwophase.hpp
   opm/simulators/SimulatorIncompTwophase.hpp

--- a/examples/sim_2p_comp_reorder.cpp
+++ b/examples/sim_2p_comp_reorder.cpp
@@ -44,6 +44,7 @@
 #include <opm/core/simulator/BlackoilState.hpp>
 #include <opm/core/simulator/WellState.hpp>
 #include <opm/simulators/SimulatorCompressibleTwophase.hpp>
+#include <opm/simulators/ensureDirectoryExists.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
@@ -195,13 +196,7 @@ try
     if (output) {
         output_dir =
             param.getDefault("output_dir", std::string("output"));
-        boost::filesystem::path fpath(output_dir);
-        try {
-            create_directories(fpath);
-        }
-        catch (...) {
-            OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-        }
+        ensureDirectoryExists(output_dir);
         std::string filename = output_dir + "/epoch_timing.param";
         epoch_os.open(filename.c_str(), std::fstream::trunc | std::fstream::out);
         // open file to clean it. The file is appended to in SimulatorTwophase

--- a/examples/sim_2p_incomp.cpp
+++ b/examples/sim_2p_incomp.cpp
@@ -44,6 +44,7 @@
 #include <opm/core/simulator/TwophaseState.hpp>
 #include <opm/core/simulator/WellState.hpp>
 #include <opm/simulators/SimulatorIncompTwophase.hpp>
+#include <opm/simulators/ensureDirectoryExists.hpp>
 
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
@@ -210,13 +211,7 @@ try
     if (output) {
         output_dir =
             param.getDefault("output_dir", std::string("output"));
-        boost::filesystem::path fpath(output_dir);
-        try {
-            create_directories(fpath);
-        }
-        catch (...) {
-            OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-        }
+        ensureDirectoryExists(output_dir);
         std::string filename = output_dir + "/epoch_timing.param";
         epoch_os.open(filename.c_str(), std::fstream::trunc | std::fstream::out);
         // open file to clean it. The file is appended to in SimulatorTwophase

--- a/examples/sim_2p_incomp_ad.cpp
+++ b/examples/sim_2p_incomp_ad.cpp
@@ -49,6 +49,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/simulators/ensureDirectoryExists.hpp>
 
 #include <boost/filesystem.hpp>
 
@@ -212,13 +213,7 @@ try
     if (output) {
         output_dir =
             param.getDefault("output_dir", std::string("output"));
-        boost::filesystem::path fpath(output_dir);
-        try {
-            create_directories(fpath);
-        }
-        catch (...) {
-            OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-        }
+        ensureDirectoryExists(output_dir);
         std::string filename = output_dir + "/epoch_timing.param";
         epoch_os.open(filename.c_str(), std::fstream::trunc | std::fstream::out);
         // open file to clean it. The file is appended to in SimulatorTwophase

--- a/examples/sim_poly2p_comp_reorder.cpp
+++ b/examples/sim_poly2p_comp_reorder.cpp
@@ -51,6 +51,8 @@
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
+#include <opm/simulators/ensureDirectoryExists.hpp>
+
 #include <boost/scoped_ptr.hpp>
 #include <boost/filesystem.hpp>
 
@@ -224,13 +226,7 @@ try
     if (output) {
       std::string output_dir =
         param.getDefault("output_dir", std::string("output"));
-      boost::filesystem::path fpath(output_dir);
-      try {
-        create_directories(fpath);
-      }
-      catch (...) {
-        OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-      }
+      ensureDirectoryExists(output_dir);
       param.writeParam(output_dir + "/simulation.param");
     }
 

--- a/examples/sim_poly2p_incomp_reorder.cpp
+++ b/examples/sim_poly2p_incomp_reorder.cpp
@@ -51,6 +51,8 @@
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
+#include <opm/simulators/ensureDirectoryExists.hpp>
+
 #include <boost/scoped_ptr.hpp>
 #include <boost/filesystem.hpp>
 
@@ -256,13 +258,7 @@ try
     if (output) {
       std::string output_dir =
         param.getDefault("output_dir", std::string("output"));
-      boost::filesystem::path fpath(output_dir);
-      try {
-        create_directories(fpath);
-      }
-      catch (...) {
-        OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-      }
+      ensureDirectoryExists(output_dir);
       param.writeParam(output_dir + "/simulation.param");
     }
 

--- a/examples/sim_poly_fi2p_comp_ad.cpp
+++ b/examples/sim_poly_fi2p_comp_ad.cpp
@@ -70,6 +70,8 @@
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
+#include <opm/simulators/ensureDirectoryExists.hpp>
+
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -128,14 +130,7 @@ try
         // Create output directory if needed.
         output_dir =
             param.getDefault("output_dir", std::string("output"));
-        boost::filesystem::path fpath(output_dir);
-        try {
-            create_directories(fpath);
-        }
-        catch (...) {
-            std::cerr << "Creating directories failed: " << fpath << std::endl;
-            return EXIT_FAILURE;
-        }
+        ensureDirectoryExists(output_dir);
         // Write simulation parameters.
         param.writeParam(output_dir + "/simulation.param");
     }

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -41,6 +41,7 @@
 #include <opm/autodiff/createGlobalCellArray.hpp>
 #include <opm/autodiff/GridInit.hpp>
 #include <opm/simulators/ParallelFileMerger.hpp>
+#include <opm/simulators/ensureDirectoryExists.hpp>
 
 #include <opm/core/wells.h>
 #include <opm/core/wells/WellsManager.hpp>
@@ -378,15 +379,7 @@ namespace Opm
             // Write parameters used for later reference. (only if rank is zero)
             if (output_to_files_) {
                 // Create output directory if needed.
-                boost::filesystem::path fpath(output_dir_);
-                if (!is_directory(fpath)) {
-                    try {
-                        create_directories(fpath);
-                    }
-                    catch (...) {
-                        OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-                    }
-                }
+                ensureDirectoryExists(output_dir_);
                 // Write simulation parameters.
                 param_.writeParam(output_dir_ + "/simulation.param");
             }

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -24,6 +24,7 @@
 #define OPM_FLOW_MAIN_EBOS_HEADER_INCLUDED
 
 #include <opm/simulators/ParallelFileMerger.hpp>
+#include <opm/simulators/ensureDirectoryExists.hpp>
 
 #include <opm/autodiff/BlackoilModelEbos.hpp>
 #include <opm/autodiff/NewtonIterationBlackoilSimple.hpp>
@@ -263,15 +264,7 @@ namespace Opm
             // Write parameters used for later reference. (only if rank is zero)
             if (output_to_files_) {
                 // Create output directory if needed.
-                boost::filesystem::path fpath(output_dir_);
-                if (!is_directory(fpath)) {
-                    try {
-                        create_directories(fpath);
-                    }
-                    catch (...) {
-                        OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-                    }
-                }
+                ensureDirectoryExists(output_dir_);
                 // Write simulation parameters.
                 param_.writeParam(output_dir_ + "/simulation.param");
             }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -66,13 +66,7 @@ namespace Opm
         // Write data in VTK format.
         std::ostringstream vtkfilename;
         vtkfilename << output_dir << "/vtk_files";
-        boost::filesystem::path fpath(vtkfilename.str());
-        try {
-            create_directories(fpath);
-        }
-        catch (...) {
-            OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-        }
+        ensureDirectoryExists(vtkfilename.str());
         vtkfilename << "/output-" << std::setw(3) << std::setfill('0') << step << ".vtu";
         std::ofstream vtkfile(vtkfilename.str().c_str());
         if (!vtkfile) {
@@ -106,13 +100,7 @@ namespace Opm
         for (Opm::DataMap::const_iterator it = dm.begin(); it != dm.end(); ++it) {
             std::ostringstream fname;
             fname << output_dir << "/" << it->first;
-            boost::filesystem::path fpath = fname.str();
-            try {
-                create_directories(fpath);
-            }
-            catch (...) {
-                OPM_THROW(std::runtime_error,"Creating directories failed: " << fpath);
-            }
+            ensureDirectoryExists(fname.str());
             fname << "/" << std::setw(3) << std::setfill('0') << step << ".txt";
             std::ofstream file(fname.str().c_str());
             if (!file) {
@@ -161,13 +149,7 @@ namespace Opm
         std::ostringstream vtkpath;
         vtkpath << output_dir << "/vtk_files";
         vtkpath << "/output-" << std::setw(3) << std::setfill('0') << step;
-        boost::filesystem::path fpath(vtkpath.str());
-        try {
-            create_directories(fpath);
-        }
-        catch (...) {
-            OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-        }
+        ensureDirectoryExists(vtkpath.str());
         vtkfilename << "output-" << std::setw(3) << std::setfill('0') << step;
 #if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
         Dune::VTKWriter<Dune::CpGrid::LeafGridView> writer(grid.leafGridView(), Dune::VTK::nonconforming);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -44,7 +44,7 @@
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
-
+#include <opm/simulators/ensureDirectoryExists.hpp>
 
 #include <string>
 #include <sstream>
@@ -123,13 +123,7 @@ namespace Opm
         for (Opm::DataMap::const_iterator it = dm.begin(); it != dm.end(); ++it) {
             std::ostringstream fname;
             fname << output_dir << "/" << it->first;
-            boost::filesystem::path fpath = fname.str();
-            try {
-                create_directories(fpath);
-            }
-            catch (...) {
-                OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-            }
+            ensureDirectoryExists(fname.str());
             fname << "/" << std::setw(3) << std::setfill('0') << step << ".txt";
             std::ofstream file(fname.str().c_str());
             if (!file) {
@@ -376,13 +370,7 @@ namespace Opm
                 eclIO_ = std::move(eclIO);
 
                 // Ensure that output dir exists
-                boost::filesystem::path fpath(outputDir_);
-                try {
-                    create_directories(fpath);
-                }
-                catch (...) {
-                    OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-                }
+                ensureDirectoryExists(outputDir_);
 
                 // create output thread if enabled and rank is I/O rank
                 // async output is enabled by default if pthread are enabled

--- a/opm/autodiff/SimulatorIncompTwophaseAd.cpp
+++ b/opm/autodiff/SimulatorIncompTwophaseAd.cpp
@@ -51,6 +51,8 @@
 #include <opm/core/transport/reorder/TransportSolverTwophaseReorder.hpp>
 #include <opm/core/transport/implicit/TransportSolverTwophaseImplicit.hpp>
 #include <opm/autodiff/TransportSolverTwophaseAd.hpp>
+#include <opm/simulators/ensureDirectoryExists.hpp>
+
 #include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -177,13 +179,7 @@ namespace Opm
         // Write data in VTK format.
         std::ostringstream vtkfilename;
         vtkfilename << output_dir << "/vtk_files";
-        boost::filesystem::path fpath(vtkfilename.str());
-        try {
-            create_directories(fpath);
-        }
-        catch (...) {
-            OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-        }
+        ensureDirectoryExists(vtkfilename.str());
         vtkfilename << "/output-" << std::setw(3) << std::setfill('0') << step << ".vtu";
         std::ofstream vtkfile(vtkfilename.str().c_str());
         if (!vtkfile) {
@@ -205,13 +201,7 @@ namespace Opm
     {
         std::ostringstream fname;
         fname << output_dir << "/" << name;
-        boost::filesystem::path fpath = fname.str();
-        try {
-            create_directories(fpath);
-        }
-        catch (...) {
-            OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-        }
+        ensureDirectoryExists(fname.str());
         fname << "/" << std::setw(3) << std::setfill('0') << step << ".txt";
         std::ofstream file(fname.str().c_str());
         if (!file) {
@@ -236,13 +226,7 @@ namespace Opm
         for (Opm::DataMap::const_iterator it = dm.begin(); it != dm.end(); ++it) {
             std::ostringstream fname;
             fname << output_dir << "/" << it->first;
-            boost::filesystem::path fpath = fname.str();
-            try {
-                create_directories(fpath);
-            }
-            catch (...) {
-                OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-            }
+            ensureDirectoryExists(fname.str());
             fname << "/" << std::setw(3) << std::setfill('0') << step << ".txt";
             std::ofstream file(fname.str().c_str());
             if (!file) {
@@ -384,13 +368,7 @@ namespace Opm
             output_vtk_ = param.getDefault("output_vtk", true);
             output_dir_ = param.getDefault("output_dir", std::string("output"));
             // Ensure that output dir exists
-            boost::filesystem::path fpath(output_dir_);
-            try {
-                create_directories(fpath);
-            }
-            catch (...) {
-                OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-            }
+            ensureDirectoryExists(output_dir_);
             output_interval_ = param.getDefault("output_interval", 1);
         }
 

--- a/opm/polymer/SimulatorCompressiblePolymer.cpp
+++ b/opm/polymer/SimulatorCompressiblePolymer.cpp
@@ -53,6 +53,8 @@
 #include <opm/polymer/PolymerProperties.hpp>
 #include <opm/polymer/polymerUtilities.hpp>
 
+#include <opm/simulators/ensureDirectoryExists.hpp>
+
 #include <boost/filesystem.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/lexical_cast.hpp>
@@ -200,13 +202,7 @@ namespace Opm
             output_vtk_ = param.getDefault("output_vtk", true);
             output_dir_ = param.getDefault("output_dir", std::string("output"));
             // Ensure that output dir exists
-            boost::filesystem::path fpath(output_dir_);
-            try {
-                create_directories(fpath);
-            }
-            catch (...) {
-                OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-            }
+            ensureDirectoryExists(output_dir_);
             output_interval_ = param.getDefault("output_interval", 1);
         }
 
@@ -525,13 +521,7 @@ namespace Opm
             // Write data in VTK format.
             std::ostringstream vtkfilename;
             vtkfilename << output_dir << "/vtk_files";
-            boost::filesystem::path fpath(vtkfilename.str());
-            try {
-                create_directories(fpath);
-            }
-            catch (...) {
-                OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-            }
+            ensureDirectoryExists(vtkfilename.str());
             vtkfilename << "/output-" << std::setw(5) << std::setfill('0') << step << ".vtu";
             std::ofstream vtkfile(vtkfilename.str().c_str());
             if (!vtkfile) {
@@ -568,13 +558,7 @@ namespace Opm
             for (Opm::DataMap::const_iterator it = dm.begin(); it != dm.end(); ++it) {
                 std::ostringstream fname;
                 fname << output_dir << "/" << it->first;
-                boost::filesystem::path fpath = fname.str();
-                try {
-                    create_directories(fpath);
-                }
-                catch (...) {
-                    OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-                }
+                ensureDirectoryExists(fname.str());
                 fname << "/" << std::setw(5) << std::setfill('0') << step << ".txt";
                 std::ofstream file(fname.str().c_str());
                 if (!file) {

--- a/opm/polymer/SimulatorPolymer.cpp
+++ b/opm/polymer/SimulatorPolymer.cpp
@@ -55,6 +55,8 @@
 #include <opm/polymer/PolymerProperties.hpp>
 #include <opm/polymer/polymerUtilities.hpp>
 
+#include <opm/simulators/ensureDirectoryExists.hpp>
+
 #include <boost/filesystem.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/lexical_cast.hpp>
@@ -211,13 +213,7 @@ namespace Opm
             output_vtk_ = param.getDefault("output_vtk", true);
             output_dir_ = param.getDefault("output_dir", std::string("output"));
             // Ensure that output dir exists
-            boost::filesystem::path fpath(output_dir_);
-            try {
-                create_directories(fpath);
-            }
-            catch (...) {
-                OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-            }
+            ensureDirectoryExists(output_dir_);
             output_interval_ = param.getDefault("output_interval", 1);
         }
 
@@ -525,13 +521,7 @@ namespace Opm
             // Write data in VTK format.
             std::ostringstream vtkfilename;
             vtkfilename << output_dir << "/vtk_files";
-            boost::filesystem::path fpath(vtkfilename.str());
-            try {
-                create_directories(fpath);
-            }
-            catch (...) {
-                OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-            }
+            ensureDirectoryExists(vtkfilename.str());
             vtkfilename << "/output-" << std::setw(5) << std::setfill('0') << step << ".vtu";
             std::ofstream vtkfile(vtkfilename.str().c_str());
             if (!vtkfile) {
@@ -566,13 +556,7 @@ namespace Opm
             for (Opm::DataMap::const_iterator it = dm.begin(); it != dm.end(); ++it) {
                 std::ostringstream fname;
                 fname << output_dir << "/" << it->first;
-                boost::filesystem::path fpath = fname.str();
-                try {
-                    create_directories(fpath);
-                }
-                catch (...) {
-                    OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-                }
+                ensureDirectoryExists(fname.str());
                 fname << "/" << std::setw(5) << std::setfill('0') << step << ".txt";
                 std::ofstream file(fname.str().c_str());
                 if (!file) {

--- a/opm/simulators/SimulatorCompressibleTwophase.cpp
+++ b/opm/simulators/SimulatorCompressibleTwophase.cpp
@@ -49,6 +49,8 @@
 #include <opm/core/simulator/WellState.hpp>
 #include <opm/core/transport/reorder/TransportSolverCompressibleTwophaseReorder.hpp>
 
+#include <opm/simulators/ensureDirectoryExists.hpp>
+
 #include <boost/filesystem.hpp>
 #include <memory>
 #include <boost/lexical_cast.hpp>
@@ -147,13 +149,7 @@ namespace Opm
         // Write data in VTK format.
         std::ostringstream vtkfilename;
         vtkfilename << output_dir << "/vtk_files";
-        boost::filesystem::path fpath(vtkfilename.str());
-        try {
-          create_directories(fpath);
-        }
-        catch (...) {
-          OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-        }
+        ensureDirectoryExists(vtkfilename.str());
         vtkfilename << "/output-" << std::setw(3) << std::setfill('0') << step << ".vtu";
         std::ofstream vtkfile(vtkfilename.str().c_str());
         if (!vtkfile) {
@@ -188,13 +184,7 @@ namespace Opm
         for (Opm::DataMap::const_iterator it = dm.begin(); it != dm.end(); ++it) {
             std::ostringstream fname;
             fname << output_dir << "/" << it->first;
-            boost::filesystem::path fpath = fname.str();
-            try {
-              create_directories(fpath);
-            }
-            catch (...) {
-              OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-            }
+            ensureDirectoryExists(fname.str());
             fname << "/" << std::setw(3) << std::setfill('0') << step << ".txt";
             std::ofstream file(fname.str().c_str());
             if (!file) {
@@ -268,13 +258,7 @@ namespace Opm
             output_vtk_ = param.getDefault("output_vtk", true);
             output_dir_ = param.getDefault("output_dir", std::string("output"));
             // Ensure that output dir exists
-            boost::filesystem::path fpath(output_dir_);
-            try {
-                create_directories(fpath);
-            }
-            catch (...) {
-                OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-            }
+            ensureDirectoryExists(output_dir_);
             output_interval_ = param.getDefault("output_interval", 1);
         }
 

--- a/opm/simulators/SimulatorIncompTwophase.cpp
+++ b/opm/simulators/SimulatorIncompTwophase.cpp
@@ -51,6 +51,9 @@
 #include <opm/core/simulator/WellState.hpp>
 #include <opm/core/transport/reorder/TransportSolverTwophaseReorder.hpp>
 #include <opm/core/transport/implicit/TransportSolverTwophaseImplicit.hpp>
+#include <opm/simulators/ensureDirectoryExists.hpp>
+
+
 #include <boost/filesystem.hpp>
 #include <memory>
 
@@ -190,13 +193,7 @@ namespace Opm
         // Write data in VTK format.
         std::ostringstream vtkfilename;
         vtkfilename << output_dir << "/vtk_files";
-        boost::filesystem::path fpath(vtkfilename.str());
-        try {
-            create_directories(fpath);
-        }
-        catch (...) {
-            OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-        }
+        ensureDirectoryExists(vtkfilename.str());
         vtkfilename << "/output-" << std::setw(3) << std::setfill('0') << step << ".vtu";
         std::ofstream vtkfile(vtkfilename.str().c_str());
         if (!vtkfile) {
@@ -219,13 +216,7 @@ namespace Opm
     {
         std::ostringstream fname;
         fname << output_dir << "/" << name;
-        boost::filesystem::path fpath = fname.str();
-        try {
-            create_directories(fpath);
-        }
-        catch (...) {
-            OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-        }
+        ensureDirectoryExists(fname.str());
         fname << "/" << std::setw(3) << std::setfill('0') << step << ".txt";
         std::ofstream file(fname.str().c_str());
         if (!file) {
@@ -250,13 +241,7 @@ namespace Opm
         for (Opm::DataMap::const_iterator it = dm.begin(); it != dm.end(); ++it) {
             std::ostringstream fname;
             fname << output_dir << "/" << it->first;
-            boost::filesystem::path fpath = fname.str();
-            try {
-                create_directories(fpath);
-            }
-            catch (...) {
-                OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-            }
+            ensureDirectoryExists(fname.str());
             fname << "/" << std::setw(3) << std::setfill('0') << step << ".txt";
             std::ofstream file(fname.str().c_str());
             if (!file) {
@@ -383,13 +368,7 @@ namespace Opm
             output_vtk_ = param.getDefault("output_vtk", true);
             output_dir_ = param.getDefault("output_dir", std::string("output"));
             // Ensure that output dir exists
-            boost::filesystem::path fpath(output_dir_);
-            try {
-                create_directories(fpath);
-            }
-            catch (...) {
-                OPM_THROW(std::runtime_error, "Creating directories failed: " << fpath);
-            }
+            ensureDirectoryExists(output_dir_);
             output_interval_ = param.getDefault("output_interval", 1);
         }
 

--- a/opm/simulators/ensureDirectoryExists.cpp
+++ b/opm/simulators/ensureDirectoryExists.cpp
@@ -1,0 +1,45 @@
+/*
+  Copyright 2017 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/simulators/ensureDirectoryExists.hpp>
+#include <opm/common/ErrorMacros.hpp>
+
+namespace Opm
+{
+
+    /// The directory pointed to by 'dirpath' will be created if it
+    /// does not already exist. Will throw an exception if this cannot
+    /// be done.
+    void ensureDirectoryExists(const boost::filesystem::path& dirpath)
+    {
+        if (dirpath != ".") { // Do not try to create the current directory.
+            if (!is_directory(dirpath)) {
+                try {
+                    create_directories(dirpath);
+                }
+                catch (...) {
+                    OPM_THROW(std::runtime_error, "Creating directories failed: " << dirpath);
+                }
+            }
+        }
+    }
+
+
+} // namespace Opm

--- a/opm/simulators/ensureDirectoryExists.hpp
+++ b/opm/simulators/ensureDirectoryExists.hpp
@@ -1,0 +1,40 @@
+/*
+  Copyright 2017 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ENSUREDIRECTORYEXISTS_HEADER_INCLUDED
+#define OPM_ENSUREDIRECTORYEXISTS_HEADER_INCLUDED
+
+#include <boost/filesystem.hpp>
+
+namespace Opm
+{
+
+    /// The directory pointed to by 'dirpath' will be created if it
+    /// does not already exist. Will throw an exception if this cannot
+    /// be done.
+    ///
+    /// Note that std::string can be passed to this functions, as they
+    /// can be implicitly converted to boost::filesystem::path objects.
+    void ensureDirectoryExists(const boost::filesystem::path& dirpath);
+
+
+} // namespace Opm
+
+#endif // OPM_ENSUREDIRECTORYEXISTS_HEADER_INCLUDED


### PR DESCRIPTION
This refactors the creation of directories, and should fix an issue reported by @dr-robertk in #1116.

The refactoring also should make it easy to replace the routine (possibly avoiding boost filesystem) later.

@dr-robertk please review this and check if this PR solves your problem.