### PR TITLE
adapt to the fluid system naming convention change in opm-material

### DIFF
--- a/examples/compute_initial_state.cpp
+++ b/examples/compute_initial_state.cpp
@@ -129,7 +129,7 @@ try
     std::vector<int> compressedToCartesianIdx
         = Opm::compressedToCartesian(grid.number_of_cells, grid.global_cell);
 
-    typedef FluidSystems::BlackOil<double> FluidSystem;
+    typedef BlackOilFluidSystem<double> FluidSystem;
 
     // Forward declaring the MaterialLawManager template.
     typedef Opm::ThreePhaseMaterialTraits<double,

--- a/opm/autodiff/BlackoilPropsAdFromDeck.hpp
+++ b/opm/autodiff/BlackoilPropsAdFromDeck.hpp
@@ -62,7 +62,7 @@ namespace Opm
     {
         friend class BlackoilPropsDataHandle;
     public:
-        typedef FluidSystems::BlackOil<double> FluidSystem;
+        typedef BlackOilFluidSystem<double> FluidSystem;
         typedef Opm::GasPvtMultiplexer<double> GasPvt;
         typedef Opm::OilPvtMultiplexer<double> OilPvt;
         typedef Opm::WaterPvtMultiplexer<double> WaterPvt;

--- a/opm/autodiff/FlowMain.hpp
+++ b/opm/autodiff/FlowMain.hpp
@@ -636,7 +636,7 @@ namespace Opm
                                                   props.numPhases()));
 
 
-                typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
+                typedef Opm::BlackOilFluidSystem<double> FluidSystem;
                 FluidSystem::initFromDeck(*deck_ , *eclipse_state_);
                 typedef EQUIL::DeckDependent::InitialStateComputer<FluidSystem> ISC;
 

--- a/opm/core/simulator/EquilibrationHelpers.hpp
+++ b/opm/core/simulator/EquilibrationHelpers.hpp
@@ -87,7 +87,7 @@ namespace Opm
     namespace EQUIL {
 
 
-    typedef Opm::FluidSystems::BlackOil<double> FluidSystemSimple;
+    typedef Opm::BlackOilFluidSystem<double> FluidSystemSimple;
 
     // Adjust oil pressure according to gas saturation and cap pressure
     typedef Opm::SimpleModularFluidState<double,

--- a/tests/test_equil_legacy.cpp
+++ b/tests/test_equil_legacy.cpp
@@ -45,7 +45,7 @@
 #include <vector>
 
 
-typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
+typedef Opm::BlackOilFluidSystem<double> FluidSystem;
 // Forward declaring the MaterialLawManager template.
 typedef Opm::ThreePhaseMaterialTraits<double,
 /*wettingPhaseIdx=*/FluidSystem::waterPhaseIdx,
@@ -409,7 +409,7 @@ BOOST_AUTO_TEST_CASE (DeckAllDead)
     MaterialLawManager materialLawManager = MaterialLawManager();
     materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
-    typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
+    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
 
     // Initialize the fluid system
     FluidSystem::initFromDeck(deck, eclipseState);
@@ -448,7 +448,7 @@ BOOST_AUTO_TEST_CASE (CapillaryInversion)
     MaterialLawManager materialLawManager = MaterialLawManager();
     materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
-    typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
+    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
     typedef MaterialLawManager::MaterialLaw MaterialLaw;
 
     if (!FluidSystem::isInitialized()) {
@@ -514,7 +514,7 @@ BOOST_AUTO_TEST_CASE (DeckWithCapillary)
     MaterialLawManager materialLawManager = MaterialLawManager();
     materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
-    typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
+    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
 
     // Initialize the fluid system
     FluidSystem::initFromDeck(deck, eclipseState);
@@ -565,7 +565,7 @@ BOOST_AUTO_TEST_CASE (DeckWithCapillaryOverlap)
     MaterialLawManager materialLawManager = MaterialLawManager();
     materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
-    typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
+    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
 
     // Initialize the fluid system
     FluidSystem::initFromDeck(deck, eclipseState);
@@ -638,7 +638,7 @@ BOOST_AUTO_TEST_CASE (DeckWithLiveOil)
     MaterialLawManager materialLawManager = MaterialLawManager();
     materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
-    typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
+    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
 
     // Initialize the fluid system
     FluidSystem::initFromDeck(deck, eclipseState);
@@ -726,7 +726,7 @@ BOOST_AUTO_TEST_CASE (DeckWithLiveGas)
     MaterialLawManager materialLawManager = MaterialLawManager();
     materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
-    typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
+    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
 
     // Initialize the fluid system
     FluidSystem::initFromDeck(deck, eclipseState);
@@ -817,7 +817,7 @@ BOOST_AUTO_TEST_CASE (DeckWithRSVDAndRVVD)
     MaterialLawManager materialLawManager = MaterialLawManager();
     materialLawManager.initFromDeck(deck, eclipseState, compressedToCartesianIdx);
 
-    typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
+    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
 
     // Initialize the fluid system
     FluidSystem::initFromDeck(deck, eclipseState);

--- a/tests/test_wellmodel.cpp
+++ b/tests/test_wellmodel.cpp
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(TestStandardWellInput) {
     const Opm::BlackoilModelParameters param;
 
     // For the conversion between the surface volume rate and resrevoir voidage rate
-    typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
+    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
     using RateConverterType = Opm::RateConverter::
         SurfaceToReservoirVoidage<FluidSystem, std::vector<int> >;
     // Compute reservoir volumes for RESV controls.
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(TestBehavoir) {
             // we should always be able to find the well in wells_ecl
             BOOST_CHECK(index_well !=  wells_ecl.size());
             // For the conversion between the surface volume rate and resrevoir voidage rate
-            typedef Opm::FluidSystems::BlackOil<double> FluidSystem;
+            typedef Opm::BlackOilFluidSystem<double> FluidSystem;
             using RateConverterType = Opm::RateConverter::
                 SurfaceToReservoirVoidage<FluidSystem, std::vector<int> >;
             // Compute reservoir volumes for RESV controls.


### PR DESCRIPTION
this is required in conjunction with OPM/opm-material#304.

note that almost the only thing which is affected is legacy code.