### PR TITLE
use a raw pointer to specify the auxiliary module for wells

### DIFF
--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -180,8 +180,8 @@ public:
              modelParam_.preconditioner_add_well_contributions_)
         {
             ebosSimulator_.model().clearAuxiliaryModules();
-            auto auxMod = std::make_shared<WellConnectionAuxiliaryModule<TypeTag> >(schedule(), grid());
-            ebosSimulator_.model().addAuxiliaryModule(auxMod);
+            wellAuxMod_.reset(new WellConnectionAuxiliaryModule<TypeTag>(schedule(), grid()));
+            ebosSimulator_.model().addAuxiliaryModule(wellAuxMod_.get());
         }
 
         AquiferModel aquifer_model(ebosSimulator_);
@@ -368,6 +368,7 @@ protected:
     // Data.
     Simulator& ebosSimulator_;
 
+    std::unique_ptr<WellConnectionAuxiliaryModule<TypeTag>> wellAuxMod_;
     typedef typename Solver::SolverParametersEbos SolverParametersEbos;
 
     SimulatorReport failureReport_;


### PR DESCRIPTION
this is necessitated by the replacement of `std::shared_ptr` by raw pointers for the eWoms auxiliary equation infrastructure done by OPM/ewoms#340. Note that this will not affect flow by default in any way because it will *not* create an auxiliary equation module if the `matrix_add_well_contributions` parameter is not explicitly set to `true`.