### PR TITLE
Initialize phase mix with (1/3, 1/3, 1/3) for producer

### DIFF
--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2405,9 +2405,9 @@ namespace Opm
                     mix[component] = std::fabs(q_out_perf[perf*num_comp + component]/tot_surf_rate);
                 }
             } else {
-                std::fill(mix.begin(), mix.end(), 0.0);
                 // No flow => use well specified fractions for mix.
                 if (this->isInjector()) {
+                    std::fill(mix.begin(), mix.end(), 0.0);
                     switch (this->wellEcl().injectorType()) {
                     case Well::InjectorType::WATER:
                         mix[FluidSystem::waterCompIdx] = 1.0;
@@ -2426,22 +2426,7 @@ namespace Opm
                     }
                 } else {
                     assert(this->isProducer());
-                    // Using the preferred phase to decide the mix initialization.
-                    switch (this->wellEcl().getPreferredPhase()) {
-                    case Phase::OIL:
-                        mix[FluidSystem::oilCompIdx] = 1.0;
-                        break;
-                    case Phase::GAS:
-                        mix[FluidSystem::gasCompIdx] = 1.0;
-                        break;
-                    case Phase::WATER:
-                        mix[FluidSystem::waterCompIdx] = 1.0;
-                        break;
-                    default:
-                        // No others supported.
-                        break;
-                    }
-
+                    std::fill(mix.begin(), mix.end(), 1.0/3.0);
                 }
             }
             // Compute volume ratio.


### PR DESCRIPTION
When a well is declared with WELSPECS there is an item to specify the well's preferred[1] phase, this phase is not (yet at least) stored in the restart files written by flow - which implies that it is tricky to get back when initializing from a restart file.

The callsite which is removed in this PR is the only callsite in all of opm; so I suggest this PR.







[1]: What exactly *preferred* implies is less than clear to me.