### PR TITLE
[WIP and discussion] using invDXDirect from MSWellHelpers to avoid inverting matrix D

### DIFF
--- a/opm-simulators-prereqs.cmake
+++ b/opm-simulators-prereqs.cmake
@@ -34,7 +34,7 @@ set (opm-simulators_DEPS
   # PETSc numerical backend
   "PETSc"
   # Tim Davis' SuiteSparse archive
-  "SuiteSparse COMPONENTS umfpack"
+  "SuiteSparse COMPONENTS umfpack REQUIRED"
   # SuperLU direct solver
   "SuperLU"
   # OPM dependency

--- a/opm/autodiff/MSWellHelpers.hpp
+++ b/opm/autodiff/MSWellHelpers.hpp
@@ -24,52 +24,12 @@
 
 #include <opm/common/ErrorMacros.hpp>
 #include <dune/istl/solvers.hh>
-#if HAVE_UMFPACK
-#include <dune/istl/umfpack.hh>
-#endif // HAVE_UMFPACK
 #include <cmath>
 
 namespace Opm {
 
 namespace mswellhelpers
 {
-    // obtain y = D^-1 * x with a direct solver
-    template <typename MatrixType, typename VectorType>
-    VectorType
-    invDXDirect(const MatrixType& D, VectorType x)
-    {
-#if HAVE_UMFPACK
-        VectorType y(x.size());
-        y = 0.;
-
-        Dune::UMFPack<MatrixType> linsolver(D, 0);
-
-        // Object storing some statistics about the solving process
-        Dune::InverseOperatorResult res;
-
-        // Solve
-        linsolver.apply(y, x, res);
-
-        // Checking if there is any inf or nan in y
-        // it will be the solution before we find a way to catch the singularity of the matrix
-        for (size_t i_block = 0; i_block < y.size(); ++i_block) {
-            for (size_t i_elem = 0; i_elem < y[i_block].size(); ++i_elem) {
-                if (std::isinf(y[i_block][i_elem]) || std::isnan(y[i_block][i_elem]) ) {
-                    OPM_THROW(Opm::NumericalIssue, "nan or inf value found in invDXDirect due to singular matrix");
-                }
-            }
-        }
-
-        return y;
-#else
-        OPM_THROW(std::runtime_error, "Cannot use invDXDirect() without UMFPACK. "
-                  "Reconfigure opm-simulator with SuiteSparse/UMFPACK support and recompile.");
-#endif // HAVE_UMFPACK
-    }
-
-
-
-
 
     // obtain y = D^-1 * x with a BICSSTAB iterative solver
     template <typename MatrixType, typename VectorType>

--- a/opm/autodiff/MultisegmentWell_impl.hpp
+++ b/opm/autodiff/MultisegmentWell_impl.hpp
@@ -495,7 +495,7 @@ namespace Opm
         duneB_.mv(x, Bx);
 
         // invDBx = duneD^-1 * Bx_
-        const BVectorWell invDBx = mswellhelpers::invDXDirect(duneD_, Bx);
+        const BVectorWell invDBx = wellhelpers::invDXDirect(duneD_, Bx);
 
         // Ax = Ax - duneC_^T * invDBx
         duneC_.mmtv(invDBx,Ax);
@@ -511,7 +511,7 @@ namespace Opm
     apply(BVector& r) const
     {
         // invDrw_ = duneD^-1 * resWell_
-        const BVectorWell invDrw = mswellhelpers::invDXDirect(duneD_, resWell_);
+        const BVectorWell invDrw = wellhelpers::invDXDirect(duneD_, resWell_);
         // r = r - duneC_^T * invDrw
         duneC_.mmtv(invDrw, r);
     }
@@ -629,7 +629,7 @@ namespace Opm
         // resWell = resWell - B * x
         duneB_.mmv(x, resWell);
         // xw = D^-1 * resWell
-        xw = mswellhelpers::invDXDirect(duneD_, resWell);
+        xw = wellhelpers::invDXDirect(duneD_, resWell);
     }
 
 
@@ -643,7 +643,7 @@ namespace Opm
     {
         // We assemble the well equations, then we check the convergence,
         // which is why we do not put the assembleWellEq here.
-        const BVectorWell dx_well = mswellhelpers::invDXDirect(duneD_, resWell_);
+        const BVectorWell dx_well = wellhelpers::invDXDirect(duneD_, resWell_);
 
         updateWellState(dx_well, false, well_state);
     }
@@ -1718,7 +1718,7 @@ namespace Opm
 
             assembleWellEqWithoutIteration(ebosSimulator, dt, well_state, true);
 
-            const BVectorWell dx_well = mswellhelpers::invDXDirect(duneD_, resWell_);
+            const BVectorWell dx_well = wellhelpers::invDXDirect(duneD_, resWell_);
 
             // TODO: use these small values for now, not intend to reach the convergence
             // in this stage, but, should we?

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -211,7 +211,7 @@ namespace Opm
         OffDiagMatWell duneB_;
         OffDiagMatWell duneC_;
         // diagonal matrix for the well
-        DiagMatWell invDuneD_;
+        DiagMatWell duneD_;
 
         // several vector used in the matrix calculation
         mutable BVectorWell Bx_;

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -39,7 +39,7 @@ namespace Opm
     {
         duneB_.setBuildMode( OffDiagMatWell::row_wise );
         duneC_.setBuildMode( OffDiagMatWell::row_wise );
-        invDuneD_.setBuildMode( DiagMatWell::row_wise );
+        duneD_.setBuildMode( DiagMatWell::row_wise );
     }
 
 
@@ -66,11 +66,11 @@ namespace Opm
         //[A C^T    [x    =  [ res
         // B D] x_well]      res_well]
         // set the size of the matrices
-        invDuneD_.setSize(1, 1, 1);
+        duneD_.setSize(1, 1, 1);
         duneB_.setSize(1, num_cells, number_of_perforations_);
         duneC_.setSize(1, num_cells, number_of_perforations_);
 
-        for (auto row=invDuneD_.createbegin(), end = invDuneD_.createend(); row!=end; ++row) {
+        for (auto row=duneD_.createbegin(), end = duneD_.createend(); row!=end; ++row) {
             // Add nonzeros for diagonal
             row.insert(row.index());
         }
@@ -94,7 +94,7 @@ namespace Opm
 
         // resize temporary class variables
         Bx_.resize( duneB_.N() );
-        invDrw_.resize( invDuneD_.N() );
+        invDrw_.resize( duneD_.N() );
     }
 
 
@@ -562,7 +562,7 @@ namespace Opm
             duneB_ = 0.0;
             duneC_ = 0.0;
         }
-        invDuneD_ = 0.0;
+        duneD_ = 0.0;
         resWell_ = 0.0;
 
         auto& ebosJac = ebosSimulator.model().linearizer().matrix();
@@ -616,7 +616,7 @@ namespace Opm
                         // also need to consider the efficiency factor when manipulating the jacobians.
                         duneC_[0][cell_idx][pvIdx][componentIdx] -= cq_s_effective.derivative(pvIdx+numEq); // intput in transformed matrix
                     }
-                    invDuneD_[0][0][componentIdx][pvIdx] -= cq_s_effective.derivative(pvIdx+numEq);
+                    duneD_[0][0][componentIdx][pvIdx] -= cq_s_effective.derivative(pvIdx+numEq);
                 }
 
                 for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
@@ -726,16 +726,10 @@ namespace Opm
             EvalWell resWell_loc = (wellSurfaceVolumeFraction(componentIdx) - F0_[componentIdx]) * volume / dt;
             resWell_loc += getQs(componentIdx) * well_efficiency_factor_;
             for (int pvIdx = 0; pvIdx < numWellEq; ++pvIdx) {
-                invDuneD_[0][0][componentIdx][pvIdx] += resWell_loc.derivative(pvIdx+numEq);
+                duneD_[0][0][componentIdx][pvIdx] += resWell_loc.derivative(pvIdx+numEq);
             }
             resWell_[0][componentIdx] += resWell_loc.value();
         }
-
-        // do the local inversion of D.
-        // we do this manually with invertMatrix to always get our
-        // specializations in for 3x3 and 4x4 matrices.
-        auto original = invDuneD_[0][0];
-        Dune::FMatrixHelp::invertMatrix(original, invDuneD_[0][0]);
     }
 
 
@@ -1619,8 +1613,7 @@ namespace Opm
     {
         // We assemble the well equations, then we check the convergence,
         // which is why we do not put the assembleWellEq here.
-        BVectorWell dx_well(1);
-        invDuneD_.mv(resWell_, dx_well);
+        const BVectorWell dx_well = wellhelpers::invDXDirect(duneD_, resWell_);
 
         updateWellState(dx_well, well_state);
     }
@@ -1670,15 +1663,12 @@ namespace Opm
             return;
         }
         assert( Bx_.size() == duneB_.N() );
-        assert( invDrw_.size() == invDuneD_.N() );
+        assert( invDrw_.size() == duneD_.N() );
 
         // Bx_ = duneB_ * x
         duneB_.mv(x, Bx_);
-        // invDBx = invDuneD_ * Bx_
-        // TODO: with this, we modified the content of the invDrw_.
-        // Is it necessary to do this to save some memory?
-        BVectorWell& invDBx = invDrw_;
-        invDuneD_.mv(Bx_, invDBx);
+        // invDBx = duneD_^-1 * Bx_
+        const BVectorWell invDBx = wellhelpers::invDXDirect(duneD_, Bx_);
 
         // Ax = Ax - duneC_^T * invDBx
         duneC_.mmtv(invDBx,Ax);
@@ -1692,10 +1682,10 @@ namespace Opm
     StandardWell<TypeTag>::
     apply(BVector& r) const
     {
-        assert( invDrw_.size() == invDuneD_.N() );
+        assert( invDrw_.size() == duneD_.N() );
 
-        // invDrw_ = invDuneD_ * resWell_
-        invDuneD_.mv(resWell_, invDrw_);
+        // invDrw_ = duneD_^-1 * resWell_
+        invDrw_ = wellhelpers::invDXDirect(duneD_, resWell_);
         // r = r - duneC_^T * invDrw_
         duneC_.mmtv(invDrw_, r);
     }
@@ -1713,7 +1703,7 @@ namespace Opm
         // resWell = resWell - B * x
         duneB_.mmv(x, resWell);
         // xw = D^-1 * resWell
-        invDuneD_.mv(resWell, xw);
+        xw = wellhelpers::invDXDirect(duneD_, resWell);
     }
 
 
@@ -2198,7 +2188,7 @@ namespace Opm
 
                 Dune::FieldMatrix<Scalar, numWellEq, numEq> tmp;
                 typename Mat::block_type tmp1;
-                Dune::FMatrixHelp::multMatrix(invDuneD_[0][0],  (*colB), tmp);
+                Dune::FMatrixHelp::multMatrix(duneD_[0][0],  (*colB), tmp);
                 Detail::multMatrixTransposed((*colC), tmp, tmp1);
                 (*col) -= tmp1;
             }


### PR DESCRIPTION
for StandardWell. Basically, as @blattms pointed out for more than one time, the `invert()` in DUNE is not very stable. This PR using a direct solver to avoid inverting the matrix D for the StandardWell. 

It is for testing and discussion purpose and it is not in a good form for going in.  When we decide what we want, I will revise and make it in a good form to go in. 

Please do not merge unless requested and agreed. 