### PR TITLE
Improve stability by changing the convergence check

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -27,7 +27,7 @@ macro (add_test_compareECLFiles casename filename simulator abs_tol rel_tol pref
     set(DIR ${casename})
   endif()
   if(${ARGC} GREATER 8)
-    set(TEST_ARGS ${OPM_DATA_ROOT}/${DIR}/${ARGV1} deckfilename=${OPM_DATA_ROOT}/${DIR}/${filename})
+    set(TEST_ARGS ${OPM_DATA_ROOT}/${DIR}/${ARGV8} deck_filename=${OPM_DATA_ROOT}/${DIR}/${filename}.DATA)
   else()
     set(TEST_ARGS ${OPM_DATA_ROOT}/${DIR}/${filename})
   endif()
@@ -113,8 +113,8 @@ add_test_compareECLFiles(spe3 SPE3CASE1 flow_legacy ${abs_tol} ${rel_tol} compar
 add_test_compareECLFiles(spe9 SPE9_CP_SHORT flow_ebos ${abs_tol} ${rel_tol} compareECLFiles "")
 add_test_compareECLFiles(spe9 SPE9_CP_SHORT flow_legacy ${abs_tol} ${rel_tol} compareECLFiles "")
 add_test_compareECLFiles(msw_2d_h 2D_H__ flow_multisegment ${abs_tol} ${rel_tol} compareECLFiles "")
-add_test_compareECLFiles(polymer_simple2D 2D_THREEPHASE_POLY_HETER flow_polymer ${abs_tol} ${rel_tol} compareECLFiles "" polymer_simple2D run.param)
-add_test_compareECLFiles(spe5 SPE5CASE1 flow_solvent ${abs_tol} ${rel_tol} compareECLFiles "")
+add_test_compareECLFiles(polymer_simple2D 2D_THREEPHASE_POLY_HETER flow_polymer ${abs_tol} ${rel_tol} compareECLFiles "")
+add_test_compareECLFiles(spe5 SPE5CASE1 flow_solvent ${abs_tol} ${rel_tol} compareECLFiles "" spe5 run.param)
 
 # Restart tests
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-restart-regressionTest.sh "")

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -979,7 +979,7 @@ namespace Opm {
 
             // do not care about the cell based residual in the last two Newton
             // iterations
-            if (iteration < param_.max_iter_ - 2)
+            if (iteration < param_.max_strict_iter_)
                 converged = converged && converged_CNV;
 
             if ( terminal_output_ )

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -975,7 +975,12 @@ namespace Opm {
                 residual_norms.push_back(CNV[compIdx]);
             }
 
-            const bool converged = converged_MB && converged_CNV && converged_Well;
+            bool converged = converged_MB && converged_Well;
+
+            // do not care about the cell based residual in the last two Newton
+            // iterations
+            if (iteration < param_.max_iter_ - 2)
+                converged = converged && converged_CNV;
 
             if ( terminal_output_ )
             {

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -52,7 +52,7 @@ namespace Opm
         tolerance_well_control_ = param.getDefault("tolerance_well_control", tolerance_well_control_);
         maxSinglePrecisionTimeStep_ = unit::convert::from(
                 param.getDefault("max_single_precision_days", unit::convert::to( maxSinglePrecisionTimeStep_, unit::day) ), unit::day );
-        max_iter_ = param.getDefault("max_iter",15);
+        max_iter_ = param.getDefault("max_iter",10);
         solve_welleq_initially_ = param.getDefault("solve_welleq_initially",solve_welleq_initially_);
         update_equations_scaling_ = param.getDefault("update_equations_scaling", update_equations_scaling_);
         use_update_stabilization_ = param.getDefault("use_update_stabilization", use_update_stabilization_);

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -52,7 +52,7 @@ namespace Opm
         tolerance_well_control_ = param.getDefault("tolerance_well_control", tolerance_well_control_);
         maxSinglePrecisionTimeStep_ = unit::convert::from(
                 param.getDefault("max_single_precision_days", unit::convert::to( maxSinglePrecisionTimeStep_, unit::day) ), unit::day );
-        max_iter_ = param.getDefault("max_iter",10);
+        max_strict_iter_ = param.getDefault("max_strict_iter",8);
         solve_welleq_initially_ = param.getDefault("solve_welleq_initially",solve_welleq_initially_);
         update_equations_scaling_ = param.getDefault("update_equations_scaling", update_equations_scaling_);
         use_update_stabilization_ = param.getDefault("use_update_stabilization", use_update_stabilization_);

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -52,6 +52,7 @@ namespace Opm
         tolerance_well_control_ = param.getDefault("tolerance_well_control", tolerance_well_control_);
         maxSinglePrecisionTimeStep_ = unit::convert::from(
                 param.getDefault("max_single_precision_days", unit::convert::to( maxSinglePrecisionTimeStep_, unit::day) ), unit::day );
+        max_iter_ = param.getDefault("max_iter",15);
         solve_welleq_initially_ = param.getDefault("solve_welleq_initially",solve_welleq_initially_);
         update_equations_scaling_ = param.getDefault("update_equations_scaling", update_equations_scaling_);
         use_update_stabilization_ = param.getDefault("use_update_stabilization", use_update_stabilization_);

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -56,8 +56,8 @@ namespace Opm
         /// for solving for the Jacobian
         double maxSinglePrecisionTimeStep_;
 
-        /// Maximum number of Newton iterations before we give up
-        int max_iter_;
+        /// Maximum number of Newton iterations before we give up on the CNV convergence criterion
+        int max_strict_iter_;
 
         /// Solve well equation initially
         bool solve_welleq_initially_;

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -56,6 +56,9 @@ namespace Opm
         /// for solving for the Jacobian
         double maxSinglePrecisionTimeStep_;
 
+        /// Maximum number of Newton iterations before we give up
+        int max_iter_;
+
         /// Solve well equation initially
         bool solve_welleq_initially_;
 

--- a/opm/autodiff/NonlinearSolver_impl.hpp
+++ b/opm/autodiff/NonlinearSolver_impl.hpp
@@ -184,7 +184,7 @@ namespace Opm
         relax_max_       = 0.5;
         relax_increment_ = 0.1;
         relax_rel_tol_   = 0.2;
-        max_iter_        = 15;
+        max_iter_        = 10;
         min_iter_        = 1;
     }
 


### PR DESCRIPTION
This PR reduces the maximum number of Newton iterations from 15 to 10, and -- more importantly -- it ignores the maximum-residual-in-all-cells criterion (CNV) for the nineth and the tenth iterations, i.e., after iteration 8 only the aggregate mass balance and the well residual criterions are considered.

I've tested this on Norne, Model 2, Model 2 realization 0 and realization 5 and I made sure that all opm-simulators tests still pass on my machine. With this PR merged, the simulator seems to be significantly more stable (e.g. it works fine with OPM/opm-material#220 applied) and performance seems to also improve by 5 to 10% even for cases  where complete breakdowns do not occur, i.e. Norne.

The results of the unit tests stay identical. That said, since the time stepping is different, the results produced for Norne are slightly different from the current master version. This considered, one needs a magnifying glass to see the difference and on average the result curves are not further away from those of E100 than the current master. 