### PR TITLE
Fixing history mode

### DIFF
--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -1489,11 +1489,8 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     computeRESV(const std::size_t step)
     {
-        typedef SimFIBODetails::WellMap WellMap;
 
-        const WellMap& wmap = SimFIBODetails::mapWells(wells_ecl_);
-
-        const std::vector<int>& resv_wells = SimFIBODetails::resvWells(wells(), step, wmap);
+        const std::vector<int>& resv_wells = SimFIBODetails::resvWells(wells());
 
         int global_number_resv_wells = resv_wells.size();
         global_number_resv_wells = ebosSimulator_.gridView().comm().sum(global_number_resv_wells);
@@ -1503,6 +1500,8 @@ namespace Opm {
         }
 
         if (! resv_wells.empty()) {
+            typedef SimFIBODetails::WellMap WellMap;
+            const WellMap& wmap = SimFIBODetails::mapWells(wells_ecl_);
 
             for (std::vector<int>::const_iterator
                      rp = resv_wells.begin(), e = resv_wells.end();
@@ -1529,7 +1528,7 @@ namespace Opm {
                             // original distr contains 0 and 1 to indicate phases under control
                             const double* old_distr = well_controls_get_current_distr(ctrl);
 
-                            for (size_t p = 0; p < np; ++p) {
+                            for (int p = 0; p < np; ++p) {
                                 distr[p] *= old_distr[p];
                             }
                         }

--- a/opm/autodiff/SimFIBODetails.hpp
+++ b/opm/autodiff/SimFIBODetails.hpp
@@ -70,42 +70,14 @@ namespace Opm
             return (0 <= resv_control(wells.ctrls[w]));
         }
 
-        inline bool
-        is_resv(const WellMap&     wmap,
-                const std::string& name,
-                const std::size_t  step)
-        {
-            bool match = false;
-
-            WellMap::const_iterator i = wmap.find(name);
-
-            if (i != wmap.end()) {
-                const Well* wp = i->second;
-
-                match = (wp->isProducer(step) &&
-                         wp->getProductionProperties(step)
-                         .hasProductionControl(WellProducer::RESV))
-                    ||  (wp->isInjector(step) &&
-                         wp->getInjectionProperties(step)
-                         .hasInjectionControl(WellInjector::RESV));
-            }
-
-            return match;
-        }
-
         inline std::vector<int>
-        resvWells(const Wells*      wells,
-                  const std::size_t step,
-                  const WellMap&    wmap)
+        resvWells(const Wells*      wells)
         {
             std::vector<int> resv_wells;
             if( wells )
             {
                 for (int w = 0, nw = wells->number_of_wells; w < nw; ++w) {
-                    if (is_resv(*wells, w) ||
-                        ((wells->name[w] != 0) &&
-                         is_resv(wmap, wells->name[w], step)))
-                    {
+                    if ( is_resv(*wells, w) ) {
                         resv_wells.push_back(w);
                     }
                 }

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -544,10 +544,7 @@ namespace Opm
                 }
 
                 if (ok) {
-                    // Always append a BHP control.
-                    // If no explicit BHP control given, use a 1 atm control.
-                    const bool has_explicit_limit = productionProperties.hasProductionControl(WellProducer::BHP);
-                    const double bhp_limit = has_explicit_limit ? productionProperties.BHPLimit : unit::convert::from(1.0, unit::atm);
+                    const double bhp_limit = productionProperties.BHPLimit;
                     control_pos[WellsManagerDetail::ProductionControl::BHP] = well_controls_get_num(w_->ctrls[well_index]);
                     ok = append_well_controls(BHP,
                                               bhp_limit,


### PR DESCRIPTION
It depends the https://github.com/OPM/opm-parser/pull/1168 . 

Trying to handle the history matching well in the proper way instead of always being treated as RESV control wells. 

Basically, it tried to fixed the issue reported in https://github.com/OPM/opm-simulators/issues/1011 . 