### PR TITLE
not throw for failure when failing in calculating well potentials

### DIFF
--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -1075,12 +1075,12 @@ namespace Opm {
         try {
             for (const auto& well : well_container_) {
                 // Only compute the well potential when asked for
-                bool needed_for_output = ((summaryConfig.hasSummaryKey( "WWPI:" + well->name()) ||
-                                           summaryConfig.hasSummaryKey( "WOPI:" + well->name()) ||
-                                           summaryConfig.hasSummaryKey( "WGPI:" + well->name())) && well->wellType() == INJECTOR) ||
-                                        ((summaryConfig.hasSummaryKey( "WWPP:" + well->name()) ||
-                                                           summaryConfig.hasSummaryKey( "WOPP:" + well->name()) ||
-                                                           summaryConfig.hasSummaryKey( "WGPP:" + well->name())) && well->wellType() == PRODUCER);
+                const bool needed_for_output = ((summaryConfig.hasSummaryKey( "WWPI:" + well->name()) ||
+                                                 summaryConfig.hasSummaryKey( "WOPI:" + well->name()) ||
+                                                 summaryConfig.hasSummaryKey( "WGPI:" + well->name())) && well->wellType() == INJECTOR) ||
+                                               ((summaryConfig.hasSummaryKey( "WWPP:" + well->name()) ||
+                                                 summaryConfig.hasSummaryKey( "WOPP:" + well->name()) ||
+                                                 summaryConfig.hasSummaryKey( "WGPP:" + well->name())) && well->wellType() == PRODUCER);
                 if (needed_for_output || wellCollection().requireWellPotentials())
                 {
                     std::vector<double> potentials;

--- a/opm/autodiff/StandardWell_impl.hpp
+++ b/opm/autodiff/StandardWell_impl.hpp
@@ -2313,7 +2313,11 @@ namespace Opm
         }
 
         if (!converged) {
-            OPM_DEFLOG_THROW(std::runtime_error, "Failed in getting converged for the potential calculation for well " << name(), deferred_logger);
+            // TODO: temporary approach to recover the running of prediction case
+            // more sophisicated treatment should be developed to handle the situation in a general way
+            // OPM_DEFLOG_THROW(std::runtime_error, "Failed in getting converged for the potential calculation for well " << name(), deferred_logger);
+            deferred_logger.warning("FAILURE_GETTING_CONVERGED_POTENTIAL",
+                    "Failed in getting converged for the potential calculation for well " + name());
         }
 
         return potentials;


### PR DESCRIPTION
it is just a temporary approach to recover the prediction case. In the
case, there is no group control, while there is some requirements of
well potential output. 