### PR TITLE
Add PORV acceptance test running Norne.

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -278,6 +278,16 @@ foreach(sim flow flow_legacy)
                                         REL_TOL ${rel_tol_restart})
 endforeach()
 
+# PORV test
+opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-porv-acceptanceTest.sh "")
+add_test_compareECLFiles(CASENAME norne
+                         FILENAME NORNE_ATW2013
+                         SIMULATOR flow
+                         ABS_TOL 1e-5
+                         REL_TOL 1e-8
+                         PREFIX comparePORV
+                         DIR_PREFIX /porv)
+
 # Init tests
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-init-regressionTest.sh "")
 

--- a/tests/run-porv-acceptanceTest.sh
+++ b/tests/run-porv-acceptanceTest.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This runs the initialization step of a simulator,
+# then compares the resulting INIT file against a reference.
+# This is meant to track regressions in INIT file writing.
+# Useful for models that are too large to do simulation on
+# as a regression test.
+
+INPUT_DATA_PATH="$1"
+RESULT_PATH="$2"
+BINPATH="$3"
+FILENAME="$4"
+ABS_TOL="$5"
+REL_TOL="$6"
+COMPARE_SUMMARY_COMMAND="$7"
+COMPARE_ECL_COMMAND="$8"
+EXE_NAME="${9}"
+shift 9
+TEST_ARGS="$@"
+
+rm -Rf  ${RESULT_PATH}
+mkdir -p ${RESULT_PATH}
+cd ${RESULT_PATH}
+${BINPATH}/${EXE_NAME} ${TEST_ARGS} nosim=true output_dir=${RESULT_PATH}
+cd ..
+
+ecode=0
+${COMPARE_ECL_COMMAND} -t INIT -k PORV ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-porevolume-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+if [ $? -ne 0 ]
+then
+  ecode=1
+  `dirname $0`/analyze_ecl_failure.sh ${COMPARE_ECL_COMMAND} INIT ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-porevolume-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+fi
+
+exit $ecode


### PR DESCRIPTION
This adds an acceptance test based on the PORV of Norne. Being an acceptance test means in this context:
 - Only PORV is verified.
 - The tolerances are strict.
 - The underlying reference will not be updated by Jenkins' update_data trigger.

The run-porv-acceptanceTest.sh script is almost a duplicate of run-init-regressionTest.sh. The differences are in the directory of the reference data, and passing "-k PORV" to the comparison tool.

This requires OPM/opm-common#439, or it may give misleading results.