### PR TITLE
[WIP] Well production and injection report print file

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -668,7 +668,6 @@ protected:
                 } 
                 wellRate += wr[n][w];
             }
-
             if (is_producer) {
                 if (pu.phase_used[Water] && pu.phase_used[Oil]) {
                     if (wellRate > 0.0001){
@@ -912,7 +911,7 @@ protected:
         ss.imbue(std::locale(std::locale::classic(), facet));
         ss << "\n                              **************************************************************************\n"
         << "  " << std::left << std::setw(8) << input << "  at    " 
-    << std::right << std::setw(5) << (double)unit::convert::to(timer.simulationTimeElapsed(), unit::day) << "  Days"
+        << std::right << std::setw(5) << (double)unit::convert::to(timer.simulationTimeElapsed(), unit::day) << "  Days"
         << " *  " << std::left << std::setw(70) << eclState().getTitle() << "*\n"
         << "  Report  " << std::right << std::setw(4) << timer.reportStepNum() << "   " << timer.currentDateTime()
         << "  *                                             Flow  version " << std::setw(11) << version << "  *\n"


### PR DESCRIPTION
Outputs the well production and injection report per report step to the .PRT file. The quantities forming part of the output are:
- Well Names
- Phase rates/well
- Field total rates
- Control mode/well
- Watercut
- Gas-Oil ratio
- Water-Gas ratio
- BHP
- THP

Additionally minor changes made to `outputTimestampFIP()`

The output looks like:
![wells](https://user-images.githubusercontent.com/18717906/27395257-780c8480-56af-11e7-9474-208f5b903f48.png)


The well report is still not complete. The following items are part of the backlog and would form part of the next PR:
- Cumulative Production/Injection Table
- Classification of wells based on groups
- Output of specific control modes (RESV, ORAT, LRAT etc.)
- Conversion from surface to reservoir volume 
- Output of well potential 
- Well location information