### PR TITLE
WIP: Started to use local actnum in FP

### DIFF
--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -279,20 +279,9 @@ protected:
             equilCartesianIndexMapper_.reset(new CartesianIndexMapper(*equilGrid_));
         }
 
-        std::vector<int> actnum;
-        unsigned long actnum_size;
-        if (mpiRank == 0) {
-            actnum = Opm::UgGridHelpers::createACTNUM(*grid_);
-            actnum_size = actnum.size();
-        }
-
-        grid_->comm().broadcast(&actnum_size, 1, 0);
-        if (mpiRank != 0)
-            actnum.resize( actnum_size );
-
-        grid_->comm().broadcast(actnum.data(), actnum_size, 0);
-
-        auto & field_props = this->eclState().fieldProps();
+        grid_->switchToDistributedView();
+        auto& field_props = this->eclState().fieldProps();
+        std::vector<int> actnum = Opm::UgGridHelpers::createACTNUM(*grid_);
         const_cast<FieldPropsManager&>(field_props).reset_actnum(actnum);
     }
 

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -1744,12 +1744,13 @@ private:
 
     void createLocalFipnum_()
     {
-        const std::vector<int> fipnumGlobal = simulator_.vanguard().eclState().fieldProps().get_global_int("FIPNUM");
-        // Get compressed cell fipnum.
+        const auto& fp = simulator_.vanguard().eclState().fieldProps();
+        const std::vector<int>& fipnum_deck = fp.get_int("FIPNUM");
+        const auto& indexmap = fp.indexmap();
         const auto& gridView = simulator_.vanguard().gridView();
         unsigned numElements = gridView.size(/*codim=*/0);
         fipnum_.resize(numElements, 0.0);
-        if (!fipnumGlobal.empty()) {
+        if (!fipnum_deck.empty()) {
             ElementContext elemCtx(simulator_);
             ElementIterator elemIt = gridView.template begin</*codim=*/0>();
             const ElementIterator& elemEndIt = gridView.template end</*codim=*/0>();
@@ -1760,7 +1761,7 @@ private:
 
                 elemCtx.updatePrimaryStencil(elem);
                 const unsigned elemIdx = elemCtx.globalSpaceIndex(/*spaceIdx=*/0, /*timeIdx=*/0);
-                fipnum_[elemIdx] = fipnumGlobal[simulator_.vanguard().cartesianIndex(elemIdx)];
+                fipnum_[elemIdx] = fipnum_deck[indexmap[simulator_.vanguard().cartesianIndex(elemIdx)]];
             }
         }
     }

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -3188,11 +3188,10 @@ private:
     EclThresholdPressure<TypeTag> thresholdPressures_;
 
     std::vector<int> pvtnum_;
-    std::vector<unsigned short> satnum_;
-    std::vector<unsigned short> miscnum_;
-    std::vector<unsigned short> plmixnum_;
-
-    std::vector<unsigned short> rockTableIdx_;
+    std::vector<int> satnum_;
+    std::vector<int> miscnum_;
+    std::vector<int> plmixnum_;
+    std::vector<int> rockTableIdx_;
     std::vector<RockParams> rockParams_;
 
     std::vector<Scalar> maxPolymerAdsorption_;

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2725,18 +2725,6 @@ private:
         // initial reservoir temperature
         tempiData = fp.get_global_double("TEMPI");
 
-
-        // make sure that the size of the data arrays is correct
-#ifndef NDEBUG
-        assert(waterSaturationData.size() == numCartesianCells);
-        assert(gasSaturationData.size() == numCartesianCells);
-        assert(pressureData.size() == numCartesianCells);
-        if (FluidSystem::enableDissolvedGas())
-            assert(rsData.size() == numCartesianCells);
-        if (FluidSystem::enableVaporizedOil())
-            assert(rvData.size() == numCartesianCells);
-#endif
-
         // calculate the initial fluid states
         for (size_t dofIdx = 0; dofIdx < numDof; ++dofIdx) {
             auto& dofFluidState = initialFluidStates_[dofIdx];

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -388,7 +388,7 @@ private:
     std::vector<Scalar> thpresDefault_;
     std::vector<Scalar> thpres_;
     unsigned numEquilRegions_;
-    std::vector<unsigned char> elemEquilRegion_;
+    std::vector<int> elemEquilRegion_;
 
     // threshold pressure accross faults. EXPERIMENTAL!
     std::vector<Scalar> thpresftValues_;

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -123,11 +123,12 @@ public:
 
         // internalize the data specified using the EQLNUM keyword
         const auto& fp = eclState.fieldProps();
-        const auto& equilRegionData = fp.get_global_int("EQLNUM");
+        const auto& indexmap = fp.indexmap();
+        const auto& equilRegionData = fp.get_int("EQLNUM");
         elemEquilRegion_.resize(numElements, 0);
         for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
             int cartElemIdx = vanguard.cartesianIndex(elemIdx);
-            elemEquilRegion_[elemIdx] = equilRegionData[cartElemIdx] - 1;
+            elemEquilRegion_[elemIdx] = equilRegionData[indexmap[cartElemIdx]] - 1;
         }
 
         /*

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -498,9 +498,10 @@ private:
 #endif
 
         const auto& fp = vanguard_.eclState().fieldProps();
-        const auto& inputTranxData = fp.get_global_double("TRANX");
-        const auto& inputTranyData = fp.get_global_double("TRANY");
-        const auto& inputTranzData = fp.get_global_double("TRANZ");
+        const auto& inputTranxData = fp.get_double("TRANX");
+        const auto& inputTranyData = fp.get_double("TRANY");
+        const auto& inputTranzData = fp.get_double("TRANZ");
+        const auto& indexmap       = fp.indexmap();
         bool tranx_deckAssigned = false;                     // Ohh my ....
         bool trany_deckAssigned = false;
         bool tranz_deckAssigned = false;
@@ -532,26 +533,26 @@ private:
                 if (gc2 - gc1 == 1) {
                     if (tranx_deckAssigned)
                         // set simulator internal transmissibilities to values from inputTranx
-                        trans_[isId] = inputTranxData[gc1];
+                        trans_[isId] = inputTranxData[indexmap[gc1]];
                     else
                         // Scale transmissibilities with scale factor from inputTranx
-                        trans_[isId] *= inputTranxData[gc1];
+                        trans_[isId] *= inputTranxData[indexmap[gc1]];
                 }
                 else if (gc2 - gc1 == cartDims[0]) {
                     if (trany_deckAssigned)
                         // set simulator internal transmissibilities to values from inputTrany
-                        trans_[isId] = inputTranyData[gc1];
+                        trans_[isId] = inputTranyData[indexmap[gc1]];
                     else
                         // Scale transmissibilities with scale factor from inputTrany
-                        trans_[isId] *= inputTranyData[gc1];
+                        trans_[isId] *= inputTranyData[indexmap[gc1]];
                 }
                 else if (gc2 - gc1 == cartDims[0]*cartDims[1]) {
                     if (tranz_deckAssigned)
                         // set simulator internal transmissibilities to values from inputTranz
-                        trans_[isId] = inputTranzData[gc1];
+                        trans_[isId] = inputTranzData[indexmap[gc1]];
                     else
                         // Scale transmissibilities with scale factor from inputTranz
-                        trans_[isId] *= inputTranzData[gc1];
+                        trans_[isId] *= inputTranzData[indexmap[gc1]];
                 }
                 //else.. We don't support modification of NNC at the moment.
             }
@@ -710,22 +711,24 @@ private:
         // over several processes.)
         const auto& fp = vanguard_.eclState().fieldProps();
         if (fp.has_double("PERMX")) {
-            const std::vector<double>& permxData = fp.get_global_double("PERMX");
+            const auto& indexmap = fp.indexmap();
+            const std::vector<double>& permxData = fp.get_double("PERMX");
 
             std::vector<double> permyData(permxData);
             if (fp.has_double("PERMY"))
-                permyData = fp.get_global_double("PERMY");
+                permyData = fp.get_double("PERMY");
 
             std::vector<double> permzData(permxData);
             if (fp.has_double("PERMZ"))
-                permzData = fp.get_global_double("PERMZ");
+                permzData = fp.get_double("PERMZ");
 
             for (size_t dofIdx = 0; dofIdx < numElem; ++ dofIdx) {
                 unsigned cartesianElemIdx = vanguard_.cartesianIndex(dofIdx);
+                const auto& input_index = indexmap[cartesianElemIdx];
                 permeability_[dofIdx] = 0.0;
-                permeability_[dofIdx][0][0] = permxData[cartesianElemIdx];
-                permeability_[dofIdx][1][1] = permyData[cartesianElemIdx];
-                permeability_[dofIdx][2][2] = permzData[cartesianElemIdx];
+                permeability_[dofIdx][0][0] = permxData[input_index];
+                permeability_[dofIdx][1][1] = permyData[input_index];
+                permeability_[dofIdx][2][2] = permzData[input_index];
             }
 
             // for now we don't care about non-diagonal entries

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -861,6 +861,8 @@ private:
         bool opmfil = eclGrid.getMinpvMode() == Opm::MinpvMode::OpmFIL;
         std::vector<double> ntg;
 
+        // ## Warning: this looks broken - in general the global data is not
+        //    really available any longer after it has been compressed.
         ntg = eclState.fieldProps().get_global_double("NTG");
         // just return the unmodified ntg if opmfil is not used
         averageNtg = ntg;

--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -1079,6 +1079,8 @@ public:
     const Vec& rv() const { return rv_; }
 
 private:
+
+    // ##Warning: This looks extremely suspicious??
     void updateInitialTemperature_(const Opm::EclipseState& eclState)
     {
         // Get the initial temperature data


### PR DESCRIPTION
The main part of the "use only active cells in the properties" PR has been merged. This is the cleanup in opm-simulators / opm-material:

For a parallell simulation there are three levels of active cells:

1. It is all nx * ny * nz cells in the cartesian box - this is what I typically call global in code I write.
2.  It is the total set of active cells in the model.
3.  It is the set of active cells for this particular process.

Previously opm-common created 3D properties of the kind 1 above, and then opm-simulators/opm-material extracted the interesting properties down to the set of active cells for the active process - i.e. the transition 1 → 3. The current implementation is on level 2 above, the transition 2 → 3 is quite simple to implement, but to keep the amount of changes down the initial merge created a temporary global vector and then subsequently reuses the existing 1 → 3 implementation. 

The purpose of this refactoring is to go directly 2 → 3. This will be the final non trivial step in the 3D refactoring.

**Update technical:**

It is clear from review comments that I have started this PR in the wrong direction; the attempt has been my best shot - so now I will need some guidance to get this in the right direction. In the example below I have tried to illustrate the three stages mentioned above with a sample model with eightcells in the input file, of these cells five are active - and finally everything is distributed on two processes. 


![DSC_0358](https://user-images.githubusercontent.com/1321665/72806393-643fa200-3c55-11ea-9a24-2350c3d525d3.JPG)

*Stage 1:*

This shows the initial property with eight cells, which have the values 0,1,2,..,7 and the corresponding ACTNUM vector. This is the way the input is organised in the ECLIPSE input file. The color coding is that black elements correspond to inactive cells, whereas red and blue elements correspond to active cells; the difference between red and blue is that they will eventually end up on two different processors in the parallel situation.


*Stage 2:*

This shows only the compressed property where the inactive cells have been removed. The ACTNUM vector is not illustrated here - it is unchanged from stage 1.

*Stage 3:*

This shows (my idea of ...) how this would be distributed to two different processes with two elementson rank 0 and three elements on rank 1. Now the two different processors have different ACTNUM vectors.

**Old implementation:**
The old property system internalized properties at stage1 and then there was code in opm-simulators / opm-material which tranferred 1 &rightarrow; 3.

**Current master:**
In the current master all properties are internalized at level 2, but when it is distributed to different processors the old 1 &rightarrow; 3 is used, so the current transformation is 2 &rightarrow; 1 &rightarrow; 3

**This PR**
The purpose of this PR is to facilitate the direct transformation 2 &rightarrow; 3. The `FieldPropsManager` class has a method `reset_actnum()` which can be used to shrink the internal property vectors when cells have been deactivated. 

This PR has been based on the following core code:
```C++
// This code runs on all PE's - i.e. each process gets it's private ACTNUM vector
std::vector<int> actnum = Opm::UgGridHelpers::createACTNUM(*grid_);

// Reset the FieldProperties to only contain the cells which are active 
// on this particualar PE
fp.reset_actnum( actnum );
```

I realize this is too simple minded; but I am at a loss of what is the correct way to approach this. Would appreciate some guidance.


**Update political:**
I realize that it seems like my PR is pushing the code in a unwanted direction when it comes to the ability to use different grids than `CpGrid` - that is totally out of ignorance/lack of competence and does not in any way represent an agenda on my part. My only goal here is to get this to work with the `FieldPropsManager` implementation in opm-common, without going through intermediate global vectors. 