### PR TITLE
Remove unused ParameterGroup.hpp header file

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -35,7 +35,6 @@
 #include <ewoms/common/propertysystem.hh>
 #include <ewoms/common/parametersystem.hh>
 #include <opm/autodiff/MissingFeatures.hpp>
-#include <opm/common/utility/parameters/ParameterGroup.hpp>
 #include <opm/material/common/ResetLocale.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>


### PR DESCRIPTION
This is mainly to get access to the `update_data` command for this PR: https://github.com/OPM/opm-common/pull/644