### PR TITLE
Remove usage of BlackoilState class

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -23,7 +23,6 @@
 # originally generated with the command:
 # find opm -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND MAIN_SOURCE_FILES
-  opm/autodiff/Compat.cpp
   opm/autodiff/ExtractParallelGridInformationToISTL.cpp
   opm/autodiff/moduleVersion.cpp
   opm/autodiff/MPIUtilities.cpp
@@ -32,7 +31,6 @@ list (APPEND MAIN_SOURCE_FILES
   opm/autodiff/MissingFeatures.cpp
   opm/core/props/rock/RockFromDeck.cpp
   opm/core/props/satfunc/RelpermDiagnostics.cpp
-  opm/core/simulator/BlackoilState.cpp
   opm/core/simulator/SimulatorReport.cpp
   opm/core/wells/InjectionSpecification.cpp
   opm/core/wells/ProductionSpecification.cpp
@@ -41,7 +39,6 @@ list (APPEND MAIN_SOURCE_FILES
   opm/core/wells/WellsManager.cpp
   opm/core/wells/well_controls.c
   opm/core/wells/wells.c
-  opm/polymer/PolymerBlackoilState.cpp
   opm/simulators/WellSwitchingLogger.cpp
   opm/simulators/timestepping/TimeStepControl.cpp
   opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
@@ -63,7 +60,6 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_timer.cpp
   tests/test_invert.cpp
   tests/test_wells.cpp
-  tests/test_blackoilstate.cpp
   tests/test_wellsmanager.cpp
   tests/test_wellcontrols.cpp
   tests/test_wellsgroup.cpp
@@ -93,8 +89,6 @@ list (APPEND TEST_DATA_FILES
   tests/equil_rsvd_and_rvvd.DATA
   tests/wetgas.DATA
   tests/satfuncEPS_B.DATA
-  tests/testBlackoilState1.DATA
-  tests/testBlackoilState2.DATA
   tests/wells_manager_data.data
   tests/wells_manager_data_expanded.data
   tests/wells_manager_data_wellSTOP.data
@@ -114,7 +108,6 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/autodiff/BlackoilModelParametersEbos.hpp
   opm/autodiff/BlackoilAquiferModel.hpp
   opm/autodiff/BlackoilAquiferModel_impl.hpp
-  opm/autodiff/Compat.hpp
   opm/autodiff/CPRPreconditioner.hpp
   opm/autodiff/createGlobalCellArray.hpp
   opm/autodiff/ExtractParallelGridInformationToISTL.hpp
@@ -151,16 +144,12 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/autodiff/MissingFeatures.hpp
   opm/core/linalg/ParallelIstlInformation.hpp
   opm/core/props/BlackoilPhases.hpp
-  opm/core/props/BlackoilPropertiesInterface.hpp
   opm/core/props/phaseUsageFromDeck.hpp
   opm/core/props/rock/RockFromDeck.hpp
   opm/core/props/satfunc/RelpermDiagnostics.hpp
   opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
-  opm/core/simulator/BlackoilState.hpp
-  opm/core/simulator/BlackoilStateToFluidState.hpp
   opm/core/simulator/SimulatorReport.hpp
   opm/core/simulator/WellState.hpp
-  opm/core/utility/initHydroCarbonState.hpp
   opm/core/well_controls.h
   opm/core/wells.h
   opm/core/wells/InjectionSpecification.hpp
@@ -170,7 +159,6 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/core/wells/WellsManager.hpp
   opm/core/wells/DynamicListEconLimited.hpp
   opm/core/wells/WellsManager_impl.hpp
-  opm/polymer/PolymerBlackoilState.hpp
   opm/simulators/ParallelFileMerger.hpp
   opm/simulators/WellSwitchingLogger.hpp
   opm/simulators/timestepping/AdaptiveSimulatorTimer.hpp

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -101,7 +101,6 @@ namespace Opm {
     {
     public:
         // ---------  Types and enums  ---------
-        typedef BlackoilState ReservoirState;
         typedef WellStateFullyImplicitBlackoil WellState;
         typedef BlackoilModelParametersEbos<TypeTag> ModelParameters;
 

--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -48,7 +48,6 @@
 #include <opm/autodiff/WellInterface.hpp>
 #include <opm/autodiff/StandardWell.hpp>
 #include <opm/autodiff/MultisegmentWell.hpp>
-#include <opm/autodiff/Compat.hpp>
 #include <opm/simulators/timestepping/gatherConvergenceReport.hpp>
 #include<opm/autodiff/SimFIBODetails.hpp>
 #include<dune/common/fmatrix.hh>
@@ -411,6 +410,11 @@ namespace Opm {
             void updatePerforationIntensiveQuantities();
 
             void wellTesting(const int timeStepIdx, const double simulationTime);
+
+            // convert well data from opm-common to well state from opm-core
+            void wellsToState( const data::Wells& wells,
+                               PhaseUsage phases,
+                               WellStateFullyImplicitBlackoil& state );
 
         };
 

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -1545,4 +1545,70 @@ namespace Opm {
         }
     }
 
+
+    // convert well data from opm-common to well state from opm-core
+    template<typename TypeTag>
+    void
+    BlackoilWellModel<TypeTag>::
+    wellsToState( const data::Wells& wells,
+                       PhaseUsage phases,
+                       WellStateFullyImplicitBlackoil& state ) {
+
+        using rt = data::Rates::opt;
+        const auto np = phases.num_phases;
+
+        std::vector< rt > phs( np );
+        if( phases.phase_used[BlackoilPhases::Aqua] ) {
+            phs.at( phases.phase_pos[BlackoilPhases::Aqua] ) = rt::wat;
+        }
+
+        if( phases.phase_used[BlackoilPhases::Liquid] ) {
+            phs.at( phases.phase_pos[BlackoilPhases::Liquid] ) = rt::oil;
+        }
+
+        if( phases.phase_used[BlackoilPhases::Vapour] ) {
+            phs.at( phases.phase_pos[BlackoilPhases::Vapour] ) = rt::gas;
+        }
+
+        for( const auto& wm : state.wellMap() ) {
+            const auto well_index = wm.second[ 0 ];
+            const auto& well = wells.at( wm.first );
+            state.bhp()[ well_index ] = well.bhp;
+            state.temperature()[ well_index ] = well.temperature;
+            state.currentControls()[ well_index ] = well.control;
+            const auto wellrate_index = well_index * np;
+            for( size_t i = 0; i < phs.size(); ++i ) {
+                assert( well.rates.has( phs[ i ] ) );
+                state.wellRates()[ wellrate_index + i ] = well.rates.get( phs[ i ] );
+            }
+
+            const auto perforation_pressure = []( const data::Connection& comp ) {
+                return comp.pressure;
+            };
+
+            const auto perforation_reservoir_rate = []( const data::Connection& comp ) {
+                return comp.reservoir_rate;
+            };
+
+            std::transform( well.connections.begin(),
+                            well.connections.end(),
+                            state.perfPress().begin() + wm.second[ 1 ],
+                    perforation_pressure );
+
+            std::transform( well.connections.begin(),
+                            well.connections.end(),
+                            state.perfRates().begin() + wm.second[ 1 ],
+                    perforation_reservoir_rate );
+
+            int local_comp_index = 0;
+            for (const data::Connection& comp : well.connections) {
+                const int global_comp_index = wm.second[1] + local_comp_index;
+                for (int phase_index = 0; phase_index < np; ++phase_index) {
+                    state.perfPhaseRates()[global_comp_index*np + phase_index] = comp.rates.get(phs[phase_index]);
+                }
+                ++local_comp_index;
+            }
+        }
+    }
+
 } // namespace Opm

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -95,7 +95,6 @@ namespace Opm
         typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
 
         typedef Opm::SimulatorFullyImplicitBlackoilEbos<TypeTag> Simulator;
-        typedef typename Simulator::ReservoirState ReservoirState;
         typedef typename BlackoilModelEbos<TypeTag>::ISTLSolverType ISTLSolverType;
 
         // Read the command line parameters. Throws an exception if something goes wrong.

--- a/opm/autodiff/NonlinearSolverEbos.hpp
+++ b/opm/autodiff/NonlinearSolverEbos.hpp
@@ -120,7 +120,6 @@ namespace Opm {
         };
 
         // Forwarding types from PhysicalModel.
-        typedef typename PhysicalModel::ReservoirState ReservoirState;
         typedef typename PhysicalModel::WellState WellState;
 
         // ---------  Public methods  ---------
@@ -235,14 +234,6 @@ namespace Opm {
         /// Number of well iterations used in all calls to step().
         int wellIterationsLastStep() const
         { return wellIterationsLast_; }
-
-        /// Compute fluid in place.
-        /// \param[in]    ReservoirState
-        /// \param[in]    FIPNUM for active cells not global cells.
-        /// \return fluid in place, number of fip regions, each region contains 5 values which are liquid, vapour, water, free gas and dissolved gas.
-        std::vector<std::vector<double> >
-        computeFluidInPlace(const ReservoirState& x, const std::vector<int>& fipnum) const
-        { return model_->computeFluidInPlace(x, fipnum); }
 
         std::vector<std::vector<double> >
         computeFluidInPlace(const std::vector<int>& fipnum) const

--- a/opm/autodiff/SimFIBODetails.hpp
+++ b/opm/autodiff/SimFIBODetails.hpp
@@ -25,7 +25,6 @@
 #include <algorithm>
 #include <locale>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
-#include <opm/core/utility/initHydroCarbonState.hpp>
 #include <opm/core/well_controls.h>
 #include <opm/core/wells/DynamicListEconLimited.hpp>
 

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -69,7 +69,6 @@ public:
     typedef Ewoms::BlackOilPolymerModule<TypeTag> PolymerModule;
 
     typedef WellStateFullyImplicitBlackoil WellState;
-    typedef BlackoilState ReservoirState;
     typedef BlackoilModelEbos<TypeTag> Model;
     typedef NonlinearSolverEbos<TypeTag, Model> Solver;
     typedef typename Model::ModelParameters ModelParameters;

--- a/tests/test_stoppedwells.cpp
+++ b/tests/test_stoppedwells.cpp
@@ -29,7 +29,6 @@
 #include <opm/core/wells/WellsManager.hpp>
 #include <opm/core/wells.h>
 #include <opm/core/well_controls.h>
-#include <opm/core/simulator/BlackoilState.hpp>
 #include <opm/core/simulator/WellState.hpp>
 #include <opm/grid/GridManager.hpp>
 
@@ -55,8 +54,6 @@ BOOST_AUTO_TEST_CASE(TestStoppedWells)
     double target_surfacerate_prod;
 
     const std::vector<double> pressure = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-    BlackoilState state( pressure.size() , 0 , 3);
-    state.pressure() = pressure;
 
     // Both wells are open in the first schedule step
     {
@@ -71,7 +68,7 @@ BOOST_AUTO_TEST_CASE(TestStoppedWells)
     target_surfacerate_prod = well_controls_iget_target(ctrls1 , 0);
 
     WellState wellstate;
-    wellstate.init(wells, state);
+    wellstate.init(wells, pressure);
     const std::vector<double> wellrates = wellstate.wellRates();
     BOOST_CHECK_EQUAL (target_surfacerate_inj, wellrates[2]); // Gas injector
     BOOST_CHECK_EQUAL (target_surfacerate_prod, wellrates[4]); // Oil target rate
@@ -88,7 +85,7 @@ BOOST_AUTO_TEST_CASE(TestStoppedWells)
     BOOST_CHECK(well_controls_well_is_open(ctrls1));
 
     WellState wellstate;
-    wellstate.init(wells, state);
+    wellstate.init(wells, pressure);
 
     const std::vector<double> wellrates = wellstate.wellRates();
     BOOST_CHECK_EQUAL (0, wellrates[2]); // Gas injector


### PR DESCRIPTION
This allows (re)moving of the following files
```
opm/autodiff/RateConverter.hpp
opm/autodiff/Compat.cpp
opm/autodiff/Compat.hpp
opm/core/props/BlackoilPropertiesInterface.hpp
opm/core/simulator/BlackoilState.cpp
opm/core/simulator/BlackoilState.hpp
opm/core/simulator/BlackoilStateToFluidState.hpp
opm/core/utility/initHydroCarbonState.hpp
opm/polymer/PolymerBlackoilState.cpp
opm/polymer/PolymerBlackoilState.hpp
tests/test_blackoilstate.cpp
```
Superseeds #1660 