### PR TITLE
changed: simplify eclmpiserializer

### DIFF
--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -137,57 +137,20 @@ ParallelEclipseState::ParallelEclipseState(const Deck& deck)
 
 
 #if HAVE_MPI
-std::size_t ParallelEclipseState::packSize(EclMpiSerializer& serializer) const
+void ParallelEclipseState::serializeOp(EclMpiSerializer& serializer)
 {
-    return serializer.packSize(m_tables) +
-           serializer.packSize(m_runspec) +
-           serializer.packSize(m_eclipseConfig) +
-           serializer.packSize(m_deckUnitSystem) +
-           serializer.packSize(m_inputNnc) +
-           serializer.packSize(m_inputEditNnc) +
-           serializer.packSize(m_gridDims) +
-           serializer.packSize(m_simulationConfig) +
-           serializer.packSize(m_transMult) +
-           serializer.packSize(m_faults) +
-           serializer.packSize(m_title) +
-           serializer.packSize(aquifer_config);
-
-}
-
-
-void ParallelEclipseState::pack(std::vector<char>& buffer, int& position,
-                                EclMpiSerializer& serializer) const
-{
-    serializer.pack(m_tables, buffer, position);
-    serializer.pack(m_runspec, buffer, position);
-    serializer.pack(m_eclipseConfig, buffer, position);
-    serializer.pack(m_deckUnitSystem, buffer, position);
-    serializer.pack(m_inputNnc, buffer, position);
-    serializer.pack(m_inputEditNnc, buffer, position);
-    serializer.pack(m_gridDims, buffer, position);
-    serializer.pack(m_simulationConfig, buffer, position);
-    serializer.pack(m_transMult, buffer, position);
-    serializer.pack(m_faults, buffer, position);
-    serializer.pack(m_title, buffer, position);
-    serializer.pack(aquifer_config, buffer, position);
-}
-
-
-void ParallelEclipseState::unpack(std::vector<char>& buffer, int& position,
-                                  EclMpiSerializer& serializer)
-{
-    serializer.unpack(m_tables, buffer, position);
-    serializer.unpack(m_runspec, buffer, position);
-    serializer.unpack(m_eclipseConfig, buffer, position);
-    serializer.unpack(m_deckUnitSystem, buffer, position);
-    serializer.unpack(m_inputNnc, buffer, position);
-    serializer.unpack(m_inputEditNnc, buffer, position);
-    serializer.unpack(m_gridDims, buffer, position);
-    serializer.unpack(m_simulationConfig, buffer, position);
-    serializer.unpack(m_transMult, buffer, position);
-    serializer.unpack(m_faults, buffer, position);
-    serializer.unpack(m_title, buffer, position);
-    serializer.unpack(aquifer_config, buffer, position);
+    serializer(m_tables);
+    serializer(m_runspec);
+    serializer(m_eclipseConfig);
+    serializer(m_deckUnitSystem);
+    serializer(m_inputNnc);
+    serializer(m_inputEditNnc);
+    serializer(m_gridDims);
+    serializer(m_simulationConfig);
+    serializer(m_transMult);
+    serializer(m_faults);
+    serializer(m_title);
+    serializer(aquifer_config);
 }
 #endif
 

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -116,20 +116,9 @@ public:
     ParallelEclipseState(const Deck& deck);
 
 #if HAVE_MPI
-    //! \brief Calculates the size of serialized data.
+    //! \brief Perform serialization operation.
     //! \param serializer The serializer to use
-    std::size_t packSize(EclMpiSerializer& serializer) const;
-
-    //! \brief Serialize data.
-    //! \param buffer Buffer to write serialized data into
-    //! \param Position in buffer
-    //! \param serializer The serializer to use
-    void pack(std::vector<char>& buffer, int& position, EclMpiSerializer& serializer) const;
-    //! \brief Deserialize data.
-    //! \param buffer Buffer to read serialized data from
-    //! \param Position in buffer
-    //! \param serializer The serializer to use
-    void unpack(std::vector<char>& buffer, int& position, EclMpiSerializer& serializer);
+    void serializeOp(EclMpiSerializer& serializer);
 #endif
 
     //! \brief Switch to global field properties.


### PR DESCRIPTION
now users only have to implement a single method for
packsize/pack/unpack.

Prerequisites:
https://github.com/OPM/opm-material/pull/412
https://github.com/OPM/opm-simulators/pull/2436