### PR TITLE
Prepare for 2p and  extended models.

### DIFF
--- a/opm/autodiff/MultisegmentWells_impl.hpp
+++ b/opm/autodiff/MultisegmentWells_impl.hpp
@@ -1040,7 +1040,7 @@ namespace Opm
         // 2. Compute densities
         std::vector<double> cd =
                 WellDensitySegmented::computeConnectionDensities(
-                        wells(), xw, fluid_->phaseUsage(),
+                        wells(), fluid_->phaseUsage(), xw.perfPhaseRates(),
                         b_perf, rsmax_perf, rvmax_perf, surf_dens_perf);
 
         // 3. Compute pressure deltas

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -57,6 +57,7 @@ public:
     typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
     typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
     typedef typename GET_PROP_TYPE(TypeTag, Indices) BlackoilIndices;
+    typedef typename GET_PROP_TYPE(TypeTag, PrimaryVariables)  PrimaryVariables;
     typedef typename GET_PROP_TYPE(TypeTag, MaterialLaw) MaterialLaw;
 
 
@@ -66,7 +67,7 @@ public:
     typedef BlackoilModelEbos Model;
     typedef BlackoilModelParameters ModelParameters;
     typedef NonlinearSolver<Model> Solver;
-    typedef StandardWellsDense<FluidSystem, BlackoilIndices,ElementContext,MaterialLaw> WellModel;
+    typedef StandardWellsDense<TypeTag> WellModel;
 
 
     /// Initialise from parameters and objects to observe.

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -315,7 +315,7 @@ namespace Opm
         // Compute densities
         std::vector<double> cd =
                 WellDensitySegmented::computeConnectionDensities(
-                        wells(), xw, fluid_->phaseUsage(),
+                        wells(), fluid_->phaseUsage(), xw.perfPhaseRates(),
                         b_perf, rsmax_perf, rvmax_perf, surf_dens_perf);
 
         const int nperf = wells().well_connpos[wells().number_of_wells];

--- a/opm/autodiff/WellDensitySegmented.hpp
+++ b/opm/autodiff/WellDensitySegmented.hpp
@@ -41,17 +41,17 @@ namespace Opm
     {
     public:
         /// Compute well segment densities
-        /// Notation: N = number of perforations, P = number of phases.
+        /// Notation: N = number of perforations, C = number of components.
         /// \param[in] wells        struct with static well info
-        /// \param[in] wstate       dynamic well solution information, only perfRates() is used
+        /// \param[in] well_rates   well rates for actiev components, size NC, P values per perforation
         /// \param[in] phase_usage  specifies which phases are active and not
-        /// \param[in] b_perf       inverse ('little b') formation volume factor, size NP, P values per perforation
+        /// \param[in] b_perf       inverse ('little b') formation volume factor, size NC, P values per perforation
         /// \param[in] rsmax_perf   saturation point for rs (gas in oil) at each perforation, size N
         /// \param[in] rvmax_perf   saturation point for rv (oil in gas) at each perforation, size N
-        /// \param[in] surf_dens    surface densities for active components, size NP, P values per perforation
+        /// \param[in] surf_dens    surface densities for active components, size NC, C values per perforation
         static std::vector<double> computeConnectionDensities(const Wells& wells,
-                                                              const WellStateFullyImplicitBlackoil& wstate,
                                                               const PhaseUsage& phase_usage,
+                                                              const std::vector<double>& perfComponentRates,
                                                               const std::vector<double>& b_perf,
                                                               const std::vector<double>& rsmax_perf,
                                                               const std::vector<double>& rvmax_perf,
@@ -80,7 +80,7 @@ namespace Opm
 
 
         /// Compute pressure deltas.
-        /// Notation: N = number of perforations, P = number of phases.
+        /// Notation: N = number of perforations
         /// \param[in] wells        struct with static well info
         /// \param[in] z_perf       depth values for each perforation, size N
         /// \param[in] dens_perf    densities for each perforation, size N (typically computed using computeConnectionDensities)

--- a/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
@@ -89,7 +89,6 @@ namespace Opm
                 return;
             }
             const int np = wells_->number_of_phases;
-
             well_solutions_.clear();
             well_solutions_.resize(nw * np, 0.0);
             std::vector<double> g = {1.0,1.0,0.01};
@@ -130,7 +129,7 @@ namespace Opm
                 const int waterpos = pu.phase_pos[Water];
                 const int gaspos = pu.phase_pos[Gas];
 
-                assert(np == 3 || (np == 2 && !pu.phase_used[Gas]));
+                assert(np > 2 || (np == 2 && !pu.phase_used[Gas]));
                 // assumes the gas fractions are stored after water fractions
                 if(std::abs(total_rates) > 0) {
                     if( pu.phase_used[Water] ) {
@@ -139,6 +138,8 @@ namespace Opm
                     if( pu.phase_used[Gas] ) {
                         wellSolutions()[2*nw + w] = g[Gas] * wellRates()[np*w + gaspos] / total_rates ;
                     }
+
+
                 } else {
                     if( pu.phase_used[Water] ) {
                         wellSolutions()[nw + w] = wells_->comp_frac[np*w + waterpos];

--- a/tests/test_welldensitysegmented.cpp
+++ b/tests/test_welldensitysegmented.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(TestPressureDeltas)
 
     std::vector<double> cd =
             WellDensitySegmented::computeConnectionDensities(
-                    *wells, wellstate, pu,
+                    *wells, pu, rates,
                     b_perf, rsmax_perf, rvmax_perf, surf_dens);
     std::vector<double> dp =
             WellDensitySegmented::computeConnectionPressureDelta(


### PR DESCRIPTION

1) Pass TypeTag as template parameter instead of all the properties.
2) Let the code loop over number of equations /components instead of number of phases.

This should not effect any of the standard blackoil cases. 
Tested on Brugge (2p), norne and Model2_0. All gives the same convergence history. 


