### PR TITLE
added: allow running the norne test in parallel

### DIFF
--- a/jenkins/run-norne.sh
+++ b/jenkins/run-norne.sh
@@ -7,7 +7,12 @@ test -z $SIM && SIM=flow
 # Run the norne case
 cd norne
 mkdir $SIM
-$WORKSPACE/$configuration/build-opm-simulators/bin/$SIM --output-dir=$SIM NORNE_ATW2013.DATA
+if test -n "$1"
+then
+  mpirun -np $1 $WORKSPACE/$configuration/build-opm-simulators/bin/$SIM --output-dir=$SIM NORNE_ATW2013.DATA
+else
+  $WORKSPACE/$configuration/build-opm-simulators/bin/$SIM --output-dir=$SIM NORNE_ATW2013.DATA
+fi
 test $? -eq 0 || exit 1
 ./plotwells.sh $WORKSPACE/$configuration/install/bin "ECL.2014.2 opm-simulation-reference/flow_legacy" norne-wells
 ./plotwells.sh $WORKSPACE/$configuration/install/bin "opm-simulation-reference/flow_legacy" norne-wells-noecl


### PR DESCRIPTION
This enables triggering a parallel norne run using 'run norne_parallel'. trigger runs with 4 procs right now.