### PR TITLE
Use output to skip debug or all files

### DIFF
--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -608,7 +608,7 @@ namespace Opm
 
         void writeInit()
         {
-            bool output      = ( output_ > OUTPUT_NONE );
+            bool output      = ( output_ > OUTPUT_LOG_ONLY );
             bool output_ecl  = param_.getDefault("output_ecl", true);
             if( output && output_ecl && grid().comm().rank() == 0 )
             {

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -241,7 +241,7 @@ namespace Opm
         // Throws std::runtime_error if failed to create (if requested) output dir.
         void setupOutput()
         {
-            std::string output = param_.getDefault("output", std::string("all"));
+            const std::string output = param_.getDefault("output", std::string("all"));
             static std::map<std::string, FileOutputValue> string2OutputEnum =
                 { {"none", OUTPUT_NONE },
                   {"false", OUTPUT_LOG_ONLY },
@@ -255,7 +255,9 @@ namespace Opm
             }
             else
             {
-                std::cerr<<"Value "<<output<<" passed to option output was invalid. Using \"all\" instead"<<std::endl;
+                std::cerr << "Value " << output <<
+                    " passed to option output was invalid. Using \"all\" instead."
+                          << std::endl;
             }
 
             output_to_files_ = output_cout_ && output_ > OUTPUT_NONE;

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -66,7 +66,7 @@ namespace Opm
         enum FileOutputValue{
             //! \brief No output to files.
             OUTPUT_NONE = 0,
-            //! \brief Output only to log files not DEBUG.
+            //! \brief Output only to log files, no eclipse output.
             OUTPUT_LOG_ONLY = 1,
             //! \brief Output to all files.
             OUTPUT_ALL = 3
@@ -318,7 +318,7 @@ namespace Opm
                 prtLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(false));
             }
 
-            if( output_ > OUTPUT_LOG_ONLY )
+            if( output_ >= OUTPUT_LOG_ONLY && !param_.getDefault("no_debug_log", false) )
             {
                 std::string debugFile = debugFileStream.str();
                 std::shared_ptr<StreamLog> debugLog = std::make_shared<EclipsePRTLog>(debugFile, Log::DefaultMessageTypes, false, output_cout_);

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -608,7 +608,7 @@ namespace Opm
 
         void writeInit()
         {
-            bool output      = param_.getDefault("output", true);
+            bool output      = ( output_ > OUTPUT_NONE );
             bool output_ecl  = param_.getDefault("output_ecl", true);
             if( output && output_ecl && grid().comm().rank() == 0 )
             {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -341,8 +341,7 @@ namespace Opm
         : output_( [&param](){
                 // If output parameter is true or all, then we do output
                 std::string outputString = param.getDefault("output", std::string("all"));
-                if ( outputString == "all" || outputString == "log" ||
-                     outputString == "true" )
+                if ( outputString == "all" ||  outputString == "true" )
                 {
                     return true;
                 }

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -338,7 +338,16 @@ namespace Opm
                          const Opm::EclipseState& eclipseState,
                          std::unique_ptr<EclipseIO>&& eclIO,
                          const Opm::PhaseUsage &phaseUsage)
-      : output_( param.getDefault("output", true) ),
+        : output_( [&param](){
+                // If output parameter is true or all, then we do output
+                std::string outputString = param.getDefault("output", std::string("all"));
+                if ( outputString == "all" || outputString == "log" ||
+                     outputString == "true" )
+                {
+                    return true;
+                }
+                return false;}()
+            ),
         parallelOutput_( output_ ? new ParallelDebugOutput< Grid >( grid, eclipseState, phaseUsage.num_phases, phaseUsage ) : 0 ),
         outputDir_( eclipseState.getIOConfig().getOutputDir() ),
         restart_double_si_( output_ ? param.getDefault("restart_double_si", false) : false ),

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -340,12 +340,9 @@ namespace Opm
                          const Opm::PhaseUsage &phaseUsage)
         : output_( [&param](){
                 // If output parameter is true or all, then we do output
-                std::string outputString = param.getDefault("output", std::string("all"));
-                if ( outputString == "all" ||  outputString == "true" )
-                {
-                    return true;
-                }
-                return false;}()
+                const std::string outputString = param.getDefault("output", std::string("all"));
+                return ( outputString == "all" ||  outputString == "true" );
+            }()
             ),
         parallelOutput_( output_ ? new ParallelDebugOutput< Grid >( grid, eclipseState, phaseUsage.num_phases, phaseUsage ) : 0 ),
         outputDir_( eclipseState.getIOConfig().getOutputDir() ),

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -338,7 +338,7 @@ namespace Opm
                          const Opm::EclipseState& eclipseState,
                          std::unique_ptr<EclipseIO>&& eclIO,
                          const Opm::PhaseUsage &phaseUsage)
-        : output_( [&param](){
+        : output_( [ &param ] () -> bool {
                 // If output parameter is true or all, then we do output
                 const std::string outputString = param.getDefault("output", std::string("all"));
                 return ( outputString == "all" ||  outputString == "true" );


### PR DESCRIPTION
Possible values are none, log, and all. The first does not do any logging
to files. The second does log to files but does not create and log to
the DEBUG file. The latter uses all possible files.

Alternative to #1225 as requested by @atgeirr and @joakim-hove 