### PR TITLE
ebos: make its core headers self sufficient

### DIFF
--- a/ebos/alucartesianindexmapper.hh
+++ b/ebos/alucartesianindexmapper.hh
@@ -33,7 +33,7 @@
 
 #include <array>
 #include <memory>
-#include <except>
+#include <exception>
 #include <vector>
 #include <cassert>
 

--- a/ebos/ebos.hh
+++ b/ebos/ebos.hh
@@ -25,6 +25,9 @@
  *
  * \brief The common settings for all ebos variants.
  */
+#ifndef EBOS_HH
+#define EBOS_HH
+
 #include "eclproblem.hh"
 
 #include <opm/autodiff/BlackoilWellModel.hpp>
@@ -133,3 +136,5 @@ public:
     using ParentType::EclProblem;
 };
 }
+
+#endif // EBOS_HH

--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -30,9 +30,13 @@
 
 #include "tracervdtable.hh"
 
+#include <ewoms/models/blackoil/blackoilmodel.hh>
+
 #include <dune/istl/operators.hh>
 #include <dune/istl/solvers.hh>
 #include <dune/istl/preconditioners.hh>
+
+#include <dune/common/version.hh>
 
 #include <string>
 #include <vector>

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -31,6 +31,7 @@
 #include "collecttoiorank.hh"
 #include "ecloutputblackoilmodule.hh"
 
+#include <ewoms/models/blackoil/blackoilmodel.hh>
 #include <ewoms/disc/ecfv/ecfvdiscretization.hh>
 #include <ewoms/io/baseoutputwriter.hh>
 #include <ewoms/parallel/tasklets.hh>


### PR DESCRIPTION
this is part of the release maintainance. in this context "core ebos headers" means the headers located underneath the `ebos` directory which do not include the well model headers, and only those which are concerned with non-exotic functionality, e.g., the PolyhedralGrid and ALUGrid vanguards are not changed.