### PR TITLE
add method for getting the surfacevolume well connection rate

### DIFF
--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -195,6 +195,10 @@ namespace Opm {
                                          unsigned spaceIdx,
                                          unsigned timeIdx) const;
 
+
+            using WellInterfacePtr = std::shared_ptr<WellInterface<TypeTag> >;
+            WellInterfacePtr well(const std::string& wellName) const;
+
             void initFromRestartFile(const RestartValue& restartValues);
 
             Opm::data::Wells wellData() const
@@ -271,7 +275,6 @@ namespace Opm {
 
             bool wells_active_;
 
-            using WellInterfacePtr = std::unique_ptr<WellInterface<TypeTag> >;
             // a vector of all the wells.
             std::vector<WellInterfacePtr > well_container_;
 

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -358,6 +358,22 @@ namespace Opm {
             well->addCellRates(rate, elemIdx);
     }
 
+
+
+    template<typename TypeTag>
+    typename BlackoilWellModel<TypeTag>::WellInterfacePtr
+    BlackoilWellModel<TypeTag>::
+    well(const std::string& wellName) const
+    {
+        for (const auto& well : well_container_) {
+            if (well->name() == wellName) {
+                return well;
+            }
+        }
+        OPM_THROW(std::invalid_argument, "The well with name " + wellName + " is not in the well Container");
+        return nullptr;
+    }
+
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -199,6 +199,9 @@ namespace Opm
 
         void addCellRates(RateVector& rates, int cellIdx) const;
 
+        Scalar volumetricSurfaceRateForConnection(int cellIdx, int phaseIdx) const;
+
+
         template <class EvalWell>
         Eval restrictEval(const EvalWell& in) const
         {

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -1206,5 +1206,19 @@ namespace Opm
         }
     }
 
+    template<typename TypeTag>
+    typename WellInterface<TypeTag>::Scalar
+    WellInterface<TypeTag>::volumetricSurfaceRateForConnection(int cellIdx, int phaseIdx) const {
+        for (int perfIdx = 0; perfIdx < number_of_perforations_; ++perfIdx) {
+            if (cells()[perfIdx] == cellIdx) {
+                const unsigned activeCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::solventComponentIndex(phaseIdx));
+                return connectionRates_[perfIdx][activeCompIdx].value();
+            }
+        }
+        OPM_THROW(std::invalid_argument, "The well with name " + name()
+                  + " does not perforate cell " + std::to_string(cellIdx));
+        return 0.0;
+    }
+
 
 }


### PR DESCRIPTION
changed wellpointer from unique to shared to make it accecible from outside the wellmodel
add method for surfacevolume well connection rate

changes are needed for tracerModel PR 

Depends on: OPM/opm-common#562 and OPM/ewoms#431