### PR TITLE
Format Specifier '%p' Requires Pointers to Void

### DIFF
--- a/opm/core/wells/well_controls.c
+++ b/opm/core/wells/well_controls.c
@@ -412,7 +412,9 @@ well_controls_equal(const struct WellControls *ctrls1, const struct WellControls
 
     if (!ctrls1 || !ctrls2) {
         if (verbose)
-            printf("ctrls1 %p or cntrls2 %p is NULL\n", ctrls2, ctrls2);
+            printf("ctrls1 %p or cntrls2 %p is NULL\n",
+                   (void*) ctrls1, (void*) ctrls2);
+
         return false;
     }
 


### PR DESCRIPTION
While here, also print both `ctrls1` and `ctrls2` instead of printing `ctrls2` twice.