### PR TITLE
fix for vrep and rein for more then one level of groups

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1191,11 +1191,9 @@ namespace Opm {
         std::vector<double> potInj(numPhases(), 0.0);
         wellGroupHelpers::updateGuideRateForGroups(fieldGroup, schedule(), phase_usage_, reportStepIdx, simulationTime, /*isInjector*/ true, well_state_, comm, guideRate_.get(), potInj);
 
-        std::vector<double> rein(numPhases(), 0.0);
         const auto& summaryState = ebosSimulator_.vanguard().summaryState();
-        wellGroupHelpers::updateREINForGroups(fieldGroup, schedule(), reportStepIdx, phase_usage_, summaryState, well_state_nupcol_, well_state_, rein);
-        double resv = 0.0;
-        wellGroupHelpers::updateVREPForGroups(fieldGroup, schedule(), reportStepIdx, well_state_nupcol_, well_state_, resv);
+        wellGroupHelpers::updateREINForGroups(fieldGroup, schedule(), reportStepIdx, phase_usage_, summaryState, well_state_nupcol_, well_state_);
+        wellGroupHelpers::updateVREPForGroups(fieldGroup, schedule(), reportStepIdx, well_state_nupcol_, well_state_);
         well_state_.communicateReinVrep(comm);
 
         // compute wsolvent fraction for REIN wells

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -408,31 +408,27 @@ namespace Opm {
     }
 
 
-    inline void updateVREPForGroups(const Group& group, const Schedule& schedule, const int reportStepIdx, const WellStateFullyImplicitBlackoil& wellStateNupcol, WellStateFullyImplicitBlackoil& wellState, double& resv) {
+    inline void updateVREPForGroups(const Group& group, const Schedule& schedule, const int reportStepIdx, const WellStateFullyImplicitBlackoil& wellStateNupcol, WellStateFullyImplicitBlackoil& wellState) {
         for (const std::string& groupName : group.groups()) {
             const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            double thisResv = 0.0;
-            updateVREPForGroups(groupTmp, schedule, reportStepIdx, wellStateNupcol, wellState, thisResv);
-            resv += thisResv;
+            updateVREPForGroups(groupTmp, schedule, reportStepIdx, wellStateNupcol, wellState);
         }
         const int np = wellState.numPhases();
+        double resv = 0.0;
         for (int phase = 0; phase < np; ++phase) {
             resv += sumWellPhaseRates(wellStateNupcol.wellReservoirRates(), group, schedule, wellState, reportStepIdx, phase, /*isInjector*/ false);
         }
-
         wellState.setCurrentInjectionVREPRates(group.name(), resv);
     }
 
-    inline void updateREINForGroups(const Group& group, const Schedule& schedule, const int reportStepIdx, const PhaseUsage& pu, const SummaryState& st, const WellStateFullyImplicitBlackoil& wellStateNupcol, WellStateFullyImplicitBlackoil& wellState, std::vector<double>& rein) {
+    inline void updateREINForGroups(const Group& group, const Schedule& schedule, const int reportStepIdx, const PhaseUsage& pu, const SummaryState& st, const WellStateFullyImplicitBlackoil& wellStateNupcol, WellStateFullyImplicitBlackoil& wellState) {
         const int np = wellState.numPhases();
         for (const std::string& groupName : group.groups()) {
             const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            std::vector<double> thisRein(np, 0.0);
-            updateREINForGroups(groupTmp, schedule, reportStepIdx, pu, st, wellStateNupcol, wellState, thisRein);
-            for (int phase = 0; phase < np; ++phase) {
-                rein[phase] = thisRein[phase];
-            }
+            updateREINForGroups(groupTmp, schedule, reportStepIdx, pu, st, wellStateNupcol, wellState);
         }
+
+        std::vector<double> rein(np, 0.0);
         for (int phase = 0; phase < np; ++phase) {
             rein[phase] = sumWellPhaseRates(wellStateNupcol.wellRates(), group, schedule, wellState, reportStepIdx, phase, /*isInjector*/ false);
         }


### PR DESCRIPTION
Avoid adding the group contribution from children twice. 
This fixes Norne 4B. 