### PR TITLE
Reduce default number of threads from four to two with OpenMP

### DIFF
--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -155,10 +155,10 @@ namespace Opm
 #ifdef _OPENMP
             // OpenMP setup.
             if (!getenv("OMP_NUM_THREADS")) {
-                // Default to at most 4 threads, regardless of
+                // Default to at most 2 threads, regardless of
                 // number of cores (unless ENV(OMP_NUM_THREADS) is defined)
                 int num_cores = omp_get_num_procs();
-                int num_threads = std::min(4, num_cores);
+                int num_threads = std::min(2, num_cores);
                 omp_set_num_threads(num_threads);
             }
             // omp_get_num_threads() only works as expected within a parallel region.


### PR DESCRIPTION
This is a preparation for turning on OpenMP compilation by default. With OpenMP turned on by default, four threads seems a bit aggressive as the first attempt at a sensible default value. Two threads on the other hand consistently seems to provide a small performance improvement on CPUs with hyperthreading (which today is most CPUs), even when all physical cores are used with MPI. Reverting back to four threads by default can be done at any point in the future if deemed a better default.

For single process runs, using two threads for assembly provides 10%-15% reduction in total computational time. Hence, this change will give a nice boost for flow.