### PR TITLE
Merge flow_tag.hpp into Main.hpp (new try)

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -19,12 +19,22 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "config.h"
-#include <opm/simulators/flow/Main.hpp>
+#include <opm/models/utils/propertysystem.hh>
+#include <opm/models/utils/parametersystem.hh>
 
+BEGIN_PROPERTIES
+
+NEW_TYPE_TAG(EclFlowProblemMain);
+
+END_PROPERTIES
+
+#define OPM_FLOW_MAIN
+#include <opm/simulators/flow/Main.hpp>
 
 int main(int argc, char** argv)
 {
-    auto mainObject = Opm::Main(argc, argv);
+    using TypeTag = TTAG(EclFlowProblemMain);
+    auto mainObject = Opm::Main<TypeTag>(argc, argv);
     return mainObject.run();
 }
 

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -389,11 +389,9 @@ namespace Opm
 #endif
                 return 1;
             }
-#ifdef OPM_FLOW_MAIN
             if (outputCout) {
                 Opm::FlowMainEbos<PreTypeTag>::printBanner();
             }
-#endif
             // Create Deck and EclipseState.
             try {
                 if (outputCout) {

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -93,7 +93,9 @@ NEW_TYPE_TAG(FlowEarlyBird, INHERITS_FROM(EclFlowProblem));
 
 END_PROPERTIES
 
-#ifndef OPM_FLOW_MAIN
+//#ifndef OPM_FLOW_MAIN  // NOTE: since the methods in this #ifndef block are
+//                          are template functions they will not be included
+//                          in the code if not used, so #ifndef is commented out
 namespace Opm {
   template <class TypeTag>
   void flowEbosSetDeck(Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
@@ -124,7 +126,7 @@ namespace Opm {
 
 }
 
-#endif  /* #ifndef OPM_FLOW_MAIN */
+//#endif  /* #ifndef OPM_FLOW_MAIN */
 
 namespace Opm
 {


### PR DESCRIPTION
Redoing PR #2523 to fixup commit history (see https://github.com/OPM/opm-simulators/pull/2523#issuecomment-61340898)

Addresses the comments in PR #2521 regarding code duplication in `Main.hpp` and `flow_tag.hpp`. This PR merges the code in `flow_tag.hpp` into `Main.hpp` such that `flow_tag.hpp` can be eliminated (which will be done in PR #2524).