### PR TITLE
[bugfix] Use NNC data with applied EDITNCC for transmissibility.

### DIFF
--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -663,7 +663,7 @@ private:
             candidate = firstCandidate;
         }
 
-        for (const auto& nncEntry : nnc.nncdata()) {
+        for (const auto& nncEntry : nncData) {
             auto c1 = nncEntry.cell1;
             auto c2 = nncEntry.cell2;
             auto low = cartesianToCompressed[c1];


### PR DESCRIPTION
Unfortunately, we first created NNC with applied EDITNNC and then still used the original NNC data to set the transmissibility. Thus we were actually ignoring EDITNNC.

This commit fixes this by using the data structure that has EDITNNC applied.