### PR TITLE
Adding time and date to time step report

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -219,8 +219,13 @@ namespace Opm {
                 const double dt = substepTimer.currentStepLength() ;
                 if (timestepVerbose_) {
                     std::ostringstream ss;
+                    boost::posix_time::time_facet* facet = new boost::posix_time::time_facet("%d-%b-%Y");
+                    ss.imbue(std::locale(std::locale::classic(), facet));
                     ss <<"\nTime step " << substepTimer.currentStepNum() << ", stepsize "
-                       << unit::convert::to(substepTimer.currentStepLength(), unit::day) << " days.";
+                       << unit::convert::to(substepTimer.currentStepLength(), unit::day) << " days,"
+                       << " at day " << (double)unit::convert::to(substepTimer.simulationTimeElapsed(), unit::day)
+                       << "/" << (double)unit::convert::to(substepTimer.totalTime(), unit::day)
+                       << ", date = " << substepTimer.currentDateTime();
                     OpmLog::info(ss.str());
                 }
 


### PR DESCRIPTION
When there are multiple time steps between two report steps, it can be difficult to see where in the total simulation time a time step is. Hence, there has been user request for the time steps to include the same day and date information found in report steps. This PR provides that.