### PR TITLE
Use MatrixBlock instead of FieldMatrix for DUNE 2.5.0

### DIFF
--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -429,7 +429,9 @@ namespace Opm
             }
         }
 
-#if DUNE_VERSION_NEWER(DUNE_ISTL, 2 , 5)
+#if DUNE_VERSION_NEWER_REV(DUNE_ISTL, 2 , 5, 1)
+        // 3x3 matrix block inversion was unstable at least 2.3 until and including
+        // 2.5.0
         typedef ParallelOverlappingILU0<Matrix,Vector,Vector> SeqPreconditioner;
 #else
         typedef ParallelOverlappingILU0<Dune::BCRSMatrix<Dune::MatrixBlock<typename Matrix::field_type,
@@ -449,7 +451,9 @@ namespace Opm
 
 #if HAVE_MPI
         typedef Dune::OwnerOverlapCopyCommunication<int, int> Comm;
-#if DUNE_VERSION_NEWER(DUNE_ISTL, 2 , 5)
+#if DUNE_VERSION_NEWER_REV(DUNE_ISTL, 2 , 5, 1)
+        // 3x3 matrix block inversion was unstable from at least 2.3 until and
+        // including 2.5.0
         typedef ParallelOverlappingILU0<Matrix,Vector,Vector,Comm> ParPreconditioner;
 #else
         typedef ParallelOverlappingILU0<Dune::BCRSMatrix<Dune::MatrixBlock<typename Matrix::field_type,

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -25,6 +25,7 @@
 
 
 #include <opm/autodiff/WellInterface.hpp>
+#include <opm/autodiff/ISTLSolver.hpp>
 
 namespace Opm
 {
@@ -82,8 +83,16 @@ namespace Opm
         typedef Dune::FieldVector<Scalar, numWellEq> VectorBlockWellType;
         typedef Dune::BlockVector<VectorBlockWellType> BVectorWell;
 
+#if  DUNE_VERSION_NEWER_REV(DUNE_ISTL, 2 , 5, 1)
+        // 3x3 matrix block inversion was unstable from at least 2.3 until and
+        // including 2.5.0
         // the matrix type for the diagonal matrix D
         typedef Dune::FieldMatrix<Scalar, numWellEq, numWellEq > DiagMatrixBlockWellType;
+#else
+        // the matrix type for the diagonal matrix D
+        typedef Dune::MatrixBlock<Scalar, numWellEq, numWellEq > DiagMatrixBlockWellType;
+#endif
+
         typedef Dune::BCRSMatrix <DiagMatrixBlockWellType> DiagMatWell;
 
         // the matrix type for the non-diagonal matrix B and C^T


### PR DESCRIPTION
3x3 matrix block inversion in FieldMatrix is numerically unstable
including version 2.5.0. Therefore the previous if clause was wrong
as it activated the use of FieldMatrix already for 2.5.0 (the version
in Debian stable). With this commit we use MatrixBlock for version 2.5.0.
This PR is an update of #1240 for DUNE 2.5.

I am sorry that this fell through the cracks and I only posted this now. 

As 2.5.0 is the version of DUNE in Debian stretch this should definitely end up in the Debian packages. Please note that this might also fix the different time stepping seen for some SPE cases after updating the jenkins server.