### PR TITLE
Add possibility to use matrix with well connections for preconditioner.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -147,6 +147,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_welldensitysegmented.cpp
   tests/test_vfpproperties.cpp
   tests/test_singlecellsolves.cpp
+  tests/test_multmatrixtransposed.cpp
   tests/test_multiphaseupwind.cpp
   tests/test_wellmodel.cpp
 #  tests/test_thresholdpressure.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -315,6 +315,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/autodiff/SimulatorIncompTwophaseAd.hpp
   opm/autodiff/SimulatorSequentialBlackoil.hpp
   opm/autodiff/TransportSolverTwophaseAd.hpp
+  opm/autodiff/WellConnectionAuxiliaryModule.hpp
   opm/autodiff/WellDensitySegmented.hpp
   opm/autodiff/WellStateFullyImplicitBlackoil.hpp
   opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -156,15 +156,6 @@ namespace Opm {
             {
                 OPM_THROW(std::logic_error,"solver down cast to ISTLSolver failed");
             }
-
-            if ( param_.matrix_add_well_contributions_ )
-            {
-                // This might be dangerous?!
-                ebosSimulator_.model().clearAuxiliaryModules();
-                auto auxMod = std::make_shared<WellConnectionAuxiliaryModule<TypeTag> >( wellModel().wells() );
-                ebosSimulator_.model().addAuxiliaryModule(auxMod);
-            }
-
         }
 
         bool isParallel() const

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -547,7 +547,7 @@ namespace Opm {
           //! constructor: just store a reference to a matrix
           WellModelMatrixAdapter (const M& A, const WellModel& wellMod,
                                   bool matrix_add_well_contributions,
-                                   const boost::any& parallelInformation = boost::any() )
+                                  const boost::any& parallelInformation = boost::any() )
               : A_( A ), wellMod_( wellMod ), comm_(),
                 matrix_add_well_contributions_(matrix_add_well_contributions)
           {

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -565,11 +565,8 @@ namespace Opm {
           {
             A_.mv( x, y );
 
-            if ( ! matrix_add_well_contributions_ )
-            {
-              // add well model modification to y
-              wellMod_.apply(x, y );
-            }
+            // add well model modification to y
+            wellMod_.apply(x, y );
 
 #if HAVE_MPI
             if( comm_ )
@@ -582,11 +579,8 @@ namespace Opm {
           {
             A_.usmv(alpha,x,y);
 
-            if ( ! matrix_add_well_contributions_ )
-            {
-              // add scaled well model modification to y
-              wellMod_.applyScaleAdd( alpha, x, y );
-            }
+            // add scaled well model modification to y
+            wellMod_.applyScaleAdd( alpha, x, y );
 
 #if HAVE_MPI
             if( comm_ )

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -156,6 +156,15 @@ namespace Opm {
             {
                 OPM_THROW(std::logic_error,"solver down cast to ISTLSolver failed");
             }
+
+            if ( param_.matrix_add_well_contributions_ )
+            {
+                // This might be dangerous?!
+                ebosSimulator_.model().clearAuxiliaryModules();
+                auto auxMod = std::make_shared<WellConnectionAuxiliaryModule<TypeTag> >( wellModel().wells() );
+                ebosSimulator_.model().addAuxiliaryModule(auxMod);
+            }
+
         }
 
         bool isParallel() const
@@ -354,15 +363,6 @@ namespace Opm {
         SimulatorReport assemble(const SimulatorTimerInterface& timer,
                                  const int iterationIdx)
         {
-            if ( param_.matrix_add_well_contributions_ )
-            {
-                // This might be dangerous?!
-                ebosSimulator_.model().clearAuxiliaryModules();
-                auto auxMod = std::make_shared<WellConnectionAuxiliaryModule<TypeTag> >( wellModel().wells() );
-                ebosSimulator_.model().addAuxiliaryModule(auxMod);
-            }
-
-
             // -------- Mass balance equations --------
             ebosSimulator_.model().newtonMethod().setIterationIndex(iterationIdx);
             ebosSimulator_.problem().beginIteration();

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -29,6 +29,7 @@
 
 #include <opm/autodiff/BlackoilModelParameters.hpp>
 #include <opm/autodiff/BlackoilWellModel.hpp>
+#include <opm/autodiff/WellConnectionAuxiliaryModule.hpp>
 #include <opm/autodiff/BlackoilDetails.hpp>
 #include <opm/autodiff/NewtonIterationBlackoilInterface.hpp>
 
@@ -353,6 +354,16 @@ namespace Opm {
         SimulatorReport assemble(const SimulatorTimerInterface& timer,
                                  const int iterationIdx)
         {
+            if ( param_.matrix_add_well_contributions_ )
+            {
+                // This might be dangerous?!
+                ebosSimulator_.model().clearAuxiliaryModules();
+                const auto* wells = wellModel().wellsPointer();
+                auto auxMod = std::make_shared<WellConnectionAuxiliaryModule<TypeTag> >(wells);
+                ebosSimulator_.model().addAuxiliaryModule(auxMod);
+            }
+
+
             // -------- Mass balance equations --------
             ebosSimulator_.model().newtonMethod().setIterationIndex(iterationIdx);
             ebosSimulator_.problem().beginIteration();
@@ -1066,6 +1077,7 @@ namespace Opm {
         }
 
     private:
+
 
         double dpMaxRel() const { return param_.dp_max_rel_; }
         double dsMax() const { return param_.ds_max_; }

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -94,7 +94,7 @@ namespace Opm
         update_equations_scaling_ = false;
         use_update_stabilization_ = true;
         use_multisegment_well_ = false;
-        matrix_add_well_contributions_=false;
+        matrix_add_well_contributions_ = false;
     }
 
 

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -65,6 +65,7 @@ namespace Opm
         update_equations_scaling_ = param.getDefault("update_equations_scaling", update_equations_scaling_);
         use_update_stabilization_ = param.getDefault("use_update_stabilization", use_update_stabilization_);
         deck_file_name_ = param.template get<std::string>("deck_filename");
+        matrix_add_well_contributions_ = param.getDefault("matrix_add_well_contributions", matrix_add_well_contributions_);
     }
 
 
@@ -93,6 +94,7 @@ namespace Opm
         update_equations_scaling_ = false;
         use_update_stabilization_ = true;
         use_multisegment_well_ = false;
+        matrix_add_well_contributions_=false;
     }
 
 

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -91,6 +91,9 @@ namespace Opm
         /// The file name of the deck
         std::string deck_file_name_;
 
+        // Whether to add influences of wells between cells to the matrix
+        bool matrix_add_well_contributions_;
+
         /// Construct from user parameters or defaults.
         explicit BlackoilModelParameters( const ParameterGroup& param );
 

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -157,12 +157,6 @@ namespace Opm {
 
             const SimulatorReport& lastReport() const;
 
-            /// \! brief Modifies matrix to include influences of the well perforations.
-            ///
-            /// \param mat The linear system with the assembled mass balance
-            ///            equations
-            void addWellContributions(Mat& mat) const;
-
 
         protected:
 

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -61,14 +61,9 @@
 
 namespace Opm {
 
-        template<typename TypeTag>
-        class BlackoilModelEbos;
-
         /// Class for handling the blackoil well model.
         template<typename TypeTag>
         class BlackoilWellModel {
-            // Needs acces to wells_ecl_
-            friend class BlackoilModelEbos<TypeTag>;
         public:
             // ---------      Types      ---------
             typedef WellStateFullyImplicitBlackoil WellState;

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -295,8 +295,16 @@ namespace Opm {
     }
 
 
-
-
+    template<typename TypeTag>
+    void
+    BlackoilWellModel<TypeTag>::
+    addWellContributions(Mat& mat) const
+    {
+        for(const auto& well: well_container_)
+        {
+            well->addWellContributions(mat);
+        }
+    }
 
     // applying the well residual to reservoir residuals
     // r = r - duneC_^T * invDuneD_ * resWell_

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -321,13 +321,15 @@ namespace Opm {
     apply(const BVector& x, BVector& Ax) const
     {
         // TODO: do we still need localWellsActive()?
-        if ( ! localWellsActive() ||
-             well_container_[0]->jacobianContainsWellContributions() ) {
+        if ( ! localWellsActive() ) {
             return;
         }
 
         for (auto& well : well_container_) {
-            well->apply(x, Ax);
+            if ( ! well->jacobianContainsWellContributions() )
+            {
+                well->apply(x, Ax);
+            }
         }
     }
 
@@ -341,8 +343,7 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     applyScaleAdd(const Scalar alpha, const BVector& x, BVector& Ax) const
     {
-        if ( ! localWellsActive() ||
-             well_container_[0]->jacobianContainsWellContributions() ) {
+        if ( ! localWellsActive() ) {
             return;
         }
 

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -294,18 +294,6 @@ namespace Opm {
         }
     }
 
-
-    template<typename TypeTag>
-    void
-    BlackoilWellModel<TypeTag>::
-    addWellContributions(Mat& mat) const
-    {
-        for(const auto& well: well_container_)
-        {
-            well->addWellContributions(mat);
-        }
-    }
-
     // applying the well residual to reservoir residuals
     // r = r - duneC_^T * invDuneD_ * resWell_
     template<typename TypeTag>
@@ -333,7 +321,8 @@ namespace Opm {
     apply(const BVector& x, BVector& Ax) const
     {
         // TODO: do we still need localWellsActive()?
-        if ( ! localWellsActive() ) {
+        if ( ! localWellsActive() ||
+             well_container_[0]->jacobianContainsWellContributions() ) {
             return;
         }
 
@@ -352,7 +341,8 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     applyScaleAdd(const Scalar alpha, const BVector& x, BVector& Ax) const
     {
-        if ( ! localWellsActive() ) {
+        if ( ! localWellsActive() ||
+             well_container_[0]->jacobianContainsWellContributions() ) {
             return;
         }
 

--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -310,6 +310,27 @@ public:
 
 namespace Opm
 {
+namespace Detail
+{
+    //! calculates ret = A^T * B
+    template< class K, int m, int n, int p >
+    static inline void multMatrixTransposed ( const Dune::FieldMatrix< K, n, m > &A,
+                                              const Dune::FieldMatrix< K, n, p > &B,
+                                              Dune::FieldMatrix< K, m, p > &ret )
+    {
+        typedef typename Dune::FieldMatrix< K, m, p > :: size_type size_type;
+
+        for( size_type i = 0; i < m; ++i )
+        {
+            for( size_type j = 0; j < p; ++j )
+            {
+                ret[ i ][ j ] = K( 0 );
+                for( size_type k = 0; k < n; ++k )
+                    ret[ i ][ j ] += A[ k ][ i ] * B[ k ][ j ];
+            }
+        }
+    }
+}
     /// This class solves the fully implicit black-oil system by
     /// solving the reduced system (after eliminating well variables)
     /// as a block-structured matrix (one block for all cell variables) for a fixed

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -179,6 +179,13 @@ public:
 
         WellState wellStateDummy; //not used. Only passed to make the old interfaces happy
 
+        if ( model_param_.matrix_add_well_contributions_ )
+        {
+            ebosSimulator_.model().clearAuxiliaryModules();
+            auto auxMod = std::make_shared<WellConnectionAuxiliaryModule<TypeTag> >(schedule(), grid());
+            ebosSimulator_.model().addAuxiliaryModule(auxMod);
+        }
+
         // Main simulation loop.
         while (!timer.done()) {
             // Report timestep.

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -157,6 +157,7 @@ namespace Opm
 
         virtual void calculateExplicitQuantities(const Simulator& ebosSimulator,
                                                  const WellState& well_state); // should be const?
+        virtual void  addWellContributions(Mat& mat) const;
     protected:
 
         // protected functions from the Base class

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -27,6 +27,7 @@
 #include <opm/autodiff/WellInterface.hpp>
 #include <opm/autodiff/ISTLSolver.hpp>
 #include <opm/autodiff/RateConverter.hpp>
+#include <opm/autodiff/ISTLSolver.hpp>
 
 namespace Opm
 {
@@ -88,15 +89,8 @@ namespace Opm
         typedef Dune::FieldVector<Scalar, numWellEq> VectorBlockWellType;
         typedef Dune::BlockVector<VectorBlockWellType> BVectorWell;
 
-#if  DUNE_VERSION_NEWER_REV(DUNE_ISTL, 2 , 5, 1)
-        // 3x3 matrix block inversion was unstable from at least 2.3 until and
-        // including 2.5.0
         // the matrix type for the diagonal matrix D
         typedef Dune::FieldMatrix<Scalar, numWellEq, numWellEq > DiagMatrixBlockWellType;
-#else
-        // the matrix type for the diagonal matrix D
-        typedef Dune::MatrixBlock<Scalar, numWellEq, numWellEq > DiagMatrixBlockWellType;
-#endif
 
         typedef Dune::BCRSMatrix <DiagMatrixBlockWellType> DiagMatWell;
 

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -151,7 +151,14 @@ namespace Opm
 
         virtual void calculateExplicitQuantities(const Simulator& ebosSimulator,
                                                  const WellState& well_state); // should be const?
+
         virtual void  addWellContributions(Mat& mat) const;
+
+        /// \brief Wether the Jacobian will also have well contributions in it.
+        virtual bool jacobianContainsWellContributions() const
+        {
+            return param_.matrix_add_well_contributions_;
+        }
     protected:
 
         // protected functions from the Base class

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -2112,7 +2112,7 @@ namespace Detail
         // A -= C^T D^-1 B
         // D is diagonal
         // B and C have 1 row, nc colums and nonzero
-        // at (i,j) only if well i has perforation at cell j.
+        // at (0,j) only if this well has a perforation at cell j.
 
         for ( auto colC = duneC_[0].begin(), endC = duneC_[0].end(); colC != endC; ++colC )
         {
@@ -2124,7 +2124,7 @@ namespace Detail
             for ( auto colB = duneB_[0].begin(), endB = duneB_[0].end(); colB != endB; ++colB )
             {
                 const auto col_index = colB.index();
-                // Move col to index pj
+                // Move col to index col_index
                 while ( col != row.end() && col.index() < col_index ) ++col;
                 assert(col != row.end() && col.index() == col_index);
 

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -2111,16 +2111,18 @@ namespace Detail
         // B and C have 1 row, nc colums and nonzero
         // at (i,j) only if well i has perforation at cell j.
 
-        for(auto colC = duneC_[0].begin(), endC = duneC_[0].end(); colC != endC; ++colC) {
+        for ( auto colC = duneC_[0].begin(), endC = duneC_[0].end(); colC != endC; ++colC )
+        {
             const auto row_index = colC.index();
             auto& row = mat[row_index];
             auto colB = duneB_[0].begin();
             auto col = row.begin();
             
-            for(auto colB = duneB_[0].begin(), endB = duneB_[0].end(); colB != endB; ++colB) {
+            for ( auto colB = duneB_[0].begin(), endB = duneB_[0].end(); colB != endB; ++colB )
+            {
                 const auto col_index = colB.index();
                 // Move col to index pj
-                while(col != row.end() && col.index() < col_index) ++col;
+                while ( col != row.end() && col.index() < col_index ) ++col;
                 assert(col != row.end() && col.index() == col_index);
 
                 Dune::FieldMatrix<Scalar, numWellEq, numEq> tmp;

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -22,27 +22,6 @@
 
 namespace Opm
 {
-namespace Detail
-{
-    //! calculates ret = A^T * B
-    template< class K, int m, int n, int p >
-    static inline void multMatrixTransposed ( const Dune::FieldMatrix< K, n, m > &A,
-                                              const Dune::FieldMatrix< K, n, p > &B,
-                                              Dune::FieldMatrix< K, m, p > &ret )
-    {
-        typedef typename Dune::FieldMatrix< K, m, p > :: size_type size_type;
-
-        for( size_type i = 0; i < m; ++i )
-        {
-            for( size_type j = 0; j < p; ++j )
-            {
-                ret[ i ][ j ] = K( 0 );
-                for( size_type k = 0; k < n; ++k )
-                    ret[ i ][ j ] += A[ k ][ i ] * B[ k ][ j ];
-            }
-        }
-    }
-}
 
     template<typename TypeTag>
     StandardWell<TypeTag>::

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -688,7 +688,10 @@ namespace Detail
         }
 
         // do the local inversion of D.
-        invDuneD_[0][0].invert();
+        // we do this manually with invertMatrix to always get our
+        // specializations in for 3x3 and 4x4 matrices.
+        auto original = invDuneD_[0][0];
+        Dune::FMatrixHelp::invertMatrix(original, invDuneD_[0][0]);
 
         if ( param_.matrix_add_well_contributions_ )
         {

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -2097,7 +2097,6 @@ namespace Opm
         {
             const auto row_index = colC.index();
             auto& row = mat[row_index];
-            auto colB = duneB_[0].begin();
             auto col = row.begin();
             
             for ( auto colB = duneB_[0].begin(), endB = duneB_[0].end(); colB != endB; ++colB )

--- a/opm/autodiff/WellConnectionAuxiliaryModule.hpp
+++ b/opm/autodiff/WellConnectionAuxiliaryModule.hpp
@@ -116,7 +116,7 @@ public:
     void applyInitial()
     {}
 
-    void linearize(JacobianMatrix& matrix, GlobalEqVector& residual)
+    void linearize(JacobianMatrix& , GlobalEqVector&)
     {
         // Linearization is done in StandardDenseWells
     }

--- a/opm/autodiff/WellConnectionAuxiliaryModule.hpp
+++ b/opm/autodiff/WellConnectionAuxiliaryModule.hpp
@@ -55,23 +55,25 @@ public:
         std::vector<int> cartesianToCompressed(size, -1);
         auto begin = globalCell.begin();
 
-        for(auto cell = begin, end= globalCell.end(); cell != end; ++cell)
+        for ( auto cell = begin, end= globalCell.end(); cell != end; ++cell )
         {
             cartesianToCompressed[ *cell ] = cell - begin;
         }
 
-        int last_time_step = schedule.getTimeMap().size()-1;
+        int last_time_step = schedule.getTimeMap().size() - 1;
         const auto& schedule_wells = schedule.getWells();
         wells_.reserve(schedule_wells.size());
 
         // initialize the additional cell connections introduced by wells.
-        for (const auto well : schedule_wells) {
+        for ( const auto well : schedule_wells )
+        {
             std::vector<int> compressed_well_perforations;
             // All possible completions of the well
             const auto& completionSet = well->getCompletions(last_time_step);
             compressed_well_perforations.reserve(completionSet.size());
 
-            for (size_t c=0; c<completionSet.size(); c++) {
+            for ( size_t c=0; c < completionSet.size(); c++ )
+            {
                 const auto& completion = completionSet.get(c);
                 int i = completion.getI();
                 int j = completion.getJ();
@@ -85,7 +87,7 @@ public:
                 }
             }
 
-            if( ! compressed_well_perforations.empty() )
+            if ( ! compressed_well_perforations.empty() )
             {
                 std::sort(compressed_well_perforations.begin(),
                           compressed_well_perforations.end());

--- a/opm/autodiff/WellConnectionAuxiliaryModule.hpp
+++ b/opm/autodiff/WellConnectionAuxiliaryModule.hpp
@@ -23,7 +23,7 @@
 
 #include <ewoms/aux/baseauxiliarymodule.hh>
 
-#include <dune/grid/CpGrid.hpp>
+#include <opm/grid/CpGrid.hpp>
 
 #include <opm/core/wells.h>
 

--- a/opm/autodiff/WellConnectionAuxiliaryModule.hpp
+++ b/opm/autodiff/WellConnectionAuxiliaryModule.hpp
@@ -1,0 +1,91 @@
+/*
+  Copyright 2017 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_WELLCONNECTIONAUXILIARYMODULE_HEADER_INCLUDED
+#define OPM_WELLCONNECTIONAUXILIARYMODULE_HEADER_INCLUDED
+
+#include <ewoms/aux/baseauxiliarymodule.hh>
+
+#include <opm/core/wells.h>
+
+namespace Opm
+{
+template<class TypeTag>
+class WellConnectionAuxiliaryModule
+    : public Ewoms::BaseAuxiliaryModule<TypeTag>
+{
+    typedef typename GET_PROP_TYPE(TypeTag, GlobalEqVector) GlobalEqVector;
+    typedef typename GET_PROP_TYPE(TypeTag, JacobianMatrix) JacobianMatrix;
+
+public:
+
+    using NeighborSet = typename
+        Ewoms::BaseAuxiliaryModule<TypeTag>::NeighborSet;
+
+    WellConnectionAuxiliaryModule(const Wells* wells)
+        : wells_(wells)
+    {
+    }
+
+    unsigned numDofs() const
+    {
+        // No extra dofs are inserted for wells.
+        return 0;
+    }
+
+    void addNeighbors(std::vector<NeighborSet>& neighbors) const
+    {
+        const int nw = wells().number_of_wells;
+
+        for (int w = 0; w < nw; ++w)
+        {
+            const int nperfs = wells().well_connpos[w+1];
+            for (int perf = wells().well_connpos[w] ; perf < nperfs; ++perf) {
+                const auto cell1_idx = wells().well_cells[perf];
+                for(int perf1 = perf; perf1 < nperfs; ++perf1)
+                {
+                    const auto cell2_idx = wells().well_cells[perf1];
+                    neighbors[cell1_idx].insert(cell2_idx);
+                    neighbors[cell2_idx].insert(cell1_idx);
+                }
+            }
+        }
+    }
+
+    void applyInitial()
+    {}
+
+    void linearize(JacobianMatrix& matrix, GlobalEqVector& residual)
+    {
+        // Linearization is done in StandardDenseWells
+    }
+
+    private:
+
+    const Wells& wells() const
+    {
+        return *wells_;
+    }
+
+    const Wells* wells_;
+};
+
+} // end namespace OPM
+#endif

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -83,13 +83,7 @@ namespace Opm
         typedef double Scalar;
 
         typedef Dune::FieldVector<Scalar, numEq    > VectorBlockType;
-#if  DUNE_VERSION_NEWER_REV(DUNE_ISTL, 2 , 5, 1)
-        // 3x3 matrix block inversion was unstable from at least 2.3 until and
-        // including 2.5.0
         typedef Dune::FieldMatrix<Scalar, numEq, numEq > MatrixBlockType;
-#else
-        typedef Dune::FieldMatrix<Scalar, numEq, numEq > MatrixBlockType;
-#endif
         typedef Dune::BCRSMatrix <MatrixBlockType> Mat;
         typedef Dune::BlockVector<VectorBlockType> BVector;
         typedef DenseAd::Evaluation<double, /*size=*/numEq> Eval;

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -203,7 +203,11 @@ namespace Opm
         virtual void calculateExplicitQuantities(const Simulator& ebosSimulator,
                                                  const WellState& well_state) = 0; // should be const?
 
-        virtual void addWellContributions(Mat& mat) const;
+        /// \brief Wether the Jacobian will also have well contributions in it.
+        virtual bool jacobianContainsWellContributions() const
+        {
+            return false;
+        }
 
         // updating the voidage rates in well_state when requested
         void calculateReservoirRates(WellState& well_state) const;

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -24,7 +24,8 @@
 #define OPM_WELLINTERFACE_HEADER_INCLUDED
 
 #include <opm/common/OpmLog/OpmLog.hpp>
-
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 #include <opm/core/wells.h>

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -82,7 +82,13 @@ namespace Opm
         typedef double Scalar;
 
         typedef Dune::FieldVector<Scalar, numEq    > VectorBlockType;
+#if  DUNE_VERSION_NEWER_REV(DUNE_ISTL, 2 , 5, 1)
+        // 3x3 matrix block inversion was unstable from at least 2.3 until and
+        // including 2.5.0
         typedef Dune::FieldMatrix<Scalar, numEq, numEq > MatrixBlockType;
+#else
+        typedef Dune::FieldMatrix<Scalar, numEq, numEq > MatrixBlockType;
+#endif
         typedef Dune::BCRSMatrix <MatrixBlockType> Mat;
         typedef Dune::BlockVector<VectorBlockType> BVector;
         typedef DenseAd::Evaluation<double, /*size=*/numEq> Eval;
@@ -201,6 +207,8 @@ namespace Opm
 
         virtual void calculateExplicitQuantities(const Simulator& ebosSimulator,
                                                  const WellState& well_state) = 0; // should be const?
+
+        virtual void addWellContributions(Mat& mat) const;
 
         // updating the voidage rates in well_state when requested
         void calculateReservoirRates(WellState& well_state) const;

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -844,14 +844,6 @@ namespace Opm
         return 1.0;
     }
 
-    template<typename TypeTag>
-    void
-    WellInterface<TypeTag>::addWellContributions(Mat& mat) const
-    {
-        OPM_THROW(NotImplemented, "This well class does not support adding well contributions"
-                  << "to the matrix");     
-    }
-
 
 
 

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -844,6 +844,13 @@ namespace Opm
         return 1.0;
     }
 
+    template<typename TypeTag>
+    void
+    WellInterface<TypeTag>::addWellContributions(Mat& mat) const
+    {
+        OPM_THROW(NotImplemented, "This well class does not support adding well contributions"
+                  << "to the matrix");     
+    }
 
 
 

--- a/tests/test_multmatrixtransposed.cpp
+++ b/tests/test_multmatrixtransposed.cpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2018 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE MultMatrixTransposed
+#include <boost/test/unit_test.hpp>
+#include <opm/autodiff/ISTLSolver.hpp>
+
+using namespace Dune;
+using namespace Opm::Detail;
+
+BOOST_AUTO_TEST_CASE(testmultmatrixtrans)
+{
+    using Scalar = FieldMatrix<double,1,1>;
+    Scalar a1 = {{ 4 }}, b1 = {{ 2 }}, res1 = {{}}, resExpect1 = {{ 8 }};
+    multMatrixTransposed(a1, b1, res1);
+    BOOST_CHECK_EQUAL(res1, resExpect1);
+
+    using Mat2 =  FieldMatrix<double,2,2>;
+
+    
+    Mat2 a2 = {{ 1, 2 }, { 3, 4} }, b2 = {{ 3, 4 }, { 5, 6} };
+    Mat2 res2 = {{}, {}}, resExpect2 = {{ 18, 22 }, {26, 32} };
+    multMatrixTransposed(a2, b2, res2);
+    BOOST_CHECK_EQUAL(res2, resExpect2);
+    
+    using Mat3 =  FieldMatrix<double,3,3>;
+
+    
+    Mat3 a3 = {{ 1, 2, 3 }, { 3, 4, 5}, {6, 7, 8} };
+    
+    Mat3 b3 = {{ 3, 4, 5 }, { 5, 6, 7}, {7, 8, 9} };
+    Mat3 res3 = {{}, {}, {}};
+    Mat3 resExpect3 = {{ 60, 70, 80 }, {75, 88, 101}, { 90, 106, 122 } };
+    multMatrixTransposed(a3, b3, res3);
+    BOOST_CHECK_EQUAL(res3, resExpect3);
+}


### PR DESCRIPTION
Currently, we never pass the full matrix to the precondioner but  a matrix that does not include the well contributions. Only for the linear operator we use the full matrix. The idea was (past tense!) to include the well influences into the matrix passed to the preconditioner and hopefully get a better one and improve the time to solution.

This PR adds a flag matrix_add_well_contributions which does that when set to true (default is false).

Well, this kind of works fine for SPE9 (total time drops from 28.8234 sec. to 26.1497). Unfortunately, for both Norne and Model 2 we the time needed for the solution increases (Norne 12%, Model 2 3%). This is due to differently failing nonlinear solves and therefore more linearizations.
But maybe this PR is missing something, @totto82 ?

Anyway I think it would still be worthwhile to merge this as it will not change the current runs and might open up opportunities in the future.