### PR TITLE
 Equilibration: Add Experimental Support for Horizontal Subdivision

### DIFF
--- a/ebos/equil/equilibrationhelpers.hh
+++ b/ebos/equil/equilibrationhelpers.hh
@@ -675,6 +675,17 @@ public:
      */
     double pcgoGoc() const { return this->rec_.gasOilContactCapillaryPressure(); }
 
+    /**
+     * Accuracy/strategy for initial fluid-in-place calculation.
+     *
+     * \return zero (N=0) for centre-point method, negative (N<0) for the
+     *   horizontal subdivision method with 2*(-N) intervals, and positive
+     *   (N>0) for the tilted subdivision method with 2*N intervals.
+     */
+    int equilibrationAccuracy() const
+    {
+        return this->rec_.initializationTargetAccuracy();
+    }
 
     /**
      * Retrieve dissolved gas-oil ratio calculator of current
@@ -694,7 +705,6 @@ public:
      * Retrieve pvtIdx of the region.
      */
     int pvtIdx() const { return this->pvtIdx_; }
-
 
 private:
     Opm::EquilRecord rec_;     /**< Equilibration data */

--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -1396,7 +1396,6 @@ invertCapPress(const double   pc,
 template <typename Grid, typename CellRange>
 void verticalExtent(const Grid&           grid,
                     const CellRange&      cells,
-                    int&                  cellcount,
                     std::array<double,2>& span)
 {
     // This code is only supported in three space dimensions
@@ -1404,7 +1403,6 @@ void verticalExtent(const Grid&           grid,
 
     span[0] = std::numeric_limits<double>::max();
     span[1] = std::numeric_limits<double>::lowest();
-    cellcount = 0;
 
     const int nd = Grid::dimensionworld;
 
@@ -1426,7 +1424,7 @@ void verticalExtent(const Grid&           grid,
 
     for (typename CellRange::const_iterator
              ci = cells.begin(), ce = cells.end();
-         ci != ce; ++ci, ++cellcount)
+         ci != ce; ++ci)
     {
         for (auto fi = cell2Faces[*ci].begin(),
                   fe = cell2Faces[*ci].end();
@@ -1687,9 +1685,7 @@ private:
 
         auto ptable = Details::PressureTable<FluidSystem, EquilReg>{ grav };
         auto psat   = PhaseSat { materialLawManager, this->swatInit_ };
-
-        auto vspan = std::array<double, 2>{};
-        auto ncell = 0;
+        auto vspan  = std::array<double, 2>{};
 
         for (const auto& r : reg.activeRegions()) {
             const auto& cells = reg.cells(r);
@@ -1699,7 +1695,7 @@ private:
                 continue;
             }
 
-            Details::verticalExtent(grid, cells, ncell, vspan);
+            Details::verticalExtent(grid, cells, vspan);
 
             const EqReg eqreg(rec[r], rsFunc_[r], rvFunc_[r], regionPvtIdx_[r]);
 

--- a/tests/test_equil.cc
+++ b/tests/test_equil.cc
@@ -192,14 +192,13 @@ void test_PhasePressure()
         0
     };
 
-    auto numCells = 0;
     auto vspan = std::array<double, 2>{};
     {
         auto cells = std::vector<int>(simulator->vanguard().grid().size(0));
         std::iota(cells.begin(), cells.end(), 0);
 
         Opm::EQUIL::Details::verticalExtent(simulator->vanguard().grid(),
-                                            cells, numCells, vspan);
+                                            cells, vspan);
     }
 
     const auto grav = 10.0;
@@ -211,7 +210,7 @@ void test_PhasePressure()
 
     const auto reltol = 1.0e-8;
     const auto first  = centerDepth(*simulator, 0);
-    const auto last   = centerDepth(*simulator, numCells - 1);
+    const auto last   = centerDepth(*simulator, simulator->vanguard().grid().size(0) - 1);
 
     CHECK_CLOSE(ptable.water(first),  90e3  , reltol);
     CHECK_CLOSE(ptable.water(last) , 180e3  , reltol);
@@ -279,14 +278,13 @@ void test_CellSubset()
         cells[ix].push_back(c);
     }
 
-    auto numCells = 0;
     auto vspan = std::array<double, 2>{};
     {
         auto vspancells = std::vector<int>(simulator->vanguard().grid().size(0));
         std::iota(vspancells.begin(), vspancells.end(), 0);
 
         Opm::EQUIL::Details::verticalExtent(simulator->vanguard().grid(),
-                                            vspancells, numCells, vspan);
+                                            vspancells, vspan);
     }
 
     const auto grav = 10.0;
@@ -294,7 +292,7 @@ void test_CellSubset()
         FluidSystem, Opm::EQUIL::EquilReg
     >{ grav };
 
-    auto ppress = PPress(2, PVal(numCells, 0.0));
+    auto ppress = PPress(2, PVal(simulator->vanguard().grid().size(0), 0.0));
     for (auto r = cells.begin(), e = cells.end(); r != e; ++r) {
         const int rno = int(r - cells.begin());
 
@@ -355,14 +353,13 @@ void test_RegMapping()
         0)
         };
 
-    auto numCells = 0;
     auto vspan = std::array<double, 2>{};
     {
         auto cells = std::vector<int>(simulator->vanguard().grid().size(0));
         std::iota(cells.begin(), cells.end(), 0);
 
         Opm::EQUIL::Details::verticalExtent(simulator->vanguard().grid(),
-                                            cells, numCells, vspan);
+                                            cells, vspan);
     }
 
     const auto grav = 10.0;
@@ -393,7 +390,7 @@ void test_RegMapping()
 
     const Opm::RegionMapping<> eqlmap(eqlnum);
 
-    auto ppress = PPress(2, PVal(numCells, 0.0));
+    auto ppress = PPress(2, PVal(simulator->vanguard().grid().size(0), 0.0));
     for (const auto& r : eqlmap.activeRegions()) {
         ptable.equilibrate(region[r], vspan);
 


### PR DESCRIPTION
This Pull Request adds a very early, alpha-quality implementation of the "horizontal subdivision" strategy (N < 0) of the EQUIL directive. This in turn enables more accurate derivations of the initial fluids in place.

Interactions with SWATINIT are completely untested, and the initial Rs/Rv derivations in this context are possibly incomplete.  More work is likely needed in this area, but this does at least enable more widespread testing.

This PR depends on (and includes) #2527 and must not be merged before that PR is in master.

### Example Initialization ###

Below is an example using [MOD4_GRP](https://github.com/OPM/opm-tests/blob/e3e4747457f9d8168909d89afc3657d6ea8523d0/model4/MOD4_GRP.DATA) from OPM-Tests, with the equilibration directive changed as
```diff
 EQUIL
 -- datum    Pres     OWC            Pcow  GOC    Pcog  Rsvd  Rvvd  N
-   1500.0   150      1514.0         0.0   610.0   1*    1     1*   0 /
-   1550.0   150      1547.5         0.0   610.0   1*    1     1*   0 /
+   1500.0   150      1514.0         0.0   610.0   1*    1     1*   1* /
+   1550.0   150      1547.5         0.0   610.0   1*    1     1*   1* /
```
meaning that the 9th item is reset to its default value of `-5` (cells divided into 5+5 horizontal sub-intervals).  At least in this simple case&mdash;a sharp interface between the phases&mdash;we're able to capture a more accurate representation of the O/W contact in the upper compartment.  We also observe that Flow runs more stably in this case and does not cut its step size as frequently or significantly as with the centre-based initialization of current master (86 timesteps in this PR vs. 98 timesteps in current master) when run as
```sh
$ flow --ecl-deck-file-name=${cse} --enable-tuning=true \
    --tolerance-cnv=1.0e-5 --tolerance-cnv-relaxed=5.0e-4
``` 

Simulator |  Initial SOIL
------------ | ---------------
Master | ![MOD4_GRP_ECL_Flow_Master_3D_View_SOIL_00_30_Jul_2019](https://user-images.githubusercontent.com/1871438/79169149-f3d79580-7deb-11ea-8564-7e300a802c38.png)
This PR | ![MOD4_GRP_ECL_Flow_Dev_3D_View_SOIL_00_30_Jul_2019](https://user-images.githubusercontent.com/1871438/79169184-0b168300-7dec-11ea-94d8-07be88b74f41.png)
ECLIPSE | ![MOD4_GRP_ECL_Eclipse_3D_View_SOIL_00_30_Jul_2019](https://user-images.githubusercontent.com/1871438/79169207-1a95cc00-7dec-11ea-91a2-5d2cd543d466.png)
