### PR TITLE
relaxation to avoid overshoot of fractions of StandardWell

### DIFF
--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -363,7 +363,7 @@ namespace Opm
         static double determineRelaxationFactorProducer(const std::vector<double>& primary_variables,
                                                         const BVectorWell& dwells);
 
-        // calcualte a relaxation factor to avoid overshoot for injectors
+        // calculate a relaxation factor to avoid overshoot for injectors
         static double determineRelaxationFactorInjector(const std::vector<double>& primary_variables,
                                                         const BVectorWell& dwells);
     };

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -358,14 +358,14 @@ namespace Opm
         static double relaxationFactorFraction(const double old_value,
                                                const double dx);
 
-        // calculate a relaxation factor to avoid overshoot
+        // calculate a relaxation factor to avoid overshoot of the fractions for producers
         // which might result in negative rates
-        static double determineRelaxationFactorProducer(const std::vector<double>& primary_variables,
+        static double relaxationFactorFractionsProducer(const std::vector<double>& primary_variables,
                                                         const BVectorWell& dwells);
 
-        // calculate a relaxation factor to avoid overshoot for injectors
-        static double determineRelaxationFactorInjector(const std::vector<double>& primary_variables,
-                                                        const BVectorWell& dwells);
+        // calculate a relaxation factor to avoid overshoot of total rates
+        static double relaxationFactorRate(const std::vector<double>& primary_variables,
+                                           const BVectorWell& dwells);
     };
 
 }

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -354,6 +354,18 @@ namespace Opm
         // handle the non reasonable fractions due to numerical overshoot
         void processFractions() const;
 
+        // relaxation factor considering only one fraction value
+        static double relaxationFactorFraction(const double old_value,
+                                               const double dx);
+
+        // calculate a relaxation factor to avoid overshoot
+        // which might result in negative rates
+        static double determineRelaxationFactorProducer(const std::vector<double>& primary_variables,
+                                                        const BVectorWell& dwells);
+
+        // calcualte a relaxation factor to avoid overshoot for injectors
+        static double determineRelaxationFactorInjector(const std::vector<double>& primary_variables,
+                                                        const BVectorWell& dwells);
     };
 
 }


### PR DESCRIPTION
It only applies to `producers` now. And solvent model is not handled yet.

For now, we have two fraction variables (F_w for water, F_g for gas) (one more when solvent is present) as primary variables for well. In theory, fraction values should always be between 0 and 1.0. (0. <= F_w <= 1.0,  0. <= F_g <= 1.0).  For oil,   0. <= (F_o = 1.0 - (F_w + F_g)) <= 1.0.

Due to numerical overshoot, from time to time, we can get some undesired fraction values. Like F_p {p = w, 0, g} is negative or above 1.0.

The current implementation is something as follows, (slightly more complicated while the spirit is the same)
if F_p < 0.  then F_p = 0.;
if F_p > 1. , then F_p = 1.;

As a result, when this numerical chopping happens, we can get some zero fractions (numerically). As a result, we get some zero rates due to numerical reason.  For most of the control mode, it does not cause problem. When THP/VFP control is involved, it is not the case anymore.  Since two interpolation directions of the VFP tables are ratios. With zero rates due to numerical reason, we get `NAN` and `INF` ratio values due to numerical reason. 

This PR is introducing a relaxation factor to avoid undesirable fraction values happens during Newton update. 

The PR is created for discussion purpose without saying this is the correct or best way to do it. 


