### PR TITLE
add some ebos variants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ cmake_minimum_required (VERSION 2.8)
 
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
 set( USE_OPENMP_DEFAULT OFF ) # Use of OpenMP is considered experimental
+option(BUILD_FLOW "Build the production oriented flow simulator?" ON)
+option(BUILD_EBOS "Build the research oriented ebos simulator and its variants?" ON)
 
 if(SIBLING_SEARCH AND NOT opm-common_DIR)
   # guess the sibling dir
@@ -127,7 +129,9 @@ opm_add_test(test_gatherdeferredlogger
     5 ${CMAKE_BINARY_DIR}
 )
 
+include(OpmBashCompletion)
 
+if (BUILD_FLOW)
 # the production oriented general-purpose ECL simulator
 opm_add_test(flow
   ONLY_COMPILE
@@ -145,12 +149,15 @@ opm_add_test(flow
     flow/flow_ebos_oilwater_polymer.cpp
     flow/flow_ebos_oilwater_polymer_injectivity.cpp)
 install(TARGETS flow DESTINATION bin)
+opm_add_bash_completion(flow)
 
 add_test(NAME flow__version
          COMMAND flow --version)
 set_tests_properties(flow__version PROPERTIES
                      PASS_REGULAR_EXPRESSION "${${project}_LABEL}")
+endif()
 
+if (BUILD_EBOS)
 # the research oriented general-purpose ECL simulator ("ebos" == &ecl
 # &black-&oil &simulator)
 opm_add_test(ebos
@@ -208,6 +215,10 @@ install(TARGETS ebos_gasoil DESTINATION bin)
 install(TARGETS ebos_oilwater DESTINATION bin)
 install(TARGETS ebos_thermal DESTINATION bin)
 
-include(OpmBashCompletion)
-opm_add_bash_completion(flow)
 opm_add_bash_completion(ebos)
+opm_add_bash_completion(ebos_solvent)
+opm_add_bash_completion(ebos_polymer)
+opm_add_bash_completion(ebos_gasoil)
+opm_add_bash_completion(ebos_oilwater)
+opm_add_bash_completion(ebos_thermal)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,8 @@ cmake_minimum_required (VERSION 2.8)
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
 set( USE_OPENMP_DEFAULT OFF ) # Use of OpenMP is considered experimental
 option(BUILD_FLOW "Build the production oriented flow simulator?" ON)
-option(BUILD_EBOS "Build the research oriented ebos simulator and its variants?" ON)
+option(BUILD_EBOS "Build the research oriented ebos simulator?" ON)
+option(BUILD_EBOS_EXTENSIONS "Build the variants for various extensions of ebos by default?" OFF)
 
 if(SIBLING_SEARCH AND NOT opm-common_DIR)
   # guess the sibling dir
@@ -131,46 +132,71 @@ opm_add_test(test_gatherdeferredlogger
 
 include(OpmBashCompletion)
 
-if (BUILD_FLOW)
+if (NOT BUILD_FLOW)
+  set(FLOW_DEFAULT_ENABLE_IF "FALSE")
+else()
+  set(FLOW_DEFAULT_ENABLE_IF "TRUE")
+endif()
+
 # the production oriented general-purpose ECL simulator
 opm_add_test(flow
   ONLY_COMPILE
   ALWAYS_ENABLE
+  DEFAULT_ENABLE_IF ${FLOW_DEFAULT_ENABLE_IF}
   DEPENDS "opmsimulators"
   LIBRARIES "opmsimulators"
   SOURCES
-    flow/flow.cpp
-    flow/flow_ebos_blackoil.cpp
-    flow/flow_ebos_gasoil.cpp
-    flow/flow_ebos_oilwater.cpp
-    flow/flow_ebos_polymer.cpp
-    flow/flow_ebos_solvent.cpp
-    flow/flow_ebos_energy.cpp
-    flow/flow_ebos_oilwater_polymer.cpp
-    flow/flow_ebos_oilwater_polymer_injectivity.cpp)
-install(TARGETS flow DESTINATION bin)
-opm_add_bash_completion(flow)
+  flow/flow.cpp
+  flow/flow_ebos_blackoil.cpp
+  flow/flow_ebos_gasoil.cpp
+  flow/flow_ebos_oilwater.cpp
+  flow/flow_ebos_polymer.cpp
+  flow/flow_ebos_solvent.cpp
+  flow/flow_ebos_energy.cpp
+  flow/flow_ebos_oilwater_polymer.cpp
+  flow/flow_ebos_oilwater_polymer_injectivity.cpp)
 
-add_test(NAME flow__version
-         COMMAND flow --version)
-set_tests_properties(flow__version PROPERTIES
-                     PASS_REGULAR_EXPRESSION "${${project}_LABEL}")
+if (BUILD_FLOW)
+  install(TARGETS flow DESTINATION bin)
+  opm_add_bash_completion(flow)
+
+  add_test(NAME flow__version
+    COMMAND flow --version)
+  set_tests_properties(flow__version PROPERTIES
+    PASS_REGULAR_EXPRESSION "${${project}_LABEL}")
 endif()
 
-if (BUILD_EBOS)
+if (NOT BUILD_EBOS)
+  set(EBOS_DEFAULT_ENABLE_IF "FALSE")
+else()
+  set(EBOS_DEFAULT_ENABLE_IF "TRUE")
+endif()
+  
 # the research oriented general-purpose ECL simulator ("ebos" == &ecl
 # &black-&oil &simulator)
 opm_add_test(ebos
   ONLY_COMPILE
+  DEFAULT_ENABLE_IF ${EBOS_DEFAULT_ENABLE_IF}
   ALWAYS_ENABLE
   EXE_NAME ebos
   DEPENDS "opmsimulators"
   LIBRARIES "opmsimulators"
   SOURCES ebos/ebos.cc)
 
+if (BUILD_EBOS)
+  install(TARGETS ebos DESTINATION bin)
+  opm_add_bash_completion(ebos)
+endif()
+
+if (NOT BUILD_EBOS_EXTENSIONS)
+  set(EBOS_EXTENSIONS_DEFAULT_ENABLE_IF "FALSE")
+else()
+  set(EBOS_EXTENSIONS_DEFAULT_ENABLE_IF "TRUE")
+endif()
+
 opm_add_test(ebos_solvent
   ONLY_COMPILE
-  ALWAYS_ENABLE
+  DEFAULT_ENABLE_IF ${EBOS_EXTENSIONS_DEFAULT_ENABLE_IF}
   SOURCES ebos/ebos_solvent.cc
   EXE_NAME ebos_solvent
   DEPENDS "opmsimulators"
@@ -178,7 +204,7 @@ opm_add_test(ebos_solvent
 
 opm_add_test(ebos_polymer
   ONLY_COMPILE
-  ALWAYS_ENABLE
+  DEFAULT_ENABLE_IF ${EBOS_EXTENSIONS_DEFAULT_ENABLE_IF}
   SOURCES ebos/ebos_polymer.cc
   EXE_NAME ebos_polymer
   DEPENDS "opmsimulators"
@@ -186,7 +212,7 @@ opm_add_test(ebos_polymer
 
 opm_add_test(ebos_gasoil
   ONLY_COMPILE
-  ALWAYS_ENABLE
+  DEFAULT_ENABLE_IF ${EBOS_EXTENSIONS_DEFAULT_ENABLE_IF}
   SOURCES ebos/ebos_gasoil.cc
   EXE_NAME ebos_gasoil
   DEPENDS "opmsimulators"
@@ -194,7 +220,7 @@ opm_add_test(ebos_gasoil
 
 opm_add_test(ebos_oilwater
   ONLY_COMPILE
-  ALWAYS_ENABLE
+  DEFAULT_ENABLE_IF ${EBOS_EXTENSIONS_DEFAULT_ENABLE_IF}
   SOURCES ebos/ebos_oilwater.cc
   EXE_NAME ebos_oilwater
   DEPENDS "opmsimulators"
@@ -202,23 +228,23 @@ opm_add_test(ebos_oilwater
 
 opm_add_test(ebos_thermal
   ONLY_COMPILE
-  ALWAYS_ENABLE
+  DEFAULT_ENABLE_IF ${EBOS_EXTENSIONS_DEFAULT_ENABLE_IF}
   SOURCES ebos/ebos_thermal.cc
   EXE_NAME ebos_thermal
   DEPENDS "opmsimulators"
   LIBRARIES "opmsimulators")
 
-install(TARGETS ebos DESTINATION bin)
-install(TARGETS ebos_solvent DESTINATION bin)
-install(TARGETS ebos_polymer DESTINATION bin)
-install(TARGETS ebos_gasoil DESTINATION bin)
-install(TARGETS ebos_oilwater DESTINATION bin)
-install(TARGETS ebos_thermal DESTINATION bin)
-
-opm_add_bash_completion(ebos)
 opm_add_bash_completion(ebos_solvent)
 opm_add_bash_completion(ebos_polymer)
 opm_add_bash_completion(ebos_gasoil)
 opm_add_bash_completion(ebos_oilwater)
 opm_add_bash_completion(ebos_thermal)
+
+if (BUILD_EBOS_EXTENSIONS)
+  install(TARGETS ebos_solvent DESTINATION bin)
+  install(TARGETS ebos_polymer DESTINATION bin)
+  install(TARGETS ebos_gasoil DESTINATION bin)
+  install(TARGETS ebos_oilwater DESTINATION bin)
+  install(TARGETS ebos_thermal DESTINATION bin)
 endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,52 @@ opm_add_test(ebos
   LIBRARIES "opmsimulators"
   SOURCES ebos/ebos.cc)
 
+opm_add_test(ebos_solvent
+  ONLY_COMPILE
+  ALWAYS_ENABLE
+  SOURCES ebos/ebos_solvent.cc
+  EXE_NAME ebos_solvent
+  DEPENDS "opmsimulators"
+  LIBRARIES "opmsimulators")
+
+opm_add_test(ebos_polymer
+  ONLY_COMPILE
+  ALWAYS_ENABLE
+  SOURCES ebos/ebos_polymer.cc
+  EXE_NAME ebos_polymer
+  DEPENDS "opmsimulators"
+  LIBRARIES "opmsimulators")
+
+opm_add_test(ebos_gasoil
+  ONLY_COMPILE
+  ALWAYS_ENABLE
+  SOURCES ebos/ebos_gasoil.cc
+  EXE_NAME ebos_gasoil
+  DEPENDS "opmsimulators"
+  LIBRARIES "opmsimulators")
+
+opm_add_test(ebos_oilwater
+  ONLY_COMPILE
+  ALWAYS_ENABLE
+  SOURCES ebos/ebos_oilwater.cc
+  EXE_NAME ebos_oilwater
+  DEPENDS "opmsimulators"
+  LIBRARIES "opmsimulators")
+
+opm_add_test(ebos_thermal
+  ONLY_COMPILE
+  ALWAYS_ENABLE
+  SOURCES ebos/ebos_thermal.cc
+  EXE_NAME ebos_thermal
+  DEPENDS "opmsimulators"
+  LIBRARIES "opmsimulators")
+
 install(TARGETS ebos DESTINATION bin)
+install(TARGETS ebos_solvent DESTINATION bin)
+install(TARGETS ebos_polymer DESTINATION bin)
+install(TARGETS ebos_gasoil DESTINATION bin)
+install(TARGETS ebos_oilwater DESTINATION bin)
+install(TARGETS ebos_thermal DESTINATION bin)
 
 include(OpmBashCompletion)
 opm_add_bash_completion(flow)

--- a/ebos/ebos_gasoil.cc
+++ b/ebos/ebos_gasoil.cc
@@ -1,0 +1,59 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ */
+#include "config.h"
+
+#include "ebos.hh"
+
+BEGIN_PROPERTIES
+
+NEW_TYPE_TAG(EbosGasOilTypeTag, INHERITS_FROM(EbosTypeTag));
+
+//! The indices indices which only enable oil and water
+SET_PROP(EbosGasOilTypeTag, Indices)
+{
+private:
+    // it is unfortunately not possible to simply use 'TypeTag' here because this leads
+    // to cyclic definitions of some properties. if this happens the compiler error
+    // messages unfortunately are *really* confusing and not really helpful.
+    typedef typename GET_PROP_TYPE(TTAG(EbosTypeTag), FluidSystem) FluidSystem;
+
+public:
+    typedef Ewoms::BlackOilTwoPhaseIndices<GET_PROP_VALUE(TypeTag, EnableSolvent),
+                                           GET_PROP_VALUE(TypeTag, EnablePolymer),
+                                           GET_PROP_VALUE(TypeTag, EnableEnergy),
+                                           /*PVOffset=*/0,
+                                           /*disabledCompIdx=*/FluidSystem::waterCompIdx> type;
+};
+
+END_PROPERTIES
+
+int main(int argc, char **argv)
+{
+    typedef TTAG(EbosGasOilTypeTag) ProblemTypeTag;
+    return Ewoms::start<ProblemTypeTag>(argc, argv);
+}

--- a/ebos/ebos_oilwater.cc
+++ b/ebos/ebos_oilwater.cc
@@ -1,0 +1,59 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ */
+#include "config.h"
+
+#include "ebos.hh"
+
+BEGIN_PROPERTIES
+
+NEW_TYPE_TAG(EbosOilWaterTypeTag, INHERITS_FROM(EbosTypeTag));
+
+//! The indices indices which only enable oil and water
+SET_PROP(EbosOilWaterTypeTag, Indices)
+{
+private:
+    // it is unfortunately not possible to simply use 'TypeTag' here because this leads
+    // to cyclic definitions of some properties. if this happens the compiler error
+    // messages unfortunately are *really* confusing and not really helpful.
+    typedef typename GET_PROP_TYPE(TTAG(EbosTypeTag), FluidSystem) FluidSystem;
+
+public:
+    typedef Ewoms::BlackOilTwoPhaseIndices<GET_PROP_VALUE(TypeTag, EnableSolvent),
+                                           GET_PROP_VALUE(TypeTag, EnablePolymer),
+                                           GET_PROP_VALUE(TypeTag, EnableEnergy),
+                                           /*PVOffset=*/0,
+                                           /*disabledCompIdx=*/FluidSystem::gasCompIdx> type;
+};
+
+END_PROPERTIES
+
+int main(int argc, char **argv)
+{
+    typedef TTAG(EbosOilWaterTypeTag) ProblemTypeTag;
+    return Ewoms::start<ProblemTypeTag>(argc, argv);
+}

--- a/ebos/ebos_plain.cc
+++ b/ebos/ebos_plain.cc
@@ -1,0 +1,44 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ */
+#include "config.h"
+
+#include "eclproblem.hh"
+
+#include <ewoms/common/start.hh>
+
+BEGIN_PROPERTIES
+
+NEW_TYPE_TAG(EbosPlainTypeTag, INHERITS_FROM(BlackOilModel, EclBaseProblem));
+
+END_PROPERTIES
+
+int main(int argc, char **argv)
+{
+    typedef TTAG(EbosPlainTypeTag) ProblemTypeTag;
+    return Ewoms::start<ProblemTypeTag>(argc, argv);
+}

--- a/ebos/ebos_polymer.cc
+++ b/ebos/ebos_polymer.cc
@@ -1,0 +1,45 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ */
+#include "config.h"
+
+#include "ebos.hh"
+
+BEGIN_PROPERTIES
+
+NEW_TYPE_TAG(EbosPolymerTypeTag, INHERITS_FROM(EbosTypeTag));
+
+// enable the polymer extension of the black oil model
+SET_BOOL_PROP(EbosPolymerTypeTag, EnablePolymer, true);
+
+END_PROPERTIES
+
+int main(int argc, char **argv)
+{
+    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
+    return Ewoms::start<ProblemTypeTag>(argc, argv);
+}

--- a/ebos/ebos_solvent.cc
+++ b/ebos/ebos_solvent.cc
@@ -1,0 +1,45 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ */
+#include "config.h"
+
+#include "ebos.hh"
+
+BEGIN_PROPERTIES
+
+NEW_TYPE_TAG(EbosSolventTypeTag, INHERITS_FROM(EbosTypeTag));
+
+// enable the solvent extension of the black oil model
+SET_BOOL_PROP(EbosSolventTypeTag, EnableSolvent, true);
+
+END_PROPERTIES
+
+int main(int argc, char **argv)
+{
+    typedef TTAG(EbosSolventTypeTag) ProblemTypeTag;
+    return Ewoms::start<ProblemTypeTag>(argc, argv);
+}

--- a/ebos/ebos_thermal.cc
+++ b/ebos/ebos_thermal.cc
@@ -1,0 +1,45 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ */
+#include "config.h"
+
+#include "ebos.hh"
+
+BEGIN_PROPERTIES
+
+NEW_TYPE_TAG(EbosThermalTypeTag, INHERITS_FROM(EbosTypeTag));
+
+// enable the energy extension of the black oil model
+SET_BOOL_PROP(EbosThermalTypeTag, EnableEnergy, true);
+
+END_PROPERTIES
+
+int main(int argc, char **argv)
+{
+    typedef TTAG(EbosThermalTypeTag) ProblemTypeTag;
+    return Ewoms::start<ProblemTypeTag>(argc, argv);
+}


### PR DESCRIPTION
these variants should cover most of the common use cases. For developers, the main advantage of using one of these instead of `flow` is that they have faster round-trip times because they build faster: 53 seconds for `ebos` instead 1 minute 25 for `flow` on my machine with 32 parallel build threads (for machines that have fewer than 9 physical cores, the difference is likely even larger).

That said, there are no plans to provide simulators for combinations of blackoil extensions or a "all-in-one" simulator like `flow`: If someone is interested in e.g., an oil-water simulator with polymer and energy enabled, a separate self-compiled executable should be added locally.