### PR TITLE
Notify user that we are aborting because of unused keywords.

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -234,6 +234,20 @@ namespace Opm
 #endif
                 if ( unknownKeyWords )
                 {
+                    if ( output_cout_ )
+                    {
+                        std::string msg = "Aborting simulation due unknown "
+                            "parameters. Please query \"flow --help\" for "
+                            "supported command line parameters.";
+                        if (OpmLog::hasBackend("STREAMLOG"))
+                        {
+                            OpmLog::error(msg);
+                        }
+                        else {
+                              std::cerr << msg << std::endl;
+                        }
+                    }
+
 #if HAVE_MPI
                     MPI_Finalize();
 #endif


### PR DESCRIPTION
Now prints an error message in this case:
```
../../opm-simulators/opm-parallel/bin/flow  --outputsir=bla SPE1CASE2.D
**********************************************************************
*                                                                    *
*                      This is flow 2019.10-pre                      *
*                                                                    *
* Flow is a simulator for fully implicit three-phase black-oil flow, *
*             including solvent and polymer capabilities.            *
*          For more information, see https://opm-project.org         *
*                                                                    *
**********************************************************************

Reading deck file 'SPE1CASE2.DATA'
# [unused run-time specified parameters]
Outputsir="bla"

Error: Aborting simulation due unknown parameters. Please query "flow --help" for supported command line parameters.
```

Closes #1885 