### PR TITLE
Add DebugTimeReport utility.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -174,6 +174,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
   opm/autodiff/BlackoilTransportModel.hpp
   opm/autodiff/fastSparseOperations.hpp
+  opm/autodiff/DebugTimeReport.hpp
   opm/autodiff/DuneMatrix.hpp
   opm/autodiff/ExtractParallelGridInformationToISTL.hpp
   opm/autodiff/FlowMain.hpp

--- a/opm/autodiff/DebugTimeReport.hpp
+++ b/opm/autodiff/DebugTimeReport.hpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_DEBUGTIMEREPORT_HEADER_INCLUDED
+#define OPM_DEBUGTIMEREPORT_HEADER_INCLUDED
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/core/utility/StopWatch.hpp>
+#include <string>
+
+namespace Opm
+{
+
+    class DebugTimeReport
+    {
+    public:
+        explicit DebugTimeReport(const std::string& report_name)
+            : report_name_(report_name)
+        {
+            clock_.start();
+        }
+
+        ~DebugTimeReport()
+        {
+            clock_.stop();
+            std::ostringstream msg;
+            msg << report_name_ << " took: " << clock_.secsSinceStart() << " seconds.";
+            OpmLog::debug(msg.str());
+        }
+
+    private:
+        std::string report_name_;
+        time::StopWatch clock_;
+    };
+
+} // namespace Opm
+
+#endif // OPM_DEBUGTIMEREPORT_HEADER_INCLUDED


### PR DESCRIPTION
This small utility is useful for simple timekeeping for numerical experiments. It reports time since construction when it goes out of scope.

Intend to self-merge when green, as it has no effect whatsoever on other code.