### PR TITLE
stdout logging only for rank 0

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -215,10 +215,11 @@ FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, con
         Opm::OpmLog::addBackend("DEBUGLOG", debugLog);
     }
 
-    std::shared_ptr<Opm::StreamLog> streamLog = std::make_shared<Opm::StreamLog>(std::cout, Opm::Log::StdoutMessageTypes);
-    Opm::OpmLog::addBackend(stdout_log_id, streamLog);
-    streamLog->setMessageFormatter(std::make_shared<Opm::SimpleMessageFormatter>(true));
-
+    if (mpi_rank_ == 0) {
+        std::shared_ptr<Opm::StreamLog> streamLog = std::make_shared<Opm::StreamLog>(std::cout, Opm::Log::StdoutMessageTypes);
+        Opm::OpmLog::addBackend(stdout_log_id, streamLog);
+        streamLog->setMessageFormatter(std::make_shared<Opm::SimpleMessageFormatter>(true));
+    }
     return output;
 }
 
@@ -350,7 +351,9 @@ int main(int argc, char** argv)
             eclipseState.reset( new Opm::EclipseState(*deck, parseContext, errorGuard ));
             schedule.reset(new Opm::Schedule(*deck, *eclipseState, parseContext, errorGuard));
             summaryConfig.reset( new Opm::SummaryConfig(*deck, *schedule, eclipseState->getTableManager(), parseContext, errorGuard));
-            setupMessageLimiter(schedule->getMessageLimits(), "STDOUT_LOGGER");
+            if (mpiRank == 0) {
+                setupMessageLimiter(schedule->getMessageLimits(), "STDOUT_LOGGER");
+            }
 
             Opm::checkConsistentArrayDimensions(*eclipseState, *schedule, parseContext, errorGuard);
 


### PR DESCRIPTION
This starts with #2059 

While discussing a suitable fix for #2059 with @atgeirr it became clear that there is a divide through the code when it comes to logging and parallell behavior:

**opm-common:** This module is totally unaware of MPI and parallell execution. The opm-common code makes many calls to `OpmLog::xxxx()` - these messages will come repeated for every PE. Up until quite recently there has been a bug in the setup of the logging, which resulted in *no messages from opm-common* - we therefor never saw these repeated messages. This bug was fixed  ~1 month ago, and now log messages from opm-common are repeated for every PE - as pointed out in #2059.

For opm-common the situation is that any logging message should be identical on all PE's, and we are only interested in the messages which come from rank 0. The fix in this PR is a good solution seen from the perspective of opm-common.

**opm-simulators:** Here the different PE's see a different world, they will log different messages and should all be able to log. The current PR might silence legitimate `stdout` messages from PE != 0 in e.g. the well code. The file backed logs will still log from all PE's.

My initial plan was to send a boolean flag down to opm-common, and that is of course still possible, but I would prefer not to do it like that. The reason I dislike this approach is:

1. We have a logging system which can be configured quite flexibly. Passing a `bool verbose` flag around is an extra log configuration mechanism on the side.

2. It is a quite invasive change to protect all logging calls in opm-common with `if (verbose) { ... }` and it also sneaks in a parellell awareness in opm-common. I think it would even constitute a *layering violation*? 

I have added the 2019.10 release tag on this PR; that does not imply that it should necessary be merged in anything close current form - but #2059 should be solved in one way or another.
