### PR TITLE
correcting the way to use efficiency factor in assembleWelEq

### DIFF
--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -571,7 +571,7 @@ namespace Opm
                 }
 
                 // subtract sum of phase fluxes in the well equations.
-                resWell_[0][componentIdx] -= cq_s[componentIdx].value();
+                resWell_[0][componentIdx] -= cq_s_effective.value();
 
                 // assemble the jacobians
                 for (int pvIdx = 0; pvIdx < numWellEq; ++pvIdx) {
@@ -579,7 +579,7 @@ namespace Opm
                         // also need to consider the efficiency factor when manipulating the jacobians.
                         duneC_[0][cell_idx][pvIdx][flowPhaseToEbosCompIdx(componentIdx)] -= cq_s_effective.derivative(pvIdx+numEq); // intput in transformed matrix
                     }
-                    invDuneD_[0][0][componentIdx][pvIdx] -= cq_s[componentIdx].derivative(pvIdx+numEq);
+                    invDuneD_[0][0][componentIdx][pvIdx] -= cq_s_effective.derivative(pvIdx+numEq);
                 }
 
                 for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
@@ -612,6 +612,7 @@ namespace Opm
                     cq_s_poly *= extendEval(intQuants.polymerConcentration() * intQuants.polymerViscosityCorrection());
                 }
                 if (!only_wells) {
+                    // TODO: we need to consider the efficiency here.
                     for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
                         ebosJac[cell_idx][cell_idx][contiPolymerEqIdx][flowToEbosPvIdx(pvIdx)] -= cq_s_poly.derivative(pvIdx);
                     }
@@ -626,7 +627,7 @@ namespace Opm
         // add vol * dF/dt + Q to the well equations;
         for (int componentIdx = 0; componentIdx < numComp; ++componentIdx) {
             EvalWell resWell_loc = (wellSurfaceVolumeFraction(componentIdx) - F0_[componentIdx]) * volume / dt;
-            resWell_loc += getQs(componentIdx);
+            resWell_loc += getQs(componentIdx) * well_efficiency_factor_;
             for (int pvIdx = 0; pvIdx < numWellEq; ++pvIdx) {
                 invDuneD_[0][0][componentIdx][pvIdx] += resWell_loc.derivative(pvIdx+numEq);
             }


### PR DESCRIPTION
For example in opm-data/spe9group, it improves the well curves of the injection wells in a relatively more significant way while makes the result of the production wells slightly worse. 
https://www.dropbox.com/s/riykfil01lf5f0r/spe9-group.pdf?dl=0

For some other examples, it improves the result slightly. 

It should not change anything for cases without `GEFAC` or `WEFAC` keywords, which are the most of the cases we have. 