### PR TITLE
updating well control during iterateWellEquations in MSW

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1853,6 +1853,9 @@ namespace Opm
 
             updateWellState(dx_well, well_state, deferred_logger, relaxation_factor);
 
+            // TODO: should we do something more if a switching of control happens
+            this->updateWellControl(ebosSimulator, well_state, deferred_logger);
+
             initPrimaryVariablesEvaluation();
         }
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -190,7 +190,7 @@ namespace Opm
                                                WellState& well_state,
                                                Opm::DeferredLogger& deferred_logger) const = 0;
 
-        void updateWellControl(/* const */ Simulator& ebos_simulator,
+        void updateWellControl(const Simulator& ebos_simulator,
                                WellState& well_state,
                                Opm::DeferredLogger& deferred_logger) /* const */;
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -430,7 +430,7 @@ namespace Opm
     template<typename TypeTag>
     void
     WellInterface<TypeTag>::
-    updateWellControl(/* const */ Simulator& ebos_simulator,
+    updateWellControl(const Simulator& ebos_simulator,
                       WellState& well_state,
                       Opm::DeferredLogger& deferred_logger) /* const */
     {


### PR DESCRIPTION
it enabled running through a real case with MSW, it should not break anything else. 

It was from https://github.com/OPM/opm-simulators/pull/1792, while I was hoping to improve it to be better form, while we need to lower the priority of it now. 