### PR TITLE
Add serialization for AquiferConfig

### DIFF
--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -139,6 +139,19 @@ template <typename TypeTag>
 void
 BlackoilAquiferModel<TypeTag>::init()
 {
+    /*
+    const auto& comm = this->simulator_.vanguard().gridView().comm();
+    const auto& aquifer = this->simulator_.vanguard().eclState().aquifer();
+    const auto& connections = aquifer.connections();
+
+
+    for (const auto& aq : aquifer.fetp())
+        aquifers_Fetkovich.push_back(AquiferFetkovich<TypeTag>(connections[aq.aquiferID], cartesian_to_compressed_, this->simulator_, aq));
+
+    for (const auto& aq : aquifer.ct())
+        aquifers_CarterTracy.push_back(AquiferCarterTracy<TypeTag>(connections[aq.aquiferID], cartesian_to_compressed_, this->simulator_, aq));
+    */
+
     const auto& deck = this->simulator_.vanguard().deck();
     const auto& comm = this->simulator_.vanguard().gridView().comm();
 

--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -562,6 +562,13 @@ std::size_t packSize(const AquiferCT& data, Dune::MPIHelper::MPICommunicator com
     return packSize(data.data(), comm);
 }
 
+std::size_t packSize(const AquiferConfig& data, Dune::MPIHelper::MPICommunicator comm)
+{
+    return packSize(data.fetp(), comm) +
+           packSize(data.ct(), comm) +
+           packSize(data.connections(), comm);
+}
+
 std::size_t packSize(const Aquancon::AquancCell& data, Dune::MPIHelper::MPICommunicator comm)
 {
     return packSize(data.aquiferID, comm) +
@@ -2352,6 +2359,13 @@ void pack(const Aquifetp::AQUFETP_data& data, std::vector<char>& buffer, int& po
 void pack(const Aquifetp& data, std::vector<char>& buffer, int& position,
           Dune::MPIHelper::MPICommunicator comm) {
     pack(data.data(), buffer, position, comm);
+}
+
+void pack(const AquiferConfig& data, std::vector<char>& buffer, int& position,
+          Dune::MPIHelper::MPICommunicator comm) {
+    pack(data.fetp(), buffer, position, comm);
+    pack(data.ct(), buffer, position, comm);
+    pack(data.connections(), buffer, position, comm);
 }
 
 void pack(const Aquancon::AquancCell& data, std::vector<char>& buffer, int& position,
@@ -4369,6 +4383,17 @@ void unpack(Aquancon::AquancCell& data, std::vector<char>& buffer, int& position
     data = Aquancon::AquancCell(aquiferID, globalIndex, influxCoeff, influxMult, faceDir);
 }
 
+
+void unpack(AquiferConfig& data, std::vector<char>& buffer, int& position, Dune::MPIHelper::MPICommunicator comm) {
+    Aquifetp fetp;
+    AquiferCT ct;
+    Aquancon conn;
+
+    unpack(fetp, buffer, position, comm);
+    unpack(ct, buffer, position, comm);
+    unpack(conn, buffer, position, comm);
+    data = AquiferConfig(fetp, ct, conn);
+}
 
 
 void unpack(Aquancon& data, std::vector<char>& buffer, int& position, Dune::MPIHelper::MPICommunicator comm)

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -40,6 +40,7 @@
 #include <opm/output/eclipse/RestartValue.hpp>
 #include <opm/output/eclipse/EclipseIO.hpp>
 #include <opm/output/eclipse/Summary.hpp>
+#include <opm/parser/eclipse/EclipseState/AquiferConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquancon.hpp>
 #include <opm/parser/eclipse/EclipseState/AquiferCT.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquifetp.hpp>
@@ -672,6 +673,7 @@ ADD_PACK_PROTOTYPES(Action::ASTNode)
 ADD_PACK_PROTOTYPES(Action::Condition)
 ADD_PACK_PROTOTYPES(Action::Quantity)
 ADD_PACK_PROTOTYPES(Aqudims)
+ADD_PACK_PROTOTYPES(AquiferConfig)
 ADD_PACK_PROTOTYPES(Aquancon)
 ADD_PACK_PROTOTYPES(Aquancon::AquancCell)
 ADD_PACK_PROTOTYPES(AquiferCT)

--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -1925,6 +1925,19 @@ BOOST_AUTO_TEST_CASE(Aquancon)
 #endif
 }
 
+BOOST_AUTO_TEST_CASE(AquferConfig)
+{
+#ifdef HAVE_MPI
+    Opm::Aquifetp fetp = getAquifetp();
+    Opm::AquiferCT ct = getAquiferCT();
+    Opm::Aquancon conn = getAquancon();
+    Opm::AquiferConfig val1(fetp, ct, conn);
+    auto val2 = PackUnpack(val1);
+    DO_CHECKS(AquiferConfig);
+#endif
+}
+
+
 
 
 BOOST_AUTO_TEST_CASE(GuideRateModel)


### PR DESCRIPTION
The first commit adds serialization for the `AquiferConfig` class. The second commit adds a commented out POC for how the new `AquiferConfig` class can be used instead of the `Deck` to configure the simulator specific Aquifer functionality. 

@akva2 : Will you complete this work?

Upstream: https://github.com/OPM/opm-common/pull/1458