### PR TITLE
changed: do not remove the result path in regression tests

### DIFF
--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -15,10 +15,10 @@ EXE_NAME="${9}"
 shift 9
 TEST_ARGS="$@"
 
-rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
 ${BINPATH}/${EXE_NAME} ${TEST_ARGS} output_dir=${RESULT_PATH}
+test $? -eq 0 || exit 1
 cd ..
 
 ecode=0


### PR DESCRIPTION
in particular this leads to issues with tests sharing result dir.

i noticed that spe12 was always marked for update when update_data was ran. this is the reason. it shares data directory with spe11. since spe11 ran after, it removed the files for spe12 and thus the test was always added to the list of changed tests. furthermore we could never update the spe12 data due to this.