### PR TITLE
Clear DeferredLogger's message container after logging.

### DIFF
--- a/opm/simulators/DeferredLogger.cpp
+++ b/opm/simulators/DeferredLogger.cpp
@@ -86,6 +86,12 @@ namespace Opm
         for (const auto& m : messages_) {
             OpmLog::addTaggedMessage(m.flag, m.tag, m.text);
         }
+        messages_.clear();
+    }
+
+    void DeferredLogger::clearMessages()
+    {
+        messages_.clear();
     }
 
 } // namespace Opm

--- a/opm/simulators/DeferredLogger.hpp
+++ b/opm/simulators/DeferredLogger.hpp
@@ -60,7 +60,12 @@ namespace Opm
         void debug(const std::string& message);
         void note(const std::string& message);
 
+        /// Log all messages to the OpmLog backends,
+        /// and clear the message container.
         void logMessages();
+
+        /// Clear the message container without logging them.
+        void clearMessages();
 
     private:
         std::vector<Message> messages_;

--- a/opm/simulators/DeferredLoggingErrorHelpers.hpp
+++ b/opm/simulators/DeferredLoggingErrorHelpers.hpp
@@ -63,6 +63,10 @@ inline void logAndCheckForExceptionsAndThrow(Opm::DeferredLogger& deferred_logge
     if (terminal_output) {
         global_deferredLogger.logMessages();
     }
+    // Now that all messages have been logged, they are automatically
+    // cleared from the global logger, but we must also clear them
+    // from the local logger.
+    deferred_logger.clearMessages();
     const auto& cc = Dune::MPIHelper::getCollectiveCommunication();
     if (cc.max(exception_thrown) == 1) {
         throw std::logic_error(message);


### PR DESCRIPTION
This keeps from logging the same messages again. Also add `clearMessages()` method, which is useful to clear the local container after gathering into a global container (which leaves the local containers untouched).