### PR TITLE
fixing different well number between Wells and Well_containers

### DIFF
--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -712,7 +712,6 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     solveWellEq(const double dt)
     {
-        const int nw = numWells();
         WellState well_state0 = well_state_;
 
         const int numComp = numComponents();
@@ -767,9 +766,10 @@ namespace Opm {
             well_state_ = well_state0;
             updatePrimaryVariables();
             // also recover the old well controls
-            for (int w = 0; w < nw; ++w) {
-                WellControls* wc = well_container_[w]->wellControls();
-                well_controls_set_current(wc, well_state_.currentControls()[w]);
+            for (const auto& well : well_container_) {
+                const int index_of_well = well->indexOfWell();
+                WellControls* wc = well->wellControls();
+                well_controls_set_current(wc, well_state_.currentControls()[index_of_well]);
             }
         }
 


### PR DESCRIPTION
when the solveWellEq did not get converged.

Due to economic reason or other causes, the number of the wells in Wells and well_container_ can be different (number of wells in well_container is always equal to or smaller than the wells in Wells). 

When recovering from the non-successful solveWellEq, we should do the for loop for the wells in the well_container instead of Wells. Otherwise, it can cause segmentation error. 