### PR TITLE
Add inner iterations for standard wells also

### DIFF
--- a/ebos/ebos.hh
+++ b/ebos/ebos.hh
@@ -136,8 +136,8 @@ public:
         EWOMS_HIDE_PARAM(TypeTag, UseMultisegmentWell);
         EWOMS_HIDE_PARAM(TypeTag, TolerancePressureMsWells);
         EWOMS_HIDE_PARAM(TypeTag, MaxPressureChangeMsWells);
-        EWOMS_HIDE_PARAM(TypeTag, UseInnerIterationsMsWells);
-        EWOMS_HIDE_PARAM(TypeTag, MaxInnerIterMsWells);
+        EWOMS_HIDE_PARAM(TypeTag, UseInnerIterationsWells);
+        EWOMS_HIDE_PARAM(TypeTag, MaxInnerIterWells);
         EWOMS_HIDE_PARAM(TypeTag, MaxSinglePrecisionDays);
         EWOMS_HIDE_PARAM(TypeTag, MaxStrictIter);
         EWOMS_HIDE_PARAM(TypeTag, SolveWelleqInitially);

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -49,12 +49,12 @@ NEW_PROP_TAG(UpdateEquationsScaling);
 NEW_PROP_TAG(UseUpdateStabilization);
 NEW_PROP_TAG(MatrixAddWellContributions);
 NEW_PROP_TAG(EnableWellOperabilityCheck);
+NEW_PROP_TAG(UseInnerIterationsWells);
+NEW_PROP_TAG(MaxInnerIterWells);
 
 // parameters for multisegment wells
 NEW_PROP_TAG(TolerancePressureMsWells);
 NEW_PROP_TAG(MaxPressureChangeMsWells);
-NEW_PROP_TAG(UseInnerIterationsMsWells);
-NEW_PROP_TAG(MaxInnerIterMsWells);
 
 SET_SCALAR_PROP(FlowModelParameters, DbhpMaxRel, 1.0);
 SET_SCALAR_PROP(FlowModelParameters, DwellFractionMax, 0.2);
@@ -74,8 +74,8 @@ SET_BOOL_PROP(FlowModelParameters, UseUpdateStabilization, true);
 SET_BOOL_PROP(FlowModelParameters, MatrixAddWellContributions, false);
 SET_SCALAR_PROP(FlowModelParameters, TolerancePressureMsWells, 0.01*1e5);
 SET_SCALAR_PROP(FlowModelParameters, MaxPressureChangeMsWells, 10*1e5);
-SET_BOOL_PROP(FlowModelParameters, UseInnerIterationsMsWells, true);
-SET_INT_PROP(FlowModelParameters, MaxInnerIterMsWells, 100);
+SET_BOOL_PROP(FlowModelParameters, UseInnerIterationsWells, true);
+SET_INT_PROP(FlowModelParameters, MaxInnerIterWells, 100);
 SET_BOOL_PROP(FlowModelParameters, EnableWellOperabilityCheck, true);
 
 // if openMP is available, determine the number threads per process automatically.
@@ -118,10 +118,10 @@ namespace Opm
         double max_pressure_change_ms_wells_;
 
         /// Whether to use inner iterations for ms wells
-        bool use_inner_iterations_ms_wells_;
+        bool use_inner_iterations_wells_;
 
         /// Maximum inner iteration number for ms wells
-        int max_inner_iter_ms_wells_;
+        int max_inner_iter_wells_;
 
         /// Maximum iteration number of the well equation solution
         int max_welleq_iter_;
@@ -170,8 +170,8 @@ namespace Opm
             use_multisegment_well_ = EWOMS_GET_PARAM(TypeTag, bool, UseMultisegmentWell);
             tolerance_pressure_ms_wells_ = EWOMS_GET_PARAM(TypeTag, Scalar, TolerancePressureMsWells);
             max_pressure_change_ms_wells_ = EWOMS_GET_PARAM(TypeTag, Scalar, MaxPressureChangeMsWells);
-            use_inner_iterations_ms_wells_ = EWOMS_GET_PARAM(TypeTag, bool, UseInnerIterationsMsWells);
-            max_inner_iter_ms_wells_ = EWOMS_GET_PARAM(TypeTag, int, MaxInnerIterMsWells);
+            use_inner_iterations_wells_ = EWOMS_GET_PARAM(TypeTag, bool, UseInnerIterationsWells);
+            max_inner_iter_wells_ = EWOMS_GET_PARAM(TypeTag, int, MaxInnerIterWells);
             maxSinglePrecisionTimeStep_ = EWOMS_GET_PARAM(TypeTag, Scalar, MaxSinglePrecisionDays) *24*60*60;
             max_strict_iter_ = EWOMS_GET_PARAM(TypeTag, int, MaxStrictIter);
             solve_welleq_initially_ = EWOMS_GET_PARAM(TypeTag, bool, SolveWelleqInitially);
@@ -196,8 +196,8 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, bool, UseMultisegmentWell, "Use the well model for multi-segment wells instead of the one for single-segment wells");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, TolerancePressureMsWells, "Tolerance for the pressure equations for multi-segment wells");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, MaxPressureChangeMsWells, "Maximum relative pressure change for a single iteration of the multi-segment well model");
-            EWOMS_REGISTER_PARAM(TypeTag, bool, UseInnerIterationsMsWells, "Use nested iterations for multi-segment wells");
-            EWOMS_REGISTER_PARAM(TypeTag, int, MaxInnerIterMsWells, "Maximum number of inner iterations for multi-segment wells");
+            EWOMS_REGISTER_PARAM(TypeTag, bool, UseInnerIterationsWells, "Use nested iterations for wells");
+            EWOMS_REGISTER_PARAM(TypeTag, int, MaxInnerIterWells, "Maximum number of inner iterations for wells");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, MaxSinglePrecisionDays, "Maximum time step size where single precision floating point arithmetic can be used solving for the linear systems of equations");
             EWOMS_REGISTER_PARAM(TypeTag, int, MaxStrictIter, "Maximum number of Newton iterations before relaxed tolerances are used for the CNV convergence criterion");
             EWOMS_REGISTER_PARAM(TypeTag, bool, SolveWelleqInitially, "Fully solve the well equations before each iteration of the reservoir model");

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -122,14 +122,6 @@ namespace Opm
                                     WellState& well_state,
                                     Opm::DeferredLogger& deferred_logger) override;
 
-        virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
-                                    const std::vector<Scalar>& B_avg,
-                                    const double dt,
-                                    const Well::InjectionControls& inj_controls,
-                                    const Well::ProductionControls& prod_controls,
-                                    WellState& well_state,
-                                    Opm::DeferredLogger& deferred_logger) override;
-
         /// updating the well state based the current control mode
         virtual void updateWellStateWithTarget(const Simulator& ebos_simulator,
                                                WellState& well_state,
@@ -429,6 +421,14 @@ namespace Opm
         virtual void wellTestingPhysical(const Simulator& simulator, const std::vector<double>& B_avg,
                                          const double simulation_time, const int report_step,
                                          WellState& well_state, WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger) override;
+
+        virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                    const std::vector<Scalar>& B_avg,
+                                    const double dt,
+                                    const Well::InjectionControls& inj_controls,
+                                    const Well::ProductionControls& prod_controls,
+                                    WellState& well_state,
+                                    Opm::DeferredLogger& deferred_logger) override;
 
         virtual void updateWaterThroughput(const double dt, WellState& well_state) const override;
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -122,6 +122,14 @@ namespace Opm
                                     WellState& well_state,
                                     Opm::DeferredLogger& deferred_logger) override;
 
+        virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                    const std::vector<Scalar>& B_avg,
+                                    const double dt,
+                                    const Well::InjectionControls& inj_controls,
+                                    const Well::ProductionControls& prod_controls,
+                                    WellState& well_state,
+                                    Opm::DeferredLogger& deferred_logger) override;
+
         /// updating the well state based the current control mode
         virtual void updateWellStateWithTarget(const Simulator& ebos_simulator,
                                                WellState& well_state,
@@ -417,13 +425,6 @@ namespace Opm
                                   const Well::ProductionControls& prod_controls,
                                   WellState& well_state,
                                   Opm::DeferredLogger& deferred_logger);
-
-        void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
-                                            const double dt,
-                                            const Well::InjectionControls& inj_controls,
-                                            const Well::ProductionControls& prod_controls,
-                                            WellState& well_state,
-                                            Opm::DeferredLogger& deferred_logger);
 
         virtual void wellTestingPhysical(const Simulator& simulator, const std::vector<double>& B_avg,
                                          const double simulation_time, const int report_step,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -258,13 +258,13 @@ namespace Opm
         const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
         const auto prod_controls = well_ecl_.isProducer() ? well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
 
-        const bool use_inner_iterations = param_.use_inner_iterations_ms_wells_;
+        const bool use_inner_iterations = param_.use_inner_iterations_wells_;
         if (use_inner_iterations) {
 
             iterateWellEquations(ebosSimulator, B_avg, dt, inj_controls, prod_controls, well_state, deferred_logger);
         }
 
-        assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, deferred_logger);
+        assembleWellEqWithoutIteration(ebosSimulator, B_avg, dt, inj_controls, prod_controls, well_state, deferred_logger);
     }
 
 
@@ -2708,7 +2708,7 @@ namespace Opm
                          WellState& well_state,
                          Opm::DeferredLogger& deferred_logger)
     {
-        const int max_iter_number = param_.max_inner_iter_ms_wells_;
+        const int max_iter_number = param_.max_inner_iter_wells_;
         const WellState well_state0 = well_state;
         const std::vector<Scalar> residuals0 = getWellResiduals(B_avg);
         std::vector<std::vector<Scalar> > residual_history;
@@ -2721,7 +2721,7 @@ namespace Opm
         int stagnate_count = 0;
         for (; it < max_iter_number; ++it, ++debug_cost_counter_) {
 
-            assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, deferred_logger);
+            assembleWellEqWithoutIteration(ebosSimulator, B_avg, dt, inj_controls, prod_controls, well_state, deferred_logger);
 
             const BVectorWell dx_well = mswellhelpers::invDXDirect(duneD_, resWell_);
 
@@ -2806,6 +2806,7 @@ namespace Opm
     void
     MultisegmentWell<TypeTag>::
     assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                   const std::vector<Scalar>& /* B_avg */,
                                    const double dt,
                                    const Well::InjectionControls& inj_controls,
                                    const Well::ProductionControls& prod_controls,

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -169,14 +169,6 @@ namespace Opm
                                     WellState& well_state,
                                     Opm::DeferredLogger& deferred_logger) override;
 
-        virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
-                                                    const std::vector<Scalar>& B_avg,
-                                                    const double dt,
-                                                    const Well::InjectionControls& inj_controls,
-                                                    const Well::ProductionControls& prod_controls,
-                                                    WellState& well_state,
-                                                    Opm::DeferredLogger& deferred_logger) override;
-
         virtual void updateWellStateWithTarget(const Simulator& ebos_simulator,
                                                WellState& well_state,
                                                Opm::DeferredLogger& deferred_logger) const override;
@@ -425,6 +417,14 @@ namespace Opm
         virtual void checkWellOperability(const Simulator& ebos_simulator,
                                           const WellState& well_state,
                                           Opm::DeferredLogger& deferred_logger) override;
+
+        virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                                    const std::vector<Scalar>& B_avg,
+                                                    const double dt,
+                                                    const Well::InjectionControls& inj_controls,
+                                                    const Well::ProductionControls& prod_controls,
+                                                    WellState& well_state,
+                                                    Opm::DeferredLogger& deferred_logger) override;
 
         // check whether the well is operable under the current reservoir condition
         // mostly related to BHP limit and THP limit

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -169,6 +169,14 @@ namespace Opm
                                     WellState& well_state,
                                     Opm::DeferredLogger& deferred_logger) override;
 
+        virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                                    const std::vector<Scalar>& B_avg,
+                                                    const double dt,
+                                                    const Well::InjectionControls& inj_controls,
+                                                    const Well::ProductionControls& prod_controls,
+                                                    WellState& well_state,
+                                                    Opm::DeferredLogger& deferred_logger) override;
+
         virtual void updateWellStateWithTarget(const Simulator& ebos_simulator,
                                                WellState& well_state,
                                                Opm::DeferredLogger& deferred_logger) const override;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -508,17 +508,39 @@ namespace Opm
     }
 
 
+    template<typename TypeTag>
+    void
+    StandardWell<TypeTag>::
+    assembleWellEq(const Simulator& ebosSimulator,
+                   const std::vector<Scalar>& B_avg,
+                   const double dt,
+                   WellState& well_state,
+                   Opm::DeferredLogger& deferred_logger)
+    {
+        const bool use_inner_iterations = param_.use_inner_iterations_wells_;
+        const auto& summary_state = ebosSimulator.vanguard().summaryState();
+        const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
+        const auto prod_controls = well_ecl_.isProducer() ? well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
+        if (use_inner_iterations) {
+            Base::solveWellEqUntilConverged(ebosSimulator, B_avg, well_state, deferred_logger);
+        }
+        assembleWellEqWithoutIteration(ebosSimulator, B_avg, dt, inj_controls, prod_controls, well_state, deferred_logger);
+    }
+
+
 
 
 
     template<typename TypeTag>
     void
     StandardWell<TypeTag>::
-    assembleWellEq(const Simulator& ebosSimulator,
-                   const std::vector<Scalar>& /* B_avg */,
-                   const double dt,
-                   WellState& well_state,
-                   Opm::DeferredLogger& deferred_logger)
+    assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                   const std::vector<Scalar>& /* B_avg */,
+                                   const double dt,
+                                   const Well::InjectionControls& /*inj_controls*/,
+                                   const Well::ProductionControls& /*prod_controls*/,
+                                   WellState& well_state,
+                                   Opm::DeferredLogger& deferred_logger)
     {
         // TODO: only_wells should be put back to save some computation
         // for example, the matrices B C does not need to update if only_wells

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -168,6 +168,15 @@ namespace Opm
                                     Opm::DeferredLogger& deferred_logger
                                     ) = 0;
 
+        virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                                    const std::vector<Scalar>& B_avg,
+                                                    const double dt,
+                                                    const Well::InjectionControls& inj_controls,
+                                                    const Well::ProductionControls& prod_controls,
+                                                    WellState& well_state,
+                                                    Opm::DeferredLogger& deferred_logger
+                                                    ) = 0;
+
         void updateWellTestState(const WellState& well_state,
                                  const double& simulationTime,
                                  const bool& writeMessageToOPMLog,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -168,15 +168,6 @@ namespace Opm
                                     Opm::DeferredLogger& deferred_logger
                                     ) = 0;
 
-        virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
-                                                    const std::vector<Scalar>& B_avg,
-                                                    const double dt,
-                                                    const Well::InjectionControls& inj_controls,
-                                                    const Well::ProductionControls& prod_controls,
-                                                    WellState& well_state,
-                                                    Opm::DeferredLogger& deferred_logger
-                                                    ) = 0;
-
         void updateWellTestState(const WellState& well_state,
                                  const double& simulationTime,
                                  const bool& writeMessageToOPMLog,
@@ -453,6 +444,16 @@ namespace Opm
         virtual void wellTestingPhysical(const Simulator& simulator, const std::vector<double>& B_avg,
                                  const double simulation_time, const int report_step,
                                          WellState& well_state, WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger) = 0;
+
+
+        virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
+                                                    const std::vector<Scalar>& B_avg,
+                                                    const double dt,
+                                                    const Well::InjectionControls& inj_controls,
+                                                    const Well::ProductionControls& prod_controls,
+                                                    WellState& well_state,
+                                                    Opm::DeferredLogger& deferred_logger
+                                                    ) = 0;
 
         void updateWellTestStateEconomic(const WellState& well_state,
                                          const double simulation_time,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1224,13 +1224,15 @@ namespace Opm
                               WellState& well_state,
                               Opm::DeferredLogger& deferred_logger)
     {
-        const int max_iter = param_.max_welleq_iter_;
+        const int max_iter = param_.max_inner_iter_wells_;
         int it = 0;
-        const double dt = 1.0; //not used for the well tests
+        const double dt = ebosSimulator.timeStepSize();
+        const auto& summary_state = ebosSimulator.vanguard().summaryState();
+        const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
+        const auto prod_controls = well_ecl_.isProducer() ? well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
         bool converged;
-        WellState well_state0 = well_state;
         do {
-            assembleWellEq(ebosSimulator, B_avg, dt, well_state, deferred_logger);
+            assembleWellEqWithoutIteration(ebosSimulator, B_avg, dt, inj_controls, prod_controls, well_state, deferred_logger);
 
             auto report = getWellConvergence(well_state, B_avg, deferred_logger);
 
@@ -1304,7 +1306,7 @@ namespace Opm
         if (converged) {
             deferred_logger.debug("WellTest: Well equation for well " + name() +  " converged");
         } else {
-            const int max_iter = param_.max_welleq_iter_;
+            const int max_iter = param_.max_inner_iter_wells_;
             deferred_logger.debug("WellTest: Well equation for well " +name() + " failed converging in "
                           + std::to_string(max_iter) + " iterations");
             well_state = well_state0;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1224,7 +1224,7 @@ namespace Opm
                               WellState& well_state,
                               Opm::DeferredLogger& deferred_logger)
     {
-        const int max_iter = param_.max_inner_iter_wells_;
+        const int max_iter = param_.max_welleq_iter_;
         int it = 0;
         const double dt = ebosSimulator.timeStepSize();
         const auto& summary_state = ebosSimulator.vanguard().summaryState();
@@ -1306,7 +1306,7 @@ namespace Opm
         if (converged) {
             deferred_logger.debug("WellTest: Well equation for well " + name() +  " converged");
         } else {
-            const int max_iter = param_.max_inner_iter_wells_;
+            const int max_iter = param_.max_welleq_iter_;
             deferred_logger.debug("WellTest: Well equation for well " +name() + " failed converging in "
                           + std::to_string(max_iter) + " iterations");
             well_state = well_state0;


### PR DESCRIPTION
Testing of #2238 seems to indicate that we sometimes for some reasons need to solve the well equations separately. Since more testing is needed before removing solveWellEq lets take it step-by-step. This PR adds inner iterations to STW similar to MSW. The inner iterations significantly improves the robustness of cases involving group control. 

