### PR TITLE
[For testing] Enable "owners first" ordering. Altered SpMV, SP and ILU.

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -78,7 +78,7 @@ NEW_PROP_TAG(EclOutputInterval);
 NEW_PROP_TAG(IgnoreKeywords);
 NEW_PROP_TAG(EnableExperiments);
 NEW_PROP_TAG(EdgeWeightsMethod);
-NEW_PROP_TAG(OwnersFirst);
+NEW_PROP_TAG(OwnerCellsFirst);
 
 SET_STRING_PROP(EclBaseVanguard, IgnoreKeywords, "");
 SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "");
@@ -87,7 +87,7 @@ SET_BOOL_PROP(EclBaseVanguard, EnableOpmRstFile, false);
 SET_BOOL_PROP(EclBaseVanguard, EclStrictParsing, false);
 SET_BOOL_PROP(EclBaseVanguard, SchedRestart, true);
 SET_INT_PROP(EclBaseVanguard, EdgeWeightsMethod, 1);
-SET_BOOL_PROP(EclBaseVanguard, OwnersFirst, false);
+SET_BOOL_PROP(EclBaseVanguard, OwnerCellsFirst, false);
 
 END_PROPERTIES
 
@@ -135,7 +135,7 @@ public:
                              "When restarting: should we try to initialize wells and groups from historical SCHEDULE section.");
         EWOMS_REGISTER_PARAM(TypeTag, int, EdgeWeightsMethod,
                              "Choose edge-weighing strategy: 0=uniform, 1=trans, 2=log(trans).");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, OwnersFirst,
+        EWOMS_REGISTER_PARAM(TypeTag, bool, OwnerCellsFirst,
                              "Order cells owned by rank before ghost/overlap cells.");
     }
 
@@ -269,7 +269,7 @@ public:
 
         std::string fileName = EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName);
         edgeWeightsMethod_   = Dune::EdgeWeightMethod(EWOMS_GET_PARAM(TypeTag, int, EdgeWeightsMethod));
-        ownersFirst_ = EWOMS_GET_PARAM(TypeTag, bool, OwnersFirst);
+        ownersFirst_ = EWOMS_GET_PARAM(TypeTag, bool, OwnerCellsFirst);
 
         // Skip processing of filename if external deck already exists.
         if (!externalDeck_)

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -78,6 +78,7 @@ NEW_PROP_TAG(EclOutputInterval);
 NEW_PROP_TAG(IgnoreKeywords);
 NEW_PROP_TAG(EnableExperiments);
 NEW_PROP_TAG(EdgeWeightsMethod);
+NEW_PROP_TAG(OwnersFirst);
 
 SET_STRING_PROP(EclBaseVanguard, IgnoreKeywords, "");
 SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "");
@@ -86,6 +87,7 @@ SET_BOOL_PROP(EclBaseVanguard, EnableOpmRstFile, false);
 SET_BOOL_PROP(EclBaseVanguard, EclStrictParsing, false);
 SET_BOOL_PROP(EclBaseVanguard, SchedRestart, true);
 SET_INT_PROP(EclBaseVanguard, EdgeWeightsMethod, 1);
+SET_BOOL_PROP(EclBaseVanguard, OwnersFirst, false);
 
 END_PROPERTIES
 
@@ -133,6 +135,8 @@ public:
                              "When restarting: should we try to initialize wells and groups from historical SCHEDULE section.");
         EWOMS_REGISTER_PARAM(TypeTag, int, EdgeWeightsMethod,
                              "Choose edge-weighing strategy: 0=uniform, 1=trans, 2=log(trans).");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, OwnersFirst,
+                             "Order cells owned by rank before ghost/overlap cells.");
     }
 
     /*!
@@ -265,6 +269,7 @@ public:
 
         std::string fileName = EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName);
         edgeWeightsMethod_   = Dune::EdgeWeightMethod(EWOMS_GET_PARAM(TypeTag, int, EdgeWeightsMethod));
+        ownersFirst_ = EWOMS_GET_PARAM(TypeTag, bool, OwnersFirst);
 
         // Skip processing of filename if external deck already exists.
         if (!externalDeck_)
@@ -451,6 +456,13 @@ public:
      */
     Dune::EdgeWeightMethod edgeWeightsMethod() const
     { return edgeWeightsMethod_; }
+
+    /*!
+     * \brief Parameter that decide if cells owned by rank are ordered before ghost cells.
+     */
+    bool ownersFirst() const
+    { return ownersFirst_; }
+    
     /*!
      * \brief Returns the name of the case.
      *
@@ -619,6 +631,7 @@ private:
     Opm::SummaryConfig* eclSummaryConfig_;
 
     Dune::EdgeWeightMethod edgeWeightsMethod_;
+    bool ownersFirst_;
 
 protected:
     /*! \brief The cell centroids after loadbalance was called.

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -193,10 +193,6 @@ public:
             {
                 const auto wells = this->schedule().getWellsatEnd();
 
-
-                auto& eclState = static_cast<ParallelEclipseState&>(this->eclState());
-                const EclipseGrid* eclGrid = nullptr;
-
                 try
                 {
                     auto& eclState = dynamic_cast<ParallelEclipseState&>(this->eclState());
@@ -209,8 +205,7 @@ public:
 
                     PropsCentroidsDataHandle<Dune::CpGrid> handle(*grid_, eclState, eclGrid, this->centroids_,
                                                                   cartesianIndexMapper());
-                    defunctWellNames_ = std::get<1>(grid_->loadBalance(handle, edgeWeightsMethod, &wells, faceTrans.data()));
-                    //defunctWellNames_ = std::get<1>(grid_->loadBalance(edgeWeightsMethod, ownersFirst, &wells, faceTrans.data()));
+                    defunctWellNames_ = std::get<1>(grid_->loadBalance(handle, edgeWeightsMethod, &wells, faceTrans.data(), ownersFirst));
                 }
                 catch(const std::bad_cast& e)
                 {

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -193,6 +193,7 @@ public:
             {
                 const auto wells = this->schedule().getWellsatEnd();
 
+
                 auto& eclState = static_cast<ParallelEclipseState&>(this->eclState());
                 const EclipseGrid* eclGrid = nullptr;
 

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -159,6 +159,7 @@ public:
             }
 
             Dune::EdgeWeightMethod edgeWeightsMethod = this->edgeWeightsMethod();
+            bool ownersFirst = this->ownersFirst();
 
             // convert to transmissibility for faces
             // TODO: grid_->numFaces() is not generic. use grid_->size(1) instead? (might
@@ -192,6 +193,9 @@ public:
             {
                 const auto wells = this->schedule().getWellsatEnd();
 
+                auto& eclState = static_cast<ParallelEclipseState&>(this->eclState());
+                const EclipseGrid* eclGrid = nullptr;
+
                 try
                 {
                     auto& eclState = dynamic_cast<ParallelEclipseState&>(this->eclState());
@@ -205,6 +209,7 @@ public:
                     PropsCentroidsDataHandle<Dune::CpGrid> handle(*grid_, eclState, eclGrid, this->centroids_,
                                                                   cartesianIndexMapper());
                     defunctWellNames_ = std::get<1>(grid_->loadBalance(handle, edgeWeightsMethod, &wells, faceTrans.data()));
+                    //defunctWellNames_ = std::get<1>(grid_->loadBalance(edgeWeightsMethod, ownersFirst, &wells, faceTrans.data()));
                 }
                 catch(const std::bad_cast& e)
                 {

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -309,8 +309,9 @@ private:
                 // store intersection, this might be costly
                 const auto& intersection = *isIt;
 
-                // ignore boundary intersections for now (TODO?)
-                if (!intersection.neighbor())
+                if (intersection.boundary())
+                    continue; // ignore boundary intersections for now (TODO?)
+                else if (!intersection.neighbor()) //processor boundary but not domain boundary
                     continue;
 
                 const auto& inside = intersection.inside();

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -310,7 +310,7 @@ private:
                 const auto& intersection = *isIt;
 
                 // ignore boundary intersections for now (TODO?)
-                if (intersection.boundary())
+                if (!intersection.neighbor())
                     continue;
 
                 const auto& inside = intersection.inside();

--- a/opm/simulators/linalg/ParallelOverlappingILU0.hpp
+++ b/opm/simulators/linalg/ParallelOverlappingILU0.hpp
@@ -445,8 +445,7 @@ namespace Opm
         typedef typename M::block_type block;
 
         // implement left looking variant with stored inverse
-        size_t row_count = 0;
-        for (rowiterator i = A.begin(); row_count < interiorSize; ++i, ++row_count)
+        for (rowiterator i = A.begin(); i.index() < interiorSize; ++i)
         {
             // coliterator is diagonal after the following loop
             coliterator endij=(*i).end();           // end of row i
@@ -694,6 +693,7 @@ public:
           comm_(nullptr), w_(w),
           relaxation_( std::abs( w - 1.0 ) > 1e-15 )
     {
+        interiorSize_ = A.N();
         // BlockMatrix is a Subclass of FieldMatrix that just adds
         // methods. Therefore this cast should be safe.
         init( reinterpret_cast<const Matrix&>(A), n, milu, redblack,
@@ -723,6 +723,7 @@ public:
           comm_(&comm), w_(w),
           relaxation_( std::abs( w - 1.0 ) > 1e-15 )
     {
+        interiorSize_ = A.N();
         // BlockMatrix is a Subclass of FieldMatrix that just adds
         // methods. Therefore this cast should be safe.
         init( reinterpret_cast<const Matrix&>(A), n, milu, redblack,
@@ -773,10 +774,44 @@ public:
           comm_(&comm), w_(w),
           relaxation_( std::abs( w - 1.0 ) > 1e-15 )
     {
+        interiorSize_ = A.N();
         // BlockMatrix is a Subclass of FieldMatrix that just adds
         // methods. Therefore this cast should be safe.
         init( reinterpret_cast<const Matrix&>(A), 0, milu, redblack,
               reorder_sphere );
+    }
+
+    /*! \brief Constructor.
+
+      Constructor gets all parameters to operate the prec.
+      \param A The matrix to operate on.
+      \param n ILU fill in level (for testing). This does not work in parallel.
+      \param w The relaxation factor.
+      \param milu The modified ILU variant to use. 0 means traditional ILU. \see MILU_VARIANT.
+      \param interiorSize The number of interior/owner rows in the matrix.
+      \param redblack Whether to use a red-black ordering.
+      \param reorder_sphere If true, we start the reordering at a root node.
+                            The vertices on each layer aound it (same distance) are
+                            ordered consecutivly. If false, we preserver the order of
+                            the vertices with the same color.
+    */
+    template<class BlockType, class Alloc>
+    ParallelOverlappingILU0 (const Dune::BCRSMatrix<BlockType,Alloc>& A,
+                             const ParallelInfo& comm,
+                             const field_type w, MILU_VARIANT milu,
+                             size_type interiorSize, bool redblack=false,
+                             bool reorder_sphere=true)
+        : lower_(),
+          upper_(),
+          inv_(),
+          comm_(&comm), w_(w),
+          relaxation_( std::abs( w - 1.0 ) > 1e-15 ),
+          interiorSize_(interiorSize)
+    {
+        // BlockMatrix is a Subclass of FieldMatrix that just adds
+        // methods. Therefore this cast should be safe.
+        init( reinterpret_cast<const Matrix&>(A), 0, milu, redblack,
+              reorder_sphere  );
     }
 
     /*!
@@ -806,13 +841,15 @@ public:
 
         const size_type iEnd = lower_.rows();
         const size_type lastRow = iEnd - 1;
+        size_type upperLoppStart = iEnd - interiorSize_;
+        size_type lowerLoopEnd = interiorSize_;
         if( iEnd != upper_.rows() )
         {
             OPM_THROW(std::logic_error,"ILU: number of lower and upper rows must be the same");
         }
 
         // lower triangular solve
-        for( size_type i=0; i<iEnd; ++ i )
+        for( size_type i=0; i<lowerLoopEnd; ++ i )
         {
           dblock rhs( md[ i ] );
           const size_type rowI     = lower_.rows_[ i ];
@@ -826,7 +863,7 @@ public:
           mv[ i ] = rhs;  // Lii = I
         }
 
-        for( size_type i=0; i<iEnd; ++ i )
+        for( size_type i=upperLoppStart; i<iEnd; ++ i )
         {
             vblock& vBlock = mv[ lastRow - i ];
             vblock rhs ( vBlock );
@@ -970,7 +1007,10 @@ protected:
                                                   detail::IsPositiveFunctor() );
                     break;
                 default:
-                    bilu0_decomposition( *ILU );
+                    if (interiorSize_ == A.N())
+                        bilu0_decomposition( *ILU );
+                    else
+                        detail::ghost_last_bilu0_decomposition(*ILU, interiorSize_);
                     break;
                 }
             }
@@ -1082,368 +1122,8 @@ protected:
     //! \brief The relaxation factor to use.
     const field_type w_;
     const bool relaxation_;
-
-};
-
-
-/// \brief A two-step version of an overlapping Schwarz preconditioner using one step ILU0 as
-///
-/// This preconditioner differs from a ParallelRestrictedOverlappingSchwarz with
-/// Dune:SeqILU0 in the follwing way:
-/// During apply we make sure that the current residual is consistent (i.e.
-/// each process knows the same value for each index. The we solve
-/// Ly= d for y and make y consistent again. Last we solve Ux = y and
-/// make sure that x is consistent.
-/// In contrast for ParallelRestrictedOverlappingSchwarz we solve (LU)x = d for x
-/// without forcing consistency between the two steps.
-/// \tparam Matrix The type of the Matrix.
-/// \tparam Domain The type of the Vector representing the domain.
-/// \tparam Range The type of the Vector representing the range.
-/// \tparam ParallelInfo The type of the parallel information object
-///         used, e.g. Dune::OwnerOverlapCommunication
-template<class Matrix, class Domain, class Range, class ParallelInfoT>
-class GhostLastParallelOverlappingILU0
-    : public Dune::Preconditioner<Domain,Range>
-{
-    typedef ParallelInfoT ParallelInfo;
-
-
-public:
-    //! \brief The matrix type the preconditioner is for.
-    typedef typename std::remove_const<Matrix>::type matrix_type;
-    //! \brief The domain type of the preconditioner.
-    typedef Domain domain_type;
-    //! \brief The range type of the preconditioner.
-    typedef Range range_type;
-    //! \brief The field type of the preconditioner.
-    typedef typename Domain::field_type field_type;
-
-    typedef typename matrix_type::block_type  block_type;
-    typedef typename matrix_type::size_type   size_type;
-
-protected:
-    struct CRS
-    {
-      CRS() : nRows_( 0 ) {}
-
-      size_type rows() const { return nRows_; }
-
-      size_type nonZeros() const
-      {
-        assert( rows_[ rows() ] != size_type(-1) );
-        return rows_[ rows() ];
-      }
-
-      void resize( const size_type nRows )
-      {
-          if( nRows_ != nRows )
-          {
-            nRows_ = nRows ;
-            rows_.resize( nRows_+1, size_type(-1) );
-          }
-      }
-
-      void reserveAdditional( const size_type nonZeros )
-      {
-          const size_type needed = values_.size() + nonZeros ;
-          if( values_.capacity() < needed )
-          {
-              const size_type estimate = needed * 1.1;
-              values_.reserve( estimate );
-              cols_.reserve( estimate );
-          }
-      }
-
-      void push_back( const block_type& value, const size_type index )
-      {
-          values_.push_back( value );
-          cols_.push_back( index );
-      }
-
-      std::vector< size_type  > rows_;
-      std::vector< block_type > values_;
-      std::vector< size_type  > cols_;
-      size_type nRows_;
-    };
-
-public:
-#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 6)
-    Dune::SolverCategory::Category category() const override
-    {
-      return std::is_same<ParallelInfoT, Dune::Amg::SequentialInformation>::value ?
-              Dune::SolverCategory::sequential : Dune::SolverCategory::overlapping;
-    }
-
-#else
-    // define the category
-    enum {
-        //! \brief The category the preconditioner is part of.
-        category = std::is_same<ParallelInfoT, Dune::Amg::SequentialInformation>::value ?
-            Dune::SolverCategory::sequential : Dune::SolverCategory::overlapping
-    };
-#endif
-
-    /*! \brief Constructor.
-      Constructor gets all parameters to operate the prec.
-      \param A The matrix to operate on.
-      \param n ILU fill in level (for testing). This does not work in parallel.
-      \param w The relaxation factor.
-      \param milu The modified ILU variant to use. 0 means traditional ILU. \see MILU_VARIANT.
-      \param redblack Whether to use a red-black ordering.
-      \param reorder_sphere If true, we start the reordering at a root node.
-                            The vertices on each layer aound it (same distance) are
-                            ordered consecutivly. If false, we preserver the order of
-                            the vertices with the same color.
-    */
-    template<class BlockType, class Alloc>
-    GhostLastParallelOverlappingILU0 (const Dune::BCRSMatrix<BlockType,Alloc>& A,
-                                      const int n, const field_type w,
-                                      MILU_VARIANT milu, unsigned interiorSize, bool redblack=false,
-                                      bool reorder_sphere=true)
-        : lower_(),
-          upper_(),
-          inv_(),
-          comm_(nullptr), w_(w),
-          relaxation_( std::abs( w - 1.0 ) > 1e-15 ),
-          interiorSize_(interiorSize)
-    {
-        // BlockMatrix is a Subclass of FieldMatrix that just adds
-        // methods. Therefore this cast should be safe.
-        init( reinterpret_cast<const Matrix&>(A), n, milu, redblack,
-              reorder_sphere  );
-    }
-
-    /*! \brief Constructor gets all parameters to operate the prec.
-      \param A The matrix to operate on.
-      \param comm   communication object, e.g. Dune::OwnerOverlapCopyCommunication
-      \param n ILU fill in level (for testing). This does not work in parallel.
-      \param w The relaxation factor.
-      \param milu The modified ILU variant to use. 0 means traditional ILU. \see MILU_VARIANT.
-      \param redblack Whether to use a red-black ordering.
-      \param reorder_sphere If true, we start the reordering at a root node.
-                            The vertices on each layer aound it (same distance) are
-                            ordered consecutivly. If false, we preserver the order of
-                            the vertices with the same color.
-    */
-    template<class BlockType, class Alloc>
-    GhostLastParallelOverlappingILU0 (const Dune::BCRSMatrix<BlockType,Alloc>& A,
-                                      const ParallelInfo& comm, const int n, const field_type w,
-                                      MILU_VARIANT milu, unsigned interiorSize, bool redblack=false,
-                                      bool reorder_sphere=true)
-        : lower_(),
-          upper_(),
-          inv_(),
-          comm_(&comm), w_(w),
-          relaxation_( std::abs( w - 1.0 ) > 1e-15 ),
-          interiorSize_(interiorSize)
-    {
-        // BlockMatrix is a Subclass of FieldMatrix that just adds
-        // methods. Therefore this cast should be safe.
-        init( reinterpret_cast<const Matrix&>(A), n, milu, redblack,
-              reorder_sphere );
-    }
-
-    /*! \brief Constructor.
-      Constructor gets all parameters to operate the prec.
-      \param A The matrix to operate on.
-      \param w The relaxation factor.
-      \param milu The modified ILU variant to use. 0 means traditional ILU. \see MILU_VARIANT.
-      \param redblack Whether to use a red-black ordering.
-      \param reorder_sphere If true, we start the reordering at a root node.
-                  The vertices on each layer aound it (same distance) are
-                  ordered consecutivly. If false, we preserver the order of
-                  the vertices with the same color.
-    */
-    template<class BlockType, class Alloc>
-    GhostLastParallelOverlappingILU0 (const Dune::BCRSMatrix<BlockType,Alloc>& A,
-                                      const field_type w, MILU_VARIANT milu, unsigned interiorSize,
-                                      bool redblack=false,
-                                      bool reorder_sphere=true)
-        : GhostLastParallelOverlappingILU0( A, 0, w, milu, interiorSize, redblack, reorder_sphere )
-    {
-    }
-
-    /*! \brief Constructor.
-      Constructor gets all parameters to operate the prec.
-      \param A      The matrix to operate on.
-      \param comm   communication object, e.g. Dune::OwnerOverlapCopyCommunication
-      \param w      The relaxation factor.
-      \param milu   The modified ILU variant to use. 0 means traditional ILU. \see MILU_VARIANT.
-      \param redblack Whether to use a red-black ordering.
-      \param reorder_sphere If true, we start the reordering at a root node.
-                            The vertices on each layer aound it (same distance) are
-                            ordered consecutivly. If false, we preserver the order of
-                            the vertices with the same color.
-    */
-    template<class BlockType, class Alloc>
-    GhostLastParallelOverlappingILU0 (const Dune::BCRSMatrix<BlockType,Alloc>& A,
-                                      const ParallelInfo& comm, const field_type w,
-                                      MILU_VARIANT milu, unsigned interiorSize,
-                                      bool redblack=false,
-                                      bool reorder_sphere=true)
-        : lower_(),
-          upper_(),
-          inv_(),
-          comm_(&comm), w_(w),
-          relaxation_( std::abs( w - 1.0 ) > 1e-15 ),
-          interiorSize_(interiorSize)
-    {
-        // BlockMatrix is a Subclass of FieldMatrix that just adds
-        // methods. Therefore this cast should be safe.
-        init( reinterpret_cast<const Matrix&>(A), 0, milu, redblack,
-              reorder_sphere );
-    }
-
-    /*!
-      \brief Prepare the preconditioner.
-      \copydoc Preconditioner::pre(X&,Y&)
-    */
-    virtual void pre (Domain& x, Range& b) override
-    {
-        DUNE_UNUSED_PARAMETER(x);
-        DUNE_UNUSED_PARAMETER(b);
-    }
-
-    /*!
-      \brief Apply the preconditoner.
-      \copydoc Preconditioner::apply(X&,const Y&)
-    */
-    virtual void apply (Domain& v, const Range& d) override
-    {
-        Range& md = const_cast<Range&>(d);;
-
-        // iterator types
-        typedef typename Range ::block_type  dblock;
-        typedef typename Domain::block_type  vblock;
-
-        const size_type iEnd = lower_.rows();
-        const size_type lastRow = iEnd - 1;
-        size_type interiorStart = iEnd - interiorSize_;
-        size_type lowerLoopEnd = interiorSize_;
-        if( iEnd != upper_.rows() )
-        {
-            OPM_THROW(std::logic_error,"ILU: number of lower and upper rows must be the same");
-        }
-
-        // lower triangular solve
-        for( size_type i = 0; i < lowerLoopEnd; ++ i )
-        {
-          dblock rhs( md[ i ] );
-          const size_type rowI     = lower_.rows_[ i ];
-          const size_type rowINext = lower_.rows_[ i+1 ];
-
-          for( size_type col = rowI; col < rowINext; ++ col )
-          {
-            lower_.values_[ col ].mmv( v[ lower_.cols_[ col ] ], rhs );
-          }
-
-          v[ i ] = rhs;  // Lii = I
-        }
-
-        for( size_type i = interiorStart; i < iEnd; ++ i )
-        {
-            vblock& vBlock = v[ lastRow - i ];
-            vblock rhs ( vBlock );
-            const size_type rowI     = upper_.rows_[ i ];
-            const size_type rowINext = upper_.rows_[ i+1 ];
-
-            for( size_type col = rowI; col < rowINext; ++ col )
-            {
-                upper_.values_[ col ].mmv( v[ upper_.cols_[ col ] ], rhs );
-            }
-
-            // apply inverse and store result
-            inv_[ i ].mv( rhs, vBlock);
-        }
-
-        copyOwnerToAll( v );
-
-        if( relaxation_ ) {
-            v *= w_;
-        }
-    }
-
-    template <class V>
-    void copyOwnerToAll( V& v ) const
-    {
-        if( comm_ ) {
-            comm_->copyOwnerToAll(v, v);
-        }
-    }
-
-    /*!
-      \brief Clean up.
-      \copydoc Preconditioner::post(X&)
-    */
-    virtual void post (Range& x) override
-    {
-        DUNE_UNUSED_PARAMETER(x);
-    }
-
-protected:
-    void init( const Matrix& A, const int iluIteration, MILU_VARIANT milu, bool redBlack, bool reorderSpheres )
-    {
-        // (For older DUNE versions the communicator might be
-        // invalid if redistribution in AMG happened on the coarset level.
-        // Therefore we check for nonzero size
-        if ( comm_ && comm_->communicator().size()<=0 )
-        {
-            if ( A.N() > 0 )
-            {
-                OPM_THROW(std::logic_error, "Expected a matrix with zero rows for an invalid communicator.");
-            }
-            else
-            {
-                // simply set the communicator to null
-                comm_ = nullptr;
-            }
-        }
-
-        int ilu_setup_successful = 1;
-        std::string message;
-        const int rank = ( comm_ ) ? comm_->communicator().rank() : 0;
-
-        std::unique_ptr< Matrix > ILU;
-
-        try
-        {
-            ILU.reset( new Matrix( A ) );
-            detail::ghost_last_bilu0_decomposition(*ILU, interiorSize_);
-        }
-        catch (const Dune::MatrixBlockError& error)
-        {
-            message = error.what();
-            std::cerr<<"Exception occured on process " << rank << " during " <<
-                "setup of ILU0 preconditioner with message: " <<
-                message<<std::endl;
-            ilu_setup_successful = 0;
-        }
-
-        // Check whether there was a problem on some process
-        const bool parallel_failure = comm_ && comm_->communicator().min(ilu_setup_successful) == 0;
-        const bool local_failure = ilu_setup_successful == 0;
-        if ( local_failure || parallel_failure )
-        {
-            throw Dune::MatrixBlockError();
-        }
-
-        // store ILU in simple CRS format
-        detail::convertToCRS( *ILU, lower_, upper_, inv_ );
-    }
-    
-protected:
-    //! \brief The ILU0 decomposition of the matrix.
-    CRS lower_;
-    CRS upper_;
-    std::vector< block_type > inv_;
-
-    const ParallelInfo* comm_;
-    //! \brief The relaxation factor to use.
-    const field_type w_;
-    const bool relaxation_;
     size_type interiorSize_;
 };
-
 
 } // end namespace Opm
 #endif

--- a/opm/simulators/linalg/findOverlapRowsAndColumns.hpp
+++ b/opm/simulators/linalg/findOverlapRowsAndColumns.hpp
@@ -112,6 +112,28 @@ namespace detail
             }
         }
     }
+    template <class Grid>
+    size_t numInteriorCells(const Grid& grid, bool ownerFirst)
+    {
+        size_t numInterior = 0;
+        if (!ownerFirst)
+            return grid.numCells();
+        const auto& gridView = grid.leafGridView();
+        auto elemIt = gridView.template begin<0>();
+        const auto& elemEndIt = gridView.template end<0>();
+
+        // loop over cells in mesh
+        for (; elemIt != elemEndIt; ++elemIt) {
+            const auto& elem = *elemIt;
+
+            // If cell has partition type not equal to interior save row
+            if (elem.partitionType() == Dune::InteriorEntity) {
+                numInterior++;
+            }
+        }
+
+        return numInterior;
+    }
 } // namespace detail
 } // namespace Opm
 

--- a/opm/simulators/linalg/findOverlapRowsAndColumns.hpp
+++ b/opm/simulators/linalg/findOverlapRowsAndColumns.hpp
@@ -112,11 +112,17 @@ namespace detail
             }
         }
     }
+
+    /// \brief If ownerFirst=true, returns the number of interior cells in grid, else just numCells().
+    ///
+    /// If cells in grid is ordered so that interior/owner cells come before overlap/copy cells, the method
+    /// returns the number of interior cells numInterior. In the linear solver only the first numInterior rows of
+    /// the matrix are needed.
     template <class Grid>
-    size_t numInteriorCells(const Grid& grid, bool ownerFirst)
+    size_t numMatrixRowsToUseInSolver(const Grid& grid, bool ownerFirst)
     {
         size_t numInterior = 0;
-        if (!ownerFirst)
+        if (!ownerFirst || grid.comm().size()==1)
             return grid.numCells();
         const auto& gridView = grid.leafGridView();
         auto elemIt = gridView.template begin<0>();
@@ -124,10 +130,9 @@ namespace detail
 
         // loop over cells in mesh
         for (; elemIt != elemEndIt; ++elemIt) {
-            const auto& elem = *elemIt;
 
-            // If cell has partition type not equal to interior save row
-            if (elem.partitionType() == Dune::InteriorEntity) {
+            // Count only the interior cells.
+            if (elemIt->partitionType() == Dune::InteriorEntity) {
                 numInterior++;
             }
         }


### PR DESCRIPTION
This PR require https://github.com/OPM/opm-grid/pull/430 in opm-grid, and in addition to what is contained there, the following is changed:

- Command line argument --owners-first, that turn on/off "owners first" ordering of cells in the parallel grid. Default is off.

- SpMV, inner product and ILU that utilise the "owners first" ordering, and therefore avoids some superfluous computations.

On dual Intel Xeon E5-2670 2.6GHz 8-core CPU nodes this time, some modest improvement in parallel performance was achieved on Norne:

| P | master: time / iter     | owners-first: time / iter  |
|---|--------------------| -----------------------|
| 2  |  426.57 / 25339     |    408.73  /  25179        |
| 4  |     259.07 / 25571    |      245.40 / 25209      |
| 8  |     181.15 / 25026     |     174.39 / 25656       |
| 16 |   129.76 / 25738     |     119.90 / 25227         |
| 32 |    98.59 / 26317     |     87.27 / 26113            |
| 64 |    77.36 / 26769     |     69.73 / 26726          |

The change in iteration count is due to the reordering and ILU being sensitive to that.

This PR was created for testing on models I don't have access to. A more elegant implementation that avoids having to copy the matrix, by altering the assembly part of the code would probably achieve similar performance without having to deal with the "owners first" ordering stuff. 