### PR TITLE
update flow startup message

### DIFF
--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -187,7 +187,7 @@ namespace Opm
             if (output_cout_) {
                 const int lineLen = 70;
                 const std::string version = moduleVersionName();
-                const std::string banner = "This is flow (version "+version+")";
+                const std::string banner = "This is flow "+version;
                 const int bannerPreLen = (lineLen - 2 - banner.size())/2;
                 const int bannerPostLen = bannerPreLen + (lineLen - 2 - banner.size())%2;
                 std::cout << "**********************************************************************\n";
@@ -195,8 +195,8 @@ namespace Opm
                 std::cout << "*" << std::string(bannerPreLen, ' ') << banner << std::string(bannerPostLen, ' ') << "*\n";
                 std::cout << "*                                                                    *\n";
                 std::cout << "* Flow is a simulator for fully implicit three-phase black-oil flow, *\n";
-                std::cout << "*            and is part of OPM. For more information see:           *\n";
-                std::cout << "*                       http://opm-project.org                       *\n";
+                std::cout << "*             including solvent and polymer capabilities.            *\n";
+                std::cout << "*          For more information, see http://opm-project.org          *\n";
                 std::cout << "*                                                                    *\n";
                 std::cout << "**********************************************************************\n\n";
             }


### PR DESCRIPTION
The old message was not really accurate anymore because flow also supports the polymer and solvent extensions. (Also, the parentheses around the version were because they are not necessary.)

v2: use the message proposed by [at]atgeirr