### PR TITLE
LOG and PRT file clean-up

### DIFF
--- a/opm/autodiff/BlackoilModelBase_impl.hpp
+++ b/opm/autodiff/BlackoilModelBase_impl.hpp
@@ -1803,7 +1803,7 @@ typedef Eigen::Array<double,
                 }
                 msg += "  WELL-CONT";
                 // std::cout << "  WELL-CONT ";
-                OpmLog::note(msg);
+                OpmLog::debug(msg);
             }
             std::ostringstream ss;
             const std::streamsize oprec = ss.precision(3);
@@ -1822,7 +1822,7 @@ typedef Eigen::Array<double,
             // std::cout << std::setw(11) << residualWell;
             ss.precision(oprec);
             ss.flags(oflags);
-            OpmLog::note(ss.str());
+            OpmLog::debug(ss.str());
         }
 
         for (int idx = 0; idx < nm; ++idx) {
@@ -1933,7 +1933,7 @@ typedef Eigen::Array<double,
                     msg += "  W-FLUX(" + materialName(idx).substr(0, 1) + ")";
                 }
                 msg += "  WELL-CONT";
-                OpmLog::note(msg);
+                OpmLog::debug(msg);
             }
             std::ostringstream ss;
             const std::streamsize oprec = ss.precision(3);
@@ -1945,7 +1945,7 @@ typedef Eigen::Array<double,
             ss << std::setw(11) << residualWell;
             ss.precision(oprec);
             ss.flags(oflags);
-            OpmLog::note(ss.str());
+            OpmLog::debug(ss.str());
         }
         return converged;
     }

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -925,7 +925,7 @@ namespace Opm {
                     for (int compIdx = 0; compIdx < numComp; ++compIdx) {
                         msg += "    CNV(" + key[ compIdx ] + ") ";
                     }
-                    OpmLog::note(msg);
+                    OpmLog::debug(msg);
                 }
                 std::ostringstream ss;
                 const std::streamsize oprec = ss.precision(3);
@@ -939,7 +939,7 @@ namespace Opm {
                 }
                 ss.precision(oprec);
                 ss.flags(oflags);
-                OpmLog::note(ss.str());
+                OpmLog::debug(ss.str());
             }
 
             for (int phaseIdx = 0; phaseIdx < numPhases(); ++phaseIdx) {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -266,7 +266,7 @@ public:
                 std::ostringstream step_msg;
                 boost::posix_time::time_facet* facet = new boost::posix_time::time_facet("%d-%b-%Y");
                 step_msg.imbue(std::locale(std::locale::classic(), facet));
-                step_msg << "\nTime step " << std::setw(4) <<timer.currentStepNum()
+                step_msg << "\nReport step " << std::setw(4) <<timer.currentStepNum()
                          << " at day " << (double)unit::convert::to(timer.simulationTimeElapsed(), unit::day)
                          << "/" << (double)unit::convert::to(timer.totalTime(), unit::day)
                          << ", date = " << timer.currentDateTime();

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -230,7 +230,7 @@ public:
             {
                 std::ostringstream ss;
                 timer.report(ss);
-                OpmLog::note(ss.str());
+                OpmLog::debug(ss.str());
             }
 
             // Run a multiple steps of the solver depending on the time step control.

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -345,7 +345,7 @@ public:
                 std::string msg =
                     "Time step took " + std::to_string(solver_timer.secsSinceStart()) + " seconds; "
                     "total solver time " + std::to_string(report.solver_time) + " seconds.";
-                OpmLog::note(msg);
+                OpmLog::debug(msg);
             }
 
             // write simulation state at the report stage

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -266,7 +266,8 @@ public:
                 std::ostringstream step_msg;
                 boost::posix_time::time_facet* facet = new boost::posix_time::time_facet("%d-%b-%Y");
                 step_msg.imbue(std::locale(std::locale::classic(), facet));
-                step_msg << "\nReport step " << std::setw(4) <<timer.currentStepNum()
+                step_msg << "\nReport step " << std::setw(2) <<timer.currentStepNum()
+                         << "/" << timer.numSteps()
                          << " at day " << (double)unit::convert::to(timer.simulationTimeElapsed(), unit::day)
                          << "/" << (double)unit::convert::to(timer.totalTime(), unit::day)
                          << ", date = " << timer.currentDateTime();

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -225,7 +225,7 @@ namespace Opm {
             if( timestep_verbose_ )
             {
                 std::ostringstream ss;
-                ss <<"  Substep " << substepTimer.currentStepNum() << ", stepsize "
+                ss <<"Time step " << substepTimer.currentStepNum() << ", stepsize "
                    << unit::convert::to(substepTimer.currentStepLength(), unit::day) << " days.";
                 OpmLog::info(ss.str());
             }
@@ -238,7 +238,7 @@ namespace Opm {
 
                 if( solver_verbose_ ) {
                     // report number of linear iterations
-                    OpmLog::note("Overall linear iterations used: " + std::to_string(substepReport.total_linear_iterations));
+                    OpmLog::debug("Overall linear iterations used: " + std::to_string(substepReport.total_linear_iterations));
                 }
             }
             catch (const Opm::TooManyIterations& e) {
@@ -309,7 +309,7 @@ namespace Opm {
                 if( timestep_verbose_ )
                 {
                     std::ostringstream ss;
-                    ss << "    Substep summary: ";
+                    ss << "Time step summary: ";
                     if (substepReport.total_well_iterations != 0) {
                         ss << "well its = " << std::setw(2) << substepReport.total_well_iterations << ", ";
                     }
@@ -389,7 +389,7 @@ namespace Opm {
             std::ostringstream ss;
             substepTimer.report(ss);
             ss << "Suggested next step size = " << unit::convert::to( suggested_next_timestep_, unit::day ) << " (days)" << std::endl;
-            OpmLog::note(ss.str());
+            OpmLog::debug(ss.str());
         }
 
         if( ! std::isfinite( suggested_next_timestep_ ) ) { // check for NaN

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -225,7 +225,7 @@ namespace Opm {
             if( timestep_verbose_ )
             {
                 std::ostringstream ss;
-                ss <<"Time step " << substepTimer.currentStepNum() << ", stepsize "
+                ss <<"\nTime step " << substepTimer.currentStepNum() << ", stepsize "
                    << unit::convert::to(substepTimer.currentStepLength(), unit::day) << " days.";
                 OpmLog::info(ss.str());
             }


### PR DESCRIPTION
Trying to move our output in a direction more tailored to users. Nothing removed, but some messages that seems developer centric have been removed from the PRT file but kept in the DEBUG file.