### PR TITLE
ebos: use the same well model, aquifer model and linear solver as flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,9 +161,7 @@ opm_add_test(ebos
   LIBRARIES "opmsimulators"
   SOURCES ebos/ebos.cc)
 
-if(OPM_GRID_FOUND AND HAVE_ECL_INPUT AND HAVE_ECL_OUTPUT)
-  install(TARGETS ebos DESTINATION bin)
-endif()
+install(TARGETS ebos DESTINATION bin)
 
 include(OpmBashCompletion)
 opm_add_bash_completion(flow)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,9 +154,12 @@ set_tests_properties(flow__version PROPERTIES
 # the research oriented general-purpose ECL simulator ("ebos" == &ecl
 # &black-&oil &simulator)
 opm_add_test(ebos
-  SOURCES ebos/ebos.cc
+  ONLY_COMPILE
+  ALWAYS_ENABLE
   EXE_NAME ebos
-  ONLY_COMPILE)
+  DEPENDS "opmsimulators"
+  LIBRARIES "opmsimulators"
+  SOURCES ebos/ebos.cc)
 
 if(OPM_GRID_FOUND AND HAVE_ECL_INPUT AND HAVE_ECL_OUTPUT)
   install(TARGETS ebos DESTINATION bin)

--- a/ebos/ebos.cc
+++ b/ebos/ebos.cc
@@ -23,28 +23,15 @@
 /*!
  * \file
  *
- * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ * \brief The main file for ebos, a general-purpose simulator for ECL decks for research
+ *        purposes.
  */
 #include "config.h"
 
-#include <opm/material/common/quad.hpp>
-#include <ewoms/common/start.hh>
-
-#include "eclproblem.hh"
-
-BEGIN_PROPERTIES
-
-NEW_TYPE_TAG(EclProblem, INHERITS_FROM(BlackOilModel, EclBaseProblem));
-
-// Enable experimental features for ebos: ebos is the research simulator of the OPM
-// project. If you're looking for a more stable "production quality" simulator, consider
-// using `flow`
-SET_BOOL_PROP(EclProblem, EnableExperiments, true);
-
-END_PROPERTIES
+#include "ebos.hh"
 
 int main(int argc, char **argv)
 {
-    typedef TTAG(EclProblem) ProblemTypeTag;
+    typedef TTAG(EbosTypeTag) ProblemTypeTag;
     return Ewoms::start<ProblemTypeTag>(argc, argv);
 }

--- a/ebos/ebos.hh
+++ b/ebos/ebos.hh
@@ -1,0 +1,135 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief The common settings for all ebos variants.
+ */
+#include "eclproblem.hh"
+
+#include <opm/autodiff/BlackoilWellModel.hpp>
+#include <opm/autodiff/BlackoilAquiferModel.hpp>
+#include <opm/autodiff/ISTLSolverEbos.hpp>
+
+#include <ewoms/common/start.hh>
+
+namespace Ewoms {
+template <class TypeTag>
+class EbosProblem;
+}
+
+BEGIN_PROPERTIES
+
+NEW_TYPE_TAG(EbosTypeTag, INHERITS_FROM(BlackOilModel, EclBaseProblem, FlowModelParameters));
+
+// Set the problem class
+SET_TYPE_PROP(EbosTypeTag, Problem, Ewoms::EbosProblem<TypeTag>);
+
+// Enable experimental features for ebos: ebos is the research simulator of the OPM
+// project. If you're looking for a more stable "production quality" simulator, consider
+// using `flow`
+SET_BOOL_PROP(EbosTypeTag, EnableExperiments, true);
+
+// use flow's well model for now
+SET_TYPE_PROP(EbosTypeTag, EclWellModel, Opm::BlackoilWellModel<TypeTag>);
+
+// set some properties that are only required by the well model
+SET_BOOL_PROP(EbosTypeTag, MatrixAddWellContributions, true);
+SET_BOOL_PROP(EbosTypeTag, EnableTerminalOutput, false);
+// flow's well model only works with surface volumes
+SET_BOOL_PROP(EbosTypeTag, BlackoilConserveSurfaceVolume, true);
+// the values for the residual are for the whole cell instead of for a cubic meter of the cell
+SET_BOOL_PROP(EbosTypeTag, UseVolumetricResidual, false);
+
+// by default use flow's aquifer model for now
+SET_TYPE_PROP(EbosTypeTag, EclAquiferModel, Opm::BlackoilAquiferModel<TypeTag>);
+
+// use flow's linear solver backend for now
+SET_TAG_PROP(EbosTypeTag, LinearSolverSplice, FlowIstlSolver);
+
+// the default for the allowed volumetric error for oil per second
+SET_SCALAR_PROP(EbosTypeTag, NewtonTolerance, 1e-1);
+
+// set fraction of the pore volume where the volumetric residual may be violated during
+// strict Newton iterations
+SET_SCALAR_PROP(EbosTypeTag, EclNewtonRelaxedVolumeFraction, 0.05);
+
+// the maximum volumetric error of a cell in the relaxed region
+SET_SCALAR_PROP(EbosTypeTag, EclNewtonRelaxedTolerance, 1e6*GET_PROP_VALUE(TypeTag, NewtonTolerance));
+
+// the tolerated amount of "incorrect" amount of oil per time step for the complete
+// reservoir. this is scaled by the pore volume of the reservoir, i.e., larger reservoirs
+// will tolerate larger residuals.
+SET_SCALAR_PROP(EbosTypeTag, EclNewtonSumTolerance, 1e-5);
+
+// make all Newton iterations strict, i.e., the volumetric Newton tolerance must be
+// always be upheld in the majority of the spatial domain. In this context, "majority"
+// means 1 - EclNewtonRelaxedVolumeFraction.
+SET_INT_PROP(EbosTypeTag, EclNewtonStrictIterations, 100);
+
+// set the maximum number of Newton iterations to 8 so that we fail quickly (albeit
+// relatively often)
+SET_INT_PROP(EbosTypeTag, NewtonMaxIterations, 8);
+
+END_PROPERTIES
+
+namespace Ewoms {
+template <class TypeTag>
+class EbosProblem : public EclProblem<TypeTag>
+{
+    typedef EclProblem<TypeTag> ParentType;
+
+public:
+    static void registerParameters()
+    {
+        ParentType::registerParameters();
+
+        Opm::BlackoilModelParametersEbos<TypeTag>::registerParameters();
+        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableTerminalOutput, "Do *NOT* use!");
+        EWOMS_HIDE_PARAM(TypeTag, DbhpMaxRel);
+        EWOMS_HIDE_PARAM(TypeTag, DwellFractionMax);
+        EWOMS_HIDE_PARAM(TypeTag, MaxResidualAllowed);
+        EWOMS_HIDE_PARAM(TypeTag, ToleranceMb);
+        EWOMS_HIDE_PARAM(TypeTag, ToleranceCnv);
+        EWOMS_HIDE_PARAM(TypeTag, ToleranceCnvRelaxed);
+        EWOMS_HIDE_PARAM(TypeTag, ToleranceWells);
+        EWOMS_HIDE_PARAM(TypeTag, ToleranceWellControl);
+        EWOMS_HIDE_PARAM(TypeTag, MaxWelleqIter);
+        EWOMS_HIDE_PARAM(TypeTag, UseMultisegmentWell);
+        EWOMS_HIDE_PARAM(TypeTag, TolerancePressureMsWells);
+        EWOMS_HIDE_PARAM(TypeTag, MaxPressureChangeMsWells);
+        EWOMS_HIDE_PARAM(TypeTag, UseInnerIterationsMsWells);
+        EWOMS_HIDE_PARAM(TypeTag, MaxInnerIterMsWells);
+        EWOMS_HIDE_PARAM(TypeTag, MaxSinglePrecisionDays);
+        EWOMS_HIDE_PARAM(TypeTag, MaxStrictIter);
+        EWOMS_HIDE_PARAM(TypeTag, SolveWelleqInitially);
+        EWOMS_HIDE_PARAM(TypeTag, UpdateEquationsScaling);
+        EWOMS_HIDE_PARAM(TypeTag, UseUpdateStabilization);
+        EWOMS_HIDE_PARAM(TypeTag, MatrixAddWellContributions);
+        EWOMS_HIDE_PARAM(TypeTag, EnableTerminalOutput);
+    }
+
+    // inherit the constructors
+    using ParentType::EclProblem;
+};
+}

--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -31,6 +31,7 @@
 #include "equil/initstateequil.hh"
 
 #include <ewoms/common/propertysystem.hh>
+#include <ewoms/models/blackoil/blackoilproperties.hh>
 
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>

--- a/ebos/eclnewtonmethod.hh
+++ b/ebos/eclnewtonmethod.hh
@@ -159,15 +159,24 @@ public:
             }
 
             const auto& r = currentResidual[dofIdx];
-            const double pvValue =
+            Scalar pvValue =
                 this->simulator_.problem().porosity(dofIdx)
                 * this->model().dofTotalVolume(dofIdx);
             sumPv += pvValue;
             bool cnvViolated = false;
 
+            Scalar dofVolume = this->model().dofTotalVolume(dofIdx);
+
             for (unsigned eqIdx = 0; eqIdx < r.size(); ++eqIdx) {
                 Scalar tmpError = r[eqIdx] * dt * this->model().eqWeight(dofIdx, eqIdx) / pvValue;
                 Scalar tmpError2 = r[eqIdx] * this->model().eqWeight(dofIdx, eqIdx);
+
+                // in the case of a volumetric formulation, the residual in the above is
+                // per cubic meter
+                if (GET_PROP_VALUE(TypeTag, UseVolumetricResidual)) {
+                    tmpError *= dofVolume;
+                    tmpError2 *= dofVolume;
+                }
 
                 this->error_ = Opm::max(std::abs(tmpError), this->error_);
 

--- a/ebos/eclnewtonmethod.hh
+++ b/ebos/eclnewtonmethod.hh
@@ -210,6 +210,8 @@ public:
         Scalar y = EWOMS_GET_PARAM(TypeTag, Scalar, EclNewtonSumToleranceExponent);
         sumTolerance_ = x*std::pow(sumPv, y);
 
+        this->endIterMsg() << " (max: " << this->tolerance_ << ", violated for " << errorPvFraction_*100 << "% of the pore volume), aggegate error: " << errorSum_ << " (max: " << sumTolerance_ << ")";
+
         // make sure that the error never grows beyond the maximum
         // allowed one
         if (this->error_ > newtonMaxError)

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -707,6 +707,18 @@ public:
         // The first thing to do in the morning of an episode is update update the
         // eclState and the deck if they need to be changed.
         int nextEpisodeIdx = simulator.episodeIndex();
+
+        if (this->gridView().comm().rank() == 0) {
+            boost::posix_time::ptime curDateTime =
+                boost::posix_time::from_time_t(timeMap.getStartTime(nextEpisodeIdx+1));
+            std::cout << "Report step " << nextEpisodeIdx + 2
+                      << "/" << timeMap.numTimesteps()
+                      << " at day " << timeMap.getTimePassedUntil(nextEpisodeIdx+1)/(24*3600)
+                      << "/" << timeMap.getTotalTime()/(24*3600)
+                      << ", date = " << curDateTime.date()
+                      << "\n ";
+        }
+
         if (nextEpisodeIdx > 0 &&
             events.hasEvent(Opm::ScheduleEvents::GEO_MODIFIER, nextEpisodeIdx))
         {

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -111,10 +111,10 @@ class EclProblem;
 BEGIN_PROPERTIES
 
 #if EBOS_USE_ALUGRID
-NEW_TYPE_TAG(EclBaseProblem, INHERITS_FROM(EclAluGridVanguard, EclOutputBlackOil));
+NEW_TYPE_TAG(EclBaseProblem, INHERITS_FROM(EclAluGridVanguard, EclOutputBlackOil, VtkEclTracer));
 #else
 NEW_TYPE_TAG(EclBaseProblem, INHERITS_FROM(EclCpGridVanguard, EclOutputBlackOil, VtkEclTracer));
-//NEW_TYPE_TAG(EclBaseProblem, INHERITS_FROM(EclPolyhedralGridVanguard, EclOutputBlackOil));
+//NEW_TYPE_TAG(EclBaseProblem, INHERITS_FROM(EclPolyhedralGridVanguard, EclOutputBlackOil, VtkEclTracer));
 #endif
 
 // The class which deals with ECL wells

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -370,6 +370,7 @@ class EclProblem : public GET_PROP_TYPE(TypeTag, BaseProblem)
     enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
     enum { numPhases = FluidSystem::numPhases };
     enum { numComponents = FluidSystem::numComponents };
+    enum { enableExperiments = GET_PROP_VALUE(TypeTag, EnableExperiments) };
     enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
     enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
     enum { enablePolymerMolarWeight = GET_PROP_VALUE(TypeTag, EnablePolymerMW) };
@@ -708,7 +709,7 @@ public:
         // eclState and the deck if they need to be changed.
         int nextEpisodeIdx = simulator.episodeIndex();
 
-        if (this->gridView().comm().rank() == 0) {
+        if (enableExperiments && this->gridView().comm().rank() == 0) {
             boost::posix_time::ptime curDateTime =
                 boost::posix_time::from_time_t(timeMap.getStartTime(nextEpisodeIdx+1));
             std::cout << "Report step " << nextEpisodeIdx + 2

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -151,6 +151,11 @@ namespace Opm
             EWOMS_HIDE_PARAM(TypeTag, NewtonTargetIterations);
             EWOMS_HIDE_PARAM(TypeTag, NewtonVerbose);
             EWOMS_HIDE_PARAM(TypeTag, NewtonWriteConvergence);
+            EWOMS_HIDE_PARAM(TypeTag, EclNewtonSumTolerance);
+            EWOMS_HIDE_PARAM(TypeTag, EclNewtonSumToleranceExponent);
+            EWOMS_HIDE_PARAM(TypeTag, EclNewtonStrictIterations);
+            EWOMS_HIDE_PARAM(TypeTag, EclNewtonRelaxedVolumeFraction);
+            EWOMS_HIDE_PARAM(TypeTag, EclNewtonRelaxedTolerance);
 
             // the default eWoms checkpoint/restart mechanism does not work with flow
             EWOMS_HIDE_PARAM(TypeTag, RestartTime);

--- a/opm/autodiff/ISTLSolverEbos.hpp
+++ b/opm/autodiff/ISTLSolverEbos.hpp
@@ -534,7 +534,7 @@ protected:
             // Check for failure of linear solver.
             if (!parameters_.ignoreConvergenceFailure_ && !result.converged) {
                 const std::string msg("Convergence failure for linear solver.");
-                OPM_THROW_NOLOG(LinearSolverProblem, msg);
+                OPM_THROW_NOLOG(NumericalIssue, msg);
             }
         }
     protected:

--- a/opm/autodiff/ParallelOverlappingILU0.hpp
+++ b/opm/autodiff/ParallelOverlappingILU0.hpp
@@ -935,7 +935,7 @@ protected:
                 milun_decomposition( A, iluIteration, milu, *ILU, *reorderer, *inverseReorderer );
             }
         }
-        catch ( const Dune::MatrixBlockError& error )
+        catch (const Dune::MatrixBlockError& error)
         {
             message = error.what();
             std::cerr<<"Exception occured on process " << rank << " during " <<

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -47,6 +47,9 @@
 #include <opm/simulators/timestepping/ConvergenceReport.hpp>
 #include <opm/simulators/DeferredLogger.hpp>
 
+#include <ewoms/models/blackoil/blackoilpolymermodules.hh>
+#include <ewoms/models/blackoil/blackoilsolventmodules.hh>
+
 #include<dune/common/fmatrix.hh>
 #include<dune/istl/bcrsmatrix.hh>
 #include<dune/istl/matrixmatrix.hh>


### PR DESCRIPTION
This enables `ebos` to run Norne and other non-trivial data sets. While at it, adapt the tolerances by `ebos`.

This patch only affects the research simulator, i.e. `flow` is unaffected by it.