### PR TITLE
Refactor flow_ebos_blackoil.cpp.

### DIFF
--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -46,8 +46,8 @@ void flowEbosBlackoilSetDeck(double setupTime, Deck *deck, EclipseState& eclStat
     Vanguard::setExternalSummaryConfig(&summaryConfig);
 }
 
-// ----------------- Main program -----------------
-int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles)
+std::unique_ptr<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>
+flowEbosBlackoilMainInit(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -59,8 +59,14 @@ int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFile
     Dune::MPIHelper::instance(argc, argv);
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    return std::make_unique<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>();
+}
+
+// ----------------- Main program -----------------
+int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    auto mainfunc = flowEbosBlackoilMainInit(argc, argv, outputCout, outputFiles);
+    return mainfunc->execute(argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/flow/flow_ebos_blackoil.hpp
+++ b/flow/flow_ebos_blackoil.hpp
@@ -21,10 +21,15 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/simulators/flow/FlowMainEbos.hpp>
 
 namespace Opm {
 void flowEbosBlackoilSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+
 int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+std::unique_ptr<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>
+    flowEbosBlackoilMainInit(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 
 #endif // FLOW_EBOS_BLACKOIL_HPP

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -116,6 +116,7 @@ namespace Opm
     class Main
     {
     private:
+        using FlowMainEbosType = Opm::FlowMainEbos<TTAG(EclFlowProblem)>;
         enum class FileOutputMode {
             //! \brief No output to files.
             OUTPUT_NONE = 0,
@@ -159,6 +160,26 @@ namespace Opm
                 return dispatchStatic_<TypeTag>();
             } else {
                 return exitCode;
+            }
+        }
+
+        std::unique_ptr<FlowMainEbosType> initFlowEbosBlackoil(int& exitCode)
+        {
+            exitCode = EXIT_SUCCESS;
+            if (initialize_(exitCode)) {
+                // TODO: check that this deck really represents a blackoil
+                // case. E.g. check that number of phases == 3
+                Opm::flowEbosBlackoilSetDeck(
+                    setupTime_,
+                    deck_.get(),
+                    *eclipseState_,
+                    *schedule_,
+                    *summaryConfig_);
+                return Opm::flowEbosBlackoilMainInit(
+                    argc_, argv_, outputCout_, outputFiles_);
+            } else {
+                exitCode = EXIT_FAILURE;
+                return std::unique_ptr<FlowMainEbosType>(); // nullptr
             }
         }
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,3 +1,4 @@
 if(NOT TARGET pybind11)
   add_subdirectory( pybind11 )
+  add_subdirectory( simulators )
 endif()

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -1,0 +1,21 @@
+pybind11_add_module(simulators simulators.cpp)
+
+set_target_properties( simulators PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/python/opm2 )
+
+target_sources(simulators
+  PRIVATE
+    ../../flow/flow_ebos_blackoil.cpp
+    ../../flow/flow_ebos_brine.cpp
+    ../../flow/flow_ebos_energy.cpp
+    ../../flow/flow_ebos_foam.cpp
+    ../../flow/flow_ebos_gasoil.cpp
+    ../../flow/flow_ebos_oilwater.cpp
+    ../../flow/flow_ebos_oilwater_polymer.cpp
+    ../../flow/flow_ebos_oilwater_polymer_injectivity.cpp
+    ../../flow/flow_ebos_polymer.cpp
+    ../../flow/flow_ebos_solvent.cpp
+    ../../flow/flow_ebos_blackoil.cpp)
+
+target_link_libraries( simulators PRIVATE opmsimulators )
+
+install(TARGETS simulators DESTINATION ${PYTHON_INSTALL_PREFIX}/simulators)

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -1,0 +1,82 @@
+#include "config.h"
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#define OPM_FLOW_MAIN
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/models/utils/propertysystem.hh>
+#include <opm/models/utils/parametersystem.hh>
+#include <pybind11/pybind11.h>
+#include <pybind11/embed.h>
+#include <iostream>
+
+BEGIN_PROPERTIES
+
+NEW_TYPE_TAG(EclFlowProblemMain);
+
+END_PROPERTIES
+
+namespace py = pybind11;
+
+class BlackOilSimulator
+{
+public:
+    BlackOilSimulator( const Opm::Deck& deck, 
+                       const Opm::EclipseState& eclipseState, 
+                       const Opm::Schedule& schedule,
+                       const Opm::SummaryConfig& summaryConfig )
+    {
+        setDeck(deck);
+        setEclipseState(eclipseState);
+        setSchedule(schedule);
+        setSummaryConfig(summaryConfig);
+    }
+
+    int run()
+    {
+        int argc = 1;
+        char *argv[1] = {"flow"};
+        using TypeTag = TTAG(EclFlowProblemMain);
+        auto mainObject = Opm::Main<TypeTag>(
+            argc, argv, deck_, eclipseState_, schedule_, summaryConfig_);
+        return mainObject.run();
+    }
+    
+    void setDeck( const Opm::Deck& deck )
+    {
+        deck_ = std::make_shared< Opm::Deck >(deck);
+    }
+
+    void setEclipseState( const Opm::EclipseState& eclipseState )
+    {
+        eclipseState_ = std::make_shared< Opm::EclipseState >(eclipseState);
+    }
+
+    void setSchedule( const Opm::Schedule& schedule )
+    {
+        schedule_ = std::make_shared< Opm::Schedule >(schedule);
+    }
+
+    void setSummaryConfig( const Opm::SummaryConfig& summaryConfig )
+    {
+        summaryConfig_ = std::make_shared< Opm::SummaryConfig >(summaryConfig);
+    }
+
+private:
+    std::shared_ptr<Opm::Deck>          deck_;
+    std::shared_ptr<Opm::EclipseState>  eclipseState_;
+    std::shared_ptr<Opm::Schedule>      schedule_;
+    std::shared_ptr<Opm::SummaryConfig> summaryConfig_;
+};
+
+PYBIND11_MODULE(simulators, m)
+{
+    py::class_<BlackOilSimulator>(m, "BlackOilSimulator")
+        .def(py::init< const Opm::Deck&, const Opm::EclipseState&, const Opm::Schedule&, const Opm::SummaryConfig& >())
+        .def("run", &BlackOilSimulator::run)
+        .def("setDeck", &BlackOilSimulator::setDeck)
+        .def("setEclipseState", &BlackOilSimulator::setEclipseState)
+        .def("setSchedule", &BlackOilSimulator::setSchedule)
+        .def("setSummaryConfig", &BlackOilSimulator::setSummaryConfig);
+}

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -3,19 +3,10 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#define OPM_FLOW_MAIN
 #include <opm/simulators/flow/Main.hpp>
-#include <opm/models/utils/propertysystem.hh>
-#include <opm/models/utils/parametersystem.hh>
 #include <pybind11/pybind11.h>
 #include <pybind11/embed.h>
 #include <iostream>
-
-BEGIN_PROPERTIES
-
-NEW_TYPE_TAG(EclFlowProblemMain);
-
-END_PROPERTIES
 
 namespace py = pybind11;
 
@@ -37,10 +28,9 @@ public:
     {
         int argc = 1;
         char *argv[1] = {"flow"};
-        using TypeTag = TTAG(EclFlowProblemMain);
-        auto mainObject = Opm::Main<TypeTag>(
+        auto mainObject = Opm::Main(
             argc, argv, deck_, eclipseState_, schedule_, summaryConfig_);
-        return mainObject.run();
+        return mainObject.runDynamic();
     }
     
     void setDeck( const Opm::Deck& deck )


### PR DESCRIPTION
NOTE: this pull request depends on #2518 which should be merged first.
    
In this PR, we return to the list of PRs presented in Pull #2403, starting with the first two:
- #2438 : *Refactor run() into prepareRun_()*, and
- #2439 : *Refactor flowEbosBlackoilMain()*.
    
The first, #2438, has already been handled by the refactoring of `flow.cpp` in #2516. The second, #2439, has diverged to much from the current master, so I decided to create a new PR (this one) instead of trying to force-adjust it.

### Description
    
We would like to add a `step()` method to `simulators.cpp`, that will let a Python script advance the simulator one report step at a time. Before calling `step()`, the Python script will have to call a `step_init()` method that initializes the simulator, similar to what is done in `run()` now.
    
Currently, the Python `run()` calls `runDynamic()` in `Main.hpp`, which calls `dispatchDynamic_()` which again calls `flowEbosBlackoilMain()` to start the simulation (which calls `execute()` in class `FlowMainEbos`). The Python `step_init()` method should also do the setup in `FlowEbosBlackoilMain()` but it should not call `execute()` directly. In order to avoid code     duplication for `run()` and `step_init()`, the initialization part of `flowEbosBlackoilMain()` is isolated into a `flowEbosBlackoilMainInit()` method.
    
The `step_init()` method (to be implemented in a later PR) will now call `initFlowEbosBlackoil()` in `Main.hpp` to initialize the simulator.
