### PR TITLE
Bugfix. enableStorageCache=false

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -174,16 +174,10 @@ namespace Opm {
         {
 
             // update the solution variables in ebos
-
-            // if the last time step failed we need to update the curent solution
-            // and recalculate the Intesive Quantities.
             if ( timer.lastStepFailed() ) {
-                ebosSimulator_.model().solution( 0 /* timeIdx */ ) = ebosSimulator_.model().solution( 1 /* timeIdx */ );
-                ebosSimulator_.model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
+                ebosSimulator_.model().updateFailed();
             } else {
-                // set the initial solution.
-                ebosSimulator_.model().solution( 1 /* timeIdx */ ) = ebosSimulator_.model().solution( 0 /* timeIdx */ );
-                ebosSimulator_.model().shiftIntensiveQuantityCache(/*numSlots=*/1);
+                ebosSimulator_.model().advanceTimeLevel();
             }
 
             // set the timestep size and index in ebos explicitly

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -183,6 +183,7 @@ namespace Opm {
             } else {
                 // set the initial solution.
                 ebosSimulator_.model().solution( 1 /* timeIdx */ ) = ebosSimulator_.model().solution( 0 /* timeIdx */ );
+                ebosSimulator_.model().shiftIntensiveQuantityCache(/*numSlots=*/1);
             }
 
             // set the timestep size and index in ebos explicitly


### PR DESCRIPTION
Shift intensiveQuantities each timestep. 
If enableStorageCache is true the call just returns (i.e. no performance penalty for the default case) 

