### PR TITLE
Work around unstable matrix block inversion in DUNE 2.3 und 2.4

### DIFF
--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -289,7 +289,14 @@ namespace Opm
             }
         }
 
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2 , 5)
         typedef ParallelOverlappingILU0<Matrix,Vector,Vector> SeqPreconditioner;
+#else
+        typedef ParallelOverlappingILU0<Dune::BCRSMatrix<Dune::MatrixBlock<typename Matrix::field_type,
+                                                                           Matrix::block_type::rows,
+                                                                           Matrix::block_type::cols> >,
+                                        Vector, Vector> SeqPreconditioner;
+#endif
 
         template <class Operator>
         std::unique_ptr<SeqPreconditioner> constructPrecond(Operator& opA, const Dune::Amg::SequentialInformation&) const
@@ -302,7 +309,14 @@ namespace Opm
 
 #if HAVE_MPI
         typedef Dune::OwnerOverlapCopyCommunication<int, int> Comm;
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2 , 5)
         typedef ParallelOverlappingILU0<Matrix,Vector,Vector,Comm> ParPreconditioner;
+#else
+        typedef ParallelOverlappingILU0<Dune::BCRSMatrix<Dune::MatrixBlock<typename Matrix::field_type,
+                                                                           Matrix::block_type::rows,
+                                                                           Matrix::block_type::cols> >,
+                                        Vector, Vector, Comm> ParPreconditioner;
+#endif
         template <class Operator>
         std::unique_ptr<ParPreconditioner>
         constructPrecond(Operator& opA, const Comm& comm) const

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -165,6 +165,7 @@ class ParallelOverlappingILU0
 {
     typedef ParallelInfoT ParallelInfo;
 
+
 public:
     //! \brief The matrix type the preconditioner is for.
     typedef typename Dune::remove_const<Matrix>::type matrix_type;
@@ -238,8 +239,9 @@ public:
       \param n ILU fill in level (for testing). This does not work in parallel.
       \param w The relaxation factor.
     */
-    template<class Matrix1>
-    ParallelOverlappingILU0 (const Matrix1& A, const int n, const field_type w )
+    template<class BlockType, class Alloc>
+    ParallelOverlappingILU0 (const Dune::BCRSMatrix<BlockType,Alloc>& A,
+                             const int n, const field_type w )
         : lower_(),
           upper_(),
           inv_(),
@@ -257,8 +259,9 @@ public:
       \param A The matrix to operate on.
       \param w The relaxation factor.
     */
-    template<class Matrix1>
-    ParallelOverlappingILU0 (const Matrix1& A, const field_type w)
+    template<class BlockType, class Alloc>
+    ParallelOverlappingILU0 (const Dune::BCRSMatrix<BlockType,Alloc>& A,
+                             const field_type w)
         : ParallelOverlappingILU0( A, 0, w )
     {
     }
@@ -270,8 +273,9 @@ public:
       \param comm   communication object, e.g. Dune::OwnerOverlapCopyCommunication
       \param w      The relaxation factor.
     */
-    template<class Matrix1>
-    ParallelOverlappingILU0 (const Matrix1& A, const ParallelInfo& comm, const field_type w)
+    template<class BlockType, class Alloc>
+    ParallelOverlappingILU0 (const Dune::BCRSMatrix<BlockType,Alloc>& A,
+                             const ParallelInfo& comm, const field_type w)
         : lower_(),
           upper_(),
           inv_(),

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -238,14 +238,17 @@ public:
       \param n ILU fill in level (for testing). This does not work in parallel.
       \param w The relaxation factor.
     */
-    ParallelOverlappingILU0 (const Matrix& A, const int n, const field_type w )
+    template<class Matrix1>
+    ParallelOverlappingILU0 (const Matrix1& A, const int n, const field_type w )
         : lower_(),
           upper_(),
           inv_(),
           comm_(nullptr), w_(w),
           relaxation_( std::abs( w - 1.0 ) > 1e-15 )
     {
-        init( A, n );
+        // BlockMatrix is a Subclass of FieldMatrix that just adds
+        // methods. Therefore this cast should be safe.
+        init( reinterpret_cast<const Matrix&>(A), n );
     }
 
     /*! \brief Constructor.
@@ -254,7 +257,8 @@ public:
       \param A The matrix to operate on.
       \param w The relaxation factor.
     */
-    ParallelOverlappingILU0 (const Matrix& A, const field_type w)
+    template<class Matrix1>
+    ParallelOverlappingILU0 (const Matrix1& A, const field_type w)
         : ParallelOverlappingILU0( A, 0, w )
     {
     }
@@ -266,14 +270,17 @@ public:
       \param comm   communication object, e.g. Dune::OwnerOverlapCopyCommunication
       \param w      The relaxation factor.
     */
-    ParallelOverlappingILU0 (const Matrix& A, const ParallelInfo& comm, const field_type w)
+    template<class Matrix1>
+    ParallelOverlappingILU0 (const Matrix1& A, const ParallelInfo& comm, const field_type w)
         : lower_(),
           upper_(),
           inv_(),
           comm_(&comm), w_(w),
           relaxation_( std::abs( w - 1.0 ) > 1e-15 )
     {
-        init( A, 0 );
+        // BlockMatrix is a Subclass of FieldMatrix that just adds
+        // methods. Therefore this cast should be safe.
+        init( reinterpret_cast<const Matrix&>(A), 0 );
     }
 
     /*!


### PR DESCRIPTION
The versions are missing the specialized code for inverting a 3x3 matrix that makes the algorithms quite a bit more stable. This made running Norne with 4 processor take forever due to minimal time steps. The reason  why we might have only experienced this in parallel to such extend might be that in the overlap/ghost region the properties of the matrix entries might be a bit different because of missing off-diagonal values.

Maybe this instability is also the cause for some of the parallel test failures produced by PRs not related to parallelism at all (reordering well euations and the likes).

This is the least invasive change to fix the problem. It simple uses our own MatrixBlock as the block_type of BCRSMatrix. That class has a specialised version of the matrix inversion for 3x3 block that seems more stable. In the long we should probably opt for not inverting the diagonal but precomputing the ilu decomposition of it and use that.

Tested with DUNE 2.3. and 2.4 running Norne with 4 processes.