### PR TITLE
Allow Wells struct initialization without wells

### DIFF
--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -315,7 +315,7 @@ namespace Opm
 
     /// Default constructor.
     WellsManager::WellsManager()
-        : w_(0), is_parallel_run_(false)
+        : w_(create_wells(0,0,0)), is_parallel_run_(false)
     {
     }
 
@@ -330,7 +330,7 @@ namespace Opm
                                const Opm::Schedule& schedule,
                                const size_t timeStep,
                                const UnstructuredGrid& grid)
-        : w_(0), is_parallel_run_(false)
+        : w_(create_wells(0,0,0)), is_parallel_run_(false)
     {
         // TODO: not sure about the usage of this WellsManager constructor
         // TODO: not sure whether this is the correct thing to do here.

--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -260,13 +260,15 @@ void WellsManager::createWellsFromSpecs(std::vector<const Well*>& wells, size_t 
     for (int w = 0; w < num_wells; ++w) {
         num_perfs += wellperf_data[w].size();
     }
-
     // Create the well data structures.
-    w_ = create_wells(phaseUsage.num_phases, num_wells, num_perfs);
-    if (!w_) {
+    struct Wells* w = create_wells(phaseUsage.num_phases, num_wells, num_perfs);
+
+    if (!w) {
         OPM_THROW(std::runtime_error, "Failed creating Wells struct.");
     }
 
+    std::swap( w, w_ );
+    destroy_wells( w );
 
     // Add wells.
     for (int w = 0; w < num_wells; ++w) {
@@ -320,7 +322,7 @@ WellsManager(const Opm::EclipseState& eclipseState,
              const DynamicListEconLimited&   list_econ_limited,
              bool                            is_parallel_run,
              const std::unordered_set<std::string>&    deactivated_wells)
-    : w_(0), is_parallel_run_(is_parallel_run)
+    : w_(create_wells(0,0,0)), is_parallel_run_(is_parallel_run)
 {
   init(eclipseState, schedule, timeStep, number_of_cells, global_cell,
          cart_dims, dimensions,


### PR DESCRIPTION
In cases where the user wish to verify that the model initializes properly it is useful to run the .DATA file without any wells.

Calling wells()->number_of_wells on nullptr causes segmentation fault. This
occurs when running a deck without wells. Allowing WellsManager::init to
continue for decks without wells enables the well struct to be set.

Authored by Sveinung Rundhovde & Lars Petter Hauge