### PR TITLE
Move BlackOilOnePhaseIndices to Opm namespace

### DIFF
--- a/flow/flow_onephase.cpp
+++ b/flow/flow_onephase.cpp
@@ -38,7 +38,7 @@ private:
     typedef typename GET_PROP_TYPE(BaseTypeTag, FluidSystem) FluidSystem;
 
 public:
-    typedef Ewoms::BlackOilOnePhaseIndices<GET_PROP_VALUE(TypeTag, EnableSolvent),
+    typedef Opm::BlackOilOnePhaseIndices<GET_PROP_VALUE(TypeTag, EnableSolvent),
                                            GET_PROP_VALUE(TypeTag, EnablePolymer),
                                            GET_PROP_VALUE(TypeTag, EnableEnergy),
                                            GET_PROP_VALUE(TypeTag, EnableFoam),

--- a/flow/flow_onephase.cpp
+++ b/flow/flow_onephase.cpp
@@ -39,11 +39,11 @@ private:
 
 public:
     typedef Opm::BlackOilOnePhaseIndices<GET_PROP_VALUE(TypeTag, EnableSolvent),
-                                           GET_PROP_VALUE(TypeTag, EnablePolymer),
-                                           GET_PROP_VALUE(TypeTag, EnableEnergy),
-                                           GET_PROP_VALUE(TypeTag, EnableFoam),
-                                           /*PVOffset=*/0,
-                                           /*enebledCompIdx=*/FluidSystem::waterCompIdx>
+                                         GET_PROP_VALUE(TypeTag, EnablePolymer),
+                                         GET_PROP_VALUE(TypeTag, EnableEnergy),
+                                         GET_PROP_VALUE(TypeTag, EnableFoam),
+                                         /*PVOffset=*/0,
+                                         /*enebledCompIdx=*/FluidSystem::waterCompIdx>
         type;
 };
 SET_PROP(EclFlowProblemSimple, FluidState)

--- a/flow/flow_onephase_energy.cpp
+++ b/flow/flow_onephase_energy.cpp
@@ -40,11 +40,11 @@ private:
 
 public:
     typedef Opm::BlackOilOnePhaseIndices<GET_PROP_VALUE(TypeTag, EnableSolvent),
-                                           GET_PROP_VALUE(TypeTag, EnablePolymer),
-                                           GET_PROP_VALUE(TypeTag, EnableEnergy),
-                                           GET_PROP_VALUE(TypeTag, EnableFoam),
-                                           /*PVOffset=*/0,
-                                           /*enebledCompIdx=*/FluidSystem::waterCompIdx>
+                                         GET_PROP_VALUE(TypeTag, EnablePolymer),
+                                         GET_PROP_VALUE(TypeTag, EnableEnergy),
+                                         GET_PROP_VALUE(TypeTag, EnableFoam),
+                                         /*PVOffset=*/0,
+                                         /*enebledCompIdx=*/FluidSystem::waterCompIdx>
         type;
 };
 SET_PROP(EclFlowProblemSimple, FluidState)

--- a/flow/flow_onephase_energy.cpp
+++ b/flow/flow_onephase_energy.cpp
@@ -39,7 +39,7 @@ private:
     typedef typename GET_PROP_TYPE(BaseTypeTag, FluidSystem) FluidSystem;
 
 public:
-    typedef Ewoms::BlackOilOnePhaseIndices<GET_PROP_VALUE(TypeTag, EnableSolvent),
+    typedef Opm::BlackOilOnePhaseIndices<GET_PROP_VALUE(TypeTag, EnableSolvent),
                                            GET_PROP_VALUE(TypeTag, EnablePolymer),
                                            GET_PROP_VALUE(TypeTag, EnableEnergy),
                                            GET_PROP_VALUE(TypeTag, EnableFoam),


### PR DESCRIPTION
to make it consistent with the rest. OPM/opm-models#530 development
must have been started before the renaming in OPM/opm-models#532
and somehow the old namespace survived.

downstream PR of OPM/opm-models#577