### PR TITLE
[Discussion] using solve() from DenseMatrix to avoid inverting D matrix

### DIFF
--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -27,7 +27,6 @@
 #include <opm/autodiff/WellInterface.hpp>
 #include <opm/autodiff/ISTLSolver.hpp>
 #include <opm/autodiff/RateConverter.hpp>
-#include <opm/autodiff/ISTLSolver.hpp>
 
 namespace Opm
 {
@@ -211,7 +210,7 @@ namespace Opm
         OffDiagMatWell duneB_;
         OffDiagMatWell duneC_;
         // diagonal matrix for the well
-        DiagMatWell invDuneD_;
+        DiagMatWell duneD_;
 
         // several vector used in the matrix calculation
         mutable BVectorWell Bx_;


### PR DESCRIPTION
Another alternative of https://github.com/OPM/opm-simulators/pull/1480 . which use the `solve` function of `DenseMatrix` without inverting the matrix. 

Each solution process will include a LU decomposition. I did not find an easy way to re-use the LU decomposition with this approach.  

Furthermore, we did not address the fixing of the
```C++
Dune::FMatrixHelp::multMatrix(duneD_[0][0],  (*colB), tmp);
``` 
from the function add well contributions. 

This PR is created for discussion and comparison, please do not merge it. 