### PR TITLE
Correct Logging for Black Oil Well Model for parallel runs

### DIFF
--- a/opm/autodiff/BlackoilWellModel.hpp
+++ b/opm/autodiff/BlackoilWellModel.hpp
@@ -348,7 +348,7 @@ namespace Opm {
 
             void updateWellControls();
 
-            void updateGroupControls();
+            void updateGroupControls(Opm::DeferredLogger& deferred_logger);
 
             // setting the well_solutions_ based on well_state.
             void updatePrimaryVariables();
@@ -379,7 +379,7 @@ namespace Opm {
             /// at the beginning of the time step and no derivatives are included in these quantities
             void calculateExplicitQuantities() const;
 
-            SimulatorReport solveWellEq(const double dt);
+            SimulatorReport solveWellEq(const double dt, Opm::DeferredLogger& deferred_logger);
 
             void initPrimaryVariablesEvaluation() const;
 
@@ -392,11 +392,11 @@ namespace Opm {
 
             void resetWellControlFromState() const;
 
-            void assembleWellEq(const double dt);
+            void assembleWellEq(const double dt, Opm::DeferredLogger& deferred_logger);
 
             // some preparation work, mostly related to group control and RESV,
             // at the beginning of each time step (Not report step)
-            void prepareTimeStep();
+            void prepareTimeStep(Opm::DeferredLogger& deferred_logger);
 
             void prepareGroupControl();
 

--- a/opm/autodiff/MultisegmentWell.hpp
+++ b/opm/autodiff/MultisegmentWell.hpp
@@ -114,11 +114,13 @@ namespace Opm
 
         virtual void assembleWellEq(const Simulator& ebosSimulator,
                                     const double dt,
-                                    WellState& well_state) override;
+                                    WellState& well_state,
+                                    Opm::DeferredLogger& deferred_logger) override;
 
         /// updating the well state based the current control mode
         virtual void updateWellStateWithTarget(const Simulator& ebos_simulator,
-                                               WellState& well_state) const override;
+                                               WellState& well_state,
+                                               Opm::DeferredLogger& deferred_logger) const override;
 
         /// check whether the well equations get converged for this well
         virtual ConvergenceReport getWellConvergence(const std::vector<double>& B_avg) const override;
@@ -136,7 +138,8 @@ namespace Opm
         /// computing the well potentials for group control
         virtual void computeWellPotentials(const Simulator& ebosSimulator,
                                            const WellState& well_state,
-                                           std::vector<double>& well_potentials) override;
+                                           std::vector<double>& well_potentials,
+                                           Opm::DeferredLogger& deferred_logger) override;
 
         virtual void updatePrimaryVariables(const WellState& well_state) const override;
 
@@ -333,7 +336,8 @@ namespace Opm
         // checking the operability of the well based on current reservoir condition
         // it is not implemented for multisegment well yet
         virtual void checkWellOperability(const Simulator& ebos_simulator,
-                                          const WellState& well_state) override;
+                                          const WellState& well_state,
+                                          Opm::DeferredLogger& deferred_logger) override;
 
         void updateWellStateFromPrimaryVariables(WellState& well_state) const;
 

--- a/opm/autodiff/MultisegmentWell_impl.hpp
+++ b/opm/autodiff/MultisegmentWell_impl.hpp
@@ -234,7 +234,8 @@ namespace Opm
     MultisegmentWell<TypeTag>::
     assembleWellEq(const Simulator& ebosSimulator,
                    const double dt,
-                   WellState& well_state)
+                   WellState& well_state,
+                   Opm::DeferredLogger& deferred_logger)
     {
 
         const bool use_inner_iterations = param_.use_inner_iterations_ms_wells_;
@@ -253,7 +254,8 @@ namespace Opm
     void
     MultisegmentWell<TypeTag>::
     updateWellStateWithTarget(const Simulator& ebos_simulator,
-                              WellState& well_state) const
+                              WellState& well_state,
+                              Opm::DeferredLogger& deferred_logger) const
     {
         // Updating well state bas on well control
         // Target values are used as initial conditions for BHP, THP, and SURFACE_RATE
@@ -558,17 +560,19 @@ namespace Opm
     MultisegmentWell<TypeTag>::
     computeWellPotentials(const Simulator& /* ebosSimulator */,
                           const WellState& /* well_state */,
-                          std::vector<double>& well_potentials)
+                          std::vector<double>& well_potentials,
+                          Opm::DeferredLogger& deferred_logger)
     {
         const std::string msg = std::string("Well potential calculation is not supported for multisegment wells \n")
                 + "A well potential of zero is returned for output purposes. \n"
                 + "If you need well potential to set the guide rate for group controled wells \n"
                 + "you will have to change the " + name() + " well to a standard well \n";
 
-        OpmLog::warning("WELL_POTENTIAL_NOT_IMPLEMENTED_FOR_MULTISEG_WELLS", msg);
+        deferred_logger.warning("WELL_POTENTIAL_NOT_IMPLEMENTED_FOR_MULTISEG_WELLS", msg);
 
         const int np = number_of_phases_;
         well_potentials.resize(np, 0.0);
+
     }
 
 
@@ -1646,11 +1650,12 @@ namespace Opm
     void
     MultisegmentWell<TypeTag>::
     checkWellOperability(const Simulator& /* ebos_simulator */,
-                         const WellState& /* well_state */)
+                         const WellState& /* well_state */,
+                         Opm::DeferredLogger& deferred_logger)
     {
         const std::string msg = "Support of well operability checking for multisegment wells is not implemented "
                                 "yet, checkWellOperability() for " + name() + " will do nothing";
-        OpmLog::warning("NO_OPERATABILITY_CHECKING_MS_WELLS", msg);
+        deferred_logger.warning("NO_OPERATABILITY_CHECKING_MS_WELLS", msg);
     }
 
 
@@ -1901,7 +1906,7 @@ namespace Opm
     {
         const std::string msg = "Support of well testing for physical limits for multisegment wells is not "
                                 "implemented yet, wellTestingPhysical() for " + name() + " will do nothing";
-        OpmLog::warning("NO_WELLTESTPHYSICAL_CHECKING_MS_WELLS", msg);
+        deferred_logger.warning("NO_WELLTESTPHYSICAL_CHECKING_MS_WELLS", msg);
     }
 
 

--- a/opm/autodiff/StandardWell.hpp
+++ b/opm/autodiff/StandardWell.hpp
@@ -143,10 +143,12 @@ namespace Opm
 
         virtual void assembleWellEq(const Simulator& ebosSimulator,
                                     const double dt,
-                                    WellState& well_state) override;
+                                    WellState& well_state,
+                                    Opm::DeferredLogger& deferred_logger) override;
 
         virtual void updateWellStateWithTarget(const Simulator& ebos_simulator,
-                                               WellState& well_state) const override;
+                                               WellState& well_state,
+                                               Opm::DeferredLogger& deferred_logger) const override;
 
         /// check whether the well equations get converged for this well
         virtual ConvergenceReport getWellConvergence(const std::vector<double>& B_avg) const override;
@@ -164,7 +166,8 @@ namespace Opm
         /// computing the well potentials for group control
         virtual void computeWellPotentials(const Simulator& ebosSimulator,
                                            const WellState& well_state,
-                                           std::vector<double>& well_potentials) /* const */ override;
+                                           std::vector<double>& well_potentials,
+                                           Opm::DeferredLogger& deferred_logger) /* const */ override;
 
         virtual void updatePrimaryVariables(const WellState& well_state) const override;
 
@@ -348,29 +351,33 @@ namespace Opm
 
         void updateThp(WellState& well_state) const;
 
-        void assembleControlEq();
+        void assembleControlEq(Opm::DeferredLogger& deferred_logger);
 
         // handle the non reasonable fractions due to numerical overshoot
         void processFractions() const;
 
         // updating the inflow based on the current reservoir condition
-        void updateIPR(const Simulator& ebos_simulator) const;
+        void updateIPR(const Simulator& ebos_simulator, Opm::DeferredLogger& deferred_logger) const;
 
         // update the operability status of the well is operable under the current reservoir condition
         // mostly related to BHP limit and THP limit
         virtual void checkWellOperability(const Simulator& ebos_simulator,
-                                          const WellState& well_state) override;
+                                          const WellState& well_state,
+                                          Opm::DeferredLogger& deferred_logger
+                                          ) override;
 
         // check whether the well is operable under the current reservoir condition
         // mostly related to BHP limit and THP limit
         void updateWellOperability(const Simulator& ebos_simulator,
-                                   const WellState& well_state);
+                                   const WellState& well_state,
+                                   Opm::DeferredLogger& deferred_logger
+                                   );
 
         // check whether the well is operable under BHP limit with current reservoir condition
         void checkOperabilityUnderBHPLimitProducer(const Simulator& ebos_simulator);
 
         // check whether the well is operable under THP limit with current reservoir condition
-        void checkOperabilityUnderTHPLimitProducer(const Simulator& ebos_simulator);
+        void checkOperabilityUnderTHPLimitProducer(const Simulator& ebos_simulator, Opm::DeferredLogger& deferred_logger);
 
         // update WellState based on IPR and associated VFP table
         void updateWellStateWithTHPTargetIPR(const Simulator& ebos_simulator,
@@ -385,7 +392,8 @@ namespace Opm
 
         // whether the well can produce / inject based on the current well state (bhp)
         bool canProduceInjectWithCurrentBhp(const Simulator& ebos_simulator,
-                                            const WellState& well_state);
+                                            const WellState& well_state,
+                                            Opm::DeferredLogger& deferred_logger);
 
         // turn on crossflow to avoid singular well equations
         // when the well is banned from cross-flow and the BHP is not properly initialized,
@@ -414,7 +422,8 @@ namespace Opm
 
         virtual void wellTestingPhysical(Simulator& simulator, const std::vector<double>& B_avg,
                                          const double simulation_time, const int report_step,
-                                         WellState& well_state, WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger) override;
+                                         WellState& well_state, WellTestState& welltest_state,
+                                         Opm::DeferredLogger& deferred_logger) override;
 
         virtual void updateWaterThroughput(const double dt, WellState& well_state) const override;
     };

--- a/opm/autodiff/StandardWellV.hpp
+++ b/opm/autodiff/StandardWellV.hpp
@@ -144,10 +144,12 @@ namespace Opm
 
         virtual void assembleWellEq(const Simulator& ebosSimulator,
                                     const double dt,
-                                    WellState& well_state) override;
+                                    WellState& well_state,
+                                    Opm::DeferredLogger& deferred_logger) override;
 
         virtual void updateWellStateWithTarget(const Simulator& ebos_simulator,
-                                               WellState& well_state) const override;
+                                               WellState& well_state,
+                                               Opm::DeferredLogger& deferred_logger) const override;
 
         /// check whether the well equations get converged for this well
         virtual ConvergenceReport getWellConvergence(const std::vector<double>& B_avg) const override;
@@ -165,7 +167,8 @@ namespace Opm
         /// computing the well potentials for group control
         virtual void computeWellPotentials(const Simulator& ebosSimulator,
                                            const WellState& well_state,
-                                           std::vector<double>& well_potentials) /* const */ override;
+                                           std::vector<double>& well_potentials,
+                                           Opm::DeferredLogger& deferred_logger) /* const */ override;
 
         virtual void updatePrimaryVariables(const WellState& well_state) const override;
 
@@ -353,29 +356,31 @@ namespace Opm
 
         void updateThp(WellState& well_state) const;
 
-        void assembleControlEq();
+        void assembleControlEq(Opm::DeferredLogger& deferred_logger);
 
         // handle the non reasonable fractions due to numerical overshoot
         void processFractions() const;
 
         // updating the inflow based on the current reservoir condition
-        void updateIPR(const Simulator& ebos_simulator) const;
+        void updateIPR(const Simulator& ebos_simulator, Opm::DeferredLogger& deferred_logger) const;
 
         // update the operability status of the well is operable under the current reservoir condition
         // mostly related to BHP limit and THP limit
         virtual void checkWellOperability(const Simulator& ebos_simulator,
-                                          const WellState& well_state) override;
+                                          const WellState& well_state,
+                                          Opm::DeferredLogger& deferred_logger) override;
 
         // check whether the well is operable under the current reservoir condition
         // mostly related to BHP limit and THP limit
         void updateWellOperability(const Simulator& ebos_simulator,
-                                   const WellState& well_state);
+                                   const WellState& well_state,
+                                   Opm::DeferredLogger& deferred_logger);
 
         // check whether the well is operable under BHP limit with current reservoir condition
         void checkOperabilityUnderBHPLimitProducer(const Simulator& ebos_simulator);
 
         // check whether the well is operable under THP limit with current reservoir condition
-        void checkOperabilityUnderTHPLimitProducer(const Simulator& ebos_simulator);
+        void checkOperabilityUnderTHPLimitProducer(const Simulator& ebos_simulator, Opm::DeferredLogger& deferred_logger);
 
         // update WellState based on IPR and associated VFP table
         void updateWellStateWithTHPTargetIPR(const Simulator& ebos_simulator,
@@ -390,7 +395,8 @@ namespace Opm
 
         // whether the well can produce / inject based on the current well state (bhp)
         bool canProduceInjectWithCurrentBhp(const Simulator& ebos_simulator,
-                                            const WellState& well_state);
+                                            const WellState& well_state,
+                                            Opm::DeferredLogger& deferred_logger);
 
         // turn on crossflow to avoid singular well equations
         // when the well is banned from cross-flow and the BHP is not properly initialized,

--- a/opm/autodiff/StandardWellV_impl.hpp
+++ b/opm/autodiff/StandardWellV_impl.hpp
@@ -479,11 +479,13 @@ namespace Opm
     StandardWellV<TypeTag>::
     assembleWellEq(const Simulator& ebosSimulator,
                    const double dt,
-                   WellState& well_state)
+                   WellState& well_state,
+                   Opm::DeferredLogger& deferred_logger
+                   )
     {
         // TODO: only_wells should be put back to save some computation
 
-        checkWellOperability(ebosSimulator, well_state);
+        checkWellOperability(ebosSimulator, well_state, deferred_logger);
 
         if (!this->isOperable()) return;
 
@@ -675,7 +677,7 @@ namespace Opm
                     const unsigned int compIdx = flowPhaseToEbosCompIdx(p);
                     const double drawdown = well_state.perfPress()[first_perf_ + perf] - intQuants.fluidState().pressure(FluidSystem::oilPhaseIdx).value();
                     double productivity_index = cq_s[compIdx].value() / drawdown;
-                    scaleProductivityIndex(perf, productivity_index);
+                    scaleProductivityIndex(perf, productivity_index, deferred_logger);
                     well_state.productivityIndex()[np*index_of_well_ + p] += productivity_index;
                 }
             }
@@ -693,7 +695,7 @@ namespace Opm
             resWell_[0][componentIdx] += resWell_loc.value();
         }
 
-        assembleControlEq();
+        assembleControlEq(deferred_logger);
 
         // do the local inversion of D.
         try
@@ -715,7 +717,7 @@ namespace Opm
     template <typename TypeTag>
     void
     StandardWellV<TypeTag>::
-    assembleControlEq()
+    assembleControlEq(Opm::DeferredLogger& deferred_logger)
     {
         EvalWell control_eq(numWellEq_ + numEq, 0.);
         switch (well_controls_get_current_type(well_controls_)) {
@@ -770,7 +772,7 @@ namespace Opm
                             const std::string msg = " Setting all rates to be zero for well " + name()
                                                   + " due to un-solvable situation. There is non-zero target for the phase "
                                                   + " that does not exist in the wellbore for the situation";
-                            OpmLog::warning("NON_SOLVABLE_WELL_SOLUTION", msg);
+                            deferred_logger.warning("NON_SOLVABLE_WELL_SOLUTION", msg);
 
                             control_eq = getWQTotal() - target_rate;
                         }
@@ -1188,7 +1190,8 @@ namespace Opm
     void
     StandardWellV<TypeTag>::
     updateWellStateWithTarget(const Simulator& ebos_simulator,
-                              WellState& well_state) const
+                              WellState& well_state,
+                              Opm::DeferredLogger& deferred_logger) const
     {
         // number of phases
         const int np = number_of_phases_;
@@ -1217,7 +1220,7 @@ namespace Opm
             } else { // go to BHP limit
                 assert(this->operability_status_.isOperableUnderBHPLimit() );
 
-                OpmLog::info("well " + name() + " can not work with THP target, switching to BHP control");
+                deferred_logger.info("well " + name() + " can not work with THP target, switching to BHP control");
 
                 well_state.bhp()[well_index] = mostStrictBhpFromBhpLimits();
             }
@@ -1294,7 +1297,7 @@ namespace Opm
     template<typename TypeTag>
     void
     StandardWellV<TypeTag>::
-    updateIPR(const Simulator& ebos_simulator) const
+    updateIPR(const Simulator& ebos_simulator, Opm::DeferredLogger& deferred_logger) const
     {
         // TODO: not handling solvent related here for now
 
@@ -1337,7 +1340,7 @@ namespace Opm
             // it should not be negative anyway. If it is negative, we might need to re-formulate
             // to taking into consideration the crossflow here.
             if (pressure_diff <= 0.) {
-                OpmLog::warning("NON_POSITIVE_DRAWDOWN_IPR",
+                deferred_logger.warning("NON_POSITIVE_DRAWDOWN_IPR",
                                 "non-positive drawdown found when updateIPR for well " + name());
             }
 
@@ -1391,7 +1394,8 @@ namespace Opm
     void
     StandardWellV<TypeTag>::
     checkWellOperability(const Simulator& ebos_simulator,
-                         const WellState& well_state)
+                         const WellState& well_state,
+                         Opm::DeferredLogger& deferred_logger)
     {
         // focusing on PRODUCER for now
         if (well_type_ == INJECTOR) {
@@ -1404,14 +1408,14 @@ namespace Opm
 
         const bool old_well_operable = this->operability_status_.isOperable();
 
-        updateWellOperability(ebos_simulator, well_state);
+        updateWellOperability(ebos_simulator, well_state, deferred_logger);
 
         const bool well_operable = this->operability_status_.isOperable();
 
         if (!well_operable && old_well_operable) {
-            OpmLog::info(" well " + name() + " gets SHUT during iteration ");
+            deferred_logger.info(" well " + name() + " gets SHUT during iteration ");
         } else if (well_operable && !old_well_operable) {
-            OpmLog::info(" well " + name() + " gets REVIVED during iteration ");
+            deferred_logger.info(" well " + name() + " gets REVIVED during iteration ");
         }
     }
 
@@ -1423,18 +1427,19 @@ namespace Opm
     void
     StandardWellV<TypeTag>::
     updateWellOperability(const Simulator& ebos_simulator,
-                          const WellState& well_state)
+                          const WellState& well_state,
+                          Opm::DeferredLogger& deferred_logger)
     {
         this->operability_status_.reset();
 
-        updateIPR(ebos_simulator);
+        updateIPR(ebos_simulator, deferred_logger);
 
         // checking the BHP limit related
         checkOperabilityUnderBHPLimitProducer(ebos_simulator);
 
         // checking whether the well can operate under the THP constraints.
         if (this->wellHasTHPConstraints()) {
-            checkOperabilityUnderTHPLimitProducer(ebos_simulator);
+            checkOperabilityUnderTHPLimitProducer(ebos_simulator, deferred_logger);
         }
     }
 
@@ -1498,7 +1503,7 @@ namespace Opm
     template<typename TypeTag>
     void
     StandardWellV<TypeTag>::
-    checkOperabilityUnderTHPLimitProducer(const Simulator& ebos_simulator)
+    checkOperabilityUnderTHPLimitProducer(const Simulator& ebos_simulator, Opm::DeferredLogger& deferred_logger)
     {
         const double obtain_bhp =  calculateBHPWithTHPTargetIPR();
 
@@ -1514,12 +1519,12 @@ namespace Opm
                                         + " bars is SMALLER than thp limit "
                                         + std::to_string(unit::convert::to(thp_limit, unit::barsa))
                                         + " bars as a producer for well " + name();
-                OpmLog::debug(msg);
+                deferred_logger.debug(msg);
             }
         } else {
             this->operability_status_.can_obtain_bhp_with_thp_limit = false;
             const double thp_limit = this->getTHPConstraint();
-            OpmLog::debug(" COULD NOT find bhp value under thp_limit "
+            deferred_logger.debug(" COULD NOT find bhp value under thp_limit "
                           + std::to_string(unit::convert::to(thp_limit, unit::barsa))
                           + " bars for well " + name() + ", the well might need to be closed ");
             this->operability_status_.obey_bhp_limit_with_thp_limit = false;
@@ -1569,7 +1574,8 @@ namespace Opm
     bool
     StandardWellV<TypeTag>::
     canProduceInjectWithCurrentBhp(const Simulator& ebos_simulator,
-                                   const WellState& well_state)
+                                   const WellState& well_state,
+                                   Opm::DeferredLogger& deferred_logger)
     {
         const double bhp = well_state.bhp()[index_of_well_];
         std::vector<double> well_rates;
@@ -1590,7 +1596,7 @@ namespace Opm
         }
 
         if (!can_produce_inject) {
-            OpmLog::debug(" well " + name() + " CANNOT produce or inejct ");
+            deferred_logger.debug(" well " + name() + " CANNOT produce or inejct ");
         }
 
         return can_produce_inject;
@@ -2413,7 +2419,8 @@ namespace Opm
     StandardWellV<TypeTag>::
     computeWellPotentials(const Simulator& ebosSimulator,
                           const WellState& well_state,
-                          std::vector<double>& well_potentials) // const
+                          std::vector<double>& well_potentials,
+                          Opm::DeferredLogger& deferred_logger) // const
     {
         updatePrimaryVariables(well_state);
         computeWellConnectionPressures(ebosSimulator, well_state);
@@ -2870,7 +2877,7 @@ namespace Opm
                         const double simulation_time, const int report_step,
                         WellState& well_state, WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger)
     {
-        OpmLog::debug(" well " + name() + " is being tested for physical limits");
+        deferred_logger.debug(" well " + name() + " is being tested for physical limits");
 
         // some most difficult things are the explicit quantities, since there is no information
         // in the WellState to do a decent initialization
@@ -2889,15 +2896,15 @@ namespace Opm
         // we should be able to provide a better initialization
         calculateExplicitQuantities(ebos_simulator, well_state_copy);
 
-        updateWellOperability(ebos_simulator, well_state_copy);
+        updateWellOperability(ebos_simulator, well_state_copy, deferred_logger);
 
         if ( !this->isOperable() ) {
             const std::string msg = " well " + name() + " is not operable during well testing for physical reason";
-            OpmLog::debug(msg);
+            deferred_logger.debug(msg);
             return;
         }
 
-        updateWellStateWithTarget(ebos_simulator, well_state_copy);
+        updateWellStateWithTarget(ebos_simulator, well_state_copy, deferred_logger);
 
         calculateExplicitQuantities(ebos_simulator, well_state_copy);
         updatePrimaryVariables(well_state_copy);
@@ -2907,18 +2914,18 @@ namespace Opm
 
         if (!converged) {
             const std::string msg = " well " + name() + " did not get converged during well testing for physical reason";
-            OpmLog::debug(msg);
+            deferred_logger.debug(msg);
             return;
         }
 
         if (this->isOperable() ) {
             welltest_state.openWell(name() );
             const std::string msg = " well " + name() + " is re-opened through well testing for physical reason";
-            OpmLog::info(msg);
+            deferred_logger.info(msg);
             well_state = well_state_copy;
         } else {
             const std::string msg = " well " + name() + " is not operable during well testing for physical reason";
-            OpmLog::debug(msg);
+            deferred_logger.debug(msg);
         }
     }
 

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -150,13 +150,15 @@ namespace Opm
 
         virtual void assembleWellEq(const Simulator& ebosSimulator,
                                     const double dt,
-                                    WellState& well_state) = 0;
+                                    WellState& well_state,
+                                    Opm::DeferredLogger& deferred_logger
+                                    ) = 0;
 
         void updateWellTestState(const WellState& well_state,
                                  const double& simulationTime,
                                  const bool& writeMessageToOPMLog,
-                                 WellTestState& wellTestState
-                                 ) const;
+                                 WellTestState& wellTestState,
+                                 Opm::DeferredLogger& deferred_logger) const;
 
         void setWellEfficiencyFactor(const double efficiency_factor);
 
@@ -176,10 +178,12 @@ namespace Opm
         // TODO: before we decide to put more information under mutable, this function is not const
         virtual void computeWellPotentials(const Simulator& ebosSimulator,
                                            const WellState& well_state,
-                                           std::vector<double>& well_potentials) = 0;
+                                           std::vector<double>& well_potentials,
+                                           Opm::DeferredLogger& deferred_logger) = 0;
 
         virtual void updateWellStateWithTarget(const Simulator& ebos_simulator,
-                                               WellState& well_state) const = 0;
+                                               WellState& well_state,
+                                               Opm::DeferredLogger& deferred_logger) const = 0;
 
         void updateWellControl(/* const */ Simulator& ebos_simulator,
                                WellState& well_state,
@@ -233,7 +237,7 @@ namespace Opm
 
         void updatePerforatedCell(std::vector<bool>& is_cell_perforated);
 
-        virtual void checkWellOperability(const Simulator& ebos_simulator, const WellState& well_state) = 0;
+        virtual void checkWellOperability(const Simulator& ebos_simulator, const WellState& well_state, Opm::DeferredLogger& deferred_logger) = 0;
 
         // whether the well is operable
         bool isOperable() const;
@@ -339,7 +343,8 @@ namespace Opm
         double wpolymer() const;
 
         bool checkRateEconLimits(const WellEconProductionLimits& econ_production_limits,
-                                 const WellState& well_state) const;
+                                 const WellState& well_state,
+                                 Opm::DeferredLogger& deferred_logger) const;
 
         double getTHPConstraint() const;
 
@@ -362,7 +367,8 @@ namespace Opm
                                               const WellState& well_state) const;
 
         RatioCheckTuple checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
-                                             const WellState& well_state) const;
+                                             const WellState& well_state,
+                                             Opm::DeferredLogger& deferred_logger) const;
 
         double scalingFactor(const int comp_idx) const;
 
@@ -384,12 +390,14 @@ namespace Opm
         void updateWellTestStateEconomic(const WellState& well_state,
                                          const double simulation_time,
                                          const bool write_message_to_opmlog,
-                                         WellTestState& well_test_state) const;
+                                         WellTestState& well_test_state,
+                                         Opm::DeferredLogger& deferred_logger) const;
 
         void updateWellTestStatePhysical(const WellState& well_state,
                                          const double simulation_time,
                                          const bool write_message_to_opmlog,
-                                         WellTestState& well_test_state) const;
+                                         WellTestState& well_test_state,
+                                         Opm::DeferredLogger& deferred_logger) const;
 
         void  solveWellForTesting(Simulator& ebosSimulator, WellState& well_state,
                                   const std::vector<double>& B_avg,
@@ -400,7 +408,7 @@ namespace Opm
                                        WellState& well_state,
                                        Opm::DeferredLogger& deferred_logger);
 
-        void scaleProductivityIndex(const int perfIdx, double& productivity_index);
+        void scaleProductivityIndex(const int perfIdx, double& productivity_index, Opm::DeferredLogger& deferred_logger);
 
         // count the number of times an output log message is created in the productivity
         // index calculations


### PR DESCRIPTION
use deferred logging to log correctly in parallel for wells