### PR TITLE
Avoid deck usage on non-root processes checking for keywords

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2466,12 +2466,12 @@ private:
     {
         const auto& simulator = this->simulator();
         const auto& vanguard = simulator.vanguard();
+        const auto& eclState = vanguard.eclState();
 
-        const auto& deck = vanguard.deck();
-        if (!deck.hasKeyword("EQUIL"))
-            readExplicitInitialCondition_();
-        else
+        if (eclState.getInitConfig().hasEquil())
             readEquilInitialCondition_();
+        else
+            readExplicitInitialCondition_();
 
         readBlackoilExtentionsInitialConditions_();
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -666,10 +666,9 @@ public:
         // disables gravity, else the standard value of the gravity constant at sea level
         // on earth is used
         this->gravity_ = 0.0;
-        const auto& deck = simulator.vanguard().deck();
         if (EWOMS_GET_PARAM(TypeTag, bool, EnableGravity))
             this->gravity_[dim - 1] = 9.80665;
-        if (deck.hasKeyword("NOGRAV"))
+        if (!eclState.getInitConfig().hasGravity())
             this->gravity_[dim - 1] = 0.0;
 
         if (enableTuning_) {

--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -591,6 +591,7 @@ std::size_t packSize(const InitConfig& data, Dune::MPIHelper::MPICommunicator co
     return packSize(data.getEquil(), comm) +
            packSize(data.getFoamConfig(), comm) +
            packSize(data.filleps(), comm) +
+           packSize(data.hasGravity(), comm) +
            packSize(data.restartRequested(), comm) +
            packSize(data.getRestartStep(), comm) +
            packSize(data.getRestartRootName(), comm);
@@ -2398,6 +2399,7 @@ void pack(const InitConfig& data, std::vector<char>& buffer, int& position,
     pack(data.getEquil(), buffer, position, comm);
     pack(data.getFoamConfig(), buffer, position, comm);
     pack(data.filleps(), buffer, position, comm);
+    pack(data.hasGravity(), buffer, position, comm);
     pack(data.restartRequested(), buffer, position, comm);
     pack(data.getRestartStep(), buffer, position, comm);
     pack(data.getRestartRootName(), buffer, position, comm);
@@ -4379,17 +4381,18 @@ void unpack(InitConfig& data, std::vector<char>& buffer, int& position,
 {
     Equil equil;
     FoamConfig foam;
-    bool filleps, restartRequested;
+    bool filleps, hasGravity, restartRequested;
     int restartStep;
     std::string restartRootName;
     unpack(equil, buffer, position, comm);
     unpack(foam, buffer, position, comm);
     unpack(filleps, buffer, position, comm);
+    unpack(hasGravity, buffer, position, comm);
     unpack(restartRequested, buffer, position, comm);
     unpack(restartStep, buffer, position, comm);
     unpack(restartRootName, buffer, position, comm);
-    data = InitConfig(equil, foam, filleps, restartRequested,
-                      restartStep, restartRootName);
+    data = InitConfig(equil, foam, filleps, hasGravity,
+                      restartRequested, restartStep, restartRootName);
 }
 
 void unpack(SimulationConfig& data, std::vector<char>& buffer, int& position,

--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -758,7 +758,7 @@ BOOST_AUTO_TEST_CASE(InitConfig)
 #if HAVE_MPI
     Opm::InitConfig val1(Opm::Equil({getEquilRecord(), getEquilRecord()}),
                          Opm::FoamConfig({getFoamData(), getFoamData()}),
-                         true, true, 20, "test1");
+                         true, true, true, 20, "test1");
     auto val2 = PackUnpack(val1);
     BOOST_CHECK(std::get<1>(val2) == std::get<2>(val2));
     BOOST_CHECK(val1 == std::get<0>(val2));
@@ -2453,7 +2453,7 @@ BOOST_AUTO_TEST_CASE(EclipseConfig)
                      "test2", true, "test3", false);
     Opm::InitConfig init(Opm::Equil({getEquilRecord(), getEquilRecord()}),
                          Opm::FoamConfig({getFoamData(), getFoamData()}),
-                         true, true, 20, "test1");
+                         true, true, true, 20, "test1");
     Opm::DynamicState<Opm::RestartSchedule> rsched({Opm::RestartSchedule(1, 2, 3)}, 2);
     Opm::DynamicState<std::map<std::string,int>> rkw({{{"test",3}}}, 3);
     Opm::RestartConfig restart(getTimeMap(), 1, true, rsched, rkw, {false, true});


### PR DESCRIPTION
Use EclipseState internalized  variables instead.

Downstream of https://github.com/OPM/opm-common/pull/1424