### PR TITLE
do not set the SimulationParameter property anymore

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -91,10 +91,6 @@ SET_BOOL_PROP(EclFlowProblem, UseVolumetricResidual, false);
 // SWATINIT is done by the flow part of flow_ebos. this can be removed once the legacy
 // code for fluid and satfunc handling gets fully retired.
 SET_BOOL_PROP(EclFlowProblem, EnableSwatinit, false);
-
-// Silence the deprecation warnings about the SimulatorParameter mechanism. This needs to
-// be removed once the SimulatorParameter mechanism bites the dust!
-SET_TYPE_PROP(EclFlowProblem, SimulatorParameter, Ewoms::EmptySimulationParameters);
 }}
 
 namespace Opm {


### PR DESCRIPTION
this needs to merged before OPM/ewoms#227. the PR can be merged before OPM/ewoms#227, but it will cause spurious deprecation warnings. (i.e., it is best to merge OPM/ewoms#227 and this one together, permission to do so for the eWoms part is hereby granted to everyone.)