### PR TITLE
update well state with THP target based on inflow performance relationship

### DIFF
--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -847,7 +847,7 @@ namespace Opm {
         wellhelpers::WellSwitchingLogger logger;
 
         for (const auto& well : well_container_) {
-            well->updateWellControl(well_state_, logger);
+            well->updateWellControl(ebosSimulator_, well_state_, logger);
         }
 
         updateGroupControls();
@@ -938,7 +938,7 @@ namespace Opm {
             well_state_.currentControls()[w] = control;
 
             if (well_state_.effectiveEventsOccurred(w) ) {
-                well->updateWellStateWithTarget(well_state_);
+                well->updateWellStateWithTarget(ebosSimulator_, well_state_);
             }
 
             // there is no new well control change input within a report step,
@@ -1186,7 +1186,7 @@ namespace Opm {
 
             // TODO: we should only do the well is involved in the update group targets
             for (auto& well : well_container_) {
-                well->updateWellStateWithTarget(well_state_);
+                well->updateWellStateWithTarget(ebosSimulator_, well_state_);
                 well->updatePrimaryVariables(well_state_);
             }
         }

--- a/opm/autodiff/MultisegmentWell.hpp
+++ b/opm/autodiff/MultisegmentWell.hpp
@@ -117,9 +117,9 @@ namespace Opm
                                     const double dt,
                                     WellState& well_state) override;
 
-        /// updating the well state based the control mode specified with current
-        // TODO: later will check wheter we need current
-        virtual void updateWellStateWithTarget(WellState& well_state) const override;
+        /// updating the well state based the current control mode
+        virtual void updateWellStateWithTarget(/* const */ Simulator& ebos_simulator,
+                                               WellState& well_state) /* const */ override;
 
         /// check whether the well equations get converged for this well
         virtual ConvergenceReport getWellConvergence(const std::vector<double>& B_avg) const override;

--- a/opm/autodiff/MultisegmentWell_impl.hpp
+++ b/opm/autodiff/MultisegmentWell_impl.hpp
@@ -254,7 +254,8 @@ namespace Opm
     template <typename TypeTag>
     void
     MultisegmentWell<TypeTag>::
-    updateWellStateWithTarget(WellState& well_state) const
+    updateWellStateWithTarget(/* const */ Simulator& ebos_simulator,
+                              WellState& well_state) /* const */
     {
         // Updating well state bas on well control
         // Target values are used as initial conditions for BHP, THP, and SURFACE_RATE

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -140,9 +140,8 @@ namespace Opm
                                     const double dt,
                                     WellState& well_state) override;
 
-        /// updating the well state based the control mode specified with current
-        // TODO: later will check wheter we need current
-        virtual void updateWellStateWithTarget(WellState& well_state) const override;
+        virtual void updateWellStateWithTarget(/* const */ Simulator& ebos_simulator,
+                                               WellState& well_state) /* const */ override;
 
         /// check whether the well equations get converged for this well
         virtual ConvergenceReport getWellConvergence(const std::vector<double>& B_avg) const override;
@@ -363,6 +362,18 @@ namespace Opm
 
         // updating the inflow based on the current reservoir condition
         void updateIPR(const Simulator& ebos_simulator) const;
+
+        // update WellState based on IPR and associated VFP table
+        void updateWellStateWithTHPTargetIPR(const Simulator& ebos_simulator,
+                                             WellState& well_state) const;
+
+        void updateWellStateWithTHPTargetIPRProducer(const Simulator& ebos_simulator,
+                                                     WellState& well_state) const;
+
+        // calculate the BHP from THP target based on IPR
+        // TODO: we need to check the operablility here first, if not operable, then maybe there is
+        // no point to do this
+        double calculateBHPWithTHPTargetIPR() const;
 
         // relaxation factor considering only one fraction value
         static double relaxationFactorFraction(const double old_value,

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -257,6 +257,13 @@ namespace Opm
         // the saturations in the well bore under surface conditions at the beginning of the time step
         std::vector<double> F0_;
 
+        // the vectors used to describe the inflow performance relationship (IPR)
+        // Q = IPR_A - BHP * IPR_B
+        // TODO: it minght need to go to WellInterface, let us implement it in StandardWell first
+        // it is only updated and used for producers for now
+        mutable std::vector<double> ipr_a_;
+        mutable std::vector<double> ipr_b_;
+
         const EvalWell& getBhp() const;
 
         EvalWell getQs(const int comp_idx) const;
@@ -353,6 +360,9 @@ namespace Opm
 
         // handle the non reasonable fractions due to numerical overshoot
         void processFractions() const;
+
+        // updating the inflow based on the current reservoir condition
+        void updateIPR(const Simulator& ebos_simulator) const;
 
         // relaxation factor considering only one fraction value
         static double relaxationFactorFraction(const double old_value,

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -1315,8 +1315,9 @@ namespace Opm
             }
 
             for (int p = 0; p < number_of_phases_; ++p) {
-                ipr_a_[p] += ipr_a_perf[p];
-                ipr_b_[p] += ipr_b_perf[p];
+                // TODO: double check the indices here
+                ipr_a_[ebosCompIdxToFlowCompIdx(p)] += ipr_a_perf[p];
+                ipr_b_[ebosCompIdxToFlowCompIdx(p)] += ipr_b_perf[p];
             }
         }
     }

--- a/opm/autodiff/VFPHelpers.hpp
+++ b/opm/autodiff/VFPHelpers.hpp
@@ -808,7 +808,7 @@ inline bool findIntersectionForBhp(const std::vector<double>&rate_samples,
                                    const double flo_rate2,
                                    const double bhp1,
                                    const double bhp2,
-                                   double& bhp)
+                                   double& obtained_bhp)
 {
     // there possibly two intersection point, then we choose the bigger one
     // we choose the bigger one, then it will be the later one in the rate_samples
@@ -851,10 +851,10 @@ inline bool findIntersectionForBhp(const std::vector<double>&rate_samples,
     const std::array<DataPoint, 2> line { DataPoint{flo_rate1, bhp1},
                                           DataPoint{flo_rate2, bhp2} };
 
-    const bool inter_section_found = findIntersection(line_segment, line, bhp);
+    const bool inter_section_found = findIntersection(line_segment, line, obtained_bhp);
 
     if (inter_section_found) {
-        std::cout << " found a bhp is " << bhp << std::endl;
+        std::cout << " found a bhp is " << obtained_bhp << std::endl;
         return true;
     } else {
         std::cout << " did not find the intersection point " << std::endl;

--- a/opm/autodiff/VFPHelpers.hpp
+++ b/opm/autodiff/VFPHelpers.hpp
@@ -765,7 +765,7 @@ inline double findTHP(
 
 
 // a data type use to do the intersection calculation to get the intial bhp under THP control
-struct DataPoint {
+struct RateBhpPair {
     double rate;
     double bhp;
 };
@@ -773,7 +773,7 @@ struct DataPoint {
 
 // looking for a intersection point a line segment and a line, they are both defined with two points
 // it is copied from #include <opm/polymer/Point2D.hpp>, which should be removed since it is only required by the lagacy polymer
-inline bool findIntersection(const std::array<DataPoint, 2>& line_segment, const std::array<DataPoint, 2>& line, double& bhp) {
+inline bool findIntersection(const std::array<RateBhpPair, 2>& line_segment, const std::array<RateBhpPair, 2>& line, double& bhp) {
     const double x1 = line_segment[0].rate;
     const double y1 = line_segment[0].bhp;
     const double x2 = line_segment[1].rate;
@@ -802,41 +802,41 @@ inline bool findIntersection(const std::array<DataPoint, 2>& line_segment, const
 }
 
 // calculating the BHP from thp through the intersection of VFP curves and inflow performance relationship
-inline bool findIntersectionForBhp(const std::vector<double>&rate_samples,
-                                   const std::vector<double>&bhp_samples,
-                                   const double flo_rate1,
-                                   const double flo_rate2,
-                                   const double bhp1,
-                                   const double bhp2,
+inline bool findIntersectionForBhp(const std::vector<RateBhpPair>& ratebhp_samples,
+                                   const std::array<RateBhpPair, 2>& ratebhp_twopoints_ipr,
                                    double& obtained_bhp)
 {
-    // there possibly two intersection point, then we choose the bigger one
-    // we choose the bigger one, then it will be the later one in the rate_samples
+    // there possibly two intersection point, then we choose the one corresponding with the bigger rate
 
-    const size_t num_samples = rate_samples.size();
-    assert(num_samples == bhp_samples.size());
+    const double bhp1 = ratebhp_twopoints_ipr[0].bhp;
+    const double rate1 = ratebhp_twopoints_ipr[0].rate;
 
-    assert(flo_rate1 != flo_rate2);
+    const double bhp2 = ratebhp_twopoints_ipr[1].bhp;
+    const double rate2 = ratebhp_twopoints_ipr[1].rate;
 
-    const double line_slope = (bhp2 - bhp1) / (flo_rate2 - flo_rate1);
+    assert(rate1 != rate2);
+
+    const double line_slope = (bhp2 - bhp1) / (rate2 - rate1);
+
     // line equation will be
     // bhp - bhp1 - line_slope * (flo_rate - flo_rate1) = 0
     auto flambda = [&](const double flo_rate, const double bhp) {
-        return bhp - bhp1 - line_slope * (flo_rate - flo_rate1);
+        return bhp - bhp1 - line_slope * (flo_rate - rate1);
     };
 
     int number_intersection_found = 0;
     int index_segment = 0; // the intersection segment that intersection happens
-    for (size_t i = 0; i < rate_samples.size() - 1; ++i) {
-        const double temp1 = flambda(rate_samples[i], bhp_samples[i]);
-        const double temp2 = flambda(rate_samples[i+1], bhp_samples[i+1]);
+    const size_t num_samples = ratebhp_samples.size();
+    for (size_t i = 0; i < num_samples - 1; ++i) {
+        const double temp1 = flambda(ratebhp_samples[i].rate, ratebhp_samples[i].bhp);
+        const double temp2 = flambda(ratebhp_samples[i+1].rate, ratebhp_samples[i+1].bhp);
         if (temp1 * temp2 <= 0.) { // intersection happens
             // in theory there should be maximum two intersection points
             // while considering the situation == 0. here, we might find more
-            // we always use the last one, which is the one has the biggest rate
+            // we always use the last one, which is the one corresponds to the biggest rate,
+            // which we assume is the more stable one
             ++number_intersection_found;
             index_segment = i;
-            std::cout << " temp1 " << temp1 << " temp2 " << temp2 << std::endl;
         }
     }
 
@@ -844,22 +844,12 @@ inline bool findIntersectionForBhp(const std::vector<double>&rate_samples,
         return false;
     }
 
-    // then we need to calculate the intersection point
-    const std::array<DataPoint, 2> line_segment{ DataPoint{rate_samples[index_segment], bhp_samples[index_segment]},
-                                                 DataPoint{rate_samples[index_segment + 1], bhp_samples[index_segment + 1]} };
+    // then we pick the segment from the VFP curve to do the line intersection calculation
+    const std::array<RateBhpPair, 2> line_segment{ ratebhp_samples[index_segment], ratebhp_samples[index_segment + 1] };
 
-    const std::array<DataPoint, 2> line { DataPoint{flo_rate1, bhp1},
-                                          DataPoint{flo_rate2, bhp2} };
+    const bool intersection_found = findIntersection(line_segment, ratebhp_twopoints_ipr, obtained_bhp);
 
-    const bool inter_section_found = findIntersection(line_segment, line, obtained_bhp);
-
-    if (inter_section_found) {
-        std::cout << " found a bhp is " << obtained_bhp << std::endl;
-        return true;
-    } else {
-        std::cout << " did not find the intersection point " << std::endl;
-        return false;
-    }
+    return intersection_found;
 }
 
 

--- a/opm/autodiff/VFPProdProperties.cpp
+++ b/opm/autodiff/VFPProdProperties.cpp
@@ -235,14 +235,18 @@ calculateBhpWithTHPTarget(const std::vector<double>& ipr_a,
     if (obtain_solution_with_thp_limit && obtain_bhp > 0.) {
         // getting too high bhp that might cause negative rates (rates in the undesired direction)
         if (obtain_bhp >= bhp_safe_limit) {
-            std::cout << " Look like we are getting a too high BHP value from the THP constraint "
-                      << " which might cause problems later " << std::endl;
+            const std::string msg (" We are getting a too high BHP value from the THP constraint, which may "
+                                   " cause problems later ");
+            OpmLog::info("TOO_HIGH_BHP_FOUND_THP_TARGET", msg);
 
-            std::cout << " obtain_bhp " << obtain_bhp << " bhp_safe_limit " << bhp_safe_limit << std::endl;
+            const std::string debug_msg = " obtain_bhp " + std::to_string(obtain_bhp)
+                                        + " bhp_safe_limit " + std::to_string(bhp_safe_limit)
+                                        + " thp limit " + std::to_string(thp_limit);
+            OpmLog::debug(debug_msg);
         }
         return obtain_bhp;
     } else {
-        std::cout << " COULD NOT find an Intersection point " << std::endl;
+        OpmLog::warning("NO_BHP_FOUND_THP_TARGET", " we could not find a bhp value with thp target.");
         return -100.;
     }
 }

--- a/opm/autodiff/VFPProdProperties.cpp
+++ b/opm/autodiff/VFPProdProperties.cpp
@@ -110,4 +110,136 @@ bool VFPProdProperties::hasTable(const int table_id) const {
 }
 
 
+std::vector<double>
+VFPProdProperties::
+bhpwithflo(const std::vector<double>& flos,
+           const int table_id,
+           const double wfr,
+           const double gfr,
+           const double thp,
+           const double alq,
+           const double dp) const
+{
+    // Get the table
+    const VFPProdTable* table = detail::getTable(m_tables, table_id);
+    const auto thp_i = detail::findInterpData( thp, table->getTHPAxis()); // assume constant
+    const auto wfr_i = detail::findInterpData( wfr, table->getWFRAxis());
+    const auto gfr_i = detail::findInterpData( gfr, table->getGFRAxis());
+    const auto alq_i = detail::findInterpData( alq, table->getALQAxis()); //assume constant
+
+    std::vector<double> bhps(flos.size(), 0.);
+    for (size_t i = 0; i < flos.size(); ++i) {
+        // Value of FLO is negative in OPM for producers, but positive in VFP table
+        const auto flo_i = detail::findInterpData(-flos[i], table->getFloAxis());
+        const detail::VFPEvaluation bhp_val = detail::interpolate(table->getTable(), flo_i, thp_i, wfr_i, gfr_i, alq_i);
+
+        // TODO: this kind of breaks the conventions for the functions here by putting dp within the function
+        bhps[i] = bhp_val.value - dp;
+    }
+
+    return bhps;
+}
+
+
+
+
+
+double
+VFPProdProperties::
+calculateBhpWithTHPTarget(const std::vector<double>& ipr_a,
+                          const std::vector<double>& ipr_b,
+                          const double bhp_limit,
+                          const double thp_table_id,
+                          const double thp_limit,
+                          const double alq,
+                          const double dp) const
+{
+    // For producers, bhp_safe_limit is the highest BHP value that can still produce based on IPR
+    double bhp_safe_limit = 1.e100;
+    for (size_t i = 0; i < ipr_a.size(); ++i) {
+        if (ipr_b[i] == 0.) continue;
+
+        const double bhp = ipr_a[i] / ipr_b[i];
+        if (bhp < bhp_safe_limit) {
+            bhp_safe_limit = bhp;
+        }
+    }
+
+    // Here, we use the middle point between the bhp_limit and bhp_safe_limit to calculate the ratio of the flow
+    // and the middle point serves one of the two points to describe inflow performance relationship line
+    const double bhp_middle = (bhp_limit + bhp_safe_limit) / 2.0;
+
+    // FLO is the rate based on the type specified with the VFP table
+    // The two points correspond to the bhp values of bhp_limit, and the middle of bhp_limit and bhp_safe_limit
+    // for producers, the rates are negative
+    std::vector<double> rates_bhp_limit(ipr_a.size());
+    std::vector<double> rates_bhp_middle(ipr_a.size());
+    for (size_t i = 0; i < rates_bhp_limit.size(); ++i) {
+        rates_bhp_limit[i] = bhp_limit * ipr_b[i] - ipr_a[i];
+        rates_bhp_middle[i] = bhp_middle * ipr_b[i] - ipr_a[i];
+    }
+
+    // TODO: we need to be careful that there is nothings wrong related to the indices here
+    const int Water = BlackoilPhases::Aqua;
+    const int Oil = BlackoilPhases::Liquid;
+    const int Gas = BlackoilPhases::Vapour;
+
+    const VFPProdTable* table = detail::getTable(m_tables, thp_table_id);
+    const double aqua_bhp_limit = rates_bhp_limit[Water];
+    const double liquid_bhp_limit = rates_bhp_limit[Oil];
+    const double vapour_bhp_limit = rates_bhp_limit[Gas];
+    const double flo_bhp_limit = detail::getFlo(aqua_bhp_limit, liquid_bhp_limit, vapour_bhp_limit, table->getFloType() );
+
+    const double aqua_bhp_middle = rates_bhp_middle[Water];
+    const double liquid_bhp_middle = rates_bhp_middle[Oil];
+    const double vapour_bhp_middle = rates_bhp_middle[Gas];
+    const double flo_bhp_middle = detail::getFlo(aqua_bhp_middle, liquid_bhp_middle, vapour_bhp_middle, table->getFloType() );
+
+    // we use the ratios based on the middle value of bhp_limit and bhp_safe_limit
+    const double wfr = detail::getWFR(aqua_bhp_middle, liquid_bhp_middle, vapour_bhp_middle, table->getWFRType());
+    const double gfr = detail::getGFR(aqua_bhp_middle, liquid_bhp_middle, vapour_bhp_middle, table->getGFRType());
+
+    // we get the flo sampling points from the table,
+    // then extend it with zero and rate under bhp_limit for extrapolation
+    std::vector<double> flo_samples = table->getFloAxis();
+
+    if (flo_samples[0] > 0.) {
+        flo_samples.insert(flo_samples.begin(), 0.);
+    }
+
+    if (flo_samples.back() < std::abs(flo_bhp_limit)) {
+        flo_samples.push_back(std::abs(flo_bhp_limit));
+    }
+
+    // kind of unncessarily following the tradation that producers should have negative rates
+    // the key is here that it should be consistent with the function bhpwithflo
+    for (double& value : flo_samples) {
+        value = -value;
+    }
+
+    // get the bhp sampling values based on the flo sample values
+    const std::vector<double> bhp_flo_samples = bhpwithflo(flo_samples, thp_table_id, wfr, gfr, thp_limit, alq, dp);
+
+    double obtain_bhp = 0.;
+    const bool obtain_solution_with_thp_limit = detail::findIntersectionForBhp(flo_samples, bhp_flo_samples,
+                                                        flo_bhp_middle, flo_bhp_limit, bhp_middle, bhp_limit, obtain_bhp);
+
+    // \Note: assuming not that negative BHP does not make sense
+    if (obtain_solution_with_thp_limit && obtain_bhp > 0.) {
+        // getting too high bhp that might cause negative rates (rates in the undesired direction)
+        if (obtain_bhp >= bhp_safe_limit) {
+            std::cout << " Look like we are getting a too high BHP value from the THP constraint "
+                      << " which might cause problems later " << std::endl;
+
+            std::cout << " obtain_bhp " << obtain_bhp << " bhp_safe_limit " << bhp_safe_limit << std::endl;
+        }
+        return obtain_bhp;
+    } else {
+        std::cout << " COULD NOT find an Intersection point " << std::endl;
+        return -100.;
+    }
+}
+
+
+
 }

--- a/opm/autodiff/VFPProdProperties.cpp
+++ b/opm/autodiff/VFPProdProperties.cpp
@@ -220,9 +220,16 @@ calculateBhpWithTHPTarget(const std::vector<double>& ipr_a,
     // get the bhp sampling values based on the flo sample values
     const std::vector<double> bhp_flo_samples = bhpwithflo(flo_samples, thp_table_id, wfr, gfr, thp_limit, alq, dp);
 
+    std::vector<detail::RateBhpPair> ratebhp_samples;
+    for (size_t i = 0; i < flo_samples.size(); ++i) {
+        ratebhp_samples.push_back( detail::RateBhpPair{flo_samples[i], bhp_flo_samples[i]} );
+    }
+
+    const std::array<detail::RateBhpPair, 2> ratebhp_twopoints_ipr {detail::RateBhpPair{flo_bhp_middle, bhp_middle},
+                                                                    detail::RateBhpPair{flo_bhp_limit, bhp_limit} };
+
     double obtain_bhp = 0.;
-    const bool obtain_solution_with_thp_limit = detail::findIntersectionForBhp(flo_samples, bhp_flo_samples,
-                                                        flo_bhp_middle, flo_bhp_limit, bhp_middle, bhp_limit, obtain_bhp);
+    const bool obtain_solution_with_thp_limit = detail::findIntersectionForBhp(ratebhp_samples, ratebhp_twopoints_ipr, obtain_bhp);
 
     // \Note: assuming not that negative BHP does not make sense
     if (obtain_solution_with_thp_limit && obtain_bhp > 0.) {

--- a/opm/autodiff/VFPProdProperties.hpp
+++ b/opm/autodiff/VFPProdProperties.hpp
@@ -170,7 +170,30 @@ public:
         return m_tables.empty();
     }
 
+
+    /**
+     * Calculate the Bhp value from the THP target/constraint value
+     * based on inflow performance relationship and VFP curves
+     */
+     double
+     calculateBhpWithTHPTarget(const std::vector<double>& ipr_a,
+                               const std::vector<double>& ipr_b,
+                               const double bhp_limit,
+                               const double thp_table_id,
+                               const double thp_limit,
+                               const double alq,
+                               const double dp) const;
+
 protected:
+    // calculate a group bhp values with a group of flo rate values
+    std::vector<double> bhpwithflo(const std::vector<double>& flos,
+                                   const int table_id,
+                                   const double wfr,
+                                   const double gfr,
+                                   const double thp,
+                                   const double alq,
+                                   const double dp) const;
+
     // Map which connects the table number with the table itself
     std::map<int, const VFPProdTable*> m_tables;
 };

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -312,6 +312,8 @@ namespace Opm
         bool checkRateEconLimits(const WellEconProductionLimits& econ_production_limits,
                                  const WellState& well_state) const;
 
+        bool underPredictionMode() const;
+
         bool wellHasTHPConstraints() const;
 
         // Component fractions for each phase for the well

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -316,6 +316,10 @@ namespace Opm
 
         bool wellHasTHPConstraints() const;
 
+        double getTHPConstraint() const;
+
+        int getTHPControlIndex() const;
+
         // Component fractions for each phase for the well
         const std::vector<double>& compFrac() const;
 

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -172,10 +172,12 @@ namespace Opm
                                            const WellState& well_state,
                                            std::vector<double>& well_potentials) = 0;
 
-        virtual void updateWellStateWithTarget(WellState& well_state) const = 0;
+        virtual void updateWellStateWithTarget(/* const */ Simulator& ebos_simulator,
+                                               WellState& well_state) /* const */ = 0;
 
-        void updateWellControl(WellState& well_state,
-                               wellhelpers::WellSwitchingLogger& logger) const;
+        void updateWellControl(/* const */ Simulator& ebos_simulator,
+                               WellState& well_state,
+                               wellhelpers::WellSwitchingLogger& logger) /* const */;
 
         virtual void updatePrimaryVariables(const WellState& well_state) const = 0;
 

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -415,8 +415,9 @@ namespace Opm
     template<typename TypeTag>
     void
     WellInterface<TypeTag>::
-    updateWellControl(WellState& well_state,
-                      wellhelpers::WellSwitchingLogger& logger) const
+    updateWellControl(/* const */ Simulator& ebos_simulator,
+                      WellState& well_state,
+                      wellhelpers::WellSwitchingLogger& logger) /* const */
     {
         const int np = number_of_phases_;
         const int w = index_of_well_;
@@ -467,7 +468,7 @@ namespace Opm
         }
 
         if (updated_control_index != old_control_index) { //  || well_collection_->groupControlActive()) {
-            updateWellStateWithTarget(well_state);
+            updateWellStateWithTarget(ebos_simulator, well_state);
             updatePrimaryVariables(well_state);
         }
     }
@@ -1133,7 +1134,7 @@ namespace Opm
             solveEqAndUpdateWellState(well_state);
 
             wellhelpers::WellSwitchingLogger logger;
-            updateWellControl(well_state, logger);
+            updateWellControl(ebosSimulator, well_state, logger);
             initPrimaryVariablesEvaluation();
         } while (it < max_iter);
 

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -449,6 +449,31 @@ namespace Opm
     template<typename TypeTag>
     bool
     WellInterface<TypeTag>::
+    underPredictionMode() const
+    {
+        bool under_prediction_mode = false;
+
+        switch( well_type_ ) {
+        case PRODUCER:
+            under_prediction_mode = well_ecl_->getProductionProperties(current_step_).predictionMode;
+            break;
+        case INJECTOR:
+            under_prediction_mode = well_ecl_->getInjectionProperties(current_step_).predictionMode;
+            break;
+        default:
+            OPM_THROW(std::logic_error, "Expected PRODUCER or INJECTOR type for well " << name());
+        }
+
+        return under_prediction_mode;
+    }
+
+
+
+
+
+    template<typename TypeTag>
+    bool
+    WellInterface<TypeTag>::
     checkRateEconLimits(const WellEconProductionLimits& econ_production_limits,
                         const WellState& well_state) const
     {

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -364,18 +364,48 @@ namespace Opm
 
 
 
+
     template<typename TypeTag>
     bool
     WellInterface<TypeTag>::
     wellHasTHPConstraints() const
     {
+        return getTHPControlIndex() >= 0;
+    }
+
+
+
+
+    template<typename TypeTag>
+    double
+    WellInterface<TypeTag>::
+    getTHPConstraint() const
+    {
+        const int thp_control_index = getTHPControlIndex();
+
+        if (thp_control_index < 0) {
+            OPM_THROW(std::runtime_error, " there is no THP constraint/limit for well " << name()
+                                          << ", while we are requesting it ");
+        }
+
+        return well_controls_iget_target(well_controls_, thp_control_index);
+    }
+
+
+
+
+    template<typename TypeTag>
+    int
+    WellInterface<TypeTag>::
+    getTHPControlIndex() const
+    {
         const int nwc = well_controls_get_num(well_controls_);
         for (int ctrl_index = 0; ctrl_index < nwc; ++ctrl_index) {
             if (well_controls_iget_type(well_controls_, ctrl_index) == THP) {
-                return true;
+                return ctrl_index;
             }
         }
-        return false;
+        return -1;
     }
 
 


### PR DESCRIPTION
In this PR, the two major functions introduced are:
1. calculate the inflow performance relationship (IPR) based on the current reservoir state
2. when there is a well switched to THP control, we will update well state based on the IPR. 


It should only change the convergence behavoir of the test `52 - compareECLFiles_flow+SPE1CASE1_METRIC_VFP1`, while not impact other cases at all, since there is no THP control involved.