### PR TITLE
Correcting a small assertion mistake introduce in PR#1803

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -229,15 +229,13 @@ add_test_compareECLFiles(CASENAME msw_2d_h
                          FILENAME 2D_H__
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
-                         REL_TOL ${coarse_rel_tol}
-                         TEST_ARGS --use-multisegment-well=true)
+                         REL_TOL ${coarse_rel_tol})
 
 add_test_compareECLFiles(CASENAME msw_3d_hfa
                          FILENAME 3D_MSW
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         TEST_ARGS --use-multisegment-well=true)
+                         REL_TOL ${rel_tol})
 
 add_test_compareECLFiles(CASENAME polymer_oilwater
                          FILENAME 2D_OILWATER_POLYMER
@@ -276,8 +274,7 @@ add_test_compareECLFiles(CASENAME msw_model_1
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
-                         DIR model1
-                         TEST_ARGS --use-multisegment-well=true)
+                         DIR model1)
 
 add_test_compareECLFiles(CASENAME base_model_1
                          FILENAME BASE_MODEL_1

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -1737,7 +1737,7 @@ namespace Opm {
                 const auto& segments = well.segments;
 
                 // \Note: eventually we need to hanlde the situations that some segments are shut
-                assert( 1u + segment_set.size() == segments.size());
+                assert(0u + segment_set.size() == segments.size());
 
                 for (const auto& segment : segments) {
                     const int segment_index = segment_set.segmentNumberToIndex(segment.first);


### PR DESCRIPTION
And also removing the explicit using of `--use-multisegment-well` in `compareECLFiles` since the multisegment well is activated by default through PR #1807