### PR TITLE
avoid instancing a new Runspec from deck to obtain active phases

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -371,7 +371,7 @@ int main(int argc, char** argv)
                 throw std::runtime_error("Unrecoverable errors were encountered while loading input.");
             }
         }
-        const auto& phases = Opm::Runspec(*deck).phases();
+        const auto& phases = eclipseState->runspec().phases();
         bool outputFiles = (outputMode != FileOutputMode::OUTPUT_NONE);
         // run the actual simulator
         //


### PR DESCRIPTION
this is already available in the eclipseState.
in particular, this is preparing for the case where only the
root-process has a deck instance.