### PR TITLE
Add commandline switch --sched-restart to control restart init

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -73,6 +73,7 @@ NEW_PROP_TAG(EclDeckFileName);
 NEW_PROP_TAG(OutputDir);
 NEW_PROP_TAG(EnableOpmRstFile);
 NEW_PROP_TAG(EclStrictParsing);
+NEW_PROP_TAG(SchedRestart);
 NEW_PROP_TAG(EclOutputInterval);
 NEW_PROP_TAG(IgnoreKeywords);
 NEW_PROP_TAG(EnableExperiments);
@@ -83,6 +84,7 @@ SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "");
 SET_INT_PROP(EclBaseVanguard, EclOutputInterval, -1); // use the deck-provided value
 SET_BOOL_PROP(EclBaseVanguard, EnableOpmRstFile, false);
 SET_BOOL_PROP(EclBaseVanguard, EclStrictParsing, false);
+SET_BOOL_PROP(EclBaseVanguard, SchedRestart, true);
 SET_INT_PROP(EclBaseVanguard, EdgeWeightsMethod, 1);
 
 END_PROPERTIES
@@ -127,6 +129,8 @@ public:
                              "List of Eclipse keywords which should be ignored. As a ':' separated string.");
         EWOMS_REGISTER_PARAM(TypeTag, bool, EclStrictParsing,
                              "Use strict mode for parsing - all errors are collected before the applicaton exists.");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, SchedRestart,
+                             "When restarting: should we try to initialize wells and groups from historical SCHEDULE section.");
         EWOMS_REGISTER_PARAM(TypeTag, int, EdgeWeightsMethod,
                              "Choose edge-weighing strategy: 0=uniform, 1=trans, 2=log(trans).");
     }

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -370,9 +370,11 @@ int main(int argc, char** argv)
                   restart file is not possible, but work is underways and it is
                   included here as a switch.
                 */
-                const bool init_from_restart_file = false;
+                const bool init_from_restart_file = !EWOMS_GET_PARAM(PreTypeTag, bool, SchedRestart);
                 const auto& init_config = eclipseState->getInitConfig();
                 if (init_config.restartRequested() && init_from_restart_file) {
+                    throw std::logic_error("Sorry - the ability to initialize wells and groups from the restart file is currently not ready");
+
                     int report_step = init_config.getRestartStep();
                     const auto& rst_filename = eclipseState->getIOConfig().getRestartFileName( init_config.getRestartRootName(), report_step, false );
                     Opm::EclIO::ERst rst_file(rst_filename);


### PR DESCRIPTION
Add a commandline switch `--sched-restart` to flow which can regulate how the schedule information should be initialized when restarting. When using `--sched-restart=true` the simulator will use the historical schedule section to initialize, whereas with `--sched-restart=false` the simulator will initialize from the restart file. The ability to initialize from the restart file is very much work in progress, and this will go through several stages:

1. (This PR) flow can *not* initialize from the restart file - and if you pass `--sched-restart=false` flow will bail with an exception; the default is of course `--sched-restart=true`.

2. When the basic functionality is in place we remove the `throw` and flow will initialize from the restart file if you pass `--sched-restart=false` - but the default will be to use the historical section if it is present (i.e. the current behavior). We keep things like this for a period with testing.

3. We switch the default `--sched-restart=false`- i.e. unless explicitly asked otherwise we will use the restart file to initialize.

4. The switch is completely removed - and restarting from the restart file is the *only* possibility.

1-2-3 - all hold your breath :-)