### PR TITLE
Adds possibility to use modified ILU0 (MILU0) decomposition

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -150,6 +150,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_welldensitysegmented.cpp
   tests/test_vfpproperties.cpp
   tests/test_singlecellsolves.cpp
+  tests/test_milu.cpp
   tests/test_multmatrixtransposed.cpp
   tests/test_multiphaseupwind.cpp
   tests/test_wellmodel.cpp

--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -440,7 +440,7 @@ namespace Detail
                 }
 
                 const double relax = parameters_.ilu_relaxation_;
-                const bool ilu_milu  = parameters_.ilu_milu_;
+                const MILU_VARIANT ilu_milu  = parameters_.ilu_milu_;
                 if (  parameters_.use_cpr_ )
                 {
                     using Matrix         = typename MatrixOperator::matrix_type;
@@ -496,7 +496,7 @@ namespace Detail
         {
             const double relax   = parameters_.ilu_relaxation_;
             const int ilu_fillin = parameters_.ilu_fillin_level_;
-            const bool ilu_milu  = parameters_.ilu_milu_;
+            const MILU_VARIANT ilu_milu  = parameters_.ilu_milu_;
                 std::unique_ptr<SeqPreconditioner> precond(new SeqPreconditioner(opA.getmat(), ilu_fillin, relax, ilu_milu));
             return precond;
         }
@@ -519,14 +519,14 @@ namespace Detail
         {
             typedef std::unique_ptr<ParPreconditioner> Pointer;
             const double relax  = parameters_.ilu_relaxation_;
-            const bool ilu_milu  = parameters_.ilu_milu_;
+            const MILU_VARIANT ilu_milu  = parameters_.ilu_milu_;
             return Pointer(new ParPreconditioner(opA.getmat(), comm, relax, ilu_milu));
         }
 #endif
 
         template <class LinearOperator, class MatrixOperator, class POrComm, class AMG >
         void
-        constructAMGPrecond(LinearOperator& /* linearOperator */, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >& opA, const double relax, const bool milu) const
+        constructAMGPrecond(LinearOperator& /* linearOperator */, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >& opA, const double relax, const MILU_VARIANT milu) const
         {
             ISTLUtility::template createAMGPreconditionerPointer<pressureIndex>( *opA, relax, milu, comm, amg );
         }
@@ -535,7 +535,7 @@ namespace Detail
         template <class MatrixOperator, class POrComm, class AMG >
         void
         constructAMGPrecond(MatrixOperator& opA, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >&, const double relax,
-                            const bool milu) const
+                            const MILU_VARIANT milu) const
         {
             ISTLUtility::template createAMGPreconditionerPointer<pressureIndex>( opA, relax,
                                                                                  milu, comm, amg );
@@ -544,7 +544,7 @@ namespace Detail
         template <class C, class LinearOperator, class MatrixOperator, class POrComm, class AMG >
         void
         constructAMGPrecond(LinearOperator& /* linearOperator */, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >& opA, const double relax,
-                            const bool milu ) const
+                            const MILU_VARIANT milu ) const
         {
             ISTLUtility::template createAMGPreconditionerPointer<C>( *opA, relax,
                                                                      comm, amg, parameters_ );
@@ -553,7 +553,7 @@ namespace Detail
 
         template <class C, class MatrixOperator, class POrComm, class AMG >
         void
-        constructAMGPrecond(MatrixOperator& opA, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >&, const double relax, const bool milu ) const
+        constructAMGPrecond(MatrixOperator& opA, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >&, const double relax, const MILU_VARIANT milu ) const
         {
             ISTLUtility::template createAMGPreconditionerPointer<C>( opA, relax, milu,
                                                                      comm, amg, parameters_ );

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -44,6 +44,7 @@ namespace Opm
         int    linear_solver_restart_;
         int    linear_solver_verbosity_;
         int    ilu_fillin_level_;
+        bool   ilu_milu_;
         bool   newton_use_gmres_;
         bool   require_full_sparsity_pattern_;
         bool   ignoreConvergenceFailure_;
@@ -69,6 +70,7 @@ namespace Opm
             linear_solver_use_amg_    = param.getDefault("linear_solver_use_amg", linear_solver_use_amg_ );
             ilu_relaxation_           = param.getDefault("ilu_relaxation", ilu_relaxation_ );
             ilu_fillin_level_         = param.getDefault("ilu_fillin_level",  ilu_fillin_level_ );
+            ilu_milu_             = param.getDefault("ilu_milu", ilu_milu_);
 
             // Check whether to use cpr approach
             const std::string cprSolver = "cpr";
@@ -89,6 +91,7 @@ namespace Opm
             linear_solver_use_amg_    = false;
             ilu_fillin_level_         = 0;
             ilu_relaxation_           = 0.9;
+            ilu_milu_                 = false;
         }
     };
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -28,6 +28,7 @@
 #include <opm/autodiff/CPRPreconditioner.hpp>
 #include <opm/autodiff/NewtonIterationBlackoilInterface.hpp>
 #include <opm/common/utility/parameters/ParameterGroup.hpp>
+#include <opm/autodiff/ParallelOverlappingILU0.hpp>
 
 #include <array>
 #include <memory>
@@ -44,7 +45,7 @@ namespace Opm
         int    linear_solver_restart_;
         int    linear_solver_verbosity_;
         int    ilu_fillin_level_;
-        bool   ilu_milu_;
+        Opm::MILU_VARIANT   ilu_milu_;
         bool   newton_use_gmres_;
         bool   require_full_sparsity_pattern_;
         bool   ignoreConvergenceFailure_;
@@ -70,7 +71,8 @@ namespace Opm
             linear_solver_use_amg_    = param.getDefault("linear_solver_use_amg", linear_solver_use_amg_ );
             ilu_relaxation_           = param.getDefault("ilu_relaxation", ilu_relaxation_ );
             ilu_fillin_level_         = param.getDefault("ilu_fillin_level",  ilu_fillin_level_ );
-            ilu_milu_             = param.getDefault("ilu_milu", ilu_milu_);
+            std::string milu("ILU");
+            ilu_milu_ = convertString2Milu(param.getDefault("ilu_milu", milu));
 
             // Check whether to use cpr approach
             const std::string cprSolver = "cpr";
@@ -91,7 +93,7 @@ namespace Opm
             linear_solver_use_amg_    = false;
             ilu_fillin_level_         = 0;
             ilu_relaxation_           = 0.9;
-            ilu_milu_                 = false;
+            ilu_milu_                 = MILU_VARIANT::ILU;
         }
     };
 

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -179,7 +179,15 @@ namespace Opm
             if ( a_ik.index() != irow.index() )
                 OPM_THROW(std::logic_error, "Matrix is missing diagonal for row " << irow.index());
 
-            *a_ik -= sum_dropped;
+            int index = 0;
+            for(const auto& row: sum_dropped)
+            {
+                for(const auto& val: row)
+                {
+                    (*a_ik)[index][index]-=val;
+                }
+                ++index;
+            }
 
             if ( diagonal )
             {

--- a/tests/test_milu.cpp
+++ b/tests/test_milu.cpp
@@ -77,6 +77,21 @@ void test_milu0(M& A)
 #endif
         BOOST_ASSERT(point_difference < 1e-12);
     }
+
+    // Test that (LU)^-1Ae=e
+    A.mv(e, x1);
+    bilu_backsolve(ILU, x2, x1);
+    diff = x2;
+    diff -= e;
+
+    for ( std::size_t i = 0, end = A.N(); i < end; ++i)
+    {
+        auto point_difference = diff[i].two_norm();
+#ifdef DEBUG
+        std::cout<<"index "<<i<<" size "<<diff.size()<<" point_difference "<<point_difference<<std::endl;
+#endif
+        BOOST_CHECK_CLOSE(x2[i].two_norm(), e[i].two_norm(), 1e-12);
+    }
 }
 
 template<class B, class Alloc>

--- a/tests/test_milu.cpp
+++ b/tests/test_milu.cpp
@@ -23,6 +23,17 @@ void test_milu0(M& A)
     diagonal.reset(new std::vector<typename M::block_type>());
 
     Opm::detail::milu0_decomposition(ILU, diagonal.get());
+#ifdef DEBUG
+    if ( A.N() < 11)
+    {
+        Dune::printmatrix(std::cout, ILU, "ILU", "row");
+        std::cout << "Diagonal: ";
+
+        for (const auto& d : *diagonal)
+            std::cout << d << " ";
+        std::cout<<std::endl;
+    }
+#endif
     Dune::BlockVector<Dune::FieldVector<typename M::field_type, M::block_type::rows>> e(A.N()), x1(A.N()), x2(A.N()), t(A.N());
     e = 1;
     A.mv(e, x1);
@@ -143,7 +154,9 @@ void test()
     Dune::BCRSMatrix<Dune::FieldMatrix<double, bsize, bsize> > A;
     setupLaplacian(A, N);
     test_milu0(A);
+#ifdef DEBUG
     std::cout<< "Tested block size "<< bsize<<std::endl;
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(MILULaplace1)

--- a/tests/test_milu.cpp
+++ b/tests/test_milu.cpp
@@ -75,7 +75,7 @@ void test_milu0(M& A)
 #ifdef DEBUG
         std::cout<<"index "<<i<<" size "<<diff.size()<<" difference"<<point_difference<<std::endl;
 #endif
-        BOOST_ASSERT(point_difference < 1e-12);
+        BOOST_CHECK(point_difference < 1e-12);
     }
 
     // Test that (LU)^-1Ae=e
@@ -86,8 +86,8 @@ void test_milu0(M& A)
 
     for ( std::size_t i = 0, end = A.N(); i < end; ++i)
     {
-        auto point_difference = diff[i].two_norm();
 #ifdef DEBUG
+        auto point_difference = diff[i].two_norm();
         std::cout<<"index "<<i<<" size "<<diff.size()<<" point_difference "<<point_difference<<std::endl;
 #endif
         BOOST_CHECK_CLOSE(x2[i].two_norm(), e[i].two_norm(), 1e-12);

--- a/tests/test_milu.cpp
+++ b/tests/test_milu.cpp
@@ -1,0 +1,165 @@
+#include<config.h>
+
+#define BOOST_TEST_MODULE MILU0Test
+
+#include<vector>
+#include<memory>
+
+#include<dune/istl/bcrsmatrix.hh>
+#include<dune/istl/bvector.hh>
+#include<dune/common/fmatrix.hh>
+#include<dune/common/fvector.hh>
+#include<opm/autodiff/ParallelOverlappingILU0.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+
+template<class M>
+void test_milu0(M& A)
+{
+    auto ILU = A;
+    
+    std::shared_ptr<std::vector<typename M::block_type>> diagonal = nullptr;
+    diagonal.reset(new std::vector<typename M::block_type>());
+
+    Opm::detail::milu0_decomposition(ILU, diagonal.get());
+    Dune::BlockVector<Dune::FieldVector<typename M::field_type, M::block_type::rows>> e(A.N()), x1(A.N()), x2(A.N()), t(A.N());
+    e = 1;
+    A.mv(e, x1);
+    // Compute L*U*e;
+    // t=Ue
+    
+    for ( auto irow = ILU.begin(), iend = ILU.end(); irow != iend; ++irow)
+    {
+        auto i = irow.index();
+        (*diagonal)[i].mv(e[0], t[i]);
+        auto col = irow->find(i);
+        auto colend = irow->end();
+
+        if ( col == colend )
+        {
+            OPM_THROW(std::logic_error, "Missing diagonal entry for row " << irow.index());
+        }
+        for (++col ;col != colend; ++col)
+        {
+            col->umv(e[0], t[i]);
+        }
+    }
+            
+    for ( auto irow = ILU.begin(), iend = ILU.end(); irow != iend; ++irow)
+    {
+        auto i = irow.index();
+        x2[i] = 0;
+        for (auto col = irow->begin(); col.index() < irow.index(); ++col)
+        {
+            col->umv(t[col.index()], x2[i]);
+        }
+        x2[i] += t[i];
+    }
+    auto diff = x2;
+    diff-=x1;
+    for ( std::size_t i = 0, end = A.N(); i < end; ++i)
+    {
+        auto point_difference = diff[i].two_norm();
+#ifdef DEBUG
+        std::cout<<"index "<<i<<" size "<<diff.size()<<" difference"<<point_difference<<std::endl;
+#endif
+        BOOST_ASSERT(point_difference < 1e-12);
+    }
+}
+
+template<class B, class Alloc>
+void setupSparsityPattern(Dune::BCRSMatrix<B,Alloc>& A, int N)
+{
+  typedef typename Dune::BCRSMatrix<B,Alloc> Matrix;
+  A.setSize(N*N, N*N, N*N*5);
+  A.setBuildMode(Matrix::row_wise);
+
+  for (typename Dune::BCRSMatrix<B,Alloc>::CreateIterator i = A.createbegin(); i != A.createend(); ++i) {
+    int x = i.index()%N; // x coordinate in the 2d field
+    int y = i.index()/N;  // y coordinate in the 2d field
+
+    if(y>0)
+      // insert lower neighbour
+      i.insert(i.index()-N);
+    if(x>0)
+      // insert left neighbour
+      i.insert(i.index()-1);
+
+    // insert diagonal value
+    i.insert(i.index());
+
+    if(x<N-1)
+      //insert right neighbour
+      i.insert(i.index()+1);
+    if(y<N-1)
+      // insert upper neighbour
+      i.insert(i.index()+N);
+  }
+}
+
+
+template<class B, class Alloc>
+void setupLaplacian(Dune::BCRSMatrix<B,Alloc>& A, int N)
+{
+  typedef typename Dune::BCRSMatrix<B,Alloc>::field_type FieldType;
+
+  setupSparsityPattern(A,N);
+
+  B diagonal(static_cast<FieldType>(0)), bone(static_cast<FieldType>(0)),
+  beps(static_cast<FieldType>(0));
+  for(typename B::RowIterator b = diagonal.begin(); b !=  diagonal.end(); ++b)
+    b->operator[](b.index())=4;
+
+
+  for(typename B::RowIterator b=bone.begin(); b !=  bone.end(); ++b)
+    b->operator[](b.index())=-1.0;
+
+
+  for (typename Dune::BCRSMatrix<B,Alloc>::RowIterator i = A.begin(); i != A.end(); ++i) {
+    int x = i.index()%N; // x coordinate in the 2d field
+    int y = i.index()/N;  // y coordinate in the 2d field
+    
+    i->operator[](i.index())=diagonal;
+    
+    if(y>0)
+        i->operator[](i.index()-N)=bone;
+
+    if(y<N-1)
+        i->operator[](i.index()+N)=bone;
+
+    if(x>0)
+        i->operator[](i.index()-1)=bone;
+
+    if(x < N-1)
+        i->operator[](i.index()+1)=bone;
+  }
+}
+
+template<int bsize>
+void test()
+{
+    std::size_t N = 32;
+    Dune::BCRSMatrix<Dune::FieldMatrix<double, bsize, bsize> > A;
+    setupLaplacian(A, N);
+    test_milu0(A);
+    std::cout<< "Tested block size "<< bsize<<std::endl;
+}
+
+BOOST_AUTO_TEST_CASE(MILULaplace1)
+{
+    test<1>();
+}
+
+BOOST_AUTO_TEST_CASE(MILULaplace2)
+{
+    test<2>();
+}
+BOOST_AUTO_TEST_CASE(MILULaplace3)
+{
+    test<3>();
+}
+BOOST_AUTO_TEST_CASE(MILULaplace4)
+{
+    test<4>();
+}


### PR DESCRIPTION
Using the parameter `ilu_milu=true|false` (default=`false`) the user can now choose to use the modified ILU0 decomposition. If selected values will not be dropped for nonzero entries but added to the diagonal of U.

This approach will result in `A*e = L*U*e` for vector `e` with all entries being 1.

In theory this approach should be better than ILU. In practice (read anisotropy, discontinuous coefficients) it turns out to be worse. E.g I am seeing a lot of timestep chopping for Norne and other cases.