### PR TITLE
fixing the inconsistency due to removed perforations for multisegment well

### DIFF
--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -29,6 +29,12 @@ namespace Opm {
 
         extractLegacyCellPvtRegionIndex_();
         extractLegacyDepth_();
+
+        Grid grid = ebosSimulator_.gridManager().grid();
+        grid.switchToGlobalView();
+
+        const auto eclipse_grid = Opm::UgGridHelpers::createEclipseGrid(grid, ebosSimulator.gridManager().eclState().getInputGrid());
+        ebosSimulator_.gridManager().schedule().filterCompletions(eclipse_grid);
     }
 
 
@@ -92,10 +98,9 @@ namespace Opm {
         // handling MS well related
         if (param_.use_multisegment_well_) { // if we use MultisegmentWell model
             for (const auto& well : wells_ecl_) {
-                // TODO: this is acutally not very accurate, because sometimes a deck just claims a MS well
-                // while keep the well shut. More accurately, we should check if the well exisits in the Wells
-                // structure here
-                if (well->isMultiSegment(timeStepIdx) ) { // there is one well is MS well
+                // TODO: more accurately, we should check the Wells struct to see what the status of the well
+                // there is one active well is MS well
+                if (well->isMultiSegment(timeStepIdx) && well->getStatus(timeStepIdx) != WellCommon::SHUT) {
                     well_state_.initWellStateMSWell(wells(), wells_ecl_, timeStepIdx, phase_usage_, previous_well_state_);
                     break;
                 }

--- a/opm/autodiff/MultisegmentWell.hpp
+++ b/opm/autodiff/MultisegmentWell.hpp
@@ -108,7 +108,7 @@ namespace Opm
         virtual void init(const PhaseUsage* phase_usage_arg,
                           const std::vector<double>& depth_arg,
                           const double gravity_arg,
-                          const int num_cells);
+                          const size_t num_cells);
 
 
         virtual void initPrimaryVariablesEvaluation() const;

--- a/opm/autodiff/MultisegmentWell_impl.hpp
+++ b/opm/autodiff/MultisegmentWell_impl.hpp
@@ -107,7 +107,7 @@ namespace Opm
     init(const PhaseUsage* phase_usage_arg,
          const std::vector<double>& depth_arg,
          const double gravity_arg,
-         const int num_cells)
+         const size_t num_cells)
     {
         Base::init(phase_usage_arg, depth_arg, gravity_arg, num_cells);
 

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -119,7 +119,7 @@ namespace Opm
         virtual void init(const PhaseUsage* phase_usage_arg,
                           const std::vector<double>& depth_arg,
                           const double gravity_arg,
-                          const int num_cells);
+                          const size_t num_cells);
 
 
         virtual void initPrimaryVariablesEvaluation() const;

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -51,7 +51,7 @@ namespace Opm
     init(const PhaseUsage* phase_usage_arg,
          const std::vector<double>& depth_arg,
          const double gravity_arg,
-         const int num_cells)
+         const size_t num_cells)
     {
         Base::init(phase_usage_arg, depth_arg, gravity_arg, num_cells);
 

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -125,7 +125,7 @@ namespace Opm
         virtual void init(const PhaseUsage* phase_usage_arg,
                           const std::vector<double>& depth_arg,
                           const double gravity_arg,
-                          const int num_cells);
+                          const size_t num_cells);
 
         virtual void initPrimaryVariablesEvaluation() const = 0;
 

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -115,7 +115,7 @@ namespace Opm
     init(const PhaseUsage* phase_usage_arg,
          const std::vector<double>& /* depth_arg */,
          const double gravity_arg,
-         const int /* num_cells */)
+         const size_t /* num_cells */)
     {
         phase_usage_ = phase_usage_arg;
         gravity_ = gravity_arg;


### PR DESCRIPTION
The multisegment wells are built based on the Well information from parser.  When creating the WellsManager, some perforations can be removed due to being completed in inactive grid blocks. 

In this PR, a mapping from the perforation from perforation number (index) in EclipseState (parser) to the perforation number in Wells struct is created to consider the situation. (-1) means the perforation has been removed. The information about the removed perforation is needed in both WellState and constructor of MultisegmentWell. 

Ideally, it will be better to be taken care of when parsing COMPDAT. 