### PR TITLE
Some minor fixes to RESV and initial well composition 

### DIFF
--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -194,6 +194,7 @@ namespace Opm {
             size_t number_of_cells_;
             double gravity_;
             std::vector<double> depth_;
+            bool initial_step_;
 
             DynamicListEconLimited dynamic_list_econ_limited_;
             std::unique_ptr<RateConverterType> rateConverter_;

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -29,6 +29,7 @@ namespace Opm {
 
         extractLegacyCellPvtRegionIndex_();
         extractLegacyDepth_();
+        initial_step_ = true;
     }
 
 
@@ -273,6 +274,12 @@ namespace Opm {
         if (param_.solve_welleq_initially_ && iterationIdx == 0) {
             // solve the well equations as a pre-processing step
             last_report_ = solveWellEq(dt);
+            if (initial_step_) {
+                // update the explixit quanteties to get the initial fluid distribution in the well correct.
+                calculateExplicitQuantities();
+                last_report_ = solveWellEq(dt);
+                initial_step_ = false;
+            }
         }
         assembleWellEq(dt, false);
 

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -275,7 +275,7 @@ namespace Opm {
             // solve the well equations as a pre-processing step
             last_report_ = solveWellEq(dt);
             if (initial_step_) {
-                // update the explixit quanteties to get the initial fluid distribution in the well correct.
+                // update the explicit quantities to get the initial fluid distribution in the well correct.
                 calculateExplicitQuantities();
                 last_report_ = solveWellEq(dt);
                 initial_step_ = false;
@@ -1196,9 +1196,9 @@ namespace Opm {
                             // observed phase rates translated to
                             // reservoir conditions.  Recall sign
                             // convention: Negative for producers.
-                            const double target =
-                                - std::inner_product(distr.begin(), distr.end(),
-                                                     hrates.begin(), 0.0);
+                            std::vector<double> hrates_resv(np);
+                            rateConverter_->calcReservoirVoidageRates(fipreg, pvtreg, hrates, hrates_resv);
+                            const double target = -std::accumulate(hrates_resv.begin(), hrates_resv.end(), 0.0);
 
                             well_controls_clear(ctrl);
                             well_controls_assert_number_of_phases(ctrl, int(np));

--- a/opm/autodiff/RateConverter.hpp
+++ b/opm/autodiff/RateConverter.hpp
@@ -613,13 +613,16 @@ namespace Opm {
                     coeff[iw] = 1.0 / bw;
                 }
 
+                // Actual Rs and Rv:
+                double Rs = ra.rs;
+                double Rv = ra.rv;
+
                 // Determinant of 'R' matrix
-                const double detR = 1.0 - (ra.rs * ra.rv);
+                const double detR = 1.0 - (Rs * Rv);
 
                 if (Details::PhaseUsed::oil(pu)) {
                     // q[o]_r = 1/(bo * (1 - rs*rv)) * (q[o]_s - rv*q[g]_s)
 
-                    const double Rs = ra.rs;
                     const double bo = FluidSystem::oilPvt().inverseFormationVolumeFactor(pvtRegionIdx, T, p, Rs);
                     const double den = bo * detR;
 
@@ -633,7 +636,6 @@ namespace Opm {
                 if (Details::PhaseUsed::gas(pu)) {
                     // q[g]_r = 1/(bg * (1 - rs*rv)) * (q[g]_s - rs*q[o]_s)
 
-                    const double Rv = ra.rv;
                     const double bg  = FluidSystem::gasPvt().inverseFormationVolumeFactor(pvtRegionIdx, T, p, Rv);
                     const double den = bg * detR;
 
@@ -689,20 +691,22 @@ namespace Opm {
                     voidage_rates[iw] = surface_rates[iw] / bw;
                 }
 
+                // Use average Rs and Rv:
+                double Rs = std::min(ra.rs, surface_rates[ig]/(surface_rates[io]+1.0e-15));
+                double Rv = std::min(ra.rv, surface_rates[io]/(surface_rates[ig]+1.0e-15));
+
                 // Determinant of 'R' matrix
-                const double detR = 1.0 - (ra.rs * ra.rv);
+                const double detR = 1.0 - (Rs * Rv);
 
                 if (Details::PhaseUsed::oil(pu)) {
                     // q[o]_r = 1/(bo * (1 - rs*rv)) * (q[o]_s - rv*q[g]_s)
 
-                    const double Rs = ra.rs;
                     const double bo = FluidSystem::oilPvt().inverseFormationVolumeFactor(pvtRegionIdx, T, p, Rs);
                     const double den = bo * detR;
 
                     voidage_rates[io] = surface_rates[io];
 
                     if (Details::PhaseUsed::gas(pu)) {
-                        const double Rv = ra.rv;
                         voidage_rates[io] -= Rv * surface_rates[ig];
                     }
 
@@ -712,14 +716,12 @@ namespace Opm {
                 if (Details::PhaseUsed::gas(pu)) {
                     // q[g]_r = 1/(bg * (1 - rs*rv)) * (q[g]_s - rs*q[o]_s)
 
-                    const double Rv = ra.rv;
                     const double bg  = FluidSystem::gasPvt().inverseFormationVolumeFactor(pvtRegionIdx, T, p, Rv);
                     const double den = bg * detR;
 
                     voidage_rates[ig] = surface_rates[ig];
 
                     if (Details::PhaseUsed::oil(pu)) {
-                        const double Rs = ra.rs;
                         voidage_rates[ig] -= Rs * surface_rates[io];
                     }
 


### PR DESCRIPTION
Some minor issues notices while debugging the CO2CASE. 

1) Fix initial fluid distribution in the well, by solving the well equation one extra time before the first timestep.  

2) Get the correct RESV values for the under-saturated case. 

I have tested this on norne and model 2 rel 0 and rel 5. There are no performance loss and the overall results are improved slightly compared to our reference simulator. The WOPTF results are improved noticeable for model 2 for some wells ( the wells in the under-saturated region).

  