### PR TITLE
Python bindings for the blackoil simulator.

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,3 +1,4 @@
 if(NOT TARGET pybind11)
   add_subdirectory( pybind11 )
+  add_subdirectory( simulators )
 endif()

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -1,0 +1,21 @@
+pybind11_add_module(simulators simulators.cpp)
+
+set_target_properties( simulators PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/python/opm2 )
+
+target_sources(simulators
+  PRIVATE
+    ../../flow/flow_ebos_blackoil.cpp
+    ../../flow/flow_ebos_brine.cpp
+    ../../flow/flow_ebos_energy.cpp
+    ../../flow/flow_ebos_foam.cpp
+    ../../flow/flow_ebos_gasoil.cpp
+    ../../flow/flow_ebos_oilwater.cpp
+    ../../flow/flow_ebos_oilwater_polymer.cpp
+    ../../flow/flow_ebos_oilwater_polymer_injectivity.cpp
+    ../../flow/flow_ebos_polymer.cpp
+    ../../flow/flow_ebos_solvent.cpp
+    ../../flow/flow_ebos_blackoil.cpp)
+
+target_link_libraries( simulators PRIVATE opmsimulators )
+
+install(TARGETS simulators DESTINATION ${PYTHON_INSTALL_PREFIX}/simulators)

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -4,16 +4,6 @@ set_target_properties( simulators PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_
 
 target_sources(simulators
   PRIVATE
-    ../../flow/flow_ebos_blackoil.cpp
-    ../../flow/flow_ebos_brine.cpp
-    ../../flow/flow_ebos_energy.cpp
-    ../../flow/flow_ebos_foam.cpp
-    ../../flow/flow_ebos_gasoil.cpp
-    ../../flow/flow_ebos_oilwater.cpp
-    ../../flow/flow_ebos_oilwater_polymer.cpp
-    ../../flow/flow_ebos_oilwater_polymer_injectivity.cpp
-    ../../flow/flow_ebos_polymer.cpp
-    ../../flow/flow_ebos_solvent.cpp
     ../../flow/flow_ebos_blackoil.cpp)
 
 target_link_libraries( simulators PRIVATE opmsimulators )

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -1,0 +1,82 @@
+#include "config.h"
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#define OPM_FLOW_MAIN
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/models/utils/propertysystem.hh>
+#include <opm/models/utils/parametersystem.hh>
+#include <pybind11/pybind11.h>
+#include <pybind11/embed.h>
+#include <iostream>
+
+BEGIN_PROPERTIES
+
+NEW_TYPE_TAG(EclFlowProblemMain);
+
+END_PROPERTIES
+
+namespace py = pybind11;
+
+class BlackOilSimulator
+{
+public:
+    BlackOilSimulator( const Opm::Deck& deck, 
+                       const Opm::EclipseState& eclipseState, 
+                       const Opm::Schedule& schedule,
+                       const Opm::SummaryConfig& summaryConfig )
+    {
+        setDeck(deck);
+        setEclipseState(eclipseState);
+        setSchedule(schedule);
+        setSummaryConfig(summaryConfig);
+    }
+
+    int run()
+    {
+        int argc = 1;
+        char *argv[1] = {"flow"};
+        using TypeTag = TTAG(EclFlowProblemMain);
+        auto mainObject = Opm::Main<TypeTag>(
+            argc, argv, deck_, eclipseState_, schedule_, summaryConfig_);
+        return mainObject.run();
+    }
+    
+    void setDeck( const Opm::Deck& deck )
+    {
+        deck_ = std::make_shared< Opm::Deck >(deck);
+    }
+
+    void setEclipseState( const Opm::EclipseState& eclipseState )
+    {
+        eclipseState_ = std::make_shared< Opm::EclipseState >(eclipseState);
+    }
+
+    void setSchedule( const Opm::Schedule& schedule )
+    {
+        schedule_ = std::make_shared< Opm::Schedule >(schedule);
+    }
+
+    void setSummaryConfig( const Opm::SummaryConfig& summaryConfig )
+    {
+        summaryConfig_ = std::make_shared< Opm::SummaryConfig >(summaryConfig);
+    }
+
+private:
+    std::shared_ptr<Opm::Deck>          deck_;
+    std::shared_ptr<Opm::EclipseState>  eclipseState_;
+    std::shared_ptr<Opm::Schedule>      schedule_;
+    std::shared_ptr<Opm::SummaryConfig> summaryConfig_;
+};
+
+PYBIND11_MODULE(simulators, m)
+{
+    py::class_<BlackOilSimulator>(m, "BlackOilSimulator")
+        .def(py::init< const Opm::Deck&, const Opm::EclipseState&, const Opm::Schedule&, const Opm::SummaryConfig& >())
+        .def("run", &BlackOilSimulator::run)
+        .def("setDeck", &BlackOilSimulator::setDeck)
+        .def("setEclipseState", &BlackOilSimulator::setEclipseState)
+        .def("setSchedule", &BlackOilSimulator::setSchedule)
+        .def("setSummaryConfig", &BlackOilSimulator::setSummaryConfig);
+}

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -3,19 +3,10 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#define OPM_FLOW_MAIN
 #include <opm/simulators/flow/Main.hpp>
-#include <opm/models/utils/propertysystem.hh>
-#include <opm/models/utils/parametersystem.hh>
 #include <pybind11/pybind11.h>
 #include <pybind11/embed.h>
 #include <iostream>
-
-BEGIN_PROPERTIES
-
-NEW_TYPE_TAG(EclFlowProblemMain);
-
-END_PROPERTIES
 
 namespace py = pybind11;
 
@@ -37,10 +28,9 @@ public:
     {
         int argc = 1;
         char *argv[1] = {"flow"};
-        using TypeTag = TTAG(EclFlowProblemMain);
-        auto mainObject = Opm::Main<TypeTag>(
+        auto mainObject = Opm::Main(
             argc, argv, deck_, eclipseState_, schedule_, summaryConfig_);
-        return mainObject.run();
+        return mainObject.runDynamic();
     }
     
     void setDeck( const Opm::Deck& deck )

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -3,6 +3,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#define FLOW_BLACKOIL_ONLY
 #include <opm/simulators/flow/Main.hpp>
 #include <pybind11/pybind11.h>
 #include <pybind11/embed.h>


### PR DESCRIPTION
Python bindings for the blackoil simulator.

NOTE: This PR depends on PR #2516 which should be merged first.

A rewrite of the Python bindings for the blackoil simulator using pybind11 as introduced in PR #2127. The new version uses the refactored `flow.cpp` introduced in PR #2516 and thus avoids duplication of the code in `simulators.cpp`.

This PR will be the starting point for implementing the Python bindings introduced in PR #2403. 

