### PR TITLE
Make sure we (re-)throw MatrixBlockError also in the serial case.

### DIFF
--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -464,7 +464,9 @@ protected:
         }
 
         // Check whether there was a problem on some process
-        if ( comm_ && comm_->communicator().min(ilu_setup_successful) == 0 )
+        const bool parallel_failure = comm_ && comm_->communicator().min(ilu_setup_successful) == 0;
+        const bool local_failure = ilu_setup_successful == 0;
+        if ( local_failure || parallel_failure )
         {
             throw Dune::MatrixBlockError();
         }


### PR DESCRIPTION
Discovered while debugging and investigating issues related to inversion of matrix blocks, #1464.

In the serial case, the *preconditioner* would essentially never throw, and the solution process would move on. Eventually the Krylov solver would not manage to reduce the residual and signal failure. With this change, inversion failures in the preconditioner will immediately throw.

There is one potential downside: if the Krylov solver could have continued successfully, in spite of a failing preconditioner, we no longer get that opportunity. However I expect this to be a very rare occurrence after #1464 is merged.