### PR TITLE
Use ebos ISTL class

### DIFF
--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -25,7 +25,7 @@
 
 
 #include <opm/autodiff/WellInterface.hpp>
-#include <opm/autodiff/ISTLSolver.hpp>
+#include <opm/autodiff/ISTLSolverEbos.hpp>
 #include <opm/autodiff/RateConverter.hpp>
 
 namespace Opm

--- a/tests/test_invert.cpp
+++ b/tests/test_invert.cpp
@@ -21,7 +21,7 @@
 
 #define BOOST_TEST_MODULE InvertSpecializationTest
 #include <boost/test/unit_test.hpp>
-#include <opm/autodiff/ISTLSolver.hpp>
+#include <opm/autodiff/ISTLSolverEbos.hpp>
 
 void checkIdentity(Dune::FieldMatrix<double, 4, 4> M) {
     double diag = 0.0;

--- a/tests/test_multmatrixtransposed.cpp
+++ b/tests/test_multmatrixtransposed.cpp
@@ -21,7 +21,7 @@
 
 #define BOOST_TEST_MODULE MultMatrixTransposed
 #include <boost/test/unit_test.hpp>
-#include <opm/autodiff/ISTLSolver.hpp>
+#include <opm/autodiff/ISTLSolverEbos.hpp>
 
 using namespace Dune;
 using namespace Opm::Detail;


### PR DESCRIPTION
to avoid legacy code in tests. the second commit has no functional reason, but it seems cleaner to me.