### PR TITLE
Move PreconditionerFactory into namespace Opm.

### DIFF
--- a/opm/simulators/linalg/FlexibleSolver.hpp
+++ b/opm/simulators/linalg/FlexibleSolver.hpp
@@ -96,7 +96,7 @@ private:
         auto linop = std::make_shared<ParOperatorType>(matrix, comm);
         linearoperator_ = linop;
         preconditioner_
-            = Dune::PreconditionerFactory<ParOperatorType, Comm>::create(*linop, prm.get_child("preconditioner"), comm);
+            = Opm::PreconditionerFactory<ParOperatorType, Comm>::create(*linop, prm.get_child("preconditioner"), comm);
         scalarproduct_ = Dune::createScalarProduct<VectorType, Comm>(comm, linearoperator_->category());
     }
 
@@ -106,7 +106,7 @@ private:
         using SeqOperatorType = Dune::MatrixAdapter<MatrixType, VectorType, VectorType>;
         auto linop = std::make_shared<SeqOperatorType>(matrix);
         linearoperator_ = linop;
-        preconditioner_ = Dune::PreconditionerFactory<SeqOperatorType>::create(*linop, prm.get_child("preconditioner"));
+        preconditioner_ = Opm::PreconditionerFactory<SeqOperatorType>::create(*linop, prm.get_child("preconditioner"));
         scalarproduct_ = std::make_shared<Dune::SeqScalarProduct<VectorType>>();
     }
 

--- a/opm/simulators/linalg/OwningTwoLevelPreconditioner.hpp
+++ b/opm/simulators/linalg/OwningTwoLevelPreconditioner.hpp
@@ -35,14 +35,18 @@
 #include <fstream>
 #include <type_traits>
 
-namespace Dune
-{
 
+namespace Opm
+{
 // Circular dependency between PreconditionerFactory [which can make an OwningTwoLevelPreconditioner]
 // and OwningTwoLevelPreconditioner [which uses PreconditionerFactory to choose the fine-level smoother]
 // must be broken, accomplished by forward-declaration here.
 template <class Operator, class Comm = Dune::Amg::SequentialInformation>
 class PreconditionerFactory;
+}
+
+namespace Dune
+{
 
 
 // Must forward-declare FlexibleSolver as we want to use it as solver for the pressure system.
@@ -63,7 +67,7 @@ class OwningTwoLevelPreconditioner : public Dune::PreconditionerWithUpdate<Vecto
 public:
     using pt = boost::property_tree::ptree;
     using MatrixType = typename OperatorType::matrix_type;
-    using PrecFactory = PreconditionerFactory<OperatorType, Communication>;
+    using PrecFactory = Opm::PreconditionerFactory<OperatorType, Communication>;
 
     OwningTwoLevelPreconditioner(const OperatorType& linearoperator, const pt& prm)
         : linear_operator_(linearoperator)

--- a/opm/simulators/linalg/PreconditionerFactory.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory.hpp
@@ -37,7 +37,7 @@
 #include <map>
 #include <memory>
 
-namespace Dune
+namespace Opm
 {
 
 /// This is an object factory for creating preconditioners.  The

--- a/tests/test_preconditionerfactory.cpp
+++ b/tests/test_preconditionerfactory.cpp
@@ -90,7 +90,7 @@ testPrec(const boost::property_tree::ptree& prm, const std::string& matrix_filen
     }
     using Operator = Dune::MatrixAdapter<Matrix, Vector, Vector>;
     Operator op(matrix);
-    using PrecFactory = Dune::PreconditionerFactory<Operator>;
+    using PrecFactory = Opm::PreconditionerFactory<Operator>;
     auto prec = PrecFactory::create(op, prm.get_child("preconditioner"));
     Dune::BiCGSTABSolver<Vector> solver(op, *prec, prm.get<double>("tol"), prm.get<int>("maxiter"), prm.get<int>("verbosity"));
     Vector x(rhs.size());
@@ -164,7 +164,7 @@ using V = Dune::BlockVector<Dune::FieldVector<double, bz>>;
 template <int bz>
 using O = Dune::MatrixAdapter<M<bz>, V<bz>, V<bz>>;
 template <int bz>
-using PF = Dune::PreconditionerFactory<O<bz>>;
+using PF = Opm::PreconditionerFactory<O<bz>>;
 
 
 BOOST_AUTO_TEST_CASE(TestAddingPreconditioner)


### PR DESCRIPTION
This fixes name clashes with DUNE's own factory that is introduced
in DUNE 2.7. Hence it closes issue #2266.

BTW: Dune's factory has more template parameters.