### PR TITLE
Move thread termination code out of destructors.

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -852,6 +852,8 @@ namespace Opm
                     }
                 }
 
+                output_writer_->finishWriting();
+
                 if (output_to_files_) {
                     std::string filename = output_dir_ + "/walltime.txt";
                     std::fstream tot_os(filename.c_str(), std::fstream::trunc | std::fstream::out);

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -638,6 +638,8 @@ namespace Opm
                     }
                 }
 
+                output_writer_->finishWriting();
+
                 if (output_to_files_) {
                     std::string filename = output_dir_ + "/walltime.txt";
                     std::fstream tot_os(filename.c_str(), std::fstream::trunc | std::fstream::out);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -455,4 +455,11 @@ namespace Opm
     bool BlackoilOutputWriter::requireFIPNUM() const {
         return eclipseState_.getSummaryConfig().requireFIPNUM();
     }
+
+    void BlackoilOutputWriter::finishWriting(){
+        if( asyncOutput_ )
+        {
+            asyncOutput_->signalEndAndJoin();
+        }
+    }
 }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -299,6 +299,9 @@ namespace Opm
 
         bool requireFIPNUM() const;
 
+        //! Finish the write out process, i.e. wait for output threads.
+        void finishWriting();
+
     protected:
         const bool output_;
         std::unique_ptr< ParallelDebugOutputInterface > parallelOutput_;

--- a/opm/autodiff/ThreadHandle.hpp
+++ b/opm/autodiff/ThreadHandle.hpp
@@ -66,15 +66,6 @@ namespace Opm
       {
       }
 
-      void waitUntilEmpty()
-      {
-        // wait until all objects have been written.
-        while( ! objQueue_.empty() )
-        {
-            wait();
-        }
-      }
-
       //! insert object into threads queue
       void push_back( std::unique_ptr< ObjectInterface >&& obj )
       {
@@ -177,9 +168,6 @@ namespace Opm
         if( thread_ )
         {
             // dispatching objects after this point is an error
-            // Wait for writes to finish
-            threadObjectQueue_.waitUntilEmpty();
-            // possible error handling from last writes.
             // dispatch end object which will terminate the thread
             threadObjectQueue_.push_back( std::unique_ptr< ObjectInterface > (new EndObject()) ) ;
             // Wait for thread to end


### PR DESCRIPTION
Error handling cannot be implemented cleanly there. Therefore we resort
to first detach the created thread in main and we signal the thread that no
objects will be written anymore and join it at the end of the program.

Alternative to #1194 
For me this is the only way to fix error handling from writing. I would do this in a combination with #1195. With the current approach we would be throwing in destructors and might even throw twice for error after the last dispatch call.