### PR TITLE
[For testing] updating IPR and determine the operability of the well based on IPR and BHP

### DIFF
--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -214,6 +214,8 @@ namespace Opm
         using Base::perf_length_;
         using Base::bore_diameters_;
 
+        using Base::is_well_operable_;
+
         // densities of the fluid in each perforation
         std::vector<double> perf_densities_;
         // pressure drop between different perforations
@@ -350,10 +352,11 @@ namespace Opm
         void updateIPR(const Simulator& ebos_simulator) const;
 
         // check whether the well is operable under the current reservoir condition
-        // mostly related to BHP limit and THP limit
-        // One thing is not covered in this function is that even we pass this check,
-        // we might not get desired well rates with respect to the well type (injector/producer)
-        // it will be called everytime when we try to assemble the well equations
+        // mostly related to BHP limit and THP limit, and also the BHP under this iteration
+        // For the BHP limit and THP limit, they are the hard limits.
+        // What if the BHP we obtained for this iteration is too high, while the well can work under
+        // BHP limit or THP limit, then how should we handle this,
+        // TODO: maybe we should switch to the less strict one between BHP limit and THP limit?
         void checkWellOperatability(const Simulator& ebos_simulator);
 
         // check whether the well is operable under BHP limit with current reservoir condition

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -242,6 +242,13 @@ namespace Opm
         // the saturations in the well bore under surface conditions at the beginning of the time step
         std::vector<double> F0_;
 
+        // the vectors used to describe the inflow performance relationship (IPR)
+        // Q = IPR_A - BHP * IPR_B
+        // TODO: it minght need to go to WellInterface, let us implement it in StandardWell first
+        // TODO: first implementationn will only hanle producers
+        mutable std::vector<double> ipr_a_;
+        mutable std::vector<double> ipr_b_;
+
         const EvalWell& getBhp() const;
 
         EvalWell getQs(const int comp_idx) const;
@@ -338,6 +345,22 @@ namespace Opm
 
         // handle the non reasonable fractions due to numerical overshoot
         void processFractions() const;
+
+        // updating the inflow based on the current reservoir condition
+        void updateIPR(const Simulator& ebos_simulator) const;
+
+        // check whether the well is operable under the current reservoir condition
+        // mostly related to BHP limit and THP limit
+        // One thing is not covered in this function is that even we pass this check,
+        // we might not get desired well rates with respect to the well type (injector/producer)
+        // it will be called everytime when we try to assemble the well equations
+        void checkWellOperatability(const Simulator& ebos_simulator);
+
+        // check whether the well is operable under BHP limit with current reservoir condition
+        bool operableUnderBHPLimit(const Simulator& ebos_simulator) const;
+
+        // check whether the well is operable under THP limit with current reservoir condition
+        bool operableUnderTHPLimit(const Simulator& ebos_simulator) const;
 
     };
 

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -2312,7 +2312,7 @@ namespace Opm
             // to taking into consideration the crossflow here.
             assert(pressure_diff > 0.);
 
-            // TODO: there are some indices related problems here
+            // TODO: there might be some indices related problems here
             // phases vs components
             // they are the ipr values for the perforation
             std::vector<double> ipr_a_perf(ipr_a_.size());
@@ -2349,7 +2349,8 @@ namespace Opm
             }
         }
 
-        std::cout << " the inflow performance relationship curves for the well " << name() << std::endl;
+        // debugging output for the IPR relationship
+        /* std::cout << " the inflow performance relationship curves for the well " << name() << std::endl;
         std::cout << " ipr_a ";
         for (const double value : ipr_a_) {
             std::cout << " " << value * 86400.;
@@ -2359,11 +2360,10 @@ namespace Opm
         for (const double value : ipr_b_) {
             std::cout << " " << value * 86400.;
         }
-        std::cout << std::endl;
-        // TODO: should we consider rs, rv and b for this
-        // ideally, yes, let us try without it first to see what gonna happen
+        std::cout << std::endl; */
+
         // TODO: we should be able to consider rs, rv and b for this, assuming we do not need to consider
-        // cross-flow here, since h_perf should be relatively small value
+        // cross-flow here, since h_perf should be relatively small value compared with reservoir pressure
     }
 
 
@@ -2403,7 +2403,7 @@ namespace Opm
                 std::cout << " well " << name() << " not operatable under BHP limit " << bhp_limit << std::endl;
                 well_operable = false;
             } else {
-                std::cout << " well " << name() << " working well with BHP limit " << bhp_limit << std::endl;
+                // std::cout << " well " << name() << " working well with BHP limit " << bhp_limit << std::endl;
             }
         }
 
@@ -2424,7 +2424,7 @@ namespace Opm
                 std::cout << " well " << name() << " not operatable under BHP value " << current_bhp << std::endl;
                 well_operable = false;
             } else {
-                std::cout << " well " << name() << " working well with current BHP value " << current_bhp << std::endl;
+                // std::cout << " well " << name() << " working well with current BHP value " << current_bhp << std::endl;
             }
         }
 
@@ -2453,7 +2453,6 @@ namespace Opm
         // 2. it does not violate the THP limit when producing under BHP limit
 
         // if either of the above is false, the well should be SHUT for this iteration
-
 
         // if the well is requested to run under THP target, we will test
         // if the well can be operated under the THP target.

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -231,6 +231,7 @@ namespace Opm
 
         const Well* wellEcl() const;
 
+        bool isWellOperable() const;
 
     protected:
 
@@ -296,8 +297,6 @@ namespace Opm
 
         const PhaseUsage* phase_usage_;
 
-        bool getAllowCrossFlow() const;
-
         const VFPProperties* vfp_properties_;
 
         double gravity_;
@@ -310,6 +309,14 @@ namespace Opm
         const int pvtRegionIdx_;
 
         const int num_components_;
+
+        // whether the well is operable under current control setup and reservoir condition
+        bool is_well_operable_;
+
+
+        // private functions
+
+        bool getAllowCrossFlow() const;
 
         const PhaseUsage& phaseUsage() const;
 


### PR DESCRIPTION
In this PR we update the inflow performance relationship (IPR) for each iteration, for each well. 

Then based on the BHP limit and BHP value obtained during iteration to determine the operability of the well. The criterion employed here most likely will not be the one we will use eventually. 

Since the criterion of  `shutting` is not well established yet, as a result, the related WTEST will not work probably.  

This PR is created for testing and it is not ready for merge or review. 