### PR TITLE
[WIP] using lapack routines to do the inversion of well matrix

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -369,16 +369,9 @@ namespace Opm {
             // -------- Well equations ----------
             double dt = timer.currentStepLength();
 
-            try
-            {
-                // assembles the well equations and applies the wells to
-                // the reservoir equations as a source term.
-                wellModel().assemble(iterationIdx, dt);
-            }
-            catch ( const Dune::FMatrixError& )
-            {
-                OPM_THROW(Opm::NumericalIssue,"Error encounted when solving well equations");
-            }
+            // assembles the well equations and applies the wells to
+            // the reservoir equations as a source term.
+            wellModel().assemble(iterationIdx, dt);
 
             auto& ebosJac = ebosSimulator_.model().linearizer().matrix();
             if (param_.matrix_add_well_contributions_) {

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -732,10 +732,10 @@ namespace Opm
         }
 
         // do the local inversion of D.
-        // we do this manually with invertMatrix to always get our
-        // specializations in for 3x3 and 4x4 matrices.
-        auto original = invDuneD_[0][0];
-        Dune::FMatrixHelp::invertMatrix(original, invDuneD_[0][0]);
+        if ( !wellhelpers::invertMatrixLapack(invDuneD_[0][0]) ) {
+            // if not inverted successfully
+            OPM_THROW(Opm::NumericalIssue, "Failed in inverting the matrix D for well " << name());
+        }
     }
 
 


### PR DESCRIPTION
to obtain more stable simulation.

The invert() from DUNE appears to be not very stable. The approach in https://github.com/OPM/opm-simulators/pull/1480 or something similar, like the `solve` from `DenseMatrix` from Dune is facing difficulties in handling the D^-1 * B (B is a matrix)  in function `addWellContributions` in `StandardWell`. 

The proposed PR hopefully represents a good compromise of the situation. Basically,  we keep the inversion, while we use lapack to achieve better stability hopefully. 

It requires the PR https://github.com/OPM/opm-common/pull/408 . 