### PR TITLE
Change dp_max_rel default from 1.0 to 0.3

### DIFF
--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -73,7 +73,7 @@ namespace Opm
     void BlackoilModelParameters::reset()
     {
         // default values for the solver parameters
-        dp_max_rel_      = 1.0;
+        dp_max_rel_      = 0.3;
         ds_max_          = 0.2;
         dr_max_rel_      = 1.0e9;
         dbhp_max_rel_    = 1.0;


### PR DESCRIPTION
This helps stabilizing the convergence for difficult cases. Tested on norne, Model 2-0 and Model 2-5. 
