### PR TITLE
Evaluate ACTIONX at the end of every timestep

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -966,7 +966,7 @@ public:
         }
 #endif // NDEBUG
 
-        const auto& simulator = this->simulator();
+        auto& simulator = this->simulator();
         wellModel_.endTimeStep();
         if (enableAquifers_)
             aquiferModel_.endTimeStep();
@@ -987,6 +987,13 @@ public:
 
         bool isSubStep = !EWOMS_GET_PARAM(TypeTag, bool, EnableWriteAllSolutions) && !this->simulator().episodeWillBeOver();
         eclWriter_->evalSummaryState(isSubStep);
+
+        auto& schedule = simulator.vanguard().schedule();
+        int episodeIdx = simulator.episodeIndex();
+        this->applyActions(episodeIdx,
+                           simulator.time() + simulator.timeStepSize(),
+                           schedule,
+                           simulator.vanguard().summaryState());
     }
 
     /*!
@@ -999,10 +1006,6 @@ public:
         const auto& timeMap = schedule.getTimeMap();
 
         int episodeIdx = simulator.episodeIndex();
-        this->applyActions(episodeIdx + 1,
-                           simulator.time() + simulator.timeStepSize(),
-                           schedule,
-                           simulator.vanguard().summaryState());
 
         // check if we're finished ...
         if (episodeIdx + 1 >= static_cast<int>(timeMap.numTimesteps())) {

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -677,6 +677,18 @@ namespace Opm {
                     }
                 }
 
+                // Due to ACTIONX the well might have been closed 'behind our back'.
+                const auto well_status = schedule().getWell(well_name, time_step).getStatus();
+                if (well_status == Well::Status::SHUT) {
+                    well_state_.shutWell(w);
+                    continue;
+                }
+
+                if (well_status == Well::Status::STOP) {
+                    well_state_.thp()[w] = 0.;
+                    wellIsStopped = true;
+                }
+
                 // Use the pvtRegionIdx from the top cell
                 const int well_cell_top = well_perf_data_[w][0].cell_index;
                 const int pvtreg = pvt_region_idx_[well_cell_top];


### PR DESCRIPTION
The ACTIONX keyword is evaluated at the end of every *time*step, whereas all of the simulator <-> deck interaction is currently at the report step granularity.

This pr is *very much* work in progress; more a draft for discussion.

After some discussion with @atgeirr it is not starting to approach something which can be merged.