### PR TITLE
Apply the well residuals to cell residuals in SolveJacobianSystem

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -355,10 +355,6 @@ namespace Opm {
                 // assembles the well equations and applies the wells to
                 // the reservoir equations as a source term.
                 wellModel().assemble(iterationIdx, dt);
-
-                // apply well residual to the residual.
-                auto& ebosResid = ebosSimulator_.model().linearizer().residual();
-                wellModel().apply(ebosResid);
             }
             catch ( const Dune::FMatrixError& e  )
             {
@@ -468,9 +464,9 @@ namespace Opm {
             // The residual is modified similarly.
             // r = [r, r_well], where r is the residual and r_well the well residual.
             // r -= B^T * D^-1 r_well
-            // Note: Currently the residual is modified in the assembleMassBalanceEq call.
-            // It conceptually belongs here, but moving it changes the solution path for some
-            // unknown reasons.
+
+            // apply well residual to the residual.
+            wellModel().apply(ebosResid);
 
             // set initial guess
             x = 0.0;


### PR DESCRIPTION
This was moved to assemble() some time ago but according to my logic it
belongs in the solve method since this is only a trick to solve the well
equations simultaneously with the reservoir equations.

A buggy side effect of the currect implementation was that the well
residual was considered in the convergence test. I.e. this move changes
the convergence behaviour of the simulator.