### PR TITLE
Not extrapolating towards negative in VFP tables

### DIFF
--- a/opm/simulators/wells/VFPHelpers.hpp
+++ b/opm/simulators/wells/VFPHelpers.hpp
@@ -199,14 +199,18 @@ struct InterpData {
 
 /**
  * Helper function to find indices etc. for linear interpolation and extrapolation
- *  @param value Value to find in values
+ *  @param value_in Value to find in values
  *  @param values Sorted list of values to search for value in.
  *  @return Data required to find the interpolated value
  */
-inline InterpData findInterpData(const double& value, const std::vector<double>& values) {
+inline InterpData findInterpData(const double& value_in, const std::vector<double>& values) {
     InterpData retval;
 
     const int nvalues = values.size();
+
+    // chopping the value to be zero, which means we do not
+    // extrapolate the table towards nagative ranges
+    const double value = value_in < 0.? 0. : value_in;
 
     //If we only have one value in our vector, return that
     if (values.size() == 1) {

--- a/tests/test_vfpproperties.cpp
+++ b/tests/test_vfpproperties.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(findInterpData)
 
     BOOST_CHECK_EQUAL(eval2.ind_[0], 0);
     BOOST_CHECK_EQUAL(eval2.ind_[1], 1);
-    BOOST_CHECK_EQUAL(eval2.factor_, -0.5);
+    BOOST_CHECK_EQUAL(eval2.factor_, -0.25);
 
     BOOST_CHECK_EQUAL(eval3.ind_[0], 4);
     BOOST_CHECK_EQUAL(eval3.ind_[1], 5);


### PR DESCRIPTION
this is part of the efforts to run the case https://github.com/OPM/opm-tests/blob/master/wtest/thp_min/MIN_THP_1.DATA . 

With master branch, the results converges with the production well injecting in a surprising way.  Basically it means, when we consider the injecting rates to be negative in the VFPPROD tables and extrapolate the table based on this negative rate, the equations basically get converged for this case with the production well injecting. 

For VFP tables, when the flow direction changes, something wrong always happens physically, it might not be very meaningful to use the same table anymore. 

The function `findInterpData` is used for more than one type of values, we need to make sure negative values is not desirable for all the situations before we consider this PR is valid. 

It does improve the result and avoid the injecting flow when under THP control for the targeting case. 

