### PR TITLE
[WIP] support GOR limit for WECON

### DIFF
--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -373,6 +373,9 @@ namespace Opm
         RatioCheckTuple checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
                                               const WellState& well_state) const;
 
+        RatioCheckTuple checkMaxGORLimit(const WellEconProductionLimits& econ_production_limits,
+                                         const WellState& well_state) const;
+
         RatioCheckTuple checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
                                              const WellState& well_state,
                                              Opm::DeferredLogger& deferred_logger) const;


### PR DESCRIPTION
It is trivial and basically a copy from the water cut limit. 

If we are about to add more ratio limit checking, we need to refactor the ratio checking to reduce the duplication of the code. And we should move it  to a helper class/file instead of keeping it in WellInterface. 

It is not tested yet. 