### PR TITLE
minimal change to make code work if HAVE_DUNE_ISTL not set

### DIFF
--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -33,7 +33,7 @@
 #include <numeric>
 #include <type_traits>
 
-#if HAVE_MPI && HAVE_DUNE_ISTL
+#if HAVE_MPI //&& HAVE_DUNE_ISTL
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <mpi.h>


### PR DESCRIPTION
Minimal change to make compilation work for parallel if HAVE_DUNE_ISTL is not set of some reason
The problem is in a lot of other code which use the 
if HAVE_MPI 
which depend on the code avoid bye including && HAVE_DUNE_ISTL
(Probably this codelines will brake in parallel, but opm should at least compile) 
