### PR TITLE
changed: use a separate output dir in the parallel norne test

### DIFF
--- a/jenkins/run-norne.sh
+++ b/jenkins/run-norne.sh
@@ -9,7 +9,7 @@ cd norne
 mkdir $SIM
 if test -n "$1"
 then
-  mpirun -np $1 $WORKSPACE/$configuration/build-opm-simulators/bin/$SIM --output-dir=$SIM NORNE_ATW2013.DATA
+  mpirun -np $1 $WORKSPACE/$configuration/build-opm-simulators/bin/$SIM --output-dir=${SIM}_${1}_proc NORNE_ATW2013.DATA
 else
   $WORKSPACE/$configuration/build-opm-simulators/bin/$SIM --output-dir=$SIM NORNE_ATW2013.DATA
 fi


### PR DESCRIPTION
this way we get curves for both the serial and parallel runs in the well plots.

requires https://github.com/OPM/opm-tests/pull/193