### PR TITLE
Updating thp when valid VFP table is specified

### DIFF
--- a/opm/autodiff/AutoDiffHelpers.hpp
+++ b/opm/autodiff/AutoDiffHelpers.hpp
@@ -365,7 +365,7 @@ spdiag(const AutoDiffBlock<double>::V& d)
     public:
         typedef AutoDiffBlock<Scalar> ADB;
 
-        enum CriterionForLeftElement { GreaterEqualZero, GreaterZero, Zero, NotEqualZero, LessZero, LessEqualZero, NotNaN };
+        enum CriterionForLeftElement { GreaterEqualZero, GreaterZero, Zero, NotEqualZero, LessZero, LessEqualZero, NotNaN, NotNaNInf };
 
         Selector(const typename ADB::V& selection_basis,
                  CriterionForLeftElement crit = GreaterEqualZero)
@@ -399,6 +399,9 @@ spdiag(const AutoDiffBlock<double>::V& d)
                     break;
                 case NotNaN:
                     chooseleft = !isnan(selection_basis[i]);
+                    break;
+                case NotNaNInf:
+                    chooseleft = !isnan(selection_basis[i]) && !std::isinf(selection_basis[i]);
                     break;
                 default:
                     OPM_THROW(std::logic_error, "No such criterion: " << crit);

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -844,8 +844,6 @@ namespace Opm {
         // we simply return.
         if( !wellsActive() ) return ;
 
-#if HAVE_OPENMP
-#endif // HAVE_OPENMP
         wellhelpers::WellSwitchingLogger logger;
 
         for (const auto& well : well_container_) {

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -331,7 +331,7 @@ namespace Opm
         template <class ValueType>
         ValueType calculateBhpFromThp(const std::vector<ValueType>& rates, const int control_index) const;
 
-        double calculateThpFromBhp(const std::vector<double>& rates, const int control_index, const double bhp) const;
+        double calculateThpFromBhp(const std::vector<double>& rates, const double bhp) const;
 
         // get the mobility for specific perforation
         void getMobility(const Simulator& ebosSimulator,

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -1110,7 +1110,6 @@ namespace Opm
                 rates[ Gas ] = well_state.wellRates()[index_of_well_ * number_of_phases_ + pu.phase_pos[ Gas ] ];
             }
 
-            // TODO: we should have some guard here to avoid some NAN or INF ratios
             const double bhp = well_state.bhp()[index_of_well_];
 
             well_state.thp()[index_of_well_] = calculateThpFromBhp(rates, bhp);

--- a/opm/autodiff/VFPHelpers.hpp
+++ b/opm/autodiff/VFPHelpers.hpp
@@ -557,6 +557,15 @@ const T* getTable(const std::map<int, T*> tables, int table_id) {
     }
 }
 
+/**
+ * Check whether we have a table with the table number
+ */
+template <typename T>
+bool hasTable(const std::map<int, T*> tables, int table_id) {
+    const auto entry = tables.find(table_id);
+    return (entry != tables.end() );
+}
+
 
 /**
  * Returns the type variable for FLO/GFR/WFR for production tables

--- a/opm/autodiff/VFPHelpers.hpp
+++ b/opm/autodiff/VFPHelpers.hpp
@@ -550,7 +550,7 @@ template <typename T>
 const T* getTable(const std::map<int, T*> tables, int table_id) {
     auto entry = tables.find(table_id);
     if (entry == tables.end()) {
-        OPM_THROW(std::invalid_argument, "Nonexistent table " << table_id << " referenced.");
+        OPM_THROW(std::invalid_argument, "Nonexistent VFP table " << table_id << " referenced.");
     }
     else {
         return entry->second;

--- a/opm/autodiff/VFPHelpersLegacy.hpp
+++ b/opm/autodiff/VFPHelpersLegacy.hpp
@@ -37,15 +37,15 @@ typedef AutoDiffBlock<double> ADB;
 
 
 /**
- * Returns zero for every entry in the ADB which is NaN
- */
-inline ADB zeroIfNan(const ADB& values) {
-    Selector<ADB::V::Scalar> not_nan_selector(values.value(), Selector<ADB::V::Scalar>::NotNaN);
+ *  * Returns zero for every entry in the ADB which is NaN or INF
+ *   */
+inline ADB zeroIfNanInf(const ADB& values) {
+    Selector<ADB::V::Scalar> not_nan_inf_selector(values.value(), Selector<ADB::V::Scalar>::NotNaNInf);
 
     const ADB::V z = ADB::V::Zero(values.size());
     const ADB zero = ADB::constant(z, values.blockPattern());
 
-    ADB retval = not_nan_selector.select(values, zero);
+    ADB retval = not_nan_inf_selector.select(values, zero);
     return retval;
 }
 

--- a/opm/autodiff/VFPInjProperties.cpp
+++ b/opm/autodiff/VFPInjProperties.cpp
@@ -91,9 +91,12 @@ double VFPInjProperties::thp(int table_id,
     return retval;
 }
 
-
 const VFPInjTable* VFPInjProperties::getTable(const int table_id) const {
     return detail::getTable(m_tables, table_id);
+}
+
+bool VFPInjProperties::hasTable(const int table_id) const {
+    return detail::hasTable(m_tables, table_id);
 }
 
 } //Namespace Opm

--- a/opm/autodiff/VFPInjProperties.hpp
+++ b/opm/autodiff/VFPInjProperties.hpp
@@ -110,6 +110,11 @@ public:
     const VFPInjTable* getTable(const int table_id) const;
 
     /**
+     * Check whether there is table associated with ID
+     */
+    bool hasTable(const int table_id) const;
+
+    /**
      * Returns true if no vfp tables are in the current map
      */
     bool empty() const {

--- a/opm/autodiff/VFPProdProperties.cpp
+++ b/opm/autodiff/VFPProdProperties.cpp
@@ -105,5 +105,9 @@ const VFPProdTable* VFPProdProperties::getTable(const int table_id) const {
     return detail::getTable(m_tables, table_id);
 }
 
+bool VFPProdProperties::hasTable(const int table_id) const {
+    return detail::hasTable(m_tables, table_id);
+}
+
 
 }

--- a/opm/autodiff/VFPProdProperties.hpp
+++ b/opm/autodiff/VFPProdProperties.hpp
@@ -159,6 +159,11 @@ public:
     const VFPProdTable* getTable(const int table_id) const;
 
     /**
+     * Check whether there is table associated with ID
+     */
+    bool hasTable(const int table_id) const;
+
+    /**
      * Returns true if no vfp tables are in the current map
      */
     bool empty() const {

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -334,6 +334,9 @@ namespace Opm
 
         double scalingFactor(const int comp_idx) const;
 
+        // whether a well is specified with a non-zero and valid VFP table number
+        bool isVFPActive() const;
+
         void wellTestingEconomic(Simulator& simulator, const std::vector<double>& B_avg,
                                  const double simulation_time, const int report_step, const bool terminal_output,
                                  const WellState& well_state, WellTestState& welltest_state);

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -979,6 +979,50 @@ namespace Opm
 
 
 
+
+    template<typename TypeTag>
+    bool
+    WellInterface<TypeTag>::isVFPActive() const
+    {
+        // since the well_controls only handles the VFP number when THP constraint/target is there.
+        // we need to get the table number through the parser, in case THP constraint/target is not there.
+        // When THP control/limit is not active, if available VFP table is provided, we will still need to
+        // update THP value. However, it will only used for output purpose.
+
+        if (well_type_ == PRODUCER) { // producer
+            const int table_id = well_ecl_->getProductionProperties(current_step_).VFPTableNumber;
+            if (table_id <= 0) {
+                return false;
+            } else {
+                if (vfp_properties_->getProd()->getTable(table_id)) {
+                    return true;
+                } else {
+                    OPM_THROW(std::runtime_error, "VFPPROD table " << std::to_string(table_id) << " is specfied,"
+                              << " for well " << name() << ", while we could not access it during simulation");
+                    return false;
+                }
+            }
+
+        } else { // injector
+            const int table_id = well_ecl_->getInjectionProperties(current_step_).VFPTableNumber;
+            if (table_id <= 0) {
+                return false;
+            } else {
+                if (vfp_properties_->getInj()->getTable(table_id)) {
+                    return true;
+                } else {
+                    OPM_THROW(std::runtime_error, "VFPINJ table " << std::to_string(table_id) << " is specfied,"
+                              << " for well " << name() << ", while we could not access it during simulation");
+                    return false;
+                }
+            }
+        }
+    }
+
+
+
+
+
     template<typename TypeTag>
     void
     WellInterface<TypeTag>::calculateReservoirRates(WellState& well_state) const

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -996,10 +996,6 @@ namespace Opm
             } else {
                 if (vfp_properties_->getProd()->getTable(table_id)) {
                     return true;
-                } else {
-                    OPM_THROW(std::runtime_error, "VFPPROD table " << std::to_string(table_id) << " is specfied,"
-                              << " for well " << name() << ", while we could not access it during simulation");
-                    return false;
                 }
             }
 
@@ -1010,10 +1006,6 @@ namespace Opm
             } else {
                 if (vfp_properties_->getInj()->getTable(table_id)) {
                     return true;
-                } else {
-                    OPM_THROW(std::runtime_error, "VFPINJ table " << std::to_string(table_id) << " is specfied,"
-                              << " for well " << name() << ", while we could not access it during simulation");
-                    return false;
                 }
             }
         }

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -994,8 +994,11 @@ namespace Opm
             if (table_id <= 0) {
                 return false;
             } else {
-                if (vfp_properties_->getProd()->getTable(table_id)) {
+                if (vfp_properties_->getProd()->hasTable(table_id)) {
                     return true;
+                } else {
+                    OPM_THROW(std::runtime_error, "VFPPROD table " << std::to_string(table_id) << " is specfied,"
+                              << " for well " << name() << ", while we could not access it during simulation");
                 }
             }
 
@@ -1004,8 +1007,11 @@ namespace Opm
             if (table_id <= 0) {
                 return false;
             } else {
-                if (vfp_properties_->getInj()->getTable(table_id)) {
+                if (vfp_properties_->getInj()->hasTable(table_id)) {
                     return true;
+                } else {
+                    OPM_THROW(std::runtime_error, "VFPINJ table " << std::to_string(table_id) << " is specfied,"
+                              << " for well " << name() << ", while we could not access it during simulation");
                 }
             }
         }


### PR DESCRIPTION
With the old implementation, VFP table number is only parsed when there is a THP constraint/target is specified. 

While we need to update/calculate the THP when the well has a valid VFP table associated with it for outputting purpose. 

When there is no valid VFP table specified, we set the thp value to be zero. 

It will make the model 2 history period able to output thp values for comparison. 

This is a PR should only impact output when THP constraint/target is not present, while some rates can result in problematic ratios causing the VFP/THP calculation failure. 
