### PR TITLE
Reordering transport model

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -173,6 +173,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/autodiff/BlackoilSolventModel_impl.hpp
   opm/autodiff/BlackoilMultiSegmentModel.hpp
   opm/autodiff/BlackoilMultiSegmentModel_impl.hpp
+  opm/autodiff/BlackoilReorderingTransportModel.hpp
   opm/autodiff/BlackoilTransportModel.hpp
   opm/autodiff/fastSparseOperations.hpp
   opm/autodiff/DebugTimeReport.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -110,6 +110,7 @@ list (APPEND TEST_DATA_FILES
 list (APPEND EXAMPLE_SOURCE_FILES
   examples/find_zero.cpp
   examples/flow_legacy.cpp
+  examples/flow_reorder.cpp
   examples/flow_sequential.cpp
   examples/flow_ebos.cpp
   examples/flow_ebos_solvent.cpp
@@ -137,6 +138,7 @@ list (APPEND PROGRAM_SOURCE_FILES
   examples/flow_ebos_solvent.cpp
   examples/flow_ebos_polymer.cpp
   examples/flow_legacy.cpp
+  examples/flow_reorder.cpp
   examples/flow_sequential.cpp
   examples/flow_solvent.cpp
   examples/opm_init_check.cpp

--- a/examples/flow_reorder.cpp
+++ b/examples/flow_reorder.cpp
@@ -1,0 +1,43 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
+
+#include <opm/core/grid.h>
+#include <opm/autodiff/SimulatorSequentialBlackoil.hpp>
+#include <opm/autodiff/FlowMainSequential.hpp>
+#include <opm/autodiff/BlackoilPressureModel.hpp>
+#include <opm/autodiff/BlackoilReorderingTransportModel.hpp>
+#include <opm/autodiff/StandardWells.hpp>
+
+
+// ----------------- Main program -----------------
+int
+main(int argc, char** argv)
+{
+    typedef UnstructuredGrid Grid;
+    typedef Opm::StandardWells WellModel;
+    typedef Opm::SimulatorSequentialBlackoil<Grid, WellModel, Opm::BlackoilPressureModel, Opm::BlackoilReorderingTransportModel> Simulator;
+
+    Opm::FlowMainSequential<Grid, Simulator> mainfunc;
+    return mainfunc.execute(argc, argv);
+}

--- a/opm/autodiff/BlackoilPressureModel.hpp
+++ b/opm/autodiff/BlackoilPressureModel.hpp
@@ -294,7 +294,7 @@ namespace Opm {
 
         bool getConvergence(const SimulatorTimerInterface& /* timer */, const int iteration)
         {
-            const double tol_p = 1e-11;
+            const double tol_p = 1e-10;
             const double resmax = residual_.material_balance_eq[0].value().abs().maxCoeff();
             if (Base::terminalOutputEnabled()) {
                 // Only rank 0 does print to std::cout

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -451,6 +451,12 @@ namespace Opm
             return *materialLawManager_;
         }
 
+        // Direct access to pvt region indices.
+        const std::vector<int>& pvtRegions() const
+        {
+            return cellPvtRegionIdx_;
+        }
+
 
     private:
         /// Initializes the properties.

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -430,19 +430,19 @@ namespace Opm
         /// Direct access to lower-level water pvt props.
         const WaterPvt& waterProps() const
         {
-            return *waterPvt_;
+            return FluidSystem::waterPvt();
         }
 
         /// Direct access to lower-level oil pvt props.
         const OilPvt& oilProps() const
         {
-            return *oilPvt_;
+            return FluidSystem::oilPvt();
         }
 
         /// Direct access to lower-level gas pvt props.
         const GasPvt& gasProps() const
         {
-            return *gasPvt_;
+            return FluidSystem::gasPvt();
         }
 
         /// Direct access to lower-level saturation functions.

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -427,6 +427,30 @@ namespace Opm
         /// \return Array of scaled critical gas saturaion values.
         V scaledCriticalGasSaturations(const Cells& cells) const;
 
+        /// Direct access to lower-level water pvt props.
+        const WaterPvt& waterProps() const
+        {
+            return *waterPvt_;
+        }
+
+        /// Direct access to lower-level oil pvt props.
+        const OilPvt& oilProps() const
+        {
+            return *oilPvt_;
+        }
+
+        /// Direct access to lower-level gas pvt props.
+        const GasPvt& gasProps() const
+        {
+            return *gasPvt_;
+        }
+
+        /// Direct access to lower-level saturation functions.
+        const MaterialLawManager& materialLaws() const
+        {
+            return *materialLawManager_;
+        }
+
 
     private:
         /// Initializes the properties.

--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -685,10 +685,11 @@ namespace Opm {
                 const int other = from == cell ? to : from;
                 const double vt = (from == cell) ? total_flux_[conn.index] : -total_flux_[conn.index];
 
-                // From this point, we treat everything about this connection as going
-                // from 'cell' to 'other'. Since we don't want derivatives from the 'other'
-                // cell to participate in the solution, we must be careful to use .value
-                // to avoid creating trouble.
+                // From this point, we treat everything about this
+                // connection as going from 'cell' to 'other'. Since
+                // we don't want derivatives from the 'other' cell to
+                // participate in the solution, we use the constant
+                // values from cstate_[other].
                 Eval dh[3];
                 Eval dh_sat[3];
                 for (int phase : { Water, Oil, Gas }) {
@@ -707,6 +708,9 @@ namespace Opm {
                                                             {{ m1[Water].value, m1[Oil].value, m1[Gas].value }},
                                                             {{ m2[Water], m2[Oil], m2[Gas] }},
                                                             tran, vt);
+                if (upw[0] != upw[1] || upw[1] != upw[2]) {
+                    OpmLog::debug("Detected countercurrent flow between cells " + std::to_string(from) + " and " + std::to_string(to));
+                }
                 Eval b[3];
                 Eval mob[3];
                 Eval tot_mob = Eval::createConstant(0.0);
@@ -749,8 +753,8 @@ namespace Opm {
 
         bool getConvergence(const Vec2& res)
         {
-            const double tol = 1e-6;
-            return res[0] < tol && res[1] < tol;
+            const double tol = 1e-9;
+            return std::fabs(res[0]) < tol && std::fabs(res[1] < tol);
         }
 
 

--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -774,7 +774,7 @@ namespace Opm {
             double* s = state_.reservoir_state.saturation().data() + 3*cell;
             s[Water] += sfactor*dsw;
             s[Gas] += sfactor*dsg;
-            s[Oil] = 1.0 - s[Water] - s[Oil];
+            s[Oil] = 1.0 - s[Water] - s[Gas];
 
             // Handle < 0 saturations.
             for (int phase : { Gas, Oil, Water }) { // TODO: check if ordering here is significant

--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -697,7 +697,8 @@ namespace Opm {
                 }
                 assert((from == cell) == (conn.sign > 0.0));
                 const int other = from == cell ? to : from;
-                const double vt = (from == cell) ? total_flux_[conn.index] : -total_flux_[conn.index];
+                const double vt = conn.sign * total_flux_[conn.index];
+                const double gdz = conn.sign * gdz_[conn.index];
 
                 // From this point, we treat everything about this
                 // connection as going from 'cell' to 'other'. Since
@@ -709,10 +710,10 @@ namespace Opm {
                 for (int phase : { Water, Oil, Gas }) {
                     const Eval gradp = cstate_[other].p[phase] - st.p[phase];
                     const Eval rhoavg = 0.5 * (st.rho[phase] + cstate_[other].rho[phase]);
-                    dh[phase] = gradp - rhoavg * gdz_[conn.index];
-                    dh_sat[phase] = rhoavg * gdz_[conn.index];
+                    dh[phase] = gradp - rhoavg * gdz;
+                    dh_sat[phase] = rhoavg * gdz; // TODO: not equivalent to formulation in BlackoilTransportModel for cap. press.
                     if (Base::use_threshold_pressure_) {
-                        applyThresholdPressure(conn.index, dh[phase]); // Should also dh_sat be treated here?
+                        applyThresholdPressure(conn.index, dh[phase]); // TODO: Should also dh_sat be treated here? Also: dh is unused, this has no effect!
                     }
                 }
                 const double tran = trans_all_[conn.index]; // TODO: include tr_mult effect.

--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -310,6 +310,7 @@ namespace Opm {
             }
 
             // Update states for output.
+            reservoir_state = state_.reservoir_state;
 
             // Create report and exit.
             const bool failed = false;

--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -258,11 +258,11 @@ namespace Opm {
 
 
 
-        void prepareStep(const double dt,
+        void prepareStep(const SimulatorTimerInterface& timer,
                          const ReservoirState& reservoir_state,
                          const WellState& well_state)
         {
-            Base::prepareStep(dt, reservoir_state, well_state);
+            Base::prepareStep(timer, reservoir_state, well_state);
             Base::param_.solve_welleq_initially_ = false;
             state0_.reservoir_state = reservoir_state;
             state0_.well_state = well_state;
@@ -285,7 +285,7 @@ namespace Opm {
 
         template <class NonlinearSolverType>
         IterationReport nonlinearIteration(const int /* iteration */,
-                                           const double /* dt */,
+                                           const SimulatorTimerInterface& /* timer */,
                                            NonlinearSolverType& /* nonlinear_solver */,
                                            ReservoirState& reservoir_state,
                                            const WellState& well_state)
@@ -324,7 +324,7 @@ namespace Opm {
 
 
 
-        void afterStep(const double /* dt */,
+        void afterStep(const SimulatorTimerInterface& /* timer */,
                        const ReservoirState& /* reservoir_state */,
                        const WellState& /* well_state */)
         {

--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -324,7 +324,7 @@ namespace Opm {
             {
                 auto rs = reservoir_state;
                 auto ws = well_state;
-                tr_model_.nonlinearIteration(iteration, timer, nonlinear_solver, rs, ws);
+                tr_model_.nonlinearIteration(/*iteration*/ 0, timer, nonlinear_solver, rs, ws);
             }
 
             // Create report and exit.
@@ -830,7 +830,7 @@ namespace Opm {
 
         bool getConvergence(const int cell, const Vec2& res)
         {
-            const double tol = 1e-5;
+            const double tol = 1e-7;
             // Compute scaled residuals (scaled like saturations).
             double sres[] = { res[0] / (cstate_[cell].b[Oil] * Base::pvdt_[cell]),
                               res[1] / (cstate_[cell].b[Gas] * Base::pvdt_[cell]) };

--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -1,0 +1,261 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_BLACKOILREORDERINGTRANSPORTMODEL_HEADER_INCLUDED
+#define OPM_BLACKOILREORDERINGTRANSPORTMODEL_HEADER_INCLUDED
+
+#include <opm/autodiff/BlackoilModelBase.hpp>
+#include <opm/core/simulator/BlackoilState.hpp>
+#include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/autodiff/BlackoilModelParameters.hpp>
+#include <opm/core/grid.h>
+#include <opm/autodiff/DebugTimeReport.hpp>
+#include <opm/core/transport/reorder/reordersequence.h>
+
+namespace Opm {
+
+    /// A model implementation for the transport equation in three-phase black oil.
+    template<class Grid, class WellModel>
+    class BlackoilReorderingTransportModel
+        : public BlackoilModelBase<Grid, WellModel, BlackoilReorderingTransportModel<Grid, WellModel> >
+    {
+    public:
+        typedef BlackoilModelBase<Grid, WellModel, BlackoilReorderingTransportModel<Grid, WellModel> > Base;
+        friend Base;
+
+        typedef typename Base::ReservoirState ReservoirState;
+        typedef typename Base::WellState WellState;
+        typedef typename Base::SolutionState SolutionState;
+        typedef typename Base::V V;
+
+
+        /// Construct the model. It will retain references to the
+        /// arguments of this functions, and they are expected to
+        /// remain in scope for the lifetime of the solver.
+        /// \param[in] param            parameters
+        /// \param[in] grid             grid data structure
+        /// \param[in] fluid            fluid properties
+        /// \param[in] geo              rock properties
+        /// \param[in] rock_comp_props  if non-null, rock compressibility properties
+        /// \param[in] wells_arg        well structure
+        /// \param[in] linsolver        linear solver
+        /// \param[in] eclState         eclipse state
+        /// \param[in] has_disgas       turn on dissolved gas
+        /// \param[in] has_vapoil       turn on vaporized oil feature
+        /// \param[in] terminal_output  request output to cout/cerr
+        BlackoilReorderingTransportModel(const typename Base::ModelParameters&   param,
+                               const Grid&                             grid,
+                               const BlackoilPropsAdInterface&         fluid,
+                               const DerivedGeology&                   geo,
+                               const RockCompressibility*              rock_comp_props,
+                               const StandardWells&                    std_wells,
+                               const NewtonIterationBlackoilInterface& linsolver,
+                               Opm::EclipseStateConstPtr               eclState,
+                               const bool                              has_disgas,
+                               const bool                              has_vapoil,
+                               const bool                              terminal_output)
+            : Base(param, grid, fluid, geo, rock_comp_props, std_wells, linsolver,
+                   eclState, has_disgas, has_vapoil, terminal_output)
+            , reservoir_state0_(0, 0, 0)
+            , well_state0_()
+        {
+        }
+
+
+
+
+
+        void prepareStep(const double dt,
+                         const ReservoirState& reservoir_state,
+                         const WellState& well_state)
+        {
+            Base::prepareStep(dt, reservoir_state, well_state);
+            Base::param_.solve_welleq_initially_ = false;
+            reservoir_state0_ = reservoir_state;
+            well_state0_ = well_state;
+        }
+
+
+
+
+
+        template <class NonlinearSolverType>
+        IterationReport nonlinearIteration(const int /* iteration */,
+                                           const double /* dt */,
+                                           NonlinearSolverType& /* nonlinear_solver */,
+                                           ReservoirState& reservoir_state,
+                                           const WellState& well_state)
+        {
+            // Extract reservoir and well fluxes.
+            {
+                DebugTimeReport tr("Extracting fluxes");
+                extractFluxes(reservoir_state, well_state);
+            }
+
+            // Compute cell ordering based on total flux.
+            {
+                DebugTimeReport tr("Topological sort");
+                computeOrdering();
+            }
+
+            // Solve in every component (cell or block of cells), in order.
+            {
+                DebugTimeReport tr("Solving all components");
+                solveComponents();
+            }
+
+            // Update states for output.
+
+            // Create report and exit.
+            const bool failed = false;
+            const bool converged = true;
+            const int linear_iterations = 0;
+            const int well_iterations = std::numeric_limits<int>::min();
+            return IterationReport{failed, converged, linear_iterations, well_iterations};
+        }
+
+
+
+
+
+        void afterStep(const double /* dt */,
+                       const ReservoirState& /* reservoir_state */,
+                       const WellState& /* well_state */)
+        {
+            // Does nothing in this model.
+        }
+
+
+
+
+
+        using Base::numPhases;
+
+
+    protected:
+
+        // ============  Data members  ============
+        using Base::grid_;
+        using Base::ops_;
+
+        ReservoirState reservoir_state0_;
+        WellState well_state0_;
+        V total_flux_;
+        V total_wellperf_flux_;
+        DataBlock comp_wellperf_flux_;
+        std::vector<int> sequence_;
+        std::vector<int> components_;
+
+
+        // ============  Member functions  ============
+
+
+        void extractFluxes(const ReservoirState& reservoir_state,
+                           const WellState& well_state)
+        {
+            // Input face fluxes are for interior faces only, while rest of code deals with all faces.
+            const V face_flux = Eigen::Map<const V>(reservoir_state.faceflux().data(),
+                                                    reservoir_state.faceflux().size());
+            using namespace Opm::AutoDiffGrid;
+            const int num_faces = numFaces(grid_);
+            assert(face_flux.size() < num_faces); // Expected to be internal only.
+            total_flux_ = superset(face_flux, ops_.internal_faces, num_faces);
+            total_wellperf_flux_ = Eigen::Map<const V>(well_state.perfRates().data(),
+                                                       well_state.perfRates().size());
+            comp_wellperf_flux_ = Eigen::Map<const DataBlock>(well_state.perfPhaseRates().data(),
+                                                              well_state.perfRates().size(),
+                                                              numPhases());
+            assert(numPhases() * well_state.perfRates().size() == well_state.perfPhaseRates().size());
+        }
+
+
+
+
+
+        void computeOrdering()
+        {
+            static_assert(std::is_same<Grid, UnstructuredGrid>::value,
+                          "compute_sequence() is written in C and therefore requires an UnstructuredGrid, "
+                          "it must be rewritten to use other grid classes such as CpGrid");
+            using namespace Opm::AutoDiffGrid;
+            const int num_cells = numCells(grid_);
+            sequence_.resize(num_cells);
+            components_.resize(num_cells + 1); // max possible size
+            int num_components = -1;
+            compute_sequence(&grid_, total_flux_.data(), sequence_.data(), components_.data(), &num_components);
+            OpmLog::debug(std::string("Number of components: ") + std::to_string(num_components));
+            components_.resize(num_components + 1); // resize to fit actually used part
+        }
+
+
+
+
+        void solveComponents()
+        {
+            const int num_components = components_.size() - 1;
+            for (int comp = 0; comp < num_components; ++comp) {
+                const int comp_size = components_[comp + 1] - components_[comp];
+                if (comp_size == 1) {
+                    solveSingleCell(sequence_[components_[comp]]);
+                } else {
+                    solveMultiCell(comp_size, &sequence_[components_[comp]]);
+                }
+            }
+        }
+
+
+
+
+
+        void solveSingleCell(const int cell)
+        {
+        }
+
+
+
+
+
+        void solveMultiCell(const int comp_size, const int* cell_array)
+        {
+        }
+    };
+
+
+
+
+
+
+
+
+    /// Providing types by template specialisation of ModelTraits for BlackoilReorderingTransportModel.
+    template <class Grid, class WellModel>
+    struct ModelTraits< BlackoilReorderingTransportModel<Grid, WellModel> >
+    {
+        typedef BlackoilState ReservoirState;
+        typedef WellStateFullyImplicitBlackoil WellState;
+        typedef BlackoilModelParameters ModelParameters;
+        typedef DefaultBlackoilSolutionState SolutionState;
+    };
+
+} // namespace Opm
+
+
+
+
+#endif // OPM_BLACKOILREORDERINGTRANSPORTMODEL_HEADER_INCLUDED


### PR DESCRIPTION
This implements an experimental reordering transport model for the implicit sequential formulation of the black-oil problem. The model has plenty of debugging and experimental features, is not quite feature complete (multi-cell block solve missing) and has at least one unfound bug (it cannot run the Norne case even though it *should* be able to). On the other hand, this does not affect any fully-implicit code at all, so it should be quite safe to merge.

This class has been lying around in a branch for a long time now, I think it should be brought into the open, in spite of its warts.

@andlaus could you review this? It's based on the Evaluation class so I think you should find it somewhat familiar.