### PR TITLE
Group controls handled at wells

### DIFF
--- a/opm/simulators/timestepping/ConvergenceReport.hpp
+++ b/opm/simulators/timestepping/ConvergenceReport.hpp
@@ -86,6 +86,7 @@ namespace Opm
             : status_{AllGood}
             , res_failures_{}
             , well_failures_{}
+            , groupConverged_(true)
         {
         }
 
@@ -94,6 +95,7 @@ namespace Opm
             status_ = AllGood;
             res_failures_.clear();
             well_failures_.clear();
+            groupConverged_ = true;
         }
 
         void setReservoirFailed(const ReservoirFailure& rf)
@@ -107,7 +109,12 @@ namespace Opm
             status_ = static_cast<Status>(status_ | WellFailed);
             well_failures_.push_back(wf);
         }
-
+        
+        void setGroupConverged(const bool groupConverged)
+        {
+            groupConverged_ = groupConverged;
+        }
+        
         ConvergenceReport& operator+=(const ConvergenceReport& other)
         {
             status_ = static_cast<Status>(status_ | other.status_);
@@ -122,7 +129,7 @@ namespace Opm
 
         bool converged() const
         {
-            return status_ == AllGood;
+            return status_ == AllGood && groupConverged_;
         }
 
         bool reservoirFailed() const
@@ -167,6 +174,7 @@ namespace Opm
         Status status_;
         std::vector<ReservoirFailure> res_failures_;
         std::vector<WellFailure> well_failures_;
+        bool groupConverged_;
     };
 
 } // namespace Opm

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -335,7 +335,9 @@ namespace Opm {
             // xw to update Well State
             void recoverWellSolutionAndUpdateWellState(const BVector& x);
 
-            void updateWellControls(Opm::DeferredLogger& deferred_logger, const bool checkGroupControl, const bool checkCurrentGroupControl);
+            void updateWellControls(Opm::DeferredLogger& deferred_logger, const bool checkGroupControls);
+
+            void updateAndCommunicateGroupData();
 
             // setting the well_solutions_ based on well_state.
             void updatePrimaryVariables(Opm::DeferredLogger& deferred_logger);
@@ -408,7 +410,10 @@ namespace Opm {
 
             const Well& getWellEcl(const std::string& well_name) const;
 
-            void checkGroupConstraints(const Group& group, const bool checkCurrentControl, Opm::DeferredLogger& deferred_logger);
+            void updateGroupIndividualControls(Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
+            void checkGroupConstraints(const Group& group, Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
+            void updateGroupHigherControls(Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
+            void checkGroupHigherConstraints(const Group& group, Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
 
             void actionOnBrokenConstraints(const Group& group, const Group::ExceedAction& exceed_action, const Group::ProductionCMode& newControl, const int reportStepIdx, Opm::DeferredLogger& deferred_logger);
 

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -411,7 +411,11 @@ namespace Opm {
             const Well& getWellEcl(const std::string& well_name) const;
 
             void updateGroupIndividualControls(Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
-            void checkGroupConstraints(const Group& group, Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
+            void updateGroupIndividualControl(const Group& group, Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
+            bool checkGroupConstraints(const Group& group, Opm::DeferredLogger& deferred_logger) const;
+            Group::ProductionCMode checkGroupProductionConstraints(const Group& group, Opm::DeferredLogger& deferred_logger) const;            
+            Group::InjectionCMode checkGroupInjectionConstraints(const Group& group, const Phase& phase, Opm::DeferredLogger& deferred_logger) const;
+
             void updateGroupHigherControls(Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
             void checkGroupHigherConstraints(const Group& group, Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2135,7 +2135,7 @@ namespace Opm {
         std::vector<double> rates(phase_usage_.num_phases, 0.0);
         const auto& comm = ebosSimulator_.vanguard().grid().comm();
 
-        const bool skip = switched_groups.count(group.name());
+        const bool skip = switched_groups.count(group.name()) || group.name() == "FIELD";
 
         if (!skip && group.isInjectionGroup()) {
             // Obtain rates for group.

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1261,7 +1261,8 @@ namespace Opm {
         wellGroupHelpers::updateVREPForGroups(fieldGroup, schedule(), reportStepIdx, well_state_nupcol_, well_state_);
 
         wellGroupHelpers::updateReservoirRatesInjectionGroups(fieldGroup, schedule(), reportStepIdx, well_state_nupcol_, well_state_);
-
+        wellGroupHelpers::updateGroupProductionRates(fieldGroup, schedule(), reportStepIdx, well_state_nupcol_, well_state_);
+        wellGroupHelpers::updateWellRates(fieldGroup, schedule(), reportStepIdx, well_state_nupcol_, well_state_);
         well_state_.communicateGroupRates(comm);
 
         // compute wsolvent fraction for REIN wells

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2215,7 +2215,7 @@ namespace Opm {
                 const Group::InjectionCMode& currentControl = well_state_.currentInjectionGroupControl(phase, group.name());
                 if (currentControl != Group::InjectionCMode::FLD) {
                     const Group& parentGroup = schedule().getGroup(group.parent(), reportStepIdx);
-                    const bool changed = wellGroupHelpers::checkGroupConstraintsInj(
+                    const std::pair<bool, double> changed = wellGroupHelpers::checkGroupConstraintsInj(
                         group.name(),
                         group.parent(),
                         parentGroup,
@@ -2231,7 +2231,7 @@ namespace Opm {
                         *rateConverter_,
                         pvtreg,
                         deferred_logger);
-                    if (changed) {
+                    if (changed.first) {
                         switched_groups.insert(group.name());
                         actionOnBrokenConstraints(group, Group::InjectionCMode::FLD, phase, reportStepIdx, deferred_logger);
                     }
@@ -2251,7 +2251,7 @@ namespace Opm {
             const Group::ProductionCMode& currentControl = well_state_.currentProductionGroupControl(group.name());
                 if (currentControl != Group::ProductionCMode::FLD) {
                     const Group& parentGroup = schedule().getGroup(group.parent(), reportStepIdx);
-                    const bool changed = wellGroupHelpers::checkGroupConstraintsProd(
+                    const std::pair<bool, double> changed = wellGroupHelpers::checkGroupConstraintsProd(
                         group.name(),
                         group.parent(),
                         parentGroup,
@@ -2266,7 +2266,7 @@ namespace Opm {
                         *rateConverter_,
                         pvtreg,
                         deferred_logger);
-                    if (changed) {
+                    if (changed.first) {
                         switched_groups.insert(group.name());
                         const auto exceed_action = group.productionControls(summaryState).exceed_action;
                         actionOnBrokenConstraints(group, exceed_action, Group::ProductionCMode::FLD, reportStepIdx, deferred_logger);

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -380,21 +380,6 @@ namespace Opm
                                const Well::ProductionControls& prod_controls,
                                Opm::DeferredLogger& deferred_logger);
 
-        void assembleGroupProductionControl(const Group& group,
-                                            const WellState& well_state,
-                                            const Opm::Schedule& schedule,
-                                            const SummaryState& summaryState,
-                                            EvalWell& control_eq,
-                                            double efficiencyFactor);
-        void assembleGroupInjectionControl(const Group& group,
-                                           const WellState& well_state,
-                                           const Opm::Schedule& schedule,
-                                           const SummaryState& summaryState,
-                                           const InjectorType& injectorType,
-                                           EvalWell& control_eq,
-                                           double efficiencyFactor,
-                                           Opm::DeferredLogger& deferred_logger);
-
         void assemblePressureEq(const int seg) const;
 
         // hytrostatic pressure loss

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -283,11 +283,9 @@ namespace Opm
 
         void initMatrixAndVectors(const int num_cells) const;
 
-        // protected functions
-        // EvalWell getBhp(); this one should be something similar to getSegmentPressure();
-        // EvalWell getQs(); this one should be something similar to getSegmentRates()
-        // EValWell wellVolumeFractionScaled, wellVolumeFraction, wellSurfaceVolumeFraction ... these should have different names, and probably will be needed.
-        // bool crossFlowAllowed(const Simulator& ebosSimulator) const; probably will be needed
+        EvalWell getBhp() const;
+        EvalWell getQs(const int comp_idx) const;
+
         // xw = inv(D)*(rw - C*x)
         void recoverSolutionWell(const BVector& x, BVectorWell& xw) const;
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -285,6 +285,7 @@ namespace Opm
 
         EvalWell getBhp() const;
         EvalWell getQs(const int comp_idx) const;
+        EvalWell getWQTotal() const;
 
         // xw = inv(D)*(rw - C*x)
         void recoverSolutionWell(const BVector& x, BVectorWell& xw) const;

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -379,8 +379,20 @@ namespace Opm
                                const Well::ProductionControls& prod_controls,
                                Opm::DeferredLogger& deferred_logger);
 
-        void assembleGroupProductionControl(const Group& group, const WellState& well_state, const Opm::Schedule& schedule, const SummaryState& summaryState, EvalWell& control_eq, double efficincyFactor, Opm::DeferredLogger& deferred_logger);
-        void assembleGroupInjectionControl(const Group& group, const WellState& well_state, const Opm::Schedule& schedule, const SummaryState& summaryState,  const InjectorType& injectorType, EvalWell& control_eq, double efficincyFactor, Opm::DeferredLogger& deferred_logger);
+        void assembleGroupProductionControl(const Group& group,
+                                            const WellState& well_state,
+                                            const Opm::Schedule& schedule,
+                                            const SummaryState& summaryState,
+                                            EvalWell& control_eq,
+                                            double efficiencyFactor);
+        void assembleGroupInjectionControl(const Group& group,
+                                           const WellState& well_state,
+                                           const Opm::Schedule& schedule,
+                                           const SummaryState& summaryState,
+                                           const InjectorType& injectorType,
+                                           EvalWell& control_eq,
+                                           double efficiencyFactor,
+                                           Opm::DeferredLogger& deferred_logger);
 
         void assemblePressureEq(const int seg) const;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -675,7 +675,7 @@ namespace Opm
         }
 
         // If the well is pressure controlled the potential equals the rate.
-        {
+/*         {
             bool pressure_controlled_well = false;
             if (this->isInjector()) {
                 const Opm::Well::InjectorCMode& current = well_state.currentInjectionControls()[index_of_well_];
@@ -695,7 +695,7 @@ namespace Opm
                 }
                 return;
             }
-        }
+        } */
 
         // creating a copy of the well itself, to avoid messing up the explicit informations
         // during this copy, the only information not copied properly is the well controls

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2332,7 +2332,7 @@ namespace Opm
         case Group::ProductionCMode::ORAT:
         {
             double groupTargetReduction = groupTargetReductions[pu.phase_pos[Oil]];
-            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::OIL));
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::OIL), pu);
 
             const double rate_target = std::max(0.0, groupcontrols.oil_target - groupTargetReduction) / efficiencyFactor;
             assert(FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx));
@@ -2343,7 +2343,7 @@ namespace Opm
         case Group::ProductionCMode::WRAT:
         {
             double groupTargetReduction = groupTargetReductions[pu.phase_pos[Water]];
-            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::WAT));
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::WAT), pu);
 
             const double rate_target = std::max(0.0, groupcontrols.gas_target - groupTargetReduction) / efficiencyFactor;
             assert(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx));
@@ -2354,7 +2354,7 @@ namespace Opm
         case Group::ProductionCMode::GRAT:
         {
             double groupTargetReduction = groupTargetReductions[pu.phase_pos[Gas]];
-            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::GAS));
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::GAS), pu);
 
             const double rate_target = std::max(0.0, groupcontrols.gas_target - groupTargetReduction) / efficiencyFactor;
             assert(FluidSystem::phaseIsActive(FluidSystem::gasCompIdx));
@@ -2365,7 +2365,7 @@ namespace Opm
         case Group::ProductionCMode::LRAT:
         {
             double groupTargetReduction = groupTargetReductions[pu.phase_pos[Oil]] + groupTargetReductions[pu.phase_pos[Water]];
-            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::LIQ));
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::LIQ), pu);
 
             const double rate_target = std::max(0.0, groupcontrols.liquid_target - groupTargetReduction) / efficiencyFactor;            assert(FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx));
             EvalWell rate = -getSegmentRate(0, Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx))

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -415,21 +415,6 @@ namespace Opm
                                const SummaryState& summaryState,
                                Opm::DeferredLogger& deferred_logger);
 
-        void assembleGroupProductionControl(const Group& group,
-                                            const WellState& well_state,
-                                            const Opm::Schedule& schedule,
-                                            const SummaryState& summaryState,
-                                            EvalWell& control_eq,
-                                            double efficiencyFactor);
-        void assembleGroupInjectionControl(const Group& group,
-                                           const WellState& well_state,
-                                           const Opm::Schedule& schedule,
-                                           const SummaryState& summaryState,
-                                           const InjectorType& injectorType,
-                                           EvalWell& control_eq,
-                                           double efficiencyFactor,
-                                           Opm::DeferredLogger& deferred_logger);
-
         // handle the non reasonable fractions due to numerical overshoot
         void processFractions() const;
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -410,10 +410,25 @@ namespace Opm
 
         void updateThp(WellState& well_state, Opm::DeferredLogger& deferred_logger) const;
 
-        void assembleControlEq(const WellState& well_state, const Opm::Schedule& schedule, const SummaryState& summaryState, Opm::DeferredLogger& deferred_logger);
+        void assembleControlEq(const WellState& well_state,
+                               const Opm::Schedule& schedule,
+                               const SummaryState& summaryState,
+                               Opm::DeferredLogger& deferred_logger);
 
-        void assembleGroupProductionControl(const Group& group, const WellState& well_state, const Opm::Schedule& schedule, const SummaryState& summaryState, EvalWell& control_eq, double efficincyFactor, Opm::DeferredLogger& deferred_logger);
-        void assembleGroupInjectionControl(const Group& group, const WellState& well_state, const Opm::Schedule& schedule, const SummaryState& summaryState,  const InjectorType& injectorType, EvalWell& control_eq, double efficincyFactor, Opm::DeferredLogger& deferred_logger);
+        void assembleGroupProductionControl(const Group& group,
+                                            const WellState& well_state,
+                                            const Opm::Schedule& schedule,
+                                            const SummaryState& summaryState,
+                                            EvalWell& control_eq,
+                                            double efficiencyFactor);
+        void assembleGroupInjectionControl(const Group& group,
+                                           const WellState& well_state,
+                                           const Opm::Schedule& schedule,
+                                           const SummaryState& summaryState,
+                                           const InjectorType& injectorType,
+                                           EvalWell& control_eq,
+                                           double efficiencyFactor,
+                                           Opm::DeferredLogger& deferred_logger);
 
         // handle the non reasonable fractions due to numerical overshoot
         void processFractions() const;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -764,8 +764,10 @@ namespace Opm
 
     template <typename TypeTag>
     void
-    StandardWell<TypeTag>::
-    assembleControlEq(const WellState& well_state, const Opm::Schedule& schedule, const SummaryState& summaryState, Opm::DeferredLogger& deferred_logger)
+    StandardWell<TypeTag>::assembleControlEq(const WellState& well_state,
+                                             const Opm::Schedule& schedule,
+                                             const SummaryState& summaryState,
+                                             Opm::DeferredLogger& deferred_logger)
     {
         EvalWell control_eq(numWellEq_ + numEq, 0.);
 
@@ -978,157 +980,24 @@ namespace Opm
 
     template <typename TypeTag>
     void
-    StandardWell<TypeTag>::
-    assembleGroupInjectionControl(const Group& group, const WellState& well_state, const Opm::Schedule& schedule, const SummaryState& summaryState, const InjectorType& injectorType, EvalWell& control_eq, double efficiencyFactor, Opm::DeferredLogger& deferred_logger)
+    StandardWell<TypeTag>::assembleGroupInjectionControl(const Group& group,
+                                                         const WellState& well_state,
+                                                         const Opm::Schedule& schedule,
+                                                         const SummaryState& summaryState,
+                                                         const InjectorType& injectorType,
+                                                         EvalWell& control_eq,
+                                                         double efficiencyFactor,
+                                                         Opm::DeferredLogger& deferred_logger)
     {
-        if (!group.isAvailableForGroupControl()) {
-            // We cannot go any further up the hierarchy. This could
-            // be the FIELD group, or any group for which this has
-            // been set in GCONINJE or GCONPROD. If we are here
-            // anyway, it is likely that the deck set inconsistent
-            // requirements, such as GRUP control mode on a well with
-            // no appropriate controls defined on any of its
-            // containing groups. We will therefore use the wells' bhp
-            // limit equation as a fallback.
-            const auto& controls = well_ecl_.injectionControls(summaryState);
-            control_eq = getBhp() - controls.bhp_limit;
-            return;
-        }
-
-        const auto& well = well_ecl_;
-        const auto pu = phaseUsage();
-
-        int phasePos;
-        Well::GuideRateTarget wellTarget;
-        Phase injectionPhase;
-
-        switch (injectorType) {
-        case InjectorType::WATER:
-        {
-            phasePos = pu.phase_pos[BlackoilPhases::Aqua];
-            wellTarget = Well::GuideRateTarget::WAT;
-            injectionPhase = Phase::WATER;
-            break;
-        }
-        case InjectorType::OIL:
-        {
-            phasePos = pu.phase_pos[BlackoilPhases::Liquid];
-            wellTarget = Well::GuideRateTarget::OIL;
-            injectionPhase = Phase::OIL;
-            break;
-        }
-        case InjectorType::GAS:
-        {
-            phasePos = pu.phase_pos[BlackoilPhases::Vapour];
-            wellTarget = Well::GuideRateTarget::GAS;
-            injectionPhase = Phase::GAS;
-            break;
-        }
-        default:
-            throw("Expected WATER, OIL or GAS as type for injectors " + well.name());
-        }
-        const Group::InjectionCMode& currentGroupControl = well_state.currentInjectionGroupControl(injectionPhase, group.name());
-
-        if (currentGroupControl == Group::InjectionCMode::FLD ||
-            currentGroupControl == Group::InjectionCMode::NONE) {
-            // Inject share of parents control
-            const auto& parent = schedule.getGroup( group.parent(), current_step_ );
-            efficiencyFactor *= group.getGroupEfficiencyFactor();
-            assembleGroupInjectionControl(parent, well_state, schedule, summaryState, injectorType, control_eq, efficiencyFactor, deferred_logger);
-            return;
-        }
-
-        assert(group.hasInjectionControl(injectionPhase));
-        const auto& groupcontrols = group.injectionControls(injectionPhase, summaryState);
-
-        const std::vector<double>& groupInjectionReductions = well_state.currentInjectionGroupReductionRates(group.name());
-        double groupTargetReduction = groupInjectionReductions[phasePos];
-        double fraction = wellGroupHelpers::fractionFromInjectionPotentials(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(wellTarget), pu, injectionPhase,false);
-        switch(currentGroupControl) {
-        case Group::InjectionCMode::NONE:
-        {
-            // The NONE case is handled earlier
-            assert(false);
-            break;
-        }
-        case Group::InjectionCMode::RATE:
-        {
-            double target = std::max(0.0, (groupcontrols.surface_max_rate - groupTargetReduction)) / efficiencyFactor;
-            control_eq = getWQTotal() - fraction * target;
-            break;
-        }
-        case Group::InjectionCMode::RESV:
-        {
-            std::vector<double> convert_coeff(number_of_phases_, 1.0);
-            Base::rateConverter_.calcCoeff(/*fipreg*/ 0, Base::pvtRegionIdx_, convert_coeff);
-            double coeff = convert_coeff[phasePos];
-            double target = std::max(0.0, (groupcontrols.resv_max_rate/coeff - groupTargetReduction)) / efficiencyFactor;
-            control_eq = getWQTotal() - fraction * target;
-            break;
-        }
-        case Group::InjectionCMode::REIN:
-        {
-            double productionRate = well_state.currentInjectionREINRates(groupcontrols.reinj_group)[phasePos];
-            double target = std::max(0.0, (groupcontrols.target_reinj_fraction*productionRate - groupTargetReduction)) / efficiencyFactor;
-            control_eq = getWQTotal() - fraction * target;
-            break;
-        }
-        case Group::InjectionCMode::VREP:
-        {
-            std::vector<double> convert_coeff(number_of_phases_, 1.0);
-            Base::rateConverter_.calcCoeff(/*fipreg*/ 0, Base::pvtRegionIdx_, convert_coeff);
-            double coeff = convert_coeff[phasePos];
-            double voidageRate = well_state.currentInjectionVREPRates(groupcontrols.voidage_group)*groupcontrols.target_void_fraction;
-
-            double injReduction = 0.0;
-            std::vector<double> groupInjectionReservoirRates = well_state.currentInjectionGroupReservoirRates(group.name());
-            if (groupcontrols.phase != Phase::WATER)
-                injReduction += groupInjectionReservoirRates[pu.phase_pos[BlackoilPhases::Aqua]];
-
-            if (groupcontrols.phase != Phase::OIL)
-                injReduction += groupInjectionReservoirRates[pu.phase_pos[BlackoilPhases::Liquid]];
-
-            if (groupcontrols.phase != Phase::GAS)
-                injReduction += groupInjectionReservoirRates[pu.phase_pos[BlackoilPhases::Vapour]];
-
-            voidageRate -= injReduction;
-
-            double target = std::max(0.0, ( voidageRate/coeff - groupTargetReduction)) / efficiencyFactor;
-            control_eq = getWQTotal() - fraction * target;
-            break;
-        }
-        case Group::InjectionCMode::FLD:
-        {
-            // The FLD case is handled earlier
-            assert(false);
-            break;
-        }
-        case Group::InjectionCMode::SALE:
-        {
-            // only for gas injectors
-            assert (phasePos == pu.phase_pos[BlackoilPhases::Vapour]);
-
-            // Gas injection rate = Total gas production rate + gas import rate - gas consumption rate - sales rate;
-            double inj_rate = well_state.currentInjectionREINRates(group.name())[phasePos];
-            if (schedule.gConSump(current_step_).has(group.name())) {
-                const auto& gconsump = schedule.gConSump(current_step_).get(group.name(), summaryState);
-                if (pu.phase_used[BlackoilPhases::Vapour]) {
-                    inj_rate += gconsump.import_rate;
-                    inj_rate -= gconsump.consumption_rate;
-                }
-            }
-            const auto& gconsale = schedule.gConSale(current_step_).get(group.name(), summaryState);
-            inj_rate -= gconsale.sales_target;
-
-            double target = std::max(0.0, (inj_rate - groupTargetReduction)) / efficiencyFactor;
-            control_eq = getWQTotal() - fraction * target;
-            break;
-        }
-        default:
-            OPM_DEFLOG_THROW(std::runtime_error, "Unvalid group control specified for group "  + well.groupName(), deferred_logger );
-        }
-
-
+        Base::getGroupInjectionControl(group,
+                                       well_state,
+                                       schedule,
+                                       summaryState,
+                                       injectorType,
+                                       getBhp(),
+                                       getWQTotal(),
+                                       control_eq,
+                                       efficiencyFactor);
     }
 
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -769,206 +769,49 @@ namespace Opm
                                              const SummaryState& summaryState,
                                              Opm::DeferredLogger& deferred_logger)
     {
-        EvalWell control_eq(numWellEq_ + numEq, 0.);
+        EvalWell control_eq(numWellEq_ + numEq, 0.0);
 
         const auto& well = well_ecl_;
-        const int well_index = index_of_well_;
-        double efficiencyFactor = well.getEfficiencyFactor();
+        const double efficiencyFactor = well.getEfficiencyFactor();
+
+        auto getRates = [&]() {
+            std::vector<EvalWell> rates(3, EvalWell(numWellEq_ + numEq, 0.0));
+            if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
+                rates[Water] = getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx));
+            }
+            if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
+                rates[Oil] = getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx));
+            }
+            if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+                rates[Gas] = getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx));
+            }
+            return rates;
+        };
 
         if (wellIsStopped_) {
             control_eq = getWQTotal();
         } else if (this->isInjector()) {
-            const Opm::Well::InjectorCMode& current = well_state.currentInjectionControls()[well_index];
-            const auto& controls = well.injectionControls(summaryState);
-            switch(current) {
-            case Well::InjectorCMode::RATE:
-            {
-                control_eq = getWQTotal() - controls.surface_rate;
-                break;
-            }
-
-            case Well::InjectorCMode::RESV:
-            {
-                std::vector<double> convert_coeff(number_of_phases_, 1.0);
-                Base::rateConverter_.calcCoeff(/*fipreg*/ 0, Base::pvtRegionIdx_, convert_coeff);
-                const auto& pu = phaseUsage();
-
-                InjectorType injectorType = controls.injector_type;
-                double coeff = 1.0;
-
-                switch (injectorType) {
-                case InjectorType::WATER:
-                {
-                    coeff = convert_coeff[pu.phase_pos[BlackoilPhases::Aqua]];
-                    break;
-                }
-                case InjectorType::OIL:
-                {
-                    coeff = convert_coeff[pu.phase_pos[BlackoilPhases::Liquid]];
-                    break;
-                }
-                case InjectorType::GAS:
-                {
-                    coeff = convert_coeff[pu.phase_pos[BlackoilPhases::Vapour]];
-                    break;
-                }
-                default:
-                    throw("Expected WATER, OIL or GAS as type for injectors " + well.name());
-
-                }
-
-                control_eq = coeff*getWQTotal() - controls.reservoir_rate;
-                break;
-            }
-
-            case Well::InjectorCMode::THP:
-            {
-                std::vector<EvalWell> rates(3, {numWellEq_ + numEq, 0.});
-                if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
-                    rates[ Water ] = getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx));
-                }
-                if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
-                    rates[ Oil ] = getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx));
-                }
-                if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
-                    rates[ Gas ] = getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx));
-                }
-                control_eq = getBhp() - calculateBhpFromThp(rates, well, summaryState, deferred_logger);
-                break;
-            }
-            case Well::InjectorCMode::BHP:
-            {
-                const auto& bhp = controls.bhp_limit;
-                control_eq = getBhp() - bhp;
-                break;
-            }
-            case Well::InjectorCMode::GRUP:
-            {
-                assert(well.isAvailableForGroupControl());
-                const auto& group = schedule.getGroup( well.groupName(), current_step_ );
-                assembleGroupInjectionControl(group, well_state, schedule, summaryState, controls.injector_type, control_eq, efficiencyFactor, deferred_logger);
-                break;
-            }
-            case Well::InjectorCMode::CMODE_UNDEFINED:
-            {
-                OPM_DEFLOG_THROW(std::runtime_error, "Well control must be specified for well "  + name() , deferred_logger);
-            }
-            }
-
-
+            // Find injection rate.
+            const EvalWell injection_rate = getWQTotal();
+            // Setup function for evaluation of BHP from THP (used only if needed).
+            auto bhp_from_thp = [&]() {
+                const auto rates = getRates();
+                return calculateBhpFromThp(rates, well, summaryState, deferred_logger);
+            };
+            // Call generic implementation.
+            const auto& inj_controls = well.injectionControls(summaryState);
+            Base::assembleControlEqInj(well_state, schedule, summaryState, inj_controls, getBhp(), injection_rate, bhp_from_thp, control_eq, deferred_logger);
+        } else {
+            // Find rates.
+            const auto rates = getRates();
+            // Setup function for evaluation of BHP from THP (used only if needed).
+            auto bhp_from_thp = [&]() {
+                return calculateBhpFromThp(rates, well, summaryState, deferred_logger);
+            };
+            // Call generic implementation.
+            const auto& prod_controls = well.productionControls(summaryState);
+            Base::assembleControlEqProd(well_state, schedule, summaryState, prod_controls, getBhp(), rates, bhp_from_thp, control_eq, deferred_logger);
         }
-        //Producer
-        else
-        {
-            const Well::ProducerCMode& current = well_state.currentProductionControls()[well_index];
-            const auto& controls = well.productionControls(summaryState);
-
-            switch (current) {
-            case Well::ProducerCMode::ORAT:
-            {
-                assert(FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx));
-                EvalWell rate = -getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx));
-                control_eq = rate - controls.oil_rate;
-                break;
-            }
-            case Well::ProducerCMode::WRAT:
-            {
-                assert(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx));
-                EvalWell rate = -getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx));
-                control_eq = rate - controls.water_rate;
-                break;
-            }
-            case Well::ProducerCMode::GRAT:
-            {
-                assert(FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx));
-                EvalWell rate = -getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx));
-                control_eq = rate - controls.gas_rate;
-                break;
-
-            }
-            case Well::ProducerCMode::LRAT:
-            {
-                assert(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx));
-                assert(FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx));
-                EvalWell rate = -getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx))
-                        - getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx));
-                control_eq =  rate - controls.liquid_rate;
-                break;
-            }
-            case Well::ProducerCMode::CRAT:
-            {
-                OPM_DEFLOG_THROW(std::runtime_error, "CRAT control not supported " << name(), deferred_logger);
-            }
-            case Well::ProducerCMode::RESV:
-            {
-                EvalWell total_rate(numWellEq_ + numEq, 0.); // reservoir rate
-                std::vector<double> convert_coeff(number_of_phases_, 1.0);
-                Base::rateConverter_.calcCoeff(/*fipreg*/ 0, Base::pvtRegionIdx_, convert_coeff);
-                for (int phase = 0; phase < number_of_phases_; ++phase) {
-                    total_rate -= getQs( flowPhaseToEbosCompIdx(phase) ) * convert_coeff[phase];
-                }
-
-                if (controls.prediction_mode) {
-                    control_eq = total_rate - controls.resv_rate;
-                } else {
-                    std::vector<double> hrates(number_of_phases_,0.);
-                    const PhaseUsage& pu = phaseUsage();
-                    if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
-                        hrates[pu.phase_pos[Water]] = controls.water_rate;
-                    }
-                    if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
-                        hrates[pu.phase_pos[Oil]] = controls.oil_rate;
-                    }
-                    if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
-                        hrates[pu.phase_pos[Gas]] = controls.gas_rate;
-                    }
-                    std::vector<double> hrates_resv(number_of_phases_,0.);
-                    Base::rateConverter_.calcReservoirVoidageRates(/*fipreg*/ 0, Base::pvtRegionIdx_, hrates, hrates_resv);
-                    double target = std::accumulate(hrates_resv.begin(), hrates_resv.end(), 0.0);
-                    control_eq = total_rate - target;
-                }
-                break;
-            }
-            case Well::ProducerCMode::BHP:
-            {
-                control_eq = getBhp() - controls.bhp_limit;
-                break;
-            }
-            case Well::ProducerCMode::THP:
-            {
-                std::vector<EvalWell> rates(3, {numWellEq_ + numEq, 0.});
-                if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
-                    rates[ Water ] = getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx));
-                }
-                if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
-                    rates[ Oil ] = getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx));
-                }
-                if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
-                    rates[ Gas ] = getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx));
-                }
-                control_eq = getBhp() - calculateBhpFromThp(rates, well, summaryState, deferred_logger);
-                break;
-            }
-            case Well::ProducerCMode::GRUP:
-            {
-                assert(well.isAvailableForGroupControl());
-
-                const auto& group = schedule.getGroup( well.groupName(), current_step_ );
-                assembleGroupProductionControl(group, well_state, schedule, summaryState, control_eq, efficiencyFactor);
-                break;
-            }
-            case Well::ProducerCMode::CMODE_UNDEFINED:
-            {
-                OPM_DEFLOG_THROW(std::runtime_error, "Well control must be specified for well "  + name(),deferred_logger);
-            }
-            case Well::ProducerCMode::NONE:
-            {
-                OPM_DEFLOG_THROW(std::runtime_error, "Well control must be specified for well "  + name(), deferred_logger);
-            }
-
-            }
-        }
-
 
         // using control_eq to update the matrix and residuals
         // TODO: we should use a different index system for the well equations
@@ -978,54 +821,6 @@ namespace Opm
         }
     }
 
-    template <typename TypeTag>
-    void
-    StandardWell<TypeTag>::assembleGroupInjectionControl(const Group& group,
-                                                         const WellState& well_state,
-                                                         const Opm::Schedule& schedule,
-                                                         const SummaryState& summaryState,
-                                                         const InjectorType& injectorType,
-                                                         EvalWell& control_eq,
-                                                         double efficiencyFactor,
-                                                         Opm::DeferredLogger& deferred_logger)
-    {
-        Base::getGroupInjectionControl(group,
-                                       well_state,
-                                       schedule,
-                                       summaryState,
-                                       injectorType,
-                                       getBhp(),
-                                       getWQTotal(),
-                                       control_eq,
-                                       efficiencyFactor);
-    }
-
-
-
-
-    template <typename TypeTag>
-    void
-    StandardWell<TypeTag>::assembleGroupProductionControl(const Group& group,
-                                                          const WellState& well_state,
-                                                          const Opm::Schedule& schedule,
-                                                          const SummaryState& summaryState,
-                                                          EvalWell& control_eq,
-                                                          double efficiencyFactor)
-    {
-        const auto pu = phaseUsage();
-        std::vector<EvalWell> rates(pu.num_phases);
-        const int compIndices[3] = { FluidSystem::waterCompIdx, FluidSystem::oilCompIdx, FluidSystem::gasCompIdx };
-        const BlackoilPhases::PhaseIndex phases[3] = { BlackoilPhases::Aqua, BlackoilPhases::Liquid, BlackoilPhases::Vapour };
-        for (int canonical_phase = 0; canonical_phase < 3; ++canonical_phase) {
-            const auto phase = phases[canonical_phase];
-            if (pu.phase_used[phase]) {
-                const auto compIdx = compIndices[canonical_phase];
-                rates[pu.phase_pos[phase]] = getQs(Indices::canonicalToActiveComponentIndex(compIdx));
-            }
-        }
-
-        Base::getGroupProductionControl(group, well_state, schedule, summaryState, getBhp(), rates, control_eq, efficiencyFactor);
-    }
 
 
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1178,7 +1178,7 @@ namespace Opm
         // If we are here, we are at the topmost group to be visited in the recursion.
         // This is the group containing the control we will check against.
         wellGroupHelpers::TargetCalculator tcalc(currentGroupControl, pu, Base::rateConverter_, Base::pvtRegionIdx_);
-        wellGroupHelpers::FractionCalculator fcalc(schedule, well_state, current_step_, Base::guide_rate_, tcalc.guideTargetMode());
+        wellGroupHelpers::FractionCalculator fcalc(schedule, well_state, current_step_, Base::guide_rate_, tcalc.guideTargetMode(), pu);
 
         auto localFraction = [&](const std::string& child) {
             return fcalc.localFraction(child, "");
@@ -1238,7 +1238,7 @@ namespace Opm
         case Group::ProductionCMode::ORAT:
         {
             double groupTargetReduction = groupTargetReductions[pu.phase_pos[Oil]];
-            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::OIL));
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::OIL), pu);
 
             const double rate_target = std::max(0.0, groupcontrols.oil_target - groupTargetReduction) / efficiencyFactor;
             assert(FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx));
@@ -1249,7 +1249,7 @@ namespace Opm
         case Group::ProductionCMode::WRAT:
         {
             double groupTargetReduction = groupTargetReductions[pu.phase_pos[Water]];
-            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::WAT));
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::WAT), pu);
 
             const double rate_target = std::max(0.0, groupcontrols.water_target - groupTargetReduction) / efficiencyFactor;
             assert(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx));
@@ -1260,7 +1260,7 @@ namespace Opm
         case Group::ProductionCMode::GRAT:
         {
             double groupTargetReduction = groupTargetReductions[pu.phase_pos[Gas]];
-            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::GAS));
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::GAS), pu);
 
             const double rate_target = std::max(0.0, groupcontrols.gas_target - groupTargetReduction) / efficiencyFactor;
             assert(FluidSystem::phaseIsActive(FluidSystem::gasCompIdx));
@@ -1271,7 +1271,7 @@ namespace Opm
         case Group::ProductionCMode::LRAT:
         {
             double groupTargetReduction = groupTargetReductions[pu.phase_pos[Oil]] + groupTargetReductions[pu.phase_pos[Water]];
-            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::LIQ));
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::LIQ), pu);
 
             const double rate_target = std::max(0.0, groupcontrols.liquid_target - groupTargetReduction) / efficiencyFactor;
             assert(FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx));
@@ -1292,7 +1292,7 @@ namespace Opm
                     + groupTargetReductions[pu.phase_pos[Gas]]
                     + groupTargetReductions[pu.phase_pos[Water]];
 
-            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::RES));
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::RES), pu);
 
             EvalWell total_rate(numWellEq_ + numEq, 0.); // reservoir rate
             std::vector<double> convert_coeff(number_of_phases_, 1.0);

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -981,6 +981,20 @@ namespace Opm
     StandardWell<TypeTag>::
     assembleGroupInjectionControl(const Group& group, const WellState& well_state, const Opm::Schedule& schedule, const SummaryState& summaryState, const InjectorType& injectorType, EvalWell& control_eq, double efficiencyFactor, Opm::DeferredLogger& deferred_logger)
     {
+        if (!group.isAvailableForGroupControl()) {
+            // We cannot go any further up the hierarchy. This could
+            // be the FIELD group, or any group for which this has
+            // been set in GCONINJE or GCONPROD. If we are here
+            // anyway, it is likely that the deck set inconsistent
+            // requirements, such as GRUP control mode on a well with
+            // no appropriate controls defined on any of its
+            // containing groups. We will therefore use the wells' bhp
+            // limit equation as a fallback.
+            const auto& controls = well_ecl_.injectionControls(summaryState);
+            control_eq = getBhp() - controls.bhp_limit;
+            return;
+        }
+
         const auto& well = well_ecl_;
         const auto pu = phaseUsage();
 
@@ -1015,31 +1029,21 @@ namespace Opm
         }
         const Group::InjectionCMode& currentGroupControl = well_state.currentInjectionGroupControl(injectionPhase, group.name());
 
-        if (currentGroupControl == Group::InjectionCMode::FLD) {
+        if (currentGroupControl == Group::InjectionCMode::FLD ||
+            currentGroupControl == Group::InjectionCMode::NONE) {
             // Inject share of parents control
             const auto& parent = schedule.getGroup( group.parent(), current_step_ );
-            if (group.getTransferGroupEfficiencyFactor())
-                efficiencyFactor *= group.getGroupEfficiencyFactor();
-
+            efficiencyFactor *= group.getGroupEfficiencyFactor();
             assembleGroupInjectionControl(parent, well_state, schedule, summaryState, injectorType, control_eq, efficiencyFactor, deferred_logger);
-            return;
-        }
-
-        if (!group.isInjectionGroup() || currentGroupControl == Group::InjectionCMode::NONE) {
-            // use bhp as control eq and let the updateControl code find a valid control
-            const auto& controls = well.injectionControls(summaryState);
-            control_eq = getBhp() - controls.bhp_limit;
             return;
         }
 
         assert(group.hasInjectionControl(injectionPhase));
         const auto& groupcontrols = group.injectionControls(injectionPhase, summaryState);
 
-
         const std::vector<double>& groupInjectionReductions = well_state.currentInjectionGroupReductionRates(group.name());
         double groupTargetReduction = groupInjectionReductions[phasePos];
-        double fraction = wellGroupHelpers::wellFractionFromGuideRates(well, schedule, well_state, current_step_, Base::guide_rate_, wellTarget, /*isInjector*/true);
-        wellGroupHelpers::accumulateGroupInjectionPotentialFractions(well.groupName(), group.name(), schedule, well_state, pu, current_step_, injectionPhase, fraction);
+        double fraction = wellGroupHelpers::fractionFromInjectionPotentials(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(wellTarget), pu, injectionPhase,false);
         switch(currentGroupControl) {
         case Group::InjectionCMode::NONE:
         {
@@ -1049,7 +1053,7 @@ namespace Opm
         }
         case Group::InjectionCMode::RATE:
         {
-            double target = std::max(0.0, (groupcontrols.surface_max_rate / efficiencyFactor - groupTargetReduction) );
+            double target = std::max(0.0, (groupcontrols.surface_max_rate - groupTargetReduction)) / efficiencyFactor;
             control_eq = getWQTotal() - fraction * target;
             break;
         }
@@ -1058,15 +1062,14 @@ namespace Opm
             std::vector<double> convert_coeff(number_of_phases_, 1.0);
             Base::rateConverter_.calcCoeff(/*fipreg*/ 0, Base::pvtRegionIdx_, convert_coeff);
             double coeff = convert_coeff[phasePos];
-            double target = std::max(0.0, (groupcontrols.resv_max_rate/coeff/efficiencyFactor - groupTargetReduction));
+            double target = std::max(0.0, (groupcontrols.resv_max_rate/coeff - groupTargetReduction)) / efficiencyFactor;
             control_eq = getWQTotal() - fraction * target;
             break;
         }
         case Group::InjectionCMode::REIN:
         {
             double productionRate = well_state.currentInjectionREINRates(groupcontrols.reinj_group)[phasePos];
-            productionRate /= efficiencyFactor;
-            double target = std::max(0.0, (groupcontrols.target_reinj_fraction*productionRate - groupTargetReduction));
+            double target = std::max(0.0, (groupcontrols.target_reinj_fraction*productionRate - groupTargetReduction)) / efficiencyFactor;
             control_eq = getWQTotal() - fraction * target;
             break;
         }
@@ -1090,9 +1093,7 @@ namespace Opm
 
             voidageRate -= injReduction;
 
-            voidageRate /= efficiencyFactor;
-
-            double target = std::max(0.0, ( voidageRate/coeff - groupTargetReduction));
+            double target = std::max(0.0, ( voidageRate/coeff - groupTargetReduction)) / efficiencyFactor;
             control_eq = getWQTotal() - fraction * target;
             break;
         }
@@ -1119,8 +1120,7 @@ namespace Opm
             const auto& gconsale = schedule.gConSale(current_step_).get(group.name(), summaryState);
             inj_rate -= gconsale.sales_target;
 
-            inj_rate /= efficiencyFactor;
-            double target = std::max(0.0, (inj_rate - groupTargetReduction));
+            double target = std::max(0.0, (inj_rate - groupTargetReduction)) / efficiencyFactor;
             control_eq = getWQTotal() - fraction * target;
             break;
         }
@@ -1139,30 +1139,94 @@ namespace Opm
     StandardWell<TypeTag>::
     assembleGroupProductionControl(const Group& group, const WellState& well_state, const Opm::Schedule& schedule, const SummaryState& summaryState, EvalWell& control_eq, double efficiencyFactor, Opm::DeferredLogger& deferred_logger)
     {
-
         const auto& well = well_ecl_;
         const auto pu = phaseUsage();
 
         const Group::ProductionCMode& currentGroupControl = well_state.currentProductionGroupControl(group.name());
-        if (currentGroupControl == Group::ProductionCMode::FLD) {
-            // Produce share of parents control
-            const auto& parent = schedule.getGroup( group.parent(), current_step_ );
-            if (group.getTransferGroupEfficiencyFactor())
+        if (currentGroupControl == Group::ProductionCMode::FLD ||
+            currentGroupControl == Group::ProductionCMode::NONE) {
+            if (!group.isAvailableForGroupControl()) {
+                // We cannot go any further up the hierarchy. This could
+                // be the FIELD group, or any group for which this has
+                // been set in GCONINJE or GCONPROD. If we are here
+                // anyway, it is likely that the deck set inconsistent
+                // requirements, such as GRUP control mode on a well with
+                // no appropriate controls defined on any of its
+                // containing groups. We will therefore use the wells' bhp
+                // limit equation as a fallback.
+                const auto& controls = well_ecl_.productionControls(summaryState);
+                control_eq = getBhp() - controls.bhp_limit;
+                return;
+            } else {
+                // Produce share of parents control
+                const auto& parent = schedule.getGroup( group.parent(), current_step_ );
                 efficiencyFactor *= group.getGroupEfficiencyFactor();
-
-            assembleGroupProductionControl(parent, well_state, schedule, summaryState, control_eq, efficiencyFactor, deferred_logger);
-            return;
+                assembleGroupProductionControl(parent, well_state, schedule, summaryState, control_eq, efficiencyFactor, deferred_logger);
+                return;
+            }
         }
 
-        if (!group.isProductionGroup() || currentGroupControl == Group::ProductionCMode::NONE) {
+        if (!group.isProductionGroup()) {
             // use bhp as control eq and let the updateControl code find a vallied control
             const auto& controls = well.productionControls(summaryState);
             control_eq = getBhp() - controls.bhp_limit;
             return;
         }
 
-        const auto& groupcontrols = group.productionControls(summaryState);
+        // ------------------------------- New code start --------------------------------
 
+        // If we are here, we are at the topmost group to be visited in the recursion.
+        // This is the group containing the control we will check against.
+        wellGroupHelpers::TargetCalculator tcalc(currentGroupControl, pu, Base::rateConverter_, Base::pvtRegionIdx_);
+        wellGroupHelpers::FractionCalculator fcalc(schedule, well_state, current_step_, Base::guide_rate_, tcalc.guideTargetMode());
+
+        auto localFraction = [&](const std::string& child) {
+            return fcalc.localFraction(child, "");
+        };
+
+        auto localReduction = [&](const std::string& group_name) {
+            const std::vector<double>& groupTargetReductions = well_state.currentProductionGroupReductionRates(group_name);
+            return tcalc.calcModeRateFromRates(groupTargetReductions);
+        };
+
+        const double orig_target = tcalc.groupTarget(group.productionControls(summaryState));
+        // Assume we have a chain of groups as follows: BOTTOM -> MIDDLE -> TOP.
+        // Then ...
+        // TODO finish explanation.
+        const auto chain = wellGroupHelpers::groupChainTopBot(name(), group.name(), schedule, current_step_);
+        // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
+        const size_t num_ancestors = chain.size() - 1;
+        double target = orig_target;
+        for (size_t ii = 0; ii < num_ancestors; ++ii) {
+            target -= localReduction(chain[ii]);
+            // Next lines: different from in WellGroupHelpers.hpp
+            // if (ii == num_ancestors - 1) {
+            //     // Final level. Add my reduction back.
+            //     target += current_rate*efficiencyFactor;
+            // }
+            target *= localFraction(chain[ii+1]);
+        }
+        const double target_rate = target / efficiencyFactor;
+
+        std::vector<EvalWell> rates(pu.num_phases);
+        const int compIndices[3] = { FluidSystem::waterCompIdx, FluidSystem::oilCompIdx, FluidSystem::gasCompIdx };
+        const BlackoilPhases::PhaseIndex phases[3] = { BlackoilPhases::Aqua, BlackoilPhases::Liquid, BlackoilPhases::Vapour };
+        for (int canonical_phase = 0; canonical_phase < 3; ++canonical_phase) {
+            const auto phase = phases[canonical_phase];
+            if (pu.phase_used[phase]) {
+                const auto compIdx = compIndices[canonical_phase];
+                rates[pu.phase_pos[phase]] = getQs(Indices::canonicalToActiveComponentIndex(compIdx));
+            }
+        }
+        const auto current_rate = -tcalc.calcModeRateFromRates(rates); // Switch sign since 'rates' are negative for producers.
+
+        control_eq = current_rate - target_rate;
+
+        // ------------------------------- New code end --------------------------------
+
+
+#if 0
+        const auto& groupcontrols = group.productionControls(summaryState);
         const std::vector<double>& groupTargetReductions = well_state.currentProductionGroupReductionRates(group.name());
 
         switch(currentGroupControl) {
@@ -1174,10 +1238,9 @@ namespace Opm
         case Group::ProductionCMode::ORAT:
         {
             double groupTargetReduction = groupTargetReductions[pu.phase_pos[Oil]];
-            double fraction = wellGroupHelpers::wellFractionFromGuideRates(well, schedule, well_state, current_step_, Base::guide_rate_, Well::GuideRateTarget::OIL, /*isInjector*/false);
-            wellGroupHelpers::accumulateGroupFractionsFromGuideRates(well.groupName(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, Group::GuideRateTarget::OIL, fraction);
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::OIL));
 
-            const double rate_target = std::max(0.0, groupcontrols.oil_target / efficiencyFactor - groupTargetReduction);
+            const double rate_target = std::max(0.0, groupcontrols.oil_target - groupTargetReduction) / efficiencyFactor;
             assert(FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx));
             EvalWell rate = -getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx));
             control_eq = rate - fraction * rate_target;
@@ -1186,10 +1249,9 @@ namespace Opm
         case Group::ProductionCMode::WRAT:
         {
             double groupTargetReduction = groupTargetReductions[pu.phase_pos[Water]];
-            double fraction = wellGroupHelpers::wellFractionFromGuideRates(well, schedule, well_state, current_step_, Base::guide_rate_, Well::GuideRateTarget::WAT, /*isInjector*/false);
-            wellGroupHelpers::accumulateGroupFractionsFromGuideRates(well.groupName(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, Group::GuideRateTarget::WAT, fraction);
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::WAT));
 
-            const double rate_target = std::max(0.0, groupcontrols.water_target / efficiencyFactor - groupTargetReduction);
+            const double rate_target = std::max(0.0, groupcontrols.water_target - groupTargetReduction) / efficiencyFactor;
             assert(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx));
             EvalWell rate = -getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx));
             control_eq = rate - fraction * rate_target;
@@ -1198,10 +1260,9 @@ namespace Opm
         case Group::ProductionCMode::GRAT:
         {
             double groupTargetReduction = groupTargetReductions[pu.phase_pos[Gas]];
-            double fraction = wellGroupHelpers::wellFractionFromGuideRates(well, schedule, well_state, current_step_, Base::guide_rate_, Well::GuideRateTarget::GAS, /*isInjector*/false);
-            wellGroupHelpers::accumulateGroupFractionsFromGuideRates(well.groupName(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, Group::GuideRateTarget::GAS, fraction);
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::GAS));
 
-            const double rate_target = std::max(0.0, groupcontrols.gas_target / efficiencyFactor - groupTargetReduction);
+            const double rate_target = std::max(0.0, groupcontrols.gas_target - groupTargetReduction) / efficiencyFactor;
             assert(FluidSystem::phaseIsActive(FluidSystem::gasCompIdx));
             EvalWell rate = -getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx));
             control_eq = rate - fraction * rate_target;
@@ -1210,10 +1271,9 @@ namespace Opm
         case Group::ProductionCMode::LRAT:
         {
             double groupTargetReduction = groupTargetReductions[pu.phase_pos[Oil]] + groupTargetReductions[pu.phase_pos[Water]];
-            double fraction = wellGroupHelpers::wellFractionFromGuideRates(well, schedule, well_state, current_step_, Base::guide_rate_, Well::GuideRateTarget::LIQ, /*isInjector*/false);
-            wellGroupHelpers::accumulateGroupFractionsFromGuideRates(well.groupName(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, Group::GuideRateTarget::LIQ, fraction);
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::LIQ));
 
-            const double rate_target = std::max(0.0, groupcontrols.liquid_target / efficiencyFactor - groupTargetReduction);
+            const double rate_target = std::max(0.0, groupcontrols.liquid_target - groupTargetReduction) / efficiencyFactor;
             assert(FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx));
 
             EvalWell rate = -getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx))
@@ -1232,8 +1292,7 @@ namespace Opm
                     + groupTargetReductions[pu.phase_pos[Gas]]
                     + groupTargetReductions[pu.phase_pos[Water]];
 
-            double fraction = wellGroupHelpers::wellFractionFromGuideRates(well, schedule, well_state, current_step_, Base::guide_rate_, Well::GuideRateTarget::RES, /*isInjector*/false);
-            wellGroupHelpers::accumulateGroupFractionsFromGuideRates(well.groupName(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, Group::GuideRateTarget::RES, fraction);
+            double fraction = wellGroupHelpers::fractionFromGuideRates(well.name(), group.name(), schedule, well_state, current_step_, Base::guide_rate_, GuideRateModel::convert_target(Well::GuideRateTarget::RES));
 
             EvalWell total_rate(numWellEq_ + numEq, 0.); // reservoir rate
             std::vector<double> convert_coeff(number_of_phases_, 1.0);
@@ -1242,7 +1301,7 @@ namespace Opm
                 total_rate -= getQs( flowPhaseToEbosCompIdx(phase) ) * convert_coeff[phase];
             }
 
-            const double rate_target = std::max(0.0, groupcontrols.resv_target/ efficiencyFactor - groupTargetReduction);
+            const double rate_target = std::max(0.0, groupcontrols.resv_target - groupTargetReduction) / efficiencyFactor;
             assert(FluidSystem::phaseIsActive(FluidSystem::gasCompIdx));
             control_eq = total_rate - fraction * rate_target;
             break;
@@ -1262,6 +1321,7 @@ namespace Opm
         default:
             OPM_DEFLOG_THROW(std::runtime_error, "Unvallied group control specified for group "  + well.groupName(), deferred_logger );
         }
+#endif
     }
 
 

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -657,7 +657,6 @@ namespace Opm {
         double guideRate(const std::string& name, const std::string& always_included_child)
         {
             if (schedule_.hasWell(name, report_step_)) {
-                std::cout << "getWellRate " << name << std::endl;
                 return guide_rate_->get(name, target_, getRateVector(well_state_, pu_, name));
             } else {
                 if (groupControlledWells(name, always_included_child) > 0) {
@@ -668,7 +667,6 @@ namespace Opm {
                         // Compute guide rate by accumulating our children's guide rates.
                         // (only children not under individual control though).
                         const Group& group = schedule_.getGroup(name, report_step_);
-                        std::cout << " guideRateSUM" << std::endl;
                         return guideRateSum(group, always_included_child);
                     }
                 } else {
@@ -705,8 +703,6 @@ namespace Opm {
 
     inline GuideRate::RateVector getGroupRateVector(const std::string& group_name) {
 
-#warning Does not work in parallell
-        std::cout << " getGroupRateVector " << group_name <<std::endl;
         std::vector<double> groupRates = well_state_.currentProductionGroupRates(group_name);
         double oilRate = 0.0;
         if (pu_.phase_used[BlackoilPhases::Liquid])

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -422,24 +422,24 @@ namespace Opm {
 
 	inline GuideRate::RateVector getRateVector(const WellState& well_state, const PhaseUsage& pu, const std::string& name) {
 
-            const auto& end = well_state.wellMap().end();
-            const auto& it = well_state.wellMap().find( name);
-            if (it == end)  // the well is not found
-                assert(false);
+        const auto& end = well_state.wellMap().end();
+        const auto& it = well_state.wellMap().find( name);
+        if (it == end)  // the well is not found
+            assert(false);
 
-            int well_index = it->second[0];
-	    int np = well_state.numPhases();
-            double oilRate = 0.0;
-            if (pu.phase_used[BlackoilPhases::Liquid])
-                oilRate = well_state.wellRates()[ well_index*np + pu.phase_pos[BlackoilPhases::Liquid]];
+        int well_index = it->second[0];
+		int np = well_state.numPhases();
+        double oilRate = 0.0;
+        if (pu.phase_used[BlackoilPhases::Liquid])
+            oilRate = well_state.wellRates()[ well_index*np + pu.phase_pos[BlackoilPhases::Liquid]];
         
-            double gasRate = 0.0;
-            if (pu.phase_used[BlackoilPhases::Vapour])
-                gasRate = well_state.wellRates()[ well_index*np + pu.phase_pos[BlackoilPhases::Vapour]];
+        double gasRate = 0.0;
+        if (pu.phase_used[BlackoilPhases::Vapour])
+            gasRate = well_state.wellRates()[ well_index*np + pu.phase_pos[BlackoilPhases::Vapour]];
 
-            double waterRate = 0.0;
-            if (pu.phase_used[BlackoilPhases::Aqua])
-                waterRate = well_state.wellRates()[well_index*np + pu.phase_pos[BlackoilPhases::Aqua]];
+		double waterRate = 0.0;
+        if (pu.phase_used[BlackoilPhases::Aqua])
+            waterRate = well_state.wellRates()[well_index*np + pu.phase_pos[BlackoilPhases::Aqua]];
 
 	    return GuideRate::RateVector{oilRate, gasRate, waterRate};
 	}
@@ -451,7 +451,7 @@ namespace Opm {
                                const int reportStepIdx,
                                const GuideRate* guideRate,
                                const GuideRateModel::Target target,
-			       const PhaseUsage& pu)
+							   const PhaseUsage& pu)
     {
         if (schedule.hasWell(name, reportStepIdx) || guideRate->has(name)) {
             return guideRate->get(name, target, getRateVector(wellState, pu, name));
@@ -678,18 +678,18 @@ namespace Opm {
 	inline GuideRate::RateVector getGroupRateVector(const std::string& group_name) {
 
 #warning Does not work in parallell
-            const Group& group = schedule_.getGroup(group_name, report_step_);
-            double oilRate = 0.0;
-            if (pu_.phase_used[BlackoilPhases::Liquid])
-		oilRate = sumWellPhaseRates(well_state_.wellRates(), group, schedule_, well_state_, report_step_, pu_.phase_pos[BlackoilPhases::Liquid], /*isInjector*/ false);
+        const Group& group = schedule_.getGroup(group_name, report_step_);
+        double oilRate = 0.0;
+        if (pu_.phase_used[BlackoilPhases::Liquid])
+			oilRate = sumWellPhaseRates(well_state_.wellRates(), group, schedule_, well_state_, report_step_, pu_.phase_pos[BlackoilPhases::Liquid], /*isInjector*/ false);
         
-            double gasRate = 0.0;
-            if (pu_.phase_used[BlackoilPhases::Vapour])
-                gasRate = sumWellPhaseRates(well_state_.wellRates(), group, schedule_, well_state_, report_step_, pu_.phase_pos[BlackoilPhases::Vapour], /*isInjector*/ false);
+        double gasRate = 0.0;
+        if (pu_.phase_used[BlackoilPhases::Vapour])
+            gasRate = sumWellPhaseRates(well_state_.wellRates(), group, schedule_, well_state_, report_step_, pu_.phase_pos[BlackoilPhases::Vapour], /*isInjector*/ false);
 
-            double waterRate = 0.0;
-            if (pu_.phase_used[BlackoilPhases::Aqua])
-                waterRate = sumWellPhaseRates(well_state_.wellRates(), group, schedule_, well_state_, report_step_, pu_.phase_pos[BlackoilPhases::Aqua], /*isInjector*/ false);
+        double waterRate = 0.0;
+        if (pu_.phase_used[BlackoilPhases::Aqua])
+            waterRate = sumWellPhaseRates(well_state_.wellRates(), group, schedule_, well_state_, report_step_, pu_.phase_pos[BlackoilPhases::Aqua], /*isInjector*/ false);
 
 	    return GuideRate::RateVector{oilRate, gasRate, waterRate};
 	}
@@ -711,7 +711,7 @@ namespace Opm {
                                          const int reportStepIdx,
                                          const GuideRate* guideRate,
                                          const GuideRateModel::Target target,
-					 const PhaseUsage& pu,
+										 const PhaseUsage& pu,
                                          const bool alwaysIncludeThis = false)
     {
         FractionCalculator calc(schedule, wellState, reportStepIdx, guideRate, target, pu);

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -1204,7 +1204,7 @@ namespace Opm {
             }
             target *= localFraction(chain[ii+1]);
         }
-        const double target_rate = target / efficiencyFactor;
+        const double target_rate = std::max(0.0, target / efficiencyFactor);
         return std::make_pair(current_rate > target_rate, target_rate / current_rate);
     }
 

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -21,10 +21,12 @@
 #ifndef OPM_WELLGROUPHELPERS_HEADER_INCLUDED
 #define OPM_WELLGROUPHELPERS_HEADER_INCLUDED
 
-#include <opm/output/data/Groups.hpp>
-
-#include <vector>
+#include <opm/simulators/utils/DeferredLogger.hpp>
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
+
+#include <algorithm>
+#include <vector>
 
 namespace Opm {
 
@@ -32,64 +34,12 @@ namespace Opm {
     namespace wellGroupHelpers
     {
 
-    inline void setGroupControl(const Group& group, const Schedule& schedule, const Phase& groupInjectionPhase, const int reportStepIdx, const bool injector, WellStateFullyImplicitBlackoil& wellState, std::ostringstream& ss) {
 
-        for (const std::string& groupName : group.groups()) {
-            const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            setGroupControl(groupTmp, schedule, groupInjectionPhase, reportStepIdx, injector, wellState, ss);
-            if (injector) {
-                wellState.setCurrentInjectionGroupControl(groupInjectionPhase, groupName, Group::InjectionCMode::FLD);
-            } else {
-                wellState.setCurrentProductionGroupControl(groupName, Group::ProductionCMode::FLD);
-            }
-        }
-
-        const auto& end = wellState.wellMap().end();
-        for (const std::string& wellName : group.wells()) {
-            const auto& it = wellState.wellMap().find( wellName );
-            if (it == end)  // the well is not found
-                continue;
-
-            int well_index = it->second[0];
-            const auto& wellEcl = schedule.getWell(wellName, reportStepIdx);
-
-            if (wellEcl.getStatus() == Well::Status::SHUT)
-                continue;
-
-            if (!wellEcl.isAvailableForGroupControl())
-                continue;
-
-            if (wellEcl.isProducer() && !injector) {
-                if (wellState.currentProductionControls()[well_index] != Well::ProducerCMode::GRUP) {
-                    wellState.currentProductionControls()[well_index] = Well::ProducerCMode::GRUP;
-                    ss <<"\n Producer " << wellName << " switches to GRUP control limit";
-                }
-            }
-
-            if (wellEcl.isInjector() && injector) {
-                // only switch if the well phase is the same as the group phase
-                // Get the current controls.
-                const InjectorType& injectorType = wellEcl.getInjectionProperties().injectorType;
-
-                if (injectorType == InjectorType::WATER && groupInjectionPhase != Phase::WATER)
-                    continue;
-
-                if (injectorType == InjectorType::OIL && groupInjectionPhase != Phase::OIL)
-                    continue;
-
-                if (injectorType == InjectorType::GAS && groupInjectionPhase != Phase::GAS)
-                    continue;
-
-                if (injectorType == InjectorType::MULTI)
-                    throw("Expected WATER, OIL or GAS as type for injectors " + wellEcl.name());
-
-                if (wellState.currentInjectionControls()[well_index] != Well::InjectorCMode::GRUP) {
-                    wellState.currentInjectionControls()[well_index] = Well::InjectorCMode::GRUP;
-                    ss <<"\n Injector " << wellName << " switches to GRUP control limit";
-                }
-            }
-        }
-    }
+    int groupControlledWells(const Schedule& schedule,
+                             const WellStateFullyImplicitBlackoil& well_state,
+                             const int report_step,
+                             const std::string& group_name,
+                             const std::string& always_included_child);
 
     inline void setCmodeGroup(const Group& group, const Schedule& schedule, const SummaryState& summaryState, const int reportStepIdx, WellStateFullyImplicitBlackoil& wellState) {
 
@@ -108,7 +58,7 @@ namespace Opm {
             wellState.setCurrentProductionGroupControl(group.name(), Group::ProductionCMode::NONE);
         }
 
-        if (group.isInjectionGroup() && schedule.hasWellGroupEvent(group.name(),  ScheduleEvents::GROUP_INJECTION_UPDATE, reportStepIdx)) {           
+        if (group.isInjectionGroup() && schedule.hasWellGroupEvent(group.name(),  ScheduleEvents::GROUP_INJECTION_UPDATE, reportStepIdx)) {
 
             for (Phase phase : all) {
                 if (!group.hasInjectionControl(phase))
@@ -126,8 +76,6 @@ namespace Opm {
 
         if (schedule.gConSale(reportStepIdx).has(group.name())) {
             wellState.setCurrentInjectionGroupControl(Phase::GAS, group.name(), Group::InjectionCMode::SALE);
-            std::ostringstream ss;
-            setGroupControl(group, schedule, Phase::GAS, reportStepIdx, /*injector*/true, wellState, ss);
         }
     }
 
@@ -136,45 +84,6 @@ namespace Opm {
         if (group.parent() != "FIELD")
             accumulateGroupEfficiencyFactor(schedule.getGroup(group.parent(), reportStepIdx), schedule, reportStepIdx, factor);
     }
-
-
-    inline void computeGroupTargetReduction(const Group& group, const WellStateFullyImplicitBlackoil& wellState, const Schedule& schedule, const int reportStepIdx, const int phasePos, const bool isInjector, double& groupTargetReduction )
-    {
-
-        for (const std::string& groupName : group.groups()) {
-            const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            computeGroupTargetReduction(groupTmp, wellState, schedule, reportStepIdx, phasePos, isInjector, groupTargetReduction);
-        }
-        for (const std::string& wellName : group.wells()) {
-            const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
-
-            if (wellTmp.isProducer() && isInjector)
-                 continue;
-
-            if (wellTmp.isInjector() && !isInjector)
-                 continue;
-
-            if (wellTmp.getStatus() == Well::Status::SHUT)
-                continue;
-
-            const auto& end = wellState.wellMap().end();
-                const auto& it = wellState.wellMap().find( wellName );
-                if (it == end)  // the well is not found
-                    continue;
-
-            int well_index = it->second[0];
-            const auto wellrate_index = well_index * wellState.numPhases();
-            // add contributino from wells not under group control
-            if (isInjector) {
-                if (wellState.currentInjectionControls()[well_index] != Well::InjectorCMode::GRUP)
-                    groupTargetReduction += wellState.wellRates()[wellrate_index + phasePos];
-            } else {
-                if (wellState.currentProductionControls()[well_index] !=  Well::ProducerCMode::GRUP)
-                    groupTargetReduction -= wellState.wellRates()[wellrate_index + phasePos];
-            }
-        }
-    }
-
 
     inline double sumWellPhaseRates(const std::vector<double>& rates, const Group& group, const Schedule& schedule, const WellStateFullyImplicitBlackoil& wellState, const int reportStepIdx, const int phasePos,
                                     const bool injector) {
@@ -253,16 +162,16 @@ namespace Opm {
     inline void updateGroupTargetReduction(const Group& group, const Schedule& schedule, const int reportStepIdx, const bool isInjector, const PhaseUsage& pu, const WellStateFullyImplicitBlackoil& wellStateNupcol, WellStateFullyImplicitBlackoil& wellState, std::vector<double>& groupTargetReduction)
     {
         const int np = wellState.numPhases();
-        for (const std::string& groupName : group.groups()) {
-            std::vector<double> thisGroupTargetReduction(np, 0.0);
-            const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            updateGroupTargetReduction(groupTmp, schedule, reportStepIdx, isInjector, pu, wellStateNupcol, wellState, thisGroupTargetReduction);
+        for (const std::string& subGroupName : group.groups()) {
+            std::vector<double> subGroupTargetReduction(np, 0.0);
+            const Group& subGroup = schedule.getGroup(subGroupName, reportStepIdx);
+            updateGroupTargetReduction(subGroup, schedule, reportStepIdx, isInjector, pu, wellStateNupcol, wellState, subGroupTargetReduction);
 
             // accumulate group contribution from sub group
             if (isInjector) {
                 const Phase all[] = {Phase::WATER, Phase::OIL, Phase::GAS};
                 for (Phase phase : all) {
-                    const Group::InjectionCMode& currentGroupControl = wellState.currentInjectionGroupControl(phase, groupName);
+                    const Group::InjectionCMode& currentGroupControl = wellState.currentInjectionGroupControl(phase, subGroupName);
                     int phasePos;
                     if (phase == Phase::GAS && pu.phase_used[BlackoilPhases::Vapour] )
                         phasePos = pu.phase_pos[BlackoilPhases::Vapour];
@@ -273,22 +182,27 @@ namespace Opm {
                     else
                         continue;
 
-                    if (currentGroupControl != Group::InjectionCMode::FLD) {
-                        groupTargetReduction[phasePos] += sumWellRates(groupTmp, schedule, wellStateNupcol, reportStepIdx, phasePos, isInjector);
+                    if (currentGroupControl != Group::InjectionCMode::FLD &&
+                        currentGroupControl != Group::InjectionCMode::NONE) {
+                        // Subgroup is under individual control.
+                        groupTargetReduction[phasePos] += sumWellRates(subGroup, schedule, wellStateNupcol, reportStepIdx, phasePos, isInjector);
                     } else {
-                        groupTargetReduction[phasePos] += thisGroupTargetReduction[phasePos];
+                        groupTargetReduction[phasePos] += subGroupTargetReduction[phasePos];
                     }
                 }
             } else {
-                const Group::ProductionCMode& currentGroupControl = wellState.currentProductionGroupControl(groupName);
-                if (currentGroupControl != Group::ProductionCMode::FLD) {
+                const Group::ProductionCMode& currentGroupControl = wellState.currentProductionGroupControl(subGroupName);
+                const bool individual_control = (currentGroupControl != Group::ProductionCMode::FLD &&
+                                                 currentGroupControl != Group::ProductionCMode::NONE);
+                const int num_group_controlled_wells = groupControlledWells(schedule, wellStateNupcol, reportStepIdx, subGroupName, "");
+                if (individual_control || num_group_controlled_wells == 0) {
                     for (int phase = 0; phase < np; phase++) {
-                        groupTargetReduction[phase] += sumWellRates(groupTmp, schedule, wellStateNupcol, reportStepIdx, phase, isInjector);
+                        groupTargetReduction[phase] += sumWellRates(subGroup, schedule, wellStateNupcol, reportStepIdx, phase, isInjector);
                     }
                 } else {
                     // or accumulate directly from the wells if controled from its parents
                     for (int phase = 0; phase < np; phase++) {
-                        groupTargetReduction[phase] += thisGroupTargetReduction[phase];
+                        // groupTargetReduction[phase] += subGroupTargetReduction[phase];
                     }
                 }
             }
@@ -312,18 +226,23 @@ namespace Opm {
 
             int well_index = it->second[0];
             const auto wellrate_index = well_index * wellState.numPhases();
+            const double efficiency = wellTmp.getEfficiencyFactor();
             // add contributino from wells not under group control
             if (isInjector) {
                 if (wellState.currentInjectionControls()[well_index] != Well::InjectorCMode::GRUP)
                     for (int phase = 0; phase < np; phase++) {
-                        groupTargetReduction[phase] += wellStateNupcol.wellRates()[wellrate_index + phase];
+                        groupTargetReduction[phase] += wellStateNupcol.wellRates()[wellrate_index + phase] * efficiency;
                     }
             } else {
                 if (wellState.currentProductionControls()[well_index] !=  Well::ProducerCMode::GRUP)
                     for (int phase = 0; phase < np; phase++) {
-                        groupTargetReduction[phase] -= wellStateNupcol.wellRates()[wellrate_index + phase];
+                        groupTargetReduction[phase] -= wellStateNupcol.wellRates()[wellrate_index + phase] * efficiency;
                     }
             }
+        }
+        const double groupEfficiency = group.getGroupEfficiencyFactor();
+        for (double& elem : groupTargetReduction) {
+            elem *= groupEfficiency;
         }
         if (isInjector)
             wellState.setCurrentInjectionGroupReductionRates(group.name(), groupTargetReduction);
@@ -340,14 +259,11 @@ namespace Opm {
             const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
             updateGuideRateForGroups(groupTmp, schedule, pu, reportStepIdx, simTime, isInjector, wellState, comm, guideRate, thisPot);
 
-            // accumulate group contribution from sub group if FLD
+            // accumulate group contribution from sub group unconditionally
             if (isInjector) {
                 const Phase all[] = {Phase::WATER, Phase::OIL, Phase::GAS};
                 for (Phase phase : all) {
                     const Group::InjectionCMode& currentGroupControl = wellState.currentInjectionGroupControl(phase, groupName);
-                    if (currentGroupControl != Group::InjectionCMode::FLD) {
-                        continue;
-                    }
                     int phasePos;
                     if (phase == Phase::GAS && pu.phase_used[BlackoilPhases::Vapour] )
                         phasePos = pu.phase_pos[BlackoilPhases::Vapour];
@@ -362,7 +278,7 @@ namespace Opm {
                 }
             } else {
                 const Group::ProductionCMode& currentGroupControl = wellState.currentProductionGroupControl(groupName);
-                if (currentGroupControl != Group::ProductionCMode::FLD) {
+                if (currentGroupControl != Group::ProductionCMode::FLD && currentGroupControl != Group::ProductionCMode::NONE) {
                     continue;
                 }
                 for (int phase = 0; phase < np; phase++) {
@@ -389,17 +305,9 @@ namespace Opm {
 
             int well_index = it->second[0];
             const auto wellrate_index = well_index * wellState.numPhases();
-            // add contribution from wells not under group control
-            if (isInjector) {
-                if (wellState.currentInjectionControls()[well_index] == Well::InjectorCMode::GRUP)
-                    for (int phase = 0; phase < np; phase++) {
-                        pot[phase] += wellState.wellPotentials()[wellrate_index + phase];
-                    }
-            } else {
-                if (wellState.currentProductionControls()[well_index] ==  Well::ProducerCMode::GRUP)
-                    for (int phase = 0; phase < np; phase++) {
-                        pot[phase] -= wellState.wellPotentials()[wellrate_index + phase];
-                    }
+            // add contribution from wells unconditionally
+            for (int phase = 0; phase < np; phase++) {
+                pot[phase] += wellState.wellPotentials()[wellrate_index + phase];
             }
         }
 
@@ -415,9 +323,11 @@ namespace Opm {
         if (pu.phase_used[BlackoilPhases::Aqua])
             waterPot = pot [pu.phase_pos[BlackoilPhases::Aqua]];
 
-        oilPot = comm.sum(oilPot);
-        gasPot = comm.sum(gasPot);
-        waterPot = comm.sum(waterPot);
+        const double gefac = group.getGroupEfficiencyFactor();
+
+        oilPot = comm.sum(oilPot) * gefac;
+        gasPot = comm.sum(gasPot) * gefac;
+        waterPot = comm.sum(waterPot) * gefac;
 
         if (isInjector) {
             wellState.setCurrentGroupInjectionPotentials(group.name(), pot);
@@ -450,9 +360,10 @@ namespace Opm {
                 if (pu.phase_used[BlackoilPhases::Aqua] > 0)
                     waterpot = wpot[pu.phase_pos[BlackoilPhases::Aqua]];
             }
-            oilpot = comm.sum(oilpot);
-            gaspot = comm.sum(gaspot);
-            waterpot = comm.sum(waterpot);
+            const double wefac = well.getEfficiencyFactor();
+            oilpot = comm.sum(oilpot) * wefac;
+            gaspot = comm.sum(gaspot) * wefac;
+            waterpot = comm.sum(waterpot) * wefac;
             guideRate->compute(well.name(), reportStepIdx, simTime, oilpot, gaspot, waterpot);
         }
 
@@ -509,105 +420,712 @@ namespace Opm {
         wellState.setCurrentInjectionREINRates(group.name(), rein);
     }
 
-    inline double wellFractionFromGuideRates(const Well& well, const Schedule& schedule, const WellStateFullyImplicitBlackoil& wellState, const int reportStepIdx, const GuideRate* guideRate, const Well::GuideRateTarget& wellTarget, const bool isInjector) {
-        double groupTotalGuideRate = 0.0;
-        const Group& groupTmp = schedule.getGroup(well.groupName(), reportStepIdx);
-        int global_well_index = -1;
-        for (const std::string& wellName : groupTmp.wells()) {
+
+
+    inline double getGuideRate(const std::string& name,
+                               const Schedule& schedule,
+                               const WellStateFullyImplicitBlackoil& wellState,
+                               const int reportStepIdx,
+                               const GuideRate* guideRate,
+                               const GuideRateModel::Target target)
+    {
+        if (schedule.hasWell(name, reportStepIdx) || guideRate->has(name)) {
+            return guideRate->get(name, target);
+        }
+
+        double totalGuideRate = 0.0;
+        const Group& group = schedule.getGroup(name, reportStepIdx);
+
+        for (const std::string& groupName : group.groups()) {
+            const Group::ProductionCMode& currentGroupControl = wellState.currentProductionGroupControl(groupName);
+            if (currentGroupControl == Group::ProductionCMode::FLD || currentGroupControl == Group::ProductionCMode::NONE) {
+                // accumulate from sub wells/groups
+                totalGuideRate += getGuideRate(groupName, schedule, wellState, reportStepIdx, guideRate, target);
+            }
+        }
+
+        for (const std::string& wellName : group.wells()) {
             const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
 
-            global_well_index++;
-
-            if (wellTmp.isProducer() && isInjector)
-                 continue;
-
-            if (wellTmp.isInjector() && !isInjector)
+            if (wellTmp.isInjector())
                  continue;
 
             if (wellTmp.getStatus() == Well::Status::SHUT)
                 continue;
 
-            // only count wells under group control
-            if (isInjector) {
-                if (!wellState.isInjectionGrup(wellName))
-                    continue;
-            } else {
-                if (!wellState.isProductionGrup(wellName))
-                    continue;
-            }
-
-            groupTotalGuideRate += guideRate->get(wellName, wellTarget);
-        }
-
-        if (groupTotalGuideRate == 0.0)
-            return 0.0;
-
-        double wellGuideRate = guideRate->get(well.name(), wellTarget);
-        return wellGuideRate / groupTotalGuideRate;
-    }
-
-    inline double groupFractionFromGuideRates(const Group& group, const Schedule& schedule, const WellStateFullyImplicitBlackoil& wellState, const int reportStepIdx, const GuideRate* guideRate, const Group::GuideRateTarget& groupTarget) {
-        double groupTotalGuideRate = 0.0;
-        const Group& groupParent = schedule.getGroup(group.parent(), reportStepIdx);
-        for (const std::string& groupName : groupParent.groups()) {
-            // only count group under group control from its parent
-            const Group::ProductionCMode& currentGroupControl = wellState.currentProductionGroupControl(groupName);
-            if (currentGroupControl != Group::ProductionCMode::FLD)
+            // Only count wells under group control or the ru
+            if (!wellState.isProductionGrup(wellName))
                 continue;
 
-            groupTotalGuideRate += guideRate->get(groupName, groupTarget);
+            totalGuideRate += guideRate->get(wellName, target);
         }
-        if (groupTotalGuideRate == 0.0)
-            return 1.0;
+        return totalGuideRate;
+   }
 
-        double groupGuideRate = guideRate->get(group.name(), groupTarget);
-        return groupGuideRate / groupTotalGuideRate;
-    }
 
-    inline void accumulateGroupFractionsFromGuideRates(const std::string& groupName, const std::string& controlGroupName, const Schedule& schedule, const WellStateFullyImplicitBlackoil& wellState,const int reportStepIdx, const GuideRate* guideRate, const Group::GuideRateTarget& groupTarget, double& fraction) {
-        const Group& group = schedule.getGroup(groupName, reportStepIdx);
-        if (groupName != controlGroupName) {
-            fraction *= groupFractionFromGuideRates(group, schedule, wellState, reportStepIdx, guideRate, groupTarget);
-            accumulateGroupFractionsFromGuideRates(group.parent(), controlGroupName, schedule, wellState, reportStepIdx, guideRate, groupTarget, fraction);
+    inline double getGuideRateInj(const std::string& name,
+                                  const Schedule& schedule,
+                                  const WellStateFullyImplicitBlackoil& wellState,
+                                  const int reportStepIdx,
+                                  const GuideRate* guideRate,
+                                  const GuideRateModel::Target target,
+                                  const Phase& injectionPhase)
+    {
+        if (schedule.hasWell(name, reportStepIdx)) {
+            return guideRate->get(name, target);
         }
-        return;
-    }
 
-    inline double groupFractionFromInjectionPotentials(const Group& group, const Schedule& schedule, const WellStateFullyImplicitBlackoil& wellState, const PhaseUsage& pu, const int reportStepIdx, const Phase& injectionPhase) {
-        double groupTotalGuideRate = 0.0;
-        const Group& groupParent = schedule.getGroup(group.parent(), reportStepIdx);
-        int phasePos;
-        if (injectionPhase == Phase::GAS && pu.phase_used[BlackoilPhases::Vapour] )
-            phasePos = pu.phase_pos[ pu.phase_pos[BlackoilPhases::Vapour] ];
-        else if (injectionPhase == Phase::OIL && pu.phase_used[BlackoilPhases::Liquid])
-            phasePos = pu.phase_pos[ pu.phase_pos[BlackoilPhases::Liquid] ];
-        else if (injectionPhase == Phase::WATER && pu.phase_used[BlackoilPhases::Aqua] )
-            phasePos = pu.phase_pos[ pu.phase_pos[BlackoilPhases::Aqua] ];
-        else
-            throw("this should not happen");
+        double totalGuideRate = 0.0;
+        const Group& group = schedule.getGroup(name, reportStepIdx);
 
-        for (const std::string& groupName : groupParent.groups()) {
-            // only count group under group control from its parent
+        for (const std::string& groupName : group.groups()) {
             const Group::InjectionCMode& currentGroupControl = wellState.currentInjectionGroupControl(injectionPhase, groupName);
-            if (currentGroupControl != Group::InjectionCMode::FLD)
+            if (currentGroupControl == Group::InjectionCMode::FLD || currentGroupControl == Group::InjectionCMode::NONE) {
+                // accumulate from sub wells/groups
+                totalGuideRate += getGuideRateInj(groupName, schedule, wellState, reportStepIdx, guideRate, target, injectionPhase);
+            }
+        }
+
+        for (const std::string& wellName : group.wells()) {
+            const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
+
+            if (!wellTmp.isInjector())
+                 continue;
+
+            if (wellTmp.getStatus() == Well::Status::SHUT)
                 continue;
 
-            groupTotalGuideRate += wellState.currentGroupInjectionPotentials(groupName)[phasePos];
-        }
-        if (groupTotalGuideRate == 0.0)
-            return 1.0;
+            // Only count wells under group control or the ru
+            if (!wellState.isInjectionGrup(wellName))
+                continue;
 
-        double groupGuideRate = wellState.currentGroupInjectionPotentials(group.name())[phasePos];
-        return groupGuideRate / groupTotalGuideRate;
+            totalGuideRate += guideRate->get(wellName, target);
+        }
+        return totalGuideRate;
     }
 
-    inline void accumulateGroupInjectionPotentialFractions(const std::string& groupName, const std::string& controlGroupName, const Schedule& schedule, const WellStateFullyImplicitBlackoil& wellState, const PhaseUsage& pu, const int reportStepIdx, const Phase& injectionPhase, double& fraction) {
-        const Group& group = schedule.getGroup(groupName, reportStepIdx);
-        if (groupName != controlGroupName) {
-            fraction *= groupFractionFromInjectionPotentials(group, schedule, wellState, pu, reportStepIdx, injectionPhase);
-            accumulateGroupInjectionPotentialFractions(group.parent(), controlGroupName, schedule, wellState, pu, reportStepIdx, injectionPhase, fraction);
+
+
+    inline int
+    groupControlledWells(const Schedule& schedule,
+                         const WellStateFullyImplicitBlackoil& well_state,
+                         const int report_step,
+                         const std::string& group_name,
+                         const std::string& always_included_child)
+    {
+        const Group& group = schedule.getGroup(group_name, report_step);
+        int num_wells = 0;
+        for (const std::string& child_group : group.groups()) {
+            const auto ctrl = well_state.currentProductionGroupControl(child_group);
+            const bool included = (ctrl == Group::ProductionCMode::FLD) || (ctrl == Group::ProductionCMode::NONE)
+                || (child_group == always_included_child);
+            if (included) {
+                num_wells += groupControlledWells(schedule, well_state, report_step, child_group, always_included_child);
+            }
         }
-        return;
+        for (const std::string& child_well : group.wells()) {
+            const bool included = (well_state.isProductionGrup(child_well)) || (child_well == always_included_child);
+            if (included) {
+                ++num_wells;
+            }
+        }
+        return num_wells;
+    }
+
+
+    class FractionCalculator
+    {
+    public:
+        FractionCalculator(const Schedule& schedule,
+                           const WellStateFullyImplicitBlackoil& well_state,
+                           const int report_step,
+                           const GuideRate* guide_rate,
+                           const GuideRateModel::Target target)
+            : schedule_(schedule)
+            , well_state_(well_state)
+            , report_step_(report_step)
+            , guide_rate_(guide_rate)
+            , target_(target)
+        {
+        }
+        double fraction(const std::string& name,
+                        const std::string& control_group_name,
+                        const bool always_include_this)
+        {
+            double fraction = 1.0;
+            std::string current = name;
+            while (current != control_group_name) {
+                fraction *= localFraction(current, always_include_this ? name : "");
+                current = parent(current);
+            }
+            return fraction;
+        }
+        double localFraction(const std::string& name, const std::string& always_included_child)
+        {
+            const double my_guide_rate = guideRate(name, always_included_child);
+            const Group& parent_group = schedule_.getGroup(parent(name), report_step_);
+            const double total_guide_rate = guideRateSum(parent_group, always_included_child);
+            assert(total_guide_rate >= my_guide_rate);
+            const double guide_rate_epsilon = 1e-12;
+            return (total_guide_rate > guide_rate_epsilon)
+                ? my_guide_rate / total_guide_rate
+                : 0.0;
+        }
+    private:
+        std::string parent(const std::string& name)
+        {
+            if (schedule_.hasWell(name)) {
+                return schedule_.getWell(name, report_step_).groupName();
+            } else {
+                return schedule_.getGroup(name, report_step_).parent();
+            }
+        }
+        double guideRateSum(const Group& group, const std::string& always_included_child)
+        {
+            double total_guide_rate = 0.0;
+            for (const std::string& child_group : group.groups()) {
+                const auto ctrl = well_state_.currentProductionGroupControl(child_group);
+                const bool included = (ctrl == Group::ProductionCMode::FLD)
+                    || (ctrl == Group::ProductionCMode::NONE)
+                    || (child_group == always_included_child);
+                if (included) {
+                    total_guide_rate += guideRate(child_group, always_included_child);
+                }
+            }
+            for (const std::string& child_well : group.wells()) {
+                const bool included = (well_state_.isProductionGrup(child_well))
+                    || (child_well == always_included_child);
+                if (included) {
+                    total_guide_rate += guideRate(child_well, always_included_child);
+                }
+            }
+            return total_guide_rate;
+        }
+        double guideRate(const std::string& name, const std::string& always_included_child)
+        {
+            if (schedule_.hasWell(name, report_step_)) {
+                return guide_rate_->get(name, target_);
+            } else {
+                if (groupControlledWells(name, always_included_child) > 0) {
+                    if (guide_rate_->has(name)) {
+                        return guide_rate_->get(name, target_);
+                    } else {
+                        // We are a group, with default guide rate.
+                        // Compute guide rate by accumulating our children's guide rates.
+                        // (only children not under individual control though).
+                        const Group& group = schedule_.getGroup(name, report_step_);
+                        return guideRateSum(group, always_included_child);
+                    }
+                } else {
+                    // No group-controlled subordinate wells.
+                    return 0.0;
+                }
+            }
+        }
+        int groupControlledWells(const std::string& group_name, const std::string& always_included_child)
+        {
+            /*
+            const Group& group = schedule_.getGroup(group_name, report_step_);
+            int num_wells = 0;
+            for (const std::string& child_group : group.groups()) {
+                const auto ctrl = well_state_.currentProductionGroupControl(child_group);
+                const bool included = (ctrl == Group::ProductionCMode::FLD)
+                    || (ctrl == Group::ProductionCMode::NONE)
+                    || (child_group == always_included_child);
+                if (included) {
+                    num_wells += groupControlledWells(child_group, always_included_child);
+                }
+            }
+            for (const std::string& child_well : group.wells()) {
+                const bool included = (well_state_.isProductionGrup(child_well))
+                    || (child_well == always_included_child);
+                if (included) {
+                    ++num_wells;
+                }
+            }
+            return num_wells;
+            */
+            return ::Opm::wellGroupHelpers::groupControlledWells(schedule_, well_state_, report_step_, group_name, always_included_child);
+        }
+        const Schedule& schedule_;
+        const WellStateFullyImplicitBlackoil& well_state_;
+        int report_step_;
+        const GuideRate* guide_rate_;
+        GuideRateModel::Target target_;
+    };
+
+
+    inline double fractionFromGuideRates(const std::string& name,
+                                         const std::string& controlGroupName,
+                                         const Schedule& schedule,
+                                         const WellStateFullyImplicitBlackoil& wellState,
+                                         const int reportStepIdx,
+                                         const GuideRate* guideRate,
+                                         const GuideRateModel::Target target,
+                                         const bool alwaysIncludeThis = false)
+    {
+        FractionCalculator calc(schedule, wellState, reportStepIdx, guideRate, target);
+        return calc.fraction(name, controlGroupName, alwaysIncludeThis);
+    }
+
+    inline double fractionFromInjectionPotentials(const std::string& name,
+                                                  const std::string& controlGroupName,
+                                                  const Schedule& schedule,
+                                                  const WellStateFullyImplicitBlackoil& wellState,
+                                                  const int reportStepIdx,
+                                                  const GuideRate* guideRate,
+                                                  const GuideRateModel::Target target,
+                                                  const PhaseUsage& pu,
+                                                  const Phase& injectionPhase,
+                                                  const bool alwaysIncludeThis = false)
+    {
+        double thisGuideRate = getGuideRateInj(name, schedule, wellState, reportStepIdx, guideRate, target, injectionPhase);
+        double controlGroupGuideRate = getGuideRateInj(controlGroupName, schedule, wellState, reportStepIdx, guideRate, target, injectionPhase);
+        if (alwaysIncludeThis)
+            controlGroupGuideRate += thisGuideRate;
+
+        assert(controlGroupGuideRate >= thisGuideRate);
+        const double guideRateEpsilon = 1e-12;
+        return (controlGroupGuideRate > guideRateEpsilon)
+            ? thisGuideRate / controlGroupGuideRate
+            : 0.0;
+    }
+
+
+    template <class RateConverterType>
+    inline bool checkGroupConstraintsInj(const std::string& name,
+                                         const std::string& parent,
+                                         const Group& group,
+                                         const WellStateFullyImplicitBlackoil& wellState,
+                                         const int reportStepIdx,
+                                         const GuideRate* guideRate,
+                                         const double* rates,
+                                         Phase injectionPhase,
+                                         const PhaseUsage& pu,
+                                         const double efficiencyFactor,
+                                         const Schedule& schedule,
+                                         const SummaryState& summaryState,
+                                         const RateConverterType& rateConverter,
+                                         const int pvtRegionIdx,
+                                         DeferredLogger& deferred_logger)
+    {
+        // When called for a well ('name' is a well name), 'parent'
+        // will be the name of 'group'. But if we recurse, 'name' and
+        // 'parent' will stay fixed while 'group' will be higher up
+        // in the group tree.
+
+        const Group::InjectionCMode& currentGroupControl = wellState.currentInjectionGroupControl(injectionPhase, group.name());
+        if (currentGroupControl == Group::InjectionCMode::FLD ||
+            currentGroupControl == Group::InjectionCMode::NONE) {
+            // Return if we are not available for parent group.
+            if (!group.isAvailableForGroupControl()) {
+                return false;
+            }
+            // Otherwise: check injection share of parent's control.
+            const auto& parentGroup = schedule.getGroup(group.parent(), reportStepIdx);
+            return checkGroupConstraintsInj(name,
+                                            parent,
+                                            parentGroup,
+                                            wellState,
+                                            reportStepIdx,
+                                            guideRate,
+                                            rates,
+                                            injectionPhase,
+                                            pu,
+                                            efficiencyFactor * group.getGroupEfficiencyFactor(),
+                                            schedule,
+                                            summaryState,
+                                            rateConverter,
+                                            pvtRegionIdx,
+                                            deferred_logger);
+        }
+
+        // If we are here, we are at the topmost group to be visited in the recursion.
+        // This is the group containing the control we will check against.
+
+        // This can be false for FLD-controlled groups, we must therefore
+        // check for FLD first (done above).
+        if (!group.isInjectionGroup()) {
+            return false;
+        }
+
+        int phasePos;
+        GuideRateModel::Target target;
+
+        switch (injectionPhase) {
+        case Phase::WATER:
+        {
+            phasePos = pu.phase_pos[BlackoilPhases::Aqua];
+            target = GuideRateModel::Target::WAT;
+            break;
+        }
+        case Phase::OIL:
+        {
+            phasePos = pu.phase_pos[BlackoilPhases::Liquid];
+            target = GuideRateModel::Target::OIL;
+            break;
+        }
+        case Phase::GAS:
+        {
+            phasePos = pu.phase_pos[BlackoilPhases::Vapour];
+            target = GuideRateModel::Target::GAS;
+            break;
+        }
+        default:
+            OPM_DEFLOG_THROW(std::logic_error, "Expected WATER, OIL or GAS as injecting type for " + name, deferred_logger);
+        }
+
+        assert(group.hasInjectionControl(injectionPhase));
+        const auto& groupcontrols = group.injectionControls(injectionPhase, summaryState);
+
+        const std::vector<double>& groupInjectionReductions = wellState.currentInjectionGroupReductionRates(group.name());
+        const double groupTargetReduction = groupInjectionReductions[phasePos];
+        double fraction = wellGroupHelpers::fractionFromInjectionPotentials(name, group.name(), schedule, wellState, reportStepIdx, guideRate, target, pu, injectionPhase, true);
+
+        bool constraint_broken = false;
+        switch(currentGroupControl) {
+        case Group::InjectionCMode::RATE:
+        {
+            const double current_rate = rates[phasePos];
+            const double target_rate = fraction * std::max(0.0, (groupcontrols.surface_max_rate - groupTargetReduction + current_rate*efficiencyFactor)) / efficiencyFactor;
+            if (current_rate > target_rate) {
+                constraint_broken = true;
+            }
+            break;
+        }
+        case Group::InjectionCMode::RESV:
+        {
+            std::vector<double> convert_coeff(pu.num_phases, 1.0);
+            rateConverter.calcCoeff(/*fipreg*/ 0, pvtRegionIdx, convert_coeff);
+            const double coeff = convert_coeff[phasePos];
+            const double current_rate = rates[phasePos];
+            const double target_rate = fraction * std::max(0.0, (groupcontrols.resv_max_rate/coeff - groupTargetReduction + current_rate*efficiencyFactor)) / efficiencyFactor;
+            if (current_rate > target_rate) {
+                constraint_broken = true;
+            }
+            break;
+        }
+        case Group::InjectionCMode::REIN:
+        {
+            double productionRate = wellState.currentInjectionREINRates(groupcontrols.reinj_group)[phasePos];
+            const double current_rate = rates[phasePos];
+            const double target_rate = fraction * std::max(0.0, (groupcontrols.target_reinj_fraction*productionRate - groupTargetReduction + current_rate*efficiencyFactor)) / efficiencyFactor;
+            if (current_rate > target_rate) {
+                constraint_broken = true;
+            }
+            break;
+        }
+        case Group::InjectionCMode::VREP:
+        {
+            std::vector<double> convert_coeff(pu.num_phases, 1.0);
+            rateConverter.calcCoeff(/*fipreg*/ 0, pvtRegionIdx, convert_coeff);
+            const double coeff = convert_coeff[phasePos];
+            double voidageRate = wellState.currentInjectionVREPRates(groupcontrols.voidage_group)*groupcontrols.target_void_fraction;
+
+            double injReduction = 0.0;
+            if (groupcontrols.phase != Phase::WATER)
+                injReduction += groupInjectionReductions[pu.phase_pos[BlackoilPhases::Aqua]]*convert_coeff[pu.phase_pos[BlackoilPhases::Aqua]];
+            if (groupcontrols.phase != Phase::OIL)
+                injReduction += groupInjectionReductions[pu.phase_pos[BlackoilPhases::Liquid]]*convert_coeff[pu.phase_pos[BlackoilPhases::Liquid]];
+            if (groupcontrols.phase != Phase::GAS)
+                injReduction += groupInjectionReductions[pu.phase_pos[BlackoilPhases::Vapour]]*convert_coeff[pu.phase_pos[BlackoilPhases::Vapour]];
+            voidageRate -= injReduction;
+
+            const double current_rate = rates[phasePos];
+            const double target_rate = fraction * std::max(0.0, ( voidageRate/coeff - groupTargetReduction + current_rate*efficiencyFactor)) / efficiencyFactor;
+            if (current_rate > target_rate) {
+                constraint_broken = true;
+            }
+            break;
+        }
+        case Group::InjectionCMode::SALE:
+        {
+            // only for gas injectors
+            assert (phasePos == pu.phase_pos[BlackoilPhases::Vapour]);
+
+            // Gas injection rate = Total gas production rate + gas import rate - gas consumption rate - sales rate;
+            double inj_rate = wellState.currentInjectionREINRates(group.name())[phasePos];
+            if (schedule.gConSump(reportStepIdx).has(group.name())) {
+                const auto& gconsump = schedule.gConSump(reportStepIdx).get(group.name(), summaryState);
+                if (pu.phase_used[BlackoilPhases::Vapour]) {
+                    inj_rate += gconsump.import_rate;
+                    inj_rate -= gconsump.consumption_rate;
+                }
+            }
+            const auto& gconsale = schedule.gConSale(reportStepIdx).get(group.name(), summaryState);
+            inj_rate -= gconsale.sales_target;
+
+            const double current_rate = rates[phasePos];
+            const double target_rate = fraction * std::max(0.0, (inj_rate - groupTargetReduction + current_rate*efficiencyFactor)) / efficiencyFactor;
+            if (current_rate > target_rate) {
+                constraint_broken = true;
+            }
+            break;
+        }
+        case Group::InjectionCMode::NONE:
+        {
+            assert(false); // Should already be handled at the top.
+        }
+        case Group::InjectionCMode::FLD:
+        {
+            assert(false); // Should already be handled at the top.
+        }
+        default:
+            OPM_DEFLOG_THROW(std::runtime_error, "Invalid group control specified for group "  + group.name(), deferred_logger );
+
+        }
+
+        return constraint_broken;
+    }
+
+    template <class RateConverterType>
+    class TargetCalculator
+    {
+    public:
+        TargetCalculator(const Group::ProductionCMode cmode,
+                         const PhaseUsage& pu,
+                         const RateConverterType& rate_converter,
+                         const int pvt_region_idx)
+            : cmode_(cmode)
+            , pu_(pu)
+            , rate_converter_(rate_converter)
+            , pvt_region_idx_(pvt_region_idx)
+        {
+        }
+        template <typename ElemType>
+        static ElemType zero()
+        {
+            // This is for Evaluation types.
+            ElemType x;
+            x = 0.0;
+            return x;
+        }
+        template <>
+        static double zero<double>()
+        {
+            return 0.0;
+        }
+        template <typename RateVec>
+        auto calcModeRateFromRates(const RateVec& rates) const
+        {
+            // ElemType is just the plain element type of the rates container,
+            // without any reference, const or volatile modifiers.
+            using ElemType = typename std::remove_cv<typename std::remove_reference<decltype(rates[0])>::type>::type;
+            switch (cmode_) {
+            case Group::ProductionCMode::ORAT: {
+                assert(pu_.phase_used[BlackoilPhases::Liquid]);
+                const int pos = pu_.phase_pos[BlackoilPhases::Liquid];
+                return rates[pos];
+            }
+            case Group::ProductionCMode::WRAT: {
+                assert(pu_.phase_used[BlackoilPhases::Aqua]);
+                const int pos = pu_.phase_pos[BlackoilPhases::Aqua];
+                return rates[pos];
+            }
+            case Group::ProductionCMode::GRAT: {
+                assert(pu_.phase_used[BlackoilPhases::Vapour]);
+                const int pos = pu_.phase_pos[BlackoilPhases::Vapour];
+                return rates[pos];
+            }
+            case Group::ProductionCMode::LRAT: {
+                assert(pu_.phase_used[BlackoilPhases::Liquid]);
+                assert(pu_.phase_used[BlackoilPhases::Aqua]);
+                const int opos = pu_.phase_pos[BlackoilPhases::Liquid];
+                const int wpos = pu_.phase_pos[BlackoilPhases::Aqua];
+                return rates[opos] + rates[wpos];
+            }
+            case Group::ProductionCMode::RESV: {
+                assert(pu_.phase_used[BlackoilPhases::Liquid]);
+                assert(pu_.phase_used[BlackoilPhases::Aqua]);
+                assert(pu_.phase_used[BlackoilPhases::Vapour]);
+                std::vector<double> convert_coeff(pu_.num_phases, 1.0);
+                rate_converter_.calcCoeff(/*fipreg*/ 0, pvt_region_idx_, convert_coeff);
+                ElemType mode_rate = zero<ElemType>();
+                for (int phase = 0; phase < pu_.num_phases; ++phase) {
+                    mode_rate += rates[phase] * convert_coeff[phase];
+                }
+                return mode_rate;
+            }
+            default:
+                // Should never be here.
+                assert(false);
+                return zero<ElemType>();
+            }
+        }
+        double groupTarget(const Group::ProductionControls ctrl) const
+        {
+            switch (cmode_) {
+            case Group::ProductionCMode::ORAT:
+                return ctrl.oil_target;
+            case Group::ProductionCMode::WRAT:
+                return ctrl.water_target;
+            case Group::ProductionCMode::GRAT:
+                return ctrl.gas_target;
+            case Group::ProductionCMode::LRAT:
+                return ctrl.liquid_target;
+            case Group::ProductionCMode::RESV:
+                return ctrl.resv_target;
+            default:
+                // Should never be here.
+                assert(false);
+                return 0.0;
+            }
+        }
+        GuideRateModel::Target guideTargetMode() const
+        {
+            switch (cmode_) {
+            case Group::ProductionCMode::ORAT:
+                return GuideRateModel::Target::OIL;
+            case Group::ProductionCMode::WRAT:
+                return GuideRateModel::Target::WAT;
+            case Group::ProductionCMode::GRAT:
+                return GuideRateModel::Target::GAS;
+            case Group::ProductionCMode::LRAT:
+                return GuideRateModel::Target::LIQ;
+            case Group::ProductionCMode::RESV:
+                return GuideRateModel::Target::RES;
+            default:
+                // Should never be here.
+                assert(false);
+                return GuideRateModel::Target::NONE;
+            }
+        }
+    private:
+        Group::ProductionCMode cmode_;
+        const PhaseUsage& pu_;
+        const RateConverterType& rate_converter_;
+        int pvt_region_idx_;
+    };
+
+
+
+
+    inline std::vector<std::string>
+    groupChainTopBot(const std::string& bottom, const std::string& top, const Schedule& schedule, const int report_step)
+    {
+        // Get initial parent, 'bottom' can be a well or a group.
+        std::string parent;
+        if (schedule.hasWell(bottom, report_step)) {
+            parent = schedule.getWell(bottom, report_step).groupName();
+        } else {
+            parent = schedule.getGroup(bottom, report_step).parent();
+        }
+
+        // Build the chain from bottom to top.
+        std::vector<std::string> chain;
+        chain.push_back(bottom);
+        chain.push_back(parent);
+        while (parent != top) {
+            parent = schedule.getGroup(parent, report_step).parent();
+            chain.push_back(parent);
+        }
+        assert(chain.back() == top);
+
+        // Reverse order and return.
+        std::reverse(chain.begin(), chain.end());
+        return chain;
+    }
+
+
+
+
+    template <class RateConverterType>
+    inline bool checkGroupConstraintsProd(const std::string& name,
+                                          const std::string& parent,
+                                          const Group& group,
+                                          const WellStateFullyImplicitBlackoil& wellState,
+                                          const int reportStepIdx,
+                                          const GuideRate* guideRate,
+                                          const double* rates,
+                                          const PhaseUsage& pu,
+                                          const double efficiencyFactor,
+                                          const Schedule& schedule,
+                                          const SummaryState& summaryState,
+                                          const RateConverterType& rateConverter,
+                                          const int pvtRegionIdx,
+                                          DeferredLogger& deferred_logger)
+    {
+        // When called for a well ('name' is a well name), 'parent'
+        // will be the name of 'group'. But if we recurse, 'name' and
+        // 'parent' will stay fixed while 'group' will be higher up
+        // in the group tree.
+
+        const Group::ProductionCMode& currentGroupControl = wellState.currentProductionGroupControl(group.name());
+
+        if (currentGroupControl == Group::ProductionCMode::FLD ||
+            currentGroupControl == Group::ProductionCMode::NONE) {
+            // Return if we are not available for parent group.
+            if (!group.isAvailableForGroupControl()) {
+                return false;
+            }
+            // Otherwise: check production share of parent's control.
+            const auto& parentGroup = schedule.getGroup(group.parent(), reportStepIdx);
+            return checkGroupConstraintsProd(name,
+                                             parent,
+                                             parentGroup,
+                                             wellState,
+                                             reportStepIdx,
+                                             guideRate,
+                                             rates,
+                                             pu,
+                                             efficiencyFactor * group.getGroupEfficiencyFactor(),
+                                             schedule,
+                                             summaryState,
+                                             rateConverter,
+                                             pvtRegionIdx,
+                                             deferred_logger);
+        }
+
+        // This can be false for FLD-controlled groups, we must therefore
+        // check for FLD first (done above).
+        if (!group.isProductionGroup()) {
+            return false;
+        }
+
+        // If we are here, we are at the topmost group to be visited in the recursion.
+        // This is the group containing the control we will check against.
+        TargetCalculator tcalc(currentGroupControl, pu, rateConverter, pvtRegionIdx);
+        FractionCalculator fcalc(schedule, wellState, reportStepIdx, guideRate, tcalc.guideTargetMode());
+
+        auto localFraction = [&](const std::string& child) {
+            return fcalc.localFraction(child, name);
+        };
+
+        auto localReduction = [&](const std::string& group_name) {
+            const std::vector<double>& groupTargetReductions = wellState.currentProductionGroupReductionRates(group_name);
+            return tcalc.calcModeRateFromRates(groupTargetReductions);
+        };
+
+        const double orig_target = tcalc.groupTarget(group.productionControls(summaryState));
+        // Assume we have a chain of groups as follows: BOTTOM -> MIDDLE -> TOP.
+        // Then ...
+        // TODO finish explanation.
+        const double current_rate = -tcalc.calcModeRateFromRates(rates); // Switch sign since 'rates' are negative for producers.
+        const auto chain = groupChainTopBot(name, group.name(), schedule, reportStepIdx);
+        // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
+        const size_t num_ancestors = chain.size() - 1;
+        double target = orig_target;
+        for (size_t ii = 0; ii < num_ancestors; ++ii) {
+            target -= localReduction(chain[ii]);
+            if (ii == num_ancestors - 1) {
+                // Final level. Add my reduction back.
+                target += current_rate*efficiencyFactor;
+            } else {
+                // Not final level. Add sub-level reduction back, if
+                // it was nonzero due to having no group-controlled
+                // wells.  Note that we make this call without setting
+                // the current well to be always included, because we
+                // want to know the situation that applied to the
+                // calculation of reductions.
+                const int num_gr_ctrl = groupControlledWells(schedule, wellState, reportStepIdx, chain[ii+1], "");
+                if (num_gr_ctrl == 0) {
+                    target += localReduction(chain[ii+1]);
+                }
+            }
+            target *= localFraction(chain[ii+1]);
+        }
+        const double target_rate = target / efficiencyFactor;
+        return current_rate > target_rate;
     }
 
 

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -900,11 +900,11 @@ namespace Opm {
             x = 0.0;
             return x;
         }
-        template <>
-        static double zero<double>()
-        {
-            return 0.0;
-        }
+        //template <>
+        //static double zero<double>()
+        //{
+        //    return 0.0;
+        //}
         template <typename RateVec>
         auto calcModeRateFromRates(const RateVec& rates) const
         {

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -201,7 +201,9 @@ namespace Opm
                                                WellState& well_state,
                                                Opm::DeferredLogger& deferred_logger) const = 0;
 
-        void updateWellControl(const Simulator& ebos_simulator,
+        enum class IndividualOrGroup { Individual, Group, Both };
+        bool updateWellControl(const Simulator& ebos_simulator,
+                               const IndividualOrGroup iog,
                                WellState& well_state,
                                Opm::DeferredLogger& deferred_logger) /* const */;
 
@@ -478,10 +480,34 @@ namespace Opm
         // index calculations
         int well_productivity_index_logger_counter_;
 
-        bool checkConstraints(WellState& well_state, const SummaryState& summaryState);
+        bool checkConstraints(WellState& well_state,
+                              const Schedule& schedule,
+                              const SummaryState& summaryState,
+                              DeferredLogger& deferred_logger) const;
 
+        bool checkIndividualConstraints(WellState& well_state,
+                                        const Schedule& schedule,
+                                        const SummaryState& summaryState,
+                                        DeferredLogger& deferred_logger) const;
 
+        bool checkGroupConstraints(WellState& well_state,
+                                   const Schedule& schedule,
+                                   const SummaryState& summaryState,
+                                   DeferredLogger& deferred_logger) const;
 
+        bool checkGroupConstraintsProd(const Group& group,
+                                       const WellState& well_state,
+                                       const double efficiencyFactor,
+                                       const Schedule& schedule,
+                                       const SummaryState& summaryState,
+                                       DeferredLogger& deferred_logger) const;
+
+        bool checkGroupConstraintsInj(const Group& group,
+                                      const WellState& well_state,
+                                      const double efficiencyFactor,
+                                      const Schedule& schedule,
+                                      const SummaryState& summaryState,
+                                      DeferredLogger& deferred_logger) const;
     };
 
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -508,6 +508,17 @@ namespace Opm
                                       const Schedule& schedule,
                                       const SummaryState& summaryState,
                                       DeferredLogger& deferred_logger) const;
+
+        template <class EvalWell>
+        void getGroupProductionControl(const Group& group,
+                                       const WellState& well_state,
+                                       const Opm::Schedule& schedule,
+                                       const SummaryState& summaryState,
+                                       const EvalWell& bhp,
+                                       const std::vector<EvalWell>& rates,
+                                       EvalWell& control_eq,
+                                       double efficiencyFactor);
+
     };
 
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -530,6 +530,27 @@ namespace Opm
                                        EvalWell& control_eq,
                                        double efficiencyFactor);
 
+        template <class EvalWell, class BhpFromThpFunc>
+        void assembleControlEqInj(const WellState& well_state,
+                                  const Opm::Schedule& schedule,
+                                  const SummaryState& summaryState,
+                                  const Well::InjectionControls& controls,
+                                  const EvalWell& bhp,
+                                  const EvalWell& injection_rate,
+                                  BhpFromThpFunc bhp_from_thp,
+                                  EvalWell& control_eq,
+                                  Opm::DeferredLogger& deferred_logger);
+
+        template <class EvalWell, class BhpFromThpFunc>
+        void assembleControlEqProd(const WellState& well_state,
+                                   const Opm::Schedule& schedule,
+                                   const SummaryState& summaryState,
+                                   const Well::ProductionControls& controls,
+                                   const EvalWell& bhp,
+                                   const std::vector<EvalWell>& rates, // Always 3 canonical rates.
+                                   BhpFromThpFunc bhp_from_thp,
+                                   EvalWell& control_eq,
+                                   Opm::DeferredLogger& deferred_logger);
     };
 
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -495,14 +495,14 @@ namespace Opm
                                    const SummaryState& summaryState,
                                    DeferredLogger& deferred_logger) const;
 
-        bool checkGroupConstraintsProd(const Group& group,
+        std::pair<bool, double> checkGroupConstraintsProd(const Group& group,
                                        const WellState& well_state,
                                        const double efficiencyFactor,
                                        const Schedule& schedule,
                                        const SummaryState& summaryState,
                                        DeferredLogger& deferred_logger) const;
 
-        bool checkGroupConstraintsInj(const Group& group,
+        std::pair<bool, double> checkGroupConstraintsInj(const Group& group,
                                       const WellState& well_state,
                                       const double efficiencyFactor,
                                       const Schedule& schedule,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -510,6 +510,17 @@ namespace Opm
                                       DeferredLogger& deferred_logger) const;
 
         template <class EvalWell>
+        void getGroupInjectionControl(const Group& group,
+                                      const WellState& well_state,
+                                      const Opm::Schedule& schedule,
+                                      const SummaryState& summaryState,
+                                      const InjectorType& injectorType,
+                                      const EvalWell& bhp,
+                                      const EvalWell& injection_rate,
+                                      EvalWell& control_eq,
+                                      double efficiencyFactor);
+
+        template <class EvalWell>
         void getGroupProductionControl(const Group& group,
                                        const WellState& well_state,
                                        const Opm::Schedule& schedule,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1814,6 +1814,81 @@ namespace Opm
 
 
 
+    template <typename TypeTag>
+    template <class EvalWell>
+    void
+    WellInterface<TypeTag>::getGroupProductionControl(const Group& group,
+                                                      const WellState& well_state,
+                                                      const Opm::Schedule& schedule,
+                                                      const SummaryState& summaryState,
+                                                      const EvalWell& bhp,
+                                                      const std::vector<EvalWell>& rates,
+                                                      EvalWell& control_eq,
+                                                      double efficiencyFactor)
+    {
+        const auto& well = well_ecl_;
+        const auto pu = phaseUsage();
+
+        const Group::ProductionCMode& currentGroupControl = well_state.currentProductionGroupControl(group.name());
+        if (currentGroupControl == Group::ProductionCMode::FLD ||
+            currentGroupControl == Group::ProductionCMode::NONE) {
+            if (!group.isAvailableForGroupControl()) {
+                // We cannot go any further up the hierarchy. This could
+                // be the FIELD group, or any group for which this has
+                // been set in GCONINJE or GCONPROD. If we are here
+                // anyway, it is likely that the deck set inconsistent
+                // requirements, such as GRUP control mode on a well with
+                // no appropriate controls defined on any of its
+                // containing groups. We will therefore use the wells' bhp
+                // limit equation as a fallback.
+                const auto& controls = well_ecl_.productionControls(summaryState);
+                control_eq = bhp - controls.bhp_limit;
+                return;
+            } else {
+                // Produce share of parents control
+                const auto& parent = schedule.getGroup( group.parent(), current_step_ );
+                efficiencyFactor *= group.getGroupEfficiencyFactor();
+                getGroupProductionControl(parent, well_state, schedule, summaryState, bhp, rates, control_eq, efficiencyFactor);
+                return;
+            }
+        }
+
+        if (!group.isProductionGroup()) {
+            // use bhp as control eq and let the updateControl code find a vallied control
+            const auto& controls = well.productionControls(summaryState);
+            control_eq = bhp - controls.bhp_limit;
+            return;
+        }
+
+        // If we are here, we are at the topmost group to be visited in the recursion.
+        // This is the group containing the control we will check against.
+        wellGroupHelpers::TargetCalculator tcalc(currentGroupControl, pu, rateConverter_, pvtRegionIdx_);
+        wellGroupHelpers::FractionCalculator fcalc(schedule, well_state, current_step_, guide_rate_, tcalc.guideTargetMode(), pu);
+
+        auto localFraction = [&](const std::string& child) {
+            return fcalc.localFraction(child, "");
+        };
+
+        auto localReduction = [&](const std::string& group_name) {
+            const std::vector<double>& groupTargetReductions = well_state.currentProductionGroupReductionRates(group_name);
+            return tcalc.calcModeRateFromRates(groupTargetReductions);
+        };
+
+        const double orig_target = tcalc.groupTarget(group.productionControls(summaryState));
+        const auto chain = wellGroupHelpers::groupChainTopBot(name(), group.name(), schedule, current_step_);
+        // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
+        const size_t num_ancestors = chain.size() - 1;
+        double target = orig_target;
+        for (size_t ii = 0; ii < num_ancestors; ++ii) {
+            target -= localReduction(chain[ii]);
+            target *= localFraction(chain[ii+1]);
+        }
+        const double target_rate = target / efficiencyFactor;
+
+        const auto current_rate = -tcalc.calcModeRateFromRates(rates); // Switch sign since 'rates' are negative for producers.
+
+        control_eq = current_rate - target_rate;
+    }
 
 
 } // namespace Opm

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1924,26 +1924,26 @@ namespace Opm
         switch (current) {
         case Well::ProducerCMode::ORAT: {
             assert(FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx));
-            const EvalWell rate = -rates[pu.phase_pos[BlackoilPhases::Liquid]];
+            const EvalWell rate = -rates[BlackoilPhases::Liquid];
             control_eq = rate - controls.oil_rate;
             break;
         }
         case Well::ProducerCMode::WRAT: {
             assert(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx));
-            const EvalWell rate = -rates[pu.phase_pos[BlackoilPhases::Aqua]];
+            const EvalWell rate = -rates[BlackoilPhases::Aqua];
             control_eq = rate - controls.water_rate;
             break;
         }
         case Well::ProducerCMode::GRAT: {
             assert(FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx));
-            const EvalWell rate = -rates[pu.phase_pos[BlackoilPhases::Vapour]];
+            const EvalWell rate = -rates[BlackoilPhases::Vapour];
             control_eq = rate - controls.gas_rate;
             break;
         }
         case Well::ProducerCMode::LRAT: {
             assert(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx));
             assert(FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx));
-            EvalWell rate = -rates[pu.phase_pos[BlackoilPhases::Aqua]] - rates[pu.phase_pos[BlackoilPhases::Liquid]];
+            EvalWell rate = -rates[BlackoilPhases::Aqua] - rates[BlackoilPhases::Liquid];
             control_eq = rate - controls.liquid_rate;
             break;
         }
@@ -1958,7 +1958,7 @@ namespace Opm
             for (int phase = 0; phase < 3; ++phase) {
                 if (pu.phase_used[phase]) {
                     const int pos = pu.phase_pos[phase];
-                    total_rate -= rates[pos] * convert_coeff[pos];
+                    total_rate -= rates[phase] * convert_coeff[pos]; // Note different indices.
                 }
             }
             if (controls.prediction_mode) {

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -350,8 +350,33 @@ namespace Opm
 
             return it->second;
         }
+        
+        void setCurrentWellRates(const std::string& wellName, const std::vector<double>& rates ) {
+            well_rates[wellName] = rates;
+        }
 
+        const std::vector<double>& currentWellRates(const std::string& wellName) const {
+            auto it = well_rates.find(wellName);
 
+            if (it == well_rates.end())
+                OPM_THROW(std::logic_error, "Could not find any rates for well  " << wellName);
+
+            return it->second;
+        }
+
+        void setCurrentProductionGroupRates(const std::string& groupName, const std::vector<double>& rates ) {
+            production_group_rates[groupName] = rates;
+        }
+
+        const std::vector<double>& currentProductionGroupRates(const std::string& groupName) const {
+            auto it = production_group_rates.find(groupName);
+
+            if (it == production_group_rates.end())
+                OPM_THROW(std::logic_error, "Could not find any rates for productino group  " << groupName);
+
+            return it->second;
+        }
+        
         void setCurrentProductionGroupReductionRates(const std::string& groupName, const std::vector<double>& target ) {
             production_group_reduction_rates[groupName] = target;
         }
@@ -873,6 +898,12 @@ namespace Opm
             for (auto& x : injection_group_reservoir_rates) {
                 comm.sum(x.second.data(), x.second.size());
             }
+            for (auto& x : production_group_rates) {
+                comm.sum(x.second.data(), x.second.size());
+            }
+            for (auto& x : well_rates) {
+                comm.sum(x.second.data(), x.second.size());
+            }
         }
 
         template<class Comm>
@@ -945,6 +976,8 @@ namespace Opm
         std::map<std::string, Group::ProductionCMode> current_production_group_controls_;
         std::map<std::pair<Opm::Phase, std::string>, Group::InjectionCMode> current_injection_group_controls_;
 
+        std::map<std::string, std::vector<double>> well_rates;
+        std::map<std::string, std::vector<double>> production_group_rates;
         std::map<std::string, std::vector<double>> production_group_reduction_rates;
         std::map<std::string, std::vector<double>> injection_group_reduction_rates;
         std::map<std::string, std::vector<double>> injection_group_reservoir_rates;

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -876,24 +876,37 @@ namespace Opm
         }
 
         template<class Comm>
-        void updateGlobalIsGrup(const Schedule& schedule, const int reportStepIdx, const Comm& comm) {
-
-            int global_well_index = -1;
+        void updateGlobalIsGrup(const Schedule& schedule, const int reportStepIdx, const Comm& comm)
+        {
+            std::fill(globalIsInjectionGrup_.begin(), globalIsInjectionGrup_.end(), 0);
+            std::fill(globalIsProductionGrup_.begin(), globalIsProductionGrup_.end(), 0);
+            int global_well_index = 0;
             const auto& end = wellMap().end();
             for (const auto& well : schedule.getWells(reportStepIdx)) {
-                global_well_index ++;
+                // Build global name->index map.
                 wellNameToGlobalIdx_[well.name()] = global_well_index;
 
+                // For wells on this process...
                 const auto& it = wellMap().find( well.name());
-                if (it == end)  // the well is not found
-                    continue;
-
-                int well_index = it->second[0];
-
-                if (well.isInjector())
-                    globalIsInjectionGrup_[global_well_index] = (currentInjectionControls()[well_index] == Well::InjectorCMode::GRUP);
-                else
-                    globalIsProductionGrup_[global_well_index] = (currentProductionControls()[well_index] == Well::ProducerCMode::GRUP);
+                if (it != end) {
+                    // ... set the GRUP/not GRUP states.
+                    const int well_index = it->second[0];
+                    if (!this->open_for_output_[well_index]) {
+                        // Well is shut.
+                        if (well.isInjector()) {
+                            globalIsInjectionGrup_[global_well_index] = 0;
+                        } else {
+                            globalIsProductionGrup_[global_well_index] = 0;
+                        }
+                    } else {
+                        if (well.isInjector()) {
+                            globalIsInjectionGrup_[global_well_index] = (currentInjectionControls()[well_index] == Well::InjectorCMode::GRUP);
+                        } else {
+                            globalIsProductionGrup_[global_well_index] = (currentProductionControls()[well_index] == Well::ProducerCMode::GRUP);
+                        }
+                    }
+                }
+                ++global_well_index;
             }
             comm.sum(globalIsInjectionGrup_.data(), globalIsInjectionGrup_.size());
             comm.sum(globalIsProductionGrup_.data(), globalIsProductionGrup_.size());


### PR DESCRIPTION
This changes the way group constraints are dealt with, and in particular ensures that wells do not produce/inject more than their (guide-rate induced) share of group targets. This also lets us eliminate some extra passes through "checking group constraints" code, reducing complexity a little.

Successful comparisons have been made on some small cases, more comparisons will be done before this can be merged. Also, there are some things to be done:
 - Handle efficiency properly in the new code.
 - Remove (now) unneeded code/calls related to group controls elsewhere.
 - Refactor to avoid much repeated code between the checking code (placed in the superclass WellInterface) and the control equation code (in the StandardWell and MultisegmentWell classes).