### PR TITLE
adapt to the new preparation procedure of ewoms linear solvers

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -481,7 +481,13 @@ namespace Opm {
             x = 0.0;
 
             auto& ebosSolver = ebosSimulator_.model().newtonMethod().linearSolver();
-            ebosSolver.prepare(ebosJac, ebosResid);
+            ebosSolver.prepare(ebosJac);
+            ebosSolver.setResidual(ebosResid);
+            // actually, the error needs to be calculated after setResidual in order to
+            // account for parallelization properly. since the residual of ECFV
+            // discretizations does not need to be synchronized across processes to be
+            // consistent, this is not relevant for OPM-flow...
+            ebosSolver.setJacobian(ebosJac);
             ebosSolver.solve(x);
        }
 

--- a/opm/autodiff/ISTLSolverEbos.hpp
+++ b/opm/autodiff/ISTLSolverEbos.hpp
@@ -208,9 +208,15 @@ protected:
             matrix_for_preconditioner_.reset();
         }
 
-        void prepare(const SparseMatrixAdapter& M, Vector& b) {
-            matrix_ = &M.istlMatrix();
+        void prepare(const SparseMatrixAdapter& M) {
+        }
+
+        void setResidual(Vector& b) {
             rhs_ = &b;
+        }
+
+        void setJacobian(const SparseMatrixAdapter& M) {
+            matrix_ = &M.istlMatrix();
         }
 
         bool solve(Vector& x) {


### PR DESCRIPTION
this is required to keep the linear solver of eWoms and opm-simulators identical, cf OPM/ewoms#461.