### PR TITLE
adding AQUFET back to MissingFeatures.cpp

### DIFF
--- a/opm/simulators/flow/MissingFeatures.cpp
+++ b/opm/simulators/flow/MissingFeatures.cpp
@@ -104,6 +104,7 @@ namespace MissingFeatures {
             "AQANTRC",
             "AQUCON",
             "AQUCWFAC",
+            "AQUFET",
             "AQUFLUX",
             "AQUNNC",
             "AQUNUM",


### PR DESCRIPTION
which was removed by mistake in PR #2162

My mistake. 