### PR TITLE
Fix icc

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -369,7 +369,7 @@ namespace Opm {
                 // the reservoir equations as a source term.
                 wellModel().assemble(iterationIdx, dt);
             }
-            catch ( const Dune::FMatrixError& e  )
+            catch ( const Dune::FMatrixError& )
             {
                 OPM_THROW(Opm::NumericalIssue,"Error encounted when solving well equations");
             }

--- a/opm/autodiff/VFPHelpers.hpp
+++ b/opm/autodiff/VFPHelpers.hpp
@@ -324,12 +324,6 @@ inline VFPEvaluation operator*(
 /**
  * Helper function which interpolates data using the indices etc. given in the inputs.
  */
-#ifdef __GNUC__
-#pragma GCC push_options
-#pragma GCC optimize ("unroll-loops")
-#endif
-
-
 inline VFPEvaluation interpolate(
         const VFPProdTable::array_type& array,
         const InterpData& flo_i,
@@ -501,17 +495,6 @@ inline VFPEvaluation interpolate(
 
     return nn[0][0];
 }
-
-
-
-
-#ifdef __GNUC__
-#pragma GCC pop_options //unroll loops
-#endif
-
-
-
-
 
 inline VFPEvaluation bhp(const VFPProdTable* table,
         const double& aqua,


### PR DESCRIPTION
this fixes a few annoying warnings on ICC. note that on that compiler some legacy simulators like e.g. `flow_reorder` do not compile, but good ol' `flow` compiles fine. `flow` seems to be significantly slower than using GCC or clang, though. (both, when it comes to time required for compililation and run-time performance of the executable)