### PR TITLE
Add Python argument to Schedule constructor

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -35,6 +35,7 @@
 #include <opm/grid/cpgrid/GridHelpers.hpp>
 #include <opm/core/props/satfunc/RelpermDiagnostics.hpp>
 
+#include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
@@ -348,7 +349,7 @@ public:
             // create the schedule object. Note that if eclState is supposed to represent
             // the internalized version of the deck, this constitutes a layering
             // violation.
-            internalEclSchedule_.reset(new Opm::Schedule(*deck_, *eclState_, *parseContext_, *errorGuard_));
+            internalEclSchedule_.reset(new Opm::Schedule(*deck_, *eclState_, *parseContext_, *errorGuard_, python));
             eclSchedule_ = internalEclSchedule_.get();
         }
         else
@@ -629,6 +630,7 @@ private:
     Opm::EclipseState* eclState_;
     Opm::Schedule* eclSchedule_;
     Opm::SummaryConfig* eclSummaryConfig_;
+    Opm::Python python;
 
     Dune::EdgeWeightMethod edgeWeightsMethod_;
     bool ownersFirst_;

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -331,6 +331,7 @@ int main(int argc, char** argv)
             std::cout << "Reading deck file '" << deckFilename << "'\n";
             std::cout.flush();
         }
+        Opm::Python python;
         std::shared_ptr<Opm::Deck> deck;
         std::shared_ptr<Opm::EclipseState> eclipseState;
         std::shared_ptr<Opm::Schedule> schedule;
@@ -376,9 +377,9 @@ int main(int argc, char** argv)
                     const auto& rst_filename = eclipseState->getIOConfig().getRestartFileName( init_config.getRestartRootName(), report_step, false );
                     Opm::EclIO::ERst rst_file(rst_filename);
                     const auto& rst_state = Opm::RestartIO::RstState::load(rst_file, report_step);
-                    schedule.reset(new Opm::Schedule(*deck, *eclipseState, parseContext, errorGuard, &rst_state) );
+                    schedule.reset(new Opm::Schedule(*deck, *eclipseState, parseContext, errorGuard, python, &rst_state) );
                 } else
-                    schedule.reset(new Opm::Schedule(*deck, *eclipseState, parseContext, errorGuard));
+                    schedule.reset(new Opm::Schedule(*deck, *eclipseState, parseContext, errorGuard, python));
 
                 setupMessageLimiter(schedule->getMessageLimits(), "STDOUT_LOGGER");
                 summaryConfig.reset( new Opm::SummaryConfig(*deck, *schedule, eclipseState->getTableManager(), parseContext, errorGuard));

--- a/flow/flow_tag.hpp
+++ b/flow/flow_tag.hpp
@@ -33,6 +33,7 @@
 #include <opm/common/OpmLog/EclipsePRTLog.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
 
+#include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -354,6 +355,7 @@ int mainFlow(int argc, char** argv)
             std::cout << "Reading deck file '" << deckFilename << "'\n";
             std::cout.flush();
         }
+        Opm::Python python;
         std::shared_ptr<Opm::Deck> deck;
         std::shared_ptr<Opm::EclipseState> eclipseState;
         std::shared_ptr<Opm::Schedule> schedule;
@@ -390,7 +392,7 @@ int mainFlow(int argc, char** argv)
 #else
                 eclipseState.reset(new Opm::EclipseState(*deck));
 #endif
-                schedule.reset(new Opm::Schedule(*deck, *eclipseState, parseContext, errorGuard));
+                schedule.reset(new Opm::Schedule(*deck, *eclipseState, parseContext, errorGuard, python));
                 setupMessageLimiter(schedule->getMessageLimits(), "STDOUT_LOGGER");
                 summaryConfig.reset( new Opm::SummaryConfig(*deck, *schedule, eclipseState->getTableManager(), parseContext, errorGuard));
             }

--- a/tests/test_norne_pvt.cpp
+++ b/tests/test_norne_pvt.cpp
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <iostream>
 
+#include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
@@ -276,11 +277,12 @@ BOOST_AUTO_TEST_CASE( Test_Norne_PVT) {
     Opm::ParseContext parseContext({{ ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE }});
     Opm::ErrorGuard errorGuard;
     Opm::Parser parser;
+    Opm::Python python;
 
     auto deck = parser.parseFile("norne_pvt.data", parseContext, errorGuard);
 
     Opm::EclipseState eclState(deck);
-    Opm::Schedule schedule(deck, eclState);
+    Opm::Schedule schedule(deck, eclState, python);
 
     verify_norne_oil_pvt_region1(eclState, schedule);
     verify_norne_oil_pvt_region2(eclState, schedule);

--- a/tests/test_stoppedwells.cpp
+++ b/tests/test_stoppedwells.cpp
@@ -24,6 +24,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
@@ -36,7 +37,8 @@ BOOST_AUTO_TEST_CASE(TestStoppedWells)
     Opm::Parser parser;
     Opm::Deck deck(parser.parseFile(filename));
     Opm::EclipseState eclipseState(deck);
-    const Schedule sched(deck, eclipseState);
+    Opm::Python python;
+    const Schedule sched(deck, eclipseState, python);
 
     // Both wells are open in the first schedule step
     {

--- a/tests/test_wellmodel.cpp
+++ b/tests/test_wellmodel.cpp
@@ -33,6 +33,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
+#include <opm/parser/eclipse/Python/Python.hpp>
 
 #include <opm/grid/GridManager.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
@@ -70,12 +71,13 @@ struct SetupTest {
         {
           const Opm::TableManager table ( deck );
           const Opm::Runspec runspec (deck);
-          schedule.reset( new Opm::Schedule(deck, *ecl_state));
+          schedule.reset( new Opm::Schedule(deck, *ecl_state, python));
           summaryState.reset( new Opm::SummaryState(std::chrono::system_clock::from_time_t(schedule->getStartTime())));
         }
         current_timestep = 0;
     };
 
+    Opm::Python python;
     std::unique_ptr<const Opm::EclipseState> ecl_state;
     std::unique_ptr<const Opm::Schedule> schedule;
     std::unique_ptr<Opm::SummaryState> summaryState;

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -22,6 +22,7 @@
 #define BOOST_TEST_MODULE WellStateFIBOTest
 
 #include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/parser/eclipse/Python/Python.hpp>
 
 #include <boost/test/unit_test.hpp>
 
@@ -51,7 +52,7 @@ struct Setup
         : es   (deck)
         , pu   (Opm::phaseUsageFromDeck(es))
         , grid (es.getInputGrid())
-        , sched(deck, es)
+        , sched(deck, es, python)
         , st(std::chrono::system_clock::from_time_t(sched.getStartTime()))
     {
         initWellPerfData();
@@ -101,6 +102,7 @@ struct Setup
         }
     }
 
+    Opm::Python       python;
     Opm::EclipseState es;
     Opm::PhaseUsage   pu;
     Opm::GridManager  grid;


### PR DESCRIPTION
Downstream of: https://github.com/OPM/opm-common/pull/1636

The new PYACTION keyword allows for loading a Python module and then run the `run()` function in that module during the simulation. The module is internalized by the Python interpreter on parse time (from opm-common) - that is essential to enable early error detection.If we do not have Python enabled the Python keywords are ignored in the Schedule construction.

The `python`argument which is added to the `Schedule`constructor is an instance of [this](https://github.com/OPM/opm-common/blob/master/src/opm/parser/eclipse/Python/Python.cpp). Iff this version of opm-common has been compiled with `OPM_ENABLE_EMBEDDED_PYTHON` the `Python`instance holds on to an interpreter - otherwise it is just an empty shell.

Will probably make a constructor argument to the `Python` class so you can can control runtime whether to support Python or not (*iff* it has been enabled compile time).

For now this PR has no consequences whatsover - apart from a warning about an unused parameter in the `Schedule`constructor. 