### PR TITLE
[WIP] Introduce more proper error handling to asynchronous output writing.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -282,7 +282,7 @@ namespace Opm
         {
             if( asyncOutput_ ) {
                 // dispatch the write call to the extra thread
-                asyncOutput_->dispatch( detail::WriterCall( *this, timer, state, wellState, cellData, extraData, substep ) );
+                std::tie(err, emsg) = asyncOutput_->dispatch( detail::WriterCall( *this, timer, state, wellState, cellData, extraData, substep ) );
             }
             else {
                 // just write the data to disk

--- a/opm/autodiff/ThreadHandle.hpp
+++ b/opm/autodiff/ThreadHandle.hpp
@@ -133,21 +133,24 @@ namespace Opm
                 }
                 return;
             }
-            try
+            if( err == 0 )
             {
-                // execute object action
-                obj->run();
-            }
-            catch(std::runtime_error& msg)
-            {
-                // signal the error
-                err_ = 1;
-                err_msg_ = msg.what();
-                // When the deconstructor is running, err_ will never be checked
-                // therefore we throw the error.
-                if( deconstructing_ )
+                try
                 {
-                    throw msg;
+                    // execute object action
+                    obj->run();
+                }
+                catch(std::runtime_error& msg)
+                {
+                    // signal the error
+                    err_ = 1;
+                    err_msg_ = msg.what();
+                    // When the deconstructor is running, err_ will never be checked
+                    // therefore we throw the error.
+                    if( deconstructing_ )
+                    {
+                        throw msg;
+                    }
                 }
             }
         }


### PR DESCRIPTION
The dispatch method now checks whether there was any error, previously.
In this case it clears the queue. In any case a tuple with the error
indicator and the messages is returned which is used outside for error
handling. For error handling for the last output write step will be done
in the ThreadHandleQueue destructor that is run by the main thread.

The reason for the [WIP] is that terminating the thread like it is done now is really giving me headaches as I cannot see how  to catch error in the last writing thread and not throw twice. This would need to be done in the destructor, but that means that `err_` might be one even if it stems from a previous unsucessful write that we already detected and have thrown an exception for already. Here I assume that the destructor is called during stack unwinding after an exception was thrown. Maybe joining the thread in FlowMain would prevent the second throw?