### PR TITLE
Use ewoms well api for the well model

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -358,6 +358,16 @@ namespace Opm {
             ebosSimulator_.model().linearizer().linearize();
             ebosSimulator_.problem().endIteration();
 
+            auto& ebosJac = ebosSimulator_.model().linearizer().matrix();
+            if (param_.matrix_add_well_contributions_) {
+                wellModel().addWellContributions(ebosJac);
+            }
+            if ( param_.preconditioner_add_well_contributions_ &&
+                                  ! param_.matrix_add_well_contributions_ ) {
+                matrix_for_preconditioner_ .reset(new Mat(ebosJac));
+                wellModel().addWellContributions(*matrix_for_preconditioner_);
+            }
+
             return wellModel().lastReport();
         }
 
@@ -486,6 +496,8 @@ namespace Opm {
 
             auto& ebosJac = ebosSimulator_.model().linearizer().matrix();
             auto& ebosResid = ebosSimulator_.model().linearizer().residual();
+
+            wellModel().apply(ebosResid);
 
             // set initial guess
             x = 0.0;

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -202,6 +202,9 @@ namespace Opm {
             Opm::data::Wells wellData() const
             { return well_state_.report(phase_usage_, Opm::UgGridHelpers::globalCell(grid())); }
 
+            // substract Binv(D)rw from r;
+            void apply( BVector& r) const;
+
             // subtract B*inv(D)*C * x from A*x
             void apply(const BVector& x, BVector& Ax) const;
 
@@ -224,6 +227,13 @@ namespace Opm {
             const WellState& wellState() const;
 
             const SimulatorReport& lastReport() const;
+
+            void addWellContributions(Mat& mat)
+            {
+                for ( const auto& well: well_container_ ) {
+                    well->addWellContributions(mat);
+                }
+            }
 
             // called at the beginning of a report step
             void beginReportStep(const int time_step);

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -24,6 +24,7 @@
 #ifndef OPM_BLACKOILWELLMODEL_HEADER_INCLUDED
 #define OPM_BLACKOILWELLMODEL_HEADER_INCLUDED
 
+#include <ebos/eclproblem.hh>
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
@@ -60,12 +61,18 @@
 
 #include <opm/simulators/WellSwitchingLogger.hpp>
 
+BEGIN_PROPERTIES
+
+NEW_PROP_TAG(EnableTerminalOutput);
+
+END_PROPERTIES
 
 namespace Opm {
 
         /// Class for handling the blackoil well model.
         template<typename TypeTag>
-        class BlackoilWellModel {
+        class BlackoilWellModel : public Ewoms::BaseAuxiliaryModule<TypeTag>
+        {
         public:
             // ---------      Types      ---------
             typedef WellStateFullyImplicitBlackoil WellState;
@@ -77,6 +84,11 @@ namespace Opm {
             typedef typename GET_PROP_TYPE(TypeTag, Indices)             Indices;
             typedef typename GET_PROP_TYPE(TypeTag, Simulator)           Simulator;
             typedef typename GET_PROP_TYPE(TypeTag, Scalar)              Scalar;
+            typedef typename GET_PROP_TYPE(TypeTag, RateVector)          RateVector;
+            typedef typename GET_PROP_TYPE(TypeTag, GlobalEqVector)      GlobalEqVector;
+            typedef typename GET_PROP_TYPE(TypeTag, JacobianMatrix)      JacobianMatrix;
+
+            typedef typename Ewoms::BaseAuxiliaryModule<TypeTag>::NeighborSet NeighborSet;
 
             static const int numEq = Indices::numEq;
             static const int solventSaturationIdx = Indices::solventSaturationIdx;
@@ -101,61 +113,100 @@ namespace Opm {
             using RateConverterType = RateConverter::
                 SurfaceToReservoirVoidage<FluidSystem, std::vector<int> >;
 
-            BlackoilWellModel(Simulator& ebosSimulator,
-                              const ModelParameters& param,
-                              const bool terminal_output);
+            BlackoilWellModel(Simulator& ebosSimulator);
 
-            void initFromRestartFile(const RestartValue& restartValues)
+            void init(const Opm::EclipseState& eclState, const Opm::Schedule& schedule);
+
+            /////////////
+            // <eWoms auxiliary module stuff>
+            /////////////
+            unsigned numDofs() const
+            // No extra dofs are inserted for wells. (we use a Schur complement.)
+            { return 0; }
+
+            void addNeighbors(std::vector<NeighborSet>& neighbors) const;
+
+            void applyInitial()
+            {}
+
+            void linearize(JacobianMatrix& mat , GlobalEqVector& res);
+
+            void postSolve(GlobalEqVector& deltaX)
             {
-                // gives a dummy dynamic_list_econ_limited
-                DynamicListEconLimited dummyListEconLimited;
-                const auto& defunctWellNames = ebosSimulator_.vanguard().defunctWellNames();
-                WellsManager wellsmanager(eclState(),
-                                          schedule(),
-                                          // The restart step value is used to identify wells present at the given
-                                          // time step. Wells that are added at the same time step as RESTART is initiated
-                                          // will not be present in a restart file. Use the previous time step to retrieve
-                                          // wells that have information written to the restart file.
-                                          std::max(eclState().getInitConfig().getRestartStep() - 1, 0),
-                                          Opm::UgGridHelpers::numCells(grid()),
-                                          Opm::UgGridHelpers::globalCell(grid()),
-                                          Opm::UgGridHelpers::cartDims(grid()),
-                                          Opm::UgGridHelpers::dimensions(grid()),
-                                          Opm::UgGridHelpers::cell2Faces(grid()),
-                                          Opm::UgGridHelpers::beginFaceCentroids(grid()),
-                                          dummyListEconLimited,
-                                          grid().comm().size() > 1,
-                                          defunctWellNames);
-
-                const Wells* wells = wellsmanager.c_wells();
-
-                const int nw = wells->number_of_wells;
-                if (nw > 0) {
-                    auto phaseUsage = phaseUsageFromDeck(eclState());
-                    size_t numCells = Opm::UgGridHelpers::numCells(grid());
-                    well_state_.resize(wells, numCells, phaseUsage); //Resize for restart step
-                    wellsToState(restartValues.wells, phaseUsage, well_state_);
-                    previous_well_state_ = well_state_;
-                }
+                recoverWellSolutionAndUpdateWellState(deltaX);
             }
 
-            // compute the well fluxes and assemble them in to the reservoir equations as source terms
-            // and in the well equations.
-            void assemble(const int iterationIdx,
-                          const double dt);
+            /////////////
+            // </ eWoms auxiliary module stuff>
+            /////////////
 
-            // substract Binv(D)rw from r;
-            void apply( BVector& r) const;
+            template <class Restarter>
+            void deserialize(Restarter& res)
+            {
+                // TODO (?)
+            }
+
+            /*!
+             * \brief This method writes the complete state of the well
+             *        to the harddisk.
+             */
+            template <class Restarter>
+            void serialize(Restarter& res)
+            {
+                // TODO (?)
+            }
+
+            void beginEpisode(const Opm::EclipseState& eclState,
+                              const Opm::Schedule& schedule,
+                              bool isRestart)
+            {
+                size_t episodeIdx = ebosSimulator_.episodeIndex();
+                // beginEpisode in eclProblem advances the episode index
+                // we don't want this when we are at the beginning of an
+                // restart.
+                if (isRestart)
+                    episodeIdx -= 1;
+
+                beginReportStep(episodeIdx);
+            }
+
+            void beginTimeStep();
+
+            void beginIteration()
+            {
+                assemble(ebosSimulator_.model().newtonMethod().numIterations(),
+                         ebosSimulator_.timeStepSize());
+            }
+
+            void endIteration()
+            { }
+
+            void endTimeStep()
+            {
+                timeStepSucceeded(ebosSimulator_.time());
+            }
+
+            void endEpisode()
+            {
+                endReportStep();
+            }
+
+            template <class Context>
+            void computeTotalRatesForDof(RateVector& rate,
+                                         const Context& context,
+                                         unsigned spaceIdx,
+                                         unsigned timeIdx) const;
+
+            void initFromRestartFile(const RestartValue& restartValues);
+
+            Opm::data::Wells wellData() const
+            { return well_state_.report(phase_usage_, Opm::UgGridHelpers::globalCell(grid())); }
 
             // subtract B*inv(D)*C * x from A*x
             void apply(const BVector& x, BVector& Ax) const;
 
             // apply well model with scaling of alpha
             void applyScaleAdd(const Scalar alpha, const BVector& x, BVector& Ax) const;
-
-            // using the solution x to recover the solution xw for wells and applying
-            // xw to update Well State
-            void recoverWellSolutionAndUpdateWellState(const BVector& x);
 
             // Check if well equations is converged.
             bool getWellConvergence(const std::vector<Scalar>& B_avg) const;
@@ -172,31 +223,13 @@ namespace Opm {
             // return the internal well state
             const WellState& wellState() const;
 
-            // only use this for restart.
-            void setRestartWellState(const WellState& well_state);
-
-            // called at the beginning of a time step
-            void beginTimeStep(const int timeStepIdx,const double simulationTime);
-            // called at the end of a time step
-            void timeStepSucceeded(const double& simulationTime);
+            const SimulatorReport& lastReport() const;
 
             // called at the beginning of a report step
             void beginReportStep(const int time_step);
 
-            // called at the end of a report step
-            void endReportStep();
-
-            const SimulatorReport& lastReport() const;
-
-
-            void addWellContributions(Mat& mat)
-            {
-                for ( const auto& well: well_container_ ) {
-                        well->addWellContributions(mat);
-                }
-            }
-
         protected:
+
             void extractLegacyPressure_(std::vector<double>& cellPressure) const
             {
                 size_t nc = number_of_cells_;
@@ -233,6 +266,9 @@ namespace Opm {
             using WellInterfacePtr = std::unique_ptr<WellInterface<TypeTag> >;
             // a vector of all the wells.
             std::vector<WellInterfacePtr > well_container_;
+
+            // map from logically cartesian cell indices to compressed ones
+            std::vector<int> cartesian_to_compressed_;
 
             // create the well container
             std::vector<WellInterfacePtr > createWellContainer(const int time_step);
@@ -276,6 +312,21 @@ namespace Opm {
             const Schedule& schedule() const
             { return ebosSimulator_.vanguard().schedule(); }
 
+            // compute the well fluxes and assemble them in to the reservoir equations as source terms
+            // and in the well equations.
+            void assemble(const int iterationIdx,
+                          const double dt);
+
+            // called at the end of a time step
+            void timeStepSucceeded(const double& simulationTime);
+
+            // called at the end of a report step
+            void endReportStep();
+
+            // using the solution x to recover the solution xw for wells and applying
+            // xw to update Well State
+            void recoverWellSolutionAndUpdateWellState(const BVector& x);
+
             void updateWellControls();
 
             void updateGroupControls();
@@ -283,7 +334,7 @@ namespace Opm {
             // setting the well_solutions_ based on well_state.
             void updatePrimaryVariables();
 
-            void setupCompressedToCartesian(const int* global_cell, int number_of_cells, std::map<int,int>& cartesian_to_compressed ) const;
+            void setupCartesianToCompressed_(const int* global_cell, int number_of_cells);
 
             void computeRepRadiusPerfLength(const Grid& grid);
 
@@ -322,8 +373,7 @@ namespace Opm {
 
             void resetWellControlFromState() const;
 
-            void assembleWellEq(const double dt,
-                                bool only_wells);
+            void assembleWellEq(const double dt);
 
             // some preparation work, mostly related to group control and RESV,
             // at the beginning of each time step (Not report step)

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -99,6 +99,9 @@ namespace Opm {
         if (!localWellsActive())
             return;
 
+        // we don't what to add the schur complement
+        // here since it affects the getConvergence method
+        /*
         for (const auto& well: well_container_) {
             if (param_.matrix_add_well_contributions_)
                 well->addWellContributions(mat);
@@ -107,6 +110,7 @@ namespace Opm {
             // r = r - duneC_^T * invDuneD_ * resWell_
             well->apply(res);
         }
+        */
     }
 
 
@@ -549,6 +553,19 @@ namespace Opm {
         }
     }
 
+    template<typename TypeTag>
+    void
+    BlackoilWellModel<TypeTag>::
+    apply( BVector& r) const
+    {
+        if ( ! localWellsActive() ) {
+            return;
+        }
+
+        for (auto& well : well_container_) {
+            well->apply(r);
+        }
+    }
 
 
     // Ax = A x - C D^-1 B x

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -437,6 +437,7 @@ namespace Opm
         void setupEbosSimulator()
         {
             ebosSimulator_.reset(new EbosSimulator(/*verbose=*/false));
+            ebosSimulator_->executionTimer().start();
             ebosSimulator_->model().applyInitialSolution();
 
             try {

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -58,6 +58,8 @@ namespace Opm
     {
         Base::init(phase_usage_arg, depth_arg, gravity_arg, num_cells);
 
+        connectionRates_.resize(number_of_perforations_);
+
         perf_depth_.resize(number_of_perforations_, 0.);
         for (int perf = 0; perf < number_of_perforations_; ++perf) {
             const int cell_idx = well_cells_[perf];
@@ -241,6 +243,7 @@ namespace Opm
     StandardWell<TypeTag>::
     wellSurfaceVolumeFraction(const int compIdx) const
     {
+
         EvalWell sum_volume_fraction_scaled = 0.;
         for (int idx = 0; idx < num_components_; ++idx) {
             sum_volume_fraction_scaled += wellVolumeFractionScaled(idx);
@@ -432,23 +435,17 @@ namespace Opm
     template<typename TypeTag>
     void
     StandardWell<TypeTag>::
-    assembleWellEq(Simulator& ebosSimulator,
+    assembleWellEq(const Simulator& ebosSimulator,
                    const double dt,
-                   WellState& well_state,
-                   bool only_wells)
+                   WellState& well_state)
     {
         const int np = number_of_phases_;
 
         // clear all entries
-        if (!only_wells) {
-            duneB_ = 0.0;
-            duneC_ = 0.0;
-        }
+        duneB_ = 0.0;
+        duneC_ = 0.0;
         invDuneD_ = 0.0;
         resWell_ = 0.0;
-
-        auto& ebosJac = ebosSimulator.model().linearizer().matrix();
-        auto& ebosResid = ebosSimulator.model().linearizer().residual();
 
         // TODO: it probably can be static member for StandardWell
         const double volume = 0.002831684659200; // 0.1 cu ft;
@@ -483,34 +480,28 @@ namespace Opm
                 well_state.wellVaporizedOilRates()[index_of_well_] += perf_vap_oil_rate;
             }
 
+            if (has_energy) {
+                connectionRates_[perf][contiEnergyEqIdx] = 0.0;
+            }
+
             for (int componentIdx = 0; componentIdx < num_components_; ++componentIdx) {
                 // the cq_s entering mass balance equations need to consider the efficiency factors.
                 const EvalWell cq_s_effective = cq_s[componentIdx] * well_efficiency_factor_;
 
-                if (!only_wells) {
-                    // subtract sum of component fluxes in the reservoir equation.
-                    // need to consider the efficiency factor
-                    ebosResid[cell_idx][componentIdx] -= cq_s_effective.value();
-                }
+                connectionRates_[perf][componentIdx] = Base::restrictEval(cq_s_effective);
 
                 // subtract sum of phase fluxes in the well equations.
                 resWell_[0][componentIdx] -= cq_s_effective.value();
 
                 // assemble the jacobians
                 for (int pvIdx = 0; pvIdx < numWellEq; ++pvIdx) {
-                    if (!only_wells) {
-                        // also need to consider the efficiency factor when manipulating the jacobians.
-                        duneC_[0][cell_idx][pvIdx][componentIdx] -= cq_s_effective.derivative(pvIdx+numEq); // intput in transformed matrix
-                    }
+                    // also need to consider the efficiency factor when manipulating the jacobians.
+                    duneC_[0][cell_idx][pvIdx][componentIdx] -= cq_s_effective.derivative(pvIdx+numEq); // intput in transformed matrix
                     invDuneD_[0][0][componentIdx][pvIdx] -= cq_s_effective.derivative(pvIdx+numEq);
                 }
 
                 for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
-                    if (!only_wells) {
-                        // also need to consider the efficiency factor when manipulating the jacobians.
-                        ebosJac[cell_idx][cell_idx][componentIdx][pvIdx] -= cq_s_effective.derivative(pvIdx);
-                        duneB_[0][cell_idx][componentIdx][pvIdx] -= cq_s_effective.derivative(pvIdx);
-                    }
+                    duneB_[0][cell_idx][componentIdx][pvIdx] -= cq_s_effective.derivative(pvIdx);
                 }
 
                 // Store the perforation phase flux for later usage.
@@ -574,15 +565,7 @@ namespace Opm
                     }
                     // compute the thermal flux
                     cq_r_thermal *= extendEval(fs.enthalpy(phaseIdx)) * extendEval(fs.density(phaseIdx));
-		    // scale the flux by the scaling factor for the energy equation
-                    cq_r_thermal *= GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
-
-                    if (!only_wells) {
-                        for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
-                            ebosJac[cell_idx][cell_idx][contiEnergyEqIdx][pvIdx] -= cq_r_thermal.derivative(pvIdx);
-                        }
-                        ebosResid[cell_idx][contiEnergyEqIdx] -= cq_r_thermal.value();
-                    }
+                    connectionRates_[perf][contiEnergyEqIdx] += Base::restrictEval(cq_r_thermal);
                 }
             }
 
@@ -595,12 +578,7 @@ namespace Opm
                 } else {
                     cq_s_poly *= extendEval(intQuants.polymerConcentration() * intQuants.polymerViscosityCorrection());
                 }
-                if (!only_wells) {
-                    for (int pvIdx = 0; pvIdx < numEq; ++pvIdx) {
-                        ebosJac[cell_idx][cell_idx][contiPolymerEqIdx][pvIdx] -= cq_s_poly.derivative(pvIdx);
-                    }
-                    ebosResid[cell_idx][contiPolymerEqIdx] -= cq_s_poly.value();
-                }
+                connectionRates_[perf][contiPolymerEqIdx] = Base::restrictEval(cq_s_poly);
             }
 
             // Store the perforation pressure for later usage.
@@ -631,9 +609,16 @@ namespace Opm
         assembleControlEq();
 
         // do the local inversion of D.
-        // we do this manually with invertMatrix to always get our
-        // specializations in for 3x3 and 4x4 matrices.
-        Dune::ISTLUtility::invertMatrix(invDuneD_[0][0]);
+        try
+        {
+            Dune::ISTLUtility::invertMatrix(invDuneD_[0][0]);
+        }
+        catch( ... )
+        {
+            OPM_THROW(Opm::NumericalIssue,"Error when inverting local well equations for well " + name());
+        }
+
+
     }
 
 

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -875,7 +875,7 @@ namespace Opm
     void
     WellInterface<TypeTag>::
     computeRepRadiusPerfLength(const Grid& grid,
-                               const std::map<int, int>& cartesian_to_compressed)
+                               const std::vector<int>& cartesian_to_compressed)
     {
         const int* cart_dims = Opm::UgGridHelpers::cartDims(grid);
         auto cell_to_faces = Opm::UgGridHelpers::cell2Faces(grid);
@@ -902,12 +902,12 @@ namespace Opm
 
                 const int* cpgdim = cart_dims;
                 const int cart_grid_indx = i + cpgdim[0]*(j + cpgdim[1]*k);
-                const std::map<int, int>::const_iterator cgit = cartesian_to_compressed.find(cart_grid_indx);
-                if (cgit == cartesian_to_compressed.end()) {
+                const int cell = cartesian_to_compressed[cart_grid_indx];
+
+                if (cell < 0) {
                     OPM_THROW(std::runtime_error, "Cell with i,j,k indices " << i << ' ' << j << ' '
                               << k << " not found in grid (well = " << name() << ')');
                 }
-                const int cell = cgit->second;
 
                 {
                     double radius = connection.rw();
@@ -1023,7 +1023,7 @@ namespace Opm
         bool converged;
         WellState well_state0 = well_state;
         do {
-            assembleWellEq(ebosSimulator, dt, well_state, true);
+            assembleWellEq(ebosSimulator, dt, well_state);
 
             auto report = getWellConvergence(B_avg);
             converged = report.converged();
@@ -1047,6 +1047,7 @@ namespace Opm
             if ( terminal_output ) {
                 OpmLog::debug("WellTest: Well equation for well" +name() + " solution failed in getting converged with " + std::to_string(it) + " iterations");
             }
+            well_state = well_state0;
         }
     }
 

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -203,7 +203,6 @@ namespace Opm {
 
             auto& ebosSimulator = solver.model().ebosSimulator();
             auto& ebosProblem = ebosSimulator.problem();
-            auto phaseUsage = Opm::phaseUsageFromDeck(ebosSimulator.vanguard().eclState());
 
             // create adaptive step timer with previously used sub step size
             AdaptiveSimulatorTimer substepTimer(simulatorTimer, suggestedNextTimestep_, maxTimeStep_);
@@ -316,13 +315,7 @@ namespace Opm {
                         Opm::time::StopWatch perfTimer;
                         perfTimer.start();
 
-                        // The writeOutput expects a local data::solution vector and a local data::well vector.
-                        auto localWellData = solver.model().wellModel().wellState().report(phaseUsage, Opm::UgGridHelpers::globalCell(ebosSimulator.vanguard().grid()));
-                        ebosProblem.writeOutput(localWellData,
-                                                substepTimer.simulationTimeElapsed(),
-                                                /*isSubstep=*/true,
-                                                substepReport.total_time,
-                                                /*nextStepSize=*/-1.0);
+                        ebosProblem.writeOutput(/*isSubStep=*/true);
 
                         report.output_write_time += perfTimer.secsSinceStart();
                     }
@@ -361,6 +354,7 @@ namespace Opm {
 
                     ++restarts;
                 }
+                ebosProblem.setNextTimeStepSize(substepTimer.currentStepLength());
             }
 
 


### PR DESCRIPTION
The main purpose of this PR is to make it possible to call the well model from the code base (used by flow) in ewoms. The main difference in the code is that now assemble() does no longer apply the well terms to the residual and the Jacobian, instead this is done later in computeTotalRatesForDof(). 

TODO. 

- [x]  Test it on the big models
- [x]  Fix the SPE9_CP_RESTART test failure 
