### PR TITLE
WIP: Remove internal variables

### DIFF
--- a/ebos/ebos_blackoil.cc
+++ b/ebos/ebos_blackoil.cc
@@ -98,9 +98,6 @@ void ebosBlackOilSetDeck(Opm::Deck* deck,
     typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
 }
 
 int ebosBlackOilMain(int argc, char **argv)

--- a/ebos/ebos_brine.cc
+++ b/ebos/ebos_brine.cc
@@ -52,7 +52,6 @@ void ebosBrineSetDeck(Opm::Deck* deck,
     Vanguard::setExternalSetupTime(externalSetupTime);
     Vanguard::setExternalParseContext(parseContext);
     Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
 }
 
 int ebosBrineMain(int argc, char **argv)

--- a/ebos/ebos_gasoil.cc
+++ b/ebos/ebos_gasoil.cc
@@ -68,7 +68,6 @@ void ebosGasOilSetDeck(Opm::Deck* deck,
     Vanguard::setExternalSetupTime(externalSetupTime);
     Vanguard::setExternalParseContext(parseContext);
     Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
 }
 
 int ebosGasOilMain(int argc, char **argv)

--- a/ebos/ebos_oilwater.cc
+++ b/ebos/ebos_oilwater.cc
@@ -68,7 +68,6 @@ void ebosOilWaterSetDeck(Opm::Deck* deck,
     Vanguard::setExternalSetupTime(externalSetupTime);
     Vanguard::setExternalParseContext(parseContext);
     Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
 }
 
 int ebosOilWaterMain(int argc, char **argv)

--- a/ebos/ebos_oilwaterpolymer.cc
+++ b/ebos/ebos_oilwaterpolymer.cc
@@ -70,7 +70,6 @@ void ebosOilWaterPolymerSetDeck(Opm::Deck* deck,
     Vanguard::setExternalSetupTime(externalSetupTime);
     Vanguard::setExternalParseContext(parseContext);
     Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
 }
 
 int ebosOilWaterPolymerMain(int argc, char **argv)

--- a/ebos/ebos_solvent.cc
+++ b/ebos/ebos_solvent.cc
@@ -52,7 +52,6 @@ void ebosSolventSetDeck(Opm::Deck* deck,
     Vanguard::setExternalSetupTime(externalSetupTime);
     Vanguard::setExternalParseContext(parseContext);
     Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
 }
 
 int ebosSolventMain(int argc, char **argv)

--- a/ebos/ebos_thermal.cc
+++ b/ebos/ebos_thermal.cc
@@ -52,7 +52,6 @@ void ebosThermalSetDeck(Opm::Deck* deck,
     Vanguard::setExternalSetupTime(externalSetupTime);
     Vanguard::setExternalParseContext(parseContext);
     Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
 }
 
 int ebosThermalMain(int argc, char **argv)

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -720,9 +720,6 @@ public:
             drift_ = 0.0;
         }
 
-        if (enableExperiments)
-            checkDeckCompatibility_();
-
         // write the static output files (EGRID, INIT, SMSPEC, etc.)
         if (enableEclOutput_)
             eclWriter_->writeInit();
@@ -1898,61 +1895,6 @@ public:
 
 
 private:
-    void checkDeckCompatibility_() const
-    {
-        const auto& deck = this->simulator().vanguard().deck();
-        const auto& comm = this->simulator().gridView().comm();
-        bool beVerbose = comm.rank() == 0;
-
-        if (enableApiTracking)
-            throw std::logic_error("API tracking is not yet implemented but requested at compile time.");
-        if (!enableApiTracking && deck.hasKeyword("API"))
-            throw std::logic_error("The simulator is build with API tracking disabled, but API tracking is requested by the deck.");
-
-        if (enableSolvent && !deck.hasKeyword("SOLVENT"))
-            throw std::runtime_error("The simulator requires the solvent option to be enabled, but the deck does not.");
-        else if (!enableSolvent && deck.hasKeyword("SOLVENT"))
-            throw std::runtime_error("The deck enables the solvent option, but the simulator is compiled without it.");
-
-        if (enablePolymer && !deck.hasKeyword("POLYMER"))
-            throw std::runtime_error("The simulator requires the polymer option to be enabled, but the deck does not.");
-        else if (!enablePolymer && deck.hasKeyword("POLYMER"))
-            throw std::runtime_error("The deck enables the polymer option, but the simulator is compiled without it.");
-
-        if (deck.hasKeyword("TEMP") && deck.hasKeyword("THERMAL"))
-            throw std::runtime_error("The deck enables both, the TEMP and the THERMAL options, but they are mutually exclusive.");
-
-        bool deckEnergyEnabled = (deck.hasKeyword("TEMP") || deck.hasKeyword("THERMAL"));
-        if (enableEnergy && !deckEnergyEnabled)
-            throw std::runtime_error("The simulator requires the TEMP or the THERMAL option to be enabled, but the deck activates neither.");
-        else if (!enableEnergy && deckEnergyEnabled)
-            throw std::runtime_error("The deck enables the TEMP or the THERMAL option, but the simulator is not compiled to support either.");
-
-        if (deckEnergyEnabled && deck.hasKeyword("TEMP") && beVerbose)
-            std::cerr << "WARNING: The deck requests the TEMP option, i.e., treating energy "
-                      << "conservation as a post processing step. This is currently unsupported, "
-                      << "i.e., energy conservation is always handled fully implicitly." << std::endl;
-
-        int numDeckPhases = FluidSystem::numActivePhases();
-        if (numDeckPhases < Indices::numPhases && beVerbose)
-            std::cerr << "WARNING: The number of active phases specified by the deck ("
-                      << numDeckPhases << ") is smaller than the number of compiled-in phases ("
-                      << Indices::numPhases << "). This usually results in a significant "
-                      << "performance degradation compared to using a specialized simulator."  << std::endl;
-        else if (numDeckPhases < Indices::numPhases)
-            throw std::runtime_error("The deck enables "+std::to_string(numDeckPhases)+" phases "
-                                     "while this simulator can only handle "+
-                                     std::to_string(Indices::numPhases)+".");
-
-        // make sure that the correct phases are active
-        if (FluidSystem::phaseIsActive(oilPhaseIdx) && !Indices::oilEnabled)
-            throw std::runtime_error("The deck enables oil, but this simulator cannot handle it.");
-        if (FluidSystem::phaseIsActive(gasPhaseIdx) && !Indices::gasEnabled)
-            throw std::runtime_error("The deck enables gas, but this simulator cannot handle it.");
-        if (FluidSystem::phaseIsActive(waterPhaseIdx) && !Indices::waterEnabled)
-            throw std::runtime_error("The deck enables water, but this simulator cannot handle it.");
-        // the opposite cases should be fine (albeit a bit slower than what's possible)
-    }
 
     bool drsdtActive_() const
     {

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -342,13 +342,6 @@ private:
                 }
             }
         }
-
-        if (enableExperiments) {
-            // apply threshold pressures accross faults (experimental!)
-            if (deck.hasKeyword("THPRESFT"))
-                extractThpresft_(deck.getKeyword("THPRESFT"));
-        }
-
     }
 
     void extractThpresft_(const Opm::DeckKeyword& thpresftKeyword)

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -290,7 +290,6 @@ private:
         const auto& gridView = vanguard.gridView();
         const auto& elementMapper = simulator_.model().elementMapper();
         const auto& eclState = simulator_.vanguard().eclState();
-        const auto& deck = simulator_.vanguard().deck();
         const Opm::SimulationConfig& simConfig = eclState.getSimulationConfig();
         const auto& thpres = simConfig.getThresholdPressure();
 

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -415,13 +415,13 @@ int main(int argc, char** argv)
             // oil-gas
             if (phases.active( Opm::Phase::GAS ))
             {
-                Opm::flowEbosGasOilSetDeck(externalSetupTimer.elapsed(), deck.get(), *eclipseState, *schedule, *summaryConfig);
+                Opm::flowEbosGasOilSetDeck(externalSetupTimer.elapsed(), *eclipseState, *schedule, *summaryConfig);
                 return Opm::flowEbosGasOilMain(argc, argv, outputCout, outputFiles);
             }
             // oil-water
             else if ( phases.active( Opm::Phase::WATER ) )
             {
-                Opm::flowEbosOilWaterSetDeck(externalSetupTimer.elapsed(), deck.get(), *eclipseState, *schedule, *summaryConfig);
+                Opm::flowEbosOilWaterSetDeck(externalSetupTimer.elapsed(), *eclipseState, *schedule, *summaryConfig);
                 return Opm::flowEbosOilWaterMain(argc, argv, outputCout, outputFiles);
             }
             else {
@@ -449,37 +449,37 @@ int main(int argc, char** argv)
             }
 
             if ( phases.size() == 3 ) { // oil water polymer case
-                Opm::flowEbosOilWaterPolymerSetDeck(externalSetupTimer.elapsed(), deck.get(), *eclipseState, *schedule, *summaryConfig);
+                Opm::flowEbosOilWaterPolymerSetDeck(externalSetupTimer.elapsed(), *eclipseState, *schedule, *summaryConfig);
                 return Opm::flowEbosOilWaterPolymerMain(argc, argv, outputCout, outputFiles);
             } else {
-                Opm::flowEbosPolymerSetDeck(externalSetupTimer.elapsed(), deck.get(), *eclipseState, *schedule, *summaryConfig);
+                Opm::flowEbosPolymerSetDeck(externalSetupTimer.elapsed(), *eclipseState, *schedule, *summaryConfig);
                 return Opm::flowEbosPolymerMain(argc, argv, outputCout, outputFiles);
             }
         }
         // Foam case
         else if ( phases.active( Opm::Phase::FOAM ) ) {
-            Opm::flowEbosFoamSetDeck(externalSetupTimer.elapsed(), deck.get(), *eclipseState, *schedule, *summaryConfig);
+            Opm::flowEbosFoamSetDeck(externalSetupTimer.elapsed(), *eclipseState, *schedule, *summaryConfig);
             return Opm::flowEbosFoamMain(argc, argv, outputCout, outputFiles);
         }
         // Brine case
         else if ( phases.active( Opm::Phase::BRINE ) ) {
-            Opm::flowEbosBrineSetDeck(externalSetupTimer.elapsed(), deck.get(), *eclipseState, *schedule, *summaryConfig);
+            Opm::flowEbosBrineSetDeck(externalSetupTimer.elapsed(), *eclipseState, *schedule, *summaryConfig);
             return Opm::flowEbosBrineMain(argc, argv, outputCout, outputFiles);
         }
         // Solvent case
         else if ( phases.active( Opm::Phase::SOLVENT ) ) {
-            Opm::flowEbosSolventSetDeck(externalSetupTimer.elapsed(), deck.get(), *eclipseState, *schedule, *summaryConfig);
+            Opm::flowEbosSolventSetDeck(externalSetupTimer.elapsed(), *eclipseState, *schedule, *summaryConfig);
             return Opm::flowEbosSolventMain(argc, argv, outputCout, outputFiles);
         }
         // Energy case
         else if (eclipseState->getSimulationConfig().isThermal()) {
-            Opm::flowEbosEnergySetDeck(externalSetupTimer.elapsed(), deck.get(), *eclipseState, *schedule, *summaryConfig);
+            Opm::flowEbosEnergySetDeck(externalSetupTimer.elapsed(), *eclipseState, *schedule, *summaryConfig);
             return Opm::flowEbosEnergyMain(argc, argv, outputCout, outputFiles);
         }
 #endif // FLOW_BLACKOIL_ONLY
         // Blackoil case
         else if( phases.size() == 3 ) {
-            Opm::flowEbosBlackoilSetDeck(externalSetupTimer.elapsed(), deck.get(), *eclipseState, *schedule, *summaryConfig);
+            Opm::flowEbosBlackoilSetDeck(externalSetupTimer.elapsed(), *eclipseState, *schedule, *summaryConfig);
             return Opm::flowEbosBlackoilMain(argc, argv, outputCout, outputFiles);
         }
         else

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -34,13 +34,12 @@
 
 namespace Opm {
 
-void flowEbosBlackoilSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosBlackoilSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
 {
     typedef TTAG(EclFlowProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
     Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);

--- a/flow/flow_ebos_blackoil.hpp
+++ b/flow/flow_ebos_blackoil.hpp
@@ -17,13 +17,12 @@
 #ifndef FLOW_EBOS_BLACKOIL_HPP
 #define FLOW_EBOS_BLACKOIL_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
-void flowEbosBlackoilSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosBlackoilSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
 int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -36,13 +36,12 @@ SET_BOOL_PROP(EclFlowBrineProblem, EnableBrine, true);
 }}
 
 namespace Opm {
-void flowEbosBrineSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosBrineSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
 {
     typedef TTAG(EclFlowBrineProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
     Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);

--- a/flow/flow_ebos_brine.hpp
+++ b/flow/flow_ebos_brine.hpp
@@ -17,14 +17,13 @@
 #ifndef FLOW_EBOS_BRINE_HPP
 #define FLOW_EBOS_BRINE_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 
 namespace Opm {
-void flowEbosBrineSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosBrineSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
 int flowEbosBrineMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -36,13 +36,12 @@ SET_BOOL_PROP(EclFlowEnergyProblem, EnableEnergy, true);
 }}
 
 namespace Opm {
-void flowEbosEnergySetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosEnergySetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
 {
     typedef TTAG(EclFlowEnergyProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
     Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);

--- a/flow/flow_ebos_energy.hpp
+++ b/flow/flow_ebos_energy.hpp
@@ -17,13 +17,12 @@
 #ifndef FLOW_EBOS_ENERGY_HPP
 #define FLOW_EBOS_ENERGY_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
-void flowEbosEnergySetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosEnergySetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
 int flowEbosEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -36,13 +36,12 @@ SET_BOOL_PROP(EclFlowFoamProblem, EnableFoam, true);
 }}
 
 namespace Opm {
-void flowEbosFoamSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosFoamSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
 {
     typedef TTAG(EclFlowFoamProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
     Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);

--- a/flow/flow_ebos_foam.hpp
+++ b/flow/flow_ebos_foam.hpp
@@ -17,14 +17,13 @@
 #ifndef FLOW_EBOS_FOAM_HPP
 #define FLOW_EBOS_FOAM_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 
 namespace Opm {
-void flowEbosFoamSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosFoamSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
 int flowEbosFoamMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -60,13 +60,12 @@ public:
 }}
 
 namespace Opm {
-void flowEbosGasOilSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosGasOilSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
 {
     typedef TTAG(EclFlowGasOilProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
     Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);

--- a/flow/flow_ebos_gasoil.hpp
+++ b/flow/flow_ebos_gasoil.hpp
@@ -17,13 +17,12 @@
 #ifndef FLOW_EBOS_GASOIL_HPP
 #define FLOW_EBOS_GASOIL_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
-void flowEbosGasOilSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosGasOilSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
 int flowEbosGasOilMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -60,13 +60,12 @@ public:
 }}
 
 namespace Opm {
-void flowEbosOilWaterSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosOilWaterSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
 {
     typedef TTAG(EclFlowOilWaterProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
     Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);

--- a/flow/flow_ebos_oilwater.hpp
+++ b/flow/flow_ebos_oilwater.hpp
@@ -17,13 +17,12 @@
 #ifndef FLOW_EBOS_OILWATER_HPP
 #define FLOW_EBOS_OILWATER_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
-void flowEbosOilWaterSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosOilWaterSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
 int flowEbosOilWaterMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -61,13 +61,12 @@ public:
 }}
 
 namespace Opm {
-void flowEbosOilWaterPolymerSetDeck(double setupTime, Deck* deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosOilWaterPolymerSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
 {
     typedef TTAG(EclFlowOilWaterPolymerProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
     Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);

--- a/flow/flow_ebos_oilwater_polymer.hpp
+++ b/flow/flow_ebos_oilwater_polymer.hpp
@@ -17,13 +17,12 @@
 #ifndef FLOW_EBOS_OILWATER_POLYMER_HPP
 #define FLOW_EBOS_OILWATER_POLYMER_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
-void flowEbosOilWaterPolymerSetDeck(double setupTime, Deck* deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosOilWaterPolymerSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
 int flowEbosOilWaterPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_oilwater_polymer_injectivity.cpp
+++ b/flow/flow_ebos_oilwater_polymer_injectivity.cpp
@@ -85,6 +85,7 @@ int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCou
 #endif
 
     Opm::FlowMainEbos<TTAG(EclFlowOilWaterPolymerInjectivityProblem)> mainfunc;
+
     return mainfunc.execute(argc, argv, outputCout, outputFiles);
 }
 

--- a/flow/flow_ebos_oilwater_polymer_injectivity.hpp
+++ b/flow/flow_ebos_oilwater_polymer_injectivity.hpp
@@ -17,11 +17,8 @@
 #ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
 #define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
 namespace Opm {
-  // void flowEbosOilWaterPolymerInjectivitySetDeck(Deck& deck, EclipseState& eclState);
 int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -36,13 +36,12 @@ SET_BOOL_PROP(EclFlowPolymerProblem, EnablePolymer, true);
 }}
 
 namespace Opm {
-void flowEbosPolymerSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosPolymerSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
 {
     typedef TTAG(EclFlowPolymerProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
     Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);

--- a/flow/flow_ebos_polymer.hpp
+++ b/flow/flow_ebos_polymer.hpp
@@ -17,13 +17,12 @@
 #ifndef FLOW_EBOS_POLYMER_HPP
 #define FLOW_EBOS_POLYMER_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
-void flowEbosPolymerSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosPolymerSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
 int flowEbosPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -36,13 +36,12 @@ SET_BOOL_PROP(EclFlowSolventProblem, EnableSolvent, true);
 }}
 
 namespace Opm {
-void flowEbosSolventSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosSolventSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
 {
     typedef TTAG(EclFlowSolventProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
     Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);

--- a/flow/flow_ebos_solvent.hpp
+++ b/flow/flow_ebos_solvent.hpp
@@ -17,14 +17,13 @@
 #ifndef FLOW_EBOS_SOLVENT_HPP
 #define FLOW_EBOS_SOLVENT_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 
 namespace Opm {
-void flowEbosSolventSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosSolventSetDeck(double setupTime, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
 int flowEbosSolventMain(int argc, char** argv, bool outoutCout, bool outputFiles);
 }
 

--- a/flow/flow_tag.hpp
+++ b/flow/flow_tag.hpp
@@ -74,7 +74,6 @@ namespace Opm {
   void flowEbosSetDeck(Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
   {
     typedef typename GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
-    Vanguard::setExternalDeck(deck);
     Vanguard::setExternalEclState(&eclState);
     Vanguard::setExternalSchedule(&schedule);
     Vanguard::setExternalSummaryConfig(&summaryConfig);


### PR DESCRIPTION
Drive by improvement which went a bit overboard. I know this is work in progress, but I really think we should merge something in this direction - it has &part;<sub>t</sub> S < 0

What I have started on here is essentially to remove the notion of an *internal* deck in `EclVanguard` class - instead the assembly of the input is completed in `flow.cpp` and then the `flowXXXXSetDeck()`function *must* be called.

If this is to fly the parsing must be repeated in all the simulators like `flow_ebos_gin_tonic` - I suggest that we use a simplified parsing for all these alternative simulators - like I have started on in `flow_ebos_foam.cpp`

 