### PR TITLE
Lessen boost usage

### DIFF
--- a/ebos/startEbos.hh
+++ b/ebos/startEbos.hh
@@ -40,6 +40,8 @@
 #include <opm/common/OpmLog/LogUtil.hpp>
 #endif
 
+#include <opm/parser/eclipse/Utility/String.hpp>
+
 BEGIN_PROPERTIES
 
 // forward declaration of property tags
@@ -93,11 +95,11 @@ static FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filena
     std::ostringstream logFileStream;
 
     // Strip extension "." or ".DATA"
-    std::string extension = boost::to_upper_copy(fpath.extension().string());
+    std::string extension = uppercase(fpath.extension().string());
     if (extension == ".DATA" || extension == ".") {
-        baseName = boost::to_upper_copy(fpath.stem().string());
+        baseName = uppercase(fpath.stem().string());
     } else {
-        baseName = boost::to_upper_copy(fpath.filename().string());
+        baseName = uppercase(fpath.filename().string());
     }
 
     std::string output_dir = cmdline_output_dir;

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -41,6 +41,7 @@
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
+#include <opm/parser/eclipse/Utility/String.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -369,14 +370,14 @@ namespace Opm
             fs::path deck_filename(EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName));
             std::string basename;
             // Strip extension "." and ".DATA"
-            std::string extension = boost::to_upper_copy(deck_filename.extension().string());
+            std::string extension = uppercase(deck_filename.extension().string());
             if ( extension == ".DATA" || extension == "." )
             {
-                basename = boost::to_upper_copy(deck_filename.stem().string());
+                basename = uppercase(deck_filename.stem().string());
             }
             else
             {
-                basename = boost::to_upper_copy(deck_filename.filename().string());
+                basename = uppercase(deck_filename.filename().string());
             }
             std::for_each(fs::directory_iterator(output_path),
                           fs::directory_iterator(),

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -537,7 +537,7 @@ namespace Opm
         std::unique_ptr<EbosSimulator> ebosSimulator_;
         int  mpi_rank_ = 0;
         int  mpi_size_ = 1;
-        boost::any parallel_information_;
+        std::any parallel_information_;
         std::unique_ptr<Simulator> simulator_;
     };
 } // namespace Opm

--- a/opm/simulators/flow/MissingFeatures.cpp
+++ b/opm/simulators/flow/MissingFeatures.cpp
@@ -32,7 +32,7 @@
 #include <unordered_set>
 #include <string>
 #include <map>
-#include <boost/lexical_cast.hpp>
+#include <type_traits>
 
 namespace Opm {
 
@@ -58,7 +58,13 @@ namespace MissingFeatures {
             const auto& record = keyword.getRecord(0);
             if (record.getItem(it->second.item).template get<T>(0) != it->second.item_value) {
                 const auto& location = keyword.location();
-                std::string msg = "For keyword '" + it->first + "' only value " + boost::lexical_cast<std::string>(it->second.item_value)
+                std::string val;
+                if constexpr (std::is_arithmetic<T>::value)
+                    val = std::to_string(it->second.item_value);
+                else
+                    val = it->second.item_value;
+
+                std::string msg = "For keyword '" + it->first + "' only value " + val
                     + " in item " + it->second.item + " is supported by flow.\n"
                     + "In file " + location.filename + ", line " + std::to_string(location.lineno) + "\n";
                 parseContext.handleError(ParseContext::SIMULATOR_KEYWORD_ITEM_NOT_SUPPORTED, msg, errorGuard);

--- a/opm/simulators/flow/countGlobalCells.hpp
+++ b/opm/simulators/flow/countGlobalCells.hpp
@@ -27,6 +27,8 @@
 #include <opm/simulators/linalg/ParallelIstlInformation.hpp>
 #include <opm/core/props/BlackoilPhases.hpp>
 
+#include <any>
+
 namespace Opm {
 namespace detail {
 
@@ -103,7 +105,7 @@ namespace detail {
         /// \param pinfo           In a parallel this holds the information about the data distribution.
         template <class Iterator>
         inline
-        double euclidianNormSquared( Iterator it, const Iterator end, int num_components, const boost::any& pinfo = boost::any() )
+        double euclidianNormSquared( Iterator it, const Iterator end, int num_components, const std::any& pinfo = std::any() )
         {
             static_cast<void>(num_components); // Suppress warning in the serial case.
             static_cast<void>(pinfo); // Suppress warning in non-MPI case.
@@ -111,7 +113,7 @@ namespace detail {
             if ( pinfo.type() == typeid(ParallelISTLInformation) )
             {
                 const ParallelISTLInformation& info =
-                    boost::any_cast<const ParallelISTLInformation&>(pinfo);
+                    std::any_cast<const ParallelISTLInformation&>(pinfo);
                 typedef typename Iterator::value_type Scalar;
                 Scalar product = 0.0;
                 int size_per_component = (end - it);

--- a/opm/simulators/linalg/ExtractParallelGridInformationToISTL.cpp
+++ b/opm/simulators/linalg/ExtractParallelGridInformationToISTL.cpp
@@ -27,7 +27,7 @@
 #if defined(HAVE_OPM_GRID)
 #if defined(HAVE_MPI) && defined(HAVE_DUNE_ISTL)
 // Extracts the information about the data decomposition from the grid for dune-istl
-void extractParallelGridInformationToISTL(const Dune::CpGrid& grid, boost::any& anyComm)
+void extractParallelGridInformationToISTL(const Dune::CpGrid& grid, std::any& anyComm)
 {
     if(grid.comm().size()>1)
     {
@@ -35,14 +35,14 @@ void extractParallelGridInformationToISTL(const Dune::CpGrid& grid, boost::any& 
         Dune::CpGrid& mgrid=const_cast<Dune::CpGrid&>(grid);
         Dune::CpGrid::ParallelIndexSet& idx=mgrid.getCellIndexSet();
         Dune::CpGrid::RemoteIndices& ridx=mgrid.getCellRemoteIndices();
-        anyComm=boost::any(Opm::ParallelISTLInformation(Dune::stackobject_to_shared_ptr(idx),
+        anyComm=std::any(Opm::ParallelISTLInformation(Dune::stackobject_to_shared_ptr(idx),
                                                         Dune::stackobject_to_shared_ptr(ridx),
                                                         grid.comm()));
     }
 }
 #else
 // Missing support for MPI or dune-istl -> do nothing.
-void extractParallelGridInformationToISTL(const Dune::CpGrid&, boost::any&)
+void extractParallelGridInformationToISTL(const Dune::CpGrid&, std::any&)
 {}
 #endif //defined(HAVE_MPI) && defined(HAVE_DUNE_ISTL)
 #endif //defined(HAVE_OPM_GRID)

--- a/opm/simulators/linalg/ExtractParallelGridInformationToISTL.hpp
+++ b/opm/simulators/linalg/ExtractParallelGridInformationToISTL.hpp
@@ -22,7 +22,7 @@
 #ifdef HAVE_OPM_GRID
 
 #include<opm/grid/CpGrid.hpp>
-#include<boost/any.hpp>
+#include <any>
 
 namespace Opm
 {
@@ -37,11 +37,11 @@ namespace Opm
 /// \param[out] anyComm The handle to to store the information in. If grid is a parallel grid
 /// then this will ecapsulate an instance of ParallelISTLInformation.
 
-void extractParallelGridInformationToISTL(const Dune::CpGrid& grid, boost::any& anyComm);
+void extractParallelGridInformationToISTL(const Dune::CpGrid& grid, std::any& anyComm);
 
 // Grid is not CpGrid --> do nothing.
 template <class Grid>
-void extractParallelGridInformationToISTL(const Grid&, boost::any&)
+void extractParallelGridInformationToISTL(const Grid&, std::any&)
 {}
 
 } // end namespace Opm

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -123,14 +123,14 @@ public:
   WellModelMatrixAdapter (const M& A,
                           const M& A_for_precond,
                           const WellModel& wellMod,
-                          const boost::any& parallelInformation OPM_UNUSED_NOMPI = boost::any() )
+                          const std::any& parallelInformation OPM_UNUSED_NOMPI = std::any() )
       : A_( A ), A_for_precond_(A_for_precond), wellMod_( wellMod ), comm_()
   {
 #if HAVE_MPI
     if( parallelInformation.type() == typeid(ParallelISTLInformation) )
     {
       const ParallelISTLInformation& info =
-          boost::any_cast<const ParallelISTLInformation&>( parallelInformation);
+          std::any_cast<const ParallelISTLInformation&>( parallelInformation);
       comm_.reset( new communication_type( info.communicator() ) );
     }
 #endif
@@ -375,7 +375,7 @@ protected:
         int iterations () const { return iterations_; }
 
         /// \copydoc NewtonIterationBlackoilInterface::parallelInformation
-        const boost::any& parallelInformation() const { return parallelInformation_; }
+        const std::any& parallelInformation() const { return parallelInformation_; }
 
     protected:
         /// \brief construct the CPR preconditioner and the solver.
@@ -568,7 +568,7 @@ protected:
             if (parallelInformation_.type() == typeid(ParallelISTLInformation))
             {
                 const ParallelISTLInformation& info =
-                    boost::any_cast<const ParallelISTLInformation&>( parallelInformation_);
+                    std::any_cast<const ParallelISTLInformation&>( parallelInformation_);
                 Comm istlComm(info.communicator());
 
                 // Construct operator, scalar product and vectors needed.
@@ -604,7 +604,7 @@ protected:
             {
                 const size_t size = opA.getmat().N();
                 const ParallelISTLInformation& info =
-                    boost::any_cast<const ParallelISTLInformation&>( parallelInformation_);
+                    std::any_cast<const ParallelISTLInformation&>( parallelInformation_);
 
                 // As we use a dune-istl with block size np the number of components
                 // per parallel is only one.
@@ -939,7 +939,7 @@ protected:
         const Simulator& simulator_;
         mutable int iterations_;
         mutable bool converged_;
-        boost::any parallelInformation_;
+        std::any parallelInformation_;
 
         std::unique_ptr<Matrix> matrix_;
         std::unique_ptr<Matrix> noGhostMat_;

--- a/opm/simulators/linalg/ISTLSolverEbosCpr.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosCpr.hpp
@@ -135,7 +135,7 @@ namespace Opm
                         const size_t size = opAParallel_->getmat().N();
 
                         const ParallelISTLInformation& info =
-                            boost::any_cast<const ParallelISTLInformation&>( this->parallelInformation_);
+                            std::any_cast<const ParallelISTLInformation&>( this->parallelInformation_);
 
                         // As we use a dune-istl with block size np the number of components
                         // per parallel is only one.

--- a/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
@@ -81,7 +81,7 @@ public:
 #if HAVE_MPI
         if (parallelInformation_.type() == typeid(ParallelISTLInformation)) {
             // Parallel case.
-            const ParallelISTLInformation* parinfo = boost::any_cast<ParallelISTLInformation>(&parallelInformation_);
+            const ParallelISTLInformation* parinfo = std::any_cast<ParallelISTLInformation>(&parallelInformation_);
             assert(parinfo);
             comm_.reset(new Communication(parinfo->communicator()));
         }
@@ -98,7 +98,7 @@ public:
         static bool firstcall = true;
         if (firstcall && parallelInformation_.type() == typeid(ParallelISTLInformation)) {
             // Parallel case.
-            const ParallelISTLInformation* parinfo = boost::any_cast<ParallelISTLInformation>(&parallelInformation_);
+            const ParallelISTLInformation* parinfo = std::any_cast<ParallelISTLInformation>(&parallelInformation_);
             assert(parinfo);
             const size_t size = mat.istlMatrix().N();
             parinfo->copyValuesTo(comm_->indexSet(), comm_->remoteIndices(), size, 1);
@@ -205,7 +205,7 @@ protected:
     boost::property_tree::ptree prm_;
     VectorType rhs_;
     Dune::InverseOperatorResult res_;
-    boost::any parallelInformation_;
+    std::any parallelInformation_;
 #if HAVE_MPI
     std::unique_ptr<Communication> comm_;
 #endif

--- a/opm/simulators/linalg/ParallelIstlInformation.hpp
+++ b/opm/simulators/linalg/ParallelIstlInformation.hpp
@@ -24,7 +24,7 @@
 
 #include <opm/grid/UnstructuredGrid.h>
 #include <opm/common/ErrorMacros.hpp>
-#include <boost/any.hpp>
+#include <any>
 #include <exception>
 
 #include <algorithm>
@@ -671,7 +671,7 @@ namespace Opm
 /// then this will ecapsulate an instance of ParallelISTLInformation.
 /// \param grid The grid to inspect.
 
-inline void extractParallelGridInformationToISTL(boost::any& anyComm, const UnstructuredGrid& grid)
+inline void extractParallelGridInformationToISTL(std::any& anyComm, const UnstructuredGrid& grid)
 {
     (void)anyComm; (void)grid;
 }

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -23,7 +23,6 @@
 
 #include <vector>
 
-#include <boost/any.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <opm/simulators/timestepping/TimeStepControlInterface.hpp>
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -462,15 +462,15 @@ namespace Opm
         bool allDrawDownWrongDirection(const Simulator& ebos_simulator) const;
 
 
-        boost::optional<double> computeBhpAtThpLimitProd(const Simulator& ebos_simulator,
-                                                         const std::vector<Scalar>& B_avg,
-                                                         const SummaryState& summary_state,
-                                                         DeferredLogger& deferred_logger) const;
+        std::optional<double> computeBhpAtThpLimitProd(const Simulator& ebos_simulator,
+                                                       const std::vector<Scalar>& B_avg,
+                                                       const SummaryState& summary_state,
+                                                       DeferredLogger& deferred_logger) const;
 
-        boost::optional<double> computeBhpAtThpLimitInj(const Simulator& ebos_simulator,
-                                                        const std::vector<Scalar>& B_avg,
-                                                        const SummaryState& summary_state,
-                                                        DeferredLogger& deferred_logger) const;
+        std::optional<double> computeBhpAtThpLimitInj(const Simulator& ebos_simulator,
+                                                      const std::vector<Scalar>& B_avg,
+                                                      const SummaryState& summary_state,
+                                                      DeferredLogger& deferred_logger) const;
 
         double maxPerfPress(const Simulator& ebos_simulator) const;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -3546,7 +3546,7 @@ namespace Opm
 
 
     template<typename TypeTag>
-    boost::optional<double>
+    std::optional<double>
     MultisegmentWell<TypeTag>::
     computeBhpAtThpLimitProd(const Simulator& ebos_simulator,
                              const std::vector<Scalar>& B_avg,
@@ -3628,7 +3628,7 @@ namespace Opm
                     // empty optional.
                     deferred_logger.warning("FAILED_ROBUST_BHP_THP_SOLVE_INOPERABLE",
                                             "Robust bhp(thp) solve failed due to inoperability for well " + name());
-                    return boost::optional<double>();
+                    return std::optional<double>();
                 } else {
                     // Still producing, even at high bhp.
                     assert(f_high < 0.0);
@@ -3712,7 +3712,7 @@ namespace Opm
                         // Return failure.
                         deferred_logger.warning("FAILED_ROBUST_BHP_THP_SOLVE_BRACKETING_FAILURE",
                                                 "Robust bhp(thp) solve failed due to bracketing failure for well " + name());
-                        return boost::optional<double>();
+                        return std::optional<double>();
                     }
                 }
             }
@@ -3738,7 +3738,7 @@ namespace Opm
         catch (...) {
             deferred_logger.warning("FAILED_ROBUST_BHP_THP_SOLVE",
                                     "Robust bhp(thp) solve failed for well " + name());
-            return boost::optional<double>();
+            return std::optional<double>();
 	}
     }
 
@@ -3746,7 +3746,7 @@ namespace Opm
 
 
     template<typename TypeTag>
-    boost::optional<double>
+    std::optional<double>
     MultisegmentWell<TypeTag>::
     computeBhpAtThpLimitInj(const Simulator& ebos_simulator,
                             const std::vector<Scalar>& B_avg,
@@ -3906,7 +3906,7 @@ namespace Opm
 
         // Handle the no solution case.
         if (sign_change_index == -1) {
-            return boost::optional<double>();
+            return std::optional<double>();
         }
 
         // Solve for the proper solution in the given interval.
@@ -3925,7 +3925,7 @@ namespace Opm
             assert(low == controls.bhp_limit);
             deferred_logger.warning("FAILED_ROBUST_BHP_THP_SOLVE",
                                     "Robust bhp(thp) solve failed for well " + name());
-            return boost::optional<double>();
+            return std::optional<double>();
         }
         try {
             const double solved_bhp = RegulaFalsiBisection<WarnAndContinueOnError>::
@@ -3939,7 +3939,7 @@ namespace Opm
         catch (...) {
             deferred_logger.warning("FAILED_ROBUST_BHP_THP_SOLVE",
                                     "Robust bhp(thp) solve failed for well " + name());
-            return boost::optional<double>();
+            return std::optional<double>();
         }
 
     }

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -38,7 +38,7 @@
 #include <dune/common/dynvector.hh>
 #include <dune/common/dynmatrix.hh>
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Opm
 {
@@ -509,13 +509,13 @@ namespace Opm
                                         DeferredLogger& deferred_logger);
 
 
-        boost::optional<double> computeBhpAtThpLimitProd(const Simulator& ebos_simulator,
-                                                         const SummaryState& summary_state,
-                                                         DeferredLogger& deferred_logger) const;
+        std::optional<double> computeBhpAtThpLimitProd(const Simulator& ebos_simulator,
+                                                       const SummaryState& summary_state,
+                                                       DeferredLogger& deferred_logger) const;
 
-        boost::optional<double> computeBhpAtThpLimitInj(const Simulator& ebos_simulator,
-                                                        const SummaryState& summary_state,
-                                                        DeferredLogger& deferred_logger) const;
+        std::optional<double> computeBhpAtThpLimitInj(const Simulator& ebos_simulator,
+                                                      const SummaryState& summary_state,
+                                                      DeferredLogger& deferred_logger) const;
 
     };
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -3759,7 +3759,7 @@ namespace Opm
 
 
     template<typename TypeTag>
-    boost::optional<double>
+    std::optional<double>
     StandardWell<TypeTag>::
     computeBhpAtThpLimitProd(const Simulator& ebos_simulator,
                              const SummaryState& summary_state,
@@ -3923,7 +3923,7 @@ namespace Opm
 
         // Handle the no solution case.
         if (sign_change_index == -1) {
-            return boost::optional<double>();
+            return std::optional<double>();
         }
 
         // Solve for the proper solution in the given interval.
@@ -3942,7 +3942,7 @@ namespace Opm
             assert(low == controls.bhp_limit);
             deferred_logger.warning("FAILED_ROBUST_BHP_THP_SOLVE",
                                     "Robust bhp(thp) solve failed for well " + name());
-            return boost::optional<double>();
+            return std::optional<double>();
         }
         try {
             const double solved_bhp = RegulaFalsiBisection<>::
@@ -3956,7 +3956,7 @@ namespace Opm
         catch (...) {
             deferred_logger.warning("FAILED_ROBUST_BHP_THP_SOLVE",
                                     "Robust bhp(thp) solve failed for well " + name());
-            return boost::optional<double>();
+            return std::optional<double>();
         }
 
     }
@@ -3964,7 +3964,7 @@ namespace Opm
 
 
     template<typename TypeTag>
-    boost::optional<double>
+    std::optional<double>
     StandardWell<TypeTag>::
     computeBhpAtThpLimitInj(const Simulator& ebos_simulator,
                             const SummaryState& summary_state,
@@ -4123,7 +4123,7 @@ namespace Opm
 
         // Handle the no solution case.
         if (sign_change_index == -1) {
-            return boost::optional<double>();
+            return std::optional<double>();
         }
 
         // Solve for the proper solution in the given interval.
@@ -4142,7 +4142,7 @@ namespace Opm
             assert(low == controls.bhp_limit);
             deferred_logger.warning("FAILED_ROBUST_BHP_THP_SOLVE",
                                     "Robust bhp(thp) solve failed for well " + name());
-            return boost::optional<double>();
+            return std::optional<double>();
         }
         try {
             const double solved_bhp = RegulaFalsiBisection<>::
@@ -4156,7 +4156,7 @@ namespace Opm
         catch (...) {
             deferred_logger.warning("FAILED_ROBUST_BHP_THP_SOLVE",
                                     "Robust bhp(thp) solve failed for well " + name());
-            return boost::optional<double>();
+            return std::optional<double>();
         }
 
     }


### PR DESCRIPTION
- use std::any
- use std::optional
- use internal uppercasing
- avoid lexical_cast
- remove unnecessary includes