### PR TITLE
Logging of multiple problems/warnings

### DIFF
--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -24,6 +24,7 @@
 #define OPM_NONLINEARSOLVER_IMPL_HEADER_INCLUDED
 
 #include <opm/autodiff/NonlinearSolver.hpp>
+#include </data/DataExchange/Rohith/opm_dev/opm-common/opm/common/Exceptions.hpp>
 #include <opm/common/Exceptions.hpp>
 #include <opm/common/ErrorMacros.hpp>
 
@@ -162,11 +163,8 @@ namespace Opm
         if (!converged) {
             failureReport_ += report;
 
-            std::string msg = "Failed to complete a time step within " + std::to_string(maxIter()) + " iterations.";
-            if (model_->terminalOutputEnabled()) {
-                OpmLog::problem(msg);
-            }
-            OPM_THROW_NOLOG(Opm::NumericalProblem, msg);
+            std::string msg = "Solver convergence failure - Failed to complete a time step within " + std::to_string(maxIter()) + " iterations.";
+            OPM_THROW_NOLOG(Opm::TooManyIterations, msg);
         }
 
         // Do model-specific post-step actions.

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -24,7 +24,6 @@
 #define OPM_NONLINEARSOLVER_IMPL_HEADER_INCLUDED
 
 #include <opm/autodiff/NonlinearSolver.hpp>
-#include </data/DataExchange/Rohith/opm_dev/opm-common/opm/common/Exceptions.hpp>
 #include <opm/common/Exceptions.hpp>
 #include <opm/common/ErrorMacros.hpp>
 

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -2,17 +2,17 @@
   Copyright 2014 IRIS AS
   
   This file is part of the Open Porous Media project (OPM).
-  
+
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-  
+
   OPM is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -1,14 +1,18 @@
 /*
   Copyright 2014 IRIS AS
+  
   This file is part of the Open Porous Media project (OPM).
+  
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
+  
   OPM is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
+  
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -353,7 +357,7 @@ namespace Opm {
                 if( solver_verbose_ ) {
                     std::string msg;
                     msg = cause_of_failure + "\n         Timestep chopped to "
-                          + std::to_string(unit::convert::to( substepTimer.currentStepLength(), unit::day )) + " days.\n";
+                        + std::to_string(unit::convert::to( substepTimer.currentStepLength(), unit::day )) + " days.\n";
                     OpmLog::problem(msg);
                 }
                 // reset states

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -1,18 +1,14 @@
 /*
   Copyright 2014 IRIS AS
-
   This file is part of the Open Porous Media project (OPM).
-
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-
   OPM is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -1,6 +1,6 @@
 /*
   Copyright 2014 IRIS AS
-  
+
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -60,9 +60,10 @@ namespace Opm {
         {
             if( verbose )
             {
-                std::ostringstream message;
-                message << "Caught Exception: " << exception.what();
-                OpmLog::debug(message.str());
+                std::string message;
+                message = "Caught Exception: ";
+                message += exception.what();
+                OpmLog::debug(message);
             }
         }
     }
@@ -227,6 +228,7 @@ namespace Opm {
             }
 
             SimulatorReport substepReport;
+            std::string cause_of_failure = "";
             try {
                 substepReport = solver.step( substepTimer, state, well_state);
                 report += substepReport;
@@ -238,6 +240,7 @@ namespace Opm {
             }
             catch (const Opm::NumericalProblem& e) {
                 substepReport += solver.failureReport();
+                cause_of_failure = e.what();
 
                 detail::logException(e, solver_verbose_);
                 // since linearIterations is < 0 this will restart the solver
@@ -349,8 +352,8 @@ namespace Opm {
                 substepTimer.provideTimeStepEstimate( newTimeStep );
                 if( solver_verbose_ ) {
                     std::string msg;
-                    msg = "Solver convergence failed, cutting timestep to "
-                        + std::to_string(unit::convert::to( substepTimer.currentStepLength(), unit::day )) + " days.\n";
+                    msg = cause_of_failure + "\n         Timestep chopped to "
+                          + std::to_string(unit::convert::to( substepTimer.currentStepLength(), unit::day )) + " days.\n";
                     OpmLog::problem(msg);
                 }
                 // reset states


### PR DESCRIPTION
Multiple problems/warnings are displayed in certain instances to report an issue and provide additional information about the issue; Used OpmLog::info to display the additional information