### PR TITLE
add an ebos variant which uses completely different numbering for phases and components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set( USE_OPENMP_DEFAULT OFF ) # Use of OpenMP is considered experimental
 option(BUILD_FLOW "Build the production oriented flow simulator?" ON)
 option(BUILD_EBOS "Build the research oriented ebos simulator?" ON)
 option(BUILD_EBOS_EXTENSIONS "Build the variants for various extensions of ebos by default?" OFF)
+option(BUILD_EBOS_DEBUG_EXTENSIONS "Build the ebos variants which are purely for debugging by default?" OFF)
 
 if(SIBLING_SEARCH AND NOT opm-common_DIR)
   # guess the sibling dir
@@ -231,6 +232,20 @@ opm_add_test(ebos_thermal
   DEFAULT_ENABLE_IF ${EBOS_EXTENSIONS_DEFAULT_ENABLE_IF}
   SOURCES ebos/ebos_thermal.cc
   EXE_NAME ebos_thermal
+  DEPENDS "opmsimulators"
+  LIBRARIES "opmsimulators")
+
+if (NOT BUILD_EBOS_DEBUG_EXTENSIONS)
+  set(EBOS_DEBUG_EXTENSIONS_DEFAULT_ENABLE_IF "FALSE")
+else()
+  set(EBOS_DEBUG_EXTENSIONS_DEFAULT_ENABLE_IF "TRUE")
+endif()
+
+opm_add_test(ebos_altidx
+  ONLY_COMPILE
+  DEFAULT_ENABLE_IF ${EBOS_DEBUG_EXTENSIONS_DEFAULT_ENABLE_IF}
+  SOURCES ebos/ebos_altidx.cc
+  EXE_NAME ebos_altidx
   DEPENDS "opmsimulators"
   LIBRARIES "opmsimulators")
 

--- a/ebos/ebos_altidx.cc
+++ b/ebos/ebos_altidx.cc
@@ -1,0 +1,71 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief This is an ebos variant which uses alternative phase and component indices than
+ *        the default variant.
+ *
+ * It is purely for testing purposes and is supposed to produce bitwise identical
+ * results.
+ */
+#include "config.h"
+
+#include "ebos.hh"
+
+namespace Ewoms {
+class EclAlternativeBlackOilIndexTraits
+{
+    typedef Opm::BlackOilDefaultIndexTraits DIT;
+
+public:
+    static const unsigned waterPhaseIdx = DIT::oilPhaseIdx;
+    static const unsigned oilPhaseIdx = DIT::gasPhaseIdx;
+    static const unsigned gasPhaseIdx = DIT::waterPhaseIdx;
+
+    static const unsigned waterCompIdx = DIT::gasCompIdx;
+    static const unsigned oilCompIdx = DIT::waterCompIdx;
+    static const unsigned gasCompIdx = DIT::oilCompIdx;
+};
+}
+
+BEGIN_PROPERTIES
+
+NEW_TYPE_TAG(EbosAltIdxTypeTag, INHERITS_FROM(EbosTypeTag));
+
+// use a fluid system with different indices than the default
+SET_PROP(EbosAltIdxTypeTag, FluidSystem)
+{
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+
+public:
+    typedef Opm::BlackOilFluidSystem<Scalar, Ewoms::EclAlternativeBlackOilIndexTraits> type;
+};
+
+END_PROPERTIES
+
+int main(int argc, char **argv)
+{
+    typedef TTAG(EbosAltIdxTypeTag) ProblemTypeTag;
+    return Ewoms::start<ProblemTypeTag>(argc, argv);
+}


### PR DESCRIPTION
for some reason, this yields quite different results for norne than the default variant, e.g. when comparing PRESSURE, we get

```
> compareECL -k PRESSURE -t UNRST ebos/NORNE_ATW2013 ebos_altidx/NORNE_ATW2013 1 1e-4
Comparing 'ebos/NORNE_ATW2013' to 'ebos_altidx/NORNE_ATW2013'.
Comparing PRESSURE...
Occurrence in first file    = 9
Occurrence in second file   = 9
Value index                 = 0
(first value, second value) = (254.195, 253.191)

Program threw an exception: [/home/and/src/opm-common/build-cmake/fake-src/examples/test_util/EclRegressionTest.cpp:161] Deviations exceed tolerances.
The absolute deviation is 1.00311, and the tolerance limit is 1.
The relative deviation is 0.00394624, and the tolerance limit is 0.0001.
```

IMO this is a bug, but the reasons for it are currently mysterious to me.