### PR TITLE
Bugfix: correct well efficiency factors for MSW

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2856,7 +2856,7 @@ namespace Opm
             // considering the contributions due to flowing out from the segment
             {
                 for (int comp_idx = 0; comp_idx < num_components_; ++comp_idx) {
-                    const EvalWell segment_rate = getSegmentRateUpwinding(seg, comp_idx);
+                    const EvalWell segment_rate = getSegmentRateUpwinding(seg, comp_idx) * well_efficiency_factor_;
 
                     const int seg_upwind = upwinding_segments_[seg];
                     // segment_rate contains the derivatives with respect to GTotal in seg,
@@ -2873,7 +2873,7 @@ namespace Opm
             {
                 for (const int inlet : segment_inlets_[seg]) {
                     for (int comp_idx = 0; comp_idx < num_components_; ++comp_idx) {
-                        const EvalWell inlet_rate = getSegmentRateUpwinding(inlet, comp_idx);
+                        const EvalWell inlet_rate = getSegmentRateUpwinding(inlet, comp_idx) * well_efficiency_factor_;
 
                         const int inlet_upwind = upwinding_segments_[inlet];
                         // inlet_rate contains the derivatives with respect to GTotal in inlet,


### PR DESCRIPTION
With this fix, a comparison based on the MSW_MODEL_1.DATA test case variants show reasonable agreement between standard and multisegment wells with or without WEFAC.

In the current code, the conservation equations for the mswell are in terms of effective flows. This is similar to the treatment for standard wells. The alternative (formulating the equations in full rates) could be better and clearer in the long run.