### PR TITLE
refactor flowEbosBlackoilMain()

### DIFF
--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -46,8 +46,8 @@ void flowEbosBlackoilSetDeck(double setupTime, Deck &deck, EclipseState& eclStat
     Vanguard::setExternalSummaryConfig(&summaryConfig);
 }
 
-// ----------------- Main program -----------------
-int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles)
+std::unique_ptr<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>
+flowEbosBlackoilMain_init(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -59,8 +59,14 @@ int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFile
     Dune::MPIHelper::instance(argc, argv);
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    return std::make_unique<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>();
+}
+
+// ----------------- Main program -----------------
+int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    auto mainfunc = flowEbosBlackoilMain_init(argc, argv, outputCout, outputFiles);
+    return mainfunc->execute(argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory( pybind11 )
+add_subdirectory( simulators )
 

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -1,0 +1,11 @@
+pybind11_add_module(simulators simulators.cpp)
+
+set_target_properties( simulators PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/python/simulators )
+
+target_sources(simulators
+  PRIVATE
+    ../../flow/flow_ebos_blackoil.cpp)
+
+target_link_libraries( simulators PRIVATE opmsimulators )
+
+install(TARGETS simulators DESTINATION ${PYTHON_INSTALL_PREFIX}/simulators)

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -17,6 +17,8 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.hpp>
+
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
 #else
@@ -24,6 +26,7 @@
 #endif
 
 #include <pybind11/pybind11.h>
+#include <pybind11/embed.h>
 #include <string>
 #include <iostream>
 
@@ -131,7 +134,6 @@ FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, con
     std::string output_dir = cmdline_output_dir;
     if (output_dir.empty()) {
         output_dir = absolute(path(baseName).parent_path()).string();
-        std::cout << "Output dir = " << output_dir << std::endl;
     }
 
     logFileStream << output_dir << "/" << baseName;
@@ -209,9 +211,10 @@ void setupMessageLimiter(const Opm::MessageLimits msgLimits,  const std::string&
 class BlackOilSimulator
 {
 public:
-    BlackOilSimulator()
+    BlackOilSimulator( const std::string& filename )
     {
         setupCmdLineArgs();
+        std::strcpy(argv_[1], filename.c_str());
     }
 
     BlackOilSimulator( const Opm::Deck& deck, 
@@ -316,21 +319,86 @@ public:
         if (mpiRank == 0)
             outputCout = EWOMS_GET_PARAM(PreTypeTag, bool, EnableTerminalOutput);
 
-        std::string deckFilename = eclipseState_->getIOConfig().fullBasePath();
-        std::string outputDir = eclipseState_->getIOConfig().getOutputDir();
+        std::string deckFilename;
+        std::string outputDir;
+        if ( eclipseState_ )
+        {
+            deckFilename = eclipseState_->getIOConfig().fullBasePath();
+            outputDir = eclipseState_->getIOConfig().getOutputDir();
+        }
+        else
+        {
+            deckFilename = EWOMS_GET_PARAM(PreTypeTag, std::string, EclDeckFileName);
+            typedef typename GET_PROP_TYPE(PreTypeTag, Vanguard) PreVanguard;
+            try {
+                deckFilename = PreVanguard::canonicalDeckPath(deckFilename).string();
+            }
+            catch (const std::exception& e) {
+                if ( mpiRank == 0 )
+                    std::cerr << "Exception received: " << e.what() << ". Try '--help' for a usage description.\n";
+#if HAVE_MPI
+                MPI_Finalize();
+#endif
+                return 1;
+            }
+        }
 
         if (outputCout) {
             Opm::FlowMainEbos<PreTypeTag>::printBanner();
         }
-        Opm::ErrorGuard errorGuard;
-        outputMode = setupLogging(mpiRank,
-                                  deckFilename,
-                                  outputDir,
-                                  EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
-                                  outputCout, "STDOUT_LOGGER");
 
-        if (mpiRank == 0) {
-            setupMessageLimiter(schedule_->getMessageLimits(), "STDOUT_LOGGER");
+        // Create Deck, EclipseState, Schedule and SummaryConfig if they don't exist
+        if ( deck_ && eclipseState_ && schedule_ && summaryConfig_ )
+        {
+            outputMode = setupLogging(mpiRank,
+                                    deckFilename,
+                                    outputDir,
+                                    EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
+                                    outputCout, "STDOUT_LOGGER");
+
+            if (mpiRank == 0) {
+                setupMessageLimiter(schedule_->getMessageLimits(), "STDOUT_LOGGER");
+            }
+        }
+        else
+        {
+            Opm::Parser parser;
+            Opm::ParseContext parseContext({{Opm::ParseContext::PARSE_RANDOM_SLASH, Opm::InputError::IGNORE},
+                                            {Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputError::WARN},
+                                            {Opm::ParseContext::SUMMARY_UNKNOWN_WELL, Opm::InputError::WARN},
+                                            {Opm::ParseContext::SUMMARY_UNKNOWN_GROUP, Opm::InputError::WARN}});
+            Opm::ErrorGuard errorGuard;
+            outputMode = setupLogging(mpiRank,
+                                      deckFilename,
+                                      EWOMS_GET_PARAM(PreTypeTag, std::string, OutputDir),
+                                      EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
+                                      outputCout, "STDOUT_LOGGER");
+
+            if (EWOMS_GET_PARAM(PreTypeTag, bool, EclStrictParsing))
+                parseContext.update( Opm::InputError::DELAYED_EXIT1);
+
+            Opm::FlowMainEbos<PreTypeTag>::printPRTHeader(outputCout);
+
+            deck_.reset( new Opm::Deck( parser.parseFile(deckFilename , parseContext, errorGuard)));
+            Opm::MissingFeatures::checkKeywords(*deck_, parseContext, errorGuard);
+            if ( outputCout )
+                Opm::checkDeck(*deck_, parser, parseContext, errorGuard);
+
+            eclipseState_.reset( new Opm::EclipseState(*deck_, parseContext, errorGuard ));
+            schedule_.reset(new Opm::Schedule(*deck_, *eclipseState_, parseContext, errorGuard));
+            summaryConfig_.reset( new Opm::SummaryConfig(*deck_, *schedule_, eclipseState_->getTableManager(), parseContext, errorGuard));
+            if (mpiRank == 0) {
+                setupMessageLimiter(schedule_->getMessageLimits(), "STDOUT_LOGGER");
+            }
+
+            Opm::checkConsistentArrayDimensions(*eclipseState_, *schedule_, parseContext, errorGuard);
+
+            if (errorGuard) {
+                errorGuard.dump();
+                errorGuard.clear();
+
+                throw std::runtime_error("Unrecoverable errors were encountered while loading input.");
+            }
         }
 
         const auto& phases = Opm::Runspec(*deck_).phases();
@@ -364,7 +432,7 @@ private:
 PYBIND11_MODULE(simulators, m)
 {
     py::class_<BlackOilSimulator>(m, "BlackOilSimulator")
-        .def(py::init<>())
+        .def(py::init< const std::string& >())
         .def(py::init< const Opm::Deck&, const Opm::EclipseState&, const Opm::Schedule&, const Opm::SummaryConfig& >())
         .def("run", &BlackOilSimulator::run)
         .def("setDeck", &BlackOilSimulator::setDeck)

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -211,12 +211,19 @@ class BlackOilSimulator
 public:
     BlackOilSimulator()
     {
-        argc_ = 2;
-        argv_ = new char*[2];
-        argv_[0] = new char[200];
-        char argv0[] = "flow";
-        std::strcpy(argv_[0], argv0);
-        argv_[1] = new char[200];
+        setupCmdLineArgs();
+    }
+
+    BlackOilSimulator( const Opm::Deck& deck, 
+                       const Opm::EclipseState& eclipseState, 
+                       const Opm::Schedule& schedule,
+                       const Opm::SummaryConfig& summaryConfig )
+    {
+        setupCmdLineArgs();
+        setDeck(deck);
+        setEclipseState(eclipseState);
+        setSchedule(schedule);
+        setSummaryConfig(summaryConfig);
     }
 
     ~BlackOilSimulator() 
@@ -224,6 +231,16 @@ public:
         delete[] argv_[0];
         delete[] argv_[1];
         delete[] argv_;
+    }
+
+    void setupCmdLineArgs()
+    {
+        argc_ = 2;
+        argv_ = new char*[2];
+        argv_[0] = new char[200];
+        char argv0[] = "flow";
+        std::strcpy(argv_[0], argv0);
+        argv_[1] = new char[200];
     }
 
     void setDeck( const Opm::Deck& deck )
@@ -348,6 +365,7 @@ PYBIND11_MODULE(simulators, m)
 {
     py::class_<BlackOilSimulator>(m, "BlackOilSimulator")
         .def(py::init<>())
+        .def(py::init< const Opm::Deck&, const Opm::EclipseState&, const Opm::Schedule&, const Opm::SummaryConfig& >())
         .def("run", &BlackOilSimulator::run)
         .def("setDeck", &BlackOilSimulator::setDeck)
         .def("setEclipseState", &BlackOilSimulator::setEclipseState)

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -1,0 +1,356 @@
+#include "config.h"
+
+#include <flow/flow_ebos_blackoil.hpp>
+
+#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/utils/moduleVersion.hpp>
+#include <opm/models/utils/propertysystem.hh>
+#include <opm/models/utils/parametersystem.hh>
+#include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/EclipsePRTLog.hpp>
+#include <opm/common/OpmLog/LogUtil.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
+
+#include <pybind11/pybind11.h>
+#include <string>
+#include <iostream>
+
+namespace py = pybind11;
+
+BEGIN_PROPERTIES
+
+// this is a dummy type tag that is used to setup the parameters before the actual
+// simulator.
+NEW_TYPE_TAG(FlowEarlyBird, INHERITS_FROM(EclFlowProblem));
+
+END_PROPERTIES
+
+namespace detail
+{
+    boost::filesystem::path simulationCaseName( const std::string& casename ) {
+        namespace fs = boost::filesystem;
+
+        const auto exists = []( const fs::path& f ) -> bool {
+            if( !fs::exists( f ) ) return false;
+
+            if( fs::is_regular_file( f ) ) return true;
+
+            return fs::is_symlink( f )
+            && fs::is_regular_file( fs::read_symlink( f ) );
+        };
+
+        auto simcase = fs::path( casename );
+
+        if( exists( simcase ) ) {
+            return simcase;
+        }
+
+        for( const auto& ext : { std::string("data"), std::string("DATA") } ) {
+            if( exists( simcase.replace_extension( ext ) ) ) {
+                return simcase;
+            }
+        }
+
+        throw std::invalid_argument( "Cannot find input case " + casename );
+    }
+
+
+    // This function is an extreme special case, if the program has been invoked
+    // *exactly* as:
+    //
+    //    flow   --version
+    //
+    // the call is intercepted by this function which will print "flow $version"
+    // on stdout and exit(0).
+    void handleVersionCmdLine(int argc, char** argv) {
+        for ( int i = 1; i < argc; ++i )
+        {
+            if (std::strcmp(argv[i], "--version") == 0) {
+                std::cout << "flow " << Opm::moduleVersionName() << std::endl;
+                std::exit(EXIT_SUCCESS);
+            }
+        }
+    }
+}
+
+enum class FileOutputMode {
+    //! \brief No output to files.
+    OUTPUT_NONE = 0,
+    //! \brief Output only to log files, no eclipse output.
+    OUTPUT_LOG_ONLY = 1,
+    //! \brief Output to all files.
+    OUTPUT_ALL = 3
+};
+
+void ensureOutputDirExists(const std::string& cmdline_output_dir)
+{
+    if (!boost::filesystem::is_directory(cmdline_output_dir)) {
+        try {
+            boost::filesystem::create_directories(cmdline_output_dir);
+        }
+        catch (...) {
+            throw std::runtime_error("Creation of output directory '" + cmdline_output_dir + "' failed\n");
+        }
+    }
+}
+
+// Setup the OpmLog backends
+FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, const std::string& cmdline_output_dir, const std::string& cmdline_output, bool output_cout_, const std::string& stdout_log_id) {
+
+    if (!cmdline_output_dir.empty()) {
+        ensureOutputDirExists(cmdline_output_dir);
+    }
+
+    // create logFile
+    using boost::filesystem::path;
+    path fpath(deck_filename);
+    std::string baseName;
+    std::ostringstream debugFileStream;
+    std::ostringstream logFileStream;
+
+    // Strip extension "." or ".DATA"
+    std::string extension = boost::to_upper_copy(fpath.extension().string());
+    if (extension == ".DATA" || extension == ".") {
+        baseName = boost::to_upper_copy(fpath.stem().string());
+    } else {
+        baseName = boost::to_upper_copy(fpath.filename().string());
+    }
+
+    std::string output_dir = cmdline_output_dir;
+    if (output_dir.empty()) {
+        output_dir = absolute(path(baseName).parent_path()).string();
+        std::cout << "Output dir = " << output_dir << std::endl;
+    }
+
+    logFileStream << output_dir << "/" << baseName;
+    debugFileStream << output_dir << "/" << baseName;
+
+    if (mpi_rank_ != 0) {
+        // Added rank to log file for non-zero ranks.
+        // This prevents message loss.
+        debugFileStream << "." << mpi_rank_;
+        // If the following file appears then there is a bug.
+        logFileStream << "." << mpi_rank_;
+    }
+    logFileStream << ".PRT";
+    debugFileStream << ".DBG";
+
+    FileOutputMode output;
+    {
+        static std::map<std::string, FileOutputMode> stringToOutputMode =
+            { {"none", FileOutputMode::OUTPUT_NONE },
+              {"false", FileOutputMode::OUTPUT_LOG_ONLY },
+              {"log", FileOutputMode::OUTPUT_LOG_ONLY },
+              {"all" , FileOutputMode::OUTPUT_ALL },
+              {"true" , FileOutputMode::OUTPUT_ALL }};
+        auto outputModeIt = stringToOutputMode.find(cmdline_output);
+        if (outputModeIt != stringToOutputMode.end()) {
+            output = outputModeIt->second;
+        }
+        else {
+            output = FileOutputMode::OUTPUT_ALL;
+            std::cerr << "Value " << cmdline_output <<
+                " is not a recognized output mode. Using \"all\" instead."
+                      << std::endl;
+        }
+    }
+
+    if (output > FileOutputMode::OUTPUT_NONE) {
+        std::shared_ptr<Opm::EclipsePRTLog> prtLog = std::make_shared<Opm::EclipsePRTLog>(logFileStream.str(), Opm::Log::NoDebugMessageTypes, false, output_cout_);
+        Opm::OpmLog::addBackend("ECLIPSEPRTLOG", prtLog);
+        prtLog->setMessageLimiter(std::make_shared<Opm::MessageLimiter>());
+        prtLog->setMessageFormatter(std::make_shared<Opm::SimpleMessageFormatter>(false));
+    }
+
+    if (output >= FileOutputMode::OUTPUT_LOG_ONLY) {
+        std::string debugFile = debugFileStream.str();
+        std::shared_ptr<Opm::StreamLog> debugLog = std::make_shared<Opm::EclipsePRTLog>(debugFileStream.str(), Opm::Log::DefaultMessageTypes, false, output_cout_);
+        Opm::OpmLog::addBackend("DEBUGLOG", debugLog);
+    }
+
+    if (mpi_rank_ == 0) {
+        std::shared_ptr<Opm::StreamLog> streamLog = std::make_shared<Opm::StreamLog>(std::cout, Opm::Log::StdoutMessageTypes);
+        Opm::OpmLog::addBackend(stdout_log_id, streamLog);
+        streamLog->setMessageFormatter(std::make_shared<Opm::SimpleMessageFormatter>(true));
+    }
+    return output;
+}
+
+void setupMessageLimiter(const Opm::MessageLimits msgLimits,  const std::string& stdout_log_id) {
+    std::shared_ptr<Opm::StreamLog> stream_log = Opm::OpmLog::getBackend<Opm::StreamLog>(stdout_log_id);
+
+    const std::map<int64_t, int> limits = {{Opm::Log::MessageType::Note,
+                                            msgLimits.getCommentPrintLimit(0)},
+                                           {Opm::Log::MessageType::Info,
+                                            msgLimits.getMessagePrintLimit(0)},
+                                           {Opm::Log::MessageType::Warning,
+                                            msgLimits.getWarningPrintLimit(0)},
+                                           {Opm::Log::MessageType::Error,
+                                            msgLimits.getErrorPrintLimit(0)},
+                                           {Opm::Log::MessageType::Problem,
+                                            msgLimits.getProblemPrintLimit(0)},
+                                           {Opm::Log::MessageType::Bug,
+                                            msgLimits.getBugPrintLimit(0)}};
+    stream_log->setMessageLimiter(std::make_shared<Opm::MessageLimiter>(10, limits));
+}
+
+class BlackOilSimulator
+{
+public:
+    BlackOilSimulator()
+    {
+        argc_ = 2;
+        argv_ = new char*[2];
+        argv_[0] = new char[200];
+        char argv0[] = "flow";
+        std::strcpy(argv_[0], argv0);
+        argv_[1] = new char[200];
+    }
+
+    ~BlackOilSimulator() 
+    {
+        delete[] argv_[0];
+        delete[] argv_[1];
+        delete[] argv_;
+    }
+
+    void setDeck( const Opm::Deck& deck )
+    {
+        deck_ = std::make_shared< Opm::Deck >(deck);
+    }
+
+    void setEclipseState( const Opm::EclipseState& eclipseState )
+    {
+        eclipseState_ = std::make_shared< Opm::EclipseState >(eclipseState);
+    }
+
+    void setSchedule( const Opm::Schedule& schedule )
+    {
+        schedule_ = std::make_shared< Opm::Schedule >(schedule);
+    }
+
+    void setSummaryConfig( const Opm::SummaryConfig& summaryConfig )
+    {
+        summaryConfig_ = std::make_shared< Opm::SummaryConfig >(summaryConfig);
+    }
+
+    int run()
+    {
+        int argc = argc_;
+        char **argv = argv_;
+
+        Dune::Timer externalSetupTimer;
+        externalSetupTimer.start();
+
+        detail::handleVersionCmdLine(argc, argv);
+        // MPI setup.
+#if HAVE_DUNE_FEM
+        Dune::Fem::MPIManager::initialize(argc, argv);
+        int mpiRank = Dune::Fem::MPIManager::rank();
+#else
+        // the design of the plain dune MPIHelper class is quite flawed: there is no way to
+        // get the instance without having the argc and argv parameters available and it is
+        // not possible to determine the MPI rank and size without an instance. (IOW: the
+        // rank() and size() methods are supposed to be static.)
+        const auto& mpiHelper = Dune::MPIHelper::instance(argc, argv);
+        int mpiRank = mpiHelper.rank();
+#endif
+
+        // we always want to use the default locale, and thus spare us the trouble
+        // with incorrect locale settings.
+        Opm::resetLocale();
+
+        // this is a work-around for a catch 22: we do not know what code path to use without
+        // parsing the deck, but we don't know the deck without having access to the
+        // parameters and this requires to know the type tag to be used. To solve this, we
+        // use a type tag just for parsing the parameters before we instantiate the actual
+        // simulator object. (Which parses the parameters again, but since this is done in an
+        // identical manner it does not matter.)
+        typedef TTAG(FlowEarlyBird) PreTypeTag;
+        typedef GET_PROP_TYPE(PreTypeTag, Problem) PreProblem;
+
+        PreProblem::setBriefDescription("Flow, an advanced reservoir simulator for ECL-decks provided by the Open Porous Media project.");
+
+        int status = Opm::FlowMainEbos<PreTypeTag>::setupParameters_(argc, argv);
+        if (status != 0) {
+            // if setupParameters_ returns a value smaller than 0, there was no error, but
+            // the program should abort. This is the case e.g. for the --help and the
+            // --print-properties parameters.
+#if HAVE_MPI
+            MPI_Finalize();
+#endif
+            return (status >= 0)?status:0;
+        }
+
+        FileOutputMode outputMode = FileOutputMode::OUTPUT_NONE;
+        bool outputCout = false;
+        if (mpiRank == 0)
+            outputCout = EWOMS_GET_PARAM(PreTypeTag, bool, EnableTerminalOutput);
+
+        std::string deckFilename = eclipseState_->getIOConfig().fullBasePath();
+        std::string outputDir = eclipseState_->getIOConfig().getOutputDir();
+
+        if (outputCout) {
+            Opm::FlowMainEbos<PreTypeTag>::printBanner();
+        }
+        Opm::ErrorGuard errorGuard;
+        outputMode = setupLogging(mpiRank,
+                                  deckFilename,
+                                  outputDir,
+                                  EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
+                                  outputCout, "STDOUT_LOGGER");
+
+        if (mpiRank == 0) {
+            setupMessageLimiter(schedule_->getMessageLimits(), "STDOUT_LOGGER");
+        }
+
+        const auto& phases = Opm::Runspec(*deck_).phases();
+        bool outputFiles = (outputMode != FileOutputMode::OUTPUT_NONE);
+
+        // Blackoil case
+        if( phases.size() == 3 ) {
+            Opm::flowEbosBlackoilSetDeck(externalSetupTimer.elapsed(), *deck_, *eclipseState_, *schedule_, *summaryConfig_);
+            return Opm::flowEbosBlackoilMain(argc, argv, outputCout, outputFiles);
+        }
+        else
+        {
+            if (outputCout)
+                std::cerr << "Only blackoil configuration is supported!" << std::endl;
+            return EXIT_FAILURE;
+        }
+        
+        return EXIT_SUCCESS;
+    }
+
+private:
+    int argc_;
+    char **argv_;
+
+    std::shared_ptr<Opm::Deck>          deck_;
+    std::shared_ptr<Opm::EclipseState>  eclipseState_;
+    std::shared_ptr<Opm::Schedule>      schedule_;
+    std::shared_ptr<Opm::SummaryConfig> summaryConfig_;
+};
+
+PYBIND11_MODULE(simulators, m)
+{
+    py::class_<BlackOilSimulator>(m, "BlackOilSimulator")
+        .def(py::init<>())
+        .def("run", &BlackOilSimulator::run)
+        .def("setDeck", &BlackOilSimulator::setDeck)
+        .def("setEclipseState", &BlackOilSimulator::setEclipseState)
+        .def("setSchedule", &BlackOilSimulator::setSchedule)
+        .def("setSummaryConfig", &BlackOilSimulator::setSummaryConfig);
+}


### PR DESCRIPTION
The second PR in the splitting of PR #2403 into smaller PRs.

NOTE: This PR depends on PR #2438 which should be merged first.

## Description
Currently, the Python `run()` calls `flowEbosBlackoilMain()` to start the simulation (which calls execute() in class `FlowMainEbos`). The Python `step_init()` method should also do the setup in `flowEbosBlackoilMain()` but it should not call `execute()` directly. In order to avoid code duplication for `run()` and `step_init()`, the initialization part of `flowEbosBlackoilMain()` is isolated into a `flowEbosBlackoilMain_init()` method. 
