### PR TITLE
mark the non-template methods of the adaptive time stepper as inline

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -949,6 +949,9 @@ protected:
                     if ( active[Water] ) {
                         fluidState.setSaturation(FluidSystem::waterPhaseIdx, saturations[cellIdx*numPhases + pu.phase_pos[Water]]);
                     }
+                    else {
+                        fluidState.setSaturation(FluidSystem::waterPhaseIdx, 0.0);
+                    }
                     fluidState.setSaturation(FluidSystem::oilPhaseIdx, saturations[cellIdx*numPhases + pu.phase_pos[Oil]]);
                     fluidState.setSaturation(FluidSystem::gasPhaseIdx, saturations[cellIdx*numPhases + pu.phase_pos[Gas]]);
 

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -74,11 +74,10 @@ namespace Opm {
 
     // AdaptiveTimeStepping
     //---------------------
-
-    AdaptiveTimeStepping::AdaptiveTimeStepping( const Tuning& tuning,
-                                                size_t time_step,
-                                                const ParameterGroup& param,
-                                                const bool terminal_output )
+    inline AdaptiveTimeStepping::AdaptiveTimeStepping( const Tuning& tuning,
+                                                       size_t time_step,
+                                                       const ParameterGroup& param,
+                                                       const bool terminal_output )
         : timeStepControl_()
         , restart_factor_( tuning.getTSFCNV(time_step) )
         , growth_factor_(tuning.getTFDIFF(time_step) )
@@ -97,8 +96,8 @@ namespace Opm {
 
     }
 
-    AdaptiveTimeStepping::AdaptiveTimeStepping( const ParameterGroup& param,
-                                                const bool terminal_output )
+    inline AdaptiveTimeStepping::AdaptiveTimeStepping( const ParameterGroup& param,
+                                                       const bool terminal_output )
         : timeStepControl_()
         , restart_factor_( param.getDefault("solver.restartfactor", double(0.33) ) )
         , growth_factor_( param.getDefault("solver.growthfactor", double(2) ) )
@@ -116,7 +115,7 @@ namespace Opm {
         init(param);
     }
 
-    void AdaptiveTimeStepping::
+    inline void AdaptiveTimeStepping::
     init(const ParameterGroup& param)
     {
         // valid are "pid" and "pid+iteration"


### PR DESCRIPTION
this is needed to avoid linker errors if this class ought to be used in multiple compile units. IMO the main problem here is the use of an _impl.hpp file.