### PR TITLE
fixed: if not tests failed, do not proceed with update data procedure

### DIFF
--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -95,6 +95,8 @@ changed_tests=""
 # Read failed tests
 FAILED_TESTS=`cat $WORKSPACE/$configuration/build-opm-simulators/Testing/Temporary/LastTestsFailed*.log`
 
+test -z "$FAILED_TESTS" && exit 5
+
 for failed_test in $FAILED_TESTS
 do
   failed=`echo $failed_test | sed -e 's/.*:compareECLFiles_//g'`


### PR DESCRIPTION
Avoid non-sense issues in opm-tests.

Downstream of https://github.com/OPM/opm-common/pull/1368