### PR TITLE
Use wells2 controls

### DIFF
--- a/opm/autodiff/SimFIBODetails.hpp
+++ b/opm/autodiff/SimFIBODetails.hpp
@@ -85,10 +85,10 @@ namespace Opm
 
         inline void
         historyRates(const PhaseUsage&               pu,
-                     const WellProductionProperties& p,
+                     const ProductionControls& p,
                      std::vector<double>&            rates)
         {
-            assert (! p.predictionMode);
+            assert (! p.prediction_mode);
             assert (rates.size() ==
                     std::vector<double>::size_type(pu.num_phases));
 
@@ -96,21 +96,21 @@ namespace Opm
                 const std::vector<double>::size_type
                     i = pu.phase_pos[ BlackoilPhases::Aqua ];
 
-                rates[i] = p.WaterRate;
+                rates[i] = p.water_rate;
             }
 
             if (pu.phase_used[ BlackoilPhases::Liquid ]) {
                 const std::vector<double>::size_type
                     i = pu.phase_pos[ BlackoilPhases::Liquid ];
 
-                rates[i] = p.OilRate;
+                rates[i] = p.oil_rate;
             }
 
             if (pu.phase_used[ BlackoilPhases::Vapour ]) {
                 const std::vector<double>::size_type
                     i = pu.phase_pos[ BlackoilPhases::Vapour ];
 
-                rates[i] = p.GasRate;
+                rates[i] = p.gas_rate;
             }
         }
     } // namespace SimFIBODetails

--- a/opm/core/wells/WellsGroup.cpp
+++ b/opm/core/wells/WellsGroup.cpp
@@ -1590,28 +1590,29 @@ namespace Opm
      */
     std::shared_ptr<WellsGroupInterface> createWellWellsGroup(const Well2& well, size_t timeStep, const PhaseUsage& phase_usage )
     {
+        SummaryState summaryState;
         InjectionSpecification injection_specification;
         ProductionSpecification production_specification;
         if (well.isInjector()) {
-            const WellInjectionProperties& properties = well.getInjectionProperties();
-            injection_specification.BHP_limit_ = properties.BHPLimit;
-            injection_specification.injector_type_ = toInjectorType(WellInjector::Type2String(properties.injectorType));
-            injection_specification.surface_flow_max_rate_ = properties.surfaceInjectionRate;
-            injection_specification.reservoir_flow_max_rate_ = properties.reservoirInjectionRate;
+            const auto controls = well.injectionControls(summaryState);
+            injection_specification.BHP_limit_ = controls.bhp_limit;
+            injection_specification.injector_type_ = toInjectorType(WellInjector::Type2String(controls.injector_type));
+            injection_specification.surface_flow_max_rate_ = controls.surface_rate;
+            injection_specification.reservoir_flow_max_rate_ = controls.reservoir_rate;
             production_specification.guide_rate_ = 0.0; // We know we're not a producer
-            if (properties.controlMode != WellInjector::CMODE_UNDEFINED) {
-                injection_specification.control_mode_ = toInjectionControlMode(WellInjector::ControlMode2String(properties.controlMode));
+            if (controls.cmode != WellInjector::CMODE_UNDEFINED) {
+                injection_specification.control_mode_ = toInjectionControlMode(WellInjector::ControlMode2String(controls.cmode));
             }
         }
         else if (well.isProducer()) {
-            const WellProductionProperties& properties = well.getProductionProperties();
-            production_specification.BHP_limit_ = properties.BHPLimit;
-            production_specification.reservoir_flow_max_rate_ = properties.ResVRate;
-            production_specification.oil_max_rate_ = properties.OilRate;
-            production_specification.water_max_rate_ = properties.WaterRate;
+            const auto controls = well.productionControls(summaryState);
+            production_specification.BHP_limit_ = controls.bhp_limit;
+            production_specification.reservoir_flow_max_rate_ = controls.resv_rate;
+            production_specification.oil_max_rate_ = controls.oil_rate;
+            production_specification.water_max_rate_ = controls.water_rate;
             injection_specification.guide_rate_ = 0.0; // we know we're not an injector
-            if (properties.controlMode != WellProducer::CMODE_UNDEFINED) {
-                production_specification.control_mode_ = toProductionControlMode(WellProducer::ControlMode2String(properties.controlMode));
+            if (controls.cmode != WellProducer::CMODE_UNDEFINED) {
+                production_specification.control_mode_ = toProductionControlMode(WellProducer::ControlMode2String(controls.cmode));
             }
         }
         // Efficiency factor given specified with WEFAC

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1589,6 +1589,7 @@ namespace Opm {
     {
 
         const std::vector<int>& resv_wells = SimFIBODetails::resvWells(wells());
+        Opm::SummaryState summaryState;
 
         int global_number_resv_wells = resv_wells.size();
         global_number_resv_wells = ebosSimulator_.gridView().comm().sum(global_number_resv_wells);
@@ -1641,10 +1642,10 @@ namespace Opm {
                                 OPM_DEFLOG_THROW(std::logic_error, "Failed to find the well " << wells()->name[*rp] << " in wmap.", deferred_logger);
                             }
                             const auto& wp = i->second;
-                            const WellProductionProperties& production_properties = wp.getProductionProperties();
+                            const auto production_controls = wp.productionControls(summaryState);
                             // historical phase rates
                             std::vector<double> hrates(np);
-                            SimFIBODetails::historyRates(phase_usage_, production_properties, hrates);
+                            SimFIBODetails::historyRates(phase_usage_, production_controls, hrates);
 
                             std::vector<double> hrates_resv(np);
                             rateConverter_->calcReservoirVoidageRates(fipreg, pvtreg, hrates, hrates_resv);

--- a/opm/simulators/wells/StandardWellV_impl.hpp
+++ b/opm/simulators/wells/StandardWellV_impl.hpp
@@ -487,7 +487,7 @@ namespace Opm
                    )
     {
         // TODO: only_wells should be put back to save some computation
-
+        Opm::SummaryState summaryState;
         checkWellOperability(ebosSimulator, well_state, deferred_logger);
 
         if (!this->isOperable()) return;
@@ -605,8 +605,11 @@ namespace Opm
 
                     // change temperature for injecting fluids
                     if (well_type_ == INJECTOR && cq_s[activeCompIdx] > 0.0){
-                        const auto& injProps = this->well_ecl_.getInjectionProperties();
-                        fs.setTemperature(injProps.temperature);
+                        const auto controls = this->well_ecl_.injectionControls(summaryState);
+                        // only handles single phase injection now
+                        assert(controls.injector_type != WellInjector::MULTI);
+
+                        fs.setTemperature(controls.temperature);
                         typedef typename std::decay<decltype(fs)>::type::Scalar FsScalar;
                         typename FluidSystem::template ParameterCache<FsScalar> paramCache;
                         const unsigned pvtRegionIdx = intQuants.pvtRegionIndex();
@@ -749,8 +752,6 @@ namespace Opm
             {
                 const double target_rate = well_controls_get_current_target(well_controls_); // surface rate target
                 if (well_type_ == INJECTOR) {
-                    // only handles single phase injection now
-                    assert(well_ecl_.getInjectionProperties().injectorType != WellInjector::MULTI);
                     control_eq = getWQTotal() - target_rate;
                 } else if (well_type_ == PRODUCER) {
                     if (target_rate != 0.) {
@@ -795,7 +796,6 @@ namespace Opm
                 const double target_rate = well_controls_get_current_target(well_controls_); // reservoir rate target
                 if (well_type_ == INJECTOR) {
                     // only handles single phase injection now
-                    assert(well_ecl_.getInjectionProperties().injectorType != WellInjector::MULTI);
                     const double* distr = well_controls_get_current_distr(well_controls_);
                     for (int phase = 0; phase < number_of_phases_; ++phase) {
                         if (distr[phase] > 0.0) {
@@ -2614,6 +2614,7 @@ namespace Opm
     {
         assert(int(rates.size()) == 3); // the vfp related only supports three phases now.
 
+        SummaryState summaryState;
         const double aqua = rates[Water];
         const double liquid = rates[Oil];
         const double vapour = rates[Gas];
@@ -2623,15 +2624,17 @@ namespace Opm
 
         double thp = 0.0;
         if (well_type_ == INJECTOR) {
-            const int table_id = well_ecl_.getInjectionProperties().VFPTableNumber;
+            const auto controls = well_ecl_.injectionControls(summaryState);
+            const int table_id = controls.vfp_table_number;
             const double vfp_ref_depth = vfp_properties_->getInj()->getTable(table_id)->getDatumDepth();
             const double dp = wellhelpers::computeHydrostaticCorrection(ref_depth_, vfp_ref_depth, rho, gravity_);
 
             thp = vfp_properties_->getInj()->thp(table_id, aqua, liquid, vapour, bhp + dp);
         }
         else if (well_type_ == PRODUCER) {
-            const int table_id = well_ecl_.getProductionProperties().VFPTableNumber;
-            const double alq = well_ecl_.getProductionProperties().ALQValue;
+            const auto controls = well_ecl_.productionControls(summaryState);
+            const int table_id = controls.vfp_table_number;
+            const double alq = controls.alq_value;
             const double vfp_ref_depth = vfp_properties_->getProd()->getTable(table_id)->getDatumDepth();
             const double dp = wellhelpers::computeHydrostaticCorrection(ref_depth_, vfp_ref_depth, rho, gravity_);
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -449,6 +449,7 @@ namespace Opm
                    WellState& well_state,
                    Opm::DeferredLogger& deferred_logger)
     {
+        SummaryState summaryState;
 
         checkWellOperability(ebosSimulator, well_state, deferred_logger);
 
@@ -564,7 +565,11 @@ namespace Opm
 
                     // change temperature for injecting fluids
                     if (well_type_ == INJECTOR && cq_s[activeCompIdx] > 0.0){
-                        const auto& injProps = this->well_ecl_.getInjectionProperties();
+                        const auto& injProps = this->well_ecl_.injectionControls(summaryState);
+
+                        // only handles single phase injection now
+                        assert(injProps.injector_type != WellInjector::MULTI);
+
                         fs.setTemperature(injProps.temperature);
                         typedef typename std::decay<decltype(fs)>::type::Scalar FsScalar;
                         typename FluidSystem::template ParameterCache<FsScalar> paramCache;
@@ -695,8 +700,6 @@ namespace Opm
             {
                 const double target_rate = well_controls_get_current_target(well_controls_); // surface rate target
                 if (well_type_ == INJECTOR) {
-                    // only handles single phase injection now
-                    assert(well_ecl_.getInjectionProperties().injectorType != WellInjector::MULTI);
                     control_eq = getWQTotal() - target_rate;
                 } else if (well_type_ == PRODUCER) {
                     if (target_rate != 0.) {
@@ -740,8 +743,6 @@ namespace Opm
             {
                 const double target_rate = well_controls_get_current_target(well_controls_); // reservoir rate target
                 if (well_type_ == INJECTOR) {
-                    // only handles single phase injection now
-                    assert(well_ecl_.getInjectionProperties().injectorType != WellInjector::MULTI);
                     const double* distr = well_controls_get_current_distr(well_controls_);
                     for (int phase = 0; phase < number_of_phases_; ++phase) {
                         if (distr[phase] > 0.0) {
@@ -2510,6 +2511,7 @@ namespace Opm
     {
         assert(int(rates.size()) == 3); // the vfp related only supports three phases now.
 
+        SummaryState summaryState;
         const double aqua = rates[Water];
         const double liquid = rates[Oil];
         const double vapour = rates[Gas];
@@ -2519,15 +2521,16 @@ namespace Opm
 
         double thp = 0.0;
         if (well_type_ == INJECTOR) {
-            const int table_id = well_ecl_.getInjectionProperties().VFPTableNumber;
+            const int table_id = well_ecl_.injectionControls(summaryState).vfp_table_number;
             const double vfp_ref_depth = vfp_properties_->getInj()->getTable(table_id)->getDatumDepth();
             const double dp = wellhelpers::computeHydrostaticCorrection(ref_depth_, vfp_ref_depth, rho, gravity_);
 
             thp = vfp_properties_->getInj()->thp(table_id, aqua, liquid, vapour, bhp + dp);
         }
         else if (well_type_ == PRODUCER) {
-            const int table_id = well_ecl_.getProductionProperties().VFPTableNumber;
-            const double alq = well_ecl_.getProductionProperties().ALQValue;
+            const auto controls = well_ecl_.productionControls(summaryState);
+            const int table_id = controls.vfp_table_number;
+            const double alq = controls.alq_value;
             const double vfp_ref_depth = vfp_properties_->getProd()->getTable(table_id)->getDatumDepth();
             const double dp = wellhelpers::computeHydrostaticCorrection(ref_depth_, vfp_ref_depth, rho, gravity_);
 

--- a/tests/test_wellsgroup.cpp
+++ b/tests/test_wellsgroup.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(ConstructGroupFromWell) {
     const Eclipse3DProperties eclipseProperties ( deck , table, grid);
     const Opm::Runspec runspec (deck);
     const Schedule sched(deck, grid, eclipseProperties, runspec);
-
+    SummaryState summaryState;
    PhaseUsage pu = phaseUsageFromDeck(eclipseState);
 
    auto wells = sched.getWells2atEnd();
@@ -62,18 +62,18 @@ BOOST_AUTO_TEST_CASE(ConstructGroupFromWell) {
         std::shared_ptr<WellsGroupInterface> wellsGroup = createWellWellsGroup(well, 2, pu);
         BOOST_CHECK_EQUAL(well.name(), wellsGroup->name());
         if (well.isInjector()) {
-            const WellInjectionProperties& properties = well.getInjectionProperties();
-            BOOST_CHECK_EQUAL(properties.surfaceInjectionRate, wellsGroup->injSpec().surface_flow_max_rate_);
-            BOOST_CHECK_EQUAL(properties.BHPLimit, wellsGroup->injSpec().BHP_limit_);
-            BOOST_CHECK_EQUAL(properties.reservoirInjectionRate, wellsGroup->injSpec().reservoir_flow_max_rate_);
+            const auto controls = well.injectionControls(summaryState);
+            BOOST_CHECK_EQUAL(controls.surface_rate, wellsGroup->injSpec().surface_flow_max_rate_);
+            BOOST_CHECK_EQUAL(controls.bhp_limit, wellsGroup->injSpec().BHP_limit_);
+            BOOST_CHECK_EQUAL(controls.reservoir_rate, wellsGroup->injSpec().reservoir_flow_max_rate_);
             BOOST_CHECK_EQUAL(0.0, wellsGroup->prodSpec().guide_rate_);
         }
         if (well.isProducer()) {
-            const WellProductionProperties& properties = well.getProductionProperties();
-            BOOST_CHECK_EQUAL(properties.ResVRate, wellsGroup->prodSpec().reservoir_flow_max_rate_);
-            BOOST_CHECK_EQUAL(properties.BHPLimit, wellsGroup->prodSpec().BHP_limit_);
-            BOOST_CHECK_EQUAL(properties.OilRate, wellsGroup->prodSpec().oil_max_rate_);
-            BOOST_CHECK_EQUAL(properties.WaterRate, wellsGroup->prodSpec().water_max_rate_);
+            const auto controls = well.productionControls(summaryState);
+            BOOST_CHECK_EQUAL(controls.resv_rate, wellsGroup->prodSpec().reservoir_flow_max_rate_);
+            BOOST_CHECK_EQUAL(controls.bhp_limit, wellsGroup->prodSpec().BHP_limit_);
+            BOOST_CHECK_EQUAL(controls.oil_rate, wellsGroup->prodSpec().oil_max_rate_);
+            BOOST_CHECK_EQUAL(controls.water_rate, wellsGroup->prodSpec().water_max_rate_);
             BOOST_CHECK_EQUAL(0.0, wellsGroup->injSpec().guide_rate_);
         }
     }


### PR DESCRIPTION
This is now ready for review - and merging. Observe that essentials of the current PR is that well controls come from the `well.injectionControls(const summaryState&)` and `well.productionControls(const summaryState&)` functions instead of the previous `well.getInjectionProperties()` and `well.getProductionProperties()` methods. Currently the `SummaryState` is typically just default instantiated, and as such no UDA evaluation can be performed - that is still OK, as the same still applies to corresponding opm-common PR.

Actually passing the simulators `SummaryState` instance around will be the topic of a subsequent PR #one-step-at-a-time.


Followup to: https://github.com/OPM/opm-common/pull/762

Merged: ~~After: https://github.com/OPM/opm-simulators/pull/1815~~