### PR TITLE
Fix episode index for restart

### DIFF
--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -266,10 +266,16 @@ public:
         std::vector<Opm::RestartKey> extraKeys = {{"OPMEXTRA", Opm::UnitSystem::measure::identity, false},
                                                   {"THRESHPR", Opm::UnitSystem::measure::pressure, inputThpres.active()}};
 
-        unsigned episodeIdx = simulator_.episodeIndex();
+        // The episodeIndex is rewined one back before beginRestart is called
+        // and can not be used here.
+        // We just ask the initconfig directly to be sure that we use the correct
+        // index.
+        const auto& initconfig = simulator_.vanguard().eclState().getInitConfig();
+        int restartStepIdx = initconfig.getRestartStep();
+
         const auto& gridView = simulator_.vanguard().gridView();
         unsigned numElements = gridView.size(/*codim=*/0);
-        eclOutputModule_.allocBuffers(numElements, episodeIdx, /*isSubStep=*/false, /*log=*/false);
+        eclOutputModule_.allocBuffers(numElements, restartStepIdx, /*isSubStep=*/false, /*log=*/false);
 
         auto restartValues = eclIO_->loadRestart(solutionKeys, extraKeys);
         for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {


### PR DESCRIPTION
This restores restart for a model where not every episode is stored. 

in  `void readEclRestartSolution_() `
the episodeidx is set `initconfig.getRestartStep() - 1;`
while the output writer in opm-common expects the episode index to be equal to   `initconfig.getRestartStep()`

A better fix may be to pass the episodeidx from initconfig directly?
Any comment @andlaus? 

