### PR TITLE
Parallel Restart: Chase RFTConfig API Update

### DIFF
--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -1500,6 +1500,7 @@ std::size_t packSize(const RFTConfig& data,
                      Dune::MPIHelper::MPICommunicator comm)
 {
     return packSize(data.timeMap(), comm) +
+           packSize(data.firstRFTOutput(), comm) +
            packSize(data.wellOpenRftTime(), comm) +
            packSize(data.wellOpenRftName(), comm) +
            packSize(data.wellOpen(), comm) +
@@ -3224,6 +3225,7 @@ void pack(const RFTConfig& data,
           Dune::MPIHelper::MPICommunicator comm)
 {
     pack(data.timeMap(), buffer, position, comm);
+    pack(data.firstRFTOutput(), buffer, position, comm);
     pack(data.wellOpenRftTime(), buffer, position, comm);
     pack(data.wellOpenRftName(), buffer, position, comm);
     pack(data.wellOpen(), buffer, position, comm);
@@ -5575,19 +5577,21 @@ void unpack(RFTConfig& data,
             Dune::MPIHelper::MPICommunicator comm)
 {
     TimeMap timeMap;
+    std::size_t first_rft;
     std::pair<bool, std::size_t> wellOpenRftTime;
-    std::unordered_set<std::string> wellOpenRftName;
-    std::unordered_map<std::string, std::size_t> wellOpen;
+    RFTConfig::WellOpenTimeMap wellOpenRftName;
+    RFTConfig::WellOpenTimeMap wellOpen;
     RFTConfig::RFTMap rftConfig;
     RFTConfig::PLTMap pltConfig;
 
     unpack(timeMap, buffer, position, comm);
+    unpack(first_rft, buffer, position, comm);
     unpack(wellOpenRftTime, buffer, position, comm);
     unpack(wellOpenRftName, buffer, position, comm);
     unpack(wellOpen, buffer, position, comm);
     unpack(rftConfig, buffer, position, comm);
     unpack(pltConfig, buffer, position, comm);
-    data = RFTConfig(timeMap, wellOpenRftTime, wellOpenRftName,
+    data = RFTConfig(timeMap, first_rft, wellOpenRftTime, wellOpenRftName,
                      wellOpen, rftConfig, pltConfig);
 }
 

--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -2076,8 +2076,9 @@ BOOST_AUTO_TEST_CASE(RFTConfig)
 {
 #ifdef HAVE_MPI
     Opm::RFTConfig val1(getTimeMap(),
+                        std::size_t{1729},
                         {true, 1},
-                        {"test1", "test2"},
+                        {{"test1", 2}, {"test2", 3}},
                         {{"test3", 2}},
                         {{"test1", {{{Opm::RFTConfig::RFT::TIMESTEP, 3}}, 4}}},
                         {{"test2", {{{Opm::RFTConfig::PLT::REPT, 5}}, 6}}});
@@ -2309,8 +2310,9 @@ BOOST_AUTO_TEST_CASE(Schedule)
     Opm::Action::Actions acnts({getActionX()});
 
     Opm::RFTConfig rftc(getTimeMap(),
+                        std::size_t{1729},
                         {true, 1},
-                        {"test1", "test2"},
+                        {{"test1", 2}, {"test2", 3}},
                         {{"test3", 2}},
                         {{"test1", {{{Opm::RFTConfig::RFT::TIMESTEP, 3}}, 4}}},
                         {{"test2", {{{Opm::RFTConfig::PLT::REPT, 5}}, 6}}});


### PR DESCRIPTION
The `RFTConfig` object gained a new data member and constructor argument, in addition to altering the type of the data member `well_open_rft_name` from an `unordered_set` to an `unordered_map` in PR OPM/opm-common#1412.

Update serialization code accordingly.