### PR TITLE
Amg cpr write matrix.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,14 @@ opm_add_test(flow_blackoil_dunecpr
   DEPENDS "opmsimulators"
   LIBRARIES "opmsimulators")
 
+opm_add_test(flow_blackoil_dunecpr_noflex
+  ONLY_COMPILE
+  DEFAULT_ENABLE_IF ${FLOW_DEFAULT_ENABLE_IF}
+  SOURCES flow/flow_blackoil_dunecpr_noflex.cpp
+  EXE_NAME flow_blackoil_dunecpr_noflex
+  CONDITION NOT MPI_FOUND
+  DEPENDS "opmsimulators"
+  LIBRARIES "opmsimulators")
 
 
 if (BUILD_FLOW)

--- a/flow/flow_blackoil_dunecpr_noflex.cpp
+++ b/flow/flow_blackoil_dunecpr_noflex.cpp
@@ -1,0 +1,95 @@
+/*
+  Copyright 2013, 2014, 2015, 2019 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2014 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015, 2017 IRIS AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+#include "flow/flow_tag.hpp"
+#include  <opm/simulators/linalg/ISTLSolverEbosCpr.hpp>
+
+
+BEGIN_PROPERTIES
+NEW_TYPE_TAG(EclFlowProblemSimple, INHERITS_FROM(EclFlowProblem));
+NEW_PROP_TAG(FluidState);
+//SET_TYPE_PROP(EclBaseProblem, Problem, Ewoms::EclProblem<TypeTag>);
+SET_PROP(EclFlowProblemSimple, FluidState)
+    {
+    private:
+      typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
+      typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
+      enum { enableTemperature = GET_PROP_VALUE(TypeTag, EnableTemperature) };
+      enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
+      enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
+      enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
+      typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+      typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+      static const bool compositionSwitchEnabled = Indices::gasEnabled;
+ 
+    public:
+//typedef Opm::BlackOilFluidSystemSimple<Scalar> type;
+       typedef Opm::BlackOilFluidState<Evaluation, FluidSystem, enableTemperature, enableEnergy, compositionSwitchEnabled,  Indices::numPhases > type;
+};
+
+SET_BOOL_PROP(EclFlowProblemSimple, MatrixAddWellContributions, true);
+SET_INT_PROP(EclFlowProblemSimple, LinearSolverVerbosity,0);
+SET_SCALAR_PROP(EclFlowProblemSimple, LinearSolverReduction, 1e-2);
+SET_INT_PROP(EclFlowProblemSimple, LinearSolverMaxIter, 100);
+SET_BOOL_PROP(EclFlowProblemSimple, UseAmg, true);//probably not used
+SET_BOOL_PROP(EclFlowProblemSimple, UseCpr, true);
+SET_INT_PROP(EclFlowProblemSimple, CprMaxEllIter, 1);
+SET_INT_PROP(EclFlowProblemSimple, CprEllSolvetype, 3);
+SET_INT_PROP(EclFlowProblemSimple, CprReuseSetup, 3);
+SET_INT_PROP(EclFlowProblemSimple, CprSolverVerbose, 0);
+SET_STRING_PROP(EclFlowProblemSimple, SystemStrategy, "quasiimpes");
+END_PROPERTIES
+
+namespace Ewoms {
+  namespace Properties {
+
+    SET_PROP(EclFlowProblemSimple, FluidSystem)
+    {
+    private:
+      //typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+      typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+      typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+
+    public:
+        typedef Opm::BlackOilFluidSystem<Scalar> type;
+    };
+    //NEW_TYPE_TAG(EclFlowProblem, INHERITS_FROM(BlackOilModel, EclBaseProblem));
+    SET_TYPE_PROP(EclFlowProblemSimple, IntensiveQuantities, Ewoms::BlackOilIntensiveQuantities<TypeTag>);
+    //SET_TYPE_PROP(EclFlowProblemSimple, LinearSolverBackend, Opm::ISTLSolverEbos<TypeTag>);
+    //SET_TAG_PROP(EclFlowProblemSimple, LinearSolverSplice, ParallelBiCGStabLinearSolver);
+    //SET_TYPE_PROP(EclFlowProblemSimple, LinearSolverBackend, Ewoms::Linear::ParallelBiCGStabSolverBackend<TypeTag>);//not work
+    //SET_TYPE_PROP(EclFlowProblemSimple, LinearSolverBackend, Ewoms::Linear::SuperLUBackend<TypeTag>)//not work
+    //SET_TAG_PROP(EclFlowProblem, FluidState, Opm::BlackOilFluidState);
+    SET_TYPE_PROP(EclFlowProblemSimple, LinearSolverBackend, Opm::ISTLSolverEbosCpr<TypeTag>);
+    SET_BOOL_PROP(EclFlowProblemSimple, EnableStorageCache, true);
+    SET_BOOL_PROP(EclFlowProblemSimple, EnableIntensiveQuantityCache, true);
+    
+    //SET_INT_PROP(EclFlowProblemSimple, NumWellAdjoint, 1);
+    //SET_BOOL_PROP(EclFlowProblem, EnableStorageCache, true);
+    //SET_BOOL_PROP(EclFlowProblem, EnableIntensiveQuantityCache, true);
+  }
+}
+
+int main(int argc, char** argv)
+{
+  typedef TTAG(EclFlowProblemSimple) TypeTag;
+  return mainFlow<TypeTag>(argc, argv);
+}

--- a/opm/simulators/linalg/BlackoilAmg.hpp
+++ b/opm/simulators/linalg/BlackoilAmg.hpp
@@ -35,6 +35,7 @@
 #include <dune/istl/scalarproducts.hh>
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
+#include "matrixmarket_ewoms.hh"
 namespace Dune
 {
 namespace Amg
@@ -553,6 +554,13 @@ public:
     CoarseLevelSolver* createCoarseLevelSolver(LTP& transferPolicy)
     {
         coarseOperator_=transferPolicy.getCoarseLevelOperator();
+	if( param_->cpr_solver_verbose_ >10 ){
+	    std::string filename = "course_matrix_istl_blackoil.txt";
+	    std::ofstream filem(filename);
+	    //const auto& matrix = *transferPolicy.getCoarseMatrix();
+	    const auto& matrix = coarseOperator_->getmat(); 
+	    Dune::writeMatrixMarket(matrix, filem);
+	}
         const LevelTransferPolicy& transfer =
             reinterpret_cast<const LevelTransferPolicy&>(transferPolicy);
         AMGInverseOperator* inv = new AMGInverseOperator(param_,

--- a/opm/simulators/linalg/FlexibleSolver.hpp
+++ b/opm/simulators/linalg/FlexibleSolver.hpp
@@ -130,6 +130,14 @@ private:
                                                               tol, // desired residual reduction factor
                                                               maxiter, // maximum number of iterations
                                                               verbosity));
+	} else if (solver_type == "cg") {
+            linsolver_.reset(new Dune::CGSolver<VectorType>(*linearoperator_,
+							    *scalarproduct_,
+							    *preconditioner_,
+							    tol, // desired residual reduction factor
+							    maxiter, // maximum number of iterations
+							    verbosity));    
+	    
         } else if (solver_type == "gmres") {
             int restart = prm.get<int>("restart");
             linsolver_.reset(new Dune::RestartedGMResSolver<VectorType>(*linearoperator_,

--- a/opm/simulators/linalg/ISTLSolverEbosCpr.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosCpr.hpp
@@ -24,7 +24,7 @@
 #include <opm/simulators/linalg/BlackoilAmgCpr.hpp>
 #include <utility>
 #include <memory>
-
+#include "WriteSystemMatrixHelper.hpp"
 namespace Opm
 {
 //=====================================================================
@@ -296,6 +296,15 @@ namespace Opm
             if (this->parameters_.scale_linear_system_) {
                 this->scaleSolution(x);
             }
+	    if(this->parameters_.linear_solver_verbosity_ > 10){
+		if(this->iterations() > (this->parameters_.linear_solver_verbosity_ - 10)){
+		    Opm::Helper::writeSystem(this->simulator_,
+					     *this->matrix_,
+					     *this->rhs_);
+		}
+	    }
+	    
+	    
 	    return this->converged_;
         }
 

--- a/opm/simulators/linalg/PreconditionerFactory.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory.hpp
@@ -29,6 +29,7 @@
 #include <opm/simulators/linalg/amgcpr.hh>
 
 #include <dune/istl/paamg/amg.hh>
+#include <dune/istl/paamg/kamg.hh>
 #include <dune/istl/paamg/fastamg.hh>
 #include <dune/istl/preconditioners.hh>
 
@@ -104,8 +105,10 @@ public:
     }
 
 private:
+    //using CriterionBase
+    //    = Dune::Amg::AggregationCriterion<Dune::Amg::SymmetricMatrixDependency<Matrix, Dune::Amg::FirstDiagonal>>;
     using CriterionBase
-        = Dune::Amg::AggregationCriterion<Dune::Amg::SymmetricMatrixDependency<Matrix, Dune::Amg::FirstDiagonal>>;
+        = Dune::Amg::AggregationCriterion<Dune::Amg::SymmetricDependency<Matrix, Dune::Amg::FirstDiagonal>>;
     using Criterion = Dune::Amg::CoarsenCriterion<CriterionBase>;
 
     // Helpers for creation of AMG preconditioner.
@@ -116,7 +119,9 @@ private:
         criterion.setAlpha(prm.get<double>("alpha"));
         criterion.setBeta(prm.get<double>("beta"));
         criterion.setMaxLevel(prm.get<int>("maxlevel"));
-        criterion.setSkipIsolated(false);
+        criterion.setSkipIsolated(prm.get<bool>("skip_isolated"));
+	criterion.setNoPreSmoothSteps(prm.get<int>("pre_smooth"));
+	criterion.setNoPostSmoothSteps(prm.get<int>("post_smooth"));
         criterion.setDebugLevel(prm.get<int>("verbosity"));
         return criterion;
     }
@@ -135,11 +140,21 @@ private:
     }
 
     template <class Smoother>
-    static PrecPtr makeAmgPreconditioner(const Operator& op, const boost::property_tree::ptree& prm)
+    static PrecPtr makeAmgPreconditioner(const Operator& op, const boost::property_tree::ptree& prm,bool use_kamg = false)
     {
         auto crit = amgCriterion(prm);
         auto sargs = amgSmootherArgs<Smoother>(prm);
-        return std::make_shared<Dune::Amg::AMGCPR<Operator, Vector, Smoother>>(op, crit, sargs);
+	if(use_kamg){
+	    return std::make_shared<
+		DummyUpdatePreconditioner<
+		    Dune::Amg::KAMG< Operator, Vector, Smoother>
+		    >
+		>(op, crit, sargs,
+		  prm.get<size_t>("max_krylov"),
+		  prm.get<double>("min_reduction")  );
+	}else{
+	    return std::make_shared<Dune::Amg::AMGCPR<Operator, Vector, Smoother>>(op, crit, sargs);
+	}
     }
 
     // Add a useful default set of preconditioners to the factory.
@@ -191,7 +206,7 @@ private:
         });
         doAddCreator("amg", [](const O& op, const P& prm, const C& comm) {
             const std::string smoother = prm.get<std::string>("smoother");
-            if (smoother == "ILU0") {
+            if (smoother == "ParOverILU0") {
                 using Smoother = Opm::ParallelOverlappingILU0<M, V, V, C>;
                 auto crit = amgCriterion(prm);
                 auto sargs = amgSmootherArgs<Smoother>(prm);
@@ -269,6 +284,32 @@ private:
             } else if (smoother == "ILUn") {
                 using Smoother = SeqILUn<M, V, V>;
                 return makeAmgPreconditioner<Smoother>(op, prm);
+            } else {
+                std::string msg("No such smoother: ");
+                msg += smoother;
+                throw std::runtime_error(msg);
+            }
+        });
+	doAddCreator("kamg", [](const O& op, const P& prm) {
+            const std::string smoother = prm.get<std::string>("smoother");
+            if (smoother == "ILU0") {
+                using Smoother = SeqILU0<M, V, V>;
+                return makeAmgPreconditioner<Smoother>(op, prm,true);
+            } else if (smoother == "Jac") {
+                using Smoother = SeqJac<M, V, V>;
+                return makeAmgPreconditioner<Smoother>(op, prm,true);
+            } else if (smoother == "SOR") {
+                using Smoother = SeqSOR<M, V, V>;
+                return makeAmgPreconditioner<Smoother>(op, prm,true);
+	    // } else if (smoother == "GS") {
+            //     using Smoother = SeqGS<M, V, V>;
+            //     return makeAmgPreconditioner<Smoother>(op, prm,true);
+            } else if (smoother == "SSOR") {
+                using Smoother = SeqSSOR<M, V, V>;
+                return makeAmgPreconditioner<Smoother>(op, prm,true);
+            } else if (smoother == "ILUn") {
+                using Smoother = SeqILUn<M, V, V>;
+                return makeAmgPreconditioner<Smoother>(op, prm,true);
             } else {
                 std::string msg("No such smoother: ");
                 msg += smoother;

--- a/opm/simulators/linalg/PressureSolverPolicy.hpp
+++ b/opm/simulators/linalg/PressureSolverPolicy.hpp
@@ -113,6 +113,16 @@ namespace Amg
             auto& tp = dynamic_cast<LevelTransferPolicy&>(transferPolicy); // TODO: make this unnecessary.
             PressureInverseOperator* inv
                 = new PressureInverseOperator(*coarseOperator_, prm_, tp.getCoarseLevelCommunication());
+	    if (prm_.get<int>("verbosity") > 10) {         
+		std::string filename = "course_matrix_istl_pressure_flex.txt";
+		std::ofstream filem(filename);
+		if (!filem) {
+		    throw std::runtime_error("Could not write matrix");
+		}
+		//const auto& matrix = *levelTransferPolicy_.getCoarseMatrix();
+		const auto& matrix = coarseOperator_->getmat(); 
+		Dune::writeMatrixMarket(matrix, filem);
+	    }
             return inv;
         }
 

--- a/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
+++ b/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
@@ -20,7 +20,7 @@
 #define OPM_WRITESYSTEMMATRIXHELPER_HEADER_INCLUDED
 //#include <dune/istl/matrixmarket.hh>
 //#include <ewoms/linear/matrixblock.hh>
-#include <ewoms/linear/matrixmarket_ewoms.hh>
+#include "matrixmarket_ewoms.hh"
 namespace Opm{
     namespace Helper {
 	template<class SimulatorType,

--- a/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
+++ b/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
@@ -1,0 +1,66 @@
+/*
+  Copyright 2019 SINTEF AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_WRITESYSTEMMATRIXHELPER_HEADER_INCLUDED
+#define OPM_WRITESYSTEMMATRIXHELPER_HEADER_INCLUDED
+//#include <dune/istl/matrixmarket.hh>
+//#include <ewoms/linear/matrixblock.hh>
+#include <ewoms/linear/matrixmarket_ewoms.hh>
+namespace Opm{
+    namespace Helper {
+	template<class SimulatorType,
+		 class MatrixType,
+		 class VectorType>
+	void writeSystem(const SimulatorType& simulator,
+			 const MatrixType& matrix,
+			 const VectorType& rhs){
+	    std::string dir = simulator.problem().outputDir();
+	    if (dir == ".")
+		dir = "";
+	    else if (!dir.empty() && dir.back() != '/')
+		dir += "/";
+	    namespace fs = boost::filesystem;
+	    fs::path output_dir(dir);
+	    fs::path subdir("reports");
+	    output_dir = output_dir / subdir;
+	    if(!(fs::exists(output_dir))){
+		fs::create_directory(output_dir);
+	    }
+	    // Combine and return.
+	    std::ostringstream oss;
+	    oss << "prob_" << simulator.episodeIndex() << "_";
+	    oss << simulator.time() << "_";
+	    std::string output_file(oss.str());
+	    fs::path full_path = output_dir / output_file;
+	    std::string prefix = full_path.string();
+	    {
+		std::string filename = prefix + "matrix_istl.txt";
+		std::ofstream filem(filename);
+		Dune::writeMatrixMarket(matrix, filem);
+	    }
+	    {		
+		std::string filename = prefix + "rhs_istl.txt";
+		std::ofstream fileb(filename);
+		Dune::writeMatrixMarket(rhs, fileb);
+	    }
+	}
+
+	
+    } //namespace helper   
+}// namespace Opm
+#endif

--- a/opm/simulators/linalg/matrixmarket_ewoms.hh
+++ b/opm/simulators/linalg/matrixmarket_ewoms.hh
@@ -1,0 +1,204 @@
+// -*- tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi: set et ts=4 sw=2 sts=2:
+#ifndef MATRIXMARKET_EWOMS_HH
+#define MATRIXMARKET_EWOMS_HH
+#include <dune/istl/matrixmarket.hh>
+#include <ewoms/linear/matrixblock.hh>
+namespace Dune
+{
+
+
+  namespace MatrixMarketImpl
+  {
+
+
+    template<typename T, typename A, int i, int j>
+    struct mm_header_printer<BCRSMatrix<Ewoms::MatrixBlock<T,i,j>,A> >
+    {
+      static void print(std::ostream& os)
+      {
+        os<<"%%MatrixMarket matrix coordinate ";
+        os<<mm_numeric_type<T>::str()<<" general"<<std::endl;
+      }
+    };
+
+
+    template<typename T, int i, int j>
+    struct mm_header_printer<Ewoms::MatrixBlock<T,i,j> >
+    {
+      static void print(std::ostream& os)
+      {
+        os<<"%%MatrixMarket matrix array ";
+        os<<mm_numeric_type<T>::str()<<" general"<<std::endl;
+      }
+    };
+
+    /**
+     * @brief Metaprogram for writing the ISTL block
+     * structure header.
+     *
+     * Member function mm_block_structure_header::print(os, mat) writes
+     * the corresponding header to the specified ostream.
+     * @tparam The type of the matrix to generate the header for.
+     */
+
+    template<typename T, typename A, int i, int j>
+    struct mm_block_structure_header<BCRSMatrix<Ewoms::MatrixBlock<T,i,j>,A> >
+    {
+      typedef BCRSMatrix<Ewoms::MatrixBlock<T,i,j>,A> M;
+
+      static void print(std::ostream& os, const M&)
+      {
+        os<<"% ISTL_STRUCT blocked ";
+        os<<i<<" "<<j<<std::endl;
+      }
+    };
+
+
+    template<typename T, int i, int j>
+    struct mm_block_structure_header<Ewoms::MatrixBlock<T,i,j> >
+    {
+      typedef Ewoms::MatrixBlock<T,i,j> M;
+
+      static void print(std::ostream& os, const M& m)
+      {}
+    };
+
+
+
+    template<typename T, typename A, int brows, int bcols, typename D>
+    void readSparseEntries(Dune::BCRSMatrix<Ewoms::MatrixBlock<T,brows,bcols>,A>& matrix,
+                           std::istream& file, std::size_t entries,
+                           const MMHeader& mmHeader, const D&)
+    {
+      typedef Dune::BCRSMatrix<Ewoms::MatrixBlock<T,brows,bcols>,A> Matrix;
+      // First path
+      // store entries together with column index in a speparate
+      // data structure
+      std::vector<std::set<IndexData<D> > > rows(matrix.N()*brows);
+
+      for(; entries>0; --entries) {
+        std::size_t row;
+        IndexData<D> data;
+        skipComments(file);
+        file>>row;
+        --row; // Index was 1 based.
+        assert(row/bcols<matrix.N());
+        file>>data;
+        assert(data.index/bcols<matrix.M());
+        rows[row].insert(data);
+      }
+
+      // TODO extend to capture the nongeneral cases.
+      if(mmHeader.structure!= general)
+        DUNE_THROW(Dune::NotImplemented, "Only general is supported right now!");
+
+      // Setup the matrix sparsity pattern
+      int nnz=0;
+      for(typename Matrix::CreateIterator iter=matrix.createbegin();
+          iter!= matrix.createend(); ++iter)
+      {
+        for(std::size_t brow=iter.index()*brows, browend=iter.index()*brows+brows;
+            brow<browend; ++brow)
+        {
+          typedef typename std::set<IndexData<D> >::const_iterator Siter;
+          for(Siter siter=rows[brow].begin(), send=rows[brow].end();
+              siter != send; ++siter, ++nnz)
+            iter.insert(siter->index/bcols);
+        }
+      }
+
+      //Set the matrix values
+      matrix=0;
+
+      MatrixValuesSetter<D,brows,bcols> Setter;
+
+      Setter(rows, matrix);
+    }
+  } // end namespace MatrixMarketImpl
+
+
+  template<typename T, typename A, int brows, int bcols>
+  void readMatrixMarket(Dune::BCRSMatrix<Ewoms::MatrixBlock<T,brows,bcols>,A>& matrix,
+                        std::istream& istr)
+  {
+    using namespace MatrixMarketImpl;
+
+    MMHeader header;
+    if(!readMatrixMarketBanner(istr, header)) {
+      std::cerr << "First line was not a correct Matrix Market banner. Using default:\n"
+                << "%%MatrixMarket matrix coordinate real general"<<std::endl;
+      // Go to the beginning of the file
+      istr.clear() ;
+      istr.seekg(0, std::ios::beg);
+    }
+    skipComments(istr);
+
+    std::size_t rows, cols, entries;
+
+    if(lineFeed(istr))
+      throw MatrixMarketFormatError();
+
+    istr >> rows;
+
+    if(lineFeed(istr))
+      throw MatrixMarketFormatError();
+    istr >> cols;
+
+    if(lineFeed(istr))
+      throw MatrixMarketFormatError();
+
+    istr >>entries;
+
+    std::size_t nnz, blockrows, blockcols;
+
+    std::tie(blockrows, blockcols, nnz) = calculateNNZ<brows, bcols>(rows, cols, entries, header);
+
+    istr.ignore(std::numeric_limits<std::streamsize>::max(),'\n');
+
+
+    matrix.setSize(blockrows, blockcols);
+    matrix.setBuildMode(Dune::BCRSMatrix<Ewoms::MatrixBlock<T,brows,bcols>,A>::row_wise);
+
+    if(header.type==array_type)
+      DUNE_THROW(Dune::NotImplemented, "Array format currently not supported for matrices!");
+
+    readSparseEntries(matrix, istr, entries, header, NumericWrapper<T>());
+  }
+
+
+
+  template<typename B, int i, int j, typename A>
+  struct mm_multipliers<BCRSMatrix<Ewoms::MatrixBlock<B,i,j>,A> >
+  {
+    enum {
+      rows = i,
+      cols = j
+    };
+  };
+
+  template<typename B, int i, int j>
+  void mm_print_entry(const Ewoms::MatrixBlock<B,i,j>& entry,
+                      typename Ewoms::MatrixBlock<B,i,j>::size_type rowidx,
+                      typename Ewoms::MatrixBlock<B,i,j>::size_type colidx,
+                      std::ostream& ostr)
+  {
+    typedef typename Ewoms::MatrixBlock<B,i,j>::const_iterator riterator;
+    typedef typename Ewoms::MatrixBlock<B,i,j>::ConstColIterator citerator;
+    for(riterator row=entry.begin(); row != entry.end(); ++row, ++rowidx) {
+      int coli=colidx;
+      for(citerator col = row->begin(); col != row->end(); ++col, ++coli)
+        ostr<< rowidx<<" "<<coli<<" "<<*col<<std::endl;
+    }
+  }
+
+  template<typename T, int n, int m>
+  std::size_t countEntries(const Ewoms::MatrixBlock<T,n, m>& vector)
+  {
+    return n*m;
+  }
+  
+  /** @} */
+}
+
+#endif // MATRIXMARKET_EWOMS_HH


### PR DESCRIPTION
Pull request for adding possibility to write out the difficult matrixes from a linear solver in a simulation. 
It write out the matrixes for solves with iterations > verbosity-10. This is introduced only in the executable flow_blackoil_dunecpr_noflex, but can easily be extended to other solvers including the default.