### PR TITLE
Allow usage of AMG if flow_ebos is used and UMFPack is available.

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -124,7 +124,7 @@ namespace Opm {
         typedef Dune::BCRSMatrix <MatrixBlockType>      Mat;
         typedef Dune::BlockVector<VectorBlockType>      BVector;
 
-        typedef ISTLSolver< MatrixBlockType, VectorBlockType >  ISTLSolverType;
+        typedef ISTLSolver< MatrixBlockType, VectorBlockType, BlackoilIndices::pressureSwitchIdx >  ISTLSolverType;
         //typedef typename SolutionVector :: value_type            PrimaryVariables ;
 
         // For the conversion between the surface volume rate and resrevoir voidage rate

--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -276,7 +276,7 @@ createEllipticPreconditionerPointer(const M& Ae, double relax,
 /// \param relax   The relaxation parameter for ILU0.
 /// \param comm    The object describing the parallelization information and communication.
 //  \param amgPtr  The unique_ptr to be filled (return)
-template <class Op, class P, class AMG >
+template <class Op, class P, class AMG, int pressureIndex=0 >
 inline void
 createAMGPreconditionerPointer( Op& opA, const double relax, const P& comm, std::unique_ptr< AMG >& amgPtr )
 {
@@ -284,7 +284,7 @@ createAMGPreconditionerPointer( Op& opA, const double relax, const P& comm, std:
     typedef typename Op::matrix_type  M;
 
     // The coupling metric used in the AMG
-    typedef Dune::Amg::FirstDiagonal CouplingMetric;
+    typedef Dune::Amg::Diagonal<pressureIndex> CouplingMetric;
 
     // The coupling criterion used in the AMG
     typedef Dune::Amg::SymmetricCriterion<M, CouplingMetric> CritBase;

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -23,6 +23,8 @@
 #ifndef OPM_FLOWMAIN_HEADER_INCLUDED
 #define OPM_FLOWMAIN_HEADER_INCLUDED
 
+// Define making clear that the simulator supports AMG
+#define FLOW_SUPPORT_AMG !defined(HAVE_UMFPACK)
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -23,7 +23,11 @@
 #ifndef OPM_FLOW_MAIN_EBOS_HEADER_INCLUDED
 #define OPM_FLOW_MAIN_EBOS_HEADER_INCLUDED
 
+// Define making clear that the simulator supports AMG
+#define FLOW_SUPPORT_AMG
+
 #include <sys/utsname.h>
+
 
 #include <opm/simulators/ParallelFileMerger.hpp>
 #include <opm/simulators/ensureDirectoryExists.hpp>

--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -174,7 +174,12 @@ namespace Opm
     /// solving the reduced system (after eliminating well variables)
     /// as a block-structured matrix (one block for all cell variables) for a fixed
     /// number of cell variables np .
-    template < class MatrixBlockType, class VectorBlockType >
+    /// \tparam MatrixBlockType The type of the matrix block used.
+    /// \tparam VectorBlockType The type of the vector block used.
+    /// \tparam pressureIndex The index of the pressure component in the vector
+    ///                       vector block. It is used to guide the AMG coarsening.
+    ///                       Default is zero.
+    template < class MatrixBlockType, class VectorBlockType, int pressureIndex=0 >
     class ISTLSolver : public NewtonIterationBlackoilInterface
     {
         typedef typename MatrixBlockType :: field_type  Scalar;
@@ -311,7 +316,7 @@ namespace Opm
         void
         constructAMGPrecond(LinearOperator& /* linearOperator */, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >& opA, const double relax ) const
         {
-            ISTLUtility::createAMGPreconditionerPointer( *opA, relax, comm, amg );
+            ISTLUtility::createAMGPreconditionerPointer<pressureIndex>( *opA, relax, comm, amg );
         }
 
 
@@ -319,7 +324,7 @@ namespace Opm
         void
         constructAMGPrecond(MatrixOperator& opA, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >&, const double relax ) const
         {
-            ISTLUtility::createAMGPreconditionerPointer( opA, relax, comm, amg );
+            ISTLUtility::createAMGPreconditionerPointer<pressureIndex>( opA, relax, comm, amg );
         }
 
         /// \brief Solve the system using the given preconditioner and scalar product.

--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -249,7 +249,7 @@ namespace Opm
             // Communicate if parallel.
             parallelInformation_arg.copyOwnerToAll(istlb, istlb);
 
-#if defined(OPM_FLOW_MAIN_EBOS_HEADER_INCLUDED) || ! HAVE_UMFPACK // activate AMG if either flow_ebos is used or UMFPack is not available
+#if FLOW_SUPPORT_AMG // activate AMG if either flow_ebos is used or UMFPack is not available
             if( parameters_.linear_solver_use_amg_ )
             {
                 typedef ISTLUtility::CPRSelector< Matrix, Vector, Vector, POrComm>  CPRSelectorType;

--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -249,7 +249,7 @@ namespace Opm
             // Communicate if parallel.
             parallelInformation_arg.copyOwnerToAll(istlb, istlb);
 
-#if ! HAVE_UMFPACK
+#if defined(OPM_FLOW_MAIN_EBOS_HEADER_INCLUDED) || ! HAVE_UMFPACK // activate AMG if either flow_ebos is used or UMFPack is not available
             if( parameters_.linear_solver_use_amg_ )
             {
                 typedef ISTLUtility::CPRSelector< Matrix, Vector, Vector, POrComm>  CPRSelectorType;


### PR DESCRIPTION
This was previously deactivated because of the single precision support of flow_legacy and missing single-precision support for UMFPack. Whenever UMFPack was available there was no AMG for flow.

As flow_ebos does not use single precision this commit allows using amg at least for flow_ebos even in the presence of UMFpack. For flow_legacy everything stays the same.