### PR TITLE
Faster ILU implementation.

### DIFF
--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -289,7 +289,6 @@ namespace Opm
             }
         }
 
-        //typedef Dune::SeqILU0<Matrix, Vector, Vector> SeqPreconditioner;
         typedef ParallelOverlappingILU0<Matrix,Vector,Vector> SeqPreconditioner;
 
         template <class Operator>

--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -294,9 +294,9 @@ namespace Opm
         template <class Operator>
         std::unique_ptr<SeqPreconditioner> constructPrecond(Operator& opA, const Dune::Amg::SequentialInformation&) const
         {
-            const double relax  = parameters_.ilu_relaxation_;
-            const int iteration = parameters_.ilu_iteration_;
-            std::unique_ptr<SeqPreconditioner> precond(new SeqPreconditioner(opA.getmat(), iteration, relax));
+            const double relax   = parameters_.ilu_relaxation_;
+            const int ilu_fillin = parameters_.ilu_fillin_level_;
+            std::unique_ptr<SeqPreconditioner> precond(new SeqPreconditioner(opA.getmat(), ilu_fillin, relax));
             return precond;
         }
 

--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -289,7 +289,8 @@ namespace Opm
             }
         }
 
-        typedef Dune::SeqILU0<Matrix, Vector, Vector> SeqPreconditioner;
+        //typedef Dune::SeqILU0<Matrix, Vector, Vector> SeqPreconditioner;
+        typedef ParallelOverlappingILU0<Matrix,Vector,Vector> SeqPreconditioner;
 
         template <class Operator>
         std::unique_ptr<SeqPreconditioner> constructPrecond(Operator& opA, const Dune::Amg::SequentialInformation&) const

--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -295,8 +295,9 @@ namespace Opm
         template <class Operator>
         std::unique_ptr<SeqPreconditioner> constructPrecond(Operator& opA, const Dune::Amg::SequentialInformation&) const
         {
-            const double relax = 0.9;
-            std::unique_ptr<SeqPreconditioner> precond(new SeqPreconditioner(opA.getmat(), relax));
+            const double relax  = parameters_.ilu_relaxation_;
+            const int iteration = parameters_.ilu_iteration_;
+            std::unique_ptr<SeqPreconditioner> precond(new SeqPreconditioner(opA.getmat(), iteration, relax));
             return precond;
         }
 
@@ -308,7 +309,7 @@ namespace Opm
         constructPrecond(Operator& opA, const Comm& comm) const
         {
             typedef std::unique_ptr<ParPreconditioner> Pointer;
-            const double relax = 0.9;
+            const double relax  = parameters_.ilu_relaxation_;
             return Pointer(new ParPreconditioner(opA.getmat(), comm, relax));
         }
 #endif

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -41,7 +41,7 @@ namespace Opm
         int    linear_solver_maxiter_;
         int    linear_solver_restart_;
         int    linear_solver_verbosity_;
-        int    ilu_iteration_;
+        int    ilu_fillin_level_;
         bool   newton_use_gmres_;
         bool   require_full_sparsity_pattern_;
         bool   ignoreConvergenceFailure_;
@@ -64,7 +64,7 @@ namespace Opm
             ignoreConvergenceFailure_ = param.getDefault("linear_solver_ignoreconvergencefailure", ignoreConvergenceFailure_);
             linear_solver_use_amg_    = param.getDefault("linear_solver_use_amg", linear_solver_use_amg_ );
             ilu_relaxation_           = param.getDefault("ilu_relaxation", ilu_relaxation_ );
-            ilu_iteration_            = param.getDefault("ilu_iteration",  ilu_iteration_ );
+            ilu_fillin_level_         = param.getDefault("ilu_fillin_level",  ilu_fillin_level_ );
         }
 
         // set default values
@@ -78,7 +78,7 @@ namespace Opm
             require_full_sparsity_pattern_ = false;
             ignoreConvergenceFailure_ = false;
             linear_solver_use_amg_    = false;
-            ilu_iteration_            = 0;
+            ilu_fillin_level_         = 0;
             ilu_relaxation_           = 0.9;
         }
     };

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -37,9 +37,11 @@ namespace Opm
     struct NewtonIterationBlackoilInterleavedParameters
     {
         double linear_solver_reduction_;
+        double ilu_relaxation_;
         int    linear_solver_maxiter_;
         int    linear_solver_restart_;
         int    linear_solver_verbosity_;
+        int    ilu_iteration_;
         bool   newton_use_gmres_;
         bool   require_full_sparsity_pattern_;
         bool   ignoreConvergenceFailure_;
@@ -61,6 +63,8 @@ namespace Opm
             require_full_sparsity_pattern_ = param.getDefault("require_full_sparsity_pattern", require_full_sparsity_pattern_);
             ignoreConvergenceFailure_ = param.getDefault("linear_solver_ignoreconvergencefailure", ignoreConvergenceFailure_);
             linear_solver_use_amg_    = param.getDefault("linear_solver_use_amg", linear_solver_use_amg_ );
+            ilu_relaxation_           = param.getDefault("ilu_relaxation", ilu_relaxation_ );
+            ilu_iteration_            = param.getDefault("ilu_iteration",  ilu_iteration_ );
         }
 
         // set default values
@@ -74,6 +78,8 @@ namespace Opm
             require_full_sparsity_pattern_ = false;
             ignoreConvergenceFailure_ = false;
             linear_solver_use_amg_    = false;
+            ilu_iteration_            = 0;
+            ilu_relaxation_           = 0.9;
         }
     };
 

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -24,13 +24,14 @@
 
 #include <dune/istl/preconditioner.hh>
 #include <dune/istl/paamg/smoother.hh>
+#include <dune/istl/paamg/pinfo.hh>
 
 namespace Opm
 {
 
 //template<class M, class X, class Y, class C>
 //class ParallelOverlappingILU0;
-template<class Matrix, class Domain, class Range, class ParallelInfo = int>
+template<class Matrix, class Domain, class Range, class ParallelInfo = Dune::Amg::SequentialInformation>
 class ParallelOverlappingILU0;
 
 } // end namespace Opm
@@ -164,11 +165,7 @@ template<class Matrix, class Domain, class Range, class ParallelInfoT>
 class ParallelOverlappingILU0
     : public Dune::Preconditioner<Domain,Range>
 {
-    // if ParallelInfoT = int was passed then sequential preconditioner is selected
-    typedef typename std::conditional<
-        std::is_same<ParallelInfoT,int>::value,
-        Dune::OwnerOverlapCopyCommunication<int, int>,
-        ParallelInfoT>::type  ParallelInfo;
+    typedef ParallelInfoT ParallelInfo;
 
 public:
     //! \brief The matrix type the preconditioner is for.
@@ -232,7 +229,7 @@ public:
     // define the category
     enum {
         //! \brief The category the preconditioner is part of.
-        category = std::is_same<ParallelInfoT,int>::value ?
+        category = std::is_same<ParallelInfoT, Dune::Amg::SequentialInformation>::value ?
             Dune::SolverCategory::sequential : Dune::SolverCategory::overlapping
     };
 


### PR DESCRIPTION
This PR improves the speed of the ILU preconditioner by storing the upper triangular matrix in a more memory coherent way. The previous implementation required backwards iteration for the upper triangular which is not optimal. This PR does not change anything on the algorithmic side. 

For NORNE the runtime reduces from 745.171 sec to 671.636. Similar or better improvements can be observed for Model2.  