### PR TITLE
Revert "Revert "Communicate the ebos solution at the beginning of the run method"

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -159,6 +159,11 @@ public:
             ebosSimulator_.model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
         }
 
+        // Sync the overlap region of the inital solution. It was generated
+        // from the ReservoirState which has wrong values in the ghost region
+        // for some models (SPE9, Norne, Model 2)
+        ebosSimulator_.model().syncOverlap();
+
         // Create timers and file for writing timing info.
         Opm::time::StopWatch solver_timer;
         Opm::time::StopWatch step_timer;


### PR DESCRIPTION
Reverts OPM/opm-simulators#1306

This makes the commit in question win the prize for being the most-flipped piece of code in OPM.

After the original commit (in #1286) was reverted (in #1306) it was discovered that even as performance for 8 threads recovered (if not fully), now the solution was a bit off. At least further away from the serial solution than it used to be. The choice between a slow (with 8 threads) solution and a wrong one is forced: we must for now take the slow one, while the whole situation is investigated further.

I'll merge this reversion straight away, as there have been quite a bit of offline discussions about it.