### PR TITLE
Use new well implementation Well2 from opm-common

### DIFF
--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -191,7 +191,7 @@ public:
 
             //distribute the grid and switch to the distributed view.
             {
-                const auto wells = this->schedule().getWells();
+                const auto wells = this->schedule().getWells2atEnd();
                 defunctWellNames_ = std::get<1>(grid_->loadBalance(&wells, faceTrans.data()));
             }
             grid_->switchToDistributedView();

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -194,18 +194,18 @@ public:
         if (!substep) {
             const auto& schedule = simulator_.vanguard().schedule();
             const auto& rft_config = schedule.rftConfig();
-            for (const auto& well: schedule.getWells(reportStepNum)) {
+            for (const auto& well: schedule.getWells2(reportStepNum)) {
 
                 // don't bother with wells not on this process
                 const auto& defunctWellNames = simulator_.vanguard().defunctWellNames();
-                if (defunctWellNames.find(well->name()) != defunctWellNames.end()) {
+                if (defunctWellNames.find(well.name()) != defunctWellNames.end()) {
                     continue;
                 }
 
                 if (!rft_config.active(reportStepNum))
                     continue;
 
-                for (const auto& connection: well->getConnections(reportStepNum)) {
+                for (const auto& connection: well.getConnections()) {
                     const size_t i = size_t(connection.getI());
                     const size_t j = size_t(connection.getJ());
                     const size_t k = size_t(connection.getK());
@@ -730,24 +730,24 @@ public:
     {
         const auto& schedule = simulator_.vanguard().schedule();
         const auto& rft_config = schedule.rftConfig();
-        for (const auto& well: schedule.getWells(reportStepNum)) {
+        for (const auto& well: schedule.getWells2(reportStepNum)) {
 
             // don't bother with wells not on this process
             const auto& defunctWellNames = simulator_.vanguard().defunctWellNames();
-            if (defunctWellNames.find(well->name()) != defunctWellNames.end()) {
+            if (defunctWellNames.find(well.name()) != defunctWellNames.end()) {
                 continue;
             }
 
             //add data infrastructure for shut wells
-            if (!wellDatas.count(well->name())) {
+            if (!wellDatas.count(well.name())) {
                 Opm::data::Well wellData;
 
                 if (!rft_config.active(reportStepNum))
                     continue;
 
-                wellData.connections.resize(well->getConnections(reportStepNum).size());
+                wellData.connections.resize(well.getConnections().size());
                 size_t count = 0;
-                for (const auto& connection: well->getConnections(reportStepNum)) {
+                for (const auto& connection: well.getConnections()) {
                     const size_t i = size_t(connection.getI());
                     const size_t j = size_t(connection.getJ());
                     const size_t k = size_t(connection.getK());
@@ -757,10 +757,10 @@ public:
                     connectionData.index = index;
                     count++;
                 }
-                wellDatas.emplace(std::make_pair(well->name(), wellData));
+                wellDatas.emplace(std::make_pair(well.name(), wellData));
             }
 
-            Opm::data::Well& wellData = wellDatas.at(well->name());
+            Opm::data::Well& wellData = wellDatas.at(well.name());
             for (auto& connectionData: wellData.connections) {
                 const auto index = connectionData.index;
                 if (oilConnectionPressures_.count(index) > 0)

--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -477,15 +477,15 @@ protected:
 
         // Wells
         const int episodeIdx = simulator_.episodeIndex();
-        const auto& wells = simulator_.vanguard().schedule().getWells(episodeIdx);
-        for (auto well : wells) {
+        const auto& wells = simulator_.vanguard().schedule().getWells2(episodeIdx);
+        for (const auto& well : wells) {
 
-            if (well->getStatus(episodeIdx) == Opm::WellCommon::SHUT)
+            if (well.getStatus() == Opm::WellCommon::SHUT)
                 continue;
 
-            const double wtracer = well->getTracerProperties(episodeIdx).getConcentration(tracerNames_[tracerIdx]);
+            const double wtracer = well.getTracerProperties().getConcentration(tracerNames_[tracerIdx]);
             std::array<int, 3> cartesianCoordinate;
-            for (auto& connection : well->getConnections(episodeIdx)) {
+            for (auto& connection : well.getConnections()) {
 
                 if (connection.state() == Opm::WellCompletion::SHUT)
                     continue;
@@ -495,7 +495,7 @@ protected:
                 cartesianCoordinate[2] = connection.getK();
                 const size_t cartIdx = simulator_.vanguard().cartesianIndex(cartesianCoordinate);
                 const int I = cartToGlobal_[cartIdx];
-                Scalar rate = simulator_.problem().wellModel().well(well->name())->volumetricSurfaceRateForConnection(I, tracerPhaseIdx_[tracerIdx]);
+                Scalar rate = simulator_.problem().wellModel().well(well.name())->volumetricSurfaceRateForConnection(I, tracerPhaseIdx_[tracerIdx]);
                 if (rate > 0)
                     tracerResidual_[I][0] -= rate*wtracer;
                 else if (rate < 0)

--- a/opm/autodiff/SimFIBODetails.hpp
+++ b/opm/autodiff/SimFIBODetails.hpp
@@ -30,18 +30,16 @@
 namespace Opm
 {
     namespace SimFIBODetails {
-        typedef std::unordered_map<std::string, const Well* > WellMap;
+        typedef std::unordered_map<std::string, Well2 > WellMap;
 
         inline WellMap
-        mapWells(const std::vector< const Well* >& wells)
+        mapWells(const std::vector< Well2 >& wells)
         {
             WellMap wmap;
 
-            for (std::vector< const Well* >::const_iterator
-                     w = wells.begin(), e = wells.end();
-                 w != e; ++w)
+            for (const auto& w : wells)
             {
-                wmap.insert(std::make_pair((*w)->name(), *w));
+                wmap.insert(std::make_pair(w.name(), w));
             }
 
             return wmap;

--- a/opm/core/wells/WellCollection.cpp
+++ b/opm/core/wells/WellCollection.cpp
@@ -20,7 +20,7 @@
 #include "config.h"
 #include <opm/core/wells/WellCollection.hpp>
 
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group.hpp>
 
 #include <boost/lexical_cast.hpp>
@@ -68,22 +68,22 @@ namespace Opm
         child->setParent(parent);
     }
 
-    void WellCollection::addWell(const Well* wellChild, size_t timeStep, const PhaseUsage& phaseUsage) {
-        if (wellChild->getStatus(timeStep) == WellCommon::SHUT) {
+    void WellCollection::addWell(const Well2& wellChild, size_t timeStep, const PhaseUsage& phaseUsage) {
+        if (wellChild.getStatus() == WellCommon::SHUT) {
             //SHUT wells are not added to the well collection
             return;
         }
 
-        WellsGroupInterface* parent = findNode(wellChild->getGroupName(timeStep));
+        WellsGroupInterface* parent = findNode(wellChild.groupName());
         if (!parent) {
-            OPM_THROW(std::runtime_error, "Trying to add well " << wellChild->name() << " Step: " << boost::lexical_cast<std::string>(timeStep) << " to group named " << wellChild->getGroupName(timeStep) << ", but this group does not exist in the WellCollection.");
+            OPM_THROW(std::runtime_error, "Trying to add well " << wellChild.name() << " Step: " << boost::lexical_cast<std::string>(timeStep) << " to group named " << wellChild.groupName() << ", but this group does not exist in the WellCollection.");
         }
 
         std::shared_ptr<WellsGroupInterface> child = createWellWellsGroup(wellChild, timeStep, phaseUsage);
 
         WellsGroup* parent_as_group = static_cast<WellsGroup*> (parent);
         if (!parent_as_group) {
-            OPM_THROW(std::runtime_error, "Trying to add well to group named " << wellChild->getGroupName(timeStep) << ", but it's not a group.");
+            OPM_THROW(std::runtime_error, "Trying to add well to group named " << wellChild.groupName() << ", but it's not a group.");
         }
         parent_as_group->addChild(child);
 

--- a/opm/core/wells/WellCollection.hpp
+++ b/opm/core/wells/WellCollection.hpp
@@ -26,7 +26,7 @@
 #include <opm/grid/UnstructuredGrid.h>
 #include <opm/core/props/phaseUsageFromDeck.hpp>
 
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group.hpp>
 
 namespace Opm
@@ -38,7 +38,7 @@ namespace Opm
 
         void addField(const Group& fieldGroup, size_t timeStep, const PhaseUsage& phaseUsage);
 
-        void addWell(const Well* wellChild, size_t timeStep, const PhaseUsage& phaseUsage);
+        void addWell(const Well2& wellChild, size_t timeStep, const PhaseUsage& phaseUsage);
 
         void addGroup(const Group& groupChild, std::string parent_name,
                       size_t timeStep, const PhaseUsage& phaseUsage);

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -1588,12 +1588,12 @@ namespace Opm
       'CMODE_UNDEFINED' - we do not carry that over the specification
       objects here.
      */
-    std::shared_ptr<WellsGroupInterface> createWellWellsGroup(const Well* well, size_t timeStep, const PhaseUsage& phase_usage )
+    std::shared_ptr<WellsGroupInterface> createWellWellsGroup(const Well2& well, size_t timeStep, const PhaseUsage& phase_usage )
     {
         InjectionSpecification injection_specification;
         ProductionSpecification production_specification;
-        if (well->isInjector(timeStep)) {
-            const WellInjectionProperties& properties = well->getInjectionProperties(timeStep);
+        if (well.isInjector()) {
+            const WellInjectionProperties& properties = well.getInjectionProperties();
             injection_specification.BHP_limit_ = properties.BHPLimit;
             injection_specification.injector_type_ = toInjectorType(WellInjector::Type2String(properties.injectorType));
             injection_specification.surface_flow_max_rate_ = properties.surfaceInjectionRate;
@@ -1603,8 +1603,8 @@ namespace Opm
                 injection_specification.control_mode_ = toInjectionControlMode(WellInjector::ControlMode2String(properties.controlMode));
             }
         }
-        else if (well->isProducer(timeStep)) {
-            const WellProductionProperties& properties = well->getProductionProperties(timeStep);
+        else if (well.isProducer()) {
+            const WellProductionProperties& properties = well.getProductionProperties();
             production_specification.BHP_limit_ = properties.BHPLimit;
             production_specification.reservoir_flow_max_rate_ = properties.ResVRate;
             production_specification.oil_max_rate_ = properties.OilRate;
@@ -1615,8 +1615,8 @@ namespace Opm
             }
         }
         // Efficiency factor given specified with WEFAC
-        const double efficiency_factor = well->getEfficiencyFactor(timeStep);
-        std::shared_ptr<WellsGroupInterface> wells_group(new WellNode(well->name(), efficiency_factor, production_specification, injection_specification, phase_usage));
+        const double efficiency_factor = well.getEfficiencyFactor();
+        std::shared_ptr<WellsGroupInterface> wells_group(new WellNode(well.name(), efficiency_factor, production_specification, injection_specification, phase_usage));
         return wells_group;
     }
 

--- a/opm/core/wells/WellsGroup.hpp
+++ b/opm/core/wells/WellsGroup.hpp
@@ -25,7 +25,7 @@
 #include <opm/grid/UnstructuredGrid.h>
 #include <opm/core/props/BlackoilPhases.hpp>
 
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group.hpp>
 
 #include <string>
@@ -541,7 +541,7 @@ namespace Opm
     /// \param[in] well the Well to construct object for
     /// \param[in] timeStep the time step in question
     /// \param[in] the phase usage
-    std::shared_ptr<WellsGroupInterface> createWellWellsGroup(const Well* well, size_t timeStep,
+    std::shared_ptr<WellsGroupInterface> createWellWellsGroup(const Well2& well, size_t timeStep,
                                                               const PhaseUsage& phase_usage );
 
     /// Creates the WellsGroupInterface for the given Group

--- a/opm/core/wells/WellsManager.hpp
+++ b/opm/core/wells/WellsManager.hpp
@@ -167,12 +167,12 @@ namespace Opm
         WellsManager(const WellsManager& other);
         WellsManager& operator=(const WellsManager& other);
         static void setupCompressedToCartesian(const int* global_cell, int number_of_cells, std::map<int,int>& cartesian_to_compressed );
-        void setupWellControls(std::vector<const Well*>& wells, size_t timeStep,
+        void setupWellControls(const std::vector<Well2>& wells, size_t timeStep,
                                std::vector<std::string>& well_names, const PhaseUsage& phaseUsage,
                                const std::vector<int>& wells_on_proc);
 
         template<class C2F, class FC, class NTG>
-        void createWellsFromSpecs( std::vector<const Well*>& wells, size_t timeStep,
+        void createWellsFromSpecs( const std::vector<Well2>& wells, size_t timeStep,
                                    const C2F& cell_to_faces,
                                    const int* cart_dims,
                                    FC begin_face_centroids,
@@ -188,7 +188,7 @@ namespace Opm
                                    std::vector<int>& wells_on_proc,
                                    const std::unordered_set<std::string>& deactivated_wells);
 
-        void setupGuideRates(std::vector<const Well*>& wells, const size_t timeStep, std::vector<WellData>& well_data, std::map<std::string, int>& well_names_to_index);
+        void setupGuideRates(const std::vector<Well2>& wells, const size_t timeStep, std::vector<WellData>& well_data, std::map<std::string, int>& well_names_to_index);
 
         // Data
         Wells* w_;

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -268,7 +268,7 @@ namespace Opm {
 
             Simulator& ebosSimulator_;
             std::unique_ptr<WellsManager> wells_manager_;
-            std::vector< const Well* > wells_ecl_;
+            std::vector< Well2 > wells_ecl_;
 
             bool wells_active_;
 
@@ -422,7 +422,7 @@ namespace Opm {
             // whether there exists any multisegment well open on this process
             bool anyMSWellOpenLocal(const Wells* wells, const int report_step) const;
 
-            const Well* getWellEcl(const std::string& well_name) const;
+            const Well2& getWellEcl(const std::string& well_name) const;
         };
 
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -98,7 +98,7 @@ namespace Opm
         // TODO: for now, we only use one type to save some implementation efforts, while improve later.
         typedef DenseAd::Evaluation<double, /*size=*/numEq + numWellEq> EvalWell;
 
-        MultisegmentWell(const Well* well, const int time_step, const Wells* wells,
+        MultisegmentWell(const Well2& well, const int time_step, const Wells* wells,
                          const ModelParameters& param,
                          const RateConverterType& rate_converter,
                          const int pvtRegionIdx,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -28,7 +28,7 @@ namespace Opm
 
     template <typename TypeTag>
     MultisegmentWell<TypeTag>::
-    MultisegmentWell(const Well* well, const int time_step, const Wells* wells,
+    MultisegmentWell(const Well2& well, const int time_step, const Wells* wells,
                      const ModelParameters& param,
                      const RateConverterType& rate_converter,
                      const int pvtRegionIdx,
@@ -61,7 +61,7 @@ namespace Opm
         // for other facilities needed but not available from parser, we need to process them here
 
         // initialize the segment_perforations_ and update perforation_segment_depth_diffs_
-        const WellConnections& completion_set = well_ecl_->getConnections(current_step_);
+        const WellConnections& completion_set = well_ecl_.getConnections();
         // index of the perforation within wells struct
         // there might be some perforations not active, which causes the number of the perforations in
         // well_ecl_ and wells struct different
@@ -812,7 +812,7 @@ namespace Opm
     MultisegmentWell<TypeTag>::
     segmentSet() const
     {
-        return well_ecl_->getWellSegments(current_step_);
+        return well_ecl_.getSegments();
     }
 
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -113,7 +113,7 @@ namespace Opm
         typedef Dune::FieldVector<Scalar, numWellEq> VectorBlockWellType;
         typedef Dune::BlockVector<VectorBlockWellType> BVectorWell;
 
-        // the matrix type for the diagonal matrix D
+        // the matrix type for the diagonal matrix D l
         typedef Dune::FieldMatrix<Scalar, numWellEq, numWellEq > DiagMatrixBlockWellType;
         typedef Dune::BCRSMatrix <DiagMatrixBlockWellType> DiagMatWell;
 
@@ -127,7 +127,7 @@ namespace Opm
         using Base::contiPolymerEqIdx;
         static const int contiEnergyEqIdx = Indices::contiEnergyEqIdx;
 
-        StandardWell(const Well* well, const int time_step, const Wells* wells,
+        StandardWell(const Well2& well, const int time_step, const Wells* wells,
                      const ModelParameters& param,
                      const RateConverterType& rate_converter,
                      const int pvtRegionIdx,

--- a/opm/simulators/wells/StandardWellV.hpp
+++ b/opm/simulators/wells/StandardWellV.hpp
@@ -128,7 +128,7 @@ namespace Opm
         using Base::contiPolymerEqIdx;
         static const int contiEnergyEqIdx = Indices::contiEnergyEqIdx;
 
-        StandardWellV(const Well* well, const int time_step, const Wells* wells,
+        StandardWellV(const Well2& well, const int time_step, const Wells* wells,
                       const ModelParameters& param,
                       const RateConverterType& rate_converter,
                       const int pvtRegionIdx,

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -26,7 +26,7 @@ namespace Opm
 
     template<typename TypeTag>
     StandardWell<TypeTag>::
-    StandardWell(const Well* well, const int time_step, const Wells* wells,
+    StandardWell(const Well2& well, const int time_step, const Wells* wells,
                  const ModelParameters& param,
                  const RateConverterType& rate_converter,
                  const int pvtRegionIdx,
@@ -531,8 +531,6 @@ namespace Opm
             if (has_energy) {
 
                 auto fs = intQuants.fluidState();
-                const int reportStepIdx = ebosSimulator.episodeIndex();
-
                 for (unsigned phaseIdx = 0; phaseIdx < FluidSystem::numPhases; ++phaseIdx) {
                     if (!FluidSystem::phaseIsActive(phaseIdx)) {
                         continue;
@@ -566,7 +564,7 @@ namespace Opm
 
                     // change temperature for injecting fluids
                     if (well_type_ == INJECTOR && cq_s[activeCompIdx] > 0.0){
-                        const auto& injProps = this->well_ecl_->getInjectionProperties(reportStepIdx);
+                        const auto& injProps = this->well_ecl_.getInjectionProperties();
                         fs.setTemperature(injProps.temperature);
                         typedef typename std::decay<decltype(fs)>::type::Scalar FsScalar;
                         typename FluidSystem::template ParameterCache<FsScalar> paramCache;
@@ -698,7 +696,7 @@ namespace Opm
                 const double target_rate = well_controls_get_current_target(well_controls_); // surface rate target
                 if (well_type_ == INJECTOR) {
                     // only handles single phase injection now
-                    assert(well_ecl_->getInjectionProperties(current_step_).injectorType != WellInjector::MULTI);
+                    assert(well_ecl_.getInjectionProperties().injectorType != WellInjector::MULTI);
                     control_eq = getWQTotal() - target_rate;
                 } else if (well_type_ == PRODUCER) {
                     if (target_rate != 0.) {
@@ -743,7 +741,7 @@ namespace Opm
                 const double target_rate = well_controls_get_current_target(well_controls_); // reservoir rate target
                 if (well_type_ == INJECTOR) {
                     // only handles single phase injection now
-                    assert(well_ecl_->getInjectionProperties(current_step_).injectorType != WellInjector::MULTI);
+                    assert(well_ecl_.getInjectionProperties().injectorType != WellInjector::MULTI);
                     const double* distr = well_controls_get_current_distr(well_controls_);
                     for (int phase = 0; phase < number_of_phases_; ++phase) {
                         if (distr[phase] > 0.0) {
@@ -2521,15 +2519,15 @@ namespace Opm
 
         double thp = 0.0;
         if (well_type_ == INJECTOR) {
-            const int table_id = well_ecl_->getInjectionProperties(current_step_).VFPTableNumber;
+            const int table_id = well_ecl_.getInjectionProperties().VFPTableNumber;
             const double vfp_ref_depth = vfp_properties_->getInj()->getTable(table_id)->getDatumDepth();
             const double dp = wellhelpers::computeHydrostaticCorrection(ref_depth_, vfp_ref_depth, rho, gravity_);
 
             thp = vfp_properties_->getInj()->thp(table_id, aqua, liquid, vapour, bhp + dp);
         }
         else if (well_type_ == PRODUCER) {
-            const int table_id = well_ecl_->getProductionProperties(current_step_).VFPTableNumber;
-            const double alq = well_ecl_->getProductionProperties(current_step_).ALQValue;
+            const int table_id = well_ecl_.getProductionProperties().VFPTableNumber;
+            const double alq = well_ecl_.getProductionProperties().ALQValue;
             const double vfp_ref_depth = vfp_properties_->getProd()->getTable(table_id)->getDatumDepth();
             const double dp = wellhelpers::computeHydrostaticCorrection(ref_depth_, vfp_ref_depth, rho, gravity_);
 

--- a/opm/simulators/wells/WellConnectionAuxiliaryModule.hpp
+++ b/opm/simulators/wells/WellConnectionAuxiliaryModule.hpp
@@ -57,11 +57,11 @@ public:
 
         for ( auto cell = begin, end= globalCell.end(); cell != end; ++cell )
         {
-            cartesianToCompressed[ *cell ] = cell - begin;
+          cartesianToCompressed[ *cell ] = cell - begin;
         }
 
         int last_time_step = schedule.getTimeMap().size() - 1;
-        const auto& schedule_wells = schedule.getWells();
+        const auto& schedule_wells = schedule.getWells2atEnd();
         wells_.reserve(schedule_wells.size());
 
         // initialize the additional cell connections introduced by wells.
@@ -69,7 +69,7 @@ public:
         {
             std::vector<int> compressed_well_perforations;
             // All possible completions of the well
-            const auto& completionSet = well->getConnections(last_time_step);
+            const auto& completionSet = well.getConnections();
             compressed_well_perforations.reserve(completionSet.size());
 
             for ( size_t c=0; c < completionSet.size(); c++ )

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -27,7 +27,7 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/Exceptions.hpp>
 
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 
@@ -114,7 +114,7 @@ namespace Opm
         SurfaceToReservoirVoidage<FluidSystem, std::vector<int> >;
 
         /// Constructor
-        WellInterface(const Well* well, const int time_step, const Wells* wells,
+        WellInterface(const Well2& well, const int time_step, const Wells* wells,
                       const ModelParameters& param,
                       const RateConverterType& rate_converter,
                       const int pvtRegionIdx,
@@ -231,11 +231,11 @@ namespace Opm
 
         void closeCompletions(WellTestState& wellTestState);
 
-        const Well* wellEcl() const;
+        const Well2* wellEcl() const;
 
         // TODO: theoretically, it should be a const function
         // Simulator is not const is because that assembleWellEq is non-const Simulator
-        void wellTesting(Simulator& simulator, const std::vector<double>& B_avg,
+        void wellTesting(Simulator& simulator, const std::vector<double>& Bavg,
                          const double simulation_time, const int report_step,
                          const WellTestConfig::Reason testing_reason,
                          /* const */ WellState& well_state, WellTestState& welltest_state,
@@ -262,7 +262,7 @@ namespace Opm
         // to indicate a invalid completion
         static const int INVALIDCOMPLETION = INT_MAX;
 
-        const Well* well_ecl_;
+        const Well2 well_ecl_;
 
         const int current_step_;
 

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -27,7 +27,7 @@
 #include <opm/core/props/BlackoilPhases.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
 
 #include <opm/common/ErrorMacros.hpp>
 
@@ -66,10 +66,13 @@ namespace Opm
         /// Allocate and initialize if wells is non-null.  Also tries
         /// to give useful initial values to the bhp(), wellRates()
         /// and perfPhaseRates() fields, depending on controls
-        void init(const Wells* wells, const std::vector<double>& cellPressures,
+        void init(const Wells* wells,
+                  const std::vector<double>& cellPressures,
                   const Schedule& schedule,
-                  const std::vector<const Well*>& wells_ecl, const int report_step,
-                  const WellStateFullyImplicitBlackoil* prevState, const PhaseUsage& pu)
+                  const std::vector<Well2>& wells_ecl,
+                  const int report_step,
+                  const WellStateFullyImplicitBlackoil* prevState,
+                  const PhaseUsage& pu)
         {
             // call init on base class
             BaseType :: init(wells, cellPressures);
@@ -109,7 +112,7 @@ namespace Opm
                     int index_well_ecl = 0;
                     const std::string well_name(wells->name[w]);
                     for (; index_well_ecl < nw_wells_ecl; ++index_well_ecl) {
-                        if (well_name == wells_ecl[index_well_ecl]->name()) {
+                        if (well_name == wells_ecl[index_well_ecl].name()) {
                             break;
                         }
                     }
@@ -293,7 +296,7 @@ namespace Opm
         }
 
 
-        void resize(const Wells* wells, const std::vector<const Well*>& wells_ecl, const Schedule& schedule,
+        void resize(const Wells* wells, const std::vector<Well2>& wells_ecl, const Schedule& schedule,
                     const bool handle_ms_well, const int report_step, const size_t numCells,
                     const PhaseUsage& pu)
         {
@@ -605,7 +608,7 @@ namespace Opm
 
 
         /// init the MS well related.
-        void initWellStateMSWell(const Wells* wells, const std::vector<const Well*>& wells_ecl,
+        void initWellStateMSWell(const Wells* wells, const std::vector<Well2>& wells_ecl,
                                  const int time_step, const PhaseUsage& pu, const WellStateFullyImplicitBlackoil* prev_well_state)
         {
             // still using the order in wells
@@ -630,7 +633,7 @@ namespace Opm
                 int index_well_ecl = 0;
                 const std::string well_name(wells->name[w]);
                 for (; index_well_ecl < nw_wells_ecl; ++index_well_ecl) {
-                    if (well_name == wells_ecl[index_well_ecl]->name()) {
+                    if (well_name == wells_ecl[index_well_ecl].name()) {
                         break;
                     }
                 }
@@ -640,9 +643,9 @@ namespace Opm
                     OPM_THROW(std::logic_error, "Could not find well " << well_name << " in wells_ecl ");
                 }
 
-                const Well* well_ecl = wells_ecl[index_well_ecl];
+                const auto& well_ecl = wells_ecl[index_well_ecl];
                 top_segment_index_.push_back(nseg_);
-                if ( !well_ecl->isMultiSegment(time_step) ) { // not multi-segment well
+                if ( !well_ecl.isMultiSegment() ) { // not multi-segment well
                     nseg_ += 1;
                     seg_number_.push_back(1); // Assign single segment (top) as number 1.
                     segpress_.push_back(bhp()[w]);
@@ -651,9 +654,9 @@ namespace Opm
                         segrates_.push_back(wellRates()[np * w + p]);
                     }
                 } else { // it is a multi-segment well
-                    const WellSegments& segment_set = well_ecl->getWellSegments(time_step);
+                    const WellSegments& segment_set = well_ecl.getSegments();
                     // assuming the order of the perforations in well_ecl is the same with Wells
-                    const WellConnections& completion_set = well_ecl->getConnections(time_step);
+                    const WellConnections& completion_set = well_ecl.getConnections();
                     // number of segment for this single well
                     const int well_nseg = segment_set.size();
                     // const int nperf = completion_set.size();

--- a/tests/test_wellcollection.cpp
+++ b/tests/test_wellcollection.cpp
@@ -27,7 +27,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp>
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(AddWellsAndGroupToCollection) {
 
     // Add wells to WellCollection
     WellCollection wellCollection;
-    auto wells = sched.getWells();
+    const auto wells = sched.getWells2atEnd();
     for (size_t i=0; i<wells.size(); i++) {
         collection.addWell(wells[i], 2, pu);
     }
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(EfficiencyFactor) {
     BOOST_CHECK_EQUAL(1.0, collection.findNode("G2")->getParent()->efficiencyFactor());
 
     // Add wells to WellCollection
-    auto wells1 = sched.getWells(timestep);
+    const auto wells1 = sched.getWells2(timestep);
     for (size_t i=0; i<wells1.size(); i++) {
         collection.addWell(wells1[i], timestep, pu);
     }

--- a/tests/test_wellmodel.cpp
+++ b/tests/test_wellmodel.cpp
@@ -134,9 +134,9 @@ BOOST_GLOBAL_FIXTURE(GlobalFixture);
 BOOST_AUTO_TEST_CASE(TestStandardWellInput) {
     const SetupTest setup_test;
     const Wells* wells = setup_test.wells_manager->c_wells();
-    const auto& wells_ecl = setup_test.schedule->getWells(setup_test.current_timestep);
+    const auto& wells_ecl = setup_test.schedule->getWells2(setup_test.current_timestep);
     BOOST_CHECK_EQUAL( wells_ecl.size(), 2);
-    const Opm::Well* well = wells_ecl[1];
+    const Opm::Well2& well = wells_ecl[1];
     const Opm::BlackoilModelParametersEbos<TTAG(EclFlowProblem) > param;
 
     // For the conversion between the surface volume rate and resrevoir voidage rate
@@ -154,7 +154,6 @@ BOOST_AUTO_TEST_CASE(TestStandardWellInput) {
     const int num_comp = wells->number_of_phases;
 
     BOOST_CHECK_THROW( StandardWell( well, -1, wells, param, *rateConverter, pvtIdx, num_comp), std::invalid_argument);
-    BOOST_CHECK_THROW( StandardWell( nullptr, 4, wells , param, *rateConverter, pvtIdx, num_comp), std::invalid_argument);
     BOOST_CHECK_THROW( StandardWell( well, 4, nullptr , param, *rateConverter, pvtIdx, num_comp), std::invalid_argument);
 }
 
@@ -162,7 +161,7 @@ BOOST_AUTO_TEST_CASE(TestStandardWellInput) {
 BOOST_AUTO_TEST_CASE(TestBehavoir) {
     const SetupTest setup_test;
     const Wells* wells_struct = setup_test.wells_manager->c_wells();
-    const auto& wells_ecl = setup_test.schedule->getWells(setup_test.current_timestep);
+    const auto& wells_ecl = setup_test.schedule->getWells2(setup_test.current_timestep);
     const int current_timestep = setup_test.current_timestep;
     std::vector<std::unique_ptr<const StandardWell> >  wells;
 
@@ -175,7 +174,7 @@ BOOST_AUTO_TEST_CASE(TestBehavoir) {
 
             size_t index_well = 0;
             for (; index_well < wells_ecl.size(); ++index_well) {
-                if (well_name == wells_ecl[index_well]->name()) {
+                if (well_name == wells_ecl[index_well].name()) {
                     break;
                 }
             }

--- a/tests/test_wellsgroup.cpp
+++ b/tests/test_wellsgroup.cpp
@@ -37,7 +37,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
 using namespace Opm;
@@ -55,21 +55,21 @@ BOOST_AUTO_TEST_CASE(ConstructGroupFromWell) {
 
    PhaseUsage pu = phaseUsageFromDeck(eclipseState);
 
-    auto wells = sched.getWells();
+   auto wells = sched.getWells2atEnd();
 
     for (size_t i=0; i<wells.size(); i++) {
-        const auto* well = wells[i];
+        const auto& well = wells[i];
         std::shared_ptr<WellsGroupInterface> wellsGroup = createWellWellsGroup(well, 2, pu);
-        BOOST_CHECK_EQUAL(well->name(), wellsGroup->name());
-        if (well->isInjector(2)) {
-            const WellInjectionProperties& properties = well->getInjectionProperties(2);
+        BOOST_CHECK_EQUAL(well.name(), wellsGroup->name());
+        if (well.isInjector()) {
+            const WellInjectionProperties& properties = well.getInjectionProperties();
             BOOST_CHECK_EQUAL(properties.surfaceInjectionRate, wellsGroup->injSpec().surface_flow_max_rate_);
             BOOST_CHECK_EQUAL(properties.BHPLimit, wellsGroup->injSpec().BHP_limit_);
             BOOST_CHECK_EQUAL(properties.reservoirInjectionRate, wellsGroup->injSpec().reservoir_flow_max_rate_);
             BOOST_CHECK_EQUAL(0.0, wellsGroup->prodSpec().guide_rate_);
         }
-        if (well->isProducer(2)) {
-            const WellProductionProperties& properties = well->getProductionProperties(2);
+        if (well.isProducer()) {
+            const WellProductionProperties& properties = well.getProductionProperties();
             BOOST_CHECK_EQUAL(properties.ResVRate, wellsGroup->prodSpec().reservoir_flow_max_rate_);
             BOOST_CHECK_EQUAL(properties.BHPLimit, wellsGroup->prodSpec().BHP_limit_);
             BOOST_CHECK_EQUAL(properties.OilRate, wellsGroup->prodSpec().oil_max_rate_);


### PR DESCRIPTION
With this PR the simulator is updated to use the new `Well2` class from opm-common. The changes in this PR are mostly mechanical - and include:

1. The well type has been renamed to `Well2`.
2. The previous API made extensive use of naked `Well *` pointers, we now use `Well2` or `Well2&`.
3. Previously the properties - like connection sets and production properties were all accessed through a function with a timestep argument - that has been removed.

Downstream of: https://github.com/OPM/opm-common/pull/731

The work in opm-common should get more testing and scrutiny before merge, but the part here  should not change significantly whatever happens to opm-common - and hence should be ready for review.

