### PR TITLE
Add special case handling of commandline argument "--version"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,13 @@ opm_add_test(flow
     flow/flow_ebos_oilwater_polymer.cpp)
 install(TARGETS flow DESTINATION bin)
 
+add_test(NAME flow__version
+         COMMAND flow --version)
+set_tests_properties(flow__version PROPERTIES
+                     PASS_REGULAR_EXPRESSION "${${project}_LABEL}")
+
+
+
 include(OpmBashCompletion)
 opm_add_bash_completion(flow)
 

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -30,6 +30,7 @@
 
 #include <opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/autodiff/FlowMainEbos.hpp>
+#include <opm/autodiff/moduleVersion.hpp>
 #include <ewoms/common/propertysystem.hh>
 #include <ewoms/common/parametersystem.hh>
 #include <opm/autodiff/MissingFeatures.hpp>
@@ -83,12 +84,31 @@ namespace detail
 
         throw std::invalid_argument( "Cannot find input case " + casename );
     }
-}
 
+
+    // This function is an extreme special case, if the program has been invoked
+    // *exactly* as:
+    //
+    //    flow   --version
+    //
+    // the call is intercepted by this function which will print "flow $version"
+    // on stdout and exit(0).
+    void handleVersionCmdLine(int argc, char** argv) {
+        if (argc != 2)
+            return;
+
+        if (std::strcmp(argv[1], "--version") == 0) {
+            std::cout << "flow " << Opm::moduleVersionName() << std::endl;
+            std::exit(EXIT_SUCCESS);
+        }
+    }
+
+}
 
 // ----------------- Main program -----------------
 int main(int argc, char** argv)
 {
+    detail::handleVersionCmdLine(argc, argv);
     // MPI setup.
 #if HAVE_DUNE_FEM
     Dune::Fem::MPIManager::initialize(argc, argv);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1321665/49701664-3f25d680-fbef-11e8-9651-22cd7bdebdfc.png)

Yes yes yes; we all agree this is grose. The `--version` commandline argument should have been handled by the parameter system, but it was not clear to me how to get that system to handle parameters without a trailing `=value` part?

If this PR is merged we will get the following behavior: When `flow` is invoked *exactly* as:
```
flow --version
```
it will print
```
flow $version
```
on stdout and `exit(0)`. The purpose of this is for *other programs* to be able easily check the version of a `flow` binary.
