### PR TITLE
well model: fix valgrind complaints if either oil or gas are disabled

### DIFF
--- a/opm/autodiff/RateConverter.hpp
+++ b/opm/autodiff/RateConverter.hpp
@@ -692,8 +692,21 @@ namespace Opm {
                 }
 
                 // Use average Rs and Rv:
-                double Rs = std::min(ra.rs, surface_rates[ig]/(surface_rates[io]+1.0e-15));
-                double Rv = std::min(ra.rv, surface_rates[io]/(surface_rates[ig]+1.0e-15));
+                auto a = ra.rs;
+                auto b = a;
+                if (io >= 0 && ig >= 0) {
+                    b = surface_rates[ig]/(surface_rates[io]+1.0e-15);
+                }
+
+                double Rs = std::min(a, b);
+
+                a = ra.rv;
+                b = a;
+                if (io >= 0 && ig >= 0) {
+                    b = surface_rates[io]/(surface_rates[ig]+1.0e-15);
+                }
+
+                double Rv = std::min(a, b);
 
                 // Determinant of 'R' matrix
                 const double detR = 1.0 - (Rs * Rv);


### PR DESCRIPTION
if a phase is disabled the active index (in the context of the well model this accessed via `PhasePos`/`phaseUsage`) is `-1` which leads to some hiccups if it is used to actually access some data.

I suspect that this is the cause for the jenkins failure of #1604 because the 2p oil-water testcase with aquifiers passes on my local machine.