### PR TITLE
Use 1 day as default initial time step

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -107,7 +107,7 @@ namespace Opm {
         , solver_restart_max_( param.getDefault("solver.restart", int(10) ) )
         , solver_verbose_( param.getDefault("solver.verbose", bool(true) ) && terminal_output )
         , timestep_verbose_( param.getDefault("timestep.verbose", bool(true) ) && terminal_output )
-        , suggested_next_timestep_( unit::convert::from(param.getDefault("timestep.initial_timestep_in_days", -1.0 ), unit::day) )
+        , suggested_next_timestep_( unit::convert::from(param.getDefault("timestep.initial_timestep_in_days", 1.0 ), unit::day) )
         , full_timestep_initially_( param.getDefault("full_timestep_initially", bool(false) ) )
         , timestep_after_event_( unit::convert::from(param.getDefault("timestep.timestep_in_days_after_event", -1.0 ), unit::day))
         , use_newton_iteration_(false)


### PR DESCRIPTION
This PR effects results and convergence on most of the cases. I have verified that it doesn't introduce any big problems on any of the big models. Since the timestepping is changed most test should fail. 