### PR TITLE
flow_ebos: print statistics about failed time steps

### DIFF
--- a/opm/autodiff/BlackoilModelBase.hpp
+++ b/opm/autodiff/BlackoilModelBase.hpp
@@ -295,6 +295,13 @@ namespace Opm {
         void applyVREPGroupControl(const ReservoirState& reservoir_state,
                                    WellState& well_state);
 
+        /// return the statistics if the nonlinearIteration() method failed.
+        ///
+        /// NOTE: for the flow_legacy simulator family this method is a stub, i.e. the
+        /// failure report object will *not* contain any meaningful data.
+        const SimulatorReport& failureReport() const
+        { return failureReport_; }
+
     protected:
 
         // ---------  Types and enums  ---------
@@ -307,6 +314,7 @@ namespace Opm {
 
         // ---------  Data members  ---------
 
+        SimulatorReport failureReport_;
         const Grid&         grid_;
         const BlackoilPropsAdFromDeck& fluid_;
         const DerivedGeology&           geo_;

--- a/opm/autodiff/BlackoilSequentialModel.hpp
+++ b/opm/autodiff/BlackoilSequentialModel.hpp
@@ -282,10 +282,18 @@ namespace Opm {
             return transport_solver_.model().getFIPData();
         }
 
+        /// return the statistics if the nonlinearIteration() method failed.
+        ///
+        /// NOTE: for the flow_legacy simulator family this method is a stub, i.e. the
+        /// failure report object will *not* contain any meaningful data.
+        const SimulatorReport& failureReport() const
+        { return failureReport_; }
 
     protected:
         typedef NonlinearSolver<PressureModel> PressureSolver;
         typedef NonlinearSolver<TransportModel> TransportSolver;
+
+        SimulatorReport failureReport_;
 
         std::unique_ptr<PressureModel> pressure_model_;
         std::unique_ptr<TransportModel> transport_model_;

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -643,12 +643,13 @@ namespace Opm
                     OpmLog::info(msg);
                 }
 
-                SimulatorReport fullReport = simulator_->run(simtimer, *state_);
+                SimulatorReport successReport = simulator_->run(simtimer, *state_);
+                SimulatorReport failureReport = simulator_->failureReport();
 
                 if (output_cout_) {
                     std::ostringstream ss;
                     ss << "\n\n================    End of simulation     ===============\n\n";
-                    fullReport.reportFullyImplicit(ss);
+                    successReport.reportFullyImplicit(ss, &failureReport);
                     OpmLog::info(ss.str());
                     if (param_.anyUnused()) {
                         // This allows a user to catch typos and misunderstandings in the
@@ -662,7 +663,7 @@ namespace Opm
                 if (output_to_files_) {
                     std::string filename = output_dir_ + "/walltime.txt";
                     std::fstream tot_os(filename.c_str(), std::fstream::trunc | std::fstream::out);
-                    fullReport.reportParam(tot_os);
+                    successReport.reportParam(tot_os);
                 }
             } else {
                 if (output_cout_) {

--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -99,6 +99,9 @@ namespace Opm {
              ReservoirState& reservoir_state,
              WellState& well_state);
 
+        /// return the statistics if the step() method failed
+        const SimulatorReport& failureReport() const
+        { return failureReport_; }
 
         /// Number of linearizations used in all calls to step().
         int linearizations() const;
@@ -173,6 +176,7 @@ namespace Opm {
 
     private:
         // ---------  Data members  ---------
+        SimulatorReport failureReport_;
         SolverParameters param_;
         std::unique_ptr<PhysicalModel> model_;
         int linearizations_;

--- a/opm/polymer/SimulatorCompressiblePolymer.hpp
+++ b/opm/polymer/SimulatorCompressiblePolymer.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_SIMULATORCOMPRESSIBLEPOLYMER_HEADER_INCLUDED
 #define OPM_SIMULATORCOMPRESSIBLEPOLYMER_HEADER_INCLUDED
 
+#include <opm/core/simulator/SimulatorReport.hpp>
 #include <boost/shared_ptr.hpp>
 #include <vector>
 
@@ -91,8 +92,18 @@ namespace Opm
                             PolymerBlackoilState& state,
                             WellState& well_state);
 
+        /// return the statistics if the nonlinearIteration() method failed.
+        ///
+        /// NOTE: for the flow_legacy simulator family this method is a stub, i.e. the
+        /// failure report object will *not* contain any meaningful data.
+        const SimulatorReport& failureReport() const
+        { return failureReport_; }
+
     private:
         class Impl;
+
+        SimulatorReport failureReport_;
+
         // Using shared_ptr instead of scoped_ptr since scoped_ptr requires complete type for Impl.
         boost::shared_ptr<Impl> pimpl_;
     };

--- a/opm/polymer/SimulatorPolymer.hpp
+++ b/opm/polymer/SimulatorPolymer.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_SIMULATORPOLYMER_HEADER_INCLUDED
 #define OPM_SIMULATORPOLYMER_HEADER_INCLUDED
 
+#include <opm/core/simulator/SimulatorReport.hpp>
 #include <boost/shared_ptr.hpp>
 #include <vector>
 
@@ -95,8 +96,18 @@ namespace Opm
                             PolymerState& state,
                             WellState& well_state);
 
+        /// return the statistics if the nonlinearIteration() method failed.
+        ///
+        /// NOTE: for the flow_legacy simulator family this method is a stub, i.e. the
+        /// failure report object will *not* contain any meaningful data.
+        const SimulatorReport& failureReport() const
+        { return failureReport_; }
+
     private:
         class Impl;
+
+        SimulatorReport failureReport_;
+
         // Using shared_ptr instead of scoped_ptr since scoped_ptr requires complete type for Impl.
         boost::shared_ptr<Impl> pimpl_;
     };

--- a/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
+++ b/opm/polymer/fullyimplicit/FullyImplicitCompressiblePolymerSolver.hpp
@@ -30,6 +30,7 @@
 #include <opm/polymer/PolymerProperties.hpp>
 #include <opm/polymer/fullyimplicit/WellStateFullyImplicitBlackoilPolymer.hpp>
 #include <opm/polymer/fullyimplicit/PolymerPropsAd.hpp>
+#include <opm/core/simulator/SimulatorReport.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/simulators/timestepping/SimulatorTimerInterface.hpp>
 #include <opm/common/data/SimulationDataContainer.hpp>
@@ -175,6 +176,13 @@ namespace Opm {
         computeFluidInPlace(const PolymerBlackoilState& x,
                             const std::vector<int>& fipnum);
 
+        /// return the statistics if the nonlinearIteration() method failed.
+        ///
+        /// NOTE: for the flow_legacy simulator family this method is a stub, i.e. the
+        /// failure report object will *not* contain any meaningful data.
+        const SimulatorReport& failureReport() const
+        { return failureReport_; }
+
     private:
 
         struct SolutionState {
@@ -197,6 +205,7 @@ namespace Opm {
                Oil   = Opm::Oil  };
 
         // Member data
+        SimulatorReport failureReport_;
         const UnstructuredGrid&         grid_;
         const BlackoilPropsAdFromDeck& fluid_;
         const DerivedGeology&           geo_;

--- a/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer.hpp
+++ b/opm/polymer/fullyimplicit/SimulatorFullyImplicitCompressiblePolymer.hpp
@@ -21,6 +21,7 @@
 #ifndef OPM_SIMULATORFULLYIMPLICITCOMPRESSIBLEPOLYMER_HEADER_INCLUDED
 #define OPM_SIMULATORFULLYIMPLICITCOMPRESSIBLEPOLYMER_HEADER_INCLUDED
 
+#include <opm/core/simulator/SimulatorReport.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/common/ErrorMacros.hpp>
 
@@ -125,7 +126,17 @@ namespace Opm
                                    const Wells* wells,
                                    const WellState& well_state,
                                    DynamicListEconLimited& list_econ_limited) const;
+
+        /// return the statistics if the nonlinearIteration() method failed.
+        ///
+        /// NOTE: for the flow_legacy simulator family this method is a stub, i.e. the
+        /// failure report object will *not* contain any meaningful data.
+        const SimulatorReport& failureReport() const
+        { return failureReport_; }
+
 private:
+        SimulatorReport failureReport_;
+
         const Deck& deck_;
         const PolymerPropsAd& polymer_props_;
 

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -88,6 +88,11 @@ namespace Opm {
                               Output& outputWriter,
                               const std::vector<int>* fipnum = nullptr);
 
+        /** \brief Returns the simulator report for the failed substeps of the last
+         *         report step.
+         */
+        const SimulatorReport& failureReport() const { return failureReport_; };
+
         double suggestedNextStep() const { return suggested_next_timestep_; }
 
         void setSuggestedNextStep(const double x) { suggested_next_timestep_ = x; }
@@ -104,6 +109,7 @@ namespace Opm {
 
         typedef std::unique_ptr< TimeStepControlInterface > TimeStepControlType;
 
+        SimulatorReport failureReport_;       //!< statistics for the failed substeps of the last timestep
         TimeStepControlType timeStepControl_; //!< time step control object
         const double restart_factor_;         //!< factor to multiply time step with when solver fails to converge
         const double growth_factor_;          //!< factor to multiply time step when solver recovered from failed convergence


### PR DESCRIPTION
the performance summary at the end of a Norne run which are printed by `flow_ebos` now looks like this on my machine:

```
Total time (seconds):         773.757
Solver time (seconds):        753.349
 Assembly time (seconds):     377.218 (Failed: 23.537; 6.23965%)
 Linear solve time (seconds): 352.022 (Failed: 23.2757; 6.61201%)
 Update time (seconds):       16.3658 (Failed: 1.13149; 6.91375%)
 Output write time (seconds): 22.5991
Overall Well Iterations:      870 (Failed: 35; 4.02299%)
Overall Linearizations:       2098 (Failed: 136; 6.48236%)
Overall Newton Iterations:    1756 (Failed: 136; 7.74487%)
Overall Linear Iterations:    26572 (Failed: 1786; 6.72136%)
```

for the flow_legacy family, nothing changes.

this PR depends on OPM/opm-core#1154.