### PR TITLE
replacing BlackoilPhases:: with Oil Water Gas in well model

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -32,7 +32,6 @@
 #include <opm/autodiff/GridHelpers.hpp>
 #include <opm/autodiff/GeoProps.hpp>
 #include <opm/autodiff/BlackoilDetails.hpp>
-#include <opm/autodiff/BlackoilModelEnums.hpp>
 #include <opm/autodiff/NewtonIterationBlackoilInterface.hpp>
 #include <opm/autodiff/RateConverter.hpp>
 

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -40,7 +40,6 @@
 #include <opm/core/simulator/SimulatorReport.hpp>
 #include <opm/autodiff/VFPProperties.hpp>
 #include <opm/autodiff/WellHelpers.hpp>
-#include <opm/autodiff/BlackoilModelEnums.hpp>
 #include <opm/autodiff/WellDensitySegmented.hpp>
 #include <opm/autodiff/BlackoilPropsAdFromDeck.hpp>
 #include <opm/autodiff/BlackoilDetails.hpp>

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -61,7 +61,7 @@ namespace Opm {
                                                 dynamic_list_econ_limited_,
                                                 grid.comm().size() > 1,
                                                 defunct_well_names) );
-	
+
         // Wells are active if they are active wells on at least
         // one process.
         wells_active_ = localWellsActive() ? 1 : 0;

--- a/opm/autodiff/MultisegmentWell_impl.hpp
+++ b/opm/autodiff/MultisegmentWell_impl.hpp
@@ -668,22 +668,22 @@ namespace Opm
             double sum_kr = 0.;
 
             const PhaseUsage& pu = phaseUsage();
-            if (pu.phase_used[BlackoilPhases::Aqua]) {
-                const int water_pos = pu.phase_pos[BlackoilPhases::Aqua];
+            if (pu.phase_used[Water]) {
+                const int water_pos = pu.phase_pos[Water];
                 kr[water_pos] = intQuants.relativePermeability(FluidSystem::waterPhaseIdx).value();
                 sum_kr += kr[water_pos];
                 density[water_pos] = fs.density(FluidSystem::waterPhaseIdx).value();
             }
 
-            if (pu.phase_used[BlackoilPhases::Liquid]) {
-                const int oil_pos = pu.phase_pos[BlackoilPhases::Liquid];
+            if (pu.phase_used[Oil]) {
+                const int oil_pos = pu.phase_pos[Oil];
                 kr[oil_pos] = intQuants.relativePermeability(FluidSystem::oilPhaseIdx).value();
                 sum_kr += kr[oil_pos];
                 density[oil_pos] = fs.density(FluidSystem::oilPhaseIdx).value();
             }
 
-            if (pu.phase_used[BlackoilPhases::Vapour]) {
-                const int gas_pos = pu.phase_pos[BlackoilPhases::Vapour];
+            if (pu.phase_used[Gas]) {
+                const int gas_pos = pu.phase_pos[Gas];
                 kr[gas_pos] = intQuants.relativePermeability(FluidSystem::gasPhaseIdx).value();
                 sum_kr += kr[gas_pos];
                 density[gas_pos] = fs.density(FluidSystem::gasPhaseIdx).value();
@@ -1129,9 +1129,8 @@ namespace Opm
             // it is the phase viscosities asked for
             std::vector<EvalWell> visc(number_of_phases_, 0.0);
             const EvalWell seg_pressure = getSegmentPressure(seg);
-            if (pu.phase_used[BlackoilPhases::Aqua]) {
-                // TODO: what is the difference between Water and BlackoilPhases::Aqua?
-                const int water_pos = pu.phase_pos[BlackoilPhases::Aqua];
+            if (pu.phase_used[Water]) {
+                const int water_pos = pu.phase_pos[Water];
                 b[water_pos] =
                     FluidSystem::waterPvt().inverseFormationVolumeFactor(pvt_region_index, temperature, seg_pressure);
                 visc[water_pos] =
@@ -1140,10 +1139,10 @@ namespace Opm
 
             EvalWell rv(0.0);
             // gas phase
-            if (pu.phase_used[BlackoilPhases::Vapour]) {
-                const int gaspos = pu.phase_pos[BlackoilPhases::Vapour];
-                if (pu.phase_used[BlackoilPhases::Liquid]) {
-                    const int oilpos = pu.phase_pos[BlackoilPhases::Liquid];
+            if (pu.phase_used[Gas]) {
+                const int gaspos = pu.phase_pos[Gas];
+                if (pu.phase_used[Oil]) {
+                    const int oilpos = pu.phase_pos[Oil];
                     const EvalWell rvmax = FluidSystem::gasPvt().saturatedOilVaporizationFactor(pvt_region_index, temperature, seg_pressure);
                     if (mix_s[oilpos] > 0.0) {
                         if (mix_s[gaspos] > 0.0) {
@@ -1174,10 +1173,10 @@ namespace Opm
 
             EvalWell rs(0.0);
             // oil phase
-            if (pu.phase_used[BlackoilPhases::Liquid]) {
-                const int oilpos = pu.phase_pos[BlackoilPhases::Liquid];
-                if (pu.phase_used[BlackoilPhases::Liquid]) {
-                    const int gaspos = pu.phase_pos[BlackoilPhases::Vapour];
+            if (pu.phase_used[Oil]) {
+                const int oilpos = pu.phase_pos[Oil];
+                if (pu.phase_used[Oil]) {
+                    const int gaspos = pu.phase_pos[Gas];
                     const EvalWell rsmax = FluidSystem::oilPvt().saturatedGasDissolutionFactor(pvt_region_index, temperature, seg_pressure);
                     if (mix_s[gaspos] > 0.0) {
                         if (mix_s[oilpos] > 0.0) {
@@ -1207,9 +1206,9 @@ namespace Opm
             }
 
             std::vector<EvalWell> mix(mix_s);
-            if (pu.phase_used[BlackoilPhases::Liquid] && pu.phase_used[BlackoilPhases::Vapour]) {
-                const int gaspos = pu.phase_pos[BlackoilPhases::Vapour];
-                const int oilpos = pu.phase_pos[BlackoilPhases::Liquid];
+            if (pu.phase_used[Oil] && pu.phase_used[Gas]) {
+                const int gaspos = pu.phase_pos[Gas];
+                const int oilpos = pu.phase_pos[Oil];
                 if (rs != 0.0) { // rs > 0.0?
                     mix[gaspos] = (mix_s[gaspos] - mix_s[oilpos] * rs) / (1. - rs * rv);
                 }

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -1133,7 +1133,7 @@ namespace Opm
         const int w = index_of_well_;
 
         //rs and rv are only used if both oil and gas is present
-        if (pu.phase_used[BlackoilPhases::Vapour] && pu.phase_used[BlackoilPhases::Liquid]) {
+        if (pu.phase_used[Gas] && pu.phase_used[Oil]) {
             rsmax_perf.resize(nperf);
             rvmax_perf.resize(nperf);
         }
@@ -1150,17 +1150,17 @@ namespace Opm
             const double p_avg = (xw.perfPress()[first_perf_ + perf] + p_above)/2;
             const double temperature = fs.temperature(FluidSystem::oilPhaseIdx).value();
 
-            if (pu.phase_used[BlackoilPhases::Aqua]) {
-                b_perf[ pu.phase_pos[BlackoilPhases::Aqua] + perf * numComp] =
+            if (pu.phase_used[Water]) {
+                b_perf[ pu.phase_pos[Water] + perf * numComp] =
                 FluidSystem::waterPvt().inverseFormationVolumeFactor(fs.pvtRegionIndex(), temperature, p_avg);
             }
 
-            if (pu.phase_used[BlackoilPhases::Vapour]) {
-                const int gaspos = pu.phase_pos[BlackoilPhases::Vapour] + perf * numComp;
-                const int gaspos_well = pu.phase_pos[BlackoilPhases::Vapour] + w * pu.num_phases;
+            if (pu.phase_used[Gas]) {
+                const int gaspos = pu.phase_pos[Gas] + perf * numComp;
+                const int gaspos_well = pu.phase_pos[Gas] + w * pu.num_phases;
 
-                if (pu.phase_used[BlackoilPhases::Liquid]) {
-                    const int oilpos_well = pu.phase_pos[BlackoilPhases::Liquid] + w * pu.num_phases;
+                if (pu.phase_used[Oil]) {
+                    const int oilpos_well = pu.phase_pos[Oil] + w * pu.num_phases;
                     const double oilrate = std::abs(xw.wellRates()[oilpos_well]); //in order to handle negative rates in producers
                     rvmax_perf[perf] = FluidSystem::gasPvt().saturatedOilVaporizationFactor(fs.pvtRegionIndex(), temperature, p_avg);
                     if (oilrate > 0) {
@@ -1182,12 +1182,12 @@ namespace Opm
                 }
             }
 
-            if (pu.phase_used[BlackoilPhases::Liquid]) {
-                const int oilpos = pu.phase_pos[BlackoilPhases::Liquid] + perf * numComp;
-                const int oilpos_well = pu.phase_pos[BlackoilPhases::Liquid] + w * pu.num_phases;
-                if (pu.phase_used[BlackoilPhases::Vapour]) {
+            if (pu.phase_used[Oil]) {
+                const int oilpos = pu.phase_pos[Oil] + perf * numComp;
+                const int oilpos_well = pu.phase_pos[Oil] + w * pu.num_phases;
+                if (pu.phase_used[Gas]) {
                     rsmax_perf[perf] = FluidSystem::oilPvt().saturatedGasDissolutionFactor(fs.pvtRegionIndex(), temperature, p_avg);
-                    const int gaspos_well = pu.phase_pos[BlackoilPhases::Vapour] + w * pu.num_phases;
+                    const int gaspos_well = pu.phase_pos[Gas] + w * pu.num_phases;
                     const double gasrate = std::abs(xw.wellRates()[gaspos_well]) - xw.solventWellRate(w);
                     if (gasrate > 0) {
                         const double oilrate = std::abs(xw.wellRates()[oilpos_well]);
@@ -1263,8 +1263,8 @@ namespace Opm
         //    absolute values of the surface rates divided by their sum.
         //    Then compute volume ratios (formation factors) for each perforation.
         //    Finally compute densities for the segments associated with each perforation.
-        const int gaspos = phase_usage.phase_pos[BlackoilPhases::Vapour];
-        const int oilpos = phase_usage.phase_pos[BlackoilPhases::Liquid];
+        const int gaspos = phase_usage.phase_pos[Gas];
+        const int oilpos = phase_usage.phase_pos[Oil];
         std::vector<double> mix(num_comp,0.0);
         std::vector<double> x(num_comp);
         std::vector<double> surf_dens(num_comp);

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -47,6 +47,11 @@ namespace Opm
     public:
         typedef BaseType :: WellMapType WellMapType;
 
+        // TODO: same definition with WellInterface, eventually they should go to a common header file.
+        static const int Water = BlackoilPhases::Aqua;
+        static const int Oil = BlackoilPhases::Liquid;
+        static const int Gas = BlackoilPhases::Vapour;
+
         using BaseType :: wellRates;
         using BaseType :: bhp;
         using BaseType :: perfPress;
@@ -243,16 +248,16 @@ namespace Opm
 
             using rt = data::Rates::opt;
             std::vector< rt > phs( np );
-            if( pu.phase_used[BlackoilPhases::Aqua] ) {
-                phs.at( pu.phase_pos[BlackoilPhases::Aqua] ) = rt::wat;
+            if( pu.phase_used[Water] ) {
+                phs.at( pu.phase_pos[Water] ) = rt::wat;
             }
 
-            if( pu.phase_used[BlackoilPhases::Liquid] ) {
-                phs.at( pu.phase_pos[BlackoilPhases::Liquid] ) = rt::oil;
+            if( pu.phase_used[Oil] ) {
+                phs.at( pu.phase_pos[Oil] ) = rt::oil;
             }
 
-            if( pu.phase_used[BlackoilPhases::Vapour] ) {
-                phs.at( pu.phase_pos[BlackoilPhases::Vapour] ) = rt::gas;
+            if( pu.phase_used[Gas] ) {
+                phs.at( pu.phase_pos[Gas] ) = rt::gas;
             }
 
             if (pu.has_solvent) {
@@ -374,8 +379,8 @@ namespace Opm
                         const int start_perf = wells->well_connpos[w];
                         const int start_perf_next_well = wells->well_connpos[w + 1];
                         assert(nperf == (start_perf_next_well - start_perf)); // make sure the information from wells_ecl consistent with wells
-                        if (pu.phase_used[BlackoilPhases::Vapour]) {
-                            const int gaspos = pu.phase_pos[BlackoilPhases::Vapour];
+                        if (pu.phase_used[Gas]) {
+                            const int gaspos = pu.phase_pos[Gas];
                             // scale the phase rates for Gas to avoid too bad initial guess for gas fraction
                             // it will probably benefit the standard well too, while it needs to be justified
                             // TODO: to see if this strategy can benefit StandardWell too


### PR DESCRIPTION
It can be just me that had problems in `Water, Oil, Gas` with the ones in `BlackPhases` ones.  Following the change in #1323, this PR tries to use only `Water Oil Gas` in the well model and also WellStateFullyImplictBlackOil. It makes the statement like 
```C++
const int water_pos = pu.phase_pos[Water]
```
much easier to read, especially for newcomers. 

It can go further to some other files, like WellDensitySegmented, VFP related, RateConverter and SimFIBODetails. It is not good  redefine it again and again (even like the one in WellStateFullImplicitBlackoil in this PR), it can be good to make it in some header files. 

The old way is `BlackoilModelEnums.hpp`, while it contains some codes we would like to get rid of. 
Should we keep using it while removing the unwanted parts when possible, or we put somewhere else, like SimFIBODetails or a new file. Any suggestion?
