### PR TITLE
Only push non-empty data to output.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -478,6 +478,10 @@ namespace Opm
                            const std::string& name,
                            const V& vec )
         {
+            if (vec.size() == 0) {
+                return;
+            }
+
             typedef std::vector< double > OutputVectorType;
 
             // get data map


### PR DESCRIPTION
This small change is sufficient to restore running the OLYMPIC benchmark case with flow_legacy. I will merge it once tested unless objections are raised.