### PR TITLE
Problems starting with group control?

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -32,7 +32,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/core/wells/WellCollection.cpp
   opm/core/wells/WellsGroup.cpp
   opm/core/wells/WellsManager.cpp
-  opm/core/wells/well_controls.c
+  opm/core/wells/well_controls.cpp
   opm/core/wells/wells.c
   opm/simulators/flow/MissingFeatures.cpp
   opm/simulators/linalg/ExtractParallelGridInformationToISTL.cpp

--- a/opm/core/wells/well_controls.cpp
+++ b/opm/core/wells/well_controls.cpp
@@ -142,7 +142,7 @@ well_controls_create(void)
 {
     struct WellControls *ctrl;
 
-    ctrl = malloc(1 * sizeof *ctrl);
+    ctrl = static_cast<WellControls*>(malloc(1 * sizeof *ctrl));
 
     if (ctrl != NULL) {
         /* Initialise empty control set; the well is created open. */
@@ -176,11 +176,11 @@ well_controls_reserve(int nctrl, struct WellControls *ctrl)
     distr  = realloc(ctrl->distr , nctrl * ctrl->number_of_phases * sizeof *ctrl->distr );
 
     int ok = 0;
-    if (type   != NULL) { ctrl->type   = type  ; ok++; }
-    if (target != NULL) { ctrl->target = target; ok++; }
-    if (alq    != NULL) { ctrl->alq    = alq;    ok++; }
-    if (vfp    != NULL) { ctrl->vfp    = vfp;    ok++; }
-    if (distr  != NULL) { ctrl->distr  = distr ; ok++; }
+    if (type   != NULL) { ctrl->type   = static_cast<WellControlType*>(type)  ; ok++; }
+    if (target != NULL) { ctrl->target = static_cast<double*>(target); ok++; }
+    if (alq    != NULL) { ctrl->alq    = static_cast<double*>(alq   ); ok++; }
+    if (vfp    != NULL) { ctrl->vfp    = static_cast<int*>(vfp);       ok++; }
+    if (distr  != NULL) { ctrl->distr  = static_cast<double*>(distr) ; ok++; }
 
     if (ok == 5) {
         for (int c = ctrl->cpty; c < nctrl; c++) {
@@ -204,18 +204,18 @@ struct WellControls *
 well_controls_clone(const struct WellControls *ctrl)
 /* ---------------------------------------------------------------------- */
 {
-    struct WellControls* new = well_controls_create();
+    struct WellControls* new_ctrls = well_controls_create();
 
-    if (new != NULL) {
+    if (new_ctrls != NULL) {
         /* Assign appropriate number of phases */
-        well_controls_assert_number_of_phases(new, ctrl->number_of_phases);
+        well_controls_assert_number_of_phases(new_ctrls, ctrl->number_of_phases);
 
         int n  = well_controls_get_num(ctrl);
-        int ok = well_controls_reserve(n, new);
+        int ok = well_controls_reserve(n, new_ctrls);
 
         if (! ok) {
-            well_controls_destroy(new);
-            new = NULL;
+            well_controls_destroy(new_ctrls);
+            new_ctrls= NULL;
         }
         else {
             int i;
@@ -226,32 +226,32 @@ well_controls_clone(const struct WellControls *ctrl)
                 double alq = well_controls_iget_alq   (ctrl, i);
                 int vfp = well_controls_iget_vfp   (ctrl, i);
 
-                ok = well_controls_add_new(type, target, alq, vfp, distr, new);
+                ok = well_controls_add_new(type, target, alq, vfp, distr, new_ctrls);
             }
 
             if (i < n) {
                 assert (!ok);
-                well_controls_destroy(new);
+                well_controls_destroy(new_ctrls);
 
-                new = NULL;
+                new_ctrls = NULL;
             }
             else {
                 i = well_controls_get_current(ctrl);
-                well_controls_set_current(new, i);
+                well_controls_set_current(new_ctrls, i);
 
                 if (well_controls_well_is_open(ctrl)) {
-                    well_controls_open_well(new);
+                    well_controls_open_well(new_ctrls);
                 }
                 else {
-                    well_controls_stop_well(new);
+                    well_controls_stop_well(new_ctrls);
                 }
             }
         }
     }
 
-    assert (well_controls_equal(ctrl, new, true));
+    assert (well_controls_equal(ctrl, new_ctrls, true));
 
-    return new;
+    return new_ctrls;
 }
 
 

--- a/opm/core/wells/well_controls.cpp
+++ b/opm/core/wells/well_controls.cpp
@@ -42,6 +42,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include <stdexcept>
+
 /**
  * Controls for a single well.
  * Each control specifies a well rate or bottom-hole pressure. Only
@@ -295,6 +297,8 @@ well_controls_iget_type(const struct WellControls * ctrl, int control_index) {
 
 enum WellControlType 
 well_controls_get_current_type(const struct WellControls * ctrl) {
+    if (ctrl->current < 0)
+        throw std::logic_error("Tried to use invalid current control < 0");
     return well_controls_iget_type( ctrl , ctrl->current);
 }
 
@@ -312,6 +316,8 @@ well_controls_iget_target(const struct WellControls * ctrl, int control_index) {
 
 double
 well_controls_get_current_target(const struct WellControls * ctrl) {
+    if (ctrl->current < 0)
+        throw std::logic_error("Tried to use invalid current control < 0");
     return ctrl->target[ctrl->current];
 }
 


### PR DESCRIPTION
The story goes as follows:

1. #1926 was merged to enable integration testing based on the UDQ_WCONPROD testcase. At the time of merging there was no reference data created, but the test machinery actually does not signal failure in this case. 

2. To ensure that jenkins indeed signals failure in the case of a missing reference solution this: #1927 was opened, and the plan was to use this PR to faciliate the necessary `update_data` to create the initial reference data.

3. While working with #1927 it turned out the simulations with the UDQ_WCONPROD testcase did not give reproducible results - some undefined behavior was clearly at play.

With assistance from @akva2 and @GitPaean I have now debugged this and my conclusion is that the well model, specifically the `WellControls` code does not really handle `GRUP` control - at the very least not for wells which *start off*[1] with `GRUP` control. In that case the `controls->current` member remains at the invalid value `-1` - and when that is later used to look up a value in vector undefined behavior is invoked.

I have not tried to actually solve this, in this PR I have just changed to compile the `WellControls` implementation as C++ and added to `throw std::logic_error()` statements which would have caught the undefined behavior we are currently looking at.

**Lessons learned**

1. Use of invalid values like `-1` to signal special state is very dangerous - it will come back to haunt you at some stage.
2. Use of *quantities* - e.g. controls as in this case - as *indicies* is dangerous - that also will come back to haunt you one day.
3. Assuming my hunch below is correct: Carrying state is dangerous - if at all possible make new objects; if new `WellControls` objects were created the issue would have surfaced at the first encounter of `GRUP`, and not only when the well starts with `GRUP` control. 

@akva2 : You might want to merge your fixes in #1927 - and revert the `UDQ` testcase from the regression testing; I do not think I will be able to fix this in short time, so unless someone else comes with a quick fix this will be with us for some time.

[1]: I have not verified this, but my hunch is that when a well is *changed* to `GRUP` control later in a simulation things "work" - because the previous value sticks around.