### PR TITLE
ebos: by default, do not abort the simulation as quickly

### DIFF
--- a/ebos/ebos.hh
+++ b/ebos/ebos.hh
@@ -105,6 +105,10 @@ SET_INT_PROP(EbosTypeTag, NewtonMaxIterations, 8);
 SET_INT_PROP(EbosTypeTag, ThreadsPerProcess, 2);
 #endif
 
+// By default, ebos accepts the result of the time integration unconditionally if the
+// smallest time step size is reached.
+SET_BOOL_PROP(EbosTypeTag, ContinueOnConvergenceError, true);
+
 END_PROPERTIES
 
 namespace Ewoms {


### PR DESCRIPTION
this is the companion PR to OPM/ewoms#526. It flips the default behavior when encountering a failed time integration for the minimum time step size for `ebos`. as usual, `flow` is unaffected by OPM/ewoms#526 as well as by this.