### PR TITLE
fixed: use of restartTimeStep() before it has been read

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2447,10 +2447,10 @@ private:
                                    timeMap.getTimeStepLength(episodeIdx));
         simulator.setEpisodeIndex(episodeIdx);
 
+        eclWriter_->beginRestart();
+
         Scalar dt = std::min(eclWriter_->restartTimeStepSize(), simulator.episodeLength());
         simulator.setTimeStepSize(dt);
-
-        eclWriter_->beginRestart();
 
         size_t numElems = this->model().numGridDof();
         initialFluidStates_.resize(numElems);


### PR DESCRIPTION
it is read in the beginRestart() method, reorder code accordingly.

ref valgrind log
```
==45745== Conditional jump or move depends on uninitialised value(s)
==45745==    at 0x177DC2A: double const& std::min<double>(double const&, double const&) (stl_algobase.h:200)
==45745==    by 0x17FF497: Ewoms::EclProblem<Ewoms::Properties::TTag::EclFlowProblem>::readEclRestartSolution_() (eclproblem.hh:2450)
==45745==    by 0x17C9451: Ewoms::EclProblem<Ewoms::Properties::TTag::EclFlowProblem>::initialSolutionApplied() (eclproblem.hh:1482)
==45745==    by 0x17B4198: Ewoms::FvBaseDiscretization<Ewoms::Properties::TTag::EclFlowProblem>::applyInitialSolution() (fvbasediscretization.hh:599)
==45745==    by 0x179C0CD: Opm::FlowMainEbos<Ewoms::Properties::TTag::EclFlowProblem>::setupEbosSimulator() (FlowMainEbos.hpp:458)
==45745==    by 0x178EE3E: Opm::FlowMainEbos<Ewoms::Properties::TTag::EclFlowProblem>::execute(int, char**) (FlowMainEbos.hpp:228)
==45745==    by 0x17427B4: Opm::flowEbosBlackoilMain(int, char**) (flow_ebos_blackoil.cpp:62)
==45745==    by 0x1640A1D: main (flow.cpp:280)
```