### PR TITLE
remove debug info from convergence failure terminal output

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -251,6 +251,7 @@ namespace Opm {
             }
             catch (const Opm::LinearSolverProblem& e) {
                 substepReport += solver.failureReport();
+                cause_of_failure = "Linear Solver convergence failure";
 
                 detail::logException(e, solver_verbose_);
                 // since linearIterations is < 0 this will restart the solver

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -258,6 +258,7 @@ namespace Opm {
             }
             catch (const Opm::NumericalProblem& e) {
                 substepReport += solver.failureReport();
+                cause_of_failure = "Solver convergence failure - Numerical problem encountered";
 
                 detail::logException(e, solver_verbose_);
                 // since linearIterations is < 0 this will restart the solver

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -242,9 +242,21 @@ namespace Opm {
                     OpmLog::note("Overall linear iterations used: " + std::to_string(substepReport.total_linear_iterations));
                 }
             }
+            catch (const Opm::TooManyIterations& e) {
+                substepReport += solver.failureReport();
+                cause_of_failure = "Solver convergence failure - Iteration limit reached";
+
+                detail::logException(e, solver_verbose_);
+                // since linearIterations is < 0 this will restart the solver
+            }
+            catch (const Opm::LinearSolverProblem& e) {
+                substepReport += solver.failureReport();
+
+                detail::logException(e, solver_verbose_);
+                // since linearIterations is < 0 this will restart the solver
+            }
             catch (const Opm::NumericalProblem& e) {
                 substepReport += solver.failureReport();
-                cause_of_failure = e.what();
 
                 detail::logException(e, solver_verbose_);
                 // since linearIterations is < 0 this will restart the solver
@@ -357,7 +369,7 @@ namespace Opm {
                 if( solver_verbose_ ) {
                     std::string msg;
                     msg = cause_of_failure + "\n         Timestep chopped to "
-                        + std::to_string(unit::convert::to( substepTimer.currentStepLength(), unit::day )) + " days.\n";
+                        + std::to_string(unit::convert::to( substepTimer.currentStepLength(), unit::day )) + " days\n";
                     OpmLog::problem(msg);
                 }
                 // reset states


### PR DESCRIPTION
This PR removes the debug info introduced to the terminal output through #1168 and also adds more detailed catch blocks for `NumericalProblems`. However, the `maxiter()` information is removed from the terminal output but can still be viewed in the debug file.