### PR TITLE
Parallel thermal simulations

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -505,4 +505,11 @@ if(MPI_FOUND)
                                        SIMULATOR flow
                                        ABS_TOL ${abs_tol}
                                        REL_TOL ${rel_tol})
+
+  add_test_compare_parallel_simulation(CASENAME spe1_thermal
+                                       FILENAME SPE1CASE2_THERMAL
+                                       SIMULATOR flow
+                                       ABS_TOL ${abs_tol_parallel}
+                                       REL_TOL 1e-1
+                                       DIR spe1)
 endif()

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -3023,7 +3023,7 @@ private:
             for (const auto& bcface : bcconfig) {
                 const auto& type = bcface.bctype;
                 if (type == BCType::RATE) {
-                    int compIdx;
+                    int compIdx = 0;
 
                     switch (bcface.component) {
                     case BCComponent::OIL:

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2387,7 +2387,6 @@ private:
 
         const auto& simulator = this->simulator();
         const auto& vanguard = simulator.vanguard();
-        const auto& deck = vanguard.deck();
         const auto& eclState = vanguard.eclState();
 
         // fluid-matrix interactions (saturation functions; relperm/capillary pressure)
@@ -2397,7 +2396,7 @@ private:
             compressedToCartesianElemIdx[elemIdx] = vanguard.cartesianIndex(elemIdx);
 
         thermalLawManager_ = std::make_shared<EclThermalLawManager>();
-        thermalLawManager_->initFromDeck(deck, eclState, compressedToCartesianElemIdx);
+        thermalLawManager_->initParamsForElements(eclState, compressedToCartesianElemIdx);
     }
 
     void updateReferencePorosity_()

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -291,8 +291,8 @@ std::size_t packSize(const LiveOilPvt<Scalar>& data,
 template<class Scalar>
 std::size_t packSize(const OilPvtThermal<Scalar>& data, Dune::MPIHelper::MPICommunicator comm);
 
-template<class Scalar, bool enableThermal>
-std::size_t packSize(const WaterPvtMultiplexer<Scalar,enableThermal>& data,
+template<class Scalar, bool enableThermal, bool enableBrine>
+std::size_t packSize(const WaterPvtMultiplexer<Scalar,enableThermal,enableBrine>& data,
                      Dune::MPIHelper::MPICommunicator comm);
 
 template<class Scalar>
@@ -451,8 +451,8 @@ template<class Scalar>
 void pack(const OilPvtThermal<Scalar>& data, std::vector<char>& buffer,
           int& position, Dune::MPIHelper::MPICommunicator comm);
 
-template<class Scalar, bool enableThermal>
-void pack(const WaterPvtMultiplexer<Scalar,enableThermal>& data,
+template<class Scalar, bool enableThermal, bool enableBrine>
+void pack(const WaterPvtMultiplexer<Scalar,enableThermal,enableBrine>& data,
           const std::vector<char>& buffer, int& position,
           Dune::MPIHelper::MPICommunicator comm);
 
@@ -615,8 +615,8 @@ template<class Scalar>
 void unpack(OilPvtThermal<Scalar>& data, std::vector<char>& buffer,
             int& position, Dune::MPIHelper::MPICommunicator comm);
 
-template<class Scalar, bool enableThermal>
-void unpack(WaterPvtMultiplexer<Scalar,enableThermal>& data,
+template<class Scalar, bool enableThermal, bool enableBrine>
+void unpack(WaterPvtMultiplexer<Scalar,enableThermal,enableBrine>& data,
             const std::vector<char>& buffer, int& position,
             Dune::MPIHelper::MPICommunicator comm);
 

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -75,8 +75,6 @@ namespace Action {
 }
 
 class Aqudims;
-class BCConfig;
-class BCConfig::BCFace;
 class BrineDensityTable;
 class ColumnSchema;
 class Connection;


### PR DESCRIPTION
- some janitoring
- some fixes after brine addition
- avoid deck usage setting up thermal law manager
- add a thermal parallel regression test

I am somewhat worried about the coarse tolerances needed for the test to pass, but in any case this is an improvement.

Downstream of https://github.com/OPM/opm-material/pull/390