### PR TITLE
Implement TCPU

### DIFF
--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -191,7 +191,7 @@ namespace Opm
 
                 // No per cell data is written for initial step, but will be
                 // for subsequent steps, when we have started simulating
-                output_writer_.writeTimeStepWithoutCellProperties( timer, state, well_state, {} );
+                output_writer_.writeTimeStepWithoutCellProperties( timer, state, well_state, {}, {} );
 
                 report.output_write_time += perfTimer.stop();
             }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -389,7 +389,7 @@ public:
             Dune::Timer perfTimer;
             perfTimer.start();
             const double nextstep = adaptiveTimeStepping ? adaptiveTimeStepping->suggestedNextStep() : -1.0;
-            output_writer_.writeTimeStep( timer, state, well_state, solver->model(), false, nextstep );
+            output_writer_.writeTimeStep( timer, state, well_state, solver->model(), false, nextstep, report);
             report.output_write_time += perfTimer.stop();
 
             prev_well_state = well_state;

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilMultiSegment_impl.hpp
@@ -145,7 +145,7 @@ namespace Opm
             if (timer.initialStep()) {
                 // No per cell data is written for initial step, but will be
                 // for subsequent steps, when we have started simulating
-                output_writer_.writeTimeStepWithoutCellProperties( timer, state, well_state, {} );
+                output_writer_.writeTimeStepWithoutCellProperties( timer, state, well_state, {}, {} );
             }
 
             // Max oil saturation (for VPPARS), hysteresis update.

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -30,6 +30,7 @@
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/core/wells/DynamicListEconLimited.hpp>
 #include <opm/core/simulator/BlackoilState.hpp>
+#include <opm/core/simulator/SimulatorReport.hpp>
 
 #include <opm/output/data/Cells.hpp>
 #include <opm/output/data/Solution.hpp>
@@ -228,8 +229,9 @@ namespace Opm
                            const SimulationDataContainer& reservoirState,
                            const Opm::WellStateFullyImplicitBlackoil& wellState,
                            const Model& physicalModel,
-                           bool substep = false,
-                           const double nextstep = -1.0);
+                           const bool substep = false,
+                           const double nextstep = -1.0,
+                           const SimulatorReport& simulatorReport = SimulatorReport());
 
 
         /*!
@@ -989,8 +991,9 @@ namespace Opm
                   const SimulationDataContainer& localState,
                   const WellStateFullyImplicitBlackoil& localWellState,
                   const Model& physicalModel,
-                  bool substep,
-                  const double nextstep)
+                  const bool substep,
+                  const double nextstep,
+                  const SimulatorReport& simulatorReport)
     {
         data::Solution localCellData{};
         const RestartConfig& restartConfig = eclipseState_.getRestartConfig();
@@ -1022,9 +1025,11 @@ namespace Opm
             // Add suggested next timestep to extra data.
             extraRestartData["OPMEXTRA"] = std::vector<double>(1, nextstep);
 
-            // @@@ HACK @@@
-            // Add TCPU
-            miscSummaryData["TCPU"] = 100.0;
+            // Add TCPU if simulatorReport is not defaulted.
+            const double totalSolverTime = simulatorReport.solver_time;
+            if (totalSolverTime != 0.0) {
+                miscSummaryData["TCPU"] = totalSolverTime;
+            }
         }
 
         writeTimeStepWithCellProperties(timer, localState, localCellData, localWellState, miscSummaryData, extraRestartData, substep);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -235,14 +235,15 @@ namespace Opm
         /*!
          * \brief Write a blackoil reservoir state to disk for later inspection with
          *        visualization tools like ResInsight. This function will write all
-         *        CellData in simProps to the file as well as the extraData.
+         *        CellData in simProps to the file as well as the extraRestartData.
          */
         void writeTimeStepWithCellProperties(
                            const SimulatorTimerInterface& timer,
                            const SimulationDataContainer& reservoirState,
                            const data::Solution& cellData,
                            const Opm::WellStateFullyImplicitBlackoil& wellState,
-                           const std::map<std::string, std::vector<double>>& extraData,
+                           const std::map<std::string, double>& miscSummaryData,
+                           const std::map<std::string, std::vector<double>>& extraRestartData,
                            bool substep = false);
 
         /*!
@@ -254,7 +255,8 @@ namespace Opm
                            const SimulatorTimerInterface& timer,
                            const SimulationDataContainer& reservoirState,
                            const Opm::WellStateFullyImplicitBlackoil& wellState,
-                           const std::map<std::string, std::vector<double>>& extraData,
+                           const std::map<std::string, double>& miscSummaryData,
+                           const std::map<std::string, std::vector<double>>& extraRestartData,
                            bool substep = false);
 
         /*!
@@ -266,7 +268,8 @@ namespace Opm
                                  const SimulationDataContainer& reservoirState,
                                  const Opm::WellStateFullyImplicitBlackoil& wellState,
                                  const data::Solution& simProps,
-                                 const std::map<std::string, std::vector<double>>& extraData,
+                                 const std::map<std::string, double>& miscSummaryData,
+                                 const std::map<std::string, std::vector<double>>& extraRestartData,
                                  bool substep);
 
         /** \brief return output directory */
@@ -994,7 +997,8 @@ namespace Opm
         const SummaryConfig& summaryConfig = eclipseState_.getSummaryConfig();
         const int reportStepNum = timer.reportStepNum();
         bool logMessages = output_ && parallelOutput_->isIORank();
-        std::map<std::string, std::vector<double>> extraData;
+        std::map<std::string, std::vector<double>> extraRestartData;
+        std::map<std::string, double> miscSummaryData;
 
         if( output_ )
         {
@@ -1016,10 +1020,14 @@ namespace Opm
             assert(!localCellData.empty());
 
             // Add suggested next timestep to extra data.
-            extraData["OPMEXTRA"] = std::vector<double>(1, nextstep);
+            extraRestartData["OPMEXTRA"] = std::vector<double>(1, nextstep);
+
+            // @@@ HACK @@@
+            // Add TCPU
+            miscSummaryData["TCPU"] = 100.0;
         }
 
-        writeTimeStepWithCellProperties(timer, localState, localCellData, localWellState, extraData, substep);
+        writeTimeStepWithCellProperties(timer, localState, localCellData, localWellState, miscSummaryData, extraRestartData, substep);
     }
 }
 #endif


### PR DESCRIPTION
This requires OPM/opm-output#191, and adapts opm-simulators to that API change (allowing misc data for summary output). It also takes advantage of that to pass TCPU for summary output (it will only be written if requested in the deck using the TCPU or PERFORMA keywords).

The timing number passed for this is actually the total solver time taken, which does not include output for example. Possibly this should be amended, and expanded with more misc data (iteration counts etc.) as needed.

@alfbr could you see if this is a reasonable match for your needs?