### PR TITLE
Avoid deck usage in simulator

### DIFF
--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -579,7 +579,7 @@ private:
         std::size_t ny = eclState().getInputGrid().getNY();
         auto nncData = sortNncAndApplyEditnnc(eclState().getInputNNC().data(),
                                               eclState().getInputEDITNNC().data());
-        const auto& unitSystem = simulator_.vanguard().deck().getActiveUnitSystem();
+        const auto& unitSystem = simulator_.vanguard().eclState().getDeckUnitSystem();
         std::vector<Opm::NNCdata> outputNnc;
         std::size_t index = 0;
 

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -26,7 +26,6 @@
 #include <sys/utsname.h>
 
 #include <opm/simulators/flow/BlackoilModelEbos.hpp>
-#include <opm/simulators/flow/MissingFeatures.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/utils/ParallelFileMerger.hpp>
 #include <opm/simulators/utils/moduleVersion.hpp>
@@ -254,7 +253,7 @@ namespace Opm
                     return status;
 
                 setupParallelism();
-                setupEbosSimulator(output_cout);
+                setupEbosSimulator();
                 runDiagnostics(output_cout);
                 createSimulator();
 
@@ -385,17 +384,13 @@ namespace Opm
                                                      EWOMS_GET_PARAM(TypeTag, bool, EnableLoggingFalloutWarning)));
         }
 
-        void setupEbosSimulator(bool output_cout)
+        void setupEbosSimulator()
         {
             ebosSimulator_.reset(new EbosSimulator(/*verbose=*/false));
             ebosSimulator_->executionTimer().start();
             ebosSimulator_->model().applyInitialSolution();
 
             try {
-                if (output_cout) {
-                    MissingFeatures::checkKeywords(deck());
-                }
-
                 // Possible to force initialization only behavior (NOSIM).
                 const std::string& dryRunString = EWOMS_GET_PARAM(TypeTag, std::string, EnableDryRun);
                 if (dryRunString != "" && dryRunString != "auto") {


### PR DESCRIPTION
- Use unit system from state
- Remove additional call to checkMissingFeatures (already called from flow.cpp / flow_tag.hpp).

With these, https://github.com/OPM/opm-common/pull/1627 and https://github.com/OPM/opm-simulators/pull/2495 I can finally run flow without a deck instance. This potentially yields huge memory savings on root process in large parallel runs. 

I'm not trying to take the convenience vs sanity fight now, but just as a FYI; On one case I am looking at this means we need 4GB insteady of 8GB on root process..