### PR TITLE
[bugfix] Make parallel file merge work again for any --output-dir.

### DIFF
--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -425,9 +425,8 @@ namespace Opm
             }
 
             namespace fs = boost::filesystem;
-            fs::path output_path(".");
             const std::string& output_dir = eclState().getIOConfig().getOutputDir();
-
+            fs::path output_path(output_dir);
             fs::path deck_filename(EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName));
             std::for_each(fs::directory_iterator(output_path),
                           fs::directory_iterator(),


### PR DESCRIPTION
This fixes fallout from the merge of PR #1512. Since then the
ParallelFileMerger was always given the current directory even if
another output directory was requested. This resulted in
CASENAME.procid.EXT files in that directory never being merged and removed.
Now the ParallelFileMerger gets the output directory path again and does its merges.