### PR TITLE
Put the ebosSimulator start and end methods where it belongs

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -164,7 +164,6 @@ namespace Opm {
         , terminal_output_ (terminal_output)
         , current_relaxation_(1.0)
         , dx_old_(AutoDiffGrid::numCells(grid_))
-        , isBeginReportStep_(false)
         {
             // compute global sum of number of cells
             global_nc_ = detail::countGlobalCells(grid_);
@@ -201,11 +200,25 @@ namespace Opm {
                 ebosSimulator_.model().solution( 1 /* timeIdx */ ) = ebosSimulator_.model().solution( 0 /* timeIdx */ );
             }
 
+            // set the timestep size and index in ebos explicitly
+            // we use our own time stepper.
+            ebosSimulator_.startNextEpisode( timer.currentStepLength() );
+            ebosSimulator_.setEpisodeIndex( timer.reportStepNum() );
+            ebosSimulator_.setTimeStepSize( timer.currentStepLength() );
+            ebosSimulator_.setTimeStepIndex( timer.reportStepNum() );
+
+            ebosSimulator_.problem().beginTimeStep();
+
             unsigned numDof = ebosSimulator_.model().numGridDof();
             wasSwitched_.resize(numDof);
             std::fill(wasSwitched_.begin(), wasSwitched_.end(), false);
 
             wellModel().beginTimeStep();
+
+            if (param_.update_equations_scaling_) {
+                std::cout << "equation scaling not suported yet" << std::endl;
+                //updateEquationsScaling();
+            }
         }
 
 
@@ -345,6 +358,7 @@ namespace Opm {
             DUNE_UNUSED_PARAMETER(well_state);
 
             wellModel().timeStepSucceeded();
+            ebosSimulator_.problem().endTimeStep();
 
         }
 
@@ -356,7 +370,10 @@ namespace Opm {
                                  const int iterationIdx)
         {
             // -------- Mass balance equations --------
-            assembleMassBalanceEq(timer, iterationIdx);
+            ebosSimulator_.model().newtonMethod().setIterationIndex(iterationIdx);
+            ebosSimulator_.problem().beginIteration();
+            ebosSimulator_.model().linearizer().linearize();
+            ebosSimulator_.problem().endIteration();
 
             // -------- Well equations ----------
             double dt = timer.currentStepLength();
@@ -1525,7 +1542,7 @@ namespace Opm {
 
         void beginReportStep()
         {
-            isBeginReportStep_ = true;
+            ebosSimulator_.problem().beginEpisode();
         }
 
         void endReportStep()
@@ -1534,48 +1551,6 @@ namespace Opm {
         }
 
     private:
-        void assembleMassBalanceEq(const SimulatorTimerInterface& timer,
-                                   const int iterationIdx)
-        {
-            ebosSimulator_.startNextEpisode( timer.currentStepLength() );
-            ebosSimulator_.setEpisodeIndex( timer.reportStepNum() );
-            ebosSimulator_.setTimeStepIndex( timer.reportStepNum() );
-            ebosSimulator_.model().newtonMethod().setIterationIndex(iterationIdx);
-
-            static int prevEpisodeIdx = 10000;
-
-            // notify ebos about the end of the previous episode and time step if applicable
-            if (isBeginReportStep_) {
-                isBeginReportStep_ = false;
-                ebosSimulator_.problem().beginEpisode();
-            }
-
-            // doing the notifactions here is conceptually wrong and also causes the
-            // endTimeStep() and endEpisode() methods to be not called for the
-            // simulation's last time step and episode.
-            if (ebosSimulator_.model().newtonMethod().numIterations() == 0
-                && prevEpisodeIdx < timer.reportStepNum())
-            {
-                ebosSimulator_.problem().endTimeStep();
-            }
-
-            ebosSimulator_.setTimeStepSize( timer.currentStepLength() );
-            if (ebosSimulator_.model().newtonMethod().numIterations() == 0)
-            {
-                ebosSimulator_.problem().beginTimeStep();
-            }
-
-            ebosSimulator_.problem().beginIteration();
-            ebosSimulator_.model().linearizer().linearize();
-            ebosSimulator_.problem().endIteration();
-
-            prevEpisodeIdx = ebosSimulator_.episodeIndex();
-
-            if (param_.update_equations_scaling_) {
-                std::cout << "equation scaling not suported yet" << std::endl;
-                //updateEquationsScaling();
-            }
-        }
 
         double dpMaxRel() const { return param_.dp_max_rel_; }
         double dsMax() const { return param_.ds_max_; }
@@ -1583,7 +1558,6 @@ namespace Opm {
         double maxResidualAllowed() const { return param_.max_residual_allowed_; }
 
     public:
-        bool isBeginReportStep_;
         std::vector<bool> wasSwitched_;
     };
 } // namespace Opm


### PR DESCRIPTION
Move the `beginEpisode()`/`endEpisode()` call to ebos to `beginReportStep()`/`endReportStep()` and `beginTimeStep()`/`endTimeStep()` call to ebos to `prepareStep()`/`afterStep()`. 

I have verified that this does not change anything on the big models. (diff master.PRT thisPR.PRT shows only random fluctuation in timing).