### PR TITLE
run compareECL once, checking all files in one go

### DIFF
--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -20,35 +20,14 @@ ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --output-dir=${RESULT_PATH}
 test $? -eq 0 || exit 1
 cd ..
 
+
 ecode=0
-echo "=== Executing comparison for summary file ==="
-${COMPARE_ECL_COMMAND} -t SMRY ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+echo "=== Executing comparison for EGRID, INIT, UNRST and RFT files if these exists in refrece folder ==="
+${COMPARE_ECL_COMMAND}  ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]
 then
   ecode=1
-  ${COMPARE_ECL_COMMAND} -a -t SMRY ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
-fi
-
-ignore_extra_kw=""
-if grep -q "ignore_extra" <<< $ghprbCommentBody
-then
-    ignore_extra_kw="-x"
-fi
-
-echo "=== Executing comparison for restart file ==="
-${COMPARE_ECL_COMMAND}  ${ignore_extra_kw} ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
-if [ $? -ne 0 ]
-then
-  ecode=1
-  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -a ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
-fi
-
-echo "=== Executing comparison for init file ==="
-${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -t INIT ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
-if [ $? -ne 0 ]
-then
-  ecode=1
-  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -a -t INIT ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} -a  ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
 exit $ecode

--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -22,12 +22,19 @@ cd ..
 
 
 ecode=0
+
+ignore_extra_kw=""
+if grep -q "ignore_extra" <<< $ghprbCommentBody
+then
+    ignore_extra_kw="-x"
+fi
+
 echo "=== Executing comparison for EGRID, INIT, UNRST and RFT files if these exists in refrece folder ==="
-${COMPARE_ECL_COMMAND}  ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]
 then
   ecode=1
-  ${COMPARE_ECL_COMMAND} -a  ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -a  ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
 exit $ecode


### PR DESCRIPTION
update of script `run-regressionTest.sh`. Should be merged after PR OPM/opm-common#765. This PR will enable testing of RFT files if these are found in opm-tests reference folder.
 
Has been tested locally by manually copying RFT files from opm-simulators/build/tests/results folders
```
./flow+msw_model_1/MSW_MODEL_1.RFT   => opm-tests/model1/opm-simulation-reference/flow/MSW_MODEL_1.RFT
./flow+base_model_1/BASE_MODEL_1.RFT  => opm-tests/model1/opm-simulation-reference/flow/BASE_MODEL_1.RFT  
.flow+faults_model_1/FAULTS_MODEL_1.RFT  => opm-tests/model1/opm-simulation-reference/flow/FAULTS_MODEL_1.RFT
```