### PR TITLE
Save and Restore Well's Current Control Target Mode

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -213,7 +213,20 @@ namespace Opm {
             }
 
             Opm::data::Wells wellData() const
-            { return well_state_.report(phase_usage_, Opm::UgGridHelpers::globalCell(grid())); }
+            {
+                auto wsrpt = well_state_.report(phase_usage_, Opm::UgGridHelpers::globalCell(grid()));
+
+                for (const auto& well : this->wells_ecl_) {
+                    auto xwPos = wsrpt.find(well.name());
+                    if (xwPos == wsrpt.end()) { // No well results.  Unexpected.
+                        continue;
+                    }
+
+                    xwPos->second.current_control.isProducer = well.isProducer();
+                }
+
+                return wsrpt;
+            }
 
             // substract Binv(D)rw from r;
             void apply( BVector& r) const;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -543,24 +543,6 @@ namespace Opm {
             wellsToState(restartValues.wells, phaseUsage, handle_ms_well, well_state_);
         }
 
-        // for ecl compatible restart the current controls are not written
-        const auto& ioCfg = eclState().getIOConfig();
-        const auto ecl_compatible_rst = ioCfg.getEclCompatibleRST();        
-        if (true || ecl_compatible_rst) { // always set the control from the schedule
-            for (int w = 0; w <nw; ++w) {
-                const auto& well = wells_ecl_[w];
-
-                if (well.isProducer()) {
-                    const auto controls = well.productionControls(summaryState);
-                    well_state_.currentProductionControls()[w] = controls.cmode;
-                }
-                else {
-                    const auto controls = well.injectionControls(summaryState);
-                    well_state_.currentInjectionControls()[w] = controls.cmode;
-                }
-            }
-        }
-
         previous_well_state_ = well_state_;
 
         initial_step_ = false;
@@ -1586,8 +1568,12 @@ namespace Opm {
             state.bhp()[ well_index ] = well.bhp;
             state.temperature()[ well_index ] = well.temperature;
 
-            //state.currentInjectionControls()[ well_index ] = static_cast<Opm::Well::InjectorCMode>(well.injectionControl);
-            //state.currentProductionControls()[ well_index ] = static_cast<Well::ProducerCMode>(well.productionControl);
+            if (well.current_control.isProducer) {
+                state.currentProductionControls()[ well_index ] = well.current_control.prod;
+            }
+            else {
+                state.currentInjectionControls()[ well_index ] = well.current_control.inj;
+            }
 
             const auto wellrate_index = well_index * np;
             for( size_t i = 0; i < phs.size(); ++i ) {

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -515,6 +515,13 @@ namespace Opm
                 well.rates.set( rt::dissolved_gas, this->well_dissolved_gas_rates_[w] );
                 well.rates.set( rt::vaporized_oil, this->well_vaporized_oil_rates_[w] );
 
+                {
+                    auto& curr = well.current_control;
+
+                    curr.prod = this->currentProductionControls()[w];
+                    curr.inj  = this->currentInjectionControls() [w];
+                }
+
                 size_t local_comp_index = 0;
                 for( auto& comp : well.connections) {
                     const auto rates = this->perfPhaseRates().begin()


### PR DESCRIPTION
This PR uses the new restart file support for active well control target modes to save and restore the ~run's~ wells' active targets.