### PR TITLE
detecting whether some well control events happens to a well

### DIFF
--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -172,7 +172,7 @@ namespace Opm {
             const double p = fs.pressure(FluidSystem::oilPhaseIdx).value();
             cellPressures[cellIdx] = p;
         }
-        well_state_.init(wells(), cellPressures, &previous_well_state_, phase_usage_);
+        well_state_.init(wells(), cellPressures, wells_ecl_, timeStepIdx, &previous_well_state_, phase_usage_);
 
         // handling MS well related
         if (param_.use_multisegment_well_) { // if we use MultisegmentWell model
@@ -364,7 +364,7 @@ namespace Opm {
         if (nw > 0) {
             auto phaseUsage = phaseUsageFromDeck(eclState());
             size_t numCells = Opm::UgGridHelpers::numCells(grid());
-            well_state_.resize(wells, numCells, phaseUsage); //Resize for restart step
+            well_state_.resize(wells, numCells); //Resize for restart step
             wellsToState(restartValues.wells, phaseUsage, well_state_);
             previous_well_state_ = well_state_;
         }
@@ -938,18 +938,19 @@ namespace Opm {
             WellControls* wc = well->wellControls();
             const int control = well_controls_get_current(wc);
             well_state_.currentControls()[w] = control;
-            // TODO: for VFP control, the perf_densities are still zero here, investigate better
-            // way to handle it later.
-            well->updateWellStateWithTarget(well_state_);
 
-            // The wells are not considered to be newly added
-            // for next time step
-            if (well_state_.isNewWell(w) ) {
-                well_state_.setNewWell(w, false);
+            if (well_state_.effectiveEventsHappen(w) ) {
+                well->updateWellStateWithTarget(well_state_);
+            }
+
+            // there is no new well control change input within a report step,
+            // so next time step, the well does not consider to have effective events anymore
+            if (well_state_.effectiveEventsHappen(w) ) {
+                well_state_.setEffeciveEventHappen(w, false);
             }
         }  // end of for (int w = 0; w < nw; ++w)
 
-
+        updatePrimaryVariables();
     }
 
 
@@ -1185,8 +1186,10 @@ namespace Opm {
             // it will not change the control mode, only update the targets
             wellCollection().updateWellTargets(well_state_.wellRates());
 
+            // TODO: we should only do the well is involved in the update group targets
             for (auto& well : well_container_) {
                 well->updateWellStateWithTarget(well_state_);
+                well->updatePrimaryVariables(well_state_);
             }
         }
     }

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -362,9 +362,9 @@ namespace Opm {
 
         const int nw = wells->number_of_wells;
         if (nw > 0) {
-            auto phaseUsage = phaseUsageFromDeck(eclState());
-            size_t numCells = Opm::UgGridHelpers::numCells(grid());
-            well_state_.resize(wells, numCells); //Resize for restart step
+            const auto phaseUsage = phaseUsageFromDeck(eclState());
+            const size_t numCells = Opm::UgGridHelpers::numCells(grid());
+            well_state_.resize(wells, numCells, phaseUsage); // Resize for restart step
             wellsToState(restartValues.wells, phaseUsage, well_state_);
             previous_well_state_ = well_state_;
         }
@@ -939,14 +939,14 @@ namespace Opm {
             const int control = well_controls_get_current(wc);
             well_state_.currentControls()[w] = control;
 
-            if (well_state_.effectiveEventsHappen(w) ) {
+            if (well_state_.effectiveEventsOccurred(w) ) {
                 well->updateWellStateWithTarget(well_state_);
             }
 
             // there is no new well control change input within a report step,
             // so next time step, the well does not consider to have effective events anymore
-            if (well_state_.effectiveEventsHappen(w) ) {
-                well_state_.setEffeciveEventHappen(w, false);
+            if (well_state_.effectiveEventsOccurred(w) ) {
+                well_state_.setEffectiveEventsOccurred(w, false);
             }
         }  // end of for (int w = 0; w < nw; ++w)
 

--- a/opm/autodiff/MultisegmentWell_impl.hpp
+++ b/opm/autodiff/MultisegmentWell_impl.hpp
@@ -373,8 +373,6 @@ namespace Opm
 
             break;
         } // end of switch
-
-        updatePrimaryVariables(well_state);
     }
 
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -460,7 +460,7 @@ namespace Opm
 
         const Wells* wells = wellsmanager.c_wells();
         size_t numCells = Opm::UgGridHelpers::numCells(grid);
-        wellstate.resize(wells, numCells, phaseUsage ); //Resize for restart step
+        wellstate.resize(wells, numCells); //Resize for restart step
         auto restart_values = eclIO_->loadRestart(solution_keys, extra_keys);
 
         solutionToSim( restart_values, phaseUsage, simulatorstate );

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilOutput.hpp
@@ -460,7 +460,7 @@ namespace Opm
 
         const Wells* wells = wellsmanager.c_wells();
         size_t numCells = Opm::UgGridHelpers::numCells(grid);
-        wellstate.resize(wells, numCells); //Resize for restart step
+        wellstate.resize(wells, numCells, phaseUsage); //Resize for restart step
         auto restart_values = eclIO_->loadRestart(solution_keys, extra_keys);
 
         solutionToSim( restart_values, phaseUsage, simulatorstate );

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -1214,8 +1214,6 @@ namespace Opm
 
             break;
         } // end of switch
-
-        updatePrimaryVariables(well_state);
     }
 
 
@@ -1908,13 +1906,14 @@ namespace Opm
         } else {
             // the well has a THP related constraint
             // checking whether a well is newly added, it only happens at the beginning of the report step
-            if ( !well_state.isNewWell(index_of_well_) ) {
+            if ( !well_state.effectiveEventsHappen(index_of_well_) ) {
                 for (int p = 0; p < np; ++p) {
                     // This is dangerous for new added well
                     // since we are not handling the initialization correctly for now
                     well_potentials[p] = well_state.wellRates()[index_of_well_ * np + p];
                 }
-            } else {
+            } else
+            {
                 // We need to generate a reasonable rates to start the iteration process
                 computeWellRatesWithBhp(ebosSimulator, bhp, well_potentials);
                 for (double& value : well_potentials) {

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -1906,14 +1906,13 @@ namespace Opm
         } else {
             // the well has a THP related constraint
             // checking whether a well is newly added, it only happens at the beginning of the report step
-            if ( !well_state.effectiveEventsHappen(index_of_well_) ) {
+            if ( !well_state.effectiveEventsOccurred(index_of_well_) ) {
                 for (int p = 0; p < np; ++p) {
                     // This is dangerous for new added well
                     // since we are not handling the initialization correctly for now
                     well_potentials[p] = well_state.wellRates()[index_of_well_ * np + p];
                 }
-            } else
-            {
+            } else {
                 // We need to generate a reasonable rates to start the iteration process
                 computeWellRatesWithBhp(ebosSimulator, bhp, well_potentials);
                 for (double& value : well_potentials) {

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -438,6 +438,7 @@ namespace Opm
 
         if (updated_control_index != old_control_index) { //  || well_collection_->groupControlActive()) {
             updateWellStateWithTarget(well_state);
+            updatePrimaryVariables(well_state);
         }
     }
 


### PR DESCRIPTION
 When there is some events happen to a well, we use the control mode
 from the DECK, and update the WellState based on the new control model.
 Otherwise, we can use the control mode from the previous well state,
 and keep the values from the previous well state as an intial guess.