### PR TITLE
Fixed typo for EclipseGrid member function

### DIFF
--- a/opm/core/wells/WellsManager_impl.hpp
+++ b/opm/core/wells/WellsManager_impl.hpp
@@ -347,7 +347,7 @@ WellsManager::init(const Opm::EclipseState& eclipseState,
     {
         std::vector<int> gc = compressedToCartesian(number_of_cells, global_cell);
         for (int cell = 0; cell < number_of_cells; ++cell) {
-            dz[cell] = eclGrid.getCellThicknes(gc[cell]);
+            dz[cell] = eclGrid.getCellThickness(gc[cell]);
         }
     }
 


### PR DESCRIPTION
getCellThicknes changed to getCellThickness. This should be merged together with PR OPM/opm-common#1009 in opm-common

(Edit: corrected link to point to the opm-common PR instead of a PR in this repo)