### PR TITLE
fixed: re-add installation of the 'flow' symlink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,4 +135,4 @@ endif()
 ADD_CUSTOM_TARGET(flow ALL
                   DEPENDS flow_ebos
                   COMMAND ${CMAKE_COMMAND} -E create_symlink "flow_ebos" "${CMAKE_BINARY_DIR}/bin/flow")
-
+install(FILES ${CMAKE_BINARY_DIR}/bin/flow DESTINATION bin)


### PR DESCRIPTION
got lost due to a bad conflict resolution in 7c4dfa784d6090874702a59ab76d7dbb4de873ce

@babrodtk (thanks for report!)