### PR TITLE
Chase Runspec Member Update

### DIFF
--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -455,6 +455,7 @@ HANDLE_AS_POD(PVTWRecord)
 HANDLE_AS_POD(PVCDORecord)
 HANDLE_AS_POD(Regdims)
 HANDLE_AS_POD(ROCKRecord)
+HANDLE_AS_POD(SatFuncControls)
 HANDLE_AS_POD(Tabdims)
 HANDLE_AS_POD(TimeStampUTC::YMD)
 HANDLE_AS_POD(VISCREFRecord)
@@ -668,7 +669,8 @@ std::size_t packSize(const Runspec& data, Dune::MPIHelper::MPICommunicator comm)
            packSize(data.wellSegmentDimensions(), comm) +
            packSize(data.udqParams(), comm) +
            packSize(data.hysterPar(), comm) +
-           packSize(data.actdims(), comm);
+           packSize(data.actdims(), comm) +
+           packSize(data.saturationFunctionControls(), comm);
 }
 
 std::size_t packSize(const PvtxTable& data, Dune::MPIHelper::MPICommunicator comm)
@@ -2502,6 +2504,7 @@ void pack(const Runspec& data, std::vector<char>& buffer, int& position,
     pack(data.udqParams(), buffer, position, comm);
     pack(data.hysterPar(), buffer, position, comm);
     pack(data.actdims(), buffer, position, comm);
+    pack(data.saturationFunctionControls(), buffer, position, comm);
 }
 
 void pack(const PvtxTable& data, std::vector<char>& buffer, int& position,
@@ -4565,6 +4568,7 @@ void unpack(Runspec& data, std::vector<char>& buffer, int& position,
     UDQParams udqparams;
     EclHysterConfig hystPar;
     Actdims actdims;
+    SatFuncControls sfuncctrl;
     unpack(phases, buffer, position, comm);
     unpack(tabdims, buffer, position, comm);
     unpack(endScale, buffer, position, comm);
@@ -4573,8 +4577,9 @@ void unpack(Runspec& data, std::vector<char>& buffer, int& position,
     unpack(udqparams, buffer, position, comm);
     unpack(hystPar, buffer, position, comm);
     unpack(actdims, buffer, position, comm);
+    unpack(sfuncctrl, buffer, position, comm);
     data = Runspec(phases, tabdims, endScale, wellDims, wsegDims,
-                   udqparams, hystPar, actdims);
+                   udqparams, hystPar, actdims, sfuncctrl);
 }
 
 template<class PVTType>

--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -922,7 +922,8 @@ BOOST_AUTO_TEST_CASE(Runspec)
                       Opm::WellSegmentDims(1,2,3),
                       Opm::UDQParams(true, 1, 2.0, 3.0, 4.0),
                       Opm::EclHysterConfig(true, 1, 2),
-                      Opm::Actdims(1,2,3,4));
+                      Opm::Actdims(1,2,3,4),
+                      Opm::SatFuncControls(5.0e-7));
 
     auto val2 = PackUnpack(val1);
     BOOST_CHECK(std::get<1>(val2) == std::get<2>(val2));
@@ -2262,7 +2263,8 @@ BOOST_AUTO_TEST_CASE(Schedule)
                          Opm::WellSegmentDims(1,2,3),
                          Opm::UDQParams(true, 1, 2.0, 3.0, 4.0),
                          Opm::EclHysterConfig(true, 1, 2),
-                         Opm::Actdims(1,2,3,4));
+                         Opm::Actdims(1,2,3,4),
+                         Opm::SatFuncControls(5.6e-7));
     Opm::Schedule::VFPProdMap vfpProd {{1, {{std::make_shared<Opm::VFPProdTable>(getVFPProdTable())},1}}};
     Opm::Schedule::VFPInjMap vfpIn{{1, {{std::make_shared<Opm::VFPInjTable>(getVFPInjTable())},1}}};
     Opm::WellTestConfig::WTESTWell tw{"test", Opm::WellTestConfig::ECONOMIC,


### PR DESCRIPTION
The Runspec class gained a new data member of type SatFuncControls.
Update the serialization code accordingly.

Downstream from OPM/opm-common#1431.