### PR TITLE
Setup logging before the simulator is initialized

### DIFF
--- a/flow/flow_blackoil_dunecpr.cpp
+++ b/flow/flow_blackoil_dunecpr.cpp
@@ -99,5 +99,7 @@ namespace Ewoms {
 int main(int argc, char** argv)
 {
   typedef TTAG(EclFlowProblemSimple) TypeTag;
-  return mainFlow<TypeTag>(argc, argv);
+  bool outputCout = true;
+  bool outputFiles = true;
+  return mainFlow<TypeTag>(argc, argv, outputCout, outputFiles);
 }

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -47,7 +47,7 @@ void flowEbosBlackoilSetDeck(double setupTime, Deck &deck, EclipseState& eclStat
 }
 
 // ----------------- Main program -----------------
-int flowEbosBlackoilMain(int argc, char** argv)
+int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -60,7 +60,7 @@ int flowEbosBlackoilMain(int argc, char** argv)
 #endif
 
     Opm::FlowMainEbos<TTAG(EclFlowProblem)> mainfunc;
-    return mainfunc.execute(argc, argv);
+    return mainfunc.execute(argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/flow/flow_ebos_blackoil.hpp
+++ b/flow/flow_ebos_blackoil.hpp
@@ -24,7 +24,7 @@
 
 namespace Opm {
 void flowEbosBlackoilSetDeck(double setupTime, Deck &deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
-int flowEbosBlackoilMain(int argc, char** argv);
+int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 
 #endif // FLOW_EBOS_BLACKOIL_HPP

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -49,7 +49,7 @@ void flowEbosEnergySetDeck(double setupTime, Deck &deck, EclipseState& eclState,
 }
 
 // ----------------- Main program -----------------
-int flowEbosEnergyMain(int argc, char** argv)
+int flowEbosEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -63,7 +63,7 @@ int flowEbosEnergyMain(int argc, char** argv)
 #endif
 
     Opm::FlowMainEbos<TTAG(EclFlowEnergyProblem)> mainfunc;
-    return mainfunc.execute(argc, argv);
+    return mainfunc.execute(argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/flow/flow_ebos_energy.hpp
+++ b/flow/flow_ebos_energy.hpp
@@ -24,7 +24,7 @@
 
 namespace Opm {
 void flowEbosEnergySetDeck(double setupTime, Deck &deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
-int flowEbosEnergyMain(int argc, char** argv);
+int flowEbosEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 
 #endif // FLOW_EBOS_ENERGY_HPP

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -50,7 +50,7 @@ void flowEbosFoamSetDeck(double setupTime, Deck &deck, EclipseState& eclState, S
 
 
 // ----------------- Main program -----------------
-int flowEbosFoamMain(int argc, char** argv)
+int flowEbosFoamMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -64,7 +64,7 @@ int flowEbosFoamMain(int argc, char** argv)
 #endif
 
     Opm::FlowMainEbos<TTAG(EclFlowFoamProblem)> mainfunc;
-    return mainfunc.execute(argc, argv);
+    return mainfunc.execute(argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/flow/flow_ebos_foam.hpp
+++ b/flow/flow_ebos_foam.hpp
@@ -25,7 +25,7 @@
 
 namespace Opm {
 void flowEbosFoamSetDeck(double setupTime, Deck &deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
-int flowEbosFoamMain(int argc, char** argv);
+int flowEbosFoamMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 
 #endif // FLOW_EBOS_FOAM_HPP

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -73,7 +73,7 @@ void flowEbosGasOilSetDeck(double setupTime, Deck &deck, EclipseState& eclState,
 
 
 // ----------------- Main program -----------------
-int flowEbosGasOilMain(int argc, char** argv)
+int flowEbosGasOilMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -86,7 +86,7 @@ int flowEbosGasOilMain(int argc, char** argv)
 #endif
 
     Opm::FlowMainEbos<TTAG(EclFlowGasOilProblem)> mainfunc;
-    return mainfunc.execute(argc, argv);
+    return mainfunc.execute(argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/flow/flow_ebos_gasoil.hpp
+++ b/flow/flow_ebos_gasoil.hpp
@@ -24,7 +24,7 @@
 
 namespace Opm {
 void flowEbosGasOilSetDeck(double setupTime, Deck &deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
-int flowEbosGasOilMain(int argc, char** argv);
+int flowEbosGasOilMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 
 #endif // FLOW_EBOS_GASOIL_HPP

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -72,7 +72,7 @@ void flowEbosOilWaterSetDeck(double setupTime, Deck &deck, EclipseState& eclStat
 }
 
 // ----------------- Main program -----------------
-int flowEbosOilWaterMain(int argc, char** argv)
+int flowEbosOilWaterMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -85,7 +85,7 @@ int flowEbosOilWaterMain(int argc, char** argv)
 #endif
 
     Opm::FlowMainEbos<TTAG(EclFlowOilWaterProblem)> mainfunc;
-    return mainfunc.execute(argc, argv);
+    return mainfunc.execute(argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/flow/flow_ebos_oilwater.hpp
+++ b/flow/flow_ebos_oilwater.hpp
@@ -24,7 +24,7 @@
 
 namespace Opm {
 void flowEbosOilWaterSetDeck(double setupTime, Deck &deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
-int flowEbosOilWaterMain(int argc, char** argv);
+int flowEbosOilWaterMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 
 #endif // FLOW_EBOS_OILWATER_HPP

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -73,7 +73,7 @@ void flowEbosOilWaterPolymerSetDeck(double setupTime, Deck& deck, EclipseState& 
 }
 
 // ----------------- Main program -----------------
-int flowEbosOilWaterPolymerMain(int argc, char** argv)
+int flowEbosOilWaterPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -86,7 +86,7 @@ int flowEbosOilWaterPolymerMain(int argc, char** argv)
 #endif
 
     Opm::FlowMainEbos<TTAG(EclFlowOilWaterPolymerProblem)> mainfunc;
-    return mainfunc.execute(argc, argv);
+    return mainfunc.execute(argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/flow/flow_ebos_oilwater_polymer.hpp
+++ b/flow/flow_ebos_oilwater_polymer.hpp
@@ -24,7 +24,7 @@
 
 namespace Opm {
 void flowEbosOilWaterPolymerSetDeck(double setupTime, Deck& deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
-int flowEbosOilWaterPolymerMain(int argc, char** argv);
+int flowEbosOilWaterPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 
 #endif // FLOW_EBOS_OILWATER_POLYMER_HPP

--- a/flow/flow_ebos_oilwater_polymer_injectivity.cpp
+++ b/flow/flow_ebos_oilwater_polymer_injectivity.cpp
@@ -71,7 +71,7 @@ namespace Opm {
 } */
 
 // ----------------- Main program -----------------
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv)
+int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -84,8 +84,7 @@ int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv)
 #endif
 
     Opm::FlowMainEbos<TTAG(EclFlowOilWaterPolymerInjectivityProblem)> mainfunc;
-
-    return mainfunc.execute(argc, argv);
+    return mainfunc.execute(argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/flow/flow_ebos_oilwater_polymer_injectivity.hpp
+++ b/flow/flow_ebos_oilwater_polymer_injectivity.hpp
@@ -22,7 +22,7 @@
 
 namespace Opm {
   // void flowEbosOilWaterPolymerInjectivitySetDeck(Deck& deck, EclipseState& eclState);
-  int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv);
+int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 
 #endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -49,7 +49,7 @@ void flowEbosPolymerSetDeck(double setupTime, Deck &deck, EclipseState& eclState
 }
 
 // ----------------- Main program -----------------
-int flowEbosPolymerMain(int argc, char** argv)
+int flowEbosPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -63,7 +63,7 @@ int flowEbosPolymerMain(int argc, char** argv)
 #endif
 
     Opm::FlowMainEbos<TTAG(EclFlowPolymerProblem)> mainfunc;
-    return mainfunc.execute(argc, argv);
+    return mainfunc.execute(argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/flow/flow_ebos_polymer.hpp
+++ b/flow/flow_ebos_polymer.hpp
@@ -24,7 +24,7 @@
 
 namespace Opm {
 void flowEbosPolymerSetDeck(double setupTime, Deck &deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
-int flowEbosPolymerMain(int argc, char** argv);
+int flowEbosPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 
 #endif // FLOW_EBOS_POLYMER_HPP

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -50,7 +50,7 @@ void flowEbosSolventSetDeck(double setupTime, Deck &deck, EclipseState& eclState
 
 
 // ----------------- Main program -----------------
-int flowEbosSolventMain(int argc, char** argv)
+int flowEbosSolventMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -64,7 +64,7 @@ int flowEbosSolventMain(int argc, char** argv)
 #endif
 
     Opm::FlowMainEbos<TTAG(EclFlowSolventProblem)> mainfunc;
-    return mainfunc.execute(argc, argv);
+    return mainfunc.execute(argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/flow/flow_ebos_solvent.hpp
+++ b/flow/flow_ebos_solvent.hpp
@@ -25,7 +25,7 @@
 
 namespace Opm {
 void flowEbosSolventSetDeck(double setupTime, Deck &deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
-int flowEbosSolventMain(int argc, char** argv);
+int flowEbosSolventMain(int argc, char** argv, bool outoutCout, bool outputFiles);
 }
 
 #endif // FLOW_EBOS_SOLVENT_HPP

--- a/flow/flow_tag.hpp
+++ b/flow/flow_tag.hpp
@@ -69,7 +69,7 @@ namespace Opm {
   
 // ----------------- Main program -----------------
   template <class TypeTag>
-  int flowEbosMain(int argc, char** argv)
+  int flowEbosMain(int argc, char** argv, bool outputCout, bool outputFiles)
   {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -81,7 +81,7 @@ namespace Opm {
     Dune::MPIHelper::instance(argc, argv);
 #endif
     Opm::FlowMainEbos<TypeTag> mainfunc;
-    return mainfunc.execute(argc, argv);
+    return mainfunc.execute(argc, argv, outputCout, outputFiles);
   }
 
 }
@@ -123,7 +123,7 @@ namespace detail
 
 // ----------------- Main program -----------------
 template<class TypeTag>
-int mainFlow(int argc, char** argv)
+int mainFlow(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // MPI setup.
 #if HAVE_DUNE_FEM
@@ -160,7 +160,6 @@ int mainFlow(int argc, char** argv)
         // --print-properties parameters.
         return (status >= 0)?status:0;
 
-    bool outputCout = false;
     if (mpiRank == 0)
         outputCout = EWOMS_GET_PARAM(PreTypeTag, bool, EnableTerminalOutput);
 
@@ -198,7 +197,7 @@ int mainFlow(int argc, char** argv)
 
       std::shared_ptr<Opm::EclipseState> eclipseState = std::make_shared< Opm::EclipseState > ( *deck, parseContext, errorGuard );
       Opm::flowEbosSetDeck<TypeTag>(*deck, *eclipseState);
-      return Opm::flowEbosMain<TypeTag>(argc, argv);
+      return Opm::flowEbosMain<TypeTag>(argc, argv, outputCout, outputFiles);
     }
   catch (const std::invalid_argument& e)
     {

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -34,10 +34,6 @@
 
 #include <opm/core/props/satfunc/RelpermDiagnostics.hpp>
 
-#include <opm/common/OpmLog/OpmLog.hpp>
-#include <opm/common/OpmLog/EclipsePRTLog.hpp>
-#include <opm/common/OpmLog/LogUtil.hpp>
-
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
@@ -70,22 +66,21 @@ SET_INT_PROP(EclFlowProblem, OutputInterval, 1);
 
 END_PROPERTIES
 
+enum FileOutputMode {
+     //! \brief No output to files.
+     OUTPUT_NONE = 0,
+     //! \brief Output only to log files, no eclipse output.
+     OUTPUT_LOG_ONLY = 1,
+     //! \brief Output to all files.
+     OUTPUT_ALL = 3
+};
+
 namespace Opm
 {
     // The FlowMain class is the ebos based black-oil simulator.
     template <class TypeTag>
     class FlowMainEbos
     {
-        enum FileOutputMode
-        {
-            //! \brief No output to files.
-            OUTPUT_NONE = 0,
-            //! \brief Output only to log files, no eclipse output.
-            OUTPUT_LOG_ONLY = 1,
-            //! \brief Output to all files.
-            OUTPUT_ALL = 3
-        };
-
     public:
         typedef typename GET_PROP(TypeTag, MaterialLaw)::EclMaterialLawManager MaterialLawManager;
         typedef typename GET_PROP_TYPE(TypeTag, Simulator) EbosSimulator;
@@ -222,9 +217,7 @@ namespace Opm
                     return status;
 
                 setupParallelism();
-                setupOutput();
                 setupEbosSimulator();
-                setupLogging();
                 int unknownKeyWords = printPRTHeader();
 #if HAVE_MPI
                 int globalUnknownKeyWords;
@@ -306,101 +299,6 @@ namespace Opm
             ThreadManager::init();
         }
 
-        // Extract the minimum priority and determines if log files ought to be created.
-        // Writes to:
-        //   output_to_files_
-        //   output_
-        void setupOutput()
-        {
-            const std::string outputModeString =
-                EWOMS_GET_PARAM(TypeTag, std::string, OutputMode);
-            static std::map<std::string, FileOutputMode> stringToOutputMode =
-                { {"none", OUTPUT_NONE },
-                  {"false", OUTPUT_LOG_ONLY },
-                  {"log", OUTPUT_LOG_ONLY },
-                  {"all" , OUTPUT_ALL },
-                  {"true" , OUTPUT_ALL }};
-            auto outputModeIt = stringToOutputMode.find(outputModeString);
-            if (outputModeIt != stringToOutputMode.end()) {
-                output_ = outputModeIt->second;
-            }
-            else {
-                output_ = OUTPUT_ALL;
-                std::cerr << "Value " << outputModeString <<
-                    " is not a recognized output mode. Using \"all\" instead."
-                          << std::endl;
-            }
-
-            output_cout_ = false;
-            if (mpi_rank_ == 0) {
-                output_cout_ = EWOMS_GET_PARAM(TypeTag, bool, EnableTerminalOutput);
-                output_to_files_ = (output_ != OUTPUT_NONE);
-            }
-        }
-
-        // Setup the OpmLog backends
-        void setupLogging()
-        {
-            std::string deck_filename = EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName);
-            // create logFile
-            using boost::filesystem::path;
-            path fpath(deck_filename);
-            std::string baseName;
-            std::ostringstream debugFileStream;
-            std::ostringstream logFileStream;
-
-            // Strip extension "." or ".DATA"
-            std::string extension = boost::to_upper_copy(fpath.extension().string());
-            if ( extension == ".DATA" || extension == "." )
-            {
-                baseName = boost::to_upper_copy(fpath.stem().string());
-            }
-            else
-            {
-                baseName = boost::to_upper_copy(fpath.filename().string());
-            }
-
-            const std::string& output_dir = eclState().getIOConfig().getOutputDir();
-            logFileStream << output_dir << "/" << baseName;
-            debugFileStream << output_dir << "/" << baseName;
-
-            if (mpi_rank_ != 0) {
-                // Added rank to log file for non-zero ranks.
-                // This prevents message loss.
-                debugFileStream << "."<< mpi_rank_;
-                // If the following file appears then there is a bug.
-                logFileStream << "." << mpi_rank_;
-            }
-            logFileStream << ".PRT";
-            debugFileStream << ".DBG";
-
-            logFile_ = logFileStream.str();
-
-            if (output_ > OUTPUT_NONE) {
-                std::shared_ptr<EclipsePRTLog> prtLog = std::make_shared<EclipsePRTLog>(logFile_ , Log::NoDebugMessageTypes, false, output_cout_);
-                OpmLog::addBackend( "ECLIPSEPRTLOG" , prtLog );
-                prtLog->setMessageLimiter(std::make_shared<MessageLimiter>());
-                prtLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(false));
-            }
-
-            if (output_ >= OUTPUT_LOG_ONLY) {
-                std::string debugFile = debugFileStream.str();
-                std::shared_ptr<StreamLog> debugLog = std::make_shared<EclipsePRTLog>(debugFile, Log::DefaultMessageTypes, false, output_cout_);
-                OpmLog::addBackend("DEBUGLOG",  debugLog);
-            }
-
-            std::shared_ptr<StreamLog> streamLog = std::make_shared<StreamLog>(std::cout, Log::StdoutMessageTypes);
-            OpmLog::addBackend( "STREAMLOG", streamLog);
-            const auto& msgLimits = schedule().getMessageLimits();
-            const std::map<int64_t, int> limits = {{Log::MessageType::Note, msgLimits.getCommentPrintLimit(0)},
-                                                   {Log::MessageType::Info, msgLimits.getMessagePrintLimit(0)},
-                                                   {Log::MessageType::Warning, msgLimits.getWarningPrintLimit(0)},
-                                                   {Log::MessageType::Error, msgLimits.getErrorPrintLimit(0)},
-                                                   {Log::MessageType::Problem, msgLimits.getProblemPrintLimit(0)},
-                                                   {Log::MessageType::Bug, msgLimits.getBugPrintLimit(0)}};
-            streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10, limits));
-            streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(true));
-        }
 
         // Print an ASCII-art header to the PRT and DEBUG files.
         // \return Whether unkown keywords were seen during parsing.
@@ -516,7 +414,7 @@ namespace Opm
                 }
             }
             catch (const std::invalid_argument& e) {
-                std::cerr << "Failed to create valid EclipseState object. See logfile: " << logFile_ << std::endl;
+                std::cerr << "Failed to create valid EclipseState object" << std::endl;
                 std::cerr << "Exception caught: " << e.what() << std::endl;
                 throw;
             }
@@ -627,11 +525,10 @@ namespace Opm
         int  mpi_rank_ = 0;
         int  mpi_size_ = 1;
         bool output_cout_ = false;
-        FileOutputMode output_ = OUTPUT_ALL;
+        //FileOutputMode output_ = OUTPUT_ALL;
         bool output_to_files_ = false;
         boost::any parallel_information_;
         std::unique_ptr<Simulator> simulator_;
-        std::string logFile_;
     };
 } // namespace Opm
 


### PR DESCRIPTION
[This](https://github.com/OPM/opm-common/pull/933) was created and merged to put messages like:

```
    6 Reading GAS      from: /path/udq_actionx/UDQ_WCONPROD.DATA:45
```
in the `.PRT` file - but it turned out that no messages appeared in the file, and as debugged by @attgeir - that was because the logging system was not initialized when the parsing was performed. This PR shuffles things a bit around, to facilitate initialization of the logging system before the parsing starts. It even works on Atgeirrs machine.

NB: this endevaour has revealed that *no* log messages originating from the opm-common setup process have been logged!   
