### PR TITLE
WIP Update RESV and ECON limits at the beginning of a timestep

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -185,7 +185,7 @@ namespace Opm {
         /// \param[in] timer                  simulation timer
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
-        void prepareStep(const SimulatorTimerInterface& /*timer*/,
+        void prepareStep(const SimulatorTimerInterface& timer,
                          const ReservoirState& /*reservoir_state*/,
                          const WellState& /* well_state */)
         {
@@ -194,7 +194,7 @@ namespace Opm {
             wasSwitched_.resize(numDof);
             std::fill(wasSwitched_.begin(), wasSwitched_.end(), false);
 
-            wellModel().beginTimeStep();
+            wellModel().beginTimeStep(timer.reportStepNum());
         }
 
 

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -136,7 +136,7 @@ namespace Opm {
             void setRestartWellState(const WellState& well_state);
 
             // called at the beginning of a time step
-            void beginTimeStep();
+            void beginTimeStep(const int timeStepIdx);
             // called at the end of a time step
             void timeStepSucceeded();
 
@@ -207,7 +207,7 @@ namespace Opm {
 
             void setupCompressedToCartesian(const int* global_cell, int number_of_cells, std::map<int,int>& cartesian_to_compressed ) const;
 
-            void computeRepRadiusPerfLength(const Grid& grid);
+            void computeRepRadiusPerfLength();
 
 
             void computeAverageFormationFactor(std::vector<double>& B_avg) const;


### PR DESCRIPTION
Before this was only done every report step. For long report steps with
many substeps this leads to wrong results.

This effect the results of norne, model 2 etc. 

