### PR TITLE
aquifers: add missing serialize() and deserialize() methods

### DIFF
--- a/opm/autodiff/BlackoilAquiferModel.hpp
+++ b/opm/autodiff/BlackoilAquiferModel.hpp
@@ -60,6 +60,12 @@ namespace Opm {
             void endTimeStep();
             void endEpisode();
 
+            template <class Restarter>
+            void serialize(Restarter& res);
+
+            template <class Restarter>
+            void deserialize(Restarter& res);
+
         protected:
             // ---------      Types      ---------
             typedef typename GET_PROP_TYPE(TypeTag, ElementContext)      ElementContext;

--- a/opm/autodiff/BlackoilAquiferModel_impl.hpp
+++ b/opm/autodiff/BlackoilAquiferModel_impl.hpp
@@ -106,6 +106,24 @@ namespace Opm {
   BlackoilAquiferModel<TypeTag>::endEpisode()
   { }
 
+    template <typename TypeTag>
+    template <class Restarter>
+    void
+    BlackoilAquiferModel<TypeTag>::serialize(Restarter& res)
+    {
+        // TODO (?)
+        throw std::logic_error("BlackoilAquiferModel::serialize() is not yet implemented");
+    }
+
+    template<typename TypeTag>
+    template <class Restarter>
+    void
+    BlackoilAquiferModel<TypeTag>::deserialize(Restarter& res)
+    {
+        // TODO (?)
+        throw std::logic_error("BlackoilAquiferModel::deserialize() is not yet implemented");
+    }
+
   // Initialize the aquifers in the deck
   template<typename TypeTag>
   void


### PR DESCRIPTION
the original purpose of these methods is to provide a checkpoint/restart mechanism using an ad-hoc file format. They might also be useful/required for implementing the adjoint functionality, though.