### PR TITLE
[WIP for discussion] remove the MatrixAddWellContributions and PreconditionerAddWellContributions parameters

### DIFF
--- a/ebos/ebos.hh
+++ b/ebos/ebos.hh
@@ -54,7 +54,6 @@ SET_BOOL_PROP(EbosTypeTag, EnableExperiments, true);
 SET_TYPE_PROP(EbosTypeTag, EclWellModel, Opm::BlackoilWellModel<TypeTag>);
 
 // set some properties that are only required by the well model
-SET_BOOL_PROP(EbosTypeTag, MatrixAddWellContributions, true);
 SET_BOOL_PROP(EbosTypeTag, EnableTerminalOutput, false);
 // flow's well model only works with surface volumes
 SET_BOOL_PROP(EbosTypeTag, BlackoilConserveSurfaceVolume, true);
@@ -125,7 +124,6 @@ public:
         EWOMS_HIDE_PARAM(TypeTag, SolveWelleqInitially);
         EWOMS_HIDE_PARAM(TypeTag, UpdateEquationsScaling);
         EWOMS_HIDE_PARAM(TypeTag, UseUpdateStabilization);
-        EWOMS_HIDE_PARAM(TypeTag, MatrixAddWellContributions);
         EWOMS_HIDE_PARAM(TypeTag, EnableTerminalOutput);
     }
 

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -374,6 +374,8 @@ namespace Opm {
             ebosSimulator_.model().linearizer().linearizeDomain();
             ebosSimulator_.problem().endIteration();
 
+            auto& ebosJac = ebosSimulator_.model().linearizer().jacobian();
+            wellModel().addWellContributions(ebosJac.istlMatrix());
             return wellModel().lastReport();
         }
 

--- a/opm/autodiff/BlackoilModelParametersEbos.hpp
+++ b/opm/autodiff/BlackoilModelParametersEbos.hpp
@@ -47,7 +47,6 @@ NEW_PROP_TAG(MaxStrictIter);
 NEW_PROP_TAG(SolveWelleqInitially);
 NEW_PROP_TAG(UpdateEquationsScaling);
 NEW_PROP_TAG(UseUpdateStabilization);
-NEW_PROP_TAG(MatrixAddWellContributions);
 
 // parameters for multisegment wells
 NEW_PROP_TAG(TolerancePressureMsWells);
@@ -70,7 +69,6 @@ SET_INT_PROP(FlowModelParameters, MaxStrictIter, 8);
 SET_BOOL_PROP(FlowModelParameters, SolveWelleqInitially, true);
 SET_BOOL_PROP(FlowModelParameters, UpdateEquationsScaling, false);
 SET_BOOL_PROP(FlowModelParameters, UseUpdateStabilization, true);
-SET_BOOL_PROP(FlowModelParameters, MatrixAddWellContributions, false);
 SET_SCALAR_PROP(FlowModelParameters, TolerancePressureMsWells, 0.01 *1e5);
 SET_SCALAR_PROP(FlowModelParameters, MaxPressureChangeMsWells, 2.0 *1e5);
 SET_BOOL_PROP(FlowModelParameters, UseInnerIterationsMsWells, true);
@@ -150,9 +148,6 @@ namespace Opm
         /// The file name of the deck
         std::string deck_file_name_;
 
-        // Whether to add influences of wells between cells to the matrix and preconditioner matrix
-        bool matrix_add_well_contributions_;
-
         /// Construct from user parameters or defaults.
         BlackoilModelParametersEbos()
         {
@@ -175,7 +170,6 @@ namespace Opm
             solve_welleq_initially_ = EWOMS_GET_PARAM(TypeTag, bool, SolveWelleqInitially);
             update_equations_scaling_ = EWOMS_GET_PARAM(TypeTag, bool, UpdateEquationsScaling);
             use_update_stabilization_ = EWOMS_GET_PARAM(TypeTag, bool, UseUpdateStabilization);
-            matrix_add_well_contributions_ = EWOMS_GET_PARAM(TypeTag, bool, MatrixAddWellContributions);
 
             deck_file_name_ = EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName);
         }
@@ -201,7 +195,6 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, bool, SolveWelleqInitially, "Fully solve the well equations before each iteration of the reservoir model");
             EWOMS_REGISTER_PARAM(TypeTag, bool, UpdateEquationsScaling, "Update scaling factors for mass balance equations during the run");
             EWOMS_REGISTER_PARAM(TypeTag, bool, UseUpdateStabilization, "Try to detect and correct oscillations or stagnation during the Newton method");
-            EWOMS_REGISTER_PARAM(TypeTag, bool, MatrixAddWellContributions, "Explicitly specify the influences of wells between cells in the Jacobian and preconditioner matrices");
         }
     };
 } // namespace Opm

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -76,10 +76,6 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     addNeighbors(std::vector<NeighborSet>& neighbors) const
     {
-        if (!param_.matrix_add_well_contributions_) {
-            return;
-        }
-
         // Create cartesian to compressed mapping
         int last_time_step = schedule().getTimeMap().size() - 1;
         const auto& schedule_wells = schedule().getWells();
@@ -121,16 +117,6 @@ namespace Opm {
     {
         if (!localWellsActive())
             return;
-
-        if (!param_.matrix_add_well_contributions_) {
-            // if the well contributions are not supposed to be included explicitly in
-            // the matrix, we only apply the vector part of the Schur complement here.
-            for (const auto& well: well_container_) {
-                // r = r - duneC_^T * invDuneD_ * resWell_
-                well->apply(res);
-            }
-            return;
-        }
 
         for (const auto& well: well_container_) {
             well->addWellContributions(mat.istlMatrix());

--- a/opm/autodiff/ISTLSolverEbos.hpp
+++ b/opm/autodiff/ISTLSolverEbos.hpp
@@ -233,47 +233,34 @@ protected:
 
         void scaleSystem()
         {
-            const bool matrix_cont_added = EWOMS_GET_PARAM(TypeTag, bool, MatrixAddWellContributions);
-	    
-            if (matrix_cont_added) {
-                bool form_cpr = true;
-                if (parameters_.system_strategy_ == "quasiimpes") {
-                    weights_ = getQuasiImpesWeights();
-                } else if (parameters_.system_strategy_ == "trueimpes") {
-                    weights_ = getStorageWeights();
-                } else if (parameters_.system_strategy_ == "simple") {
-                    BlockVector bvec(1.0);
-                    weights_ = getSimpleWeights(bvec);
-                } else if (parameters_.system_strategy_ == "original") {
-                    BlockVector bvec(0.0);
-                    bvec[pressureEqnIndex] = 1;
-                    weights_ = getSimpleWeights(bvec);
-                } else {
-                    if (parameters_.system_strategy_ != "none") {
-                        OpmLog::warning("unknown_system_strategy", "Unknown linear solver system strategy: '" + parameters_.system_strategy_ + "', applying 'none' strategy.");
-                    }
-                    form_cpr = false;
-                }
-                if (parameters_.scale_linear_system_) {
-                    // also scale weights
-                    this->scaleEquationsAndVariables(weights_);
-                }
-                if (form_cpr && !(parameters_.cpr_use_drs_)) {
-                    scaleMatrixAndRhs(weights_);
-                }
-                if (weights_.size() == 0) {
-                    // if weights are not set cpr_use_drs_=false;
-                    parameters_.cpr_use_drs_ = false;
-                }
+            bool form_cpr = true;
+            if (parameters_.system_strategy_ == "quasiimpes") {
+                weights_ = getQuasiImpesWeights();
+            } else if (parameters_.system_strategy_ == "trueimpes") {
+                weights_ = getStorageWeights();
+            } else if (parameters_.system_strategy_ == "simple") {
+                BlockVector bvec(1.0);
+                weights_ = getSimpleWeights(bvec);
+            } else if (parameters_.system_strategy_ == "original") {
+                BlockVector bvec(0.0);
+                bvec[pressureEqnIndex] = 1;
+                weights_ = getSimpleWeights(bvec);
             } else {
-                if (parameters_.use_cpr_ && parameters_.cpr_use_drs_) {
-                   OpmLog::warning("DRS_DISABLE", "Disabling DRS as matrix does not contain well contributions");
+                if (parameters_.system_strategy_ != "none") {
+                    OpmLog::warning("unknown_system_strategy", "Unknown linear solver system strategy: '" + parameters_.system_strategy_ + "', applying 'none' strategy.");
                 }
+                form_cpr = false;
+            }
+            if (parameters_.scale_linear_system_) {
+                // also scale weights
+                this->scaleEquationsAndVariables(weights_);
+            }
+            if (form_cpr && !(parameters_.cpr_use_drs_)) {
+                scaleMatrixAndRhs(weights_);
+            }
+            if (weights_.size() == 0) {
+                // if weights are not set cpr_use_drs_=false;
                 parameters_.cpr_use_drs_ = false;
-                if (parameters_.scale_linear_system_) {
-                    // also scale weights
-                    this->scaleEquationsAndVariables(weights_);
-                }
             }
         }
 

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -181,12 +181,6 @@ namespace Opm
 
         virtual void  addWellContributions(Mat& mat) const override;
 
-        /// \brief Wether the Jacobian will also have well contributions in it.
-        virtual bool jacobianContainsWellContributions() const override
-        {
-            return param_.matrix_add_well_contributions_;
-        }
-
     protected:
 
         // protected functions from the Base class

--- a/opm/autodiff/StandardWellV.hpp
+++ b/opm/autodiff/StandardWellV.hpp
@@ -181,12 +181,6 @@ namespace Opm
 
         virtual void  addWellContributions(Mat& mat) const override;
 
-        /// \brief Wether the Jacobian will also have well contributions in it.
-        virtual bool jacobianContainsWellContributions() const override
-        {
-            return param_.matrix_add_well_contributions_;
-        }
-
     protected:
 
         // protected functions from the Base class

--- a/opm/autodiff/StandardWellV_impl.hpp
+++ b/opm/autodiff/StandardWellV_impl.hpp
@@ -2206,26 +2206,7 @@ namespace Opm
     StandardWellV<TypeTag>::
     apply(const BVector& x, BVector& Ax) const
     {
-        if (!this->isOperable()) return;
-
-        if ( param_.matrix_add_well_contributions_ )
-        {
-            // Contributions are already in the matrix itself
-            return;
-        }
-        assert( Bx_.size() == duneB_.N() );
-        assert( invDrw_.size() == invDuneD_.N() );
-
-        // Bx_ = duneB_ * x
-        duneB_.mv(x, Bx_);
-        // invDBx = invDuneD_ * Bx_
-        // TODO: with this, we modified the content of the invDrw_.
-        // Is it necessary to do this to save some memory?
-        BVectorWell& invDBx = invDrw_;
-        invDuneD_.mv(Bx_, invDBx);
-
-        // Ax = Ax - duneC_^T * invDBx
-        duneC_.mmtv(invDBx,Ax);
+        // nothing needs to be done here
     }
 
 

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -2103,26 +2103,7 @@ namespace Opm
     StandardWell<TypeTag>::
     apply(const BVector& x, BVector& Ax) const
     {
-        if (!this->isOperable()) return;
-
-        if ( param_.matrix_add_well_contributions_ )
-        {
-            // Contributions are already in the matrix itself
-            return;
-        }
-        assert( Bx_.size() == duneB_.N() );
-        assert( invDrw_.size() == invDuneD_.N() );
-
-        // Bx_ = duneB_ * x
-        duneB_.mv(x, Bx_);
-        // invDBx = invDuneD_ * Bx_
-        // TODO: with this, we modified the content of the invDrw_.
-        // Is it necessary to do this to save some memory?
-        BVectorWell& invDBx = invDrw_;
-        invDuneD_.mv(Bx_, invDBx);
-
-        // Ax = Ax - duneC_^T * invDBx
-        duneC_.mmtv(invDBx,Ax);
+        // nothing needs to be done here
     }
 
 


### PR DESCRIPTION
This gets rid of some obscure fiddling parameters and allows more flexibility with regard to the linear solver being used. instead of doing the Schur complement sometimes in the linear operator it is now always explicitly included in the Jacobian matrix.

this emerged from the discussion of #1618. So far, the patch has only be minimally tested and might come with some implications for performance and might require a reference data update for Jenkins.