### PR TITLE
Well potential improvements

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -334,11 +334,10 @@ namespace Opm
                          const int perf,
                          std::vector<EvalWell>& mob) const;
 
-        void computeWellRatesWithBhpPotential(const Simulator& ebosSimulator,
-                                              const std::vector<Scalar>& B_avg,
-                                              const double& bhp,
-                                              std::vector<double>& well_flux,
-                                              Opm::DeferredLogger& deferred_logger);
+        void computeWellPotentialsWithBHPLimit(const Simulator& ebosSimulator,
+                                               const std::vector<Scalar>& B_avg,
+                                               std::vector<double>& well_flux,
+                                               Opm::DeferredLogger& deferred_logger);
 
         void assembleControlEq(Opm::DeferredLogger& deferred_logger) const;
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -344,21 +344,19 @@ namespace Opm
                              Opm::DeferredLogger& deferred_logger) const;
 
         void computeWellRatesWithBhp(const Simulator& ebosSimulator,
-                                             const double& bhp,
-                                             std::vector<double>& well_flux,
-                                             Opm::DeferredLogger& deferred_logger) const;
+                                     const double& bhp,
+                                     std::vector<double>& well_flux,
+                                     Opm::DeferredLogger& deferred_logger) const;
 
-        void computeWellRatesWithBhpPotential(const Simulator& ebosSimulator,
-                                              const std::vector<Scalar>& B_avg,
-                                              const double& bhp,
-                                              std::vector<double>& well_flux,
-                                              Opm::DeferredLogger& deferred_logger);
+        void computeWellPotentialsWithBHPLimit(const Simulator& ebosSimulator,
+                                               const std::vector<Scalar>& B_avg,
+                                               std::vector<double>& well_flux,
+                                               Opm::DeferredLogger& deferred_logger);
 
-        std::vector<double> computeWellPotentialWithTHP(const Simulator& ebosSimulator,
-                                                        const std::vector<Scalar>& B_avg,
-                                                        const double initial_bhp, // bhp from BHP constraints
-                                                        const std::vector<double>& initial_potential,
-                                                        Opm::DeferredLogger& deferred_logger);
+        std::vector<double> computeWellPotentialsWithTHP(const Simulator& ebosSimulator,
+                                                         const std::vector<Scalar>& B_avg,
+                                                         const std::vector<double>& initial_potential,
+                                                         Opm::DeferredLogger& deferred_logger);
 
         template <class ValueType>
         ValueType calculateBhpFromThp(const std::vector<ValueType>& rates, const int control_index, Opm::DeferredLogger& deferred_logger) const;

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -446,7 +446,9 @@ namespace Opm
 
         void initCompletions();
 
-        WellControls* createWellControlsWithBHPAndTHP(DeferredLogger& deferred_logger) const;
+        WellControls* createWellControlsWithBHPAndTHPLimits(DeferredLogger& deferred_logger) const;
+
+        WellControls* createWellControlsWithBHPLimit(DeferredLogger& deferred_logger) const;
 
         // count the number of times an output log message is created in the productivity
         // index calculations


### PR DESCRIPTION
It is after https://github.com/OPM/opm-simulators/pull/1955 .  https://github.com/OPM/opm-simulators/pull/1955 needs to go in first. 

This is a PR to correct some code related to well potential calculation. 

in the original code, when computing the well potential for BHP limit, it is possible that in the well_controls_ there are THP limit. The solution might be obtained not under BHP limit. 

And also, the resetting of the bhp limit is not necessary and is not correct.

It is still implementation based on the code level. It is not aiming to obtain more correct result for any cases. 