### PR TITLE
Create oil-in-place data if overall efficiency is requested by output.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -924,7 +924,7 @@ namespace Opm
                                   data::TargetType::SUMMARY );
                 }
                 // Oil in place (in liquid and gas phases)
-                if (hasFRBKeyword(summaryConfig, "OIP")) {
+                if (hasFRBKeyword(summaryConfig, "OIP") || hasFRBKeyword(summaryConfig, "OE")) {
                     output.insert("OIP",
                                   Opm::UnitSystem::measure::volume,
                                   std::move( oip ),


### PR DESCRIPTION
If the user requests FOE (field overall efficiency) output, then we must provide the output facilities with OIP (oil in place) data to be able to compute it.

A simple and minor fix, I intend to self-merge when tests are green.