### PR TITLE
Pass EnableBrine flag to BlackOilFluidState used for equilibration.

### DIFF
--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -85,6 +85,7 @@ class EclEquilInitializer
     enum { dimWorld = GridView::dimensionworld };
     enum { enableTemperature = GET_PROP_VALUE(TypeTag, EnableTemperature) };
     enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
+    enum { enableBrine = GET_PROP_VALUE(TypeTag, EnableBrine) };
 
 public:
     // NB: setting the enableEnergy argument to true enables storage of enthalpy and
@@ -94,6 +95,7 @@ public:
                                     enableTemperature,
                                     enableEnergy,
                                     Indices::gasEnabled,
+                                    enableBrine,
                                     Indices::numPhases
                                     > ScalarFluidState;
 


### PR DESCRIPTION
Gave compile error on clang due to narrowing (the int 3 -> bool). Bug did not cause trouble because default number of phases in the fluid state (3) was sufficient.