### PR TITLE
Only load wells that have simulated data

### DIFF
--- a/opm/autodiff/BlackoilOutputEbos.hpp
+++ b/opm/autodiff/BlackoilOutputEbos.hpp
@@ -133,7 +133,11 @@ namespace Opm
             const auto& defunct_well_names = ebosSimulator_.vanguard().defunctWellNames();
             WellsManager wellsmanager(eclState(),
                                       schedule(),
-                                      eclState().getInitConfig().getRestartStep(),
+                                      // The restart step value is used to identify wells present at the given
+                                      // time step. Wells that are added at the same time step as RESTART is initiated
+                                      // will not be present in a restart file. Use the previous time step to retrieve
+                                      // wells that have information written to the restart file.
+                                      std::max(eclState().getInitConfig().getRestartStep() - 1, 0),
                                       Opm::UgGridHelpers::numCells(grid()),
                                       Opm::UgGridHelpers::globalCell(grid()),
                                       Opm::UgGridHelpers::cartDims(grid()),

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -439,7 +439,11 @@ namespace Opm
         DynamicListEconLimited dummy_list_econ_limited;
         WellsManager wellsmanager(eclipseState_,
                                   schedule_,
-                                  eclipseState_.getInitConfig().getRestartStep(),
+                                  // The restart step value is used to identify wells present at the given time step.
+                                  // Wells that are added at the same time step as RESTART is initiated will not be
+                                  // present in a restart file. Use the previous time step to retrieve wells
+                                  // that have information written to the restart file.
+                                  std::max(eclipseState_.getInitConfig().getRestartStep() - 1, 0),
                                   Opm::UgGridHelpers::numCells(grid),
                                   Opm::UgGridHelpers::globalCell(grid),
                                   Opm::UgGridHelpers::cartDims(grid),


### PR DESCRIPTION
Wells that are added at the same time step as RESTART is initiated will
not be present in a restart file. Use the previous time step to retrieve
wells

This PR relates to https://github.com/OPM/opm-common/pull/383, and will mitigate https://github.com/OPM/opm-simulators/issues/1412
Given the fix in opm:common, segfaults will occur if a restart is issued at the same time step as a well (or additional completions) is introduced in the schedule file.

The PR alone should not introduce any issues otherwise, even without the pr in opm:common.