### PR TITLE
Enable multi-segment wells by default.

### DIFF
--- a/opm/autodiff/BlackoilModelParametersEbos.hpp
+++ b/opm/autodiff/BlackoilModelParametersEbos.hpp
@@ -64,7 +64,7 @@ SET_SCALAR_PROP(FlowModelParameters, ToleranceCnvRelaxed, 1e9);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceWells, 1e-4);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceWellControl, 1e-7);
 SET_INT_PROP(FlowModelParameters, MaxWelleqIter, 30);
-SET_BOOL_PROP(FlowModelParameters, UseMultisegmentWell, false);
+SET_BOOL_PROP(FlowModelParameters, UseMultisegmentWell, true);
 SET_SCALAR_PROP(FlowModelParameters, MaxSinglePrecisionDays, 20.0);
 SET_INT_PROP(FlowModelParameters, MaxStrictIter, 8);
 SET_BOOL_PROP(FlowModelParameters, SolveWelleqInitially, true);


### PR DESCRIPTION
With this, the multisegment well model will be used by default for wells that are defined as multisegment in the input deck. Override this on the command line with `--use-multisegment-well=false` to force using the standard well model for such wells.