### PR TITLE
print usage message if the input case cannot be found

### DIFF
--- a/examples/flow.cpp
+++ b/examples/flow.cpp
@@ -130,7 +130,14 @@ int main(int argc, char** argv)
 
     std::string deckFilename = EWOMS_GET_PARAM(PreTypeTag, std::string, EclDeckFileName);
     typedef typename GET_PROP_TYPE(PreTypeTag, Vanguard) PreVanguard;
-    deckFilename = PreVanguard::canonicalDeckPath(deckFilename).string();
+    try {
+        deckFilename = PreVanguard::canonicalDeckPath(deckFilename).string();
+    }
+    catch (const std::exception& e) {
+        Ewoms::Parameters::printUsage<PreTypeTag>(PreProblem::helpPreamble(argc, const_cast<const char**>(argv)),
+                                                  e.what());
+        return 1;
+    }
 
     // Create Deck and EclipseState.
     try {


### PR DESCRIPTION
this fixes the terse error message if no input deck has been found mentioned in OPM/ewoms#364.

@akva2: please merge if this is what you had in mind.