### PR TITLE
also pass the parseContext and errorGuard to Opm::checkDeck()

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -198,7 +198,7 @@ int main(int argc, char** argv)
             Opm::MissingFeatures::checkKeywords(*deck, parseContext, errorGuard);
 
             if ( outputCout )
-                Opm::checkDeck(*deck, parser);
+                Opm::checkDeck(*deck, parser, parseContext, errorGuard);
 
             eclipseState.reset( new Opm::EclipseState(*deck, parseContext, errorGuard ));
             schedule.reset(new Opm::Schedule(*deck, *eclipseState, parseContext, errorGuard));

--- a/tests/test_vfpproperties.cpp
+++ b/tests/test_vfpproperties.cpp
@@ -648,11 +648,13 @@ BOOST_AUTO_TEST_CASE(ParseInterpolateRealisticVFPPROD)
 {
     auto units = Opm::UnitSystem::newMETRIC();
 
+    Opm::ParseContext parseContext;
+    Opm::ErrorGuard errorGuard;
     Opm::Parser parser;
     boost::filesystem::path file("VFPPROD2");
 
     auto deck = parser.parseFile(file.string());
-    Opm::checkDeck(deck, parser);
+    Opm::checkDeck(deck, parser, parseContext, errorGuard);
 
     BOOST_REQUIRE(deck.hasKeyword("VFPPROD"));
     BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);


### PR DESCRIPTION
this is needed because of the API change implied by OPM/opm-common#710.