### PR TITLE
Refactor WellState SHUT

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -668,14 +668,7 @@ namespace Opm {
                     wellTestState_.hasWellClosed(well_name, WellTestConfig::Reason::PHYSICAL) ) {
                     if( well_ecl.getAutomaticShutIn() ) {
                         // shut wells are not added to the well container
-                        // TODO: make a function from well_state side to handle the following
-                        well_state_.thp()[w] = 0.;
-                        well_state_.bhp()[w] = 0.;
-                        const int np = numPhases();
-                        for (int p = 0; p < np; ++p) {
-                            well_state_.wellRates()[np * w + p] = 0.;
-                            well_state_.wellReservoirRates()[np * w + p] = 0.;
-                        }
+                        well_state_.shutWell(w);
                         continue;
                     } else {
                         // stopped wells are added to the container but marked as stopped

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -63,6 +63,7 @@ namespace Opm
                 const int nw = wells_ecl.size();
                 // const int np = wells->number_of_phases;
                 const int np = pu.num_phases;
+                open_for_output_.resize(nw, true);
                 bhp_.resize(nw, 0.0);
                 thp_.resize(nw, 0.0);
                 temperature_.resize(nw, 273.15 + 20); // standard temperature for now
@@ -152,6 +153,17 @@ namespace Opm
             return wellRates().size() / numWells();
         }
 
+
+        virtual void shutWell(int well_index) {
+            this->open_for_output_[well_index] = false;
+            this->thp_[well_index] = 0;
+            this->bhp_[well_index] = 0;
+            const int np = numPhases();
+            for (int p = 0; p < np; ++p)
+                this->wellrates_[np * well_index + p] = 0;
+        }
+
+
         virtual data::Wells report(const PhaseUsage& pu, const int* globalCellIdxMap) const
         {
             using rt = data::Rates::opt;
@@ -159,6 +171,8 @@ namespace Opm
             data::Wells dw;
             for( const auto& itr : this->wellMap_ ) {
                 const auto well_index = itr.second[ 0 ];
+                if (!this->open_for_output_[well_index])
+                    continue;
 
                 auto& well = dw[ itr.first ];
                 well.bhp = this->bhp().at( well_index );
@@ -208,6 +222,9 @@ namespace Opm
         std::vector<double> wellrates_;
         std::vector<double> perfrates_;
         std::vector<double> perfpress_;
+    protected:
+        std::vector<bool>   open_for_output_;
+    private:
 
         WellMapType wellMap_;
 

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -425,6 +425,9 @@ namespace Opm
 
             for( const auto& wt : this->wellMap() ) {
                 const auto w = wt.second[ 0 ];
+                if (!this->open_for_output_[w])
+                    continue;
+
                 auto& well = res.at( wt.first );
                 //well.injectionControl = static_cast<int>(this->currentInjectionControls()[ w ]);
                 //well.productionControl = static_cast<int>(this->currentProductionControls()[ w ]);
@@ -805,6 +808,14 @@ namespace Opm
         const std::vector<double>& perfWaterVelocity() const {
             return perf_water_velocity_;
         }
+
+        virtual void shutWell(int well_index) {
+            WellState::shutWell(well_index);
+            const int np = numPhases();
+            for (int p = 0; p < np; ++p)
+                this->well_reservoir_rates_[np * well_index + p] = 0;
+        }
+
 
     private:
         std::vector<double> perfphaserates_;


### PR DESCRIPTION
- Move some WellState shut code to separate method.
- Add bool flag open_for_output_ to WellState to ensure that shut wells do not
  create output.

Part of the effort to be able to handle ACTIONX in the middle of a report step.