### PR TITLE
Not switching the order of well primary variables and well equations

### DIFF
--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -174,8 +174,6 @@ enum WellVariablePositions {
 
             int flowPhaseToEbosPhaseIdx( const int phaseIdx ) const;
 
-            int ebosCompToFlowPhaseIdx( const int compIdx ) const;
-
             std::vector<double>
             extractPerfData(const std::vector<double>& in) const;
 

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -209,7 +209,7 @@ namespace Opm {
                     }
 
                     // subtract sum of phase fluxes in the well equations.
-                    resWell_[w][flowPhaseToEbosCompIdx(componentIdx)] -= cq_s[componentIdx].value();
+                    resWell_[w][componentIdx] -= cq_s[componentIdx].value();
 
                     // assemble the jacobians
                     for (int pvIdx = 0; pvIdx < numWellEq; ++pvIdx) {
@@ -217,15 +217,15 @@ namespace Opm {
                             // also need to consider the efficiency factor when manipulating the jacobians.
                             ebosJac[cell_idx][cell_idx][flowPhaseToEbosCompIdx(componentIdx)][flowToEbosPvIdx(pvIdx)] -= cq_s_effective.derivative(pvIdx);
                             duneB_[w][cell_idx][pvIdx][flowPhaseToEbosCompIdx(componentIdx)] -= cq_s_effective.derivative(pvIdx+numEq); // intput in transformed matrix
-                            duneC_[w][cell_idx][flowPhaseToEbosCompIdx(componentIdx)][flowToEbosPvIdx(pvIdx)] -= cq_s_effective.derivative(pvIdx);
+                            duneC_[w][cell_idx][componentIdx][flowToEbosPvIdx(pvIdx)] -= cq_s_effective.derivative(pvIdx);
                         }
-                        invDuneD_[w][w][flowPhaseToEbosCompIdx(componentIdx)][pvIdx] -= cq_s[componentIdx].derivative(pvIdx+numEq);
+                        invDuneD_[w][w][componentIdx][pvIdx] -= cq_s[componentIdx].derivative(pvIdx+numEq);
                     }
 
                     // add trivial equation for 2p cases (Only support water + oil)
                     if (numComp == 2) {
                         assert(!active_[ Gas ]);
-                        invDuneD_[w][w][flowPhaseToEbosCompIdx(Gas)][Gas] = 1.0;
+                        invDuneD_[w][w][Gas][Gas] = 1.0;
                     }
 
                     // Store the perforation phase flux for later usage.
@@ -245,9 +245,9 @@ namespace Opm {
                 EvalWell resWell_loc = (wellSurfaceVolumeFraction(w, componentIdx) - F0_[w + nw*componentIdx]) * volume / dt;
                 resWell_loc += getQs(w, componentIdx);
                 for (int pvIdx = 0; pvIdx < numWellEq; ++pvIdx) {
-                    invDuneD_[w][w][flowPhaseToEbosCompIdx(componentIdx)][pvIdx] += resWell_loc.derivative(pvIdx+numEq);
+                    invDuneD_[w][w][componentIdx][pvIdx] += resWell_loc.derivative(pvIdx+numEq);
                 }
-                resWell_[w][flowPhaseToEbosCompIdx(componentIdx)] += resWell_loc.value();
+                resWell_[w][componentIdx] += resWell_loc.value();
             }
         }
 
@@ -968,10 +968,9 @@ namespace Opm {
         const int numComp = numComponents();
         std::vector<double> res(numComp*nw);
         for( int compIdx = 0; compIdx < numComp; ++compIdx) {
-            const int ebosCompIdx = flowPhaseToEbosCompIdx(compIdx);
             for (int wellIdx = 0; wellIdx < nw; ++wellIdx) {
                 int idx = wellIdx + nw*compIdx;
-                res[idx] = resWell_[ wellIdx ][ ebosCompIdx ];
+                res[idx] = resWell_[ wellIdx ][ compIdx ];
             }
         }
         return res;

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -502,20 +502,6 @@ namespace Opm {
 
 
     template<typename TypeTag>
-    int
-    StandardWellsDense<TypeTag>::
-    ebosCompToFlowPhaseIdx( const int compIdx ) const
-    {
-        assert(compIdx < 3);
-        const int compToPhase[ 3 ] = { Oil, Water, Gas };
-        return compToPhase[ compIdx ];
-    }
-
-
-
-
-
-    template<typename TypeTag>
     std::vector<double>
     StandardWellsDense<TypeTag>::
     extractPerfData(const std::vector<double>& in) const


### PR DESCRIPTION
This PR contains the following contents related to StandardWellsDense
1. remove the order switching of well primary variables 
2. remove the order switching of well equations. 
3. remove the unused function `ebosCompToFlowPhaseIdx`

Notably, this PR only contains removal of stuff. 

Since the solvent related variable/equation currently always holds the last position, we omit the solvent related in the following discussion. The first change is more significant than the second one. We discuss mostly about the first change. 

In the well state, we assume the information in `wellSolution` in order is  bhp/rate, water fraction, gas fraction. 
 
In the function `assembleWellEq`, we use `flowToEbosPvIdx` to switch the order of the well primary variables a little bit, while the definition of the `flowToEbosPvIdx` is related to the order of the primary variables of the mass balance equations of the reservoir, which is not related to the well primary variables at all. And further, in `updateWellState`, we use `flowPhaseToEbosCompIdx` to switch back the orders of the well primary variables to obtain the correct increments for the well primary variables.  And again, the definition of the `flowPhaseToEbosCompIdx` is not related to well primary variables at all. 
 
In this PR I suggest to remove the switching of the order of well primary variables. 

The switching of the order of well equations also makes the extension more complicated.  

It is not a very difficult while sometimes a little confusing problem to me. Please excuse and correct me if any of the above statement is false. 