### PR TITLE
fixing the running of polymer cases.

### DIFF
--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -238,8 +238,8 @@ namespace Opm {
                         }
                     }
 
-                    // add trivial equation for 2p cases (Only support water + oil)
-                    if (numComp < numEq ) {
+                    // add a trivial equation for the dummy phase for 2p cases (Only support water + oil)
+                    if ( numComp < numWellEq ) {
                         assert(!active_[ Gas ]);
                         invDuneD_[w][w][Gas][Gas] = 1.0;
                     }


### PR DESCRIPTION
Using more clear standards to tell if it is a two-phase case.

When `numComp < numEq`, it looks like it can also be the case with polymer, which makes the following `assert` not sensible. 

Since it is a small change, it will be helpful for other development if this PR can get in quickly. 

@totto82 , do you think the change makes sense?