### PR TITLE
Add setupSimpleDefaultLogging() to old two-phase sims.

### DIFF
--- a/examples/sim_2p_comp_reorder.cpp
+++ b/examples/sim_2p_comp_reorder.cpp
@@ -81,6 +81,7 @@ try
 {
     using namespace Opm;
 
+    OpmLog::setupSimpleDefaultLogging(false, true, 10);
     std::cout << "\n================    Test program for weakly compressible two-phase flow     ===============\n\n";
     ParameterGroup param(argc, argv, false);
     std::cout << "---------------    Reading parameters     ---------------" << std::endl;

--- a/examples/sim_2p_incomp.cpp
+++ b/examples/sim_2p_incomp.cpp
@@ -81,6 +81,7 @@ try
 {
     using namespace Opm;
 
+    OpmLog::setupSimpleDefaultLogging(false, true, 10);
     std::cout << "\n================    Test program for incompressible two-phase flow     ===============\n\n";
     ParameterGroup param(argc, argv, false);
     std::cout << "---------------    Reading parameters     ---------------" << std::endl;

--- a/examples/sim_2p_incomp_ad.cpp
+++ b/examples/sim_2p_incomp_ad.cpp
@@ -81,6 +81,7 @@ try
 {
     using namespace Opm;
 
+    OpmLog::setupSimpleDefaultLogging(false, true, 10);
     std::cout << "\n================    Test program for incompressible two-phase flow     ===============\n\n";
     ParameterGroup param(argc, argv, false);
     std::cout << "---------------    Reading parameters     ---------------" << std::endl;

--- a/examples/sim_poly2p_comp_reorder.cpp
+++ b/examples/sim_poly2p_comp_reorder.cpp
@@ -83,6 +83,7 @@ try
 {
     using namespace Opm;
 
+    OpmLog::setupSimpleDefaultLogging(false, true, 10);
     std::cout << "\n================    Test program for weakly compressible two-phase flow with polymer    ===============\n\n";
     ParameterGroup param(argc, argv, false);
     std::cout << "---------------    Reading parameters     ---------------" << std::endl;

--- a/examples/sim_poly2p_incomp_reorder.cpp
+++ b/examples/sim_poly2p_incomp_reorder.cpp
@@ -83,6 +83,7 @@ try
 {
     using namespace Opm;
 
+    OpmLog::setupSimpleDefaultLogging(false, true, 10);
     std::cout << "\n================    Test program for incompressible two-phase flow with polymer    ===============\n\n";
     ParameterGroup param(argc, argv, false);
     std::cout << "---------------    Reading parameters     ---------------" << std::endl;


### PR DESCRIPTION
Without this, the log output from some subsystems (such as the parameters) will be lost as there is no log picking it up.  If no-one beats me to it I'll self-merge when green.

@andlaus if you want to get OpmLog output from some ewoms programs this is the simplest way.