### PR TITLE
Call Summary::eval() and ::add_timestep separately 

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -390,12 +390,8 @@ public:
     * computed, ready to use summary values. The values will typically be used by
     * the UDQ, WTEST and ACTIONX calculations.
     */
-    const Opm::SummaryState& summaryState() const
+    Opm::SummaryState& summaryState() 
     { return summaryState_; }
-
-    Opm::SummaryState& summaryState()
-    { return summaryState_; }
-
 
     /*!
      * \brief Returns the name of the case.

--- a/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/autodiff/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -137,12 +137,13 @@ public:
         // handle restarts
         std::unique_ptr<RestartValue> restartValues;
         if (isRestart()) {
+            Opm::SummaryState& summaryState = ebosSimulator_.vanguard().summaryState();
             std::vector<RestartKey> extraKeys = {
                 {"OPMEXTRA" , Opm::UnitSystem::measure::identity, false}
             };
 
             std::vector<RestartKey> solutionKeys = {};
-            restartValues.reset(new RestartValue(ebosSimulator_.problem().eclIO().loadRestart(solutionKeys, extraKeys)));
+            restartValues.reset(new RestartValue(ebosSimulator_.problem().eclIO().loadRestart(summaryState, solutionKeys, extraKeys)));
         }
 
         // Create timers and file for writing timing info.


### PR DESCRIPTION
Followup to: https://github.com/OPM/opm-common/pull/795

Again a step in UDQ/ACTIONX sequel