### PR TITLE
considering not OPEN connection when updateCompletions in WellInterface.

### DIFF
--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -331,7 +331,9 @@ namespace Opm
          *   }
          *   The integer IDs correspond to the COMPLETION id given by the COMPLUMP keyword.
          *   When there is no COMPLUMP keyword used, a default completion number will be assigned
-         *   based on the order of the declaration of the connections
+         *   based on the order of the declaration of the connections.
+         *   Since the connections not OPEN is not included in the Wells, so they will not be considered
+         *   in this mapping relation.
          */
         std::map<int, std::vector<int>> completions_;
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -150,11 +150,13 @@ namespace Opm
         const WellConnections& connections = well_ecl_.getConnections();
         const int num_conns = connections.size();
 
-        assert(num_conns == number_of_perforations_);
-
-        for (int c = 0; c < num_conns; c++) {
-            completions_[connections[c].complnum()].push_back(c);
+        int num_active_connections = 0;
+        for (int c = 0; c < num_conns; ++c) {
+            if (connections[c].state() == WellCompletion::OPEN) {
+                completions_[connections[c].complnum()].push_back(num_active_connections++);
+            }
         }
+        assert(num_active_connections == number_of_perforations_);
     }
 
 


### PR DESCRIPTION
The PR https://github.com/OPM/opm-simulators/pull/1898 broke the running of Norne, probably many other big cases that have not-OPEN connections. 

Thanks @bska to report the problem. The original assert did reveal the wrong assumption of the programming. 