### PR TITLE
NewtonIterationBlackoilInterface: make its destructor virtual

### DIFF
--- a/opm/autodiff/NewtonIterationBlackoilInterface.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterface.hpp
@@ -34,6 +34,8 @@ namespace Opm
         /// Return type for linearSolve(). A simple, non-ad vector type.
         typedef LinearisedBlackoilResidual::ADB::V SolutionVector;
 
+        virtual ~NewtonIterationBlackoilInterface() {}
+
         /// Solve the linear system Ax = b, with A being the
         /// combined derivative matrix of the residual and b
         /// being the residual itself.


### PR DESCRIPTION
this prevents GCC-7's address sanitizer from complaining about a delete for a new of a different type. (i.e., the new is for the derived class, but if the destructor is non-virtual only the dtor of the base class is called if a pointer to the base class is deleted.)

finding this was quite some fun, mainly because it took a while to grasp what the issue was.

this should also go into the release branch.