### PR TITLE
fixed: VAPPARS is supported, remove from unsupported features list

### DIFF
--- a/opm/simulators/flow/MissingFeatures.cpp
+++ b/opm/simulators/flow/MissingFeatures.cpp
@@ -726,7 +726,6 @@ namespace MissingFeatures {
             "TUNINGS",
             "TVDP",
             "TZONE",
-            "VAPPARS",
             "UDT",
             "UDTDIMS",
             "UNCODHMD",


### PR DESCRIPTION
Unless I'm missing something?