### PR TITLE
Simulator Blackoil and StandardWellsDense uses same rate_converter

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -112,6 +112,7 @@ add_test_compareECLFiles(spe1 SPE1CASE1 flow_sequential ${abs_tol} ${rel_tol} co
 add_test_compareECLFiles(spe3 SPE3CASE1 flow_ebos ${abs_tol} ${rel_tol} compareECLFiles "")
 add_test_compareECLFiles(spe3 SPE3CASE1 flow_legacy ${abs_tol} ${rel_tol} compareECLFiles "")
 add_test_compareECLFiles(spe9 SPE9_CP_SHORT flow_ebos ${abs_tol} ${rel_tol} compareECLFiles "")
+add_test_compareECLFiles(spe9group SPE9_CP_GROUP flow_ebos ${abs_tol} ${rel_tol} compareECLFiles "")
 add_test_compareECLFiles(spe9 SPE9_CP_SHORT flow_legacy ${abs_tol} ${rel_tol} compareECLFiles "")
 add_test_compareECLFiles(msw_2d_h 2D_H__ flow_multisegment ${abs_tol} ${rel_tol} compareECLFiles "")
 add_test_compareECLFiles(polymer_simple2D 2D_THREEPHASE_POLY_HETER flow_polymer ${abs_tol} ${rel_tol} compareECLFiles "")

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -171,9 +171,9 @@ namespace Opm {
         , has_solvent_(GET_PROP_VALUE(TypeTag, EnableSolvent))
         , has_polymer_(GET_PROP_VALUE(TypeTag, EnablePolymer))
         , param_( param )
-        , well_model_ (well_model)        
+        , well_model_ (well_model)
         , terminal_output_ (terminal_output)
-        , rate_converter_(phaseUsage_, ebosSimulator_.problem().pvtRegionArray().empty()?nullptr:ebosSimulator_.problem().pvtRegionArray().data(), AutoDiffGrid::numCells(grid_), std::vector<int>(AutoDiffGrid::numCells(grid_),0))
+        , rate_converter_(wellModel().rateConverter())
         , current_relaxation_(1.0)
         , dx_old_(AutoDiffGrid::numCells(grid_))
         , isBeginReportStep_(false)
@@ -1505,7 +1505,7 @@ namespace Opm {
         long int global_nc_;
 
         // rate converter between the surface volume rates and reservoir voidage rates
-        RateConverterType rate_converter_;
+        RateConverterType* rate_converter_;
 
         std::vector<std::vector<double>> residual_norms_history_;
         double current_relaxation_;
@@ -1660,7 +1660,7 @@ namespace Opm {
                 global_number_wells = info.communicator().sum(global_number_wells);
                 if ( global_number_wells )
                 {
-                    rate_converter_.defineState(reservoir_state, boost::any_cast<const ParallelISTLInformation&>(istlSolver_->parallelInformation()));
+                    rate_converter_->defineState(reservoir_state, boost::any_cast<const ParallelISTLInformation&>(istlSolver_->parallelInformation()));
                 }
             }
             else
@@ -1668,7 +1668,7 @@ namespace Opm {
             {
                 if ( global_number_wells )
                 {
-                    rate_converter_.defineState(reservoir_state);
+                    rate_converter_->defineState(reservoir_state);
                 }
             }
         }

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -155,6 +155,7 @@ namespace Opm {
         BlackoilModelEbos(Simulator& ebosSimulator,
                           const ModelParameters& param,
                           const StandardWellsDense<TypeTag>& well_model,
+                          RateConverterType& rate_converter,
                           const NewtonIterationBlackoilInterface& linsolver,
                           const bool terminal_output
                           )
@@ -173,7 +174,7 @@ namespace Opm {
         , param_( param )
         , well_model_ (well_model)
         , terminal_output_ (terminal_output)
-        , rate_converter_(wellModel().rateConverter())
+        , rate_converter_(rate_converter)
         , current_relaxation_(1.0)
         , dx_old_(AutoDiffGrid::numCells(grid_))
         , isBeginReportStep_(false)
@@ -1505,7 +1506,7 @@ namespace Opm {
         long int global_nc_;
 
         // rate converter between the surface volume rates and reservoir voidage rates
-        RateConverterType* rate_converter_;
+        RateConverterType& rate_converter_;
 
         std::vector<std::vector<double>> residual_norms_history_;
         double current_relaxation_;
@@ -1660,7 +1661,7 @@ namespace Opm {
                 global_number_wells = info.communicator().sum(global_number_wells);
                 if ( global_number_wells )
                 {
-                    rate_converter_->defineState(reservoir_state, boost::any_cast<const ParallelISTLInformation&>(istlSolver_->parallelInformation()));
+                    rate_converter_.defineState(reservoir_state, boost::any_cast<const ParallelISTLInformation&>(istlSolver_->parallelInformation()));
                 }
             }
             else
@@ -1668,7 +1669,7 @@ namespace Opm {
             {
                 if ( global_number_wells )
                 {
-                    rate_converter_->defineState(reservoir_state);
+                    rate_converter_.defineState(reservoir_state);
                 }
             }
         }

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -113,6 +113,7 @@ enum WellVariablePositions {
                                WellCollection* well_collection,
                                const std::vector< const Well* >& wells_ecl,
                                const ModelParameters& param,
+                               const RateConverterType& rate_converter,
                                const bool terminal_output,
                                const int current_index);
 
@@ -121,7 +122,6 @@ enum WellVariablePositions {
                       const double gravity_arg,
                       const std::vector<double>& depth_arg,
                       const std::vector<double>& pv_arg,
-                      RateConverterType* rate_converter,
                       long int global_nc,
                       const Grid& grid);
 
@@ -291,8 +291,6 @@ enum WellVariablePositions {
 
             void applyVREPGroupControl(WellState& well_state) const;
 
-            RateConverterType* rateConverter() const;
-
         protected:
             bool wells_active_;
             const Wells*   wells_;
@@ -311,7 +309,7 @@ enum WellVariablePositions {
             std::vector<bool>  active_;
             const VFPProperties* vfp_properties_;
             double gravity_;
-            RateConverterType* rate_converter_;
+            const RateConverterType& rate_converter_;
 
             // The efficiency factor for each connection. It is specified based on wells and groups,
             // We calculate the factor for each connection for the computation of contributions to the mass balance equations.

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -121,7 +121,7 @@ enum WellVariablePositions {
                       const double gravity_arg,
                       const std::vector<double>& depth_arg,
                       const std::vector<double>& pv_arg,
-                      const RateConverterType* rate_converter,
+                      RateConverterType* rate_converter,
                       long int global_nc,
                       const Grid& grid);
 
@@ -291,6 +291,7 @@ enum WellVariablePositions {
 
             void applyVREPGroupControl(WellState& well_state) const;
 
+            RateConverterType* rateConverter() const;
 
         protected:
             bool wells_active_;
@@ -310,7 +311,7 @@ enum WellVariablePositions {
             std::vector<bool>  active_;
             const VFPProperties* vfp_properties_;
             double gravity_;
-            const RateConverterType* rate_converter_;
+            RateConverterType* rate_converter_;
 
             // The efficiency factor for each connection. It is specified based on wells and groups,
             // We calculate the factor for each connection for the computation of contributions to the mass balance equations.

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -46,7 +46,7 @@ namespace Opm {
          const double gravity_arg,
          const std::vector<double>& depth_arg,
          const std::vector<double>& pv_arg,
-         const RateConverterType* rate_converter,
+         RateConverterType* rate_converter,
          long int global_nc,
          const Grid& grid)
     {
@@ -139,6 +139,19 @@ namespace Opm {
     {
         vfp_properties_ = vfp_properties_arg;
     }
+
+
+
+
+
+    template<typename TypeTag>
+    typename StandardWellsDense<TypeTag>::RateConverterType*
+    StandardWellsDense<TypeTag>::
+    rateConverter() const
+    {
+        return rate_converter_;
+    }
+
 
 
 


### PR DESCRIPTION
to fix the running of the group control. 

Very originally, the BlackoilModelEbos and SimulatorFullyImplicitBlackoilEbos have their own rate converters. StandardWellsDense points to the one in BlackoilModelEbos.  Due to some later code change, StandardWellsDense points to the one in SimulatorFullyImplicitBlackoilEbos, which causes the failure of running with VREP group control. 

With this PR, we make the SimulatorFullyImplicitBlackoilEbos, BlackoilModelEbos, and StandardWellsDense use the same rate_converter to fix the problem. 
