### PR TITLE
Make sure subclass functions are not called before subclass is initia…

### DIFF
--- a/ebos/eclalugridvanguard.hh
+++ b/ebos/eclalugridvanguard.hh
@@ -81,10 +81,11 @@ private:
     static const int dimension = Grid::dimension;
 
 public:
-    /*!
-     * \brief Inherit the constructors from the base class.
-     */
-    using EclBaseVanguard<TypeTag>::EclBaseVanguard;
+    EclAluGridVanguard(Simulator& simulator)
+        : EclBaseVanguard<TypeTag>(simulator)
+    {
+        this->callImplementationInit();
+    }
 
     ~EclAluGridVanguard()
     {

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -373,16 +373,6 @@ public:
         int outputInterval = EWOMS_GET_PARAM(TypeTag, int, EclOutputInterval);
         if (outputInterval >= 0)
             eclState_->getRestartConfig().overrideRestartWriteInterval(outputInterval);
-
-        asImp_().createGrids_();
-        asImp_().filterConnections_();
-        asImp_().updateOutputDir_();
-        asImp_().finalizeInit_();
-
-        if (enableExperiments) {
-            Opm::RelpermDiagnostics relpermDiagnostics;
-            relpermDiagnostics.diagnosis(*eclState_, *deck_, asImp_().grid());
-        }
     }
 
     /*!
@@ -538,6 +528,19 @@ public:
     std::unordered_set<std::string> defunctWellNames() const
     { return std::unordered_set<std::string>(); }
 
+protected:
+    void callImplementationInit()
+    {
+        asImp_().createGrids_();
+        asImp_().filterConnections_();
+        asImp_().updateOutputDir_();
+        asImp_().finalizeInit_();
+
+        if (enableExperiments) {
+            Opm::RelpermDiagnostics relpermDiagnostics;
+            relpermDiagnostics.diagnosis(*eclState_, *deck_, asImp_().grid());
+        }
+    }
 private:
     void updateOutputDir_()
     {

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -70,6 +70,7 @@ class EclCpGridVanguard : public EclBaseVanguard<TypeTag>
     typedef EclBaseVanguard<TypeTag> ParentType;
 
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, ElementMapper) ElementMapper;
 
 public:
@@ -81,10 +82,11 @@ private:
     typedef Dune::CartesianIndexMapper<Grid> CartesianIndexMapper;
 
 public:
-    /*!
-     * \brief Inherit the constructors from the base class.
-     */
-    using EclBaseVanguard<TypeTag>::EclBaseVanguard;
+    EclCpGridVanguard(Simulator& simulator)
+        : EclBaseVanguard<TypeTag>(simulator)
+    {
+        this->callImplementationInit();
+    }
 
     ~EclCpGridVanguard()
     {

--- a/ebos/eclpolyhedralgridvanguard.hh
+++ b/ebos/eclpolyhedralgridvanguard.hh
@@ -77,10 +77,11 @@ private:
     typedef CartesianIndexMapper* CartesianIndexMapperPointer;
 
 public:
-    /*!
-     * \brief Inherit the constructors from the base class.
-     */
-    using EclBaseVanguard<TypeTag>::EclBaseVanguard;
+    EclPolyhedralGridVanguard(Simulator& simulator)
+        : EclBaseVanguard<TypeTag>(simulator)
+    {
+        this->callImplementationInit();
+    }
 
     ~EclPolyhedralGridVanguard()
     {


### PR DESCRIPTION
…lized.

This at least slightly improves the old design. In that design the
subclass had no own constructor but inherited the one of the base class.
That base class constructor called certain subclass
functions (createGrids_, filterConnections_, updateOutputDir_, and
finalizeInit_)that would initialize raw pointers of the
subclass. Hence subclasses where not allowed to have non-pod members
and those used later (e.g. deleted in the destructor) had to be
initialized in these functions.

The new (still ugly) design introduces constructors into the
subclasses and skips inheriting constructors. Now one must call a base
class function classImplementationInit which will still call the
functions createGrids_, filterConnections_, updateOutputDir_, and
finalizeInit_, but at least at this point the baseclass is fully
constructed and the subclass is constructed as much as
possible/needed (non-pod types will be initialized now.)

Closes #2035.