### PR TITLE
Only print usage information on one processes.

### DIFF
--- a/flow/flow_tag.hpp
+++ b/flow/flow_tag.hpp
@@ -329,8 +329,14 @@ int mainFlow(int argc, char** argv)
         deckFilename = PreVanguard::canonicalDeckPath(deckFilename).string();
     }
     catch (const std::exception& e) {
-        Opm::Parameters::printUsage<PreTypeTag>(PreProblem::helpPreamble(argc, const_cast<const char**>(argv)),
-                                                  e.what());
+        if (mpiRank == 0)
+        {
+            Opm::Parameters::printUsage<PreTypeTag>(PreProblem::helpPreamble(argc, const_cast<const char**>(argv)),
+                                                    e.what());
+        }
+#if HAVE_MPI
+        MPI_Finalize();
+#endif
         return 1;
     }
 

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -142,14 +142,14 @@ namespace Opm
 
             EWOMS_END_PARAM_REGISTRATION(TypeTag);
 
-            // read in the command line parameters
-            int status = Opm::setupParameters_<TypeTag>(argc, const_cast<const char**>(argv), /*doRegistration=*/false, /*allowUnused=*/true, /*handleHelp=*/true);
-            if (status == 0) {
-
-                int mpiRank = 0;
+            int mpiRank = 0;
 #if HAVE_MPI
-                MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+            MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
 #endif
+
+            // read in the command line parameters
+            int status = Opm::setupParameters_<TypeTag>(argc, const_cast<const char**>(argv), /*doRegistration=*/false, /*allowUnused=*/true, /*handleHelp=*/(mpiRank==0));
+            if (status == 0) {
 
                 // deal with unknown parameters.
 


### PR DESCRIPTION
No matter whether requested via --help or printed due to a wrong command line parameter.

Closes #2012.