### PR TITLE
[WIP] Linear solver flexibility, including amgcl and UMFPACK testing

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -42,6 +42,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/autodiff/NewtonIterationUtilities.cpp
   opm/autodiff/GridHelpers.cpp
   opm/autodiff/ImpesTPFAAD.cpp
+  opm/autodiff/LinearSolverAmgcl.cpp
   opm/autodiff/moduleVersion.cpp
   opm/autodiff/multiPhaseUpwind.cpp
   opm/autodiff/SimulatorFullyImplicitBlackoilOutput.cpp
@@ -295,6 +296,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/autodiff/ImpesTPFAAD.hpp
   opm/autodiff/ISTLSolver.hpp
   opm/autodiff/IterationReport.hpp
+  opm/autodiff/LinearSolverAmgcl.hpp
   opm/autodiff/moduleVersion.hpp
   opm/autodiff/multiPhaseUpwind.hpp
   opm/autodiff/NewtonIterationBlackoilCPR.hpp

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -482,7 +482,7 @@ namespace Opm {
         /// Number of linear iterations used in last call to solveJacobianSystem().
         int linearIterationsLastSolve() const
         {
-            return istlSolver().iterations();
+            return linear_iters_last_solve_;
         }
 
         /// Solve the Jacobian system Jx = r where J is the Jacobian and
@@ -569,6 +569,7 @@ namespace Opm {
                         x[cell][phase] = sol[np*cell + phase];
                     }
                 }
+                const_cast<int&>(linear_iters_last_solve_) = iters;
                 return;
             }
 
@@ -588,6 +589,7 @@ namespace Opm {
                 Operator opA(ebosJac, actual_mat_for_prec, wellModel());
                 istlSolver().solve( opA, x, ebosResid );
             }
+            const_cast<int&>(linear_iters_last_solve_) = istlSolver().iterations();
         }
 
         //=====================================================================
@@ -1163,6 +1165,7 @@ namespace Opm {
         BVector dx_old_;
 
         std::unique_ptr<Mat> matrix_for_preconditioner_;
+        int linear_iters_last_solve_ = -1;
 
     public:
         /// return the StandardWells object

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -525,7 +525,8 @@ namespace Opm {
                         const int istlcol = indexptr[elem];
                         const auto& block = dataptr[elem];
                         for (int bcol = 0; bcol < np; ++bcol) {
-                            A.val[index] = block[brow][bcol];
+                            static int bcolmap[] = { 1, 0, 2};
+                            A.val[index] = block[brow][bcolmap[bcol]];
                             A.col[index] = np*istlcol + bcol;
                             ++index;
                         }

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -507,85 +507,87 @@ namespace Opm {
             // set initial guess
             x = 0.0;
 
-
-            // Create matrix for amgcl
-            const int n = ebosResid.size();
-            assert(ebosResid.size() == ebosJac.N());
-            const int np = numPhases();
-            const int sz = n * np;
-            const int nnz = ebosJac.nonzeroes();
-            assert(x.size() == ebosResid.size());
-            std::vector<int>    ptr(sz + 1,         -1);
-            std::vector<int>    col(nnz * np * np,  -1);
-            std::vector<double> val(nnz * np * np, 0.0);
-            std::vector<double> rhs(sz,            0.0);
-            ptr[0] = 0;
-            int index = 0;
-            for (int row_index = 0; row_index < n; ++row_index) {
-                const auto& row = ebosJac[row_index];
-                const auto* dataptr = row.getptr();
-                const auto* indexptr = row.getindexptr();
-                for (int brow = 0; brow < np; ++brow) {
-                    ptr[row_index*np + brow + 1] = ptr[row_index*np + brow] + row.N() * np;
-                    for (int elem = 0; elem < row.N(); ++elem) {
-                        const int istlcol = indexptr[elem];
-                        const auto& block = dataptr[elem];
-                        for (int bcol = 0; bcol < np; ++bcol) {
-                            val[index] = block[brow][bcol];
-                            col[index] = np*istlcol + bcol;
-                            ++index;
+            if (param_.use_amgcl_) {
+                // Create matrix for amgcl
+                const int n = ebosResid.size();
+                assert(ebosResid.size() == ebosJac.N());
+                const int np = numPhases();
+                const int sz = n * np;
+                const int nnz = ebosJac.nonzeroes();
+                assert(x.size() == ebosResid.size());
+                std::vector<int>    ptr(sz + 1,         -1);
+                std::vector<int>    col(nnz * np * np,  -1);
+                std::vector<double> val(nnz * np * np, 0.0);
+                std::vector<double> rhs(sz,            0.0);
+                ptr[0] = 0;
+                int index = 0;
+                for (int row_index = 0; row_index < n; ++row_index) {
+                    const auto& row = ebosJac[row_index];
+                    const auto* dataptr = row.getptr();
+                    const auto* indexptr = row.getindexptr();
+                    for (int brow = 0; brow < np; ++brow) {
+                        ptr[row_index*np + brow + 1] = ptr[row_index*np + brow] + row.N() * np;
+                        for (int elem = 0; elem < row.N(); ++elem) {
+                            const int istlcol = indexptr[elem];
+                            const auto& block = dataptr[elem];
+                            for (int bcol = 0; bcol < np; ++bcol) {
+                                val[index] = block[brow][bcol];
+                                col[index] = np*istlcol + bcol;
+                                ++index;
+                            }
                         }
                     }
                 }
-            }
-            for (int cell = 0; cell < n; ++cell) {
-                for (int phase = 0; phase < np; ++phase) {
-                    rhs[np*cell + phase] = ebosResid[cell][phase];
+                for (int cell = 0; cell < n; ++cell) {
+                    for (int phase = 0; phase < np; ++phase) {
+                        rhs[np*cell + phase] = ebosResid[cell][phase];
+                    }
                 }
-            }
 
-            // Call amgcl to solve system
-            typedef amgcl::backend::builtin<double> Backend;
-            typedef amgcl::make_solver<
-                // Use AMG as preconditioner:
-                amgcl::amg<
-                    Backend,
-                    amgcl::coarsening::smoothed_aggregation,
-                    amgcl::relaxation::spai0
-                    >,
-                // And BiCGStab as iterative solver:
-                amgcl::solver::bicgstab<Backend>
-                > Solver;
-            Solver solve( boost::tie(sz, ptr, col, val) );
-            std::vector<double> sol(sz, 0.0);
-            int    iters;
-            double error;
-            boost::tie(iters, error) = solve(rhs, sol);
+                // Call amgcl to solve system
+                typedef amgcl::backend::builtin<double> Backend;
+                typedef amgcl::make_solver<
+                    // Use AMG as preconditioner:
+                    amgcl::amg<
+                        Backend,
+                        amgcl::coarsening::smoothed_aggregation,
+                        amgcl::relaxation::spai0
+                        >,
+                    // And BiCGStab as iterative solver:
+                    amgcl::solver::bicgstab<Backend>
+                    > Solver;
+                Solver solve( boost::tie(sz, ptr, col, val) );
+                std::vector<double> sol(sz, 0.0);
+                int    iters;
+                double error;
+                boost::tie(iters, error) = solve(rhs, sol);
 
-            // Extract solution
-            assert(sol.size() == x.size() * numPhases());
-            for (int cell = 0; cell < n; ++cell) {
-                for (int phase = 0; phase < np; ++phase) {
-                    x[cell][phase] = sol[np*cell + phase];
+                // Extract solution
+                assert(sol.size() == x.size() * numPhases());
+                for (int cell = 0; cell < n; ++cell) {
+                    for (int phase = 0; phase < np; ++phase) {
+                        x[cell][phase] = sol[np*cell + phase];
+                    }
                 }
+                return;
             }
 
-            // const Mat& actual_mat_for_prec = matrix_for_preconditioner_ ? *matrix_for_preconditioner_.get() : ebosJac;
-            // // Solve system.
-            // if( isParallel() )
-            // {
-            //     typedef WellModelMatrixAdapter< Mat, BVector, BVector, BlackoilWellModel<TypeTag>, true > Operator;
-            //     Operator opA(ebosJac, actual_mat_for_prec, wellModel(),
-            //                  istlSolver().parallelInformation() );
-            //     assert( opA.comm() );
-            //     istlSolver().solve( opA, x, ebosResid, *(opA.comm()) );
-            // }
-            // else
-            // {
-            //     typedef WellModelMatrixAdapter< Mat, BVector, BVector, BlackoilWellModel<TypeTag>, false > Operator;
-            //     Operator opA(ebosJac, actual_mat_for_prec, wellModel());
-            //     istlSolver().solve( opA, x, ebosResid );
-            // }
+            const Mat& actual_mat_for_prec = matrix_for_preconditioner_ ? *matrix_for_preconditioner_.get() : ebosJac;
+            // Solve system.
+            if( isParallel() )
+            {
+                typedef WellModelMatrixAdapter< Mat, BVector, BVector, BlackoilWellModel<TypeTag>, true > Operator;
+                Operator opA(ebosJac, actual_mat_for_prec, wellModel(),
+                             istlSolver().parallelInformation() );
+                assert( opA.comm() );
+                istlSolver().solve( opA, x, ebosResid, *(opA.comm()) );
+            }
+            else
+            {
+                typedef WellModelMatrixAdapter< Mat, BVector, BVector, BlackoilWellModel<TypeTag>, false > Operator;
+                Operator opA(ebosJac, actual_mat_for_prec, wellModel());
+                istlSolver().solve( opA, x, ebosResid );
+            }
         }
 
         //=====================================================================

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -500,7 +500,7 @@ namespace Opm {
 
         /// Build a CRS matrix (not block-structured) from
         /// the block structured system matrix.
-        CRSMatrixHelper buildCRSMatrix() const
+        CRSMatrixHelper buildCRSMatrixNoBlocks() const
         {
             const auto& ebosJac = ebosSimulator_.model().linearizer().matrix();
 
@@ -554,11 +554,11 @@ namespace Opm {
             // set initial guess
             x = 0.0;
 
-            if (param_.use_amgcl_) {
-                // Create matrix for amgcl
-                CRSMatrixHelper matrix = buildCRSMatrix();
+            if (param_.use_amgcl_ || param_.use_umfpack_) {
+                // Create matrix for external linear solvers.
+                CRSMatrixHelper matrix = buildCRSMatrixNoBlocks();
 
-                // Copy right-hand side.
+                // Copy right-hand side (blocked structure -> unblocked).
                 const int n = ebosResid.size();
                 const int np = numPhases();
                 const int sz = n * np;
@@ -569,57 +569,34 @@ namespace Opm {
                     }
                 }
 
-                // Call amgcl to solve system
-                const double tol = 1e-2;
-                const int maxiter = 150;
                 std::vector<double> sol(sz, 0.0);
-                int    iters;
-                double error;
-                LinearSolverAmgcl::solve(sz, matrix.ptr, matrix.col, matrix.val, rhs, tol, maxiter, sol, iters, error);
+                if (param_.use_amgcl_) {
+                    // Call amgcl to solve system
+                    const double tol = 1e-2;
+                    const int maxiter = 150;
+                    int    iters;
+                    double error;
+                    LinearSolverAmgcl::solve(sz, matrix.ptr, matrix.col, matrix.val, rhs, tol, maxiter, sol, iters, error);
+                    const_cast<int&>(linear_iters_last_solve_) = iters;
+                } else if (param_.use_umfpack_) {
+                    // Call UMFPACK to solve system
+                    const int nnz = matrix.ptr[sz];
+                    LinearSolverUmfpack solver;
+                    solver.solve(sz, nnz, matrix.ptr.data(), matrix.col.data(), matrix.val.data(), rhs.data(), sol.data());
+                    const_cast<int&>(linear_iters_last_solve_) = 0;
+                }
 
-                // Extract solution
+                // Extract solution (unblocked structure -> blocked).
                 assert(sol.size() == x.size() * numPhases());
                 for (int cell = 0; cell < n; ++cell) {
                     for (int phase = 0; phase < np; ++phase) {
                         x[cell][phase] = sol[np*cell + phase];
                     }
                 }
-                const_cast<int&>(linear_iters_last_solve_) = iters;
                 return;
             }
 
-            if (param_.use_umfpack_) {
-                // Create matrix for umfpack
-                CRSMatrixHelper matrix = buildCRSMatrix();
-
-                // Copy right-hand side.
-                const int n = ebosResid.size();
-                const int np = numPhases();
-                const int sz = n * np;
-                std::vector<double> rhs(sz, 0.0);
-                for (int cell = 0; cell < n; ++cell) {
-                    for (int phase = 0; phase < np; ++phase) {
-                        rhs[np*cell + phase] = ebosResid[cell][phase];
-                    }
-                }
-
-                // Call UMFPACK to solve system
-                const int nnz = matrix.ptr[sz];
-                std::vector<double> sol(sz, 0.0);
-                LinearSolverUmfpack solver;
-                solver.solve(sz, nnz, matrix.ptr.data(), matrix.col.data(), matrix.val.data(), rhs.data(), sol.data());
-
-                // Extract solution   // NOTE: copied from amgcl block
-                assert(sol.size() == x.size() * numPhases());
-                for (int cell = 0; cell < n; ++cell) {
-                    for (int phase = 0; phase < np; ++phase) {
-                        x[cell][phase] = sol[np*cell + phase];
-                    }
-                }
-                const_cast<int&>(linear_iters_last_solve_) = 0;
-                return;
-            }
-
+            // Use the default ISTLSolver to solve the system.
             const Mat& actual_mat_for_prec = matrix_for_preconditioner_ ? *matrix_for_preconditioner_.get() : ebosJac;
             // Solve system.
             if( isParallel() )

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -32,6 +32,7 @@
 #include <opm/autodiff/WellConnectionAuxiliaryModule.hpp>
 #include <opm/autodiff/BlackoilDetails.hpp>
 #include <opm/autodiff/NewtonIterationBlackoilInterface.hpp>
+#include <opm/autodiff/LinearSolverAmgcl.hpp>
 
 #include <opm/grid/UnstructuredGrid.h>
 #include <opm/core/simulator/SimulatorReport.hpp>
@@ -54,13 +55,6 @@
 #include <dune/common/parallel/collectivecommunication.hh>
 #include <dune/common/timer.hh>
 #include <dune/common/unused.hh>
-
-#include <amgcl/make_solver.hpp>
-#include <amgcl/solver/bicgstab.hpp>
-#include <amgcl/amg.hpp>
-#include <amgcl/coarsening/smoothed_aggregation.hpp>
-#include <amgcl/relaxation/spai0.hpp>
-#include <amgcl/adapter/crs_tuple.hpp>
 
 #include <cassert>
 #include <cmath>
@@ -545,22 +539,12 @@ namespace Opm {
                 }
 
                 // Call amgcl to solve system
-                typedef amgcl::backend::builtin<double> Backend;
-                typedef amgcl::make_solver<
-                    // Use AMG as preconditioner:
-                    amgcl::amg<
-                        Backend,
-                        amgcl::coarsening::smoothed_aggregation,
-                        amgcl::relaxation::spai0
-                        >,
-                    // And BiCGStab as iterative solver:
-                    amgcl::solver::bicgstab<Backend>
-                    > Solver;
-                Solver solve( boost::tie(sz, ptr, col, val) );
+                const double tol = 1e-2;
+                const int maxiter = 150;
                 std::vector<double> sol(sz, 0.0);
                 int    iters;
                 double error;
-                boost::tie(iters, error) = solve(rhs, sol);
+                LinearSolverAmgcl::solve(sz, ptr, col, val, rhs, tol, maxiter, sol, iters, error);
 
                 // Extract solution
                 assert(sol.size() == x.size() * numPhases());

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -555,6 +555,11 @@ namespace Opm {
             x = 0.0;
 
             if (param_.use_amgcl_ || param_.use_umfpack_) {
+                if (!param_.matrix_add_well_contributions_) {
+                    // This should be handled by combining interacting options into a single one eventually.
+                    OPM_THROW(std::runtime_error, "Cannot run with amgcl or UMFPACK without also using 'matrix_add_well_contributions=true'.");
+                }
+
                 // Create matrix for external linear solvers.
                 CRSMatrixHelper matrix = buildCRSMatrixNoBlocks();
 

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -69,6 +69,7 @@ namespace Opm
         matrix_add_well_contributions_ = param.getDefault("matrix_add_well_contributions", matrix_add_well_contributions_);
         preconditioner_add_well_contributions_ = param.getDefault("preconditioner_add_well_contributions", preconditioner_add_well_contributions_);
         use_amgcl_ = param.getDefault("use_amgcl", use_amgcl_);
+        use_umfpack_ = param.getDefault("use_umfpack", use_umfpack_);
     }
 
 
@@ -101,6 +102,7 @@ namespace Opm
         matrix_add_well_contributions_ = false;
         preconditioner_add_well_contributions_ = false;
         use_amgcl_ = false;
+        use_umfpack_ = false;
     }
 
 

--- a/opm/autodiff/BlackoilModelParameters.cpp
+++ b/opm/autodiff/BlackoilModelParameters.cpp
@@ -68,6 +68,7 @@ namespace Opm
         deck_file_name_ = param.template get<std::string>("deck_filename");
         matrix_add_well_contributions_ = param.getDefault("matrix_add_well_contributions", matrix_add_well_contributions_);
         preconditioner_add_well_contributions_ = param.getDefault("preconditioner_add_well_contributions", preconditioner_add_well_contributions_);
+        use_amgcl_ = param.getDefault("use_amgcl", use_amgcl_);
     }
 
 
@@ -99,6 +100,7 @@ namespace Opm
         use_multisegment_well_ = false;
         matrix_add_well_contributions_ = false;
         preconditioner_add_well_contributions_ = false;
+        use_amgcl_ = false;
     }
 
 

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -99,6 +99,9 @@ namespace Opm
         // Whether to add influences of wells between cells to the preconditioner matrix only
         bool preconditioner_add_well_contributions_;
 
+        // Use amgcl instead of dune-istl
+        bool use_amgcl_;
+
         /// Construct from user parameters or defaults.
         explicit BlackoilModelParameters( const ParameterGroup& param );
 

--- a/opm/autodiff/BlackoilModelParameters.hpp
+++ b/opm/autodiff/BlackoilModelParameters.hpp
@@ -102,6 +102,9 @@ namespace Opm
         // Use amgcl instead of dune-istl
         bool use_amgcl_;
 
+        // Use UMFPACK instead of dune-istl
+        bool use_umfpack_;
+
         /// Construct from user parameters or defaults.
         explicit BlackoilModelParameters( const ParameterGroup& param );
 

--- a/opm/autodiff/DebugTimeReport.hpp
+++ b/opm/autodiff/DebugTimeReport.hpp
@@ -23,6 +23,7 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/grid/utility/StopWatch.hpp>
 #include <string>
+#include <sstream>
 
 namespace Opm
 {

--- a/opm/autodiff/LinearSolverAmgcl.cpp
+++ b/opm/autodiff/LinearSolverAmgcl.cpp
@@ -18,33 +18,285 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <opm/autodiff/LinearSolverAmgcl.hpp>
+
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/autodiff/DebugTimeReport.hpp>
+
+#include <boost/property_tree/ptree.hpp>
+
+#include <amgcl/make_solver.hpp>
+#include <amgcl/solver/bicgstab.hpp>
+#include <amgcl/amg.hpp>
+#include <amgcl/coarsening/smoothed_aggregation.hpp>
+#include <amgcl/relaxation/spai0.hpp>
+#include <amgcl/adapter/crs_tuple.hpp>
+#include <amgcl/runtime.hpp>
+#include <amgcl/relaxation/runtime.hpp>
+#include <amgcl/preconditioner/dummy.hpp>
+#include <amgcl/adapter/crs_tuple.hpp>
+#include <amgcl/adapter/zero_copy.hpp>
+#include <amgcl/backend/builtin.hpp>
+#include <amgcl/preconditioner/runtime.hpp>
+#include <amgcl/preconditioner/cpr.hpp>
+#include <amgcl/preconditioner/cpr_drs.hpp>
+
+
 namespace Opm
 {
 
-    static void LinearSolverAmgcl::solve(const int sz,
-                                         const std::vector<int>& ptr,
-                                         const std::vector<int>& col,
-                                         const std::vector<double>& val,
-                                         int& iters,
-                                         double& error)
+
+
+
+    namespace {
+
+
+
+
+        struct AmgOptions
+        {
+            int coarsen_id = 1;
+            int coarse_enough = -1;
+            bool direct_coarse = true;
+            int max_levels = -1;
+            int ncycle = -1;
+            int npre = -1;
+            int npost = -1;
+            int pre_cycles = -1;
+        };
+
+
+
+
+        void setCoarseningAMGCL(const std::string& prefix, const AmgOptions& options, boost::property_tree::ptree& prm)
+        {
+            std::string coarsetype = prefix + "coarsening.type";
+            switch(options.coarsen_id) {
+            case 1: 
+                prm.put(coarsetype,  amgcl::runtime::coarsening::smoothed_aggregation);
+                break;
+            case 2: 
+                prm.put(coarsetype,  amgcl::runtime::coarsening::ruge_stuben);
+                break;
+            case 3: 
+                prm.put(coarsetype,  amgcl::runtime::coarsening::aggregation);
+                break;
+            case 4: 
+                prm.put(coarsetype,  amgcl::runtime::coarsening::smoothed_aggr_emin);
+                break;
+            default:
+                OPM_THROW(std::runtime_error, "Unknown coarsening id: " << options.coarsen_id);
+            }
+            // When is a level coarse enough
+            if (options.coarse_enough >= 0){
+                prm.put(prefix + "coarse_enough", options.coarse_enough);
+            }
+            // Use direct solver for coarse sys
+            prm.put(prefix + "direct_coarse", options.direct_coarse);
+            // Max levels
+            if (options.max_levels >= 0){
+                prm.put(prefix + "max_levels", options.max_levels);
+            }
+            // Number of cycles
+            if (options.ncycle >= 0){
+                prm.put(prefix + "ncycle", options.ncycle);
+            }
+            // Pre cycles
+            if (options.npre >= 0){
+                prm.put(prefix + "npre", options.npre);
+            }
+            // Post cycles
+            if (options.npost >= 0){
+                prm.put(prefix + "npost", options.npost);
+            }
+            // Pre cycles (precond)
+            if (options.pre_cycles >= 0){
+                prm.put(prefix + "pre_cycles", options.pre_cycles);
+            }
+        }
+
+
+
+
+        void setRelaxationAMGCL(const std::string& relaxParam, const int relax_id, boost::property_tree::ptree& prm)
+        {
+            std::string relaxType = relaxParam + "type";
+            switch(relax_id) {
+            case 1: 
+                prm.put(relaxType,  amgcl::runtime::relaxation::spai0);
+                break;
+            case 2: 
+                prm.put(relaxType,  amgcl::runtime::relaxation::gauss_seidel);
+                break;
+            case 3: 
+                prm.put(relaxType,  amgcl::runtime::relaxation::ilu0);
+                break;
+            case 4: 
+                prm.put(relaxType,  amgcl::runtime::relaxation::iluk);
+                break;
+            case 5: 
+                prm.put(relaxType,  amgcl::runtime::relaxation::ilut);
+                break;
+            case 6: 
+                prm.put(relaxType,  amgcl::runtime::relaxation::damped_jacobi);
+                break;
+            case 7: 
+                prm.put(relaxType,  amgcl::runtime::relaxation::spai1);
+                break;
+            case 8: 
+                prm.put(relaxType,  amgcl::runtime::relaxation::chebyshev);
+                break;
+            default:
+                OPM_THROW(std::runtime_error, "Unknown relaxation type: " << relax_id);
+            }
+        }
+
+
+
+
+        void setupPreconditioner(boost::property_tree::ptree& prm)
+        {
+            // Use AMG.
+            prm.put("precond.class", amgcl::runtime::precond_class::amg);
+            AmgOptions opts;
+            opts.coarsen_id = 3; // aggregation
+            setCoarseningAMGCL("precond.", opts, prm);
+            setRelaxationAMGCL("precond.relax.", 1, prm);
+
+            // using Precond = amgcl::runtime::relaxation::as_preconditioner<Backend>;
+            // relaxParam = "precond.";
+            // prm.put("precond.class", amgcl::runtime::precond_class::relaxation);
+            // relaxParam = "precond.relax.";
+            // prm.put("precond.class", amgcl::runtime::precond_class::dummy);
+        }
+
+
+
+
+        void setupSolver(const double tolerance,
+                         const int maxiter,
+                         boost::property_tree::ptree& prm)
+        {
+            prm.put("solver.type", amgcl::runtime::solver::bicgstab);
+            prm.put("solver.tol", tolerance);
+            prm.put("solver.maxiter", maxiter);
+        }
+
+
+
+
+        void solveCPR(const int sz,
+                      const std::vector<int>& ptr,
+                      const std::vector<int>& col,
+                      const std::vector<double>& val,
+                      const std::vector<double>& rhs,
+                      const double tolerance,
+                      const int maxiter,
+                      std::vector<double>& sol,
+                      int& iters,
+                      double& error)
+        {
+            boost::property_tree::ptree prm;
+
+            // setupPreconditioner(prm);
+            const int block_size = 3;
+            const double dd = 0.2;
+            const double ps = 0.02;
+            prm.put("precond.block_size", block_size);
+            prm.put("precond.active_rows", sz);
+            AmgOptions opts;
+            setCoarseningAMGCL("precond.pprecond.", opts, prm);
+            setRelaxationAMGCL("precond.pprecond.relax.", 1, prm);
+            setRelaxationAMGCL("precond.sprecond.", 3, prm);
+            prm.put("precond.eps_dd", dd);
+            prm.put("precond.eps_ps", ps);
+
+            setupSolver(tolerance, maxiter, prm);
+
+            using Backend = amgcl::backend::builtin<double>;
+            using PPrecond = amgcl::runtime::amg<Backend>;
+            using SPrecond = amgcl::runtime::relaxation::as_preconditioner<Backend>;
+            using Precond = amgcl::preconditioner::cpr_drs<PPrecond, SPrecond>;
+            using IterativeSolver = amgcl::runtime::iterative_solver<Backend>;
+            using Solver = amgcl::make_solver<Precond, IterativeSolver>;
+            auto x = new DebugTimeReport("setup");
+            Solver solve(boost::tie(sz, ptr, col, val), prm);
+            delete x;
+            auto y = new DebugTimeReport("solution");
+            boost::tie(iters, error) = solve(rhs, sol);
+            delete y;
+        }
+
+
+
+
+        void solveRegular(const int sz,
+                          const std::vector<int>& ptr,
+                          const std::vector<int>& col,
+                          const std::vector<double>& val,
+                          const std::vector<double>& rhs,
+                          const double tolerance,
+                          const int maxiter,
+                          std::vector<double>& sol,
+                          int& iters,
+                          double& error)
+        {
+            // Using dynamic choice of preconditioners and solvers, all
+            // setup information is therefore put into a property_tree.
+            boost::property_tree::ptree prm;
+            setupPreconditioner(prm);
+            setupSolver(tolerance, maxiter, prm);
+
+            using Backend = amgcl::backend::builtin<double>;
+            using Precond = amgcl::runtime::preconditioner<Backend>;
+            using IterativeSolver = amgcl::runtime::iterative_solver<Backend>;
+            using Solver = amgcl::make_solver<Precond, IterativeSolver>;
+            Solver solve(boost::tie(sz, ptr, col, val), prm);
+            boost::tie(iters, error) = solve(rhs, sol);
+        }
+
+
+
+
+        void hackScalingFactors(const int sz,
+                                const std::vector<int>& ptr,
+                                std::vector<double>& val,
+                                std::vector<double>& rhs)
+        {
+            const int block_size = 3;
+            const double b_gas = 100.0;
+            const int n = sz / block_size;
+            assert(n*block_size == sz);
+            for (int blockrow = 0; blockrow < n; ++blockrow) {
+                const int gasrow = block_size*blockrow + 2;
+                for (int jj = ptr[gasrow]; jj < ptr[gasrow + 1]; ++jj) {
+                    val[jj] /= b_gas;
+                }
+                rhs[gasrow] /= b_gas;
+            }
+        }
+
+
+    } // anonymous namespace
+
+
+
+
+    void LinearSolverAmgcl::solve(const int sz,
+                                  const std::vector<int>& ptr,
+                                  const std::vector<int>& col,
+                                  const std::vector<double>& val,
+                                  const std::vector<double>& rhs,
+                                  const double tolerance,
+                                  const int maxiter,
+                                  std::vector<double>& sol,
+                                  int& iters,
+                                  double& error)
     {
-        // Call amgcl to solve system
-        typedef amgcl::backend::builtin<double> Backend;
-        typedef amgcl::make_solver<
-            // Use AMG as preconditioner:
-            amgcl::amg<
-                Backend,
-                amgcl::coarsening::smoothed_aggregation,
-                amgcl::relaxation::spai0
-                >,
-            // And BiCGStab as iterative solver:
-            amgcl::solver::bicgstab<Backend>
-            > Solver;
-        Solver solve( boost::tie(sz, ptr, col, val) );
-        std::vector<double> sol(sz, 0.0);
-        int    iters;
-        double error;
-        boost::tie(iters, error) = solve(rhs, sol);
+        hackScalingFactors(sz, ptr, const_cast<std::vector<double>&>(val), const_cast<std::vector<double>&>(rhs));
+        DebugTimeReport rep("amgcl-timer");
+        // solveRegular(sz, ptr, col, val, rhs, tolerance, maxiter, sol, iters, error);
+        solveCPR(sz, ptr, col, val, rhs, tolerance, maxiter, sol, iters, error);
     }
 
 } // namespace Opm

--- a/opm/autodiff/LinearSolverAmgcl.cpp
+++ b/opm/autodiff/LinearSolverAmgcl.cpp
@@ -1,0 +1,50 @@
+/*
+  Copyright 2018 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2018 Statoil Petroleum AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Opm
+{
+
+    static void LinearSolverAmgcl::solve(const int sz,
+                                         const std::vector<int>& ptr,
+                                         const std::vector<int>& col,
+                                         const std::vector<double>& val,
+                                         int& iters,
+                                         double& error)
+    {
+        // Call amgcl to solve system
+        typedef amgcl::backend::builtin<double> Backend;
+        typedef amgcl::make_solver<
+            // Use AMG as preconditioner:
+            amgcl::amg<
+                Backend,
+                amgcl::coarsening::smoothed_aggregation,
+                amgcl::relaxation::spai0
+                >,
+            // And BiCGStab as iterative solver:
+            amgcl::solver::bicgstab<Backend>
+            > Solver;
+        Solver solve( boost::tie(sz, ptr, col, val) );
+        std::vector<double> sol(sz, 0.0);
+        int    iters;
+        double error;
+        boost::tie(iters, error) = solve(rhs, sol);
+    }
+
+} // namespace Opm

--- a/opm/autodiff/LinearSolverAmgcl.hpp
+++ b/opm/autodiff/LinearSolverAmgcl.hpp
@@ -21,6 +21,8 @@
 #ifndef OPM_LINEARSOLVERAMGCL_HEADER_INCLUDED
 #define OPM_LINEARSOLVERAMGCL_HEADER_INCLUDED
 
+#include <vector>
+
 namespace Opm
 {
 
@@ -31,6 +33,10 @@ namespace Opm
                           const std::vector<int>& ptr,
                           const std::vector<int>& col,
                           const std::vector<double>& val,
+                          const std::vector<double>& rhs,
+                          const double tolerance,
+                          const int maxiter,
+                          std::vector<double>& sol,
                           int& iters,
                           double& error);
     };

--- a/opm/autodiff/LinearSolverAmgcl.hpp
+++ b/opm/autodiff/LinearSolverAmgcl.hpp
@@ -1,0 +1,40 @@
+/*
+  Copyright 2018 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2018 Statoil Petroleum AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_LINEARSOLVERAMGCL_HEADER_INCLUDED
+#define OPM_LINEARSOLVERAMGCL_HEADER_INCLUDED
+
+namespace Opm
+{
+
+    class LinearSolverAmgcl
+    {
+    public:
+        static void solve(const int sz,
+                          const std::vector<int>& ptr,
+                          const std::vector<int>& col,
+                          const std::vector<double>& val,
+                          int& iters,
+                          double& error);
+    };
+
+} // namespace Opm
+
+#endif // OPM_LINEARSOLVERAMGCL_HEADER_INCLUDED


### PR DESCRIPTION
This is a starting point for getting more flexibility for the linear solvers, so we can more easily experiment. This is a work in progress because:
 - It depends on amgcl dependency, yet does not add it to build system requirements (an optional requirement would be needed for a final version). Note however that it is very easy to download and install if you just want to play around:  https://github.com/ddemidov/amgcl
 - We should organize run-time options to avoid having options that depend on each other, in the current version you must pass `matrix_add_well_contributions=true` if you want to try `use_umfpack=true` for example.
 - We should make sure it is flexible enough to allow PETSc to be used as well.
 - It contains experimental (disabled) parts.