### PR TITLE
fixed: do not abuse TEST_ARGS in restart test machinery

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -58,7 +58,6 @@ function(add_test_compare_restarted_simulation)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
   set(RESULT_PATH ${BASE_RESULT_PATH}/restart/${PARAM_SIMULATOR}+${PARAM_CASENAME})
-  set(TEST_ARGS ${OPM_TESTS_ROOT}/${PARAM_CASENAME}/${PARAM_FILENAME} ${PARAM_TEST_ARGS})
 
   opm_add_test(compareRestartedSim_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
                EXE_NAME ${PARAM_SIMULATOR}
@@ -69,7 +68,7 @@ function(add_test_compare_restarted_simulation)
                            ${COMPARE_ECL_COMMAND}
                            ${OPM_PACK_COMMAND}
                            0
-               TEST_ARGS ${TEST_ARGS})
+               TEST_ARGS ${PARAM_TEST_ARGS})
 endfunction()
 
 ###########################################################################
@@ -124,7 +123,6 @@ function(add_test_compare_parallel_restarted_simulation)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
   set(RESULT_PATH ${BASE_RESULT_PATH}/parallelRestart/${PARAM_SIMULATOR}+${PARAM_CASENAME})
-  set(TEST_ARGS ${OPM_TESTS_ROOT}/${PARAM_CASENAME}/${PARAM_FILENAME} ${PARAM_TEST_ARGS})
 
   opm_add_test(compareParallelRestartedSim_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
                EXE_NAME ${PARAM_SIMULATOR}
@@ -135,7 +133,7 @@ function(add_test_compare_parallel_restarted_simulation)
                            ${COMPARE_ECL_COMMAND}
                            ${OPM_PACK_COMMAND}
                            1
-               TEST_ARGS ${TEST_ARGS})
+               TEST_ARGS ${PARAM_TEST_ARGS})
   set_tests_properties(compareParallelRestartedSim_${PARAM_SIMULATOR}+${PARAM_FILENAME}
                        PROPERTIES RUN_SERIAL 1)
 endfunction()

--- a/tests/run-restart-regressionTest.sh
+++ b/tests/run-restart-regressionTest.sh
@@ -17,7 +17,7 @@ EXE_NAME="${10}"
 shift 10
 TEST_ARGS="$@"
 
-BASE_NAME=`basename ${TEST_ARGS}_RESTART.DATA`
+BASE_NAME=${FILENAME}_RESTART.DATA
 
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
@@ -28,13 +28,13 @@ then
 else
   CMD_PREFIX=""
 fi
- ${CMD_PREFIX} ${BINPATH}/${EXE_NAME} ${TEST_ARGS}.DATA --enable-adaptive-time-stepping=false --output-dir=${RESULT_PATH}
+ ${CMD_PREFIX} ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --enable-adaptive-time-stepping=false --output-dir=${RESULT_PATH} ${TEST_ARGS}
 
 test $? -eq 0 || exit 1
 
-${OPM_PACK_COMMAND} -o ${BASE_NAME} ${TEST_ARGS}_RESTART.DATA
+${OPM_PACK_COMMAND} -o ${BASE_NAME} ${INPUT_DATA_PATH}/${FILENAME}_RESTART.DATA
 
-${CMD_PREFIX} ${BINPATH}/${EXE_NAME} ${BASE_NAME} --enable-adaptive-time-stepping=false --output-dir=${RESULT_PATH}
+${CMD_PREFIX} ${BINPATH}/${EXE_NAME} ${BASE_NAME} --enable-adaptive-time-stepping=false --output-dir=${RESULT_PATH} ${TEST_ARGS}
 test $? -eq 0 || exit 1
 
 ecode=0


### PR DESCRIPTION
Ref https://github.com/OPM/opm-simulators/pull/2432