### PR TITLE
Improve polymorphic flow

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -62,6 +62,11 @@ list (APPEND MAIN_SOURCE_FILES
   opm/polymer/TransportSolverTwophaseCompressiblePolymer.cpp
   opm/polymer/TransportSolverTwophasePolymer.cpp
   opm/polymer/fullyimplicit/PolymerPropsAd.cpp
+	opm/simulators/flow_ebos_blackoil.cpp
+  opm/simulators/flow_ebos_gasoil.cpp
+  opm/simulators/flow_ebos_oilwater.cpp
+  opm/simulators/flow_ebos_polymer.cpp
+  opm/simulators/flow_ebos_solvent.cpp
   opm/simulators/ensureDirectoryExists.cpp
   opm/simulators/SimulatorCompressibleTwophase.cpp
   opm/simulators/SimulatorIncompTwophase.cpp
@@ -273,6 +278,11 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer.hpp
   opm/polymer/fullyimplicit/SimulatorFullyImplicitBlackoilPolymer_impl.hpp
   opm/polymer/fullyimplicit/WellStateFullyImplicitBlackoilPolymer.hpp
+	opm/simulators/flow_ebos_blackoil.hpp
+  opm/simulators/flow_ebos_gasoil.hpp
+  opm/simulators/flow_ebos_oilwater.hpp
+  opm/simulators/flow_ebos_polymer.hpp
+  opm/simulators/flow_ebos_solvent.hpp
   opm/simulators/ensureDirectoryExists.hpp
   opm/simulators/ParallelFileMerger.hpp
   opm/simulators/SimulatorCompressibleTwophase.hpp

--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -18,69 +18,28 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif // HAVE_CONFIG_H
 
-#include <memory>
+#include <opm/simulators/flow_ebos_blackoil.hpp>
+#include <opm/simulators/flow_ebos_gasoil.hpp>
+#include <opm/simulators/flow_ebos_oilwater.hpp>
+#include <opm/simulators/flow_ebos_solvent.hpp>
+#include <opm/simulators/flow_ebos_polymer.hpp>
 
+#include <opm/autodiff/MissingFeatures.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
-
 #include <opm/common/ResetLocale.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 
-// Define making clear that the simulator supports AMG
-#define FLOW_SUPPORT_AMG 1
-
-#include <ewoms/models/blackoil/blackoiltwophaseindices.hh>
-
-#include <opm/autodiff/DuneMatrix.hpp>
-#include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/autodiff/FlowMainEbos.hpp>
-
-namespace Ewoms {
-namespace Properties {
-
-    ///////////////////////////////////
-    //   Twophase case
-    ///////////////////////////////////
-
-    NEW_TYPE_TAG(EclFlowOilWaterProblem, INHERITS_FROM(EclFlowProblem));
-    //! The indices required by the model
-    SET_TYPE_PROP(EclFlowOilWaterProblem, Indices,
-      Ewoms::BlackOilTwoPhaseIndices<GET_PROP_VALUE(TypeTag, EnableSolvent)?1:0, GET_PROP_VALUE(TypeTag, EnablePolymer)?1:0,  /*PVOffset=*/0, /*disabledCompIdx=*/2>);
-
-
-    NEW_TYPE_TAG(EclFlowGasOilProblem, INHERITS_FROM(EclFlowProblem));
-    //! The indices required by the model
-    SET_TYPE_PROP(EclFlowGasOilProblem, Indices,
-      Ewoms::BlackOilTwoPhaseIndices<GET_PROP_VALUE(TypeTag, EnableSolvent)?1:0, GET_PROP_VALUE(TypeTag, EnablePolymer)?1:0,  /*PVOffset=*/0, /*disabledCompIdx=*/1>);
-
-    ///////////////////////////////////
-    //   Polymer case
-    ///////////////////////////////////
-
-    NEW_TYPE_TAG(EclFlowPolymerProblem, INHERITS_FROM(EclFlowProblem));
-    SET_BOOL_PROP(EclFlowPolymerProblem, EnablePolymer, true);
-
-
-    ///////////////////////////////////
-    //   Solvent case
-    ///////////////////////////////////
-
-    NEW_TYPE_TAG(EclFlowSolventProblem, INHERITS_FROM(EclFlowProblem));
-    SET_BOOL_PROP(EclFlowSolventProblem, EnableSolvent, true);
-
-}} // end namespaces
-
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
 
 namespace detail
 {
@@ -191,14 +150,14 @@ int main(int argc, char** argv)
             // oil-gas
             if (phases.active( Opm::Phase::GAS ))
             {
-                Opm::FlowMainEbos<TTAG(EclFlowGasOilProblem)> mainfunc;
-                return mainfunc.execute(argc, argv, deck, eclipseState );
+                Opm::flowEbosGasOilSetDeck(*deck, *eclipseState);
+                return Opm::flowEbosGasOilMain(argc, argv);
             }
             // oil-water
             else if ( phases.active( Opm::Phase::WATER ) )
             {
-                Opm::FlowMainEbos<TTAG(EclFlowOilWaterProblem)> mainfunc;
-                return mainfunc.execute(argc, argv, deck, eclipseState );
+                Opm::flowEbosOilWaterSetDeck(*deck, *eclipseState);
+                return Opm::flowEbosOilWaterMain(argc, argv);
             }
             else {
                 if (outputCout)
@@ -208,20 +167,18 @@ int main(int argc, char** argv)
         }
         // Polymer case
         else if ( phases.active( Opm::Phase::POLYMER ) ) {
-            Opm::FlowMainEbos<TTAG(EclFlowPolymerProblem)> mainfunc;
-            return mainfunc.execute(argc, argv, deck, eclipseState );
-
+            Opm::flowEbosPolymerSetDeck(*deck, *eclipseState);
+            return Opm::flowEbosPolymerMain(argc, argv);
         }
         // Solvent case
         else if ( phases.active( Opm::Phase::SOLVENT ) ) {
-            Opm::FlowMainEbos<TTAG(EclFlowSolventProblem)> mainfunc;
-            return mainfunc.execute(argc, argv, deck, eclipseState );
-
+            Opm::flowEbosSolventSetDeck(*deck, *eclipseState);
+            return Opm::flowEbosSolventMain(argc, argv);
         }
         // Blackoil case
         else if( phases.size() == 3 ) {
-            Opm::FlowMainEbos<TTAG(EclFlowProblem)> mainfunc;
-            return mainfunc.execute(argc, argv, deck, eclipseState );
+            Opm::flowEbosBlackoilSetDeck(*deck, *eclipseState);
+            return Opm::flowEbosBlackoilMain(argc, argv);
         }
         else
         {

--- a/examples/flow_ebos.cpp
+++ b/examples/flow_ebos.cpp
@@ -1,8 +1,4 @@
 /*
-  Copyright 2013, 2014, 2015 SINTEF ICT, Applied Mathematics.
-  Copyright 2014 Dr. Blatt - HPC-Simulation-Software & Services
-  Copyright 2015 IRIS AS
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -18,39 +14,12 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif // HAVE_CONFIG_H
 
-// Define making clear that the simulator supports AMG
-#define FLOW_SUPPORT_AMG 1
-
-#include <opm/common/ResetLocale.hpp>
-#include <dune/grid/CpGrid.hpp>
-#include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/autodiff/FlowMainEbos.hpp>
-
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
+#include <opm/simulators/flow_ebos_blackoil.hpp>
 
 // ----------------- Main program -----------------
 int main(int argc, char** argv)
 {
-    // we always want to use the default locale, and thus spare us the trouble
-    // with incorrect locale settings.
-    Opm::resetLocale();
-
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv);
-#endif
-
-    Opm::FlowMainEbos<TTAG(EclFlowProblem)> mainfunc;
-    return mainfunc.execute(argc, argv);
+    return Opm::flowEbosBlackoilMain(argc, argv);
 }

--- a/examples/flow_ebos.cpp
+++ b/examples/flow_ebos.cpp
@@ -27,16 +27,30 @@
 // Define making clear that the simulator supports AMG
 #define FLOW_SUPPORT_AMG 1
 
-#include <opm/material/densead/Evaluation.hpp>
-#include <opm/autodiff/DuneMatrix.hpp>
+#include <opm/common/ResetLocale.hpp>
 #include <dune/grid/CpGrid.hpp>
 #include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/autodiff/FlowMainEbos.hpp>
 
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
 
 // ----------------- Main program -----------------
 int main(int argc, char** argv)
 {
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+#else
+    Dune::MPIHelper::instance(argc, argv);
+#endif
+
     Opm::FlowMainEbos<TTAG(EclFlowProblem)> mainfunc;
     return mainfunc.execute(argc, argv);
 }

--- a/examples/flow_ebos_2p.cpp
+++ b/examples/flow_ebos_2p.cpp
@@ -25,13 +25,18 @@
 // Define making clear that the simulator supports AMG
 #define FLOW_SUPPORT_AMG 1
 
-#include <opm/material/densead/Evaluation.hpp>
+#include <opm/common/ResetLocale.hpp>
 #include <ewoms/models/blackoil/blackoiltwophaseindices.hh>
 
-#include <opm/autodiff/DuneMatrix.hpp>
 #include <dune/grid/CpGrid.hpp>
 #include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/autodiff/FlowMainEbos.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
 
 namespace Ewoms {
 namespace Properties {
@@ -44,6 +49,16 @@ SET_TYPE_PROP(EclFlowTwoPhaseProblem, Indices,
 // ----------------- Main program -----------------
 int main(int argc, char** argv)
 {
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+#else
+    Dune::MPIHelper::instance(argc, argv);
+#endif
+
     Opm::FlowMainEbos<TTAG(EclFlowTwoPhaseProblem)> mainfunc;
     return mainfunc.execute(argc, argv);
 }

--- a/examples/flow_ebos_polymer.cpp
+++ b/examples/flow_ebos_polymer.cpp
@@ -22,11 +22,16 @@
 #include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <opm/material/densead/Evaluation.hpp>
-#include <opm/autodiff/DuneMatrix.hpp>
+#include <opm/common/ResetLocale.hpp>
 #include <dune/grid/CpGrid.hpp>
 #include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/autodiff/FlowMainEbos.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
 
 namespace Ewoms {
 namespace Properties {
@@ -37,6 +42,18 @@ SET_BOOL_PROP(EclFlowPolymerProblem, EnablePolymer, true);
 // ----------------- Main program -----------------
 int main(int argc, char** argv)
 {
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+    // initialize MPI, finalize is done automatically on exit
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+    const int myRank = Dune::Fem::MPIManager::rank();
+#else
+    const int myRank = Dune::MPIHelper::instance(argc, argv).rank();
+#endif
+
     Opm::FlowMainEbos<TTAG(EclFlowPolymerProblem)> mainfunc;
     return mainfunc.execute(argc, argv);
 }

--- a/examples/flow_ebos_polymer.cpp
+++ b/examples/flow_ebos_polymer.cpp
@@ -1,6 +1,4 @@
 /*
-  Copyright 2017 IRIS AS
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -16,44 +14,12 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif // HAVE_CONFIG_H
 
-#include <opm/common/ResetLocale.hpp>
-#include <dune/grid/CpGrid.hpp>
-#include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/autodiff/FlowMainEbos.hpp>
-
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
-namespace Ewoms {
-namespace Properties {
-NEW_TYPE_TAG(EclFlowPolymerProblem, INHERITS_FROM(EclFlowProblem));
-SET_BOOL_PROP(EclFlowPolymerProblem, EnablePolymer, true);
-}}
+#include <opm/simulators/flow_ebos_polymer.hpp>
 
 // ----------------- Main program -----------------
 int main(int argc, char** argv)
 {
-    // we always want to use the default locale, and thus spare us the trouble
-    // with incorrect locale settings.
-    Opm::resetLocale();
-
-    // initialize MPI, finalize is done automatically on exit
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-    const int myRank = Dune::Fem::MPIManager::rank();
-#else
-    const int myRank = Dune::MPIHelper::instance(argc, argv).rank();
-#endif
-
-    Opm::FlowMainEbos<TTAG(EclFlowPolymerProblem)> mainfunc;
-    return mainfunc.execute(argc, argv);
+    return Opm::flowEbosPolymerMain(argc, argv);
 }

--- a/examples/flow_ebos_solvent.cpp
+++ b/examples/flow_ebos_solvent.cpp
@@ -22,11 +22,16 @@
 #include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <opm/material/densead/Evaluation.hpp>
-#include <opm/autodiff/DuneMatrix.hpp>
+#include <opm/common/ResetLocale.hpp>
 #include <dune/grid/CpGrid.hpp>
 #include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/autodiff/FlowMainEbos.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
 
 namespace Ewoms {
 namespace Properties {
@@ -37,6 +42,18 @@ SET_BOOL_PROP(EclFlowSolventProblem, EnableSolvent, true);
 // ----------------- Main program -----------------
 int main(int argc, char** argv)
 {
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+    // initialize MPI, finalize is done automatically on exit
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+    const int myRank = Dune::Fem::MPIManager::rank();
+#else
+    const int myRank = Dune::MPIHelper::instance(argc, argv).rank();
+#endif
+
     Opm::FlowMainEbos<TTAG(EclFlowSolventProblem)> mainfunc;
     return mainfunc.execute(argc, argv);
 }

--- a/examples/flow_ebos_solvent.cpp
+++ b/examples/flow_ebos_solvent.cpp
@@ -1,6 +1,4 @@
 /*
-  Copyright 2017 IRIS AS
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -16,44 +14,12 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif // HAVE_CONFIG_H
 
-#include <opm/common/ResetLocale.hpp>
-#include <dune/grid/CpGrid.hpp>
-#include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/autodiff/FlowMainEbos.hpp>
-
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
-namespace Ewoms {
-namespace Properties {
-NEW_TYPE_TAG(EclFlowSolventProblem, INHERITS_FROM(EclFlowProblem));
-SET_BOOL_PROP(EclFlowSolventProblem, EnableSolvent, true);
-}}
+#include <opm/simulators/flow_ebos_solvent.hpp>
 
 // ----------------- Main program -----------------
 int main(int argc, char** argv)
 {
-    // we always want to use the default locale, and thus spare us the trouble
-    // with incorrect locale settings.
-    Opm::resetLocale();
-
-    // initialize MPI, finalize is done automatically on exit
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-    const int myRank = Dune::Fem::MPIManager::rank();
-#else
-    const int myRank = Dune::MPIHelper::instance(argc, argv).rank();
-#endif
-
-    Opm::FlowMainEbos<TTAG(EclFlowSolventProblem)> mainfunc;
-    return mainfunc.execute(argc, argv);
+    return Opm::flowEbosSolventMain(argc, argv);
 }

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -91,6 +91,10 @@ SET_BOOL_PROP(EclFlowProblem, UseVolumetricResidual, false);
 // SWATINIT is done by the flow part of flow_ebos. this can be removed once the legacy
 // code for fluid and satfunc handling gets fully retired.
 SET_BOOL_PROP(EclFlowProblem, EnableSwatinit, false);
+
+// Silence the deprecation warnings about the SimulatorParameter mechanism. This needs to
+// be removed once the SimulatorParameter mechanism bites the dust!
+SET_TYPE_PROP(EclFlowProblem, SimulatorParameter, Ewoms::EmptySimulationParameters);
 }}
 
 namespace Opm {

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -93,19 +93,17 @@ namespace Opm
         /// simulator classes, based on user command-line input.  The
         /// content of this function used to be in the main() function of
         /// flow.cpp.
-        int execute(int argc, char** argv,
-                    std::shared_ptr<Opm::Deck> deck = std::shared_ptr<Opm::Deck>(),
-                    std::shared_ptr<Opm::EclipseState> eclipseState = std::shared_ptr<Opm::EclipseState>() )
+        int execute(int argc, char** argv)
         {
             try {
-                setupParallelism(argc, argv);
+                setupParallelism();
                 printStartupMessage();
                 const bool ok = setupParameters(argc, argv);
                 if (!ok) {
                     return EXIT_FAILURE;
                 }
 
-                setupEbosSimulator( deck, eclipseState );
+                setupEbosSimulator();
                 setupOutput();
                 setupLogging();
                 printPRTHeader();
@@ -145,7 +143,7 @@ namespace Opm
         }
 
     protected:
-        void setupParallelism(int argc, char** argv)
+        void setupParallelism()
         {
             // determine the rank of the current process and the number of processes
             // involved in the simulation. MPI must have already been initialized here.
@@ -410,7 +408,7 @@ namespace Opm
                           detail::ParallelFileMerger(output_path, deck_filename.stem().string()));
         }
 
-        void setupEbosSimulator( std::shared_ptr<Opm::Deck>& dck, std::shared_ptr<Opm::EclipseState>& eclipseState)
+        void setupEbosSimulator()
         {
             std::string progName("flow_ebos");
             std::string deckFile("--ecl-deck-file-name=");

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -78,7 +78,6 @@ namespace Opm
     public:
         typedef typename GET_PROP(TypeTag, MaterialLaw)::EclMaterialLawManager MaterialLawManager;
         typedef typename GET_PROP_TYPE(TypeTag, Simulator) EbosSimulator;
-        typedef typename GET_PROP_TYPE(TypeTag, SimulatorParameter) EbosSimulatorParameter;
         typedef typename GET_PROP_TYPE(TypeTag, Grid) Grid;
         typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
         typedef typename GET_PROP_TYPE(TypeTag, Problem) Problem;
@@ -419,10 +418,9 @@ namespace Opm
             char* ptr[2];
             ptr[ 0 ] = const_cast< char * > (progName.c_str());
             ptr[ 1 ] = const_cast< char * > (deckFile.c_str());
-            EbosSimulatorParameter simParam( dck, eclipseState );
             EbosSimulator::registerParameters();
             Ewoms::setupParameters_< TypeTag > ( 2, ptr );
-            ebosSimulator_.reset(new EbosSimulator(simParam, /*verbose=*/false));
+            ebosSimulator_.reset(new EbosSimulator(/*verbose=*/false));
             ebosSimulator_->model().applyInitialSolution();
 
             // Create a grid with a global view.

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -949,6 +949,9 @@ protected:
                     if ( active[Water] ) {
                         fluidState.setSaturation(FluidSystem::waterPhaseIdx, saturations[cellIdx*numPhases + pu.phase_pos[Water]]);
                     }
+                    else {
+                        fluidState.setSaturation(FluidSystem::waterPhaseIdx, 0.0);
+                    }
                     fluidState.setSaturation(FluidSystem::oilPhaseIdx, saturations[cellIdx*numPhases + pu.phase_pos[Oil]]);
                     fluidState.setSaturation(FluidSystem::gasPhaseIdx, saturations[cellIdx*numPhases + pu.phase_pos[Gas]]);
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -455,7 +455,7 @@ public:
     { return ebosSimulator_.gridManager().grid(); }
 
 protected:
-    void handleAdditionalWellInflow(SimulatorTimer& timer,
+    void handleAdditionalWellInflow(SimulatorTimer& /*timer*/,
                                     WellsManager& /* wells_manager */,
                                     WellState& /* well_state */,
                                     const Wells* /* wells */)

--- a/opm/simulators/flow_ebos_blackoil.cpp
+++ b/opm/simulators/flow_ebos_blackoil.cpp
@@ -1,0 +1,62 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+// Define making clear that the simulator supports AMG
+#define FLOW_SUPPORT_AMG 1
+
+#include <opm/simulators/flow_ebos_blackoil.hpp>
+
+#include <opm/common/ResetLocale.hpp>
+#include <dune/grid/CpGrid.hpp>
+#include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
+#include <opm/autodiff/FlowMainEbos.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
+
+namespace Opm {
+
+void flowEbosBlackoilSetDeck(Deck &deck, EclipseState& eclState)
+{
+    typedef TTAG(EclFlowProblem) TypeTag;
+    typedef GET_PROP_TYPE(TypeTag, GridManager) GridManager;
+
+    GridManager::setExternalDeck(&deck, &eclState);
+}
+
+// ----------------- Main program -----------------
+int flowEbosBlackoilMain(int argc, char** argv)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+#else
+    Dune::MPIHelper::instance(argc, argv);
+#endif
+
+    Opm::FlowMainEbos<TTAG(EclFlowProblem)> mainfunc;
+    return mainfunc.execute(argc, argv);
+}
+
+}

--- a/opm/simulators/flow_ebos_blackoil.hpp
+++ b/opm/simulators/flow_ebos_blackoil.hpp
@@ -14,12 +14,15 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "config.h"
+#ifndef FLOW_EBOS_BLACKOIL_HPP
+#define FLOW_EBOS_BLACKOIL_HPP
 
-#include <opm/simulators/flow_ebos_oilwater.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
-// ----------------- Main program -----------------
-int main(int argc, char** argv)
-{
-    return Opm::flowEbosOilWaterMain(argc, argv);
+namespace Opm {
+void flowEbosBlackoilSetDeck(Deck &deck, EclipseState& eclState);
+int flowEbosBlackoilMain(int argc, char** argv);
 }
+
+#endif // FLOW_EBOS_BLACKOIL_HPP

--- a/opm/simulators/flow_ebos_gasoil.cpp
+++ b/opm/simulators/flow_ebos_gasoil.cpp
@@ -1,0 +1,74 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+// Define making clear that the simulator supports AMG
+#define FLOW_SUPPORT_AMG 1
+
+#include <opm/simulators/flow_ebos_gasoil.hpp>
+
+#include <opm/common/ResetLocale.hpp>
+#include <ewoms/models/blackoil/blackoiltwophaseindices.hh>
+
+#include <dune/grid/CpGrid.hpp>
+#include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
+#include <opm/autodiff/FlowMainEbos.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
+
+namespace Ewoms {
+namespace Properties {
+NEW_TYPE_TAG(EclFlowGasOilProblem, INHERITS_FROM(EclFlowProblem));
+//! The indices required by the model
+SET_TYPE_PROP(EclFlowGasOilProblem, Indices,
+              Ewoms::BlackOilTwoPhaseIndices<GET_PROP_VALUE(TypeTag, EnableSolvent)?1:0,
+                GET_PROP_VALUE(TypeTag, EnablePolymer)?1:0,
+                /*PVOffset=*/0, /*disabledCompIdx=*/1>);
+}}
+
+namespace Opm {
+void flowEbosGasOilSetDeck(Deck &deck, EclipseState& eclState)
+{
+    typedef TTAG(EclFlowGasOilProblem) TypeTag;
+    typedef GET_PROP_TYPE(TypeTag, GridManager) GridManager;
+
+    GridManager::setExternalDeck(&deck, &eclState);
+}
+
+
+// ----------------- Main program -----------------
+int flowEbosGasOilMain(int argc, char** argv)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+#else
+    Dune::MPIHelper::instance(argc, argv);
+#endif
+
+    Opm::FlowMainEbos<TTAG(EclFlowGasOilProblem)> mainfunc;
+    return mainfunc.execute(argc, argv);
+}
+
+}

--- a/opm/simulators/flow_ebos_gasoil.hpp
+++ b/opm/simulators/flow_ebos_gasoil.hpp
@@ -14,12 +14,15 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "config.h"
+#ifndef FLOW_EBOS_GASOIL_HPP
+#define FLOW_EBOS_GASOIL_HPP
 
-#include <opm/simulators/flow_ebos_oilwater.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
-// ----------------- Main program -----------------
-int main(int argc, char** argv)
-{
-    return Opm::flowEbosOilWaterMain(argc, argv);
+namespace Opm {
+void flowEbosGasOilSetDeck(Deck &deck, EclipseState& eclState);
+int flowEbosGasOilMain(int argc, char** argv);
 }
+
+#endif // FLOW_EBOS_GASOIL_HPP

--- a/opm/simulators/flow_ebos_oilwater.cpp
+++ b/opm/simulators/flow_ebos_oilwater.cpp
@@ -1,0 +1,73 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+// Define making clear that the simulator supports AMG
+#define FLOW_SUPPORT_AMG 1
+
+#include <opm/simulators/flow_ebos_oilwater.hpp>
+
+#include <opm/common/ResetLocale.hpp>
+#include <ewoms/models/blackoil/blackoiltwophaseindices.hh>
+
+#include <dune/grid/CpGrid.hpp>
+#include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
+#include <opm/autodiff/FlowMainEbos.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
+
+namespace Ewoms {
+namespace Properties {
+NEW_TYPE_TAG(EclFlowOilWaterProblem, INHERITS_FROM(EclFlowProblem));
+//! The indices required by the model
+SET_TYPE_PROP(EclFlowOilWaterProblem, Indices,
+              Ewoms::BlackOilTwoPhaseIndices<GET_PROP_VALUE(TypeTag, EnableSolvent)?1:0,
+                GET_PROP_VALUE(TypeTag, EnablePolymer)?1:0,
+                /*PVOffset=*/0, /*disabledCompIdx=*/2>);
+}}
+
+namespace Opm {
+void flowEbosOilWaterSetDeck(Deck &deck, EclipseState& eclState)
+{
+    typedef TTAG(EclFlowOilWaterProblem) TypeTag;
+    typedef GET_PROP_TYPE(TypeTag, GridManager) GridManager;
+
+    GridManager::setExternalDeck(&deck, &eclState);
+}
+
+// ----------------- Main program -----------------
+int flowEbosOilWaterMain(int argc, char** argv)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+#else
+    Dune::MPIHelper::instance(argc, argv);
+#endif
+
+    Opm::FlowMainEbos<TTAG(EclFlowOilWaterProblem)> mainfunc;
+    return mainfunc.execute(argc, argv);
+}
+
+}

--- a/opm/simulators/flow_ebos_oilwater.hpp
+++ b/opm/simulators/flow_ebos_oilwater.hpp
@@ -14,12 +14,15 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "config.h"
+#ifndef FLOW_EBOS_OILWATER_HPP
+#define FLOW_EBOS_OILWATER_HPP
 
-#include <opm/simulators/flow_ebos_oilwater.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
-// ----------------- Main program -----------------
-int main(int argc, char** argv)
-{
-    return Opm::flowEbosOilWaterMain(argc, argv);
+namespace Opm {
+void flowEbosOilWaterSetDeck(Deck &deck, EclipseState& eclState);
+int flowEbosOilWaterMain(int argc, char** argv);
 }
+
+#endif // FLOW_EBOS_OILWATER_HPP

--- a/opm/simulators/flow_ebos_polymer.cpp
+++ b/opm/simulators/flow_ebos_polymer.cpp
@@ -1,0 +1,65 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#include <opm/simulators/flow_ebos_polymer.hpp>
+
+#include <opm/common/ResetLocale.hpp>
+#include <dune/grid/CpGrid.hpp>
+#include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
+#include <opm/autodiff/FlowMainEbos.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
+
+namespace Ewoms {
+namespace Properties {
+NEW_TYPE_TAG(EclFlowPolymerProblem, INHERITS_FROM(EclFlowProblem));
+SET_BOOL_PROP(EclFlowPolymerProblem, EnablePolymer, true);
+}}
+
+namespace Opm {
+void flowEbosPolymerSetDeck(Deck &deck, EclipseState& eclState)
+{
+    typedef TTAG(EclFlowPolymerProblem) TypeTag;
+    typedef GET_PROP_TYPE(TypeTag, GridManager) GridManager;
+
+    GridManager::setExternalDeck(&deck, &eclState);
+}
+
+// ----------------- Main program -----------------
+int flowEbosPolymerMain(int argc, char** argv)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+    // initialize MPI, finalize is done automatically on exit
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+#else
+    Dune::MPIHelper::instance(argc, argv).rank();
+#endif
+
+    Opm::FlowMainEbos<TTAG(EclFlowPolymerProblem)> mainfunc;
+    return mainfunc.execute(argc, argv);
+}
+
+}

--- a/opm/simulators/flow_ebos_polymer.hpp
+++ b/opm/simulators/flow_ebos_polymer.hpp
@@ -14,12 +14,15 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "config.h"
+#ifndef FLOW_EBOS_POLYMER_HPP
+#define FLOW_EBOS_POLYMER_HPP
 
-#include <opm/simulators/flow_ebos_oilwater.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
-// ----------------- Main program -----------------
-int main(int argc, char** argv)
-{
-    return Opm::flowEbosOilWaterMain(argc, argv);
+namespace Opm {
+void flowEbosPolymerSetDeck(Deck &deck, EclipseState& eclState);
+int flowEbosPolymerMain(int argc, char** argv);
 }
+
+#endif // FLOW_EBOS_POLYMER_HPP

--- a/opm/simulators/flow_ebos_solvent.cpp
+++ b/opm/simulators/flow_ebos_solvent.cpp
@@ -1,0 +1,65 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#include <opm/simulators/flow_ebos_solvent.hpp>
+
+#include <opm/common/ResetLocale.hpp>
+#include <dune/grid/CpGrid.hpp>
+#include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
+#include <opm/autodiff/FlowMainEbos.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
+
+namespace Ewoms {
+namespace Properties {
+NEW_TYPE_TAG(EclFlowSolventProblem, INHERITS_FROM(EclFlowProblem));
+SET_BOOL_PROP(EclFlowSolventProblem, EnableSolvent, true);
+}}
+
+namespace Opm {
+void flowEbosSolventSetDeck(Deck &deck, EclipseState& eclState)
+{
+    typedef TTAG(EclFlowSolventProblem) TypeTag;
+    typedef GET_PROP_TYPE(TypeTag, GridManager) GridManager;
+
+    GridManager::setExternalDeck(&deck, &eclState);
+}
+
+// ----------------- Main program -----------------
+int flowEbosSolventMain(int argc, char** argv)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+    // initialize MPI, finalize is done automatically on exit
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+#else
+    Dune::MPIHelper::instance(argc, argv).rank();
+#endif
+
+    Opm::FlowMainEbos<TTAG(EclFlowSolventProblem)> mainfunc;
+    return mainfunc.execute(argc, argv);
+}
+
+}

--- a/opm/simulators/flow_ebos_solvent.hpp
+++ b/opm/simulators/flow_ebos_solvent.hpp
@@ -14,12 +14,15 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "config.h"
+#ifndef FLOW_EBOS_SOLVENT_HPP
+#define FLOW_EBOS_SOLVENT_HPP
 
-#include <opm/simulators/flow_ebos_oilwater.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
-// ----------------- Main program -----------------
-int main(int argc, char** argv)
-{
-    return Opm::flowEbosOilWaterMain(argc, argv);
+namespace Opm {
+void flowEbosSolventSetDeck(Deck &deck, EclipseState& eclState);
+int flowEbosSolventMain(int argc, char** argv);
 }
+
+#endif // FLOW_EBOS_SOLVENT_HPP

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -74,11 +74,10 @@ namespace Opm {
 
     // AdaptiveTimeStepping
     //---------------------
-
-    AdaptiveTimeStepping::AdaptiveTimeStepping( const Tuning& tuning,
-                                                size_t time_step,
-                                                const ParameterGroup& param,
-                                                const bool terminal_output )
+    inline AdaptiveTimeStepping::AdaptiveTimeStepping( const Tuning& tuning,
+                                                       size_t time_step,
+                                                       const ParameterGroup& param,
+                                                       const bool terminal_output )
         : timeStepControl_()
         , restart_factor_( tuning.getTSFCNV(time_step) )
         , growth_factor_(tuning.getTFDIFF(time_step) )
@@ -97,8 +96,8 @@ namespace Opm {
 
     }
 
-    AdaptiveTimeStepping::AdaptiveTimeStepping( const ParameterGroup& param,
-                                                const bool terminal_output )
+    inline AdaptiveTimeStepping::AdaptiveTimeStepping( const ParameterGroup& param,
+                                                       const bool terminal_output )
         : timeStepControl_()
         , restart_factor_( param.getDefault("solver.restartfactor", double(0.33) ) )
         , growth_factor_( param.getDefault("solver.growthfactor", double(2) ) )
@@ -116,7 +115,7 @@ namespace Opm {
         init(param);
     }
 
-    void AdaptiveTimeStepping::
+    inline void AdaptiveTimeStepping::
     init(const ParameterGroup& param)
     {
         // valid are "pid" and "pid+iteration"


### PR DESCRIPTION
The motivation for this PR is that currently the build fails on my Ubuntu 17.10 laptop with two processes because that machine "only" has 8 GB of RAM (granted, the optimization options may have been a bit too excessive). under the new scheme, each specialization of the simulator
is put into a separate compile unit which is part of libopmsimulators. this has the advantages that the specialized simulators and the main binary automatically stay consistent, the compilation is faster (2m25s vs 4m16s on my machine) because all compile units can be built in parallel and that compilation takes up less RAM because there is no need to instantiate all specializations in a single compile unit.

on the minus side, all specializations must now always be compiled, the approach means slightly more work for the maintainers and the flow_* startup code gets even more complicated.

note that this PR has a symbiotic dependency on OPM/ewoms#226. permission to merge both is hereby granted.

further note that this PR requires #1283 and thus includes it, so #1283 can be closed if the present PR is merged.