### PR TITLE
use the common API opm-material for functions

### DIFF
--- a/opm/autodiff/StandardWellV_impl.hpp
+++ b/opm/autodiff/StandardWellV_impl.hpp
@@ -2944,7 +2944,7 @@ namespace Opm
         const EvalWell throughput_eval(numWellEq_ + numEq, throughput);
         // the skin pressure when injecting water, which also means the polymer concentration is zero
         EvalWell pskin_water(numWellEq_ + numEq, 0.0);
-        water_table_func.eval(throughput_eval, water_velocity, pskin_water);
+        pskin_water = water_table_func.eval(throughput_eval, water_velocity);
         return pskin_water;
     }
 
@@ -2977,7 +2977,7 @@ namespace Opm
         const EvalWell throughput_eval(numWellEq_ + numEq, throughput);
         // the skin pressure when injecting water, which also means the polymer concentration is zero
         EvalWell pskin_poly(numWellEq_ + numEq, 0.0);
-        skprpolytable.table_func.eval(throughput_eval, water_velocity_abs, pskin_poly);
+        pskin_poly = skprpolytable.table_func.eval(throughput_eval, water_velocity_abs);
         if (poly_inj_conc == reference_concentration) {
             return sign * pskin_poly;
         }
@@ -3008,7 +3008,7 @@ namespace Opm
         if (wpolymer() == 0.) { // not injecting polymer
             return molecular_weight;
         }
-        table_func.eval(throughput_eval, Opm::abs(water_velocity), molecular_weight);
+        molecular_weight = table_func.eval(throughput_eval, Opm::abs(water_velocity));
         return molecular_weight;
     }
 


### PR DESCRIPTION
the way to get the result of an evaluation is by return value, i.e.,

 z = fn.eval(x, y);

not by passing a separate argument to the eval() function like

 fn.eval(x, y, z);

the `XYTabulated2DFunction` used the latter approach causing an API inconsistency with all other tabulation classes in opm-material. OPM/opm-material#319 fixes that but requires this mop-up as a consequence.