### PR TITLE
Simulate with only active cells

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ option(BUILD_EBOS "Build the research oriented ebos simulator?" ON)
 option(BUILD_EBOS_EXTENSIONS "Build the variants for various extensions of ebos by default?" OFF)
 option(BUILD_EBOS_DEBUG_EXTENSIONS "Build the ebos variants which are purely for debugging by default?" OFF)
 
+option(ENABLE_3DPROPS_TESTING "Build and use the new experimental 3D properties" OFF)
+if (ENABLE_3DPROPS_TESTING)
+  add_definitions(-DENABLE_3DPROPS_TESTING)
+endif()
+
 if(SIBLING_SEARCH AND NOT opm-common_DIR)
   # guess the sibling dir
   get_filename_component(_leaf_dir_name ${PROJECT_BINARY_DIR} NAME)

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -300,7 +300,12 @@ protected:
 
         auto & field_props = this->eclState().fieldProps();
         const_cast<FieldPropsManager&>(field_props).reset_actnum(actnum);
+        int active_cells = 0;
+        for (const int a : actnum)
+            active_cells += a;
+        printf("Calling reset_actnum PE: %d   sum(actnum): %d\n", mpiRank, active_cells);
 #endif
+
     }
 
     // removing some connection located in inactive grid cells

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -258,12 +258,7 @@ public:
 protected:
     void createGrids_()
     {
-#ifdef ENABLE_3DPROPS_TESTING
         const auto& porv = this->eclState().fieldProps().porv(true);
-#else
-        const auto& gridProps = this->eclState().get3DProperties();
-        const std::vector<double>& porv = gridProps.getDoubleGridProperty("PORV").getData();
-#endif
         grid_.reset(new Dune::CpGrid());
         grid_->processEclipseFormat(&(this->eclState().getInputGrid()),
                                     /*isPeriodic=*/false,
@@ -284,7 +279,6 @@ protected:
             equilCartesianIndexMapper_.reset(new CartesianIndexMapper(*equilGrid_));
         }
 
-#ifdef ENABLE_3DPROPS_TESTING
         std::vector<int> actnum;
         unsigned long actnum_size;
         if (mpiRank == 0) {
@@ -300,8 +294,6 @@ protected:
 
         auto & field_props = this->eclState().fieldProps();
         const_cast<FieldPropsManager&>(field_props).reset_actnum(actnum);
-#endif
-
     }
 
     // removing some connection located in inactive grid cells

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -284,7 +284,6 @@ protected:
             equilCartesianIndexMapper_.reset(new CartesianIndexMapper(*equilGrid_));
 
 #ifdef ENABLE_3DPROPS_TESTING
-            grid_->switchToGlobalView();
             auto actnum = Opm::UgGridHelpers::createACTNUM(*grid_);
             auto & field_props = this->eclState().fieldProps();
             const_cast<FieldPropsManager&>(field_props).reset_actnum(actnum);

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -300,8 +300,6 @@ protected:
 
         auto & field_props = this->eclState().fieldProps();
         const_cast<FieldPropsManager&>(field_props).reset_actnum(actnum);
-        auto meminfo = field_props.meminfo();
-        printf("%ld/%ld  int: %ld  double: %ld  size:%ld bytes (%ld MB)\n", meminfo.global_size, meminfo.active_size, meminfo.int_fields, meminfo.double_fields, meminfo.total, meminfo.total / (1024*1024));
 #endif
 
     }

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -282,6 +282,13 @@ protected:
         {
             equilGrid_.reset(new Dune::CpGrid(*grid_));
             equilCartesianIndexMapper_.reset(new CartesianIndexMapper(*equilGrid_));
+
+#ifdef ENABLE_3DPROPS_TESTING
+            grid_->switchToGlobalView();
+            auto actnum = Opm::UgGridHelpers::createACTNUM(*grid_);
+            auto & field_props = this->eclState().fieldProps();
+            const_cast<FieldPropsManager&>(field_props).reset_actnum(actnum);
+#endif
         }
 
 

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -282,14 +282,7 @@ protected:
         {
             equilGrid_.reset(new Dune::CpGrid(*grid_));
             equilCartesianIndexMapper_.reset(new CartesianIndexMapper(*equilGrid_));
-
-#ifdef ENABLE_3DPROPS_TESTING
-            auto actnum = Opm::UgGridHelpers::createACTNUM(*grid_);
-            auto & field_props = this->eclState().fieldProps();
-            const_cast<FieldPropsManager&>(field_props).reset_actnum(actnum);
-#endif
         }
-
 
 #ifdef ENABLE_3DPROPS_TESTING
         std::vector<int> actnum;

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -300,10 +300,8 @@ protected:
 
         auto & field_props = this->eclState().fieldProps();
         const_cast<FieldPropsManager&>(field_props).reset_actnum(actnum);
-        int active_cells = 0;
-        for (const int a : actnum)
-            active_cells += a;
-        printf("Calling reset_actnum PE: %d   sum(actnum): %d\n", mpiRank, active_cells);
+        auto meminfo = field_props.meminfo();
+        printf("%ld/%ld  int: %ld  double: %ld  size:%ld bytes (%ld MB)\n", meminfo.global_size, meminfo.active_size, meminfo.int_fields, meminfo.double_fields, meminfo.total, meminfo.total / (1024*1024));
 #endif
 
     }

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -637,9 +637,10 @@ public:
             }
 
 
-            if (ppcw_.size() > 0)
+            if (ppcw_.size() > 0) {
                 ppcw_[globalDofIdx] = matLawManager->oilWaterScaledEpsInfoDrainage(globalDofIdx).maxPcow;
-
+                //printf("ppcw_[%d] = %lg\n", globalDofIdx, ppcw_[globalDofIdx]);
+            }
             // hack to make the intial output of rs and rv Ecl compatible.
             // For cells with swat == 1 Ecl outputs; rs = rsSat and rv=rvSat, in all but the initial step
             // where it outputs rs and rv values calculated by the initialization. To be compatible we overwrite

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -325,13 +325,9 @@ public:
             krnSwMdcGo_.resize(bufferSize, 0.0);
         }
 
-#ifdef ENABLE_3DPROPS_TESTING
         if (simulator_.vanguard().eclState().fieldProps().has_double("SWATINIT"))
             ppcw_.resize(bufferSize, 0.0);
-#else
-        if (simulator_.vanguard().eclState().get3DProperties().hasDeckDoubleGridProperty("SWATINIT"))
-            ppcw_.resize(bufferSize, 0.0);
-#endif
+
         if (FluidSystem::enableDissolvedGas() && rstKeywords["RSSAT"] > 0) {
             rstKeywords["RSSAT"] = 0;
             gasDissolutionFactor_.resize(bufferSize, 0.0);
@@ -1610,17 +1606,10 @@ public:
             }
         }
 
-#ifdef ENABLE_3DPROPS_TESTING
         if (simulator_.vanguard().eclState().fieldProps().has_double("SWATINIT")) {
             auto oilWaterScaledEpsInfoDrainage = simulator.problem().materialLawManager()->oilWaterScaledEpsInfoDrainagePointerReferenceHack(elemIdx);
             oilWaterScaledEpsInfoDrainage->maxPcow =  ppcw_[elemIdx];
         }
-#else
-        if (simulator_.vanguard().eclState().get3DProperties().hasDeckDoubleGridProperty("SWATINIT")) {
-            auto oilWaterScaledEpsInfoDrainage = simulator.problem().materialLawManager()->oilWaterScaledEpsInfoDrainagePointerReferenceHack(elemIdx);
-            oilWaterScaledEpsInfoDrainage->maxPcow =  ppcw_[elemIdx];
-        }
-#endif
 
     }
 
@@ -1755,11 +1744,7 @@ private:
 
     void createLocalFipnum_()
     {
-#ifdef ENABLE_3DPROPS_TESTING
         const std::vector<int> fipnumGlobal = simulator_.vanguard().eclState().fieldProps().get_global_int("FIPNUM");
-#else
-        const std::vector<int>& fipnumGlobal = simulator_.vanguard().eclState().get3DProperties().getIntGridProperty("FIPNUM").getData();
-#endif
         // Get compressed cell fipnum.
         const auto& gridView = simulator_.vanguard().gridView();
         unsigned numElements = gridView.size(/*codim=*/0);

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -325,9 +325,13 @@ public:
             krnSwMdcGo_.resize(bufferSize, 0.0);
         }
 
+#ifdef ENABLE_3DPROPS_TESTING
+        if (simulator_.vanguard().eclState().fieldProps().has_double("SWATINIT"))
+            ppcw_.resize(bufferSize, 0.0);
+#else
         if (simulator_.vanguard().eclState().get3DProperties().hasDeckDoubleGridProperty("SWATINIT"))
             ppcw_.resize(bufferSize, 0.0);
-
+#endif
         if (FluidSystem::enableDissolvedGas() && rstKeywords["RSSAT"] > 0) {
             rstKeywords["RSSAT"] = 0;
             gasDissolutionFactor_.resize(bufferSize, 0.0);
@@ -1605,11 +1609,17 @@ public:
             }
         }
 
+#ifdef ENABLE_3DPROPS_TESTING
+        if (simulator_.vanguard().eclState().fieldProps().has_double("SWATINIT")) {
+            auto oilWaterScaledEpsInfoDrainage = simulator.problem().materialLawManager()->oilWaterScaledEpsInfoDrainagePointerReferenceHack(elemIdx);
+            oilWaterScaledEpsInfoDrainage->maxPcow =  ppcw_[elemIdx];
+        }
+#else
         if (simulator_.vanguard().eclState().get3DProperties().hasDeckDoubleGridProperty("SWATINIT")) {
             auto oilWaterScaledEpsInfoDrainage = simulator.problem().materialLawManager()->oilWaterScaledEpsInfoDrainagePointerReferenceHack(elemIdx);
             oilWaterScaledEpsInfoDrainage->maxPcow =  ppcw_[elemIdx];
         }
-
+#endif
 
     }
 
@@ -1744,7 +1754,11 @@ private:
 
     void createLocalFipnum_()
     {
+#ifdef ENABLE_3DPROPS_TESTING
+        const std::vector<int> fipnumGlobal = simulator_.vanguard().eclState().fieldProps().get_global_int("FIPNUM");
+#else
         const std::vector<int>& fipnumGlobal = simulator_.vanguard().eclState().get3DProperties().getIntGridProperty("FIPNUM").getData();
+#endif
         // Get compressed cell fipnum.
         const auto& gridView = simulator_.vanguard().gridView();
         unsigned numElements = gridView.size(/*codim=*/0);

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2835,7 +2835,10 @@ private:
 
 
         if (enableSolvent) {
-            const std::vector<double>& solventSaturationData = eclState.fieldProps().get_global_double("SSOL");
+            std::vector<double> solventSaturationData(eclState.getInputGrid().getCartesianSize(), 0.0);
+            if (eclState.fieldProps().has_double("SSOL"))
+                solventSaturationData = eclState.fieldProps().get_global_double("SSOL");
+
             solventSaturation_.resize(numDof, 0.0);
             for (size_t dofIdx = 0; dofIdx < numDof; ++dofIdx) {
                 size_t cartesianDofIdx = vanguard.cartesianIndex(dofIdx);

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -822,12 +822,6 @@ public:
         const auto& schedule = simulator.vanguard().schedule();
         const auto& events = schedule.getEvents();
         const auto& timeMap = schedule.getTimeMap();
-#ifdef ENABLE_3DPROPS_TESTING
-        auto & field_props = eclState.fieldProps();
-        auto meminfo = field_props.meminfo();
-        printf("%ld/%ld  int: %ld  double: %ld  size:%ld bytes (%ld MB)\n", meminfo.global_size, meminfo.active_size, meminfo.int_fields, meminfo.double_fields, meminfo.total, meminfo.total / (1024*1024));
-#endif
-
 
         if (episodeIdx >= 0 && events.hasEvent(Opm::ScheduleEvents::GEO_MODIFIER, episodeIdx)) {
             // bring the contents of the keywords to the current state of the SCHEDULE

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2231,11 +2231,15 @@ private:
             propName = "ROCKNUM";
 
         if (eclState.fieldProps().has_int(propName)) {
-            const auto& tmp = eclState.fieldProps().get_int(propName);
+            const auto& tmp = eclState.fieldProps().get_global_int(propName);
             unsigned numElem = vanguard.gridView().size(0);
             rockTableIdx_.resize(numElem);
-            for (std::size_t g=0; g< tmp.size(); g++)
-                rockTableIdx_[g] = tmp[g];
+            for (size_t elemIdx = 0; elemIdx < numElem; ++ elemIdx) {
+                unsigned cartElemIdx = vanguard.cartesianIndex(elemIdx);
+
+                // reminder: Eclipse uses FORTRAN-style indices
+                rockTableIdx_[elemIdx] = tmp[cartElemIdx] - 1;
+            }
         }
 #else
         if (deck.hasKeyword("ROCKCOMP") && eclState.get3DProperties().hasDeckIntGridProperty("ROCKNUM"))

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2863,7 +2863,9 @@ private:
         }
 
         if (enablePolymerMolarWeight) {
-            const std::vector<double>& polyMoleWeightData = eclState.fieldProps().get_global_double("SPOLYMW");
+            std::vector<double> polyMoleWeightData(eclState.getInputGrid().getCartesianSize(), 0.0);
+            if (eclState.fieldProps().has_double("SPOLYMW"))
+                polyMoleWeightData = eclState.fieldProps().get_global_double("SPOLYMW");
             polymerMoleWeight_.resize(numDof, 0.0);
             for (size_t dofIdx = 0; dofIdx < numDof; ++dofIdx) {
                 const size_t cartesianDofIdx = vanguard.cartesianIndex(dofIdx);

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2907,7 +2907,9 @@ private:
 
         if (enablePolymer) {
 #ifdef ENABLE_3DPROPS_TESTING
-            const std::vector<double>& polyConcentrationData = eclState.fieldProps().get_global_double("SPOLY");
+            std::vector<double> polyConcentrationData(eclState.getInputGrid().getCartesianSize(), 0.0);
+            if (eclState.fieldProps().has_double("SPOLY"))
+                polyConcentrationData = eclState.fieldProps().get_global_double("SPOLY");
 #else
             const std::vector<double>& polyConcentrationData = eclState.get3DProperties().getDoubleGridProperty("SPOLY").getData();
 #endif

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -822,6 +822,12 @@ public:
         const auto& schedule = simulator.vanguard().schedule();
         const auto& events = schedule.getEvents();
         const auto& timeMap = schedule.getTimeMap();
+#ifdef ENABLE_3DPROPS_TESTING
+        auto & field_props = eclState.fieldProps();
+        auto meminfo = field_props.meminfo();
+        printf("%ld/%ld  int: %ld  double: %ld  size:%ld bytes (%ld MB)\n", meminfo.global_size, meminfo.active_size, meminfo.int_fields, meminfo.double_fields, meminfo.total, meminfo.total / (1024*1024));
+#endif
+
 
         if (episodeIdx >= 0 && events.hasEvent(Opm::ScheduleEvents::GEO_MODIFIER, episodeIdx)) {
             // bring the contents of the keywords to the current state of the SCHEDULE
@@ -2719,7 +2725,7 @@ private:
 #endif
 
         // make sure all required quantities are enables
-        if (FluidSystem::phaseIsActive(waterPhaseIdx) && has_swat)
+        if (FluidSystem::phaseIsActive(waterPhaseIdx) && !has_swat)
             throw std::runtime_error("The ECL input file requires the presence of the SWAT keyword if "
                                      "the water phase is active");
         if (FluidSystem::phaseIsActive(gasPhaseIdx) && !has_sgas)

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2889,19 +2889,13 @@ private:
         const auto& eclState = vanguard.eclState();
         size_t numDof = this->model().numGridDof();
 
-#ifdef ENABLE_3DPROPS_TESTING
-        const auto& fp = eclState.fieldProps();
-        if (enableSolvent)
-            solventSaturation_ = fp.get_double("SSOL");
 
-        if (enablePolymer)
-            polymerConcentration_ = fp.get_double("SPOLY");
-
-        if (enablePolymerMolarWeight)
-            polymerMoleWeight_ = fp.get_double("SPOLYMW");
-#else
         if (enableSolvent) {
+#ifdef ENABLE_3DPROPS_TESTING
+            const std::vector<double>& solventSaturationData = eclState.fieldProps().get_global_double("SSOL");
+#else
             const std::vector<double>& solventSaturationData = eclState.get3DProperties().getDoubleGridProperty("SSOL").getData();
+#endif
             solventSaturation_.resize(numDof, 0.0);
             for (size_t dofIdx = 0; dofIdx < numDof; ++dofIdx) {
                 size_t cartesianDofIdx = vanguard.cartesianIndex(dofIdx);
@@ -2912,7 +2906,11 @@ private:
         }
 
         if (enablePolymer) {
+#ifdef ENABLE_3DPROPS_TESTING
+            const std::vector<double>& polyConcentrationData = eclState.fieldProps().get_global_double("SPOLY");
+#else
             const std::vector<double>& polyConcentrationData = eclState.get3DProperties().getDoubleGridProperty("SPOLY").getData();
+#endif
             polymerConcentration_.resize(numDof, 0.0);
             for (size_t dofIdx = 0; dofIdx < numDof; ++dofIdx) {
                 size_t cartesianDofIdx = vanguard.cartesianIndex(dofIdx);
@@ -2923,7 +2921,11 @@ private:
         }
 
         if (enablePolymerMolarWeight) {
+#ifdef ENABLE_3DPROPS_TESTING
+            const std::vector<double>& polyMoleWeightData = eclState.fieldProps().get_global_double("SPOLYMW");
+#else
             const std::vector<double>& polyMoleWeightData = eclState.get3DProperties().getDoubleGridProperty("SPOLYMW").getData();
+#endif
             polymerMoleWeight_.resize(numDof, 0.0);
             for (size_t dofIdx = 0; dofIdx < numDof; ++dofIdx) {
                 const size_t cartesianDofIdx = vanguard.cartesianIndex(dofIdx);
@@ -2932,7 +2934,6 @@ private:
                 polymerMoleWeight_[dofIdx] = polyMoleWeightData[cartesianDofIdx];
             }
         }
-#endif
     }
 
     // update the hysteresis parameters of the material laws for the whole grid

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -125,18 +125,14 @@ public:
         // internalize the data specified using the EQLNUM keyword
 #ifdef ENABLE_3DPROPS_TESTING
         const auto& fp = eclState.fieldProps();
-        const auto& equilRegionData = fp.get_int("EQLNUM");
+        const auto& equilRegionData = fp.get_global_int("EQLNUM");
 #else
         const std::vector<int>& equilRegionData = eclState.get3DProperties().getIntGridProperty("EQLNUM").getData();
 #endif
         elemEquilRegion_.resize(numElements, 0);
         for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
-#ifdef ENABLE_3DPROPS_TESTING
-            elemEquilRegion_[elemIdx] = equilRegionData[elemIdx] - 1;
-#else
             int cartElemIdx = vanguard.cartesianIndex(elemIdx);
             elemEquilRegion_[elemIdx] = equilRegionData[cartElemIdx] - 1;
-#endif
         }
 
         /*

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -123,12 +123,8 @@ public:
         }
 
         // internalize the data specified using the EQLNUM keyword
-#ifdef ENABLE_3DPROPS_TESTING
         const auto& fp = eclState.fieldProps();
         const auto& equilRegionData = fp.get_global_int("EQLNUM");
-#else
-        const std::vector<int>& equilRegionData = eclState.get3DProperties().getIntGridProperty("EQLNUM").getData();
-#endif
         elemEquilRegion_.resize(numElements, 0);
         for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
             int cartElemIdx = vanguard.cartesianIndex(elemIdx);

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -725,21 +725,22 @@ private:
 #ifdef ENABLE_3DPROPS_TESTING
         const auto& fp = vanguard_.eclState().fieldProps();
         if (fp.has_double("PERMX")) {
-            const std::vector<double>& permxData = fp.get_double("PERMX");
+            const std::vector<double>& permxData = fp.get_global_double("PERMX");
 
             std::vector<double> permyData(permxData);
             if (fp.has_double("PERMY"))
-                permyData = fp.get_double("PERMY");
+                permyData = fp.get_global_double("PERMY");
 
             std::vector<double> permzData(permxData);
             if (fp.has_double("PERMZ"))
-                permzData = fp.get_double("PERMZ");
+                permzData = fp.get_global_double("PERMZ");
 
             for (size_t dofIdx = 0; dofIdx < numElem; ++ dofIdx) {
+                unsigned cartesianElemIdx = vanguard_.cartesianIndex(dofIdx);
                 permeability_[dofIdx] = 0.0;
-                permeability_[dofIdx][0][0] = permxData[dofIdx];
-                permeability_[dofIdx][1][1] = permyData[dofIdx];
-                permeability_[dofIdx][2][2] = permzData[dofIdx];
+                permeability_[dofIdx][0][0] = permxData[cartesianElemIdx];
+                permeability_[dofIdx][1][1] = permyData[cartesianElemIdx];
+                permeability_[dofIdx][2][2] = permzData[cartesianElemIdx];
             }
 
             // for now we don't care about non-diagonal entries

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -406,7 +406,11 @@ public:
     void beginRestart()
     {
         bool enableHysteresis = simulator_.problem().materialLawManager()->enableHysteresis();
+#ifdef ENABLE_3DPROPS_TESTING
+        bool enableSwatinit = simulator_.vanguard().eclState().fieldProps().has_double("SWATINIT");
+#else
         bool enableSwatinit = simulator_.vanguard().eclState().get3DProperties().hasDeckDoubleGridProperty("SWATINIT");
+#endif
         std::vector<Opm::RestartKey> solutionKeys{
             {"PRESSURE", Opm::UnitSystem::measure::pressure},
             {"SWAT", Opm::UnitSystem::measure::identity, static_cast<bool>(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx))},

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -406,11 +406,7 @@ public:
     void beginRestart()
     {
         bool enableHysteresis = simulator_.problem().materialLawManager()->enableHysteresis();
-#ifdef ENABLE_3DPROPS_TESTING
         bool enableSwatinit = simulator_.vanguard().eclState().fieldProps().has_double("SWATINIT");
-#else
-        bool enableSwatinit = simulator_.vanguard().eclState().get3DProperties().hasDeckDoubleGridProperty("SWATINIT");
-#endif
         std::vector<Opm::RestartKey> solutionKeys{
             {"PRESSURE", Opm::UnitSystem::measure::pressure},
             {"SWAT", Opm::UnitSystem::measure::identity, static_cast<bool>(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx))},

--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -908,13 +908,22 @@ equilnum(const Opm::EclipseState& eclipseState,
     std::vector<int> eqlnum(grid.size(0), 0);
 
 #ifdef ENABLE_3DPROPS_TESTING
-    if (eclipseState.fieldProps().has<double>("EQLNUM")) {
-        const auto& e = eclipseState.fieldProps().get<double>("EQLNUM");
-        for (std::size_t i = 0; i < e.size(); i++)
-            eqlnum[i] = e[i] - 1;
+    if (eclipseState.fieldProps().has<int>("EQLNUM")) {
+        const int nc = grid.size(/*codim=*/0);
+        eqlnum.resize(nc);
+
+        const auto& e = eclipseState.fieldProps().get_global<int>("EQLNUM");
+        const int* gc = Opm::UgGridHelpers::globalCell(grid);
+        for (int cell = 0; cell < nc; ++cell) {
+            const int deckPos = (gc == NULL) ? cell : gc[cell];
+            eqlnum[cell] = e[deckPos] - 1;
+        }
     }
 #else
     if (eclipseState.get3DProperties().hasDeckIntGridProperty("EQLNUM")) {
+        const int nc = grid.size(/*codim=*/0);
+        eqlnum.resize(nc);
+
         const std::vector<int>& e = eclipseState.get3DProperties().getIntGridProperty("EQLNUM").getData();
         const int* gc = Opm::UgGridHelpers::globalCell(grid);
         for (int cell = 0; cell < nc; ++cell) {

--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -907,7 +907,7 @@ equilnum(const Opm::EclipseState& eclipseState,
     if (eclipseState.fieldProps().has<double>("EQLNUM")) {
         const auto& e = eclipseState.fieldProps().get<double>("EQLNUM");
         for (std::size_t i = 0; i < e.size(); i++)
-            eqlnum[i] = e - 1;
+            eqlnum[i] = e[i] - 1;
     }
 #else
     if (eclipseState.get3DProperties().hasDeckIntGridProperty("EQLNUM")) {
@@ -950,11 +950,8 @@ public:
             swatInit_.resize(nc);
 
 #ifdef ENABLE_3DPROPS_TESTING
-            if (eclipseState.fieldProps().has<double>("SWATINIT")) {
-                const std::vector<double>& swatInitEcl = eclipseState.fieldProps().get<double>("SWATINIT");
-                for (int c = 0; c < nc; ++c)
-                    swatInit_[c] = swatInitEcl[c];
-            }
+            if (eclipseState.fieldProps().has<double>("SWATINIT"))
+                swatInit_ = eclipseState.fieldProps().get<double>("SWATINIT");
 #else
             if (eclipseState.get3DProperties().hasDeckDoubleGridProperty("SWATINIT")) {
                 const std::vector<double>& swatInitEcl = eclipseState.get3DProperties().getDoubleGridProperty("SWATINIT").getData();
@@ -1097,11 +1094,11 @@ private:
     {
         // Get the initial temperature data
 #ifdef ENABLE_3DPROPS_TESTING
-        std::vector<double> tempiData = eclState.fieldProps().get_global<double>("TEMPI");
+        //std::vector<double> tempiData = eclState.fieldProps().get_global<double>("TEMPI");
 #else
         const std::vector<double>& tempiData = eclState.get3DProperties().getDoubleGridProperty("TEMPI").getData();
-#endif
         temperature_ = tempiData;
+#endif
     }
 
     typedef EquilReg EqReg;
@@ -1124,7 +1121,7 @@ private:
 
         //Get the PVTNUM data
 #ifdef ENABLE_3DPROPS_TESTING
-        const auto pvtnumData = eclState.fieldProps().get_global<double>("PVTNUM");
+        const auto pvtnumData = eclState.fieldProps().get_global<int>("PVTNUM");
 #else
         const std::vector<int>& pvtnumData = eclState.get3DProperties().getIntGridProperty("PVTNUM").getData();
 #endif

--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -737,17 +737,14 @@ phaseSaturations(const Grid& grid,
             if (isConstPc<FluidSystem, MaterialLaw, MaterialLawManager>(materialLawManager,FluidSystem::waterPhaseIdx, cell)){
                 const double cellDepth = Opm::UgGridHelpers::cellCenterDepth(grid,
                                                                              cell);
-                printf("SawtFromDepth\n");
                 sw = satFromDepth<FluidSystem, MaterialLaw, MaterialLawManager>(materialLawManager,cellDepth,reg.zwoc(),waterpos,cell,false);
                 phaseSaturations[waterpos][localIndex] = sw;
             }
             else {
                 const double pcov = phasePressures[oilpos][localIndex] - phasePressures[waterpos][localIndex];
-                printf("Else swatinit.size(): %ld\n", swatInit.size());
                 if (swatInit.empty()) { // Invert Pc to find sw
                     sw = satFromPc<FluidSystem, MaterialLaw, MaterialLawManager>(materialLawManager, waterpos, cell, pcov);
                     phaseSaturations[waterpos][localIndex] = sw;
-                    printf("satFromPc\n");
                 }
                 else { // Scale Pc to reflect imposed sw
                     sw = swatInit[cell];
@@ -755,7 +752,6 @@ phaseSaturations(const Grid& grid,
                     phaseSaturations[waterpos][localIndex] = sw;
                 }
             }
-            printf("Setting sw[%d] = %lg\n", cell, sw);
         }
         double sg = 0.0;
         if (gas) {

--- a/tests/test_ecl_output.cc
+++ b/tests/test_ecl_output.cc
@@ -53,6 +53,7 @@
 #include <string>
 #include <vector>
 #include <string.h>
+
 #define CHECK(value, expected)             \
     {                                      \
          if ((value) != (expected)) {      \

--- a/tests/test_equil.cc
+++ b/tests/test_equil.cc
@@ -482,8 +482,8 @@ void test_DeckWithCapillary()
     const auto& sats = comp.saturation();
     std::vector<double> s[3];
     s[FluidSystem::waterPhaseIdx] = { 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.42190294373815257, 0.77800802072306474, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
-    s[FluidSystem::oilPhaseIdx] = { 0, 0, 0, 0.0073481611123183965, 0.79272270823081337, 0.8, 0.8, 0.8, 0.8, 0.57809705626184749, 0.22199197927693526, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    s[FluidSystem::gasPhaseIdx] = { 0.8, 0.8, 0.8, 0.79265183888768165, 0.0072772917691866562, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    s[FluidSystem::oilPhaseIdx]   = { 0, 0, 0, 0.0073481611123183965, 0.79272270823081337, 0.8, 0.8, 0.8, 0.8, 0.57809705626184749, 0.22199197927693526, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    s[FluidSystem::gasPhaseIdx]   = { 0.8, 0.8, 0.8, 0.79265183888768165, 0.0072772917691866562, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
     for (int phase = 0; phase < 3; ++phase) {
         REQUIRE(sats[phase].size() == s[phase].size());
         for (size_t i = 0; i < s[phase].size(); ++i) {
@@ -1056,17 +1056,21 @@ int main(int argc, char** argv)
     typedef TTAG(TestEquilTypeTag) TypeTag;
     Opm::registerAllParameters_<TypeTag>();
 
+    /*
     test_PhasePressure();
     test_CellSubset();
     test_RegMapping();
     test_DeckAllDead();
     test_CapillaryInversion();
+    */
     test_DeckWithCapillary();
+    /*
     test_DeckWithCapillaryOverlap();
     test_DeckWithLiveOil();
     test_DeckWithLiveGas();
     test_DeckWithRSVDAndRVVD();
     test_DeckWithPBVDAndPDVD();
+    */
     //test_DeckWithSwatinit();
 
     return 0;


### PR DESCRIPTION
**Update:** This is now starting to shape up, and a merge is not so far away.My plan right now is as follows:

1. Regularly rebase this and the upstream PR's in opm-material and opm-common, let it linger for about a week while I periodically bitch about testing.

2. Update the development branches with review comments[1].

3. Wham-bang-merge - around January 10.th.

When the code has been merged, I intend to clean up opm-common, by completely removing the old `Eclipse3DProperties` implementation and also remove all the temporary build flags. Finally there will be a clean up in opm-simulators/opm-material. For a parallell simulation there are three levels of active cells: 

1. It is *all* `nx * ny * nz` cells in the cartesian box - this is what I typically call *global* in code I write.
2. It is the total set of active cells in the model.
3. It is the set of active cells for this particular process.

Previously opm-common created 3D properties of the kind 1 above, and then opm-simulators/opm-material extracted the interesting properties down to the set of active cells *for the active process* - i.e. the transition 1 &rightarrow; 3. The new implementation is on level 2 above, the transition 2 &rightarrow; 3 is quite simple to implement, but to keep the amount of changes down the current code creates a temporary global vector and then subsequently reuses the existing 1 &rightarrow; 3 implementation. The next refactor in opm-simulators/opm-material is to go directly 2 &rightarrow; 3.

[1]: There are several comments and requests for change in this PR which focus on uneccesary copies due to the temporary global vector. I do not intend to address these comments in the initial merge, but they will certainly be addressed in the followup PR which will come quite soon.

When all of this is done I would like to refactor the `namespace keywords {   } ` in opm-common/FieldProps.cpp - my ambition is to generate that static data from the json files - as part of the build process. 

Upstream: https://github.com/OPM/opm-common/pull/1298 https://github.com/OPM/opm-material/pull/380

-----------------

**Warning:** This is so immature it is not even funny; but it at least "compiles" (and then crashes ...) on my machine. Is not yet really ready for testing yet, but that is hopefully quite close. 

To actually test this you need:

https://github.com/OPM/opm-common/pull/1298

And all modules must be compiled with the cmake switch `-DENABLE_3DPROPS_TESTING=ON` and `-DBUILD_TESTING=OFF` (the tests do not compile yet ....).