### PR TITLE
adding POLYMW to the injectorType determination

### DIFF
--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -1483,6 +1483,7 @@ namespace Opm
                 case Phase::SOLVENT: OPM_THROW(std::invalid_argument, "Solvent injector is not supported.");
                 case Phase::POLYMER: OPM_THROW(std::invalid_argument, "Polymer injector is not supported.");
                 case Phase::ENERGY:  OPM_THROW(std::invalid_argument, "Energy injector is not supported.");
+                case Phase::POLYMW:  OPM_THROW(std::invalid_argument, "PolyMW injector is not supported.");
             }
             OPM_THROW(std::logic_error, "Invalid state." );
         }


### PR DESCRIPTION
just to silence a warning resulting from OPM/opm-common#348 .  It should only be merged if the upstream PR is merged. 