### PR TITLE
Avoid segfault when a well has no perforations.

### DIFF
--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -540,8 +540,9 @@ namespace Opm {
                     }
                 }
 
-                // Use the pvtRegionIdx from the top cell
-                const int well_cell_top = wells()->well_cells[wells()->well_connpos[w]];
+                // Use the pvtRegionIdx from the top cell, or cell 0 if there are no perforations.
+                const bool has_perf = wells()->well_connpos[w] < wells()->well_connpos[w + 1];
+                const int well_cell_top = has_perf ? (wells()->well_cells[wells()->well_connpos[w]]) : 0;
                 const int pvtreg = pvt_region_idx_[well_cell_top];
 
                 if ( !well_ecl->isMultiSegment(time_step) || !param_.use_multisegment_well_) {


### PR DESCRIPTION
In #1687 an example was given that had a well with no perforations. That caused a segfault, although it was not trivial to reproduce, as reading uninitialized memory cannot be trusted to always cause a crash.

The proposed fix does only minimal changes to the simulator, in particular the well with no perforations is still added to the well container. Changing that behaviour may be appropriate, but I have here only tried to fix the immediate problem.