### PR TITLE
EclProblem: Rename NewtonRawTolerance to NewtonTolerance

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -240,7 +240,7 @@ SET_SCALAR_PROP(EclBaseProblem, EndTime, 1e100);
 SET_SCALAR_PROP(EclBaseProblem, InitialTimeStepSize, 3600*24);
 
 // the default for the allowed volumetric error for oil per second
-SET_SCALAR_PROP(EclBaseProblem, NewtonRawTolerance, 1e-2);
+SET_SCALAR_PROP(EclBaseProblem, NewtonTolerance, 1e-2);
 
 // the tolerated amount of "incorrect" amount of oil per time step for the complete
 // reservoir. this is scaled by the pore volume of the reservoir, i.e., larger reservoirs

--- a/opm/autodiff/FlowMainEbos.hpp
+++ b/opm/autodiff/FlowMainEbos.hpp
@@ -147,7 +147,7 @@ namespace Opm
             // flow also does not use the eWoms Newton method
             EWOMS_HIDE_PARAM(TypeTag, NewtonMaxError);
             EWOMS_HIDE_PARAM(TypeTag, NewtonMaxIterations);
-            EWOMS_HIDE_PARAM(TypeTag, NewtonRawTolerance);
+            EWOMS_HIDE_PARAM(TypeTag, NewtonTolerance);
             EWOMS_HIDE_PARAM(TypeTag, NewtonTargetIterations);
             EWOMS_HIDE_PARAM(TypeTag, NewtonVerbose);
             EWOMS_HIDE_PARAM(TypeTag, NewtonWriteConvergence);


### PR DESCRIPTION
this is the downstream of OPM/ewoms#486: this property is actually not used by `flow` because `flow` implements its own Newton method, but it not renaming the property prevents `flow` from building.