### PR TITLE
quell warning about unused local typedef

### DIFF
--- a/opm/simulators/linalg/ParallelIstlInformation.hpp
+++ b/opm/simulators/linalg/ParallelIstlInformation.hpp
@@ -585,7 +585,7 @@ private:
         struct MaxOp
         {
             using result_type = T;
-            const T& operator()(const T& t1, const T& t2)
+            const result_type& operator()(const T& t1, const T& t2)
             {
                 return std::max(t1, t2);
             }
@@ -641,7 +641,7 @@ private:
         struct MinOp
         {
             using result_type = T;
-            const T& operator()(const T& t1, const T& t2)
+            const result_type& operator()(const T& t1, const T& t2)
             {
                 return std::min(t1, t2);
             }


### PR DESCRIPTION
strictly speaking the gcc diagnostics are wrong, the typedef is actually
used once templates are invoked on the structs.
simply use the typedef in the structs itself to avoid the warning
like is done for other variants.

replaces https://github.com/OPM/opm-simulators/pull/2345