### PR TITLE
Fix compilation issue of flow_legacy without UMFPack.

### DIFF
--- a/opm/autodiff/ISTLSolver.hpp
+++ b/opm/autodiff/ISTLSolver.hpp
@@ -155,20 +155,14 @@ namespace Opm
                 const MILU_VARIANT ilu_milu  = parameters_.ilu_milu_;
                 if (  parameters_.use_cpr_ )
                 {
-                    using Matrix         = typename MatrixOperator::matrix_type;
-                    using CouplingMetric = Dune::Amg::Diagonal<pressureIndex>;
-                    using CritBase       = Dune::Amg::SymmetricCriterion<Matrix, CouplingMetric>;
-                    using Criterion      = Dune::Amg::CoarsenCriterion<CritBase>;
-                    using AMG = typename ISTLUtility
-                        ::BlackoilAmgSelector< Matrix, Vector, Vector,POrComm, Criterion, pressureIndex >::AMG;
-
-                    std::unique_ptr< AMG > amg;
-                    // Construct preconditioner.
-                    Criterion crit(15, 2000);
-                    constructAMGPrecond<Criterion>( linearOperator, parallelInformation_arg, amg, opA, relax, ilu_milu );
-
-                    // Solve.
-                    solve(linearOperator, x, istlb, *sp, *amg, result);
+                    // We should never end up here as this code is
+                    // only part of flow_legacy  and if use_cpr_ is
+                    // true for flow_legacy then solver_approach=cpr
+                    // was specified and NewtonIterationBlackoilCPR
+                    // is used as a solve and not ISTLSolver.
+                    OPM_THROW(std::logic_error,
+                              "This code path should bever be exectuded for parameters_.use_cpr_="
+                              <<parameters_.use_cpr_<<" in flow_legacy.");
                 }
                 else
                 {


### PR DESCRIPTION
The problem was only present if UMFPack was not found and therefore
FLOW_SUPPORT_AMG was defined to true. In that case we experienced compile
errors in a source branch that would never be executed. Therefore we remove
the code there and throw an exception.

Closes #1574 