### PR TITLE
set the SparseMatrixAdapter property in the linear solver type tag

### DIFF
--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -57,6 +57,19 @@ NEW_PROP_TAG(Indices);
 NEW_PROP_TAG(Simulator);
 NEW_PROP_TAG(EclWellModel);
 
+//! Set the type of a global jacobian matrix for linear solvers that are based on
+//! dune-istl.
+SET_PROP(FlowIstlSolver, SparseMatrixAdapter)
+{
+private:
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
+    typedef Ewoms::MatrixBlock<Scalar, numEq, numEq> Block;
+
+public:
+    typedef typename Ewoms::Linear::IstlSparseMatrixAdapter<Block> type;
+};
+
 END_PROPERTIES
 
 namespace Opm


### PR DESCRIPTION
this will become required after OPM/ewoms#513, until then it is good style but optional. The reason why this will becom mandatory is that with OPM/ewoms#513 the `SparseMatrixAdapter` property will be "owned" by the linear solver and because `ISTLSolverEbos` does not build on top of `Ewoms::ParallelBaseBackend`.