### PR TITLE
flow: fix the time held by the simulator object

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -189,12 +189,16 @@ namespace Opm {
                 ebosSimulator_.model().advanceTimeLevel();
             }
 
-            // set the timestep size and index in ebos explicitly
-            // we use our own time stepper.
-            ebosSimulator_.startNextEpisode( timer.currentStepLength() );
-            ebosSimulator_.setEpisodeIndex( timer.reportStepNum() );
-            ebosSimulator_.setTimeStepSize( timer.currentStepLength() );
-            ebosSimulator_.setTimeStepIndex( timer.reportStepNum() );
+            // set the timestep size and episode index for ebos explicitly. ebos needs to
+            // know the report step/episode index because of timing dependend data
+            // despide the fact that flow uses its own time stepper. (The length of the
+            // episode does not matter, though.)
+            Scalar t = timer.simulationTimeElapsed();
+            ebosSimulator_.startNextEpisode(/*episodeStartTime=*/t, /*episodeLength=*/1e30);
+            ebosSimulator_.setEpisodeIndex(timer.reportStepNum());
+            ebosSimulator_.setTime(t);
+            ebosSimulator_.setTimeStepSize(timer.currentStepLength());
+            ebosSimulator_.setTimeStepIndex(ebosSimulator_.timeStepIndex() + 1);
 
             ebosSimulator_.problem().beginTimeStep();
 
@@ -354,7 +358,7 @@ namespace Opm {
             ebosSimulator_.problem().beginIteration();
             ebosSimulator_.model().linearizer().linearize();
             ebosSimulator_.problem().endIteration();
-            
+
             // -------- Aquifer models ----------
             try
             {

--- a/opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
+++ b/opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
@@ -77,7 +77,7 @@ AdaptiveSimulatorTimer& AdaptiveSimulatorTimer::operator++ ()
             // set new time step (depending on remaining time)
             if( 1.05 * dt_ > remaining ) {
                 dt_ = remaining;
-                // check max time step again and use half remaining if to large
+                // check max time step again and use half remaining if too large
                 if( dt_ > max_time_step_ ) {
                     dt_ = 0.5 * remaining;
                 }


### PR DESCRIPTION
in conjunction with #1512, this makes VTK output work out of the box if `--enable-vtk-output=true` is specified:

![screenshot_20180627_123736](https://user-images.githubusercontent.com/1837735/41969179-e351f3e4-7a06-11e8-90a8-b6d7db194824.png)
