### PR TITLE
Support WGR limit check for WECON

### DIFF
--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -411,6 +411,10 @@ namespace Opm
                               const WellState& well_state,
                               RatioLimitCheckReport& report) const;
 
+        void checkMaxWGRLimit(const WellEconProductionLimits& econ_production_limits,
+                              const WellState& well_state,
+                              RatioLimitCheckReport& report) const;
+
         void checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
                                   const WellState& well_state,
                                   RatioLimitCheckReport& report,


### PR DESCRIPTION
The targeting case is more troublesome due to some wells got shut due to physics limit. 

As a result, this PR is WIP and need to wait for more development of the physics limits first. 