### PR TITLE
Add missing includes

### DIFF
--- a/opm/autodiff/MatrixBlock.hpp
+++ b/opm/autodiff/MatrixBlock.hpp
@@ -22,6 +22,10 @@
 
 #include <dune/common/fmatrix.hh>
 #include <dune/common/fvector.hh>
+#include <dune/common/version.hh>
+#include <dune/istl/matrixutils.hh>
+#include <dune/istl/umfpack.hh>
+#include <dune/istl/superlu.hh>
 
 namespace Dune
 {


### PR DESCRIPTION
Fixes issue causing Jenkins post-builder to break, as described in a new comment in #1617.

Since this is rather trivial yet cruical, I will self-merge immediately.