### PR TITLE
Python bindings for the blackoil simulator (simplified).

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -64,6 +64,7 @@
 #include <opm/simulators/utils/ParallelSerialization.hpp>
 #endif
 
+#include <string>
 #include <type_traits>
 
 BEGIN_PROPERTIES
@@ -126,6 +127,17 @@ namespace Opm
         };
     public:
         Main(int argc, char** argv) : argc_(argc), argv_(argv)  {  }
+
+        Main(const std::string &filename)
+        {
+            deckFilename_.assign(filename);
+            flowProgName_.assign("flow");
+            argc_ = 2;
+            saveArgs_[0] = const_cast<char *>(flowProgName_.c_str());
+            saveArgs_[1] = const_cast<char *>(deckFilename_.c_str());
+            argv_ = saveArgs_;
+        }
+
         Main(int argc,
              char** argv,
              std::shared_ptr<Opm::Deck> deck,
@@ -603,6 +615,9 @@ namespace Opm
         bool outputCout_;
         bool outputFiles_;
         double setupTime_;
+        std::string deckFilename_;
+        std::string flowProgName_;
+        char *saveArgs_[2];
         std::shared_ptr<Opm::Deck> deck_;
         std::shared_ptr<Opm::EclipseState> eclipseState_;
         std::shared_ptr<Opm::Schedule> schedule_;

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,3 +1,4 @@
 if(NOT TARGET pybind11)
   add_subdirectory( pybind11 )
+  add_subdirectory( simulators )
 endif()

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -1,0 +1,11 @@
+pybind11_add_module(simulators simulators.cpp)
+
+set_target_properties( simulators PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/python/opm2 )
+
+target_sources(simulators
+  PRIVATE
+    ../../flow/flow_ebos_blackoil.cpp)
+
+target_link_libraries( simulators PRIVATE opmsimulators )
+
+install(TARGETS simulators DESTINATION ${PYTHON_INSTALL_PREFIX}/simulators)

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -8,4 +8,7 @@ target_sources(simulators
 
 target_link_libraries( simulators PRIVATE opmsimulators )
 
-install(TARGETS simulators DESTINATION ${PYTHON_INSTALL_PREFIX}/simulators)
+set(PYTHON_PACKAGE_PATH "site-packages")
+set(PYTHON_INSTALL_PREFIX "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/${PYTHON_PACKAGE_PATH}" CACHE STRING "Subdirectory to install Python modules in")
+
+install(TARGETS simulators DESTINATION ${DEST_PREFIX}${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_PREFIX}/opm/simulators)

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -11,4 +11,4 @@ target_link_libraries( simulators PRIVATE opmsimulators )
 set(PYTHON_PACKAGE_PATH "site-packages")
 set(PYTHON_INSTALL_PREFIX "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/${PYTHON_PACKAGE_PATH}" CACHE STRING "Subdirectory to install Python modules in")
 
-install(TARGETS simulators DESTINATION ${DEST_PREFIX}${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_PREFIX}/opm/simulators)
+install(TARGETS simulators DESTINATION ${DEST_PREFIX}${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_PREFIX}/opm)

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -1,0 +1,38 @@
+#include "config.h"
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#define FLOW_BLACKOIL_ONLY
+#include <opm/simulators/flow/Main.hpp>
+#include <pybind11/pybind11.h>
+#include <pybind11/embed.h>
+#include <iostream>
+#include <string>
+
+namespace py = pybind11;
+
+class BlackOilSimulator
+{
+public:
+
+    BlackOilSimulator( const std::string &deckFilename) : deckFilename_(deckFilename)
+    {
+    }
+
+    int run()
+    {
+        auto mainObject = Opm::Main( deckFilename_ );
+        return mainObject.runDynamic();
+    }
+    
+private:
+    const std::string deckFilename_;
+};
+
+PYBIND11_MODULE(simulators, m)
+{
+    py::class_<BlackOilSimulator>(m, "BlackOilSimulator")
+        .def(py::init< const std::string& >())
+        .def("run", &BlackOilSimulator::run);
+}


### PR DESCRIPTION
A simplified version of PR #2518 that uses a deck filename to construct the simulator.

After private discussion with @joakim-hove it was decided that the construction of the blackoil simulator from Python using `deck`, `eclipseState`, `schedule`, and `summaryConfig` as constructor arguments (as implemented in #2518) should be replaced by a constructor taking only the deck filename as parameter.

A rewrite of the Python bindings for the blackoil simulator using pybind11 as introduced in #2127. The new version uses the refactored `flow.cpp` introduced in #2516 and thus avoids duplication
of the code in `simulators.cpp`.

This PR will be the starting point for implementing the Python bindings introduced in #2403.