### PR TITLE
Store ConvergenceReport objects

### DIFF
--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -816,14 +816,6 @@ namespace Opm {
             }
         }
 
-        // Throw if any NaN or too large residual found.
-        ConvergenceReport::Severity severity = report.severityOfWorstFailure();
-        if (severity == ConvergenceReport::Severity::NotANumber) {
-            OPM_THROW(Opm::NumericalIssue, "NaN residual found!");
-        } else if (severity == ConvergenceReport::Severity::TooLarge) {
-            OPM_THROW(Opm::NumericalIssue, "Too large residual found!");
-        }
-
         return report;
     }
 


### PR DESCRIPTION
With this, we refactor BlackoilModelEbos::getConvergence() to use the ConvergenceReport class, and store such objects for all timesteps and iterations.

This may initially be useful for debugging, but the intention is to use this to decide when a well is causing too much trouble by causing timesteps cuts, to close that well.