### PR TITLE
Preparatory changes for single-process parsing

### DIFF
--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -258,13 +258,14 @@ public:
 protected:
     void createGrids_()
     {
-        const auto& porv = this->eclState().fieldProps().porv(true);
         grid_.reset(new Dune::CpGrid());
-        grid_->processEclipseFormat(&(this->eclState().getInputGrid()),
+        grid_->processEclipseFormat(mpiRank == 0 ? &this->eclState().getInputGrid()
+                                                 : nullptr,
                                     /*isPeriodic=*/false,
                                     /*flipNormals=*/false,
                                     /*clipZ=*/false,
-                                    porv,
+                                    mpiRank == 0 ? this->eclState().fieldProps().porv(true)
+                                                 : std::vector<double>(),
                                     this->eclState().getInputNNC());
 
         // we use separate grid objects: one for the calculation of the initial condition

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -278,23 +278,11 @@ protected:
         {
             equilGrid_.reset(new Dune::CpGrid(*grid_));
             equilCartesianIndexMapper_.reset(new CartesianIndexMapper(*equilGrid_));
+
+            std::vector<int> actnum = Opm::UgGridHelpers::createACTNUM(*grid_);
+            auto &field_props = this->eclState().fieldProps();
+            const_cast<FieldPropsManager&>(field_props).reset_actnum(actnum);
         }
-
-        std::vector<int> actnum;
-        unsigned long actnum_size;
-        if (mpiRank == 0) {
-            actnum = Opm::UgGridHelpers::createACTNUM(*grid_);
-            actnum_size = actnum.size();
-        }
-
-        grid_->comm().broadcast(&actnum_size, 1, 0);
-        if (mpiRank != 0)
-            actnum.resize( actnum_size );
-
-        grid_->comm().broadcast(actnum.data(), actnum_size, 0);
-
-        auto & field_props = this->eclState().fieldProps();
-        const_cast<FieldPropsManager&>(field_props).reset_actnum(actnum);
     }
 
     // removing some connection located in inactive grid cells

--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -96,8 +96,14 @@ public:
     void init()
     {
         const Opm::Deck& deck = simulator_.vanguard().deck();
+        const auto& comm = simulator_.gridView().comm();
 
-        if (!deck.hasKeyword("TRACERS"))
+        bool has;
+        if (comm.rank() == 0)
+            has = deck.hasKeyword("TRACERS");
+        comm.broadcast(&has, 1, 0);
+
+        if (!has)
             return; // tracer treatment is supposed to be disabled
 
         if (!EWOMS_GET_PARAM(TypeTag, bool, EnableTracerModel)) {

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -140,7 +140,17 @@ void
 BlackoilAquiferModel<TypeTag>::init()
 {
     const auto& deck = this->simulator_.vanguard().deck();
-    if (deck.hasKeyword("AQUCT")) {
+    const auto& comm = this->simulator_.vanguard().gridView().comm();
+
+    bool has;
+    if (comm.rank() == 0)
+        has = deck.hasKeyword("AQUCT");
+    comm.broadcast(&has, 1, 0);
+
+    if (has) {
+         if (comm.size() > 1)
+             throw std::runtime_error("Aquifers currently do not work in parallel.");
+
         // updateConnectionIntensiveQuantities();
         const auto& eclState = this->simulator_.vanguard().eclState();
 

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -173,7 +173,14 @@ BlackoilAquiferModel<TypeTag>::init()
                 aquifer_connection.at(i), cartesian_to_compressed_, this->simulator_, aquifersData.at(i)));
         }
     }
-    if (deck.hasKeyword("AQUFETP")) {
+    if (comm.rank() == 0)
+        has = deck.hasKeyword("AQUFETP");
+    comm.broadcast(&has, 1, 0);
+
+    if (has) {
+         if (comm.size() > 1)
+             throw std::runtime_error("Aquifers currently do not work in parallel.");
+
         // updateConnectionIntensiveQuantities();
         const auto& eclState = this->simulator_.vanguard().eclState();
 


### PR DESCRIPTION
Avoid some deck usage, avoid some dereferencing.

The deck-access avoid is done simple right now, ideally these things would be internalized in EclipseState, but I don't want to be held up by them right now. Furthermore,  since neither tracers nor aquifers currently work in parallel, it's not that big of a deal.