### PR TITLE
Load aquifer data

### DIFF
--- a/ebos/eclbaseaquifermodel.hh
+++ b/ebos/eclbaseaquifermodel.hh
@@ -31,6 +31,8 @@
 
 #include <opm/models/utils/propertysystem.hh>
 
+#include <exception>
+#include <stdexcept>
 #include <vector>
 
 BEGIN_PROPERTIES
@@ -78,7 +80,12 @@ public:
      *        volume from the model's aquifers.
      */
     void initFromRestart(const std::vector<data::AquiferData>& aquiferSoln OPM_UNUSED)
-    { }
+    {
+        throw std::logic_error {
+            "Initialization from restart data not supported "
+            "for base aquifer model"
+        };
+    }
 
     /*!
      * \brief This method is called when a new episode (report step) starts.

--- a/ebos/eclbaseaquifermodel.hh
+++ b/ebos/eclbaseaquifermodel.hh
@@ -27,7 +27,11 @@
 #ifndef EWOMS_ECL_BASE_AQUIFER_MODEL_HH
 #define EWOMS_ECL_BASE_AQUIFER_MODEL_HH
 
+#include <opm/output/data/Aquifer.hpp>
+
 #include <opm/models/utils/propertysystem.hh>
+
+#include <vector>
 
 BEGIN_PROPERTIES
 
@@ -62,6 +66,18 @@ public:
      *        condition has been applied.
      */
     void initialSolutionApplied()
+    { }
+
+    /*!
+     * \brief Called if aquifers are being initialized from values retrieved
+     *        from a restart file.
+     *
+     * \param[in] aquiferSoln Set of aquifer-related initial values, mostly
+     *        pertaining to analytic aquifers.  Contains at minimum the
+     *        aquifer pressure and the base run's total produced liquid
+     *        volume from the model's aquifers.
+     */
+    void initFromRestart(const std::vector<data::AquiferData>& aquiferSoln OPM_UNUSED)
     { }
 
     /*!

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1748,6 +1748,9 @@ public:
     EclWellModel& wellModel()
     { return wellModel_; }
 
+    EclAquiferModel& mutableAquiferModel()
+    { return aquiferModel_; }
+
     // temporary solution to facilitate output of initial state from flow
     const InitialFluidState& initialFluidState(unsigned globalDofIdx) const
     { return initialFluidStates_[globalDofIdx]; }

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -454,6 +454,9 @@ public:
 
             // initialize the well model from restart values
             simulator_.problem().wellModel().initFromRestartFile(restartValues);
+
+            if (!restartValues.aquifer.empty())
+                simulator_.problem().mutableAquiferModel().initFromRestart(restartValues.aquifer);
         }
     }
 

--- a/opm/simulators/aquifers/AquiferCarterTracy.hpp
+++ b/opm/simulators/aquifers/AquiferCarterTracy.hpp
@@ -23,6 +23,8 @@
 
 #include <opm/simulators/aquifers/AquiferInterface.hpp>
 
+#include <opm/output/data/Aquifer.hpp>
+
 namespace Opm
 {
 
@@ -144,6 +146,9 @@ namespace Opm
                     : ( connection.influx_multiplier.at(idx) * Base::faceArea_connected_.at(idx) )/denom_face_areas;
                 }
             }
+
+            void assignRestartData(const data::AquiferData& /* xaq */) override
+            {}
 
             inline void getInfluenceTableValues(Scalar& pitd, Scalar& pitd_prime, const Scalar& td)
             {

--- a/opm/simulators/aquifers/AquiferCarterTracy.hpp
+++ b/opm/simulators/aquifers/AquiferCarterTracy.hpp
@@ -25,6 +25,9 @@
 
 #include <opm/output/data/Aquifer.hpp>
 
+#include <exception>
+#include <stdexcept>
+
 namespace Opm
 {
 
@@ -148,7 +151,12 @@ namespace Opm
             }
 
             void assignRestartData(const data::AquiferData& /* xaq */) override
-            {}
+            {
+                throw std::runtime_error {
+                    "Restart-based initialization not currently supported "
+                    "for Carter-Tracey analytic aquifers"
+                };
+            }
 
             inline void getInfluenceTableValues(Scalar& pitd, Scalar& pitd_prime, const Scalar& td)
             {

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -27,6 +27,8 @@
 #include <opm/parser/eclipse/EclipseState/Aquancon.hpp>
 #include <opm/common/utility/numeric/linearInterpolation.hpp>
 
+#include <opm/output/data/Aquifer.hpp>
+
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/densead/Math.hpp>
 #include <opm/material/densead/Evaluation.hpp>
@@ -73,6 +75,26 @@ namespace Opm
 
     // Deconstructor
     virtual ~AquiferInterface() {}
+
+    void initFromRestart(const std::vector<data::AquiferData>& aquiferSoln)
+    {
+      auto xaqPos = std::find_if(aquiferSoln.begin(), aquiferSoln.end(),
+        [this](const data::AquiferData& xaq) -> bool
+      {
+        return xaq.aquiferID == this->connection_.aquiferID;
+      });
+
+      if (xaqPos == aquiferSoln.end()) {
+        // No restart value applies to this aquifer.  Nothing to do.
+        return;
+      }
+
+      this->assignRestartData(*xaqPos);
+
+      this->W_flux_ = xaqPos->volume;
+      this->pa0_    = xaqPos->initPressure;
+      this->solution_set_from_restart_ = true;
+    }
 
     void initialSolutionApplied()
     {
@@ -129,7 +151,10 @@ namespace Opm
     inline void initQuantities(const Aquancon::AquanconOutput& connection)
     {
       // We reset the cumulative flux at the start of any simulation, so, W_flux = 0
-      W_flux_ = 0.;
+      if (!this->solution_set_from_restart_)
+      {
+        W_flux_ = 0.;
+      }
 
       // We next get our connections to the aquifer and initialize these quantities using the initialize_connections function
       initializeConnections(connection);
@@ -207,7 +232,11 @@ namespace Opm
 
     Eval W_flux_;
 
+    bool solution_set_from_restart_{false};
+
     virtual void initializeConnections(const Aquancon::AquanconOutput& connection) =0;
+
+    virtual void assignRestartData(const data::AquiferData& xaq) = 0;
 
     virtual void calculateInflowRate(int idx, const Simulator& simulator) = 0;
 

--- a/opm/simulators/aquifers/BlackoilAquiferModel.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel.hpp
@@ -34,7 +34,6 @@
 
 #include <opm/simulators/aquifers/AquiferCarterTracy.hpp>
 #include <opm/simulators/aquifers/AquiferFetkovich.hpp>
-#include <opm/simulators/timestepping/SimulatorTimer.hpp>
 
 #include <opm/material/densead/Math.hpp>
 

--- a/opm/simulators/aquifers/BlackoilAquiferModel.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel.hpp
@@ -29,10 +29,16 @@
 #include <opm/parser/eclipse/EclipseState/AquiferCT.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquifetp.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquancon.hpp>
-#include <opm/simulators/timestepping/SimulatorTimer.hpp>
+
+#include <opm/output/data/Aquifer.hpp>
+
 #include <opm/simulators/aquifers/AquiferCarterTracy.hpp>
 #include <opm/simulators/aquifers/AquiferFetkovich.hpp>
+#include <opm/simulators/timestepping/SimulatorTimer.hpp>
+
 #include <opm/material/densead/Math.hpp>
+
+#include <vector>
 
 namespace Opm {
 
@@ -47,6 +53,8 @@ namespace Opm {
             explicit BlackoilAquiferModel(Simulator& simulator);
 
             void initialSolutionApplied();
+            void initFromRestart(const std::vector<data::AquiferData>& aquiferSoln);
+
             void beginEpisode();
             void beginTimeStep();
             void beginIteration();

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -31,6 +31,26 @@ namespace Opm {
 
   template<typename TypeTag>
   void
+  BlackoilAquiferModel<TypeTag>::initFromRestart(const std::vector<data::AquiferData>& aquiferSoln)
+  {
+    if(aquiferCarterTracyActive())
+    {
+      for (auto& aquifer : aquifers_CarterTracy)
+      {
+        aquifer.initFromRestart(aquiferSoln);
+      }
+    }
+    if(aquiferFetkovichActive())
+    {
+      for (auto& aquifer : aquifers_Fetkovich)
+      {
+        aquifer.initFromRestart(aquiferSoln);
+      }
+    }
+  }
+
+  template<typename TypeTag>
+  void
   BlackoilAquiferModel<TypeTag>::beginEpisode()
   { }
 


### PR DESCRIPTION
This PR adds a new member function,
```C++
AquiferInterface::initFromRestart()
```
that consumes a `vector<data::AquiferData>` constructed from information in the restart file's `XAAQ` vector.  At the moment, we use only the total produced liquid volume and the aquifer pressure.

We implement the interface's member function in terms of the virtual function
```C++
AquiferInterface::assignRestartData()
```
that must be overridden in derived classes.

Implement a trivial such function for Carter-Tracy aquifers, and a function that only stores the aquifer pressure for the Fetkovich aquifer model.

Additionally, record whether or not the aquifer object was initialised from a previous solution.  If so, don't reset total produce liquid volumes or aquifer pressures to their base values from the model input file.

We thread calls to this function through from the restart information loaded in `EclWriter::beginRestart()`.

---

This PR depends on OPM/opm-common#1277.