### PR TITLE
Local actnum prep

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -3199,11 +3199,10 @@ private:
     EclThresholdPressure<TypeTag> thresholdPressures_;
 
     std::vector<int> pvtnum_;
-    std::vector<unsigned short> satnum_;
-    std::vector<unsigned short> miscnum_;
-    std::vector<unsigned short> plmixnum_;
-
-    std::vector<unsigned short> rockTableIdx_;
+    std::vector<int> satnum_;
+    std::vector<int> miscnum_;
+    std::vector<int> plmixnum_;
+    std::vector<int> rockTableIdx_;
     std::vector<RockParams> rockParams_;
 
     std::vector<Scalar> maxPolymerAdsorption_;

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2736,18 +2736,6 @@ private:
         // initial reservoir temperature
         tempiData = fp.get_global_double("TEMPI");
 
-
-        // make sure that the size of the data arrays is correct
-#ifndef NDEBUG
-        assert(waterSaturationData.size() == numCartesianCells);
-        assert(gasSaturationData.size() == numCartesianCells);
-        assert(pressureData.size() == numCartesianCells);
-        if (FluidSystem::enableDissolvedGas())
-            assert(rsData.size() == numCartesianCells);
-        if (FluidSystem::enableVaporizedOil())
-            assert(rvData.size() == numCartesianCells);
-#endif
-
         // calculate the initial fluid states
         for (size_t dofIdx = 0; dofIdx < numDof; ++dofIdx) {
             auto& dofFluidState = initialFluidStates_[dofIdx];

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -388,7 +388,7 @@ private:
     std::vector<Scalar> thpresDefault_;
     std::vector<Scalar> thpres_;
     unsigned numEquilRegions_;
-    std::vector<unsigned char> elemEquilRegion_;
+    std::vector<int> elemEquilRegion_;
 
     // threshold pressure accross faults. EXPERIMENTAL!
     std::vector<Scalar> thpresftValues_;


### PR DESCRIPTION
Extracted two trivial commits from: https://github.com/OPM/opm-simulators/pull/2289

The change to use `std::vector<int>` is to allow for simpler interoperability with the data which comes from opm-common.

The content in the secomd commit is removed because we no longer use properties of global size - I.e it has become irrelevant/wrong. 