### PR TITLE
Make BlackoilWellModel::hasTHPConstraints() work correctly in parallel.

### DIFF
--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -122,12 +122,13 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     hasTHPConstraints() const
     {
+        int local_result = false;
         for (const auto& well : well_container_) {
             if (well->wellHasTHPConstraints()) {
-                return true;
+                local_result=true;
             }
         }
-        return false;
+        return grid().comm().max(local_result);
     }
 
 


### PR DESCRIPTION
Previously, this method did not take parallelism into account but just checked the local wells for the constraints. Depending on the load balancing of the wells this sometimes led to different return values of the function on different processors. As the output is used to limit the time step size, different processors were sometimes using different time steps in their local computations. This screwed up convergence checks int the nonlinear operator such that only some processor thought convergence was already achieved while others wanted to do more iterations.

With this commit the method now returns whether there is any well on any processor with the constraint being true.

Tested with model 2 using 2 processors. Test with 4 processors is running now.