### PR TITLE
Drop use of boost::multi_array in VFP classes 

### DIFF
--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -1132,8 +1132,7 @@ std::size_t packSize(const VFPProdTable& data,
            packSize(data.getWFRAxis(), comm) +
            packSize(data.getGFRAxis(), comm) +
            packSize(data.getALQAxis(), comm) +
-           data.getTable().num_elements() *
-           packSize(double(), comm);
+           packSize(data.getTable(), comm);
 }
 
 std::size_t packSize(const WellTestConfig::WTESTWell& data,
@@ -2868,8 +2867,7 @@ void pack(const VFPProdTable& data,
     pack(data.getWFRAxis(), buffer, position, comm);
     pack(data.getGFRAxis(), buffer, position, comm);
     pack(data.getALQAxis(), buffer, position, comm);
-    for (size_t i = 0; i < data.getTable().num_elements(); ++i)
-        pack(*(data.getTable().data() + i), buffer, position, comm);
+    pack(data.getTable(), buffer, position, comm);
 }
 
 void pack(const WellTestConfig::WTESTWell& data,
@@ -5070,15 +5068,7 @@ void unpack(VFPProdTable& data,
     unpack(wfrAxis, buffer, position, comm);
     unpack(gfrAxis, buffer, position, comm);
     unpack(alqAxis, buffer, position, comm);
-    VFPProdTable::extents extents;
-    extents[0] = thpAxis.size();
-    extents[1] = wfrAxis.size();
-    extents[2] = gfrAxis.size();
-    extents[3] = alqAxis.size();
-    extents[4] = floAxis.size();
-    table.resize(extents);
-    for (size_t i = 0; i < table.num_elements(); ++i)
-      unpack(*(table.data() + i), buffer, position, comm);
+    unpack(table, buffer, position, comm);
 
     data = VFPProdTable(tableNum, datumDepth, floType, wfrType,
                         gfrType, alqType, floAxis, thpAxis,

--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -1115,8 +1115,7 @@ std::size_t packSize(const VFPInjTable& data,
            packSize(data.getFloType(), comm) +
            packSize(data.getFloAxis(), comm) +
            packSize(data.getTHPAxis(), comm) +
-           data.getTable().num_elements() *
-           packSize(double(), comm);
+           packSize(data.getTable(), comm);
 }
 
 std::size_t packSize(const VFPProdTable& data,
@@ -2851,8 +2850,7 @@ void pack(const VFPInjTable& data,
     pack(data.getFloType(), buffer, position, comm);
     pack(data.getFloAxis(), buffer, position, comm);
     pack(data.getTHPAxis(), buffer, position, comm);
-    for (size_t i = 0; i < data.getTable().num_elements(); ++i)
-        pack(*(data.getTable().data() + i), buffer, position, comm);
+    pack(data.getTable(), buffer, position, comm);
 }
 
 void pack(const VFPProdTable& data,
@@ -5042,12 +5040,7 @@ void unpack(VFPInjTable& data,
     unpack(floType, buffer, position, comm);
     unpack(floAxis, buffer, position, comm);
     unpack(thpAxis, buffer, position, comm);
-    VFPInjTable::extents extents;
-    extents[0] = thpAxis.size();
-    extents[1] = floAxis.size();
-    table.resize(extents);
-    for (size_t i = 0; i < table.num_elements(); ++i)
-        unpack(*(table.data() + i), buffer, position, comm);
+    unpack(table, buffer, position, comm);
 
     data = VFPInjTable(tableNum, datumDepth, floType,
                        floAxis, thpAxis, table);

--- a/opm/simulators/wells/VFPHelpers.hpp
+++ b/opm/simulators/wells/VFPHelpers.hpp
@@ -449,7 +449,7 @@ inline VFPEvaluation interpolate(
  * which performs 5D interpolation, but here for the 2D case only
  */
 inline VFPEvaluation interpolate(
-        const VFPInjTable::array_type& array,
+        const VFPInjTable& table,
         const InterpData& flo_i,
         const InterpData& thp_i) {
 
@@ -466,7 +466,7 @@ inline VFPEvaluation interpolate(
             const int fi = flo_i.ind_[f];
 
             //Copy element
-            nn[t][f].value = array[ti][fi];
+            nn[t][f].value = table(ti,fi);
         }
     }
 
@@ -544,7 +544,7 @@ inline VFPEvaluation bhp(const VFPInjTable* table,
     auto thp_i = detail::findInterpData(thp, table->getTHPAxis());
 
     //Then perform the interpolation itself
-    detail::VFPEvaluation retval = detail::interpolate(table->getTable(), flo_i, thp_i);
+    detail::VFPEvaluation retval = detail::interpolate(*table, flo_i, thp_i);
 
     return retval;
 }

--- a/opm/simulators/wells/VFPHelpers.hpp
+++ b/opm/simulators/wells/VFPHelpers.hpp
@@ -332,7 +332,7 @@ inline VFPEvaluation operator*(
  * Helper function which interpolates data using the indices etc. given in the inputs.
  */
 inline VFPEvaluation interpolate(
-        const VFPProdTable::array_type& array,
+        const VFPProdTable& table,
         const InterpData& flo_i,
         const InterpData& thp_i,
         const InterpData& wfr_i,
@@ -361,7 +361,7 @@ inline VFPEvaluation interpolate(
                         const int fi = flo_i.ind_[f];
 
                         //Copy element
-                        nn[t][w][g][a][f].value = array[ti][wi][gi][ai][fi];
+                        nn[t][w][g][a][f].value = table(ti,wi,gi,ai,fi);
                     }
                 }
             }
@@ -522,7 +522,7 @@ inline VFPEvaluation bhp(const VFPProdTable* table,
     auto gfr_i = detail::findInterpData( gfr, table->getGFRAxis());
     auto alq_i = detail::findInterpData( alq, table->getALQAxis());
 
-    detail::VFPEvaluation retval = detail::interpolate(table->getTable(), flo_i, thp_i, wfr_i, gfr_i, alq_i);
+    detail::VFPEvaluation retval = detail::interpolate(*table, flo_i, thp_i, wfr_i, gfr_i, alq_i);
 
     return retval;
 }

--- a/opm/simulators/wells/VFPInjProperties.cpp
+++ b/opm/simulators/wells/VFPInjProperties.cpp
@@ -67,7 +67,6 @@ double VFPInjProperties::thp(int table_id,
                              const double& vapour,
                              const double& bhp_arg) const {
     const VFPInjTable* table = detail::getTable(m_tables, table_id);
-    const VFPInjTable::array_type& data = table->getTable();
 
     //Find interpolation variables
     double flo = detail::getFlo(aqua, liquid, vapour, table->getFloType());
@@ -84,7 +83,7 @@ double VFPInjProperties::thp(int table_id,
     std::vector<double> bhp_array(nthp);
     for (int i=0; i<nthp; ++i) {
         auto thp_i = detail::findInterpData(thp_array[i], thp_array);
-        bhp_array[i] = detail::interpolate(data, flo_i, thp_i).value;
+        bhp_array[i] = detail::interpolate(*table, flo_i, thp_i).value;
     }
 
     double retval = detail::findTHP(bhp_array, thp_array, bhp_arg);

--- a/opm/simulators/wells/VFPInjProperties.hpp
+++ b/opm/simulators/wells/VFPInjProperties.hpp
@@ -91,7 +91,7 @@ public:
             auto flo_i = detail::findInterpData(flo.value(), table->getFloAxis());
             auto thp_i = detail::findInterpData( thp, table->getTHPAxis()); // assume constant
 
-            detail::VFPEvaluation bhp_val = detail::interpolate(table->getTable(), flo_i, thp_i);
+            detail::VFPEvaluation bhp_val = detail::interpolate(*table, flo_i, thp_i);
 
             bhp = bhp_val.dflo * flo;
             bhp.setValue(bhp_val.value); // thp is assumed constant i.e.

--- a/opm/simulators/wells/VFPProdProperties.cpp
+++ b/opm/simulators/wells/VFPProdProperties.cpp
@@ -57,7 +57,6 @@ double VFPProdProperties::thp(int table_id,
                               const double& bhp_arg,
                               const double& alq) const {
     const VFPProdTable* table = detail::getTable(m_tables, table_id);
-    const VFPProdTable::array_type& data = table->getTable();
 
     //Find interpolation variables
     double flo = detail::getFlo(aqua, liquid, vapour, table->getFloType());
@@ -80,7 +79,7 @@ double VFPProdProperties::thp(int table_id,
     std::vector<double> bhp_array(nthp);
     for (int i=0; i<nthp; ++i) {
         auto thp_i = detail::findInterpData(thp_array[i], thp_array);
-        bhp_array[i] = detail::interpolate(data, flo_i, thp_i, wfr_i, gfr_i, alq_i).value;
+        bhp_array[i] = detail::interpolate(*table, flo_i, thp_i, wfr_i, gfr_i, alq_i).value;
     }
 
     double retval = detail::findTHP(bhp_array, thp_array, bhp_arg);
@@ -131,7 +130,7 @@ bhpwithflo(const std::vector<double>& flos,
     for (size_t i = 0; i < flos.size(); ++i) {
         // Value of FLO is negative in OPM for producers, but positive in VFP table
         const auto flo_i = detail::findInterpData(-flos[i], table->getFloAxis());
-        const detail::VFPEvaluation bhp_val = detail::interpolate(table->getTable(), flo_i, thp_i, wfr_i, gfr_i, alq_i);
+        const detail::VFPEvaluation bhp_val = detail::interpolate(*table, flo_i, thp_i, wfr_i, gfr_i, alq_i);
 
         // TODO: this kind of breaks the conventions for the functions here by putting dp within the function
         bhps[i] = bhp_val.value - dp;

--- a/opm/simulators/wells/VFPProdProperties.hpp
+++ b/opm/simulators/wells/VFPProdProperties.hpp
@@ -102,7 +102,7 @@ public:
             auto gfr_i = detail::findInterpData( gfr.value(), table->getGFRAxis());
             auto alq_i = detail::findInterpData( alq, table->getALQAxis()); //assume constant
 
-            detail::VFPEvaluation bhp_val = detail::interpolate(table->getTable(), flo_i, thp_i, wfr_i, gfr_i, alq_i);
+            detail::VFPEvaluation bhp_val = detail::interpolate(*table, flo_i, thp_i, wfr_i, gfr_i, alq_i);
 
             bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (bhp_val.dflo * flo);
             bhp.setValue(bhp_val.value);

--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -321,16 +321,9 @@ Opm::VFPInjTable getVFPInjTable()
 Opm::VFPProdTable getVFPProdTable()
 {
     Opm::VFPProdTable::array_type table;
-    Opm::VFPProdTable::extents shape;
-    shape[0] = 1;
-    shape[1] = 2;
-    shape[2] = 3;
-    shape[3] = 4;
-    shape[4] = 5;
-    table.resize(shape);
-    double foo = 1.0;
-    for (size_t i = 0; i < table.num_elements(); ++i)
-        *(table.data() + i) = foo++;
+    table.resize(1*2*3*4*5);
+    std::iota(table.begin(), table.end(), 1.0);
+
     return Opm::VFPProdTable(1, 2.0, Opm::VFPProdTable::FLO_OIL,
                              Opm::VFPProdTable::WFR_WOR,
                              Opm::VFPProdTable::GFR_GLR,

--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -310,13 +310,9 @@ Opm::Well getFullWell()
 Opm::VFPInjTable getVFPInjTable()
 {
     Opm::VFPInjTable::array_type table;
-    Opm::VFPInjTable::extents shape;
-    shape[0] = 3;
-    shape[1] = 2;
-    table.resize(shape);
-    double foo = 1.0;
-    for (size_t i = 0; i < table.num_elements(); ++i)
-        *(table.data() + i) = foo++;
+    table.resize(3*2);
+    std::iota(table.begin(), table.end(), 1.0);
+
     return Opm::VFPInjTable(1, 2.0, Opm::VFPInjTable::FLO_WAT, {1.0, 2.0},
                             {3.0, 4.0, 5.0}, table);
 }

--- a/tests/test_vfpproperties.cpp
+++ b/tests/test_vfpproperties.cpp
@@ -124,10 +124,8 @@ struct TrivialFixture {
             nz(gfr_axis.size()),
             nu(alq_axis.size()),
             nv(flo_axis.size()),
-            size{{ nx, ny, nz, nu, nv }},
-            data(size)
+            data(nx*ny*nz*nu*nv)
     {
-
     }
 
     ~TrivialFixture() {
@@ -143,7 +141,7 @@ struct TrivialFixture {
                 for (int k=0; k<nz; ++k) {
                     for (int l=0; l<nu; ++l) {
                         for (int m=0; m<nv; ++m) {
-                            data[i][j][k][l][m] = value;
+                            (*this)(i,j,k,l,m) = value;
                         }
                     }
                 }
@@ -166,7 +164,7 @@ struct TrivialFixture {
                         for (int m=0; m<nv; ++m) {
                             double v = m / static_cast<double>(nv-1);
                             // table[thp_idx][wfr_idx][gfr_idx][alq_idx][flo_idx];
-                            data[i][j][k][l][m] = x + 2*y + 3*z + 4*u + 5*v;
+                            (*this)(i,j,k,l,m) = x + 2*y + 3*z + 4*u + 5*v;
                         }
                     }
                 }
@@ -187,7 +185,7 @@ struct TrivialFixture {
                 for (int k=0; k<nz; ++k) {
                     for (int l=0; l<nu; ++l) {
                         for (int m=0; m<nv; ++m) {
-                            data[i][j][k][l][m] = randx / max_val;
+                            (*this)(i,j,k,l,m) = randx / max_val;
                             randx = (randx*1103515245 + 12345);
                         }
                     }
@@ -214,6 +212,11 @@ struct TrivialFixture {
         properties.reset(new Opm::VFPProdProperties(table.get()));
     }
 
+    double& operator()(size_t thp_idx, size_t wfr_idx, size_t gfr_idx, size_t alq_idx, size_t flo_idx) {
+    return data[thp_idx*ny*nz*nu*nv + wfr_idx*nz*nu*nv + gfr_idx*nu*nv + alq_idx*nv + flo_idx];
+}
+
+
 
 
     std::shared_ptr<Opm::VFPProdProperties> properties;
@@ -231,7 +234,6 @@ private:
     int nz;
     int nu;
     int nv;
-    Opm::VFPProdTable::extents size;
     Opm::VFPProdTable::array_type data;
 };
 


### PR DESCRIPTION
Downstream of https://github.com/OPM/opm-common/pull/1478