### PR TITLE
flow: default to 2 threads if OpenMP is available

### DIFF
--- a/opm/autodiff/BlackoilModelParametersEbos.hpp
+++ b/opm/autodiff/BlackoilModelParametersEbos.hpp
@@ -78,6 +78,11 @@ SET_SCALAR_PROP(FlowModelParameters, MaxPressureChangeMsWells, 2.0 *1e5);
 SET_BOOL_PROP(FlowModelParameters, UseInnerIterationsMsWells, true);
 SET_INT_PROP(FlowModelParameters, MaxInnerIterMsWells, 10);
 
+// if openMP is available, determine the number threads per process automatically.
+#if _OPENMP
+SET_INT_PROP(FlowModelParameters, ThreadsPerProcess, -1);
+#endif
+
 END_PROPERTIES
 
 namespace Opm

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -255,6 +255,13 @@ namespace Opm
             mpi_rank_ = 0;
             mpi_size_ = 1;
 #endif
+
+#if _OPENMP
+            // if openMP is available, default to 2 threads per process.
+            if (!getenv("OMP_NUM_THREADS"))
+                omp_set_num_threads(std::min(2, omp_get_num_procs()));
+#endif
+
             typedef typename GET_PROP_TYPE(TypeTag, ThreadManager) ThreadManager;
             ThreadManager::init();
         }


### PR DESCRIPTION
This sets the number of threads to 2 if openMP is available. once OPM/ewoms#377 is merged, this PR is required to keep the current default behaviour, but the present PR can be merged independently.

Note that I still think it is better to specify `--threads-per-process` explicitly, but this patch is better than the current machinery...