### PR TITLE
changed: make libdune-uggrid-dev an alternative for libug-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: build-essential, debhelper (>= 9), libboost-filesystem-dev,
                texlive-latex-extra, texlive-latex-recommended, ghostscript,
                libopm-core-dev, libopm-material-dev, libeigen3-dev,
                libopm-parser-dev, libboost-iostreams-dev, libopm-common-dev,
-               libopm-grid-dev, libdune-grid-dev, libug-dev, libopm-output-dev,
+               libopm-grid-dev, libdune-grid-dev, libopm-output-dev,
                libtrilinos-zoltan-dev, libopenmpi-dev, mpi-default-bin, libewoms-dev
 Standards-Version: 3.9.2
 Section: libs


### PR DESCRIPTION
former is used on stretch, latter is used on xenial