### PR TITLE
Hopefully fixes issue with network file systems and async_output=true.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -852,6 +852,8 @@ namespace Opm
                     }
                 }
 
+                output_writer_->finishWriting();
+
                 if (output_to_files_) {
                     std::string filename = output_dir_ + "/walltime.txt";
                     std::fstream tot_os(filename.c_str(), std::fstream::trunc | std::fstream::out);

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -638,6 +638,8 @@ namespace Opm
                     }
                 }
 
+                output_writer_->finishWriting();
+
                 if (output_to_files_) {
                     std::string filename = output_dir_ + "/walltime.txt";
                     std::fstream tot_os(filename.c_str(), std::fstream::trunc | std::fstream::out);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -455,4 +455,11 @@ namespace Opm
     bool BlackoilOutputWriter::requireFIPNUM() const {
         return eclipseState_.getSummaryConfig().requireFIPNUM();
     }
+
+    void BlackoilOutputWriter::finishWriting(){
+        if( asyncOutput_ )
+        {
+            asyncOutput_->signalEndAndJoin();
+        }
+    }
 }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -299,6 +299,9 @@ namespace Opm
 
         bool requireFIPNUM() const;
 
+        //! Finish the write out process, i.e. wait for output threads.
+        void finishWriting();
+
     protected:
         const bool output_;
         std::unique_ptr< ParallelDebugOutputInterface > parallelOutput_;

--- a/opm/autodiff/ThreadHandle.hpp
+++ b/opm/autodiff/ThreadHandle.hpp
@@ -130,10 +130,7 @@ namespace Opm
     ThreadHandle()
       : threadObjectQueue_(),
         thread_( startThread, &threadObjectQueue_ )
-    {
-      // detach thread into nirvana
-      thread_.detach();
-    } // end constructor
+    { }
 
     //! dispatch object to queue of separate thread
     template <class Object>
@@ -148,9 +145,15 @@ namespace Opm
 
     //! destructor terminating the thread
     ~ThreadHandle()
+    { }
+
+    //! send terminal obect to pool and wait until the thread finishes.
+    void signalEndAndJoin()
     {
       // dispatch end object which will terminate the thread
       threadObjectQueue_.push_back( std::unique_ptr< ObjectInterface > (new EndObject()) ) ;
+      // Wait for thread to end
+      thread_.join();
     }
   };
 


### PR DESCRIPTION
There have been reports by people that parallel runs with async_output=true
that write to network file systems do not behave as expected.

This commit is a guess on how to fix these issues. I cannot test it myself.
Judging from the code the only thing that could go wrong before is that the
program might have terminated before all write processes finished. This was
possible because the writer thread was detached when setting up the output
writer and we never checked whether everything was actually written before
the program exists.

With this commit, we do not detach anymore. Instead we signal the thread that no
objects will be written anymore and join it at the end of the run method.

@alfbr Please test whether this fixes your issue. I cannot test myself.