### PR TITLE
workaround eigen 3.3.2 issue

### DIFF
--- a/tests/test_autodiffmatrix.cpp
+++ b/tests/test_autodiffmatrix.cpp
@@ -331,16 +331,24 @@ BOOST_AUTO_TEST_CASE(DivOpsDouble)
     Sp x;
     auto zd = z/factor;
     zd.toSparse(x);
-    BOOST_CHECK(x == zs/factor);
+    Sp tmp = zs/factor;
+    tmp.prune(1e-16);
+    BOOST_CHECK(x == tmp);
     auto id = i/factor;
     id.toSparse(x);
-    BOOST_CHECK(x == is/factor);
+    tmp = is/factor;
+    tmp.prune(1e-16);
+    BOOST_CHECK(x == tmp);
     auto dd = d/factor;
     dd.toSparse(x);
-    BOOST_CHECK(x == ds/factor);
+    tmp = ds/factor;
+    tmp.prune(1e-16);
+    BOOST_CHECK(x == tmp);
     auto sd = s/factor;
     sd.toSparse(x);
-    BOOST_CHECK(x == ss/factor);
+    tmp = ss/factor;
+    tmp.prune(1e-16);
+    BOOST_CHECK(x == tmp);
 }
 
 BOOST_AUTO_TEST_CASE(MultVectorXd)


### PR DESCRIPTION
eigen returns a matrix with all coefficients stored from the operator/
this makes the comparison fail as x has no nonzeros. this broke the autodiffmatrix test.

not very happy about this but i see no other way to go about it.