### PR TITLE
Pass ParseContext settings in constructor

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -324,7 +324,10 @@ int main(int argc, char** argv)
         std::shared_ptr<Opm::SummaryConfig> summaryConfig;
         {
             Opm::Parser parser;
-            Opm::ParseContext parseContext;
+            Opm::ParseContext parseContext({{Opm::ParseContext::PARSE_RANDOM_SLASH, Opm::InputError::IGNORE},
+                                            {Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputError::WARN},
+                                            {Opm::ParseContext::SUMMARY_UNKNOWN_WELL, Opm::InputError::WARN},
+                                            {Opm::ParseContext::SUMMARY_UNKNOWN_GROUP, Opm::InputError::WARN}});
             Opm::ErrorGuard errorGuard;
             outputMode = setupLogging(mpiRank,
                                       deckFilename,
@@ -334,12 +337,6 @@ int main(int argc, char** argv)
 
             if (EWOMS_GET_PARAM(PreTypeTag, bool, EclStrictParsing))
                 parseContext.update( Opm::InputError::DELAYED_EXIT1);
-            else {
-                parseContext.update(Opm::ParseContext::PARSE_RANDOM_SLASH, Opm::InputError::IGNORE);
-                parseContext.update(Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputError::WARN);
-                parseContext.update(Opm::ParseContext::SUMMARY_UNKNOWN_WELL, Opm::InputError::WARN);
-                parseContext.update(Opm::ParseContext::SUMMARY_UNKNOWN_GROUP, Opm::InputError::WARN);
-            }
 
             Opm::FlowMainEbos<PreTypeTag>::printPRTHeader(outputCout);
 


### PR DESCRIPTION
Use an alterntative `ParseContext` constructor to enable environment variable based settings. 

In master the ParseContext settings are set with the `update`method *after* the environment variables have been processed; i.e. for the four settings which are explicitly set in flow it is not possible to override with environment variables. In current master flow will only warn if the summary section mentions an unknown well; if the current PR is merged this can be changed with:
```bash
bash% export OPM_ERRORS_EXIT1=SUMMARY_UNKNOWN_WELL
bash% flow CASE.DATA
...
Error: Error in keyword:WWIR No such well: C-1H
A fatal error has occured and the application will stop.
Error in keyword:WWIR No such well: C-1H
```
