### PR TITLE
check groups from top

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1684,12 +1684,7 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     checkGroupConstraints(const Group& group, Opm::DeferredLogger& deferred_logger) {
 
-        // call recursively
         const int reportStepIdx = ebosSimulator_.episodeIndex();
-        for (const std::string& groupName : group.groups()) {
-            checkGroupConstraints( schedule().getGroup(groupName, reportStepIdx), deferred_logger);
-        }
-
         const auto& summaryState = ebosSimulator_.vanguard().summaryState();
         auto& well_state = well_state_;
 
@@ -1879,6 +1874,10 @@ namespace Opm {
             //neither production or injecting group FIELD?
         }
 
+        // call recursively down the group hiearchy
+        for (const std::string& groupName : group.groups()) {
+            checkGroupConstraints( schedule().getGroup(groupName, reportStepIdx), deferred_logger);
+        }
 
 
     }


### PR DESCRIPTION
Check group constraints from the top to allow for groups down in the hierarchy to switch to its own control. 