### PR TITLE
Remove non-contributing computations in parallel solver by changing matrix sparsity pattern.

### DIFF
--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -645,27 +645,6 @@ protected:
 #endif
         }
 
-        /// Zero out off-diagonal blocks on rows corresponding to overlap cells
-        /// Diagonal blocks on ovelap rows are set to diag(1.0).
-        void makeOverlapRowsInvalid(Matrix& ebosJacIgnoreOverlap) const
-        {
-            //value to set on diagonal
-            Dune::FieldMatrix<Scalar, numEq, numEq> diag_block(0.0);
-            for (int eq = 0; eq < numEq; ++eq)
-                diag_block[eq][eq] = 1.0;
-
-            //loop over precalculated overlap rows and columns
-            for (auto row = overlapRows_.begin(); row != overlapRows_.end(); row++ )
-            {
-                int lcell = *row;
-                // Zero out row.
-                ebosJacIgnoreOverlap[lcell] = 0.0;
-
-                //diagonal block set to diag(1.0).
-                ebosJacIgnoreOverlap[lcell][lcell] = diag_block;
-            }
-        }
-
         /// Create sparsity pattern of matrix without off-diagonal ghost entries.
         void noGhostAdjacency()
         {

--- a/opm/simulators/linalg/ISTLSolverEbosCpr.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosCpr.hpp
@@ -99,7 +99,7 @@ namespace Opm
             : SuperClass(simulator), oldMat()
         {
             extractParallelGridInformationToISTL(this->simulator_.vanguard().grid(), this->parallelInformation_);
-            detail::findOverlapRowsAndColumns(this->simulator_.vanguard().grid(), this->overlapRowAndColumns_);
+            detail::findOverlapAndInterior(this->simulator_.vanguard().grid(), this->overlapRows_, this->interiorRows_);
         }
 
         void prepare(const SparseMatrixAdapter& M, Vector& b)

--- a/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
@@ -180,7 +180,8 @@ protected:
     void makeOverlapRowsInvalid(MatrixType& matrix) const
     {
         //value to set on diagonal
-        Dune::FieldMatrix<Scalar, numEq, numEq> diag_block(0.0);
+	const int numEq = MatrixType::block_type::rows;
+        typename MatrixType::block_type diag_block(0.0);
         for (int eq = 0; eq < numEq; ++eq)
             diag_block[eq][eq] = 1.0;
 

--- a/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
@@ -180,7 +180,7 @@ protected:
     void makeOverlapRowsInvalid(MatrixType& matrix) const
     {
         //value to set on diagonal
-	const int numEq = MatrixType::block_type::rows;
+        const int numEq = MatrixType::block_type::rows;
         typename MatrixType::block_type diag_block(0.0);
         for (int eq = 0; eq < numEq; ++eq)
             diag_block[eq][eq] = 1.0;

--- a/opm/simulators/linalg/ParallelOverlappingILU0.hpp
+++ b/opm/simulators/linalg/ParallelOverlappingILU0.hpp
@@ -750,7 +750,6 @@ public:
     {
         Range& md = reorderD(d);
         Domain& mv = reorderV(v);
-        copyOwnerToAll( md );
 
         // iterator types
         typedef typename Range ::block_type  dblock;
@@ -777,8 +776,6 @@ public:
 
           mv[ i ] = rhs;  // Lii = I
         }
-
-        copyOwnerToAll( mv );
 
         for( size_type i=0; i<iEnd; ++ i )
         {

--- a/opm/simulators/linalg/findOverlapRowsAndColumns.hpp
+++ b/opm/simulators/linalg/findOverlapRowsAndColumns.hpp
@@ -22,59 +22,94 @@
 
 #include <vector>
 #include <utility>
+#include <opm/grid/common/WellConnections.hpp>
 
 namespace Opm
 {
 namespace detail
 {
+    /// \brief Find cell IDs for wells contained in local grid.
+    ///
+    /// Cell IDs of wells stored in a graph, so it can be used to create 
+    /// an adjacency pattern. Only relevant when the UseWellContribusion option is set to true
+    /// \tparam The type of the DUNE grid.
+    /// \tparam Well vector type
+    /// \param grid The grid where we look for overlap cells.
+    /// \param wells List of wells contained in grid.
+    /// \param useWellConn Boolean that is true when UseWellContribusion is true
+    /// \param wellGraph Cell IDs of well cells stored in a graph.
+    template<class Grid, class W>
+    void setWellConnections(const Grid& grid, const W& wells, bool useWellConn, std::vector<std::set<int>>& wellGraph)
+    {
+        if ( grid.comm().size() > 1) 
+        {
+            wellGraph.resize(grid.numCells());
+
+            if (useWellConn) {
+                const auto& cpgdim = grid.logicalCartesianSize();
+
+                std::vector<int> cart(cpgdim[0]*cpgdim[1]*cpgdim[2], -1);
+
+                for( int i=0; i < grid.numCells(); ++i )
+                    cart[grid.globalCell()[i]] = i;
+
+                Dune::cpgrid::WellConnections well_indices;
+                well_indices.init(wells, cpgdim, cart);
+
+                for (auto& well : well_indices)
+                {
+                    for (auto perf = well.begin(); perf != well.end(); ++perf)
+                    {
+                        auto perf2 = perf;
+                        for (++perf2; perf2 != well.end(); ++perf2)
+                        {
+                            wellGraph[*perf].insert(*perf2);
+                            wellGraph[*perf2].insert(*perf);
+                        }
+                    } 
+                }
+            }
+        }
+    }
 
     /// \brief Find the rows corresponding to overlap cells
     ///
-    /// Loop over grid and store cell ids of row-column pairs
+    /// Loop over grid and store cell ids of rows
     /// corresponding to overlap cells.
     /// \tparam The type of the DUNE grid.
     /// \param grid The grid where we look for overlap cells.
-    /// \param overlapRowAndColumns List where overlap rows and columns are stored.
-    template <class Grid>
-    void findOverlapRowsAndColumns(const Grid& grid,
-                                   std::vector<std::pair<int, std::vector<int>>>& overlapRowAndColumns)
+    /// \param overlapRows List where overlap rows are stored.
+    /// \param interiorRows List where overlap rows are stored.
+    template<class Grid>
+    void findOverlapAndInterior(const Grid& grid, std::vector<int>& overlapRows, 
+                                std::vector<int>& interiorRows)
     {
-        // only relevant in parallel case.
-        if (grid.comm().size() > 1) {
-            // Numbering of cells
+        //only relevant in parallel case.
+        if ( grid.comm().size() > 1) 
+        {
+            //Numbering of cells
             auto lid = grid.localIdSet();
 
             const auto& gridView = grid.leafGridView();
             auto elemIt = gridView.template begin<0>();
             const auto& elemEndIt = gridView.template end<0>();
 
-            // loop over cells in mesh
-            for (; elemIt != elemEndIt; ++elemIt) {
+            //loop over cells in mesh
+            for (; elemIt != elemEndIt; ++elemIt) 
+            {                
                 const auto& elem = *elemIt;
-
-                // If cell has partition type not equal to interior save row
-                if (elem.partitionType() != Dune::InteriorEntity) {
-                    // local id of overlap cell
-                    int lcell = lid.id(elem);
-
-                    std::vector<int> columns;
-                    // loop over faces of cell
-                    auto isend = gridView.iend(elem);
-                    for (auto is = gridView.ibegin(elem); is != isend; ++is) {
-                        // check if face has neighbor
-                        if (is->neighbor()) {
-                            // get index of neighbor cell
-                            int ncell = lid.id(is->outside());
-                            columns.push_back(ncell);
-                        }
-                    }
-                    // add row to list
-                    overlapRowAndColumns.push_back(std::pair<int, std::vector<int>>(lcell, columns));
+                int lcell = lid.id(elem);
+                
+                if (elem.partitionType() != Dune::InteriorEntity)
+                {  
+                    //add row to list
+                    overlapRows.push_back(lcell);
+                } else {
+                    interiorRows.push_back(lcell);
                 }
             }
         }
     }
-
 } // namespace detail
 } // namespace Opm
 


### PR DESCRIPTION
Content of this PR:

- Remove superfluous copyOwnerToAll calls in ILU.

- Set overlap/ghost diagonal to 1 instead of 1e100.

- Create a new sparsity pattern for the parallel system matrix to avoid non-contributing computations in SpMV and ILU factorisation and apply.


The changes result in some improvement in parallel performance. The changes should not alter the convergence or simulation result at all. On a a DualProcessor AMD Epyc7601 node I observed the following runtimes (best of 10) using Flow (ILU) on the Norne model:

| MPI-processes  | master2019.10 + PR | master2019.10 | 
| ------------- | ------------- | ------------- |
|  2                     |        384.49         |      414.0              |
|  4                    |          219.9             |    242.7              |
|  8                    |           144.2            |    173.4              |
|  16                   |           101.9           |     124.7                 |
|  32                   |           92.7           |     116.9                  |
|  64                   |            72.2           |     91.2                 |

The improvement in execution time will differ from model to model and will also depend on hardware.