### PR TITLE
Multiple problem logging for linear solver failure

### DIFF
--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -446,9 +446,6 @@ namespace Opm
             // Check for failure of linear solver.
             if (!parameters_.ignoreConvergenceFailure_ && !result.converged) {
                 const std::string msg("Convergence failure for linear solver.");
-                if (isIORank_) {
-                    OpmLog::problem(msg);
-                }
                 OPM_THROW_NOLOG(LinearSolverProblem, msg);
             }
         }

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -251,7 +251,7 @@ namespace Opm {
             }
             catch (const Opm::LinearSolverProblem& e) {
                 substepReport += solver.failureReport();
-                cause_of_failure = "Linear Solver convergence failure";
+                cause_of_failure = "Linear solver convergence failure";
 
                 detail::logException(e, solver_verbose_);
                 // since linearIterations is < 0 this will restart the solver

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -370,7 +370,7 @@ namespace Opm {
                 substepTimer.provideTimeStepEstimate( newTimeStep );
                 if( solver_verbose_ ) {
                     std::string msg;
-                    msg = cause_of_failure + "\n         Timestep chopped to "
+                    msg = cause_of_failure + "\nTimestep chopped to "
                         + std::to_string(unit::convert::to( substepTimer.currentStepLength(), unit::day )) + " days\n";
                     OpmLog::problem(msg);
                 }


### PR DESCRIPTION
- Removes multiple problem linear solver failure
- Removes whitespaces before timestep chopped message to ensure consistency of message formating 