### PR TITLE
Only create step_timing.txt file if it gets written to.

### DIFF
--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -103,7 +103,12 @@ namespace Opm
         Opm::time::StopWatch total_timer;
         total_timer.start();
         std::string tstep_filename = output_writer_.outputDirectory() + "/step_timing.txt";
-        std::ofstream tstep_os(tstep_filename.c_str());
+        std::ofstream tstep_os;
+
+        if ( output_writer_.output() ) {
+            if ( output_writer_.isIORank() )
+                tstep_os.open(tstep_filename.c_str());
+        }
 
         const auto& schedule = eclipse_state_->getSchedule();
 
@@ -307,11 +312,8 @@ namespace Opm
                 OpmLog::note(msg);
             }
 
-            if ( output_writer_.output() ) {
-                if ( output_writer_.isIORank() )
-                {
+            if ( tstep_os.is_open() ) {
                     stepReport.reportParam(tstep_os);
-                }
             }
 
             // Increment timer, remember well state.

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -163,7 +163,14 @@ public:
         Opm::time::StopWatch total_timer;
         total_timer.start();
         std::string tstep_filename = output_writer_.outputDirectory() + "/step_timing.txt";
-        std::ofstream tstep_os(tstep_filename.c_str());
+        std::ofstream tstep_os;
+
+        if ( output_writer_.output() ) {
+            if ( output_writer_.isIORank() )
+            {
+                tstep_os.open(tstep_filename.c_str());
+            }
+        }
 
         const auto& schedule = eclState().getSchedule();
 
@@ -351,11 +358,8 @@ public:
             // update timing.
             report.solver_time += solver_timer.secsSinceStart();
 
-            if ( output_writer_.output() ) {
-                if ( output_writer_.isIORank() )
-                {
-                    stepReport.reportParam(tstep_os);
-                }
+            if ( tstep_os.is_open() ) {
+                stepReport.reportParam(tstep_os);
             }
 
             // Increment timer, remember well state.

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -165,11 +165,9 @@ public:
         std::string tstep_filename = output_writer_.outputDirectory() + "/step_timing.txt";
         std::ofstream tstep_os;
 
-        if ( output_writer_.output() ) {
-            if ( output_writer_.isIORank() )
-            {
-                tstep_os.open(tstep_filename.c_str());
-            }
+        if ( output_writer_.output() && output_writer_.isIORank() )
+        {
+            tstep_os.open(tstep_filename.c_str());
         }
 
         const auto& schedule = eclState().getSchedule();
@@ -358,7 +356,8 @@ public:
             // update timing.
             report.solver_time += solver_timer.secsSinceStart();
 
-            if ( tstep_os.is_open() ) {
+            if ( output_writer_.output() && output_writer_.isIORank() )
+            {
                 stepReport.reportParam(tstep_os);
             }
 


### PR DESCRIPTION
If output=false is requested we created an empty file.
Now that file will only be created if output was requested
and it will only be opened on one rank in a parallel run.