### PR TITLE
Extend Internal Wells Structure to Capture and Provide Effective Kh Product Per Connection

### DIFF
--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -117,7 +117,7 @@ namespace Opm
         const std::string& name() const;
 
         /// Index of well in the wells struct and wellState
-        const int indexOfWell() const;
+        int indexOfWell() const;
 
         /// Well cells.
         const std::vector<int>& cells() {return well_cells_; }

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -170,7 +170,7 @@ namespace Opm
     }
 
     template<typename TypeTag>
-    const int
+    int
     WellInterface<TypeTag>::
     indexOfWell() const
     {

--- a/opm/core/simulator/WellState.hpp
+++ b/opm/core/simulator/WellState.hpp
@@ -263,6 +263,7 @@ namespace Opm
                     connection.index = globalCellIdxMap[active_index];
                     connection.pressure = this->perfPress()[ itr.second[1] + i ];
                     connection.reservoir_rate = this->perfRates()[ itr.second[1] + i ];
+                    connection.effective_Kh = this->wells_->conn_Kh[ wi ];
                 }
                 assert(num_perf_well == int(well.connections.size()));
             }

--- a/opm/core/wells.h
+++ b/opm/core/wells.h
@@ -92,6 +92,11 @@ struct Wells
     double *WI;
 
     /**
+     *  Connection effective Kh, same size and structure as well_cells.
+     */
+    double *conn_Kh;
+
+    /**
      *  Saturation table number , same size and structure as well_cells.
      */
     int *sat_table_id;
@@ -116,7 +121,6 @@ struct Wells
      * Internal management structure.
      */
     void *data;
-
 };
 
 
@@ -191,10 +195,15 @@ create_wells(int nphases, int nwells, int nperf);
  * \param[in] type       Type of well.
  * \param[in] depth_ref  Reference depth for well's BHP.
  * \param[in] nperf      Number of perforations.
- * \param[in] comp_frac  Injection fraction array (size equal to W->number_of_phases) or NULL.
+ *
+ * \param[in] comp_frac  Injection fraction array (size equal to
+ *                       W->number_of_phases) or NULL.
+ *
  * \param[in] cells      Grid cells in which well is perforated.  Should
  *                       ideally be track ordered.
  * \param[in] WI         Well production index per perforation, or NULL.
+ * \param[in] conn_Kh    Effective Kh product per perforation, or NULL.
+ * \param[in] sat_table_id Saturation table index per perforation, or NULL.
  * \param[in] name       Name of new well. NULL if no name.
  * \param[in] allow_cf   Flag to determine whether crossflow is allowed or not.
  * \param[in,out] W      Existing set of wells to which new well will
@@ -203,16 +212,17 @@ create_wells(int nphases, int nwells, int nperf);
  * \return Non-zero (true) if successful and zero otherwise.
  */
 int
-add_well(enum WellType  type     ,
-         double         depth_ref,
-         int            nperf    ,
-         const double  *comp_frac,
-         const int     *cells    ,
-         const double  *WI       ,
+add_well(enum WellType  type        ,
+         double         depth_ref   ,
+         int            nperf       ,
+         const double  *comp_frac   ,
+         const int     *cells       ,
+         const double  *WI          ,
+         const double  *conn_Kh     ,
          const int     *sat_table_id,
-         const char    *name     ,
-         int            allow_cf ,
-         struct Wells  *W        );
+         const char    *name        ,
+         int            allow_cf    ,
+         struct Wells  *W           );
 
 
 /**
@@ -233,8 +243,6 @@ add_well(enum WellType  type     ,
  * \param[in,out] W  Existing set of well controls.
  * \return Non-zero (true) if successful and zero (false) otherwise.
  */
-
-
 int
 append_well_controls(enum WellControlType type  ,
                      double               target,

--- a/opm/core/wells/WellsManager.cpp
+++ b/opm/core/wells/WellsManager.cpp
@@ -226,8 +226,8 @@ namespace WellsManagerDetail
     // rather than reference-to-const to support NTG manipulation.
     inline std::array<double,3>
     effectiveExtent(const Opm::WellCompletion::DirectionEnum direction,
-                    const double                                  ntg,
-                    std::array<double,3>                          extent)
+                    const double                             ntg,
+                    std::array<double,3>                     extent)
     {
         // Vertical extent affected by net-to-gross ratio.
         extent[2] *= ntg;
@@ -268,13 +268,13 @@ namespace WellsManagerDetail
     // (Note that the well model asumes that each cell is a cuboid).
     // cell_permeability is the permeability tensor of the given cell.
     // returns the well index of the cell.
-    double
-    computeWellIndex(const double                                  radius,
-                     const std::array<double, 3>&                  cubical,
-                     const double*                                 cell_permeability,
-                     const double                                  skin_factor,
+    DerivedCTFQuantities
+    computeWellIndex(const double                             radius,
+                     const std::array<double, 3>&             cubical,
+                     const double*                            cell_permeability,
+                     const double                             skin_factor,
                      const Opm::WellCompletion::DirectionEnum direction,
-                     const double                                  ntg)
+                     const double                             ntg)
     {
         const std::array<double,3>& K =
             permComponents(direction, cell_permeability);
@@ -298,9 +298,9 @@ namespace WellsManagerDetail
             rw = r0;
         }
 
-        // NOTE: The formula is originally derived and valid for
-        // Cartesian grids only.
-        return (angle * Kh) / (std::log(r0 / rw) + skin_factor);
+        // NOTE: The formula for the connection transmissibility factor is
+        // originally derived and valid for Cartesian grids only.
+        return { (angle * Kh) / (std::log(r0 / rw) + skin_factor), Kh };
     }
 
 } // anonymous namespace

--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -51,13 +51,6 @@ namespace Opm
         int welspecsline;
     };
 
-
-    struct PerfData
-    {
-        int cell;
-        double well_index;
-        int satnumid;
-    };
     /// This class manages a Wells struct in the sense that it
     /// encapsulates creation and destruction of the wells
     /// data structure.
@@ -154,6 +147,14 @@ namespace Opm
 
 
     private:
+        struct PerfData
+        {
+            int cell;
+            double well_index;
+            double Kh;
+            int satnumid;
+        };
+
         template<class C2F, class FC>
         void init(const Opm::EclipseState& eclipseState,
                   const Opm::Schedule& schedule,
@@ -166,9 +167,11 @@ namespace Opm
                   FC begin_face_centroids,
                   const DynamicListEconLimited& list_econ_limited,
                   const std::unordered_set<std::string>& deactivated_wells);
+
         // Disable copying and assignment.
         WellsManager(const WellsManager& other);
         WellsManager& operator=(const WellsManager& other);
+
         static void setupCompressedToCartesian(const int* global_cell, int number_of_cells, std::map<int,int>& cartesian_to_compressed );
         void setupWellControls(std::vector<const Well*>& wells, size_t timeStep,
                                std::vector<std::string>& well_names, const PhaseUsage& phaseUsage,

--- a/opm/simulators/thresholdPressures.hpp
+++ b/opm/simulators/thresholdPressures.hpp
@@ -380,9 +380,10 @@ void computeMaxDp(std::map<std::pair<int, int>, double>& maxDp,
     ///                           particular connection. An empty vector is
     ///                           returned if there is no THPRES
     ///                           feature used in the deck.
-     std::vector<double> thresholdPressuresNNC(const EclipseState& eclipseState,
-                                               const NNC& nnc,
-                                               const std::map<std::pair<int, int>, double>& maxDp)
+    inline std::vector<double>
+    thresholdPressuresNNC(const EclipseState& eclipseState,
+                          const NNC& nnc,
+                          const std::map<std::pair<int, int>, double>& maxDp)
     {
         const SimulationConfig& simulationConfig = eclipseState.getSimulationConfig();
         std::vector<double> thpres_vals;

--- a/tests/test_vfpproperties.cpp
+++ b/tests/test_vfpproperties.cpp
@@ -439,7 +439,8 @@ BOOST_AUTO_TEST_CASE(GetTable)
     std::shared_ptr<Wells> wells(create_wells(nphases, nwells, nperfs),
                                 destroy_wells);
     const int cells[] = {5};
-    add_well(INJECTOR, 100, 1, NULL, cells, NULL, 0, NULL, true, wells.get());
+    add_well(INJECTOR, 100, 1, nullptr, cells,
+             nullptr, nullptr, nullptr, nullptr, true, wells.get());
 
     //Create interpolation points
     double aqua_d   = -0.15;
@@ -775,8 +776,9 @@ BOOST_AUTO_TEST_CASE(InterpolateADBAndQs)
 
         std::stringstream ss;
         ss << "WELL_" << i;
-        const bool ok = add_well(INJECTOR, 0.0, 1, NULL, &cells,
-                                 NULL, 0, ss.str().c_str(), true, wells.get());
+        const bool ok = add_well(INJECTOR, 0.0, 1, nullptr, &cells,
+                                 nullptr, nullptr, nullptr,
+                                 ss.str().c_str(), true, wells.get());
         BOOST_REQUIRE(ok);
     }
 

--- a/tests/test_welldensitysegmented.cpp
+++ b/tests/test_welldensitysegmented.cpp
@@ -45,13 +45,24 @@ BOOST_AUTO_TEST_CASE(TestPressureDeltas)
     const double comp_frac_o[np] = { 0.0, 1.0, 0.0 };
     const int cells[nperf/2] = { 0, 1, 2, 3, 4 };
     const double WI[nperf/2] = { 1.0, 1.0, 1.0, 1.0, 1.0 };
+    const double Kh[nperf/2] = { 1.0e-5, 1.0e-5, 1.0e-5, 1.0e-5, 1.0e-5 };
     const bool allow_crossflow = true;
     std::shared_ptr<Wells> wells(create_wells(np, 2, nperf), destroy_wells);
-    BOOST_REQUIRE(wells);
-    int ok = add_well(INJECTOR, ref_depth, nperf/2, comp_frac_w, cells, WI, 0, "INJ", allow_crossflow, wells.get());
+
+    BOOST_REQUIRE(wells != nullptr);
+
+    int ok = add_well(INJECTOR, ref_depth, nperf/2, comp_frac_w,
+                      cells, WI, Kh, nullptr, "INJ",
+                      allow_crossflow, wells.get());
+
     BOOST_REQUIRE(ok);
-    ok = add_well(PRODUCER, ref_depth, nperf/2, comp_frac_o, cells, WI, 0, "PROD", allow_crossflow, wells.get());
+
+    ok = add_well(PRODUCER, ref_depth, nperf/2, comp_frac_o,
+                  cells, WI, Kh, nullptr, "PROD",
+                  allow_crossflow, wells.get());
+
     BOOST_REQUIRE(ok);
+
     std::vector<double> rates = { 1.0, 0.0, 0.0,
                                   1.0, 0.0, 0.0,
                                   1.0, 0.0, 0.0,

--- a/tests/test_wells.cpp
+++ b/tests/test_wells.cpp
@@ -49,15 +49,18 @@ BOOST_AUTO_TEST_CASE(Construction)
     if (W) {
         int          cells[] = { 0, 9 };
         double       WI      = 1.0;
+        double       Kh      = 1.0e-5;
         int          sat_table_id = -1;
         const double ifrac[] = { 1.0, 0.0 };
 
         const bool ok0 = add_well(INJECTOR, 0.0, 1, &ifrac[0], &cells[0],
-                                  &WI, &sat_table_id,"INJECTOR", true, W.get());
+                                  &WI, &Kh, &sat_table_id,
+                                  "INJECTOR", true, W.get());
 
         const double pfrac[] = { 0.0, 0.0 };
         const bool ok1 = add_well(PRODUCER, 0.0, 1, &pfrac[0], &cells[1],
-                                  &WI, &sat_table_id,"PRODUCER", true, W.get());
+                                  &WI, &Kh, &sat_table_id,
+                                  "PRODUCER", true, W.get());
 
         if (ok0 && ok1) {
             BOOST_CHECK_EQUAL(W->number_of_phases, nphases);
@@ -91,13 +94,15 @@ BOOST_AUTO_TEST_CASE(Controls)
                                destroy_wells);
 
     if (W) {
-        int          cells[] = { 0  , 9   };
-        double       WI   [] = { 1.0, 1.0 };
-        const double ifrac[] = { 1.0, 0.0 };
-        int   sat_table_id = -1;
+        int          cells[] = { 0     , 9      };
+        double       WI   [] = { 1.0   , 1.0    };
+        double       Kh   [] = { 1.0e-5, 1.0e-5 };
+        const double ifrac[] = { 1.0   , 0.0    };
+        int          sat_table_id[] = { -1, -1 };
 
         const bool ok = add_well(INJECTOR, 0.0, nperfs, &ifrac[0], &cells[0],
-                                 &WI[0], &sat_table_id,  "INJECTOR", true, W.get());
+                                 &WI[0], &Kh[0], &sat_table_id[0],
+                                 "INJECTOR", true, W.get());
 
         if (ok) {
             const double distr[] = { 1.0, 0.0 };
@@ -144,18 +149,21 @@ BOOST_AUTO_TEST_CASE(Copy)
     std::shared_ptr<Wells> W2;
 
     if (W1) {
-        int          cells[] = { 0, 9 };
-        const double WI      = 1.0;
-        const double ifrac[] = { 1.0, 0.0 };
-        int   sat_table_id = -1;
+        int          cells[] = { 0     , 9      };
+        const double WI[]    = { 1.0   , 1.0    };
+        const double Kh[]    = { 1.0e-5, 1.0e-5 };
+        const double ifrac[] = { 1.0   , 0.0    };
+        int          sat_table_id[] = { -1, -1 };
 
 
         const bool ok0 = add_well(INJECTOR, 0.0, 1, &ifrac[0], &cells[0],
-                                  &WI, &sat_table_id, "INJECTOR", true, W1.get());
+                                  &WI[0], &Kh[0], &sat_table_id[0],
+                                  "INJECTOR", true, W1.get());
 
         const double pfrac[] = { 0.0, 0.0 };
         const bool ok1 = add_well(PRODUCER, 0.0, 1, &pfrac[0], &cells[1],
-                                  &WI, &sat_table_id, "PRODUCER", true, W1.get());
+                                  &WI[0], &Kh[0], &sat_table_id[0],
+                                  "PRODUCER", true, W1.get());
 
         bool ok = ok0 && ok1;
         for (int w = 0; ok && (w < W1->number_of_wells); ++w) {

--- a/tests/test_wellsmanager.cpp
+++ b/tests/test_wellsmanager.cpp
@@ -35,6 +35,7 @@
 
 #include <opm/grid/GridManager.hpp>
 
+namespace {
 void wells_static_check(const Wells* wells) {
     BOOST_CHECK_EQUAL(2, wells->number_of_wells);
     BOOST_CHECK_EQUAL(3, wells->number_of_phases);
@@ -171,6 +172,7 @@ void check_controls_epoch3(struct WellControls ** ctrls) {
     // and also an ORAT control
     BOOST_CHECK_EQUAL(2, well_controls_get_num(ctrls1));
 }
+} // namespace anonymous
 
 BOOST_AUTO_TEST_CASE(New_Constructor_Works) {
 

--- a/tutorials/sim_tutorial4.cpp
+++ b/tutorials/sim_tutorial4.cpp
@@ -324,12 +324,14 @@ try
     for (int i = 0; i < num_wells; ++i) {
         const int well_cells = i*nx;
         const double well_index = 1;
+        const double Kh = 1.0e-5;
         const int sat_table_id = -1;
         std::stringstream well_name;
         well_name << "well" << i;
         bool allowCrossFlow = true;
-        add_well(PRODUCER, 0, 1, NULL, &well_cells, &well_index, &sat_table_id,
-                 well_name.str().c_str(), allowCrossFlow, wells);
+        add_well(PRODUCER, 0, 1, NULL, &well_cells, &well_index, &Kh,
+                 &sat_table_id, well_name.str().c_str(), allowCrossFlow,
+                 wells);
     }
     /// \internal[well cells]
     /// \endinternal


### PR DESCRIPTION
This is mostly to assist the creation of the SCON restart array.

In particular, the helper function
```
WellManagerDetail::computeWellIndex()
```
now returns a structure that holds both the connection transmissibility factor and the effective Kh product for one particular connection.  Those values are then passed on to function
```
add_well()
```
as one additional parameter, which we store in the usual way in the new `Wells::conn_Kh` data member.

Update the callers of `add_well()` accordingly, and hide a data structure type that is only meaningful in the context of the implementation of `WellsManager::createWellsFromSpecs()`.

---

Note: This depends on&mdash;and must be merged together with&mdash;Pull Request OPM/opm-common#461.