### PR TITLE
Refined output to terminal and log

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -309,7 +309,7 @@ namespace Opm {
                     current_relaxation_ -= nonlinear_solver.relaxIncrement();
                     current_relaxation_ = std::max(current_relaxation_, nonlinear_solver.relaxMax());
                     if (terminalOutputEnabled()) {
-                        std::string msg = " Oscillating behavior detected: Relaxation set to "
+                        std::string msg = "    Oscillating behavior detected: Relaxation set to "
                             + std::to_string(current_relaxation_);
                         OpmLog::info(msg);
                     }

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -150,13 +150,11 @@ namespace Opm
         } while ( (!converged && (iteration <= maxIter())) || (iteration <= minIter()));
 
         if (!converged) {
+            std::string msg = "Failed to complete a time step within " + std::to_string(maxIter()) + " iterations.";
             if (model_->terminalOutputEnabled()) {
-                OPM_THROW(Opm::NumericalProblem, "Failed to complete a time step within "+std::to_string(maxIter())+" iterations.");
+                OpmLog::problem(msg);
             }
-            else
-            {
-                OPM_THROW_NOLOG(Opm::NumericalProblem, "Failed to complete a time step within "+std::to_string(maxIter())+" iterations.");
-            }
+            OPM_THROW_NOLOG(Opm::NumericalProblem, msg);
         }
 
         // Do model-specific post-step actions.

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -324,8 +324,9 @@ public:
                         events.hasEvent(ScheduleEvents::PRODUCTION_UPDATE, timer.currentStepNum()) ||
                         events.hasEvent(ScheduleEvents::INJECTION_UPDATE, timer.currentStepNum()) ||
                         events.hasEvent(ScheduleEvents::WELL_STATUS_CHANGE, timer.currentStepNum());
-                report += adaptiveTimeStepping->step( timer, *solver, state, well_state, event, output_writer_,
-                                                      output_writer_.requireFIPNUM() ? &fipnum : nullptr );
+                stepReport = adaptiveTimeStepping->step( timer, *solver, state, well_state, event, output_writer_,
+                                                         output_writer_.requireFIPNUM() ? &fipnum : nullptr );
+                report += stepReport;
             }
             else {
                 // solve for complete report step
@@ -384,7 +385,7 @@ public:
 
                 std::string msg;
                 msg =
-                    "Time step took " + std::to_string(stepReport.solver_time) + " seconds; "
+                    "Time step took " + std::to_string(solver_timer.secsSinceStart()) + " seconds; "
                     "total solver time " + std::to_string(report.solver_time) + " seconds.";
                 OpmLog::note(msg);
             }

--- a/opm/simulators/WellSwitchingLogger.cpp
+++ b/opm/simulators/WellSwitchingLogger.cpp
@@ -140,7 +140,7 @@ void WellSwitchingLogger::logSwitch(const char* name, std::array<char,2> fromto,
             ss << "    Switching control mode for well " << name
                << " from " << modestring[WellControlType(fromto[0])]
                << " to " <<  modestring[WellControlType(fromto[1])]
-               << " on rank " << rank << std::endl;
+               << " on rank " << rank;
             OpmLog::info(ss.str());
 }
 #endif

--- a/opm/simulators/WellSwitchingLogger.hpp
+++ b/opm/simulators/WellSwitchingLogger.hpp
@@ -76,7 +76,7 @@ public:
             std::ostringstream ss;
             ss << "    Switching control mode for well " << name
                << " from " << modestring[from]
-               << " to " <<  modestring[to] << std::endl;
+               << " to " <<  modestring[to];
             OpmLog::info(ss.str());
         }
     }

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -283,14 +283,14 @@ namespace Opm {
                 {
                     std::ostringstream ss;
                     ss << "    Substep summary: ";
-                    if (report.total_well_iterations != 0) {
-                        ss << "well iterations = " << report.total_well_iterations << ", ";
+                    if (substepReport.total_well_iterations != 0) {
+                        ss << "well its = " << std::setw(2) << substepReport.total_well_iterations << ", ";
                     }
-                    ss << "newton iterations = " << report.total_newton_iterations << ", "
-                       << "linearizations = " << report.total_linearizations
-                       << " (" << report.assemble_time << " sec), "
-                       << "linear iterations = " << report.total_linear_iterations
-                       << " (" << report.linear_solve_time << " sec)";
+                    ss << "newton its = " << std::setw(2) << substepReport.total_newton_iterations << ", "
+                       << "linearizations = "  << std::setw(2) << substepReport.total_linearizations
+                       << " ("  << std::fixed << std::setprecision(3) << std::setw(6) << substepReport.assemble_time << " sec), "
+                       << "linear its = " << std::setw(3) << substepReport.total_linear_iterations
+                       << " ("  << std::fixed << std::setprecision(3) << std::setw(6) << substepReport.linear_solve_time << " sec)";
                     OpmLog::info(ss.str());
                 }
 
@@ -327,8 +327,8 @@ namespace Opm {
                 substepTimer.setLastStepFailed(true);
                 // increase restart counter
                 if( restarts >= solver_restart_max_ ) {
-                    const auto msg = std::string("Solver failed to converge after ")
-                        + std::to_string(restarts) + " restarts.";
+                    const auto msg = std::string("Solver failed to converge after cutting timestep ")
+                        + std::to_string(restarts) + " times.";
                     if (solver_verbose_) {
                         OpmLog::error(msg);
                     }
@@ -340,8 +340,8 @@ namespace Opm {
                 substepTimer.provideTimeStepEstimate( newTimeStep );
                 if( solver_verbose_ ) {
                     std::string msg;
-                    msg = "Solver convergence failed, restarting solver with new time step ("
-                        + std::to_string(unit::convert::to( newTimeStep, unit::day )) + " days).\n";
+                    msg = "Solver convergence failed, cutting timestep to "
+                        + std::to_string(unit::convert::to( newTimeStep, unit::day )) + " days.\n";
                     OpmLog::problem(msg);
                 }
                 // reset states


### PR DESCRIPTION
This fixes a minor bug in output (cumulative times and iterations for substeps), makes "too many nonlinear iterations" a Problem, not an Error, and makes some formatting improvements while at it.

Screenshot below.

<img width="1401" alt="skjermbilde 2017-04-06 kl 14 50 55" src="https://cloud.githubusercontent.com/assets/1876621/24755182/7e98fc82-1ad9-11e7-9085-a4a4b983ee8c.png">
