### PR TITLE
add 'flow_ebos' to the dependencies of the 'flow' target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,8 @@ if (HAVE_OPM_DATA)
     include (${CMAKE_CURRENT_SOURCE_DIR}/compareECLFiles.cmake)
 endif()
 
- # create a symbolic link from flow to flow_legacy
+# create a symbolic link from flow to flow_legacy
 ADD_CUSTOM_TARGET(flow ALL
-	                COMMAND ${CMAKE_COMMAND} -E create_symlink "flow_ebos" "${CMAKE_BINARY_DIR}/bin/flow")
+                  DEPENDS flow_ebos
+                  COMMAND ${CMAKE_COMMAND} -E create_symlink "flow_ebos" "${CMAKE_BINARY_DIR}/bin/flow")
 


### PR DESCRIPTION
this allows to use `make flow` instead of `make flow_ebos flow` to build the stuff.

IMO this is just a convenience measure to make the build infinitesimally more bullet-proof and is thus not important enough to be included into the release.