### PR TITLE
Use bc

### DIFF
--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -464,6 +464,7 @@ HANDLE_AS_POD(WellBrineProperties)
 HANDLE_AS_POD(Welldims)
 HANDLE_AS_POD(WellFoamProperties)
 HANDLE_AS_POD(WellSegmentDims)
+HANDLE_AS_POD(BCConfig::BCFace)
 
 std::size_t packSize(const data::Well& data, Dune::MPIHelper::MPICommunicator comm)
 {

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -75,6 +75,7 @@ namespace Action {
 }
 
 class Aqudims;
+class BCConfig;
 class BrineDensityTable;
 class ColumnSchema;
 class Connection;
@@ -656,6 +657,7 @@ ADD_PACK_PROTOTYPES(Action::ASTNode)
 ADD_PACK_PROTOTYPES(Action::Condition)
 ADD_PACK_PROTOTYPES(Action::Quantity)
 ADD_PACK_PROTOTYPES(Aqudims)
+ADD_PACK_PROTOTYPES(BCConfig)
 ADD_PACK_PROTOTYPES(BrineDensityTable)
 ADD_PACK_PROTOTYPES(ColumnSchema)
 ADD_PACK_PROTOTYPES(Connection)

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -76,6 +76,7 @@ namespace Action {
 
 class Aqudims;
 class BCConfig;
+class BCConfig::BCFace;
 class BrineDensityTable;
 class ColumnSchema;
 class Connection;
@@ -658,6 +659,7 @@ ADD_PACK_PROTOTYPES(Action::Condition)
 ADD_PACK_PROTOTYPES(Action::Quantity)
 ADD_PACK_PROTOTYPES(Aqudims)
 ADD_PACK_PROTOTYPES(BCConfig)
+ADD_PACK_PROTOTYPES(BCConfig::BCFace)
 ADD_PACK_PROTOTYPES(BrineDensityTable)
 ADD_PACK_PROTOTYPES(ColumnSchema)
 ADD_PACK_PROTOTYPES(Connection)

--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -73,6 +73,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WList.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WListManager.hpp>
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
@@ -182,6 +183,11 @@ Opm::ThresholdPressure getThresholdPressure()
                                   {{{1,2},{false,3.0}},{{2,3},{true,4.0}}});
 }
 
+
+Opm::BCConfig getBCConfig()
+{
+    return Opm::BCConfig({{10,11,12,13,14,15,Opm::BCType::RATE,Opm::FaceDir::XPlus, Opm::BCComponent::GAS, 100.0}});
+}
 
 Opm::TableSchema getTableSchema()
 {
@@ -768,7 +774,18 @@ BOOST_AUTO_TEST_CASE(InitConfig)
 BOOST_AUTO_TEST_CASE(SimulationConfig)
 {
 #if HAVE_MPI
-    Opm::SimulationConfig val1(getThresholdPressure(), false, true, false, true);
+    Opm::SimulationConfig val1(getThresholdPressure(), getBCConfig(), false, true, false, true);
+    auto val2 = PackUnpack(val1);
+    BOOST_CHECK(std::get<1>(val2) == std::get<2>(val2));
+    BOOST_CHECK(val1 == std::get<0>(val2));
+#endif
+}
+
+
+BOOST_AUTO_TEST_CASE(BCConfig)
+{
+#if HAVE_MPI
+    Opm::BCConfig val1({{10,11,12,13,14,15,Opm::BCType::RATE, Opm::FaceDir::XPlus, Opm::BCComponent::GAS, 100}});
     auto val2 = PackUnpack(val1);
     BOOST_CHECK(std::get<1>(val2) == std::get<2>(val2));
     BOOST_CHECK(val1 == std::get<0>(val2));


### PR DESCRIPTION
Add class BCConfig to serialization.

Use BCConfig instead of  `Deck` when setting up boundary conditions.

Downstream of : https://github.com/OPM/opm-common/pull/1430