### PR TITLE
[WIP] Enable Regression Tests of ECLIPSE Compatible Restart Files

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -73,6 +73,42 @@ function(add_test_compare_restarted_simulation)
 endfunction()
 
 ###########################################################################
+# TEST: add_test_compare_restarted_simulation_eclcompat
+###########################################################################
+
+# Input:
+#   - casename: basename (no extension)
+#
+# Details:
+#   - This test class compares the output from a restarted simulation
+#     to that of a non-restarted simulation.  Uses ECLIPSE-compatible
+#     restart files.
+function(add_test_compare_restarted_simulation_eclcompat)
+  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL)
+  set(multiValueArgs TEST_ARGS)
+  cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+  set(RESULT_PATH ${BASE_RESULT_PATH}/restart/${PARAM_SIMULATOR}+${PARAM_CASENAME})
+  set(OPM_EXTENDED_RESTART_FILE "false")
+  set(TEST_ARGS
+      ${OPM_TESTS_ROOT}/${PARAM_CASENAME}/${PARAM_FILENAME}
+      ${OPM_EXTENDED_RESTART_FILE}
+      ${PARAM_TEST_ARGS}
+  )
+
+  opm_add_test(compareECLCompatRestartedSim_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
+               EXE_NAME ${PARAM_SIMULATOR}
+               DRIVER_ARGS ${OPM_TESTS_ROOT}/${PARAM_CASENAME} ${RESULT_PATH}
+                           ${PROJECT_BINARY_DIR}/bin
+                           ${PARAM_FILENAME}
+                           ${PARAM_ABS_TOL} ${PARAM_REL_TOL}
+                           ${COMPARE_ECL_COMMAND}
+                           ${OPM_PACK_COMMAND}
+                           0
+               TEST_ARGS ${TEST_ARGS})
+endfunction()
+
+###########################################################################
 # TEST: add_test_compare_parallel_simulation
 ###########################################################################
 

--- a/tests/run-parallel-regressionTest.sh
+++ b/tests/run-parallel-regressionTest.sh
@@ -27,21 +27,27 @@ mpirun -np 4 ${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA --enable-opm-rst-file=true
 test $? -eq 0 || exit 1
 cd ..
 
+ignore_extra_kw=""
+if grep -q "ignore_extra" <<< $ghprbCommentBody
+then
+    ignore_extra_kw="-x"
+fi
+
 ecode=0
 echo "=== Executing comparison for summary file ==="
-${COMPARE_ECL_COMMAND} -t SMRY -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -t SMRY -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]
 then
   ecode=1
-  ${COMPARE_ECL_COMMAND} -t SMRY -a -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -t SMRY -a -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
 echo "=== Executing comparison for restart file ==="
-${COMPARE_ECL_COMMAND} -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -l -t UNRST${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]
 then
   ecode=1
-  ${COMPARE_ECL_COMMAND} -a -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -a -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
 exit $ecode

--- a/tests/run-restart-regressionTest.sh
+++ b/tests/run-restart-regressionTest.sh
@@ -1,57 +1,82 @@
 #!/bin/bash
 
-# This runs a simulator from start to end, then a restarted
-# run of the simulator, before comparing the output from the two runs.
-# This is meant to track regressions in the restart support.
+# This runs a simulator from start to end, then a restarted run of the
+# simulator, before comparing the output from the two runs.  This is
+# meant to track regressions in the restart support.
 
-INPUT_DATA_PATH="$1"
-RESULT_PATH="$2"
-BINPATH="$3"
-FILENAME="$4"
-ABS_TOL="$5"
-REL_TOL="$6"
-COMPARE_ECL_COMMAND="$7"
-OPM_PACK_COMMAND="$8"
-PARALLEL="${9}"
-EXE_NAME="${10}"
-shift 10
-TEST_ARGS="$@"
+INPUT_DATA_PATH="${1}";       shift
+RESULT_PATH="${1}";           shift
+BINPATH="${1}";               shift
+FILENAME="${1}";              shift
+ABS_TOL="${1}";               shift
+REL_TOL="${1}";               shift
+COMPARE_ECL_COMMAND="${1}";   shift
+OPM_PACK_COMMAND="${1}";      shift
+PARALLEL="${1}";              shift
+EXE_NAME="${1}";              shift
+CASENAME="${1}";              shift
+OPM_RSTFILE=$(echo "${1:-true}" | tr "[:upper:]" "[:lower:]");
 
-BASE_NAME=`basename ${TEST_ARGS}_RESTART.DATA`
-
-rm -Rf ${RESULT_PATH}
-mkdir -p ${RESULT_PATH}
-cd ${RESULT_PATH}
-if test $PARALLEL -eq 1
+if [ $# -gt 0 ]
 then
-  CMD_PREFIX="mpirun -np 4 "
-else
-  CMD_PREFIX=""
+    # Caller provided OPM_RSTFILE.  Shift away that setting to enable
+    # passing all other parameters on to ${EXE_NAME}.
+    shift
 fi
- ${CMD_PREFIX} ${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA --enable-adaptive-time-stepping=false --output-dir=${RESULT_PATH}
 
+BASE_NAME=`basename "${CASENAME}_RESTART.DATA"`
+
+rm -Rf "${RESULT_PATH}"
+mkdir -p "${RESULT_PATH}"
+
+cd "${RESULT_PATH}"
+if test "$PARALLEL" -eq 1
+then
+    CMD_PREFIX="mpirun -np 4 "
+else
+    CMD_PREFIX=""
+fi
+
+${CMD_PREFIX} "${BINPATH}/${EXE_NAME}" "${CASENAME}.DATA" \
+    --enable-adaptive-time-stepping=false \
+    --enable-opm-rst-file="${OPM_RSTFILE}" \
+    --output-dir="${RESULT_PATH}" "$@"
 test $? -eq 0 || exit 1
 
-${OPM_PACK_COMMAND} -o ${BASE_NAME} ${TEST_ARGS}_RESTART.DATA
+${OPM_PACK_COMMAND} -o "${BASE_NAME}" "${CASENAME}_RESTART.DATA"
 
-${CMD_PREFIX} ${BINPATH}/${EXE_NAME} ${BASE_NAME} --enable-adaptive-time-stepping=false --output-dir=${RESULT_PATH}
+    --enable-adaptive-time-stepping=false \
+    --enable-opm-rst-file="${OPM_RSTFILE}" \
+    --output-dir="${RESULT_PATH}" "$@"
 test $? -eq 0 || exit 1
 
 ecode=0
 echo "=== Executing comparison for summary file ==="
-${COMPARE_ECL_COMMAND} -R -t SMRY ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/${FILENAME}_RESTART ${ABS_TOL} ${REL_TOL}
+${COMPARE_ECL_COMMAND} -R -t SMRY \
+    "${RESULT_PATH}/${FILENAME}" \
+    "${RESULT_PATH}/${FILENAME}_RESTART" \
+    ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]
 then
-  ecode=1
-  ${COMPARE_ECL_COMMAND} -a -R -t SMRY ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/${FILENAME}_RESTART ${ABS_TOL} ${REL_TOL}
+    ecode=1
+    ${COMPARE_ECL_COMMAND} -a -R -t SMRY \
+        "${RESULT_PATH}/${FILENAME}" \
+        "${RESULT_PATH}/${FILENAME}_RESTART" \
+        ${ABS_TOL} ${REL_TOL}
 fi
 
 echo "=== Executing comparison for restart file ==="
-${COMPARE_ECL_COMMAND} -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/${FILENAME}_RESTART ${ABS_TOL} ${REL_TOL}
+${COMPARE_ECL_COMMAND} -l -t UNRST \
+    "${RESULT_PATH}/${FILENAME}" \
+    "${RESULT_PATH}/${FILENAME}_RESTART" \
+    ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]
 then
-  ecode=1
-  ${COMPARE_ECL_COMMAND} -a -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/${FILENAME}_RESTART ${ABS_TOL} ${REL_TOL}
+    ecode=1
+    ${COMPARE_ECL_COMMAND} -a -l -t UNRST \
+        "${RESULT_PATH}/${FILENAME}" \
+        "${RESULT_PATH}/${FILENAME}_RESTART" \
+        ${ABS_TOL} ${REL_TOL}
 fi
 
 exit $ecode


### PR DESCRIPTION
This pull request adds a new test category
```
add_test_compare_restarted_simulation_eclcompat
```
which is intended to compare the results of running restarted simulations when using ECLIPSE compatible restart files (OPM-specific vectors missing, solution data output as 'float').  We also update the restart-related regression test runner to cater to the possibility that a particular caller regression test might wish to specify
```
--enable-opm-rst-file=false
```
instead of the default `true` value.

I am marking this as a work in progress because there is as yet no regression test that uses said flag, but I wanted to solicity early opinions on the general approach, both in the CMake code and the shell script.