### PR TITLE
Simplify serialization of WellSegments

### DIFF
--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -1432,9 +1432,7 @@ std::size_t packSize(const WellSegments& data,
                      Dune::MPIHelper::MPICommunicator comm)
 {
     return packSize(data.compPressureDrop(), comm) +
-           packSize(data.segments(), comm) +
-           packSize(data.segmentNumberIndex(), comm);
-
+           packSize(data.segments(), comm);
 }
 
 std::size_t packSize(const Well& data,
@@ -3259,7 +3257,6 @@ void pack(const WellSegments& data,
 {
     pack(data.compPressureDrop(), buffer, position, comm);
     pack(data.segments(), buffer, position, comm);
-    pack(data.segmentNumberIndex(), buffer, position, comm);
 }
 
 void pack(const Well& data,
@@ -5726,14 +5723,11 @@ void unpack(WellSegments& data,
 {
     WellSegments::CompPressureDrop compPressureDrop;
     std::vector<Segment> segments;
-    std::map<int,int> segmentNumberIndex;
 
     unpack(compPressureDrop, buffer, position, comm);
     unpack(segments, buffer, position, comm);
-    unpack(segmentNumberIndex, buffer, position, comm);
 
-    data = WellSegments(compPressureDrop,
-                        segments, segmentNumberIndex);
+    data = WellSegments(compPressureDrop, segments);
 }
 
 void unpack(Well& data,

--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -1712,8 +1712,7 @@ BOOST_AUTO_TEST_CASE(WellSegments)
                      std::make_shared<Opm::SpiralICD>(),
                      std::make_shared<Opm::Valve>());
     Opm::WellSegments val1(Opm::WellSegments::CompPressureDrop::HF_,
-                           {seg, seg},
-                           {{1,2},{3,4}});
+                           {seg, seg});
 
     auto val2 = PackUnpack(val1);
     DO_CHECKS(WellSegments)


### PR DESCRIPTION
Use an alternative constructor in the serialization of WellSegments.

Downstream of: https://github.com/OPM/opm-common/pull/1503

