### PR TITLE
Remove serialization support for UDQFunctionTable and UDQFunction

### DIFF
--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -1470,19 +1470,7 @@ std::size_t packSize(const WListManager& data,
     return packSize(data.lists(), comm);
 }
 
-std::size_t packSize(const UDQFunction& data,
-                     Dune::MPIHelper::MPICommunicator comm)
-{
-    return packSize(data.name(), comm) +
-           packSize(data.type(), comm);
-}
 
-std::size_t packSize(const UDQFunctionTable& data,
-                     Dune::MPIHelper::MPICommunicator comm)
-{
-    return packSize(data.getParams(), comm) +
-           packSize(data.functionMap(), comm);
-}
 
 std::size_t packSize(const UDQASTNode& data,
                      Dune::MPIHelper::MPICommunicator comm)
@@ -3234,21 +3222,6 @@ void pack(const WListManager& data,
     pack(data.lists(), buffer, position, comm);
 }
 
-void pack(const UDQFunction& data,
-          std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm)
-{
-    pack(data.name(), buffer, position, comm);
-    pack(data.type(), buffer, position, comm);
-}
-
-void pack(const UDQFunctionTable& data,
-          std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm)
-{
-    pack(data.getParams(), buffer, position, comm);
-    pack(data.functionMap(), buffer, position, comm);
-}
 
 void pack(const UDQASTNode& data,
           std::vector<char>& buffer, int& position,
@@ -5666,27 +5639,6 @@ void unpack(WListManager& data,
     data = WListManager(lists);
 }
 
-void unpack(UDQFunction& data,
-            std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm)
-{
-    std::string name;
-    UDQTokenType type;
-    unpack(name, buffer, position, comm);
-    unpack(type, buffer, position, comm);
-    data = UDQFunction(name, type);
-}
-
-void unpack(UDQFunctionTable& data,
-            std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm)
-{
-    UDQParams params;
-    UDQFunctionTable::FunctionMap map;
-    unpack(params, buffer, position, comm);
-    unpack(map, buffer, position, comm);
-    data = UDQFunctionTable(params, map);
-}
 
 void unpack(UDQASTNode& data,
             std::vector<char>& buffer, int& position,

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -151,8 +151,6 @@ class UDAValue;
 class UDQASTNode;
 class UDQConfig;
 class UDQDefine;
-class UDQFunction;
-class UDQFunctionTable;
 class UDQIndex;
 class UDQParams;
 class UnitSystem;
@@ -764,8 +762,6 @@ ADD_PACK_PROTOTYPES(UDQAssign::AssignRecord)
 ADD_PACK_PROTOTYPES(UDQASTNode)
 ADD_PACK_PROTOTYPES(UDQConfig)
 ADD_PACK_PROTOTYPES(UDQDefine)
-ADD_PACK_PROTOTYPES(UDQFunction)
-ADD_PACK_PROTOTYPES(UDQFunctionTable)
 ADD_PACK_PROTOTYPES(UDQIndex)
 ADD_PACK_PROTOTYPES(UDQParams)
 ADD_PACK_PROTOTYPES(UnitSystem)

--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -1746,28 +1746,6 @@ BOOST_AUTO_TEST_CASE(WListManager)
 }
 
 
-BOOST_AUTO_TEST_CASE(UDQFunction)
-{
-#ifdef HAVE_MPI
-    Opm::UDQFunction val1("test", Opm::UDQTokenType::binary_op_add);
-    auto val2 = PackUnpack(val1);
-    DO_CHECKS(UDQFunction)
-#endif
-}
-
-
-BOOST_AUTO_TEST_CASE(UDQFunctionTable)
-{
-#ifdef HAVE_MPI
-    Opm::UDQFunctionTable::FunctionMap map{{"test",
-                                            std::make_shared<Opm::UDQFunction>()}};
-    Opm::UDQFunctionTable val1(Opm::UDQParams(true, 1, 2.0, 3.0, 4.0), map);
-    auto val2 = PackUnpack(val1);
-    DO_CHECKS(UDQFunctionTable)
-#endif
-}
-
-
 BOOST_AUTO_TEST_CASE(UDQASTNode)
 {
 #ifdef HAVE_MPI


### PR DESCRIPTION
The `UDQFunctionTable` can be instantiated without any user data - no need to pass between nodes.