### PR TITLE
Implement Python step_init() method

### DIFF
--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -47,7 +47,7 @@ void flowEbosBlackoilSetDeck(double setupTime, Deck &deck, EclipseState& eclStat
 }
 
 std::unique_ptr<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>
-flowEbosBlackoilMain_init(int argc, char** argv, bool outputCout, bool outputFiles)
+flowEbosBlackoilMainInit(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -65,7 +65,7 @@ flowEbosBlackoilMain_init(int argc, char** argv, bool outputCout, bool outputFil
 // ----------------- Main program -----------------
 int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
-    auto mainfunc = flowEbosBlackoilMain_init(argc, argv, outputCout, outputFiles);
+    auto mainfunc = flowEbosBlackoilMainInit(argc, argv, outputCout, outputFiles);
     return mainfunc->execute(argc, argv, outputCout, outputFiles);
 }
 

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -46,8 +46,8 @@ void flowEbosBlackoilSetDeck(double setupTime, Deck &deck, EclipseState& eclStat
     Vanguard::setExternalSummaryConfig(&summaryConfig);
 }
 
-// ----------------- Main program -----------------
-int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles)
+std::unique_ptr<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>
+flowEbosBlackoilMain_init(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -59,8 +59,14 @@ int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFile
     Dune::MPIHelper::instance(argc, argv);
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    return std::make_unique<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>();
+}
+
+// ----------------- Main program -----------------
+int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    auto mainfunc = flowEbosBlackoilMain_init(argc, argv, outputCout, outputFiles);
+    return mainfunc->execute(argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/flow/flow_ebos_blackoil.hpp
+++ b/flow/flow_ebos_blackoil.hpp
@@ -21,10 +21,13 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/simulators/flow/FlowMainEbos.hpp>
 
 namespace Opm {
 void flowEbosBlackoilSetDeck(double setupTime, Deck &deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
 int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles);
+std::unique_ptr<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>
+    flowEbosBlackoilMainInit(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 
 #endif // FLOW_EBOS_BLACKOIL_HPP

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -243,12 +243,17 @@ namespace Opm
         /// This is the main function of Flow.  It runs a complete simulation with the
         /// given grid and simulator classes, based on the user-specified command-line
         /// input.
-        int execute(int argc, char** argv, bool output_cout, bool output_to_files)
+        int execute(int argc, char** argv, bool outputCout, bool outputToFiles)
         {
-            return execute_(argc, argv, output_cout, output_to_files,
+            return execute_(argc, argv, outputCout, outputToFiles,
                 &FlowMainEbos::runSimulator);
         }
 
+        int executeInitStep(int argc, char** argv, bool outputCout, bool outputToFiles)
+        {
+            return execute_(argc, argv, outputCout, outputToFiles,
+                &FlowMainEbos::runSimulatorInit);
+        }
 
         // Print an ASCII-art header to the PRT and DEBUG files.
         // \return Whether unkown keywords were seen during parsing.
@@ -296,7 +301,7 @@ namespace Opm
 
     private:
         // called by execute() or executeInitStep()
-        int execute_(int argc, char** argv, bool output_cout, bool output_to_files,
+        int execute_(int argc, char** argv, bool outputCout, bool outputToFiles,
             void (FlowMainEbos::* runOrInitFunc)(bool))
         {
             try {
@@ -307,15 +312,15 @@ namespace Opm
                     return status;
 
                 setupParallelism();
-                setupEbosSimulator(output_cout);
-                runDiagnostics(output_cout);
+                setupEbosSimulator(outputCout);
+                runDiagnostics(outputCout);
                 createSimulator();
 
                 // if run, do the actual work, else just initialize
-                (this->*runOrInitFunc)(output_cout);
+                (this->*runOrInitFunc)(outputCout);
 
                 // clean up
-                mergeParallelLogFiles(output_to_files);
+                mergeParallelLogFiles(outputToFiles);
 
                 return EXIT_SUCCESS;
             }
@@ -323,7 +328,7 @@ namespace Opm
                 std::ostringstream message;
                 message  << "Program threw an exception: " << e.what();
 
-                if (output_cout) {
+                if (outputCout) {
                     // in some cases exceptions are thrown before the logging system is set
                     // up.
                     if (OpmLog::hasBackend("STREAMLOG")) {
@@ -467,24 +472,35 @@ namespace Opm
         }
 
         // Run the simulator.
-        void runSimulator(bool output_cout)
+        void runSimulator(bool outputCout)
         {
-            runSimulatorInitOrRun_(output_cout, &FlowMainEbos::runSimulatorRunCallback_);
+            runSimulatorInitOrRun_(outputCout, &FlowMainEbos::runSimulatorRunCallback_);
+        }
+
+        void runSimulatorInit(bool outputCout)
+        {
+            runSimulatorInitOrRun_(outputCout, &FlowMainEbos::runSimulatorInitCallback_);
         }
 
     private:
         // Callback that will be called from runSimulatorInitOrRun_().
-        void runSimulatorRunCallback_(bool output_cout)
+        void runSimulatorRunCallback_(bool outputCout)
         {
             SimulatorReport successReport = simulator_->run(*simtimer_);
-            runSimulatorAfterSim_(output_cout, successReport);
+            runSimulatorAfterSim_(outputCout, successReport);
+        }
+
+        // Callback that will be called from runSimulatorInitOrRun_().
+        void runSimulatorInitCallback_(bool outputCout)
+        {
+            simulator_->runInit(*simtimer_);
         }
 
         // Output summary after simulation has completed
-        void runSimulatorAfterSim_(bool output_cout, SimulatorReport &successReport)
+        void runSimulatorAfterSim_(bool outputCout, SimulatorReport &successReport)
         {
             SimulatorReport failureReport = simulator_->failureReport();
-            if (output_cout) {
+            if (outputCout) {
                 std::ostringstream ss;
                 ss << "\n\n================    End of simulation     ===============\n\n";
                 ss << "Number of MPI processes: " << std::setw(6) << mpi_size_ << "\n";
@@ -501,7 +517,7 @@ namespace Opm
 
         // Run the simulator.
         void runSimulatorInitOrRun_(
-             bool output_cout, void (FlowMainEbos::* initOrRunFunc)(bool))
+             bool outputCout, void (FlowMainEbos::* initOrRunFunc)(bool))
         {
             const auto& schedule = this->schedule();
             const auto& timeMap = schedule.getTimeMap();
@@ -512,7 +528,7 @@ namespace Opm
             const auto& initConfig = eclState().getInitConfig();
             simtimer_->init(timeMap, (size_t)initConfig.getRestartStep());
 
-            if (output_cout) {
+            if (outputCout) {
                 std::ostringstream oss;
 
                 // This allows a user to catch typos and misunderstandings in the
@@ -525,15 +541,15 @@ namespace Opm
             }
 
             if (!ioConfig.initOnly()) {
-                if (output_cout) {
+                if (outputCout) {
                     std::string msg;
                     msg = "\n\n================ Starting main simulation loop ===============\n";
                     OpmLog::info(msg);
                 }
-                (this->*initOrRunFunc)(output_cout);
+                (this->*initOrRunFunc)(outputCout);
             }
             else {
-                if (output_cout) {
+                if (outputCout) {
                     std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;
                 }
             }

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -469,14 +469,48 @@ namespace Opm
         // Run the simulator.
         void runSimulator(bool output_cout)
         {
+            runSimulatorInitOrRun_(output_cout, &FlowMainEbos::runSimulatorRunCallback_);
+        }
+
+    private:
+        // Callback that will be called from runSimulatorInitOrRun_().
+        void runSimulatorRunCallback_(bool output_cout)
+        {
+            SimulatorReport successReport = simulator_->run(*simtimer_);
+            runSimulatorAfterSim_(output_cout, successReport);
+        }
+
+        // Output summary after simulation has completed
+        void runSimulatorAfterSim_(bool output_cout, SimulatorReport &successReport)
+        {
+            SimulatorReport failureReport = simulator_->failureReport();
+            if (output_cout) {
+                std::ostringstream ss;
+                ss << "\n\n================    End of simulation     ===============\n\n";
+                ss << "Number of MPI processes: " << std::setw(6) << mpi_size_ << "\n";
+#if _OPENMP
+                int threads = omp_get_max_threads();
+#else
+                int threads = 1;
+#endif
+                ss << "Threads per MPI process:  " << std::setw(5) << threads << "\n";
+                successReport.reportFullyImplicit(ss, &failureReport);
+                OpmLog::info(ss.str());
+            }
+        }
+
+        // Run the simulator.
+        void runSimulatorInitOrRun_(
+             bool output_cout, void (FlowMainEbos::* initOrRunFunc)(bool))
+        {
             const auto& schedule = this->schedule();
             const auto& timeMap = schedule.getTimeMap();
             auto& ioConfig = eclState().getIOConfig();
-            SimulatorTimer simtimer;
+            simtimer_ = std::make_unique<SimulatorTimer>();
 
             // initialize variables
             const auto& initConfig = eclState().getInitConfig();
-            simtimer.init(timeMap, (size_t)initConfig.getRestartStep());
+            simtimer_->init(timeMap, (size_t)initConfig.getRestartStep());
 
             if (output_cout) {
                 std::ostringstream oss;
@@ -496,31 +530,16 @@ namespace Opm
                     msg = "\n\n================ Starting main simulation loop ===============\n";
                     OpmLog::info(msg);
                 }
-
-                SimulatorReport successReport = simulator_->run(simtimer);
-                SimulatorReport failureReport = simulator_->failureReport();
-                if (output_cout) {
-                    std::ostringstream ss;
-                    ss << "\n\n================    End of simulation     ===============\n\n";
-                    ss << "Number of MPI processes: " << std::setw(6) << mpi_size_ << "\n";
-#if _OPENMP
-                    int threads = omp_get_max_threads();
-#else
-                    int threads = 1;
-#endif
-                    ss << "Threads per MPI process:  " << std::setw(5) << threads << "\n";
-                    successReport.reportFullyImplicit(ss, &failureReport);
-                    OpmLog::info(ss.str());
-                }
-
-            } else {
+                (this->*initOrRunFunc)(output_cout);
+            }
+            else {
                 if (output_cout) {
                     std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;
                 }
-
             }
         }
 
+    protected:
         /// This is the main function of Flow.
         // Create simulator instance.
         // Writes to:
@@ -548,6 +567,7 @@ namespace Opm
         int  mpi_size_ = 1;
         boost::any parallel_information_;
         std::unique_ptr<Simulator> simulator_;
+        std::unique_ptr<SimulatorTimer> simtimer_;
     };
 } // namespace Opm
 

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -245,44 +245,10 @@ namespace Opm
         /// input.
         int execute(int argc, char** argv, bool output_cout, bool output_to_files)
         {
-            try {
-                // deal with some administrative boilerplate
-
-                int status = setupParameters_(argc, argv);
-                if (status)
-                    return status;
-
-                setupParallelism();
-                setupEbosSimulator(output_cout);
-                runDiagnostics(output_cout);
-                createSimulator();
-
-                // do the actual work
-                runSimulator(output_cout);
-
-                // clean up
-                mergeParallelLogFiles(output_to_files);
-
-                return EXIT_SUCCESS;
-            }
-            catch (const std::exception& e) {
-                std::ostringstream message;
-                message  << "Program threw an exception: " << e.what();
-
-                if (output_cout) {
-                    // in some cases exceptions are thrown before the logging system is set
-                    // up.
-                    if (OpmLog::hasBackend("STREAMLOG")) {
-                        OpmLog::error(message.str());
-                    }
-                    else {
-                        std::cout << message.str() << "\n";
-                    }
-                }
-
-                return EXIT_FAILURE;
-            }
+            return execute_(argc, argv, output_cout, output_to_files,
+                &FlowMainEbos::runSimulator);
         }
+
 
         // Print an ASCII-art header to the PRT and DEBUG files.
         // \return Whether unkown keywords were seen during parsing.
@@ -328,6 +294,49 @@ namespace Opm
           }
         }
 
+    private:
+        // called by execute() or executeInitStep()
+        int execute_(int argc, char** argv, bool output_cout, bool output_to_files,
+            void (FlowMainEbos::* runOrInitFunc)(bool))
+        {
+            try {
+                // deal with some administrative boilerplate
+
+                int status = setupParameters_(argc, argv);
+                if (status)
+                    return status;
+
+                setupParallelism();
+                setupEbosSimulator(output_cout);
+                runDiagnostics(output_cout);
+                createSimulator();
+
+                // if run, do the actual work, else just initialize
+                (this->*runOrInitFunc)(output_cout);
+
+                // clean up
+                mergeParallelLogFiles(output_to_files);
+
+                return EXIT_SUCCESS;
+            }
+            catch (const std::exception& e) {
+                std::ostringstream message;
+                message  << "Program threw an exception: " << e.what();
+
+                if (output_cout) {
+                    // in some cases exceptions are thrown before the logging system is set
+                    // up.
+                    if (OpmLog::hasBackend("STREAMLOG")) {
+                        OpmLog::error(message.str());
+                    }
+                    else {
+                        std::cout << message.str() << "\n";
+                    }
+                }
+
+                return EXIT_FAILURE;
+            }
+        }
     protected:
         void setupParallelism()
         {

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory( pybind11 )
+add_subdirectory( simulators )
 

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -1,0 +1,11 @@
+pybind11_add_module(simulators simulators.cpp)
+
+set_target_properties( simulators PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/python/simulators )
+
+target_sources(simulators
+  PRIVATE
+    ../../flow/flow_ebos_blackoil.cpp)
+
+target_link_libraries( simulators PRIVATE opmsimulators )
+
+install(TARGETS simulators DESTINATION ${PYTHON_INSTALL_PREFIX}/simulators)

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -17,6 +17,8 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.hpp>
+
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
 #else
@@ -24,6 +26,7 @@
 #endif
 
 #include <pybind11/pybind11.h>
+#include <pybind11/embed.h>
 #include <string>
 #include <iostream>
 
@@ -131,7 +134,6 @@ FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, con
     std::string output_dir = cmdline_output_dir;
     if (output_dir.empty()) {
         output_dir = absolute(path(baseName).parent_path()).string();
-        std::cout << "Output dir = " << output_dir << std::endl;
     }
 
     logFileStream << output_dir << "/" << baseName;
@@ -209,9 +211,10 @@ void setupMessageLimiter(const Opm::MessageLimits msgLimits,  const std::string&
 class BlackOilSimulator
 {
 public:
-    BlackOilSimulator()
+    BlackOilSimulator( const std::string& filename )
     {
         setupCmdLineArgs();
+        std::strcpy(argv_[1], filename.c_str());
     }
 
     BlackOilSimulator( const Opm::Deck& deck, 
@@ -316,21 +319,86 @@ public:
         if (mpiRank == 0)
             outputCout = EWOMS_GET_PARAM(PreTypeTag, bool, EnableTerminalOutput);
 
-        std::string deckFilename = eclipseState_->getIOConfig().fullBasePath();
-        std::string outputDir = eclipseState_->getIOConfig().getOutputDir();
+        std::string deckFilename;
+        std::string outputDir;
+        if ( eclipseState_ )
+        {
+            deckFilename = eclipseState_->getIOConfig().fullBasePath();
+            outputDir = eclipseState_->getIOConfig().getOutputDir();
+        }
+        else
+        {
+            deckFilename = EWOMS_GET_PARAM(PreTypeTag, std::string, EclDeckFileName);
+            typedef typename GET_PROP_TYPE(PreTypeTag, Vanguard) PreVanguard;
+            try {
+                deckFilename = PreVanguard::canonicalDeckPath(deckFilename).string();
+            }
+            catch (const std::exception& e) {
+                if ( mpiRank == 0 )
+                    std::cerr << "Exception received: " << e.what() << ". Try '--help' for a usage description.\n";
+#if HAVE_MPI
+                MPI_Finalize();
+#endif
+                return 1;
+            }
+        }
 
         if (outputCout) {
             Opm::FlowMainEbos<PreTypeTag>::printBanner();
         }
-        Opm::ErrorGuard errorGuard;
-        outputMode = setupLogging(mpiRank,
-                                  deckFilename,
-                                  outputDir,
-                                  EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
-                                  outputCout, "STDOUT_LOGGER");
 
-        if (mpiRank == 0) {
-            setupMessageLimiter(schedule_->getMessageLimits(), "STDOUT_LOGGER");
+        // Create Deck, EclipseState, Schedule and SummaryConfig if they don't exist
+        if ( deck_ && eclipseState_ && schedule_ && summaryConfig_ )
+        {
+            outputMode = setupLogging(mpiRank,
+                                    deckFilename,
+                                    outputDir,
+                                    EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
+                                    outputCout, "STDOUT_LOGGER");
+
+            if (mpiRank == 0) {
+                setupMessageLimiter(schedule_->getMessageLimits(), "STDOUT_LOGGER");
+            }
+        }
+        else
+        {
+            Opm::Parser parser;
+            Opm::ParseContext parseContext({{Opm::ParseContext::PARSE_RANDOM_SLASH, Opm::InputError::IGNORE},
+                                            {Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputError::WARN},
+                                            {Opm::ParseContext::SUMMARY_UNKNOWN_WELL, Opm::InputError::WARN},
+                                            {Opm::ParseContext::SUMMARY_UNKNOWN_GROUP, Opm::InputError::WARN}});
+            Opm::ErrorGuard errorGuard;
+            outputMode = setupLogging(mpiRank,
+                                      deckFilename,
+                                      EWOMS_GET_PARAM(PreTypeTag, std::string, OutputDir),
+                                      EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
+                                      outputCout, "STDOUT_LOGGER");
+
+            if (EWOMS_GET_PARAM(PreTypeTag, bool, EclStrictParsing))
+                parseContext.update( Opm::InputError::DELAYED_EXIT1);
+
+            Opm::FlowMainEbos<PreTypeTag>::printPRTHeader(outputCout);
+
+            deck_.reset( new Opm::Deck( parser.parseFile(deckFilename , parseContext, errorGuard)));
+            Opm::MissingFeatures::checkKeywords(*deck_, parseContext, errorGuard);
+            if ( outputCout )
+                Opm::checkDeck(*deck_, parser, parseContext, errorGuard);
+
+            eclipseState_.reset( new Opm::EclipseState(*deck_, parseContext, errorGuard ));
+            schedule_.reset(new Opm::Schedule(*deck_, *eclipseState_, parseContext, errorGuard));
+            summaryConfig_.reset( new Opm::SummaryConfig(*deck_, *schedule_, eclipseState_->getTableManager(), parseContext, errorGuard));
+            if (mpiRank == 0) {
+                setupMessageLimiter(schedule_->getMessageLimits(), "STDOUT_LOGGER");
+            }
+
+            Opm::checkConsistentArrayDimensions(*eclipseState_, *schedule_, parseContext, errorGuard);
+
+            if (errorGuard) {
+                errorGuard.dump();
+                errorGuard.clear();
+
+                throw std::runtime_error("Unrecoverable errors were encountered while loading input.");
+            }
         }
 
         const auto& phases = Opm::Runspec(*deck_).phases();
@@ -364,7 +432,7 @@ private:
 PYBIND11_MODULE(simulators, m)
 {
     py::class_<BlackOilSimulator>(m, "BlackOilSimulator")
-        .def(py::init<>())
+        .def(py::init< const std::string& >())
         .def(py::init< const Opm::Deck&, const Opm::EclipseState&, const Opm::Schedule&, const Opm::SummaryConfig& >())
         .def("run", &BlackOilSimulator::run)
         .def("setDeck", &BlackOilSimulator::setDeck)

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -211,12 +211,19 @@ class BlackOilSimulator
 public:
     BlackOilSimulator()
     {
-        argc_ = 2;
-        argv_ = new char*[2];
-        argv_[0] = new char[200];
-        char argv0[] = "flow";
-        std::strcpy(argv_[0], argv0);
-        argv_[1] = new char[200];
+        setupCmdLineArgs();
+    }
+
+    BlackOilSimulator( const Opm::Deck& deck, 
+                       const Opm::EclipseState& eclipseState, 
+                       const Opm::Schedule& schedule,
+                       const Opm::SummaryConfig& summaryConfig )
+    {
+        setupCmdLineArgs();
+        setDeck(deck);
+        setEclipseState(eclipseState);
+        setSchedule(schedule);
+        setSummaryConfig(summaryConfig);
     }
 
     ~BlackOilSimulator() 
@@ -224,6 +231,16 @@ public:
         delete[] argv_[0];
         delete[] argv_[1];
         delete[] argv_;
+    }
+
+    void setupCmdLineArgs()
+    {
+        argc_ = 2;
+        argv_ = new char*[2];
+        argv_[0] = new char[200];
+        char argv0[] = "flow";
+        std::strcpy(argv_[0], argv0);
+        argv_[1] = new char[200];
     }
 
     void setDeck( const Opm::Deck& deck )
@@ -348,6 +365,7 @@ PYBIND11_MODULE(simulators, m)
 {
     py::class_<BlackOilSimulator>(m, "BlackOilSimulator")
         .def(py::init<>())
+        .def(py::init< const Opm::Deck&, const Opm::EclipseState&, const Opm::Schedule&, const Opm::SummaryConfig& >())
         .def("run", &BlackOilSimulator::run)
         .def("setDeck", &BlackOilSimulator::setDeck)
         .def("setEclipseState", &BlackOilSimulator::setEclipseState)

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -1,0 +1,356 @@
+#include "config.h"
+
+#include <flow/flow_ebos_blackoil.hpp>
+
+#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/utils/moduleVersion.hpp>
+#include <opm/models/utils/propertysystem.hh>
+#include <opm/models/utils/parametersystem.hh>
+#include <opm/material/common/ResetLocale.hpp>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/EclipsePRTLog.hpp>
+#include <opm/common/OpmLog/LogUtil.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
+
+#include <pybind11/pybind11.h>
+#include <string>
+#include <iostream>
+
+namespace py = pybind11;
+
+BEGIN_PROPERTIES
+
+// this is a dummy type tag that is used to setup the parameters before the actual
+// simulator.
+NEW_TYPE_TAG(FlowEarlyBird, INHERITS_FROM(EclFlowProblem));
+
+END_PROPERTIES
+
+namespace detail
+{
+    boost::filesystem::path simulationCaseName( const std::string& casename ) {
+        namespace fs = boost::filesystem;
+
+        const auto exists = []( const fs::path& f ) -> bool {
+            if( !fs::exists( f ) ) return false;
+
+            if( fs::is_regular_file( f ) ) return true;
+
+            return fs::is_symlink( f )
+            && fs::is_regular_file( fs::read_symlink( f ) );
+        };
+
+        auto simcase = fs::path( casename );
+
+        if( exists( simcase ) ) {
+            return simcase;
+        }
+
+        for( const auto& ext : { std::string("data"), std::string("DATA") } ) {
+            if( exists( simcase.replace_extension( ext ) ) ) {
+                return simcase;
+            }
+        }
+
+        throw std::invalid_argument( "Cannot find input case " + casename );
+    }
+
+
+    // This function is an extreme special case, if the program has been invoked
+    // *exactly* as:
+    //
+    //    flow   --version
+    //
+    // the call is intercepted by this function which will print "flow $version"
+    // on stdout and exit(0).
+    void handleVersionCmdLine(int argc, char** argv) {
+        for ( int i = 1; i < argc; ++i )
+        {
+            if (std::strcmp(argv[i], "--version") == 0) {
+                std::cout << "flow " << Opm::moduleVersionName() << std::endl;
+                std::exit(EXIT_SUCCESS);
+            }
+        }
+    }
+}
+
+enum class FileOutputMode {
+    //! \brief No output to files.
+    OUTPUT_NONE = 0,
+    //! \brief Output only to log files, no eclipse output.
+    OUTPUT_LOG_ONLY = 1,
+    //! \brief Output to all files.
+    OUTPUT_ALL = 3
+};
+
+void ensureOutputDirExists(const std::string& cmdline_output_dir)
+{
+    if (!boost::filesystem::is_directory(cmdline_output_dir)) {
+        try {
+            boost::filesystem::create_directories(cmdline_output_dir);
+        }
+        catch (...) {
+            throw std::runtime_error("Creation of output directory '" + cmdline_output_dir + "' failed\n");
+        }
+    }
+}
+
+// Setup the OpmLog backends
+FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, const std::string& cmdline_output_dir, const std::string& cmdline_output, bool output_cout_, const std::string& stdout_log_id) {
+
+    if (!cmdline_output_dir.empty()) {
+        ensureOutputDirExists(cmdline_output_dir);
+    }
+
+    // create logFile
+    using boost::filesystem::path;
+    path fpath(deck_filename);
+    std::string baseName;
+    std::ostringstream debugFileStream;
+    std::ostringstream logFileStream;
+
+    // Strip extension "." or ".DATA"
+    std::string extension = boost::to_upper_copy(fpath.extension().string());
+    if (extension == ".DATA" || extension == ".") {
+        baseName = boost::to_upper_copy(fpath.stem().string());
+    } else {
+        baseName = boost::to_upper_copy(fpath.filename().string());
+    }
+
+    std::string output_dir = cmdline_output_dir;
+    if (output_dir.empty()) {
+        output_dir = absolute(path(baseName).parent_path()).string();
+        std::cout << "Output dir = " << output_dir << std::endl;
+    }
+
+    logFileStream << output_dir << "/" << baseName;
+    debugFileStream << output_dir << "/" << baseName;
+
+    if (mpi_rank_ != 0) {
+        // Added rank to log file for non-zero ranks.
+        // This prevents message loss.
+        debugFileStream << "." << mpi_rank_;
+        // If the following file appears then there is a bug.
+        logFileStream << "." << mpi_rank_;
+    }
+    logFileStream << ".PRT";
+    debugFileStream << ".DBG";
+
+    FileOutputMode output;
+    {
+        static std::map<std::string, FileOutputMode> stringToOutputMode =
+            { {"none", FileOutputMode::OUTPUT_NONE },
+              {"false", FileOutputMode::OUTPUT_LOG_ONLY },
+              {"log", FileOutputMode::OUTPUT_LOG_ONLY },
+              {"all" , FileOutputMode::OUTPUT_ALL },
+              {"true" , FileOutputMode::OUTPUT_ALL }};
+        auto outputModeIt = stringToOutputMode.find(cmdline_output);
+        if (outputModeIt != stringToOutputMode.end()) {
+            output = outputModeIt->second;
+        }
+        else {
+            output = FileOutputMode::OUTPUT_ALL;
+            std::cerr << "Value " << cmdline_output <<
+                " is not a recognized output mode. Using \"all\" instead."
+                      << std::endl;
+        }
+    }
+
+    if (output > FileOutputMode::OUTPUT_NONE) {
+        std::shared_ptr<Opm::EclipsePRTLog> prtLog = std::make_shared<Opm::EclipsePRTLog>(logFileStream.str(), Opm::Log::NoDebugMessageTypes, false, output_cout_);
+        Opm::OpmLog::addBackend("ECLIPSEPRTLOG", prtLog);
+        prtLog->setMessageLimiter(std::make_shared<Opm::MessageLimiter>());
+        prtLog->setMessageFormatter(std::make_shared<Opm::SimpleMessageFormatter>(false));
+    }
+
+    if (output >= FileOutputMode::OUTPUT_LOG_ONLY) {
+        std::string debugFile = debugFileStream.str();
+        std::shared_ptr<Opm::StreamLog> debugLog = std::make_shared<Opm::EclipsePRTLog>(debugFileStream.str(), Opm::Log::DefaultMessageTypes, false, output_cout_);
+        Opm::OpmLog::addBackend("DEBUGLOG", debugLog);
+    }
+
+    if (mpi_rank_ == 0) {
+        std::shared_ptr<Opm::StreamLog> streamLog = std::make_shared<Opm::StreamLog>(std::cout, Opm::Log::StdoutMessageTypes);
+        Opm::OpmLog::addBackend(stdout_log_id, streamLog);
+        streamLog->setMessageFormatter(std::make_shared<Opm::SimpleMessageFormatter>(true));
+    }
+    return output;
+}
+
+void setupMessageLimiter(const Opm::MessageLimits msgLimits,  const std::string& stdout_log_id) {
+    std::shared_ptr<Opm::StreamLog> stream_log = Opm::OpmLog::getBackend<Opm::StreamLog>(stdout_log_id);
+
+    const std::map<int64_t, int> limits = {{Opm::Log::MessageType::Note,
+                                            msgLimits.getCommentPrintLimit(0)},
+                                           {Opm::Log::MessageType::Info,
+                                            msgLimits.getMessagePrintLimit(0)},
+                                           {Opm::Log::MessageType::Warning,
+                                            msgLimits.getWarningPrintLimit(0)},
+                                           {Opm::Log::MessageType::Error,
+                                            msgLimits.getErrorPrintLimit(0)},
+                                           {Opm::Log::MessageType::Problem,
+                                            msgLimits.getProblemPrintLimit(0)},
+                                           {Opm::Log::MessageType::Bug,
+                                            msgLimits.getBugPrintLimit(0)}};
+    stream_log->setMessageLimiter(std::make_shared<Opm::MessageLimiter>(10, limits));
+}
+
+class BlackOilSimulator
+{
+public:
+    BlackOilSimulator()
+    {
+        argc_ = 2;
+        argv_ = new char*[2];
+        argv_[0] = new char[200];
+        char argv0[] = "flow";
+        std::strcpy(argv_[0], argv0);
+        argv_[1] = new char[200];
+    }
+
+    ~BlackOilSimulator() 
+    {
+        delete[] argv_[0];
+        delete[] argv_[1];
+        delete[] argv_;
+    }
+
+    void setDeck( const Opm::Deck& deck )
+    {
+        deck_ = std::make_shared< Opm::Deck >(deck);
+    }
+
+    void setEclipseState( const Opm::EclipseState& eclipseState )
+    {
+        eclipseState_ = std::make_shared< Opm::EclipseState >(eclipseState);
+    }
+
+    void setSchedule( const Opm::Schedule& schedule )
+    {
+        schedule_ = std::make_shared< Opm::Schedule >(schedule);
+    }
+
+    void setSummaryConfig( const Opm::SummaryConfig& summaryConfig )
+    {
+        summaryConfig_ = std::make_shared< Opm::SummaryConfig >(summaryConfig);
+    }
+
+    int run()
+    {
+        int argc = argc_;
+        char **argv = argv_;
+
+        Dune::Timer externalSetupTimer;
+        externalSetupTimer.start();
+
+        detail::handleVersionCmdLine(argc, argv);
+        // MPI setup.
+#if HAVE_DUNE_FEM
+        Dune::Fem::MPIManager::initialize(argc, argv);
+        int mpiRank = Dune::Fem::MPIManager::rank();
+#else
+        // the design of the plain dune MPIHelper class is quite flawed: there is no way to
+        // get the instance without having the argc and argv parameters available and it is
+        // not possible to determine the MPI rank and size without an instance. (IOW: the
+        // rank() and size() methods are supposed to be static.)
+        const auto& mpiHelper = Dune::MPIHelper::instance(argc, argv);
+        int mpiRank = mpiHelper.rank();
+#endif
+
+        // we always want to use the default locale, and thus spare us the trouble
+        // with incorrect locale settings.
+        Opm::resetLocale();
+
+        // this is a work-around for a catch 22: we do not know what code path to use without
+        // parsing the deck, but we don't know the deck without having access to the
+        // parameters and this requires to know the type tag to be used. To solve this, we
+        // use a type tag just for parsing the parameters before we instantiate the actual
+        // simulator object. (Which parses the parameters again, but since this is done in an
+        // identical manner it does not matter.)
+        typedef TTAG(FlowEarlyBird) PreTypeTag;
+        typedef GET_PROP_TYPE(PreTypeTag, Problem) PreProblem;
+
+        PreProblem::setBriefDescription("Flow, an advanced reservoir simulator for ECL-decks provided by the Open Porous Media project.");
+
+        int status = Opm::FlowMainEbos<PreTypeTag>::setupParameters_(argc, argv);
+        if (status != 0) {
+            // if setupParameters_ returns a value smaller than 0, there was no error, but
+            // the program should abort. This is the case e.g. for the --help and the
+            // --print-properties parameters.
+#if HAVE_MPI
+            MPI_Finalize();
+#endif
+            return (status >= 0)?status:0;
+        }
+
+        FileOutputMode outputMode = FileOutputMode::OUTPUT_NONE;
+        bool outputCout = false;
+        if (mpiRank == 0)
+            outputCout = EWOMS_GET_PARAM(PreTypeTag, bool, EnableTerminalOutput);
+
+        std::string deckFilename = eclipseState_->getIOConfig().fullBasePath();
+        std::string outputDir = eclipseState_->getIOConfig().getOutputDir();
+
+        if (outputCout) {
+            Opm::FlowMainEbos<PreTypeTag>::printBanner();
+        }
+        Opm::ErrorGuard errorGuard;
+        outputMode = setupLogging(mpiRank,
+                                  deckFilename,
+                                  outputDir,
+                                  EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
+                                  outputCout, "STDOUT_LOGGER");
+
+        if (mpiRank == 0) {
+            setupMessageLimiter(schedule_->getMessageLimits(), "STDOUT_LOGGER");
+        }
+
+        const auto& phases = Opm::Runspec(*deck_).phases();
+        bool outputFiles = (outputMode != FileOutputMode::OUTPUT_NONE);
+
+        // Blackoil case
+        if( phases.size() == 3 ) {
+            Opm::flowEbosBlackoilSetDeck(externalSetupTimer.elapsed(), *deck_, *eclipseState_, *schedule_, *summaryConfig_);
+            return Opm::flowEbosBlackoilMain(argc, argv, outputCout, outputFiles);
+        }
+        else
+        {
+            if (outputCout)
+                std::cerr << "Only blackoil configuration is supported!" << std::endl;
+            return EXIT_FAILURE;
+        }
+        
+        return EXIT_SUCCESS;
+    }
+
+private:
+    int argc_;
+    char **argv_;
+
+    std::shared_ptr<Opm::Deck>          deck_;
+    std::shared_ptr<Opm::EclipseState>  eclipseState_;
+    std::shared_ptr<Opm::Schedule>      schedule_;
+    std::shared_ptr<Opm::SummaryConfig> summaryConfig_;
+};
+
+PYBIND11_MODULE(simulators, m)
+{
+    py::class_<BlackOilSimulator>(m, "BlackOilSimulator")
+        .def(py::init<>())
+        .def("run", &BlackOilSimulator::run)
+        .def("setDeck", &BlackOilSimulator::setDeck)
+        .def("setEclipseState", &BlackOilSimulator::setEclipseState)
+        .def("setSchedule", &BlackOilSimulator::setSchedule)
+        .def("setSummaryConfig", &BlackOilSimulator::setSummaryConfig);
+}

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -276,7 +276,6 @@ public:
         }
     }
 
-
 private:
 
     bool prepareRun_()
@@ -447,8 +446,8 @@ PYBIND11_MODULE(simulators, m)
         .def(py::init< const std::string& >())
         .def(py::init< const Opm::Deck&, const Opm::EclipseState&, const Opm::Schedule&, const Opm::SummaryConfig& >())
         .def("run", &BlackOilSimulator::run)
-        .def("setDeck", &BlackOilSimulator::setDeck)
-        .def("setEclipseState", &BlackOilSimulator::setEclipseState)
-        .def("setSchedule", &BlackOilSimulator::setSchedule)
-        .def("setSummaryConfig", &BlackOilSimulator::setSummaryConfig);
+        .def("set_deck", &BlackOilSimulator::setDeck)
+        .def("set_eclipse_state", &BlackOilSimulator::setEclipseState)
+        .def("set_schedule", &BlackOilSimulator::setSchedule)
+        .def("set_summary_config", &BlackOilSimulator::setSummaryConfig);
 }


### PR DESCRIPTION
The 6th PR in the splitting of PR #2403 into smaller PRs.

This PR depends on PR #2442 which should be merged first.

## Description

The `step_init()` method initializes the simulation. It is required for the Python script to `run step_init()` before calling the `step()` method (which will be implemented in the next PR).  

