### PR TITLE
do not use the saturated{InverseFormationFactor,viscosity} low-level PVT functions anymore

### DIFF
--- a/opm/autodiff/BlackoilPropsAdFromDeck.cpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.cpp
@@ -342,7 +342,9 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             TEval.setValue(T.value()[i]);
 
             if (cond[i].hasFreeGas()) {
-                muEval = FluidSystem::oilPvt().saturatedViscosity(pvtRegionIdx, TEval, pEval);
+                const Eval& RsSatEval =
+                    FluidSystem::oilPvt().saturatedGasDissolutionFactor(pvtRegionIdx, TEval, pEval);
+                muEval = FluidSystem::oilPvt().viscosity(pvtRegionIdx, TEval, pEval, RsSatEval);
             }
             else {
                 if (phase_usage_.phase_used[Gas]) {
@@ -409,7 +411,10 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             TEval.setValue(T.value()[i]);
 
             if (cond[i].hasFreeOil()) {
-                muEval = FluidSystem::gasPvt().saturatedViscosity(pvtRegionIdx, TEval, pEval);
+                const Eval& RvSatEval =
+                    FluidSystem::gasPvt().saturatedOilVaporizationFactor(pvtRegionIdx, TEval, pEval);
+
+                muEval = FluidSystem::gasPvt().viscosity(pvtRegionIdx, TEval, pEval, RvSatEval);
             }
             else {
                 RvEval.setValue(rv.value()[i]);
@@ -523,7 +528,9 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
 
             //RS/RV only makes sense when gas phase is active
             if (cond[i].hasFreeGas()) {
-                bEval = FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(pvtRegionIdx, TEval, pEval);
+                const Eval& RsSatEval =
+                    FluidSystem::oilPvt().saturatedGasDissolutionFactor(pvtRegionIdx, TEval, pEval);
+                bEval = FluidSystem::oilPvt().inverseFormationVolumeFactor(pvtRegionIdx, TEval, pEval, RsSatEval);
             }
             else {
                 if (rs.size() == 0) {
@@ -595,7 +602,9 @@ BlackoilPropsAdFromDeck::BlackoilPropsAdFromDeck(const BlackoilPropsAdFromDeck& 
             TEval.setValue(T.value()[i]);
 
             if (cond[i].hasFreeOil()) {
-                bEval = FluidSystem::gasPvt().saturatedInverseFormationVolumeFactor(pvtRegionIdx, TEval, pEval);
+                const Eval& RvSatEval =
+                    FluidSystem::gasPvt().saturatedOilVaporizationFactor(pvtRegionIdx, TEval, pEval);
+                bEval = FluidSystem::gasPvt().inverseFormationVolumeFactor(pvtRegionIdx, TEval, pEval, RvSatEval);
             }
             else {
                 RvEval.setValue(rv.value()[i]);

--- a/opm/autodiff/MultisegmentWell_impl.hpp
+++ b/opm/autodiff/MultisegmentWell_impl.hpp
@@ -1157,17 +1157,19 @@ namespace Opm
                         visc[gaspos] =
                             FluidSystem::gasPvt().viscosity(pvt_region_index, temperature, seg_pressure, rv);
                     } else { // no oil exists
+                        const EvalWell Rs(0.0);
                         b[gaspos] =
-                            FluidSystem::gasPvt().saturatedInverseFormationVolumeFactor(pvt_region_index, temperature, seg_pressure);
+                            FluidSystem::gasPvt().inverseFormationVolumeFactor(pvt_region_index, temperature, seg_pressure, Rs);
                         visc[gaspos] =
-                            FluidSystem::gasPvt().saturatedViscosity(pvt_region_index, temperature, seg_pressure);
+                            FluidSystem::gasPvt().viscosity(pvt_region_index, temperature, seg_pressure, Rs);
                     }
                 } else { // no Liquid phase
                     // it is the same with zero mix_s[Oil]
+                    const EvalWell Rv(0.0);
                     b[gaspos] =
-                        FluidSystem::gasPvt().saturatedInverseFormationVolumeFactor(pvt_region_index, temperature, seg_pressure);
+                        FluidSystem::gasPvt().inverseFormationVolumeFactor(pvt_region_index, temperature, seg_pressure, Rv);
                     visc[gaspos] =
-                        FluidSystem::gasPvt().saturatedViscosity(pvt_region_index, temperature, seg_pressure);
+                        FluidSystem::gasPvt().viscosity(pvt_region_index, temperature, seg_pressure, Rv);
                 }
             }
 
@@ -1191,17 +1193,19 @@ namespace Opm
                         visc[oilpos] =
                             FluidSystem::oilPvt().viscosity(pvt_region_index, temperature, seg_pressure, rs);
                     } else { // no oil exists
+                        const EvalWell Rs(0.0);
                         b[oilpos] =
-                            FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(pvt_region_index, temperature, seg_pressure);
+                            FluidSystem::oilPvt().inverseFormationVolumeFactor(pvt_region_index, temperature, seg_pressure, Rs);
                         visc[oilpos] =
-                            FluidSystem::oilPvt().saturatedViscosity(pvt_region_index, temperature, seg_pressure);
+                            FluidSystem::oilPvt().viscosity(pvt_region_index, temperature, seg_pressure, Rs);
                     }
                 } else { // no Liquid phase
                     // it is the same with zero mix_s[Oil]
+                    const EvalWell Rv(0.0);
                     b[oilpos] =
-                        FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(pvt_region_index, temperature, seg_pressure);
+                        FluidSystem::oilPvt().inverseFormationVolumeFactor(pvt_region_index, temperature, seg_pressure, Rv);
                     visc[oilpos] =
-                        FluidSystem::oilPvt().saturatedViscosity(pvt_region_index, temperature, seg_pressure);
+                        FluidSystem::oilPvt().viscosity(pvt_region_index, temperature, seg_pressure, Rv);
                 }
             }
 

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -1138,11 +1138,13 @@ namespace Opm
                         b_perf[gaspos] = FluidSystem::gasPvt().inverseFormationVolumeFactor(fs.pvtRegionIndex(), temperature, p_avg, rv);
                     }
                     else {
-                        b_perf[gaspos] = FluidSystem::gasPvt().saturatedInverseFormationVolumeFactor(fs.pvtRegionIndex(), temperature, p_avg);
+                        const double Rv(0.0);
+                        b_perf[gaspos] = FluidSystem::gasPvt().inverseFormationVolumeFactor(fs.pvtRegionIndex(), temperature, p_avg, Rv);
                     }
 
                 } else {
-                    b_perf[gaspos] = FluidSystem::gasPvt().saturatedInverseFormationVolumeFactor(fs.pvtRegionIndex(), temperature, p_avg);
+                    const double Rv(0.0);
+                    b_perf[gaspos] = FluidSystem::gasPvt().inverseFormationVolumeFactor(fs.pvtRegionIndex(), temperature, p_avg, Rv);
                 }
             }
 
@@ -1162,10 +1164,12 @@ namespace Opm
                         rs = std::min(rs, rsmax_perf[perf]);
                         b_perf[oilpos] = FluidSystem::oilPvt().inverseFormationVolumeFactor(fs.pvtRegionIndex(), temperature, p_avg, rs);
                     } else {
-                        b_perf[oilpos] = FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(fs.pvtRegionIndex(), temperature, p_avg);
+                        const double Rs(0.0);
+                        b_perf[oilpos] = FluidSystem::oilPvt().inverseFormationVolumeFactor(fs.pvtRegionIndex(), temperature, p_avg, Rs);
                     }
                 } else {
-                    b_perf[oilpos] = FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(fs.pvtRegionIndex(), temperature, p_avg);
+                    const double Rs(0.0);
+                    b_perf[oilpos] = FluidSystem::oilPvt().inverseFormationVolumeFactor(fs.pvtRegionIndex(), temperature, p_avg, Rs);
                 }
             }
 


### PR DESCRIPTION
these are (hopefully) going to be removed soon.