### PR TITLE
Add missing keywords to list

### DIFF
--- a/opm/simulators/flow/MissingFeatures.cpp
+++ b/opm/simulators/flow/MissingFeatures.cpp
@@ -770,6 +770,8 @@ namespace MissingFeatures {
             "WDRILRES",
             "WECONINJ",
             "WECONT",
+            "WEIR",
+            "WEIT",
             "WELCNTL",
             "WELDEBUG",
             "WELDRAW",


### PR DESCRIPTION
Add keywords WEIR (Energy Injection Rate) and WEIR (Energy Injection Rate).