### PR TITLE
Load thpres

### DIFF
--- a/opm/simulators/thresholdPressures.hpp
+++ b/opm/simulators/thresholdPressures.hpp
@@ -325,7 +325,7 @@ void computeMaxDp(std::map<std::pair<int, int>, double>& maxDp,
     {
         const SimulationConfig& simulationConfig = eclipseState.getSimulationConfig();
         std::vector<double> thpres_vals;
-        if (simulationConfig.hasThresholdPressure()) {
+        if (simulationConfig.useThresholdPressure()) {
             const ThresholdPressure& thresholdPressure = simulationConfig.getThresholdPressure();
             const auto& eqlnum = eclipseState.get3DProperties().getIntGridProperty("EQLNUM");
             const auto& eqlnumData = eqlnum.getData();
@@ -386,7 +386,7 @@ void computeMaxDp(std::map<std::pair<int, int>, double>& maxDp,
     {
         const SimulationConfig& simulationConfig = eclipseState.getSimulationConfig();
         std::vector<double> thpres_vals;
-        if (simulationConfig.hasThresholdPressure()) {
+        if (simulationConfig.useThresholdPressure()) {
             const ThresholdPressure& thresholdPressure = simulationConfig.getThresholdPressure();
             const auto& eqlnum = eclipseState.get3DProperties().getIntGridProperty("EQLNUM");
             const auto& eqlnumData = eqlnum.getData();


### PR DESCRIPTION
See opm/opm-common#410

Observe that the changes in this repo are on a "get it to compile basis"; i.e. the `flow_legacy` simulators will not load THPRES values from the restart file (however - if they are still in the deck - that will still work).