### PR TITLE
Add UDQ_WCONPROD model to integration testing

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -304,6 +304,13 @@ add_test_compareECLFiles(CASENAME multregt_model2
                          REL_TOL ${rel_tol}
                          DIR model2)
 
+add_test_compareECLFiles(CASENAME udq_wconprod
+                         FILENAME UDQ_WCONPROD
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR udq_actionx)
+
 add_test_compareECLFiles(CASENAME multxyz_model2
 			  FILENAME 2_MULTXYZ_MODEL2
 			  SIMULATOR flow

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -64,6 +64,7 @@ tests[multiply_tranxyz_model2]="flow model2 8_MULTIPLY_TRANXYZ_MODEL2 multiply_t
 tests[editnnc_model2]="flow model2 9_EDITNNC_MODEL2 editnnc_model2"
 tests[polymer_injectivity]="flow polymer_injectivity 2D_POLYMER_INJECTIVITY"
 tests[nnc]="flow editnnc NNC_AND_EDITNNC nnc"
+tests[udq]="flow udq_actionx UDQ_WCONPROD"
 
 changed_tests=""
 for test_name in ${!tests[*]}


### PR DESCRIPTION
When https://github.com/OPM/opm-common/pull/870 is merged I consider the UDQ/UDA features sufficiently mature to enable integration testing. Some random plots shown below - more can be provided.

Although I am probably the most trigger happy self-merger around I will *not* push this one in - but I sincerely hope someone else will do!

PS: When this is in I might go and get really drunk - this has been a long haul.

![Figure_1](https://user-images.githubusercontent.com/1321665/60337517-916bf080-99a3-11e9-8304-0981f1353ab3.png)
![Figure_2](https://user-images.githubusercontent.com/1321665/60337519-916bf080-99a3-11e9-822d-bc79d33a4e41.png)
![Figure_3](https://user-images.githubusercontent.com/1321665/60337520-916bf080-99a3-11e9-9dd4-79c03b70f857.png)
![Figure_4](https://user-images.githubusercontent.com/1321665/60337521-92048700-99a3-11e9-9881-1c426007d5a5.png)
