### PR TITLE
changed: check for pre-existing pybind11 target

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,2 +1,3 @@
-add_subdirectory( pybind11 )
-
+if(NOT TARGET pybind11)
+  add_subdirectory( pybind11 )
+endif()


### PR DESCRIPTION
this is necessary to allow building all modules in a 'super-build' with python enabled.