### PR TITLE
remove last usage of boost::filesystem

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -76,8 +76,8 @@ END_PROPERTIES
 
 namespace detail
 {
-    boost::filesystem::path simulationCaseName( const std::string& casename ) {
-        namespace fs = boost::filesystem;
+    Opm::filesystem::path simulationCaseName( const std::string& casename ) {
+        namespace fs = Opm::filesystem;
 
         const auto exists = []( const fs::path& f ) -> bool {
             if( !fs::exists( f ) ) return false;
@@ -136,9 +136,9 @@ enum class FileOutputMode {
 
 void ensureOutputDirExists(const std::string& cmdline_output_dir)
 {
-    if (!boost::filesystem::is_directory(cmdline_output_dir)) {
+    if (!Opm::filesystem::is_directory(cmdline_output_dir)) {
         try {
-            boost::filesystem::create_directories(cmdline_output_dir);
+            Opm::filesystem::create_directories(cmdline_output_dir);
         }
         catch (...) {
             throw std::runtime_error("Creation of output directory '" + cmdline_output_dir + "' failed\n");
@@ -155,7 +155,7 @@ FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, con
     }
 
     // create logFile
-    using boost::filesystem::path;
+    using Opm::filesystem::path;
     path fpath(deck_filename);
     std::string baseName;
     std::ostringstream debugFileStream;

--- a/flow/flow_tag.hpp
+++ b/flow/flow_tag.hpp
@@ -97,8 +97,8 @@ namespace Opm {
 
 namespace detail
 {
-    boost::filesystem::path simulationCaseName( const std::string& casename ) {
-        namespace fs = boost::filesystem;
+    Opm::filesystem::path simulationCaseName( const std::string& casename ) {
+        namespace fs = Opm::filesystem;
 
         const auto exists = []( const fs::path& f ) -> bool {
             if( !fs::exists( f ) ) return false;
@@ -159,9 +159,9 @@ enum class FileOutputMode {
 
 void ensureOutputDirExists(const std::string& cmdline_output_dir)
 {
-    if (!boost::filesystem::is_directory(cmdline_output_dir)) {
+    if (!Opm::filesystem::is_directory(cmdline_output_dir)) {
         try {
-            boost::filesystem::create_directories(cmdline_output_dir);
+            Opm::filesystem::create_directories(cmdline_output_dir);
         }
         catch (...) {
             throw std::runtime_error("Creation of output directory '" + cmdline_output_dir + "' failed\n");
@@ -178,7 +178,7 @@ FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, con
     }
 
     // create logFile
-    using boost::filesystem::path;
+    using Opm::filesystem::path;
     path fpath(deck_filename);
     std::string baseName;
     std::ostringstream debugFileStream;

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -363,7 +363,7 @@ namespace Opm
                 return;
             }
 
-            namespace fs = boost::filesystem;
+            namespace fs = Opm::filesystem;
             const std::string& output_dir = eclState().getIOConfig().getOutputDir();
             fs::path output_path(output_dir);
             fs::path deck_filename(EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName));

--- a/opm/simulators/utils/ParallelFileMerger.hpp
+++ b/opm/simulators/utils/ParallelFileMerger.hpp
@@ -24,8 +24,7 @@
 #include <memory>
 #include <iostream>
 
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
+#include <opm/common/utility/FileSystem.hpp>
 #include <regex>
 
 namespace Opm
@@ -33,7 +32,7 @@ namespace Opm
 namespace detail
 {
 
-namespace fs = boost::filesystem;
+namespace fs = Opm::filesystem;
 
 /// \brief A functor that merges multiple files of a parallel run to one file.
 ///
@@ -59,11 +58,11 @@ public:
         {
             auto debugPath = output_dir;
             debugPath /= (deckname + ".DBG");
-            debugStream_.reset(new fs::ofstream(debugPath,
+            debugStream_.reset(new std::ofstream(debugPath,
                                                 std::ofstream::app));
             auto logPath = output_dir;
             logPath /= ( deckname + ".PRT");
-            logStream_.reset(new fs::ofstream(logPath,
+            logStream_.reset(new std::ofstream(logPath,
                                               std::ofstream::app));
         }
     }
@@ -112,7 +111,7 @@ private:
     /// \brief of The output stream to use.
     /// \brief file The file whose content to append.
     /// \brief rank The rank that wrote the file.
-    void appendFile(fs::ofstream& of, const fs::path& file, const std::string& rank)
+    void appendFile(std::ofstream& of, const fs::path& file, const std::string& rank)
     {
         if( fs::file_size(file) )
         {
@@ -120,7 +119,7 @@ private:
                       << file.string() <<" by process "
                       << rank << std::endl;
 
-            fs::ifstream in(file);
+            std::ifstream in(file);
             of<<std::endl<< std::endl;
             of<<"=======================================================";
             of<<std::endl<<std::endl;
@@ -141,9 +140,9 @@ private:
     /// \brief Regex to capture  CASENAME.[0-9]+.[A-Z]+
     std::regex fileWarningRegex_;
     /// \brief Stream to *.DBG file
-    std::unique_ptr<fs::ofstream> debugStream_;
+    std::unique_ptr<std::ofstream> debugStream_;
     /// \brief Stream to *.PRT file
-    std::unique_ptr<fs::ofstream> logStream_;
+    std::unique_ptr<std::ofstream> logStream_;
     /// \brief Whether to show any logging fallout
     bool show_fallout_;
 };


### PR DESCRIPTION
I did not notice these before for some reason.. https://github.com/OPM/opm-material/pull/399 made me notice.