### PR TITLE
froze wellState at nupcol iterations

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -256,6 +256,7 @@ namespace Opm {
 
             WellState well_state_;
             WellState previous_well_state_;
+            WellState well_state_nupcol_;
 
             const ModelParameters param_;
             bool terminal_output_;

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -226,20 +226,20 @@ namespace Opm {
         return rate;
     }
 
-    inline void updateGroupTargetReduction(const Group& group, const Schedule& schedule, const int reportStepIdx, const bool isInjector, WellStateFullyImplicitBlackoil& wellState, std::vector<double>& groupTargetReduction)
+    inline void updateGroupTargetReduction(const Group& group, const Schedule& schedule, const int reportStepIdx, const bool isInjector, const WellStateFullyImplicitBlackoil& wellStateNupcol, WellStateFullyImplicitBlackoil& wellState, std::vector<double>& groupTargetReduction)
     {
         const int np = wellState.numPhases();
         for (const std::string& groupName : group.groups()) {
             std::vector<double> thisGroupTargetReduction(np, 0.0);
             const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            updateGroupTargetReduction(groupTmp, schedule, reportStepIdx, isInjector, wellState, thisGroupTargetReduction);
+            updateGroupTargetReduction(groupTmp, schedule, reportStepIdx, isInjector, wellStateNupcol, wellState, thisGroupTargetReduction);
 
             // accumulate group contribution from sub group
             if (isInjector) {
                 const Group::InjectionCMode& currentGroupControl = wellState.currentInjectionGroupControl(groupName);
                 if (currentGroupControl != Group::InjectionCMode::FLD) {
                     for (int phase = 0; phase < np; phase++) {
-                        groupTargetReduction[phase] += sumWellRates(groupTmp, schedule, wellState, reportStepIdx, phase, isInjector);
+                        groupTargetReduction[phase] += sumWellRates(groupTmp, schedule, wellStateNupcol, reportStepIdx, phase, isInjector);
                     }
                     continue;
                 }
@@ -247,7 +247,7 @@ namespace Opm {
                 const Group::ProductionCMode& currentGroupControl = wellState.currentProductionGroupControl(groupName);
                 if (currentGroupControl != Group::ProductionCMode::FLD) {
                     for (int phase = 0; phase < np; phase++) {
-                        groupTargetReduction[phase] += sumWellRates(groupTmp, schedule, wellState, reportStepIdx, phase, isInjector);
+                        groupTargetReduction[phase] += sumWellRates(groupTmp, schedule, wellStateNupcol, reportStepIdx, phase, isInjector);
                     }
                     continue;
                 }
@@ -280,12 +280,12 @@ namespace Opm {
             if (isInjector) {
                 if (wellState.currentInjectionControls()[well_index] != Well::InjectorCMode::GRUP)
                     for (int phase = 0; phase < np; phase++) {
-                        groupTargetReduction[phase] += wellState.wellRates()[wellrate_index + phase];
+                        groupTargetReduction[phase] += wellStateNupcol.wellRates()[wellrate_index + phase];
                     }
             } else {
                 if (wellState.currentProductionControls()[well_index] !=  Well::ProducerCMode::GRUP)
                     for (int phase = 0; phase < np; phase++) {
-                        groupTargetReduction[phase] -= wellState.wellRates()[wellrate_index + phase];
+                        groupTargetReduction[phase] -= wellStateNupcol.wellRates()[wellrate_index + phase];
                     }
             }
         }
@@ -371,34 +371,33 @@ namespace Opm {
         }
     }
 
-
-    inline void updateVREPForGroups(const Group& group, const Schedule& schedule, const int reportStepIdx, WellStateFullyImplicitBlackoil& wellState, double& resv) {
+    inline void updateVREPForGroups(const Group& group, const Schedule& schedule, const int reportStepIdx, const WellStateFullyImplicitBlackoil& wellStateNupcol, WellStateFullyImplicitBlackoil& wellState, double& resv) {
         for (const std::string& groupName : group.groups()) {
             const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
             double thisResv = 0.0;
-            updateVREPForGroups(groupTmp, schedule, reportStepIdx, wellState, thisResv);
+            updateVREPForGroups(groupTmp, schedule, reportStepIdx, wellStateNupcol, wellState, thisResv);
             resv += thisResv;
         }
         const int np = wellState.numPhases();
         for (int phase = 0; phase < np; ++phase) {
-            resv += sumWellPhaseRates(wellState.wellReservoirRates(), group, schedule, wellState, reportStepIdx, phase, /*isInjector*/ false);
+            resv += sumWellPhaseRates(wellStateNupcol.wellReservoirRates(), group, schedule, wellState, reportStepIdx, phase, /*isInjector*/ false);
         }
 
         wellState.setCurrentInjectionVREPRates(group.name(), resv);
     }
 
-    inline void updateREINForGroups(const Group& group, const Schedule& schedule, const int reportStepIdx, const PhaseUsage& pu, const SummaryState& st, WellStateFullyImplicitBlackoil& wellState, std::vector<double>& rein) {
+    inline void updateREINForGroups(const Group& group, const Schedule& schedule, const int reportStepIdx, const PhaseUsage& pu, const SummaryState& st, const WellStateFullyImplicitBlackoil& wellStateNupcol, WellStateFullyImplicitBlackoil& wellState, std::vector<double>& rein) {
         const int np = wellState.numPhases();
         for (const std::string& groupName : group.groups()) {
             const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
             std::vector<double> thisRein(np, 0.0);
-            updateREINForGroups(groupTmp, schedule, reportStepIdx, pu, st, wellState, thisRein);
+            updateREINForGroups(groupTmp, schedule, reportStepIdx, pu, st, wellStateNupcol, wellState, thisRein);
             for (int phase = 0; phase < np; ++phase) {
                 rein[phase] = thisRein[phase];
             }
         }
         for (int phase = 0; phase < np; ++phase) {
-            rein[phase] = sumWellPhaseRates(wellState.wellRates(), group, schedule, wellState, reportStepIdx, phase, /*isInjector*/ false);
+            rein[phase] = sumWellPhaseRates(wellStateNupcol.wellRates(), group, schedule, wellState, reportStepIdx, phase, /*isInjector*/ false);
         }
 
         // add import rate and substract consumption rate for group for gas


### PR DESCRIPTION
The group reduction rates and REIN and VREP values are recomputed every iterations to account for changing well and group controls. But the values are fixed after the iterations number exceeds the value given by NUPCOL to avoid oscillation.  