### PR TITLE
Add option for relaxed CNV tolerance

### DIFF
--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -48,6 +48,7 @@ namespace Opm
         max_residual_allowed_ = param.getDefault("max_residual_allowed", max_residual_allowed_);
         tolerance_mb_    = param.getDefault("tolerance_mb", tolerance_mb_);
         tolerance_cnv_   = param.getDefault("tolerance_cnv", tolerance_cnv_);
+        tolerance_cnv_relaxed_   = param.getDefault("tolerance_cnv_relaxed", tolerance_cnv_relaxed_);
         tolerance_wells_ = param.getDefault("tolerance_wells", tolerance_wells_ );
         tolerance_well_control_ = param.getDefault("tolerance_well_control", tolerance_well_control_);
         max_welleq_iter_ = param.getDefault("max_welleq_iter", max_welleq_iter_);
@@ -82,6 +83,7 @@ namespace Opm
         max_residual_allowed_ = 1e7;
         tolerance_mb_    = 1.0e-5;
         tolerance_cnv_   = 1.0e-2;
+        tolerance_cnv_relaxed_ = 1.0e9;
         tolerance_wells_ = 1.0e-4;
         tolerance_well_control_ = 1.0e-7;
         tolerance_pressure_ms_wells_ = unit::convert::from(0.01, unit::barsa); // 0.01 bar

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -46,6 +46,8 @@ namespace Opm
         double tolerance_mb_;
         /// Local convergence tolerance (max of local saturation errors).
         double tolerance_cnv_;
+        /// Relaxed local convergence tolerance (used when iter >= max_strict_iter_).
+        double tolerance_cnv_relaxed_;
         /// Well convergence tolerance.
         double tolerance_wells_;
         /// Tolerance for the well control equations


### PR DESCRIPTION
Use a relaxed tolerance for individual cells (CNV) when `iter > max_strict_iter`. `tolerance_cnv_relaxed_` is defaulted to 1.0;

This is a safer version of the current approach of ignoring CNV for `iter > max_strict_iter`. Setting `tolerance_cnv_relaxed_` to a large number will give back the current approach.

I have tested this on Model 2 rel 0 and rel 5 and on the CO2 cases. In general this increases the run time of the simulator and makes it more accurate. 

For Model 2 rel 5 this gives an increase of run time of 25%, without giving much improved accuracy. 
For some of the CO2 cases this improves the accuracy significantly with < 10% increase in time. 
others are more or less unaffected.

I have tested different variants of this PR as well as different default tolerances and the current approach gives the overall best performance while not compromising the accuracy.