### PR TITLE
Use pore volume weighted averaged hydrocarbon state in rateConverted.

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -143,7 +143,7 @@ typedef Eigen::Array<double,
         // the field will be calculated.
         // TODO: more delicate implementation will be required if we want to handle different
         // FIP regions specified from the well specifications.
-        , rate_converter_(fluid_.phaseUsage(), fluid_.cellPvtRegionIndex(), AutoDiffGrid::numCells(grid_), std::vector<int>(AutoDiffGrid::numCells(grid_),0))
+        , rate_converter_(fluid_.phaseUsage(), std::vector<int>(AutoDiffGrid::numCells(grid_),0))
     {
         if (active_[Water]) {
             material_name_.push_back("Water");
@@ -2513,8 +2513,10 @@ typedef Eigen::Array<double,
 
                     // the average hydrocarbon conditions of the whole field will be used
                     const int fipreg = 0; // Not considering FIP for the moment.
+                    const int well_cell_top = wells->well_cells[wells->well_connpos[w]];
+                    const int pvtreg = fluid_.cellPvtRegionIndex()[well_cell_top];
 
-                    rate_converter_.calcCoeff(well_rates, fipreg, convert_coeff);
+                    rate_converter_.calcCoeff(fipreg, pvtreg, convert_coeff);
                     well_voidage_rates[w] = std::inner_product(well_rates.begin(), well_rates.end(),
                                                                convert_coeff.begin(), 0.0);
                 } else {
@@ -2525,7 +2527,9 @@ typedef Eigen::Array<double,
                               well_rates.begin());
                     // the average hydrocarbon conditions of the whole field will be used
                     const int fipreg = 0; // Not considering FIP for the moment.
-                    rate_converter_.calcCoeff(well_rates, fipreg, convert_coeff);
+                    const int well_cell_top = wells->well_cells[wells->well_connpos[w]];
+                    const int pvtreg = fluid_.cellPvtRegionIndex()[well_cell_top];
+                    rate_converter_.calcCoeff(fipreg, pvtreg, convert_coeff);
                     std::copy(convert_coeff.begin(), convert_coeff.end(),
                               voidage_conversion_coeffs.begin() + np * w);
                 }

--- a/opm/autodiff/SimulatorBase_impl.hpp
+++ b/opm/autodiff/SimulatorBase_impl.hpp
@@ -60,7 +60,7 @@ namespace Opm
           terminal_output_(param.getDefault("output_terminal", true)),
           eclipse_state_(eclipse_state),
           output_writer_(output_writer),
-          rateConverter_(props_.phaseUsage(), props.cellPvtRegionIndex(), AutoDiffGrid::numCells(grid_), std::vector<int>(AutoDiffGrid::numCells(grid_), 0)),
+          rateConverter_(props_.phaseUsage(), std::vector<int>(AutoDiffGrid::numCells(grid_), 0)),
           threshold_pressures_by_face_(threshold_pressures_by_face),
           is_parallel_run_( false ),
           defunct_well_names_(defunct_well_names)
@@ -560,7 +560,9 @@ namespace Opm
                         }
 
                         const int fipreg = 0; // Hack.  Ignore FIP regions.
-                        rateConverter_.calcCoeff(prates, fipreg, distr);
+                        const int well_cell_top = wells->well_cells[wells->well_connpos[*rp]];
+                        const int pvtreg = props_.cellPvtRegionIndex()[well_cell_top];
+                        rateConverter_.calcCoeff(fipreg, pvtreg, distr);
 
                         well_controls_iset_distr(ctrl, rctrl, & distr[0]);
                     }
@@ -582,7 +584,9 @@ namespace Opm
                             SimFIBODetails::historyRates(pu, p, hrates);
 
                             const int fipreg = 0; // Hack.  Ignore FIP regions.
-                            rateConverter_.calcCoeff(hrates, fipreg, distr);
+                            const int well_cell_top = wells->well_cells[wells->well_connpos[*rp]];
+                            const int pvtreg = props_.cellPvtRegionIndex()[well_cell_top];
+                            rateConverter_.calcCoeff(fipreg, pvtreg, distr);
 
                             // WCONHIST/RESV target is sum of all
                             // observed phase rates translated to

--- a/opm/autodiff/StandardWellsDense.hpp
+++ b/opm/autodiff/StandardWellsDense.hpp
@@ -96,7 +96,8 @@ namespace Opm {
                                const ModelParameters& param,
                                const RateConverterType& rate_converter,
                                const bool terminal_output,
-                               const int current_index);
+                               const int current_index,
+                               std::vector<int>& pvt_region_idx);
 
             void init(const PhaseUsage phase_usage_arg,
                       const std::vector<bool>& active_arg,
@@ -187,6 +188,7 @@ namespace Opm {
             PhaseUsage phase_usage_;
             std::vector<bool>  active_;
             const RateConverterType& rate_converter_;
+            std::vector<int> pvt_region_idx_;
 
             // the number of the cells in the local grid
             int number_of_cells_;

--- a/opm/autodiff/StandardWellsDense_impl.hpp
+++ b/opm/autodiff/StandardWellsDense_impl.hpp
@@ -11,7 +11,8 @@ namespace Opm {
                        const ModelParameters& param,
                        const RateConverterType& rate_converter,
                        const bool terminal_output,
-                       const int current_timeIdx)
+                       const int current_timeIdx,
+                       std::vector<int>& pvt_region_idx)
        : wells_active_(wells_arg!=nullptr)
        , wells_(wells_arg)
        , wells_ecl_(wells_ecl)
@@ -25,6 +26,7 @@ namespace Opm {
        , has_polymer_(GET_PROP_VALUE(TypeTag, EnablePolymer))
        , current_timeIdx_(current_timeIdx)
        , rate_converter_(rate_converter)
+       , pvt_region_idx_(pvt_region_idx)
     {
     }
 
@@ -776,6 +778,8 @@ namespace Opm {
 
         for (int w = 0; w < nw; ++w) {
             const bool is_producer = well_container_[w]->wellType() == PRODUCER;
+            const int well_cell_top = well_container_[w]->cells()[0];
+            const int pvtRegionIdx = pvt_region_idx_[well_cell_top];
 
             // not sure necessary to change all the value to be positive
             if (is_producer) {
@@ -786,7 +790,7 @@ namespace Opm {
                 // the average hydrocarbon conditions of the whole field will be used
                 const int fipreg = 0; // Not considering FIP for the moment.
 
-                rate_converter_.calcCoeff(well_rates, fipreg, convert_coeff);
+                rate_converter_.calcCoeff(fipreg, pvtRegionIdx, convert_coeff);
                 well_voidage_rates[w] = std::inner_product(well_rates.begin(), well_rates.end(),
                                                            convert_coeff.begin(), 0.0);
             } else {
@@ -797,7 +801,7 @@ namespace Opm {
                           well_rates.begin());
                 // the average hydrocarbon conditions of the whole field will be used
                 const int fipreg = 0; // Not considering FIP for the moment.
-                rate_converter_.calcCoeff(well_rates, fipreg, convert_coeff);
+                rate_converter_.calcCoeff(fipreg, pvtRegionIdx, convert_coeff);
                 std::copy(convert_coeff.begin(), convert_coeff.end(),
                           voidage_conversion_coeffs.begin() + np * w);
             }

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -94,6 +94,9 @@ namespace Opm
         /// Well name.
         const std::string& name() const;
 
+        /// Well cells.
+        const std::vector<int>& cells() {return well_cells_; }
+
         /// Well type, INJECTOR or PRODUCER.
         WellType wellType() const;
 

--- a/tests/test_rateconverter.cpp
+++ b/tests/test_rateconverter.cpp
@@ -90,8 +90,7 @@ BOOST_FIXTURE_TEST_CASE(Construction, TestFixture<SetupSimple>)
         SurfaceToReservoirVoidage<Props::FluidSystem, Region> RCvrt;
 
     Region reg{ 0 };
-    int numCells = Opm::UgGridHelpers::numCells(*grid.c_grid());
-    RCvrt  cvrt(ad_props.phaseUsage(), ad_props.cellPvtRegionIndex(), numCells, reg);
+    RCvrt  cvrt(ad_props.phaseUsage(), reg);
 }
 
 
@@ -105,18 +104,17 @@ BOOST_FIXTURE_TEST_CASE(ThreePhase, TestFixture<SetupSimple>)
 
     Region reg{ 0 };
     int numCells = Opm::UgGridHelpers::numCells(*grid.c_grid());
-    RCvrt  cvrt(ad_props.phaseUsage(), ad_props.cellPvtRegionIndex(), numCells, reg);
+    RCvrt  cvrt(ad_props.phaseUsage(), reg);
 
     Opm::BlackoilState x(numCells, Opm::UgGridHelpers::numFaces( *grid.c_grid()) , 3);
 
     cvrt.defineState(x);
 
-    std::vector<double> qs{1.0e3, 1.0e1, 1.0e-1};
-    std::vector<double> coeff(qs.size(), 0.0);
+    std::vector<double> coeff(3, 0.0);
 
     // Immiscible and incompressible: All coefficients are one (1),
     // irrespective of actual surface rates.
-    cvrt.calcCoeff(qs, 0, coeff);
+    cvrt.calcCoeff(0, 0, coeff);
     BOOST_CHECK_CLOSE(coeff[0], 1.0, 1.0e-6);
     BOOST_CHECK_CLOSE(coeff[1], 1.0, 1.0e-6);
     BOOST_CHECK_CLOSE(coeff[2], 1.0, 1.0e-6);


### PR DESCRIPTION
- pressure, rs and rv is averaged using hydrocarbon pore volume weights.
- pvtRegions is used as input in the conversion factor calculations.
- the pvt cell of the first well cell is used as the pvt index.
(Completing a well in two different PVT regions sounds like a very bad
idea anyway)
- FIP region support is added to the rate converter also for the ebos
interface.