### PR TITLE
Relperm diag no deck

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -552,7 +552,7 @@ protected:
 
         if (enableExperiments) {
             Opm::RelpermDiagnostics relpermDiagnostics;
-            relpermDiagnostics.diagnosis(*eclState_, *deck_, asImp_().grid());
+            relpermDiagnostics.diagnosis(*eclState_, asImp_().grid());
         }
     }
 private:

--- a/opm/core/props/satfunc/RelpermDiagnostics.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.hpp
@@ -29,7 +29,6 @@
 
 #include <opm/common/utility/numeric/linearInterpolation.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/MiscTable.hpp>
@@ -52,11 +51,9 @@ namespace Opm {
         ///eclipse data file. Errors and warings will be
         ///output if they're found.
         ///\param[in] eclState  eclipse state.
-        ///\param[in] deck      ecliplise data file.
         ///\param[in] grid      unstructured grid.
         template <class GridT>
         void diagnosis(const EclipseState& eclState,
-                       const Deck& deck,
                        const GridT& grid);
 
     private:
@@ -95,8 +92,7 @@ namespace Opm {
         void unscaledEndPointsCheck_(const EclipseState& eclState);
 
         template <class GridT>
-        void scaledEndPointsCheck_(const Deck& deck,
-                                   const EclipseState& eclState,
+        void scaledEndPointsCheck_(const EclipseState& eclState,
                                    const GridT& grid);
 
         ///For every table, need to deal with case by case.

--- a/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
@@ -33,7 +33,6 @@ namespace Opm {
 
     template <class GridT>
     void RelpermDiagnostics::diagnosis(const Opm::EclipseState& eclState,
-                                       const Opm::Deck& deck,
                                        const GridT& grid)
     {
         OpmLog::info("\n===============Saturation Functions Diagnostics===============\n");
@@ -41,12 +40,11 @@ namespace Opm {
         satFamilyCheck_(eclState);
         tableCheck_(eclState);
         unscaledEndPointsCheck_(eclState);
-        scaledEndPointsCheck_(deck, eclState, grid);
+        scaledEndPointsCheck_(eclState, grid);
     }
 
     template <class GridT>
-    void RelpermDiagnostics::scaledEndPointsCheck_(const Deck& deck,
-                                                   const EclipseState& eclState,
+    void RelpermDiagnostics::scaledEndPointsCheck_(const EclipseState& eclState,
                                                    const GridT& grid)
     {
         // All end points are subject to round-off errors, checks should account for it

--- a/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics_impl.hpp
@@ -55,6 +55,7 @@ namespace Opm {
         const auto& global_cell = Opm::UgGridHelpers::globalCell(grid);
         const auto dims = Opm::UgGridHelpers::cartDims(grid);
         const auto& compressedToCartesianIdx = Opm::compressedToCartesian(nc, global_cell);
+        const bool threepoint = eclState.runspec().endpointScaling().threepoint();
         scaledEpsInfo_.resize(nc);
         EclEpsGridProperties epsGridProperties(eclState, false);
         const std::string tag = "Scaled endpoints";
@@ -85,7 +86,7 @@ namespace Opm {
                 OpmLog::warning(tag, msg);
             }
 
-            if (deck.hasKeyword("SCALECRS") && fluidSystem_ == FluidSystem::BlackOil) {
+            if (threepoint && fluidSystem_ == FluidSystem::BlackOil) {
                 // Mobilility check.
 		    if ((scaledEpsInfo_[c].Sowcr + scaledEpsInfo_[c].Swcr) >= (1.0 + tolerance)) {
                     const std::string msg = "For scaled endpoints input, cell" + cellIdx + " SATNUM = " + satnumIdx + ", SOWCR + SWCR exceed 1.0";

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -454,7 +454,7 @@ namespace Opm
                     this->grid().switchToGlobalView();
                     static_cast<ParallelEclipseState&>(this->eclState()).switchToGlobalProps();
                 }
-                diagnostic.diagnosis(eclState(), deck(), this->grid());
+                diagnostic.diagnosis(eclState(), this->grid());
                 if (mpi_size_ > 1) {
                     this->grid().switchToDistributedView();
                     static_cast<ParallelEclipseState&>(this->eclState()).switchToDistributedProps();

--- a/tests/test_relpermdiagnostics.cpp
+++ b/tests/test_relpermdiagnostics.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(diagnosis)
     std::shared_ptr<CounterLog> counterLog = std::make_shared<CounterLog>(Log::DefaultMessageTypes);
     OpmLog::addBackend( "COUNTERLOG" , counterLog );
     RelpermDiagnostics diagnostics;
-    diagnostics.diagnosis(eclState, deck, grid);
+    diagnostics.diagnosis(eclState, grid);
     BOOST_CHECK_EQUAL(1, counterLog->numMessages(Log::MessageType::Warning));
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Use the [EndpointScaling](https://github.com/OPM/opm-common/blob/master/opm/parser/eclipse/EclipseState/EndpointScaling.hpp) instead of `deck.hasKeyword("SCALESRC")` in the relperm diagnostic. *This reduces deck usage.*

Observe that the semantic of the two is not 100% identical:

Old:
```
if (deck.hasKeyword("SCALESRC")) {
    // do stuff 
}
```

New:
```
if (deck.hasKeyword("SCALESRC")) {
   const auto& keyword = deck.getKeyword("SCALESRC");
   if (keyword.getRecord(0).getItem(0) == "YES") {
        // do stuff
    }
}
```
i.e. the `EndpointSCaling`based implementation checks the value of the `SCALESRC`keyword, which the old implementation ignored. 