### PR TITLE
fixed: need to init ewoms thread manager

### DIFF
--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -255,6 +255,8 @@ namespace Opm
             mpi_rank_ = 0;
             mpi_size_ = 1;
 #endif
+            typedef typename GET_PROP_TYPE(TypeTag, ThreadManager) ThreadManager;
+            ThreadManager::init();
         }
 
         // Print startup message if on output rank.


### PR DESCRIPTION
This fixes OpenMP. Not entirely sure this is where the call is wanted etc etc, but at least it points out the issue.

Without this call, manager returns 1 thread and we crash and burn in the fvbaselinearizer due to missing contexts.