### PR TITLE
[WIP] Correct Two Instances of Out-of-Bounds Indexing

### DIFF
--- a/opm/core/well_controls.h
+++ b/opm/core/well_controls.h
@@ -32,10 +32,12 @@ extern "C" {
 #endif
 
 enum WellControlType  {
-    BHP,              /**< Well constrained by BHP target */
+    BHP = 0,          /**< Well constrained by BHP target */
     THP,              /**< Well constrained by THP target */
     RESERVOIR_RATE,   /**< Well constrained by reservoir volume flow rate */
-    SURFACE_RATE      /**< Well constrained by surface volume flow rate */
+    SURFACE_RATE,     /**< Well constrained by surface volume flow rate */
+    GROUP,            /**< Well subject to group control */
+    INVALID           /**< Well has invalid control */
 };
 
 struct WellControls; 

--- a/opm/core/wells/well_controls.c
+++ b/opm/core/wells/well_controls.c
@@ -153,9 +153,9 @@ well_controls_create(void)
         ctrl->alq               = NULL;
         ctrl->vfp               = NULL;
         ctrl->distr             = NULL;
-        ctrl->current           = -1;
-        ctrl->cpty              = 0;         
-        ctrl->well_is_open      = true;  
+        ctrl->current           = -10;
+        ctrl->cpty              = 0;
+        ctrl->well_is_open      = true;
     }
 
     return ctrl;
@@ -184,11 +184,15 @@ well_controls_reserve(int nctrl, struct WellControls *ctrl)
 
     if (ok == 5) {
         for (int c = ctrl->cpty; c < nctrl; c++) {
-            ctrl->type  [c] =  BHP;
+            ctrl->type  [c] =  INVALID;
             ctrl->target[c] = -1.0;
+            ctrl->alq   [c] =  0.0;
+            ctrl->vfp   [c] = -1;
         }
 
-        for (int p = ctrl->cpty * ctrl->number_of_phases; p < nctrl * ctrl->number_of_phases; ++p) {
+        for (int p = ctrl->cpty * ctrl->number_of_phases;
+                 p < nctrl * ctrl->number_of_phases; ++p)
+       	{
             ctrl->distr[ p ] = 0.0;
         }
 
@@ -289,6 +293,12 @@ void well_controls_stop_well( struct WellControls * ctrl) {
 
 enum WellControlType 
 well_controls_iget_type(const struct WellControls * ctrl, int control_index) {
+    if ((control_index < -1) || (control_index >= ctrl->num)) {
+        return INVALID;
+    }
+
+    if (control_index == -1) { return GROUP; }
+
     return ctrl->type[control_index];
 }
 

--- a/opm/core/wells/wells.c
+++ b/opm/core/wells/wells.c
@@ -534,18 +534,18 @@ clone_wells(const struct Wells *W)
     return newWells;
 }
 
+
 /* ---------------------------------------------------------------------- */
 bool
 wells_equal(const struct Wells *W1, const struct Wells *W2 , bool verbose)
 /* ---------------------------------------------------------------------- */
 {
-    // Cater the case where W1 and W2 are the same (null) pointers.
-    if( W1 == W2 )
-    {
+    /* Cater the case where W1 and W2 are the same (null) pointers. */
+    if (W1 == W2) {
         return true;
     }
-    if( W1 == NULL || W2 == NULL)
-    {
+
+    if ((W1 == NULL) || (W2 == NULL)) {
         return false;
     }
     
@@ -555,8 +555,7 @@ wells_equal(const struct Wells *W1, const struct Wells *W2 , bool verbose)
         return are_equal;
     }
 
-    int i;
-    for (i=0; i<W1->number_of_wells; i++) {
+    for (i = 0; i < W1->number_of_wells; i++) {
         if (are_equal) {
             /*
               The name attribute can be NULL. The comparison is as
@@ -573,24 +572,32 @@ wells_equal(const struct Wells *W1, const struct Wells *W2 , bool verbose)
             else 
                 are_equal = are_equal && (W1->name[i] == W2->name[i]);  
 
-            if (verbose && !are_equal) 
-                printf("Well name[%d] %s and %s are different \n",  i , W1->name[i] ,  W2->name[i]);
+            if (verbose && !are_equal) {
+                const char *wn1 = W1->name[i] == NULL ? "NULL" : W1->name[i];
+                const char *wn2 = W2->name[i] == NULL ? "NULL" : W2->name[i];
+
+                printf("Well name[%d] %s and %s are different\n", i, wn1, wn2);
+            }
         }
+
         if (W1->type[i] != W2->type[i]) {
             are_equal = false;
             if (verbose)
                 printf("Well->type[%d] different %d %d \n",i , W1->type[i] , W2->type[i] );
         }
+
         if (W1->depth_ref[i] != W2->depth_ref[i]) {
             are_equal = false;
             if (verbose)
                 printf("Well->depth_ref[%d] different %g %g \n",i , W1->depth_ref[i] , W2->depth_ref[i] );
         }
-        if (!well_controls_equal(W1->ctrls[i], W2->ctrls[i],verbose)) {
+
+        if (!well_controls_equal(W1->ctrls[i], W2->ctrls[i], verbose)) {
             are_equal = false;
             if (verbose)
                 printf("Well controls are different for well[%d]:%s \n",i,W1->name[i]);
         }
+
         if (W1->allow_cf[i] != W2->allow_cf[i]) {
             are_equal = false;
             if (verbose)
@@ -628,5 +635,3 @@ wells_equal(const struct Wells *W1, const struct Wells *W2 , bool verbose)
 
     return are_equal;
 }
-
-/* ---------------------------------------------------------------------- */

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -308,6 +308,7 @@ namespace Opm
 
         case RESERVOIR_RATE: // intentional fall-through
         case SURFACE_RATE:
+        {
             // for the update of the rates, after we update the well rates, we can try to scale
             // the segment rates and perforation rates with the same factor
             // or the other way, we can use the same approach like the initialization of the well state,
@@ -379,7 +380,14 @@ namespace Opm
                 }
             }
 
+        }
             break;
+
+        case GROUP:             // Fall-through
+        case INVALID:
+            // Nothing to do.
+            break;
+
         } // end of switch
     }
 

--- a/opm/simulators/wells/RateConverter.hpp
+++ b/opm/simulators/wells/RateConverter.hpp
@@ -657,21 +657,14 @@ namespace Opm {
                 }
 
                 // Use average Rs and Rv:
-                auto a = ra.rs;
-                auto b = a;
-                if (io >= 0 && ig >= 0) {
-                    b = surface_rates[ig]/(surface_rates[io]+1.0e-15);
+                double Rs = ra.rs;
+                double Rv = ra.rv;
+                if (Details::PhaseUsed::oil(pu) && Details::PhaseUsed::gas(pu)) {
+                    const auto& qs = surface_rates;
+
+                    Rs = std::min(Rs, qs[ig] / (qs[io] + 1.0e-15));
+                    Rv = std::min(Rv, qs[io] / (qs[ig] + 1.0e-15));
                 }
-
-                double Rs = std::min(a, b);
-
-                a = ra.rv;
-                b = a;
-                if (io >= 0 && ig >= 0) {
-                    b = surface_rates[io]/(surface_rates[ig]+1.0e-15);
-                }
-
-                double Rv = std::min(a, b);
 
                 // Determinant of 'R' matrix
                 const double detR = 1.0 - (Rs * Rv);

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -788,6 +788,19 @@ namespace Opm
                 }
                 break;
             }
+
+            case GROUP:
+                OPM_THROW(std::runtime_error,
+                          "Don't know how to assemble single well control "
+                          "equation for wells on GROUP control in well "
+                          << this->name());
+                break;
+
+            case INVALID:
+                OPM_THROW(std::runtime_error, "Well " << this->name()
+                          << " can't have INVALID control mode");
+                break;
+
             default:
                 OPM_DEFLOG_THROW(std::runtime_error, "Unknown well control control types for well " << name(), deferred_logger);
         }
@@ -1222,6 +1235,7 @@ namespace Opm
         case SURFACE_RATE:
             // TODO: something needs to be done with BHP and THP here
             // TODO: they should go to a separate function
+        {
             // checking the number of the phases under control
             int numPhasesWithTargetsUnderThisControl = 0;
             for (int phase = 0; phase < np; ++phase) {
@@ -1261,8 +1275,10 @@ namespace Opm
                     for (int phase = 0; phase < np; ++phase) {
                         well_state.wellRates()[np * well_index + phase] *= scaling_factor;
                     }
-                } else { // scaling factor is not well defined when original_rates_under_phase_control is zero
-                    // separating targets equally between phases under control
+                } else {
+                    // scaling factor is not well defined when
+                    // original_rates_under_phase_control is zero separating
+                    // targets equally between phases under control
                     const double target_rate_divided = target / numPhasesWithTargetsUnderThisControl;
                     for (int phase = 0; phase < np; ++phase) {
                         if (distr[phase] > 0.0) {
@@ -1276,8 +1292,14 @@ namespace Opm
             } else {
                 OPM_DEFLOG_THROW(std::logic_error, "Expected PRODUCER or INJECTOR type of well", deferred_logger);
             }
+        }
+        break;
 
+        case GROUP:             // Fall-through.
+        case INVALID:
+            // Nothing to do.
             break;
+
         } // end of switch
     }
 

--- a/opm/simulators/wells/WellHelpers.hpp
+++ b/opm/simulators/wells/WellHelpers.hpp
@@ -84,6 +84,11 @@ namespace Opm {
                     broken = rateToCompare(well_phase_flow_rate,
                                            well, num_phases, distr) > target;
                     break;
+
+                case GROUP:  // Fall-through.
+                case INVALID:
+                    // Nothing to do.
+                    break;
                 }
             }
             break;
@@ -106,6 +111,11 @@ namespace Opm {
                     // (as for injection).
                     broken = rateToCompare(well_phase_flow_rate,
                                            well, num_phases, distr) < target;
+                    break;
+
+                case GROUP:  // Fall-through.
+                case INVALID:
+                    // Nothing to do.
                     break;
                 }
             }

--- a/tests/test_wellcontrols.cpp
+++ b/tests/test_wellcontrols.cpp
@@ -36,6 +36,10 @@ BOOST_AUTO_TEST_CASE(Construction)
 {
     struct WellControls * ctrls = well_controls_create();
 
+    BOOST_CHECK_EQUAL(well_controls_get_current(ctrls), -10);
+    BOOST_CHECK_EQUAL(well_controls_get_current_type(ctrls),
+                      WellControlType::INVALID);
+
     well_controls_set_current( ctrls , 1 );
     BOOST_CHECK_EQUAL( 1 , well_controls_get_current( ctrls ));
     well_controls_set_current( ctrls , 2 );

--- a/tests/test_wells.cpp
+++ b/tests/test_wells.cpp
@@ -113,8 +113,8 @@ BOOST_AUTO_TEST_CASE(Controls)
             if (ok1 && ok2) {
                 WellControls* ctrls = W->ctrls[0];
 
-                BOOST_CHECK_EQUAL(well_controls_get_num(ctrls)    ,  2);
-                BOOST_CHECK_EQUAL(well_controls_get_current(ctrls), -1);
+                BOOST_CHECK_EQUAL(well_controls_get_num(ctrls)    ,   2);
+                BOOST_CHECK_EQUAL(well_controls_get_current(ctrls), -10);
 
                 set_current_control(0, 0, W.get());
                 BOOST_CHECK_EQUAL(well_controls_get_current(ctrls), 0);


### PR DESCRIPTION
Member function
```
SurfaceToReservoirVoidage<>::calcReservoirVoidageRates();
```
must not unconditionally index into `surface_rates` using the gas/oil indices from `PhasePos::gas()` and `PhasePos::oil()`.  These indices will be `-1` if the corresponding phase is not active in a particular run (e.g., gas index in an O/W simulation run).

Similarly, function `add_well()` assumes that the `sat_table_id` argument is either `NULL` or has one value for each perforation.  Ensure that `test_wells.cpp` honours that requirement.