### PR TITLE
Fix how the group reduction works

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1233,9 +1233,9 @@ namespace Opm {
         // the group target reduction rates needs to be update since wells may have swicthed to/from GRUP control
         // Currently the group target reduction does not honor NUPCOL. TODO: is that true?
         std::vector<double> groupTargetReduction(numPhases(), 0.0);
-        WellGroupHelpers::updateGroupTargetReduction(fieldGroup, schedule(), reportStepIdx, /*isInjector*/ false, phase_usage_, well_state_nupcol_, well_state_, groupTargetReduction);
+        WellGroupHelpers::updateGroupTargetReduction(fieldGroup, schedule(), reportStepIdx, /*isInjector*/ false, phase_usage_, *guideRate_, well_state_nupcol_, well_state_, groupTargetReduction);
         std::vector<double> groupTargetReductionInj(numPhases(), 0.0);
-        WellGroupHelpers::updateGroupTargetReduction(fieldGroup, schedule(), reportStepIdx, /*isInjector*/ true, phase_usage_, well_state_nupcol_, well_state_, groupTargetReductionInj);
+        WellGroupHelpers::updateGroupTargetReduction(fieldGroup, schedule(), reportStepIdx, /*isInjector*/ true, phase_usage_, *guideRate_, well_state_nupcol_, well_state_, groupTargetReductionInj);
 
         const double simulationTime = ebosSimulator_.time();
         std::vector<double> pot(numPhases(), 0.0);

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -262,10 +262,6 @@ namespace WellGroupHelpers
             }
         }
 
-
-
-
-
         for (const std::string& wellName : group.wells()) {
             const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
 
@@ -734,7 +730,7 @@ namespace WellGroupHelpers
     {
         const double my_guide_rate = guideRate(name, always_included_child);
         const Group& parent_group = schedule_.getGroup(parent(name), report_step_);
-        const double total_guide_rate = guideRateSum(parent_group, always_included_child, false);
+        const double total_guide_rate = guideRateSum(parent_group, always_included_child);
         assert(total_guide_rate >= my_guide_rate);
         const double guide_rate_epsilon = 1e-12;
         return (total_guide_rate > guide_rate_epsilon) ? my_guide_rate / total_guide_rate : 0.0;
@@ -747,20 +743,20 @@ namespace WellGroupHelpers
             return schedule_.getGroup(name, report_step_).parent();
         }
     }
-    double FractionCalculator::guideRateSum(const Group& group, const std::string& always_included_child, const bool include_all)
+    double FractionCalculator::guideRateSum(const Group& group, const std::string& always_included_child)
     {
         double total_guide_rate = 0.0;
         for (const std::string& child_group : group.groups()) {
             const auto ctrl = well_state_.currentProductionGroupControl(child_group);
             const bool included = (ctrl == Group::ProductionCMode::FLD) || (ctrl == Group::ProductionCMode::NONE)
                 || (child_group == always_included_child);
-            if (included || include_all) {
+            if (included) {
                 total_guide_rate += guideRate(child_group, always_included_child);
             }
         }
         for (const std::string& child_well : group.wells()) {
             const bool included = (well_state_.isProductionGrup(child_well)) || (child_well == always_included_child);
-            if (included || include_all) {
+            if (included) {
                 total_guide_rate += guideRate(child_well, always_included_child);
             }
         }
@@ -778,7 +774,7 @@ namespace WellGroupHelpers
                     // We are a group, with default guide rate.
                     // Compute guide rate by accumulating our children's guide rates.
                     const Group& group = schedule_.getGroup(name, report_step_);
-                    return guideRateSum(group, always_included_child, false);
+                    return guideRateSum(group, always_included_child);
                 }
             } else {
                 // No group-controlled subordinate wells.
@@ -1169,7 +1165,9 @@ namespace WellGroupHelpers
                 // calculation of reductions.
                 const int num_gr_ctrl = groupControlledWells(schedule, wellState, reportStepIdx, chain[ii + 1], "");
                 if (num_gr_ctrl == 0) {
-                    target += localReduction(chain[ii + 1]);
+                    if (guideRate->has(chain[ii + 1])) {
+                        target += localReduction(chain[ii + 1]);
+                    }
                 }
             }
             target *= localFraction(chain[ii + 1]);

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -86,6 +86,7 @@ namespace WellGroupHelpers
                                     const int reportStepIdx,
                                     const bool isInjector,
                                     const PhaseUsage& pu,
+                                    const GuideRate& guide_rate,
                                     const WellStateFullyImplicitBlackoil& wellStateNupcol,
                                     WellStateFullyImplicitBlackoil& wellState,
                                     std::vector<double>& groupTargetReduction);

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -302,7 +302,7 @@ namespace WellGroupHelpers
 
     private:
         std::string parent(const std::string& name);
-        double guideRateSum(const Group& group, const std::string& always_included_child, const bool include_all);
+        double guideRateSum(const Group& group, const std::string& always_included_child);
         double guideRate(const std::string& name, const std::string& always_included_child);
         int groupControlledWells(const std::string& group_name, const std::string& always_included_child);
         GuideRate::RateVector getGroupRateVector(const std::string& group_name);

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -2270,10 +2270,15 @@ namespace Opm
         const size_t num_ancestors = chain.size() - 1;
         double target = orig_target;
         for (size_t ii = 0; ii < num_ancestors; ++ii) {
-            target -= localReduction(chain[ii]);
+            if ((ii == 0) || guide_rate_->has(chain[ii])) {
+                // Apply local reductions only at the control level
+                // (top) and for levels where we have a specified
+                // group guide rate.
+                target -= localReduction(chain[ii]);
+            }
             target *= localFraction(chain[ii+1]);
         }
-        // Avoid negative target rates comming from too large local reductions. 
+        // Avoid negative target rates coming from too large local reductions.
         const double target_rate = std::max(0.0, target / efficiencyFactor);
         const auto current_rate = -tcalc.calcModeRateFromRates(rates); // Switch sign since 'rates' are negative for producers.
         control_eq = current_rate - target_rate;


### PR DESCRIPTION
The target reduction due to wells not under group control is applied on the group under control level or on levels where the guiderates are explicitly set. 