### PR TITLE
move the flow_ebos_*.cpp files to the beginning of the source list

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -26,6 +26,11 @@
 # originally generated with the command:
 # find opm -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND MAIN_SOURCE_FILES
+  opm/simulators/flow_ebos_blackoil.cpp
+  opm/simulators/flow_ebos_gasoil.cpp
+  opm/simulators/flow_ebos_oilwater.cpp
+  opm/simulators/flow_ebos_polymer.cpp
+  opm/simulators/flow_ebos_solvent.cpp
   opm/autodiff/Compat.cpp
   opm/autodiff/ExtractParallelGridInformationToISTL.cpp
   opm/autodiff/NewtonIterationBlackoilCPR.cpp
@@ -113,11 +118,6 @@ list (APPEND MAIN_SOURCE_FILES
   opm/polymer/SimulatorPolymer.cpp
   opm/polymer/TransportSolverTwophaseCompressiblePolymer.cpp
   opm/polymer/TransportSolverTwophasePolymer.cpp
-  opm/simulators/flow_ebos_blackoil.cpp
-  opm/simulators/flow_ebos_gasoil.cpp
-  opm/simulators/flow_ebos_oilwater.cpp
-  opm/simulators/flow_ebos_polymer.cpp
-  opm/simulators/flow_ebos_solvent.cpp
   opm/simulators/ensureDirectoryExists.cpp
   opm/simulators/SimulatorCompressibleTwophase.cpp
   opm/simulators/WellSwitchingLogger.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -26,11 +26,15 @@
 # originally generated with the command:
 # find opm -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND MAIN_SOURCE_FILES
+	# place the flow_ebos_*.cpp files on top of the list because they
+	# take the longest to compile, and compiling them first speeds up
+	# parallel builds because it allows the jobserver to do better scheduling
   opm/simulators/flow_ebos_blackoil.cpp
   opm/simulators/flow_ebos_gasoil.cpp
   opm/simulators/flow_ebos_oilwater.cpp
   opm/simulators/flow_ebos_polymer.cpp
   opm/simulators/flow_ebos_solvent.cpp
+
   opm/autodiff/Compat.cpp
   opm/autodiff/ExtractParallelGridInformationToISTL.cpp
   opm/autodiff/NewtonIterationBlackoilCPR.cpp


### PR DESCRIPTION
these files take the longest to compile. moving them to the beginning speeds things up for parallel fulll rebuilds because the remaining compile units can be processed while dealing with the flow_ebos files. currently, the build stalls if these files are at the bottom of the list because they are required for the library.