### PR TITLE
flow: tell EclProblem the size of our next time step before writing output

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -322,6 +322,7 @@ namespace Opm {
                         Opm::time::StopWatch perfTimer;
                         perfTimer.start();
 
+                        ebosProblem.setForcedNextStepSize(dtEstimate);
                         ebosProblem.writeOutput(/*isSubStep=*/true);
 
                         report.output_write_time += perfTimer.secsSinceStart();


### PR DESCRIPTION
if we don't do this, the internal logic of EclProblem is used instead. this is an attempt to fix OPM/ewoms#479. As mentioned by @totto82 there, if the correct time step size is written by the current master it rather a coincidence than expected behavior...