### PR TITLE
avoid potentially uninitialized warnings in serial

### DIFF
--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -161,13 +161,15 @@ public:
             // compute the axis specific "centroids" used for the transmissibilities. for
             // consistency with the flow simulator, we use the element centers as
             // computed by opm-parser's Opm::EclipseGrid class for all axes.
-            const double* centroid;
+            std::array<double, 3> centroid;
             if (vanguard_.gridView().comm().rank() == 0) {
                 const auto& eclGrid = eclState.getInputGrid();
                 unsigned cartesianCellIdx = cartMapper.cartesianIndex(elemIdx);
-                centroid = &eclGrid.getCellCenter(cartesianCellIdx)[0];
+                centroid = eclGrid.getCellCenter(cartesianCellIdx);
             } else
-                centroid = &centroids[centroidIdx * dimWorld];
+                std::copy(centroids.begin() + centroidIdx * dimWorld,
+                          centroids.begin() + (centroidIdx + 1) * dimWorld,
+                          centroid.begin());
 
             for (unsigned axisIdx = 0; axisIdx < dimWorld; ++axisIdx)
                 for (unsigned dimIdx = 0; dimIdx < dimWorld; ++dimIdx)


### PR DESCRIPTION
this was actually broken by an upstream change from return-by-reference
to return-by-value (https://github.com/OPM/opm-common/commit/a595e68608830b5c643f19f881422b7d4b80f357), but we were lucky, the return value was
kept in memory until end of block it seems.