### PR TITLE
add `mebos`, a multiplexed ebos variant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,14 +185,17 @@ endif()
   
 # the research oriented general-purpose ECL simulator ("ebos" == &ecl
 # &black-&oil &simulator)
+get_target_property(ecl_INCLUDE_DIRS ecl INTERFACE_INCLUDE_DIRECTORIES)
+include_directories("${ecl_INCLUDE_DIRS}")
+
+add_library(ebos_libblackoil STATIC EXCLUDE_FROM_ALL ebos/ebos_blackoil.cc)
 opm_add_test(ebos
   ONLY_COMPILE
   DEFAULT_ENABLE_IF ${EBOS_DEFAULT_ENABLE_IF}
   ALWAYS_ENABLE
-  EXE_NAME ebos
-  DEPENDS "opmsimulators"
-  LIBRARIES "opmsimulators"
-  SOURCES ebos/ebos.cc)
+  EXE_NAME "ebos"
+  LIBRARIES "ebos_libblackoil" "opmsimulators"
+  SOURCES "ebos/ebos_main.cc")
 
 if (BUILD_EBOS)
   install(TARGETS ebos DESTINATION bin)
@@ -205,45 +208,52 @@ else()
   set(EBOS_EXTENSIONS_DEFAULT_ENABLE_IF "TRUE")
 endif()
 
+add_library(ebos_libsolvent STATIC EXCLUDE_FROM_ALL ebos/ebos_solvent.cc)
 opm_add_test(ebos_solvent
   ONLY_COMPILE
   DEFAULT_ENABLE_IF ${EBOS_EXTENSIONS_DEFAULT_ENABLE_IF}
-  SOURCES ebos/ebos_solvent.cc
-  EXE_NAME ebos_solvent
-  DEPENDS "opmsimulators"
-  LIBRARIES "opmsimulators")
+  SOURCES "ebos/ebos_solvent_main.cc"
+  EXE_NAME "ebos_solvent"
+  LIBRARIES "ebos_libsolvent" "opmsimulators")
 
+add_library(ebos_libpolymer STATIC EXCLUDE_FROM_ALL ebos/ebos_polymer.cc)
 opm_add_test(ebos_polymer
   ONLY_COMPILE
   DEFAULT_ENABLE_IF ${EBOS_EXTENSIONS_DEFAULT_ENABLE_IF}
-  SOURCES ebos/ebos_polymer.cc
-  EXE_NAME ebos_polymer
-  DEPENDS "opmsimulators"
-  LIBRARIES "opmsimulators")
+  SOURCES "ebos/ebos_polymer_main.cc"
+  EXE_NAME "ebos_polymer"
+  LIBRARIES "ebos_libpolymer" "opmsimulators")
 
+add_library(ebos_libgasoil STATIC EXCLUDE_FROM_ALL ebos/ebos_gasoil.cc)
 opm_add_test(ebos_gasoil
   ONLY_COMPILE
   DEFAULT_ENABLE_IF ${EBOS_EXTENSIONS_DEFAULT_ENABLE_IF}
-  SOURCES ebos/ebos_gasoil.cc
-  EXE_NAME ebos_gasoil
-  DEPENDS "opmsimulators"
-  LIBRARIES "opmsimulators")
+  SOURCES "ebos/ebos_gasoil_main.cc"
+  EXE_NAME "ebos_gasoil"
+  LIBRARIES "ebos_libgasoil" "opmsimulators")
 
+add_library(ebos_liboilwater STATIC EXCLUDE_FROM_ALL ebos/ebos_oilwater.cc)
 opm_add_test(ebos_oilwater
   ONLY_COMPILE
   DEFAULT_ENABLE_IF ${EBOS_EXTENSIONS_DEFAULT_ENABLE_IF}
-  SOURCES ebos/ebos_oilwater.cc
+  SOURCES ebos/ebos_oilwater_main.cc
   EXE_NAME ebos_oilwater
-  DEPENDS "opmsimulators"
-  LIBRARIES "opmsimulators")
+  LIBRARIES "ebos_liboilwater" "opmsimulators")
 
+add_library(ebos_libthermal STATIC EXCLUDE_FROM_ALL ebos/ebos_thermal.cc)
 opm_add_test(ebos_thermal
   ONLY_COMPILE
   DEFAULT_ENABLE_IF ${EBOS_EXTENSIONS_DEFAULT_ENABLE_IF}
-  SOURCES ebos/ebos_thermal.cc
-  EXE_NAME ebos_thermal
-  DEPENDS "opmsimulators"
-  LIBRARIES "opmsimulators")
+  SOURCES "ebos/ebos_thermal_main.cc"
+  EXE_NAME "ebos_thermal"
+  LIBRARIES "ebos_libthermal" "opmsimulators")
+
+opm_add_test(mebos
+  ONLY_COMPILE
+  DEFAULT_ENABLE_IF ${EBOS_EXTENSIONS_DEFAULT_ENABLE_IF}
+  SOURCES "ebos/mebos_main.cc"
+  EXE_NAME "mebos"
+  LIBRARIES "ebos_libblackoil" "ebos_libpolymer" "ebos_libsolvent" "ebos_libthermal" "ebos_liboilwater" "ebos_libgasoil" "opmsimulators")
 
 if (NOT BUILD_EBOS_DEBUG_EXTENSIONS)
   set(EBOS_DEBUG_EXTENSIONS_DEFAULT_ENABLE_IF "FALSE")
@@ -279,5 +289,6 @@ if (BUILD_EBOS_EXTENSIONS)
   install(TARGETS ebos_gasoil DESTINATION bin)
   install(TARGETS ebos_oilwater DESTINATION bin)
   install(TARGETS ebos_thermal DESTINATION bin)
+  install(TARGETS mebos DESTINATION bin)
 endif()
 

--- a/ebos/ebos_blackoil.cc
+++ b/ebos/ebos_blackoil.cc
@@ -1,0 +1,99 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ */
+#include "config.h"
+
+#include "ebos.hh"
+
+namespace Ewoms {
+
+bool ebosBlackOilDeckFileNameIsSet(int argc, char** argv)
+{
+    typedef TTAG(EbosTypeTag) ProblemTypeTag;
+
+    // use the ewoms parameter machinery and the blackoil vanguard to handle the grunt of
+    // the work
+    EWOMS_RESET_PARAMS_(ProblemTypeTag);
+    Ewoms::setupParameters_<ProblemTypeTag>(argc, const_cast<const char**>(argv), /*doRegistration=*/true);
+    bool result = EWOMS_PARAM_IS_SET(ProblemTypeTag, std::string, EclDeckFileName);
+    EWOMS_RESET_PARAMS_(ProblemTypeTag);
+
+    return result;
+}
+
+std::string ebosBlackOilGetDeckFileName(int argc, char** argv)
+{
+    typedef TTAG(EbosTypeTag) ProblemTypeTag;
+    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+
+    // use the ewoms parameter machinery and the blackoil vanguard to handle the grunt of
+    // the work
+    EWOMS_RESET_PARAMS_(ProblemTypeTag);
+    Ewoms::setupParameters_<ProblemTypeTag>(argc, const_cast<const char**>(argv), /*doRegistration=*/true);
+    std::string rawDeckFileName = EWOMS_GET_PARAM(ProblemTypeTag, std::string, EclDeckFileName);
+    std::string result = Vanguard::canonicalDeckPath(rawDeckFileName).string();
+    EWOMS_RESET_PARAMS_(ProblemTypeTag);
+
+    return result;
+}
+
+std::unique_ptr<Opm::ParseContext> ebosBlackOilCreateParseContext(int argc, char** argv)
+{
+    typedef TTAG(EbosTypeTag) ProblemTypeTag;
+    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+
+    // use the ewoms parameter machinery and the blackoil vanguard to handle the grunt of
+    // the work
+    EWOMS_RESET_PARAMS_(ProblemTypeTag);
+    Ewoms::setupParameters_<ProblemTypeTag>(argc, const_cast<const char**>(argv), /*doRegistration=*/true);
+    std::unique_ptr<Opm::ParseContext> result = Vanguard::createParseContext();
+    EWOMS_RESET_PARAMS_(ProblemTypeTag);
+
+    return result;
+}
+
+void ebosBlackOilSetDeck(Opm::Deck* deck,
+                         Opm::ParseContext* parseContext,
+                         Opm::ErrorGuard* errorGuard,
+                         double externalSetupTime)
+{
+    typedef TTAG(EbosTypeTag) ProblemTypeTag;
+    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+
+    Vanguard::setExternalSetupTime(externalSetupTime);
+    Vanguard::setExternalParseContext(parseContext);
+    Vanguard::setExternalErrorGuard(errorGuard);
+    Vanguard::setExternalDeck(deck);
+}
+
+int ebosBlackOilMain(int argc, char **argv)
+{
+    typedef TTAG(EbosTypeTag) ProblemTypeTag;
+    return Ewoms::start<ProblemTypeTag>(argc, argv);
+}
+
+}

--- a/ebos/ebos_blackoil.hh
+++ b/ebos/ebos_blackoil.hh
@@ -23,41 +23,29 @@
 /*!
  * \file
  *
- * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ * \brief The function prototypes required to start the oil-water variant of ebos
  */
-#include "config.h"
+#ifndef EBOS_BLACK_OIL_HH
+#define EBOS_BLACK_OIL_HH
 
-#include "ebos.hh"
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
-BEGIN_PROPERTIES
-
-NEW_TYPE_TAG(EbosPolymerTypeTag, INHERITS_FROM(EbosTypeTag));
-
-// enable the polymer extension of the black oil model
-SET_BOOL_PROP(EbosPolymerTypeTag, EnablePolymer, true);
-
-END_PROPERTIES
+#include <memory>
+#include <string>
 
 namespace Ewoms {
+bool ebosBlackOilDeckFileNameIsSet(int argc, char** argv);
+std::string ebosBlackOilGetDeckFileName(int argc, char** argv);
+std::unique_ptr<Opm::ParseContext> ebosBlackOilCreateParseContext(int argc, char** argv);
 
-void ebosPolymerSetDeck(Opm::Deck* deck,
+void ebosBlackOilSetDeck(Opm::Deck* deck,
                          Opm::ParseContext* parseContext,
                          Opm::ErrorGuard* errorGuard,
-                         double externalSetupTime)
-{
-    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
-    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+                         double externalSetupTime);
 
-    Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+int ebosBlackOilMain(int argc, char** argv);
 }
 
-int ebosPolymerMain(int argc, char **argv)
-{
-    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
-    return Ewoms::start<ProblemTypeTag>(argc, argv);
-}
-
-}
+#endif

--- a/ebos/ebos_gasoil.cc
+++ b/ebos/ebos_gasoil.cc
@@ -52,8 +52,26 @@ public:
 
 END_PROPERTIES
 
-int main(int argc, char **argv)
+namespace Ewoms {
+
+void ebosGasOilSetDeck(Opm::Deck* deck,
+                       Opm::ParseContext* parseContext,
+                       Opm::ErrorGuard* errorGuard,
+                       double externalSetupTime)
+{
+    typedef TTAG(EbosGasOilTypeTag) ProblemTypeTag;
+    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+
+    Vanguard::setExternalSetupTime(externalSetupTime);
+    Vanguard::setExternalParseContext(parseContext);
+    Vanguard::setExternalErrorGuard(errorGuard);
+    Vanguard::setExternalDeck(deck);
+}
+
+int ebosGasOilMain(int argc, char **argv)
 {
     typedef TTAG(EbosGasOilTypeTag) ProblemTypeTag;
     return Ewoms::start<ProblemTypeTag>(argc, argv);
+}
+
 }

--- a/ebos/ebos_gasoil.hh
+++ b/ebos/ebos_gasoil.hh
@@ -23,41 +23,22 @@
 /*!
  * \file
  *
- * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ * \brief The function prototypes required to start the gas-oil variant of ebos
  */
-#include "config.h"
+#ifndef EBOS_GAS_OIL_HH
+#define EBOS_GAS_OIL_HH
 
-#include "ebos.hh"
-
-BEGIN_PROPERTIES
-
-NEW_TYPE_TAG(EbosPolymerTypeTag, INHERITS_FROM(EbosTypeTag));
-
-// enable the polymer extension of the black oil model
-SET_BOOL_PROP(EbosPolymerTypeTag, EnablePolymer, true);
-
-END_PROPERTIES
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Ewoms {
-
-void ebosPolymerSetDeck(Opm::Deck* deck,
+void ebosGasOilSetDeck(Opm::Deck* deck,
                          Opm::ParseContext* parseContext,
                          Opm::ErrorGuard* errorGuard,
-                         double externalSetupTime)
-{
-    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
-    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+                         double externalSetupTime);
 
-    Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+int ebosGasOilMain(int argc, char** argv);
 }
 
-int ebosPolymerMain(int argc, char **argv)
-{
-    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
-    return Ewoms::start<ProblemTypeTag>(argc, argv);
-}
-
-}
+#endif

--- a/ebos/ebos_gasoil_main.cc
+++ b/ebos/ebos_gasoil_main.cc
@@ -1,0 +1,37 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief The main function for the stand alone gas-oil variant of ebos.
+ *
+ * This only calls the ebosGasOilMain() function.
+ */
+#include "config.h"
+
+#include "ebos_gasoil.hh"
+
+int main(int argc, char** argv)
+{
+    return Ewoms::ebosGasOilMain(argc, argv);
+}

--- a/ebos/ebos_main.cc
+++ b/ebos/ebos_main.cc
@@ -1,0 +1,37 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief The main function for the stand alone black-oil variant of ebos.
+ *
+ * This only calls the ebosBlackOilMain() function.
+ */
+#include "config.h"
+
+#include "ebos_blackoil.hh"
+
+int main(int argc, char** argv)
+{
+    return Ewoms::ebosBlackOilMain(argc, argv);
+}

--- a/ebos/ebos_oilwater.cc
+++ b/ebos/ebos_oilwater.cc
@@ -52,8 +52,26 @@ public:
 
 END_PROPERTIES
 
-int main(int argc, char **argv)
+namespace Ewoms {
+
+void ebosOilWaterSetDeck(Opm::Deck* deck,
+                         Opm::ParseContext* parseContext,
+                         Opm::ErrorGuard* errorGuard,
+                         double externalSetupTime)
+{
+    typedef TTAG(EbosOilWaterTypeTag) ProblemTypeTag;
+    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+
+    Vanguard::setExternalSetupTime(externalSetupTime);
+    Vanguard::setExternalParseContext(parseContext);
+    Vanguard::setExternalErrorGuard(errorGuard);
+    Vanguard::setExternalDeck(deck);
+}
+
+int ebosOilWaterMain(int argc, char **argv)
 {
     typedef TTAG(EbosOilWaterTypeTag) ProblemTypeTag;
     return Ewoms::start<ProblemTypeTag>(argc, argv);
+}
+
 }

--- a/ebos/ebos_oilwater.hh
+++ b/ebos/ebos_oilwater.hh
@@ -23,41 +23,22 @@
 /*!
  * \file
  *
- * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ * \brief The function prototypes required to start the oil-water variant of ebos
  */
-#include "config.h"
+#ifndef EBOS_OIL_WATER_HH
+#define EBOS_OIL_WATER_HH
 
-#include "ebos.hh"
-
-BEGIN_PROPERTIES
-
-NEW_TYPE_TAG(EbosPolymerTypeTag, INHERITS_FROM(EbosTypeTag));
-
-// enable the polymer extension of the black oil model
-SET_BOOL_PROP(EbosPolymerTypeTag, EnablePolymer, true);
-
-END_PROPERTIES
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Ewoms {
-
-void ebosPolymerSetDeck(Opm::Deck* deck,
+void ebosOilWaterSetDeck(Opm::Deck* deck,
                          Opm::ParseContext* parseContext,
                          Opm::ErrorGuard* errorGuard,
-                         double externalSetupTime)
-{
-    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
-    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+                         double externalSetupTime);
 
-    Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+int ebosOilWaterMain(int argc, char** argv);
 }
 
-int ebosPolymerMain(int argc, char **argv)
-{
-    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
-    return Ewoms::start<ProblemTypeTag>(argc, argv);
-}
-
-}
+#endif

--- a/ebos/ebos_oilwater_main.cc
+++ b/ebos/ebos_oilwater_main.cc
@@ -23,15 +23,15 @@
 /*!
  * \file
  *
- * \brief The main file for ebos, a general-purpose simulator for ECL decks for research
- *        purposes.
+ * \brief The main function for the stand alone oil-water variant of ebos.
+ *
+ * This only calls the ebosOilWaterMain() function.
  */
 #include "config.h"
 
-#include "ebos.hh"
+#include "ebos_oilwater.hh"
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-    typedef TTAG(EbosTypeTag) ProblemTypeTag;
-    return Ewoms::start<ProblemTypeTag>(argc, argv);
+    return Ewoms::ebosOilWaterMain(argc, argv);
 }

--- a/ebos/ebos_polymer.hh
+++ b/ebos/ebos_polymer.hh
@@ -23,41 +23,22 @@
 /*!
  * \file
  *
- * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ * \brief The function prototypes required to start the polymer variant of ebos
  */
-#include "config.h"
+#ifndef EBOS_POLYMER_HH
+#define EBOS_POLYMER_HH
 
-#include "ebos.hh"
-
-BEGIN_PROPERTIES
-
-NEW_TYPE_TAG(EbosPolymerTypeTag, INHERITS_FROM(EbosTypeTag));
-
-// enable the polymer extension of the black oil model
-SET_BOOL_PROP(EbosPolymerTypeTag, EnablePolymer, true);
-
-END_PROPERTIES
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Ewoms {
-
 void ebosPolymerSetDeck(Opm::Deck* deck,
                          Opm::ParseContext* parseContext,
                          Opm::ErrorGuard* errorGuard,
-                         double externalSetupTime)
-{
-    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
-    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+                         double externalSetupTime);
 
-    Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+int ebosPolymerMain(int argc, char** argv);
 }
 
-int ebosPolymerMain(int argc, char **argv)
-{
-    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
-    return Ewoms::start<ProblemTypeTag>(argc, argv);
-}
-
-}
+#endif

--- a/ebos/ebos_polymer_main.cc
+++ b/ebos/ebos_polymer_main.cc
@@ -1,0 +1,37 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief The main function for the stand alone polymer variant of ebos.
+ *
+ * This only calls the ebosPolymerMain() function.
+ */
+#include "config.h"
+
+#include "ebos_polymer.hh"
+
+int main(int argc, char** argv)
+{
+    return Ewoms::ebosPolymerMain(argc, argv);
+}

--- a/ebos/ebos_solvent.cc
+++ b/ebos/ebos_solvent.cc
@@ -38,8 +38,26 @@ SET_BOOL_PROP(EbosSolventTypeTag, EnableSolvent, true);
 
 END_PROPERTIES
 
-int main(int argc, char **argv)
+namespace Ewoms {
+
+void ebosSolventSetDeck(Opm::Deck* deck,
+                         Opm::ParseContext* parseContext,
+                         Opm::ErrorGuard* errorGuard,
+                         double externalSetupTime)
+{
+    typedef TTAG(EbosSolventTypeTag) ProblemTypeTag;
+    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+
+    Vanguard::setExternalSetupTime(externalSetupTime);
+    Vanguard::setExternalParseContext(parseContext);
+    Vanguard::setExternalErrorGuard(errorGuard);
+    Vanguard::setExternalDeck(deck);
+}
+
+int ebosSolventMain(int argc, char **argv)
 {
     typedef TTAG(EbosSolventTypeTag) ProblemTypeTag;
     return Ewoms::start<ProblemTypeTag>(argc, argv);
+}
+
 }

--- a/ebos/ebos_solvent.hh
+++ b/ebos/ebos_solvent.hh
@@ -23,41 +23,22 @@
 /*!
  * \file
  *
- * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ * \brief The function prototypes required to start the solvent variant of ebos
  */
-#include "config.h"
+#ifndef EBOS_SOLVENT_HH
+#define EBOS_SOLVENT_HH
 
-#include "ebos.hh"
-
-BEGIN_PROPERTIES
-
-NEW_TYPE_TAG(EbosPolymerTypeTag, INHERITS_FROM(EbosTypeTag));
-
-// enable the polymer extension of the black oil model
-SET_BOOL_PROP(EbosPolymerTypeTag, EnablePolymer, true);
-
-END_PROPERTIES
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Ewoms {
-
-void ebosPolymerSetDeck(Opm::Deck* deck,
+void ebosSolventSetDeck(Opm::Deck* deck,
                          Opm::ParseContext* parseContext,
                          Opm::ErrorGuard* errorGuard,
-                         double externalSetupTime)
-{
-    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
-    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+                         double externalSetupTime);
 
-    Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+int ebosSolventMain(int argc, char** argv);
 }
 
-int ebosPolymerMain(int argc, char **argv)
-{
-    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
-    return Ewoms::start<ProblemTypeTag>(argc, argv);
-}
-
-}
+#endif

--- a/ebos/ebos_solvent_main.cc
+++ b/ebos/ebos_solvent_main.cc
@@ -1,0 +1,37 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief The main function for the stand alone solvent variant of ebos.
+ *
+ * This only calls the ebosSolventMain() function.
+ */
+#include "config.h"
+
+#include "ebos_solvent.hh"
+
+int main(int argc, char** argv)
+{
+    return Ewoms::ebosSolventMain(argc, argv);
+}

--- a/ebos/ebos_thermal.cc
+++ b/ebos/ebos_thermal.cc
@@ -38,8 +38,26 @@ SET_BOOL_PROP(EbosThermalTypeTag, EnableEnergy, true);
 
 END_PROPERTIES
 
-int main(int argc, char **argv)
+namespace Ewoms {
+
+void ebosThermalSetDeck(Opm::Deck* deck,
+                         Opm::ParseContext* parseContext,
+                         Opm::ErrorGuard* errorGuard,
+                         double externalSetupTime)
+{
+    typedef TTAG(EbosThermalTypeTag) ProblemTypeTag;
+    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+
+    Vanguard::setExternalSetupTime(externalSetupTime);
+    Vanguard::setExternalParseContext(parseContext);
+    Vanguard::setExternalErrorGuard(errorGuard);
+    Vanguard::setExternalDeck(deck);
+}
+
+int ebosThermalMain(int argc, char **argv)
 {
     typedef TTAG(EbosThermalTypeTag) ProblemTypeTag;
     return Ewoms::start<ProblemTypeTag>(argc, argv);
+}
+
 }

--- a/ebos/ebos_thermal.hh
+++ b/ebos/ebos_thermal.hh
@@ -23,41 +23,22 @@
 /*!
  * \file
  *
- * \brief A general-purpose simulator for ECL decks using the black-oil model.
+ * \brief The function prototypes required to start the thermal variant of ebos
  */
-#include "config.h"
+#ifndef EBOS_THERMAL_HH
+#define EBOS_THERMAL_HH
 
-#include "ebos.hh"
-
-BEGIN_PROPERTIES
-
-NEW_TYPE_TAG(EbosPolymerTypeTag, INHERITS_FROM(EbosTypeTag));
-
-// enable the polymer extension of the black oil model
-SET_BOOL_PROP(EbosPolymerTypeTag, EnablePolymer, true);
-
-END_PROPERTIES
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Ewoms {
-
-void ebosPolymerSetDeck(Opm::Deck* deck,
+void ebosThermalSetDeck(Opm::Deck* deck,
                          Opm::ParseContext* parseContext,
                          Opm::ErrorGuard* errorGuard,
-                         double externalSetupTime)
-{
-    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
-    typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
+                         double externalSetupTime);
 
-    Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+int ebosThermalMain(int argc, char** argv);
 }
 
-int ebosPolymerMain(int argc, char **argv)
-{
-    typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
-    return Ewoms::start<ProblemTypeTag>(argc, argv);
-}
-
-}
+#endif

--- a/ebos/ebos_thermal_main.cc
+++ b/ebos/ebos_thermal_main.cc
@@ -1,0 +1,37 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief The main function for the stand alone thermal variant of ebos.
+ *
+ * This only calls the ebosThermalMain() function.
+ */
+#include "config.h"
+
+#include "ebos_thermal.hh"
+
+int main(int argc, char** argv)
+{
+    return Ewoms::ebosThermalMain(argc, argv);
+}

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -158,6 +158,43 @@ public:
     }
 
     /*!
+     * \brief Creates an Opm::parseContext object assuming that the parameters are ready.
+     */
+    static std::unique_ptr<Opm::ParseContext> createParseContext()
+    {
+        typedef std::pair<std::string, Opm::InputError::Action> ParseModePair;
+        typedef std::vector<ParseModePair> ParseModePairs;
+        ParseModePairs tmp;
+        tmp.emplace_back(Opm::ParseContext::PARSE_RANDOM_SLASH, Opm::InputError::IGNORE);
+        tmp.emplace_back(Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputError::WARN);
+        tmp.emplace_back(Opm::ParseContext::SUMMARY_UNKNOWN_WELL, Opm::InputError::WARN);
+        tmp.emplace_back(Opm::ParseContext::SUMMARY_UNKNOWN_GROUP, Opm::InputError::WARN);
+        tmp.emplace_back(Opm::ParseContext::PARSE_EXTRA_RECORDS, Opm::InputError::WARN);
+
+        std::unique_ptr<Opm::ParseContext> parseContext(new Opm::ParseContext(tmp));
+
+        const std::string ignoredKeywords = EWOMS_GET_PARAM(TypeTag, std::string, IgnoreKeywords);
+        if (ignoredKeywords.size() > 0) {
+            size_t pos;
+            size_t offset = 0;
+            while (true) {
+                pos = ignoredKeywords.find(':', offset);
+                if (pos == std::string::npos) {
+                    parseContext->ignoreKeyword(ignoredKeywords.substr(offset));
+                    break;
+                }
+                parseContext->ignoreKeyword(ignoredKeywords.substr(offset, pos - offset));
+                offset = pos + 1;
+            }
+        }
+
+        if (EWOMS_GET_PARAM(TypeTag, bool, EclStrictParsing))
+            parseContext->update(Opm::InputError::DELAYED_EXIT1);
+
+        return parseContext;
+    }
+
+    /*!
      * \brief Set the wall time which was spend externally to set up the external data structures
      *
      * i.e., the objects specified via the other setExternal*() methods.
@@ -172,8 +209,20 @@ public:
     { return externalSetupTime_; }
 
     /*!
-     * \brief Set the Opm::EclipseState and the Opm::Deck object which ought to be used
-     *        when the simulator vanguard is instantiated.
+     * \brief Set the Opm::ParseContext object which ought to be used for parsing the deck and creating the Opm::EclipseState object.
+     */
+    static void setExternalParseContext(Opm::ParseContext* parseContext)
+    { externalParseContext_ = parseContext; }
+
+    /*!
+     * \brief Set the Opm::ErrorGuard object which ought to be used for parsing the deck and creating the Opm::EclipseState object.
+     */
+    static void setExternalErrorGuard(Opm::ErrorGuard* errorGuard)
+    { externalErrorGuard_ = errorGuard; }
+
+    /*!
+     * \brief Set the Opm::Deck object which ought to be used when the simulator vanguard
+     *        is instantiated.
      *
      * This is basically an optimization: In cases where the ECL input deck must be
      * examined to decide which simulator ought to be used, this avoids having to parse
@@ -181,11 +230,15 @@ public:
      * management of these two objects, i.e., they are not allowed to be deleted as long
      * as the simulator vanguard object is alive.
      */
-    static void setExternalDeck(Opm::Deck* deck, Opm::EclipseState* eclState)
-    {
-        externalDeck_ = deck;
-        externalEclState_ = eclState;
-    }
+    static void setExternalDeck(Opm::Deck* deck)
+    { externalDeck_ = deck; }
+
+    /*!
+     * \brief Set the Opm::EclipseState object which ought to be used when the simulator
+     *        vanguard is instantiated.
+     */
+    static void setExternalEclState(Opm::EclipseState* eclState)
+    { externalEclState_ = eclState; }
 
     /*!
      * \brief Create the grid for problem data files which use the ECL file format.
@@ -231,47 +284,42 @@ public:
         caseName_ = rawCaseName;
         std::transform(caseName_.begin(), caseName_.end(), caseName_.begin(), ::toupper);
 
-        typedef std::pair<std::string, Opm::InputError::Action> ParseModePair;
-        typedef std::vector<ParseModePair> ParseModePairs;
-        ParseModePairs tmp;
-        tmp.emplace_back(Opm::ParseContext::PARSE_RANDOM_SLASH, Opm::InputError::IGNORE);
-        tmp.emplace_back(Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputError::WARN);
-        tmp.emplace_back(Opm::ParseContext::SUMMARY_UNKNOWN_WELL, Opm::InputError::WARN);
-        tmp.emplace_back(Opm::ParseContext::SUMMARY_UNKNOWN_GROUP, Opm::InputError::WARN);
-        tmp.emplace_back(Opm::ParseContext::PARSE_EXTRA_RECORDS, Opm::InputError::WARN);
-        Opm::ParseContext parseContext(tmp);
-        Opm::ErrorGuard errorGuard;
-
-        const std::string ignoredKeywords = EWOMS_GET_PARAM(TypeTag, std::string, IgnoreKeywords);
-        if (ignoredKeywords.size() > 0) {
-            size_t pos, offset = 0;
-            while (true) {
-                pos = ignoredKeywords.find(':', offset);
-                if (pos == std::string::npos) {
-                    parseContext.ignoreKeyword(ignoredKeywords.substr(offset));
-                    break;
-                }
-                parseContext.ignoreKeyword(ignoredKeywords.substr(offset, pos - offset));
-                offset = pos + 1;
-            }
+        // create the parser objects for the deck or use their externally specified
+        // versions (if desired)
+        if (!externalParseContext_) {
+            internalParseContext_ = createParseContext();
+            parseContext_ = internalParseContext_.get();
         }
+        else
+            parseContext_ = externalParseContext_;
 
-        if (EWOMS_GET_PARAM(TypeTag, bool , EclStrictParsing))
-            parseContext.update(Opm::InputError::DELAYED_EXIT1);
+        if (!externalParseContext_) {
+            internalErrorGuard_.reset(new Opm::ErrorGuard);
+            errorGuard_ = internalErrorGuard_.get();
+        }
+        else
+            errorGuard_ = externalErrorGuard_;
 
         if (!externalDeck_) {
             if (myRank == 0)
                 std::cout << "Reading the deck file '" << fileName << "'" << std::endl;
 
             Opm::Parser parser;
-            internalDeck_.reset(new Opm::Deck(parser.parseFile(fileName , parseContext, errorGuard)));
-            internalEclState_.reset(new Opm::EclipseState(*internalDeck_, parseContext, errorGuard));
+            internalDeck_.reset(new Opm::Deck(parser.parseFile(fileName, *parseContext_, *errorGuard_)));
+            deck_ = internalDeck_.get();
 
             if (enableExperiments && myRank == 0)
-                Opm::checkDeck(*internalDeck_, parser, parseContext, errorGuard);
+                Opm::checkDeck(*deck_, parser,  *parseContext_, *errorGuard_);
+        }
+        else {
+            assert(externalDeck_);
 
-            deck_ = &(*internalDeck_);
-            eclState_ = &(*internalEclState_);
+            deck_ = externalDeck_;
+        }
+
+        if (!externalEclState_) {
+            internalEclState_.reset(new Opm::EclipseState(*deck_, *parseContext_, *errorGuard_));
+            eclState_ = internalEclState_.get();
         }
         else {
             assert(externalDeck_);
@@ -285,8 +333,8 @@ public:
             // create the schedule object. Note that if eclState is supposed to represent
             // the internalized version of the deck, this constitutes a layering
             // violation.
-            internalEclSchedule_.reset(new Opm::Schedule(*deck_, *eclState_, parseContext, errorGuard));
-            eclSchedule_ = &(*internalEclSchedule_);
+            internalEclSchedule_.reset(new Opm::Schedule(*deck_, *eclState_, *parseContext_, *errorGuard_));
+            eclSchedule_ = internalEclSchedule_.get();
         }
         else
             eclSchedule_ = externalEclSchedule_;
@@ -298,17 +346,17 @@ public:
             internalEclSummaryConfig_.reset(new Opm::SummaryConfig(*deck_,
                                                                    *eclSchedule_,
                                                                    eclState_->getTableManager(),
-                                                                   parseContext,
-                                                                   errorGuard));
+                                                                   *parseContext_,
+                                                                   *errorGuard_));
 
-            eclSummaryConfig_ = &(*internalEclSummaryConfig_);
+            eclSummaryConfig_ = internalEclSummaryConfig_.get();
         }
         else
             eclSummaryConfig_ = externalEclSummaryConfig_;
 
-        if (errorGuard) {
-            errorGuard.dump();
-            errorGuard.clear();
+        if (*errorGuard_) {
+            errorGuard_->dump();
+            errorGuard_->clear();
 
             throw std::runtime_error("Unrecoverable errors were encountered while loading input.");
         }
@@ -326,7 +374,7 @@ public:
 
         if (enableExperiments) {
             Opm::RelpermDiagnostics relpermDiagnostics;
-            relpermDiagnostics.diagnosis(*internalEclState_, *internalDeck_, asImp_().grid());
+            relpermDiagnostics.diagnosis(*eclState_, *deck_, asImp_().grid());
         }
     }
 
@@ -517,20 +565,27 @@ private:
     std::string caseName_;
 
     static Scalar externalSetupTime_;
+
+    static Opm::ParseContext* externalParseContext_;
+    static Opm::ErrorGuard* externalErrorGuard_;
     static Opm::Deck* externalDeck_;
     static Opm::EclipseState* externalEclState_;
     static Opm::Schedule* externalEclSchedule_;
     static Opm::SummaryConfig* externalEclSummaryConfig_;
+
+    std::unique_ptr<Opm::ParseContext> internalParseContext_;
+    std::unique_ptr<Opm::ErrorGuard> internalErrorGuard_;
     std::unique_ptr<Opm::Deck> internalDeck_;
     std::unique_ptr<Opm::EclipseState> internalEclState_;
     std::unique_ptr<Opm::Schedule> internalEclSchedule_;
     std::unique_ptr<Opm::SummaryConfig> internalEclSummaryConfig_;
 
-    // these two attributes point either to the internal or to the external version of the
-    // Deck and EclipsState objects.
+    // these attributes point  either to the internal  or to the external version of the
+    // parser objects.
+    Opm::ParseContext* parseContext_;
+    Opm::ErrorGuard* errorGuard_;
     Opm::Deck* deck_;
     Opm::EclipseState* eclState_;
-
     Opm::Schedule* eclSchedule_;
     Opm::SummaryConfig* eclSummaryConfig_;
 
@@ -540,6 +595,12 @@ private:
 
 template <class TypeTag>
 typename EclBaseVanguard<TypeTag>::Scalar EclBaseVanguard<TypeTag>::externalSetupTime_ = 0.0;
+
+template <class TypeTag>
+Opm::ParseContext* EclBaseVanguard<TypeTag>::externalParseContext_ = nullptr;
+
+template <class TypeTag>
+Opm::ErrorGuard* EclBaseVanguard<TypeTag>::externalErrorGuard_ = nullptr;
 
 template <class TypeTag>
 Opm::Deck* EclBaseVanguard<TypeTag>::externalDeck_ = nullptr;

--- a/ebos/mebos_main.cc
+++ b/ebos/mebos_main.cc
@@ -1,0 +1,247 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief The main file of mebos, an multiplexed-version of ebos, the general-purpose
+ *        black-oil simulator for ECL decks for research purposes.
+ *
+ * Just like 'flow', it does not require to select the simulator binary to run a deck
+ * that uses certain options like twophase, solvent, polymer or thermal in advance.
+ */
+#include "config.h"
+
+#include "ebos_blackoil.hh"
+#include "ebos_oilwater.hh"
+#include "ebos_gasoil.hh"
+// TODO (?): #include "ebos_watergas.hh"
+#include "ebos_thermal.hh"
+#include "ebos_solvent.hh"
+#include "ebos_polymer.hh"
+
+#include <ewoms/common/propertysystem.hh>
+
+#include <dune/common/parallel/mpihelper.hh>
+#include <dune/common/timer.hh>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
+#include <string>
+#include <memory>
+
+int main(int argc, char **argv)
+{
+    Dune::Timer externalSetupTimer;
+    externalSetupTimer.start();
+
+    if (!Ewoms::ebosBlackOilDeckFileNameIsSet(argc, argv))
+        // no deck was specified, e.g., --help. use the black oil variant to figure out
+        // what exactly should be done
+        return Ewoms::ebosBlackOilMain(argc, argv);
+
+    std::string deckFileName =
+        Ewoms::ebosBlackOilGetDeckFileName(argc, argv);
+
+    std::unique_ptr<Opm::ParseContext> parseContext
+        = Ewoms::ebosBlackOilCreateParseContext(argc, argv);
+    std::unique_ptr<Opm::ErrorGuard> errorGuard(new Opm::ErrorGuard);
+
+    // deal with parallel runs
+    int myRank = Dune::MPIHelper::instance(argc, argv).rank();
+
+    Opm::Parser parser;
+    // parse the deck file
+    if (myRank == 0)
+        std::cout << "Parsing deck file \"" << deckFileName << "\"" << std::endl;
+    std::unique_ptr<Opm::Deck> deck(new Opm::Deck(parser.parseFile(deckFileName, *parseContext, *errorGuard)));
+
+    // TODO: check which variant ought to be used
+    bool waterActive = deck->hasKeyword("WATER");
+    bool gasActive = deck->hasKeyword("GAS");
+    bool oilActive = deck->hasKeyword("OIL");
+    bool solventActive = deck->hasKeyword("SOLVENT");
+    bool polymerActive = deck->hasKeyword("POLYMER");
+    bool thermalActive = deck->hasKeyword("THERMAL") || deck->hasKeyword("TEMP");
+
+    std::stringstream notSupportedErrorStream;
+    notSupportedErrorStream << "deck not supported by mebos, you might want to use a specialized binary. Active options:\n"
+                            << "   water: " << waterActive << "\n"
+                            << "   gas: " << gasActive << "\n"
+                            << "   oil: " << oilActive << "\n"
+                            << "   solvent: " << solventActive << "\n"
+                            << "   polymer: " << polymerActive << "\n"
+                            << "   thermal/temperature: " << thermalActive << "\n";
+
+    int numBlackOilPhases = (waterActive?1:0) + (gasActive?1:0) + (oilActive?1:0);
+    if (numBlackOilPhases == 0) {
+        notSupportedErrorStream << "\n"
+                                << "no black-oil phase (water, gas or oil) specified.\n";
+        std::cerr << notSupportedErrorStream.str() << std::endl;
+        std::abort();
+    }
+    else if (numBlackOilPhases == 1) {
+        notSupportedErrorStream << "\n"
+                                << "single-phase simulations are unsupported\n";
+        std::cerr << notSupportedErrorStream.str() << std::endl;
+        std::abort();
+    }
+    else if (numBlackOilPhases == 2) {
+        if (solventActive) {
+            notSupportedErrorStream << "\n"
+                                    << "combining twophase and solvent is not supported by the multiplexed simulator\n";
+            std::cerr << notSupportedErrorStream.str() << std::endl;
+            std::abort();
+        }
+
+        if (polymerActive) {
+            notSupportedErrorStream << "\n"
+                                    << "combining twophase and polymer is not supported by the multiplexed simulator\n";
+            std::cerr << notSupportedErrorStream.str() << std::endl;
+            std::abort();
+        }
+
+        if (thermalActive) {
+            notSupportedErrorStream << "\n"
+                                    << "combining twophase and energy conservation is not supported by the multiplexed simulator\n";
+            std::cerr << notSupportedErrorStream.str() << std::endl;
+            std::abort();
+        }
+
+        if (oilActive && waterActive) {
+            if (myRank == 0)
+                std::cout << "Using oil-water mode" << std::endl;
+            Ewoms::ebosOilWaterSetDeck(deck.get(),
+                                       parseContext.get(),
+                                       errorGuard.get(),
+                                       externalSetupTimer.elapsed());
+            return Ewoms::ebosOilWaterMain(argc, argv);
+        }
+        else if (oilActive && gasActive) {
+            // run ebos_gasoil
+            if (myRank == 0)
+                std::cout << "Using gas-oil mode" << std::endl;
+            Ewoms::ebosGasOilSetDeck(deck.get(),
+                                     parseContext.get(),
+                                     errorGuard.get(),
+                                     externalSetupTimer.elapsed());
+            return Ewoms::ebosGasOilMain(argc, argv);
+        }
+        else if (waterActive && gasActive) {
+            notSupportedErrorStream << "\n"
+                                    << "water-gas simulations are currently unsupported\n";
+            std::cerr << notSupportedErrorStream.str() << std::endl;
+            std::abort();
+        }
+    }
+    else if (polymerActive) {
+        if (solventActive) {
+            notSupportedErrorStream << "\n"
+                                    << "combining polymer and solvent is not supported by the multiplexed simulator\n";
+            std::cerr << notSupportedErrorStream.str() << std::endl;
+            std::abort();
+        }
+
+        if (thermalActive) {
+            notSupportedErrorStream << "\n"
+                                    << "combining polymer and and energy conservation is not supported by the multiplexed simulator\n";
+            std::cerr << notSupportedErrorStream.str() << std::endl;
+            std::abort();
+        }
+
+        // run ebos_polymer
+        if (myRank == 0)
+            std::cout << "Using polymer mode" << std::endl;
+        Ewoms::ebosPolymerSetDeck(deck.get(),
+                                  parseContext.get(),
+                                  errorGuard.get(),
+                                  externalSetupTimer.elapsed());
+        return Ewoms::ebosPolymerMain(argc, argv);
+    }
+    else if (solventActive) {
+        if (polymerActive) {
+            notSupportedErrorStream << "\n"
+                                    << "combining polymer and solvent is not supported\n";
+            std::cerr << notSupportedErrorStream.str() << std::endl;
+            std::abort();
+        }
+
+        if (thermalActive) {
+            notSupportedErrorStream << "\n"
+                                    << "combining polymer and and energy conservation is not supported\n";
+            std::cerr << notSupportedErrorStream.str() << std::endl;
+            std::abort();
+        }
+
+        // run ebos_solvent
+        if (myRank == 0)
+            std::cout << "Using solvent mode" << std::endl;
+        Ewoms::ebosSolventSetDeck(deck.get(),
+                                  parseContext.get(),
+                                  errorGuard.get(),
+                                  externalSetupTimer.elapsed());
+        return Ewoms::ebosSolventMain(argc, argv);
+    }
+    else if (thermalActive) {
+        if (solventActive) {
+            notSupportedErrorStream << "\n"
+                                    << "combining thermal and solvent is not supported by the multiplexed simulator\n";
+            std::cerr << notSupportedErrorStream.str() << std::endl;
+            std::abort();
+        }
+
+        if (polymerActive) {
+            notSupportedErrorStream << "\n"
+                                    << "combining thermal and polymer is not supported by the multiplexed simulator\n";
+            std::cerr << notSupportedErrorStream.str() << std::endl;
+            std::abort();
+        }
+
+        // run ebos_thermal
+        if (myRank == 0)
+            std::cout << "Using thermal mode" << std::endl;
+        Ewoms::ebosThermalSetDeck(deck.get(),
+                                  parseContext.get(),
+                                  errorGuard.get(),
+                                  externalSetupTimer.elapsed());
+        return Ewoms::ebosThermalMain(argc, argv);
+    }
+    else {
+        if (myRank == 0)
+            std::cout << "Using blackoil mode" << std::endl;
+        Ewoms::ebosBlackOilSetDeck(deck.get(),
+                                   parseContext.get(),
+                                   errorGuard.get(),
+                                   externalSetupTimer.elapsed());
+        return Ewoms::ebosBlackOilMain(argc, argv);
+    }
+
+    if (myRank == 0)
+        // this is supposed to be unreachable. this should not happen!
+        std::cerr << "Oops: something went wrong when deciding which simulator ought to be used" << std::endl;
+    std::abort();
+
+    return 0;
+}

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -40,7 +40,8 @@ void flowEbosBlackoilSetDeck(double setupTime, Deck &deck, EclipseState& eclStat
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(&deck, &eclState);
+    Vanguard::setExternalDeck(&deck);
+    Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);
 }

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -42,7 +42,8 @@ void flowEbosEnergySetDeck(double setupTime, Deck &deck, EclipseState& eclState,
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(&deck, &eclState);
+    Vanguard::setExternalDeck(&deck);
+    Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);
 }

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -64,7 +64,8 @@ void flowEbosGasOilSetDeck(double setupTime, Deck &deck, EclipseState& eclState,
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(&deck, &eclState);
+    Vanguard::setExternalDeck(&deck);
+    Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);
 }

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -64,7 +64,8 @@ void flowEbosOilWaterSetDeck(double setupTime, Deck &deck, EclipseState& eclStat
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(&deck, &eclState);
+    Vanguard::setExternalDeck(&deck);
+    Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);
 }

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -65,7 +65,8 @@ void flowEbosOilWaterPolymerSetDeck(double setupTime, Deck& deck, EclipseState& 
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(&deck, &eclState);
+    Vanguard::setExternalDeck(&deck);
+    Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);
 }

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -42,7 +42,8 @@ void flowEbosPolymerSetDeck(double setupTime, Deck &deck, EclipseState& eclState
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(&deck, &eclState);
+    Vanguard::setExternalDeck(&deck);
+    Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);
 }

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -42,7 +42,8 @@ void flowEbosSolventSetDeck(double setupTime, Deck &deck, EclipseState& eclState
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(&deck, &eclState);
+    Vanguard::setExternalDeck(&deck);
+    Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);
 }

--- a/flow/flow_tag.hpp
+++ b/flow/flow_tag.hpp
@@ -62,7 +62,8 @@ namespace Opm {
   void flowEbosSetDeck(Deck &deck, EclipseState& eclState)
   {
     typedef typename GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
-    Vanguard::setExternalDeck(&deck, &eclState);
+    Vanguard::setExternalDeck(&deck);
+    Vanguard::setExternalEclState(&eclState);
   }
   
 // ----------------- Main program -----------------


### PR DESCRIPTION
`mebos` works similarly as `flow`, but in contrast to `flow`, `mebos` only creates the deck in the common code path whilst the 'EclipseState' and the other higher-level parser objects are always created internally by the vanguard. this approach avoids code duplication and the worst effects of parser API creep.

to avoid having to compile non-trivial compile units multiple times, the actual code of the variants is moved into `ebos_$VARIANT.{hh,cc}` files and the respective compile units are each put into a small static library whilst the main function of said libraries are invoked by either the multiplexed or the respective specialized simulator's `main()`. This is also somewhat similar of how `flow` works, with the difference that `mebos` uses the blackoil variant to determine the parameters it needs to know for parsing the deck instead of introducing a "fake" type tag for this. The rationale is to reduce compile time compared to the "fake type tag" approach and -- to a lesser extend -- avoid unnecessary copy-and-pasting of code. In particular, this means that for the vast majority of cases, only one place needs changed in the code for all `ebos` variants if, for example, the parser API requires further objects in the future.