### PR TITLE
Well refactoring, avoid using the old Wells struct.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -189,6 +189,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/utils/gatherDeferredLogger.hpp
   opm/simulators/utils/moduleVersion.hpp
   opm/simulators/utils/ParallelRestart.hpp
+  opm/simulators/wells/PerforationData.hpp
   opm/simulators/wells/RateConverter.hpp
   opm/simulators/wells/SimFIBODetails.hpp
   opm/simulators/wells/WellConnectionAuxiliaryModule.hpp

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -40,6 +40,7 @@
 #include <opm/core/wells.h>
 #include <opm/core/wells/WellCollection.hpp>
 #include <opm/simulators/timestepping/SimulatorReport.hpp>
+#include <opm/simulators/wells/PerforationData.hpp>
 #include <opm/simulators/wells/VFPInjProperties.hpp>
 #include <opm/simulators/wells/VFPProdProperties.hpp>
 #include <opm/simulators/flow/countGlobalCells.hpp>
@@ -233,8 +234,10 @@ namespace Opm {
 
         protected:
             Simulator& ebosSimulator_;
-            std::unique_ptr<WellsManager> wells_manager_;
             std::vector< Well2 > wells_ecl_;
+
+            std::vector< std::vector<PerforationData> > well_perf_data_;
+            std::vector<int> first_perf_index_;
 
             bool wells_active_;
 
@@ -245,6 +248,8 @@ namespace Opm {
             std::vector<int> cartesian_to_compressed_;
 
             std::vector<bool> is_cell_perforated_;
+
+            void initializeWellPerfData();
 
             // create the well container
             std::vector<WellInterfacePtr > createWellContainer(const int time_step, Opm::DeferredLogger& deferred_logger);
@@ -277,8 +282,6 @@ namespace Opm {
 
             // used to better efficiency of calcuation
             mutable BVector scaleAddRes_;
-
-            const Wells* wells() const { return wells_manager_->c_wells(); }
 
             const Grid& grid() const
             { return ebosSimulator_.vanguard().grid(); }
@@ -373,7 +376,7 @@ namespace Opm {
                                WellStateFullyImplicitBlackoil& state ) const;
 
             // whether there exists any multisegment well open on this process
-            bool anyMSWellOpenLocal(const Wells* wells) const;
+            bool anyMSWellOpenLocal() const;
 
             const Well2& getWellEcl(const std::string& well_name) const;
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -98,11 +98,15 @@ namespace Opm
         // TODO: for now, we only use one type to save some implementation efforts, while improve later.
         typedef DenseAd::Evaluation<double, /*size=*/numEq + numWellEq> EvalWell;
 
-        MultisegmentWell(const Well2& well, const int time_step, const Wells* wells,
+        MultisegmentWell(const Well2& well, const int time_step,
                          const ModelParameters& param,
                          const RateConverterType& rate_converter,
                          const int pvtRegionIdx,
-                         const int num_components);
+                         const int num_components,
+                         const int num_phases,
+                         const int index_of_well,
+                         const int first_perf_index,
+                         const std::vector<PerforationData>& perf_data);
 
         virtual void init(const PhaseUsage* phase_usage_arg,
                           const std::vector<double>& depth_arg,
@@ -183,7 +187,6 @@ namespace Opm
         using Base::well_cells_;
         using Base::param_;
         using Base::well_index_;
-        using Base::well_type_;
         using Base::first_perf_;
         using Base::saturation_table_number_;
         using Base::well_efficiency_factor_;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -28,12 +28,16 @@ namespace Opm
 
     template <typename TypeTag>
     MultisegmentWell<TypeTag>::
-    MultisegmentWell(const Well2& well, const int time_step, const Wells* wells,
+    MultisegmentWell(const Well2& well, const int time_step,
                      const ModelParameters& param,
                      const RateConverterType& rate_converter,
                      const int pvtRegionIdx,
-                     const int num_components)
-    : Base(well, time_step, wells, param, rate_converter, pvtRegionIdx, num_components)
+                     const int num_components,
+                     const int num_phases,
+                     const int index_of_well,
+                     const int first_perf_index,
+                     const std::vector<PerforationData>& perf_data)
+        : Base(well, time_step, param, rate_converter, pvtRegionIdx, num_components, num_phases, index_of_well, first_perf_index, perf_data)
     , segment_perforations_(numberOfSegments())
     , segment_inlets_(numberOfSegments())
     , cell_perforation_depth_diffs_(number_of_perforations_, 0.0)
@@ -746,7 +750,7 @@ namespace Opm
                     primary_variables_[seg][GFrac] = scalingFactor(gas_pos) * segment_rates[number_of_phases_ * seg_index + gas_pos] / total_seg_rate;
                 }
             } else { // total_seg_rate == 0
-                if (well_type_ == INJECTOR) {
+                if (this->isInjector()) {
                     // only single phase injection handled
                     auto phase = well.getInjectionProperties().injectorType;
 
@@ -766,7 +770,7 @@ namespace Opm
                         }
                     }
 
-                } else if (well_type_ == PRODUCER) { // producers
+                } else if (this->isProducer()) { // producers
                     if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
                         primary_variables_[seg][WFrac] = 1.0 / number_of_phases_;
                     }
@@ -931,7 +935,7 @@ namespace Opm
 
                 // make sure that no injector produce and no producer inject
                 if (seg == 0) {
-                    if (well_type_ == INJECTOR) {
+                    if (this->isInjector()) {
                         primary_variables_[seg][GTotal] = std::max( primary_variables_[seg][GTotal], 0.0);
                     } else {
                         primary_variables_[seg][GTotal] = std::min( primary_variables_[seg][GTotal], 0.0);
@@ -1174,7 +1178,7 @@ namespace Opm
         // producing perforations
         if ( drawdown > 0.0) {
             // Do nothing is crossflow is not allowed
-            if (!allow_cf && well_type_ == INJECTOR) {
+            if (!allow_cf && this->isInjector()) {
                 return;
             }
 
@@ -1194,7 +1198,7 @@ namespace Opm
             }
         } else { // injecting perforations
             // Do nothing if crossflow is not allowed
-            if (!allow_cf && well_type_ == PRODUCER) {
+            if (!allow_cf && this->isProducer()) {
                 return;
             }
 
@@ -1251,7 +1255,7 @@ namespace Opm
         } // end for injection perforations
 
         // calculating the perforation solution gas rate and solution oil rates
-        if (well_type_ == PRODUCER) {
+        if (this->isProducer()) {
             if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) && FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
                 const unsigned oilCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx);
                 const unsigned gasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);
@@ -1504,7 +1508,7 @@ namespace Opm
         // the result will contain the derivative with resepct to GTotal in segment seg,
         // and the derivatives with respect to WFrac GFrac in segment seg_upwind.
         // the derivative with respect to SPres should be zero.
-        if (seg == 0 && well_type_ == INJECTOR) {
+        if (seg == 0 && this->isInjector()) {
             const Well2& well = Base::wellEcl();
             auto phase = well.getInjectionProperties().injectorType;
 
@@ -1618,7 +1622,7 @@ namespace Opm
 
         if (wellIsStopped_) {
             control_eq = getSegmentGTotal(0);
-        } else if (well.isInjector() ) {
+        } else if (this->isInjector() ) {
             const Opm::Well2::InjectorCMode& current = well_state.currentInjectionControls()[well_index];
             const auto controls = well.injectionControls(summaryState);
             switch(current) {
@@ -2495,7 +2499,7 @@ namespace Opm
                 computePerfRatePressure(int_quants, mob, seg, perf, seg_pressure, allow_cf, cq_s, perf_press, perf_dis_gas_rate, perf_vap_oil_rate, deferred_logger);
 
                 // updating the solution gas rate and solution oil rate
-                if (well_type_ == PRODUCER) {
+                if (this->isProducer()) {
                     well_state.wellDissolvedGasRates()[index_of_well_] += perf_dis_gas_rate;
                     well_state.wellVaporizedOilRates()[index_of_well_] += perf_vap_oil_rate;
                 }
@@ -2832,7 +2836,7 @@ namespace Opm
 
         const auto& well = well_ecl_;
         const int well_index = index_of_well_;
-        if (well.isInjector() )
+        if (this->isInjector() )
         {
             const Opm::Well2::InjectorCMode& current = well_state.currentInjectionControls()[well_index];
             switch(current) {
@@ -2854,7 +2858,7 @@ namespace Opm
             }
         }
 
-        if (well.isProducer() )
+        if (this->isProducer() )
         {
             const Well2::ProducerCMode& current = well_state.currentProductionControls()[well_index];
             switch(current) {
@@ -2900,7 +2904,7 @@ namespace Opm
 
         const auto& well = well_ecl_;
         const int well_index = index_of_well_;
-        if (well.isInjector() )
+        if (this->isInjector() )
         {
             const Opm::Well2::InjectorCMode& current = well_state.currentInjectionControls()[well_index];
             switch(current) {
@@ -2926,7 +2930,7 @@ namespace Opm
             }
         }
 
-        if (well.isProducer() )
+        if (this->isProducer() )
         {
             const Well2::ProducerCMode& current = well_state.currentProductionControls()[well_index];
             switch(current) {
@@ -2982,8 +2986,8 @@ namespace Opm
             // special treatment is needed for segment 0
             if (seg == 0) {
                 // we are not supposed to have injecting producers and producing injectors
-                assert( ! (well_type_ == PRODUCER && primary_variables_evaluation_[seg][GTotal] > 0.) );
-                assert( ! (well_type_ == INJECTOR && primary_variables_evaluation_[seg][GTotal] < 0.) );
+                assert( ! (this->isProducer() && primary_variables_evaluation_[seg][GTotal] > 0.) );
+                assert( ! (this->isInjector() && primary_variables_evaluation_[seg][GTotal] < 0.) );
                 upwinding_segments_[seg] = seg;
                 continue;
             }

--- a/opm/simulators/wells/PerforationData.hpp
+++ b/opm/simulators/wells/PerforationData.hpp
@@ -1,0 +1,36 @@
+/*
+  Copyright 2019 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PERFORATIONDATA_HEADER_INCLUDED
+#define OPM_PERFORATIONDATA_HEADER_INCLUDED
+
+namespace Opm
+{
+
+/// Static data associated with a well perforation.
+struct PerforationData
+{
+    int cell_index;
+    double connection_transmissibility_factor;
+    int satnum_id;
+};
+
+} // namespace Opm
+
+#endif // OPM_PERFORATIONDATA_HEADER_INCLUDED

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -140,11 +140,15 @@ namespace Opm
         using Base::contiFoamEqIdx;
         static const int contiEnergyEqIdx = Indices::contiEnergyEqIdx;
 
-        StandardWell(const Well2& well, const int time_step, const Wells* wells,
+        StandardWell(const Well2& well, const int time_step,
                      const ModelParameters& param,
                      const RateConverterType& rate_converter,
                      const int pvtRegionIdx,
-                     const int num_components);
+                     const int num_components,
+                     const int num_phases,
+                     const int index_of_well,
+                     const int first_perf_index,
+                     const std::vector<PerforationData>& perf_data);
 
         virtual void init(const PhaseUsage* phase_usage_arg,
                           const std::vector<double>& depth_arg,
@@ -231,10 +235,8 @@ namespace Opm
         using Base::number_of_perforations_;
         using Base::number_of_phases_;
         using Base::saturation_table_number_;
-        using Base::comp_frac_;
         using Base::well_index_;
         using Base::index_of_well_;
-        using Base::well_type_;
         using Base::num_components_;
         using Base::connectionRates_;
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -118,11 +118,15 @@ namespace Opm
                                                    compositionSwitchEnabled,
                                                    Indices::numPhases >;
         /// Constructor
-        WellInterface(const Well2& well, const int time_step, const Wells* wells,
+        WellInterface(const Well2& well, const int time_step,
                       const ModelParameters& param,
                       const RateConverterType& rate_converter,
                       const int pvtRegionIdx,
-                      const int num_components);
+                      const int num_components,
+                      const int num_phases,
+                      const int index_of_well,
+                      const int first_perf_index,
+                      const std::vector<PerforationData>& perf_data);
 
         /// Virutal destructor
         virtual ~WellInterface() {}
@@ -130,14 +134,17 @@ namespace Opm
         /// Well name.
         const std::string& name() const;
 
+        /// True if the well is an injector.
+        bool isInjector() const;
+
+        /// True if the well is a producer.
+        bool isProducer() const;
+
         /// Index of well in the wells struct and wellState
         int indexOfWell() const;
 
         /// Well cells.
         const std::vector<int>& cells() const {return well_cells_; }
-
-        /// Well type, INJECTOR or PRODUCER.
-        WellType wellType() const;
 
         /// Well controls
         WellControls* wellControls() const;
@@ -286,29 +293,11 @@ namespace Opm
 
         const int current_step_;
 
-        // the index of well in Wells struct
-        int index_of_well_;
-
         // simulation parameters
         const ModelParameters& param_;
 
-        // well type
-        // INJECTOR or PRODUCER
-        enum WellType well_type_;
-
-        // number of phases
-        int number_of_phases_;
-
-        // component fractions for each well
-        // typically, it should apply to injection wells
-        std::vector<double> comp_frac_;
-
         // number of the perforations for this well
         int number_of_perforations_;
-
-        // record the index of the first perforation
-        // of states of individual well.
-        int first_perf_;
 
         // well index for each perforation
         std::vector<double> well_index_;
@@ -371,6 +360,18 @@ namespace Opm
         const int pvtRegionIdx_;
 
         const int num_components_;
+
+        // number of phases
+        int number_of_phases_;
+
+        // the index of well in Wells struct
+        int index_of_well_;
+
+        // record the index of the first perforation
+        // of states of individual well.
+        int first_perf_;
+
+        std::vector<int> originalConnectionIndex_;
 
         std::vector<RateVector> connectionRates_;
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -27,75 +27,58 @@ namespace Opm
 
     template<typename TypeTag>
     WellInterface<TypeTag>::
-    WellInterface(const Well2& well, const int time_step, const Wells* wells,
+    WellInterface(const Well2& well,
+                  const int time_step,
                   const ModelParameters& param,
                   const RateConverterType& rate_converter,
                   const int pvtRegionIdx,
-                  const int num_components)
+                  const int num_components,
+                  const int num_phases,
+                  const int index_of_well,
+                  const int first_perf_index,
+                  const std::vector<PerforationData>& perf_data)
       : well_ecl_(well)
       , current_step_(time_step)
       , param_(param)
       , rateConverter_(rate_converter)
       , pvtRegionIdx_(pvtRegionIdx)
       , num_components_(num_components)
+      , number_of_phases_(num_phases)
+      , index_of_well_(index_of_well)
+      , first_perf_(first_perf_index)
     {
         if (time_step < 0) {
             OPM_THROW(std::invalid_argument, "Negtive time step is used to construct WellInterface");
         }
 
-        if (!wells) {
-            OPM_THROW(std::invalid_argument, "Null pointer of Wells is used to construct WellInterface");
-        }
+        ref_depth_ = well.getRefDepth();
 
-        const std::string& well_name = well.name();
-
-        // looking for the location of the well in the wells struct
-        int index_well;
-        for (index_well = 0; index_well < wells->number_of_wells; ++index_well) {
-            if (well_name == std::string(wells->name[index_well])) {
-                break;
-            }
-        }
-
-        // should not enter the constructor if the well does not exist in the wells struct
-        // here, just another assertion.
-        assert(index_well != wells->number_of_wells);
-
-        index_of_well_ = index_well;
-        well_type_ = wells->type[index_well];
-        number_of_phases_ = wells->number_of_phases;
-
-        // copying the comp_frac
-        {
-            comp_frac_.resize(number_of_phases_);
-            const int index_begin = index_well * number_of_phases_;
-            std::copy(wells->comp_frac + index_begin,
-                      wells->comp_frac + index_begin + number_of_phases_, comp_frac_.begin() );
-        }
-
-        ref_depth_ = wells->depth_ref[index_well];
+        // We do not want to count SHUT perforations here, so
+        // it would be wrong to use wells.getConnections().size().
+        number_of_perforations_ = perf_data.size();
 
         // perforations related
         {
-            const int perf_index_begin = wells->well_connpos[index_well];
-            const int perf_index_end = wells->well_connpos[index_well + 1];
-            number_of_perforations_ = perf_index_end - perf_index_begin;
-            first_perf_ = perf_index_begin;
-
             well_cells_.resize(number_of_perforations_);
-            std::copy(wells->well_cells + perf_index_begin,
-                      wells->well_cells + perf_index_end,
-                      well_cells_.begin() );
-
             well_index_.resize(number_of_perforations_);
-            std::copy(wells->WI + perf_index_begin,
-                      wells->WI + perf_index_end,
-                      well_index_.begin() );
-
             saturation_table_number_.resize(number_of_perforations_);
-            std::copy(wells->sat_table_id + perf_index_begin,
-                      wells->sat_table_id + perf_index_end,
-                      saturation_table_number_.begin() );
+            int perf = 0;
+            for (const auto& pd : perf_data) {
+                well_cells_[perf] = pd.cell_index;
+                well_index_[perf] = pd.connection_transmissibility_factor;
+                saturation_table_number_[perf] = pd.satnum_id;
+                ++perf;
+            }
+
+            int all_perf = 0;
+            originalConnectionIndex_.reserve(perf_data.size());
+            for (const auto connection : well.getConnections()) {
+                if (connection.state() == Connection::State::OPEN) {
+                    originalConnectionIndex_.push_back(all_perf);
+                }
+                ++all_perf;
+            }
+            assert(originalConnectionIndex_.size() == perf_data.size());
         }
 
         // initialization of the completions mapping
@@ -205,11 +188,22 @@ namespace Opm
 
 
     template<typename TypeTag>
-    WellType
+    bool
     WellInterface<TypeTag>::
-    wellType() const
+    isInjector() const
     {
-        return well_type_;
+        return well_ecl_.isInjector();
+    }
+
+
+
+
+    template<typename TypeTag>
+    bool
+    WellInterface<TypeTag>::
+    isProducer() const
+    {
+        return well_ecl_.isProducer();
     }
 
 
@@ -781,7 +775,7 @@ namespace Opm
     {
 
         // currently, we only updateWellTestState for producers
-        if (wellType() != PRODUCER) {
+        if (this->isProducer()) {
             return;
         }
 
@@ -930,7 +924,8 @@ namespace Opm
                     bool allCompletionsClosed = true;
                     const auto& connections = well_ecl_.getConnections();
                     for (const auto& connection : connections) {
-                        if (!well_test_state.hasCompletion(name(), connection.complnum())) {
+                        if (connection.state() == Connection::State::OPEN
+                            && !well_test_state.hasCompletion(name(), connection.complnum())) {
                             allCompletionsClosed = false;
                         }
                     }
@@ -1166,7 +1161,7 @@ namespace Opm
         // we need to get the table number through the parser, in case THP constraint/target is not there.
         // When THP control/limit is not active, if available VFP table is provided, we will still need to
         // update THP value. However, it will only used for output purpose.
-        if (well_type_ == PRODUCER) { // producer
+        if (isProducer()) { // producer
             const int table_id = well_ecl_.vfp_table_number();
             if (table_id <= 0) {
                 return false;
@@ -1264,10 +1259,12 @@ namespace Opm
         const auto& connections = well_ecl_.getConnections();
         int perfIdx = 0;
         for (const auto& connection : connections) {
-            if (wellTestState.hasCompletion(name(), connection.complnum())) {
-                well_index_[perfIdx] = 0.0;
+            if (connection.state() == Connection::State::OPEN) {
+                if (wellTestState.hasCompletion(name(), connection.complnum())) {
+                    well_index_[perfIdx] = 0.0;
+                }
+                perfIdx++;
             }
-            perfIdx++;
         }
     }
 
@@ -1295,7 +1292,7 @@ namespace Opm
     void
     WellInterface<TypeTag>::scaleProductivityIndex(const int perfIdx, double& productivity_index, const bool new_well, Opm::DeferredLogger& deferred_logger)
     {
-        const auto& connection = well_ecl_.getConnections()[perfIdx];
+        const auto& connection = well_ecl_.getConnections()[originalConnectionIndex_[perfIdx]];
         if (well_ecl_.getDrainageRadius() < 0) {
             if (new_well && perfIdx == 0) {
                 deferred_logger.warning("PRODUCTIVITY_INDEX_WARNING", "Negative drainage radius not supported. The productivity index is set to zero");

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -204,12 +204,12 @@ namespace Opm
                         }
                     }
 
-                    // 3. Thp: assign thp equal to thp target/limit, if applicable,
+                    // 3. Thp: assign thp equal to thp target/limit, if such a limit exists,
                     //    otherwise keep it zero.
-                    const bool is_thp = well.isInjector() ? (inj_controls.cmode == Well2::InjectorCMode::THP)
-                        : (prod_controls.cmode == Well2::ProducerCMode::THP);
+                    const bool has_thp = well.isInjector() ? inj_controls.hasControl(Well2::InjectorCMode::THP)
+                        : prod_controls.hasControl(Well2::ProducerCMode::THP);
                     const double thp_limit = well.isInjector() ? inj_controls.thp_limit : prod_controls.thp_limit;
-                    if (is_thp) {
+                    if (has_thp) {
                         thp_[w] = thp_limit;
                     }
 

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -67,29 +67,29 @@ namespace Opm
         /// Allocate and initialize if wells is non-null.  Also tries
         /// to give useful initial values to the bhp(), wellRates()
         /// and perfPhaseRates() fields, depending on controls
-        void init(const Wells* wells,
-                  const std::vector<double>& cellPressures,
+        void init(const std::vector<double>& cellPressures,
                   const Schedule& schedule,
                   const std::vector<Well2>& wells_ecl,
                   const int report_step,
                   const WellStateFullyImplicitBlackoil* prevState,
-                  const PhaseUsage& pu)
+                  const PhaseUsage& pu,
+                  const std::vector<std::vector<PerforationData>>& well_perf_data,
+                  const SummaryState& summary_state)
         {
             // call init on base class
-            BaseType :: init(wells, cellPressures);
+            BaseType :: init(cellPressures, wells_ecl, pu, well_perf_data, summary_state);
 
-            // if there are no well, do nothing in init
-            if (wells == 0) {
-                return;
-            }
-
-            const int nw = wells->number_of_wells;
+            const int nw = wells_ecl.size();
 
             if( nw == 0 ) return ;
 
             // Initialize perfphaserates_, which must be done here.
-            const int np = wells->number_of_phases;
-            const int nperf = wells->well_connpos[nw];
+            const int np = pu.num_phases;
+
+            int nperf = 0;
+            for (const auto& wpd : well_perf_data) {
+                nperf += wpd.size();
+            }
 
             well_reservoir_rates_.resize(nw * np, 0.0);
             well_dissolved_gas_rates_.resize(nw, 0.0);
@@ -105,25 +105,11 @@ namespace Opm
                 // PRODUCTION_UPDATE, INJECTION_UPDATE, WELL_STATUS_CHANGE
                 // 16 + 32 + 128
                 const uint64_t effective_events_mask = ScheduleEvents::WELL_STATUS_CHANGE
-                                                     + ScheduleEvents::PRODUCTION_UPDATE
-                                                     + ScheduleEvents::INJECTION_UPDATE;
-
-                for (int w = 0; w <nw; ++w) {
-                    const int nw_wells_ecl = wells_ecl.size();
-                    int index_well_ecl = 0;
-                    const std::string well_name(wells->name[w]);
-                    for (; index_well_ecl < nw_wells_ecl; ++index_well_ecl) {
-                        if (well_name == wells_ecl[index_well_ecl].name()) {
-                            break;
-                        }
-                    }
-
-                    // It should be able to find in wells_ecl.
-                    if (index_well_ecl == nw_wells_ecl) {
-                        OPM_THROW(std::logic_error, "Could not find well " << well_name << " in wells_ecl ");
-                    }
-
-                    effective_events_occurred_[w] = (schedule.hasWellEvent(well_name, effective_events_mask, report_step) );
+                    + ScheduleEvents::PRODUCTION_UPDATE
+                    + ScheduleEvents::INJECTION_UPDATE;
+                for (int w = 0; w < nw; ++w) {
+                    effective_events_occurred_[w]
+                        = schedule.hasWellEvent(wells_ecl[w].name(), effective_events_mask, report_step);
                 }
             } // end of if (!well_ecl.empty() )
 
@@ -139,23 +125,18 @@ namespace Opm
             perf_skin_pressure_.clear();
             perf_skin_pressure_.resize(nperf, 0.0);
 
+            int connpos = 0;
             for (int w = 0; w < nw; ++w) {
-                assert((wells->type[w] == INJECTOR) || (wells->type[w] == PRODUCER));
-                const WellControls* ctrl = wells->ctrls[w];
-
-                if (well_controls_well_is_stopped(ctrl)) {
-                    // Shut well: perfphaserates_ are all zero.
-                } else {
-                    const int num_perf_this_well = wells->well_connpos[w + 1] - wells->well_connpos[w];
-                    // Open well: Initialize perfphaserates_ to well
-                    // rates divided by the number of perforations.
-                    for (int perf = wells->well_connpos[w]; perf < wells->well_connpos[w + 1]; ++perf) {
-                        for (int p = 0; p < np; ++p) {
-                            perfphaserates_[np*perf + p] = wellRates()[np*w + p] / double(num_perf_this_well);
-                        }
-                        perfPress()[perf] = cellPressures[wells->well_cells[perf]];
+                // Initialize perfphaserates_ to well
+                // rates divided by the number of perforations.
+                const int num_perf_this_well = well_perf_data[w].size();
+                for (int perf = connpos; perf < connpos + num_perf_this_well; ++perf) {
+                    for (int p = 0; p < np; ++p) {
+                        perfphaserates_[np*perf + p] = wellRates()[np*w + p] / double(num_perf_this_well);
                     }
+                    perfPress()[perf] = cellPressures[well_perf_data[w][perf-connpos].cell_index];
                 }
+                connpos += num_perf_this_well;
             }
 
             current_injection_controls_.resize(nw);
@@ -171,13 +152,14 @@ namespace Opm
 
             // intialize wells that have been there before
             // order may change so the mapping is based on the well name
-            if(prevState && !prevState->wellMap().empty()) {
-                typedef typename WellMapType :: const_iterator const_iterator;
-                const_iterator end = prevState->wellMap().end();
+            if (prevState && !prevState->wellMap().empty()) {
+                connpos = 0;
+                auto end = prevState->wellMap().end();
                 for (int w = 0; w < nw; ++w) {
-                    const std::string name( wells->name[ w ] );
-                    const_iterator it = prevState->wellMap().find( name );
-                    if( it != end )
+                    const Well2& well = wells_ecl[w];
+                    const int num_perf_this_well = well_perf_data[w].size();
+                    auto it = prevState->wellMap().find(well.name());
+                    if ( it != end )
                     {
                         const int oldIndex = (*it).second[ 0 ];
                         const int newIndex = w;
@@ -209,19 +191,18 @@ namespace Opm
                         // perfPhaseRates
                         const int oldPerf_idx_beg = (*it).second[ 1 ];
                         const int num_perf_old_well = (*it).second[ 2 ];
-                        const int num_perf_this_well = wells->well_connpos[newIndex + 1] - wells->well_connpos[newIndex];
                         // copy perforation rates when the number of perforations is equal,
                         // otherwise initialize perfphaserates to well rates divided by the number of perforations.
                         if( num_perf_old_well == num_perf_this_well )
                         {
                             int old_perf_phase_idx = oldPerf_idx_beg *np;
-                            for (int perf_phase_idx = wells->well_connpos[ newIndex ]*np;
-                                 perf_phase_idx < wells->well_connpos[ newIndex + 1]*np; ++perf_phase_idx, ++old_perf_phase_idx )
+                            for (int perf_phase_idx = connpos*np;
+                                 perf_phase_idx < (connpos + num_perf_this_well)*np; ++perf_phase_idx, ++old_perf_phase_idx )
                             {
                                 perfPhaseRates()[ perf_phase_idx ] = prevState->perfPhaseRates()[ old_perf_phase_idx ];
                             }
                         } else {
-                            for (int perf = wells->well_connpos[newIndex]; perf < wells->well_connpos[newIndex + 1]; ++perf) {
+                            for (int perf = connpos; perf < connpos + num_perf_this_well; ++perf) {
                                 for (int p = 0; p < np; ++p) {
                                     perfPhaseRates()[np*perf + p] = wellRates()[np*newIndex + p] / double(num_perf_this_well);
                                 }
@@ -231,8 +212,7 @@ namespace Opm
                         if( num_perf_old_well == num_perf_this_well )
                         {
                             int oldPerf_idx = oldPerf_idx_beg;
-                            for (int perf = wells->well_connpos[ newIndex ];
-                                 perf < wells->well_connpos[ newIndex + 1]; ++perf, ++oldPerf_idx )
+                            for (int perf = connpos; perf < connpos + num_perf_this_well; ++perf, ++oldPerf_idx )
                             {
                                 perfPress()[ perf ] = prevState->perfPress()[ oldPerf_idx ];
                             }
@@ -242,8 +222,7 @@ namespace Opm
                             if( num_perf_old_well == num_perf_this_well )
                             {
                                 int oldPerf_idx = oldPerf_idx_beg;
-                                for (int perf = wells->well_connpos[ newIndex ];
-                                     perf < wells->well_connpos[ newIndex + 1]; ++perf, ++oldPerf_idx )
+                                for (int perf = connpos; perf < connpos + num_perf_this_well; ++perf, ++oldPerf_idx )
                                 {
                                     perfRateSolvent()[ perf ] = prevState->perfRateSolvent()[ oldPerf_idx ];
                                 }
@@ -257,8 +236,7 @@ namespace Opm
                             if( num_perf_old_well == num_perf_this_well )
                             {
                                 int oldPerf_idx = oldPerf_idx_beg;
-                                for (int perf = wells->well_connpos[ newIndex ];
-                                     perf < wells->well_connpos[ newIndex + 1]; ++perf, ++oldPerf_idx )
+                                for (int perf = connpos; perf < connpos + num_perf_this_well; ++perf, ++oldPerf_idx )
                                 {
                                     perf_water_throughput_[ perf ] = prevState->perfThroughput()[ oldPerf_idx ];
                                     perf_skin_pressure_[ perf ] = prevState->perfSkinPressure()[ oldPerf_idx ];
@@ -268,21 +246,16 @@ namespace Opm
                         }
                     }
 
-
                     // If in the new step, there is no THP related target/limit anymore, its thp value should be
                     // set to zero.
-                    const WellControls* ctrl = wells->ctrls[w];
-                    const int nwc = well_controls_get_num(ctrl);
-                    int ctrl_index = 0;
-                    for (; ctrl_index < nwc; ++ctrl_index) {
-                        if (well_controls_iget_type(ctrl, ctrl_index) == THP) {
-                            break;
-                        }
+                    const bool has_thp = well.isInjector() ? well.injectionControls(summary_state).hasControl(Well2::InjectorCMode::THP)
+                        : well.productionControls(summary_state).hasControl(Well2::ProducerCMode::THP);
+                    if (!has_thp) {
+                        thp()[w] = 0.0;
                     }
-                    // not finding any thp related control/limits
-                    if (ctrl_index == nwc) {
-                        thp()[w] = 0.;
-                    }
+
+                    // Increment connection position offset.
+                    connpos += num_perf_this_well;
                 }
             }
 
@@ -302,14 +275,19 @@ namespace Opm
         }
 
 
-        void resize(const Wells* wells, const std::vector<Well2>& wells_ecl, const Schedule& schedule,
-                    const bool handle_ms_well, const size_t numCells, const PhaseUsage& pu)
+        void resize(const std::vector<Well2>& wells_ecl,
+                    const Schedule& schedule,
+                    const bool handle_ms_well,
+                    const size_t numCells,
+                    const PhaseUsage& pu,
+                    const std::vector<std::vector<PerforationData>>& well_perf_data,
+                    const SummaryState& summary_state)
         {
             const std::vector<double> tmp(numCells, 0.0); // <- UGLY HACK to pass the size
-            init(wells, tmp, schedule, wells_ecl, 0, nullptr, pu);
+            init(tmp, schedule, wells_ecl, 0, nullptr, pu, well_perf_data, summary_state);
 
             if (handle_ms_well) {
-                initWellStateMSWell(wells, wells_ecl, pu, nullptr);
+                initWellStateMSWell(wells_ecl, pu, nullptr);
             }
         }
 
@@ -375,13 +353,6 @@ namespace Opm
                 phs.at( pu.phase_pos[Gas] ) = rt::gas;
             }
 
-            if (pu.has_solvent) {
-                // add solvent component
-                for( int w = 0; w < nw; ++w ) {
-                    res.at( wells_->name[ w ]).rates.set( rt::solvent, solventWellRate(w) );
-                }
-            }
-
             /* this is a reference or example on **how** to convert from
              * WellState to something understood by opm-output. it is intended
              * to be properly implemented and maintained as a part of
@@ -432,10 +403,14 @@ namespace Opm
                     well.rates.set( rt::well_potential_gas, this->well_potentials_[well_rate_index + pu.phase_pos[Gas]] );
                 }
 
+                if ( pu.has_solvent ) {
+                    well.rates.set( rt::solvent, solventWellRate(w) );
+                }
+
                 well.rates.set( rt::dissolved_gas, this->well_dissolved_gas_rates_[w] );
                 well.rates.set( rt::vaporized_oil, this->well_vaporized_oil_rates_[w] );
 
-                int local_comp_index = 0;
+                size_t local_comp_index = 0;
                 for( auto& comp : well.connections) {
                     const auto rates = this->perfPhaseRates().begin()
                                      + (np * wt.second[ 1 ])
@@ -446,7 +421,7 @@ namespace Opm
                         comp.rates.set( phs[ i ], *(rates + i) );
                     }
                 }
-                assert(local_comp_index == this->wells_->well_connpos[ w + 1 ] - this->wells_->well_connpos[ w ]);
+                assert(local_comp_index == this->well_perf_data_[w].size());
 
                 const auto nseg = this->numSegments(w);
                 for (auto seg_ix = 0*nseg; seg_ix < nseg; ++seg_ix) {
@@ -461,11 +436,11 @@ namespace Opm
 
 
         /// init the MS well related.
-        void initWellStateMSWell(const Wells* wells, const std::vector<Well2>& wells_ecl,
+        void initWellStateMSWell(const std::vector<Well2>& wells_ecl,
                                  const PhaseUsage& pu, const WellStateFullyImplicitBlackoil* prev_well_state)
         {
             // still using the order in wells
-            const int nw = wells->number_of_wells;
+            const int nw = wells_ecl.size();
             if (nw == 0) {
                 return;
             }
@@ -479,24 +454,12 @@ namespace Opm
             seg_number_.clear();
 
             nseg_ = 0;
+            int connpos = 0;
             // in the init function, the well rates and perforation rates have been initialized or copied from prevState
             // what we do here, is to set the segment rates and perforation rates
             for (int w = 0; w < nw; ++w) {
-                const int nw_wells_ecl = wells_ecl.size();
-                int index_well_ecl = 0;
-                const std::string well_name(wells->name[w]);
-                for (; index_well_ecl < nw_wells_ecl; ++index_well_ecl) {
-                    if (well_name == wells_ecl[index_well_ecl].name()) {
-                        break;
-                    }
-                }
-
-                // It should be able to find in wells_ecl.
-                if (index_well_ecl == nw_wells_ecl) {
-                    OPM_THROW(std::logic_error, "Could not find well " << well_name << " in wells_ecl ");
-                }
-
-                const auto& well_ecl = wells_ecl[index_well_ecl];
+                const auto& well_ecl = wells_ecl[w];
+                int num_perf_this_well = well_perf_data_[w].size();
                 top_segment_index_.push_back(nseg_);
                 if ( !well_ecl.isMultiSegment() ) { // not multi-segment well
                     nseg_ += 1;
@@ -512,7 +475,6 @@ namespace Opm
                     const WellConnections& completion_set = well_ecl.getConnections();
                     // number of segment for this single well
                     const int well_nseg = segment_set.size();
-                    // const int nperf = completion_set.size();
                     int n_activeperf = 0;
                     nseg_ += well_nseg;
                     for (auto segID = 0*well_nseg; segID < well_nseg; ++segID) {
@@ -546,8 +508,8 @@ namespace Opm
                     // for the segrates_, now it becomes a recursive solution procedure.
                     {
                         const int np = numPhases();
-                        const int start_perf = wells->well_connpos[w];
-                        const int start_perf_next_well = wells->well_connpos[w + 1];
+                        const int start_perf = connpos;
+                        const int start_perf_next_well = connpos + num_perf_this_well;
 
                         // make sure the information from wells_ecl consistent with wells
                         assert(n_activeperf == (start_perf_next_well - start_perf));
@@ -581,7 +543,7 @@ namespace Opm
                         // top segment is always the first one, and its pressure is the well bhp
                         segpress_.push_back(bhp()[w]);
                         const int top_segment = top_segment_index_[w];
-                        const int start_perf = wells->well_connpos[w];
+                        const int start_perf = connpos;
                         for (int seg = 1; seg < well_nseg; ++seg) {
                             if ( !segment_perforations[seg].empty() ) {
                                 const int first_perf = segment_perforations[seg][0];
@@ -595,6 +557,7 @@ namespace Opm
                         }
                     }
                 }
+                connpos += num_perf_this_well;
             }
             assert(int(segpress_.size()) == nseg_);
             assert(int(segrates_.size()) == nseg_ * numPhases() );
@@ -604,8 +567,7 @@ namespace Opm
                 const auto& end = prev_well_state->wellMap().end();
                 const int np = numPhases();
                 for (int w = 0; w < nw; ++w) {
-                    const std::string name( wells->name[w] );
-                    const auto& it = prev_well_state->wellMap().find( name );
+                    const auto& it = prev_well_state->wellMap().find( wells_ecl[w].name() );
 
                     if (it != end) { // the well is found in the prev_well_state
                         // TODO: the well with same name can change a lot, like they might not have same number of segments
@@ -677,8 +639,13 @@ namespace Opm
 
         /// One rate pr well
         double solventWellRate(const int w) const {
+            int connpos = 0;
+            for (int iw = 0; iw < w; ++iw) {
+                connpos += this->well_perf_data_[iw].size();
+            }
             double solvent_well_rate = 0.0;
-            for (int perf = wells_->well_connpos[w]; perf < wells_->well_connpos[w+1]; ++perf ) {
+            const int endperf = connpos + this->well_perf_data_[w].size();
+            for (int perf = connpos; perf < endperf; ++perf ) {
                 solvent_well_rate += perfRateSolvent_[perf];
             }
             return solvent_well_rate;

--- a/tests/test_wellmodel.cpp
+++ b/tests/test_wellmodel.cpp
@@ -86,27 +86,12 @@ struct SetupTest {
         const Grid& grid = *(gm.c_grid());
 
         current_timestep = 0;
-
-        // Create wells.
-        wells_manager.reset(new Opm::WellsManager(*ecl_state,
-                                                  *schedule,
-                                                  *summaryState,
-                                                  current_timestep,
-                                                  Opm::UgGridHelpers::numCells(grid),
-                                                  Opm::UgGridHelpers::globalCell(grid),
-                                                  Opm::UgGridHelpers::cartDims(grid),
-                                                  Opm::UgGridHelpers::dimensions(grid),
-                                                  Opm::UgGridHelpers::cell2Faces(grid),
-                                                  Opm::UgGridHelpers::beginFaceCentroids(grid),
-                                                  false,
-                                                  std::unordered_set<std::string>() ) );
-
     };
 
-    std::unique_ptr<const Opm::WellsManager> wells_manager;
     std::unique_ptr<const Opm::EclipseState> ecl_state;
     std::unique_ptr<const Opm::Schedule> schedule;
     std::unique_ptr<Opm::SummaryState> summaryState;
+    std::vector<std::vector<Opm::PerforationData>> well_perf_data;
     int current_timestep;
 };
 
@@ -132,7 +117,6 @@ BOOST_GLOBAL_FIXTURE(GlobalFixture);
 
 BOOST_AUTO_TEST_CASE(TestStandardWellInput) {
     const SetupTest setup_test;
-    const Wells* wells = setup_test.wells_manager->c_wells();
     const auto& wells_ecl = setup_test.schedule->getWells2(setup_test.current_timestep);
     BOOST_CHECK_EQUAL( wells_ecl.size(), 2);
     const Opm::Well2& well = wells_ecl[1];
@@ -149,36 +133,24 @@ BOOST_AUTO_TEST_CASE(TestStandardWellInput) {
     rateConverter.reset(new RateConverterType (phaseUsage,
                                      std::vector<int>(10, 0)));
 
-    const int pvtIdx = 0;
-    const int num_comp = wells->number_of_phases;
+    Opm::PerforationData dummy;
+    std::vector<Opm::PerforationData> pdata(well.getConnections().size(), dummy);
 
-    BOOST_CHECK_THROW( StandardWell( well, -1, wells, param, *rateConverter, pvtIdx, num_comp), std::invalid_argument);
-    BOOST_CHECK_THROW( StandardWell( well, 4, nullptr , param, *rateConverter, pvtIdx, num_comp), std::invalid_argument);
+    BOOST_CHECK_THROW( StandardWell( well, -1, param, *rateConverter, 0, 3, 3, 0, 0, pdata), std::invalid_argument);
 }
 
 
 BOOST_AUTO_TEST_CASE(TestBehavoir) {
     const SetupTest setup_test;
-    const Wells* wells_struct = setup_test.wells_manager->c_wells();
     const auto& wells_ecl = setup_test.schedule->getWells2(setup_test.current_timestep);
     const int current_timestep = setup_test.current_timestep;
     std::vector<std::unique_ptr<const StandardWell> >  wells;
 
     {
-        const int nw = wells_struct ? (wells_struct->number_of_wells) : 0;
+        const int nw = wells_ecl.size();
         const Opm::BlackoilModelParametersEbos<TTAG(EclFlowProblem)> param;
 
         for (int w = 0; w < nw; ++w) {
-            const std::string well_name(wells_struct->name[w]);
-
-            size_t index_well = 0;
-            for (; index_well < wells_ecl.size(); ++index_well) {
-                if (well_name == wells_ecl[index_well].name()) {
-                    break;
-                }
-            }
-            // we should always be able to find the well in wells_ecl
-            BOOST_CHECK(index_well !=  wells_ecl.size());
             // For the conversion between the surface volume rate and resrevoir voidage rate
             typedef Opm::BlackOilFluidSystem<double> FluidSystem;
             using RateConverterType = Opm::RateConverter::
@@ -191,11 +163,9 @@ BOOST_AUTO_TEST_CASE(TestBehavoir) {
             // Compute reservoir volumes for RESV controls.
             rateConverter.reset(new RateConverterType (phaseUsage,
                                              std::vector<int>(10, 0)));
-
-            const int pvtIdx = 0;
-            const int num_comp = wells_struct->number_of_phases;
-
-            wells.emplace_back(new StandardWell(wells_ecl[index_well], current_timestep, wells_struct, param, *rateConverter, pvtIdx, num_comp) );
+            Opm::PerforationData dummy;
+            std::vector<Opm::PerforationData> pdata(wells_ecl[w].getConnections().size(), dummy);
+            wells.emplace_back(new StandardWell(wells_ecl[w], current_timestep, param, *rateConverter, 0, 3, 3, w, 0, pdata) );
         }
     }
 
@@ -203,7 +173,7 @@ BOOST_AUTO_TEST_CASE(TestBehavoir) {
     {
         const auto& well = wells[0];
         BOOST_CHECK_EQUAL(well->name(), "PROD1");
-        BOOST_CHECK(well->wellType() == PRODUCER);
+        BOOST_CHECK(well->isProducer());
         BOOST_CHECK(well->numEq == 3);
         BOOST_CHECK(well->numStaticWellEq== 4);
     }
@@ -212,7 +182,7 @@ BOOST_AUTO_TEST_CASE(TestBehavoir) {
     {
         const auto& well = wells[1];
         BOOST_CHECK_EQUAL(well->name(), "INJE1");
-        BOOST_CHECK(well->wellType() == INJECTOR);
+        BOOST_CHECK(well->isInjector());
         BOOST_CHECK(well->numEq == 3);
         BOOST_CHECK(well->numStaticWellEq== 4);      
     }

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -53,13 +53,60 @@ struct Setup
         , grid (es.getInputGrid())
         , sched(deck, es)
         , st(std::chrono::system_clock::from_time_t(sched.getStartTime()))
-    {}
+    {
+        initWellPerfData();
+    }
+
+    void initWellPerfData()
+    {
+        const auto& wells = sched.getWells2(0);
+        const auto& cartDims = Opm::UgGridHelpers::cartDims(*grid.c_grid());
+        const int* compressed_to_cartesian = Opm::UgGridHelpers::globalCell(*grid.c_grid());
+        std::vector<int> cartesian_to_compressed(cartDims[0] * cartDims[1] * cartDims[2], -1);
+        for (size_t ii = 0; ii < Opm::UgGridHelpers::numCells(*grid.c_grid()); ++ii) {
+            cartesian_to_compressed[compressed_to_cartesian[ii]] = ii;
+        }
+        well_perf_data.resize(wells.size());
+        int well_index = 0;
+        for (const auto& well : wells) {
+            well_perf_data[well_index].clear();
+            well_perf_data[well_index].reserve(well.getConnections().size());
+            for (const auto& completion : well.getConnections()) {
+                if (completion.state() == Opm::Connection::State::OPEN) {
+                    const int i = completion.getI();
+                    const int j = completion.getJ();
+                    const int k = completion.getK();
+                    const int cart_grid_indx = i + cartDims[0] * (j + cartDims[1] * k);
+                    const int active_index = cartesian_to_compressed[cart_grid_indx];
+                    if (active_index < 0) {
+                        const std::string msg
+                            = ("Cell with i,j,k indices " + std::to_string(i) + " " + std::to_string(j) + " "
+                               + std::to_string(k) + " not found in grid (well = " + well.name() + ").");
+                        OPM_THROW(std::runtime_error, msg);
+                    } else {
+                        Opm::PerforationData pd;
+                        pd.cell_index = active_index;
+                        pd.connection_transmissibility_factor = completion.CF() * completion.wellPi();
+                        pd.satnum_id = completion.satTableId();
+                        well_perf_data[well_index].push_back(pd);
+                    }
+                } else {
+                    if (completion.state() != Opm::Connection::State::SHUT) {
+                        OPM_THROW(std::runtime_error,
+                                  "Completion state: " << Opm::Connection::State2String(completion.state()) << " not handled");
+                    }
+                }
+            }
+            ++well_index;
+        }
+    }
 
     Opm::EclipseState es;
     Opm::PhaseUsage   pu;
     Opm::GridManager  grid;
     Opm::Schedule     sched;
     Opm::SummaryState st;
+    std::vector<std::vector<Opm::PerforationData>> well_perf_data;
 };
 
 namespace {
@@ -72,14 +119,11 @@ namespace {
             std::vector<double>(setup.grid.c_grid()->number_of_cells,
                                 100.0*Opm::unit::barsa);
 
-        const Opm::WellsManager wmgr{setup.es, setup.sched, setup.st, timeStep, *setup.grid.c_grid()};
-
-        state.init(wmgr.c_wells(), cpress, setup.sched,
+        state.init(cpress, setup.sched,
                    setup.sched.getWells2(timeStep),
-                   timeStep, nullptr, setup.pu);
+                   timeStep, nullptr, setup.pu, setup.well_perf_data, setup.st);
 
-        state.initWellStateMSWell(wmgr.c_wells(),
-                                  setup.sched.getWells2(timeStep),
+        state.initWellStateMSWell(setup.sched.getWells2(timeStep),
                                   setup.pu, nullptr);
 
         return state;


### PR DESCRIPTION
This is intended to simplify the well code, as well(ha) as simulator setup. When this is complete, the WellsManager and all related code can be removed.