### PR TITLE
Adjust to shared_ptr change in dune-istl >= 2.7.

### DIFF
--- a/opm/simulators/linalg/BlackoilAmgCpr.hpp
+++ b/opm/simulators/linalg/BlackoilAmgCpr.hpp
@@ -141,12 +141,12 @@ namespace Opm
                                   const Communication& comm)
         {
             *scaledMatrix_ = *Detail::scaleMatrixDRS(fineOperator, COMPONENT_INDEX, weights_, param_);
-            smoother_.reset(Detail::constructSmoother<Smoother>(*scaledMatrixOperator_, smargs, comm));
+            smoother_ = Detail::constructSmoother<Smoother>(*scaledMatrixOperator_, smargs, comm);
             twoLevelMethod_.updatePreconditioner(*scaledMatrixOperator_,
                                                  smoother_,
                                                  coarseSolverPolicy_);
         }
-    
+
         void pre(typename TwoLevelMethod::FineDomainType& x,
                  typename TwoLevelMethod::FineRangeType& b) override
         {

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -176,7 +176,7 @@ public:
 protected:
   const matrix_type& A_ ;
   const matrix_type& A_for_precond_ ;
-  const WellModel& wellMod_;    
+  const WellModel& wellMod_;
   std::shared_ptr< communication_type > comm_;
 };
 
@@ -246,7 +246,7 @@ protected:
         void scaleSystem()
         {
             const bool matrix_cont_added = EWOMS_GET_PARAM(TypeTag, bool, MatrixAddWellContributions);
-	    
+
             if (matrix_cont_added) {
                 bool form_cpr = true;
                 if (parameters_.system_strategy_ == "quasiimpes") {
@@ -663,7 +663,7 @@ protected:
         // conservation equations, ignoring all other terms.
         Vector getStorageWeights() const
         {
-            Vector weights(rhs_->size()); 
+            Vector weights(rhs_->size());
             BlockVector rhs(0.0);
             rhs[pressureVarIndex] = 1.0;
             int index = 0;
@@ -830,7 +830,7 @@ protected:
                 }
             }
         }
-      
+
         static void multBlocksVector(Vector& ebosResid_cp, const MatrixBlockType& leftTrans)
         {
             for (auto& bvec : ebosResid_cp) {

--- a/opm/simulators/linalg/ParallelRestrictedAdditiveSchwarz.hpp
+++ b/opm/simulators/linalg/ParallelRestrictedAdditiveSchwarz.hpp
@@ -55,16 +55,33 @@ struct ConstructionTraits<Opm::ParallelRestrictedOverlappingSchwarz<Range,
     typedef ConstructionTraits<SeqPreconditioner> SeqConstructionTraits;
 
     /// \brief Construct a parallel restricted overlapping schwarz preconditioner.
-    static inline Opm::ParallelRestrictedOverlappingSchwarz<Range,
-                                                            Domain,
-                                                            ParallelInfo,
-                                                            SeqPreconditioner>*
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 7)
+    typedef std::shared_ptr< Opm::ParallelRestrictedOverlappingSchwarz<Range,
+                                                                       Domain,
+                                                                       ParallelInfo,
+                                                                       SeqPreconditioner> > ParallelRestrictedOverlappingSchwarzPointer;
+#else
+    typedef Opm::ParallelRestrictedOverlappingSchwarz<Range,
+                                                      Domain,
+                                                      ParallelInfo,
+                                                      SeqPreconditioner>*  ParallelRestrictedOverlappingSchwarzPointer;
+#endif
+
+    static inline ParallelRestrictedOverlappingSchwarzPointer
     construct(Arguments& args)
     {
-        return new Opm::ParallelRestrictedOverlappingSchwarz
-            <Range,Domain,ParallelInfo,SeqPreconditioner>(*SeqConstructionTraits
-                                                          ::construct(args),
-                                                          args.getComm());
+        return
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 7)
+             std::make_shared(
+#endif
+                new Opm::ParallelRestrictedOverlappingSchwarz
+                              <Range,Domain,ParallelInfo,SeqPreconditioner>(*SeqConstructionTraits ::construct(args),
+                                                         args.getComm())
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 7)
+        );
+#else
+        ;
+#endif
     }
 
     /// \brief Deconstruct and free a parallel restricted overlapping schwarz preconditioner.


### PR DESCRIPTION
This PR fixes compilation issues with flow when using the current DUNE master. In dune-istl the return value of the ConstructionTraits and the Constructor parameters have been changed from raw pointers to std::shared_ptr. 