### PR TITLE
fixed: do not make root dir

### DIFF
--- a/jenkins/run-norne.sh
+++ b/jenkins/run-norne.sh
@@ -6,7 +6,6 @@ test -z $SIM && SIM=flow
 
 # Run the norne case
 cd norne
-mkdir $SIM
 if test -n "$1"
 then
   mpirun -np $1 $WORKSPACE/$configuration/build-opm-simulators/bin/$SIM --output-dir=${SIM}_${1}_proc NORNE_ATW2013.DATA


### PR DESCRIPTION
the simulator handles this itself. this fixes errors in the
well plot script when only parallel norne is run.