### PR TITLE
Return EXIT_FAILURE in main() instead of rethrow

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -293,7 +293,7 @@ int main(int argc, char** argv)
             std::cerr << "Failed to create valid EclipseState object." << std::endl;
             std::cerr << "Exception caught: " << e.what() << std::endl;
         }
-        throw;
+        return EXIT_FAILURE;
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
No reason to `throw` our way out of `main`. 