### PR TITLE
make BlackoilWellModel::numComponents return consistent values.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -238,6 +238,8 @@ namespace Opm {
 
             bool wells_active_;
 
+            int global_num_phases_;
+
             // a vector of all the wells.
             std::vector<WellInterfacePtr > well_container_;
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1151,6 +1151,10 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     computeWellPotentials(std::vector<double>& well_potentials, const int reportStepIdx, Opm::DeferredLogger& deferred_logger)
     {
+        if ( ! wellsActive() ) {
+            return;
+        }
+
         // number of wells and phases
         const int nw = numLocalWells();
         const int np = numPhases();
@@ -1311,6 +1315,9 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     computeAverageFormationFactor(std::vector<Scalar>& B_avg) const
     {
+        if ( ! wellsActive() ) {
+            return;
+        }
         const auto& grid = ebosSimulator_.vanguard().grid();
         const auto& gridView = grid.leafGridView();
         ElementContext elemCtx(ebosSimulator_);

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -233,6 +233,10 @@ namespace Opm {
         // one process.
         wells_active_ = localWellsActive() ? 1 : 0;
         wells_active_ = grid.comm().max(wells_active_);
+        // Number of phases can only be determined globally as it needs
+        // an active well and there might be processes without wells.
+        global_num_phases_ = numPhases();
+        global_num_phases_ = grid.comm().max(global_num_phases_);
 
         // The well state initialize bhp with the cell pressure in the top cell.
         // We must therefore provide it with updated cell pressures
@@ -1380,8 +1384,8 @@ namespace Opm {
     int
     BlackoilWellModel<TypeTag>::numComponents() const
     {
-        if (wellsActive()  && numPhases() < 3) {
-            return numPhases();
+        if (global_num_phases_ < 3) {
+            return global_num_phases_;
         }
         int numComp = FluidSystem::numComponents;
         if (has_solvent_) {


### PR DESCRIPTION
The return value is used to resize a vector that is used unconditionally
(i.e. whether there are wells or not) elsewhere, e.g. in
computeAverageFormationFactor, called from computeWellPotentials
called from timeStepSucceeded. Hence it has to return the same value
whether on all processes whether there wells (globally or locally) or
not.

This is done by this commit that introduces global_num_phases_ that
is the max of all phases on any process.