### PR TITLE
[cleanup] Removes unnecessary if clauses for unsupported DUNE versions.

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -413,11 +413,7 @@ namespace Opm {
                 if (elem.partitionType() != Dune::InteriorEntity)
                     continue;
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
 		unsigned globalElemIdx = elemMapper.index(elem);
-#else
-		unsigned globalElemIdx = elemMapper.map(elem);
-#endif
                 const auto& priVarsNew = ebosSimulator_.model().solution(/*timeIdx=*/0)[globalElemIdx];
 
                 Scalar pressureNew;

--- a/opm/autodiff/DuneMatrix.hpp
+++ b/opm/autodiff/DuneMatrix.hpp
@@ -33,14 +33,7 @@
 #include <dune/common/fmatrix.hh>
 #include <dune/common/version.hh>
 
-#if DUNE_VERSION_NEWER(DUNE_ISTL,2,4)
 #include <dune/istl/bcrsmatrix.hh>
-#else
-// Include matrix header with hackery to make it possible to inherit.
-#define private protected
-#include <dune/istl/bcrsmatrix.hh>
-#undef private
-#endif
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
@@ -90,15 +83,13 @@ namespace Opm
 
             nnz = ia[rows];
 
-#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 3)
-    #if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 5)
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 5)
             this->allocationSize_ = nnz;
-    #else
+#else
             this->allocationSize = nnz;
-    #endif
+#endif
             this->avg = 0;
             this->overflowsize = -1.0;
-#endif
 
             // make sure to use the allocators of this matrix
             // because the same allocators are used to deallocate the data

--- a/opm/autodiff/ExtractParallelGridInformationToISTL.cpp
+++ b/opm/autodiff/ExtractParallelGridInformationToISTL.cpp
@@ -25,7 +25,7 @@
  namespace Opm
 {
 #if defined(HAVE_OPM_GRID)
-#if defined(HAVE_MPI) && defined(HAVE_DUNE_ISTL) && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#if defined(HAVE_MPI) && defined(HAVE_DUNE_ISTL)
 // Extracts the information about the data decomposition from the grid for dune-istl
 void extractParallelGridInformationToISTL(const Dune::CpGrid& grid, boost::any& anyComm)
 {
@@ -44,6 +44,6 @@ void extractParallelGridInformationToISTL(const Dune::CpGrid& grid, boost::any& 
 // Missing support for MPI or dune-istl -> do nothing.
 void extractParallelGridInformationToISTL(const Dune::CpGrid&, boost::any&)
 {}
-#endif //defined(HAVE_MPI) && defined(HAVE_DUNE_ISTL)  && DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
+#endif //defined(HAVE_MPI) && defined(HAVE_DUNE_ISTL)
 #endif //defined(HAVE_OPM_GRID)
 } // end namespace Opm

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -27,11 +27,7 @@
 
 
 #include <dune/common/version.hh>
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
-#else
-#include <dune/common/mpihelper.hh>
-#endif
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -837,13 +837,8 @@ namespace Opm
                         continue; // intersection is on the domain boundary
                     }
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
                     unsigned c1 = globalElemMapper.index(is.inside());
                     unsigned c2 = globalElemMapper.index(is.outside());
-#else
-                    unsigned c1 = globalElemMapper.map(is.inside());
-                    unsigned c2 = globalElemMapper.map(is.outside());
-#endif
 
                     if (c1 > c2)
                     {
@@ -909,13 +904,8 @@ namespace Opm
                         continue; // intersection is on the domain boundary
                     }
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
                     unsigned c1 = globalElemMapper.index(is.inside());
                     unsigned c2 = globalElemMapper.index(is.outside());
-#else
-                    unsigned c1 = globalElemMapper.map(is.inside());
-                    unsigned c2 = globalElemMapper.map(is.outside());
-#endif
 
                     if (c1 > c2)
                     {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -151,11 +151,7 @@ namespace Opm
         vtkpath << "/output-" << std::setw(3) << std::setfill('0') << step;
         ensureDirectoryExists(vtkpath.str());
         vtkfilename << "output-" << std::setw(3) << std::setfill('0') << step;
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 3)
         Dune::VTKWriter<Dune::CpGrid::LeafGridView> writer(grid.leafGridView(), Dune::VTK::nonconforming);
-#else
-        Dune::VTKWriter<Dune::CpGrid::LeafGridView> writer(grid.leafView(), Dune::VTK::nonconforming);
-#endif
         writer.addCellData(state.saturation(), "saturation", state.numPhases());
         writer.addCellData(state.pressure(), "pressure", 1);
 

--- a/tests/test_transmissibilitymultipliers.cpp
+++ b/tests/test_transmissibilitymultipliers.cpp
@@ -37,11 +37,7 @@
 
 #if HAVE_OPM_GRID
 #include <dune/common/version.hh>
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2,3)
 #include <dune/common/parallel/mpihelper.hh>
-#else
-#include <dune/common/mpihelper.hh>
-#endif
 #include <dune/grid/CpGrid.hpp>
 #endif
 


### PR DESCRIPTION
We are targetting DUNE 2.4.* and 2.5.* currently. Therefore this commit removes
the if checks for lower versions to cleanup the code.