### PR TITLE
Restart flow from restart state

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -430,13 +430,13 @@ add_test_compare_restarted_simulation(CASENAME spe1
                                       SIMULATOR flow
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
-                                      TEST_ARGS --sched-restart=true)
+                                      TEST_ARGS --sched-restart=false)
 add_test_compare_restarted_simulation(CASENAME spe9
                                       FILENAME SPE9_CP_SHORT
                                       SIMULATOR flow
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
-                                      TEST_ARGS --sched-restart=true)
+                                      TEST_ARGS --sched-restart=false)
 
 # PORV test
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-porv-acceptanceTest.sh "")
@@ -467,7 +467,7 @@ if(MPI_FOUND)
                                                  SIMULATOR flow
                                                  ABS_TOL ${abs_tol_restart}
                                                  REL_TOL ${rel_tol_restart}
-                                                 TEST_ARGS --sched-restart=true)
+                                                 TEST_ARGS --sched-restart=false)
 
 
   opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-parallel-regressionTest.sh "")

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -373,8 +373,6 @@ int main(int argc, char** argv)
                 const bool init_from_restart_file = !EWOMS_GET_PARAM(PreTypeTag, bool, SchedRestart);
                 const auto& init_config = eclipseState->getInitConfig();
                 if (init_config.restartRequested() && init_from_restart_file) {
-                    throw std::logic_error("Sorry - the ability to initialize wells and groups from the restart file is currently not ready");
-
                     int report_step = init_config.getRestartStep();
                     const auto& rst_filename = eclipseState->getIOConfig().getRestartFileName( init_config.getRestartRootName(), report_step, false );
                     Opm::EclIO::ERst rst_file(rst_filename);


### PR DESCRIPTION
Along with opm/opm-common#1436 this can now restart the testcases in opm-test with `--sched-restart=false`. There is is still *much* more work to be done before we can say that the case of restarting only from the restart-file is generally solved - see upstream. 

