### PR TITLE
Fix error message for COMPORD partially support keyword

### DIFF
--- a/opm/simulators/flow/MissingFeatures.cpp
+++ b/opm/simulators/flow/MissingFeatures.cpp
@@ -209,7 +209,7 @@ namespace MissingFeatures {
             "ZIPPY2" };
         std::multimap<std::string, PartiallySupported<std::string> > string_options;
         std::multimap<std::string, PartiallySupported<int> > int_options;
-        addSupported<ParserKeywords::COMPORD, ParserKeywords::COMPORD::ORDER_TYPE, std::string>(string_options , "DEPTH");
+        addSupported<ParserKeywords::COMPORD, ParserKeywords::COMPORD::ORDER_TYPE, std::string>(string_options , "INPUT");
         addSupported<ParserKeywords::ENDSCALE, ParserKeywords::ENDSCALE::DIRECT, std::string>(string_options, "NODIR");
         addSupported<ParserKeywords::ENDSCALE, ParserKeywords::ENDSCALE::IRREVERS, std::string>(string_options, "REVER");
         addSupported<ParserKeywords::PINCH, ParserKeywords::PINCH::CONTROL_OPTION, std::string>(string_options, "GAP");


### PR DESCRIPTION
See: #1930 - fixed the `COMPORD` keyword in the machinery for partially supported keywords.