### PR TITLE
Flow: Verify Consistent Array Dimensions

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -46,6 +46,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -207,6 +208,8 @@ int main(int argc, char** argv)
             eclipseState.reset( new Opm::EclipseState(*deck, parseContext, errorGuard ));
             schedule.reset(new Opm::Schedule(*deck, *eclipseState, parseContext, errorGuard));
             summaryConfig.reset( new Opm::SummaryConfig(*deck, *schedule, eclipseState->getTableManager(), parseContext, errorGuard));
+
+            Opm::checkConsistentArrayDimensions(*eclipseState, *schedule, parseContext, errorGuard);
 
             if (errorGuard) {
                 errorGuard.dump();


### PR DESCRIPTION
The output code used to have an unfriendly error mode in which we would unceremoniously crash&mdash;without writing any data&mdash;if some declared array dimensions from RUNSPEC weren't big enough to hold all the dynamic objects (wells, groups, connections &c).

Since commit OPM/opm-common@7986e99e (PR OPM/opm-common#640) we've had an extension that sizes the output tables according to the maximum of the active number of entities (e.g., number of connections, groups, wells, wells per group) and the declared maximums in RUNSPEC keyword WELLDIMS.  On the other hand if the active number of entities exceeds the declared maximums, then the output files won't be compatible with ECLIPSE, and users with access to ECLIPSE won't be able to restart an ECLIPSE run from an OPM base run.

This PR performs an array dimension check before starting the simulation.  The check verifies that the declared dimensions are indeed big enough for the current simulation run before starting the actual simulation run.  This, in turn, ensures that we don't waste a lot of computational effort in creating strictly ECLIPSE compatible restart files if, for instance, the first output is very close to the end of the simulation and the active array sizes exceed the declared maximums.