### PR TITLE
Ignoring overlap cells in parallel ILU factorization

### DIFF
--- a/opm/autodiff/BlackoilDetails.hpp
+++ b/opm/autodiff/BlackoilDetails.hpp
@@ -221,7 +221,7 @@ namespace detail {
                 {		
                     const auto& elem = *elemIt;
 
-                    //If cell has partition type not equual to interior save row
+                    //If cell has partition type not equal to interior save row
                     if (elem.partitionType() != Dune::InteriorEntity)
                     {		    
                         //local id of overlap cell

--- a/opm/autodiff/BlackoilDetails.hpp
+++ b/opm/autodiff/BlackoilDetails.hpp
@@ -195,61 +195,57 @@ namespace detail {
             std::size_t count = countLocalInteriorCells(grid);
             return grid.comm().sum(count);
         }
+
         /// \brief Find the rows corresponding to overlap cells
         ///
         /// Loop over grid and store cell ids of row-column pairs 
-        /// corrsponding to overlap cells.
+        /// corresponding to overlap cells.
         /// \tparam The type of the DUNE grid.
         /// \param grid The grid where we look for overlap cells.
         /// \param overlapRowAndColumns List where overlap rows and columns are stored.
         template<class Grid>
-	void findOverlapRowsAndColumns(const Grid & grid,std::vector<std::pair<int,std::vector<int>>> &overlapRowAndColumns )
-	{
-	  //only relevant in parallel case.
-	  if ( grid.comm().size() > 1)
-	    {
-	      //Numbering of cells
-	      auto lid = grid.localIdSet();
-	      
-	      const auto& gridView = grid.leafGridView();
-	      auto elemIt = gridView.template begin<0>();
-	      const auto& elemEndIt = gridView.template end<0>();
-	      
-	      //loop over cells in mesh
-	      for (; elemIt != elemEndIt; ++elemIt) {
-		
-		const auto& elem = *elemIt;
-		
-		//If cell has partition type not equual to interior save row
-		if (elem.partitionType() != Dune::InteriorEntity)
-		  {
-		    
-		    //local id of overlap cell
-		    int lcell = lid.id(elem);
-		    
-		    //
-		    std::vector<int> columns;
-		    //loop over faces of cell
-		    auto isend = gridView.iend(elem);
-		    for (auto is = gridView.ibegin(elem); is!=isend; ++is) 
-		      {
-			//check if face has neighbor
-			if (is->neighbor())
-			  {
-			    //get index of neighbor cell
-			    int ncell = lid.id(is->outside());
-			    
-			    columns.push_back(ncell);
-			  }
-			
-		      }
-		    //add row to list
-		    overlapRowAndColumns.push_back(std::pair<int,std::vector<int>>(lcell,columns));	
-		  }    
-	      }	      
-	    }
-	}
+        void findOverlapRowsAndColumns(const Grid& grid, std::vector<std::pair<int,std::vector<int>>>& overlapRowAndColumns )
+        {
+            //only relevant in parallel case.
+            if ( grid.comm().size() > 1) 
+            {
+                //Numbering of cells
+                auto lid = grid.localIdSet();
 
+                const auto& gridView = grid.leafGridView();
+                auto elemIt = gridView.template begin<0>();
+                const auto& elemEndIt = gridView.template end<0>();
+
+                //loop over cells in mesh
+                for (; elemIt != elemEndIt; ++elemIt) 
+                {		
+                    const auto& elem = *elemIt;
+
+                    //If cell has partition type not equual to interior save row
+                    if (elem.partitionType() != Dune::InteriorEntity)
+                    {		    
+                        //local id of overlap cell
+                        int lcell = lid.id(elem);
+
+                        std::vector<int> columns;
+                        //loop over faces of cell
+                        auto isend = gridView.iend(elem);
+                        for (auto is = gridView.ibegin(elem); is!=isend; ++is) 
+                        {
+                            //check if face has neighbor
+                            if (is->neighbor())
+                            {
+                                //get index of neighbor cell
+                                int ncell = lid.id(is->outside());			    
+                                columns.push_back(ncell);
+                            }		
+                        }
+                        //add row to list
+                        overlapRowAndColumns.push_back(std::pair<int,std::vector<int>>(lcell,columns));	
+                    }    
+                }	      
+            }
+        }				       
     } // namespace detail
 } // namespace Opm
 

--- a/opm/autodiff/BlackoilDetails.hpp
+++ b/opm/autodiff/BlackoilDetails.hpp
@@ -195,7 +195,60 @@ namespace detail {
             std::size_t count = countLocalInteriorCells(grid);
             return grid.comm().sum(count);
         }
-
+        /// \brief Find the rows corresponding to overlap cells
+        ///
+        /// Loop over grid and store cell ids of row-column pairs 
+        /// corrsponding to overlap cells.
+        /// \tparam The type of the DUNE grid.
+        /// \param grid The grid where we look for overlap cells.
+        /// \param overlapRowAndColumns List where overlap rows and columns are stored.
+        template<class Grid>
+	void findOverlapRowsAndColumns(const Grid & grid,std::vector<std::pair<int,std::vector<int>>> &overlapRowAndColumns )
+	{
+	  //only relevant in parallel case.
+	  if ( grid.comm().size() > 1)
+	    {
+	      //Numbering of cells
+	      auto lid = grid.localIdSet();
+	      
+	      const auto& gridView = grid.leafGridView();
+	      auto elemIt = gridView.template begin<0>();
+	      const auto& elemEndIt = gridView.template end<0>();
+	      
+	      //loop over cells in mesh
+	      for (; elemIt != elemEndIt; ++elemIt) {
+		
+		const auto& elem = *elemIt;
+		
+		//If cell has partition type not equual to interior save row
+		if (elem.partitionType() != Dune::InteriorEntity)
+		  {
+		    
+		    //local id of overlap cell
+		    int lcell = lid.id(elem);
+		    
+		    //
+		    std::vector<int> columns;
+		    //loop over faces of cell
+		    auto isend = gridView.iend(elem);
+		    for (auto is = gridView.ibegin(elem); is!=isend; ++is) 
+		      {
+			//check if face has neighbor
+			if (is->neighbor())
+			  {
+			    //get index of neighbor cell
+			    int ncell = lid.id(is->outside());
+			    
+			    columns.push_back(ncell);
+			  }
+			
+		      }
+		    //add row to list
+		    overlapRowAndColumns.push_back(std::pair<int,std::vector<int>>(lcell,columns));	
+		  }    
+	      }	      
+	    }
+	}
 
     } // namespace detail
 } // namespace Opm

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -510,8 +510,82 @@ namespace Opm {
             // Solve system.
             if( isParallel() )
             {
-                typedef WellModelMatrixAdapter< Mat, BVector, BVector, BlackoilWellModel<TypeTag>, true > Operator;
-                Operator opA(ebosJac, actual_mat_for_prec, wellModel(),
+
+	      
+	        typedef WellModelMatrixAdapter< Mat, BVector, BVector, BlackoilWellModel<TypeTag>, true > Operator;
+
+
+		auto ebosJacIgnoreOverlap = Dune::BCRSMatrix< MatrixBlockType >(ebosJac);
+  
+  
+		//local id's of cells
+		auto lid = grid_.localIdSet();
+		
+		//value to set on diagonal
+		double diag_val = 1.0e100;
+		
+		const auto& gridView = ebosSimulator_.gridView();
+		auto elemIt = gridView.template begin<0>();
+		const auto& elemEndIt = gridView.template end<0>();
+		
+		//loop over cells in mesh
+		for (; elemIt != elemEndIt; ++elemIt) {
+		  
+		  const auto& elem = *elemIt;
+		  
+		  //If cell has partition type not equal to Interior change matrix
+		  if (elem.partitionType() != Dune::InteriorEntity)
+		    {
+		      
+		      //find local id of overlap cell
+		      int lcell = lid.id(elem);
+		      
+		      //loop over block matrix 
+		      for (int ii=0;ii<numEq;++ii)
+			{
+			  for (int jj=0;jj<numEq;++jj)
+			    {
+			      //If we are on the diagonal set matrix to "large" value. Otherwise set value to zero
+			      if (ii==jj)
+				{	
+				  ebosJacIgnoreOverlap[lcell][lcell][ii][jj]=diag_val;//std::numeric_limits<double>::max();   
+				}
+			      else
+				{
+				  ebosJacIgnoreOverlap[lcell][lcell][ii][jj]=0.0;
+				}
+			    }
+			}
+		      
+		      //loop over faces of cell
+		      auto isend = gridView.iend(elem);
+		      for (auto is = gridView.ibegin(elem); is!=isend; ++is) 
+			{
+			  //check if face has neighbour
+			  if (is->neighbor())
+			    {
+			      //get index of neighbour cell
+			      int ncell = lid.id(is->outside());
+			      
+			      //loop over block matrix and zero out all values.
+			      for (int ii=0;ii<numEq;++ii)
+				{
+				  for (int jj=0;jj<numEq;++jj)
+				    { 
+				      ebosJacIgnoreOverlap[lcell][ncell][ii][jj]=0.0;
+				    }
+				}
+			    }
+			  
+			}
+		      
+		    }
+		  
+		}
+
+		//Not sure what actual_mat_for_prec is, so put ebosJacIgnoreOverlap as both variables
+		//to be certain that correct matrix is used for preconditioning.
+                Operator opA(ebosJacIgnoreOverlap, ebosJacIgnoreOverlap, wellModel(),
                              istlSolver().parallelInformation() );
                 assert( opA.comm() );
                 istlSolver().solve( opA, x, ebosResid, *(opA.comm()) );

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -492,22 +492,22 @@ namespace Opm {
         {	  	  
             //value to set on diagonal
             MatrixBlockType diag_block(0.0);
-            for (int ii=0;ii<numEq;++ii)	    
-                diag_block[ii][ii]=1.0e100;
+            for (int eq = 0; eq < numEq; ++eq)	    
+                diag_block[eq][eq] = 1.0e100;
 	  	  
             //loop over precalculated overlap rows and columns
-            for ( auto row = overlapRowAndColumns_.begin(); row != overlapRowAndColumns_.end(); row++ )
+            for (auto row = overlapRowAndColumns_.begin(); row != overlapRowAndColumns_.end(); row++ )
             {
                 int lcell = row->first; 
                 //diagonal block set to large value diagonal
-                ebosJacIgnoreOverlap[lcell][lcell]=diag_block;
+                ebosJacIgnoreOverlap[lcell][lcell] = diag_block;
 
                 //loop over off diagonal blocks in overlap row	      
-                for(auto col = row->second.begin(); col != row->second.end(); ++col)
+                for (auto col = row->second.begin(); col != row->second.end(); ++col)
                 {
                     int ncell = *col;
                     //zero out block
-                    ebosJacIgnoreOverlap[lcell][ncell]=0.0;
+                    ebosJacIgnoreOverlap[lcell][ncell] = 0.0;
                 }
             }    	  
         }

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -538,7 +538,7 @@ namespace Opm {
             // Solve system.
             if( isParallel() )
             {	      
-	        typedef WellModelMatrixAdapter< Mat, BVector, BVector, BlackoilWellModel<TypeTag>, true > Operator;
+                typedef WellModelMatrixAdapter< Mat, BVector, BVector, BlackoilWellModel<TypeTag>, true > Operator;
 
                 auto ebosJacIgnoreOverlap = Mat(ebosJac);
                 //remove ghost rows in local matrix

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -166,8 +166,8 @@ namespace Opm {
         {
             // compute global sum of number of cells
             global_nc_ = detail::countGlobalCells(grid_);
-	    //find rows of matrix corresponding to overlap
-	    detail::findOverlapRowsAndColumns(grid_,overlapRowAndColumns_);
+            //find rows of matrix corresponding to overlap
+            detail::findOverlapRowsAndColumns(grid_,overlapRowAndColumns_);
             if (!istlSolver_)
             {
                 OPM_THROW(std::logic_error,"solver down cast to ISTLSolver failed");
@@ -486,33 +486,31 @@ namespace Opm {
             return istlSolver().iterations();
         }
 
-
+        /// Zero out off-diagonal blocks on rows corresponding to overlap cells
+        /// Diagonal blocks on ovelap rows are set to diag(1e100).
         void makeOverlapRowsInvalid(Mat& ebosJacIgnoreOverlap) const
-        {
+        {	  	  
+            //value to set on diagonal
+            MatrixBlockType diag_block(0.0);
+            for (int ii=0;ii<numEq;++ii)	    
+                diag_block[ii][ii]=1.0e100;
 	  	  
-	  //value to set on diagonal
-	  MatrixBlockType diag_block(0.0);
-	  for (int ii=0;ii<numEq;++ii)
-	    diag_block[ii][ii]=1.0e100;
-	  	  
-	  //loop over precalculated overlap rows and columns
-	  for ( auto row = overlapRowAndColumns_.begin(); row != overlapRowAndColumns_.end(); row++ )
-	    {
-	      int lcell = row->first; 
-	      //diagonal block set to large value diagonal
-	      ebosJacIgnoreOverlap[lcell][lcell]=diag_block;
-	      
-	      //loop over off diagonal blocks in overlap row	      
-	      for(auto col = row->second.begin(); col != row->second.end(); ++col)
-		{
-		  int ncell = *col;
-		  //zero out block
-		  ebosJacIgnoreOverlap[lcell][ncell]=0.0;
-		}
-	    }
-    
-	  
-	}
+            //loop over precalculated overlap rows and columns
+            for ( auto row = overlapRowAndColumns_.begin(); row != overlapRowAndColumns_.end(); row++ )
+            {
+                int lcell = row->first; 
+                //diagonal block set to large value diagonal
+                ebosJacIgnoreOverlap[lcell][lcell]=diag_block;
+
+                //loop over off diagonal blocks in overlap row	      
+                for(auto col = row->second.begin(); col != row->second.end(); ++col)
+                {
+                    int ncell = *col;
+                    //zero out block
+                    ebosJacIgnoreOverlap[lcell][ncell]=0.0;
+                }
+            }    	  
+        }
 
         /// Solve the Jacobian system Jx = r where J is the Jacobian and
         /// r is the residual.
@@ -539,18 +537,15 @@ namespace Opm {
             const Mat& actual_mat_for_prec = matrix_for_preconditioner_ ? *matrix_for_preconditioner_.get() : ebosJac;
             // Solve system.
             if( isParallel() )
-            {
-
-	      
+            {	      
 	        typedef WellModelMatrixAdapter< Mat, BVector, BVector, BlackoilWellModel<TypeTag>, true > Operator;
 
+                auto ebosJacIgnoreOverlap = Mat(ebosJac);
+                //remove ghost rows in local matrix
+                makeOverlapRowsInvalid(ebosJacIgnoreOverlap);
 
-		auto ebosJacIgnoreOverlap = Mat(ebosJac);
-		//remove ghost rows in local matrix
-		makeOverlapRowsInvalid(ebosJacIgnoreOverlap);
-		
-		//Not sure what actual_mat_for_prec is, so put ebosJacIgnoreOverlap as both variables
-		//to be certain that correct matrix is used for preconditioning.
+                //Not sure what actual_mat_for_prec is, so put ebosJacIgnoreOverlap as both variables
+                //to be certain that correct matrix is used for preconditioning.
                 Operator opA(ebosJacIgnoreOverlap, ebosJacIgnoreOverlap, wellModel(),
                              istlSolver().parallelInformation() );
                 assert( opA.comm() );
@@ -1011,8 +1006,7 @@ namespace Opm {
         double current_relaxation_;
         BVector dx_old_;
 
-        std::unique_ptr<Mat> matrix_for_preconditioner_;
-      
+        std::unique_ptr<Mat> matrix_for_preconditioner_;        
         std::vector<std::pair<int,std::vector<int>>> overlapRowAndColumns_;
     public:
         /// return the StandardWells object


### PR DESCRIPTION
In parallel Flow, the ILU factorization of the local matrix is based on the entire local matrix, composed of rows, corresponding to both interior and overlap cells. This is a mistake, since overlap rows are not correct. 

One should instead restrict the ILU factorization to the "interior" local matrix. An easy way of achieving this in Flow without changing the data structures is to zero out overlap rows, but leaving infinity (or a large number) in the diagonal. This is implemented in this pull request, by altering the method solveJacobianSystem in the BlackoilModelEbos class.

The improvements in convergence of the linear solver for parallel Flow are quite good, and can be observed in tables below for the Norne and Modell 2 cases (note that results for Norne comes from a somewhat older version of Flow). Linear iterations here refer to total linear iteration required to run through a case.

Table for Norne:

                          
|procs|        modified lin. iter       |   original   lin. iter.   |
|----------|------------------|----------------|
|1|                24182      |       24182|
|2  |             23842       |      27513|
|4 |              24170        |      29162|
|8   |            24712        |      29949|
|16   |       24290           |   29826|
|32    |        24036         |     34294|
|48  |          24607         |     43258 |
|64 |           25465         |     45970|
|80|            24896         |     41038 |
|96| 25583  | 38173| 
|112| 26092|44846 |
|128|26110 |39583 |

   
 
Table for Model 2, due to testing by Markus (focus on linear iterations): 

                                       
|procs | Master lin. iter| Master  time |      modified   lin. iter  | modified  time |
|-----|-----------|---------|--------|------------|
  | 16 |    100051  | 1987.8   |   51011 | 1277.1 |
 | 8   |   70555  | 1276.5   |   50348 | 1024.5 |
|4  |    67035  | 1198.2  |    52707  |1007.5 |
|2 |     52978  | 1202.2 |     52257  |1135.9| 
