### PR TITLE
Adding well control equations

### DIFF
--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -272,10 +272,6 @@ namespace Opm {
         // Set the well primary variables based on the value of well solutions
         initPrimaryVariablesEvaluation();
 
-        if (iterationIdx == 0) {
-            //calculateExplicitQuantities();
-        }
-
         if (param_.solve_welleq_initially_ && iterationIdx == 0) {
             // solve the well equations as a pre-processing step
             last_report_ = solveWellEq(dt);
@@ -286,6 +282,9 @@ namespace Opm {
                 last_report_ = solveWellEq(dt);
                 initial_step_ = false;
             }
+            // TODO: should we update the explicit related here again, or even prepareTimeStep().
+            // basically, this is a more updated state from the solveWellEq based on fixed
+            // reservoir state, will tihs be a better place to inialize the explict information?
         }
         assembleWellEq(dt, false);
 

--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -214,6 +214,7 @@ static inline void invertMatrix (FieldMatrix<K,4,4> &matrix)
 template <typename K, int n>
 static inline void invertMatrix (FieldMatrix<K,n,n> &matrix)
 {
+    Dune::FMatrixPrecision<K>::set_singular_limit(1.e-20);
     matrix.invert();
 }
 

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -328,6 +328,9 @@ namespace Opm
         void updateWellStateFromPrimaryVariables(WellState& well_state) const;
 
         void assembleControlEq();
+
+        // handle the non reasonable fractions due to numerical overshoot
+        void processFractions() const;
     };
 
 }

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -285,7 +285,7 @@ namespace Opm
                                                     const std::vector<double>& rvmax_perf,
                                                     const std::vector<double>& surf_dens_perf);
 
-
+        // computing the accumulation term for later use in well mass equations
         void computeAccumWell();
 
         void computeWellConnectionPressures(const Simulator& ebosSimulator,

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -64,24 +64,22 @@ namespace Opm
         static const int numWellEq = numEq + 1 - numPolymerEq - numEnergyEq;
 
         // the positions of the primary variables for StandardWell
-        // there are four primary variables, the second and the third ones are F_w and F_g
-        // the first one is the weighted total rate (G_t), the second and the third ones are F_w and F_g
-        // the last one is the BHP.
-        // the fraction of the solvent, as an extension of the blackoil model, is behind the BHP
+        // the first one is the weighted total rate (G_t), the second and the third ones are F_w and F_g,
+        // which represent the fraction of Water and Gas based on the weighted total rate, the last one is BHP.
         // correspondingly, we have four well equations for blackoil model, the first three are mass
         // converstation equations, and the last one is the well control equation.
         // primary variables related to other components, will be before the Bhp and after F_g.
-        // well control equation is always the last well equation, other equations will be before the
-        // well control equation and are conservation equations for components involved.
-        // TODO: in the current implementation, we use the well rate as the first primary variables for injectors
-        // TODO: not sure we should change it.
+        // well control equation is always the last well equation.
+        // TODO: in the current implementation, we use the well rate as the first primary variables for injectors,
+        // instead of G_t.
         static const bool gasoil = numEq == 2 && (Indices::compositionSwitchIdx >= 0);
         static const int GTotal = 0;
         static const int WFrac = gasoil? -1000: 1;
         static const int GFrac = gasoil? 1: 2;
         static const int SFrac = !has_solvent ? -1000 : 3;
         // the index for Bhp in primary variables and also the index of well control equation
-        // they both will be the last one in their system.
+        // they both will be the last one in their respective system.
+        // TODO: we should have indices for the well equations and well primary variables separately
         static const int Bhp = numWellEq - 1;
 
         using typename Base::Scalar;
@@ -239,12 +237,8 @@ namespace Opm
         // the saturations in the well bore under surface conditions at the beginning of the time step
         std::vector<double> F0_;
 
-        // TODO: this function should be moved to the base class.
-        // while it faces chanllenges for MSWell later, since the calculation of bhp
-        // based on THP is never implemented for MSWell yet.
         const EvalWell& getBhp() const;
 
-        // TODO: it is also possible to be moved to the base class.
         EvalWell getQs(const int comp_idx) const;
 
         const EvalWell& getGTotal() const;
@@ -291,7 +285,7 @@ namespace Opm
                                                     const std::vector<double>& rvmax_perf,
                                                     const std::vector<double>& surf_dens_perf);
 
-        // computing the accumulation term for later use in well mass equations
+
         void computeAccumWell();
 
         void computeWellConnectionPressures(const Simulator& ebosSimulator,

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -327,6 +327,8 @@ namespace Opm
 
         void updateWellStateFromPrimaryVariables(WellState& well_state) const;
 
+        void updateThp(WellState& well_state) const;
+
         void assembleControlEq();
 
         // handle the non reasonable fractions due to numerical overshoot

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -323,6 +323,11 @@ namespace Opm
         void updateWaterMobilityWithPolymer(const Simulator& ebos_simulator,
                                             const int perf,
                                             std::vector<EvalWell>& mob_water) const;
+
+        void updatePrimaryVariablesNewton(const BVectorWell& dwells,
+                                          const WellState& well_state) const;
+
+        void updateWellStateFromPrimaryVariables(WellState& well_state) const;
     };
 
 }

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -61,7 +61,11 @@ namespace Opm
         // polymer and energy conservation do not need to be considered explicitly
         static const int numPolymerEq = has_polymer ? 1 : 0;
         static const int numEnergyEq = has_energy ? 1 : 0;
-        static const int numWellEq = numEq + 1 - numPolymerEq - numEnergyEq;
+        // number of the conservation equations
+        static const int numWellConservationEq = numEq - numPolymerEq - numEnergyEq;
+        // number of the well control equations
+        static const int numWellControlEq = 1;
+        static const int numWellEq = numWellConservationEq + numWellControlEq;
 
         // the positions of the primary variables for StandardWell
         // the first one is the weighted total rate (G_t), the second and the third ones are F_w and F_g,
@@ -80,7 +84,7 @@ namespace Opm
         // the index for Bhp in primary variables and also the index of well control equation
         // they both will be the last one in their respective system.
         // TODO: we should have indices for the well equations and well primary variables separately
-        static const int Bhp = numWellEq - 1;
+        static const int Bhp = numWellEq - numWellControlEq;
 
         using typename Base::Scalar;
         using typename Base::ConvergenceReport;
@@ -187,6 +191,8 @@ namespace Opm
         using Base::scalingFactor;
 
         // protected member variables from the Base class
+        using Base::current_step_;
+        using Base::well_ecl_;
         using Base::vfp_properties_;
         using Base::gravity_;
         using Base::param_;

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -58,14 +58,24 @@ namespace Opm
         using Base::has_energy;
 
         // the positions of the primary variables for StandardWell
-        // there are three primary variables, the second and the third ones are F_w and F_g
-        // the first one can be total rate (G_t) or bhp, based on the control
+        // there are four primary variables, the second and the third ones are F_w and F_g
+        // the first one is the weighted total rate (G_t), the second and the third ones are F_w and F_g
+        // the last one is the BHP.
+        // the fraction of the solvent, as an extension of the blackoil model, is behind the BHP
+        // correspondingly, we have four well equations for blackoil model, the first three are mass
+        // converstation equations, and the last one is the well control equation.
+        // TODO: in the current implementation, we use the well rate as the first primary variables for injectors
+        // TODO: not sure we should change it.
 
         static const bool gasoil = numEq == 2 && (Indices::compositionSwitchIdx >= 0);
-        static const int XvarWell = 0;
+        static const int GTotal = 0;
         static const int WFrac = gasoil? -1000: 1;
         static const int GFrac = gasoil? 1: 2;
-        static const int SFrac = !has_solvent ? -1000 : 3;
+        // TODO: it is possible the order of Bhp and SFrac need to switched, due to scalingFactor function
+        // TODO: we will do that when we see the problem.
+        static const int Bhp = gasoil? 2 : 3;
+        static const int SFrac = !has_solvent ? -1000 : Bhp + 1;
+
 
         using typename Base::Scalar;
         using typename Base::ConvergenceReport;

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -76,7 +76,6 @@ namespace Opm
         static const int Bhp = gasoil? 2 : 3;
         static const int SFrac = !has_solvent ? -1000 : Bhp + 1;
 
-
         using typename Base::Scalar;
         using typename Base::ConvergenceReport;
 
@@ -245,6 +244,8 @@ namespace Opm
         // TODO: it is also possible to be moved to the base class.
         EvalWell getQs(const int comp_idx) const;
 
+        const EvalWell& getGTotal() const;
+
         EvalWell wellVolumeFractionScaled(const int phase) const;
 
         EvalWell wellVolumeFraction(const unsigned compIdx) const;
@@ -328,6 +329,8 @@ namespace Opm
                                           const WellState& well_state) const;
 
         void updateWellStateFromPrimaryVariables(WellState& well_state) const;
+
+        void assembleControlEq();
     };
 
 }

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -67,7 +67,7 @@ namespace Opm
         static const int numWellEq = numWellConservationEq + numWellControlEq;
 
         // the positions of the primary variables for StandardWell
-        // the first one is the weighted total rate (G_t), the second and the third ones are F_w and F_g,
+        // the first one is the weighted total rate (WQ_t), the second and the third ones are F_w and F_g,
         // which represent the fraction of Water and Gas based on the weighted total rate, the last one is BHP.
         // correspondingly, we have four well equations for blackoil model, the first three are mass
         // converstation equations, and the last one is the well control equation.
@@ -76,7 +76,7 @@ namespace Opm
         // TODO: in the current implementation, we use the well rate as the first primary variables for injectors,
         // instead of G_t.
         static const bool gasoil = numEq == 2 && (Indices::compositionSwitchIdx >= 0);
-        static const int GTotal = 0;
+        static const int WQTotal = 0;
         static const int WFrac = gasoil? -1000: 1;
         static const int GFrac = gasoil? 1: 2;
         static const int SFrac = !has_solvent ? -1000 : 3;
@@ -246,7 +246,7 @@ namespace Opm
 
         EvalWell getQs(const int comp_idx) const;
 
-        const EvalWell& getGTotal() const;
+        const EvalWell& getWQTotal() const;
 
         EvalWell wellVolumeFractionScaled(const int phase) const;
 

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -27,7 +27,6 @@
 #include <opm/autodiff/WellInterface.hpp>
 #include <opm/autodiff/ISTLSolver.hpp>
 #include <opm/autodiff/RateConverter.hpp>
-#include <opm/autodiff/ISTLSolver.hpp>
 
 namespace Opm
 {

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -154,8 +154,6 @@ namespace Opm
             // TODO: using comp_frac here is dangerous, it should be changed later
             // Most likely, it should be changed to use distr, or at least, we need to update comp_frac_ based on distr
             // while solvent might complicate the situation
-            //
-            // TODO: it is possible that the RESV for the injector is not well handled here.
             const auto pu = phaseUsage();
             const int legacyCompIdx = ebosCompIdxToFlowCompIdx(comp_idx);
             double comp_frac = 0.0;
@@ -170,7 +168,6 @@ namespace Opm
                 comp_frac = comp_frac_[legacyCompIdx];
             }
 
-            // testing code end
             return comp_frac * primary_variables_evaluation_[GTotal];
         } else { // producers
             return primary_variables_evaluation_[GTotal] * wellVolumeFractionScaled(comp_idx);
@@ -666,13 +663,9 @@ namespace Opm
                 }
                 assert(number_phases_under_control > 0);
 
-                const double target_rate = well_controls_get_current_target(well_controls_);
-
+                const double target_rate = well_controls_get_current_target(well_controls_); // surface rate target
                 if (well_type_ == INJECTOR) {
                     assert(number_phases_under_control == 1); // only handles single phase injection now
-                    // TODO: considering the solvent part here
-                    // Better way to cover solvent part will be getQs() - target_rate, while it turned out not correct
-                    // for the solvent case.
                     control_eq = getGTotal() - target_rate;
                 } else if (well_type_ == PRODUCER) {
                     EvalWell rate_for_control(0.);
@@ -688,7 +681,7 @@ namespace Opm
             }
             case RESERVOIR_RATE:
             {
-                // TODO: repeated code here
+                // TODO: repeated code here, while hopefully it gives better readability
                 int number_phases_under_control = 0;
                 const double* distr = well_controls_get_current_distr(well_controls_);
                 for (int phase = 0; phase < number_of_phases_; ++phase) {

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -668,14 +668,22 @@ namespace Opm
                     assert(number_phases_under_control == 1); // only handles single phase injection now
                     control_eq = getGTotal() - target_rate;
                 } else if (well_type_ == PRODUCER) {
-                    EvalWell rate_for_control(0.);
-                    const EvalWell& g_total = getGTotal();
-                    for (int phase = 0; phase < number_of_phases_; ++phase) {
-                        if (distr[phase] > 0.) {
-                            rate_for_control += g_total * wellVolumeFractionScaled(flowPhaseToEbosCompIdx(phase));
-                        }
+                    if (target_rate != 0.) {
+                        EvalWell rate_for_control(0.);
+                        const EvalWell& g_total = getGTotal();
+                        for (int phase = 0; phase < number_of_phases_; ++phase) {
+                            if (distr[phase] > 0.) {
+                                 rate_for_control += g_total * wellVolumeFractionScaled(flowPhaseToEbosCompIdx(phase));
+                            }
+                         }
+                         control_eq = rate_for_control - target_rate;
+                    } else {
+                        // there is some special treatment for the zero rate control well
+                        // 1. if the well can produce the specified phase, it means the well should not produce any fluid
+                        // 2. if the well can not produce the specified phase, it cause a under-determined problem, we
+                        //    basically assume the well not producing any fluid as a solution
+                        control_eq = getGTotal() - target_rate;
                     }
-                    control_eq = rate_for_control - target_rate;
                 }
                 break;
             }

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -1043,10 +1043,23 @@ namespace Opm
             }
         }
 
+        updateThp(well_state);
+    }
+
+
+
+
+
+    template<typename TypeTag>
+    void
+    StandardWell<TypeTag>::
+    updateThp(WellState& well_state) const
+    {
         // for the wells having a THP constaint, we should update their thp value
         // If it is under THP control, it will be set to be the target value.
         // TODO: a better standard is probably whether we have the table to calculate the THP value
         // TODO: it is something we need to check the output to decide.
+        const PhaseUsage& pu = phaseUsage();
         const WellControls* wc = well_controls_;
         // TODO: we should only maintain one current control either from the well_state or from well_controls struct.
         // Either one can be more favored depending on the final strategy for the initilzation of the well control

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -105,10 +105,7 @@ namespace Opm
     void StandardWell<TypeTag>::
     initPrimaryVariablesEvaluation() const
     {
-        // TODO: using num_components_ here is only to make the 2p + dummy phase work
-        // TODO: in theory, we should use numWellEq here.
-        // for (int eqIdx = 0; eqIdx < numWellEq; ++eqIdx) {
-        for (int eqIdx = 0; eqIdx < num_components_; ++eqIdx) {
+        for (int eqIdx = 0; eqIdx < numWellEq; ++eqIdx) {
             assert( (size_t)eqIdx < primary_variables_.size() );
 
             primary_variables_evaluation_[eqIdx] = 0.0;
@@ -122,7 +119,7 @@ namespace Opm
 
 
     template<typename TypeTag>
-    typename StandardWell<TypeTag>::EvalWell
+    const typename StandardWell<TypeTag>::EvalWell&
     StandardWell<TypeTag>::
     getBhp() const
     {
@@ -148,10 +145,10 @@ namespace Opm
     template<typename TypeTag>
     typename StandardWell<TypeTag>::EvalWell
     StandardWell<TypeTag>::
-    getQs(const int comp_idx) const // TODO: phase or component?
+    getQs(const int comp_idx) const
     {
         // TODO: not sure the best way to handle solvent injection
-        // TODO: we need to come back to hanlde the solvent case here, the following implementation does not
+        // TODO: we need to come back to handle the solvent case here, the following implementation does not
         // TODO: consider solvent injection yet.
 
         // TODO: currently, the GTotal definition is still depends on Injector/Producer.
@@ -161,7 +158,6 @@ namespace Opm
             // TODO: using comp_frac here is dangerous, it should be changed later
             // Most likely, it should be changed to use distr, or at least, we need to update comp_frac_ based on distr
             // while solvent might complicate the situation
-            EvalWell qs = 0.0;
             const auto pu = phaseUsage();
             const int legacyCompIdx = ebosCompIdxToFlowCompIdx(comp_idx);
             double comp_frac = 0.0;
@@ -746,7 +742,7 @@ namespace Opm
             const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
             const auto& fs = intQuants.fluidState();
             const EvalWell pressure = extendEval(fs.pressure(FluidSystem::oilPhaseIdx));
-            const EvalWell bhp = getBhp();
+            const EvalWell& bhp = getBhp();
 
             // Pressure drawdown (also used to determine direction of flow)
             const EvalWell well_pressure = bhp + perf_pressure_diffs_[perf];
@@ -1045,7 +1041,6 @@ namespace Opm
         // TODO: we should only maintain one current control either from the well_state or from well_controls struct.
         // Either one can be more favored depending on the final strategy for the initilzation of the well control
         const int current = well_state.currentControls()[index_of_well_];
-        const double target_rate = well_controls_iget_target(wc, current);
         const int nwc = well_controls_get_num(wc);
         // Looping over all controls until we find a THP constraint
         for (int ctrl_index = 0; ctrl_index < nwc; ++ctrl_index) {

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -1073,7 +1073,6 @@ namespace Opm
         // If it is under THP control, it will be set to be the target value.
         // TODO: a better standard is probably whether we have the table to calculate the THP value
         // TODO: it is something we need to check the output to decide.
-        const PhaseUsage& pu = phaseUsage();
         const WellControls* wc = well_controls_;
         // TODO: we should only maintain one current control either from the well_state or from well_controls struct.
         // Either one can be more favored depending on the final strategy for the initilzation of the well control

--- a/opm/autodiff/StandardWells_impl.hpp
+++ b/opm/autodiff/StandardWells_impl.hpp
@@ -295,7 +295,6 @@ namespace Opm
             rho += superset(fluid_->surfaceDensity(phase , well_cells), Span(nperf, pu.num_phases, phase), nperf*pu.num_phases);
         }
         surf_dens_perf.assign(rho.data(), rho.data() + nperf * pu.num_phases);
-
     }
 
 

--- a/opm/autodiff/WellDensitySegmented.cpp
+++ b/opm/autodiff/WellDensitySegmented.cpp
@@ -25,8 +25,6 @@
 #include <numeric>
 #include <cmath>
 
-
-
 std::vector<double>
 Opm::WellDensitySegmented::computeConnectionDensities(const Wells& wells,
                                                       const PhaseUsage& phase_usage,

--- a/tests/test_wellmodel.cpp
+++ b/tests/test_wellmodel.cpp
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(TestBehavoir) {
         BOOST_CHECK_EQUAL(well->name(), "PROD1");
         BOOST_CHECK(well->wellType() == PRODUCER);
         BOOST_CHECK(well->numEq == 3);
-        BOOST_CHECK(well->numWellEq == 3);
+        BOOST_CHECK(well->numWellEq == 4);
         const auto& wc = well->wellControls();
         const int ctrl_num = well_controls_get_num(wc);
         BOOST_CHECK(ctrl_num > 0);
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(TestBehavoir) {
         BOOST_CHECK_EQUAL(well->name(), "INJE1");
         BOOST_CHECK(well->wellType() == INJECTOR);
         BOOST_CHECK(well->numEq == 3);
-        BOOST_CHECK(well->numWellEq == 3);
+        BOOST_CHECK(well->numWellEq == 4);
         const auto& wc = well->wellControls();
         const int ctrl_num = well_controls_get_num(wc);
         BOOST_CHECK(ctrl_num > 0);


### PR DESCRIPTION
This is part of the efforts to have proper VFP support. At the stage, it only recovers to the extent of the VFP capacity of the `flow_legacy`, while it not suitable for more general THP/VFP treatment yet. 

Please do not merge before requesting. 

`Adding well control equations` is the major part, basically, it reduces the complexity of the functions `getQs` and `updateWellstate`, and also, it provides functionality to monitor the convergence of the well control equations. 