### PR TITLE
Shut wells under zero WCONPROD when disallowing crossflow

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -636,6 +636,8 @@ namespace Opm {
     {
         std::vector<WellInterfacePtr> well_container;
 
+        Opm::DeferredLogger local_deferredLogger;
+
         const int nw = numLocalWells();
 
         if (nw > 0) {
@@ -684,6 +686,40 @@ namespace Opm {
                     continue;
                 }
 
+                // If a production well disallows crossflow and its
+                // (prediction type) rate control is zero, then it is effectively shut.
+                if (!well_ecl.getAllowCrossFlow() && well_ecl.isProducer() && well_ecl.predictionMode()) {
+                    const auto& summaryState = ebosSimulator_.vanguard().summaryState();
+                    auto prod_controls = well_ecl.productionControls(summaryState);
+                    bool zero_rate_control = false;
+                    switch (prod_controls.cmode) {
+                    case Well::ProducerCMode::ORAT:
+                        zero_rate_control = (prod_controls.oil_rate == 0.0);
+                        break;
+                    case Well::ProducerCMode::WRAT:
+                        zero_rate_control = (prod_controls.water_rate == 0.0);
+                        break;
+                    case Well::ProducerCMode::GRAT:
+                        zero_rate_control = (prod_controls.gas_rate == 0.0);
+                        break;
+                    case Well::ProducerCMode::LRAT:
+                        zero_rate_control = (prod_controls.liquid_rate == 0.0);
+                        break;
+                    case Well::ProducerCMode::RESV:
+                        zero_rate_control = (prod_controls.resv_rate == 0.0);
+                        break;
+                    default:
+                        // Might still have zero rate controls, but is pressure controlled.
+                        zero_rate_control = false;
+                    }
+                    if (zero_rate_control) {
+                        // Treat as shut, do not add to container.
+                        local_deferredLogger.info("  Well shut due to zero rate control and disallowing crossflow: " + well_ecl.name());
+                        well_state_.shutWell(w);
+                        continue;
+                    }
+                }
+
                 if (well_status == Well::Status::STOP) {
                     well_state_.thp()[w] = 0.;
                     wellIsStopped = true;
@@ -719,6 +755,12 @@ namespace Opm {
                 if (wellIsStopped)
                     well_container.back()->stopWell();
             }
+        }
+
+        // Collect log messages and print.
+        Opm::DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger);
+        if (terminal_output_) {
+            global_deferredLogger.logMessages();
         }
 
         return well_container;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2592,6 +2592,20 @@ namespace Opm
                          const WellState& /* well_state */,
                          Opm::DeferredLogger& deferred_logger)
     {
+        const bool checkOperability = EWOMS_GET_PARAM(TypeTag, bool, EnableWellOperabilityCheck);
+        if (!checkOperability) {
+            return;
+        }
+
+        // focusing on PRODUCER for now
+        if (this->isInjector()) {
+            return;
+        }
+
+        if (!this->underPredictionMode() ) {
+            return;
+        }
+
         const std::string msg = "Support of well operability checking for multisegment wells is not implemented "
                                 "yet, checkWellOperability() for " + name() + " will do nothing";
         deferred_logger.warning("NO_OPERATABILITY_CHECKING_MS_WELLS", msg);

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -63,7 +63,7 @@ namespace Opm
                 const int nw = wells_ecl.size();
                 // const int np = wells->number_of_phases;
                 const int np = pu.num_phases;
-                open_for_output_.resize(nw, true);
+                open_for_output_.assign(nw, true);
                 bhp_.resize(nw, 0.0);
                 thp_.resize(nw, 0.0);
                 temperature_.resize(nw, 273.15 + 20); // standard temperature for now


### PR DESCRIPTION
The first commit is a minor bugfix, but necessary for the functioning of this PR. The open_for_output_ flag should eventually be made redundant.

The second commit fixes an annoyance (warning spamming) discovered during the work with this PR.

The third commit is the actual fix: closing wells as described in the title.