### PR TITLE
Also distribute the centroids when loadbalancing CpGrid.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -175,11 +175,11 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/utils/ParallelFileMerger.hpp
   opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
   opm/simulators/utils/DeferredLogger.hpp
-  opm/simulators/utils/FieldPropsDataHandle.hpp
   opm/simulators/utils/gatherDeferredLogger.hpp
   opm/simulators/utils/moduleVersion.hpp
   opm/simulators/utils/ParallelEclipseState.hpp
   opm/simulators/utils/ParallelRestart.hpp
+  opm/simulators/utils/PropsCentroidsDataHandle.hpp
   opm/simulators/wells/PerforationData.hpp
   opm/simulators/wells/RateConverter.hpp
   opm/simulators/wells/SimFIBODetails.hpp

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -533,6 +533,15 @@ public:
     std::unordered_set<std::string> defunctWellNames() const
     { return std::unordered_set<std::string>(); }
 
+    /*!
+     * \brief Get the cell centroids for a distributed grid.
+     *
+     * Currently this only non-empty for a loadbalanced CpGrid.
+     */
+    const std::vector<double>& cellCentroids() const
+    {
+        return centroids_;
+    }
 protected:
     void callImplementationInit()
     {
@@ -610,6 +619,12 @@ private:
     Opm::SummaryConfig* eclSummaryConfig_;
 
     Dune::EdgeWeightMethod edgeWeightsMethod_;
+
+protected:
+    /*! \brief The cell centroids after loadbalance was called.
+     * Empty otherwise. Used by EclTransmissibilty.
+     */
+    std::vector<double> centroids_;
 };
 
 template <class TypeTag>

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -34,7 +34,7 @@
 #include <opm/grid/CpGrid.hpp>
 #include <opm/grid/cpgrid/GridHelpers.hpp>
 #include <opm/simulators/utils/ParallelEclipseState.hpp>
-#include <opm/simulators/utils/FieldPropsDataHandle.hpp>
+#include <opm/simulators/utils/PropsCentroidsDataHandle.hpp>
 
 #include <dune/grid/common/mcmgmapper.hh>
 
@@ -190,7 +190,15 @@ public:
             {
                 const auto wells = this->schedule().getWellsatEnd();
                 auto& eclState = static_cast<ParallelEclipseState&>(this->eclState());
-                FieldPropsDataHandle<Dune::CpGrid> handle(*grid_, eclState);
+                const EclipseGrid* eclGrid = nullptr;
+
+                if (grid_->comm().rank() == 0)
+                {
+                    eclGrid = &this->eclState().getInputGrid();
+                }
+
+                PropsCentroidsDataHandle<Dune::CpGrid> handle(*grid_, eclState, eclGrid, this->centroids_,
+                                                              cartesianIndexMapper());
                 defunctWellNames_ = std::get<1>(grid_->loadBalance(handle, edgeWeightsMethod, &wells, faceTrans.data()));
             }
             grid_->switchToDistributedView();

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -20,7 +20,6 @@
 #define PARALLEL_ECLIPSE_STATE_HPP
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-//#include <opm/simulators/utils/FieldPropsDataHandle.hpp>
 #include <dune/common/parallel/mpihelper.hh>
 
 namespace Opm {
@@ -41,7 +40,7 @@ public:
     friend class ParallelEclipseState; //!< Friend so props can be setup.
     //! \brief Friend to set up props
     template<class Grid>
-    friend class FieldPropsDataHandle;
+    friend class PropsCentroidsDataHandle;
 
     //! \brief Constructor.
     //! \param manager The field property manager to wrap.
@@ -106,7 +105,7 @@ protected:
 class ParallelEclipseState : public EclipseState {
     //! \brief Friend to set up props
     template<class Grid>
-    friend class FieldPropsDataHandle;
+    friend class PropsCentroidsDataHandle;
 public:
     //! \brief Default constructor.
     ParallelEclipseState();


### PR DESCRIPTION
They are attached to the cells as well and are now distributed during CpGrid::loadBalance. Due to this change we also rename FieldPropsDataHandle to PropsCentroidsDataHandle.

Based on and includes PR #2406 and is rebased onto current master