### PR TITLE
Add integration test for restart & MSW

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -437,6 +437,12 @@ add_test_compare_restarted_simulation(CASENAME spe9
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
                                       TEST_ARGS --sched-restart=false)
+add_test_compare_restarted_simulation(CASENAME msw_3d_hfa
+                                      FILENAME 3D_MSW
+                                      SIMULATOR flow
+                                      ABS_TOL ${abs_tol_restart}
+                                      REL_TOL ${rel_tol_restart}
+                                      TEST_ARGS --sched-restart=false)
 
 # PORV test
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-porv-acceptanceTest.sh "")


### PR DESCRIPTION
This adds a restart regression test based on the MSW model in opm-tests. The restart is invoked with `--sched-restart=false`