### PR TITLE
NNC sorter test: include config.h

### DIFF
--- a/tests/test_nncsorter.cpp
+++ b/tests/test_nncsorter.cpp
@@ -17,6 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
+
 #define BOOST_TEST_MODULE NNCSortTest
 #include <boost/test/unit_test.hpp>
 #include <ebos/nncsorter.hpp>


### PR DESCRIPTION
This caused some issues on my machine and it is supposed to be done by any compile unit anyway.