### PR TITLE
Disregard non-active cells when writing MPI_RANK in writeInitial.

### DIFF
--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -818,11 +818,9 @@ namespace Opm
                 using ElementMapper =  Dune::MultipleCodimMultipleGeomTypeMapper<GridView, Dune::MCMGElementLayout>;
                 using Handle = CellOwnerDataHandle<ElementMapper>;
                 ElementMapper globalMapper(this->globalGrid().leafGridView());
-                const auto* dims = UgGridHelpers::cartDims(grid());
-                const auto globalSize = dims[0]*dims[1]*dims[2];
+                const auto globalSize = this->globalGrid().size(0);
                 std::vector<int> ranks(globalSize, -1);
-                Handle handle(globalMapper, ranks,
-                              this->globalGrid().globalCell());
+                Handle handle(globalMapper, ranks);
                 this->grid().gatherData(handle);
                 integerVectors.emplace("MPI_RANK", ranks);
             }

--- a/opm/autodiff/RedistributeDataHandles.hpp
+++ b/opm/autodiff/RedistributeDataHandles.hpp
@@ -126,9 +126,8 @@ class CellOwnerDataHandle
 public:
     using DataType = int;
 
-    CellOwnerDataHandle(const Mapper& globalMapper, std::vector<int>& globalData,
-                        const std::vector<int>& globalCell)
-        : globalMapper_(globalMapper), globalData_(globalData), globalCell_(globalCell)
+    CellOwnerDataHandle(const Mapper& globalMapper, std::vector<int>& globalData)
+        : globalMapper_(globalMapper), globalData_(globalData)
     {
         int argc = 0;
         char** argv = nullptr;
@@ -158,7 +157,7 @@ public:
     template<class B, class T>
     void scatter(B& buffer, const T& e, std::size_t /* size */)
     {
-        const auto& index = globalCell_[globalMapper_.index(e)];
+        const auto& index = globalMapper_.index(e);
         buffer.read(globalData_[index]);
     }
     bool contains(int dim, int codim)
@@ -170,7 +169,6 @@ private:
     int my_rank_;
     const Mapper& globalMapper_;
     std::vector<int>& globalData_;
-    const std::vector<int>& globalCell_;
 };
 
 #if HAVE_OPM_GRID && HAVE_MPI


### PR DESCRIPTION
This saves space and it is allowed and recommended (spacewise) to
use integer arrays with only values for active cells in writeInitial. This addresses the comments made in #1336