### PR TITLE
Filter connections on non-IO ranks and remove parallel deadlock

### DIFF
--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -280,6 +280,13 @@ protected:
             const auto eclipseGrid = Opm::UgGridHelpers::createEclipseGrid(equilGrid(), this->eclState().getInputGrid());
             this->schedule().filterConnections(eclipseGrid);
         }
+        else
+        {
+            // for the other processes we filter using the local grid since there
+            // are models with connections specified to inactive cells
+            const auto eclipseGrid = Opm::UgGridHelpers::createEclipseGrid(grid(), this->eclState().getInputGrid());
+            this->schedule().filterConnections(eclipseGrid);
+        }
     }
 
     std::unique_ptr<Grid> grid_;


### PR DESCRIPTION
This removes a deadlock experienced for some models where we have specified connections to non-active cells.

On non-IO ranks we are using the local grid since in the future there will be no global grid available. Wells connecting cells not on these processors are neglected anyway.

Closes #2101