### PR TITLE
[bugfix][StandardWellsDense] Remove auto from method parameter list, take 2

### DIFF
--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -417,7 +417,7 @@ enum WellVariablePositions {
 
             void setupCompressedToCartesian(const int* global_cell, int number_of_cells, std::map<int,int>& cartesian_to_compressed ) const;
 
-            void computeRepRadiusPerfLength(const auto& grid);
+            void computeRepRadiusPerfLength(const Grid& grid);
 
 
         };

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -77,6 +77,7 @@ enum WellVariablePositions {
             typedef WellStateFullyImplicitBlackoilDense WellState;
             typedef BlackoilModelParameters ModelParameters;
 
+            typedef typename GET_PROP_TYPE(TypeTag, Grid)                Grid;
             typedef typename GET_PROP_TYPE(TypeTag, FluidSystem)         FluidSystem;
             typedef typename GET_PROP_TYPE(TypeTag, ElementContext)      ElementContext;
             typedef typename GET_PROP_TYPE(TypeTag, Indices)             BlackoilIndices;
@@ -121,7 +122,7 @@ enum WellVariablePositions {
                       const std::vector<double>& pv_arg,
                       const RateConverterType* rate_converter,
                       long int global_nc,
-                      const auto& grid);
+                      const Grid& grid);
 
 
             /// The number of components in the model.

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -3161,7 +3161,7 @@ namespace Opm {
     template<typename TypeTag>
     void
     StandardWellsDense<TypeTag>::
-    computeRepRadiusPerfLength(const auto& grid)
+    computeRepRadiusPerfLength(const Grid& grid)
     {
 
         // TODO, the function does not work for parallel running

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -49,7 +49,7 @@ namespace Opm {
          const std::vector<double>& pv_arg,
          const RateConverterType* rate_converter,
          long int global_nc,
-         const auto& grid)
+         const Grid& grid)
     {
         // has to be set always for the convergence check!
         global_nc_   = global_nc;


### PR DESCRIPTION
This should restore the build for those on older compilers at least.

Today we had two separate issues that caused Jenkins trouble.

First was that I forgot to co-merge OPM/opm-data#232. That was a pure human error on my behalf.

The second was that C++17 code was merged. I do not quite understand why Jenkins accepted it, I would have assumed that when asking for C++11 as we do C++17 is not considered?

In any case, with this PR I hope both issues are laid to rest. I will self-merge when (if...) Jenkins is green on this.