### PR TITLE
Fix WTEST in parallel

### DIFF
--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -318,6 +318,7 @@ namespace Opm {
         // no wells needing testing, otherwise we will have locking.
         std::vector< Scalar > B_avg(numComponents(), Scalar() );
         computeAverageFormationFactor(B_avg);
+        wellhelpers::WellSwitchingLogger logger;
 
         const auto& wellsForTesting = wellTestState_.updateWell(wtest_config, simulationTime);
         for (const auto& testWell : wellsForTesting) {
@@ -336,7 +337,7 @@ namespace Opm {
             const WellTestConfig::Reason testing_reason = testWell.second;
 
             well->wellTesting(ebosSimulator_, B_avg, simulationTime, timeStepIdx, terminal_output_,
-                              testing_reason, well_state_, wellTestState_);
+                              testing_reason, well_state_, wellTestState_, logger);
         }
     }
 

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -313,15 +313,13 @@ namespace Opm {
             return;
         }
 
-        const auto& wellsForTesting = wellTestState_.updateWell(wtest_config, simulationTime);
-        if (wellsForTesting.size() == 0) { // there is no well available for WTEST at the moment
-            return;
-        }
-
         // average B factors are required for the convergence checking of well equations
+        // Note: this must be done on all processes, even those with
+        // no wells needing testing, otherwise we will have locking.
         std::vector< Scalar > B_avg(numComponents(), Scalar() );
         computeAverageFormationFactor(B_avg);
 
+        const auto& wellsForTesting = wellTestState_.updateWell(wtest_config, simulationTime);
         for (const auto& testWell : wellsForTesting) {
             const std::string& well_name = testWell.first;
 

--- a/opm/autodiff/MultisegmentWell.hpp
+++ b/opm/autodiff/MultisegmentWell.hpp
@@ -353,7 +353,7 @@ namespace Opm
         virtual void wellTestingPhysical(Simulator& simulator, const std::vector<double>& B_avg,
                                          const double simulation_time, const int report_step,
                                          const bool terminal_output,
-                                         WellState& well_state, WellTestState& welltest_state) override;
+                                         WellState& well_state, WellTestState& welltest_state, wellhelpers::WellSwitchingLogger& logger) override;
     };
 
 }

--- a/opm/autodiff/MultisegmentWell_impl.hpp
+++ b/opm/autodiff/MultisegmentWell_impl.hpp
@@ -1897,7 +1897,7 @@ namespace Opm
     MultisegmentWell<TypeTag>::
     wellTestingPhysical(Simulator& simulator, const std::vector<double>& B_avg,
                         const double simulation_time, const int report_step, const bool terminal_output,
-                        WellState& well_state, WellTestState& welltest_state)
+                        WellState& well_state, WellTestState& welltest_state, wellhelpers::WellSwitchingLogger& logger)
     {
         const std::string msg = "Support of well testing for physical limits for multisegment wells is not "
                                 "implemented yet, wellTestingPhysical() for " + name() + " will do nothing";

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -406,7 +406,7 @@ namespace Opm
 
         virtual void wellTestingPhysical(Simulator& simulator, const std::vector<double>& B_avg,
                                          const double simulation_time, const int report_step, const bool terminal_output,
-                                         WellState& well_state, WellTestState& welltest_state);
+                                         WellState& well_state, WellTestState& welltest_state, wellhelpers::WellSwitchingLogger& logger) override;
     };
 
 }

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -2724,7 +2724,7 @@ namespace Opm
     StandardWell<TypeTag>::
     wellTestingPhysical(Simulator& ebos_simulator, const std::vector<double>& B_avg,
                         const double simulation_time, const int report_step, const bool terminal_output,
-                        WellState& well_state, WellTestState& welltest_state)
+                        WellState& well_state, WellTestState& welltest_state, wellhelpers::WellSwitchingLogger& logger)
     {
         OpmLog::debug(" well " + name() + " is being tested for physical limits");
 
@@ -2759,7 +2759,7 @@ namespace Opm
         updatePrimaryVariables(well_state_copy);
         initPrimaryVariablesEvaluation();
 
-        const bool converged = this->solveWellEqUntilConverged(ebos_simulator, B_avg, well_state_copy);
+        const bool converged = this->solveWellEqUntilConverged(ebos_simulator, B_avg, well_state_copy, logger);
 
         if (!converged) {
             const std::string msg = " well " + name() + " did not get converged during well testing for physical reason";

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -219,7 +219,8 @@ namespace Opm
         void wellTesting(Simulator& simulator, const std::vector<double>& B_avg,
                          const double simulation_time, const int report_step,  const bool terminal_output,
                          const WellTestConfig::Reason testing_reason,
-                         /* const */ WellState& well_state, WellTestState& welltest_state);
+                         /* const */ WellState& well_state, WellTestState& welltest_state,
+                         wellhelpers::WellSwitchingLogger& logger);
 
         void updatePerforatedCell(std::vector<bool>& is_cell_perforated);
 
@@ -362,11 +363,11 @@ namespace Opm
 
         void wellTestingEconomic(Simulator& simulator, const std::vector<double>& B_avg,
                                  const double simulation_time, const int report_step, const bool terminal_output,
-                                 const WellState& well_state, WellTestState& welltest_state);
+                                 const WellState& well_state, WellTestState& welltest_state, wellhelpers::WellSwitchingLogger& logger);
 
         virtual void wellTestingPhysical(Simulator& simulator, const std::vector<double>& B_avg,
                                  const double simulation_time, const int report_step, const bool terminal_output,
-                                 WellState& well_state, WellTestState& welltest_state) = 0;
+                                         WellState& well_state, WellTestState& welltest_state, wellhelpers::WellSwitchingLogger& logger) = 0;
 
         void updateWellTestStateEconomic(const WellState& well_state,
                                          const double simulation_time,
@@ -379,11 +380,13 @@ namespace Opm
                                          WellTestState& well_test_state) const;
 
         void  solveWellForTesting(Simulator& ebosSimulator, WellState& well_state,
-                                  const std::vector<double>& B_avg, bool terminal_output);
+                                  const std::vector<double>& B_avg, bool terminal_output,
+                                  wellhelpers::WellSwitchingLogger& logger);
 
         bool solveWellEqUntilConverged(Simulator& ebosSimulator,
-                                        const std::vector<double>& B_avg,
-                                        WellState& well_state);
+                                       const std::vector<double>& B_avg,
+                                       WellState& well_state,
+                                       wellhelpers::WellSwitchingLogger& logger);
 
         void scaleProductivityIndex(const int perfIdx, double& productivity_index) const;
 


### PR DESCRIPTION
This fixes two crashing bugs in the WTEST implementation that only bite when run in parallel.

Note that there are still *output* bugs in the WTEST implementation, so for now one must expect the following diagnostic:
```
WARNING: There has been logging to file ./3D_WECON.1.DBG by process 1
WARNING: There has been logging to file ./3D_WECON.1.PRT by process 1
```
... and find some output related to WTEST appended to the end of the DBG file instead of at the appropriate location. Fixing the output bugs is less critical, but should be done.