### PR TITLE
If requested use matrix with well contributions only for the preconditioner.

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -376,6 +376,10 @@ namespace Opm {
 
             auto& ebosJac = ebosSimulator_.model().linearizer().matrix();
             if (param_.matrix_add_well_contributions_) {
+                wellModel().addWellContributions(ebosJac);
+            }
+            if ( param_.preconditioner_add_well_contributions_ &&
+                 ! param_.matrix_add_well_contributions_ ) {
                 matrix_for_preconditioner_ .reset(new Mat(ebosJac));
                 wellModel().addWellContributions(*matrix_for_preconditioner_);
             }

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -66,6 +66,7 @@ namespace Opm
         use_update_stabilization_ = param.getDefault("use_update_stabilization", use_update_stabilization_);
         deck_file_name_ = param.template get<std::string>("deck_filename");
         matrix_add_well_contributions_ = param.getDefault("matrix_add_well_contributions", matrix_add_well_contributions_);
+        preconditioner_add_well_contributions_ = param.getDefault("preconditioner_add_well_contributions", preconditioner_add_well_contributions_);
     }
 
 
@@ -95,6 +96,7 @@ namespace Opm
         use_update_stabilization_ = true;
         use_multisegment_well_ = false;
         matrix_add_well_contributions_ = false;
+        preconditioner_add_well_contributions_ = false;
     }
 
 

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -91,8 +91,11 @@ namespace Opm
         /// The file name of the deck
         std::string deck_file_name_;
 
-        // Whether to add influences of wells between cells to the matrix
+        // Whether to add influences of wells between cells to the matrix and preconditioner matrix
         bool matrix_add_well_contributions_;
+
+        // Whether to add influences of wells between cells to the preconditioner matrix only
+        bool preconditioner_add_well_contributions_;
 
         /// Construct from user parameters or defaults.
         explicit BlackoilModelParameters( const ParameterGroup& param );

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -153,6 +153,16 @@ namespace Opm {
             const SimulatorReport& lastReport() const;
 
 
+            void addWellContributions(Mat& mat)
+            {
+                for (int w = 0; w < numWells(); ++w) {
+                    auto* well = dynamic_cast<StandardWell<TypeTag>*>(well_container_[w].get());
+                    if (well) {
+                        well->addWellContributions(mat);
+                    }
+                }
+            }
+
         protected:
 
             Simulator& ebosSimulator_;

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -155,11 +155,8 @@ namespace Opm {
 
             void addWellContributions(Mat& mat)
             {
-                for (int w = 0; w < numWells(); ++w) {
-                    auto* well = dynamic_cast<StandardWell<TypeTag>*>(well_container_[w].get());
-                    if (well) {
+                for ( const auto& well: well_container_ ) {
                         well->addWellContributions(mat);
-                    }
                 }
             }
 

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -326,10 +326,7 @@ namespace Opm {
         }
 
         for (auto& well : well_container_) {
-            if ( ! well->jacobianContainsWellContributions() )
-            {
-                well->apply(x, Ax);
-            }
+            well->apply(x, Ax);
         }
     }
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -179,12 +179,12 @@ public:
 
         WellState wellStateDummy; //not used. Only passed to make the old interfaces happy
 
-        if ( model_param_.matrix_add_well_contributions_ )
-        {
+        // if ( model_param_.matrix_add_well_contributions_ )
+        // {
             ebosSimulator_.model().clearAuxiliaryModules();
             auto auxMod = std::make_shared<WellConnectionAuxiliaryModule<TypeTag> >(schedule(), grid());
             ebosSimulator_.model().addAuxiliaryModule(auxMod);
-        }
+        // }
 
         // Main simulation loop.
         while (!timer.done()) {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -179,12 +179,12 @@ public:
 
         WellState wellStateDummy; //not used. Only passed to make the old interfaces happy
 
-        // if ( model_param_.matrix_add_well_contributions_ )
-        // {
+        if ( model_param_.matrix_add_well_contributions_ )
+        {
             ebosSimulator_.model().clearAuxiliaryModules();
             auto auxMod = std::make_shared<WellConnectionAuxiliaryModule<TypeTag> >(schedule(), grid());
             ebosSimulator_.model().addAuxiliaryModule(auxMod);
-        // }
+        }
 
         // Main simulation loop.
         while (!timer.done()) {

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -179,7 +179,8 @@ public:
 
         WellState wellStateDummy; //not used. Only passed to make the old interfaces happy
 
-        if ( model_param_.matrix_add_well_contributions_ )
+        if ( model_param_.matrix_add_well_contributions_ ||
+             model_param_.preconditioner_add_well_contributions_ )
         {
             ebosSimulator_.model().clearAuxiliaryModules();
             auto auxMod = std::make_shared<WellConnectionAuxiliaryModule<TypeTag> >(schedule(), grid());

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -671,11 +671,6 @@ namespace Opm
         // specializations in for 3x3 and 4x4 matrices.
         auto original = invDuneD_[0][0];
         Dune::FMatrixHelp::invertMatrix(original, invDuneD_[0][0]);
-
-        // if ( param_.matrix_add_well_contributions_ )
-        // {
-        //     addWellContributions( ebosJac );
-        // }
     }
 
 

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -672,10 +672,10 @@ namespace Opm
         auto original = invDuneD_[0][0];
         Dune::FMatrixHelp::invertMatrix(original, invDuneD_[0][0]);
 
-        if ( param_.matrix_add_well_contributions_ )
-        {
-            addWellContributions( ebosJac );
-        }
+        // if ( param_.matrix_add_well_contributions_ )
+        // {
+        //     addWellContributions( ebosJac );
+        // }
     }
 
 

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -1599,6 +1599,11 @@ namespace Opm
     StandardWell<TypeTag>::
     apply(const BVector& x, BVector& Ax) const
     {
+        if ( param_.matrix_add_well_contributions_ )
+        {
+            // Contributions are already in the matrix itself
+            return;
+        }
         assert( Bx_.size() == duneB_.N() );
         assert( invDrw_.size() == invDuneD_.N() );
 

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -212,6 +212,9 @@ namespace Opm
         // updating the voidage rates in well_state when requested
         void calculateReservoirRates(WellState& well_state) const;
 
+        // Add well contributions to matrix
+        virtual void addWellContributions(Mat&) const
+        {}
     protected:
 
         // to indicate a invalid connection


### PR DESCRIPTION
For the linear operator we use the old approach of first applying the reservoir part and then
the contributions of the wells.

With this a run with `matrix_add_well_contributions=true` results in
```
Total time (seconds):         701.562
Solver time (seconds):        697.49
 Assembly time (seconds):     360.866 (Failed: 10.3181; 2.85925%)
 Linear solve time (seconds): 312.278 (Failed: 8.73115; 2.79596%)
 Update time (seconds):       14.8467 (Failed: 0.462793; 3.11714%)
 Output write time (seconds): 5.25062
Overall Well Iterations:      968 (Failed: 12; 1.23967%)
Overall Linearizations:       1925 (Failed: 55; 2.85714%)
Overall Newton Iterations:    1587 (Failed: 55; 3.46566%)
Overall Linear Iterations:    23263 (Failed: 616; 2.64798%)
```

with `matrix_add_well_contributions=false` (default):
```
Total time (seconds):         653.698
Solver time (seconds):        649.741
 Assembly time (seconds):     326.275 (Failed: 5.76016; 1.76543%)
 Linear solve time (seconds): 300.36 (Failed: 7.3053; 2.43218%)
 Update time (seconds):       14.0123 (Failed: 0.271889; 1.94036%)
 Output write time (seconds): 5.11316
Overall Well Iterations:      968 (Failed: 9; 0.929752%)
Overall Linearizations:       1882 (Failed: 33; 1.75345%)
Overall Newton Iterations:    1545 (Failed: 33; 2.13592%)
Overall Linear Iterations:    23761 (Failed: 599; 2.52094%)
```

One of the reasons for the worse runtime is that the nonlinear solver fails to converge 5 times instead of just 3 times.
BTW: Just storing zeros for the entries that would appear due to the well contributions and changing nothing else, I see even 7 convergence failures for the linear solver. Therefore one could argue that
the additional nonzeros are the fault.