### PR TITLE
Added support for red black ilu

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -142,6 +142,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_blackoil_amg.cpp
   tests/test_block.cpp
   tests/test_boprops_ad.cpp
+  tests/test_graphcoloring.cpp
   tests/test_rateconverter.cpp
   tests/test_span.cpp
   tests/test_syntax.cpp
@@ -291,6 +292,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/autodiff/FlowMainEbos.hpp
   opm/autodiff/FlowMainSequential.hpp
   opm/autodiff/GeoProps.hpp
+  opm/autodiff/GraphColoring.hpp
   opm/autodiff/GridHelpers.hpp
   opm/autodiff/GridInit.hpp
   opm/autodiff/ImpesTPFAAD.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -150,6 +150,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_welldensitysegmented.cpp
   tests/test_vfpproperties.cpp
   tests/test_singlecellsolves.cpp
+  tests/test_milu.cpp
   tests/test_multmatrixtransposed.cpp
   tests/test_multiphaseupwind.cpp
   tests/test_wellmodel.cpp

--- a/opm/autodiff/CPRPreconditioner.hpp
+++ b/opm/autodiff/CPRPreconditioner.hpp
@@ -66,6 +66,8 @@ struct CPRParameter
     double cpr_solver_tol_;
     int cpr_ilu_n_;
     MILU_VARIANT cpr_ilu_milu_;
+    bool cpr_ilu_redblack_;
+    bool cpr_ilu_reorder_sphere_;
     int cpr_max_ell_iter_;
     bool cpr_use_amg_;
     bool cpr_use_bicgstab_;
@@ -79,13 +81,15 @@ struct CPRParameter
         // reset values to default
         reset();
 
-        cpr_relax_          = param.getDefault("cpr_relax", cpr_relax_);
-        cpr_solver_tol_     = param.getDefault("cpr_solver_tol", cpr_solver_tol_);
-        cpr_ilu_n_          = param.getDefault("cpr_ilu_n", cpr_ilu_n_);
-        cpr_max_ell_iter_   = param.getDefault("cpr_max_elliptic_iter",cpr_max_ell_iter_);
-        cpr_use_amg_        = param.getDefault("cpr_use_amg", cpr_use_amg_);
-        cpr_use_bicgstab_   = param.getDefault("cpr_use_bicgstab", cpr_use_bicgstab_);
-        cpr_solver_verbose_ = param.getDefault("cpr_solver_verbose", cpr_solver_verbose_);
+        cpr_relax_                = param.getDefault("cpr_relax", cpr_relax_);
+        cpr_solver_tol_           = param.getDefault("cpr_solver_tol", cpr_solver_tol_);
+        cpr_ilu_n_                = param.getDefault("cpr_ilu_n", cpr_ilu_n_);
+        cpr_ilu_redblack_         = param.getDefault("ilu_redblack", cpr_ilu_redblack_);
+        cpr_ilu_reorder_sphere_   = param.getDefault("ilu_reorder_sphere", cpr_ilu_reorder_sphere_);
+        cpr_max_ell_iter_         = param.getDefault("cpr_max_elliptic_iter",cpr_max_ell_iter_);
+        cpr_use_amg_              = param.getDefault("cpr_use_amg", cpr_use_amg_);
+        cpr_use_bicgstab_         = param.getDefault("cpr_use_bicgstab", cpr_use_bicgstab_);
+        cpr_solver_verbose_       = param.getDefault("cpr_solver_verbose", cpr_solver_verbose_);
         cpr_pressure_aggregation_ = param.getDefault("cpr_pressure_aggregation", cpr_pressure_aggregation_);
 
         std::string milu("ILU");
@@ -94,14 +98,16 @@ struct CPRParameter
 
     void reset()
     {
-        cpr_relax_          = 1.0;
-        cpr_solver_tol_     = 1e-2;
-        cpr_ilu_n_          = 0;
-        cpr_ilu_milu_       = MILU_VARIANT::ILU;
-        cpr_max_ell_iter_   = 25;
-        cpr_use_amg_        = true;
-        cpr_use_bicgstab_   = true;
-        cpr_solver_verbose_ = false;
+        cpr_relax_                = 1.0;
+        cpr_solver_tol_           = 1e-2;
+        cpr_ilu_n_                = 0;
+        cpr_ilu_milu_             = MILU_VARIANT::ILU;
+        cpr_ilu_redblack_         = false;
+        cpr_ilu_reorder_sphere_   = true;
+        cpr_max_ell_iter_         = 25;
+        cpr_use_amg_              = true;
+        cpr_use_bicgstab_         = true;
+        cpr_solver_verbose_       = false;
         cpr_pressure_aggregation_ = false;
     }
 };

--- a/opm/autodiff/GraphColoring.hpp
+++ b/opm/autodiff/GraphColoring.hpp
@@ -1,0 +1,143 @@
+/*
+  Copyright 2018 Equinor
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_GRAPHCOLORING_HEADER_INCLUDED
+#define OPM_GRAPHCOLORING_HEADER_INCLUDED
+
+#include <vector>
+#include <deque>
+#include <tuple>
+#include <algorithm>
+
+namespace Opm
+{
+
+namespace Detail
+{
+template<class Graph>
+void colorGraphWelshPowell(const Graph& graph,
+                           std::deque<typename Graph::VertexDescriptor>& orderedVertices,
+                           std::vector<int>& colors,
+                           int color, int noVertices)
+{
+    std::vector<int> forbidden(noVertices, false);
+
+    for(auto vertex = orderedVertices.begin(),
+            vertexEnd = orderedVertices.end();
+        vertex != vertexEnd; ++vertex)
+    {
+        // Skip forbidden vertices
+        while(vertex != vertexEnd && forbidden[*vertex])
+            ++vertex;
+        if ( vertex == vertexEnd )
+        {
+            break;
+        }
+
+        // Color Vertex
+        colors[*vertex] = color;
+        // Forbid neighors
+        for(auto edge = graph.beginEdges(*vertex), endEdge = graph.endEdges(*vertex);
+            edge != endEdge; ++edge)
+        {
+            forbidden[edge.target()] = true;
+        }
+    }
+    // forbidden vertices will be colored next for coloring
+    using Vertex = typename Graph::VertexDescriptor;
+    auto newEnd = std::remove_if(orderedVertices.begin(), orderedVertices.end(),
+                                 [&forbidden](const Vertex& vertex)
+                                 {
+                                     return !forbidden[vertex];
+                                 });
+    orderedVertices.resize(newEnd-orderedVertices.begin());
+}
+} // end namespace Detail
+
+
+/// \brief Color the vertices of graph-
+///
+/// It uses the algorithm of Welsh and Powell for this.
+/// \param graph The graph to color. Must adhere to the graph interface of dune-istl.
+/// \return A pair of a vector with the colors of the vertices and the number of colors
+///         assigned
+template<class Graph>
+std::tuple<std::vector<int>, int> colorVerticesWelshPowell(const Graph& graph)
+{
+    using Vertex = typename Graph::VertexDescriptor;
+    std::deque<Vertex> orderedVertices;
+    auto noVertices = graph.maxVertex()+1;
+    std::vector<int> degrees(noVertices, 0);
+    int maxDegree = 0;
+    std::ptrdiff_t firstDegreeChange = 0;
+
+    // populate deque
+    for( auto vertex = graph.begin(), endVertex = graph.end();
+         vertex != endVertex; ++vertex)
+    {
+        auto currentVertex = *vertex;
+        auto& degree = degrees[currentVertex];
+
+        for(auto edge = graph.beginEdges(currentVertex),
+                endEdge = graph.endEdges(currentVertex);
+            edge != endEdge; ++edge)
+        {
+            ++degree;
+        }
+
+
+        if( degree >= maxDegree )
+        {
+            orderedVertices.emplace_front(currentVertex);
+            ++firstDegreeChange;
+            if(degree > maxDegree)
+            {
+                firstDegreeChange = 1;
+                maxDegree = degree;
+            }
+        }
+        else
+        {
+            orderedVertices.emplace_back(currentVertex);
+        }
+    }
+
+    // order deque by descending degree
+    std::stable_sort(orderedVertices.begin() + firstDegreeChange,
+                     orderedVertices.end(),
+              [&degrees](const Vertex& v1, const Vertex& v2)
+              {
+                  return degrees[v1] > degrees[v2];
+              });
+
+    // Overwrite degree with color
+    auto& colors = degrees;
+    std::fill(colors.begin(), colors.end(), -1);
+
+    int color = 0;
+
+    while(!orderedVertices.empty())
+    {
+        Detail::colorGraphWelshPowell(graph, orderedVertices, colors, color++,
+                                      noVertices);
+    }
+    return std::make_tuple(colors, color);
+}
+}
+// end namespace Opm
+#endif

--- a/opm/autodiff/GraphColoring.hpp
+++ b/opm/autodiff/GraphColoring.hpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <numeric>
 #include <queue>
+#include <cstddef>
 
 namespace Opm
 {

--- a/opm/autodiff/GraphColoring.hpp
+++ b/opm/autodiff/GraphColoring.hpp
@@ -183,7 +183,7 @@ colorVerticesWelshPowell(const Graph& graph)
 template<class Graph>
 std::vector<std::size_t>
 reorderVerticesPreserving(const std::vector<int>& colors, int noColors,
-                          const std::vector<std::size_t> verticesPerColor,
+                          const std::vector<std::size_t>& verticesPerColor,
                           const Graph& graph)
 {
     std::vector<std::size_t> colorIndex(noColors, 0);
@@ -203,7 +203,7 @@ reorderVerticesPreserving(const std::vector<int>& colors, int noColors,
 template<class Graph>
 std::vector<std::size_t>
 reorderVerticesSpheres(const std::vector<int>& colors, int noColors,
-                       const std::vector<std::size_t> verticesPerColor,
+                       const std::vector<std::size_t>& verticesPerColor,
                        const Graph& graph,
                        typename Graph::VertexDescriptor root)
 {

--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -440,7 +440,7 @@ namespace Detail
                 }
 
                 const double relax = parameters_.ilu_relaxation_;
-                const bool ilu_milu  = parameters_.ilu_milu_;
+                const MILU_VARIANT ilu_milu  = parameters_.ilu_milu_;
                 if (  parameters_.use_cpr_ )
                 {
                     using Matrix         = typename MatrixOperator::matrix_type;
@@ -496,7 +496,7 @@ namespace Detail
         {
             const double relax   = parameters_.ilu_relaxation_;
             const int ilu_fillin = parameters_.ilu_fillin_level_;
-            const bool ilu_milu  = parameters_.ilu_milu_;
+            const MILU_VARIANT ilu_milu  = parameters_.ilu_milu_;
                 std::unique_ptr<SeqPreconditioner> precond(new SeqPreconditioner(opA.getmat(), ilu_fillin, relax, ilu_milu));
             return precond;
         }
@@ -519,14 +519,14 @@ namespace Detail
         {
             typedef std::unique_ptr<ParPreconditioner> Pointer;
             const double relax  = parameters_.ilu_relaxation_;
-            const bool ilu_milu  = parameters_.ilu_milu_;
+            const MILU_VARIANT ilu_milu  = parameters_.ilu_milu_;
             return Pointer(new ParPreconditioner(opA.getmat(), comm, relax, ilu_milu));
         }
 #endif
 
         template <class LinearOperator, class MatrixOperator, class POrComm, class AMG >
         void
-        constructAMGPrecond(LinearOperator& /* linearOperator */, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >& opA, const double relax, const bool milu) const
+        constructAMGPrecond(LinearOperator& /* linearOperator */, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >& opA, const double relax, const MILU_VARIANT milu) const
         {
             ISTLUtility::template createAMGPreconditionerPointer<pressureIndex>( *opA, relax, milu, comm, amg );
         }
@@ -535,7 +535,7 @@ namespace Detail
         template <class MatrixOperator, class POrComm, class AMG >
         void
         constructAMGPrecond(MatrixOperator& opA, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >&, const double relax,
-                            const bool milu) const
+                            const MILU_VARIANT milu) const
         {
             ISTLUtility::template createAMGPreconditionerPointer<pressureIndex>( opA, relax,
                                                                                  milu, comm, amg );
@@ -544,7 +544,7 @@ namespace Detail
         template <class C, class LinearOperator, class MatrixOperator, class POrComm, class AMG >
         void
         constructAMGPrecond(LinearOperator& /* linearOperator */, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >& opA, const double relax,
-                            const bool milu ) const
+                            const MILU_VARIANT milu ) const
         {
             ISTLUtility::template createAMGPreconditionerPointer<C>( *opA, relax,
                                                                      comm, amg, parameters_ );
@@ -553,7 +553,7 @@ namespace Detail
 
         template <class C, class MatrixOperator, class POrComm, class AMG >
         void
-        constructAMGPrecond(MatrixOperator& opA, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >&, const double relax, const bool milu ) const
+        constructAMGPrecond(MatrixOperator& opA, const POrComm& comm, std::unique_ptr< AMG >& amg, std::unique_ptr< MatrixOperator >&, const double relax, const MILU_VARIANT milu ) const
         {
             ISTLUtility::template createAMGPreconditionerPointer<C>( opA, relax, milu,
                                                                      comm, amg, parameters_ );

--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -497,7 +497,9 @@ namespace Detail
             const double relax   = parameters_.ilu_relaxation_;
             const int ilu_fillin = parameters_.ilu_fillin_level_;
             const MILU_VARIANT ilu_milu  = parameters_.ilu_milu_;
-                std::unique_ptr<SeqPreconditioner> precond(new SeqPreconditioner(opA.getmat(), ilu_fillin, relax, ilu_milu));
+            const bool ilu_redblack = parameters_.ilu_redblack_;
+            const bool ilu_reorder_spheres = parameters_.ilu_reorder_sphere_;
+            std::unique_ptr<SeqPreconditioner> precond(new SeqPreconditioner(opA.getmat(), ilu_fillin, relax, ilu_milu, ilu_redblack, ilu_reorder_spheres));
             return precond;
         }
 
@@ -520,7 +522,9 @@ namespace Detail
             typedef std::unique_ptr<ParPreconditioner> Pointer;
             const double relax  = parameters_.ilu_relaxation_;
             const MILU_VARIANT ilu_milu  = parameters_.ilu_milu_;
-            return Pointer(new ParPreconditioner(opA.getmat(), comm, relax, ilu_milu));
+            const bool ilu_redblack = parameters_.ilu_redblack_;
+            const bool ilu_reorder_spheres = parameters_.ilu_reorder_sphere_;
+            return Pointer(new ParPreconditioner(opA.getmat(), comm, relax, ilu_milu, ilu_redblack, ilu_reorder_spheres));
         }
 #endif
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -44,6 +44,7 @@ namespace Opm
         int    linear_solver_restart_;
         int    linear_solver_verbosity_;
         int    ilu_fillin_level_;
+        bool   ilu_milu_;
         bool   newton_use_gmres_;
         bool   require_full_sparsity_pattern_;
         bool   ignoreConvergenceFailure_;
@@ -69,6 +70,7 @@ namespace Opm
             linear_solver_use_amg_    = param.getDefault("linear_solver_use_amg", linear_solver_use_amg_ );
             ilu_relaxation_           = param.getDefault("ilu_relaxation", ilu_relaxation_ );
             ilu_fillin_level_         = param.getDefault("ilu_fillin_level",  ilu_fillin_level_ );
+            ilu_milu_             = param.getDefault("ilu_milu", ilu_milu_);
 
             // Check whether to use cpr approach
             const std::string cprSolver = "cpr";
@@ -89,6 +91,7 @@ namespace Opm
             linear_solver_use_amg_    = false;
             ilu_fillin_level_         = 0;
             ilu_relaxation_           = 0.9;
+            ilu_milu_                 = false;
         }
     };
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -46,6 +46,8 @@ namespace Opm
         int    linear_solver_verbosity_;
         int    ilu_fillin_level_;
         Opm::MILU_VARIANT   ilu_milu_;
+        bool   ilu_redblack_;
+        bool   ilu_reorder_sphere_;
         bool   newton_use_gmres_;
         bool   require_full_sparsity_pattern_;
         bool   ignoreConvergenceFailure_;
@@ -71,6 +73,8 @@ namespace Opm
             linear_solver_use_amg_    = param.getDefault("linear_solver_use_amg", linear_solver_use_amg_ );
             ilu_relaxation_           = param.getDefault("ilu_relaxation", ilu_relaxation_ );
             ilu_fillin_level_         = param.getDefault("ilu_fillin_level",  ilu_fillin_level_ );
+            ilu_redblack_             = param.getDefault("ilu_redblack", cpr_ilu_redblack_);
+            ilu_reorder_sphere_       = param.getDefault("ilu_reorder_sphere", cpr_ilu_reorder_sphere_);
             std::string milu("ILU");
             ilu_milu_ = convertString2Milu(param.getDefault("ilu_milu", milu));
 
@@ -94,6 +98,8 @@ namespace Opm
             ilu_fillin_level_         = 0;
             ilu_relaxation_           = 0.9;
             ilu_milu_                 = MILU_VARIANT::ILU;
+            ilu_redblack_             = false;
+            ilu_reorder_sphere_       = true;
         }
     };
 

--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -28,6 +28,7 @@
 #include <opm/autodiff/CPRPreconditioner.hpp>
 #include <opm/autodiff/NewtonIterationBlackoilInterface.hpp>
 #include <opm/common/utility/parameters/ParameterGroup.hpp>
+#include <opm/autodiff/ParallelOverlappingILU0.hpp>
 
 #include <array>
 #include <memory>
@@ -44,7 +45,7 @@ namespace Opm
         int    linear_solver_restart_;
         int    linear_solver_verbosity_;
         int    ilu_fillin_level_;
-        bool   ilu_milu_;
+        Opm::MILU_VARIANT   ilu_milu_;
         bool   newton_use_gmres_;
         bool   require_full_sparsity_pattern_;
         bool   ignoreConvergenceFailure_;
@@ -70,7 +71,8 @@ namespace Opm
             linear_solver_use_amg_    = param.getDefault("linear_solver_use_amg", linear_solver_use_amg_ );
             ilu_relaxation_           = param.getDefault("ilu_relaxation", ilu_relaxation_ );
             ilu_fillin_level_         = param.getDefault("ilu_fillin_level",  ilu_fillin_level_ );
-            ilu_milu_             = param.getDefault("ilu_milu", ilu_milu_);
+            std::string milu("ILU");
+            ilu_milu_ = convertString2Milu(param.getDefault("ilu_milu", milu));
 
             // Check whether to use cpr approach
             const std::string cprSolver = "cpr";
@@ -91,7 +93,7 @@ namespace Opm
             linear_solver_use_amg_    = false;
             ilu_fillin_level_         = 0;
             ilu_relaxation_           = 0.9;
-            ilu_milu_                 = false;
+            ilu_milu_                 = MILU_VARIANT::ILU;
         }
     };
 

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -947,6 +947,10 @@ protected:
     {
         if ( ordering_.empty())
         {
+            // As d is non-const in the apply method of the
+            // solver casting away constness in this particular
+            // setting is not undefined. It is ugly though but due
+            // to the preconditioner interface of dune-istl.
             return const_cast<Range&>(d);
         }
         else

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -179,7 +179,15 @@ namespace Opm
             if ( a_ik.index() != irow.index() )
                 OPM_THROW(std::logic_error, "Matrix is missing diagonal for row " << irow.index());
 
-            *a_ik -= sum_dropped;
+            int index = 0;
+            for(const auto& row: sum_dropped)
+            {
+                for(const auto& val: row)
+                {
+                    (*a_ik)[index][index]-=val;
+                }
+                ++index;
+            }
 
             if ( diagonal )
             {

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -168,14 +168,14 @@ namespace Opm
 
     struct RealReorderer : public Reorderer
     {
-        RealReorderer(std::vector<std::size_t> ordering)
-            : ordering_(ordering)
+        RealReorderer(const std::vector<std::size_t>& ordering)
+            : ordering_(&ordering)
         {}
         virtual std::size_t operator[](std::size_t i) const
         {
-            return ordering_[i];
+            return (*ordering_)[i];
         }
-        std::vector<std::size_t> ordering_;
+        const std::vector<std::size_t>* ordering_;
     };
 
     struct IdentityFunctor

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -31,6 +31,9 @@
 
 #include <type_traits>
 #include <numeric>
+#include <limits>
+#include <cstddef>
+#include <string>
 
 namespace Opm
 {

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -396,6 +396,8 @@ class ParallelOverlappingILU0
 
 
 public:
+    enum{
+        };
     //! \brief The matrix type the preconditioner is for.
     typedef typename std::remove_const<Matrix>::type matrix_type;
     //! \brief The domain type of the preconditioner.

--- a/tests/test_graphcoloring.cpp
+++ b/tests/test_graphcoloring.cpp
@@ -1,0 +1,69 @@
+#include <config.h>
+
+#include <dune/common/fmatrix.hh>
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/paamg/graph.hh>
+
+#include <opm/autodiff/GraphColoring.hpp>
+
+#define BOOST_TEST_MODULE GraphColoringTest
+#define BOOST_TEST_MAIN
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(TestWelschPowell)
+{
+    using Matrix = Dune::BCRSMatrix<Dune::FieldMatrix<double,1,1>>;
+    using Graph = Dune::Amg::MatrixGraph<Matrix>;
+    int N = 10;
+    Matrix matrix(N*N, N*N, 5, 0.4, Matrix::implicit);
+    for( int j = 0; j < N; j++)
+    {
+        for(int i = 0; i < N; i++)
+        {
+            auto index = j*10+i;
+            matrix.entry(index,index) = 1;
+
+            if ( i > 0 )
+            {
+                matrix.entry(index,index-1) = 1;
+            }
+            if ( i  < N - 1)
+            {
+                matrix.entry(index,index+1) = 1;
+            }
+
+            if ( j > 0 )
+            {
+                matrix.entry(index,index-N) = 1;
+            }
+            if ( j  < N - 1)
+            {
+                matrix.entry(index,index+N) = 1;
+            }
+
+        }
+    }
+    matrix.compress();
+
+    auto colorsTuple = Opm::colorVerticesWelshPowell(Graph(matrix));
+    const auto& colors = std::get<0>(colorsTuple);
+    auto noColors = std::get<1>(colorsTuple);
+    auto firstCornerColor = colors[0];
+    BOOST_CHECK(noColors == 2);
+
+    // Check for checkerboard coloring
+
+    for( int j = 0, index = 0; j < N; j++)
+    {
+        auto expectedColor = firstCornerColor;
+
+        for(int i = 0; i < N; i++)
+        {
+            BOOST_CHECK(colors[index]==expectedColor);
+            index++;
+            expectedColor = (expectedColor + 1) % 2;
+        }
+        firstCornerColor=(firstCornerColor + 1) % 2;
+    }
+}

--- a/tests/test_milu.cpp
+++ b/tests/test_milu.cpp
@@ -77,6 +77,21 @@ void test_milu0(M& A)
 #endif
         BOOST_ASSERT(point_difference < 1e-12);
     }
+
+    // Test that (LU)^-1Ae=e
+    A.mv(e, x1);
+    bilu_backsolve(ILU, x2, x1);
+    diff = x2;
+    diff -= e;
+
+    for ( std::size_t i = 0, end = A.N(); i < end; ++i)
+    {
+        auto point_difference = diff[i].two_norm();
+#ifdef DEBUG
+        std::cout<<"index "<<i<<" size "<<diff.size()<<" point_difference "<<point_difference<<std::endl;
+#endif
+        BOOST_CHECK_CLOSE(x2[i].two_norm(), e[i].two_norm(), 1e-12);
+    }
 }
 
 template<class B, class Alloc>

--- a/tests/test_milu.cpp
+++ b/tests/test_milu.cpp
@@ -23,6 +23,17 @@ void test_milu0(M& A)
     diagonal.reset(new std::vector<typename M::block_type>());
 
     Opm::detail::milu0_decomposition(ILU, diagonal.get());
+#ifdef DEBUG
+    if ( A.N() < 11)
+    {
+        Dune::printmatrix(std::cout, ILU, "ILU", "row");
+        std::cout << "Diagonal: ";
+
+        for (const auto& d : *diagonal)
+            std::cout << d << " ";
+        std::cout<<std::endl;
+    }
+#endif
     Dune::BlockVector<Dune::FieldVector<typename M::field_type, M::block_type::rows>> e(A.N()), x1(A.N()), x2(A.N()), t(A.N());
     e = 1;
     A.mv(e, x1);
@@ -143,7 +154,9 @@ void test()
     Dune::BCRSMatrix<Dune::FieldMatrix<double, bsize, bsize> > A;
     setupLaplacian(A, N);
     test_milu0(A);
+#ifdef DEBUG
     std::cout<< "Tested block size "<< bsize<<std::endl;
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(MILULaplace1)

--- a/tests/test_milu.cpp
+++ b/tests/test_milu.cpp
@@ -75,7 +75,7 @@ void test_milu0(M& A)
 #ifdef DEBUG
         std::cout<<"index "<<i<<" size "<<diff.size()<<" difference"<<point_difference<<std::endl;
 #endif
-        BOOST_ASSERT(point_difference < 1e-12);
+        BOOST_CHECK(point_difference < 1e-12);
     }
 
     // Test that (LU)^-1Ae=e
@@ -86,8 +86,8 @@ void test_milu0(M& A)
 
     for ( std::size_t i = 0, end = A.N(); i < end; ++i)
     {
-        auto point_difference = diff[i].two_norm();
 #ifdef DEBUG
+        auto point_difference = diff[i].two_norm();
         std::cout<<"index "<<i<<" size "<<diff.size()<<" point_difference "<<point_difference<<std::endl;
 #endif
         BOOST_CHECK_CLOSE(x2[i].two_norm(), e[i].two_norm(), 1e-12);

--- a/tests/test_milu.cpp
+++ b/tests/test_milu.cpp
@@ -1,0 +1,165 @@
+#include<config.h>
+
+#define BOOST_TEST_MODULE MILU0Test
+
+#include<vector>
+#include<memory>
+
+#include<dune/istl/bcrsmatrix.hh>
+#include<dune/istl/bvector.hh>
+#include<dune/common/fmatrix.hh>
+#include<dune/common/fvector.hh>
+#include<opm/autodiff/ParallelOverlappingILU0.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+
+template<class M>
+void test_milu0(M& A)
+{
+    auto ILU = A;
+    
+    std::shared_ptr<std::vector<typename M::block_type>> diagonal = nullptr;
+    diagonal.reset(new std::vector<typename M::block_type>());
+
+    Opm::detail::milu0_decomposition(ILU, diagonal.get());
+    Dune::BlockVector<Dune::FieldVector<typename M::field_type, M::block_type::rows>> e(A.N()), x1(A.N()), x2(A.N()), t(A.N());
+    e = 1;
+    A.mv(e, x1);
+    // Compute L*U*e;
+    // t=Ue
+    
+    for ( auto irow = ILU.begin(), iend = ILU.end(); irow != iend; ++irow)
+    {
+        auto i = irow.index();
+        (*diagonal)[i].mv(e[0], t[i]);
+        auto col = irow->find(i);
+        auto colend = irow->end();
+
+        if ( col == colend )
+        {
+            OPM_THROW(std::logic_error, "Missing diagonal entry for row " << irow.index());
+        }
+        for (++col ;col != colend; ++col)
+        {
+            col->umv(e[0], t[i]);
+        }
+    }
+            
+    for ( auto irow = ILU.begin(), iend = ILU.end(); irow != iend; ++irow)
+    {
+        auto i = irow.index();
+        x2[i] = 0;
+        for (auto col = irow->begin(); col.index() < irow.index(); ++col)
+        {
+            col->umv(t[col.index()], x2[i]);
+        }
+        x2[i] += t[i];
+    }
+    auto diff = x2;
+    diff-=x1;
+    for ( std::size_t i = 0, end = A.N(); i < end; ++i)
+    {
+        auto point_difference = diff[i].two_norm();
+#ifdef DEBUG
+        std::cout<<"index "<<i<<" size "<<diff.size()<<" difference"<<point_difference<<std::endl;
+#endif
+        BOOST_ASSERT(point_difference < 1e-12);
+    }
+}
+
+template<class B, class Alloc>
+void setupSparsityPattern(Dune::BCRSMatrix<B,Alloc>& A, int N)
+{
+  typedef typename Dune::BCRSMatrix<B,Alloc> Matrix;
+  A.setSize(N*N, N*N, N*N*5);
+  A.setBuildMode(Matrix::row_wise);
+
+  for (typename Dune::BCRSMatrix<B,Alloc>::CreateIterator i = A.createbegin(); i != A.createend(); ++i) {
+    int x = i.index()%N; // x coordinate in the 2d field
+    int y = i.index()/N;  // y coordinate in the 2d field
+
+    if(y>0)
+      // insert lower neighbour
+      i.insert(i.index()-N);
+    if(x>0)
+      // insert left neighbour
+      i.insert(i.index()-1);
+
+    // insert diagonal value
+    i.insert(i.index());
+
+    if(x<N-1)
+      //insert right neighbour
+      i.insert(i.index()+1);
+    if(y<N-1)
+      // insert upper neighbour
+      i.insert(i.index()+N);
+  }
+}
+
+
+template<class B, class Alloc>
+void setupLaplacian(Dune::BCRSMatrix<B,Alloc>& A, int N)
+{
+  typedef typename Dune::BCRSMatrix<B,Alloc>::field_type FieldType;
+
+  setupSparsityPattern(A,N);
+
+  B diagonal(static_cast<FieldType>(0)), bone(static_cast<FieldType>(0)),
+  beps(static_cast<FieldType>(0));
+  for(typename B::RowIterator b = diagonal.begin(); b !=  diagonal.end(); ++b)
+    b->operator[](b.index())=4;
+
+
+  for(typename B::RowIterator b=bone.begin(); b !=  bone.end(); ++b)
+    b->operator[](b.index())=-1.0;
+
+
+  for (typename Dune::BCRSMatrix<B,Alloc>::RowIterator i = A.begin(); i != A.end(); ++i) {
+    int x = i.index()%N; // x coordinate in the 2d field
+    int y = i.index()/N;  // y coordinate in the 2d field
+    
+    i->operator[](i.index())=diagonal;
+    
+    if(y>0)
+        i->operator[](i.index()-N)=bone;
+
+    if(y<N-1)
+        i->operator[](i.index()+N)=bone;
+
+    if(x>0)
+        i->operator[](i.index()-1)=bone;
+
+    if(x < N-1)
+        i->operator[](i.index()+1)=bone;
+  }
+}
+
+template<int bsize>
+void test()
+{
+    std::size_t N = 32;
+    Dune::BCRSMatrix<Dune::FieldMatrix<double, bsize, bsize> > A;
+    setupLaplacian(A, N);
+    test_milu0(A);
+    std::cout<< "Tested block size "<< bsize<<std::endl;
+}
+
+BOOST_AUTO_TEST_CASE(MILULaplace1)
+{
+    test<1>();
+}
+
+BOOST_AUTO_TEST_CASE(MILULaplace2)
+{
+    test<2>();
+}
+BOOST_AUTO_TEST_CASE(MILULaplace3)
+{
+    test<3>();
+}
+BOOST_AUTO_TEST_CASE(MILULaplace4)
+{
+    test<4>();
+}


### PR DESCRIPTION
For convenience this is based on #1479 (and adds support for milu to ILUn). From that PR the  following MILU variants can be requested via the ilu_milu command line parameter:
- MILU_0 is the unmodified ILU0, i.e. the default preconditioner
- MILU_1 will add the dropped entries to the diagonal (traditional MILU)
- MILU_2 will add the sum of the absolute values of the dropped elemets to the diagonal
- MILU_3 if diagonal is positive add sum of dropped row entrires. Otherwise substract them.
- MILU_4 if diagonal is positive add sum of dropped row entrires. Otherwise do nothing

As expected (if one reads the literature carefully) red black ordering gives worse convergence rates but when allowing considerable fill-in one iteration gets so fast that the runtime improves compared to natural ordering.

This PR adds adds two new parameters. ilu_redblack=(true|false), default false, to switch the coloring and reordering on and ilu_reorder_sphere=(true|false), default true, to change how the vertices of one color are ordered. If false the previous ordering of vertices with one color is presered. Otherwise we start with a root cell and make sure that nearer to it come before those farer away. The distance between to cells is the minimum number of faces between them if we draw a path that moves from one cell to the other only over a face between them. In a structured grid we would expect that all cells forming a diagonal would have the same color and due to this ordering would have indices out of a consecutive range if we start with an edge cell. In general this will not hold.

Currently only tested with SPE1CASE2:
( iter is number of iterations, time is total time. normal is ilu_redblack=false, red-black is ilu_redblack=true, al other settings are the default)

| n | iter normal | time normal | iter red-black | time red-black |
|--|--|--|--|--|
| 0 | 2719 | .74 | 13540 | .95 |
| 1 | 1268 | .76 | 13171 | 1.24 |
| 2 | 1068| 2.37 | 11896 | 1.94 |
| 4 | 704 | 10.5 | 11851 | 2.07 |
| 6 | 593 | 13.01 | 11851 | 2.20 |
| 8 | 519 | 14.00| 11851 | 2.23 |

Better runtime is due to the fact that red-black produces less fill-in (worse convergence, too).

Currently the reordering is done everytime ILU is set up. This needs to be done only once as the sparsity pattern of the matrix never changes. But I do not think the savings will be very dramatic.

Another option would be to also test reverse Cuthill-McGee or Gibbs-Poole-Stockmeyer ordering.