### PR TITLE
only output the bubble and dew point pressures if they are available

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -771,12 +771,20 @@ namespace Opm
                                   std::move( sd.getCellData("PBUB") ),
                                   data::TargetType::RESTART_AUXILIARY);
                 }
+                else if (log) {
+                    Opm::OpmLog::warning("Output of bubble point pressure requested but not available in this simulator. Ignoring.");
+                }
+
                 if (sd.hasCellData("PDEW")) {
                     output.insert("PDEW",
                                   Opm::UnitSystem::measure::pressure,
                                   std::move( sd.getCellData("PDEW") ),
                                   data::TargetType::RESTART_AUXILIARY);
                 }
+                else if (log) {
+                    Opm::OpmLog::warning("Output of dew point pressure requested but not available in this simulator. Ignoring.");
+                }
+
             }
 
             if (sd.hasCellData("SOMAX")) {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -765,14 +765,18 @@ namespace Opm
              */
             if (vapour_active && liquid_active && rstKeywords["PBPD"] > 0) {
                 rstKeywords["PBPD"] = 0;
-                output.insert("PBUB",
-                        Opm::UnitSystem::measure::pressure,
-                        std::move( sd.getCellData("PBUB") ),
-                        data::TargetType::RESTART_AUXILIARY);
-                output.insert("PDEW",
-                        Opm::UnitSystem::measure::pressure,
-                        std::move( sd.getCellData("PDEW") ),
-                        data::TargetType::RESTART_AUXILIARY);
+                if (sd.hasCellData("PBUB")) {
+                    output.insert("PBUB",
+                                  Opm::UnitSystem::measure::pressure,
+                                  std::move( sd.getCellData("PBUB") ),
+                                  data::TargetType::RESTART_AUXILIARY);
+                }
+                if (sd.hasCellData("PDEW")) {
+                    output.insert("PDEW",
+                                  Opm::UnitSystem::measure::pressure,
+                                  std::move( sd.getCellData("PDEW") ),
+                                  data::TargetType::RESTART_AUXILIARY);
+                }
             }
 
             if (sd.hasCellData("SOMAX")) {


### PR DESCRIPTION
this is an alternative to #1145. IMO it is slightly better because it does not require an additional parameter for the `getRestartData()` method and also touches slightly fewer lines of code.  