### PR TITLE
The "default" Schedule constructor has Python argument

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -402,7 +402,7 @@ namespace Opm
 #if HAVE_MPI
                     else {
                         summaryConfig.reset(new Opm::SummaryConfig);
-                        schedule.reset(new Opm::Schedule);
+                        schedule.reset(new Opm::Schedule(python));
                         eclipseState.reset(new Opm::ParallelEclipseState);
                     }
                     Opm::eclStateBroadcast(*eclipseState, *schedule, *summaryConfig);


### PR DESCRIPTION
Downstream from: https://github.com/OPM/opm-common/pull/1689