### PR TITLE
Properly adapt to the new linear solver API used by eWoms

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -69,7 +69,7 @@
 
 BEGIN_PROPERTIES
 
-NEW_TYPE_TAG(EclFlowProblem, INHERITS_FROM(BlackOilModel, EclBaseProblem, FlowNonLinearSolver, FlowIstlSolver, FlowModelParameters, FlowTimeSteppingParameters));
+NEW_TYPE_TAG(EclFlowProblem, INHERITS_FROM(BlackOilModel, EclBaseProblem, FlowNonLinearSolver, FlowModelParameters, FlowTimeSteppingParameters));
 SET_STRING_PROP(EclFlowProblem, OutputDir, "");
 SET_BOOL_PROP(EclFlowProblem, EnableDebuggingChecks, false);
 // default in flow is to formulate the equations in surface volumes
@@ -481,13 +481,13 @@ namespace Opm {
             x = 0.0;
 
             auto& ebosSolver = ebosSimulator_.model().newtonMethod().linearSolver();
-            ebosSolver.prepare(ebosJac);
+            ebosSolver.prepare(ebosJac, ebosResid);
             ebosSolver.setResidual(ebosResid);
             // actually, the error needs to be calculated after setResidual in order to
             // account for parallelization properly. since the residual of ECFV
             // discretizations does not need to be synchronized across processes to be
             // consistent, this is not relevant for OPM-flow...
-            ebosSolver.setJacobian(ebosJac);
+            ebosSolver.setMatrix(ebosJac);
             ebosSolver.solve(x);
        }
 

--- a/opm/autodiff/ISTLSolverEbos.hpp
+++ b/opm/autodiff/ISTLSolverEbos.hpp
@@ -208,14 +208,18 @@ protected:
             matrix_for_preconditioner_.reset();
         }
 
-        void prepare(const SparseMatrixAdapter& M) {
+        void prepare(const SparseMatrixAdapter& M, const Vector& b) {
         }
 
         void setResidual(Vector& b) {
             rhs_ = &b;
         }
 
-        void setJacobian(const SparseMatrixAdapter& M) {
+        void getResidual(Vector& b) const {
+            b = *rhs_;
+        }
+
+        void setMatrix(const SparseMatrixAdapter& M) {
             matrix_ = &M.istlMatrix();
         }
 


### PR DESCRIPTION
I tested #1712 without deriving the `EclFlowProblem` type tag from `FlowIstlSolver`, and it worked because the linear solver was still `Opm::ISTLSolverEbos` as the linear solver is set via the `LinearSolverSplice` a few lines down.

This time, I verified that the `Ewoms::Linear::ParallelBiCGStabSolverBackend` was used if the offending line was commented out. also, Norne worked fine with the default solver as long as the Schur complement for the wells was done explicitly.

Finally, the naming of the eWoms API is a bit inconsistent (`setMatrix()` vs. `setResidual()`). any opinions here? I'm fine with whatever.