### PR TITLE
warning instead of throwing for nnc between active cells and inactive cells

### DIFF
--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -676,9 +676,14 @@ private:
                 // Silently discard as it is not between active cells
                 continue;
 
-            if (low == -1 || high == -1)
-                OPM_THROW(std::logic_error, "NNC between active and inactive cells (" <<
-                          low << " -> " << high);
+            if (low == -1 || high == -1) {
+                // Discard the NNC if it is between active cell and inactive cell
+                std::ostringstream sstr;
+                sstr << "NNC between active and inactive cells ("
+                     << low << " -> " << high << ")";
+                Opm::OpmLog::warning(sstr.str());
+                continue;
+            }
 
             auto candidate = trans_.find(isId_(low, high));
 


### PR DESCRIPTION
to make the current targeting case to run through. 

Something wired is that, now it runs, while I could not find the warning message anywhere. 