### PR TITLE
fixed: do not build ParallelRestart test without MPI

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -37,7 +37,6 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/utils/DeferredLogger.cpp
   opm/simulators/utils/gatherDeferredLogger.cpp
   opm/simulators/utils/moduleVersion.cpp
-  opm/simulators/utils/ParallelEclipseState.cpp
   opm/simulators/utils/ParallelRestart.cpp
   opm/simulators/wells/VFPProdProperties.cpp
   opm/simulators/wells/VFPInjProperties.cpp
@@ -45,6 +44,9 @@ list (APPEND MAIN_SOURCE_FILES
 
 if(CUDA_FOUND)
   list (APPEND MAIN_SOURCE_FILES opm/simulators/linalg/bda/cusparseSolverBackend.cu)
+endif()
+if(MPI_FOUND)
+  list(APPEND MAIN_SOURCE_FILES opm/simulators/utils/ParallelEclipseState.cpp)
 endif()
 
 # originally generated with the command:
@@ -68,12 +70,12 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_stoppedwells.cpp
   tests/test_relpermdiagnostics.cpp
   tests/test_norne_pvt.cpp
-  tests/test_ParallelRestart.cpp
   tests/test_wellstatefullyimplicitblackoil.cpp
   )
 
 if(MPI_FOUND)
-  list(APPEND TEST_SOURCE_FILES tests/test_parallelistlinformation.cpp)
+  list(APPEND TEST_SOURCE_FILES tests/test_parallelistlinformation.cpp
+                                tests/test_ParallelRestart.cpp)
 endif()
 
 list (APPEND TEST_DATA_FILES

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -53,7 +53,6 @@
 #endif
 #include "eclwellmanager.hh"
 #include "eclequilinitializer.hh"
-#include "eclmpiserializer.hh"
 #include "eclwriter.hh"
 #include "ecloutputblackoilmodule.hh"
 #include "ecltransmissibility.hh"

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -20,8 +20,6 @@
 */
 #include "config.h"
 
-#include <ebos/eclmpiserializer.hh>
-
 #include <flow/flow_ebos_blackoil.hpp>
 
 #ifndef FLOW_BLACKOIL_ONLY
@@ -39,7 +37,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/FlowMainEbos.hpp>
 #include <opm/simulators/utils/moduleVersion.hpp>
-#include <opm/simulators/utils/ParallelEclipseState.hpp>
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
 #include <opm/simulators/flow/MissingFeatures.hpp>
@@ -69,6 +66,11 @@
 #include <dune/fem/misc/mpimanager.hh>
 #else
 #include <dune/common/parallel/mpihelper.hh>
+#endif
+
+#if HAVE_MPI
+#include <ebos/eclmpiserializer.hh>
+#include <opm/simulators/utils/ParallelEclipseState.hpp>
 #endif
 
 BEGIN_PROPERTIES

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -451,13 +451,17 @@ namespace Opm
             if (FluidSystem::numActivePhases() > 1) {
                 RelpermDiagnostics diagnostic;
                 if (mpi_size_ > 1) {
+#if HAVE_MPI
                     this->grid().switchToGlobalView();
                     static_cast<ParallelEclipseState&>(this->eclState()).switchToGlobalProps();
+#endif
                 }
                 diagnostic.diagnosis(eclState(), deck(), this->grid());
                 if (mpi_size_ > 1) {
+#if HAVE_MPI
                     this->grid().switchToDistributedView();
                     static_cast<ParallelEclipseState&>(this->eclState()).switchToDistributedProps();
+#endif
                 }
             }
         }


### PR DESCRIPTION
Argh, I always forget to check this!