### PR TITLE
Include <sstream> for Class "ostringstream"

### DIFF
--- a/opm/core/simulator/SimulatorReport.cpp
+++ b/opm/core/simulator/SimulatorReport.cpp
@@ -18,10 +18,12 @@
 */
 
 #include "config.h"
-#include <opm/core/simulator/SimulatorReport.hpp>
-#include <ostream>
-#include <iomanip>
 
+#include <opm/core/simulator/SimulatorReport.hpp>
+
+#include <iomanip>
+#include <ostream>
+#include <sstream>
 
 namespace Opm
 {


### PR DESCRIPTION
Some implementations do not get a transitive definition of class "ostringstream" in scope through the other headers and therefore fail to compile the member function
```C++
void SimulatorReport::reportStep(std::ostringstream&);
```

Prompted by PR #1433 (commit 7c9dab1a).