### PR TITLE
updated test scripts to use eclipse compatible restart

### DIFF
--- a/tests/run-init-regressionTest.sh
+++ b/tests/run-init-regressionTest.sh
@@ -20,7 +20,7 @@ TEST_ARGS="$@"
 rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-opm-rst-file=true --enable-dry-run=true --output-dir=${RESULT_PATH}
+${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_PATH}
 cd ..
 
 ecode=0

--- a/tests/run-porv-acceptanceTest.sh
+++ b/tests/run-porv-acceptanceTest.sh
@@ -20,7 +20,7 @@ TEST_ARGS="$@"
 rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-opm-rst-file=true --enable-dry-run=true --output-dir=${RESULT_PATH}
+${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_PATH}
 cd ..
 
 

--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -16,7 +16,7 @@ TEST_ARGS="$@"
 
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-opm-rst-file=true --output-dir=${RESULT_PATH}
+${BINPATH}/${EXE_NAME} ${TEST_ARGS} --output-dir=${RESULT_PATH}
 test $? -eq 0 || exit 1
 cd ..
 

--- a/tests/run-restart-regressionTest.sh
+++ b/tests/run-restart-regressionTest.sh
@@ -28,13 +28,13 @@ then
 else
   CMD_PREFIX=""
 fi
- ${CMD_PREFIX} ${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA --enable-adaptive-time-stepping=false --enable-opm-rst-file=true --output-dir=${RESULT_PATH}
+ ${CMD_PREFIX} ${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA --enable-adaptive-time-stepping=false --output-dir=${RESULT_PATH}
 
 test $? -eq 0 || exit 1
 
 ${OPM_PACK_COMMAND} -o ${BASE_NAME} ${TEST_ARGS}_RESTART.DATA
 
-${CMD_PREFIX} ${BINPATH}/${EXE_NAME} ${BASE_NAME} --enable-adaptive-time-stepping=false --enable-opm-rst-file=true --output-dir=${RESULT_PATH}
+${CMD_PREFIX} ${BINPATH}/${EXE_NAME} ${BASE_NAME} --enable-adaptive-time-stepping=false --output-dir=${RESULT_PATH}
 test $? -eq 0 || exit 1
 
 ecode=0


### PR DESCRIPTION
Reference solutions must be updated since arrays used by opm compatible restart, no longer will be output to restart. It has been verified that remaining arrays still are within tolerances.