### PR TITLE
Warn about parallel logging fallout only on request / Use uppercase logfiles

### DIFF
--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -326,8 +326,16 @@ namespace Opm
             std::ostringstream debugFileStream;
             std::ostringstream logFileStream;
 
-            // Strip extension if any
-            baseName = boost::to_upper_copy(path(fpath.stem()).string());
+            // Strip extension "." or ".DATA"
+            std::string extension = boost::to_upper_copy(fpath.extension().string());
+            if ( extension == ".DATA" || extension == "." )
+            {
+                baseName = boost::to_upper_copy(fpath.stem().string());
+            }
+            else
+            {
+                baseName = boost::to_upper_copy(fpath.filename().string());
+            }
 
             const std::string& output_dir = eclState().getIOConfig().getOutputDir();
             logFileStream << output_dir << "/" << baseName;
@@ -427,7 +435,17 @@ namespace Opm
             const std::string& output_dir = eclState().getIOConfig().getOutputDir();
             fs::path output_path(output_dir);
             fs::path deck_filename(EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName));
-            std::string basename = boost::to_upper_copy(fs::path(deck_filename).stem().string());
+            std::string basename;
+            // Strip extension "." and ".DATA"
+            std::string extension = boost::to_upper_copy(deck_filename.extension().string());
+            if ( extension == ".DATA" || extension == "." )
+            {
+                basename = boost::to_upper_copy(deck_filename.stem().string());
+            }
+            else
+            {
+                basename = boost::to_upper_copy(deck_filename.filename().string());
+            }
             std::for_each(fs::directory_iterator(output_path),
                           fs::directory_iterator(),
                           detail::ParallelFileMerger(output_path, basename,

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -449,7 +449,7 @@ namespace Opm
             std::for_each(fs::directory_iterator(output_path),
                           fs::directory_iterator(),
                           detail::ParallelFileMerger(output_path, basename,
-                                                     EWOMS_GET_PARAM(TypeTag, bool, EnableLoggingFalloutWarning));
+                                                     EWOMS_GET_PARAM(TypeTag, bool, EnableLoggingFalloutWarning)));
         }
 
         void setupEbosSimulator()

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -321,11 +321,8 @@ namespace Opm
             std::ostringstream debugFileStream;
             std::ostringstream logFileStream;
 
-            if (boost::to_upper_copy(path(fpath.extension()).string()) == ".DATA") {
-                baseName = path(fpath.stem()).string();
-            } else {
-                baseName = path(fpath.filename()).string();
-            }
+            // Strip extension if any
+            baseName = boost::to_upper_copy(path(fpath.stem()).string());
 
             const std::string& output_dir = eclState().getIOConfig().getOutputDir();
             logFileStream << output_dir << "/" << baseName;
@@ -425,9 +422,10 @@ namespace Opm
             const std::string& output_dir = eclState().getIOConfig().getOutputDir();
             fs::path output_path(output_dir);
             fs::path deck_filename(EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName));
+            std::string basename = boost::to_upper_copy(deck_filename.stem().string());
             std::for_each(fs::directory_iterator(output_path),
                           fs::directory_iterator(),
-                          detail::ParallelFileMerger(output_path, deck_filename.stem().string()));
+                          detail::ParallelFileMerger(output_path, basename));
         }
 
         void setupEbosSimulator()

--- a/opm/simulators/ParallelFileMerger.hpp
+++ b/opm/simulators/ParallelFileMerger.hpp
@@ -48,19 +48,25 @@ public:
     /// \param output_dir The output directory to use for reading/Writing.
     /// \param deckanme The name of the deck.
     ParallelFileMerger(const fs::path& output_dir,
-                       const std::string& deckname)
+                       const std::string& deckname,
+                       bool show_fallout = false)
         : debugFileRegex_(deckname+"\\.\\d+\\.DBG"),
           logFileRegex_(deckname+"\\.\\d+\\.PRT"),
-          fileWarningRegex_(deckname+"\\.(\\d+)\\.[^.]+")
+          fileWarningRegex_(deckname+"\\.(\\d+)\\.[^.]+"),
+          show_fallout_(show_fallout)
     {
-        auto debugPath = output_dir;
-        debugPath /= (deckname + ".DBG");
-        debugStream_.reset(new fs::ofstream(debugPath,
-                                            std::ofstream::app));
-        auto logPath = output_dir;
-        logPath /= ( deckname + ".PRT");
-        logStream_.reset(new fs::ofstream(logPath,
-                                          std::ofstream::app));
+        std::cout<<"show_fallout="<<show_fallout_<<" "<<deckname<<std::endl;
+        if ( show_fallout_ )
+        {
+            auto debugPath = output_dir;
+            debugPath /= (deckname + ".DBG");
+            debugStream_.reset(new fs::ofstream(debugPath,
+                                                std::ofstream::app));
+            auto logPath = output_dir;
+            logPath /= ( deckname + ".PRT");
+            logStream_.reset(new fs::ofstream(logPath,
+                                              std::ofstream::app));
+        }
     }
 
     void operator()(const fs::path& file)
@@ -74,20 +80,31 @@ public:
 
             if( boost::regex_match(filename, logFileRegex_) )
             {
-                appendFile(*logStream_, file, rank);
+                if ( show_fallout_ ){
+                    appendFile(*logStream_, file, rank);
+                }else{
+                    fs::remove(filename);
+                }
             }
             else
             {
                 if (boost::regex_match(filename, debugFileRegex_)  )
                 {
-                    appendFile(*debugStream_, file, rank);
+                    if ( show_fallout_ ){
+                        appendFile(*debugStream_, file, rank);
+                    }else
+                    {
+                        fs::remove(filename);
+                    }
                 }
                 else
                 {
-                    std::cerr << "WARNING: Unrecognized file with name "
-                              << filename
-                              << " that might stem from a  parallel run."
-                              << std::endl;
+                    if ( show_fallout_ ){
+                        std::cerr << "WARNING: Unrecognized file with name "
+                                  << filename
+                                  << " that might stem from a  parallel run."
+                                  << std::endl;
+                    }
                 }
             }
         }
@@ -129,6 +146,8 @@ private:
     std::unique_ptr<fs::ofstream> debugStream_;
     /// \brief Stream to *.PRT file
     std::unique_ptr<fs::ofstream> logStream_;
+    /// \brief Whether to show any logging fallout
+    bool show_fallout_;
 };
 } // end namespace detail
 } // end namespace OPM

--- a/opm/simulators/ParallelFileMerger.hpp
+++ b/opm/simulators/ParallelFileMerger.hpp
@@ -82,7 +82,7 @@ public:
                 if ( show_fallout_ ){
                     appendFile(*logStream_, file, rank);
                 }else{
-                    fs::remove(filename);
+                    fs::remove(file);
                 }
             }
             else
@@ -91,9 +91,8 @@ public:
                 {
                     if ( show_fallout_ ){
                         appendFile(*debugStream_, file, rank);
-                    }else
-                    {
-                        fs::remove(filename);
+                    }else{
+                        fs::remove(file);
                     }
                 }
                 else

--- a/opm/simulators/ParallelFileMerger.hpp
+++ b/opm/simulators/ParallelFileMerger.hpp
@@ -55,7 +55,6 @@ public:
           fileWarningRegex_(deckname+"\\.(\\d+)\\.[^.]+"),
           show_fallout_(show_fallout)
     {
-        std::cout<<"show_fallout="<<show_fallout_<<" "<<deckname<<std::endl;
         if ( show_fallout_ )
         {
             auto debugPath = output_dir;


### PR DESCRIPTION
One PR three changes:

1. Use always uppercase *.PRT and *.DBG. 
2. When construcing the logfile names always strip the extension.
3. Only warn about and append parallel logging fallout if explicitly requested using new option --enable-logging-fallout-warning

Coments:
1) Seems consistent as all other output files seem to use that convention, too.  There was a comment/Issue about this but I cannot find it.
2) Is needed as we can start flow like `flow MODEL.` (omitting DATA) and would get MODEL..DBG and MODEL..PRT files.
3) Only annoys users that are not developing flow using MPI