### PR TITLE
Fix BlackoilWellModel::numComponents for parallel runs.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -337,7 +337,7 @@ namespace Opm {
             // The number of components in the model.
             int numComponents() const;
 
-            int numWells() const;
+            int numLocalWells() const;
 
             int numPhases() const;
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1380,7 +1380,7 @@ namespace Opm {
     int
     BlackoilWellModel<TypeTag>::numComponents() const
     {
-        if (numWells() > 0 && numPhases() < 3) {
+        if (wellsActive()  && numPhases() < 3) {
             return numPhases();
         }
         int numComp = FluidSystem::numComponents;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -620,7 +620,7 @@ namespace Opm {
     {
         std::vector<WellInterfacePtr> well_container;
 
-        const int nw = numWells();
+        const int nw = numLocalWells();
 
         if (nw > 0) {
             well_container.reserve(nw);
@@ -732,7 +732,7 @@ namespace Opm {
         const Well2& well_ecl = wells_ecl_[index_well_ecl];
 
         // Finding the location of the well in wells struct.
-        const int nw = numWells();
+        const int nw = numLocalWells();
         int well_index_wells = -999;
         for (int w = 0; w < nw; ++w) {
             if (well_name == std::string(wells()->name[w])) {
@@ -944,7 +944,7 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     localWellsActive() const
     {
-        return numWells() > 0;
+        return numLocalWells() > 0;
     }
 
 
@@ -1148,7 +1148,7 @@ namespace Opm {
     computeWellPotentials(std::vector<double>& well_potentials, const int reportStepIdx, Opm::DeferredLogger& deferred_logger)
     {
         // number of wells and phases
-        const int nw = numWells();
+        const int nw = numLocalWells();
         const int np = numPhases();
         well_potentials.resize(nw * np, 0.0);
 
@@ -1393,7 +1393,7 @@ namespace Opm {
 
     template<typename TypeTag>
     int
-    BlackoilWellModel<TypeTag>:: numWells() const
+    BlackoilWellModel<TypeTag>:: numLocalWells() const
     {
         return wells() ? wells()->number_of_wells : 0;
     }


### PR DESCRIPTION
In the case with active solvent (BlackoilWellModel::has_solvent_ is
true, e.g. case 2D_OILWATER_POLYMER.DATA) and one process have no
wells while another has some this lead to numComponents returning
different values. Later this lead to truncated message in MPI_Allgather.

The underlying problem was the usage of numWells() which returns just
the number of local wells. We resort to using wellsActive which
returns whether there any well active regardless which process knows it.