### PR TITLE
Increase default maximum iterations for both non-linear and linear solver

### DIFF
--- a/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
+++ b/opm/autodiff/NewtonIterationBlackoilInterleaved.hpp
@@ -57,7 +57,7 @@ NEW_PROP_TAG(UseCpr);
 
 SET_SCALAR_PROP(FlowIstlSolverParams, LinearSolverReduction, 1e-2);
 SET_SCALAR_PROP(FlowIstlSolverParams, IluRelaxation, 0.9);
-SET_INT_PROP(FlowIstlSolverParams, LinearSolverMaxIter, 150);
+SET_INT_PROP(FlowIstlSolverParams, LinearSolverMaxIter, 200);
 SET_INT_PROP(FlowIstlSolverParams, LinearSolverRestart, 40);
 SET_INT_PROP(FlowIstlSolverParams, FlowLinearSolverVerbosity, 0);
 SET_INT_PROP(FlowIstlSolverParams, IluFillinLevel, 0);

--- a/opm/autodiff/NonlinearSolverEbos.hpp
+++ b/opm/autodiff/NonlinearSolverEbos.hpp
@@ -45,7 +45,7 @@ NEW_PROP_TAG(FlowNewtonMinIterations);
 NEW_PROP_TAG(NewtonRelaxationType);
 
 SET_SCALAR_PROP(FlowNonLinearSolver, NewtonMaxRelax, 0.5);
-SET_INT_PROP(FlowNonLinearSolver, FlowNewtonMaxIterations, 10);
+SET_INT_PROP(FlowNonLinearSolver, FlowNewtonMaxIterations, 20);
 SET_INT_PROP(FlowNonLinearSolver, FlowNewtonMinIterations, 1);
 SET_STRING_PROP(FlowNonLinearSolver, NewtonRelaxationType, "dampen");
 


### PR DESCRIPTION
During testing we needed to increase the number of iterations to get all simulations through. Please double check that I have done this the right places, I find setting of defaults quite confusing at this point in time. The legacy code and the new parameter system co-existing is not helping in this respect. These changes are presumed uncontroversial, so hopefully possible to merge. More controversial changes will be posted in a separate PR.