### PR TITLE
Avoid global ecl state in setting up additional modules

### DIFF
--- a/ebos/eclmpiserializer.hh
+++ b/ebos/eclmpiserializer.hh
@@ -1,0 +1,55 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#ifndef ECL_MPI_SERIALIZER_HH
+#define ECL_MPI_SERIALIZER_HH
+
+#include <opm/simulators/utils/ParallelRestart.hpp>
+
+namespace Opm {
+
+class EclMpiSerializer {
+public:
+    EclMpiSerializer(Dune::MPIHelper::MPICommunicator comm) :
+        m_comm(comm)
+    {}
+
+    template<class T>
+    std::size_t packSize(const T& data) {
+        return Mpi::packSize(data, m_comm);
+    }
+
+    template<class T>
+    void pack(const T& data, std::vector<char>& buffer, int& pos) {
+        Mpi::pack(data, buffer, pos, m_comm);
+    }
+
+    template<class T>
+    void unpack(T& data, std::vector<char>& buffer, int& pos) {
+        Mpi::unpack(data, buffer, pos, m_comm);
+    }
+
+protected:
+    Dune::MPIHelper::MPICommunicator m_comm;
+};
+
+}
+
+#endif

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -606,19 +606,21 @@ public:
         this->model().addOutputModule(new VtkEclTracerModule<TypeTag>(simulator));
         // Tell the black-oil extensions to initialize their internal data structures
         const auto& vanguard = simulator.vanguard();
-        FoamModule::initFromDeck(vanguard.deck(), vanguard.eclState());
         const auto& comm = this->gridView().comm();
         if (comm.rank() == 0) {
             SolventModule::initFromDeck(vanguard.deck(), vanguard.eclState());
             PolymerModule::initFromDeck(vanguard.deck(), vanguard.eclState());
+            FoamModule::initFromDeck(vanguard.deck(), vanguard.eclState());
             if (comm.size() > 1) {
                 EclMpiSerializer ser(comm);
                 size_t size = SolventModule::packSize(ser) +
-                              PolymerModule::packSize(ser);
+                              PolymerModule::packSize(ser) +
+                              FoamModule::packSize(ser);
                 std::vector<char> buffer(size);
                 int position = 0;
                 SolventModule::pack(buffer, position, ser);
                 PolymerModule::pack(buffer, position, ser);
+                FoamModule::pack(buffer, position, ser);
                 comm.broadcast(&position, 1, 0);
                 comm.broadcast(buffer.data(), position, 0);
             }
@@ -631,6 +633,7 @@ public:
             EclMpiSerializer ser(comm);
             SolventModule::unpack(buffer, position, ser);
             PolymerModule::unpack(buffer, position, ser);
+            FoamModule::unpack(buffer, position, ser);
         }
 
         // create the ECL writer

--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -657,6 +657,13 @@ std::size_t packSize(const IntervalTabulated2DFunction<Scalar>& data,
 template std::size_t packSize(const IntervalTabulated2DFunction<double>& data,
                               Dune::MPIHelper::MPICommunicator comm);
 
+template
+std::size_t packSize(const std::vector<IntervalTabulated2DFunction<double>>& data,
+                     Dune::MPIHelper::MPICommunicator comm);
+template
+std::size_t packSize(const std::map<int,IntervalTabulated2DFunction<double>>& data,
+                     Dune::MPIHelper::MPICommunicator comm);
+
 template<class Scalar>
 std::size_t packSize(const UniformXTabulated2DFunction<Scalar>& data,
                      Dune::MPIHelper::MPICommunicator comm)
@@ -3761,6 +3768,14 @@ void unpack(IntervalTabulated2DFunction<Scalar>& data, std::vector<char>& buffer
 }
 
 template void unpack(IntervalTabulated2DFunction<double>& data,
+                     std::vector<char>& buffer,
+                     int& position, Dune::MPIHelper::MPICommunicator comm);
+
+template void unpack(std::vector<IntervalTabulated2DFunction<double>>& data,
+                     std::vector<char>& buffer,
+                     int& position, Dune::MPIHelper::MPICommunicator comm);
+
+template void unpack(std::map<int,IntervalTabulated2DFunction<double>>& data,
                      std::vector<char>& buffer,
                      int& position, Dune::MPIHelper::MPICommunicator comm);
 


### PR DESCRIPTION
Avoid using deck directly on non-root processes when setting up the solvent, polymer and foam modules.

Downstream of https://github.com/OPM/opm-models/pull/584