### PR TITLE
mebos, flow: adapt to the eWoms changes in handling unknown parameters

### DIFF
--- a/ebos/ebos_blackoil.cc
+++ b/ebos/ebos_blackoil.cc
@@ -38,7 +38,11 @@ bool ebosBlackOilDeckFileNameIsSet(int argc, char** argv)
     // use the ewoms parameter machinery and the blackoil vanguard to handle the grunt of
     // the work
     EWOMS_RESET_PARAMS_(ProblemTypeTag);
-    Ewoms::setupParameters_<ProblemTypeTag>(argc, const_cast<const char**>(argv), /*doRegistration=*/true);
+    Ewoms::setupParameters_<ProblemTypeTag>(argc,
+                                            const_cast<const char**>(argv),
+                                            /*doRegistration=*/true,
+                                            /*allowUnused=*/true,
+                                            /*handleHelp=*/false);
     bool result = EWOMS_PARAM_IS_SET(ProblemTypeTag, std::string, EclDeckFileName);
     EWOMS_RESET_PARAMS_(ProblemTypeTag);
 
@@ -53,7 +57,11 @@ std::string ebosBlackOilGetDeckFileName(int argc, char** argv)
     // use the ewoms parameter machinery and the blackoil vanguard to handle the grunt of
     // the work
     EWOMS_RESET_PARAMS_(ProblemTypeTag);
-    Ewoms::setupParameters_<ProblemTypeTag>(argc, const_cast<const char**>(argv), /*doRegistration=*/true);
+    Ewoms::setupParameters_<ProblemTypeTag>(argc,
+                                            const_cast<const char**>(argv),
+                                            /*doRegistration=*/true,
+                                            /*allowUnused=*/true,
+                                            /*handleHelp=*/false);
     std::string rawDeckFileName = EWOMS_GET_PARAM(ProblemTypeTag, std::string, EclDeckFileName);
     std::string result = Vanguard::canonicalDeckPath(rawDeckFileName).string();
     EWOMS_RESET_PARAMS_(ProblemTypeTag);
@@ -69,7 +77,11 @@ std::unique_ptr<Opm::ParseContext> ebosBlackOilCreateParseContext(int argc, char
     // use the ewoms parameter machinery and the blackoil vanguard to handle the grunt of
     // the work
     EWOMS_RESET_PARAMS_(ProblemTypeTag);
-    Ewoms::setupParameters_<ProblemTypeTag>(argc, const_cast<const char**>(argv), /*doRegistration=*/true);
+    Ewoms::setupParameters_<ProblemTypeTag>(argc,
+                                            const_cast<const char**>(argv),
+                                            /*doRegistration=*/true,
+                                            /*allowUnused=*/true,
+                                            /*handleHelp=*/false);
     std::unique_ptr<Opm::ParseContext> result = Vanguard::createParseContext();
     EWOMS_RESET_PARAMS_(ProblemTypeTag);
 

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -163,7 +163,7 @@ namespace Opm
             EWOMS_END_PARAM_REGISTRATION(TypeTag);
 
             // read in the command line parameters
-            int status = Ewoms::setupParameters_<TypeTag>(argc, const_cast<const char**>(argv), false, true, true);
+            int status = Ewoms::setupParameters_<TypeTag>(argc, const_cast<const char**>(argv), /*doRegistration=*/false, /*allowUnused=*/true, /*handleHelp=*/true);
             if (status == 0) {
                 // deal with --print-properties and --print-parameters
 

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -163,7 +163,7 @@ namespace Opm
             EWOMS_END_PARAM_REGISTRATION(TypeTag);
 
             // read in the command line parameters
-            int status = Ewoms::setupParameters_<TypeTag>(argc, const_cast<const char**>(argv), /*doRegistration=*/false);
+            int status = Ewoms::setupParameters_<TypeTag>(argc, const_cast<const char**>(argv), false, true, true);
             if (status == 0) {
                 // deal with --print-properties and --print-parameters
 


### PR DESCRIPTION
this is the downstream for OPM/ewoms#524. With this patch, there's no change at all for `flow` compared to the current behavior, `ebos` and its variants will complain when it encounters unused parameters and the `--help` handling is correct for `mebos`.