### PR TITLE
Separate wellcontributions for gpu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,8 @@ if(NOT CMAKE_DISABLE_FIND_PACKAGE_CUDA AND
   # While the documentation says that it is deprecated, FindCUDA seems the
   # only easy way to determine the cublas and cusparse libraries.
   # Hence we call it unconditionally
-  find_package(CUDA)
+  # The WellContributions kernel uses __shfl_down_sync, which was introduced in CUDA 9.0
+  find_package(CUDA 9.0)
 endif()
 
 if(CUDA_FOUND)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -45,6 +45,7 @@ list (APPEND MAIN_SOURCE_FILES
 
 if(CUDA_FOUND)
   list (APPEND MAIN_SOURCE_FILES opm/simulators/linalg/bda/cusparseSolverBackend.cu)
+  list (APPEND MAIN_SOURCE_FILES opm/simulators/linalg/bda/WellContributions.cu)
 endif()
 
 # originally generated with the command:

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -29,7 +29,6 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/flow/MissingFeatures.cpp
   opm/simulators/linalg/ExtractParallelGridInformationToISTL.cpp
   opm/simulators/linalg/setupPropertyTree.cpp
-  opm/simulators/linalg/bda/BdaBridge.cpp
   opm/simulators/timestepping/TimeStepControl.cpp
   opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
   opm/simulators/timestepping/SimulatorTimer.cpp
@@ -46,6 +45,7 @@ list (APPEND MAIN_SOURCE_FILES
 if(CUDA_FOUND)
   list (APPEND MAIN_SOURCE_FILES opm/simulators/linalg/bda/cusparseSolverBackend.cu)
   list (APPEND MAIN_SOURCE_FILES opm/simulators/linalg/bda/WellContributions.cu)
+  list (APPEND MAIN_SOURCE_FILES opm/simulators/linalg/bda/BdaBridge.cpp)
 endif()
 
 # originally generated with the command:

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -140,6 +140,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/linalg/bda/BdaResult.hpp
   opm/simulators/linalg/bda/cuda_header.hpp
   opm/simulators/linalg/bda/cusparseSolverBackend.hpp
+  opm/simulators/linalg/bda/WellContributions.hpp
   opm/simulators/linalg/BlackoilAmg.hpp
   opm/simulators/linalg/BlackoilAmgCpr.hpp
   opm/simulators/linalg/amgcpr.hh

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -45,7 +45,9 @@
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
+#if HAVE_CUDA
 #include <opm/simulators/linalg/bda/BdaBridge.hpp>
+#endif
 
 BEGIN_PROPERTIES
 

--- a/opm/simulators/linalg/bda/BdaBridge.cpp
+++ b/opm/simulators/linalg/bda/BdaBridge.cpp
@@ -41,7 +41,6 @@ BdaBridge::BdaBridge(bool use_gpu_, int linear_solver_verbosity, int maxit, doub
 {
     if (use_gpu) {
         backend.reset(new cusparseSolverBackend(linear_solver_verbosity, maxit, tolerance));
-        WellContributions::setMode(use_gpu);
     }
 }
 #else

--- a/opm/simulators/linalg/bda/BdaBridge.cpp
+++ b/opm/simulators/linalg/bda/BdaBridge.cpp
@@ -128,6 +128,7 @@ void BdaBridge::solve_system(BridgeMatrix *mat OPM_UNUSED, BridgeVector &b OPM_U
         if (dim != 3) {
             OpmLog::warning("cusparseSolver only accepts blocksize = 3 at this time, will use Dune for the remainder of the program");
             use_gpu = false;
+            return;
         }
 
         if (h_rows.capacity() == 0) {

--- a/opm/simulators/linalg/bda/BdaBridge.cpp
+++ b/opm/simulators/linalg/bda/BdaBridge.cpp
@@ -41,6 +41,7 @@ BdaBridge::BdaBridge(bool use_gpu_, int linear_solver_verbosity, int maxit, doub
 {
     if (use_gpu) {
         backend.reset(new cusparseSolverBackend(linear_solver_verbosity, maxit, tolerance));
+        WellContributions::setMode(use_gpu);
     }
 }
 #else
@@ -121,7 +122,7 @@ void getSparsityPattern(BridgeMatrix& mat, std::vector<int> &h_rows, std::vector
 #endif
 
 template <class BridgeMatrix, class BridgeVector>
-void BdaBridge::solve_system(BridgeMatrix *mat OPM_UNUSED, BridgeVector &b OPM_UNUSED, InverseOperatorResult &res OPM_UNUSED)
+void BdaBridge::solve_system(BridgeMatrix *mat OPM_UNUSED, BridgeVector &b OPM_UNUSED, WellContributions& wellContribs OPM_UNUSED, InverseOperatorResult &res OPM_UNUSED)
 {
 
 #if HAVE_CUDA
@@ -169,7 +170,7 @@ void BdaBridge::solve_system(BridgeMatrix *mat OPM_UNUSED, BridgeVector &b OPM_U
 
         typedef cusparseSolverBackend::cusparseSolverStatus cusparseSolverStatus;
         // assume that underlying data (nonzeroes) from mat (Dune::BCRSMatrix) are contiguous, if this is not the case, cusparseSolver is expected to perform undefined behaviour
-        cusparseSolverStatus status = backend->solve_system(N, nnz, dim, static_cast<double*>(&(((*mat)[0][0][0][0]))), h_rows.data(), h_cols.data(), static_cast<double*>(&(b[0][0])), result);
+        cusparseSolverStatus status = backend->solve_system(N, nnz, dim, static_cast<double*>(&(((*mat)[0][0][0][0]))), h_rows.data(), h_cols.data(), static_cast<double*>(&(b[0][0])), wellContribs, result);
         switch(status) {
         case cusparseSolverStatus::CUSPARSE_SOLVER_SUCCESS:
             //OpmLog::info("cusparseSolver converged");
@@ -210,6 +211,7 @@ Dune::BCRSMatrix<Opm::MatrixBlock<double, 1, 1>, std::allocator<Opm::MatrixBlock
 Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > > \
 (Dune::BCRSMatrix<Opm::MatrixBlock<double, 1, 1>, std::allocator<Opm::MatrixBlock<double, 1, 1> > > *mat, \
     Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > &b, \
+    WellContributions& wellContribs, \
     InverseOperatorResult &res);
 
 template void BdaBridge::solve_system< \
@@ -217,6 +219,7 @@ Dune::BCRSMatrix<Opm::MatrixBlock<double, 2, 2>, std::allocator<Opm::MatrixBlock
 Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > > \
 (Dune::BCRSMatrix<Opm::MatrixBlock<double, 2, 2>, std::allocator<Opm::MatrixBlock<double, 2, 2> > > *mat, \
     Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > &b, \
+    WellContributions& wellContribs, \
     InverseOperatorResult &res);
 
 template void BdaBridge::solve_system< \
@@ -224,6 +227,7 @@ Dune::BCRSMatrix<Opm::MatrixBlock<double, 3, 3>, std::allocator<Opm::MatrixBlock
 Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > > \
 (Dune::BCRSMatrix<Opm::MatrixBlock<double, 3, 3>, std::allocator<Opm::MatrixBlock<double, 3, 3> > > *mat, \
     Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > &b, \
+    WellContributions& wellContribs, \
     InverseOperatorResult &res);
 
 template void BdaBridge::solve_system< \
@@ -231,6 +235,7 @@ Dune::BCRSMatrix<Opm::MatrixBlock<double, 4, 4>, std::allocator<Opm::MatrixBlock
 Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > > \
 (Dune::BCRSMatrix<Opm::MatrixBlock<double, 4, 4>, std::allocator<Opm::MatrixBlock<double, 4, 4> > > *mat, \
     Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > &b, \
+    WellContributions& wellContribs, \
     InverseOperatorResult &res);
 
 template void BdaBridge::get_result< \

--- a/opm/simulators/linalg/bda/BdaBridge.cpp
+++ b/opm/simulators/linalg/bda/BdaBridge.cpp
@@ -205,52 +205,52 @@ void BdaBridge::get_result(BridgeVector &x OPM_UNUSED) {
 #endif
 }
 
-template void BdaBridge::solve_system< \
-Dune::BCRSMatrix<Opm::MatrixBlock<double, 1, 1>, std::allocator<Opm::MatrixBlock<double, 1, 1> > > , \
-Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > > \
-(Dune::BCRSMatrix<Opm::MatrixBlock<double, 1, 1>, std::allocator<Opm::MatrixBlock<double, 1, 1> > > *mat, \
-    Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > &b, \
-    WellContributions& wellContribs, \
+template void BdaBridge::solve_system<
+Dune::BCRSMatrix<Opm::MatrixBlock<double, 1, 1>, std::allocator<Opm::MatrixBlock<double, 1, 1> > > ,
+Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > >
+(Dune::BCRSMatrix<Opm::MatrixBlock<double, 1, 1>, std::allocator<Opm::MatrixBlock<double, 1, 1> > > *mat,
+    Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > &b,
+    WellContributions& wellContribs,
     InverseOperatorResult &res);
 
-template void BdaBridge::solve_system< \
-Dune::BCRSMatrix<Opm::MatrixBlock<double, 2, 2>, std::allocator<Opm::MatrixBlock<double, 2, 2> > > , \
-Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > > \
-(Dune::BCRSMatrix<Opm::MatrixBlock<double, 2, 2>, std::allocator<Opm::MatrixBlock<double, 2, 2> > > *mat, \
-    Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > &b, \
-    WellContributions& wellContribs, \
+template void BdaBridge::solve_system<
+Dune::BCRSMatrix<Opm::MatrixBlock<double, 2, 2>, std::allocator<Opm::MatrixBlock<double, 2, 2> > > ,
+Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > >
+(Dune::BCRSMatrix<Opm::MatrixBlock<double, 2, 2>, std::allocator<Opm::MatrixBlock<double, 2, 2> > > *mat,
+    Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > &b,
+    WellContributions& wellContribs,
     InverseOperatorResult &res);
 
-template void BdaBridge::solve_system< \
-Dune::BCRSMatrix<Opm::MatrixBlock<double, 3, 3>, std::allocator<Opm::MatrixBlock<double, 3, 3> > > , \
-Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > > \
-(Dune::BCRSMatrix<Opm::MatrixBlock<double, 3, 3>, std::allocator<Opm::MatrixBlock<double, 3, 3> > > *mat, \
-    Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > &b, \
-    WellContributions& wellContribs, \
+template void BdaBridge::solve_system<
+Dune::BCRSMatrix<Opm::MatrixBlock<double, 3, 3>, std::allocator<Opm::MatrixBlock<double, 3, 3> > > ,
+Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > >
+(Dune::BCRSMatrix<Opm::MatrixBlock<double, 3, 3>, std::allocator<Opm::MatrixBlock<double, 3, 3> > > *mat,
+    Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > &b,
+    WellContributions& wellContribs,
     InverseOperatorResult &res);
 
-template void BdaBridge::solve_system< \
-Dune::BCRSMatrix<Opm::MatrixBlock<double, 4, 4>, std::allocator<Opm::MatrixBlock<double, 4, 4> > > , \
-Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > > \
-(Dune::BCRSMatrix<Opm::MatrixBlock<double, 4, 4>, std::allocator<Opm::MatrixBlock<double, 4, 4> > > *mat, \
-    Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > &b, \
-    WellContributions& wellContribs, \
+template void BdaBridge::solve_system<
+Dune::BCRSMatrix<Opm::MatrixBlock<double, 4, 4>, std::allocator<Opm::MatrixBlock<double, 4, 4> > > ,
+Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > >
+(Dune::BCRSMatrix<Opm::MatrixBlock<double, 4, 4>, std::allocator<Opm::MatrixBlock<double, 4, 4> > > *mat,
+    Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > &b,
+    WellContributions& wellContribs,
     InverseOperatorResult &res);
 
-template void BdaBridge::get_result< \
-Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > > \
+template void BdaBridge::get_result<
+Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > >
 (Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > &x);
 
-template void BdaBridge::get_result< \
-Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > > \
+template void BdaBridge::get_result<
+Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > >
 (Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > &x);
 
-template void BdaBridge::get_result< \
-Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > > \
+template void BdaBridge::get_result<
+Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > >
 (Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > &x);
 
-template void BdaBridge::get_result< \
-Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > > \
+template void BdaBridge::get_result<
+Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > >
 (Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > &x);
 
 

--- a/opm/simulators/linalg/bda/BdaBridge.cpp
+++ b/opm/simulators/linalg/bda/BdaBridge.cpp
@@ -35,7 +35,6 @@ typedef Dune::InverseOperatorResult InverseOperatorResult;
 namespace Opm
 {
 
-#if HAVE_CUDA
 BdaBridge::BdaBridge(bool use_gpu_, int linear_solver_verbosity, int maxit, double tolerance)
     : use_gpu(use_gpu_)
 {
@@ -43,15 +42,9 @@ BdaBridge::BdaBridge(bool use_gpu_, int linear_solver_verbosity, int maxit, doub
         backend.reset(new cusparseSolverBackend(linear_solver_verbosity, maxit, tolerance));
     }
 }
-#else
-BdaBridge::BdaBridge(bool use_gpu_ OPM_UNUSED, int linear_solver_verbosity OPM_UNUSED, int maxit OPM_UNUSED, double tolerance OPM_UNUSED)
-{
-}
-#endif
 
 
 
-#if HAVE_CUDA
 template <class BridgeMatrix>
 int checkZeroDiagonal(BridgeMatrix& mat) {
     static std::vector<typename BridgeMatrix::size_type> diag_indices;   // contains offsets of the diagonal nnzs
@@ -118,13 +111,11 @@ void getSparsityPattern(BridgeMatrix& mat, std::vector<int> &h_rows, std::vector
     }
 } // end getSparsityPattern()
 
-#endif
 
 template <class BridgeMatrix, class BridgeVector>
 void BdaBridge::solve_system(BridgeMatrix *mat OPM_UNUSED, BridgeVector &b OPM_UNUSED, WellContributions& wellContribs OPM_UNUSED, InverseOperatorResult &res OPM_UNUSED)
 {
 
-#if HAVE_CUDA
     if (use_gpu) {
         BdaResult result;
         result.converged = false;
@@ -192,17 +183,14 @@ void BdaBridge::solve_system(BridgeMatrix *mat OPM_UNUSED, BridgeVector &b OPM_U
     }else{
         res.converged = false;
     }
-#endif // HAVE_CUDA
 }
 
 
 template <class BridgeVector>
 void BdaBridge::get_result(BridgeVector &x OPM_UNUSED) {
-#if HAVE_CUDA
     if (use_gpu) {
         backend->post_process(static_cast<double*>(&(x[0][0])));
     }
-#endif
 }
 
 template void BdaBridge::solve_system<

--- a/opm/simulators/linalg/bda/BdaBridge.hpp
+++ b/opm/simulators/linalg/bda/BdaBridge.hpp
@@ -26,6 +26,8 @@
 #include "dune/istl/bcrsmatrix.hh"
 #include <opm/simulators/linalg/matrixblock.hh>
 
+#include <opm/simulators/linalg/bda/WellContributions.hpp>
+
 #if HAVE_CUDA
 #include <opm/simulators/linalg/bda/cusparseSolverBackend.hpp>
 #endif
@@ -55,11 +57,12 @@ public:
 
 
     /// Solve linear system, A*x = b
-    /// \param[in] mat     matrix A, should be of type Dune::BCRSMatrix
-    /// \param[in] b       vector b, should be of type Dune::BlockVector
-    /// \param[in] result  summary of solver result
+    /// \param[in] mat          matrix A, should be of type Dune::BCRSMatrix
+    /// \param[in] b            vector b, should be of type Dune::BlockVector
+    /// \param[in] wellContribs contains all WellContributions, to apply them separately, instead of adding them to matrix A
+    /// \param[inout] result    summary of solver result
     template <class BridgeMatrix, class BridgeVector>
-    void solve_system(BridgeMatrix *mat, BridgeVector &b, InverseOperatorResult &result);
+    void solve_system(BridgeMatrix *mat, BridgeVector &b, WellContributions& wellContribs, InverseOperatorResult &result);
 
     /// Get the resulting x vector
     /// \param[inout] x    vector x, should be of type Dune::BlockVector

--- a/opm/simulators/linalg/bda/BdaBridge.hpp
+++ b/opm/simulators/linalg/bda/BdaBridge.hpp
@@ -21,6 +21,11 @@
 #define BDABRIDGE_HEADER_INCLUDED
 
 #include <config.h>
+
+#if ! HAVE_CUDA
+  #error "This file should only be included if CUDA is found"
+#endif
+
 #include "dune/istl/solver.hh" // for struct InverseOperatorResult
 
 #include "dune/istl/bcrsmatrix.hh"
@@ -28,9 +33,7 @@
 
 #include <opm/simulators/linalg/bda/WellContributions.hpp>
 
-#if HAVE_CUDA
 #include <opm/simulators/linalg/bda/cusparseSolverBackend.hpp>
-#endif
 
 namespace Opm
 {
@@ -42,10 +45,8 @@ typedef Dune::InverseOperatorResult InverseOperatorResult;
 class BdaBridge
 {
 private:
-#if HAVE_CUDA
     std::unique_ptr<cusparseSolverBackend> backend;
     bool use_gpu;
-#endif
 
 public:
     /// Construct a BdaBridge

--- a/opm/simulators/linalg/bda/BdaBridge.hpp
+++ b/opm/simulators/linalg/bda/BdaBridge.hpp
@@ -69,6 +69,12 @@ public:
     template <class BridgeVector>
     void get_result(BridgeVector &x);
 
+    /// Return whether the BdaBridge will use the GPU or not
+    /// return whether the BdaBridge will use the GPU or not
+    bool getUseGpu(){
+        return use_gpu;
+    }
+
 }; // end class BdaBridge
 
 }

--- a/opm/simulators/linalg/bda/WellContributions.cu
+++ b/opm/simulators/linalg/bda/WellContributions.cu
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Equinor ASA
+  Copyright 2020 Equinor ASA
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/simulators/linalg/bda/WellContributions.cu
+++ b/opm/simulators/linalg/bda/WellContributions.cu
@@ -50,7 +50,6 @@ namespace Opm
     {
         const int idx_b = blockIdx.x;
         const int idx_t = threadIdx.x;
-        int idx = idx_b * blockDim.x + idx_t;
         const unsigned int val_size = val_pointers[idx_b+1] - val_pointers[idx_b];
 
         const int vals_per_block = dim * dim_wells;        // 12
@@ -59,7 +58,6 @@ namespace Opm
         const int lane = idx_t % 32;
         const int c = lane % dim;                           // col in block
         const int r = (lane / dim) % dim_wells;             // row in block
-        const int NUM_THREADS = gridDim.x * blockDim.x;
 
         extern __shared__ double smem[];
         double * __restrict__ z1 = smem;

--- a/opm/simulators/linalg/bda/WellContributions.cu
+++ b/opm/simulators/linalg/bda/WellContributions.cu
@@ -27,13 +27,14 @@
 #include <cuda_runtime.h>
 #endif
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include "opm/simulators/linalg/bda/WellContributions.hpp"
 
 namespace Opm
 {
 
     // apply WellContributions using y -= C^T * (D^-1 * (B * x))
-#if HAVE_CUDA
     __global__ void apply_well_contributions(
         const double * __restrict__ Cnnzs,
         const double * __restrict__ Dnnzs,
@@ -127,7 +128,6 @@ namespace Opm
         }
 
     }
-#endif
 
 
         void WellContributions::alloc(){

--- a/opm/simulators/linalg/bda/WellContributions.cu
+++ b/opm/simulators/linalg/bda/WellContributions.cu
@@ -161,20 +161,21 @@ namespace Opm
     }
 
 
-    void WellContributions::addMatrix(int idx, int *colIndices, double *values, unsigned int val_size)
+    void WellContributions::addMatrix(MatrixType type, int *colIndices, double *values, unsigned int val_size)
     {
         if (!allocated) {
             OPM_THROW(std::logic_error,"Error cannot add wellcontribution before allocating memory in WellContributions");
         }
-        switch (idx) {
-        case 0:
+
+        switch (type) {
+        case MatrixType::C:
             cudaMemcpy(d_Cnnzs + num_blocks_so_far * dim * dim_wells, values, sizeof(double) * val_size * dim * dim_wells, cudaMemcpyHostToDevice);
             cudaMemcpy(d_Ccols + num_blocks_so_far, colIndices, sizeof(int) * val_size, cudaMemcpyHostToDevice);
             break;
-        case 1:
+        case MatrixType::D:
             cudaMemcpy(d_Dnnzs + num_wells_so_far * dim_wells * dim_wells, values, sizeof(double) * dim_wells * dim_wells, cudaMemcpyHostToDevice);
             break;
-        case 2:
+        case MatrixType::B:
             cudaMemcpy(d_Bnnzs + num_blocks_so_far * dim * dim_wells, values, sizeof(double) * val_size * dim * dim_wells, cudaMemcpyHostToDevice);
             cudaMemcpy(d_Bcols + num_blocks_so_far, colIndices, sizeof(int) * val_size, cudaMemcpyHostToDevice);
             val_pointers[num_wells_so_far] = num_blocks_so_far;
@@ -187,10 +188,8 @@ namespace Opm
             OPM_THROW(std::logic_error,"Error unsupported matrix ID for WellContributions::addMatrix()");
         }
         cudaCheckLastError("WellContributions::addMatrix() failed");
-        if(idx == 2){
+        if (MatrixType::B == type) {
             num_blocks_so_far += val_size;
-        }
-        if(idx == 2){
             num_wells_so_far++;
         }
     }

--- a/opm/simulators/linalg/bda/WellContributions.cu
+++ b/opm/simulators/linalg/bda/WellContributions.cu
@@ -34,17 +34,17 @@ namespace Opm
 
     // apply WellContributions using y -= C^T * (D^-1 * (B * x))
 #if HAVE_CUDA
-    __global__ void apply_well_contributions( \
-        const double * __restrict__ Cnnzs, \
-        const double * __restrict__ Dnnzs, \
-        const double * __restrict__ Bnnzs, \
-        const int * __restrict__ Ccols, \
-        const int * __restrict__ Bcols, \
-        const double * __restrict__ x, \
-        double * __restrict__ y, \
-        const int dim, \
-        const int dim_wells, \
-        const unsigned int * __restrict__ val_pointers \
+    __global__ void apply_well_contributions(
+        const double * __restrict__ Cnnzs,
+        const double * __restrict__ Dnnzs,
+        const double * __restrict__ Bnnzs,
+        const int * __restrict__ Ccols,
+        const int * __restrict__ Bcols,
+        const double * __restrict__ x,
+        double * __restrict__ y,
+        const int dim,
+        const int dim_wells,
+        const unsigned int * __restrict__ val_pointers
         )
     {
         const int idx_b = blockIdx.x;
@@ -182,14 +182,8 @@ namespace Opm
                 }
                 cudaMemcpy(d_val_pointers, val_pointers, sizeof(int) * (num_wells+1), cudaMemcpyHostToDevice);
                 break;
-            case 3:
-                // store (C*D*B)
-                printf("ERROR unsupported matrix ID for WellContributions::addMatrix()\n");
-                exit(1);
-                break;
             default:
-                printf("ERROR unknown matrix ID for WellContributions::addMatrix()\n");
-                exit(1);
+                OPM_THROW(std::logic_error,"Error unsupported matrix ID for WellContributions::addMatrix()");
             }
             cudaCheckLastError("WellContributions::addMatrix() failed");
             if(idx == 2){
@@ -209,8 +203,7 @@ namespace Opm
         void WellContributions::addSizes(unsigned int nnz, unsigned int numEq, unsigned int numWellEq)
         {
             if(allocated){
-                std::cerr << "Error cannot add more sizes after allocated in WellContributions" << std::endl;
-                exit(1);
+                OPM_THROW(std::logic_error,"Error cannot add more sizes after allocated in WellContributions");
             }
             num_blocks += nnz;
             dim = numEq;

--- a/opm/simulators/linalg/bda/WellContributions.cu
+++ b/opm/simulators/linalg/bda/WellContributions.cu
@@ -1,0 +1,420 @@
+/*
+  Copyright 2019 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <cstdlib>
+#include <cstring>
+#include <config.h> // CMake
+
+#ifdef __NVCC__
+#include "opm/simulators/linalg/bda/cuda_header.hpp"
+#include <cuda_runtime.h>
+#endif
+
+#include "opm/simulators/linalg/bda/WellContributions.hpp"
+
+namespace Opm
+{
+
+    // apply WellContributions using y -= C^T * (D^-1 * (B * x))
+#if HAVE_CUDA
+    __global__ void apply_well_contributions( \
+        const double * __restrict__ Cnnzs, \
+        const double * __restrict__ Dnnzs, \
+        const double * __restrict__ Bnnzs, \
+        const int * __restrict__ Ccols, \
+        const int * __restrict__ Bcols, \
+        const double * __restrict__ x, \
+        double * __restrict__ y, \
+        const int dim, \
+        const int dim_wells, \
+        const unsigned int * __restrict__ val_pointers \
+        )
+    {
+        const int idx_b = blockIdx.x;
+        const int idx_t = threadIdx.x;
+        int idx = idx_b * blockDim.x + idx_t;
+        const unsigned int val_size = val_pointers[idx_b+1] - val_pointers[idx_b];
+
+        const int vals_per_block = dim * dim_wells;        // 12
+        const int num_active_threads = (32/vals_per_block)*vals_per_block; // 24
+        const int num_blocks_per_warp = 32/vals_per_block; // 2
+        const int lane = idx_t % 32;
+        const int c = lane % dim;                           // col in block
+        const int r = (lane / dim) % dim_wells;             // row in block
+        const int NUM_THREADS = gridDim.x * blockDim.x;
+
+        extern __shared__ double smem[];
+        double * __restrict__ z1 = smem;
+        double * __restrict__ z2 = z1 + dim_wells;
+
+        if(idx_t < dim_wells){
+            z1[idx_t] = 0.0;
+        }
+
+        __syncthreads();
+
+        // z1 = B * x
+        if(idx_t < num_active_threads){
+            // multiply all blocks with x
+            double temp = 0.0;
+            int b = idx_t / vals_per_block + val_pointers[idx_b];       // block id, val_size indicates number of blocks
+            while(b < val_size + val_pointers[idx_b]){
+                int colIdx = Bcols[b];
+                temp += Bnnzs[b * dim * dim_wells + r * dim + c] * x[colIdx * dim + c];
+                b += num_blocks_per_warp;
+            }
+
+            // merge all blocks into 1 dim*dim_wells block
+            // since NORNE has only 2 parallel blocks, do not use a loop
+            temp += __shfl_down_sync(0x00ffffff, temp, dim * dim_wells);
+
+            b = idx_t / vals_per_block + val_pointers[idx_b];
+
+            // merge all (dim) columns of 1 block, results in a single 1*dim_wells vector, which is used to multiply with invD
+            if(idx_t < vals_per_block){
+                // should be a loop as well, now only works for dim == 3
+                if(c == 0 || c == 2){temp += __shfl_down_sync(0x00000B6D, temp, 2);}  // add col 2 to col 0
+                if(c == 0 || c == 1){temp += __shfl_down_sync(0x000006DB, temp, 1);}  // add col 1 to col 0
+            }
+
+            // write 1*dim_wells vector to gmem, could be replaced with shfl broadcast to remove z1 altogether
+            if(c == 0 && idx_t < vals_per_block){
+                z1[r] = temp;
+            }
+        }
+
+        __syncthreads();
+
+        // z2 = D^-1 * B * x = D^-1 * z1
+        if(idx_t < dim_wells){
+            double temp = 0.0;
+            for(int c = 0; c < dim_wells; ++c){
+                temp += Dnnzs[idx_b * dim_wells * dim_wells + idx_t * dim_wells + c] * z1[c];
+            }
+            z2[idx_t] = temp;
+        }
+
+        __syncthreads();
+
+        // y -= C^T * D^-1 * B * x
+        // use dim * val_size threads, each block is assigned 'dim' threads
+        if(idx_t < dim * val_size){
+            double temp = 0.0;
+            int b = idx_t / dim + val_pointers[idx_b];
+            int cc = idx_t % dim;
+            int colIdx = Ccols[b];
+            for(unsigned int c = 0; c < dim_wells; ++c){
+                temp += Cnnzs[b * dim * dim_wells + c * dim + cc] * z2[c];
+            }
+            y[colIdx * dim + cc] -= temp;
+        }
+
+    }
+#endif
+
+        void WellContributions::alloc_all(){
+#if HAVE_CUDA
+            if(gpu_mode){
+                alloc_gpu();
+            }else{
+                alloc_cpu();
+            }
+#else
+            alloc_cpu();
+#endif
+            allocated = true;
+        }
+
+        void WellContributions::alloc_cpu(){
+            Cnnzs = new double[num_blocks * dim * dim_wells];
+            Dnnzs = new double[num_wells * dim_wells * dim_wells];
+            Bnnzs = new double[num_blocks * dim * dim_wells];
+            Ccols = new int[num_blocks];
+            Bcols = new int[num_blocks];
+            val_pointers = new unsigned int[num_wells + 1];
+            z1 = new double[dim_wells];    //        B * x
+            z2 = new double[dim_wells];    // D^-1 * B * x
+        }
+
+#if HAVE_CUDA
+        void WellContributions::alloc_gpu(){
+            cudaMalloc((void**)&d_Cnnzs, sizeof(double) * num_blocks * dim * dim_wells);
+            cudaMalloc((void**)&d_Dnnzs, sizeof(double) * num_wells * dim_wells * dim_wells);
+            cudaMalloc((void**)&d_Bnnzs, sizeof(double) * num_blocks * dim * dim_wells);
+            cudaMalloc((void**)&d_Ccols, sizeof(int) * num_blocks);
+            cudaMalloc((void**)&d_Bcols, sizeof(int) * num_blocks);
+            val_pointers = new unsigned int[num_wells + 1];
+            cudaMalloc((void**)&d_val_pointers, sizeof(int) * (num_wells + 1));
+            cudaCheckLastError("apply_gpu malloc failed");
+        }
+#endif
+
+        WellContributions::~WellContributions()
+        {
+#if HAVE_CUDA
+            if(gpu_mode){
+                free_gpu();
+            }else{
+                free_cpu();
+            }
+#else
+            free_cpu();
+#endif
+        }
+
+        void WellContributions::free_cpu(){
+            delete[] Cnnzs;
+            delete[] Dnnzs;
+            delete[] Bnnzs;
+            delete[] Ccols;
+            delete[] Bcols;
+            delete[] val_pointers;
+            delete[] z1;
+            delete[] z2;
+            //delete[] Mnnzs;
+        }
+
+#if HAVE_CUDA
+        void WellContributions::free_gpu(){
+            cudaFree(d_Cnnzs);
+            cudaFree(d_Dnnzs);
+            cudaFree(d_Bnnzs);
+            cudaFree(d_Ccols);
+            cudaFree(d_Bcols);
+            delete[] val_pointers;
+            cudaFree(d_val_pointers);
+            // cudaFree(d_z1);
+            // cudaFree(d_z2);
+        }
+#endif
+
+
+        void WellContributions::apply(double *x, double *y){
+#if HAVE_CUDA
+            if (gpu_mode){
+                apply_gpu(x, y);
+            }else{
+                apply_cpu(x, y);
+            }
+#else
+            apply_cpu(x, y);
+#endif
+        }
+
+        // Apply the WellContributions, similar to StandardWell::apply()
+        // y -= (C^T *(D^-1*(   B*x)))
+        void WellContributions::apply_cpu(double *x, double *y)
+        {
+#if 0
+            // Mnnzs contains a sparse matrix with a symmetric pattern
+            // Mrows would contain 'i*val_size' for every entry i, since every row has the same number of blocks
+            // Mcols are the same as Ccols, normally, there is an entry for every block, but since all rows have the same sparsity pattern, we only have to store 1 row
+            bool dbg = false;
+            for(int i = 0; i < dim*dim*val_size*val_size; ++i){
+                if(dbg)printf("Mnnzs[%d]: %.5e\n", i, Mnnzs[i]);
+            }
+            if(dbg)printf("row_size: %u, val_size: %u\n", row_size, val_size);
+            for(int r = 0; r < val_size; ++r){
+                for(int c = 0; c < val_size; ++c){
+                    int colIdx = Ccols[c];
+                    if(dbg)printf("colIdx: %d\n", colIdx);
+                    for(int i = 0; i < dim; ++i){
+                        double sum = 0.0;
+                        for(int j = 0; j < dim; ++j){
+                            sum += Mnnzs[r * dim * dim * val_size + c * dim * dim + i * dim + j] * x[colIdx * dim + j];
+                        }
+                        if(dbg)printf("sum: %f\n", sum);
+                        y[colIdx * dim + i] -= sum;
+                    }
+                }
+            }
+            if(dbg)exit(0);
+#else
+            for(int wellID = 0; wellID < num_wells; ++wellID){
+                unsigned int val_size = val_pointers[wellID+1] - val_pointers[wellID];
+
+                // B * x
+                for (unsigned int i = 0; i < dim_wells; ++i) {
+                    z1[i] = 0.0;
+                }
+                for (unsigned int i = 0; i < val_size; ++i) {
+                    unsigned int blockID = i + val_pointers[wellID];
+                    int colIdx = Bcols[blockID];
+                    for (unsigned int j = 0; j < dim_wells; ++j) {
+                        double temp = 0.0;
+                        for (unsigned int k = 0; k < dim; ++k) {
+                            temp += Bnnzs[blockID * dim * dim_wells + j * dim + k] * x[colIdx * dim + k];
+                        }
+                        z1[j] += temp;
+                    }
+                }
+
+                // D^-1 * B * x
+                for (unsigned int i = 0; i < dim_wells; ++i) {
+                    z2[i] = 0.0;
+                }
+                for (unsigned int j = 0; j < dim_wells; ++j) {
+                    double temp = 0.0;
+                    for (unsigned int k = 0; k < dim_wells; ++k) {
+                        temp += Dnnzs[wellID * dim_wells * dim_wells + j * dim_wells + k] * z1[k];
+                    }
+                    z2[j] += temp;
+                }
+
+                // C^T * D^-1 * B * x
+                for (unsigned int i = 0; i < val_size; ++i) {
+                    unsigned int blockID = i + val_pointers[wellID];
+                    int colIdx = Ccols[blockID];
+                    for (unsigned int j = 0; j < dim; ++j) {
+                        double temp = 0.0;
+                        for (unsigned int k = 0; k < dim_wells; ++k) {
+                            temp += Cnnzs[blockID * dim * dim_wells + j + k * dim] * z2[k];
+                        }
+                        y[colIdx * dim + j] -= temp;
+                    }
+                }
+            }
+#endif
+        }
+
+
+        // Apply the WellContributions, similar to StandardWell::apply()
+        // y -= (C^T *(D^-1*(   B*x)))
+#if HAVE_CUDA
+        void WellContributions::apply_gpu(double *d_x, double *d_y)
+        {
+            int smem_size = 2 * sizeof(double) * dim_wells;
+            apply_well_contributions<<<num_wells, 32, smem_size, stream>>>(d_Cnnzs, d_Dnnzs, d_Bnnzs, d_Ccols, d_Bcols, d_x, d_y, dim, dim_wells, d_val_pointers);
+        }
+#endif
+
+        void WellContributions::addMatrix(int idx, int *colIndices, double *values, unsigned int val_size)
+        {
+#if HAVE_CUDA
+            if(gpu_mode){
+                addMatrix_gpu(idx, colIndices, values, val_size);
+            }else{
+                addMatrix_cpu(idx, colIndices, values, val_size);
+            }
+#else
+            addMatrix_cpu(idx, colIndices, values, val_size);
+#endif
+            if(idx == 2){
+                num_blocks_so_far += val_size;
+            }
+            if(idx == 2){
+                num_wells_so_far++;
+            }
+        }
+
+
+        void WellContributions::addMatrix_cpu(int idx, int *colIndices, double *values, unsigned int val_size)
+        {
+            switch (idx) {
+            case 0:
+                memcpy(Cnnzs + num_blocks_so_far * dim * dim_wells, values, sizeof(double) * val_size * dim * dim_wells);
+                memcpy(Ccols + num_blocks_so_far, colIndices, sizeof(int) * val_size);
+                break;
+            case 1:
+                memcpy(Dnnzs + num_wells_so_far * dim_wells * dim_wells, values, sizeof(double) * dim_wells * dim_wells);
+                break;
+            case 2:
+                memcpy(Bnnzs + num_blocks_so_far * dim * dim_wells, values, sizeof(double) * val_size * dim * dim_wells);
+                memcpy(Bcols + num_blocks_so_far, colIndices, sizeof(int) * val_size);
+                val_pointers[num_wells_so_far] = num_blocks_so_far;
+                if(num_wells_so_far == num_wells - 1){
+                    val_pointers[num_wells] = num_blocks;
+                }
+                break;
+            case 3:
+                // store (C*D*B)
+                printf("ERROR unsupported matrix ID for WellContributions::addMatrix()\n");
+                exit(1);
+                // memcpy(Mnnzs, values, sizeof(double) * dim * dim * val_size * val_size);
+                // memcpy(Ccols, colIndices, sizeof(int) * val_size);
+                break;
+            default:
+                printf("ERROR unknown matrix ID for WellContributions::addMatrix()\n");
+                exit(1);
+            }
+        }
+
+
+#if HAVE_CUDA
+        void WellContributions::addMatrix_gpu(int idx, int *colIndices, double *values, unsigned int val_size)
+        {
+            switch (idx) {
+            case 0:
+                cudaMemcpy(d_Cnnzs + num_blocks_so_far * dim * dim_wells, values, sizeof(double) * val_size * dim * dim_wells, cudaMemcpyHostToDevice);
+                cudaMemcpy(d_Ccols + num_blocks_so_far, colIndices, sizeof(int) * val_size, cudaMemcpyHostToDevice);
+                break;
+            case 1:
+                cudaMemcpy(d_Dnnzs + num_wells_so_far * dim_wells * dim_wells, values, sizeof(double) * dim_wells * dim_wells, cudaMemcpyHostToDevice);
+                break;
+            case 2:
+                cudaMemcpy(d_Bnnzs + num_blocks_so_far * dim * dim_wells, values, sizeof(double) * val_size * dim * dim_wells, cudaMemcpyHostToDevice);
+                cudaMemcpy(d_Bcols + num_blocks_so_far, colIndices, sizeof(int) * val_size, cudaMemcpyHostToDevice);
+                val_pointers[num_wells_so_far] = num_blocks_so_far;
+                if(num_wells_so_far == num_wells - 1){
+                    val_pointers[num_wells] = num_blocks;
+                }
+                cudaMemcpy(d_val_pointers, val_pointers, sizeof(int) * (num_wells+1), cudaMemcpyHostToDevice);
+                break;
+            case 3:
+                // store (C*D*B)
+                printf("ERROR unsupported matrix ID for WellContributions::addMatrix()\n");
+                exit(1);
+                break;
+            default:
+                printf("ERROR unknown matrix ID for WellContributions::addMatrix()\n");
+                exit(1);
+            }
+            cudaCheckLastError("WellContributions::addMatrix() failed");
+        }
+
+        void WellContributions::setCudaStream(cudaStream_t stream_)
+        {
+            this->stream = stream_;
+        }
+
+#endif
+
+        void WellContributions::addSizes(unsigned int nnz, unsigned int numEq, unsigned int numWellEq)
+        {
+            if(allocated){
+                std::cerr << "Error cannot add more sizes after allocated in WellContributions" << std::endl;
+                exit(1);
+            }
+            num_blocks += nnz;
+            dim = numEq;
+            dim_wells = numWellEq;
+            num_wells++;
+        }
+
+        // Default value
+        bool WellContributions::gpu_mode = false;
+
+        // If HAVE_CUDA is false, use_gpu must be false too
+        void WellContributions::setMode(bool use_gpu){
+            gpu_mode = use_gpu;
+        }
+
+} //namespace Opm
+

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Equinor ASA
+  Copyright 2020 Equinor ASA
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -1,0 +1,136 @@
+/*
+  Copyright 2019 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef WellContributions_H
+#define WellContributions_H
+
+#include <vector>
+
+#if HAVE_CUDA
+#include <cuda_runtime.h>
+#endif
+
+#include <config.h>
+
+namespace Opm
+{
+
+    /// This class serves to eliminate the need to include the WellContributions into the matrix (with --matrix-add-well-contributions=true) for the cusparseSolver
+    /// If the --matrix-add-well-contributions commandline parameter is true, this class should not be used
+    class WellContributions
+    {
+
+    private:
+        static bool gpu_mode;     // gpu_mode should be initialized in the ISTLSolverEbos constructor, and its value must not change afterwards
+        unsigned int num_blocks = 0;    // total number of blocks in all wells
+        unsigned int dim;
+        unsigned int dim_wells;
+        unsigned int num_wells = 0;
+        unsigned int num_blocks_so_far = 0;
+        unsigned int num_wells_so_far = 0;
+        unsigned int *val_pointers = nullptr;     // val_pointers[wellID] == index of first block for this well in Ccols and Bcols
+        bool allocated = false;
+
+#if HAVE_CUDA
+        double *d_Cnnzs = nullptr;
+        double *d_Dnnzs = nullptr;
+        double *d_Bnnzs = nullptr;
+        int *d_Ccols = nullptr;
+        int *d_Bcols = nullptr;
+        double *d_z1 = nullptr;
+        double *d_z2 = nullptr;
+        unsigned int *d_val_pointers = nullptr;
+        cudaStream_t stream;
+#endif
+
+        double *Cnnzs = nullptr;
+        double *Dnnzs = nullptr;
+        double *Bnnzs = nullptr;
+        int *Ccols = nullptr;
+        int *Dcols = nullptr;
+        int *Bcols = nullptr;
+        double *z1 = nullptr;                // z1 = B * x
+        double *z2 = nullptr;                // z2 = D^-1 * B * x
+
+        /// Apply the WellContributions on CPU
+        void apply_cpu(double *x, double *y);
+
+        /// Allocate memory on the CPU
+        void alloc_cpu();
+
+        /// Free memory on the CPU
+        void free_cpu();
+
+        /// Same as addMatrix(), stores matrix on CPU
+        void addMatrix_cpu(int idx, int *colIndices, double *values, unsigned int val_size);
+
+#if HAVE_CUDA
+        /// Apply all wellcontributions on GPU, performs y -= C^T * (D^-1 * (B * x))
+        /// Kernel is asynchronous
+        void apply_gpu(double *d_x, double *d_y);
+
+        /// Allocate memory on the GPU
+        void alloc_gpu();
+
+        /// Free memory on the GPU
+        void free_gpu();
+
+        /// Same as addMatrix(), stores matrix on GPU
+        void addMatrix_gpu(int idx, int *colIndices, double *values, unsigned int val_size);
+#endif
+
+    public:
+#if HAVE_CUDA
+        /// Set a cudaStream to be used
+        /// \param[in] stream           the cudaStream that is used to launch the kernel in
+        void setCudaStream(cudaStream_t stream);
+#endif
+
+        /// Create a new WellContributions, implementation is empty
+        WellContributions(){};
+
+        /// Destroy a WellContributions, and free memory
+        ~WellContributions();
+
+        /// Apply all wellcontributions in this object
+        void apply(double *x, double *y);
+
+        /// Allocate memory for the wellcontributions
+        void alloc_all();
+
+        /// Indicate how large the next wellcontributions are, this function cannot be called after alloc_all() is called
+        void addSizes(unsigned int nnz, unsigned int numEq, unsigned int numWellEq);
+
+        /// Store a matrix in this object, in blocked csr format
+        void addMatrix(int idx, int *colIndices, double *values, unsigned int val_size);
+
+        /// Return the number of wells added to this object
+        unsigned int get_num_wells(){
+            return num_wells;
+        }
+
+        /// WellContributions can be applied on CPU or GPU
+        /// This function sets the static variable, so each WellContributions is applied on the correct hardware
+        static void setMode(bool use_gpu);
+
+    };
+
+} //namespace Opm
+
+#endif

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -17,16 +17,18 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef WellContributions_H
-#define WellContributions_H
+#ifndef WELLCONTRIBUTIONS_HEADER_INCLUDED
+#define WELLCONTRIBUTIONS_HEADER_INCLUDED
+
+#include <config.h>
+
+#if ! HAVE_CUDA
+  #error "This file should only be included if CUDA is found"
+#endif
 
 #include <vector>
 
-#if HAVE_CUDA
 #include <cuda_runtime.h>
-#endif
-
-#include <config.h>
 
 namespace Opm
 {
@@ -46,7 +48,6 @@ namespace Opm
         unsigned int *val_pointers = nullptr;     // val_pointers[wellID] == index of first block for this well in Ccols and Bcols
         bool allocated = false;
 
-#if HAVE_CUDA
         double *d_Cnnzs = nullptr;
         double *d_Dnnzs = nullptr;
         double *d_Bnnzs = nullptr;
@@ -56,23 +57,10 @@ namespace Opm
         double *d_z2 = nullptr;
         unsigned int *d_val_pointers = nullptr;
         cudaStream_t stream;
-#endif
-
-        double *Cnnzs = nullptr;
-        double *Dnnzs = nullptr;
-        double *Bnnzs = nullptr;
-        int *Ccols = nullptr;
-        int *Dcols = nullptr;
-        int *Bcols = nullptr;
-        double *z1 = nullptr;                // z1 = B * x
-        double *z2 = nullptr;                // z2 = D^-1 * B * x
-
     public:
-#if HAVE_CUDA
         /// Set a cudaStream to be used
         /// \param[in] stream           the cudaStream that is used to launch the kernel in
         void setCudaStream(cudaStream_t stream);
-#endif
 
         /// Create a new WellContributions, implementation is empty
         WellContributions(){};
@@ -93,7 +81,7 @@ namespace Opm
         void addMatrix(int idx, int *colIndices, double *values, unsigned int val_size);
 
         /// Return the number of wells added to this object
-        unsigned int get_num_wells(){
+        unsigned int getNumWells(){
             return num_wells;
         }
 

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -68,6 +68,14 @@ namespace Opm
         unsigned int *d_val_pointers = nullptr;
         cudaStream_t stream;
     public:
+
+        /// StandardWell has C, D and B matrices that need to be copied
+        enum class MatrixType {
+            C,
+            D,
+            B
+        };
+
         /// Set a cudaStream to be used
         /// \param[in] stream           the cudaStream that is used to launch the kernel in
         void setCudaStream(cudaStream_t stream);
@@ -97,11 +105,11 @@ namespace Opm
         void addNumBlocks(unsigned int numBlocks);
 
         /// Store a matrix in this object, in blocked csr format, can only be called after alloc() is called
-        /// \param[in] idx         indicate if C, D or B is sent
+        /// \param[in] type        indicate if C, D or B is sent
         /// \param[in] colIndices  columnindices of blocks in C or B, ignored for D
         /// \param[in] values      array of nonzeroes
         /// \param[in] val_size    number of blocks in C or B, ignored for D
-        void addMatrix(int idx, int *colIndices, double *values, unsigned int val_size);
+        void addMatrix(MatrixType type, int *colIndices, double *values, unsigned int val_size);
 
         /// Return the number of wells added to this object
         /// \return the number of wells added to this object

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -35,17 +35,27 @@ namespace Opm
 
     /// This class serves to eliminate the need to include the WellContributions into the matrix (with --matrix-add-well-contributions=true) for the cusparseSolver
     /// If the --matrix-add-well-contributions commandline parameter is true, this class should not be used
+    /// A StandardWell uses C, D and B and performs y -= (C^T * (D^-1 * (B*x)))
+    /// B and C are vectors, disguised as matrices and contain blocks of StandardWell::numEq by StandardWell::numStaticWellEq
+    /// D is a block, disguised as matrix, the square block has size StandardWell::numStaticWellEq. D is actually stored as D^-1
+    /// B*x and D*B*x are a vector with numStaticWellEq doubles
+    /// C*D*B*x is a blocked matrix with a symmetric sparsity pattern, contains square blocks with size numEq. For every columnindex i, j in StandardWell::duneB_, there is a block on (i, j) in C*D*B*x.
+    ///
+    /// This class is used in 3 phases:
+    /// - get total size of all wellcontributions that must be stored here
+    /// - allocate memory
+    /// - copy data of wellcontributions
     class WellContributions
     {
 
     private:
-        unsigned int num_blocks = 0;    // total number of blocks in all wells
-        unsigned int dim;
-        unsigned int dim_wells;
-        unsigned int num_wells = 0;
-        unsigned int num_blocks_so_far = 0;
-        unsigned int num_wells_so_far = 0;
-        unsigned int *val_pointers = nullptr;     // val_pointers[wellID] == index of first block for this well in Ccols and Bcols
+        unsigned int num_blocks = 0;             // total number of blocks in all wells
+        unsigned int dim;                        // number of columns of blocks in B and C, equal to StandardWell::numEq
+        unsigned int dim_wells;                  // number of rows of blocks in B and C, equal to StandardWell::numStaticWellEq
+        unsigned int num_wells = 0;              // number of wellcontributions in this object
+        unsigned int num_blocks_so_far = 0;      // keep track of where next data is written
+        unsigned int num_wells_so_far = 0;       // keep track of where next data is written
+        unsigned int *val_pointers = nullptr;    // val_pointers[wellID] == index of first block for this well in Ccols and Bcols
         bool allocated = false;
 
         double *d_Cnnzs = nullptr;
@@ -69,26 +79,35 @@ namespace Opm
         ~WellContributions();
 
         /// Apply all wellcontributions in this object
+        /// performs y -= (C^T * (D^-1 * (B*x))) for StandardWell
+        /// \param[in] x          vector x
+        /// \param[inout] y       vector y
         void apply(double *x, double *y);
 
         /// Allocate memory for the wellcontributions
         void alloc();
 
-        /// Indicate how large the next wellcontributions are, this function cannot be called after alloc_all() is called
-        void addSizes(unsigned int nnz, unsigned int numEq, unsigned int numWellEq);
+        /// Indicate how large the blocks of the wellcontributions (C and B) are
+        /// \param[in] dim         number of columns
+        /// \param[in] dim_wells   number of rows
+        void setBlockSize(unsigned int dim, unsigned int dim_wells);
 
-        /// Store a matrix in this object, in blocked csr format
+        /// Indicate how large the next wellcontribution is, this function cannot be called after alloc() is called
+        /// \param[in] numBlocks   number of blocks in C and B of next wellcontribution
+        void addNumBlocks(unsigned int numBlocks);
+
+        /// Store a matrix in this object, in blocked csr format, can only be called after alloc() is called
+        /// \param[in] idx         indicate if C, D or B is sent
+        /// \param[in] colIndices  columnindices of blocks in C or B, ignored for D
+        /// \param[in] values      array of nonzeroes
+        /// \param[in] val_size    number of blocks in C or B, ignored for D
         void addMatrix(int idx, int *colIndices, double *values, unsigned int val_size);
 
         /// Return the number of wells added to this object
+        /// \return the number of wells added to this object
         unsigned int getNumWells(){
             return num_wells;
         }
-
-        /// WellContributions can be applied on CPU or GPU
-        /// This function sets the static variable, so each WellContributions is applied on the correct hardware
-        static void setMode(bool use_gpu);
-
     };
 
 } //namespace Opm

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -37,7 +37,6 @@ namespace Opm
     {
 
     private:
-        static bool gpu_mode;     // gpu_mode should be initialized in the ISTLSolverEbos constructor, and its value must not change afterwards
         unsigned int num_blocks = 0;    // total number of blocks in all wells
         unsigned int dim;
         unsigned int dim_wells;
@@ -68,33 +67,6 @@ namespace Opm
         double *z1 = nullptr;                // z1 = B * x
         double *z2 = nullptr;                // z2 = D^-1 * B * x
 
-        /// Apply the WellContributions on CPU
-        void apply_cpu(double *x, double *y);
-
-        /// Allocate memory on the CPU
-        void alloc_cpu();
-
-        /// Free memory on the CPU
-        void free_cpu();
-
-        /// Same as addMatrix(), stores matrix on CPU
-        void addMatrix_cpu(int idx, int *colIndices, double *values, unsigned int val_size);
-
-#if HAVE_CUDA
-        /// Apply all wellcontributions on GPU, performs y -= C^T * (D^-1 * (B * x))
-        /// Kernel is asynchronous
-        void apply_gpu(double *d_x, double *d_y);
-
-        /// Allocate memory on the GPU
-        void alloc_gpu();
-
-        /// Free memory on the GPU
-        void free_gpu();
-
-        /// Same as addMatrix(), stores matrix on GPU
-        void addMatrix_gpu(int idx, int *colIndices, double *values, unsigned int val_size);
-#endif
-
     public:
 #if HAVE_CUDA
         /// Set a cudaStream to be used
@@ -112,7 +84,7 @@ namespace Opm
         void apply(double *x, double *y);
 
         /// Allocate memory for the wellcontributions
-        void alloc_all();
+        void alloc();
 
         /// Indicate how large the next wellcontributions are, this function cannot be called after alloc_all() is called
         void addSizes(unsigned int nnz, unsigned int numEq, unsigned int numWellEq);

--- a/opm/simulators/linalg/bda/cusparseSolverBackend.cu
+++ b/opm/simulators/linalg/bda/cusparseSolverBackend.cu
@@ -256,33 +256,35 @@ namespace Opm
     } // end initialize()
 
     void cusparseSolverBackend::finalize() {
-        cudaFree(d_x);
-        cudaFree(d_b);
-        cudaFree(d_r);
-        cudaFree(d_rw);
-        cudaFree(d_p);
-        cudaFree(d_pw);
-        cudaFree(d_s);
-        cudaFree(d_t);
-        cudaFree(d_v);
-        cudaFree(d_mVals);
-        cudaFree(d_bVals);
-        cudaFree(d_bCols);
-        cudaFree(d_bRows);
-        cudaFree(d_buffer);
-        cusparseDestroyBsrilu02Info(info_M);
-        cusparseDestroyBsrsv2Info(info_L);
-        cusparseDestroyBsrsv2Info(info_U);
-        cusparseDestroyMatDescr(descr_B);
-        cusparseDestroyMatDescr(descr_M);
-        cusparseDestroyMatDescr(descr_L);
-        cusparseDestroyMatDescr(descr_U);
-        cusparseDestroy(cusparseHandle);
-        cublasDestroy(cublasHandle);
+        if (initialized) {
+            cudaFree(d_x);
+            cudaFree(d_b);
+            cudaFree(d_r);
+            cudaFree(d_rw);
+            cudaFree(d_p);
+            cudaFree(d_pw);
+            cudaFree(d_s);
+            cudaFree(d_t);
+            cudaFree(d_v);
+            cudaFree(d_mVals);
+            cudaFree(d_bVals);
+            cudaFree(d_bCols);
+            cudaFree(d_bRows);
+            cudaFree(d_buffer);
+            cusparseDestroyBsrilu02Info(info_M);
+            cusparseDestroyBsrsv2Info(info_L);
+            cusparseDestroyBsrsv2Info(info_U);
+            cusparseDestroyMatDescr(descr_B);
+            cusparseDestroyMatDescr(descr_M);
+            cusparseDestroyMatDescr(descr_L);
+            cusparseDestroyMatDescr(descr_U);
+            cusparseDestroy(cusparseHandle);
+            cublasDestroy(cublasHandle);
 #if COPY_ROW_BY_ROW
-        cudaFreeHost(vals_contiguous);
+            cudaFreeHost(vals_contiguous);
 #endif
-        cudaStreamDestroy(stream);
+            cudaStreamDestroy(stream);
+        }
     } // end finalize()
 
 

--- a/opm/simulators/linalg/bda/cusparseSolverBackend.cu
+++ b/opm/simulators/linalg/bda/cusparseSolverBackend.cu
@@ -76,7 +76,7 @@ namespace Opm
 
         t_total1 = second();
 
-        if(wellContribs.get_num_wells() > 0){
+        if(wellContribs.getNumWells() > 0){
             wellContribs.setCudaStream(stream);
         }
 
@@ -120,7 +120,7 @@ namespace Opm
                 &one, descr_M, d_bVals, d_bRows, d_bCols, block_size, d_pw, &zero, d_v);
 
             // apply wellContributions
-            if(wellContribs.get_num_wells() > 0){
+            if(wellContribs.getNumWells() > 0){
                 wellContribs.apply(d_pw, d_v);
             }
 
@@ -151,7 +151,7 @@ namespace Opm
                 d_bVals, d_bRows, d_bCols, block_size, d_s, &zero, d_t);
 
             // apply wellContributions
-            if(wellContribs.get_num_wells() > 0){
+            if(wellContribs.getNumWells() > 0){
                 wellContribs.apply(d_s, d_t);
             }
 

--- a/opm/simulators/linalg/bda/cusparseSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/cusparseSolverBackend.hpp
@@ -25,6 +25,7 @@
 #include "cusparse_v2.h"
 
 #include "opm/simulators/linalg/bda/BdaResult.hpp"
+#include <opm/simulators/linalg/bda/WellContributions.hpp>
 
 namespace Opm
 {
@@ -50,13 +51,11 @@ private:
     int *d_bRows, *d_mRows;
     double *d_x, *d_b, *d_r, *d_rw, *d_p;
     double *d_pw, *d_s, *d_t, *d_v;
-    double *vals;
-    int *cols, *rows;
-    double *x, *b;
     void *d_buffer;
     int N, Nb, nnz, nnzb;
+    double *vals_contiguous;
 
-    int BLOCK_SIZE;
+    int block_size;
 
     bool initialized = false;
     bool analysis_done = false;
@@ -70,8 +69,9 @@ private:
     int verbosity = 0;
 
     /// Solve linear system using ilu0-bicgstab
-    /// \param[inout] res     summary of solver result
-    void gpu_pbicgstab(BdaResult& res);
+    /// \param[in] wellContribs   contains all WellContributions, to apply them separately, instead of adding them to matrix A
+    /// \param[inout] res         summary of solver result
+    void gpu_pbicgstab(WellContributions& wellContribs, BdaResult& res);
 
     /// Initialize GPU and allocate memory
     /// \param[in] N         number of nonzeroes, divide by dim*dim to get number of blocks
@@ -83,16 +83,17 @@ private:
     void finalize();
 
     /// Copy linear system to GPU
-    /// \param[in] vals        array of nonzeroes, each block is stored row-wise and contiguous, contains nnz values
+    /// \param[in] vals        array of nonzeroes, each block is stored row-wise, contains nnz values
     /// \param[in] rows        array of rowPointers, contains N/dim+1 values
     /// \param[in] cols        array of columnIndices, contains nnz values
     /// \param[in] b           input vector, contains N values
     void copy_system_to_gpu(double *vals, int *rows, int *cols, double *b);
 
     // Update linear system on GPU, don't copy rowpointers and colindices, they stay the same
-    /// \param[in] vals        array of nonzeroes, each block is stored row-wise and contiguous, contains nnz values
+    /// \param[in] vals        array of nonzeroes, each block is stored row-wise, contains nnz values
+    /// \param[in] rows        array of rowPointers, contains N/dim+1 values, only used if COPY_ROW_BY_ROW is true
     /// \param[in] b           input vector, contains N values
-    void update_system_on_gpu(double *vals, double *b);
+    void update_system_on_gpu(double *vals, int *rows, double *b);
 
     /// Reset preconditioner on GPU, ilu0-decomposition is done inplace by cusparse
     void reset_prec_on_gpu();
@@ -106,8 +107,9 @@ private:
     bool create_preconditioner();
 
     /// Solve linear system
-    /// \param[inout] res     summary of solver result
-    void solve_system(BdaResult &res);
+    /// \param[in] wellContribs   contains all WellContributions, to apply them separately, instead of adding them to matrix A
+    /// \param[inout] res         summary of solver result
+    void solve_system(WellContributions& wellContribs, BdaResult &res);
 
 public:
 
@@ -128,16 +130,17 @@ public:
     ~cusparseSolverBackend();
 
     /// Solve linear system, A*x = b, matrix A must be in blocked-CSR format
-    /// \param[in] N           number of rows, divide by dim to get number of blockrows
-    /// \param[in] nnz         number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] dim         size of block
-    /// \param[in] vals        array of nonzeroes, each block is stored row-wise and contiguous, contains nnz values
-    /// \param[in] rows        array of rowPointers, contains N/dim+1 values
-    /// \param[in] cols        array of columnIndices, contains nnz values
-    /// \param[in] b           input vector, contains N values
-    /// \param[inout] res      summary of solver result
-    /// \return                status code
-    cusparseSolverStatus solve_system(int N, int nnz, int dim, double *vals, int *rows, int *cols, double *b, BdaResult &res);
+    /// \param[in] N              number of rows, divide by dim to get number of blockrows
+    /// \param[in] nnz            number of nonzeroes, divide by dim*dim to get number of blocks
+    /// \param[in] dim            size of block
+    /// \param[in] vals           array of nonzeroes, each block is stored row-wise and contiguous, contains nnz values
+    /// \param[in] rows           array of rowPointers, contains N/dim+1 values
+    /// \param[in] cols           array of columnIndices, contains nnz values
+    /// \param[in] b              input vector, contains N values
+    /// \param[in] wellContribs   contains all WellContributions, to apply them separately, instead of adding them to matrix A
+    /// \param[inout] res         summary of solver result
+    /// \return                   status code
+    cusparseSolverStatus solve_system(int N, int nnz, int dim, double *vals, int *rows, int *cols, double *b, WellContributions& wellContribs, BdaResult &res);
 
     /// Post processing after linear solve, now only copies resulting x vector back
     /// \param[inout] x        resulting x vector, caller must guarantee that x points to a valid array

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -192,8 +192,10 @@ namespace Opm {
             // subtract B*inv(D)*C * x from A*x
             void apply(const BVector& x, BVector& Ax) const;
 
+#if HAVE_CUDA
             // accumulate the contributions of all Wells in the WellContributions object
             void getWellContributions(WellContributions& x) const;
+#endif
 
             // apply well model with scaling of alpha
             void applyScaleAdd(const Scalar alpha, const BVector& x, BVector& Ax) const;

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -192,6 +192,9 @@ namespace Opm {
             // subtract B*inv(D)*C * x from A*x
             void apply(const BVector& x, BVector& Ax) const;
 
+            // accumulate the contributions of all Wells in the WellContributions object
+            void getWellContributions(WellContributions& x) const;
+
             // apply well model with scaling of alpha
             void applyScaleAdd(const Scalar alpha, const BVector& x, BVector& Ax) const;
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -936,7 +936,11 @@ namespace Opm {
         for(unsigned int i = 0; i < well_container_.size(); i++){
             auto& well = well_container_[i];
             std::shared_ptr<StandardWell<TypeTag> > derived = std::dynamic_pointer_cast<StandardWell<TypeTag> >(well);
-            derived->addWellContribution(wellContribs);
+            if (derived) {
+                derived->addWellContribution(wellContribs);
+            } else {
+                OpmLog::warning("Warning only StandardWell is supported by WellContributions for GPU");
+            }
         }
     }
 #endif

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -924,12 +924,13 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     getWellContributions(WellContributions& wellContribs) const
     {
+        wellContribs.setBlockSize(StandardWell<TypeTag>::numEq, StandardWell<TypeTag>::numStaticWellEq);
         for(unsigned int i = 0; i < well_container_.size(); i++){
             auto& well = well_container_[i];
             std::shared_ptr<StandardWell<TypeTag> > derived = std::dynamic_pointer_cast<StandardWell<TypeTag> >(well);
-            unsigned int nnz, numEq, numWellEq;
-            derived->getWellSizes(nnz, numEq, numWellEq);
-            wellContribs.addSizes(nnz, numEq, numWellEq);
+            unsigned int numBlocks;
+            derived->getNumBlocks(numBlocks);
+            wellContribs.addNumBlocks(numBlocks);
         }
         wellContribs.alloc();
         for(unsigned int i = 0; i < well_container_.size(); i++){

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -918,7 +918,7 @@ namespace Opm {
         }
     }
 
-
+#if HAVE_CUDA
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::
@@ -938,7 +938,7 @@ namespace Opm {
             derived->addWellContribution(wellContribs);
         }
     }
-
+#endif
 
     // Ax = Ax - alpha * C D^-1 B x
     template<typename TypeTag>

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -931,7 +931,7 @@ namespace Opm {
             derived->getWellSizes(nnz, numEq, numWellEq);
             wellContribs.addSizes(nnz, numEq, numWellEq);
         }
-        wellContribs.alloc_all();
+        wellContribs.alloc();
         for(unsigned int i = 0; i < well_container_.size(); i++){
             auto& well = well_container_[i];
             std::shared_ptr<StandardWell<TypeTag> > derived = std::dynamic_pointer_cast<StandardWell<TypeTag> >(well);

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -919,7 +919,25 @@ namespace Opm {
     }
 
 
-
+    template<typename TypeTag>
+    void
+    BlackoilWellModel<TypeTag>::
+    getWellContributions(WellContributions& wellContribs) const
+    {
+        for(unsigned int i = 0; i < well_container_.size(); i++){
+            auto& well = well_container_[i];
+            std::shared_ptr<StandardWell<TypeTag> > derived = std::dynamic_pointer_cast<StandardWell<TypeTag> >(well);
+            unsigned int nnz, numEq, numWellEq;
+            derived->getWellSizes(nnz, numEq, numWellEq);
+            wellContribs.addSizes(nnz, numEq, numWellEq);
+        }
+        wellContribs.alloc_all();
+        for(unsigned int i = 0; i < well_container_.size(); i++){
+            auto& well = well_container_[i];
+            std::shared_ptr<StandardWell<TypeTag> > derived = std::dynamic_pointer_cast<StandardWell<TypeTag> >(well);
+            derived->addWellContribution(wellContribs);
+        }
+    }
 
 
     // Ax = Ax - alpha * C D^-1 B x

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -184,11 +184,13 @@ namespace Opm
         /// r = r - C D^-1 Rw
         virtual void apply(BVector& r) const override;
 
+#if HAVE_CUDA
         /// add the contribution (C, D^-1, B matrices) of this Well to the WellContributions object
         void addWellContribution(WellContributions& wellContribs) const;
 
         /// get the sizes of the C, D^-1 and B matrices, used to allocate memory in a WellContributions object
         void getWellSizes(unsigned int& _nnzs, unsigned int& _numEq, unsigned int& _numWellEq) const;
+#endif
 
         /// using the solution x to recover the solution xw for wells and applying
         /// xw to update Well State

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -188,8 +188,8 @@ namespace Opm
         /// add the contribution (C, D^-1, B matrices) of this Well to the WellContributions object
         void addWellContribution(WellContributions& wellContribs) const;
 
-        /// get the sizes of the C, D^-1 and B matrices, used to allocate memory in a WellContributions object
-        void getWellSizes(unsigned int& _nnzs, unsigned int& _numEq, unsigned int& _numWellEq) const;
+        /// get the number of blocks of the C and B matrices, used to allocate memory in a WellContributions object
+        void getNumBlocks(unsigned int& _nnzs) const;
 #endif
 
         /// using the solution x to recover the solution xw for wells and applying

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -184,6 +184,12 @@ namespace Opm
         /// r = r - C D^-1 Rw
         virtual void apply(BVector& r) const override;
 
+        /// add the contribution (C, D^-1, B matrices) of this Well to the WellContributions object
+        void addWellContribution(WellContributions& wellContribs) const;
+
+        /// get the sizes of the C, D^-1 and B matrices, used to allocate memory in a WellContributions object
+        void getWellSizes(unsigned int& _nnzs, unsigned int& _numEq, unsigned int& _numWellEq) const;
+
         /// using the solution x to recover the solution xw for wells and applying
         /// xw to update Well State
         virtual void recoverWellSolutionAndUpdateWellState(const BVector& x,

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2756,7 +2756,7 @@ namespace Opm
                 }
             }
         }
-        wellContribs.addMatrix(0, colIndices.data(), nnzValues.data(), duneC_.nonzeroes());
+        wellContribs.addMatrix(WellContributions::MatrixType::C, colIndices.data(), nnzValues.data(), duneC_.nonzeroes());
 
         // invDuneD
         colIndices.clear();
@@ -2768,7 +2768,7 @@ namespace Opm
                 nnzValues.emplace_back(invDuneD_[0][0][i][j]);
             }
         }
-        wellContribs.addMatrix(1, colIndices.data(), nnzValues.data(), 1);
+        wellContribs.addMatrix(WellContributions::MatrixType::D, colIndices.data(), nnzValues.data(), 1);
 
         // duneB
         colIndices.clear();
@@ -2782,7 +2782,7 @@ namespace Opm
                 }
             }
         }
-        wellContribs.addMatrix(2, colIndices.data(), nnzValues.data(), duneB_.nonzeroes());
+        wellContribs.addMatrix(WellContributions::MatrixType::B, colIndices.data(), nnzValues.data(), duneB_.nonzeroes());
     }
 
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2789,11 +2789,9 @@ namespace Opm
     template<typename TypeTag>
     void
     StandardWell<TypeTag>::
-    getWellSizes(unsigned int& _nnzs, unsigned int& _numEq, unsigned int& _numWellEq) const
+    getNumBlocks(unsigned int& numBlocks) const
     {
-        _nnzs = duneB_.nonzeroes();
-        _numEq = numEq;
-        _numWellEq = numStaticWellEq;
+        numBlocks = duneB_.nonzeroes();
     }
 #endif
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2735,7 +2735,7 @@ namespace Opm
         duneC_.mmtv(invDrw_, r);
     }
 
-
+#if HAVE_CUDA
     template<typename TypeTag>
     void
     StandardWell<TypeTag>::
@@ -2795,7 +2795,7 @@ namespace Opm
         _numEq = numEq;
         _numWellEq = numStaticWellEq;
     }
-
+#endif
 
 
     template<typename TypeTag>


### PR DESCRIPTION
This PR adds the WellContributions class, and allows the cusparseSolver to be used without `--matrix-add-well-contributions=true. The wellcontributions can be processed coupled (like previous PR) or separate (default).

The use must pass
```
--use-gpu=true
```

Notes:
- Assumes `BlackoilWellModel` only has `StandardWell`, probably not scalable, but NORNE only uses these.
- All wells are applied simultaneously, this means that the columnIndices in `StandardWell::duneB_` and `duneC_` must be unique, to prevent write-after-write hazards.
- Applying the wellcontributions on GPU takes <1 second for a full NORNE run (< 0.7% of linear solve time).
- It might be better to do 1 `addMatrix()` call instead of 3 when adding the data of a well to the `WellContributions` object.
- A `WellContributions` object is created and filled for every linear solve. There is potential for reusing, but the number of wells and the size of their data can change per linear solve.
- The `COPY_ROW_BY_ROW` macro is defined in cusparseSolverBackend.cu, when true, it copies the nonzero values of the matrix row-by-row. Normally, these values are stored contiguously, but that is not guaranteed.

## Results ##
Intel Xeon E5-2620 v3 @ 2.4GHz, NVIDIA RTX GeForce 2080Ti

### Dune: ###
```
separate wellcontributions:
    Total runtime: 835 s
    Total linear solve: 480 s
    Newton Iterations: 1636
    Linear Iterations: 25110
```
```
coupled wellcontributions:
    Total runtime: 840 s
    Total linear solve: 477 s
    Newton Iterations: 1606
    Linear Iterations: 24078
```
### cusparse: ###
```
separate wellcontributions, this PR:
    Total runtime: 480 s
    Total linear solve: 138 s
    Newton Iterations: 1691
    Linear Iterations: 25608
```
```
coupled wellcontributions:
    Total runtime: 470 s
    Total linear solve: 137 s
    Newton Iterations: 1623
    Linear Iterations: 23956
```

The total runtime for coupled wellcontributions seems faster, but that is because the total assembly time varies a bit. The total linear solve time is roughly equal.
