### PR TITLE
Do not try to output unsupported bubble point pressure for flow_legacy.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -784,7 +784,6 @@ namespace Opm
                                          "Writing bubble points and dew points (PBPD) to file is unsupported, "
                                          "as the simulator does not use these internally.");
                 }
-                
             }
 
             if (sd.hasCellData("SOMAX")) {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -765,14 +765,9 @@ namespace Opm
              */
             if (vapour_active && liquid_active && rstKeywords["PBPD"] > 0) {
                 rstKeywords["PBPD"] = 0;
-                output.insert("PBUB",
-                        Opm::UnitSystem::measure::pressure,
-                        std::move( sd.getCellData("PBUB") ),
-                        data::TargetType::RESTART_AUXILIARY);
-                output.insert("PDEW",
-                        Opm::UnitSystem::measure::pressure,
-                        std::move( sd.getCellData("PDEW") ),
-                        data::TargetType::RESTART_AUXILIARY);
+                Opm::OpmLog::warning("Bubble/dew point pressure output unsupported",
+                                     "Writing bubble points and dew points (PBPD) to file is unsupported, "
+                                     "as the simulator does not use these internally.");
             }
 
             if (sd.hasCellData("SOMAX")) {


### PR DESCRIPTION
It is not computed by it and therefore the extraction from SimulatorData
fails miserably with an exception: "Error: Program threw an exception: The cell data with name: PBUB does not exist"

This reverts parts of the changed of 4a46451d95fb11f7224ed7e6d32567299ed7ed74
and closes #1144