### PR TITLE
fixed: don't flag error if rfts are missing (most cases lack them)

### DIFF
--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -17,6 +17,12 @@ copyToReferenceDir () {
   DIFF=1
   for filetype in $FILETYPES
   do
+    # Don't flag as changed if both reference and result dir lack a file type
+    # In particular to handle the optional RFT's
+    if [ ! -f $WORKSPACE/$SRC_DIR$STEM.$filetype ] && [ ! -f $DST_DIR/$STEM.$filetype ]
+    then
+      continue
+    fi
     diff -q "$WORKSPACE/$SRC_DIR$STEM.$filetype" "$DST_DIR/$STEM.$filetype"
     if test $? -ne 0
     then


### PR DESCRIPTION
A while back .rft was added to the list of files.

Since most cases lack these files, we got a lot of false positives leading to confusing commit messages in the update_data trigger.