### PR TITLE
Use member variable in Aquifer code

### DIFF
--- a/opm/simulators/aquifers/AquiferCarterTracy.hpp
+++ b/opm/simulators/aquifers/AquiferCarterTracy.hpp
@@ -73,19 +73,14 @@ protected:
     Scalar mu_w_; // water viscosity
 
     // This function is used to initialize and calculate the alpha_i for each grid connection to the aquifer
-    inline void initializeConnections(const Aquancon::AquanconOutput& connection) override
+    inline void initializeConnections() override
     {
         const auto& eclState = Base::ebos_simulator_.vanguard().eclState();
         const auto& ugrid = Base::ebos_simulator_.vanguard().grid();
         const auto& grid = eclState.getInputGrid();
 
-        Base::cell_idx_ = connection.global_index;
+        Base::cell_idx_ = this->connection_.global_index;
         auto globalCellIdx = ugrid.globalCell();
-
-        assert(Base::cell_idx_ == connection.global_index);
-        assert((Base::cell_idx_.size() <= connection.influx_coeff.size()));
-        assert((connection.influx_coeff.size() == connection.influx_multiplier.size()));
-        assert((connection.influx_multiplier.size() == connection.reservoir_face_dir.size()));
 
         // We hack the cell depth values for now. We can actually get it from elementcontext pos
         Base::cell_depth_.resize(Base::cell_idx_.size(), aquct_data_.d0);
@@ -137,9 +132,9 @@ protected:
                               "Initialization of Aquifer Carter Tracy problem. Make sure faceTag is correctly defined");
                 }
 
-                if (faceDirection == connection.reservoir_face_dir.at(idx)) {
-                    Base::faceArea_connected_.at(idx) = Base::getFaceArea(faceCells, ugrid, faceIdx, idx, connection);
-                    denom_face_areas += (connection.influx_multiplier.at(idx) * Base::faceArea_connected_.at(idx));
+                if (faceDirection == this->connection_.reservoir_face_dir.at(idx)) {
+                    Base::faceArea_connected_.at(idx) = Base::getFaceArea(faceCells, ugrid, faceIdx, idx);
+                    denom_face_areas += (this->connection_.influx_multiplier.at(idx) * Base::faceArea_connected_.at(idx));
                 }
             }
             auto cellCenter = grid.getCellCenter(Base::cell_idx_.at(idx));
@@ -151,7 +146,7 @@ protected:
             Base::alphai_.at(idx) = (denom_face_areas < eps_sqrt)
                 ? // Prevent no connection NaNs due to division by zero
                 0.
-                : (connection.influx_multiplier.at(idx) * Base::faceArea_connected_.at(idx)) / denom_face_areas;
+                : (this->connection_.influx_multiplier.at(idx) * Base::faceArea_connected_.at(idx)) / denom_face_areas;
         }
     }
 

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -80,6 +80,9 @@ public:
         , ebos_simulator_(ebosSimulator)
         , cartesian_to_compressed_(cartesian_to_compressed)
     {
+        assert(this->connection_.influx_coeff.size() == this->connection_.global_index.size());
+        assert(this->connection_.influx_coeff.size() == this->connection_.influx_multiplier.size());
+        assert(this->connection_.influx_multiplier.size() == this->connection_.reservoir_face_dir.size());
     }
 
     // Deconstructor
@@ -108,7 +111,7 @@ public:
 
     void initialSolutionApplied()
     {
-        initQuantities(connection_);
+        initQuantities();
     }
 
     void beginTimeStep()
@@ -158,7 +161,7 @@ protected:
         return ebos_simulator_.problem().gravity()[2];
     }
 
-    inline void initQuantities(const Aquancon::AquanconOutput& connection)
+    inline void initQuantities()
     {
         // We reset the cumulative flux at the start of any simulation, so, W_flux = 0
         if (!this->solution_set_from_restart_) {
@@ -167,7 +170,7 @@ protected:
 
         // We next get our connections to the aquifer and initialize these quantities using the initialize_connections
         // function
-        initializeConnections(connection);
+        initializeConnections();
         calculateAquiferCondition();
         calculateAquiferConstants();
 
@@ -200,8 +203,7 @@ protected:
     inline double getFaceArea(const faceCellType& faceCells,
                               const ugridType& ugrid,
                               const int faceIdx,
-                              const int idx,
-                              const Aquancon::AquanconOutput& connection) const
+                              const int idx) const
     {
         // Check now if the face is outside of the reservoir, or if it adjoins an inactive cell
         // Do not make the connection if the product of the two cellIdx > 0. This is because the
@@ -212,7 +214,7 @@ protected:
         const auto cellNeighbour1 = faceCells(faceIdx, 1);
         const auto defaultFaceArea = Opm::UgGridHelpers::faceArea(ugrid, faceIdx);
         const auto calculatedFaceArea
-            = (!connection.influx_coeff.at(idx)) ? defaultFaceArea : *(connection.influx_coeff.at(idx));
+            = (!this->connection_.influx_coeff.at(idx)) ? defaultFaceArea : *(this->connection_.influx_coeff.at(idx));
         faceArea = (cellNeighbour0 * cellNeighbour1 > 0) ? 0. : calculatedFaceArea;
         if (cellNeighbour1 == 0) {
             faceArea = (cellNeighbour0 < 0) ? faceArea : 0.;
@@ -247,7 +249,7 @@ protected:
 
     bool solution_set_from_restart_ {false};
 
-    virtual void initializeConnections(const Aquancon::AquanconOutput& connection) = 0;
+    virtual void initializeConnections() = 0;
 
     virtual void assignRestartData(const data::AquiferData& xaq) = 0;
 


### PR DESCRIPTION
The AquiferInterface base class has a member `connection_` which was sent up and down in the class hierarchy as a method parameter. With this PR we just use `this->connection_` instead - main purpose is to increase readability - and simplify this: https://github.com/OPM/opm-simulators/pull/2320