### PR TITLE
fix the build after the maximum oil saturation refactoring in core ebos

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -1259,7 +1259,7 @@ namespace Opm {
 
                 temperature[cellIdx] = fs.temperature(FluidSystem::oilPhaseIdx).value();
 
-                somax[cellIdx] = ebosSimulator().model().maxOilSaturation(cellIdx);
+                somax[cellIdx] = ebosSimulator().problem().maxOilSaturation(cellIdx);
 
                 const auto& matLawManager = ebosSimulator().problem().materialLawManager();
                 if (matLawManager->enableHysteresis()) {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -560,10 +560,12 @@ protected:
 
         typedef std::vector<double> VectorType;
 
+        // HACK: This currently only considers the VAPPARS case, not DR[SV]DT.
+        //
+        // TODO: move this to EclProblem and do it properly there
         const VectorType& somax = state.getCellData( "SOMAX" );
-
         for (int cellIdx = 0; cellIdx < num_cells; ++cellIdx) {
-            ebosSimulator_.model().setMaxOilSaturation(somax[cellIdx], cellIdx);
+            ebosSimulator_.problem().setMaxOilSaturation(somax[cellIdx], cellIdx);
         }
 
         if (ebosSimulator_.problem().materialLawManager()->enableHysteresis()) {


### PR DESCRIPTION
this is a small mop up for OPM/ewoms#265 which is required by the move of the maximum oil saturation from the model to the problem.