### PR TITLE
flow_ebos: update banner

### DIFF
--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -193,16 +193,12 @@ namespace Opm
             if (output_cout_) {
                 const int lineLen = 70;
                 const std::string version = moduleVersionName();
-                const std::string banner = "This is flow_ebos (version "+version+")";
-                const std::string ewomsVersion = "(eWoms version: " + Ewoms::versionString() + ")";
+                const std::string banner = "This is flow (version "+version+")";
                 const int bannerPreLen = (lineLen - 2 - banner.size())/2;
                 const int bannerPostLen = bannerPreLen + (lineLen - 2 - banner.size())%2;
-                const int eVPreLen = (lineLen - 2 - ewomsVersion.size())/2;
-                const int eVPostLen = eVPreLen + (lineLen - 2 - ewomsVersion.size())%2;
                 std::cout << "**********************************************************************\n";
                 std::cout << "*                                                                    *\n";
                 std::cout << "*" << std::string(bannerPreLen, ' ') << banner << std::string(bannerPostLen, ' ') << "*\n";
-                std::cout << "*" << std::string(eVPreLen, ' ') << ewomsVersion << std::string(eVPostLen, ' ') << "*\n";
                 std::cout << "*                                                                    *\n";
                 std::cout << "* Flow is a simulator for fully implicit three-phase black-oil flow, *\n";
                 std::cout << "*            and is part of OPM. For more information see:           *\n";


### PR DESCRIPTION
since flow_ebos is the new silverback simulator of the opm-simulators clan, it should itself as "flow"(the old silverback announces itself as "flow_legacy" already).

Also, some people seem to have been confused by the eWoms version and codename. Since this information only exhibits limited value IMO, let's remove it here.