### PR TITLE
Do not use local id set to index matrices.

### DIFF
--- a/opm/simulators/linalg/ISTLSolverEbosCpr.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosCpr.hpp
@@ -97,10 +97,7 @@ namespace Opm
         ///                                with dune-istl the information about the parallelization.
         explicit ISTLSolverEbosCpr(const Simulator& simulator)
             : SuperClass(simulator), oldMat()
-        {
-            extractParallelGridInformationToISTL(this->simulator_.vanguard().grid(), this->parallelInformation_);
-            detail::findOverlapAndInterior(this->simulator_.vanguard().grid(), this->overlapRows_, this->interiorRows_);
-        }
+        {}
 
         void prepare(const SparseMatrixAdapter& M, Vector& b)
         {

--- a/opm/simulators/linalg/findOverlapRowsAndColumns.hpp
+++ b/opm/simulators/linalg/findOverlapRowsAndColumns.hpp
@@ -82,16 +82,14 @@ namespace detail
     /// \param grid The grid where we look for overlap cells.
     /// \param overlapRows List where overlap rows are stored.
     /// \param interiorRows List where overlap rows are stored.
-    template<class Grid>
-    void findOverlapAndInterior(const Grid& grid, std::vector<int>& overlapRows,
+    template<class Grid, class Mapper>
+    void findOverlapAndInterior(const Grid& grid, const Mapper& mapper, std::vector<int>& overlapRows,
                                 std::vector<int>& interiorRows)
     {
         //only relevant in parallel case.
         if ( grid.comm().size() > 1)
         {
             //Numbering of cells
-            const auto& lid = grid.localIdSet();
-
             const auto& gridView = grid.leafGridView();
             auto elemIt = gridView.template begin<0>();
             const auto& elemEndIt = gridView.template end<0>();
@@ -100,7 +98,7 @@ namespace detail
             for (; elemIt != elemEndIt; ++elemIt)
             {
                 const auto& elem = *elemIt;
-                int lcell = lid.id(elem);
+                int lcell = mapper.index(elem);
 
                 if (elem.partitionType() != Dune::InteriorEntity)
                 {


### PR DESCRIPTION
That the local ids were consecutive and starting from 0 was just a coincidence and they should never be used to access linear systems or vectors. This commit fixes this by using the correct mappers instead.

It is a preparation needed to fix the idsets of CpGrid.

Note the we removed some computations from the constructor of ISTLSolverEbosCpr as it inherits from ISTLSolverEbos and the operations already happnen in constructor of the base class.