### PR TITLE
avoiding the oscillation treatment applied to well solution

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -301,6 +301,15 @@ namespace Opm {
                 perfTimer.reset();
                 perfTimer.start();
 
+                // handling well state update before oscillation treatment is a decision based
+                // on observation to avoid some big performance degeneration under some circumstances.
+                // there is no theorectical explanation which way is better for sure.
+
+                if( nw > 0 )
+                {
+                    wellModel().recoverWellSolutionAndUpdateWellState(x, well_state);
+                }
+
                 if (param_.use_update_stabilization_) {
                     // Stabilize the nonlinear update.
                     bool isOscillate = false;
@@ -322,10 +331,6 @@ namespace Opm {
                 // chopping of the update.
                 updateState(x,iteration);
 
-                if( nw > 0 )
-                {
-                    wellModel().recoverWellSolutionAndUpdateWellState(x, well_state);
-                }
                 report.update_time += perfTimer.stop();
             }
 


### PR DESCRIPTION
It is a design to recover the old way to handle the oscillation before #1250, to avoid some performance degeneration for parallel running which was reported by @blattms . 

Not sure how it impacts serial and parallel running of other cases yet.  By theory, it should be okay, since the way handling oscillation introduced with #1250 only improves slightly for other running.  Recovering that should not introduce big performance degeneration. 

Anyway, this PR is only for testing purpose for now should not be considered to be merged before thorough testing. 