### PR TITLE
The missing features check takes a ParseContext argument

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -193,10 +193,10 @@ int main(int argc, char** argv)
             }
 
             deck.reset( new Opm::Deck( parser.parseFile(deckFilename , parseContext, errorGuard)));
-            if ( outputCout ) {
+            Opm::MissingFeatures::checkKeywords(*deck, parseContext, errorGuard);
+
+            if ( outputCout )
                 Opm::checkDeck(*deck, parser);
-                Opm::MissingFeatures::checkKeywords(*deck);
-            }
 
             eclipseState.reset( new Opm::EclipseState(*deck, parseContext, errorGuard ));
             schedule.reset(new Opm::Schedule(*deck, *eclipseState, parseContext, errorGuard));

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -20,6 +20,8 @@
 
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/E.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/P.hpp>
@@ -45,7 +47,7 @@ namespace MissingFeatures {
 
 
     template <typename T>
-    void checkOptions(const DeckKeyword& keyword, std::multimap<std::string , PartiallySupported<T> >& map)
+    void checkOptions(const DeckKeyword& keyword, std::multimap<std::string , PartiallySupported<T> >& map, const ParseContext& parseContext, ErrorGuard& errorGuard)
     {
         // check for partially supported keywords.
         typename std::multimap<std::string, PartiallySupported<T> >::iterator it, itlow, itup;
@@ -57,12 +59,21 @@ namespace MissingFeatures {
                 std::string msg = "For keyword '" + it->first + "' only value " + boost::lexical_cast<std::string>(it->second.item_value)
                     + " in item " + it->second.item + " is supported by flow.\n"
                     + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n";
-                OpmLog::warning(msg);
+                parseContext.handleError(ParseContext::SIMULATOR_KEYWORD_ITEM_NOT_SUPPORTED, msg, errorGuard);
             }
         }
     }
 
-    void checkKeywords(const Deck& deck)
+    template <typename T>
+    void checkKeywords(const Deck& deck, const ParseContext& parseContext, T&& errorGuard) {
+        checkKeywords(deck, parseContext, errorGuard);
+    }
+
+    void checkKeywords(const Deck& deck) {
+        checkKeywords(deck, ParseContext(), ErrorGuard());
+    }
+
+    void checkKeywords(const Deck& deck, const ParseContext& parseContext, ErrorGuard& errorGuard)
     {
         // These keywords are supported by opm-parser, but are not supported
         // by flow. For some of them, only part of the options are supported.
@@ -214,10 +225,10 @@ namespace MissingFeatures {
             if (it != unsupported_keywords.end()) {
                 std::string msg = "Keyword '" + keyword.name() + "' is not supported by flow.\n"
                     + "In file " + keyword.getFileName() + ", line " + std::to_string(keyword.getLineNumber()) + "\n";
-                OpmLog::warning(msg);
+                parseContext.handleError(ParseContext::SIMULATOR_KEYWORD_NOT_SUPPORTED, msg, errorGuard);
             }
-            checkOptions<std::string>(keyword, string_options);
-            checkOptions<int>(keyword, int_options);
+            checkOptions<std::string>(keyword, string_options, parseContext, errorGuard);
+            checkOptions<int>(keyword, int_options, parseContext, errorGuard);
         }
     }
 } // namespace MissingFeatures

--- a/opm/autodiff/MissingFeatures.hpp
+++ b/opm/autodiff/MissingFeatures.hpp
@@ -20,7 +20,11 @@
 #ifndef OPM_MISSINGFEATURES_HEADER_INCLUDED
 #define OPM_MISSINGFEATURES_HEADER_INCLUDED
 
+
 namespace Opm {
+
+class ErrorGuard;
+class ParseContext;
 
 namespace MissingFeatures {
 
@@ -34,10 +38,14 @@ namespace MissingFeatures {
     void addSupported(std::multimap<std::string, PartiallySupported<T> >& map, T itemValue);
 
     template <typename T>
-    void checkOptions(const DeckKeyword& keyword, std::multimap<std::string , PartiallySupported<T> >& map);
+    void checkOptions(const DeckKeyword& keyword, std::multimap<std::string , PartiallySupported<T> >& map, const ParseContext& parseContext, ErrorGuard& errorGuard);
+
+    void checkKeywords(const Deck& deck, const ParseContext& parseContext, ErrorGuard& errorGuard);
+
+    template<typename T>
+    void checkKeywords(const Deck& deck, const ParseContext& parseContext, T&& errorGuard);
 
     void checkKeywords(const Deck& deck);
-
 }
 
 }


### PR DESCRIPTION
Downstream of: https://github.com/OPM/opm-common/pull/617