### PR TITLE
Autocreate parallel fieldprops and use compressed ones in initstateequil.hh

### DIFF
--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -40,6 +40,8 @@
 
 #include <dune/common/version.hh>
 
+#include <sstream>
+
 namespace Opm {
 template <class TypeTag>
 class EclCpGridVanguard;
@@ -189,17 +191,29 @@ public:
             //distribute the grid and switch to the distributed view.
             {
                 const auto wells = this->schedule().getWellsatEnd();
-                auto& eclState = static_cast<ParallelEclipseState&>(this->eclState());
-                const EclipseGrid* eclGrid = nullptr;
 
-                if (grid_->comm().rank() == 0)
+                try
                 {
-                    eclGrid = &this->eclState().getInputGrid();
-                }
+                    auto& eclState = dynamic_cast<ParallelEclipseState&>(this->eclState());
+                    const EclipseGrid* eclGrid = nullptr;
 
-                PropsCentroidsDataHandle<Dune::CpGrid> handle(*grid_, eclState, eclGrid, this->centroids_,
-                                                              cartesianIndexMapper());
-                defunctWellNames_ = std::get<1>(grid_->loadBalance(handle, edgeWeightsMethod, &wells, faceTrans.data()));
+                    if (grid_->comm().rank() == 0)
+                    {
+                        eclGrid = &this->eclState().getInputGrid();
+                    }
+
+                    PropsCentroidsDataHandle<Dune::CpGrid> handle(*grid_, eclState, eclGrid, this->centroids_,
+                                                                  cartesianIndexMapper());
+                    defunctWellNames_ = std::get<1>(grid_->loadBalance(handle, edgeWeightsMethod, &wells, faceTrans.data()));
+                }
+                catch(const std::bad_cast& e)
+                {
+                    std::ostringstream message;
+                    message << "Parallel simulator setup is incorrect as it does not use ParallelEclipseState ("
+                            << e.what() <<")"<<std::flush;
+                    OpmLog::error(message.str());
+                    std::rethrow_exception(std::current_exception());
+                }
             }
             grid_->switchToDistributedView();
 
@@ -218,12 +232,24 @@ public:
 #endif
 
         cartesianIndexMapper_.reset(new CartesianIndexMapper(*grid_));
-        // reset cartesian index mapper for auto creation of field properties
-        static_cast<ParallelEclipseState&>(this->eclState()).resetCartesianMapper(cartesianIndexMapper_.get());
         this->updateGridView_();
 #if HAVE_MPI
         if (mpiSize > 1) {
-            static_cast<ParallelEclipseState&>(this->eclState()).switchToDistributedProps();
+            try
+            {
+                auto& parallelEclState = dynamic_cast<ParallelEclipseState&>(this->eclState());
+                // reset cartesian index mapper for auto creation of field properties
+                parallelEclState.resetCartesianMapper(cartesianIndexMapper_.get());
+                parallelEclState.switchToDistributedProps();
+            }
+            catch(const std::bad_cast& e)
+            {
+                std::ostringstream message;
+                message << "Parallel simulator setup is incorrect as it does not use ParallelEclipseState ("
+                        << e.what() <<")"<<std::flush;
+                OpmLog::error(message.str());
+                std::rethrow_exception(std::current_exception());
+            }
         }
 #endif
     }

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -218,6 +218,8 @@ public:
 #endif
 
         cartesianIndexMapper_.reset(new CartesianIndexMapper(*grid_));
+        // reset cartesian index mapper for auto creation of field properties
+        static_cast<ParallelEclipseState&>(this->eclState()).resetCartesianMapper(cartesianIndexMapper_.get());
         this->updateGridView_();
 #if HAVE_MPI
         if (mpiSize > 1) {

--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -66,7 +66,19 @@ const std::vector<int>& ParallelFieldPropsManager::get_int(const std::string& ke
 {
     auto it = m_intProps.find(keyword);
     if (it == m_intProps.end())
-        OPM_THROW(std::runtime_error, "No integer property field: " + keyword);
+    {
+        // Some of the keywords might be defaulted.
+        // We will let rank 0 create them and distribute them using get_global_int
+        auto data = get_global_int(keyword);
+        auto& local_data = const_cast<std::map<std::string, std::vector<int>>&>(m_intProps)[keyword];
+        local_data.resize(m_activeSize());
+
+        for (int i = 0; i < m_activeSize(); ++i)
+        {
+            local_data[i] = data[m_local2Global(i)];
+        }
+        return local_data;
+    }
 
     return it->second;
 }
@@ -107,7 +119,18 @@ const std::vector<double>& ParallelFieldPropsManager::get_double(const std::stri
 {
     auto it = m_doubleProps.find(keyword);
     if (it == m_doubleProps.end())
-        OPM_THROW(std::runtime_error, "No double property field: " + keyword);
+    {
+        // Some of the keywords might be defaulted.
+        // We will let rank 0 create them and distribute them using get_global_int
+        auto data = get_global_double(keyword);
+        auto& local_data = const_cast<std::map<std::string, std::vector<double>>&>(m_doubleProps)[keyword];
+        local_data.resize(m_activeSize());
+        for (int i = 0; i < m_activeSize(); ++i)
+        {
+            local_data[i] = data[m_local2Global(i)];
+        }
+        return local_data;
+    }
 
     return it->second;
 }

--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -74,8 +74,26 @@ const std::vector<int>& ParallelFieldPropsManager::get_int(const std::string& ke
 std::vector<int> ParallelFieldPropsManager::get_global_int(const std::string& keyword) const
 {
     std::vector<int> result;
+    int exceptionThrown{};
+
     if (m_comm.rank() == 0)
-        result = m_manager.get_global_int(keyword);
+    {
+        try
+        {
+            result = m_manager.get_global_int(keyword);
+        }catch(std::exception& e) {
+            exceptionThrown = 1;
+            OpmLog::error("No integer property field: " + keyword + " ("+e.what()+")");
+            m_comm.broadcast(&exceptionThrown, 1, 0);
+            throw e;
+        }
+    }
+
+    m_comm.broadcast(&exceptionThrown, 1, 0);
+
+    if (exceptionThrown)
+        OPM_THROW_NOLOG(std::runtime_error, "No integer property field: " + keyword);
+
     size_t size = result.size();
     m_comm.broadcast(&size, 1, 0);
     result.resize(size);
@@ -98,8 +116,26 @@ const std::vector<double>& ParallelFieldPropsManager::get_double(const std::stri
 std::vector<double> ParallelFieldPropsManager::get_global_double(const std::string& keyword) const
 {
     std::vector<double> result;
+    int exceptionThrown{};
+
     if (m_comm.rank() == 0)
-        result = m_manager.get_global_double(keyword);
+    {
+        try
+        {
+            result = m_manager.get_global_double(keyword);
+        }catch(std::exception& e) {
+            exceptionThrown = 1;
+            OpmLog::error("No double property field: " + keyword + " ("+e.what()+")");
+            m_comm.broadcast(&exceptionThrown, 1, 0);
+            throw e;
+        }
+    }
+
+    m_comm.broadcast(&exceptionThrown, 1, 0);
+
+    if (exceptionThrown)
+        OPM_THROW_NOLOG(std::runtime_error, "No double property field: " + keyword);
+
     size_t size = result.size();
     m_comm.broadcast(&size, 1, 0);
     result.resize(size);


### PR DESCRIPTION
With this PR `ParallelEclipseState` will be able to autocreate data for somekeywords that have not been explicitly specified in the input file (just like the serial version). For now this still happens by wasting some space, creating global arrays of cartesian size and then compressing them manually. We use this to get rid off using the get_global_* accessors initstateequil.hh except for the temperature stuff which appears to be buggy in parallel (issue #2423) and hence might lead to differing results.

As a drive-by improvement we get rid off (at least) one unneccessary copy (PVTNUM) and on my system this give us  a 10% performance boost for Norne on 4 processors due to faster assembly.