### PR TITLE
[WIP] Populating reservoir rate related output

### DIFF
--- a/opm/autodiff/BlackoilOutputEbos.hpp
+++ b/opm/autodiff/BlackoilOutputEbos.hpp
@@ -41,7 +41,6 @@
 #include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 
 #include <string>

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -180,6 +180,12 @@ namespace Opm {
     void
     BlackoilWellModel<TypeTag>::
     timeStepSucceeded() {
+        // TODO: when necessary
+        rateConverter_->template defineState<ElementContext>(ebosSimulator_);
+        for (const auto& well : well_container_) {
+            well->calculateReservoirRates(well_state_);
+        }
+
         previous_well_state_ = well_state_;
     }
 

--- a/opm/autodiff/RateConverter.hpp
+++ b/opm/autodiff/RateConverter.hpp
@@ -582,7 +582,13 @@ namespace Opm {
              *
              *
              * \param[out] coeff Surface-to-reservoir conversion
-             * coefficients for all active phases.
+             * coefficients that can be used to compute total reservoir
+             * volumes from surface volumes with the formula
+             *               q_{rT} = \sum_p coeff[p] q_{sp}.
+             * However, individual phase reservoir volumes cannot be calculated from
+             * these coefficients (i.e. q_{rp} is not equal to coeff[p] q_{sp})
+             * since they can depend on more than one surface volume rate when
+             * we have dissolved gas or vaporized oil.
              */
             template <class Coeff>
             void
@@ -663,6 +669,8 @@ namespace Opm {
                                       Rates& voidage_rates) const
             {
                 assert(voidage_rates.size() == surface_rates.size());
+
+                std::fill(voidage_rates.begin(), voidage_rates.end(), 0.0);
 
                 const auto& pu = phaseUsage_;
                 const auto& ra = attr_.attributes(r);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -288,7 +288,8 @@ public:
             // write simulation state at the report stage
             Dune::Timer perfTimer;
             perfTimer.start();
-            const double nextstep = adaptiveTimeStepping ? adaptiveTimeStepping->suggestedNextStep() : -1.0;            
+            const double nextstep = adaptiveTimeStepping ? adaptiveTimeStepping->suggestedNextStep() : -1.0;
+
             output_writer_.writeTimeStep( timer, dummy_state, well_model.wellState(), solver->model(), false, nextstep, report);
             report.output_write_time += perfTimer.stop();
 

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -281,7 +281,8 @@ namespace Opm
         void computePerfRate(const IntensiveQuantities& intQuants,
                              const std::vector<EvalWell>& mob_perfcells_dense,
                              const double Tw, const EvalWell& bhp, const double& cdp,
-                             const bool& allow_cf, std::vector<EvalWell>& cq_s) const;
+                             const bool& allow_cf, std::vector<EvalWell>& cq_s,
+                             double& perf_dis_gas_rate, double& perf_vap_oil_rate) const;
 
         // TODO: maybe we should provide a light version of computePerfRate, which does not include the
         // calculation of the derivatives

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -522,10 +522,21 @@ namespace Opm
                 if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) && FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
                     const unsigned oilCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx);
                     const unsigned gasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);
-                    // TODO: not sure if this is the correct way
+                    // TODO: the formulations here remain to be tested with cases with strong crossflow through production wells
+                    // s means standard condition, r means reservoir condition
+                    // q_os = q_or * b_o + rv * q_gr * b_g
+                    // q_gs = q_gr * g_g + rs * q_or * b_o
+                    // d = 1.0 - rs * rv
+                    // q_or = 1 / (b_o * d) * (q_os - rv * q_gs)
+                    // q_gr = 1 / (b_g * d) * (q_gs - rs * q_os)
+
                     const double d = 1.0 - rv.value() * rs.value();
-                    perf_vap_oil_rate = (rv.value() * cq_s[gasCompIdx].value()) / d;
-                    perf_dis_gas_rate = (rs.value() * cq_s[oilCompIdx].value()) / d;
+                    // vaporized oil into gas
+                    // rv * q_gr * b_g = rv * (q_gs - rs * q_os) / d
+                    perf_vap_oil_rate = rv.value() * (cq_s[gasCompIdx].value() - rs.value() * cq_s[oilCompIdx].value()) / d;
+                    // dissolved of gas in oil
+                    // rs * q_or * b_o = rs * (q_os - rv * q_gs) / d
+                    perf_dis_gas_rate = rs.value() * (cq_s[oilCompIdx].value() - rv.value() * cq_s[gasCompIdx].value()) / d;
                 }
             }
         }

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -563,9 +563,9 @@ namespace Opm
 
         const EvalWell& bhp = getBhp();
 
-        // the solution gas rate and solution oil rate needs to be updated for well_state.
-        std::fill(well_state.wellVaporizedOilRates().begin(), well_state.wellVaporizedOilRates().end(), 0.0);
-        std::fill(well_state.wellDissolvedGasRates().begin(), well_state.wellDissolvedGasRates().end(), 0.0);
+        // the solution gas rate and solution oil rate needs to be reset to be zero for well_state.
+        well_state.wellVaporizedOilRates()[index_of_well_] = 0.;
+        well_state.wellDissolvedGasRates()[index_of_well_] = 0.;
 
         for (int perf = 0; perf < number_of_perforations_; ++perf) {
 

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -395,7 +395,8 @@ namespace Opm
     computePerfRate(const IntensiveQuantities& intQuants,
                     const std::vector<EvalWell>& mob_perfcells_dense,
                     const double Tw, const EvalWell& bhp, const double& cdp,
-                    const bool& allow_cf, std::vector<EvalWell>& cq_s) const
+                    const bool& allow_cf, std::vector<EvalWell>& cq_s,
+                    double& perf_dis_gas_rate, double& perf_vap_oil_rate) const
     {
         std::vector<EvalWell> cmix_s(num_components_,0.0);
         for (int componentIdx = 0; componentIdx < num_components_; ++componentIdx) {
@@ -440,8 +441,17 @@ namespace Opm
                 const unsigned gasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);
                 const EvalWell cq_sOil = cq_s[oilCompIdx];
                 const EvalWell cq_sGas = cq_s[gasCompIdx];
-                cq_s[gasCompIdx] += rs * cq_sOil;
-                cq_s[oilCompIdx] += rv * cq_sGas;
+                const EvalWell dis_gas = rs * cq_sOil;
+                const EvalWell vap_oil = rv * cq_sGas;
+
+                cq_s[gasCompIdx] += dis_gas;
+                cq_s[oilCompIdx] += vap_oil;
+
+                // recording the perforation solution gas rate and solution oil rates
+                if (well_type_ == PRODUCER) {
+                    perf_dis_gas_rate = dis_gas.value();
+                    perf_vap_oil_rate = vap_oil.value();
+                }
             }
 
         } else {
@@ -506,6 +516,18 @@ namespace Opm
             for (int componentIdx = 0; componentIdx < num_components_; ++componentIdx) {
                 cq_s[componentIdx] = cmix_s[componentIdx] * cqt_is; // * b_perfcells_dense[phase];
             }
+
+            // calculating the perforation solution gas rate and solution oil rates
+            if (well_type_ == PRODUCER) {
+                if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) && FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+                    const unsigned oilCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx);
+                    const unsigned gasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);
+                    // TODO: not sure if this is the correct way
+                    const double d = 1.0 - rv.value() * rs.value();
+                    perf_vap_oil_rate = (rv.value() * cq_s[gasCompIdx].value()) / d;
+                    perf_dis_gas_rate = (rs.value() * cq_s[oilCompIdx].value()) / d;
+                }
+            }
         }
     }
 
@@ -541,6 +563,10 @@ namespace Opm
 
         const EvalWell& bhp = getBhp();
 
+        // the solution gas rate and solution oil rate needs to be updated for well_state.
+        std::fill(well_state.wellVaporizedOilRates().begin(), well_state.wellVaporizedOilRates().end(), 0.0);
+        std::fill(well_state.wellDissolvedGasRates().begin(), well_state.wellDissolvedGasRates().end(), 0.0);
+
         for (int perf = 0; perf < number_of_perforations_; ++perf) {
 
             const int cell_idx = well_cells_[perf];
@@ -548,7 +574,16 @@ namespace Opm
             std::vector<EvalWell> cq_s(num_components_,0.0);
             std::vector<EvalWell> mob(num_components_, 0.0);
             getMobility(ebosSimulator, perf, mob);
-            computePerfRate(intQuants, mob, well_index_[perf], bhp, perf_pressure_diffs_[perf], allow_cf, cq_s);
+            double perf_dis_gas_rate = 0.;
+            double perf_vap_oil_rate = 0.;
+            computePerfRate(intQuants, mob, well_index_[perf], bhp, perf_pressure_diffs_[perf], allow_cf,
+                            cq_s, perf_dis_gas_rate, perf_vap_oil_rate);
+
+            // updating the solution gas rate and solution oil rate
+            if (well_type_ == PRODUCER) {
+                well_state.wellDissolvedGasRates()[index_of_well_] += perf_dis_gas_rate;
+                well_state.wellVaporizedOilRates()[index_of_well_] += perf_vap_oil_rate;
+            }
 
             for (int componentIdx = 0; componentIdx < num_components_; ++componentIdx) {
                 // the cq_s entering mass balance equations need to consider the efficiency factors.
@@ -1609,7 +1644,10 @@ namespace Opm
             std::vector<EvalWell> cq_s(num_components_, 0.0);
             std::vector<EvalWell> mob(num_components_, 0.0);
             getMobility(ebosSimulator, perf, mob);
-            computePerfRate(intQuants, mob, well_index_[perf], bhp, perf_pressure_diffs_[perf], allow_cf, cq_s);
+            double perf_dis_gas_rate = 0.;
+            double perf_vap_oil_rate = 0.;
+            computePerfRate(intQuants, mob, well_index_[perf], bhp, perf_pressure_diffs_[perf], allow_cf,
+                            cq_s, perf_dis_gas_rate, perf_vap_oil_rate);
 
             for(int p = 0; p < np; ++p) {
                 well_flux[ebosCompIdxToFlowCompIdx(p)] += cq_s[p].value();
@@ -1995,7 +2033,10 @@ namespace Opm
             const bool allow_cf = crossFlowAllowed(ebos_simulator);
             const EvalWell& bhp = getBhp();
             std::vector<EvalWell> cq_s(num_components_,0.0);
-            computePerfRate(int_quant, mob, well_index_[perf], bhp, perf_pressure_diffs_[perf], allow_cf, cq_s);
+            double perf_dis_gas_rate = 0.;
+            double perf_vap_oil_rate = 0.;
+            computePerfRate(int_quant, mob, well_index_[perf], bhp, perf_pressure_diffs_[perf], allow_cf,
+                            cq_s, perf_dis_gas_rate, perf_vap_oil_rate);
             // TODO: make area a member
             const double area = 2 * M_PI * perf_rep_radius_[perf] * perf_length_[perf];
             const auto& material_law_manager = ebos_simulator.problem().materialLawManager();

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -202,6 +202,9 @@ namespace Opm
         virtual void calculateExplicitQuantities(const Simulator& ebosSimulator,
                                                  const WellState& well_state) = 0; // should be const?
 
+        // updating the voidage rates in well_state when requested
+        void calculateReservoirRates(WellState& well_state) const;
+
     protected:
 
         // to indicate a invalid connection
@@ -317,7 +320,6 @@ namespace Opm
                                              const WellState& well_state) const;
 
         double scalingFactor(const int comp_idx) const;
-
 
     };
 

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -844,4 +844,29 @@ namespace Opm
         return 1.0;
     }
 
+
+
+
+
+    template<typename TypeTag>
+    void
+    WellInterface<TypeTag>::calculateReservoirRates(WellState& well_state) const
+    {
+        const int fipreg = 0; // not considering the region for now
+        const int np = number_of_phases_;
+
+        std::vector<double> surface_rates(np, 0.0);
+        const int well_rate_index = np * index_of_well_;
+        for (int p =0; p < np; ++p) {
+            surface_rates[p] = well_state.wellRates()[well_rate_index + p];
+        }
+
+        std::vector<double> voidage_rates(np, 0.0);
+        rateConverter_.calcReservoirVoidageRates(fipreg, pvtRegionIdx_, surface_rates, voidage_rates);
+
+        for (int p = 0; p < np; ++p) {
+            well_state.wellReservoirRates()[well_rate_index + p] = voidage_rates[p];
+        }
+    }
+
 }

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -857,7 +857,7 @@ namespace Opm
 
         std::vector<double> surface_rates(np, 0.0);
         const int well_rate_index = np * index_of_well_;
-        for (int p =0; p < np; ++p) {
+        for (int p = 0; p < np; ++p) {
             surface_rates[p] = well_state.wellRates()[well_rate_index + p];
         }
 

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -296,7 +296,7 @@ namespace Opm
                 }
 
                 if ( pu.phase_used[Gas] ) {
-                    well.rates.set( rt::reservoir_oil, this->well_reservoir_rates_[well_rate_index + pu.phase_pos[Gas]] );
+                    well.rates.set( rt::reservoir_gas, this->well_reservoir_rates_[well_rate_index + pu.phase_pos[Gas]] );
                 }
 
                 well.rates.set( rt::dissolved_gas, this->well_dissolved_gas_rates_[w] );
@@ -548,7 +548,6 @@ namespace Opm
         {
             return well_vaporized_oil_rates_;
         }
-
 
         const std::vector<double>& segRates() const
         {

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -534,30 +534,15 @@ namespace Opm
             return solvent_well_rate;
         }
 
-        /* const std::vector<double>& wellReservoirRates() const
-        {
-            return well_reservoir_rates_;
-        } */
-
         std::vector<double>& wellReservoirRates()
         {
             return well_reservoir_rates_;
         }
 
-        /* const std::vector<double>& wellDissolvedGasRates() const
-        {
-            return well_dissolved_gas_rates_;
-        } */
-
         std::vector<double>& wellDissolvedGasRates()
         {
             return well_dissolved_gas_rates_;
         }
-
-        /* const std::vector<double>& wellVaporizedOilRates() const
-        {
-            return well_vaporized_oil_rates_;
-        } */
 
         std::vector<double>& wellVaporizedOilRates()
         {

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -80,11 +80,17 @@ namespace Opm
             }
 
             const int nw = wells->number_of_wells;
+
             if( nw == 0 ) return ;
 
             // Initialize perfphaserates_, which must be done here.
             const int np = wells->number_of_phases;
             const int nperf = wells->well_connpos[nw];
+
+            well_reservoir_rates_.resize(nw * np, 0.0);
+            well_dissolved_gas_rates_.resize(nw, 0.0);
+            well_vaporized_oil_rates_.resize(nw, 0.0);
+
             // Ensure that we start out with zero rates by default.
             perfphaserates_.clear();
             perfphaserates_.resize(nperf * np, 0.0);
@@ -278,6 +284,23 @@ namespace Opm
                 const auto w = wt.second[ 0 ];
                 auto& well = res.at( wt.first );
                 well.control = this->currentControls()[ w ];
+
+                const int well_rate_index = w * pu.num_phases;
+
+                if ( pu.phase_used[Water] ) {
+                    well.rates.set( rt::reservoir_water, this->well_reservoir_rates_[well_rate_index + pu.phase_pos[Water]] );
+                }
+
+                if ( pu.phase_used[Oil] ) {
+                    well.rates.set( rt::reservoir_oil, this->well_reservoir_rates_[well_rate_index + pu.phase_pos[Oil]] );
+                }
+
+                if ( pu.phase_used[Gas] ) {
+                    well.rates.set( rt::reservoir_oil, this->well_reservoir_rates_[well_rate_index + pu.phase_pos[Gas]] );
+                }
+
+                well.rates.set( rt::dissolved_gas, this->well_dissolved_gas_rates_[w] );
+                well.rates.set( rt::vaporized_oil, this->well_vaporized_oil_rates_[w] );
 
                 int local_comp_index = 0;
                 for( auto& comp : well.completions ) {
@@ -511,6 +534,37 @@ namespace Opm
             return solvent_well_rate;
         }
 
+        /* const std::vector<double>& wellReservoirRates() const
+        {
+            return well_reservoir_rates_;
+        } */
+
+        std::vector<double>& wellReservoirRates()
+        {
+            return well_reservoir_rates_;
+        }
+
+        /* const std::vector<double>& wellDissolvedGasRates() const
+        {
+            return well_dissolved_gas_rates_;
+        } */
+
+        std::vector<double>& wellDissolvedGasRates()
+        {
+            return well_dissolved_gas_rates_;
+        }
+
+        /* const std::vector<double>& wellVaporizedOilRates() const
+        {
+            return well_vaporized_oil_rates_;
+        } */
+
+        std::vector<double>& wellVaporizedOilRates()
+        {
+            return well_vaporized_oil_rates_;
+        }
+
+
         const std::vector<double>& segRates() const
         {
             return segrates_;
@@ -547,6 +601,18 @@ namespace Opm
         std::vector<double> perfphaserates_;
         std::vector<int> current_controls_;
         std::vector<double> perfRateSolvent_;
+
+        // phase rates under reservoir condition for wells
+        // or voidage phase rates
+        std::vector<double> well_reservoir_rates_;
+
+        // dissolved gas rates or solution gas production rates
+        // should be zero for injection wells
+        std::vector<double> well_dissolved_gas_rates_;
+
+        // vaporized oil rates or solution oil producation rates
+        // should be zero for injection wells
+        std::vector<double> well_vaporized_oil_rates_;
 
         // marking whether the well is just added
         // for newly added well, the current initialized rates from WellState


### PR DESCRIPTION
Adding dissolution gas production rate, dissolution oil production rate and the three reservoir phase rate for output purpose. It works well for my only simple test case, while it will face big challenges when cross flow and multiple FIP regions are involved. 

It depends on PR OPM/opm-parser#1211 and OPM/opm-output#253. 

And also, we probably should not update these values always, we should check the `SummaryCfg` to see if we need these values are needed for output purpose. 

Please help to test it. If there are some discrepancy is found, please help to share your case with me for debugging purpose.   

The following is the comparison plot of my test cases. 
[temp_3d_cases.pdf](https://github.com/OPM/opm-simulators/files/1724267/temp_3d_cases.pdf)
