### PR TITLE
changed: no need to serialize the FluidSystem any more

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -610,7 +610,7 @@ public:
         const auto& vanguard = simulator.vanguard();
         const auto& comm = this->gridView().comm();
         if (comm.rank() == 0) {
-            SolventModule::initFromDeck(vanguard.deck(), vanguard.eclState());
+            SolventModule::initFromDeck(vanguard.deck(), vanguard.eclState(), vanguard.schedule());
             PolymerModule::initFromDeck(vanguard.deck(), vanguard.eclState());
             FoamModule::initFromDeck(vanguard.deck(), vanguard.eclState());
             BrineModule::initFromDeck(vanguard.deck(), vanguard.eclState());
@@ -2380,15 +2380,10 @@ private:
     void initFluidSystem_()
     {
         const auto& simulator = this->simulator();
-        const auto& deck = simulator.vanguard().deck();
         const auto& eclState = simulator.vanguard().eclState();
-        const auto& comm = simulator.gridView().comm();
+        const auto& schedule = simulator.vanguard().schedule();
 
-        if (comm.rank() == 0)
-            FluidSystem::initFromDeck(deck, eclState);
-
-        EclMpiSerializer ser(comm);
-        ser.staticBroadcast<FluidSystem>();
+        FluidSystem::initFromState(eclState, schedule);
    }
 
     void readInitialCondition_()

--- a/tests/test_norne_pvt.cpp
+++ b/tests/test_norne_pvt.cpp
@@ -55,9 +55,9 @@ using namespace Opm;
   further semantic meaning.
 */
 
-void verify_norne_oil_pvt_region1(const Opm::Deck& deck, const Opm::EclipseState& eclState) {
+void verify_norne_oil_pvt_region1(const Opm::EclipseState& eclState, const Opm::Schedule& schedule) {
     Opm::LiveOilPvt<double> oilPvt;
-    oilPvt.initFromDeck(deck, eclState);
+    oilPvt.initFromState(eclState, schedule);
 
     std::vector<double> rs = {33, 33,
                               43, 43,
@@ -129,9 +129,9 @@ void verify_norne_oil_pvt_region1(const Opm::Deck& deck, const Opm::EclipseState
 }
 
 
-void verify_norne_oil_pvt_region2(const Opm::Deck& deck, const Opm::EclipseState& eclState) {
+void verify_norne_oil_pvt_region2(const Opm::EclipseState& eclState, const Opm::Schedule& schedule) {
     Opm::LiveOilPvt<double> oilPvt;
-    oilPvt.initFromDeck(deck, eclState);
+    oilPvt.initFromState(eclState, schedule);
 
     std::vector<double> rs = {21 , 21,
                               30 , 30,
@@ -280,7 +280,8 @@ BOOST_AUTO_TEST_CASE( Test_Norne_PVT) {
     auto deck = parser.parseFile("norne_pvt.data", parseContext, errorGuard);
 
     Opm::EclipseState eclState(deck);
+    Opm::Schedule schedule(deck, eclState);
 
-    verify_norne_oil_pvt_region1( deck, eclState );
-    verify_norne_oil_pvt_region2( deck, eclState );
+    verify_norne_oil_pvt_region1(eclState, schedule);
+    verify_norne_oil_pvt_region2(eclState, schedule);
 }


### PR DESCRIPTION
setup is now done all from state, which means it can be done
independently on all processes

Downstream of https://github.com/OPM/opm-material/pull/411
Downstream of https://github.com/OPM/opm-models/pull/597