### PR TITLE
Quell warnings

### DIFF
--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -376,7 +376,7 @@ createAMGPreconditionerPointer( Op& opA, const double relax, const P& comm, std:
         //! \brief The type describing the parallel information
         typedef P ParallelInformation;
         //! \brief The matrix type the preconditioner is for.
-        typedef typename Dune::remove_const<M>::type matrix_type;
+        typedef typename std::remove_const<M>::type matrix_type;
         //! \brief The domain type of the preconditioner.
         typedef X domain_type;
         //! \brief The range type of the preconditioner.

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -168,7 +168,7 @@ class ParallelOverlappingILU0
 
 public:
     //! \brief The matrix type the preconditioner is for.
-    typedef typename Dune::remove_const<Matrix>::type matrix_type;
+    typedef typename std::remove_const<Matrix>::type matrix_type;
     //! \brief The domain type of the preconditioner.
     typedef Domain domain_type;
     //! \brief The range type of the preconditioner.

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -1043,10 +1043,6 @@ namespace Opm
                 rates[ Gas ] = xw.wellRates()[well_index*np + pu.phase_pos[ Gas ] ];
             }
 
-            const int table_id = well_controls_iget_vfp(wc, current);
-            const double& thp    = well_controls_iget_target(wc, current);
-            const double& alq    = well_controls_iget_alq(wc, current);
-
             xw.bhp()[well_index] = calculateBhpFromThp(rates, current);
             break;
         }
@@ -1193,7 +1189,6 @@ namespace Opm
     {
         const int nperf = number_of_perforations_;
         // TODO: can make this a member?
-        const int nw = xw.bhp().size();
         const int numComp = numComponents();
         const PhaseUsage& pu = *phase_usage_;
         b_perf.resize(nperf*numComp);


### PR DESCRIPTION
- use std::remove_const
- remove unused variables