### PR TITLE
Update Data: Make Protocol Aware of RFT Files

### DIFF
--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -67,7 +67,7 @@ do
       $configuration/build-opm-simulators/tests/results/$binary+$tname/ \
       $OPM_TESTS_ROOT/$dirname/opm-simulation-reference/$binary \
       $casename \
-      EGRID INIT SMSPEC UNRST UNSMRY
+      EGRID INIT RFT SMSPEC UNRST UNSMRY
   test $? -eq 0 && changed_tests="$changed_tests $test_name"
 done
 


### PR DESCRIPTION
If a simulation run intentionally changes an RFT file, then that change should be reflected in the new reference data.

This is in preparation of merging PRs OPM/opm-common#765 and #1833.