### PR TITLE
fixed: check for existence of reference data paths

### DIFF
--- a/tests/run-init-regressionTest.sh
+++ b/tests/run-init-regressionTest.sh
@@ -23,6 +23,12 @@ cd ${RESULT_PATH}
 ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_PATH}
 cd ..
 
+if ! test -d ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}
+then
+  echo "Reference data does not exists"
+  exit 1
+fi
+
 ecode=0
 ${COMPARE_ECL_COMMAND} -t INIT ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]

--- a/tests/run-porv-acceptanceTest.sh
+++ b/tests/run-porv-acceptanceTest.sh
@@ -23,6 +23,11 @@ cd ${RESULT_PATH}
 ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_PATH}
 cd ..
 
+if ! test -d ${INPUT_DATA_PATH}/opm-porevolume-reference/${EXE_NAME}/
+then
+  echo "Reference data does not exists"
+  exit 1
+fi
 
 ecode=0
 ${COMPARE_ECL_COMMAND} -t INIT -k PORV ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-porevolume-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}

--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -29,6 +29,12 @@ then
     ignore_extra_kw="-x"
 fi
 
+if ! test -d ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}
+then
+  echo "Reference data does not exists"
+  exit 1
+fi
+
 echo "=== Executing comparison for EGRID, INIT, UNRST and RFT files if these exists in refrece folder ==="
 ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 if [ $? -ne 0 ]

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -17,11 +17,14 @@ copyToReferenceDir () {
   DIFF=1
   for filetype in $FILETYPES
   do
-    diff -q "$WORKSPACE/$SRC_DIR$STEM.$filetype" "$DST_DIR/$STEM.$filetype"
-    if test $? -ne 0
+    if [ -f $WORKSPACE/$SRC_DIR$STEM.$filetype ] || [ -f $DST_DIR/$STEM.$filetype ]
     then
-      cp "$WORKSPACE/$SRC_DIR$STEM.$filetype" $DST_DIR
-      DIFF=0
+      diff -q "$WORKSPACE/$SRC_DIR$STEM.$filetype" "$DST_DIR/$STEM.$filetype"
+      if test $? -ne 0
+      then
+        cp "$WORKSPACE/$SRC_DIR$STEM.$filetype" $DST_DIR
+        DIFF=0
+      fi
     fi
   done
 

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -32,8 +32,12 @@ copyToReferenceDir () {
 }
 
 declare -A tests
-# binary dirname casename [testname]
-# you only have to specify testname if it differs from dirname
+# The tests are listed in a dictionary mapping name of the test to the commands used to
+# run the test:
+#
+# tests[name in log message]="binary dirname casename [testname]"
+#
+# The fourth argument testname is optional and only required if it differs from the test name.
 tests[spe1]="flow spe1 SPE1CASE1"
 tests[spe12]="flow spe1 SPE1CASE2"
 tests[spe12p]="flow spe1 SPE1CASE2_2P spe1_2p"

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -64,7 +64,7 @@ tests[multiply_tranxyz_model2]="flow model2 8_MULTIPLY_TRANXYZ_MODEL2 multiply_t
 tests[editnnc_model2]="flow model2 9_EDITNNC_MODEL2 editnnc_model2"
 tests[polymer_injectivity]="flow polymer_injectivity 2D_POLYMER_INJECTIVITY"
 tests[nnc]="flow editnnc NNC_AND_EDITNNC nnc"
-tests[udq]="flow udq_actionx UDQ_WCONPROD"
+tests[udq]="flow udq_actionx UDQ_WCONPROD udq_wconprod"
 
 changed_tests=""
 for test_name in ${!tests[*]}


### PR DESCRIPTION
if not, compareECL will silently not fail and thus
tests do not fail