### PR TITLE
Fixes unused variable warning in standard wells.

### DIFF
--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -985,9 +985,11 @@ namespace Opm
 
         updateExtraPrimaryVariables(dwells);
 
+#ifndef NDEBUG
         for (double v : primary_variables_) {
             assert(Opm::isfinite(v));
         }
+#endif
     }
 
 
@@ -1329,9 +1331,11 @@ namespace Opm
             break;
         } // end of switch
 
+#ifndef NDEBUG
         for (double v : primary_variables_) {
             assert(Opm::isfinite(v));
         }
+#endif
     }
 
 
@@ -2623,9 +2627,11 @@ namespace Opm
             }
         }
 
+#ifndef NDEBUG
         for (double v : primary_variables_) {
             assert(Opm::isfinite(v));
         }
+#endif
     }
 
 


### PR DESCRIPTION
Only occurs when compiling with -DNDEBUG since the body of the for-loop is an assert using the loop variable. Loop is now deactivated.