### PR TITLE
Added branch for running the jenkins script multiple times with out ma…

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -34,13 +34,22 @@ declare -A downstreamRev
 
 # Clone opm-common
 pushd .
-mkdir -p $WORKSPACE/deps/opm-common
-cd $WORKSPACE/deps/opm-common
-git init .
-git remote add origin https://github.com/OPM/opm-common
-git fetch --depth 1 origin ${upstreamRev[opm-common]}:branch_to_build
-test $? -eq 0 || exit 1
-git checkout branch_to_build
+if [ ! -d $WORKSPACE/deps/opm-common ];then
+    mkdir -p $WORKSPACE/deps/opm-common
+    cd $WORKSPACE/deps/opm-common
+    git init .
+    git remote add origin https://github.com/OPM/opm-common
+    git fetch --depth 1 origin ${upstreamRev[opm-common]}:branch_to_build
+    test $? -eq 0 || exit 1
+    git checkout branch_to_build
+else
+    cd $WORKSPACE/deps/opm-common
+    #git fetch --depth 1 origin ${upstreamRev[opm-common]}:branch_to_build
+    #test $? -eq 0 || exit 1
+    git checkout branch_to_build   
+    git pull
+fi
+       
 popd
 
 source $WORKSPACE/deps/opm-common/jenkins/build-opm-module.sh


### PR DESCRIPTION
A small change to make the jenkin's script possible to use multiple times
Example of master skript which clone and build opm on ubuntu  (from hnil/opm-building/clone_and_build_opm_jenkins.sh) 

------------------------------------
```sh
#!/bin/bash

pushd .

#touch serial.cmake
#touch mpi.cmake
git clone git@github.com:OPM/opm-simulators.git
cd opm-simulators
export WORKSPACE=$PWD
export BTYPES="serial mpi"
export CMAKE_TOOLCHAIN_FILES="$PWD/../serial.cmake $PWD/../mpi.cmake"
export BUILDTHREADS=10
export ghprbCommentBody=

echo WORKSPACE is $WORKSPACE
echo BTYPES is $BTYPES
echo CMAKE_TOOLCHAIN_FILES is $CMAKE_TOOLCHAIN_FILES
jenkins/build.sh

popd
```
--------------------------------------------------------
