### PR TITLE
EclProblem: remove the isSubstep parameter from writeOutput()

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -982,16 +982,14 @@ public:
      * \brief Write the requested quantities of the current solution into the output
      *        files.
      */
-    void writeOutput(bool isSubStep, bool verbose = true)
+    void writeOutput(bool verbose = true)
     {
-        assert(!this->simulator().episodeWillBeOver() == isSubStep);
-
         // use the generic code to prepare the output fields and to
         // write the desired VTK files.
-        ParentType::writeOutput(isSubStep, verbose);
+        ParentType::writeOutput(verbose);
 
         if (enableEclOutput_)
-            eclWriter_->writeOutput(isSubStep);
+            eclWriter_->writeOutput(/*isSubStep=*/!this->simulator().episodeWillBeOver());
     }
 
     /*!

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -239,7 +239,7 @@ public:
                 ebosSimulator_.setTimeStepSize(0.0);
 
                 wellModel_().beginReportStep(timer.currentStepNum());
-                ebosSimulator_.problem().writeOutput(false);
+                ebosSimulator_.problem().writeOutput();
 
                 report.output_write_time += perfTimer.stop();
             }
@@ -294,7 +294,7 @@ public:
             perfTimer.start();
             const double nextstep = adaptiveTimeStepping ? adaptiveTimeStepping->suggestedNextStep() : -1.0;
             ebosSimulator_.problem().setNextTimeStepSize(nextstep);
-            ebosSimulator_.problem().writeOutput(false);
+            ebosSimulator_.problem().writeOutput();
             report.output_write_time += perfTimer.stop();
 
             solver->model().endReportStep();

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -322,7 +322,7 @@ namespace Opm {
                         Opm::time::StopWatch perfTimer;
                         perfTimer.start();
 
-                        ebosProblem.writeOutput(/*isSubStep=*/true);
+                        ebosProblem.writeOutput();
 
                         report.output_write_time += perfTimer.secsSinceStart();
                     }


### PR DESCRIPTION
Now that the book keeping for time stepping is correct even in `flow`, this parameter has become redundant.