### PR TITLE
fixed: use PROJECT_BINARY_DIR, not CMAKE_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ opm_add_test(test_gatherconvergencereport
   CONDITION
     MPI_FOUND AND Boost_UNIT_TEST_FRAMEWORK_FOUND
   DRIVER_ARGS
-    5 ${CMAKE_BINARY_DIR}
+    5 ${PROJECT_BINARY_DIR}
 )
 
 opm_add_test(test_gatherdeferredlogger
@@ -179,7 +179,7 @@ opm_add_test(test_gatherdeferredlogger
   CONDITION
     MPI_FOUND AND Boost_UNIT_TEST_FRAMEWORK_FOUND
   DRIVER_ARGS
-    5 ${CMAKE_BINARY_DIR}
+    5 ${PROJECT_BINARY_DIR}
 )
 
 include(OpmBashCompletion)


### PR DESCRIPTION
tests fail to execute in super-build otherwise