### PR TITLE
Shut time-chopping wells

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -243,8 +243,8 @@ namespace Opm {
                 residual_norms_history_.clear();
                 current_relaxation_ = 1.0;
                 dx_old_ = 0.0;
-                convergence_reports_.push_back({});
-                convergence_reports_.back().reserve(11);
+                convergence_reports_.push_back({timer.reportStepNum(), timer.currentStepNum(), {}});
+                convergence_reports_.back().report.reserve(11);
             }
 
             report.total_linearizations = 1;
@@ -267,7 +267,7 @@ namespace Opm {
             {
                 auto convrep = getConvergence(timer, iteration,residual_norms);
                 report.converged = convrep.converged()  && iteration > nonlinear_solver.minIter();;
-                convergence_reports_.back().push_back(std::move(convrep));
+                convergence_reports_.back().report.push_back(std::move(convrep));
             }
 
              // checking whether the group targets are converged
@@ -965,6 +965,18 @@ namespace Opm {
         const SimulatorReport& failureReport() const
         { return failureReport_; }
 
+        struct StepReport
+        {
+            int report_step;
+            int current_step;
+            std::vector<ConvergenceReport> report;
+        };
+
+        const std::vector<StepReport>& stepReports() const
+        {
+            return convergence_reports_;
+        }
+
     protected:
         const ISTLSolverType& istlSolver() const
         {
@@ -1002,7 +1014,7 @@ namespace Opm {
         std::unique_ptr<Mat> matrix_for_preconditioner_;        
         std::vector<std::pair<int,std::vector<int>>> overlapRowAndColumns_;
 
-        std::vector<std::vector<ConvergenceReport>> convergence_reports_;
+        std::vector<StepReport> convergence_reports_;
     public:
         /// return the StandardWells object
         BlackoilWellModel<TypeTag>&

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -239,6 +239,9 @@ namespace Opm {
             /// Return true if any well has a THP constraint.
             bool hasTHPConstraints() const;
 
+            /// Shut down any single well.
+            void forceShutWellByName(const std::string& wellname, const double simulation_time);
+
         protected:
 
             void extractLegacyPressure_(std::vector<double>& cellPressure) const

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -239,8 +239,8 @@ namespace Opm {
             /// Return true if any well has a THP constraint.
             bool hasTHPConstraints() const;
 
-            /// Shut down any single well.
-            void forceShutWellByName(const std::string& wellname, const double simulation_time);
+            /// Shut down any single well, but only if it is in prediction mode.
+            void forceShutWellByNameIfPredictionMode(const std::string& wellname, const double simulation_time);
 
         protected:
 

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -236,6 +236,9 @@ namespace Opm {
             // called at the beginning of a report step
             void beginReportStep(const int time_step);
 
+            /// Return true if any well has a THP constraint.
+            bool hasTHPConstraints() const;
+
         protected:
 
             void extractLegacyPressure_(std::vector<double>& cellPressure) const

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -116,6 +116,23 @@ namespace Opm {
     }
 
 
+    /// Return true if any well has a THP constraint.
+    template<typename TypeTag>
+    bool
+    BlackoilWellModel<TypeTag>::
+    hasTHPConstraints() const
+    {
+        for (const auto& well : well_container_) {
+            if (well->wellHasTHPConstraints()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+
+
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -133,6 +133,33 @@ namespace Opm {
 
 
 
+    /// Return true if any well has a THP constraint.
+    template<typename TypeTag>
+    void
+    BlackoilWellModel<TypeTag>::
+    forceShutWellByName(const std::string& wellname,
+                        const double simulation_time)
+    {
+        // Only add the well to the closed list on the
+        // process that owns it.
+        for (const auto& well : well_container_) {
+            if (well->name() == wellname) {
+                wellTestState_.addClosedWell(wellname, WellTestConfig::Reason::PHYSICAL, simulation_time);
+                break;
+            }
+        }
+
+        // Only log a message on the output rank.
+        if (terminal_output_) {
+            const std::string msg = "Well " + wellname
+                + " will be shut because it cannot get converged.";
+            OpmLog::info(msg);
+        }
+    }
+
+
+
+
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -137,14 +137,16 @@ namespace Opm {
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::
-    forceShutWellByName(const std::string& wellname,
-                        const double simulation_time)
+    forceShutWellByNameIfPredictionMode(const std::string& wellname,
+                                        const double simulation_time)
     {
         // Only add the well to the closed list on the
         // process that owns it.
         for (const auto& well : well_container_) {
             if (well->name() == wellname) {
-                wellTestState_.addClosedWell(wellname, WellTestConfig::Reason::PHYSICAL, simulation_time);
+                if (well->underPredictionMode()) {
+                    wellTestState_.addClosedWell(wellname, WellTestConfig::Reason::PHYSICAL, simulation_time);
+                }
                 break;
             }
         }

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -228,6 +228,9 @@ namespace Opm
         // whether the well is operable
         bool isOperable() const;
 
+        /// Returns true if the well has one or more THP limits/constraints.
+        bool wellHasTHPConstraints() const;
+
     protected:
 
         // to indicate a invalid completion
@@ -323,8 +326,6 @@ namespace Opm
                                  const WellState& well_state) const;
 
         bool underPredictionMode() const;
-
-        bool wellHasTHPConstraints() const;
 
         double getTHPConstraint() const;
 

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -231,6 +231,9 @@ namespace Opm
         /// Returns true if the well has one or more THP limits/constraints.
         bool wellHasTHPConstraints() const;
 
+        /// Returns true if the well is currently in prediction mode (i.e. not history mode).
+        bool underPredictionMode() const;
+
     protected:
 
         // to indicate a invalid completion
@@ -324,8 +327,6 @@ namespace Opm
 
         bool checkRateEconLimits(const WellEconProductionLimits& econ_production_limits,
                                  const WellState& well_state) const;
-
-        bool underPredictionMode() const;
 
         double getTHPConstraint() const;
 

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -378,7 +378,7 @@ namespace Opm {
                         } else {
                             // Close all consistently failing wells.
                             for (const auto& well : failing_wells) {
-                                solver.model().wellModel().forceShutWellByName(well, substepTimer.simulationTimeElapsed());
+                                solver.model().wellModel().forceShutWellByNameIfPredictionMode(well, substepTimer.simulationTimeElapsed());
                             }
                             substepTimer.provideTimeStepEstimate(dt);
                             if (solverVerbose_) {

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -298,6 +298,13 @@ namespace Opm {
                         restarts = 0;
                     }
 
+                    // further restrict time step size if we are in
+                    // prediction mode with THP constraints.
+                    if (solver.model().wellModel().hasTHPConstraints()) {
+                        const double maxPredictionTHPTimestep = 16.0 * unit::day;
+                        dtEstimate = std::min(dtEstimate, maxPredictionTHPTimestep);
+                    }
+
                     if (timestepVerbose_) {
                         std::ostringstream ss;
                         substepReport.reportStep(ss);

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -298,7 +298,7 @@ namespace Opm {
                         restarts = 0;
                     }
 
-                    // further restrict time step size if we are in
+                    // Further restrict time step size if we are in
                     // prediction mode with THP constraints.
                     if (solver.model().wellModel().hasTHPConstraints()) {
                         const double maxPredictionTHPTimestep = 16.0 * unit::day;
@@ -350,16 +350,50 @@ namespace Opm {
                     }
 
                     const double newTimeStep = restartFactor_ * dt;
-                    // we need to revise this
-                    substepTimer.provideTimeStepEstimate(newTimeStep);
-                    if (solverVerbose_) {
-                        std::string msg;
-                        msg = causeOfFailure + "\nTimestep chopped to "
-                            + std::to_string(unit::convert::to(substepTimer.currentStepLength(), unit::day)) + " days\n";
-                        OpmLog::problem(msg);
-                    }
+                    const double minimumChoppedTimestep = 0.25 * unit::day;
+                    if (newTimeStep > minimumChoppedTimestep) {
+                        // Chop the timestep.
+                        substepTimer.provideTimeStepEstimate(newTimeStep);
+                        if (solverVerbose_) {
+                            std::string msg;
+                            msg = causeOfFailure + "\nTimestep chopped to "
+                                + std::to_string(unit::convert::to(substepTimer.currentStepLength(), unit::day)) + " days\n";
+                            OpmLog::problem(msg);
+                        }
+                        ++restarts;
+                    } else {
+                        // We are below the threshold, and will check if there are any
+                        // wells we should close rather than chopping again.
+                        std::set<std::string> failing_wells = consistentlyFailingWells(solver.model().stepReports());
+                        if (failing_wells.empty()) {
+                            // Found no wells to close, chop the timestep as above.
+                            substepTimer.provideTimeStepEstimate(newTimeStep);
+                            if (solverVerbose_) {
+                                std::string msg;
+                                msg = causeOfFailure + "\nTimestep chopped to "
+                                    + std::to_string(unit::convert::to(substepTimer.currentStepLength(), unit::day)) + " days\n";
+                                OpmLog::problem(msg);
+                            }
+                            ++restarts;
+                        } else {
+                            // Close all consistently failing wells.
+                            for (const auto& well : failing_wells) {
+                                solver.model().wellModel().forceShutWellByName(well, substepTimer.simulationTimeElapsed());
+                            }
+                            substepTimer.provideTimeStepEstimate(dt);
+                            if (solverVerbose_) {
+                                std::string msg;
+                                msg = "\nProblematic well(s) were shut: ";
+                                for (const auto& well : failing_wells) {
+                                    msg += well;
+                                    msg += " ";
+                                }
+                                msg += "(retrying timestep)\n";
+                                OpmLog::problem(msg);
+                            }
+                        }
 
-                    ++restarts;
+                    }
                 }
                 ebosProblem.setNextTimeStepSize(substepTimer.currentStepLength());
             }
@@ -439,6 +473,54 @@ namespace Opm {
             // make sure growth factor is something reasonable
             assert(growthFactor_ >= 1.0);
         }
+
+
+        template <class StepReportVector>
+        std::set<std::string> consistentlyFailingWells(const StepReportVector& sr)
+        {
+            // If there are wells that cause repeated failures, we
+            // close them, and restart the un-chopped timestep.
+            std::ostringstream msg;
+            msg << "    Excessive chopping detected in report step "
+                << sr.back().report_step << ", substep " << sr.back().current_step << "\n";
+            const auto& wfs = sr.back().report.back().wellFailures();
+            for (const auto& wf : wfs) {
+                msg << "        Well that failed: " << wf.wellName() << "\n";
+            }
+            msg.flush();
+            OpmLog::debug(msg.str());
+
+            // Check the last few step reports.
+            const int num_steps = 3;
+            const int rep_step = sr.back().report_step;
+            const int sub_step = sr.back().current_step;
+            const int sr_size = sr.size();
+            std::set<std::string> failing_wells;
+            for (const auto& wf : wfs) {
+                failing_wells.insert(wf.wellName());
+            }
+            if (sr_size >= num_steps) {
+                for (int step = 1; step < num_steps; ++step) {
+                    const auto& srep = sr[sr_size - 1 - step];
+                    // Report must be from same report step and substep, otherwise we have
+                    // not chopped/retried enough times on this step.
+                    if (srep.report_step != rep_step || srep.current_step != sub_step) {
+                        break;
+                    }
+                    // Get the failing wells for this step, that also failed all other steps.
+                    std::set<std::string> failing_wells_step;
+                    for (const auto& wf : srep.report.back().wellFailures()) {
+                        if (failing_wells.count(wf.wellName()) > 0) {
+                            failing_wells_step.insert(wf.wellName());
+                        }
+                    }
+                    failing_wells.swap(failing_wells_step);
+                }
+            }
+            return failing_wells;
+        }
+
+
 
         typedef std::unique_ptr<TimeStepControlInterface> TimeStepControlType;
 


### PR DESCRIPTION
With this, we avoid some cases where timesteps are chopped repeatedly, sometimes to the point of terminating the simulation. Such deep chopping is avoided by shutting misbehaving wells. A well is misbehaving if:
 - the timestep would be chopped below a minimum limit (currently set to 0.25 day)
 - we have tried this step at least K times (currently K is set to 3)
 - each of those times, the well failed to converge.

We also enforce a maximum timestep limit that is only applied when THP constraints are active (currently set to 16 days).