### PR TITLE
Communicate the ebos solution at the beginning of the run method.

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -159,6 +159,11 @@ public:
             ebosSimulator_.model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
         }
 
+        // Sync the overlap region of the inital solution. It was generated
+        // from the ReservoirState which has wrong values in the ghost region
+        // for some models (SPE9, Norne, Model 2)
+        ebosSimulator_.model().syncOverlap();
+
         // Create timers and file for writing timing info.
         Opm::time::StopWatch solver_timer;
         Opm::time::StopWatch step_timer;


### PR DESCRIPTION
Currently, the ReservoirState passed to the method and converted
to the initial solution of the Ebos simulator might have wrong
values in the ghost layer (this is the case for SPE9, Norne, Model 2).
This commit uses the syncOverlap method to update these values once they
are converted to the Ebos solution. The  ReservoirState remains untouched.
This is enough to have consistent values throughout the simulation and only
introduces one additional communication step.