### PR TITLE
Fixing bugs and improving the reordering solver

### DIFF
--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -888,20 +888,24 @@ namespace Opm {
             double& rs = state_.reservoir_state.gasoilratio()[cell];
             const double rs_old = rs;
             if (hcstate == HydroCarbonState::OilOnly) {
-                const double max_allowed_change = std::fabs(rs_old) * Base::drMaxRel();
+                // const double max_allowed_change = std::fabs(rs_old) * Base::drMaxRel();
                 const double drs = dx[1];
-                const double factor = std::min(1.0, max_allowed_change / std::fabs(drs));
-                rs += factor*drs;
+                // const double factor = std::min(1.0, max_allowed_change / std::fabs(drs));
+                // rs += factor*drs;
+                rs += drs;
+                rs = std::max(rs, 0.0);
             }
 
             // Update rv.
             double& rv = state_.reservoir_state.rv()[cell];
             const double rv_old = rv;
             if (hcstate == HydroCarbonState::GasOnly) {
-                const double max_allowed_change = std::fabs(rv_old) * Base::drMaxRel();
+                // const double max_allowed_change = std::fabs(rv_old) * Base::drMaxRel();
                 const double drv = dx[1];
-                const double factor = std::min(1.0, max_allowed_change / std::fabs(drv));
-                rv += factor*drv;
+                // const double factor = std::min(1.0, max_allowed_change / std::fabs(drv));
+                // rv += factor*drv;
+                rv += drv;
+                rv = std::max(rv, 0.0);
             }
 
             const double epsilon = std::sqrt(std::numeric_limits<double>::epsilon());

--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -499,8 +499,8 @@ namespace Opm {
 
             // Compute phase pressures.
             cstate.p[Oil] = constant(poval);
-            cstate.p[Water] = cstate.p[Oil] - cstate.pc[Water]; // pcow = po - pw
-            cstate.p[Gas] =   cstate.p[Oil] + cstate.pc[Gas];   // pcog = pg - po (!)
+            cstate.p[Water] = cstate.p[Oil] + cstate.pc[Water]; // pcow = pw - po (!) [different from old convention]
+            cstate.p[Gas] =   cstate.p[Oil] + cstate.pc[Gas];   // pcog = pg - po
 
             // Compute PVT properties.
             cstate.temperature = constant(0.0); // Temperature is not used.

--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -855,13 +855,14 @@ namespace Opm {
 
             // Get saturation updates.
             const double dsw = dx[0];
-            double dso = -dsw;
             double dsg = 0.0;
             auto& hcstate = state_.reservoir_state.hydroCarbonState()[cell];
             if (hcstate == HydroCarbonState::GasAndOil) {
                 dsg = dx[1];
-                dso -= dsg;
+            } else if (hcstate == HydroCarbonState::GasOnly) {
+                dsg = -dsw;
             }
+            const double dso = -(dsw + dsg);
 
             // Handle too large saturation changes.
             const double maxval = std::max(std::fabs(dsw), std::max(std::fabs(dso), std::fabs(dsg)));

--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -667,11 +667,11 @@ namespace Opm {
                     if (iter > 30) {
                         relaxation = 0.25;
                     }
-                    std::ostringstream os;
-                    os << "Iteration " << iter << " in cell " << cell << ", residual = " << res
-                       << ", cell values { s = ( " << cstate_[cell].s[Water] << ", " << cstate_[cell].s[Oil] << ", " << cstate_[cell].s[Gas]
-                       << " ), rs = " << cstate_[cell].rs << ", rv = " << cstate_[cell].rv << "}, dx = " << dx << ", hcstate: " << hcstate_old << " -> " << hcstate;
-                    OpmLog::debug(os.str());
+                    // std::ostringstream os;
+                    // os << "Iteration " << iter << " in cell " << cell << ", residual = " << res
+                    //    << ", cell values { s = ( " << cstate_[cell].s[Water] << ", " << cstate_[cell].s[Oil] << ", " << cstate_[cell].s[Gas]
+                    //    << " ), rs = " << cstate_[cell].rs << ", rv = " << cstate_[cell].rv << "}, dx = " << dx << ", hcstate: " << hcstate_old << " -> " << hcstate;
+                    // OpmLog::debug(os.str());
                 }
             }
             if (iter == max_iter) {

--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -753,14 +753,15 @@ namespace Opm {
                 // values from cstate_[other].
                 Eval dh[3];
                 Eval dh_sat[3];
+                const Eval grad_oil_press = cstate_[other].p[Oil] - st.p[Oil];
                 for (int phase : { Water, Oil, Gas }) {
                     const Eval gradp = cstate_[other].p[phase] - st.p[phase];
                     const Eval rhoavg = 0.5 * (st.rho[phase] + cstate_[other].rho[phase]);
                     dh[phase] = gradp - rhoavg * gdz;
-                    dh_sat[phase] = rhoavg * gdz; // TODO: not equivalent to formulation in BlackoilTransportModel for cap. press.
                     if (Base::use_threshold_pressure_) {
-                        applyThresholdPressure(conn.index, dh[phase]); // TODO: Should also dh_sat be treated here? Also: dh is unused, this has no effect!
+                        applyThresholdPressure(conn.index, dh[phase]);
                     }
+                    dh_sat[phase] = grad_oil_press - dh[phase];
                 }
                 const double tran = trans_all_[conn.index]; // TODO: include tr_mult effect.
                 const auto& m1 = st.lambda;

--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -460,7 +460,7 @@ namespace Opm {
 
 
         template <typename Scalar>
-        void computeCellState(const int cell, const State& state, CellState<Scalar>& cstate)
+        void computeCellState(const int cell, const State& state, CellState<Scalar>& cstate) const
         {
             assert(numPhases() == 3); // I apologize for this to my future self, that will have to fix it.
 


### PR DESCRIPTION
Various minor (and less minor...) bugs have been fixed.

With this, it is possible to run the Norne case with flow_reorder, with two caveats: you must set ds_max=0.1 (the default is too large for this case) to make it run through, and it does not support VAPPARS (yet).

A note on (the lack of) performance:
performance is not too bad considering that it runs the legacy assembly for the pressure solve, and again to verify the residuals after solving (1800 seconds on Norne). I expect that it can be significantly improved. Making a local-ad pressure solver would give the biggest gain.

I intend to self-merge this when green, as it
 - affects no other code, and
 - is an experimental simulator.