### PR TITLE
Stop simulating if the schedule has set an exit condition.

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -258,12 +258,12 @@ namespace Opm
                 createSimulator();
 
                 // do the actual work
-                runSimulator(output_cout);
+                int retval = runSimulator(output_cout);
 
                 // clean up
                 mergeParallelLogFiles(output_to_files);
 
-                return EXIT_SUCCESS;
+                return retval;
             }
             catch (const std::exception& e) {
                 std::ostringstream message;
@@ -463,7 +463,7 @@ namespace Opm
         }
 
         // Run the simulator.
-        void runSimulator(bool output_cout)
+        int runSimulator(bool output_cout)
         {
             const auto& schedule = this->schedule();
             const auto& timeMap = schedule.getTimeMap();
@@ -508,12 +508,12 @@ namespace Opm
                     successReport.reportFullyImplicit(ss, &failureReport);
                     OpmLog::info(ss.str());
                 }
-
+                return successReport.exit_status;
             } else {
                 if (output_cout) {
                     std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;
                 }
-
+                return EXIT_SUCCESS;
             }
         }
 

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -164,6 +164,14 @@ public:
 
         // Main simulation loop.
         while (!timer.done()) {
+            if (schedule().exitStatus().has_value()) {
+                if (terminalOutput_) {
+                    OpmLog::info("Stopping simulation since EXIT was triggered by an action keyword.");
+                }
+                report.exit_status = schedule().exitStatus().value();
+                break;
+            }
+
             // Report timestep.
             if (terminalOutput_) {
                 std::ostringstream ss;

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -42,6 +42,7 @@ namespace Opm
           total_newton_iterations( 0 ),
           total_linear_iterations( 0 ),
           converged(false),
+          exit_status(EXIT_SUCCESS),
           verbose_(verbose)
     {
     }

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -44,6 +44,7 @@ namespace Opm
         unsigned int total_linear_iterations;
 
         bool converged;
+        int exit_status;
 
         /// Default constructor initializing all times to 0.0.
         explicit SimulatorReport(bool verbose=true);


### PR DESCRIPTION
Depends on OPM/opm-common#1692.

This simply queries the `exitStatus()` of the schedule at the start of a report timestep. It does not honor the value, that could be added but require modifying the return values down a chain of calls, so I did not implement that (yet), is it important? What does the commercial sims do?

I tested it using an ACTIONX condition to stop simulation, and behaviour is consistent in the following sense: if I use the "gas rate > 100 k" condition, with `EXIT` the last timestep has just above 100k gas rate. If I instead do `WELOPEN * SHUT`, the last timestep with nonzero rate is the same as the last above, with the same rate.