### PR TITLE
changed: use CpGrid centroids

### DIFF
--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -160,11 +160,7 @@ public:
             const auto& elem = *elemIt;
             unsigned elemIdx = elemMapper.index(elem);
 
-            // compute the axis specific "centroids" used for the transmissibilities. for
-            // consistency with the flow simulator, we use the element centers as
-            // computed by opm-parser's Opm::EclipseGrid class for all axes.
-            unsigned cartesianCellIdx = cartMapper.cartesianIndex(elemIdx);
-            const auto& centroid = eclGrid.getCellCenter(cartesianCellIdx);
+            const auto& centroid = vanguard_.grid().cellCentroid(elemIdx);
             for (unsigned axisIdx = 0; axisIdx < dimWorld; ++axisIdx)
                 for (unsigned dimIdx = 0; dimIdx < dimWorld; ++dimIdx)
                     axisCentroids[axisIdx][elemIdx][dimIdx] = centroid[dimIdx];


### PR DESCRIPTION
Is the use of the EclipseGrid centroids really crucial here?

I see it causes small failures, but.. I don't want to do the complicated thing unless it actually is important.

Context: No eclipsegrid on non-root processes in parallel.