### PR TITLE
BUGFIX Don't try to compute effective properties for FIP if no solvent

### DIFF
--- a/opm/autodiff/BlackoilSolventModel_impl.hpp
+++ b/opm/autodiff/BlackoilSolventModel_impl.hpp
@@ -1095,7 +1095,7 @@ namespace Opm {
     computeFluidInPlace(const ReservoirState& x,
                         const std::vector<int>& fipnum)
     {
-        if (b_eff_[0].size() == 0) {
+        if (has_solvent_ && is_miscible_ && b_eff_[0].size() == 0) {
             // A hack to avoid trouble for initial fluid in place, due to usage of b_eff_.
             WellState xw, xwdummy;
             xw.init(&wells(), x, xwdummy);


### PR DESCRIPTION
This prevent SEGFAULT if you try to run a standard blackoil case using flow_solvent. Not many do I think, so I don't think this is very critical. But it is good to have the possibility when testing. 