### PR TITLE
Fix ptr() template for strict compilers (clang)

### DIFF
--- a/ebos/eclmpiserializer.hh
+++ b/ebos/eclmpiserializer.hh
@@ -242,8 +242,8 @@ protected:
         constexpr static bool value = true;
     };
 
-    template<class T1>
-    struct is_ptr<std::unique_ptr<T1>> {
+    template<class T1, class Deleter>
+    struct is_ptr<std::unique_ptr<T1, Deleter>> {
         constexpr static bool value = true;
     };
 

--- a/ebos/eclmpiserializer.hh
+++ b/ebos/eclmpiserializer.hh
@@ -278,13 +278,14 @@ protected:
     //! \brief Handler for smart pointers.
     //! \details If data is POD or a string, we pass it to the underlying serializer,
     //!          if not we assume a complex type.
-    template<template<class T> class PtrType, class T1>
-    void ptr(const PtrType<T1>& data)
+    template<class PtrType>
+    void ptr(const PtrType& data)
     {
+        using T1 = typename PtrType::element_type;
         bool value = data ? true : false;
         (*this)(value);
         if (m_op == Operation::UNPACK && value) {
-            const_cast<PtrType<T1>&>(data).reset(new T1);
+            const_cast<PtrType&>(data).reset(new T1);
         }
         if (data)
             data->serializeOp(*this);

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -235,7 +235,7 @@ public:
 #endif
     }
     
-    virtual void apply( const X& x, Y& y ) const
+    virtual void apply( const X& x, Y& y ) const override
     {
         for (auto row = A_.begin(); row.index() < interiorSize_; ++row)
         {
@@ -252,7 +252,7 @@ public:
     }
 
     // y += \alpha * A * x
-    virtual void applyscaleadd (field_type alpha, const X& x, Y& y) const
+    virtual void applyscaleadd (field_type alpha, const X& x, Y& y) const override
     {
         for (auto row = A_.begin(); row.index() < interiorSize_; ++row)
         {
@@ -266,7 +266,7 @@ public:
         ghostLastProject( y );
     }
 
-    virtual const matrix_type& getmat() const { return A_for_precond_; }
+    virtual const matrix_type& getmat() const override { return A_for_precond_; }
 
     communication_type* comm()
     {


### PR DESCRIPTION
The first commit fixes a compile error with clang.

The second just silences warnings.