### PR TITLE
Don't output SSOL if no solvent

### DIFF
--- a/opm/autodiff/Compat.cpp
+++ b/opm/autodiff/Compat.cpp
@@ -110,7 +110,7 @@ data::Solution simToSolution( const SimulationDataContainer& reservoir,
         sol.insert( "RV", rv_unit, reservoir.getCellData( BlackoilState::RV ) , data::TargetType::RESTART_SOLUTION );
     }
 
-    if (reservoir.hasCellData( BlackoilSolventState::SSOL)) {
+    if (phases.has_solvent) {
         sol.insert( "SSOL", UnitSystem::measure::identity, reservoir.getCellData( BlackoilSolventState::SSOL ) , data::TargetType::RESTART_SOLUTION );
     }
 


### PR DESCRIPTION
Depends on and fixes test failure due to OPM/opm-core#1162
