### PR TITLE
flow: provide the correct episode size

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -984,6 +984,8 @@ public:
      */
     void writeOutput(bool isSubStep, bool verbose = true)
     {
+        assert(!this->simulator().episodeWillBeOver() == isSubStep);
+
         // use the generic code to prepare the output fields and to
         // write the desired VTK files.
         ParentType::writeOutput(isSubStep, verbose);

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -232,13 +232,14 @@ public:
                 report.output_write_time += perfTimer.stop();
             }
 
-            ebosSimulator_.setEpisodeIndex(timer.currentStepNum());
-
             // Run a multiple steps of the solver depending on the time step control.
             solverTimer.start();
 
             auto solver = createSolver(wellModel_());
 
+            ebosSimulator_.startNextEpisode(ebosSimulator_.startTime() + schedule().getTimeMap().getTimePassedUntil(timer.currentStepNum()),
+                                            timer.currentStepLength());
+            ebosSimulator_.setEpisodeIndex(timer.currentStepNum());
             solver->model().beginReportStep(firstRestartStep);
             firstRestartStep = false;
 


### PR DESCRIPTION
this PR is a follow-up to #1775. It actually ensures that the correct time step and episode sizes are used by flow. For some reason, this seems to require a data update, but I have not drilled into why this is the case yet and I would like to avoid wasting too much time on this.

maybe @bska or @GitPaean know what could cause the difference...