### PR TITLE
make the build work if UMFPACK is not available

### DIFF
--- a/opm/autodiff/MSWellHelpers.hpp
+++ b/opm/autodiff/MSWellHelpers.hpp
@@ -24,14 +24,16 @@
 
 #include <opm/common/ErrorMacros.hpp>
 #include <dune/istl/solvers.hh>
+#if HAVE_UMFPACK
 #include <dune/istl/umfpack.hh>
+#endif // HAVE_UMFPACK
 #include <cmath>
 
 namespace Opm {
 
 namespace mswellhelpers
 {
-
+#if HAVE_UMFPACK
     // obtain y = D^-1 * x with a direct solver
     template <typename MatrixType, typename VectorType>
     VectorType
@@ -60,6 +62,7 @@ namespace mswellhelpers
 
         return y;
     }
+#endif // HAVE_UMFPACK
 
 
 

--- a/opm/autodiff/MultisegmentWell_impl.hpp
+++ b/opm/autodiff/MultisegmentWell_impl.hpp
@@ -494,7 +494,11 @@ namespace Opm
         duneB_.mv(x, Bx);
 
         // invDBx = duneD^-1 * Bx_
+#if HAVE_UMFPACK
         const BVectorWell invDBx = mswellhelpers::invDXDirect(duneD_, Bx);
+#else
+        const BVectorWell invDBx = mswellhelpers::invDX(duneD_, Bx);
+#endif
 
         // Ax = Ax - duneC_^T * invDBx
         duneC_.mmtv(invDBx,Ax);
@@ -510,7 +514,11 @@ namespace Opm
     apply(BVector& r) const
     {
         // invDrw_ = duneD^-1 * resWell_
+#if HAVE_UMFPACK
         const BVectorWell invDrw = mswellhelpers::invDXDirect(duneD_, resWell_);
+#else
+        const BVectorWell invDrw = mswellhelpers::invDX(duneD_, resWell_);
+#endif // HAVE_UMFPACK
         // r = r - duneC_^T * invDrw
         duneC_.mmtv(invDrw, r);
     }
@@ -628,7 +636,11 @@ namespace Opm
         // resWell = resWell - B * x
         duneB_.mmv(x, resWell);
         // xw = D^-1 * resWell
+#if HAVE_UMFPACK
         xw = mswellhelpers::invDXDirect(duneD_, resWell);
+#else
+        xw = mswellhelpers::invDX(duneD_, resWell);
+#endif // HAVE_UMFPACK
     }
 
 
@@ -640,9 +652,13 @@ namespace Opm
     MultisegmentWell<TypeTag>::
     solveEqAndUpdateWellState(WellState& well_state)
     {
+#if HAVE_UMFPACK
         // We assemble the well equations, then we check the convergence,
         // which is why we do not put the assembleWellEq here.
         const BVectorWell dx_well = mswellhelpers::invDXDirect(duneD_, resWell_);
+#else
+        const BVectorWell dx_well = mswellhelpers::invDX(duneD_, resWell_);
+#endif
 
         updateWellState(dx_well, false, well_state);
     }
@@ -1744,7 +1760,11 @@ namespace Opm
 
             assembleWellEqWithoutIteration(ebosSimulator, dt, well_state, true);
 
+#if HAVE_UMFPACK
             const BVectorWell dx_well = mswellhelpers::invDXDirect(duneD_, resWell_);
+#else
+            const BVectorWell dx_well = mswellhelpers::invDX(duneD_, resWell_);
+#endif
 
             // TODO: use these small values for now, not intend to reach the convergence
             // in this stage, but, should we?


### PR DESCRIPTION
this was caused by the recent work on multisegmented wells. If UMFPack is available, it compiled.

@akva2: this is a candidate for backporting to the release/2017.10 branch.