### PR TITLE
adapting to the upstream change

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -176,7 +176,7 @@ namespace Opm {
         for (const auto& well : well_container_) {
             if (well->name() == wellname) {
                 if (well->underPredictionMode(local_deferredLogger)) {
-                    wellTestState_.addClosedWell(wellname, WellTestConfig::Reason::PHYSICAL, simulation_time);
+                    wellTestState_.closeWell(wellname, WellTestConfig::Reason::PHYSICAL, simulation_time);
                     well_was_shut = 1;
                 }
                 break;
@@ -549,7 +549,7 @@ namespace Opm {
 
                 if (allow_closing_opening_wells) {
                     // A new WCON keywords can re-open a well that was closed/shut due to Physical limit
-                    if ( wellTestState_.hasWell(well_name, WellTestConfig::Reason::PHYSICAL ) ) {
+                    if ( wellTestState_.hasWellClosed(well_name, WellTestConfig::Reason::PHYSICAL ) ) {
                         // TODO: more checking here, to make sure this standard more specific and complete
                         // maybe there is some WCON keywords will not open the well
                         if (well_state_.effectiveEventsOccurred(w)) {
@@ -560,7 +560,7 @@ namespace Opm {
                                 // even if it was new or received new targets this report step.
                                 well_state_.setEffectiveEventsOccurred(w, false);
                             } else {
-                                wellTestState_.openWell(well_name);
+                                wellTestState_.openWell(well_name, WellTestConfig::Reason::PHYSICAL);
                             }
                         }
                     }
@@ -568,8 +568,8 @@ namespace Opm {
 
                     // TODO: should we do this for all kinds of closing reasons?
                     // something like wellTestState_.hasWell(well_name)?
-                    if ( wellTestState_.hasWell(well_name, WellTestConfig::Reason::ECONOMIC) ||
-                         wellTestState_.hasWell(well_name, WellTestConfig::Reason::PHYSICAL) ) {
+                    if ( wellTestState_.hasWellClosed(well_name, WellTestConfig::Reason::ECONOMIC) ||
+                         wellTestState_.hasWellClosed(well_name, WellTestConfig::Reason::PHYSICAL) ) {
                         if( well_ecl.getAutomaticShutIn() ) {
                             // shut wells are not added to the well container
                             // TODO: make a function from well_state side to handle the following

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2920,7 +2920,7 @@ namespace Opm
         }
 
         if (this->isOperable() ) {
-            welltest_state.openWell(name() );
+            welltest_state.openWell(name(), WellTestConfig::PHYSICAL );
             const std::string msg = " well " + name() + " is re-opened through well testing for physical reason";
             deferred_logger.info(msg);
             well_state = well_state_copy;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -826,7 +826,7 @@ namespace Opm
                                 Opm::DeferredLogger& deferred_logger) const
     {
         if (!isOperable()) {
-            well_test_state.addClosedWell(name(), WellTestConfig::Reason::PHYSICAL, simulation_time);
+            well_test_state.closeWell(name(), WellTestConfig::Reason::PHYSICAL, simulation_time);
             if (write_message_to_opmlog) {
                 // TODO: considering auto shut in?
                 const std::string msg = "well " + name()
@@ -886,7 +886,7 @@ namespace Opm
                 deferred_logger.warning("NOT_SUPPORTING_FOLLOWONWELL", "opening following on well after well closed is not supported yet");
             }
 
-            well_test_state.addClosedWell(name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
+            well_test_state.closeWell(name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
             if (write_message_to_opmlog) {
                 if (well_ecl_.getAutomaticShutIn()) {
                     const std::string msg = std::string("well ") + name() + std::string(" will be shut due to rate economic limit");
@@ -938,7 +938,7 @@ namespace Opm
                     }
 
                     if (allCompletionsClosed) {
-                        well_test_state.addClosedWell(name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
+                        well_test_state.closeWell(name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
                         if (write_message_to_opmlog) {
                             if (well_ecl_.getAutomaticShutIn()) {
                                 const std::string msg = name() + std::string(" will be shut due to last completion closed");
@@ -953,10 +953,10 @@ namespace Opm
                 }
                 case WellEcon::WELL:
                 {
-                well_test_state.addClosedWell(name(), WellTestConfig::Reason::ECONOMIC, 0);
+                well_test_state.closeWell(name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
                 if (write_message_to_opmlog) {
                     if (well_ecl_.getAutomaticShutIn()) {
-                        // tell the controll that the well is closed
+                        // tell the control that the well is closed
                         const std::string msg = name() + std::string(" will be shut due to ratio economic limit");
                         deferred_logger.info(msg);
                     } else {
@@ -1044,9 +1044,9 @@ namespace Opm
         }
 
         // update wellTestState if the well test succeeds
-        if (!welltest_state_temp.hasWell(name(), WellTestConfig::Reason::ECONOMIC)) {
-            welltest_state.openWell(name());
-            const std::string msg = std::string("well ") + name() + std::string(" is re-opened");
+        if (!welltest_state_temp.hasWellClosed(name(), WellTestConfig::Reason::ECONOMIC)) {
+            welltest_state.openWell(name(), WellTestConfig::Reason::ECONOMIC);
+            const std::string msg = std::string("well ") + name() + std::string(" is re-opened through ECONOMIC testing");
             deferred_logger.info(msg);
 
             // also reopen completions


### PR DESCRIPTION
it adapts the code following https://github.com/OPM/opm-common/pull/854 . 

And a small bug fix.  It should be `sim_time` while the original code is `0`. 