### PR TITLE
Pass a pointer to the EclipseGrid to CpGrid::processEclipseGrid.

### DIFF
--- a/ebos/eclalugridvanguard.hh
+++ b/ebos/eclalugridvanguard.hh
@@ -180,7 +180,7 @@ protected:
         // create the EQUIL grid
         /////
         equilGrid_ = new EquilGrid();
-        equilGrid_->processEclipseFormat(this->eclState().getInputGrid(),
+        equilGrid_->processEclipseFormat(&(this->eclState().getInputGrid()),
                                          /*isPeriodic=*/false,
                                          /*flipNormals=*/false,
                                          /*clipZ=*/false,

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -265,7 +265,7 @@ protected:
         const std::vector<double>& porv = gridProps.getDoubleGridProperty("PORV").getData();
 #endif
         grid_.reset(new Dune::CpGrid());
-        grid_->processEclipseFormat(this->eclState().getInputGrid(),
+        grid_->processEclipseFormat(&(this->eclState().getInputGrid()),
                                     /*isPeriodic=*/false,
                                     /*flipNormals=*/false,
                                     /*clipZ=*/false,


### PR DESCRIPTION
... instead of a reference This is needed as we only want to read the
full deck and construct the EclipseGrid only on the master process
with rank 0. Hence all other ranks will pass a nullptr to this
function. This will be possible with this move from a reference to a
pointer.

downstream of PR OPM/opm-grid#433