### PR TITLE
avoid usage of solveEq, instead iterate during assembly

### DIFF
--- a/ebos/ebos.hh
+++ b/ebos/ebos.hh
@@ -132,12 +132,11 @@ public:
         EWOMS_HIDE_PARAM(TypeTag, ToleranceCnvRelaxed);
         EWOMS_HIDE_PARAM(TypeTag, ToleranceWells);
         EWOMS_HIDE_PARAM(TypeTag, ToleranceWellControl);
-        EWOMS_HIDE_PARAM(TypeTag, MaxWelleqIter);
         EWOMS_HIDE_PARAM(TypeTag, UseMultisegmentWell);
         EWOMS_HIDE_PARAM(TypeTag, TolerancePressureMsWells);
         EWOMS_HIDE_PARAM(TypeTag, MaxPressureChangeMsWells);
-        EWOMS_HIDE_PARAM(TypeTag, UseInnerIterationsMsWells);
-        EWOMS_HIDE_PARAM(TypeTag, MaxInnerIterMsWells);
+        EWOMS_HIDE_PARAM(TypeTag, UseInnerIterationsWells);
+        EWOMS_HIDE_PARAM(TypeTag, MaxInnerIterWells);
         EWOMS_HIDE_PARAM(TypeTag, MaxSinglePrecisionDays);
         EWOMS_HIDE_PARAM(TypeTag, MaxStrictIter);
         EWOMS_HIDE_PARAM(TypeTag, SolveWelleqInitially);

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -40,7 +40,6 @@ NEW_PROP_TAG(ToleranceCnv);
 NEW_PROP_TAG(ToleranceCnvRelaxed);
 NEW_PROP_TAG(ToleranceWells);
 NEW_PROP_TAG(ToleranceWellControl);
-NEW_PROP_TAG(MaxWelleqIter);
 NEW_PROP_TAG(UseMultisegmentWell);
 NEW_PROP_TAG(MaxSinglePrecisionDays);
 NEW_PROP_TAG(MaxStrictIter);
@@ -49,12 +48,12 @@ NEW_PROP_TAG(UpdateEquationsScaling);
 NEW_PROP_TAG(UseUpdateStabilization);
 NEW_PROP_TAG(MatrixAddWellContributions);
 NEW_PROP_TAG(EnableWellOperabilityCheck);
+NEW_PROP_TAG(UseInnerIterationsWells);
+NEW_PROP_TAG(MaxInnerIterWells);
 
 // parameters for multisegment wells
 NEW_PROP_TAG(TolerancePressureMsWells);
 NEW_PROP_TAG(MaxPressureChangeMsWells);
-NEW_PROP_TAG(UseInnerIterationsMsWells);
-NEW_PROP_TAG(MaxInnerIterMsWells);
 
 SET_SCALAR_PROP(FlowModelParameters, DbhpMaxRel, 1.0);
 SET_SCALAR_PROP(FlowModelParameters, DwellFractionMax, 0.2);
@@ -64,7 +63,6 @@ SET_SCALAR_PROP(FlowModelParameters, ToleranceCnv,1e-2);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceCnvRelaxed, 1e9);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceWells, 1e-4);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceWellControl, 1e-7);
-SET_INT_PROP(FlowModelParameters, MaxWelleqIter, 30);
 SET_BOOL_PROP(FlowModelParameters, UseMultisegmentWell, true);
 SET_SCALAR_PROP(FlowModelParameters, MaxSinglePrecisionDays, 20.0);
 SET_INT_PROP(FlowModelParameters, MaxStrictIter, 8);
@@ -74,8 +72,8 @@ SET_BOOL_PROP(FlowModelParameters, UseUpdateStabilization, true);
 SET_BOOL_PROP(FlowModelParameters, MatrixAddWellContributions, false);
 SET_SCALAR_PROP(FlowModelParameters, TolerancePressureMsWells, 0.01*1e5);
 SET_SCALAR_PROP(FlowModelParameters, MaxPressureChangeMsWells, 10*1e5);
-SET_BOOL_PROP(FlowModelParameters, UseInnerIterationsMsWells, true);
-SET_INT_PROP(FlowModelParameters, MaxInnerIterMsWells, 100);
+SET_BOOL_PROP(FlowModelParameters, UseInnerIterationsWells, true);
+SET_INT_PROP(FlowModelParameters, MaxInnerIterWells, 100);
 SET_BOOL_PROP(FlowModelParameters, EnableWellOperabilityCheck, true);
 
 // if openMP is available, determine the number threads per process automatically.
@@ -118,13 +116,10 @@ namespace Opm
         double max_pressure_change_ms_wells_;
 
         /// Whether to use inner iterations for ms wells
-        bool use_inner_iterations_ms_wells_;
+        bool use_inner_iterations_wells_;
 
         /// Maximum inner iteration number for ms wells
-        int max_inner_iter_ms_wells_;
-
-        /// Maximum iteration number of the well equation solution
-        int max_welleq_iter_;
+        int max_inner_iter_wells_;
 
         /// Tolerance for time step in seconds where single precision can be used
         /// for solving for the Jacobian
@@ -166,12 +161,11 @@ namespace Opm
             tolerance_cnv_relaxed_ = EWOMS_GET_PARAM(TypeTag, Scalar, ToleranceCnvRelaxed);
             tolerance_wells_ = EWOMS_GET_PARAM(TypeTag, Scalar, ToleranceWells);
             tolerance_well_control_ = EWOMS_GET_PARAM(TypeTag, Scalar, ToleranceWellControl);
-            max_welleq_iter_ = EWOMS_GET_PARAM(TypeTag, int, MaxWelleqIter);
             use_multisegment_well_ = EWOMS_GET_PARAM(TypeTag, bool, UseMultisegmentWell);
             tolerance_pressure_ms_wells_ = EWOMS_GET_PARAM(TypeTag, Scalar, TolerancePressureMsWells);
             max_pressure_change_ms_wells_ = EWOMS_GET_PARAM(TypeTag, Scalar, MaxPressureChangeMsWells);
-            use_inner_iterations_ms_wells_ = EWOMS_GET_PARAM(TypeTag, bool, UseInnerIterationsMsWells);
-            max_inner_iter_ms_wells_ = EWOMS_GET_PARAM(TypeTag, int, MaxInnerIterMsWells);
+            use_inner_iterations_wells_ = EWOMS_GET_PARAM(TypeTag, bool, UseInnerIterationsWells);
+            max_inner_iter_wells_ = EWOMS_GET_PARAM(TypeTag, int, MaxInnerIterWells);
             maxSinglePrecisionTimeStep_ = EWOMS_GET_PARAM(TypeTag, Scalar, MaxSinglePrecisionDays) *24*60*60;
             max_strict_iter_ = EWOMS_GET_PARAM(TypeTag, int, MaxStrictIter);
             solve_welleq_initially_ = EWOMS_GET_PARAM(TypeTag, bool, SolveWelleqInitially);
@@ -192,12 +186,11 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, ToleranceCnvRelaxed, "Relaxed local convergence tolerance that applies for iterations after the iterations with the strict tolerance");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, ToleranceWells, "Well convergence tolerance");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, ToleranceWellControl, "Tolerance for the well control equations");
-            EWOMS_REGISTER_PARAM(TypeTag, int, MaxWelleqIter, "Maximum number of iterations to determine solution the  well equations");
             EWOMS_REGISTER_PARAM(TypeTag, bool, UseMultisegmentWell, "Use the well model for multi-segment wells instead of the one for single-segment wells");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, TolerancePressureMsWells, "Tolerance for the pressure equations for multi-segment wells");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, MaxPressureChangeMsWells, "Maximum relative pressure change for a single iteration of the multi-segment well model");
-            EWOMS_REGISTER_PARAM(TypeTag, bool, UseInnerIterationsMsWells, "Use nested iterations for multi-segment wells");
-            EWOMS_REGISTER_PARAM(TypeTag, int, MaxInnerIterMsWells, "Maximum number of inner iterations for multi-segment wells");
+            EWOMS_REGISTER_PARAM(TypeTag, bool, UseInnerIterationsWells, "Use nested iterations for wells");
+            EWOMS_REGISTER_PARAM(TypeTag, int, MaxInnerIterWells, "Maximum number of inner iterations for wells");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, MaxSinglePrecisionDays, "Maximum time step size where single precision floating point arithmetic can be used solving for the linear systems of equations");
             EWOMS_REGISTER_PARAM(TypeTag, int, MaxStrictIter, "Maximum number of Newton iterations before relaxed tolerances are used for the CNV convergence criterion");
             EWOMS_REGISTER_PARAM(TypeTag, bool, SolveWelleqInitially, "Fully solve the well equations before each iteration of the reservoir model");

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -331,8 +331,6 @@ namespace Opm {
             /// at the beginning of the time step and no derivatives are included in these quantities
             void calculateExplicitQuantities(Opm::DeferredLogger& deferred_logger) const;
 
-            SimulatorReport solveWellEq(const std::vector<Scalar>& B_avg, const double dt, Opm::DeferredLogger& deferred_logger);
-
             void initPrimaryVariablesEvaluation() const;
 
             // The number of components in the model.

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -870,21 +870,13 @@ namespace Opm {
             std::vector< Scalar > B_avg(numComponents(), Scalar() );
             computeAverageFormationFactor(B_avg);
 
-            if (param_.solve_welleq_initially_ && iterationIdx == 0) {
-                // solve the well equations as a pre-processing step
-                last_report_ = solveWellEq(B_avg, dt, local_deferredLogger);
-
-
-                if (initial_step_) {
-                    // update the explicit quantities to get the initial fluid distribution in the well correct.
-                    calculateExplicitQuantities(local_deferredLogger);
-                    prepareTimeStep(local_deferredLogger);
-                    last_report_ = solveWellEq(B_avg, dt, local_deferredLogger);
-                    initial_step_ = false;
-                }
-                // TODO: should we update the explicit related here again, or even prepareTimeStep().
-                // basically, this is a more updated state from the solveWellEq based on fixed
-                // reservoir state, will tihs be a better place to inialize the explict information?
+            if (param_.solve_welleq_initially_ && iterationIdx == 0  && initial_step_) {
+                // update the explicit quantities to get the initial fluid distribution in the well correct.
+                // the assembleWellEq will iterate the well solution until convergece.
+                assembleWellEq(B_avg, dt, local_deferredLogger);
+                calculateExplicitQuantities(local_deferredLogger);
+                prepareTimeStep(local_deferredLogger);
+                initial_step_ = false;
             }
 
             assembleWellEq(B_avg, dt, local_deferredLogger);
@@ -1035,86 +1027,6 @@ namespace Opm {
             well->initPrimaryVariablesEvaluation();
         }
     }
-
-
-
-
-
-    template<typename TypeTag>
-    SimulatorReport
-    BlackoilWellModel<TypeTag>::
-    solveWellEq(const std::vector<Scalar>& B_avg, const double dt, Opm::DeferredLogger& deferred_logger)
-    {
-        WellState well_state0 = well_state_;
-
-        const int max_iter = param_.max_welleq_iter_;
-
-        int it  = 0;
-        bool converged;
-        int exception_thrown = 0;
-        do {
-            try {
-                assembleWellEq(B_avg, dt, deferred_logger);
-            } catch (std::exception& e) {
-                exception_thrown = 1;
-            }
-            // We need to check on all processes, as getWellConvergence() below communicates on all processes.
-            logAndCheckForExceptionsAndThrow(deferred_logger, exception_thrown, "solveWellEq() failed.", terminal_output_);
-
-            const auto report = getWellConvergence(B_avg);
-            converged = report.converged();
-
-            if (converged) {
-                break;
-            }
-
-            try {
-                if( localWellsActive() )
-                {
-                    for (auto& well : well_container_) {
-                        well->solveEqAndUpdateWellState(well_state_, deferred_logger);
-                    }
-                }
-                // updateWellControls uses communication
-                // Therefore the following is executed if there
-                // are active wells anywhere in the global domain.
-                if( wellsActive() )
-                {
-                    updateWellControls(deferred_logger, /*don't switch group controls*/false);
-                    initPrimaryVariablesEvaluation();
-                }
-            } catch (std::exception& e) {
-                exception_thrown = 1;
-            }
-
-            logAndCheckForExceptionsAndThrow(deferred_logger, exception_thrown, "solveWellEq() failed.", terminal_output_);
-            ++it;
-        } while (it < max_iter);
-
-        try {
-            if (converged) {
-                if (terminal_output_) {
-                    deferred_logger.debug("Well equation solution gets converged with " + std::to_string(it) + " iterations");
-                }
-            } else {
-                if (terminal_output_) {
-                    deferred_logger.debug("Well equation solution failed in getting converged with " + std::to_string(it) + " iterations");
-                }
-                well_state_ = well_state0;
-                updatePrimaryVariables(deferred_logger);
-            }
-        } catch (std::exception& e) {
-            exception_thrown = 1;
-        }
-
-        logAndCheckForExceptionsAndThrow(deferred_logger, exception_thrown, "solveWellEq() failed.", terminal_output_);
-
-        SimulatorReport report;
-        report.converged = converged;
-        report.total_well_iterations = it;
-        return report;
-    }
-
 
 
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -122,6 +122,14 @@ namespace Opm
                                     WellState& well_state,
                                     Opm::DeferredLogger& deferred_logger) override;
 
+        virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                    const std::vector<Scalar>& B_avg,
+                                    const double dt,
+                                    const Well::InjectionControls& inj_controls,
+                                    const Well::ProductionControls& prod_controls,
+                                    WellState& well_state,
+                                    Opm::DeferredLogger& deferred_logger) override;
+
         /// updating the well state based the current control mode
         virtual void updateWellStateWithTarget(const Simulator& ebos_simulator,
                                                WellState& well_state,
@@ -417,13 +425,6 @@ namespace Opm
                                   const Well::ProductionControls& prod_controls,
                                   WellState& well_state,
                                   Opm::DeferredLogger& deferred_logger);
-
-        void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
-                                            const double dt,
-                                            const Well::InjectionControls& inj_controls,
-                                            const Well::ProductionControls& prod_controls,
-                                            WellState& well_state,
-                                            Opm::DeferredLogger& deferred_logger);
 
         virtual void wellTestingPhysical(const Simulator& simulator, const std::vector<double>& B_avg,
                                          const double simulation_time, const int report_step,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -258,13 +258,13 @@ namespace Opm
         const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
         const auto prod_controls = well_ecl_.isProducer() ? well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
 
-        const bool use_inner_iterations = param_.use_inner_iterations_ms_wells_;
+        const bool use_inner_iterations = param_.use_inner_iterations_wells_;
         if (use_inner_iterations) {
 
             iterateWellEquations(ebosSimulator, B_avg, dt, inj_controls, prod_controls, well_state, deferred_logger);
         }
 
-        assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, deferred_logger);
+        assembleWellEqWithoutIteration(ebosSimulator, B_avg, dt, inj_controls, prod_controls, well_state, deferred_logger);
     }
 
 
@@ -2712,7 +2712,7 @@ namespace Opm
                          WellState& well_state,
                          Opm::DeferredLogger& deferred_logger)
     {
-        const int max_iter_number = param_.max_inner_iter_ms_wells_;
+        const int max_iter_number = param_.max_inner_iter_wells_;
         const WellState well_state0 = well_state;
         const std::vector<Scalar> residuals0 = getWellResiduals(B_avg);
         std::vector<std::vector<Scalar> > residual_history;
@@ -2725,7 +2725,7 @@ namespace Opm
         int stagnate_count = 0;
         for (; it < max_iter_number; ++it, ++debug_cost_counter_) {
 
-            assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, deferred_logger);
+            assembleWellEqWithoutIteration(ebosSimulator, B_avg, dt, inj_controls, prod_controls, well_state, deferred_logger);
 
             const BVectorWell dx_well = mswellhelpers::invDXDirect(duneD_, resWell_);
 
@@ -2810,6 +2810,7 @@ namespace Opm
     void
     MultisegmentWell<TypeTag>::
     assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                   const std::vector<Scalar>& /* B_avg */,
                                    const double dt,
                                    const Well::InjectionControls& inj_controls,
                                    const Well::ProductionControls& prod_controls,

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -159,10 +159,18 @@ namespace Opm
         virtual void initPrimaryVariablesEvaluation() const override;
 
         virtual void assembleWellEq(const Simulator& ebosSimulator,
-                                    const std::vector<Scalar>& B_avg,
-                                    const double dt,
-                                    WellState& well_state,
-                                    Opm::DeferredLogger& deferred_logger) override;
+                                                    const std::vector<Scalar>& B_avg,
+                                                    const double dt,
+                                                    WellState& well_state,
+                                                    Opm::DeferredLogger& deferred_logger) override;
+
+        virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                                    const std::vector<Scalar>& B_avg,
+                                                    const double dt,
+                                                    const Well::InjectionControls& inj_controls,
+                                                    const Well::ProductionControls& prod_controls,
+                                                    WellState& well_state,
+                                                    Opm::DeferredLogger& deferred_logger) override;
 
         virtual void updateWellStateWithTarget(const Simulator& ebos_simulator,
                                                WellState& well_state,

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -508,17 +508,39 @@ namespace Opm
     }
 
 
+    template<typename TypeTag>
+    void
+    StandardWell<TypeTag>::
+    assembleWellEq(const Simulator& ebosSimulator,
+                   const std::vector<Scalar>& B_avg,
+                   const double dt,
+                   WellState& well_state,
+                   Opm::DeferredLogger& deferred_logger)
+    {
+        const bool use_inner_iterations = param_.use_inner_iterations_wells_;
+        const auto& summary_state = ebosSimulator.vanguard().summaryState();
+        const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
+        const auto prod_controls = well_ecl_.isProducer() ? well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
+        if (use_inner_iterations) {
+            Base::solveWellEqUntilConverged(ebosSimulator, B_avg, well_state, deferred_logger);
+        }
+        assembleWellEqWithoutIteration(ebosSimulator, B_avg, dt, inj_controls, prod_controls, well_state, deferred_logger);
+    }
+
+
 
 
 
     template<typename TypeTag>
     void
     StandardWell<TypeTag>::
-    assembleWellEq(const Simulator& ebosSimulator,
-                   const std::vector<Scalar>& /* B_avg */,
-                   const double dt,
-                   WellState& well_state,
-                   Opm::DeferredLogger& deferred_logger)
+    assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                   const std::vector<Scalar>& /* B_avg */,
+                                   const double dt,
+                                   const Well::InjectionControls& /*inj_controls*/,
+                                   const Well::ProductionControls& /*prod_controls*/,
+                                   WellState& well_state,
+                                   Opm::DeferredLogger& deferred_logger)
     {
         // TODO: only_wells should be put back to save some computation
         // for example, the matrices B C does not need to update if only_wells

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -165,6 +165,15 @@ namespace Opm
                                     Opm::DeferredLogger& deferred_logger
                                     ) = 0;
 
+        virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                                    const std::vector<Scalar>& B_avg,
+                                                    const double dt,
+                                                    const Well::InjectionControls& inj_controls,
+                                                    const Well::ProductionControls& prod_controls,
+                                                    WellState& well_state,
+                                                    Opm::DeferredLogger& deferred_logger
+                                                    ) = 0;
+
         void updateWellTestState(const WellState& well_state,
                                  const double& simulationTime,
                                  const bool& writeMessageToOPMLog,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1201,13 +1201,15 @@ namespace Opm
                               WellState& well_state,
                               Opm::DeferredLogger& deferred_logger)
     {
-        const int max_iter = param_.max_welleq_iter_;
+        const int max_iter = param_.max_inner_iter_wells_;
         int it = 0;
-        const double dt = 1.0; //not used for the well tests
+        const double dt = ebosSimulator.timeStepSize();
+        const auto& summary_state = ebosSimulator.vanguard().summaryState();
+        const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
+        const auto prod_controls = well_ecl_.isProducer() ? well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
         bool converged;
-        WellState well_state0 = well_state;
         do {
-            assembleWellEq(ebosSimulator, B_avg, dt, well_state, deferred_logger);
+            assembleWellEqWithoutIteration(ebosSimulator, B_avg, dt, inj_controls, prod_controls, well_state, deferred_logger);
 
             auto report = getWellConvergence(well_state, B_avg, deferred_logger);
 
@@ -1281,7 +1283,7 @@ namespace Opm
         if (converged) {
             deferred_logger.debug("WellTest: Well equation for well " + name() +  " converged");
         } else {
-            const int max_iter = param_.max_welleq_iter_;
+            const int max_iter = param_.max_inner_iter_wells_;
             deferred_logger.debug("WellTest: Well equation for well " +name() + " failed converging in "
                           + std::to_string(max_iter) + " iterations");
             well_state = well_state0;


### PR DESCRIPTION
This commit skips the outer well iteration using solveEq and instead use inner iterations during the assembly process also for the standard wells. 

This commit affects performance and should be tested carefully. 
This PR replaces #2211 and #2212. 
