### PR TITLE
Make sure the perforation pressures is initialized also for STOP wells

### DIFF
--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -143,18 +143,16 @@ namespace Opm
                 assert((wells->type[w] == INJECTOR) || (wells->type[w] == PRODUCER));
                 const WellControls* ctrl = wells->ctrls[w];
 
-                if (well_controls_well_is_stopped(ctrl)) {
-                    // Shut well: perfphaserates_ are all zero.
-                } else {
-                    const int num_perf_this_well = wells->well_connpos[w + 1] - wells->well_connpos[w];
-                    // Open well: Initialize perfphaserates_ to well
-                    // rates divided by the number of perforations.
-                    for (int perf = wells->well_connpos[w]; perf < wells->well_connpos[w + 1]; ++perf) {
+                const int num_perf_this_well = wells->well_connpos[w + 1] - wells->well_connpos[w];
+                // Open well: Initialize perfphaserates_ to well
+                // rates divided by the number of perforations.
+                for (int perf = wells->well_connpos[w]; perf < wells->well_connpos[w + 1]; ++perf) {
+                    if (well_controls_well_is_open(ctrl)) {
                         for (int p = 0; p < np; ++p) {
                             perfphaserates_[np*perf + p] = wellRates()[np*w + p] / double(num_perf_this_well);
                         }
-                        perfPress()[perf] = cellPressures[wells->well_cells[perf]];
                     }
+                    perfPress()[perf] = cellPressures[wells->well_cells[perf]];
                 }
             }
 

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -303,4 +303,18 @@ BOOST_AUTO_TEST_CASE(Rates)
     }
 }
 
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(STOP_well)
+{
+    /*
+      This test verifies that the perforation pressures is correctly initialized
+      also for wells in the STOP state.
+    */
+    const Setup setup{ "wells_manager_data_wellSTOP.data" };
+    auto wstate = buildWellState(setup, 0);
+    for (const auto& p : wstate.perfPress())
+        BOOST_CHECK(p > 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/wells_manager_data_wellSTOP.data
+++ b/tests/wells_manager_data_wellSTOP.data
@@ -35,11 +35,17 @@ SCHEDULE
 WELSPECS
     'INJ1' 'G'    1  1    8335 'GAS'  /
     'PROD1' 'G'   10 10    8400 'OIL'  /
+    'STOP'  'G'   5  5     8400 'OIL'  /
 /
 
 COMPDAT
     'INJ1'   1  1 1  1 'OPEN' 1   10.6092   0.5  /
     'PROD1'  10 3 3  3 'OPEN' 0   10.6092   0.5  /
+    'STOP'   5  3 1  3 'OPEN' 0   10.6092   0.5  /
+/
+
+WCONHIST
+     'STOP' 'STOP' 'GRAT' 0 0 0 /
 /
 
 WCONPROD


### PR DESCRIPTION
For a well which starts in the state `STOP` the perforation pressures are not properly initialized, and the `-1e100` value from: [`WellState` initialization](https://github.com/OPM/opm-simulators/blob/master/opm/simulators/wells/WellState.hpp#L177) spreads around creating havoc.

~~The current PR works for me - I am trying to make a proper test for it.~~ Help from @atgeirr in the debugging process is acknowledged.

