### PR TITLE
Improve time integration

### DIFF
--- a/ebos/ebos.hh
+++ b/ebos/ebos.hh
@@ -99,6 +99,12 @@ SET_INT_PROP(EbosTypeTag, EclNewtonStrictIterations, 100);
 // relatively often)
 SET_INT_PROP(EbosTypeTag, NewtonMaxIterations, 8);
 
+// if openMP is available, set the default the number of threads per process for the main
+// simulation to 2 (instead of grabbing everything that is available).
+#if _OPENMP
+SET_INT_PROP(EbosTypeTag, ThreadsPerProcess, 2);
+#endif
+
 END_PROPERTIES
 
 namespace Ewoms {

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -140,7 +140,6 @@ namespace Opm
 
             EWOMS_HIDE_PARAM(TypeTag, EclMaxTimeStepSizeAfterWellEvent);
             EWOMS_HIDE_PARAM(TypeTag, EclRestartShrinkFactor);
-            EWOMS_HIDE_PARAM(TypeTag, EclMaxFails);
             EWOMS_HIDE_PARAM(TypeTag, EclEnableTuning);
 
             // flow also does not use the eWoms Newton method


### PR DESCRIPTION
Together with OPM/ewoms#522, this improves the time integration code of `EclProblem`. This piece of code caused problems when I was using `ebos` for one of the confidential decks I need to work with when tuning was enabled and the minimum time step size was undercut. Since `flow` rolls its own time stepping code, it is almost certainly unaffected.

@totto82: It would be good if you could ensure that the confidential cases which I recently lost access to do not regress with tuning enabled. (I still expect the majority of them to be faster without tuning, but if tuning is enabled, `ebos` with these patches ought not to be slower than on the current master.)