### PR TITLE
Update missing features

### DIFF
--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -204,7 +204,6 @@ namespace MissingFeatures {
             "WPAVE",
             "WPITAB",
             "WTEMP",
-            "WTEST",
             "WTRACER",
             "ZIPPY2" };
         std::multimap<std::string, PartiallySupported<std::string> > string_options;

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -170,7 +170,6 @@ namespace MissingFeatures {
             "RPTPROS",
             "PRTRST",
             "RPTRUNSP",
-            "RPTSCHED",
             "RPTSMRY",
             "RPTSOL",
             "RSCONST",

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -95,7 +95,6 @@ namespace MissingFeatures {
             "CPR",
             "DATE",
             "ECHO",
-            "EDITNNC",
             "ENDACTIO",
             "ENDFIN"
             "ENDNUM",

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -94,7 +94,6 @@ namespace MissingFeatures {
             "CONNECTION",
             "CPR",
             "DATE",
-            "ECHO",
             "ENDACTIO",
             "ENDFIN"
             "ENDNUM",
@@ -130,7 +129,6 @@ namespace MissingFeatures {
             "NETBALAN",
             "NEXTSTEP",
             "NOCASC",
-            "NOECHO",
             "NOGGF",
             "NOINSPEC",
             "NOMONITO",


### PR DESCRIPTION
See: https://github.com/OPM/opm-common/issues/701

The RPTSCEHD, WTEST and EDITNNC are (to best of my knowledge) fully supported all the way through and should be remowed from this list. The ECHO and NOECHO keywords are not supported - but if/when we are to support them that will be in the input layer, so it is really not the simulators business to complain about that.