### PR TITLE
[bugfix][FlowEbos] make compile when Scalar != double.

### DIFF
--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -209,7 +209,7 @@ namespace Opm {
             void computeRepRadiusPerfLength(const Grid& grid);
 
 
-            void computeAverageFormationFactor(std::vector<double>& B_avg) const;
+            void computeAverageFormationFactor(std::vector<Scalar>& B_avg) const;
 
             void applyVREPGroupControl();
 

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -1002,7 +1002,7 @@ namespace Opm {
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::
-    computeAverageFormationFactor(std::vector<double>& B_avg) const
+    computeAverageFormationFactor(std::vector<Scalar>& B_avg) const
     {
         const int np = numPhases();
 

--- a/opm/autodiff/MultisegmentWell.hpp
+++ b/opm/autodiff/MultisegmentWell.hpp
@@ -97,7 +97,7 @@ namespace Opm
         // TODO: for more efficient implementation, we should have EvalReservoir, EvalWell, and EvalRerservoirAndWell
         //                                                         EvalR (Eval), EvalW, EvalRW
         // TODO: for now, we only use one type to save some implementation efforts, while improve later.
-        typedef DenseAd::Evaluation<double, /*size=*/numEq + numWellEq> EvalWell;
+        typedef DenseAd::Evaluation<Scalar, /*size=*/numEq + numWellEq> EvalWell;
 
         MultisegmentWell(const Well* well, const int time_step, const Wells* wells,
                          const ModelParameters& param,
@@ -124,7 +124,7 @@ namespace Opm
         virtual void updateWellStateWithTarget(WellState& well_state) const;
 
         /// check whether the well equations get converged for this well
-        virtual ConvergenceReport getWellConvergence(const std::vector<double>& B_avg) const;
+        virtual ConvergenceReport getWellConvergence(const std::vector<Scalar>& B_avg) const;
 
         /// Ax = Ax - C D^-1 B x
         virtual void apply(const BVector& x, BVector& Ax) const;

--- a/opm/autodiff/MultisegmentWell_impl.hpp
+++ b/opm/autodiff/MultisegmentWell_impl.hpp
@@ -410,7 +410,7 @@ namespace Opm
     template <typename TypeTag>
     typename MultisegmentWell<TypeTag>::ConvergenceReport
     MultisegmentWell<TypeTag>::
-    getWellConvergence(const std::vector<double>& B_avg) const
+    getWellConvergence(const std::vector<Scalar>& B_avg) const
     {
         assert(int(B_avg.size()) == num_components_);
 
@@ -1715,8 +1715,8 @@ namespace Opm
             // in this stage, but, should we?
             // We should try to avoid hard-code values in the code.
             // If we want to use the real one, we need to find a way to get them.
-            // const std::vector<double> B {0.8, 0.8, 0.008};
-            const std::vector<double> B {0.5, 0.5, 0.005};
+            // const std::vector<Scalar> B {0.8, 0.8, 0.008};
+            const std::vector<Scalar> B {0.5, 0.5, 0.005};
 
             const ConvergenceReport report = getWellConvergence(B);
 

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -135,7 +135,7 @@ namespace Opm
         virtual void updateWellStateWithTarget(WellState& well_state) const;
 
         /// check whether the well equations get converged for this well
-        virtual ConvergenceReport getWellConvergence(const std::vector<double>& B_avg) const;
+        virtual ConvergenceReport getWellConvergence(const std::vector<Scalar>& B_avg) const;
 
         /// Ax = Ax - C D^-1 B x
         virtual void apply(const BVector& x, BVector& Ax) const;

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -1327,7 +1327,7 @@ namespace Opm
     template<typename TypeTag>
     typename StandardWell<TypeTag>::ConvergenceReport
     StandardWell<TypeTag>::
-    getWellConvergence(const std::vector<double>& B_avg) const
+    getWellConvergence(const std::vector<Scalar>& B_avg) const
     {
         const int np = number_of_phases_;
 

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -77,15 +77,15 @@ namespace Opm
         typedef typename GET_PROP_TYPE(TypeTag, Indices) BlackoilIndices;
         typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) IntensiveQuantities;
         typedef typename GET_PROP_TYPE(TypeTag, MaterialLaw) MaterialLaw;
+        typedef typename GET_PROP_TYPE(TypeTag, Scalar)      Scalar;
 
         static const int numEq = BlackoilIndices::numEq;
-        typedef double Scalar;
 
         typedef Dune::FieldVector<Scalar, numEq    > VectorBlockType;
         typedef Dune::FieldMatrix<Scalar, numEq, numEq > MatrixBlockType;
         typedef Dune::BCRSMatrix <MatrixBlockType> Mat;
         typedef Dune::BlockVector<VectorBlockType> BVector;
-        typedef DenseAd::Evaluation<double, /*size=*/numEq> Eval;
+        typedef DenseAd::Evaluation<Scalar, /*size=*/numEq> Eval;
 
         typedef Ewoms::BlackOilPolymerModule<TypeTag> PolymerModule;
 
@@ -161,7 +161,7 @@ namespace Opm
             }
         };
 
-        virtual ConvergenceReport getWellConvergence(const std::vector<double>& B_avg) const = 0;
+        virtual ConvergenceReport getWellConvergence(const std::vector<Scalar>& B_avg) const = 0;
 
         virtual void solveEqAndUpdateWellState(WellState& well_state) = 0;
 


### PR DESCRIPTION
This PR fixes some compile issues when Scalar is chosen not to be double but something else.