### PR TITLE
WellState FIBO: Return Segment Vectors from report()

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -70,6 +70,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_stoppedwells.cpp
   tests/test_relpermdiagnostics.cpp
   tests/test_norne_pvt.cpp
+  tests/test_wellstatefullyimplicitblackoil.cpp
   )
 
 if(MPI_FOUND)

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -428,7 +428,8 @@ namespace Opm {
                                const int report_step,
                                WellStateFullyImplicitBlackoil& state ) const;
 
-            bool anyMSWellOpen(const Wells* wells, const int report_step) const;
+            // whether there exists any multisegment well open on this process
+            bool anyMSWellOpenLocal(const Wells* wells, const int report_step) const;
 
             const Well* getWellEcl(const std::string& well_name) const;
         };

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -423,9 +423,14 @@ namespace Opm {
 
             // convert well data from opm-common to well state from opm-core
             void wellsToState( const data::Wells& wells,
-                               PhaseUsage phases,
-                               WellStateFullyImplicitBlackoil& state );
+                               const PhaseUsage& phases,
+                               const bool handle_ms_well,
+                               const int report_step,
+                               WellStateFullyImplicitBlackoil& state ) const;
 
+            bool anyMSWellOpen(const Wells* wells, const int report_step) const;
+
+            const Well* getWellEcl(const std::string& well_name) const;
         };
 
 

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -456,9 +456,13 @@ namespace Opm
             {
                 // we need to create a trival segment related values to avoid there will be some
                 // multi-segment wells added later.
+                nseg_ = nw;
+                seg_number_.clear();
                 top_segment_index_.reserve(nw);
+                seg_number_.reserve(nw);
                 for (int w = 0; w < nw; ++w) {
                     top_segment_index_.push_back(w);
+                    seg_number_.push_back(1); // Top segment is segment #1
                 }
                 segpress_ = bhp();
                 segrates_ = wellRates();

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -280,6 +280,7 @@ namespace Opm
             {
                 // we need to create a trival segment related values to avoid there will be some
                 // multi-segment wells added later.
+                nseg_ = nw;
                 top_segment_index_.reserve(nw);
                 for (int w = 0; w < nw; ++w) {
                     top_segment_index_.push_back(w);

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -281,23 +281,28 @@ namespace Opm
                 // we need to create a trival segment related values to avoid there will be some
                 // multi-segment wells added later.
                 nseg_ = nw;
-                seg_number_.clear();
-                top_segment_index_.reserve(nw);
-                seg_number_.reserve(nw);
+                top_segment_index_.resize(nw);
+                seg_number_.resize(nw);
                 for (int w = 0; w < nw; ++w) {
-                    top_segment_index_.push_back(w);
-                    seg_number_.push_back(1); // Top segment is segment #1
+                    top_segment_index_[w] = w;
+                    seg_number_[w] = 1; // Top segment is segment #1
                 }
                 segpress_ = bhp();
                 segrates_ = wellRates();
             }
         }
 
-        void resize(const Wells* wells, const Schedule& schedule, std::size_t numCells, const PhaseUsage& pu)
+
+        void resize(const Wells* wells, const std::vector<const Well*>& wells_ecl, const Schedule& schedule,
+                    const bool handle_ms_well, const int report_step, const size_t numCells,
+                    const PhaseUsage& pu)
         {
             const std::vector<double> tmp(numCells, 0.0); // <- UGLY HACK to pass the size
-            const std::vector<const Well*> wells_ecl;
             init(wells, tmp, schedule, wells_ecl, 0, nullptr, pu);
+
+            if (handle_ms_well) {
+                initWellStateMSWell(wells, wells_ecl, report_step, pu, nullptr);
+            }
         }
 
         /// Allocate and initialize if wells is non-null.  Also tries
@@ -601,9 +606,8 @@ namespace Opm
 
 
         /// init the MS well related.
-        template <typename PrevWellState>
         void initWellStateMSWell(const Wells* wells, const std::vector<const Well*>& wells_ecl,
-                                 const int time_step, const PhaseUsage& pu, const PrevWellState& prev_well_state)
+                                 const int time_step, const PhaseUsage& pu, const WellStateFullyImplicitBlackoil* prev_well_state)
         {
             // still using the order in wells
             const int nw = wells->number_of_wells;
@@ -733,13 +737,13 @@ namespace Opm
             assert(int(segpress_.size()) == nseg_);
             assert(int(segrates_.size()) == nseg_ * numPhases() );
 
-            if (!prev_well_state.wellMap().empty()) {
+            if (prev_well_state && !prev_well_state->wellMap().empty()) {
                 // copying MS well related
-                const auto& end = prev_well_state.wellMap().end();
+                const auto& end = prev_well_state->wellMap().end();
                 const int np = numPhases();
                 for (int w = 0; w < nw; ++w) {
                     const std::string name( wells->name[w] );
-                    const auto& it = prev_well_state.wellMap().find( name );
+                    const auto& it = prev_well_state->wellMap().find( name );
 
                     if (it != end) { // the well is found in the prev_well_state
                         // TODO: the well with same name can change a lot, like they might not have same number of segments
@@ -747,7 +751,7 @@ namespace Opm
                         // for now, we just copy them.
                         const int old_index_well = (*it).second[0];
                         const int new_index_well = w;
-                        const int old_top_segment_index = prev_well_state.topSegmentIndex(old_index_well);
+                        const int old_top_segment_index = prev_well_state->topSegmentIndex(old_index_well);
                         const int new_top_segmnet_index = topSegmentIndex(new_index_well);
                         int number_of_segment = 0;
                         // if it is the last well in list
@@ -758,11 +762,11 @@ namespace Opm
                         }
 
                         for (int i = 0; i < number_of_segment * np; ++i) {
-                            segrates_[new_top_segmnet_index * np + i] = prev_well_state.segRates()[old_top_segment_index * np + i];
+                            segrates_[new_top_segmnet_index * np + i] = prev_well_state->segRates()[old_top_segment_index * np + i];
                         }
 
                         for (int i = 0; i < number_of_segment; ++i) {
-                            segpress_[new_top_segmnet_index + i] = prev_well_state.segPress()[old_top_segment_index + i];
+                            segpress_[new_top_segmnet_index + i] = prev_well_state->segPress()[old_top_segment_index + i];
                         }
                     }
                 }

--- a/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/autodiff/WellStateFullyImplicitBlackoil.hpp
@@ -25,8 +25,12 @@
 #include <opm/core/well_controls.h>
 #include <opm/core/simulator/WellState.hpp>
 #include <opm/core/props/BlackoilPhases.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+
 #include <opm/common/ErrorMacros.hpp>
+
 #include <vector>
 #include <cassert>
 #include <string>

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -74,8 +74,7 @@ namespace {
             setup.es, setup.sched, timeStep, *setup.grid.c_grid()
         };
 
-        state.init(wmgr.c_wells(), cpress, setup.sched,
-                   setup.sched.getWells(timeStep),
+        state.init(wmgr.c_wells(), cpress, setup.sched.getWells(timeStep),
                    timeStep, nullptr, setup.pu);
 
         state.initWellStateMSWell(wmgr.c_wells(), setup.sched.getWells(timeStep),

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -64,7 +64,6 @@ namespace {
     buildWellState(const Setup& setup, const std::size_t timeStep)
     {
         auto state  = Opm::WellStateFullyImplicitBlackoil{};
-        auto state0 = Opm::WellStateFullyImplicitBlackoil{}; // Empty.
 
         const auto cpress =
             std::vector<double>(setup.grid.c_grid()->number_of_cells,
@@ -74,11 +73,13 @@ namespace {
             setup.es, setup.sched, timeStep, *setup.grid.c_grid()
         };
 
-        state.init(wmgr.c_wells(), cpress, setup.sched.getWells(timeStep),
+        state.init(wmgr.c_wells(), cpress, setup.sched,
+                   setup.sched.getWells(timeStep),
                    timeStep, nullptr, setup.pu);
 
-        state.initWellStateMSWell(wmgr.c_wells(), setup.sched.getWells(timeStep),
-                                  timeStep, setup.pu, state0);
+        state.initWellStateMSWell(wmgr.c_wells(),
+                                  setup.sched.getWells(timeStep),
+                                  timeStep, setup.pu, nullptr);
 
         return state;
     }

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -84,6 +84,7 @@ namespace {
         return state;
     }
 
+
     void setSegPress(const std::vector<const Opm::Well*>& wells,
                      const std::size_t                    tstep,
                      Opm::WellStateFullyImplicitBlackoil& wstate)
@@ -110,6 +111,7 @@ namespace {
             }
         }
     }
+
 
     void setSegRates(const std::vector<const Opm::Well*>& wells,
                      const std::size_t                    tstep,
@@ -159,6 +161,8 @@ namespace {
 
 BOOST_AUTO_TEST_SUITE(Segment)
 
+// ---------------------------------------------------------------------
+
 BOOST_AUTO_TEST_CASE(Linearisation)
 {
     const Setup setup{ "msw.data" };
@@ -177,6 +181,8 @@ BOOST_AUTO_TEST_CASE(Linearisation)
     BOOST_CHECK_EQUAL(wstate.topSegmentIndex(1),
                       prod01_first ? 6 : 1);
 }
+
+// ---------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(Pressure)
 {
@@ -219,6 +225,8 @@ BOOST_AUTO_TEST_CASE(Pressure)
         }
     }
 }
+
+// ---------------------------------------------------------------------
 
 BOOST_AUTO_TEST_CASE(Rates)
 {

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -1,0 +1,285 @@
+/*
+  Copyright 2018 Equinor ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE WellStateFIBOTest
+
+#include <opm/autodiff/WellStateFullyImplicitBlackoil.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
+
+#include <opm/core/props/BlackoilPhases.hpp>
+#include <opm/core/props/phaseUsageFromDeck.hpp>
+#include <opm/core/wells/WellsManager.hpp>
+#include <opm/core/wells.h>
+
+#include <opm/grid/GridManager.hpp>
+
+#include <cstddef>
+#include <string>
+
+struct Setup
+{
+    Setup(const std::string& filename)
+        : Setup(Opm::Parser{}.parseFile(filename))
+    {}
+
+    Setup(const Opm::Deck& deck)
+        : es   (deck)
+        , pu   (Opm::phaseUsageFromDeck(es))
+        , grid (es.getInputGrid())
+        , sched(deck, es)
+    {}
+
+    Opm::EclipseState es;
+    Opm::PhaseUsage   pu;
+    Opm::GridManager  grid;
+    Opm::Schedule     sched;
+};
+
+namespace {
+    Opm::WellStateFullyImplicitBlackoil
+    buildWellState(const Setup& setup, const std::size_t timeStep)
+    {
+        auto state  = Opm::WellStateFullyImplicitBlackoil{};
+        auto state0 = Opm::WellStateFullyImplicitBlackoil{}; // Empty.
+
+        const auto cpress =
+            std::vector<double>(setup.grid.c_grid()->number_of_cells,
+                                100.0*Opm::unit::barsa);
+
+        const Opm::WellsManager wmgr{
+            setup.es, setup.sched, timeStep, *setup.grid.c_grid()
+        };
+
+        state.init(wmgr.c_wells(), cpress, setup.sched,
+                   setup.sched.getWells(timeStep),
+                   timeStep, nullptr, setup.pu);
+
+        state.initWellStateMSWell(wmgr.c_wells(), setup.sched.getWells(timeStep),
+                                  timeStep, setup.pu, state0);
+
+        return state;
+    }
+
+    void setSegPress(const std::vector<const Opm::Well*>& wells,
+                     const std::size_t                    tstep,
+                     Opm::WellStateFullyImplicitBlackoil& wstate)
+    {
+        const auto nWell = wells.size();
+
+        auto& segPress = wstate.segPress();
+
+        for (auto wellID = 0*nWell; wellID < nWell; ++wellID) {
+            const auto* well     = wells[wellID];
+            const auto  topSegIx = wstate.topSegmentIndex(wellID);
+            const auto  pressTop = 100.0 * wellID;
+
+            segPress[topSegIx] = pressTop;
+
+            if (! well->isMultiSegment(tstep)) {
+                continue;
+            }
+
+            const auto nSeg = well->getWellSegments(tstep).size();
+
+            for (auto segID = 0*nSeg + 1; segID < nSeg; ++segID) {
+                segPress[topSegIx + segID] = pressTop + 1.0*segID;
+            }
+        }
+    }
+
+    void setSegRates(const std::vector<const Opm::Well*>& wells,
+                     const std::size_t                    tstep,
+                     const Opm::PhaseUsage&               pu,
+                     Opm::WellStateFullyImplicitBlackoil& wstate)
+    {
+        const auto wat = pu.phase_used[Opm::BlackoilPhases::Aqua];
+        const auto iw  = wat ? pu.phase_pos[Opm::BlackoilPhases::Aqua] : -1;
+
+        const auto oil = pu.phase_used[Opm::BlackoilPhases::Liquid];
+        const auto io  = oil ? pu.phase_pos[Opm::BlackoilPhases::Liquid] : -1;
+
+        const auto gas = pu.phase_used[Opm::BlackoilPhases::Vapour];
+        const auto ig  = gas ? pu.phase_pos[Opm::BlackoilPhases::Vapour] : -1;
+
+        const auto np = wstate.numPhases();
+
+        const auto nWell = wells.size();
+
+        auto& segRates = wstate.segRates();
+
+        for (auto wellID = 0*nWell; wellID < nWell; ++wellID) {
+            const auto* well     = wells[wellID];
+            const auto  topSegIx = wstate.topSegmentIndex(wellID);
+            const auto  rateTop = 1000.0 * wellID;
+
+            if (wat) { segRates[np*topSegIx + iw] = rateTop; }
+            if (oil) { segRates[np*topSegIx + io] = rateTop; }
+            if (gas) { segRates[np*topSegIx + ig] = rateTop; }
+
+            if (! well->isMultiSegment(tstep)) {
+                continue;
+            }
+
+            const auto nSeg = well->getWellSegments(tstep).size();
+
+            for (auto segID = 0*nSeg + 1; segID < nSeg; ++segID) {
+                auto* rates = &segRates[(topSegIx + segID) * np];
+
+                if (wat) { rates[iw] = rateTop + 100.0*segID; }
+                if (oil) { rates[io] = rateTop + 200.0*segID; }
+                if (gas) { rates[ig] = rateTop + 400.0*segID; }
+            }
+        }
+    }
+} // Anonymous
+
+BOOST_AUTO_TEST_SUITE(Segment)
+
+BOOST_AUTO_TEST_CASE(Linearisation)
+{
+    const Setup setup{ "msw.data" };
+    const auto tstep = std::size_t{0};
+
+    const auto wstate = buildWellState(setup, tstep);
+
+    BOOST_CHECK_EQUAL(wstate.numSegment(), 6 + 1);
+
+    const auto& wells = setup.sched.getWells(tstep);
+    BOOST_CHECK_EQUAL(wells.size(), 2);
+
+    const auto prod01_first = wells[0]->name() == "PROD01";
+
+    BOOST_CHECK_EQUAL(wstate.topSegmentIndex(0), 0);
+    BOOST_CHECK_EQUAL(wstate.topSegmentIndex(1),
+                      prod01_first ? 6 : 1);
+}
+
+BOOST_AUTO_TEST_CASE(Pressure)
+{
+    const Setup setup{ "msw.data" };
+    const auto tstep = std::size_t{0};
+
+    auto wstate = buildWellState(setup, tstep);
+
+    const auto& wells = setup.sched.getWells(tstep);
+    const auto prod01_first = wells[0]->name() == "PROD01";
+
+    setSegPress(wells, tstep, wstate);
+
+    const auto rpt = wstate.report(setup.pu, setup.grid.c_grid()->global_cell);
+
+    {
+        const auto& xw = rpt.at("INJE01");
+
+        BOOST_CHECK_EQUAL(xw.segments.size(), 1); // Top Segment
+
+        const auto& xseg = xw.segments.at(1);
+
+        BOOST_CHECK_EQUAL(xseg.segNumber, 1);
+        BOOST_CHECK_CLOSE(xseg.pressure, prod01_first ? 100.0 : 0.0, 1.0e-10);
+    }
+
+    {
+        const auto expect_nSeg = 6;
+        const auto& xw = rpt.at("PROD01");
+
+        BOOST_CHECK_EQUAL(xw.segments.size(), expect_nSeg);
+
+        const auto pressTop = prod01_first ? 0.0 : 100.0;
+
+        for (auto segID = 0; segID < expect_nSeg; ++segID) {
+            const auto& xseg = xw.segments.at(segID + 1);
+
+            BOOST_CHECK_EQUAL(xseg.segNumber, segID + 1);
+            BOOST_CHECK_CLOSE(xseg.pressure, pressTop + 1.0*segID, 1.0e-10);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Rates)
+{
+    const Setup setup{ "msw.data" };
+    const auto tstep = std::size_t{0};
+
+    auto wstate = buildWellState(setup, tstep);
+
+    const auto& wells = setup.sched.getWells(tstep);
+    const auto prod01_first = wells[0]->name() == "PROD01";
+
+    const auto& pu = setup.pu;
+
+    setSegRates(wells, tstep, pu, wstate);
+
+    const auto rpt = wstate.report(pu, setup.grid.c_grid()->global_cell);
+
+    const auto wat = pu.phase_used[Opm::BlackoilPhases::Aqua];
+    const auto oil = pu.phase_used[Opm::BlackoilPhases::Liquid];
+    const auto gas = pu.phase_used[Opm::BlackoilPhases::Vapour];
+
+    BOOST_CHECK(wat && oil && gas);
+
+    {
+        const auto rateTop = prod01_first ? 1000.0 : 0.0;
+
+        const auto& xw = rpt.at("INJE01");
+
+        BOOST_CHECK_EQUAL(xw.segments.size(), 1); // Top Segment
+
+        const auto& xseg = xw.segments.at(1);
+
+        BOOST_CHECK_EQUAL(xseg.segNumber, 1);
+        BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::wat), rateTop, 1.0e-10);
+        BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::oil), rateTop, 1.0e-10);
+        BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::gas), rateTop, 1.0e-10);
+    }
+
+    {
+        const auto expect_nSeg = 6;
+        const auto& xw = rpt.at("PROD01");
+
+        BOOST_CHECK_EQUAL(xw.segments.size(), expect_nSeg);
+
+        const auto rateTop = prod01_first ? 0.0 : 1000.0;
+
+        for (auto segID = 0; segID < expect_nSeg; ++segID) {
+            const auto& xseg = xw.segments.at(segID + 1);
+
+            BOOST_CHECK_EQUAL(xseg.segNumber, segID + 1);
+
+            BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::wat),
+                              rateTop + 100.0*segID, 1.0e-10);
+
+            BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::oil),
+                              rateTop + 200.0*segID, 1.0e-10);
+
+            BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::gas),
+                              rateTop + 400.0*segID, 1.0e-10);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This pull request extends class `WellStateFullyImplictBlackoil` to report segment-related quantities as `Opm::data::Segment` objects (included in `Opm::data::WellRates` objects).  All wells have at least a top
segment in the context of WellState FIBO, so there is a meaningful value to report for each well.

We put the extraction of segment-related quantities into a new helper function
```
WellStateFullyImplicitBlackoil::reportSegmentResults()
```
to avoid cluttering up the body of `report()` more than absolutely needed.

The primary use-case for this is assigning appropriate values to items 8 through 11 of restart vector `RSEG`.  In turn, this will enable restoring these quantities from a restart file.

The implementation is based on reading the surrounding and calling source code, so I am not fully convinced that the way I am indexing into `segRates()` and `segPress()` is correct.  Corrections is much appreciated.

---
**Note**

This pull request depends on OPM/opm-common#514 and must not be merged before that is in place.