### PR TITLE
Bugfix: fix MPI deadlock in output when asyncOutput is enabled.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -372,22 +372,6 @@ namespace Opm
                 // Ensure that output dir exists
                 ensureDirectoryExists(outputDir_);
 
-                // create output thread if enabled and rank is I/O rank
-                // async output is enabled by default if pthread are enabled
-#if HAVE_PTHREAD
-                const bool asyncOutputDefault = false;
-#else
-                const bool asyncOutputDefault = false;
-#endif
-                if( param.getDefault("async_output", asyncOutputDefault ) )
-                {
-#if HAVE_PTHREAD
-                    asyncOutput_.reset( new ThreadHandle() );
-#else
-                    OPM_THROW(std::runtime_error,"Pthreads were not found, cannot enable async_output");
-#endif
-                }
-
                 std::string backupfilename = param.getDefault("backupfile", std::string("") );
                 if( ! backupfilename.empty() )
                 {
@@ -395,6 +379,23 @@ namespace Opm
                 }
             }
         }
+
+        // create output thread if enabled and rank is I/O rank
+        // async output is enabled by default if pthread are enabled
+#if HAVE_PTHREAD
+        const bool asyncOutputDefault = true;
+#else
+        const bool asyncOutputDefault = false;
+#endif
+        if( param.getDefault("async_output", asyncOutputDefault ) )
+        {
+#if HAVE_PTHREAD
+            asyncOutput_.reset( new ThreadHandle( parallelOutput_->isIORank() ) );
+#else
+            OPM_THROW(std::runtime_error,"Pthreads were not found, cannot enable async_output");
+#endif
+        }
+
     }
 
 


### PR DESCRIPTION
1) fix MPI deadlock caused by MPI_Bcast call only initiated on ioRank. in writeTimeStepWithCellProperties.
2) ThreadHandle now waits on destruction until all objects have been dealt with.

This PR fixes the issues raised by @blattms in #1188 .

