### PR TITLE
using self-copying when calculating well potentials

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -251,7 +251,7 @@ namespace Opm {
             std::vector<bool> is_cell_perforated_;
 
             // create the well container
-            std::vector<WellInterfacePtr > createWellContainer(const int time_step, const Wells* wells, const bool allow_closing_opening_wells, Opm::DeferredLogger& deferred_logger);
+            std::vector<WellInterfacePtr > createWellContainer(const int time_step, Opm::DeferredLogger& deferred_logger);
 
             WellInterfacePtr createWellForWellTest(const std::string& well_name, const int report_step, Opm::DeferredLogger& deferred_logger) const;
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -304,7 +304,7 @@ namespace Opm {
             wellTesting(reportStepIdx, simulationTime, local_deferredLogger);
 
             // create the well container
-            well_container_ = createWellContainer(reportStepIdx, wells(), /*allow_closing_opening_wells=*/true, local_deferredLogger);
+            well_container_ = createWellContainer(reportStepIdx, local_deferredLogger);
 
             // do the initialization for all the wells
             // TODO: to see whether we can postpone of the intialization of the well containers to
@@ -512,7 +512,7 @@ namespace Opm {
     template<typename TypeTag>
     std::vector<typename BlackoilWellModel<TypeTag>::WellInterfacePtr >
     BlackoilWellModel<TypeTag>::
-    createWellContainer(const int time_step, const Wells* wells, const bool allow_closing_opening_wells, Opm::DeferredLogger& deferred_logger)
+    createWellContainer(const int time_step, Opm::DeferredLogger& deferred_logger)
     {
         std::vector<WellInterfacePtr> well_container;
 
@@ -524,7 +524,7 @@ namespace Opm {
             // With the following way, it will have the same order with wells struct
             // Hopefully, it can generate the same residual history with master branch
             for (int w = 0; w < nw; ++w) {
-                const std::string well_name = std::string(wells->name[w]);
+                const std::string well_name = std::string(wells()->name[w]);
 
                 // finding the location of the well in wells_ecl
                 const int nw_wells_ecl = wells_ecl_.size();
@@ -542,56 +542,54 @@ namespace Opm {
 
                 const Well2& well_ecl = wells_ecl_[index_well];
 
-                if (allow_closing_opening_wells) {
-                    // A new WCON keywords can re-open a well that was closed/shut due to Physical limit
-                    if ( wellTestState_.hasWellClosed(well_name)) {
-                        // TODO: more checking here, to make sure this standard more specific and complete
-                        // maybe there is some WCON keywords will not open the well
-                        if (well_state_.effectiveEventsOccurred(w)) {
-                            if (wellTestState_.lastTestTime(well_name) == ebosSimulator_.time()) {
-                                // The well was shut this timestep, we are most likely retrying
-                                // a timestep without the well in question, after it caused
-                                // repeated timestep cuts. It should therefore not be opened,
-                                // even if it was new or received new targets this report step.
-                                well_state_.setEffectiveEventsOccurred(w, false);
-                            } else {
-                                wellTestState_.openWell(well_name);
-                            }
-                        }
-                    }
-
-
-                    // TODO: should we do this for all kinds of closing reasons?
-                    // something like wellTestState_.hasWell(well_name)?
-                    if ( wellTestState_.hasWellClosed(well_name, WellTestConfig::Reason::ECONOMIC) ||
-                         wellTestState_.hasWellClosed(well_name, WellTestConfig::Reason::PHYSICAL) ) {
-                        if( well_ecl.getAutomaticShutIn() ) {
-                            // shut wells are not added to the well container
-                            // TODO: make a function from well_state side to handle the following
-                            well_state_.thp()[w] = 0.;
-                            well_state_.bhp()[w] = 0.;
-                            const int np = numPhases();
-                            for (int p = 0; p < np; ++p) {
-                                well_state_.wellRates()[np * w + p] = 0.;
-                            }
-                            continue;
+                // A new WCON keywords can re-open a well that was closed/shut due to Physical limit
+                if ( wellTestState_.hasWellClosed(well_name)) {
+                    // TODO: more checking here, to make sure this standard more specific and complete
+                    // maybe there is some WCON keywords will not open the well
+                    if (well_state_.effectiveEventsOccurred(w)) {
+                        if (wellTestState_.lastTestTime(well_name) == ebosSimulator_.time()) {
+                            // The well was shut this timestep, we are most likely retrying
+                            // a timestep without the well in question, after it caused
+                            // repeated timestep cuts. It should therefore not be opened,
+                            // even if it was new or received new targets this report step.
+                            well_state_.setEffectiveEventsOccurred(w, false);
                         } else {
-                            // close wells are added to the container but marked as closed
-                            struct WellControls* well_controls = wells->ctrls[w];
-                            well_controls_stop_well(well_controls);
+                            wellTestState_.openWell(well_name);
                         }
                     }
                 }
 
+
+                // TODO: should we do this for all kinds of closing reasons?
+                // something like wellTestState_.hasWell(well_name)?
+                if ( wellTestState_.hasWellClosed(well_name, WellTestConfig::Reason::ECONOMIC) ||
+                    wellTestState_.hasWellClosed(well_name, WellTestConfig::Reason::PHYSICAL) ) {
+                    if( well_ecl.getAutomaticShutIn() ) {
+                        // shut wells are not added to the well container
+                        // TODO: make a function from well_state side to handle the following
+                        well_state_.thp()[w] = 0.;
+                        well_state_.bhp()[w] = 0.;
+                        const int np = numPhases();
+                        for (int p = 0; p < np; ++p) {
+                            well_state_.wellRates()[np * w + p] = 0.;
+                        }
+                        continue;
+                    } else {
+                        // close wells are added to the container but marked as closed
+                        struct WellControls* well_controls = wells()->ctrls[w];
+                        well_controls_stop_well(well_controls);
+                    }
+                }
+
                 // Use the pvtRegionIdx from the top cell
-                const int well_cell_top = wells->well_cells[wells->well_connpos[w]];
+                const int well_cell_top = wells()->well_cells[wells()->well_connpos[w]];
                 const int pvtreg = pvt_region_idx_[well_cell_top];
 
                 if ( !well_ecl.isMultiSegment() || !param_.use_multisegment_well_) {
-                    well_container.emplace_back(new StandardWell<TypeTag>(well_ecl, time_step, wells,
+                    well_container.emplace_back(new StandardWell<TypeTag>(well_ecl, time_step, wells(),
                                                 param_, *rateConverter_, pvtreg, numComponents() ) );
                 } else {
-                    well_container.emplace_back(new MultisegmentWell<TypeTag>(well_ecl, time_step, wells,
+                    well_container.emplace_back(new MultisegmentWell<TypeTag>(well_ecl, time_step, wells(),
                                                 param_, *rateConverter_, pvtreg, numComponents() ) );
                 }
             }
@@ -1076,8 +1074,8 @@ namespace Opm {
         std::vector< Scalar > B_avg(numComponents(), Scalar() );
         computeAverageFormationFactor(B_avg);
 
+        const int reportStepIdx = ebosSimulator_.episodeIndex();
         const Opm::SummaryConfig& summaryConfig = ebosSimulator_.vanguard().summaryConfig();
-        const auto& summaryState = ebosSimulator_.vanguard().summaryState();
         const bool write_restart_file = ebosSimulator_.vanguard().eclState().getRestartConfig().getWriteRestartFile(reportStepIdx);
         int exception_thrown = 0;
         try {

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -447,6 +447,8 @@ namespace Opm
 
         void initCompletions();
 
+        WellControls* createWellControlsWithBHPAndTHP(DeferredLogger& deferred_logger) const;
+
         // count the number of times an output log message is created in the productivity
         // index calculations
         int well_productivity_index_logger_counter_;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1442,4 +1442,35 @@ namespace Opm
     }
 
 
+
+
+
+
+    template<typename TypeTag>
+    WellControls*
+    WellInterface<TypeTag>::
+    createWellControlsWithBHPAndTHP(DeferredLogger& deferred_logger) const
+    {
+        WellControls* wc = well_controls_create();
+        well_controls_assert_number_of_phases(wc, number_of_phases_);
+
+        // a well always has a bhp limit
+        const double invalid_alq = -1e100;
+        const double invalid_vfp = -2147483647;
+        const double bhp_limit = this->mostStrictBhpFromBhpLimits(deferred_logger);
+        well_controls_add_new(BHP, bhp_limit, invalid_alq, invalid_vfp, NULL, wc);
+
+        if (this->wellHasTHPConstraints()) {
+            // it might be better to do it through EclipseState?
+            const double thp_limit = this->getTHPConstraint(deferred_logger);
+            const double thp_control_index = this->getControlIndex(THP);
+            const  int vfp_number = well_controls_iget_vfp(well_controls_, thp_control_index);
+            const double alq = well_controls_iget_alq(well_controls_, thp_control_index);
+            well_controls_add_new(THP, thp_limit, alq, vfp_number, NULL, wc);
+        }
+
+        return wc;
+    }
+
+
 }


### PR DESCRIPTION
The major benefit is that we can simplify the usage of the function `createWellContainer()`. 

This PR tries not to change the simulation behavoir, while it does due to numerical reasons. More investigation of the results are on-going. 

This PR should be only considered as refactoring. Some corrections will be put in later PRs. 