### PR TITLE
Refactor sequential solver

### DIFF
--- a/examples/flow_sequential.cpp
+++ b/examples/flow_sequential.cpp
@@ -25,6 +25,9 @@
 #include <opm/core/grid.h>
 #include <opm/autodiff/SimulatorSequentialBlackoil.hpp>
 #include <opm/autodiff/FlowMainSequential.hpp>
+#include <opm/autodiff/BlackoilPressureModel.hpp>
+#include <opm/autodiff/BlackoilTransportModel.hpp>
+#include <opm/autodiff/StandardWells.hpp>
 
 
 // ----------------- Main program -----------------
@@ -32,7 +35,8 @@ int
 main(int argc, char** argv)
 {
     typedef UnstructuredGrid Grid;
-    typedef Opm::SimulatorSequentialBlackoil<Grid> Simulator;
+    typedef Opm::StandardWells WellModel;
+    typedef Opm::SimulatorSequentialBlackoil<Grid, WellModel, Opm::BlackoilPressureModel, Opm::BlackoilTransportModel> Simulator;
 
     Opm::FlowMainSequential<Grid, Simulator> mainfunc;
     return mainfunc.execute(argc, argv);

--- a/opm/autodiff/BlackoilSequentialModel.hpp
+++ b/opm/autodiff/BlackoilSequentialModel.hpp
@@ -23,8 +23,6 @@
 
 
 #include <opm/autodiff/BlackoilModelBase.hpp>
-#include <opm/autodiff/BlackoilPressureModel.hpp>
-#include <opm/autodiff/BlackoilTransportModel.hpp>
 #include <opm/core/simulator/BlackoilState.hpp>
 #include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
 #include <opm/autodiff/BlackoilModelParameters.hpp>
@@ -44,7 +42,9 @@ namespace Opm {
 
 
     /// A sequential splitting model implementation for three-phase black oil.
-    template<class Grid, class WellModel>
+    template<class Grid, class WellModel,
+             template <class G, class W> class PressureModelT,
+             template <class G, class W> class TransportModelT>
     class BlackoilSequentialModel
     {
     public:
@@ -297,6 +297,8 @@ namespace Opm {
         { return failureReport_; }
 
     protected:
+        typedef PressureModelT<Grid, WellModel> PressureModel;
+        typedef TransportModelT<Grid, WellModel> TransportModel;
         typedef NonlinearSolver<PressureModel> PressureSolver;
         typedef NonlinearSolver<TransportModel> TransportSolver;
 

--- a/opm/autodiff/BlackoilSequentialModel.hpp
+++ b/opm/autodiff/BlackoilSequentialModel.hpp
@@ -88,11 +88,18 @@ namespace Opm {
                                             linsolver, eclState, has_disgas, has_vapoil, terminal_output)),
           transport_model_(new TransportModel(param, grid, fluid, geo, rock_comp_props, well_model,
                                               linsolver, eclState, has_disgas, has_vapoil, terminal_output)),
+          // TODO: fix solver parameters for pressure and transport solver.
           pressure_solver_(typename PressureSolver::SolverParameters(), std::move(pressure_model_)),
           transport_solver_(typename TransportSolver::SolverParameters(), std::move(transport_model_)),
           initial_reservoir_state_(0, 0, 0), // will be overwritten
           iterate_to_fully_implicit_(param.iterate_to_fully_implicit)
         {
+            typename PressureSolver::SolverParameters pp;
+            pp.min_iter_ = 0;
+            pressure_solver_.setParameters(pp);
+            typename TransportSolver::SolverParameters tp;
+            tp.min_iter_ = 0;
+            transport_solver_.setParameters(tp);
         }
 
 

--- a/opm/autodiff/BlackoilSequentialModel.hpp
+++ b/opm/autodiff/BlackoilSequentialModel.hpp
@@ -53,8 +53,11 @@ namespace Opm {
         typedef BlackoilSequentialModelParameters ModelParameters;
         typedef DefaultBlackoilSolutionState SolutionState;
 
-        typedef BlackoilPressureModel<Grid, WellModel> PressureModel;
-        typedef BlackoilTransportModel<Grid, WellModel> TransportModel;
+        typedef PressureModelT<Grid, WellModel> PressureModel;
+        typedef TransportModelT<Grid, WellModel> TransportModel;
+        typedef NonlinearSolver<PressureModel> PressureSolver;
+        typedef NonlinearSolver<TransportModel> TransportSolver;
+
         typedef typename TransportModel::SimulatorData SimulatorData;
         typedef typename TransportModel::FIPDataType   FIPDataType;
 
@@ -297,11 +300,6 @@ namespace Opm {
         { return failureReport_; }
 
     protected:
-        typedef PressureModelT<Grid, WellModel> PressureModel;
-        typedef TransportModelT<Grid, WellModel> TransportModel;
-        typedef NonlinearSolver<PressureModel> PressureSolver;
-        typedef NonlinearSolver<TransportModel> TransportSolver;
-
         SimulatorReport failureReport_;
 
         std::unique_ptr<PressureModel> pressure_model_;

--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -169,10 +169,13 @@ namespace Opm {
         double relaxRelTol() const       { return param_.relax_rel_tol_; }
 
         /// The maximum number of nonlinear iterations allowed.
-        int maxIter() const           { return param_.max_iter_; }
+        int maxIter() const              { return param_.max_iter_; }
 
         /// The minimum number of nonlinear iterations allowed.
-        double minIter() const           { return param_.min_iter_; }
+        int minIter() const              { return param_.min_iter_; }
+
+        /// Set parameters to override those given at construction time.
+        void setParameters(SolverParameters param) { param_ = param; }
 
     private:
         // ---------  Data members  ---------

--- a/opm/autodiff/NonlinearSolver.hpp
+++ b/opm/autodiff/NonlinearSolver.hpp
@@ -175,7 +175,7 @@ namespace Opm {
         int minIter() const              { return param_.min_iter_; }
 
         /// Set parameters to override those given at construction time.
-        void setParameters(SolverParameters param) { param_ = param; }
+        void setParameters(const SolverParameters& param) { param_ = param; }
 
     private:
         // ---------  Data members  ---------

--- a/opm/autodiff/SimulatorSequentialBlackoil.hpp
+++ b/opm/autodiff/SimulatorSequentialBlackoil.hpp
@@ -24,32 +24,36 @@
 #include <opm/autodiff/SimulatorBase.hpp>
 #include <opm/autodiff/NonlinearSolver.hpp>
 #include <opm/autodiff/BlackoilSequentialModel.hpp>
-#include <opm/autodiff/StandardWells.hpp>
 
 namespace Opm {
 
-template <class GridT>
+template <class GridT, class WellModelT,
+          template <class G, class W> class PressureModel,
+          template <class G, class W> class TransportModel>
 class SimulatorSequentialBlackoil;
-class StandardWells;
 
-template <class GridT>
-struct SimulatorTraits<SimulatorSequentialBlackoil<GridT> >
+template <class GridT, class WellModelT,
+          template <class G, class W> class PressureModel,
+          template <class G, class W> class TransportModel>
+struct SimulatorTraits<SimulatorSequentialBlackoil<GridT, WellModelT, PressureModel, TransportModel> >
 {
     typedef WellStateFullyImplicitBlackoil WellState;
     typedef BlackoilState ReservoirState;
     typedef BlackoilOutputWriter OutputWriter;
     typedef GridT Grid;
-    typedef BlackoilSequentialModel<Grid, StandardWells> Model;
+    typedef BlackoilSequentialModel<Grid, StandardWells, PressureModel, TransportModel> Model;
     typedef NonlinearSolver<Model> Solver;
-    typedef StandardWells WellModel;
+    typedef WellModelT WellModel;
 };
 
 /// a simulator for the blackoil model
-template <class GridT>
+template <class GridT, class WellModelT,
+          template <class G, class W> class PressureModel,
+          template <class G, class W> class TransportModel>
 class SimulatorSequentialBlackoil
-    : public SimulatorBase<SimulatorSequentialBlackoil<GridT> >
+    : public SimulatorBase<SimulatorSequentialBlackoil<GridT, WellModelT, PressureModel, TransportModel> >
 {
-    typedef SimulatorBase<SimulatorSequentialBlackoil<GridT> > Base;
+    typedef SimulatorBase<SimulatorSequentialBlackoil<GridT, WellModelT, PressureModel, TransportModel> > Base;
 public:
     // forward the constructor to the base class
     SimulatorSequentialBlackoil(const ParameterGroup& param,


### PR DESCRIPTION
This PR refactors the sequential solver, in preparation for the reordering solver. It also includes a proper convergence check for its "iterate_to_fully_implicit" option.

The only part of this that affects (fully implicit) Flow is the NonlinearSolver class, which receives a new setter member (unused from Flow) and fixing the return value type of minIter(), which is int not double.