### PR TITLE
Added cusparseSolver, requires NVIDIA GPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,17 @@
 #                                                                         #
 ###########################################################################
 
+
+set(CUDA_ENABLED false)
+
 # Mandatory call to project
-project(opm-simulators C CXX)
+if(CUDA_ENABLED)
+  project(opm-simulators LANGUAGES CUDA C CXX)
+  # cuda_runtime.h
+  include_directories(/path/to/cuda/include)
+else()
+  project(opm-simulators LANGUAGES C CXX)
+endif()
 
 cmake_minimum_required (VERSION 2.8)
 
@@ -273,3 +282,8 @@ if (BUILD_EBOS_EXTENSIONS)
   install(TARGETS ebos_thermal DESTINATION bin)
 endif()
 
+# must link libraries after target 'flow' has been defined
+if(CUDA_ENABLED)
+  target_link_libraries( flow ${CUDA_cublas_LIBRARY} )
+  target_link_libraries( flow ${CUDA_cusparse_LIBRARY} )
+endif()

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -29,6 +29,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/autodiff/VFPProdProperties.cpp
   opm/autodiff/VFPInjProperties.cpp
   opm/autodiff/MissingFeatures.cpp
+  opm/bda/BdaBridge.cpp
   opm/core/props/rock/RockFromDeck.cpp
   opm/core/props/satfunc/RelpermDiagnostics.cpp
   opm/core/simulator/SimulatorReport.cpp
@@ -46,6 +47,10 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/timestepping/gatherConvergenceReport.cpp
   opm/simulators/gatherDeferredLogger.cpp
   )
+
+if(CUDA_ENABLED)
+  list (APPEND MAIN_SOURCE_FILES opm/bda/cusparseSolverBackend.cu)
+endif()
 
 # originally generated with the command:
 # find tests -name '*.cpp' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-opm-simulators (2019.04-rc1-1~xenial) xenial; urgency=low
+opm-simulators (2019.04-rc2-1~xenial) xenial; urgency=low
 
   * New release
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-opm-simulators (2019.04-rc2-1~xenial) xenial; urgency=low
+opm-simulators (2019.04-rc3-1~xenial) xenial; urgency=low
 
   * New release
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-opm-simulators (2013.10-2~precise) precise; urgency=low
+opm-simulators (2019.04-rc1-1~xenial) xenial; urgency=low
 
   * New release
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-opm-simulators (2019.04-rc3-1~xenial) xenial; urgency=low
+opm-simulators (2019.04-rfinal-1~xenial) xenial; urgency=low
 
   * New release
 

--- a/dune.module
+++ b/dune.module
@@ -5,8 +5,8 @@
 
 Module: opm-simulators
 Description: Simulators and utilities for automatic differentiation
-Version: 2019.04-rc1
-Label: 2019.04-rc1
+Version: 2019.04-rc2
+Label: 2019.04-rc2
 Maintainer: atgeirr@sintef.no
 MaintainerName: Atgeirr F. Rasmussen
 Url: http://opm-project.org

--- a/dune.module
+++ b/dune.module
@@ -5,8 +5,8 @@
 
 Module: opm-simulators
 Description: Simulators and utilities for automatic differentiation
-Version: 2019.04-rc2
-Label: 2019.04-rc2
+Version: 2019.04-rc3
+Label: 2019.04-rc3
 Maintainer: atgeirr@sintef.no
 MaintainerName: Atgeirr F. Rasmussen
 Url: http://opm-project.org

--- a/dune.module
+++ b/dune.module
@@ -5,8 +5,8 @@
 
 Module: opm-simulators
 Description: Simulators and utilities for automatic differentiation
-Version: 2019.04-pre
-Label: 2019.04-pre
+Version: 2019.04-rc1
+Label: 2019.04-rc1
 Maintainer: atgeirr@sintef.no
 MaintainerName: Atgeirr F. Rasmussen
 Url: http://opm-project.org

--- a/dune.module
+++ b/dune.module
@@ -5,8 +5,8 @@
 
 Module: opm-simulators
 Description: Simulators and utilities for automatic differentiation
-Version: 2019.04-rc3
-Label: 2019.04-rc3
+Version: 2019.04
+Label: 2019.04
 Maintainer: atgeirr@sintef.no
 MaintainerName: Atgeirr F. Rasmussen
 Url: http://opm-project.org

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -172,8 +172,8 @@ public:
                 int cartElem1Idx = vanguard.cartesianIndex(elem1Idx);
                 int cartElem2Idx = vanguard.cartesianIndex(elem2Idx);
 
-                assert(0 <= cartElem1Idx && cartElemFaultIdx_.size() > cartElem1Idx);
-                assert(0 <= cartElem2Idx && cartElemFaultIdx_.size() > cartElem2Idx);
+                assert(0 <= cartElem1Idx && cartElemFaultIdx_.size() > 0U + cartElem1Idx);
+                assert(0 <= cartElem2Idx && cartElemFaultIdx_.size() > 0U + cartElem2Idx);
 
                 int fault1Idx = cartElemFaultIdx_[cartElem1Idx];
                 int fault2Idx = cartElemFaultIdx_[cartElem2Idx];

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -663,7 +663,7 @@ private:
             candidate = firstCandidate;
         }
 
-        for (const auto& nncEntry : nnc.nncdata()) {
+        for (const auto& nncEntry : nncData) {
             auto c1 = nncEntry.cell1;
             auto c2 = nncEntry.cell2;
             auto low = cartesianToCompressed[c1];

--- a/opm/autodiff/AquiferInterface.hpp
+++ b/opm/autodiff/AquiferInterface.hpp
@@ -161,9 +161,9 @@ namespace Opm
     }
 
     template<class faceCellType, class ugridType>
-    inline const double getFaceArea(const faceCellType& faceCells, const ugridType& ugrid,
-                                    const int faceIdx, const int idx,
-                                    const Aquancon::AquanconOutput& connection) const
+    inline double getFaceArea(const faceCellType& faceCells, const ugridType& ugrid,
+                              const int faceIdx, const int idx,
+                              const Aquancon::AquanconOutput& connection) const
     {
       // Check now if the face is outside of the reservoir, or if it adjoins an inactive cell
       // Do not make the connection if the product of the two cellIdx > 0. This is because the

--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -795,14 +795,6 @@ namespace Opm {
             auto report = getReservoirConvergence(timer.currentStepLength(), iteration, B_avg, residual_norms);
             report += wellModel().getWellConvergence(B_avg);
 
-            // Throw if any NaN or too large residual found.
-            ConvergenceReport::Severity severity = report.severityOfWorstFailure();
-            if (severity == ConvergenceReport::Severity::NotANumber) {
-                OPM_THROW(Opm::NumericalIssue, "NaN residual found!");
-            } else if (severity == ConvergenceReport::Severity::TooLarge) {
-                OPM_THROW(Opm::NumericalIssue, "Too large residual found!");
-            }
-
             return report;
         }
 

--- a/opm/autodiff/BlackoilModelParametersEbos.hpp
+++ b/opm/autodiff/BlackoilModelParametersEbos.hpp
@@ -64,7 +64,7 @@ SET_SCALAR_PROP(FlowModelParameters, ToleranceCnvRelaxed, 1e9);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceWells, 1e-4);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceWellControl, 1e-7);
 SET_INT_PROP(FlowModelParameters, MaxWelleqIter, 30);
-SET_BOOL_PROP(FlowModelParameters, UseMultisegmentWell, false);
+SET_BOOL_PROP(FlowModelParameters, UseMultisegmentWell, true);
 SET_SCALAR_PROP(FlowModelParameters, MaxSinglePrecisionDays, 20.0);
 SET_INT_PROP(FlowModelParameters, MaxStrictIter, 8);
 SET_BOOL_PROP(FlowModelParameters, SolveWelleqInitially, true);

--- a/opm/autodiff/BlackoilWellModel_impl.hpp
+++ b/opm/autodiff/BlackoilWellModel_impl.hpp
@@ -1737,7 +1737,7 @@ namespace Opm {
                 const auto& segments = well.segments;
 
                 // \Note: eventually we need to hanlde the situations that some segments are shut
-                assert(int(segment_set.size()) == segments.size());
+                assert( 1u + segment_set.size() == segments.size());
 
                 for (const auto& segment : segments) {
                     const int segment_index = segment_set.segmentNumberToIndex(segment.first);

--- a/opm/autodiff/FlowLinearSolverParameters.hpp
+++ b/opm/autodiff/FlowLinearSolverParameters.hpp
@@ -66,6 +66,7 @@ NEW_PROP_TAG(CprUseDrs);
 NEW_PROP_TAG(CprMaxEllIter);
 NEW_PROP_TAG(CprEllSolvetype);
 NEW_PROP_TAG(CprReuseSetup);
+NEW_PROP_TAG(UseGpu);
 
 SET_SCALAR_PROP(FlowIstlSolverParams, LinearSolverReduction, 1e-2);
 SET_SCALAR_PROP(FlowIstlSolverParams, IluRelaxation, 0.9);
@@ -90,6 +91,7 @@ SET_BOOL_PROP(FlowIstlSolverParams, CprUseDrs, false);
 SET_INT_PROP(FlowIstlSolverParams, CprMaxEllIter, 20);
 SET_INT_PROP(FlowIstlSolverParams, CprEllSolvetype, 0);
 SET_INT_PROP(FlowIstlSolverParams, CprReuseSetup, 0);
+SET_BOOL_PROP(FlowIstlSolverParams, UseGpu, false);
 
 
 
@@ -160,6 +162,7 @@ namespace Opm
         bool   use_cpr_;
         std::string system_strategy_;
         bool scale_linear_system_;
+        bool use_gpu_;
 
         template <class TypeTag>
         void init()
@@ -186,6 +189,7 @@ namespace Opm
             cpr_max_ell_iter_  =  EWOMS_GET_PARAM(TypeTag, int, CprMaxEllIter);
             cpr_ell_solvetype_  =  EWOMS_GET_PARAM(TypeTag, int, CprEllSolvetype);
             cpr_reuse_setup_  =  EWOMS_GET_PARAM(TypeTag, int, CprReuseSetup);
+            use_gpu_ = EWOMS_GET_PARAM(TypeTag, bool, UseGpu);
         }
 
         template <class TypeTag>
@@ -212,6 +216,7 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, int, CprMaxEllIter, "MaxIterations of the elliptic pressure part of the cpr solver");
             EWOMS_REGISTER_PARAM(TypeTag, int, CprEllSolvetype, "Solver type of elliptic pressure solve (0: bicgstab, 1: cg, 2: only amg preconditioner)");
             EWOMS_REGISTER_PARAM(TypeTag, int, CprReuseSetup, "Reuse Amg Setup");
+            EWOMS_REGISTER_PARAM(TypeTag, bool, UseGpu, "Use GPU cusparseSolver as the linear solver");
         }
 
         FlowLinearSolverParameters() { reset(); }
@@ -233,6 +238,7 @@ namespace Opm
             ilu_milu_                 = MILU_VARIANT::ILU;
             ilu_redblack_             = false;
             ilu_reorder_sphere_       = true;
+            use_gpu_                  = false;
         }
     };
 

--- a/opm/autodiff/ISTLSolverEbosCpr.hpp
+++ b/opm/autodiff/ISTLSolverEbosCpr.hpp
@@ -215,9 +215,6 @@ namespace Opm
 
             const double relax = this->parameters_.ilu_relaxation_;
             const MILU_VARIANT ilu_milu  = this->parameters_.ilu_milu_;
-            using Matrix         = typename MatrixAdapter::matrix_type;
-            const int verbosity    = ( this->parameters_.cpr_solver_verbose_ &&
-                                       comm.communicator().rank()==0 ) ? 1 : 0;
 
             // TODO: revise choice of parameters
             // int coarsenTarget = 4000;
@@ -250,7 +247,6 @@ namespace Opm
 
             auto& opARef = reinterpret_cast<OperatorType&>(*opA_);
             int newton_iteration = this->simulator_.model().newtonMethod().numIterations();
-            double dt = this->simulator_.timeStepSize();
             bool update_preconditioner = false;
 
             if (this->parameters_.cpr_reuse_setup_ < 1) {

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -87,8 +87,8 @@ namespace MissingFeatures {
             "AQUCON",
             "AQUCT",
             "AQUTAB",
-            "AQUNUM"
-            "CARFIN"
+            "AQUNUM",
+            "CARFIN",
             "COMPDATL",
             "COMPLUMP",
             "CONNECTION",

--- a/opm/autodiff/MissingFeatures.cpp
+++ b/opm/autodiff/MissingFeatures.cpp
@@ -106,6 +106,7 @@ namespace MissingFeatures {
             "EXTRAPMS",
             "FILLEPS",
             "FIPNUM",
+            "FLUXTYPE",
             "FULLIMP",
             "GDORIENT",
             "GECON",

--- a/opm/autodiff/WellInterface.hpp
+++ b/opm/autodiff/WellInterface.hpp
@@ -127,7 +127,7 @@ namespace Opm
         const std::string& name() const;
 
         /// Index of well in the wells struct and wellState
-        const int indexOfWell() const;
+        int indexOfWell() const;
 
         /// Well cells.
         const std::vector<int>& cells() const {return well_cells_; }

--- a/opm/autodiff/WellInterface_impl.hpp
+++ b/opm/autodiff/WellInterface_impl.hpp
@@ -186,7 +186,7 @@ namespace Opm
     }
 
     template<typename TypeTag>
-    const int
+    int
     WellInterface<TypeTag>::
     indexOfWell() const
     {

--- a/opm/bda/BdaBridge.cpp
+++ b/opm/bda/BdaBridge.cpp
@@ -1,0 +1,240 @@
+
+
+#include <memory>
+
+//#define HAVE_NULLPTR 1 // otherwise dune/common/nullptr.hh will not compile
+
+#include <opm/bda/BdaBridge.hpp>
+#include <opm/bda/BdaResult.hpp>
+
+#define PRINT_TIMERS_BRIDGE_BRIDGE 0
+
+typedef Dune::InverseOperatorResult InverseOperatorResult;
+
+namespace Opm
+{
+
+BdaBridge::BdaBridge(bool use_gpu_, int maxit, double tolerance) : use_gpu(use_gpu_){
+#ifdef __NVCC__
+    if(use_gpu){
+    	backend = new cusparseSolverBackend(maxit, tolerance);
+    }
+#endif
+}
+
+BdaBridge::~BdaBridge(){
+#ifdef __NVCC__
+	if(use_gpu){
+		delete backend;
+	}
+#endif
+}
+
+#ifdef __NVCC__
+template <class BridgeMatrix>
+int checkZeroDiagonal(BridgeMatrix& mat) {
+	static std::vector<int> diag_indices;   // contains offsets of the diagonal nnzs
+	int numZeros = 0;
+	const int dim = 3;
+	const double zero_replace = 1e-15;
+	double *nnzs = &(mat[0][0][0][0]);
+	if(diag_indices.size() == 0){
+		int N = mat.N()*dim;
+		diag_indices.reserve(N);
+		for(typename BridgeMatrix::const_iterator r = mat.begin(); r != mat.end(); ++r){
+			for(auto c = r->begin(); c != r->end(); ++c){
+				if(r.index() == c.index()){
+					for(int rr = 0; rr < dim; ++rr){
+						// pointer arithmetic
+						int offset = (int)((long unsigned)&(mat[r.index()][c.index()][rr][rr]) - (long unsigned)nnzs); // in bytes
+						offset /= sizeof(double);  // convert offset to doubles
+						diag_indices.emplace_back(offset);
+						double val = nnzs[offset];
+						if(val == 0.0){ // could be replaced by '< 1e-30' or similar
+							nnzs[offset] = zero_replace;
+							++numZeros;
+						}
+					}
+					break;
+				}
+			}
+		}
+	}else{
+		for(int offset : diag_indices){
+			if(nnzs[offset] == 0.0){ // could be replaced by '< 1e-30' or similar
+				nnzs[offset] = zero_replace;
+				++numZeros;
+			}
+		}
+	}
+	return numZeros;
+}
+
+
+// convert matrix to blocked csr (bsr) arrays
+// if only_vals, do not convert rowPointers and colIndices
+// sparsity pattern should stay the same due to matrix-add-well-contributions
+template <class BridgeMatrix>
+void convertMatrixBsr(BridgeMatrix& mat, std::vector<double> &h_vals, std::vector<int> &h_rows, std::vector<int> &h_cols, int dim, bool only_vals) {
+	int sum_nnzs = 0;
+	int nnz = mat.nonzeroes()*dim*dim;
+
+	// copy nonzeros
+	memcpy(h_vals.data(), &(mat[0][0][0][0]), sizeof(double)*nnz);
+
+	// convert colIndices and rowPointers
+	if(only_vals == false){
+		h_rows.emplace_back(0);
+			for(typename BridgeMatrix::const_iterator r = mat.begin(); r != mat.end(); ++r){
+				int size_row = 0;
+				for(auto c = r->begin(); c != r->end(); ++c){
+					h_cols.emplace_back(c.index());
+					size_row++;
+				}
+				sum_nnzs += size_row;
+				h_rows.emplace_back(sum_nnzs);
+			}
+		// set last rowpointer
+		h_rows[mat.N()] = mat.nonzeroes();
+	}
+} // end convertMatrixBsr()
+
+// converts the BlockVector b to a flat array
+template <class BridgeVector>
+void convertBlockVectorToArray(BridgeVector& b, std::vector<double> &h_b) {
+	memcpy(h_b.data(), &(b[0]), sizeof(double) * b.N() * b[0].dim());
+}
+#endif
+
+template <class BridgeMatrix, class BridgeVector>
+void BdaBridge::solve_system(BridgeMatrix *mat, BridgeVector &b, InverseOperatorResult &res)
+{
+
+#ifdef __NVCC__
+	BdaResult result;
+	result.converged = false;
+	static std::vector<double> h_vals;
+	static std::vector<double> h_b;
+	static std::vector<int> h_rows;
+	static std::vector<int> h_cols;
+	int dim = (*mat)[0][0].N();
+	int N = mat->N()*dim;
+	int nnz = mat->nonzeroes()*dim*dim;
+
+	if(dim != 3){
+		std::cerr << "Error can only use cusparseSolver with blocksize = 3" << std::endl;
+		exit(1);
+	}
+
+	if(h_vals.capacity() == 0){
+		h_vals.reserve(nnz);    // allocate arbitrary overflow for wellContribs in the future
+		h_vals.resize(nnz);
+		h_b.reserve(N);
+		h_rows.reserve(N+1);
+		h_cols.reserve(nnz);
+	}else{
+		// clear() removes all elements, but keeps capacity. Now we can add without reallocs
+		h_rows.clear();
+		h_cols.clear();
+		h_b.clear();
+	}
+
+// if cusparseSolver is used, always check and replace the zeros
+#if PRINT_TIMERS_BRIDGE
+	Dune::Timer t_zeros;
+	int numZeros = checkZeroDiagonal(*mat);
+	printf("Checking zeros took %f s, found %d zeros\n", t_zeros.stop(), numZeros);
+#else
+	checkZeroDiagonal(*mat);
+#endif
+
+	bool initialized = backend->isInitialized();
+
+#if PRINT_TIMERS_BRIDGE
+	Dune::Timer t;
+#endif
+
+	convertMatrixBsr(*mat, h_vals, h_rows, h_cols, dim, initialized);
+	convertBlockVectorToArray(b, h_b);
+
+#if PRINT_TIMERS_BRIDGE
+	printf("Conversion to flat arrays: %.4f s\n", t.stop());
+#endif
+
+	/////////////////////////
+	// actually solve
+
+	if(use_gpu){
+		if(initialized == false){
+			backend->initialize(N, nnz, dim);
+			backend->copy_system_to_gpu(h_vals.data(), h_rows.data(), h_cols.data(), h_b.data());
+			backend->analyse_matrix();
+		}else{
+			backend->update_system_on_gpu(h_vals.data(), h_b.data());
+		}
+		backend->reset_prec_on_gpu();
+		if(backend->create_preconditioner()){
+			backend->solve_system(result);
+		}
+		res.iterations = result.iterations;
+		res.reduction = result.reduction;
+		res.converged = result.converged;
+		res.conv_rate = result.conv_rate;
+		res.elapsed = result.elapsed;
+	}else{
+		res.converged = false;
+	}
+#endif // NVCC
+}
+
+
+template <class BridgeVector>
+void BdaBridge::get_result(BridgeVector &x){
+#ifdef __NVCC__
+	if(use_gpu){
+		double *h_x = backend->post_process();
+        // convert flat array to blockvector
+        memcpy(&(x[0]), h_x, sizeof(double) * x.N() * x[0].dim());
+	}
+#endif
+}
+
+template void BdaBridge::solve_system<\
+Dune::BCRSMatrix<Ewoms::MatrixBlock<double, 2, 2>, std::allocator<Ewoms::MatrixBlock<double, 2, 2> > > , \
+Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > >\
+(Dune::BCRSMatrix<Ewoms::MatrixBlock<double, 2, 2>, std::allocator<Ewoms::MatrixBlock<double, 2, 2> > > *mat, \
+	Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > &b, \
+	InverseOperatorResult &res);
+
+template void BdaBridge::solve_system<\
+Dune::BCRSMatrix<Ewoms::MatrixBlock<double, 3, 3>, std::allocator<Ewoms::MatrixBlock<double, 3, 3> > > , \
+Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > >\
+(Dune::BCRSMatrix<Ewoms::MatrixBlock<double, 3, 3>, std::allocator<Ewoms::MatrixBlock<double, 3, 3> > > *mat, \
+	Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > &b, \
+	InverseOperatorResult &res);
+
+template void BdaBridge::solve_system<\
+Dune::BCRSMatrix<Ewoms::MatrixBlock<double, 4, 4>, std::allocator<Ewoms::MatrixBlock<double, 4, 4> > > , \
+Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > >\
+(Dune::BCRSMatrix<Ewoms::MatrixBlock<double, 4, 4>, std::allocator<Ewoms::MatrixBlock<double, 4, 4> > > *mat, \
+	Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > &b, \
+	InverseOperatorResult &res);
+
+
+template void BdaBridge::get_result<\
+Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > >\
+(Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > &x);
+
+template void BdaBridge::get_result<\
+Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > >\
+(Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > &x);
+
+template void BdaBridge::get_result<\
+Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > >\
+(Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > &x);
+
+
+
+}
+
+

--- a/opm/bda/BdaBridge.hpp
+++ b/opm/bda/BdaBridge.hpp
@@ -1,0 +1,43 @@
+
+#ifndef BDABRIDGE_HEADER_INCLUDED
+#define BDABRIDGE_HEADER_INCLUDED
+
+#include "dune/istl/solver.hh" // for struct InverseOperatorResult
+
+#include "dune/istl/bcrsmatrix.hh"
+#include <ewoms/linear/matrixblock.hh>
+
+#ifdef __NVCC__
+#include <opm/bda/cusparseSolverBackend.hpp>
+#endif
+
+namespace Opm
+{
+
+typedef Dune::InverseOperatorResult InverseOperatorResult;
+
+
+class BdaBridge
+{
+private:
+#ifdef __NVCC__
+	cusparseSolverBackend *backend;
+#endif
+	bool use_gpu;
+
+public:
+	BdaBridge(bool use_gpu, int maxit, double tolerance);
+
+	~BdaBridge();
+
+	template <class BridgeMatrix, class BridgeVector>
+	void solve_system(BridgeMatrix *mat, BridgeVector &b, InverseOperatorResult &result);
+
+	template <class BridgeVector>
+	void get_result(BridgeVector &x);
+
+}; // end class BdaBridge
+
+}
+
+#endif

--- a/opm/bda/BdaResult.hpp
+++ b/opm/bda/BdaResult.hpp
@@ -1,0 +1,25 @@
+
+#ifndef BDARESULT_HEADER_INCLUDED
+#define BDARESULT_HEADER_INCLUDED
+
+namespace Opm
+{
+
+// based on InverseOperatorResult struct from dune/istl/solver.hh
+class BdaResult
+{
+
+public:
+	int iterations = 0;			// number of iterations
+	double reduction = 0.0;		// reduction of norm, norm_start / norm_final
+	bool converged = false;		// true iff the linear solver reached the desired norm within maxit iterations
+	double conv_rate = 0.0;		// average reduction of norm per iteration, usually calculated with 'static_cast<double>(pow(res.reduction,1.0/it));'
+	double elapsed = 0.0;		// time in seconds to run the linear solver
+
+	// Dune 2.6 has a member 'double condition_estimate = -1' in InverseOperatorResult
+
+}; // end class BdaResult
+
+}
+
+#endif

--- a/opm/bda/cuda_header.h
+++ b/opm/bda/cuda_header.h
@@ -1,0 +1,95 @@
+
+#ifndef CUDA_HEADER_H
+#define CUDA_HEADER_H
+
+#include <stdio.h>
+
+typedef double Block[9];
+
+static const char *_cudaGetErrorEnum(cudaError_t error) {
+  return cudaGetErrorName(error);
+}
+
+#ifdef CUBLAS_API_H_
+// cuBLAS API errors
+static const char *_cudaGetErrorEnum(cublasStatus_t error) {
+  switch (error) {
+    case CUBLAS_STATUS_SUCCESS:
+      return "CUBLAS_STATUS_SUCCESS";
+    case CUBLAS_STATUS_NOT_INITIALIZED:
+      return "CUBLAS_STATUS_NOT_INITIALIZED";
+    case CUBLAS_STATUS_ALLOC_FAILED:
+      return "CUBLAS_STATUS_ALLOC_FAILED";
+    case CUBLAS_STATUS_INVALID_VALUE:
+      return "CUBLAS_STATUS_INVALID_VALUE";
+    case CUBLAS_STATUS_ARCH_MISMATCH:
+      return "CUBLAS_STATUS_ARCH_MISMATCH";
+    case CUBLAS_STATUS_MAPPING_ERROR:
+      return "CUBLAS_STATUS_MAPPING_ERROR";
+    case CUBLAS_STATUS_EXECUTION_FAILED:
+      return "CUBLAS_STATUS_EXECUTION_FAILED";
+    case CUBLAS_STATUS_INTERNAL_ERROR:
+      return "CUBLAS_STATUS_INTERNAL_ERROR";
+    case CUBLAS_STATUS_NOT_SUPPORTED:
+      return "CUBLAS_STATUS_NOT_SUPPORTED";
+    case CUBLAS_STATUS_LICENSE_ERROR:
+      return "CUBLAS_STATUS_LICENSE_ERROR";
+  }
+  return "<unknown>";
+}
+#endif
+
+#ifdef CUSPARSEAPI
+// cuSPARSE API errors
+static const char *_cudaGetErrorEnum(cusparseStatus_t error) {
+  switch (error) {
+    case CUSPARSE_STATUS_SUCCESS:
+      return "CUSPARSE_STATUS_SUCCESS";
+    case CUSPARSE_STATUS_NOT_INITIALIZED:
+      return "CUSPARSE_STATUS_NOT_INITIALIZED";
+    case CUSPARSE_STATUS_ALLOC_FAILED:
+      return "CUSPARSE_STATUS_ALLOC_FAILED";
+    case CUSPARSE_STATUS_INVALID_VALUE:
+      return "CUSPARSE_STATUS_INVALID_VALUE";
+    case CUSPARSE_STATUS_ARCH_MISMATCH:
+      return "CUSPARSE_STATUS_ARCH_MISMATCH";
+    case CUSPARSE_STATUS_MAPPING_ERROR:
+      return "CUSPARSE_STATUS_MAPPING_ERROR";
+    case CUSPARSE_STATUS_EXECUTION_FAILED:
+      return "CUSPARSE_STATUS_EXECUTION_FAILED";
+    case CUSPARSE_STATUS_INTERNAL_ERROR:
+      return "CUSPARSE_STATUS_INTERNAL_ERROR";
+    case CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
+      return "CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED";
+  }
+  return "<unknown>";
+}
+#endif
+
+
+template <typename T>
+void __cudaSafeCall(T result, char const *const func, const char *const file, int const line) {
+	if (result) {
+		fprintf(stderr, "CUDA error at %s:%d code=%d(%s) \"%s\" \n", file, line, static_cast<unsigned int>(result), _cudaGetErrorEnum(result), func);
+		exit(1);
+	}
+}
+
+
+#define cudaSafeCall( err ) __cudaSafeCall( (err), #err, __FILE__, __LINE__ )
+#define cudaCheckError()    __cudaCheckError( __FILE__, __LINE__ )
+
+inline void __cudaCheckError( const char *file, const int line )
+  {
+	  cudaError err = cudaGetLastError();
+	  if ( cudaSuccess != err )
+	  {
+		  //std::cerr << "cudaCheckError() failed at " << file << ":" << line << ":" << cudaGetErrorString(err) << std::endl;
+		  printf("\ncudaSafeCall() failed at %s: %d: %s\n\n", file, line, cudaGetErrorString(err));
+		  exit( -1 );
+	  }
+  }
+// end of error checking code
+
+
+#endif

--- a/opm/bda/cusparseSolverBackend.cu
+++ b/opm/bda/cusparseSolverBackend.cu
@@ -1,0 +1,456 @@
+
+
+#ifndef __NVCC__
+    #error "Cannot compile for cusparse: NVIDIA compiler not found"
+#endif
+
+#include <cstdio>
+#include <cstdlib>
+#include <cuda_runtime.h>
+#include <iostream>
+#include <sys/time.h>
+
+#include <opm/bda/cusparseSolverBackend.hpp>
+#include <opm/bda/BdaResult.hpp>
+#include <opm/bda/cuda_header.h>
+
+#include "cublas_v2.h"
+#include "cusparse_v2.h"
+
+// print initial, intermediate and final norms, and used iterations
+#define VERBOSE_BACKEND 0
+
+// print more detailed timers of various solve elements and backend functions
+#define PRINT_TIMERS_BACKEND 0
+
+namespace Opm
+{
+
+    const cusparseSolvePolicy_t policy_L = CUSPARSE_SOLVE_POLICY_USE_LEVEL;
+    const cusparseSolvePolicy_t policy_U = CUSPARSE_SOLVE_POLICY_USE_LEVEL;
+    const cusparseSolvePolicy_t policy_M = CUSPARSE_SOLVE_POLICY_USE_LEVEL;
+    //const cusparseSolvePolicy_t policy_L = CUSPARSE_SOLVE_POLICY_NO_LEVEL;
+    //const cusparseSolvePolicy_t policy_U = CUSPARSE_SOLVE_POLICY_NO_LEVEL;
+    //const cusparseSolvePolicy_t policy_M = CUSPARSE_SOLVE_POLICY_NO_LEVEL;
+    const cusparseOperation_t trans_L  = CUSPARSE_OPERATION_NON_TRANSPOSE;
+    const cusparseOperation_t trans_U  = CUSPARSE_OPERATION_NON_TRANSPOSE;
+    const cusparseOperation_t trans_M  = CUSPARSE_OPERATION_NON_TRANSPOSE;
+    const cusparseDirection_t dir = CUSPARSE_DIRECTION_ROW;
+    //const cusparseDirection_t dir = CUSPARSE_DIRECTION_COLUMN;
+
+    const int BLOCK_SIZE = 3;
+
+    double second (void){
+        struct timeval tv;
+        gettimeofday(&tv, nullptr);
+        return (double)tv.tv_sec + (double)tv.tv_usec / 1000000.0;
+    }
+
+    cusparseSolverBackend::cusparseSolverBackend(int maxit_, double tolerance_) : maxit(maxit_), tolerance(tolerance_), minit(0){
+    }
+
+    cusparseSolverBackend::~cusparseSolverBackend(){
+        finalize();
+    }
+
+    // return true iff converged
+    bool cusparseSolverBackend::gpu_pbicgstab(BdaResult& res){
+        double t_total1, t_total2;
+        int n = matrixN;
+        double rho, rhop, beta, alpha, negalpha, omega, negomega, temp, temp2;
+        double nrmr, nrmr0;
+        rho = 1.0;
+        double zero = 0.0;
+        double one  = 1.0;
+        double mone = -1.0;
+        int i = 0;
+        int j = 0;
+
+        //compute initial residual r0=b-Ax0 (using initial guess in x)
+        t_total1 = second();
+
+        cudaSafeCall(cusparseDbsrmv(cusparseHandle, dir, trans_M, mb, mb, nnzb, &one, descr_M, d_bVals, d_bRows, d_bCols, blockDim, d_x, &zero, d_r));
+
+        cudaSafeCall(cublasDscal(cublasHandle, n, &mone, d_r, 1));
+        cudaSafeCall(cublasDaxpy(cublasHandle, n, &one, d_f, 1, d_r, 1));
+        //copy residual r into r^{\hat} and p
+        cudaSafeCall(cublasDcopy(cublasHandle, n, d_r, 1, d_rw, 1));
+        cudaSafeCall(cublasDcopy(cublasHandle, n, d_r, 1, d_p, 1)); 
+        cudaSafeCall(cublasDnrm2(cublasHandle, n, d_r, 1, &nrmr0));
+
+#if VERBOSE_BACKEND
+        printf("Initial norm: %.5e\n", nrmr0);
+        printf("Tolerance: %.0e, nnzb: %d\n", tol, nnzb);
+#endif
+
+        for (i = 0; i < maxit; ++i){
+            rhop = rho;
+            cudaSafeCall(cublasDdot(cublasHandle, n, d_rw, 1, d_r, 1, &rho));
+
+            if (i > 0){
+                beta = (rho/rhop) * (alpha/omega);
+                negomega = -omega;
+                cudaSafeCall(cublasDaxpy(cublasHandle, n, &negomega, d_v, 1, d_p, 1));
+                cudaSafeCall(cublasDscal(cublasHandle, n, &beta, d_p, 1));
+                cudaSafeCall(cublasDaxpy(cublasHandle, n, &one, d_r, 1, d_p, 1));
+            }
+
+            //preconditioning step (lower and upper triangular solve)
+            cudaSafeCall(cusparseDbsrsv2_solve(cusparseHandle,dir,\
+                trans_L,mb,nnzb,&one,\
+                descr_L,d_mVals,d_mRows,d_mCols,blockDim,info_L,d_p,d_t, policy_L, pBuffer));
+            cudaSafeCall(cusparseDbsrsv2_solve(cusparseHandle,dir,\
+                trans_U,mb,nnzb,&one,\
+                descr_U,d_mVals,d_mRows,d_mCols,blockDim,info_U,d_t,d_pw, policy_U, pBuffer));
+
+            //matrix-vector multiplication
+            cudaSafeCall(cusparseDbsrmv(cusparseHandle, dir, \
+                trans_M, mb, mb, nnzb, \
+                &one, descr_M, d_bVals, d_bRows, d_bCols, blockDim, d_pw, &zero, d_v));
+
+            cudaSafeCall(cublasDdot(cublasHandle, n, d_rw, 1, d_v, 1, &temp));
+            alpha= rho / temp;
+            negalpha = -(alpha);
+            cudaSafeCall(cublasDaxpy(cublasHandle, n, &negalpha, d_v, 1, d_r, 1));
+            cudaSafeCall(cublasDaxpy(cublasHandle, n, &alpha, d_pw, 1, d_x, 1));
+            cudaSafeCall(cublasDnrm2(cublasHandle, n, d_r, 1, &nrmr));
+
+            if (nrmr < tolerance*nrmr0 && i > minit){
+                j = 5;
+                break;
+            }
+
+            //preconditioning step (lower and upper triangular solve)
+            cudaSafeCall(cusparseDbsrsv2_solve(cusparseHandle,dir,\
+                trans_L,mb,nnzb,&one,\
+                descr_L,d_mVals,d_mRows,d_mCols,blockDim,info_L,d_r,d_t, policy_L, pBuffer));
+            cudaSafeCall(cusparseDbsrsv2_solve(cusparseHandle,dir,\
+                trans_U,mb,nnzb,&one,\
+                descr_U,d_mVals,d_mRows,d_mCols,blockDim,info_U,d_t,d_s, policy_U, pBuffer));
+
+            //matrix-vector multiplication
+            cudaSafeCall(cusparseDbsrmv(cusparseHandle, dir, \
+                trans_M, mb, mb, nnzb, &one, descr_M, \
+                d_bVals, d_bRows, d_bCols, blockDim, d_s, &zero, d_t));
+
+            cudaSafeCall(cublasDdot(cublasHandle, n, d_t, 1, d_r, 1, &temp));
+            cudaSafeCall(cublasDdot(cublasHandle, n, d_t, 1, d_t, 1, &temp2));
+            omega = temp / temp2;
+            negomega = -(omega);
+            cudaSafeCall(cublasDaxpy(cublasHandle, n, &omega, d_s, 1, d_x, 1));
+            cudaSafeCall(cublasDaxpy(cublasHandle, n, &negomega, d_t, 1, d_r, 1));
+
+            cudaSafeCall(cublasDnrm2(cublasHandle, n, d_r, 1, &nrmr));
+
+
+            if (nrmr < tolerance*nrmr0 && i > minit){
+                i++;
+                j=0;
+                break;
+            }
+#if VERBOSE_BACKEND
+            if(i % 1 == 0){
+                printf("it: %d.0, norm: %.5e\n", i, nrmr);
+            }
+#endif
+        }
+
+        t_total2 = second();
+#if PRINT_TIMERS_BACKEND
+        printf("Total solve time: %.6f s\n", t_total2-t_total1);
+#endif
+#if VERBOSE_BACKEND
+        printf("Iterations: %d.%d\n", i, j);
+        printf("Final norm: %.5e\n", nrmr);
+#endif
+        res.iterations = i + (j == 5);
+        res.reduction = nrmr/nrmr0;
+        res.conv_rate  = static_cast<double>(pow(res.reduction,1.0/i));
+        res.elapsed = t_total2-t_total1;
+        res.converged = (i != maxit);
+        return res.converged;
+    }
+
+
+    void cusparseSolverBackend::initialize(int N, int nnz, int dim){
+        this->matrixN = N;
+        this->nnz = nnz;
+        this->blockDim = dim;
+        mb = (N + dim - 1) / dim;
+        printf("Initializing GPU, N: %d, nnz: %d, mb: %d\n", N, nnz, mb);
+        printf("Minit: %d, maxit: %d, tol: %.1e\n", minit, maxit, tolerance);
+        
+        int deviceID = 0;
+        cudaSafeCall(cudaSetDevice(deviceID));
+        struct cudaDeviceProp props;
+        cudaSafeCall(cudaGetDeviceProperties(&props, deviceID));
+        std::cout << "Name: " << props.name << "\n";
+        printf("CC: %d.%d\n", props.major, props.minor);
+
+        cudaSafeCall(cudaStreamCreate(&stream));
+
+        /* initialize cublas */
+        cudaSafeCall(cublasCreate(&cublasHandle));
+
+        /* initialize cusparse */
+        cudaSafeCall(cusparseCreate(&cusparseHandle));
+
+        /* allocate device memory for csr matrix and vectors */
+        cudaSafeCall(cudaMalloc ((void**)&d_x, sizeof(d_x[0]) * N));
+        cudaSafeCall(cudaMalloc ((void**)&d_f, sizeof(d_f[0]) * N));
+        cudaSafeCall(cudaMalloc ((void**)&d_r, sizeof(d_r[0]) * N));
+        cudaSafeCall(cudaMalloc ((void**)&d_rw,sizeof(d_rw[0])* N));
+        cudaSafeCall(cudaMalloc ((void**)&d_p, sizeof(d_p[0]) * N));
+        cudaSafeCall(cudaMalloc ((void**)&d_pw,sizeof(d_pw[0])* N));
+        cudaSafeCall(cudaMalloc ((void**)&d_s, sizeof(d_s[0]) * N));
+        cudaSafeCall(cudaMalloc ((void**)&d_t, sizeof(d_t[0]) * N));
+        cudaSafeCall(cudaMalloc ((void**)&d_v, sizeof(d_v[0]) * N));
+        cudaSafeCall(cudaMalloc ((void**)&d_bVals, sizeof(d_bVals[0]) * nnz));
+        cudaSafeCall(cudaMalloc ((void**)&d_bCols, sizeof(d_bCols[0]) * nnz));
+        cudaSafeCall(cudaMalloc ((void**)&d_bRows, sizeof(d_bRows[0]) * (mb+1)));
+        cudaSafeCall(cudaMalloc ((void**)&d_mVals, sizeof(d_mVals[0]) * nnz));
+
+        cudaSafeCall(cusparseSetStream(cusparseHandle, stream));
+        cudaSafeCall(cudaMallocHost((void**)&x, sizeof(double) * N));
+        cudaSafeCall(cudaMallocHost((void**)&v, sizeof(double) * N));
+        cudaSafeCall(cudaMallocHost((void**)&tx, sizeof(double) * N));
+
+        initialized = true;
+    } // end initialize()
+
+    void cusparseSolverBackend::finalize(){
+        cudaSafeCall(cudaFree(d_x));
+        cudaSafeCall(cudaFree(d_f));
+        cudaSafeCall(cudaFree(d_r));
+        cudaSafeCall(cudaFree(d_rw));
+        cudaSafeCall(cudaFree(d_p));
+        cudaSafeCall(cudaFree(d_pw));
+        cudaSafeCall(cudaFree(d_s));
+        cudaSafeCall(cudaFree(d_t));
+        cudaSafeCall(cudaFree(d_v));
+        cudaSafeCall(cudaFree(d_mVals));
+        cudaSafeCall(cudaFree(d_bVals));
+        cudaSafeCall(cudaFree(d_bCols));
+        cudaSafeCall(cudaFree(d_bRows));
+        cudaSafeCall(cudaFree(pBuffer));
+        cudaSafeCall(cusparseDestroyBsrilu02Info(info_M));
+        cudaSafeCall(cusparseDestroyBsrsv2Info(info_L));
+        cudaSafeCall(cusparseDestroyBsrsv2Info(info_U));
+        cudaSafeCall(cusparseDestroyMatDescr(descra));
+        cudaSafeCall(cusparseDestroyMatDescr(descr_M));
+        cudaSafeCall(cusparseDestroyMatDescr(descr_L));
+        cudaSafeCall(cusparseDestroyMatDescr(descr_U));
+        cudaSafeCall(cusparseDestroy(cusparseHandle));
+        cudaSafeCall(cublasDestroy(cublasHandle));
+        cudaHostUnregister(vals);
+        cudaHostUnregister(cols);
+        cudaHostUnregister(rows);
+        cudaSafeCall(cudaStreamDestroy(stream));
+        cudaSafeCall(cudaFreeHost(x));
+        cudaSafeCall(cudaFreeHost(v));
+        cudaSafeCall(cudaFreeHost(tx));
+    } // end finalize()
+
+
+    void cusparseSolverBackend::copy_system_to_gpu(double *vals, int *rows, int *cols, double *f){
+
+        /* copy the csr matrix and vectors into device memory */
+#if PRINT_TIMERS_BACKEND
+        double t1, t2;
+        t1 = second();
+#endif
+
+        // information: https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html#group__CUDART__MEMORY_1ge8d5c17670f16ac4fc8fcb4181cb490c
+        // possible flags for cudaHostRegister: cudaHostRegisterDefault, cudaHostRegisterPortable, cudaHostRegisterMapped, cudaHostRegisterIoMemory
+        cudaSafeCall(cudaHostRegister(vals, nnz * sizeof(double), cudaHostRegisterDefault));
+        cudaSafeCall(cudaHostRegister(cols, nnz * sizeof(int), cudaHostRegisterDefault));
+        cudaSafeCall(cudaHostRegister(rows, (matrixN/BLOCK_SIZE+1) * sizeof(int), cudaHostRegisterDefault));
+        cudaSafeCall(cudaMemcpyAsync(d_bVals, vals, (size_t)(nnz * sizeof(double)), cudaMemcpyHostToDevice, stream));
+        cudaSafeCall(cudaMemcpyAsync(d_bCols, cols, (size_t)(nnz * sizeof(int)), cudaMemcpyHostToDevice, stream));
+        cudaSafeCall(cudaMemcpyAsync(d_bRows, rows, (size_t)((matrixN/BLOCK_SIZE+1) * sizeof(int)), cudaMemcpyHostToDevice, stream));
+        cudaSafeCall(cudaMemcpyAsync(d_f, f, (size_t)(matrixN * sizeof(d_f[0])), cudaMemcpyHostToDevice, stream));
+        /* clean memory */
+        cudaSafeCall(cudaMemsetAsync((void *)d_x, 0, sizeof(d_x[0]) * matrixN, stream));
+
+        this->vals = vals;
+        this->cols = cols;
+        this->rows = rows;
+
+#if PRINT_TIMERS_BACKEND
+        t2 = second();
+        printf("copy_system_to_gpu(): %f s\n", t2-t1);
+#endif
+    } // end copy_system_to_gpu()
+
+
+    // don't copy rowpointers and colindices, they stay the same
+    void cusparseSolverBackend::update_system_on_gpu(double *vals, double *f){
+
+        /* copy the csr matrix and vectors into device memory */
+#if PRINT_TIMERS_BACKEND
+        double t1, t2;
+        t1 = second();
+#endif
+
+        cudaSafeCall(cudaMemcpyAsync(d_bVals, vals, (size_t)(nnz * sizeof(vals[0])), cudaMemcpyHostToDevice, stream));
+        cudaSafeCall(cudaMemcpyAsync(d_f, f, (size_t)(matrixN * sizeof(d_f[0])), cudaMemcpyHostToDevice, stream));
+        /* clean memory */
+        cudaSafeCall(cudaMemsetAsync((void *)d_x, 0, sizeof(d_x[0]) * matrixN, stream));
+
+#if PRINT_TIMERS_BACKEND
+        t2 = second();
+        printf("update_system_on_gpu(): %f s\n", t2-t1);
+#endif
+    } // end update_system_on_gpu()
+
+
+    void cusparseSolverBackend::reset_prec_on_gpu(){
+        cudaSafeCall(cudaMemcpyAsync(d_mVals, d_bVals, (size_t)(nnz  * sizeof(d_mVals[0])), cudaMemcpyDeviceToDevice, stream));
+    }
+
+
+    void cusparseSolverBackend::analyse_matrix(){
+
+        int pBufferSize_M, pBufferSize_L, pBufferSize_U, pBufferSize;
+
+        // step 1: create a descriptor which contains
+        cusparseCreateMatDescr(&descra);
+        cusparseCreateMatDescr(&descr_M);
+        cusparseSetMatType(descra,CUSPARSE_MATRIX_TYPE_GENERAL);
+        cusparseSetMatType(descr_M, CUSPARSE_MATRIX_TYPE_GENERAL);
+        cusparseIndexBase_t base_type;
+
+        if(base){
+            base_type = CUSPARSE_INDEX_BASE_ONE;
+        }else{
+            base_type = CUSPARSE_INDEX_BASE_ZERO;
+        }
+
+        cusparseSetMatIndexBase(descra, base_type);
+        cusparseSetMatIndexBase(descr_M, base_type);
+
+        cusparseCreateMatDescr(&descr_L);
+        cusparseSetMatIndexBase(descr_L, base_type);
+        cusparseSetMatType(descr_L, CUSPARSE_MATRIX_TYPE_GENERAL);
+        cusparseSetMatFillMode(descr_L, CUSPARSE_FILL_MODE_LOWER);
+        cusparseSetMatDiagType(descr_L, CUSPARSE_DIAG_TYPE_UNIT);
+
+        cusparseCreateMatDescr(&descr_U);
+        cusparseSetMatIndexBase(descr_U, base_type);
+        cusparseSetMatType(descr_U, CUSPARSE_MATRIX_TYPE_GENERAL);
+        cusparseSetMatFillMode(descr_U, CUSPARSE_FILL_MODE_UPPER);
+        cusparseSetMatDiagType(descr_U, CUSPARSE_DIAG_TYPE_NON_UNIT);
+        cudaCheckError();
+
+        // step 2: create a empty info structure
+        // we need one info for csrilu02 and two info's for csrsv2
+        cusparseCreateBsrilu02Info(&info_M);
+        cusparseCreateBsrsv2Info(&info_L);
+        cusparseCreateBsrsv2Info(&info_U);
+        cudaCheckError();
+
+        cudaSafeCall(cudaMemcpyAsync(d_bRows, rows, sizeof(int)*(mb+1), cudaMemcpyHostToDevice, stream));
+        cudaSafeCall(cudaMemcpyAsync(d_bCols, cols, sizeof(int)*nnz, cudaMemcpyHostToDevice, stream));
+        cudaSafeCall(cudaMemcpyAsync(d_bVals, vals, sizeof(double)*nnz, cudaMemcpyHostToDevice, stream));
+
+        // step 3: query how much memory used in csrilu02 and csrsv2, and allocate the buffer
+        nnzb = nnz/BLOCK_SIZE/BLOCK_SIZE;
+        cusparseDbsrilu02_bufferSize(cusparseHandle, dir, mb, nnzb,
+            descr_M, d_bVals, d_bRows, d_bCols, blockDim, info_M, &pBufferSize_M);
+        cusparseDbsrsv2_bufferSize(cusparseHandle, dir, trans_L, mb, nnzb,
+            descr_L, d_bVals, d_bRows, d_bCols, blockDim, info_L, &pBufferSize_L);
+        cusparseDbsrsv2_bufferSize(cusparseHandle, dir, trans_U, mb, nnzb,
+            descr_U, d_bVals, d_bRows, d_bCols, blockDim, info_U, &pBufferSize_U);
+        cudaCheckError();
+        pBufferSize = std::max(pBufferSize_M, std::max(pBufferSize_L, pBufferSize_U));
+        
+        // pBuffer returned by cudaMalloc is automatically aligned to 128 bytes.
+        cudaSafeCall(cudaMalloc((void**)&pBuffer, pBufferSize));
+
+        // analysis of ilu LU decomposition
+        cudaSafeCall(cusparseDbsrilu02_analysis(cusparseHandle, dir, \
+            mb, nnzb, descra, d_bVals, d_bRows, d_bCols, \
+            blockDim, info_M, policy_M, pBuffer));
+        int structural_zero;
+
+        status1 = cusparseXbsrilu02_zeroPivot(cusparseHandle, info_M, &structural_zero);
+        if (CUSPARSE_STATUS_ZERO_PIVOT == status1){
+            printf("WARNING block U(%d,%d) is not invertible\n", structural_zero, structural_zero);
+            fprintf(stderr, "WARNING block U(%d,%d) is not invertible\n", structural_zero, structural_zero);
+        }
+
+        /* analyse the lower and upper triangular factors */
+        cudaSafeCall(cusparseDbsrsv2_analysis(cusparseHandle, dir, trans_L, \
+            mb, nnzb, descr_L, d_bVals, d_bRows, d_bCols, \
+            blockDim, info_L, policy_L, pBuffer));
+        cudaSafeCall(cudaDeviceSynchronize());
+
+        cudaSafeCall(cusparseDbsrsv2_analysis(cusparseHandle, dir, trans_U, \
+            mb, nnzb, descr_U, d_bVals, d_bRows, d_bCols, \
+            blockDim, info_U, policy_U, pBuffer));
+        cudaSafeCall(cudaDeviceSynchronize());
+
+    } // end analyse_matrix()
+
+    bool cusparseSolverBackend::create_preconditioner(){
+        /* compute the lower and upper triangular factors using CUSPARSE csrilu0 routine (on the GPU) */
+#if PRINT_TIMERS_BACKEND
+        double t1, t2;
+        t1 = second();
+#endif
+        d_mCols = d_bCols;
+        d_mRows = d_bRows;
+        cudaSafeCall(cusparseDbsrilu02(cusparseHandle, dir, \
+            mb, nnzb, descr_M, d_mVals, d_mRows, d_mCols, \
+            blockDim, info_M, policy_M, pBuffer));
+        int numerical_zero;
+        status1 = cusparseXbsrilu02_zeroPivot(cusparseHandle, info_M, &numerical_zero);
+        if (CUSPARSE_STATUS_ZERO_PIVOT == status1){
+           printf("WARNING block U(%d,%d) is not invertible\n", numerical_zero, numerical_zero);
+           fprintf(stderr, "WARNING block U(%d,%d) is not invertible\n", numerical_zero, numerical_zero);
+           return false;
+        }
+        cudaSafeCall(cudaDeviceSynchronize());
+#if PRINT_TIMERS_BACKEND
+        t2 = second();
+        printf("Decomp time: %.6f s\n", t2-t1);
+#endif
+        return true;
+    } // end create_preconditioner()
+
+
+    // return true iff converged
+    bool cusparseSolverBackend::solve_system(BdaResult &res){
+        // actually solve
+        bool converged = gpu_pbicgstab(res);
+        cudaSafeCall(cudaDeviceSynchronize());
+        return converged;
+    } // end solve_system()
+
+
+    double* cusparseSolverBackend::post_process(){
+        /* copy the result into host memory */
+#if PRINT_TIMERS_BACKEND
+        double t1, t2;
+        t1 = second();
+#endif
+
+        cudaSafeCall(cudaMemcpyAsync(tx, d_x, (size_t)(matrixN * sizeof(tx[0])), cudaMemcpyDeviceToHost, stream));
+        cudaSafeCall(cudaStreamSynchronize(stream));
+
+#if PRINT_TIMERS_BACKEND
+        t2 = second();
+        printf("Copy result back to CPU: %.6f s\n", t2-t1);
+#endif
+
+        return tx;
+    } // end post_process()
+
+
+    bool cusparseSolverBackend::isInitialized(){
+        return initialized;
+    }
+
+}
+
+

--- a/opm/bda/cusparseSolverBackend.hpp
+++ b/opm/bda/cusparseSolverBackend.hpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
+ *
+ * Please refer to the NVIDIA end user license agreement (EULA) associated
+ * with this source code for terms and conditions that govern your use of
+ * this software. Any use, reproduction, disclosure, or distribution of
+ * this software and related documentation outside the terms of the EULA
+ * is strictly prohibited.
+ *
+ */
+
+#ifndef OPM_cuSPARSESOLVER_BACKEND_HEADER_INCLUDED
+#define OPM_cuSPARSESOLVER_BACKEND_HEADER_INCLUDED
+
+
+#include "cublas_v2.h"
+#include "cusparse_v2.h"
+
+#include "opm/bda/BdaResult.hpp"
+
+namespace Opm
+{
+
+class cusparseSolverBackend{
+
+private:
+
+    int minit;
+    int maxit;
+    double tolerance;
+
+    cublasHandle_t cublasHandle = 0;
+    cusparseHandle_t cusparseHandle = 0;
+    cudaStream_t stream = 0;
+    cusparseMatDescr_t descra, descr_M, descr_L, descr_U;
+    bsrilu02Info_t info_M = 0;
+    bsrsv2Info_t info_L, info_U;
+    cusparseStatus_t status1;
+    // a: csr matrix, b: bsr matrix, m: preconditioner
+    double *d_bVals, *d_mVals;
+    int    *d_bCols, *d_bRows;
+    int    *d_mCols, *d_mRows;
+    double *d_x, *d_f, *d_r, *d_rw, *d_p;
+    double *d_pw, *d_s, *d_t, *d_v;
+    double *vals;
+    int    *cols, *rows;
+    double *x, *tx, *f, *v, *xg, *bg;
+    void *pBuffer;
+    int matrixN, nnz, mb, nnzb;
+    int *h_nnzTotal = &nnzb;
+    int base = 0;
+    int blockDim;
+
+    bool initialized = false;
+
+public:
+
+    cusparseSolverBackend(int maxit, double tolerance);
+
+    ~cusparseSolverBackend();
+
+    // return true iff converged
+    bool gpu_pbicgstab(BdaResult& res);
+
+    void initialize(int N, int nnz, int dim);
+
+    void finalize();
+
+    void copy_system_to_gpu(double *vals, int *rows, int *cols, double *f);
+
+    // don't copy rowpointers and colindices, they stay the same
+    void update_system_on_gpu(double *vals, double *f);
+
+    void reset_prec_on_gpu();
+
+    void analyse_matrix();
+
+    bool create_preconditioner();
+
+    // return true iff converged
+    bool solve_system(BdaResult &res);
+
+    double* post_process();
+
+    bool isInitialized();
+
+}; // end class cusparseSolverBackend
+
+}
+
+#endif
+

--- a/opm/simulators/DeferredLogger.cpp
+++ b/opm/simulators/DeferredLogger.cpp
@@ -86,6 +86,12 @@ namespace Opm
         for (const auto& m : messages_) {
             OpmLog::addTaggedMessage(m.flag, m.tag, m.text);
         }
+        messages_.clear();
+    }
+
+    void DeferredLogger::clearMessages()
+    {
+        messages_.clear();
     }
 
 } // namespace Opm

--- a/opm/simulators/DeferredLogger.hpp
+++ b/opm/simulators/DeferredLogger.hpp
@@ -60,7 +60,12 @@ namespace Opm
         void debug(const std::string& message);
         void note(const std::string& message);
 
+        /// Log all messages to the OpmLog backends,
+        /// and clear the message container.
         void logMessages();
+
+        /// Clear the message container without logging them.
+        void clearMessages();
 
     private:
         std::vector<Message> messages_;

--- a/opm/simulators/DeferredLoggingErrorHelpers.hpp
+++ b/opm/simulators/DeferredLoggingErrorHelpers.hpp
@@ -63,6 +63,10 @@ inline void logAndCheckForExceptionsAndThrow(Opm::DeferredLogger& deferred_logge
     if (terminal_output) {
         global_deferredLogger.logMessages();
     }
+    // Now that all messages have been logged, they are automatically
+    // cleared from the global logger, but we must also clear them
+    // from the local logger.
+    deferred_logger.clearMessages();
     const auto& cc = Dune::MPIHelper::getCollectiveCommunication();
     if (cc.max(exception_thrown) == 1) {
         throw std::logic_error(message);

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -491,6 +491,7 @@ namespace Opm {
             std::ostringstream msg;
             msg << "    Excessive chopping detected in report step "
                 << sr.back().report_step << ", substep " << sr.back().current_step << "\n";
+            assert(!sr.back().report.empty());
             const auto& wfs = sr.back().report.back().wellFailures();
             for (const auto& wf : wfs) {
                 msg << "        Well that failed: " << wf.wellName() << "\n";

--- a/redhat/opm-simulators.spec
+++ b/redhat/opm-simulators.spec
@@ -2,7 +2,7 @@
 # spec file for package opm-simulators
 #
 
-%define tag rc1
+%define tag rc2
 
 Name:           opm-simulators
 Version:        2019.04

--- a/redhat/opm-simulators.spec
+++ b/redhat/opm-simulators.spec
@@ -2,10 +2,10 @@
 # spec file for package opm-simulators
 #
 
-%define tag final
+%define tag rc1
 
 Name:           opm-simulators
-Version:        2018.10
+Version:        2019.04
 Release:        0
 Summary:        Open Porous Media - core library
 License:        GPL-3.0

--- a/redhat/opm-simulators.spec
+++ b/redhat/opm-simulators.spec
@@ -2,7 +2,7 @@
 # spec file for package opm-simulators
 #
 
-%define tag rc2
+%define tag rc3
 
 Name:           opm-simulators
 Version:        2019.04

--- a/redhat/opm-simulators.spec
+++ b/redhat/opm-simulators.spec
@@ -2,7 +2,7 @@
 # spec file for package opm-simulators
 #
 
-%define tag rc3
+%define tag final
 
 Name:           opm-simulators
 Version:        2019.04

--- a/tests/test_ecl_output.cc
+++ b/tests/test_ecl_output.cc
@@ -211,14 +211,14 @@ void test_readWriteWells()
      *  the connection keys (active indices) and well names correspond to the
      *  input deck. All other entries in the well structures are arbitrary.
      */
-    w1.connections.push_back( { 88, rc1, 30.45, 123.45, 0.0, 0.0, 0.0 } );
-    w1.connections.push_back( { 288, rc2, 33.19, 67.89, 0.0, 0.0, 0.0 } );
+    w1.connections.push_back( { 88, rc1, 30.45, 123.45, 0.0, 0.0, 0.0, 0.0 } );
+    w1.connections.push_back( { 288, rc2, 33.19, 67.89, 0.0, 0.0, 0.0, 0.0 } );
 
     w2.rates = r2;
     w2.bhp = 2.34;
     w2.temperature = 4.56;
     w2.control = 2;
-    w2.connections.push_back( { 188, rc3, 36.22, 19.28, 0.0, 0.0, 0.0 } );
+    w2.connections.push_back( { 188, rc3, 36.22, 19.28, 0.0, 0.0, 0.0, 0.0 } );
 
     Opm::data::Wells wellRates;
 


### PR DESCRIPTION
This branch contains a linear solver, implemented in cusparse, which can run on an NVIDIA GPU.
To use it, CUDA_ENABLED must be set to true and the path to the CUDA install must be fixed at the top of CMakeLists.txt. The user must pass
```sh
--matrix-add-well-contributions=true --use-gpu=true
```
to the executable in order to use it. If the gpu is selected, but the well contributions are not added, an error is printed and the program exits. Only NORNE is tested, which generates blocks of 3x3. Other blocksizes do not work, but might in the future.

Some notes:
- based on release/2019.04
- now exits when `matrix-add-well-contribs` is `false` and `use_gpu` is true, should it print a warning instead and fallback to the cpu?
- forward template declarations in `BdaBridge.cpp` are a not very nice
- converting from `BCRSMatrix` to our format and back assumes underlying data is contiguous, testing shows that it is, but is it guaranteed?
- the part from `backend->initialize()` to `backend->solve_system()` should probably be moved to within the backend.
- why `BdaResult`? Because the `cusparseSolverBackend.cu` is compiled using nvcc, adding the `InverseOperatorResult` there causes a compile error:
```
/data/work/tqiu/dune/dune-istl/dune/istl/basearray.hh:101:58: error: ‘typename Dune::Imp::base_array_unmanaged<B, A>::RealIterator’ names ‘template<class B, class A> template<class T> struct Dune::Imp::base_array_unmanaged<B, A>::RealIterator’, which is not a type
       friend class RealIterator<const ValueType>;
```
- timing functions in `cusparseSolverBackend` use `gettimeofday()`
- BdaBridge misuses the std::vectors a bit.
- the CUDA compiler nvcc defines the macro `__NVCC__`, if not defined, the `BdaBridge` will be mostly empty.

---

## Results ##
Intel Xeon E5-2620 v3 @ 2.4GHz, NVIDIA RTX GeForce 2080Ti

### Dune: ###
```
Total time (seconds):         774.473
Solver time (seconds):        767.034
Assembly time (seconds):     298.541 (Failed: 3.21499; 1.0769%)
Linear solve time (seconds): 443.508 (Failed: 5.63787; 1.2712%)
Linear solve setup time (seconds): 14.3272 (Failed: 0.184655; 1.28884%)
Update time (seconds):       11.2785 (Failed: 0.130548; 1.1575%)
Output write time (seconds): 9.36335
Overall Well Iterations:      918 (Failed: 2; 0.217865%)
Overall Linearizations:       1932 (Failed: 21; 1.08696%)
Overall Newton Iterations:    1598 (Failed: 21; 1.31414%)
Overall Linear Iterations:    23982 (Failed: 308; 1.2843%)
```

### cusparseSolver: ###
```
Total time (seconds):         460.21
Solver time (seconds):        452.812
Assembly time (seconds):     293.769 (Failed: 6.40129; 2.17902%)
Linear solve time (seconds): 134.676 (Failed: 4.4542; 3.30735%)
Linear solve setup time (seconds): 14.3 (Failed: 0.37382; 2.61413%)
Update time (seconds):       11.2345 (Failed: 0.259182; 2.30703%)
Output write time (seconds): 9.33874
Overall Well Iterations:      921 (Failed: 4; 0.434311%)
Overall Linearizations:       1940 (Failed: 42; 2.16495%)
Overall Newton Iterations:    1605 (Failed: 42; 2.61682%)
Overall Linear Iterations:    24387 (Failed: 861; 3.53057%)
```