### PR TITLE
 Changes to provide Summary data output of additional block variables

### DIFF
--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -611,33 +611,21 @@ public:
                         val.second = 1. - Opm::getValue(fs.saturation(gasPhaseIdx)) - Opm::getValue(fs.saturation(waterPhaseIdx));
                     else if (key.first == "BPR")
                         val.second = Opm::getValue(fs.pressure(oilPhaseIdx));
-		    else if (key.first == "BWKR")
+		    else if (key.first == "BWKR" || key.first == "BKRW")
                         val.second = Opm::getValue(intQuants.relativePermeability(waterPhaseIdx));
-		    else if (key.first == "BKRW")
-                        val.second = Opm::getValue(intQuants.relativePermeability(waterPhaseIdx));
-		    else if (key.first == "BGKR")
+		    else if (key.first == "BGKR" || key.first == "BKRG")
                         val.second = Opm::getValue(intQuants.relativePermeability(gasPhaseIdx));
-		    else if (key.first == "BKRG")
-                        val.second = Opm::getValue(intQuants.relativePermeability(gasPhaseIdx));
-		    else if (key.first == "BOKR")
-                        val.second = Opm::getValue(intQuants.relativePermeability(oilPhaseIdx));
-		    else if (key.first == "BKRO")
+		    else if (key.first == "BOKR" || key.first == "BKRO")
                         val.second = Opm::getValue(intQuants.relativePermeability(oilPhaseIdx));
 		    else if (key.first == "BWPC")
                         val.second = Opm::getValue(fs.pressure(oilPhaseIdx)) - Opm::getValue(fs.pressure(waterPhaseIdx));
 		    else if (key.first == "BGPC")
                         val.second = Opm::getValue(fs.pressure(gasPhaseIdx)) - Opm::getValue(fs.pressure(oilPhaseIdx));
-		    else if (key.first == "BVWAT")
+		    else if (key.first == "BVWAT" || key.first == "BWVIS")
                         val.second = Opm::getValue(fs.viscosity(waterPhaseIdx));
-		    else if (key.first == "BWVIS")
-                        val.second = Opm::getValue(fs.viscosity(waterPhaseIdx));
-		    else if (key.first == "BVGAS")
+		    else if (key.first == "BVGAS" || key.first == "BGVIS")
                         val.second = Opm::getValue(fs.viscosity(gasPhaseIdx));
-		    else if (key.first == "BGVIS")
-                        val.second = Opm::getValue(fs.viscosity(gasPhaseIdx));
-		    else if (key.first == "BVOIL")
-                        val.second = Opm::getValue(fs.viscosity(oilPhaseIdx));
-		    else if (key.first == "BOVIS")
+		    else if (key.first == "BVOIL" || key.first == "BOVIS")
                         val.second = Opm::getValue(fs.viscosity(oilPhaseIdx));
                     else {
                         std::string logstring = "Keyword '";

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -1,4 +1,4 @@
-// -*- mode: C++; tab-width: 4dent-tabs-mode: nil; c-basic-offset: 4 -*-
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
   This file is part of the Open Porous Media project (OPM).
@@ -307,7 +307,7 @@ public:
         }
 
         if (FluidSystem::phaseIsActive(waterPhaseIdx) && rstKeywords["KRW"] > 0) {
-	    rstKeywords["KRW"] = 0;
+            rstKeywords["KRW"] = 0;
             relativePermeability_[waterPhaseIdx].resize(bufferSize, 0.0);
         }
         if (FluidSystem::phaseIsActive(oilPhaseIdx) && rstKeywords["KRO"] > 0) {

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -1,4 +1,4 @@
-// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// -*- mode: C++; tab-width: 4dent-tabs-mode: nil; c-basic-offset: 4 -*-
 // vi: set et ts=4 sw=4 sts=4:
 /*
   This file is part of the Open Porous Media project (OPM).
@@ -307,7 +307,7 @@ public:
         }
 
         if (FluidSystem::phaseIsActive(waterPhaseIdx) && rstKeywords["KRW"] > 0) {
-            rstKeywords["KRW"] = 0;
+	    rstKeywords["KRW"] = 0;
             relativePermeability_[waterPhaseIdx].resize(bufferSize, 0.0);
         }
         if (FluidSystem::phaseIsActive(oilPhaseIdx) && rstKeywords["KRO"] > 0) {
@@ -607,8 +607,38 @@ public:
                         val.second = Opm::getValue(fs.saturation(waterPhaseIdx));
                     else if (key.first == "BGSAT")
                         val.second = Opm::getValue(fs.saturation(gasPhaseIdx));
+		    else if (key.first == "BOSAT")
+                        val.second = 1. - Opm::getValue(fs.saturation(gasPhaseIdx)) - Opm::getValue(fs.saturation(waterPhaseIdx));
                     else if (key.first == "BPR")
                         val.second = Opm::getValue(fs.pressure(oilPhaseIdx));
+		    else if (key.first == "BWKR")
+                        val.second = Opm::getValue(intQuants.relativePermeability(waterPhaseIdx));
+		    else if (key.first == "BKRW")
+                        val.second = Opm::getValue(intQuants.relativePermeability(waterPhaseIdx));
+		    else if (key.first == "BGKR")
+                        val.second = Opm::getValue(intQuants.relativePermeability(gasPhaseIdx));
+		    else if (key.first == "BKRG")
+                        val.second = Opm::getValue(intQuants.relativePermeability(gasPhaseIdx));
+		    else if (key.first == "BOKR")
+                        val.second = Opm::getValue(intQuants.relativePermeability(oilPhaseIdx));
+		    else if (key.first == "BKRO")
+                        val.second = Opm::getValue(intQuants.relativePermeability(oilPhaseIdx));
+		    else if (key.first == "BWPC")
+                        val.second = Opm::getValue(fs.pressure(oilPhaseIdx)) - Opm::getValue(fs.pressure(waterPhaseIdx));
+		    else if (key.first == "BGPC")
+                        val.second = Opm::getValue(fs.pressure(gasPhaseIdx)) - Opm::getValue(fs.pressure(oilPhaseIdx));
+		    else if (key.first == "BVWAT")
+                        val.second = Opm::getValue(fs.viscosity(waterPhaseIdx));
+		    else if (key.first == "BWVIS")
+                        val.second = Opm::getValue(fs.viscosity(waterPhaseIdx));
+		    else if (key.first == "BVGAS")
+                        val.second = Opm::getValue(fs.viscosity(gasPhaseIdx));
+		    else if (key.first == "BGVIS")
+                        val.second = Opm::getValue(fs.viscosity(gasPhaseIdx));
+		    else if (key.first == "BVOIL")
+                        val.second = Opm::getValue(fs.viscosity(oilPhaseIdx));
+		    else if (key.first == "BOVIS")
+                        val.second = Opm::getValue(fs.viscosity(oilPhaseIdx));
                     else {
                         std::string logstring = "Keyword '";
                         logstring.append(key.first);


### PR DESCRIPTION
Provide output data for:

    BOSAT
    BWKR
    BOKR
    BKRO
    BGKR
    BKRG
    BKRW
    BWPC
    BGPC
    BVWAT
    BWVIS
    BVGAS
    BGVIS
    BVOIL
    BOVIS

This pull request is needed in order to output Summary data, see pull request OPM/opm-common#724