### PR TITLE
[WIP] Refactor well state

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -69,6 +69,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_norne_pvt.cpp
   tests/test_ParallelRestart.cpp
   tests/test_wellstatefullyimplicitblackoil.cpp
+  tests/test_wellandgroupstates.cpp
   )
 
 if(MPI_FOUND)
@@ -197,4 +198,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/MSWellHelpers.hpp
   opm/simulators/wells/BlackoilWellModel.hpp
   opm/simulators/wells/BlackoilWellModel_impl.hpp
+  opm/simulators/wells/SingleGroupState.hpp
+  opm/simulators/wells/SingleWellState.hpp
+  opm/simulators/wells/WellAndGroupStates.hpp
   )

--- a/opm/simulators/wells/SingleGroupState.hpp
+++ b/opm/simulators/wells/SingleGroupState.hpp
@@ -47,11 +47,11 @@ struct SingleGroupState
     Group::ProductionCMode current_production_control = Group::ProductionCMode::NONE;
 
     // Quantities.
-    PhaseRates production_reduction_surface_rates;
-    PhaseRates injection_reduction_surface_rates;
-    PhaseRates injection_potentials;
-    PhaseRates injection_vrep_rates;
-    PhaseRates injection_rein_rates;
+    PhaseRates production_reduction_surface_rates = {0.0};
+    PhaseRates injection_reduction_surface_rates = {0.0};
+    PhaseRates injection_potentials = {0.0};
+    PhaseRates injection_vrep_rates = {0.0};
+    PhaseRates injection_rein_rates = {0.0};
 };
 
 

--- a/opm/simulators/wells/SingleGroupState.hpp
+++ b/opm/simulators/wells/SingleGroupState.hpp
@@ -1,0 +1,62 @@
+/*
+  Copyright 2012, 2014 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2017, 2019 NORCE.
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_SINGLEGROUPSTATE_HEADER_INCLUDED
+#define OPM_SINGLEGROUPSTATE_HEADER_INCLUDED
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
+
+#include <array>
+
+namespace Opm
+{
+
+/// Encapsulate all data needed to represent the state of a well group
+/// for persistence purposes, i.e. from one timestep to the next or
+/// for restarting, and for accumulating rates to get correct group
+/// rate limits.
+template <int NumActiveComponents, int NumActivePhases>
+struct SingleGroupState
+{
+    // ------ Types ------
+
+    using ComponentRates = std::array<double, NumActiveComponents>;
+    using PhaseRates = std::array<double, NumActivePhases>;
+
+    // ------ Data members ------
+
+    // Flags and statuses.
+    Group::InjectionCMode current_injection_control = Group::InjectionCMode::NONE;
+    Group::ProductionCMode current_production_control = Group::ProductionCMode::NONE;
+
+    // Quantities.
+    ComponentRates production_reduction_rates;
+    ComponentRates injection_reduction_rates;
+    ComponentRates injection_potentials;
+    PhaseRates injection_vrep_rates;
+    ComponentRates injection_rein_rates;
+};
+
+
+} // namespace Opm
+
+
+#endif // OPM_SINGLEGROUPSTATE_HEADER_INCLUDED

--- a/opm/simulators/wells/SingleGroupState.hpp
+++ b/opm/simulators/wells/SingleGroupState.hpp
@@ -33,12 +33,11 @@ namespace Opm
 /// for persistence purposes, i.e. from one timestep to the next or
 /// for restarting, and for accumulating rates to get correct group
 /// rate limits.
-template <int NumActiveComponents, int NumActivePhases>
+template <int NumActivePhases>
 struct SingleGroupState
 {
     // ------ Types ------
 
-    using ComponentRates = std::array<double, NumActiveComponents>;
     using PhaseRates = std::array<double, NumActivePhases>;
 
     // ------ Data members ------
@@ -48,11 +47,11 @@ struct SingleGroupState
     Group::ProductionCMode current_production_control = Group::ProductionCMode::NONE;
 
     // Quantities.
-    ComponentRates production_reduction_rates;
-    ComponentRates injection_reduction_rates;
-    ComponentRates injection_potentials;
+    PhaseRates production_reduction_surface_rates;
+    PhaseRates injection_reduction_surface_rates;
+    PhaseRates injection_potentials;
     PhaseRates injection_vrep_rates;
-    ComponentRates injection_rein_rates;
+    PhaseRates injection_rein_rates;
 };
 
 

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -73,6 +73,7 @@ struct SingleWellState
     double dissolved_gas_rate = 0.0;
     double vaporized_oil_rate = 0.0;
     PhaseRates potentials = {0.0};
+    PhaseRates productivity_index = {0.0};
 
     // Connection and segment data.
     std::vector<Connection> connections;

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -1,0 +1,86 @@
+/*
+  Copyright 2012, 2014 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2017 NORCE.
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_SINGLEWELLSTATE_HEADER_INCLUDED
+#define OPM_SINGLEWELLSTATE_HEADER_INCLUDED
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+
+#include <array>
+#include <vector>
+
+namespace Opm
+{
+
+/// Encapsulate all data needed to represent the state of a well for persistence purposes,
+/// i.e. from one timestep to the next or for restarting.
+template <int NumActiveComponents, int NumActivePhases>
+struct SingleWellState
+{
+    // ------ Types ------
+
+    using ComponentRates = std::array<double, NumActiveComponents>;
+    using PhaseRates = std::array<double, NumActivePhases>;
+
+    struct Connection {
+        double pressure = -1e100;
+        ComponentRates surface_rates = {0.0};
+        PhaseRates reservoir_rates = {0.0};
+        double water_throughput = 0.0;
+        double skin_pressure = 0.0;
+        double water_velocity = 0.0;
+    };
+
+    struct Segment {
+        int segment_number = -1;
+        double pressure = -1e100;
+        ComponentRates surface_rates = {0.0};
+    };
+
+    // ------ Data members ------
+
+    // Flags and statuses.
+    Well::Status status = Well::Status::SHUT;
+    bool is_producer = true;
+    Well::InjectorCMode current_injection_control = Well::InjectorCMode::CMODE_UNDEFINED;
+    Well::ProducerCMode current_production_control = Well::ProducerCMode::CMODE_UNDEFINED;
+    bool effective_events_occurred = false;
+
+    // Quantities.
+    double bhp = -1e100;
+    double thp = -1e100;
+    double temperature = 273.15 + 20; // 20 degrees Celcius by default.
+    ComponentRates surface_rates = {0.0};
+    PhaseRates reservoir_rates = {0.0};
+    double dissolved_gas_rate = 0.0;
+    double vaporized_oil_rate = 0.0;
+    ComponentRates potentials = {0.0};
+
+    // Connection and segment data.
+    std::vector<Connection> connections;
+    std::vector<Segment> segments;
+};
+
+
+} // namespace Opm
+
+
+#endif // OPM_SINGLEWELLSTATE_HEADER_INCLUDED

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -32,18 +32,18 @@ namespace Opm
 
 /// Encapsulate all data needed to represent the state of a well for persistence purposes,
 /// i.e. from one timestep to the next or for restarting.
-template <int NumActiveComponents, int NumActivePhases>
+template <int NumActivePhases>
 struct SingleWellState
 {
     // ------ Types ------
 
-    using ComponentRates = std::array<double, NumActiveComponents>;
     using PhaseRates = std::array<double, NumActivePhases>;
 
     struct Connection {
         double pressure = -1e100;
-        ComponentRates surface_rates = {0.0};
+        PhaseRates surface_rates = {0.0};
         PhaseRates reservoir_rates = {0.0};
+        double solvent_rate = 0.0;
         double water_throughput = 0.0;
         double skin_pressure = 0.0;
         double water_velocity = 0.0;
@@ -52,7 +52,7 @@ struct SingleWellState
     struct Segment {
         int segment_number = -1;
         double pressure = -1e100;
-        ComponentRates surface_rates = {0.0};
+        PhaseRates surface_rates = {0.0};
     };
 
     // ------ Data members ------
@@ -60,19 +60,19 @@ struct SingleWellState
     // Flags and statuses.
     Well::Status status = Well::Status::SHUT;
     bool is_producer = true;
+    bool effective_events_occurred = true;
     Well::InjectorCMode current_injection_control = Well::InjectorCMode::CMODE_UNDEFINED;
     Well::ProducerCMode current_production_control = Well::ProducerCMode::CMODE_UNDEFINED;
-    bool effective_events_occurred = false;
 
     // Quantities.
     double bhp = -1e100;
     double thp = -1e100;
     double temperature = 273.15 + 20; // 20 degrees Celcius by default.
-    ComponentRates surface_rates = {0.0};
+    PhaseRates surface_rates = {0.0};
     PhaseRates reservoir_rates = {0.0};
     double dissolved_gas_rate = 0.0;
     double vaporized_oil_rate = 0.0;
-    ComponentRates potentials = {0.0};
+    PhaseRates potentials = {0.0};
 
     // Connection and segment data.
     std::vector<Connection> connections;

--- a/opm/simulators/wells/WellAndGroupStates.hpp
+++ b/opm/simulators/wells/WellAndGroupStates.hpp
@@ -58,23 +58,23 @@ public:
         const int nw = wells.size();
         well_states_.resize(nw);
         for (int w = 0; w < nw; ++w) {
-            initSingleWell(cell_pressures, schedule, w, wells[w], report_step, phase_usage, well_perf_data[w], summary_state);
+            initSingleWell(cell_pressures, schedule, wells[w], report_step, phase_usage, well_perf_data[w], summary_state, well_states_[w]);
         }
         static_cast<void>(prev_state);
+        // TODO: deal with previous state.
     }
 
-    void initSingleWell(const std::vector<double>& cell_pressures,
-                        const Schedule& schedule,
-                        const int w,
-                        const Well& well,
-                        const int report_step,
-                        const PhaseUsage& phase_usage,
-                        const std::vector<PerforationData>& perf_data,
-                        const SummaryState& summary_state)
+    static void initSingleWell(const std::vector<double>& cell_pressures,
+                               const Schedule& schedule,
+                               const Well& well,
+                               const int report_step,
+                               const PhaseUsage& phase_usage,
+                               const std::vector<PerforationData>& perf_data,
+                               const SummaryState& summary_state,
+                               SingleWellState<NumActivePhases>& wstate)
     {
         assert(well.isInjector() || well.isProducer());
 
-        auto& wstate = well_states_[w];
         wstate.status = well.getStatus();
         wstate.is_producer = well.isProducer();
         // At the moment, the following events are considered to be effective events
@@ -216,7 +216,7 @@ public:
 
 
 
-    void initMultiSegment(const Well& well, SingleWellState<NumActivePhases>& wstate)
+    static void initMultiSegment(const Well& well, SingleWellState<NumActivePhases>& wstate)
     {
         const WellSegments& segment_set = well.getSegments();
         const int well_nseg = segment_set.size();

--- a/opm/simulators/wells/WellAndGroupStates.hpp
+++ b/opm/simulators/wells/WellAndGroupStates.hpp
@@ -147,10 +147,7 @@ private:
             wstate.current_production_control = prod_controls.cmode;
         }
 
-        const int num_conn = perf_data.size();
-        wstate.connections.resize(num_conn);
-
-        if ( num_conn == 0 ) {
+        if (perf_data.empty()) {
             // No perforations of the well. Initialize pressures to zero.
             wstate.bhp = 0.0;
             wstate.thp = 0.0;
@@ -261,6 +258,23 @@ private:
         }
 
         // Initialize connection pressures and rates.
+        initConnections(cell_pressures, perf_data, wstate);
+
+        // Initialize multi-segment well parts.
+        if (well.isMultiSegment()) {
+            initMultiSegment(well, wstate);
+        }
+    } // initSingleWell()
+
+
+
+
+    static void initConnections(const std::vector<double>& cell_pressures,
+                                const std::vector<PerforationData>& perf_data,
+                                SingleWellState<NumActivePhases>& wstate)
+    {
+        const int num_conn = perf_data.size();
+        wstate.connections.resize(num_conn);
         for (int conn = 0; conn < num_conn; ++conn) {
             auto& connection = wstate.connections[conn];
             connection.pressure = cell_pressures[perf_data[conn].cell_index];
@@ -269,12 +283,7 @@ private:
                 q /= num_conn;
             }
         }
-
-        // Initialize multi-segment well parts.
-        if (well.isMultiSegment()) {
-            initMultiSegment(well, wstate);
-        }
-    } // initSingleWell()
+    }
 
 
 

--- a/opm/simulators/wells/WellAndGroupStates.hpp
+++ b/opm/simulators/wells/WellAndGroupStates.hpp
@@ -147,10 +147,10 @@ private:
             wstate.current_production_control = prod_controls.cmode;
         }
 
-        const int num_perf_this_well = perf_data.size();
-        wstate.connections.resize(num_perf_this_well);
+        const int num_conn = perf_data.size();
+        wstate.connections.resize(num_conn);
 
-        if ( num_perf_this_well == 0 ) {
+        if ( num_conn == 0 ) {
             // No perforations of the well. Initialize pressures to zero.
             wstate.bhp = 0.0;
             wstate.thp = 0.0;
@@ -260,6 +260,16 @@ private:
             wstate.thp = thp_limit;
         }
 
+        // Initialize connection pressures and rates.
+        for (int conn = 0; conn < num_conn; ++conn) {
+            auto& connection = wstate.connections[conn];
+            connection.pressure = cell_pressures[perf_data[conn].cell_index];
+            connection.surface_rates = wstate.surface_rates;
+            for (double& q : connection.surface_rates) {
+                q /= num_conn;
+            }
+        }
+
         // Initialize multi-segment well parts.
         if (well.isMultiSegment()) {
             initMultiSegment(well, wstate);
@@ -353,9 +363,9 @@ private:
         }
 
         // Make the connections vector.
-        const int num_perf_well = wstate.connections.size();
-        dwell.connections.resize(num_perf_well);
-        for( int i = 0; i < num_perf_well; ++i ) {
+        const int num_conn = wstate.connections.size();
+        dwell.connections.resize(num_conn);
+        for( int i = 0; i < num_conn; ++i ) {
             auto& connection = dwell.connections[ i ];
             // TODO
             // const auto active_index = this->well_perf_data_[well_index][i].cell_index;

--- a/opm/simulators/wells/WellAndGroupStates.hpp
+++ b/opm/simulators/wells/WellAndGroupStates.hpp
@@ -352,6 +352,7 @@ private:
             dwell.rates.set( rt::gas, wstate.surface_rates[ pu.phase_pos[BlackoilPhases::Vapour] ] );
         }
 
+        // Make the connections vector.
         const int num_perf_well = wstate.connections.size();
         dwell.connections.resize(num_perf_well);
         for( int i = 0; i < num_perf_well; ++i ) {
@@ -363,9 +364,41 @@ private:
             // TODO
             // connection.reservoir_rate = this->perfRates()[ itr.second[1] + i ];
         }
+
+        // Make the segments map.
+        for (const auto& seg : wstate.segments) {
+            dwell.segments[seg.segment_number] = reportSegmentResults(pu, seg);
+        }
+    }
+
+
+
+    static data::Segment
+    reportSegmentResults(const PhaseUsage& pu, const typename SingleWellState<NumActivePhases>::Segment& seg)
+    {
+        auto seg_res = data::Segment{};
+
+        seg_res.pressure = seg.pressure;
+
+        if (pu.phase_used[BlackoilPhases::Aqua]) {
+            seg_res.rates.set(data::Rates::opt::wat,
+                              seg.surface_rates[pu.phase_pos[BlackoilPhases::Aqua]]);
+        }
+        if (pu.phase_used[BlackoilPhases::Liquid]) {
+            seg_res.rates.set(data::Rates::opt::oil,
+                              seg.surface_rates[pu.phase_pos[BlackoilPhases::Liquid]]);
+        }
+        if (pu.phase_used[BlackoilPhases::Vapour]) {
+            seg_res.rates.set(data::Rates::opt::gas,
+                              seg.surface_rates[pu.phase_pos[BlackoilPhases::Vapour]]);
+        }
+
+        seg_res.segNumber = seg.segment_number;
+
+        return seg_res;
     }
 };
 
-}
+} // namespace Opm
 
 #endif // OPM_WELLANDGROUPSTATES_HEADER_INCLUDED

--- a/opm/simulators/wells/WellAndGroupStates.hpp
+++ b/opm/simulators/wells/WellAndGroupStates.hpp
@@ -62,7 +62,50 @@ public:
         }
         static_cast<void>(prev_state);
         // TODO: deal with previous state.
+
+        // TODO: initialize group state
     }
+
+    data::Wells report(const PhaseUsage& phase_usage, const int* globalCellIdxMap) const
+    {
+        data::Wells dw;
+        static_cast<void>(phase_usage);
+        static_cast<void>(globalCellIdxMap);
+        return dw;
+    }
+
+    using WellState = SingleWellState<NumActivePhases>;
+    using GroupState = SingleGroupState<NumActivePhases>;
+
+    std::vector<WellState>& wellStates()
+    {
+        return well_states_;
+    }
+    const std::vector<WellState>& wellStates() const
+    {
+        return well_states_;
+    }
+
+    std::map<std::string, GroupState>& groupStates()
+    {
+        return group_states_;
+    }
+    const std::map<std::string, GroupState>& groupStates() const
+    {
+        return group_states_;
+    }
+
+
+private:
+
+    // -----------  Data members  -----------
+
+    std::vector<WellState> well_states_;
+    std::map<std::string, GroupState> group_states_;
+
+
+
+    // -----------  Private functions  -----------
 
     static void initSingleWell(const std::vector<double>& cell_pressures,
                                const Schedule& schedule,
@@ -216,6 +259,7 @@ public:
 
 
 
+
     static void initMultiSegment(const Well& well, SingleWellState<NumActivePhases>& wstate)
     {
         const WellSegments& segment_set = well.getSegments();
@@ -273,42 +317,6 @@ public:
         // TODO
         // ...
     }
-
-
-
-    data::Wells report(const PhaseUsage& phase_usage, const int* globalCellIdxMap) const
-    {
-        static_cast<void>(phase_usage);
-        static_cast<void>(globalCellIdxMap);
-        return data::Wells{};
-    }
-
-
-
-    using WellState = SingleWellState<NumActivePhases>;
-    using GroupState = SingleGroupState<NumActivePhases>;
-
-    std::vector<WellState>& wellStates()
-    {
-        return well_states_;
-    }
-    const std::vector<WellState>& wellStates() const
-    {
-        return well_states_;
-    }
-
-    std::map<std::string, GroupState>& groupStates()
-    {
-        return group_states_;
-    }
-    const std::map<std::string, GroupState>& groupStates() const
-    {
-        return group_states_;
-    }
-
-private:
-    std::vector<WellState> well_states_;
-    std::map<std::string, GroupState> group_states_;
 };
 
 }

--- a/opm/simulators/wells/WellAndGroupStates.hpp
+++ b/opm/simulators/wells/WellAndGroupStates.hpp
@@ -1,0 +1,53 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_WELLANDGROUPSTATES_HEADER_INCLUDED
+#define OPM_WELLANDGROUPSTATES_HEADER_INCLUDED
+
+#include <opm/simulators/wells/SingleWellState.hpp>
+#include <opm/simulators/wells/SingleGroupState.hpp>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace Opm
+{
+
+/// Encapsulate all data needed to represent the state of all wells
+/// and groups for persistence purposes, i.e. from one timestep to the
+/// next or for restarting, and for accumulating rates to get correct
+/// group rate limits.
+/// In a parallel context, the well states will be those for local
+/// wells only, while the group information will be global (and
+/// communicated as needed).
+template <int NumActiveComponents, int NumActivePhases>
+class WellAndGroupStates
+{
+public:
+private:
+    using WellState = SingleWellState<NumActiveComponents, NumActivePhases>;
+    using GroupState = SingleGroupState<NumActiveComponents, NumActivePhases>;
+    std::vector<WellState> well_states_;
+    std::map<std::string, GroupState> group_states_;
+};
+
+}
+
+#endif // OPM_WELLANDGROUPSTATES_HEADER_INCLUDED

--- a/tests/test_wellandgroupstates.cpp
+++ b/tests/test_wellandgroupstates.cpp
@@ -1,0 +1,366 @@
+/*
+  Copyright 2018, 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE WellAndGroupStatesTest
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/wells/WellAndGroupStates.hpp>
+
+#include <opm/simulators/wells/PerforationData.hpp>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
+
+#include <opm/grid/GridHelpers.hpp>
+
+#include <opm/core/props/BlackoilPhases.hpp>
+#include <opm/core/props/phaseUsageFromDeck.hpp>
+
+#include <opm/grid/GridManager.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <string>
+
+struct Setup
+{
+    Setup(const std::string& filename)
+        : Setup(Opm::Parser{}.parseFile(filename))
+    {}
+
+    Setup(const Opm::Deck& deck)
+        : es   (deck)
+        , pu   (Opm::phaseUsageFromDeck(es))
+        , grid (es.getInputGrid())
+        , sched(deck, es)
+        , st(std::chrono::system_clock::from_time_t(sched.getStartTime()))
+    {
+        initWellPerfData();
+    }
+
+    void initWellPerfData()
+    {
+        const auto& wells = sched.getWells(0);
+        const auto& cartDims = Opm::UgGridHelpers::cartDims(*grid.c_grid());
+        const int* compressed_to_cartesian = Opm::UgGridHelpers::globalCell(*grid.c_grid());
+        std::vector<int> cartesian_to_compressed(cartDims[0] * cartDims[1] * cartDims[2], -1);
+        for (int ii = 0; ii < Opm::UgGridHelpers::numCells(*grid.c_grid()); ++ii) {
+            cartesian_to_compressed[compressed_to_cartesian[ii]] = ii;
+        }
+        well_perf_data.resize(wells.size());
+        int well_index = 0;
+        for (const auto& well : wells) {
+            well_perf_data[well_index].clear();
+            well_perf_data[well_index].reserve(well.getConnections().size());
+            for (const auto& completion : well.getConnections()) {
+                if (completion.state() == Opm::Connection::State::OPEN) {
+                    const int i = completion.getI();
+                    const int j = completion.getJ();
+                    const int k = completion.getK();
+                    const int cart_grid_indx = i + cartDims[0] * (j + cartDims[1] * k);
+                    const int active_index = cartesian_to_compressed[cart_grid_indx];
+                    if (active_index < 0) {
+                        const std::string msg
+                            = ("Cell with i,j,k indices " + std::to_string(i) + " " + std::to_string(j) + " "
+                               + std::to_string(k) + " not found in grid (well = " + well.name() + ").");
+                        OPM_THROW(std::runtime_error, msg);
+                    } else {
+                        Opm::PerforationData pd;
+                        pd.cell_index = active_index;
+                        pd.connection_transmissibility_factor = completion.CF() * completion.wellPi();
+                        pd.satnum_id = completion.satTableId();
+                        well_perf_data[well_index].push_back(pd);
+                    }
+                } else {
+                    if (completion.state() != Opm::Connection::State::SHUT) {
+                        OPM_THROW(std::runtime_error,
+                                  "Completion state: " << Opm::Connection::State2String(completion.state()) << " not handled");
+                    }
+                }
+            }
+            ++well_index;
+        }
+    }
+
+    Opm::EclipseState es;
+    Opm::PhaseUsage   pu;
+    Opm::GridManager  grid;
+    Opm::Schedule     sched;
+    Opm::SummaryState st;
+    std::vector<std::vector<Opm::PerforationData>> well_perf_data;
+};
+
+namespace {
+    Opm::WellStateFullyImplicitBlackoil
+    buildWellState(const Setup& setup, const std::size_t timeStep)
+    {
+        auto state  = Opm::WellStateFullyImplicitBlackoil{};
+
+        const auto cpress =
+            std::vector<double>(setup.grid.c_grid()->number_of_cells,
+                                100.0*Opm::unit::barsa);
+
+        state.init(cpress, setup.sched,
+                   setup.sched.getWells(timeStep),
+                   timeStep, nullptr, setup.pu, setup.well_perf_data, setup.st);
+
+        state.initWellStateMSWell(setup.sched.getWells(timeStep),
+                                  setup.pu, nullptr);
+
+        return state;
+    }
+
+
+    void setSegPress(const std::vector<Opm::Well>& wells,
+                     Opm::WellStateFullyImplicitBlackoil& wstate)
+    {
+        const auto nWell = wells.size();
+
+        auto& segPress = wstate.segPress();
+
+        for (auto wellID = 0*nWell; wellID < nWell; ++wellID) {
+            const auto& well     = wells[wellID];
+            const auto  topSegIx = wstate.topSegmentIndex(wellID);
+            const auto  pressTop = 100.0 * wellID;
+
+            auto* press = &segPress[topSegIx];
+
+            press[0] = pressTop;
+
+            if (! well.isMultiSegment()) {
+                continue;
+            }
+
+            const auto& segSet = well.getSegments();
+            const auto  nSeg   = segSet.size();
+
+            for (auto segID = 0*nSeg + 1; segID < nSeg; ++segID) {
+                // One-based numbering scheme for segments.
+                const auto segNo = segSet[segID].segmentNumber();
+                press[segNo - 1] = pressTop + 1.0*(segNo - 1);
+            }
+        }
+    }
+
+
+  void setSegRates(const std::vector<Opm::Well>& wells,
+                     const Opm::PhaseUsage&               pu,
+                     Opm::WellStateFullyImplicitBlackoil& wstate)
+    {
+        const auto wat = pu.phase_used[Opm::BlackoilPhases::Aqua];
+        const auto iw  = wat ? pu.phase_pos[Opm::BlackoilPhases::Aqua] : -1;
+
+        const auto oil = pu.phase_used[Opm::BlackoilPhases::Liquid];
+        const auto io  = oil ? pu.phase_pos[Opm::BlackoilPhases::Liquid] : -1;
+
+        const auto gas = pu.phase_used[Opm::BlackoilPhases::Vapour];
+        const auto ig  = gas ? pu.phase_pos[Opm::BlackoilPhases::Vapour] : -1;
+
+        const auto np = wstate.numPhases();
+
+        const auto nWell = wells.size();
+
+        auto& segRates = wstate.segRates();
+
+        for (auto wellID = 0*nWell; wellID < nWell; ++wellID) {
+            const auto& well     = wells[wellID];
+            const auto  topSegIx = wstate.topSegmentIndex(wellID);
+            const auto  rateTop  = 1000.0 * wellID;
+
+            if (wat) { segRates[np*topSegIx + iw] = rateTop; }
+            if (oil) { segRates[np*topSegIx + io] = rateTop; }
+            if (gas) { segRates[np*topSegIx + ig] = rateTop; }
+
+            if (! well.isMultiSegment()) {
+                continue;
+            }
+
+            const auto& segSet = well.getSegments();
+            const auto  nSeg   = segSet.size();
+
+            for (auto segID = 0*nSeg + 1; segID < nSeg; ++segID) {
+                // One-based numbering scheme for segments.
+                const auto segNo = segSet[segID].segmentNumber();
+
+                auto* rates = &segRates[(topSegIx + segNo - 1) * np];
+
+                if (wat) { rates[iw] = rateTop + 100.0*(segNo - 1); }
+                if (oil) { rates[io] = rateTop + 200.0*(segNo - 1); }
+                if (gas) { rates[ig] = rateTop + 400.0*(segNo - 1); }
+            }
+        }
+    }
+} // Anonymous
+
+BOOST_AUTO_TEST_SUITE(Segment)
+
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(Linearisation)
+{
+    const Setup setup{ "msw.data" };
+    const auto tstep = std::size_t{0};
+
+    const auto wstate = buildWellState(setup, tstep);
+
+    BOOST_CHECK_EQUAL(wstate.numSegment(), 6 + 1);
+
+    const auto& wells = setup.sched.getWellsatEnd();
+    BOOST_CHECK_EQUAL(wells.size(), 2);
+
+    const auto prod01_first = wells[0].name() == "PROD01";
+
+    BOOST_CHECK_EQUAL(wstate.topSegmentIndex(0), 0);
+    BOOST_CHECK_EQUAL(wstate.topSegmentIndex(1),
+                      prod01_first ? 6 : 1);
+}
+
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(Pressure)
+{
+    const Setup setup{ "msw.data" };
+    const auto tstep = std::size_t{0};
+
+    auto wstate = buildWellState(setup, tstep);
+
+    const auto& wells = setup.sched.getWells(tstep);
+    const auto prod01_first = wells[0].name() == "PROD01";
+
+    setSegPress(wells, wstate);
+
+    const auto rpt = wstate.report(setup.pu, setup.grid.c_grid()->global_cell);
+
+    {
+        const auto& xw = rpt.at("INJE01");
+
+        BOOST_CHECK_EQUAL(xw.segments.size(), 1); // Top Segment
+
+        const auto& xseg = xw.segments.at(1);
+
+        BOOST_CHECK_EQUAL(xseg.segNumber, 1);
+        BOOST_CHECK_CLOSE(xseg.pressure, prod01_first ? 100.0 : 0.0, 1.0e-10);
+    }
+
+    {
+        const auto expect_nSeg = 6;
+        const auto& xw = rpt.at("PROD01");
+
+        BOOST_CHECK_EQUAL(xw.segments.size(), expect_nSeg);
+
+        const auto pressTop = prod01_first ? 0.0 : 100.0;
+
+        for (auto segID = 0; segID < expect_nSeg; ++segID) {
+            const auto& xseg = xw.segments.at(segID + 1);
+
+            BOOST_CHECK_EQUAL(xseg.segNumber, segID + 1);
+            BOOST_CHECK_CLOSE(xseg.pressure, pressTop + 1.0*segID, 1.0e-10);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(Rates)
+{
+    const Setup setup{ "msw.data" };
+    const auto tstep = std::size_t{0};
+
+    auto wstate = buildWellState(setup, tstep);
+
+    const auto wells = setup.sched.getWells(tstep);
+    const auto prod01_first = wells[0].name() == "PROD01";
+
+    const auto& pu = setup.pu;
+
+    setSegRates(wells, pu, wstate);
+
+    const auto rpt = wstate.report(pu, setup.grid.c_grid()->global_cell);
+
+    const auto wat = pu.phase_used[Opm::BlackoilPhases::Aqua];
+    const auto oil = pu.phase_used[Opm::BlackoilPhases::Liquid];
+    const auto gas = pu.phase_used[Opm::BlackoilPhases::Vapour];
+
+    BOOST_CHECK(wat && oil && gas);
+
+    {
+        const auto rateTop = prod01_first ? 1000.0 : 0.0;
+
+        const auto& xw = rpt.at("INJE01");
+
+        BOOST_CHECK_EQUAL(xw.segments.size(), 1); // Top Segment
+
+        const auto& xseg = xw.segments.at(1);
+
+        BOOST_CHECK_EQUAL(xseg.segNumber, 1);
+        BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::wat),
+                          rateTop, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::oil),
+                          rateTop, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::gas),
+                          rateTop, 1.0e-10);
+    }
+
+    {
+        const auto expect_nSeg = 6;
+        const auto& xw = rpt.at("PROD01");
+
+        BOOST_CHECK_EQUAL(xw.segments.size(), expect_nSeg);
+
+        const auto rateTop = prod01_first ? 0.0 : 1000.0;
+
+        for (auto segNum = 1; segNum <= expect_nSeg; ++segNum) {
+            const auto& xseg = xw.segments.at(segNum);
+
+            BOOST_CHECK_EQUAL(xseg.segNumber, segNum);
+
+            BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::wat),
+                              rateTop + 100.0*(segNum - 1), 1.0e-10);
+
+            BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::oil),
+                              rateTop + 200.0*(segNum - 1), 1.0e-10);
+
+            BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::gas),
+                              rateTop + 400.0*(segNum - 1), 1.0e-10);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(STOP_well)
+{
+    /*
+      This test verifies that the perforation pressures is correctly initialized
+      also for wells in the STOP state.
+    */
+    const Setup setup{ "wells_manager_data_wellSTOP.data" };
+    auto wstate = buildWellState(setup, 0);
+    for (const auto& p : wstate.perfPress())
+        BOOST_CHECK(p > 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_wellandgroupstates.cpp
+++ b/tests/test_wellandgroupstates.cpp
@@ -249,12 +249,7 @@ BOOST_AUTO_TEST_CASE(Pressure)
     {
         const auto& xw = rpt.at("INJE01");
 
-        BOOST_CHECK_EQUAL(xw.segments.size(), 1); // Top Segment
-
-        const auto& xseg = xw.segments.at(1);
-
-        BOOST_CHECK_EQUAL(xseg.segNumber, 1);
-        BOOST_CHECK_CLOSE(xseg.pressure, prod01_first ? 100.0 : 0.0, 1.0e-10);
+        BOOST_CHECK(xw.segments.empty()); // Not a multisegment well.
     }
 
     {
@@ -303,19 +298,7 @@ BOOST_AUTO_TEST_CASE(Rates)
 
         const auto& xw = rpt.at("INJE01");
 
-        BOOST_CHECK_EQUAL(xw.segments.size(), 1); // Top Segment
-
-        const auto& xseg = xw.segments.at(1);
-
-        BOOST_CHECK_EQUAL(xseg.segNumber, 1);
-        BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::wat),
-                          rateTop, 1.0e-10);
-
-        BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::oil),
-                          rateTop, 1.0e-10);
-
-        BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::gas),
-                          rateTop, 1.0e-10);
+        BOOST_CHECK(xw.segments.empty()); // Not a multisegment well.
     }
 
     {


### PR DESCRIPTION
The code here implements a suggested new well state approach. We have discussed earlier, that we should move to using well state objects that are individual for each well rather than a single object for all wells. This PR implements this, but does not yet use it in the simulator code. It is relatively complete in itself (missing a few very recent additions to WellStateFullyImplicitBlackoil), including a test.

The class WellAndGroupStates would replace WellStateFullyImplicitBlackoil, using the SingleWellState and SingleGroupState classes as building blocks.

This is intended for discussion, especially for interfaces: the Single* classes are done as simple structs, rather than with an abstract interface, and there is a single class covering all current options itself (msw, solvent etc.). I think that's worth discussing before changing!