### PR TITLE
Enable owner first ordering by default

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -88,7 +88,7 @@ SET_BOOL_PROP(EclBaseVanguard, EnableOpmRstFile, false);
 SET_BOOL_PROP(EclBaseVanguard, EclStrictParsing, false);
 SET_BOOL_PROP(EclBaseVanguard, SchedRestart, true);
 SET_INT_PROP(EclBaseVanguard, EdgeWeightsMethod, 1);
-SET_BOOL_PROP(EclBaseVanguard, OwnerCellsFirst, false);
+SET_BOOL_PROP(EclBaseVanguard, OwnerCellsFirst, true);
 
 END_PROPERTIES
 


### PR DESCRIPTION
I have tested the owner-first ordering on a number of cases and a number of process counts. It has consistently yielded better performance. Hence, I suggest we enable it  by default.