### PR TITLE
Fixing completion water cut checking for WTEST and some related refactoring

### DIFF
--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -323,13 +323,13 @@ namespace Opm
         /*
          *  completions_ contains the mapping from completion id to connection indices
          *  {
-         *      2 : [ConnectionIndex, ConnectioniIndex],
-         *      1 : [ConnectionIndex, ConnectionIndex, ConnectoniIndex],
+         *      2 : [ConnectionIndex, ConnectionIndex],
+         *      1 : [ConnectionIndex, ConnectionIndex, ConnectionIndex],
          *      5 : [ConnectionIndex],
          *      7 : [ConnectionIndex]
          *      ...
          *   }
-         *   The integer ID's correspond to the COMPLETION id given by the COMPLUMP keyword.
+         *   The integer IDs correspond to the COMPLETION id given by the COMPLUMP keyword.
          *   When there is no COMPLUMP keyword used, a default completion number will be assigned
          *   based on the order of the declaration of the connections
          */
@@ -392,9 +392,15 @@ namespace Opm
                                              const WellState& well_state,
                                              Opm::DeferredLogger& deferred_logger) const;
 
-        bool checkMaxRatioLimitWell(const std::vector<double>& well_rates,
+        bool checkMaxRatioLimitWell(const WellState& well_state,
                                     const double max_ratio_limit,
                                     double (*ratioFunc)(const std::vector<double>&, const PhaseUsage&) ) const;
+
+        void checkMaxRatioLimitCompletions(const WellState& well_state,
+                                           const double max_ratio_limit,
+                                           double (*ratioFunc)(const std::vector<double>&, const PhaseUsage&),
+                                           int& worst_offending_completion,
+                                           double& violation_extent) const;
 
         double scalingFactor(const int comp_idx) const;
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -392,13 +392,15 @@ namespace Opm
                                              const WellState& well_state,
                                              Opm::DeferredLogger& deferred_logger) const;
 
+        template <typename RatioFunc>
         bool checkMaxRatioLimitWell(const WellState& well_state,
                                     const double max_ratio_limit,
-                                    double (*ratioFunc)(const std::vector<double>&, const PhaseUsage&) ) const;
+                                    const RatioFunc& ratioFunc) const;
 
+        template <typename RatioFunc>
         void checkMaxRatioLimitCompletions(const WellState& well_state,
                                            const double max_ratio_limit,
-                                           double (*ratioFunc)(const std::vector<double>&, const PhaseUsage&),
+                                           const RatioFunc& ratioFunc,
                                            int& worst_offending_completion,
                                            double& violation_extent) const;
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -320,6 +320,21 @@ namespace Opm
         // well bore diameter
         std::vector<double> bore_diameters_;
 
+        /*
+         *  completions_ contains the mapping from completion id to connection indices
+         *  {
+         *      2 : [ConnectionIndex, ConnectioniIndex],
+         *      1 : [ConnectionIndex, ConnectionIndex, ConnectoniIndex],
+         *      5 : [ConnectionIndex],
+         *      7 : [ConnectionIndex]
+         *      ...
+         *   }
+         *   The integer ID's correspond to the COMPLETION id given by the COMPLUMP keyword.
+         *   When there is no COMPLUMP keyword used, a default completion number will be assigned
+         *   based on the order of the declaration of the connections
+         */
+        std::map<int, std::vector<int>> completions_;
+
         const PhaseUsage* phase_usage_;
 
         bool getAllowCrossFlow() const;
@@ -416,6 +431,8 @@ namespace Opm
                                        Opm::DeferredLogger& deferred_logger);
 
         void scaleProductivityIndex(const int perfIdx, double& productivity_index, const bool new_well, Opm::DeferredLogger& deferred_logger);
+
+        void initCompletions();
 
         // count the number of times an output log message is created in the productivity
         // index calculations

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -392,6 +392,10 @@ namespace Opm
                                              const WellState& well_state,
                                              Opm::DeferredLogger& deferred_logger) const;
 
+        bool checkMaxRatioLimitWell(const std::vector<double>& well_rates,
+                                    const double max_ratio_limit,
+                                    double (*ratioFunc)(const std::vector<double>&, const PhaseUsage&) ) const;
+
         double scalingFactor(const int comp_idx) const;
 
         // whether a well is specified with a non-zero and valid VFP table number

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -706,11 +706,12 @@ namespace Opm
 
 
     template<typename TypeTag>
+    template<typename RatioFunc>
     bool
     WellInterface<TypeTag>::
     checkMaxRatioLimitWell(const WellState& well_state,
                            const double max_ratio_limit,
-                           double (*ratioFunc)(const std::vector<double>&, const PhaseUsage&)) const
+                           const RatioFunc& ratioFunc) const
     {
         const int np = number_of_phases_;
 
@@ -729,11 +730,12 @@ namespace Opm
 
 
     template<typename TypeTag>
+    template<typename RatioFunc>
     void
     WellInterface<TypeTag>::
     checkMaxRatioLimitCompletions(const WellState& well_state,
                                   const double max_ratio_limit,
-                                  double (*ratioFunc)(const std::vector<double>&, const PhaseUsage&),
+                                  const RatioFunc& ratioFunc,
                                   int& worst_offending_completion,
                                   double& violation_extent) const
     {

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -100,6 +100,9 @@ namespace Opm
                       saturation_table_number_.begin() );
         }
 
+        // initialization of the completions mapping
+        initCompletions();
+
         well_efficiency_factor_ = 1.0;
 
         connectionRates_.resize(number_of_perforations_);
@@ -132,6 +135,28 @@ namespace Opm
         phase_usage_ = phase_usage_arg;
         gravity_ = gravity_arg;
     }
+
+
+
+
+
+    template<typename TypeTag>
+    void
+    WellInterface<TypeTag>::
+    initCompletions()
+    {
+        assert(completions_.empty() );
+
+        const WellConnections& connections = well_ecl_.getConnections();
+        const int num_conns = connections.size();
+
+        assert(num_conns == number_of_perforations_);
+
+        for (int c = 0; c < num_conns; c++) {
+            completions_[connections[c].complnum()].push_back(c);
+        }
+    }
+
 
 
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -608,77 +608,71 @@ namespace Opm
     checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
                           const WellState& well_state) const
     {
-        bool water_cut_limit_violated = false;
-        int worst_offending_completion = INVALIDCOMPLETION;
-        double violation_extent = -1.0;
-
-        const int np = number_of_phases_;
-        const Opm::PhaseUsage& pu = phaseUsage();
-        const int well_number = index_of_well_;
 
         assert(FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx));
         assert(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx));
 
-        const double oil_rate = well_state.wellRates()[well_number * np + pu.phase_pos[ Oil ] ];
-        const double water_rate = well_state.wellRates()[well_number * np + pu.phase_pos[ Water ] ];
-        const double liquid_rate = oil_rate + water_rate;
-        double water_cut;
-        if (std::abs(liquid_rate) != 0.) {
-            water_cut = water_rate / liquid_rate;
-        } else {
-            water_cut = 0.0;
-        }
+        auto waterCut = [](const double oil_rate, const double water_rate) {
+
+            // both rate should be in the same direction
+            assert(oil_rate * water_rate >= 0.);
+
+            const double liquid_rate = oil_rate + water_rate;
+            if (liquid_rate != 0.) {
+                return (water_rate / liquid_rate);
+            } else {
+                return 0.;
+            }
+        };
+
+        const int np = number_of_phases_;
+        const Opm::PhaseUsage& pu = phaseUsage();
+
+        const double oil_rate = well_state.wellRates()[index_of_well_ * np + pu.phase_pos[ Oil ] ];
+        const double water_rate = well_state.wellRates()[index_of_well_ * np + pu.phase_pos[ Water ] ];
+        const double water_cut = waterCut(oil_rate, water_rate);
 
         const double max_water_cut_limit = econ_production_limits.maxWaterCut();
-        if (water_cut > max_water_cut_limit) {
-            water_cut_limit_violated = true;
-        }
+        assert(max_water_cut_limit != 0.);
+
+        const bool water_cut_limit_violated = (water_cut > max_water_cut_limit);
+
+        int worst_offending_completion = INVALIDCOMPLETION;
+        double violation_extent = -1.0;
 
         if (water_cut_limit_violated) {
-            // need to handle the worst_offending_connection
-            const int perf_start = first_perf_;
-            const int perf_number = number_of_perforations_;
+            // the maximum water cut value of the completions
+            double max_water_cut_completion = 0.;
 
-            std::vector<double> water_cut_perf(perf_number);
-            for (int perf = 0; perf < perf_number; ++perf) {
-                const int i_perf = perf_start + perf;
-                const double oil_perf_rate = well_state.perfPhaseRates()[i_perf * np + pu.phase_pos[ Oil ] ];
-                const double water_perf_rate = well_state.perfPhaseRates()[i_perf * np + pu.phase_pos[ Water ] ];
-                const double liquid_perf_rate = oil_perf_rate + water_perf_rate;
-                if (std::abs(liquid_perf_rate) != 0.) {
-                    water_cut_perf[perf] = water_perf_rate / liquid_perf_rate;
-                } else {
-                    water_cut_perf[perf] = 0.;
+            // look for the worst_offending_completion
+            for (const auto& completion : completions_) {
+
+                double oil_completion_rate = 0.;
+                double water_completion_rate = 0.;
+
+                const std::vector<int>& conns = completion.second;
+                for(const int c : conns) {
+                    const int index_con = c + first_perf_;
+
+                    const double oil_connection_rate = well_state.perfPhaseRates()[index_con * np + pu.phase_pos[ Oil ] ];
+                    oil_completion_rate += oil_connection_rate;
+
+                    const double water_connection_rate = well_state.perfPhaseRates()[index_con * np + pu.phase_pos[ Water ] ];
+                    water_completion_rate += water_connection_rate;
                 }
-            }
-            const auto& completions = well_ecl_.getCompletions();
-            const auto& connections = well_ecl_.getConnections();
 
-            int complnumIdx = 0;
-            std::vector<double> water_cut_in_completions(completions.size(), 0.0);
-            for (const auto& completion : completions) {
-                int complnum = completion.first;
-                for (int perf = 0; perf < perf_number; ++perf) {
-                    if (complnum == connections.get ( perf ).complnum()) {
-                        water_cut_in_completions[complnumIdx] +=  water_cut_perf[perf];
-                    }
-                }
-                complnumIdx++;
-            }
+                const double water_cut_completion = waterCut(oil_completion_rate, water_completion_rate);
 
-            double max_water_cut_perf = 0.;
-            complnumIdx = 0;
-            for (const auto& completion : completions) {
-                if (water_cut_in_completions[complnumIdx] > max_water_cut_perf) {
+                if (water_cut_completion > max_water_cut_completion) {
                     worst_offending_completion = completion.first;
-                    max_water_cut_perf = water_cut_in_completions[complnumIdx];
+                    max_water_cut_completion = water_cut_completion;
                 }
-                complnumIdx++;
-            }
+            } // end of for (const auto& completion : completions_)
 
-            assert(max_water_cut_limit != 0.);
+            assert(max_water_cut_completion >= max_water_cut_limit);
             assert(worst_offending_completion != INVALIDCOMPLETION);
-            violation_extent = max_water_cut_perf / max_water_cut_limit;
+
+            violation_extent = max_water_cut_completion / max_water_cut_limit;
         }
 
         return std::make_tuple(water_cut_limit_violated, worst_offending_completion, violation_extent);


### PR DESCRIPTION
Mostly addressing two issues was discovered when developing https://github.com/OPM/opm-simulators/pull/1882 . 

One is related to performance related to completions.  The other one is related to the calculation of completion water cut based on the rates of each connections.  And an function is introduced to reduce the duplicated code when calculating the water cut. 

We begin to use connection instead of perforation with this PR. Connection will be the more proper name numerically. 


fixing here refer to the comment https://github.com/OPM/opm-simulators/pull/1882/files#r292866208