### PR TITLE
disable json input for boost 1.48

### DIFF
--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -21,6 +21,7 @@
 
 #include <opm/simulators/linalg/setupPropertyTree.hpp>
 
+#include <boost/version.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace Opm
@@ -35,9 +36,12 @@ boost::property_tree::ptree
 setupPropertyTree(const FlowLinearSolverParameters& p)
 {
     boost::property_tree::ptree prm;
+#if BOOST_VERSION / 100 % 1000 > 48
     if (p.linear_solver_configuration_json_file_ != "none") {
         boost::property_tree::read_json(p.linear_solver_configuration_json_file_, prm);
-    } else {
+    } else
+#endif
+    {
         prm.put("tol", p.linear_solver_reduction_);
         prm.put("maxiter", p.linear_solver_maxiter_);
         prm.put("verbosity", p.linear_solver_verbosity_);

--- a/tests/test_flexiblesolver.cpp
+++ b/tests/test_flexiblesolver.cpp
@@ -21,10 +21,12 @@
 
 #define BOOST_TEST_MODULE OPM_test_FlexibleSolver
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
 
 #include <dune/common/version.hh>
 
-#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 6)
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 6) && \
+    BOOST_VERSION / 100 % 1000 > 48
 
 #include <opm/simulators/linalg/FlexibleSolver.hpp>
 

--- a/tests/test_preconditionerfactory.cpp
+++ b/tests/test_preconditionerfactory.cpp
@@ -21,10 +21,12 @@
 
 #define BOOST_TEST_MODULE OPM_test_PreconditionerFactory
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
 
 #include <dune/common/version.hh>
 
-#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 6)
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 6) && \
+    BOOST_VERSION / 100 % 1000 > 48
 
 #include <opm/simulators/linalg/PreconditionerFactory.hpp>
 #include <opm/simulators/linalg/FlexibleSolver.hpp>


### PR DESCRIPTION
Context: Now that we use std::filesystem, the brokenness of boost::property_tree is the only reason why we need to use non-standard boost packages on rhel6/7. Since I doubt anyone would be doing development on these platforms, at least while using standard boost, I deem it better to disable this functionality to make for pain-free installs for end users.