### PR TITLE
flow: print the startup banner immediately

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -138,7 +138,8 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    Opm::FlowMainEbos<PreTypeTag>::printBanner();
+    if (outputCout)
+        Opm::FlowMainEbos<PreTypeTag>::printBanner();
 
     // Create Deck and EclipseState.
     try {

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -134,13 +134,16 @@ int main(int argc, char** argv)
         deckFilename = PreVanguard::canonicalDeckPath(deckFilename).string();
     }
     catch (const std::exception& e) {
-        Ewoms::Parameters::printUsage<PreTypeTag>(PreProblem::helpPreamble(argc, const_cast<const char**>(argv)),
-                                                  e.what());
+        std::cerr << "Exception received: " << e.what() << ". Try '--help' for a usage description.\n";
         return 1;
     }
 
+    Opm::FlowMainEbos<PreTypeTag>::printBanner();
+
     // Create Deck and EclipseState.
     try {
+        std::cout << "Reading deck file '" << deckFilename << "'\n";
+        std::cout.flush();
         Opm::Parser parser;
         typedef std::pair<std::string, Opm::InputError::Action> ParseModePair;
         typedef std::vector<ParseModePair> ParseModePairs;

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -19,7 +19,6 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-
 #ifndef OPM_FLOW_MAIN_EBOS_HEADER_INCLUDED
 #define OPM_FLOW_MAIN_EBOS_HEADER_INCLUDED
 

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -193,6 +193,24 @@ namespace Opm
             return status;
         }
 
+        static void printBanner()
+        {
+            const int lineLen = 70;
+            const std::string version = moduleVersionName();
+            const std::string banner = "This is flow "+version;
+            const int bannerPreLen = (lineLen - 2 - banner.size())/2;
+            const int bannerPostLen = bannerPreLen + (lineLen - 2 - banner.size())%2;
+            std::cout << "**********************************************************************\n";
+            std::cout << "*                                                                    *\n";
+            std::cout << "*" << std::string(bannerPreLen, ' ') << banner << std::string(bannerPostLen, ' ') << "*\n";
+            std::cout << "*                                                                    *\n";
+            std::cout << "* Flow is a simulator for fully implicit three-phase black-oil flow, *\n";
+            std::cout << "*             including solvent and polymer capabilities.            *\n";
+            std::cout << "*          For more information, see https://opm-project.org         *\n";
+            std::cout << "*                                                                    *\n";
+            std::cout << "**********************************************************************\n\n";
+        }
+
         /// This is the main function of Flow.  It runs a complete simulation with the
         /// given grid and simulator classes, based on the user-specified command-line
         /// input.
@@ -207,7 +225,6 @@ namespace Opm
 
                 setupParallelism();
                 setupOutput();
-                printStartupMessage();
                 setupEbosSimulator();
                 setupLogging();
                 printPRTHeader();
@@ -264,28 +281,6 @@ namespace Opm
 
             typedef typename GET_PROP_TYPE(TypeTag, ThreadManager) ThreadManager;
             ThreadManager::init();
-        }
-
-        // Print startup message if on output rank.
-        void printStartupMessage()
-        {
-
-            if (output_cout_) {
-                const int lineLen = 70;
-                const std::string version = moduleVersionName();
-                const std::string banner = "This is flow "+version;
-                const int bannerPreLen = (lineLen - 2 - banner.size())/2;
-                const int bannerPostLen = bannerPreLen + (lineLen - 2 - banner.size())%2;
-                std::cout << "**********************************************************************\n";
-                std::cout << "*                                                                    *\n";
-                std::cout << "*" << std::string(bannerPreLen, ' ') << banner << std::string(bannerPostLen, ' ') << "*\n";
-                std::cout << "*                                                                    *\n";
-                std::cout << "* Flow is a simulator for fully implicit three-phase black-oil flow, *\n";
-                std::cout << "*             including solvent and polymer capabilities.            *\n";
-                std::cout << "*          For more information, see https://opm-project.org          *\n";
-                std::cout << "*                                                                    *\n";
-                std::cout << "**********************************************************************\n\n";
-            }
         }
 
         // Extract the minimum priority and determines if log files ought to be created.

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -921,7 +921,7 @@ protected:
                 milun_decomposition( A, iluIteration, milu, *ILU, *reorderer, *inverseReorderer );
             }
         }
-        catch ( Dune::MatrixBlockError error )
+        catch ( const Dune::MatrixBlockError& error )
         {
             message = error.what();
             std::cerr<<"Exception occured on process " << rank << " during " <<


### PR DESCRIPTION
also, add a "reading deck" output. The idea is to make `flow`'s behaviour less surprising by preventing people from thinking that it got stuck after starting `flow` for a large deck.
