### PR TITLE
flow_ebos: do not use BlackoilPropsAdFromDeck anymore

### DIFF
--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -90,7 +90,7 @@ public:
     }
 
     template<class Buffer>
-    void scatter(Buffer& buffer, std::size_t i, std::size_t s)
+    void scatter(Buffer& buffer, std::size_t i, std::size_t s OPM_OPTIM_UNUSED)
     {
         assert(s==size(i));
         static_cast<void>(s);


### PR DESCRIPTION
the only thing that was used of this class was the phase usage object, but the phase usage object can be accessed via much leaner interfaces.

The old BlackoilPropsFromDeck (without "Ad") is still required to compute the initial condition, but the init code should be refactored soon anyway.

this PR depends on OPM/ewoms#197