### PR TITLE
Shrink EclEquilInitializer::initialFluidStates_.

### DIFF
--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -109,7 +109,6 @@ public:
         const auto& eclState = vanguard.eclState();
 
         unsigned numElems = vanguard.grid().size(0);
-        unsigned numCartesianElems = vanguard.cartesianSize();
 
         EQUIL::DeckDependent::InitialStateComputer<TypeTag> initialState(materialLawManager,
                                                                          eclState,
@@ -117,10 +116,9 @@ public:
                                                                          simulator.problem().gravity()[dimWorld - 1]);
 
         // copy the result into the array of initial fluid states
-        initialFluidStates_.resize(numCartesianElems);
+        initialFluidStates_.resize(numElems);
         for (unsigned int elemIdx = 0; elemIdx < numElems; ++elemIdx) {
-            unsigned cartesianElemIdx = vanguard.cartesianIndex(elemIdx);
-            auto& fluidState = initialFluidStates_[cartesianElemIdx];
+            auto& fluidState = initialFluidStates_[elemIdx];
 
             // get the PVT region index of the current element
             unsigned regionIdx = simulator_.problem().pvtRegionIndex(elemIdx);
@@ -173,10 +171,7 @@ public:
      */
     const ScalarFluidState& initialFluidState(unsigned elemIdx) const
     {
-        const auto& vanguard = simulator_.vanguard();
-
-        unsigned cartesianElemIdx = vanguard.cartesianIndex(elemIdx);
-        return initialFluidStates_[cartesianElemIdx];
+        return initialFluidStates_[elemIdx];
     }
 
 protected:


### PR DESCRIPTION
There is not reason to it as a vector of cartesian size as we access its entries by the compressed element index. This should save space and speedup the lookup.

A further step would be to either remove this class or move the initialization into an function of the class that directly return the vector. The class is currently only temporarily initiated by eclproblem to copy out the values of the vector [here](/OPM/opm-simulators/blob/master/ebos/eclproblem.hh#L2408-L2423)