### PR TITLE
Use correct region temperature when calculating RS/RV

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -526,8 +526,8 @@ if(MPI_FOUND)
   add_test_compare_parallel_simulation(CASENAME spe1_thermal
                                        FILENAME SPE1CASE2_THERMAL
                                        SIMULATOR flow
-                                       ABS_TOL ${abs_tol_parallel}
-                                       REL_TOL 1e-1
+                                       ABS_TOL ${abs_tol}
+                                       REL_TOL ${rel_tol}
                                        DIR spe1
                                        TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
 


### PR DESCRIPTION
The `InitialStateComputer::temperature_` array, previously used, was of Cartesian size, but used as if it only contained the values of the cells of a region. With this commit `InitialStateComputer::temperature_` is a compressed local array and we explicitly copy out only the region values when computing RS/RV.

Closes #2423.

Needs  #2446 to be merged first! Won't work otherwise