### PR TITLE
Add missing include for std::vector.

### DIFF
--- a/opm/core/linalg/ParallelIstlInformation.hpp
+++ b/opm/core/linalg/ParallelIstlInformation.hpp
@@ -32,6 +32,7 @@
 #include <limits>
 #include <numeric>
 #include <type_traits>
+#include <vector>
 
 #if HAVE_MPI && HAVE_DUNE_ISTL
 


### PR DESCRIPTION
Should hopefully fix the Jenkins post-builder failure.