### PR TITLE
Moved well test messages from debug to log and prt

### DIFF
--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2881,7 +2881,7 @@ namespace Opm
                         WellState& well_state, WellTestState& welltest_state,
                         Opm::DeferredLogger& deferred_logger)
     {
-        deferred_logger.debug(" well " + name() + " is being tested for physical limits");
+        deferred_logger.info(" well " + name() + " is being tested for physical limits");
 
         // some most difficult things are the explicit quantities, since there is no information
         // in the WellState to do a decent initialization

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -950,7 +950,7 @@ namespace Opm
                         const double simulation_time, const int report_step,
                         const WellState& well_state, WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger)
     {
-        deferred_logger.debug(" well " + name() + " is being tested for economic limits");
+        deferred_logger.info(" well " + name() + " is being tested for economic limits");
 
         WellState well_state_copy = well_state;
 


### PR DESCRIPTION
Two important wtest messages was only visible in the DBG-file. With this pull request they are now also shown in the terminal/LOG and in the PRT file.