### PR TITLE
Silence unused variable warnings.

### DIFF
--- a/opm/autodiff/BlackoilReorderingTransportModel.hpp
+++ b/opm/autodiff/BlackoilReorderingTransportModel.hpp
@@ -648,9 +648,9 @@ namespace Opm {
                 Vec2 dx;
                 jac.solve(dx, res);
                 dx *= relaxation;
-                const auto hcstate_old = state_.reservoir_state.hydroCarbonState()[cell];
+                // const auto hcstate_old = state_.reservoir_state.hydroCarbonState()[cell];
                 updateState(cell, -dx);
-                const auto hcstate = state_.reservoir_state.hydroCarbonState()[cell];
+                // const auto hcstate = state_.reservoir_state.hydroCarbonState()[cell];
                 assembleSingleCell(cell, res, jac);
                 ++iter;
                 if (iter > 10) {


### PR DESCRIPTION
This should fix warnings reported by other users. Curiously, clang did not give me a warning, even upon instantiation of the template. I have kept the commented-out lines as they are useful for continued debugging and experimentation (the solver should still be counted as experimental).

@akva2 I hope this removes all warnings you got.