### PR TITLE
Remove std::pointer_to_binary_function and silence a warning.

### DIFF
--- a/opm/simulators/linalg/ParallelIstlInformation.hpp
+++ b/opm/simulators/linalg/ParallelIstlInformation.hpp
@@ -580,12 +580,17 @@ private:
     ///
     /// To be used with ParallelISTLInformation::computeReduction.
     template<class T>
-    MaskToMinOperator<std::pointer_to_binary_function<const T&,const T&,const T&> >
-    makeGlobalMaxFunctor()
+    auto makeGlobalMaxFunctor()
     {
-        return MaskToMinOperator<std::pointer_to_binary_function<const T&,const T&,const T&> >
-            (std::pointer_to_binary_function<const T&,const T&,const T&>
-             ((const T&(*)(const T&, const T&))std::max<T>));
+        struct MaxOp
+        {
+            using result_type = T;
+            const T& operator()(const T& t1, const T& t2)
+            {
+                return std::max(t1, t2);
+            }
+        };
+        return MaskToMinOperator(MaxOp());
     }
 
     namespace detail
@@ -630,12 +635,18 @@ private:
     ///
     /// To be used with ParallelISTLInformation::computeReduction.
     template<class T>
-    MaskToMaxOperator<std::pointer_to_binary_function<const T&,const T&,const T&> >
+    auto
     makeGlobalMinFunctor()
     {
-        return MaskToMaxOperator<std::pointer_to_binary_function<const T&,const T&,const T&> >
-            (std::pointer_to_binary_function<const T&,const T&,const T&>
-             ((const T&(*)(const T&, const T&))std::min<T>));
+        struct MinOp
+        {
+            using result_type = T;
+            const T& operator()(const T& t1, const T& t2)
+            {
+                return std::min(t1, t2);
+            }
+        };
+        return MaskToMaxOperator(MinOp());
     }
     template<class T>
     InnerProductFunctor<T>

--- a/opm/simulators/linalg/bda/BdaBridge.cpp
+++ b/opm/simulators/linalg/bda/BdaBridge.cpp
@@ -35,13 +35,19 @@ typedef Dune::InverseOperatorResult InverseOperatorResult;
 namespace Opm
 {
 
-BdaBridge::BdaBridge(bool use_gpu_ OPM_UNUSED, int linear_solver_verbosity OPM_UNUSED, int maxit OPM_UNUSED, double tolerance OPM_UNUSED) : use_gpu(use_gpu_) {
 #if HAVE_CUDA
+BdaBridge::BdaBridge(bool use_gpu_, int linear_solver_verbosity, int maxit, double tolerance)
+    : use_gpu(use_gpu_)
+{
     if (use_gpu) {
         backend.reset(new cusparseSolverBackend(linear_solver_verbosity, maxit, tolerance));
     }
-#endif
 }
+#else
+BdaBridge::BdaBridge(bool use_gpu_ OPM_UNUSED, int linear_solver_verbosity OPM_UNUSED, int maxit OPM_UNUSED, double tolerance OPM_UNUSED)
+{
+}
+#endif
 
 
 

--- a/opm/simulators/linalg/bda/BdaBridge.hpp
+++ b/opm/simulators/linalg/bda/BdaBridge.hpp
@@ -42,8 +42,8 @@ class BdaBridge
 private:
 #if HAVE_CUDA
     std::unique_ptr<cusparseSolverBackend> backend;
-#endif
     bool use_gpu;
+#endif
 
 public:
     /// Construct a BdaBridge


### PR DESCRIPTION
The first commit is a compile failure on clang (std::pointer_to_binary_function was deprecated already when it was introduced into the code, removed in c++17), the second is just warning suppression.