### PR TITLE
fixing a polymer running with both shear and non-fully mixed polymer. 

### DIFF
--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -308,6 +308,9 @@ namespace Opm
                          const int perf,
                          std::vector<EvalWell>& mob) const;
 
+        void updateWaterMobilityWithPolymer(const Simulator& ebos_simulator,
+                                            const int perf,
+                                            std::vector<EvalWell>& mob_water) const;
     };
 
 }


### PR DESCRIPTION
in StandardWell.

The only thing changes the behavior is the following statement. 
```
+            if (well_type_ == INJECTOR && wpolymer() == 0.) {
+                return;
+            }
```

And move all the polymer related in StandardWell into a function updateWaterMobilityWithPolymer for better clarity. 
