### PR TITLE
add custom target 'opm-simulators_prepare'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,8 @@ if (HAVE_OPM_TESTS)
     include (${CMAKE_CURRENT_SOURCE_DIR}/compareECLFiles.cmake)
 endif()
 
+add_custom_target(opm-simulators_prepare)
+
 opm_set_test_driver(${CMAKE_CURRENT_SOURCE_DIR}/tests/run-parallel-unitTest.sh "")
 
 opm_add_test(test_gatherconvergencereport


### PR DESCRIPTION
this acts as a syncronization point for the super-build.
the ebos objects do not depend directly on opm-common, and thus
they are can be built before the generated headers, which are
required, are in place. we can now use this to ensure the
generated headers are in place before proceeding.