### PR TITLE
Removed dubious warning during MPI run

### DIFF
--- a/opm/simulators/ParallelFileMerger.hpp
+++ b/opm/simulators/ParallelFileMerger.hpp
@@ -82,13 +82,6 @@ public:
                 {
                     appendFile(*debugStream_, file, rank);
                 }
-                else
-                {
-                    std::cerr << "WARNING: Unrecognized file with name "
-                              << filename
-                              << " that might stem from a  parallel run."
-                              << std::endl;
-                }
             }
         }
     }


### PR DESCRIPTION
The warning message seems to match just about any file in the folder, so something is wrong with the regular expression it is supposed to match or the logic of the branching. As I do not understand what the purpose is, I simply removed it. If the warning indeed is important, please advice what it should do.