### PR TITLE
Only create asyncOutput if output is true

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -387,7 +387,7 @@ namespace Opm
 #else
         const bool asyncOutputDefault = false;
 #endif
-        if( param.getDefault("async_output", asyncOutputDefault ) )
+        if( asyncOutput_ && param.getDefault("async_output", asyncOutputDefault ) )
         {
 #if HAVE_PTHREAD
             asyncOutput_.reset( new ThreadHandle( parallelOutput_->isIORank() ) );


### PR DESCRIPTION
This fixes a segementation fault when running with output=false.