### PR TITLE
Adapt writeInitial call to use integer vectors for printing ranks

### DIFF
--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -767,7 +767,7 @@ namespace Opm
                                                     UgGridHelpers::createEclipseGrid( grid , inputGrid ),
                                                     *schedule_,
                                                     *summary_config_ ));
-                eclipse_writer_->writeInitial(geoprops_->simProps(grid),
+                eclipse_writer_->writeInitial(geoprops_->simProps(grid), {},
                                               geoprops_->nonCartesianConnections());
             }
         }

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -824,7 +824,7 @@ namespace Opm
                 Handle handle(globalMapper, ranks,
                               this->globalGrid().globalCell());
                 this->grid().gatherData(handle);
-                integerVectors.emplace("MPI_RANKS", ranks);
+                integerVectors.emplace("MPI_RANK", ranks);
             }
 
             return integerVectors;

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -119,7 +119,6 @@ private:
 };
 
 
-#if HAVE_OPM_GRID && HAVE_MPI
 /// \brief Data handle for gathering the rank that owns a cell
 template<class Mapper>
 class CellOwnerDataHandle
@@ -174,7 +173,7 @@ private:
     const std::vector<int>& globalCell_;
 };
 
-
+#if HAVE_OPM_GRID && HAVE_MPI
 /// \brief a data handle to distribute the threshold pressures
 class ThresholdPressureDataHandle
 {


### PR DESCRIPTION
This adapts to the new function signature as of OPM/opm-output#216. It uses the
newly introduced map of integer vectors to print the MPI ranks in a parallel run.

I have not tested whether what is printed makes sense. But this change is needed to compile opm-simulators with the PR of opm-output