### PR TITLE
Fix potential infinite loop

### DIFF
--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -239,7 +239,8 @@ namespace Opm {
             bool hasTHPConstraints() const;
 
             /// Shut down any single well, but only if it is in prediction mode.
-            void forceShutWellByNameIfPredictionMode(const std::string& wellname, const double simulation_time);
+            /// Returns true if the well was actually found and shut.
+            bool forceShutWellByNameIfPredictionMode(const std::string& wellname, const double simulation_time);
 
         protected:
 

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -133,30 +133,37 @@ namespace Opm {
 
 
 
-    /// Return true if any well has a THP constraint.
+    /// Return true if the well was found and shut.
     template<typename TypeTag>
-    void
+    bool
     BlackoilWellModel<TypeTag>::
     forceShutWellByNameIfPredictionMode(const std::string& wellname,
                                         const double simulation_time)
     {
         // Only add the well to the closed list on the
         // process that owns it.
+        int well_was_shut = 0;
         for (const auto& well : well_container_) {
             if (well->name() == wellname) {
                 if (well->underPredictionMode()) {
                     wellTestState_.addClosedWell(wellname, WellTestConfig::Reason::PHYSICAL, simulation_time);
+                    well_was_shut = 1;
                 }
                 break;
             }
         }
 
+        // Communicate across processes if a well was shut.
+        well_was_shut = ebosSimulator_.vanguard().grid().comm().max(well_was_shut);
+
         // Only log a message on the output rank.
-        if (terminal_output_) {
+        if (terminal_output_ && well_was_shut) {
             const std::string msg = "Well " + wellname
                 + " will be shut because it cannot get converged.";
             OpmLog::info(msg);
         }
+
+        return (well_was_shut == 1);
     }
 
 


### PR DESCRIPTION
In the post-merge discussion of #1658, @totto82 raised two problems:
 - history matching wells were shut on one case,
 - an infinite loop could occur.

This PR addresses the second problem.

About the first problem (shutting history wells), I cannot see how that would happen. I think the current master can print a message about shutting a well even though it would not actually shut it (if not a prediction well), and I hope that this holds for the case observed by @totto82 (if not, I need more information to fix). In any case, that printing error has been fixed here.