### PR TITLE
Make available current Production/Injection Group Control parameters for use in  Restart

### DIFF
--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -42,6 +42,7 @@
 #include <opm/output/eclipse/RestartValue.hpp>
 
 #include <opm/output/data/Wells.hpp>
+#include <opm/output/data/Groups.hpp>
 #include <opm/material/common/Exceptions.hpp>
 
 #include <opm/models/utils/propertysystem.hh>
@@ -565,6 +566,10 @@ public:
         }
 
         return wellDat;
+    }
+
+    Opm::data::Group groupData(const int reportStepIdx, Opm::Schedule& sched) const {
+        return {};
     }
 
     /*!

--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -568,7 +568,7 @@ public:
         return wellDat;
     }
 
-    Opm::data::Group groupData(const int reportStepIdx, Opm::Schedule& sched) const {
+    Opm::data::Group groupData(const int /* reportStepIdx */, Opm::Schedule& /* sched */) const {
         return {};
     }
 

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -263,10 +263,6 @@ public:
 
         Opm::data::Group localGroupData = simulator_.problem().wellModel().groupData(reportStepNum, simulator_.vanguard().schedule());
 
-        for (const auto& cp_constr : localGroupData) {
-             std::cout << "cp_constr.first: " << cp_constr.first << " cp_constr.second.currentProdConstraint: " << static_cast<int>(cp_constr.second.currentProdConstraint) << std::endl;
-        }
-
         const auto& gridView = simulator_.vanguard().gridView();
         int numElements = gridView.size(/*codim=*/0);
         bool log = collectToIORank_.isIORank();

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -32,6 +32,9 @@
 #include "ecloutputblackoilmodule.hh"
 
 #include <opm/models/blackoil/blackoilmodel.hh>
+
+#include <opm/simulators/wells/BlackoilWellModel.hpp>
+
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>
 #include <opm/models/io/baseoutputwriter.hh>
 #include <opm/models/parallel/tasklets.hh>
@@ -39,6 +42,7 @@
 #include <ebos/nncsorter.hpp>
 
 #include <opm/output/eclipse/EclipseIO.hpp>
+
 #include <opm/output/eclipse/RestartValue.hpp>
 #include <opm/output/eclipse/Summary.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
@@ -256,6 +260,15 @@ public:
             simulator_.vanguard().externalSetupTime();
 
         Opm::data::Wells localWellData = simulator_.problem().wellModel().wellData();
+
+        /*const Group& fieldGroup = schedule().getGroup("FIELD", reportStepNum);
+        wellGroupHelpers::setCmodeGroup(fieldGroup, simulator_.vanguard().schedule(), simulator_.vanguard().summaryState(), reportStepNum, well_state_);
+
+        Opm::data::Group localGroupData = simulator_.problem().wellModel().groupData(reportStepNum, simulator_.vanguard().schedule());
+
+        for (const auto& cp_constr : localGroupData.currentProdConstraint) {
+             std::cout << "cp_constr.first: " << cp_constr.first << " cp_constr.second: " << static_cast<int>(cp_constr.second) << std::endl;
+        }*/
 
         const auto& gridView = simulator_.vanguard().gridView();
         int numElements = gridView.size(/*codim=*/0);

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -385,7 +385,6 @@ public:
             bool enableDoublePrecisionOutput = EWOMS_GET_PARAM(TypeTag, bool, EclOutputDoublePrecision);
             const Opm::data::Solution& cellData = collectToIORank_.isParallel() ? collectToIORank_.globalCellData() : localCellData;
             const Opm::data::Wells& wellData = collectToIORank_.isParallel() ? collectToIORank_.globalWellData() : localWellData;
-            const Opm::data::Group& groupData = collectToIORank_.isParallel() ? collectToIORank_.globalGroupData() : localGroupData;
             Opm::RestartValue restartValue(cellData, wellData);
 
             if (simConfig.useThresholdPressure())

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -39,7 +39,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
-//#include <opm/output/data/Groups.hpp>
 
 #include <opm/simulators/timestepping/SimulatorReport.hpp>
 #include <opm/simulators/wells/PerforationData.hpp>
@@ -279,7 +278,6 @@ namespace Opm {
             WellInterfacePtr createWellForWellTest(const std::string& well_name, const int report_step, Opm::DeferredLogger& deferred_logger) const;
 
             WellState well_state_;
-
             WellState previous_well_state_;
             WellState well_state_nupcol_;
 

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -33,9 +33,12 @@
 #include <cassert>
 #include <tuple>
 
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 //#include <opm/output/data/Groups.hpp>
 
 #include <opm/simulators/timestepping/SimulatorReport.hpp>
@@ -184,29 +187,39 @@ namespace Opm {
 
             void initFromRestartFile(const RestartValue& restartValues);
 
-            /*Opm::data::Group groupData(const int reportStepIdx, Opm::Schedule& sched)
+            Opm::data::Group groupData(const int reportStepIdx, Opm::Schedule& sched) const
             {
                 Opm::data::Group dw;
-                std::pair<const std::string, const Opm::Group::ProductionCMode> groupPCPair;
-                std::pair<const std::string, const Opm::Group::InjectionCMode> groupICPair;
                 for (const std::string gname :  sched.groupNames(reportStepIdx))  {
+                    const auto& grup = sched.getGroup(gname, reportStepIdx);
+                    const auto& grup_type = grup.getGroupType();
+                    const auto& i_phase = grup.injection_phase();
+                    Opm::data::currentGroupConstraints cgc;
+                    cgc.currentProdConstraint =  Opm::Group::ProductionCMode::NONE;
+                    cgc.currentGasInjectionConstraint = Opm::Group::InjectionCMode::NONE;
+                    cgc.currentWaterInjectionConstraint = Opm::Group::InjectionCMode::NONE;
                     if (this->well_state_.hasProductionGroupControl(gname)) {
-                       groupPCPair = std::make_pair(gname, this->well_state_.currentProductionGroupControl(gname));
-                        dw.currentProdConstraint.insert(groupPCPair);
+                        cgc.currentProdConstraint = this->well_state_.currentProductionGroupControl(gname);
                     }
-                    if (this->well_state_.hasInjectionGroupControl(gname)) {
-                        groupICPair = std::make_pair(gname, this->well_state_.currentInjectionGroupControl(gname));
-                        dw.currentInjectionConstraint.insert(groupICPair);
+                    if ((grup_type == Opm::Group::GroupType::INJECTION) || (grup_type == Opm::Group::GroupType::MIXED))  {
+                        if (i_phase == Opm::Phase::WATER) {
+                            if (this->well_state_.hasInjectionGroupControl(gname)) {
+                                cgc.currentWaterInjectionConstraint = this->well_state_.currentInjectionGroupControl(gname);
+                            }
+                        }
+                        if (i_phase == Opm::Phase::GAS) {
+                            if (this->well_state_.hasInjectionGroupControl(gname)) {
+                                cgc.currentGasInjectionConstraint = this->well_state_.currentInjectionGroupControl(gname);
+                            }
+                        }
                     }
+                    dw.emplace(gname, cgc);
                 }
                 return dw;
-            } */
+            }
 
             Opm::data::Wells wellData() const
             { return well_state_.report(phase_usage_, Opm::UgGridHelpers::globalCell(grid())); }
-
-            //Opm::data::Group groupData(const int reportStepIdx) const
-            //{ return g_report(reportStepIdx); }
 
             // substract Binv(D)rw from r;
             void apply( BVector& r) const;

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -193,7 +193,6 @@ namespace Opm {
                 for (const std::string gname :  sched.groupNames(reportStepIdx))  {
                     const auto& grup = sched.getGroup(gname, reportStepIdx);
                     const auto& grup_type = grup.getGroupType();
-                    const auto& i_phase = grup.injection_phase();
                     Opm::data::currentGroupConstraints cgc;
                     cgc.currentProdConstraint =  Opm::Group::ProductionCMode::NONE;
                     cgc.currentGasInjectionConstraint = Opm::Group::InjectionCMode::NONE;
@@ -202,15 +201,11 @@ namespace Opm {
                         cgc.currentProdConstraint = this->well_state_.currentProductionGroupControl(gname);
                     }
                     if ((grup_type == Opm::Group::GroupType::INJECTION) || (grup_type == Opm::Group::GroupType::MIXED))  {
-                        if (i_phase == Opm::Phase::WATER) {
-                            if (this->well_state_.hasInjectionGroupControl(gname)) {
-                                cgc.currentWaterInjectionConstraint = this->well_state_.currentInjectionGroupControl(gname);
-                            }
+                        if (this->well_state_.hasInjectionGroupControl(Opm::Phase::WATER, gname)) {
+                            cgc.currentWaterInjectionConstraint = this->well_state_.currentInjectionGroupControl(Opm::Phase::WATER, gname);
                         }
-                        if (i_phase == Opm::Phase::GAS) {
-                            if (this->well_state_.hasInjectionGroupControl(gname)) {
-                                cgc.currentGasInjectionConstraint = this->well_state_.currentInjectionGroupControl(gname);
-                            }
+                        if (this->well_state_.hasInjectionGroupControl(Opm::Phase::GAS, gname)) {
+                            cgc.currentGasInjectionConstraint = this->well_state_.currentInjectionGroupControl(Opm::Phase::GAS, gname);
                         }
                     }
                     dw.emplace(gname, cgc);

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -36,6 +36,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp>
+//#include <opm/output/data/Groups.hpp>
 
 #include <opm/simulators/timestepping/SimulatorReport.hpp>
 #include <opm/simulators/wells/PerforationData.hpp>
@@ -183,8 +184,29 @@ namespace Opm {
 
             void initFromRestartFile(const RestartValue& restartValues);
 
+            /*Opm::data::Group groupData(const int reportStepIdx, Opm::Schedule& sched)
+            {
+                Opm::data::Group dw;
+                std::pair<const std::string, const Opm::Group::ProductionCMode> groupPCPair;
+                std::pair<const std::string, const Opm::Group::InjectionCMode> groupICPair;
+                for (const std::string gname :  sched.groupNames(reportStepIdx))  {
+                    if (this->well_state_.hasProductionGroupControl(gname)) {
+                       groupPCPair = std::make_pair(gname, this->well_state_.currentProductionGroupControl(gname));
+                        dw.currentProdConstraint.insert(groupPCPair);
+                    }
+                    if (this->well_state_.hasInjectionGroupControl(gname)) {
+                        groupICPair = std::make_pair(gname, this->well_state_.currentInjectionGroupControl(gname));
+                        dw.currentInjectionConstraint.insert(groupICPair);
+                    }
+                }
+                return dw;
+            } */
+
             Opm::data::Wells wellData() const
             { return well_state_.report(phase_usage_, Opm::UgGridHelpers::globalCell(grid())); }
+
+            //Opm::data::Group groupData(const int reportStepIdx) const
+            //{ return g_report(reportStepIdx); }
 
             // substract Binv(D)rw from r;
             void apply( BVector& r) const;
@@ -249,6 +271,7 @@ namespace Opm {
             WellInterfacePtr createWellForWellTest(const std::string& well_name, const int report_step, Opm::DeferredLogger& deferred_logger) const;
 
             WellState well_state_;
+
             WellState previous_well_state_;
             WellState well_state_nupcol_;
 

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -21,6 +21,8 @@
 #ifndef OPM_WELLGROUPHELPERS_HEADER_INCLUDED
 #define OPM_WELLGROUPHELPERS_HEADER_INCLUDED
 
+#include <opm/output/data/Groups.hpp>
+
 #include <vector>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
 
@@ -127,6 +129,33 @@ namespace Opm {
             std::ostringstream ss;
             setGroupControl(group, schedule, Phase::GAS, reportStepIdx, /*injector*/true, wellState, ss);
         }
+    }
+
+        Opm::data::Group getActiveCmodeGroup(const Group& group, const Schedule& schedule, const SummaryState& summaryState, const int reportStepIdx, WellStateFullyImplicitBlackoil& wellState) {
+
+        Opm::data::Group cagc;
+        std::pair<const std::string, const Opm::Group::ProductionCMode> groupPCPair;
+        std::pair<const std::string, const Opm::Group::InjectionCMode> groupICPair;
+
+        for (const std::string& groupName : group.groups()) {
+            Opm::data::Group cagc_tmp = getActiveCmodeGroup( schedule.getGroup(groupName, reportStepIdx), schedule, summaryState, reportStepIdx, wellState);
+            for (const auto& item : cagc_tmp.currentInjectionConstraint) {
+                    cagc.currentInjectionConstraint.insert(item);
+            }
+            for (const auto& item : cagc_tmp.currentProdConstraint) {
+                    cagc.currentProdConstraint.insert(item);
+            }
+        }
+
+        if (wellState.hasInjectionGroupControl(group.name())) {
+            groupICPair = std::make_pair(group.name(), wellState.currentInjectionGroupControl(group.name()));
+            cagc.currentInjectionConstraint.insert(groupICPair);
+        }
+        if (wellState.hasProductionGroupControl(group.name())) {
+            groupPCPair = std::make_pair(group.name(), wellState.currentProductionGroupControl(group.name()));
+            cagc.currentProdConstraint.insert(groupPCPair);
+        }
+
     }
 
 

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -131,34 +131,6 @@ namespace Opm {
         }
     }
 
-        Opm::data::Group getActiveCmodeGroup(const Group& group, const Schedule& schedule, const SummaryState& summaryState, const int reportStepIdx, WellStateFullyImplicitBlackoil& wellState) {
-
-        Opm::data::Group cagc;
-        std::pair<const std::string, const Opm::Group::ProductionCMode> groupPCPair;
-        std::pair<const std::string, const Opm::Group::InjectionCMode> groupICPair;
-
-        for (const std::string& groupName : group.groups()) {
-            Opm::data::Group cagc_tmp = getActiveCmodeGroup( schedule.getGroup(groupName, reportStepIdx), schedule, summaryState, reportStepIdx, wellState);
-            for (const auto& item : cagc_tmp.currentInjectionConstraint) {
-                    cagc.currentInjectionConstraint.insert(item);
-            }
-            for (const auto& item : cagc_tmp.currentProdConstraint) {
-                    cagc.currentProdConstraint.insert(item);
-            }
-        }
-
-        if (wellState.hasInjectionGroupControl(group.name())) {
-            groupICPair = std::make_pair(group.name(), wellState.currentInjectionGroupControl(group.name()));
-            cagc.currentInjectionConstraint.insert(groupICPair);
-        }
-        if (wellState.hasProductionGroupControl(group.name())) {
-            groupPCPair = std::make_pair(group.name(), wellState.currentProductionGroupControl(group.name()));
-            cagc.currentProdConstraint.insert(groupPCPair);
-        }
-
-    }
-
-
     inline void accumulateGroupEfficiencyFactor(const Group& group, const Schedule& schedule, const int reportStepIdx, double& factor) {
         factor *= group.getGroupEfficiencyFactor();
         if (group.parent() != "FIELD")

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -22,7 +22,9 @@
 
 #include <opm/core/props/BlackoilPhases.hpp>
 #include <opm/output/data/Wells.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+//#include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 #include <opm/simulators/wells/PerforationData.hpp>
 
 #include <array>
@@ -227,6 +229,7 @@ namespace Opm
     protected:
         std::vector<bool>   open_for_output_;
     private:
+
 
         WellMapType wellMap_;
 

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -24,7 +24,6 @@
 #include <opm/output/data/Wells.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
-//#include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 #include <opm/simulators/wells/PerforationData.hpp>
 
 #include <array>
@@ -229,7 +228,6 @@ namespace Opm
     protected:
         std::vector<bool>   open_for_output_;
     private:
-
 
         WellMapType wellMap_;
 

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -315,11 +315,11 @@ namespace Opm
         std::vector<Well::ProducerCMode>& currentProductionControls() { return current_production_controls_; }
         const std::vector<Well::ProducerCMode>& currentProductionControls() const { return current_production_controls_; }
 
-        bool hasProductionGroupControl(const std::string& groupName) {
+        bool hasProductionGroupControl(const std::string& groupName) const {
             return current_production_group_controls_.count(groupName) > 0;
         }
 
-        bool hasInjectionGroupControl(const Opm::Phase& phase, const std::string& groupName) {
+        bool hasInjectionGroupControl(const Opm::Phase& phase, const std::string& groupName) const {
             return current_injection_group_controls_.count(std::make_pair(phase, groupName)) > 0;
         }
 


### PR DESCRIPTION
This PR has changes that make parameters: currentProductionGroupControl and currentInjectionGroupControl available for writing Eclipse compatible restart files and for use as Summary file data. The content of the restart files will be changed as a consequence of using this information, to be included in a separate PR in opm-common.  

I would like to get this pull request merged soon since it is required to use together with other PRs for further work / improvment of the eclipse compatible restart files. 