### PR TITLE
Minor cleanups

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1321,12 +1321,10 @@ public:
     template <class Context>
     Scalar temperature(const Context& context, unsigned spaceIdx, unsigned timeIdx) const
     {
-        // use the temporally constant temperature, i.e. use the initial temperature of
-        // the DOF
+        // use the initial temperature of the DOF if temperature is not a primary
+        // variable
         unsigned globalDofIdx = context.globalSpaceIndex(spaceIdx, timeIdx);
-        if (!initialFluidStates_.empty())
-            return initialFluidStates_[globalDofIdx].temperature(/*phaseIdx=*/0);
-        return initialTemperature_[globalDofIdx];
+        return initialFluidStates_[globalDofIdx].temperature(/*phaseIdx=*/0);
     }
 
     /*!
@@ -2666,7 +2664,6 @@ private:
     std::vector<Scalar> maxPolymerAdsorption_;
 
     std::vector<InitialFluidState> initialFluidStates_;
-    std::vector<Scalar> initialTemperature_;
 
     std::vector<Scalar> polymerConcentration_;
     // polymer molecular weight

--- a/opm/autodiff/ISTLSolverEbos.hpp
+++ b/opm/autodiff/ISTLSolverEbos.hpp
@@ -492,7 +492,9 @@ protected:
             // TODO: Revise when linear solvers interface opm-core is done
             // Construct linear solver.
             // GMRes solver
-            int verbosity = ( isIORank_ ) ? parameters_.linear_solver_verbosity_ : 0;
+            int verbosity = 0;
+            if (simulator_.gridView().comm().rank() == 0)
+                verbosity = parameters_.linear_solver_verbosity_;
 
             if ( parameters_.newton_use_gmres_ ) {
                 Dune::RestartedGMResSolver<Vector> linsolve(opA, sp, precond,
@@ -836,7 +838,6 @@ protected:
         mutable int iterations_;
         mutable bool converged_;
         boost::any parallelInformation_;
-        bool isIORank_;
 
         std::unique_ptr<Matrix> matrix_;
         Vector *rhs_;


### PR DESCRIPTION
remove the unused `initialTemperature_` array in `EclProblem` and do not use the uninitialized `isIoRank_` member in `ISTLSolverEbos` anymore.