### PR TITLE
Remove reservoirState from BlackoilModelEbos

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -172,7 +172,7 @@ namespace Opm {
         , has_solvent_(GET_PROP_VALUE(TypeTag, EnableSolvent))
         , has_polymer_(GET_PROP_VALUE(TypeTag, EnablePolymer))
         , param_( param )
-        , well_model_ (well_model)        
+        , well_model_ (well_model)
         , terminal_output_ (terminal_output)
         , rate_converter_(rate_converter)
         , current_relaxation_(1.0)
@@ -303,20 +303,20 @@ namespace Opm {
                 perfTimer.start();
 
                 if (param_.use_update_stabilization_) {
-                // Stabilize the nonlinear update.
-                bool isOscillate = false;
-                bool isStagnate = false;
-                nonlinear_solver.detectOscillations(residual_norms_history_, iteration, isOscillate, isStagnate);
-                if (isOscillate) {
-                    current_relaxation_ -= nonlinear_solver.relaxIncrement();
-                    current_relaxation_ = std::max(current_relaxation_, nonlinear_solver.relaxMax());
-                    if (terminalOutputEnabled()) {
-                        std::string msg = "    Oscillating behavior detected: Relaxation set to "
-                            + std::to_string(current_relaxation_);
-                        OpmLog::info(msg);
+                    // Stabilize the nonlinear update.
+                    bool isOscillate = false;
+                    bool isStagnate = false;
+                    nonlinear_solver.detectOscillations(residual_norms_history_, iteration, isOscillate, isStagnate);
+                    if (isOscillate) {
+                        current_relaxation_ -= nonlinear_solver.relaxIncrement();
+                        current_relaxation_ = std::max(current_relaxation_, nonlinear_solver.relaxMax());
+                        if (terminalOutputEnabled()) {
+                            std::string msg = "    Oscillating behavior detected: Relaxation set to "
+                                    + std::to_string(current_relaxation_);
+                            OpmLog::info(msg);
+                        }
                     }
-                }
-                nonlinear_solver.stabilizeNonlinearUpdate(x, dx_old_, current_relaxation_);
+                    nonlinear_solver.stabilizeNonlinearUpdate(x, dx_old_, current_relaxation_);
                 }
 
                 // Apply the update, with considering model-dependent limitations and
@@ -396,7 +396,7 @@ namespace Opm {
             Scalar resultDelta = 0.0;
             Scalar resultDenom = 0.0;
 
-	    const auto& elemMapper = ebosSimulator_.model().elementMapper();
+            const auto& elemMapper = ebosSimulator_.model().elementMapper();
             const auto& gridView = ebosSimulator_.gridView();
             auto elemIt = gridView.template begin</*codim=*/0>();
             const auto& elemEndIt = gridView.template end</*codim=*/0>();
@@ -621,6 +621,7 @@ namespace Opm {
             const auto& elemEndIt = gridView.template end</*codim=*/0>();
             SolutionVector& solution = ebosSimulator_.model().solution( 0 /* timeIdx */ );
 
+            // Store the initial solution.
             if( iterationIdx == 0 )
             {
                 ebosSimulator_.model().solution( 1 /* timeIdx */ ) = solution;
@@ -674,6 +675,7 @@ namespace Opm {
                 // polymer
                 const double dc = has_polymer_ ? dx[cell_idx][Indices::polymerConcentrationIdx] : 0.0;
 
+                // oil
                 dso = - (dsw + dsg + dss);
 
                 // compute a scaling factor for the saturation update so that the maximum

--- a/opm/autodiff/Compat.cpp
+++ b/opm/autodiff/Compat.cpp
@@ -174,14 +174,17 @@ void solutionToSim( const data::Solution& sol,
     }
 
     if( sol.has( "RS" ) ) {
+        state.registerCellData("GASOILRATIO", 1);
         state.getCellData( "GASOILRATIO" ) = sol.data( "RS" );
     }
 
     if( sol.has( "RV" ) ) {
+        state.registerCellData("RV", 1);
         state.getCellData( "RV" ) = sol.data( "RV" );
     }
 
     if ( sol.has( "SSOL" ) ) {
+        state.registerCellData("SSOL", 1);
         state.getCellData("SSOL") = sol.data("SSOL");
     }
 

--- a/opm/autodiff/RateConverter.hpp
+++ b/opm/autodiff/RateConverter.hpp
@@ -485,7 +485,11 @@ namespace Opm {
                      elemIt != elemEndIt;
                      ++elemIt)
                 {
+
                     const auto& elem = *elemIt;
+                    if (elem.partitionType() != Dune::InteriorEntity)
+                        continue;
+
                     elemCtx.updatePrimaryStencil(elem);
                     elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
                     const auto& intQuants = elemCtx.intensiveQuantities(/*spaceIdx=*/0, /*timeIdx=*/0);

--- a/opm/autodiff/RateConverter.hpp
+++ b/opm/autodiff/RateConverter.hpp
@@ -450,7 +450,62 @@ namespace Opm {
                 }   
                 calcRmax();
             }
+
             /**
+             * Compute average hydrocarbon pressure and maximum
+             * dissolution and evaporation at average hydrocarbon
+             * pressure in all regions in field.
+             *
+             * Fluid properties are evaluated at average hydrocarbon
+             * pressure for purpose of conversion from surface rate to
+             * reservoir voidage rate.
+             *
+             * \param[in] state Dynamic reservoir state.
+             * \param[in] any  The information and communication utilities
+             *                 about/of the parallelization. in any parallel
+             *                 it wraps a ParallelISTLInformation. Parameter
+             *                 is optional.
+             */
+            template <typename ElementContext, class EbosSimulator>
+            void defineState(const EbosSimulator& simulator)
+            {
+
+                //const int numCells = cellPvtIdx_.size();
+                //const Region region = std::vector<int>(numCells, 0);
+                auto& ra = attr_.attributes(0);
+                auto& p  = ra.pressure;
+                auto& T  = ra.temperature;
+                std::size_t n = 0;
+
+                ElementContext elemCtx( simulator );
+                const auto& gridView = simulator.gridView();
+
+                const auto& elemEndIt = gridView.template end</*codim=*/0>();
+                for (auto elemIt = gridView.template begin</*codim=*/0>();
+                     elemIt != elemEndIt;
+                     ++elemIt)
+                {
+                    const auto& elem = *elemIt;
+                    elemCtx.updatePrimaryStencil(elem);
+                    elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
+                    const auto& intQuants = elemCtx.intensiveQuantities(/*spaceIdx=*/0, /*timeIdx=*/0);
+                    const auto& fs = intQuants.fluidState();
+
+                    p += fs.pressure(FluidSystem::oilPhaseIdx).value();
+                    T += fs.temperature(FluidSystem::oilPhaseIdx).value();
+                    n += 1;
+                }
+                p = gridView.comm().sum(p);
+                T = gridView.comm().sum(T);
+                n = gridView.comm().sum(n);
+
+                p /= n;
+                T /= n;
+
+                calcRmax();
+            }
+
+	    /**
              * Region identifier.
              *
              * Integral type.

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -55,6 +55,8 @@ public:
     typedef typename GET_PROP_TYPE(TypeTag, Indices) BlackoilIndices;
     typedef typename GET_PROP_TYPE(TypeTag, PrimaryVariables)  PrimaryVariables;
     typedef typename GET_PROP_TYPE(TypeTag, MaterialLaw) MaterialLaw;
+    typedef typename GET_PROP_TYPE(TypeTag, SolutionVector)    SolutionVector ;
+    typedef typename GET_PROP_TYPE(TypeTag, MaterialLawParams) MaterialLawParams;
 
     typedef Ewoms::BlackOilPolymerModule<TypeTag> PolymerModule;
 
@@ -516,7 +518,7 @@ protected:
                 // to calculate averages over regions that might cross process
                 // borders. This needs to be done by all processes and therefore
                 // outside of the next if statement.
-                rateConverter_->template defineState<ElementContext>(ebosSimulator_);
+                rateConverter_.template defineState<ElementContext>(ebosSimulator_);
             }
         }
         else
@@ -524,7 +526,7 @@ protected:
         {
             if ( global_number_resv_wells )
             {
-                rateConverter_->template defineState<ElementContext>(ebosSimulator_);
+                rateConverter_.template defineState<ElementContext>(ebosSimulator_);
             }
         }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -988,6 +988,7 @@ protected:
             }
         }
 
+        // store the solution at the beginning of the time step
         if( iterationIdx == 0 )
         {
             simulator.model().solution( 1 /* timeIdx */ ) = solution;

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -53,14 +53,20 @@ namespace Opm
         using BaseType :: numWells;
         using BaseType :: numPhases;
 
+        template <class State, class PrevWellState>
+        void init(const Wells* wells, const State& state, const PrevWellState& prevState)
+        {
+            init(wells, state.pressure(), prevState);
+        }
+
         /// Allocate and initialize if wells is non-null.  Also tries
         /// to give useful initial values to the bhp(), wellRates()
         /// and perfPhaseRates() fields, depending on controls
-        template <class State, class PrevState>
-        void init(const Wells* wells, const State& state, const PrevState& prevState)
+        template <class PrevWellState>
+        void init(const Wells* wells, const std::vector<double>& cellPressures , const PrevWellState& prevState)
         {
             // call init on base class
-            BaseType :: init(wells, state);
+            BaseType :: init(wells, cellPressures);
 
             // if there are no well, do nothing in init
             if (wells == 0) {
@@ -90,7 +96,7 @@ namespace Opm
                         for (int p = 0; p < np; ++p) {
                             perfphaserates_[np*perf + p] = wellRates()[np*w + p] / double(num_perf_this_well);
                         }
-                        perfPress()[perf] = state.pressure()[wells->well_cells[perf]];
+                        perfPress()[perf] = cellPressures[wells->well_cells[perf]];
                     }
                 }
             }

--- a/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoilDense.hpp
@@ -61,11 +61,12 @@ namespace Opm
         /// Allocate and initialize if wells is non-null.  Also tries
         /// to give useful initial values to the bhp(), wellRates()
         /// and perfPhaseRates() fields, depending on controls
-        template <class State, class PrevState>
-        void init(const Wells* wells, const State& state, const PrevState& prevState, const PhaseUsage& pu)
+        template <class PrevWellState>
+        void init(const Wells* wells, const std::vector<double>& cellPressures, const PrevWellState& prevState, const PhaseUsage& pu)
         {
+
             // call init on base class
-            BaseType :: init(wells, state, prevState);
+            BaseType :: init(wells, cellPressures, prevState);
 
 
             const int nw = wells->number_of_wells;
@@ -207,8 +208,8 @@ namespace Opm
 
         template <class State>
         void resize(const Wells* wells, const State& state, const PhaseUsage& pu ) {
-            const WellStateFullyImplicitBlackoilDense dummy_state{}; // Init with an empty previous state only resizes
-            init(wells, state, dummy_state, pu) ;
+            const WellStateFullyImplicitBlackoilDense dummy_state{}; // Init with an empty previous state only resizes            
+            init(wells, state.pressure(), dummy_state, pu) ;
         }
 
 


### PR DESCRIPTION
**Motivation** 
Currently the solution state is stored both as global arrays in the BlackoilState and as local solution variables  for each cell in ebos and great care need to be taken to communicate the solution between these two storages. The aim of this PR is to avoid this duplication. This PR does not remove the BlackoilState completely from flow_ebos, it is still kept in the signature of the step methods in AdaptiveTimeStepping and NonlinearSolver. And also in the initialization, for restart and for output of the initial state. After the initial step, an empty reservoirState is passed around in the code to avoid abuse. 

**Changes**
1) Use the solution variable directly in RelativeChange(...)
2) Add a method in the RateConverter that takes the simulator instead of the state.
3) Pass the reservoir pressure directly to the well initialization.
4) Move convertInput(...) to SimulatorFullyImplicitBlackoilEbos.hpp.
This code is only used to convert the initial reservoir state.
5) Modify  updateState(...). The solution variable is updated directly and adaptPrimaryVariable(...)
from ewoms is used to switch primary variables. An epsilon is passed to adaptPrimaryVarible(...) after a switch of primary variables to make it harder to immediately switch back.

**Dependencies**
OPM/opm-core#1172 and OPM/ewoms#215

**Testing** 
flow_ebos is tested on SPE9, Norne, Model2-0, Model2-5
flow_ebos_solvent is tested on SPE5CASE1

This PR introduces small changes in the variable switching code that changes the convergence behavior and therefore also the results. The conditional usage of an epsilon just after a switch (not always as the old code) to avoid oscillations is meant to improve the convergence. Taking into account VAPPARS in the variable switching makes fixes a bug in the old code. The impact of VAPPARS in the variable switching is however very small for the only case with currently run with VAPPARS i.e. The Norne case.  

I have verified that this PR does not deteriorate the results and performance of the simulator for the tested cases. 