### PR TITLE
Fix report step number associated with substeps.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -344,7 +344,8 @@ namespace Opm
                     eclIO_->overwriteInitialOIP(simProps);
                 }
                 // ... insert "extra" data (KR, VISC, ...)
-                eclIO_->writeTimeStep(timer.reportStepNum(),
+                const int reportStepForOutput = substep ? timer.reportStepNum() + 1 : timer.reportStepNum();
+                eclIO_->writeTimeStep(reportStepForOutput,
                                       substep,
                                       timer.simulationTimeElapsed(),
                                       simProps,


### PR DESCRIPTION
It appears summary files by convention expect all substep data points to be chunked together with the data point at the end of the report step. The report step index passed is used by opm-output to chunk the data points, we therefore must pass the same index for all data points that should be in the same chunk.

This is intended to fix a problem reported by Statoil. Marked as WIP as I cannot test that this actually solves their issue, so @alfbr you have to test this PR and report back if it addresses your problem without breaking anything!