### PR TITLE
Remove bogus debug output printing in MILU.

### DIFF
--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -306,8 +306,6 @@ namespace Opm
             for(const auto& entry: sum_dropped)
             {
                 auto& bdiag = (*a_ik)[index][index];
-                if(entry<0)
-                    std::cout << entry << std::endl;
                 bdiag += signFunctor(bdiag) * entry;
                 ++index;
             }


### PR DESCRIPTION
Somehow some standard output when running MILU () is still there and
it really clutters the output and and makes it unusable. This commit
removes it from flow.