### PR TITLE
adapt to the removal of the `ewoms/aux` directory

### DIFF
--- a/opm/autodiff/WellConnectionAuxiliaryModule.hpp
+++ b/opm/autodiff/WellConnectionAuxiliaryModule.hpp
@@ -21,7 +21,7 @@
 #ifndef OPM_WELLCONNECTIONAUXILIARYMODULE_HEADER_INCLUDED
 #define OPM_WELLCONNECTIONAUXILIARYMODULE_HEADER_INCLUDED
 
-#include <ewoms/aux/baseauxiliarymodule.hh>
+#include <ewoms/disc/common/baseauxiliarymodule.hh>
 
 #include <opm/grid/CpGrid.hpp>
 


### PR DESCRIPTION
this is the mop-up PR required for OPM/ewoms#309