### PR TITLE
Add Main.hpp to CMakeLists_files.cmake.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -125,6 +125,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/flow/BlackoilModelEbos.hpp
   opm/simulators/flow/BlackoilModelParametersEbos.hpp
   opm/simulators/flow/FlowMainEbos.hpp
+  opm/simulators/flow/Main.hpp
   opm/simulators/flow/NonlinearSolverEbos.hpp
   opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
   opm/simulators/flow/MissingFeatures.hpp


### PR DESCRIPTION
Pull request #2521 forgot to add `Main.hpp` to `CMakeLists_files.cmake`. Adding `Main.hpp` to `CMakeLists_files.cmake` will enable [`OpmInstall.cmake`](https://github.com/OPM/opm-common/blob/master/cmake/Modules/OpmInstall.cmake) to install the file to `$CMAKE_INSTALL_PREFIX/include/opm/simulators/flow` when running `make install`.