### PR TITLE
update polymer integration test for new data file path

### DIFF
--- a/jenkins/run-polymer.sh
+++ b/jenkins/run-polymer.sh
@@ -4,15 +4,15 @@ pushd .
 cd deps/opm-data
 
 # Run the simple2D polymer case
-cd polymer_test_suite/simple2D
+cd polymer_simple2D
 $WORKSPACE/$configuration/build-opm-simulators/bin/flow_polymer run.param
 test $? -eq 0 || exit 1
-cd ../..
+cd ..
 
 # Compare OPM with eclipse reference
 compareECL=$WORKSPACE/$configuration/install/bin/compareECL
-reffile=polymer_test_suite/simple2D/eclipse-simulation/2D_THREEPHASE_POLY_HETER
-opmfile=polymer_test_suite/simple2D/opm-simulation/2D_THREEPHASE_POLY_HETER
+reffile=polymer_simple2D/eclipse-simulation/2D_THREEPHASE_POLY_HETER
+opmfile=polymer_simple2D/opm-simulation-reference/flow_polymer/2D_THREEPHASE_POLY_HETER
 $compareECL $reffile $opmfile 1.0 0.004 -k SGAS
 test $? -eq 0 || exit 1
 $compareECL $reffile $opmfile 1.0 0.004 -k SWAT


### PR DESCRIPTION
The data path was updated to add a regression test, but that has halted for various reasons. This is the bit needed to make the integration test run again.