### PR TITLE
Add virtual destructor to base class.

### DIFF
--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -156,6 +156,7 @@ namespace Opm
     struct Reorderer
     {
         virtual std::size_t operator[](std::size_t i) const = 0;
+        virtual ~Reorderer() {}
     };
 
     struct NoReorderer : public Reorderer


### PR DESCRIPTION
This silences a warning from clang. Base classes with virtual functions should always have a virtual destructor (although in this case there was no harm).