### PR TITLE
Remove COMPDAT from list of unsupported keywords

### DIFF
--- a/opm/simulators/flow/MissingFeatures.cpp
+++ b/opm/simulators/flow/MissingFeatures.cpp
@@ -128,7 +128,6 @@ namespace MissingFeatures {
             "COLLAPSE",
             "COLUMNS",
             "CBMOPTS",
-            "COMPDAT",
             "COMPDATL",
             "COMPIMB",
             "COMPFLSH",


### PR DESCRIPTION
The `COMPDAT`keyword had sneaked in on the list of unsupported keywords.