### PR TITLE
Speed up add cell rates

### DIFF
--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -278,6 +278,8 @@ namespace Opm {
             // map from logically cartesian cell indices to compressed ones
             std::vector<int> cartesian_to_compressed_;
 
+            std::vector<bool> is_cell_perforated_;
+
             // create the well container
             std::vector<WellInterfacePtr > createWellContainer(const int time_step);
 

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -202,6 +202,8 @@ namespace Opm {
                                    schedule().getVFPInjTables(timeStepIdx),
                                    schedule().getVFPProdTables(timeStepIdx)) );
 
+
+
     }
 
 
@@ -889,7 +891,7 @@ namespace Opm {
         const int np = numPhases();
         well_potentials.resize(nw * np, 0.0);
 
-        const Opm::SummaryConfig summaryConfig = ebosSimulator_.vanguard().summaryConfig();
+        const Opm::SummaryConfig& summaryConfig = ebosSimulator_.vanguard().summaryConfig();
         for (const auto& well : well_container_) {
             // Only compute the well potential when asked for
             bool needed_for_output = ((summaryConfig.hasSummaryKey( "WWPI:" + well->name()) ||

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -1367,7 +1367,13 @@ namespace Opm {
              elemIt != elemEndIt;
              ++elemIt)
         {
+
             elemCtx.updatePrimaryStencil(*elemIt);
+            int elemIdx = elemCtx.globalSpaceIndex(0, 0);
+
+            if (!is_cell_perforated_[elemIdx]) {
+                continue;
+            }
             elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
         }
     }

--- a/opm/autodiff/MultisegmentWell.hpp
+++ b/opm/autodiff/MultisegmentWell.hpp
@@ -33,7 +33,6 @@ namespace Opm
     {
     public:
         typedef WellInterface<TypeTag> Base;
-        typedef typename GET_PROP_TYPE(TypeTag, RateVector) RateVector;
 
         using typename Base::WellState;
         using typename Base::Simulator;
@@ -152,17 +151,6 @@ namespace Opm
 
         int numberOfPerforations() const;
 
-        void addCellRates(RateVector& rates, int cellIdx) const override
-        {
-            for (int perfIdx = 0; perfIdx < number_of_perforations_; ++perfIdx) {
-                if (Base::cells()[perfIdx] == cellIdx) {
-                    for (int i = 0; i < RateVector::dimension; ++i) {
-                        rates[i] += connectionRates_[perfIdx][i];
-                    }
-                }
-            }
-        }
-
     protected:
         int number_segments_;
 
@@ -194,6 +182,7 @@ namespace Opm
         using Base::well_controls_;
         using Base::perf_depth_;
         using Base::num_components_;
+        using Base::connectionRates_;
 
         // protected functions from the Base class
         using Base::phaseUsage;
@@ -263,8 +252,6 @@ namespace Opm
         std::vector<EvalWell> segment_mass_rates_;
 
         std::vector<double> segment_depth_diffs_;
-
-        std::vector<RateVector> connectionRates_;
 
         void initMatrixAndVectors(const int num_cells) const;
 

--- a/opm/autodiff/MultisegmentWell_impl.hpp
+++ b/opm/autodiff/MultisegmentWell_impl.hpp
@@ -114,8 +114,6 @@ namespace Opm
     {
         Base::init(phase_usage_arg, depth_arg, gravity_arg, num_cells);
 
-        connectionRates_.resize(number_of_perforations_);
-
         // TODO: for StandardWell, we need to update the perf depth here using depth_arg.
         // for MultisegmentWell, it is much more complicated.
         // It can be specified directly, it can be calculated from the segment depth,

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -37,7 +37,6 @@ namespace Opm
 
     public:
         typedef WellInterface<TypeTag> Base;
-        typedef typename GET_PROP_TYPE(TypeTag, RateVector) RateVector;
 
         // TODO: some functions working with AD variables handles only with values (double) without
         // dealing with derivatives. It can be beneficial to make functions can work with either AD or scalar value.
@@ -177,17 +176,6 @@ namespace Opm
             return param_.matrix_add_well_contributions_;
         }
 
-        void addCellRates(RateVector& rates, int cellIdx) const override
-        {
-            for (int perfIdx = 0; perfIdx < number_of_perforations_; ++perfIdx) {
-                if (Base::cells()[perfIdx] == cellIdx) {
-                    for (int i = 0; i < RateVector::dimension; ++i) {
-                        rates[i] += connectionRates_[perfIdx][i];
-                    }
-                }
-            }
-        }
-
     protected:
 
         // protected functions from the Base class
@@ -222,6 +210,7 @@ namespace Opm
         using Base::well_controls_;
         using Base::well_type_;
         using Base::num_components_;
+        using Base::connectionRates_;
 
         using Base::perf_rep_radius_;
         using Base::perf_length_;
@@ -240,8 +229,6 @@ namespace Opm
         OffDiagMatWell duneC_;
         // diagonal matrix for the well
         DiagMatWell invDuneD_;
-
-        std::vector<RateVector> connectionRates_;
 
         // several vector used in the matrix calculation
         mutable BVectorWell Bx_;

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -58,8 +58,6 @@ namespace Opm
     {
         Base::init(phase_usage_arg, depth_arg, gravity_arg, num_cells);
 
-        connectionRates_.resize(number_of_perforations_);
-
         perf_depth_.resize(number_of_perforations_, 0.);
         for (int perf = 0; perf < number_of_perforations_; ++perf) {
             const int cell_idx = well_cells_[perf];

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -438,7 +438,7 @@ namespace Opm
                    WellState& well_state)
     {
 
-        const Opm::SummaryConfig summaryConfig = ebosSimulator.vanguard().summaryConfig();
+        const Opm::SummaryConfig& summaryConfig = ebosSimulator.vanguard().summaryConfig();
 
         const int np = number_of_phases_;
 

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -195,8 +195,7 @@ namespace Opm
         virtual void addWellContributions(Mat&) const
         {}
 
-        virtual void addCellRates(RateVector& rates, int cellIdx) const
-        {}
+        void addCellRates(RateVector& rates, int cellIdx) const;
 
         template <class EvalWell>
         Eval restrictEval(const EvalWell& in) const
@@ -219,6 +218,9 @@ namespace Opm
                          const double simulation_time, const int report_step,  const bool terminal_output,
                          const WellTestConfig::Reason testing_reason, const WellState& well_state,
                          WellTestState& welltest_state);
+
+        void updatePerforatedCell(std::vector<bool>& is_cell_perforated);
+
 
     protected:
 
@@ -299,6 +301,8 @@ namespace Opm
 
         const int num_components_;
 
+        std::vector<RateVector> connectionRates_;
+
         const PhaseUsage& phaseUsage() const;
 
         int flowPhaseToEbosCompIdx( const int phaseIdx ) const;
@@ -350,6 +354,7 @@ namespace Opm
         void solveWellForTesting(Simulator& ebosSimulator, WellState& well_state, const std::vector<double>& B_avg, bool terminal_output);
 
         void scaleProductivityIndex(const int perfIdx, double& productivity_index) const;
+
 
     };
 

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -128,11 +128,12 @@ namespace Opm
     init(const PhaseUsage* phase_usage_arg,
          const std::vector<double>& /* depth_arg */,
          const double gravity_arg,
-         const int /*num_cells*/)
+         const int /* num_cells */)
     {
         phase_usage_ = phase_usage_arg;
         gravity_ = gravity_arg;
     }
+
 
 
 

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -102,11 +102,23 @@ namespace Opm
                       wells->sat_table_id + perf_index_end,
                       saturation_table_number_.begin() );
         }
+
         well_efficiency_factor_ = 1.0;
+
+        connectionRates_.resize(number_of_perforations_);
 
     }
 
+    template<typename TypeTag>
+    void
+    WellInterface<TypeTag>::
+    updatePerforatedCell(std::vector<bool>& is_cell_perforated)
+    {
 
+        for (int perf_idx = 0; perf_idx<number_of_perforations_; ++perf_idx) {
+            is_cell_perforated[well_cells_[perf_idx]] = true;
+        }
+    }
 
 
 
@@ -116,12 +128,11 @@ namespace Opm
     init(const PhaseUsage* phase_usage_arg,
          const std::vector<double>& /* depth_arg */,
          const double gravity_arg,
-         const int /* num_cells */)
+         const int /*num_cells*/)
     {
         phase_usage_ = phase_usage_arg;
         gravity_ = gravity_arg;
     }
-
 
 
 
@@ -1123,6 +1134,19 @@ namespace Opm
         productivity_index *=
         (std::log(connection.r0() / connection.rw()) + connection.skinFactor()) /
         (std::log(well_ecl_->getDrainageRadius(current_step_) / connection.rw()) + connection.skinFactor());
+    }
+
+    template<typename TypeTag>
+    void
+    WellInterface<TypeTag>::addCellRates(RateVector& rates, int cellIdx) const
+    {
+        for (int perfIdx = 0; perfIdx < number_of_perforations_; ++perfIdx) {
+            if (cells()[perfIdx] == cellIdx) {
+                for (int i = 0; i < RateVector::dimension; ++i) {
+                    rates[i] += connectionRates_[perfIdx][i];
+                }
+            }
+        }
     }
 
 


### PR DESCRIPTION
PR #1555 caused a almost 5% regression of the run time of most models. The reason is that now the update of the intensive quantities is done in the well model in the method updatePerforationIntensiveQuantities() which are not OpenMP parallel . This PR makes sure that only the intensive quantities of the perforated cells are updated and thus restores the performance.

NB. There are several other call to  updatePerforationIntensiveQuantities() in the well model that are not  OpenMP parallel, that could cause similar unexpected problems in the future. These should be addressed in later PRs. But currently they do not cause any performance regression, since they are only called when the intensive quantities are cached. 