### PR TITLE
fixing a small bug in multisegment well

### DIFF
--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -1190,13 +1190,17 @@ namespace Opm
                     }
                 }
 
-                if (original_rates_under_phase_control != 0.0 ) {
+                // sometimes the previous report step is zero-rate control,it causes original_rates_under_phase_control
+                // to be some extremely small value if not zero. Scaling with either zero or extremely small value will
+                // cause problematic rates for later.
+                constexpr double rate_threshold = 1.e-10;
+                if (std::abs(original_rates_under_phase_control) > rate_threshold) {
                     const double scaling_factor = target / original_rates_under_phase_control;
 
                     for (int phase = 0; phase < np; ++phase) {
                         well_state.wellRates()[np * well_index + phase] *= scaling_factor;
                     }
-                } else { // scaling factor is not well defined when original_rates_under_phase_control is zero
+                } else { // original_rates_under_phase_control is not close to zero
                     // separating targets equally between phases under control
                     const double target_rate_divided = target / numPhasesWithTargetsUnderThisControl;
                     for (int phase = 0; phase < np; ++phase) {


### PR DESCRIPTION
which is due to the previous report step to be zero-rate control, we might not get exactly 0 value rates. Doing division with it is causing problem.