### PR TITLE
[bugfix,flow_ebos] Fix parallel convergence max

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -803,24 +803,12 @@ namespace Opm {
             // computation
             for ( int idx = 0; idx < np; ++idx )
             {
-                B_avg[idx] = accumulateMaskedValues(B[ idx ], mask) / double(ncGlobal);
-                R_sum[idx] = accumulateMaskedValues(R[ idx ], mask);
+                B_avg[idx] = std::accumulate( B[ idx ].begin(), B[ idx ].end(),
+                                              0.0 ) / double(ncGlobal);
+                R_sum[idx] = std::accumulate( R[ idx ].begin(), R[ idx ].end(),
+                                              0.0 );
 
-                if(comm.size()>1)
-                {
-                    auto mi = mask->begin();
-                    for(auto elem = tempV[idx].begin(), end = tempV[idx].end(); elem != end; ++elem, ++mi)
-                    {
-                        if ( *mi )
-                        {
-                            maxCoeff[idx] = std::max( maxCoeff[idx], *elem);
-                        }
-                    }
-                }
-                else
-                {
-                    maxCoeff[idx] = *(std::max_element( tempV[ idx ].begin(), tempV[ idx ].end() ));
-                }
+                maxCoeff[idx] = *(std::max_element( tempV[ idx ].begin(), tempV[ idx ].end() ));
 
                 assert(np >= np);
                 if (idx < np) {

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -901,18 +901,22 @@ namespace Opm {
             Vector maxCoeff(np);
             Vector maxNormWell(np);
 
-            std::vector< Vector > B( np, Vector( nc ) );
-            std::vector< Vector > R( np, Vector( nc ) );
-            std::vector< Vector > R2( np, Vector( nc ) );
-            std::vector< Vector > tempV( np, Vector( nc ) );
+            // As we will not initialize values in the following arrays
+            // for the non-interior elements, we have to make sure
+            // (at least for tempV) that the values there do not influence
+            // our reduction.
+            std::vector< Vector > B( np, Vector( nc, 0.0) );
+            //std::vector< Vector > R( np, Vector( nc, 0.0) ) );
+            std::vector< Vector > R2( np, Vector( nc, 0.0 ) );
+            std::vector< Vector > tempV( np, Vector( nc, std::numeric_limits<double>::lowest() ) );
 
             const auto& ebosResid = ebosSimulator_.model().linearizer().residual();
 
             ElementContext elemCtx(ebosSimulator_);
             const auto& gridView = ebosSimulator().gridView();
-            const auto& elemEndIt = gridView.template end</*codim=*/0>();
+            const auto& elemEndIt = gridView.template end</*codim=*/0, Dune::Interior_Partition>();
 
-            for (auto elemIt = gridView.template begin</*codim=*/0>();
+            for (auto elemIt = gridView.template begin</*codim=*/0, Dune::Interior_Partition>();
               elemIt != elemEndIt;
               ++elemIt)
             {

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -135,7 +135,7 @@ namespace Opm {
         }
 
         SimulatorReport report;
-        if ( ! localWellsActive() ) {
+        if ( ! wellsActive() ) {
             return report;
         }
 
@@ -891,6 +891,12 @@ namespace Opm {
                 invDuneD_.mv(resWell_, dx_well);
 
                 updateWellState(dx_well, well_state);
+            }
+            // updateWellControls uses communication
+            // Therefore the following is executed if there
+            // are active wells anywhere in the global domain.
+            if( wellsActive() )
+            {
                 updateWellControls(well_state);
                 setWellVariables(well_state);
             }
@@ -1483,7 +1489,11 @@ namespace Opm {
     StandardWellsDense<FluidSystem, BlackoilIndices, ElementContext, MaterialLaw>::
     updateWellControls(WellState& xw) const
     {
-        if( !localWellsActive() ) return ;
+        // Even if there no wells active locally, we cannot
+        // return as the Destructor of the WellSwitchingLogger
+        // uses global communication. For no well active globally
+        // we simply return.
+        if( !wellsActive() ) return ;
 
         const int np = wells().number_of_phases;
         const int nw = wells().number_of_wells;


### PR DESCRIPTION
This fixes another serious bug and makes SPE1 finally converge in parallel. Even though this fix is rather trivial it took me quite some find it. Somehow I was under the impression that we only compute values in the convergence check on interior elements. This is turned out not to be the case and explained why the nonlinear solver did not convergence even when I solved the linear systems exactly on one master process.

I finally changed my mind regarding who to compute the global sums and maxima and concur with @dr-robertk and @andlaus that we should do this using the grid information and standard algorithm. I included this change in this PR.

Would be nice if this would make into the release. Sequential results should remain unchanged.