### PR TITLE
fixed: use std::make_tuple instead of initializer list

### DIFF
--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -1241,7 +1241,9 @@ BOOST_AUTO_TEST_CASE(UniformXTabulatedTwoDFunction)
 #ifdef HAVE_MPI
     std::vector<double> xPos{1.0, 2.0};
     std::vector<double> yPos{3.0, 4.0};
-    std::vector<std::vector<std::tuple<double,double,double>>> samples{{{1.0, 2.0, 3.0}}, {{4.0, 5.0, 6.0}}};
+    using SampleType = std::vector<std::vector<std::tuple<double,double,double>>>;
+    SampleType samples{{std::make_tuple(1.0, 2.0, 3.0)},
+                       {std::make_tuple(4.0, 5.0, 6.0)}};
     using FFuncType = Opm::UniformXTabulated2DFunction<double>;
     FFuncType val1(xPos, yPos, samples, FFuncType::Vertical);
     auto val2 = PackUnpack(val1);
@@ -1301,7 +1303,7 @@ BOOST_AUTO_TEST_CASE(WetGasPvt)
     std::vector<double> yPos{3.0, 4.0};
     using FFuncType = Opm::UniformXTabulated2DFunction<double>;
     using Samples = std::vector<std::vector<FFuncType::SamplePoint>>;
-    Samples samples({{{1.0, 2.0, 3.0}, {3.0, 4.0, 5.0}}});
+    Samples samples({{std::make_tuple(1.0, 2.0, 3.0), std::make_tuple(3.0, 4.0, 5.0)}});
     FFuncType func2(xPos, yPos, samples, FFuncType::Vertical);
     Opm::WetGasPvt<double> val1({1.0, 2.0}, {3.0, 4.0},
                                 {func2}, {func}, {func2},
@@ -1347,7 +1349,7 @@ BOOST_AUTO_TEST_CASE(LiveOilPvt)
     std::vector<double> yPos{3.0, 4.0};
     using FFuncType = Opm::UniformXTabulated2DFunction<double>;
     using Samples = std::vector<std::vector<FFuncType::SamplePoint>>;
-    Samples samples({{{1.0, 2.0, 3.0}, {3.0, 4.0, 5.0}}});
+    Samples samples({{std::make_tuple(1.0, 2.0, 3.0), std::make_tuple(3.0, 4.0, 5.0)}});
     FFuncType func2(xPos, yPos, samples, FFuncType::Vertical);
     Opm::LiveOilPvt<double> val1({1.0, 2.0}, {3.0, 4.0},
                                  {func2}, {func2}, {func2},


### PR DESCRIPTION
the constructor is explicit with gcc5.

Closes #2271 