### PR TITLE
Fix GCONSALE

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -428,6 +428,7 @@ namespace Opm {
             bool checkGroupConstraints(const Group& group, Opm::DeferredLogger& deferred_logger) const;
             Group::ProductionCMode checkGroupProductionConstraints(const Group& group, Opm::DeferredLogger& deferred_logger) const;
             Group::InjectionCMode checkGroupInjectionConstraints(const Group& group, const Phase& phase) const;
+            void checkGconsaleLimits(const Group& group) const;
 
             void updateGroupHigherControls(Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
             void checkGroupHigherConstraints(const Group& group, Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -442,6 +442,7 @@ namespace Opm {
 
         // time step is finished and we are not any more at the beginning of an report step
         report_step_starts_ = false;
+        const int reportStepIdx = ebosSimulator_.episodeIndex();
 
         Opm::DeferredLogger local_deferredLogger;
         for (const auto& well : well_container_) {
@@ -457,7 +458,7 @@ namespace Opm {
         // calculate the well potentials
         try {
             std::vector<double> well_potentials;
-            const int reportStepIdx = ebosSimulator_.episodeIndex();
+
             computeWellPotentials(well_potentials, reportStepIdx, local_deferredLogger);
         } catch ( std::runtime_error& e ) {
             const std::string msg = "A zero well potential is returned for output purposes. ";
@@ -470,6 +471,9 @@ namespace Opm {
             global_deferredLogger.logMessages();
         }
 
+        // check group sales limits at the end of the timestep
+        const Group& fieldGroup = schedule().getGroup("FIELD", reportStepIdx);
+        checkGconsaleLimits(fieldGroup);
     }
 
 
@@ -2028,43 +2032,65 @@ namespace Opm {
                 }
             }
         }
-        // Handle GCONSALE
-        if (schedule().gConSale(reportStepIdx).has(group.name())) {
-
-            if (controls.phase != Phase::GAS)
-                OPM_THROW(std::runtime_error, "Group " + group.name() + " has GCONSALE control but is not a GAS group" );
-
-            const auto& gconsale = schedule().gConSale(reportStepIdx).get(group.name(), summaryState);
-
-            double sales_rate = 0.0;
-            int gasPos = phase_usage_.phase_pos[BlackoilPhases::Vapour];
-            sales_rate += WellGroupHelpers::sumWellRates(group, schedule(), well_state, reportStepIdx, gasPos, /*isInjector*/false);
-            sales_rate -= WellGroupHelpers::sumWellRates(group, schedule(), well_state, reportStepIdx, gasPos, /*isInjector*/true);
-
-            // sum over all nodes
-            sales_rate = comm.sum(sales_rate);
-
-            // add import rate and substract consumption rate for group for gas
-            if (schedule().gConSump(reportStepIdx).has(group.name())) {
-                const auto& gconsump = schedule().gConSump(reportStepIdx).get(group.name(), summaryState);
-                if (phase_usage_.phase_used[BlackoilPhases::Vapour]) {
-                    sales_rate += gconsump.import_rate;
-                    sales_rate -= gconsump.consumption_rate;
-                }
-            }
-            if (sales_rate > gconsale.max_sales_rate) {
-                OPM_THROW(std::runtime_error, "Group " + group.name() + " has sale rate more then the maximum permitted value. Not implemented in Flow" );
-            }
-            if (sales_rate < gconsale.min_sales_rate) {
-                OPM_THROW(std::runtime_error, "Group " + group.name() + " has sale rate less then minimum permitted value. Not implemented in Flow" );
-            }
-            if (gconsale.sales_target < 0.0) {
-                OPM_THROW(std::runtime_error, "Group " + group.name() + " has sale rate target less then zero. Not implemented in Flow" );
-            }
-
-        }
         return Group::InjectionCMode::NONE;
     }
+
+    template<typename TypeTag>
+    void
+    BlackoilWellModel<TypeTag>::
+    checkGconsaleLimits(const Group& group) const
+    {
+        const int reportStepIdx = ebosSimulator_.episodeIndex();
+         // call recursively down the group hiearchy
+        for (const std::string& groupName : group.groups()) {
+            checkGconsaleLimits( schedule().getGroup(groupName, reportStepIdx));
+        }
+
+        // only for groups with gas injection controls
+        if (!group.hasInjectionControl(Phase::GAS)) {
+            return;
+        }
+
+        // check if gconsale is used for this group
+        if (!schedule().gConSale(reportStepIdx).has(group.name()))
+            return;
+
+        const auto& summaryState = ebosSimulator_.vanguard().summaryState();
+        const auto& comm = ebosSimulator_.vanguard().grid().comm();
+        const auto& well_state = well_state_;
+
+        const auto& controls = group.injectionControls(Phase::GAS, summaryState);
+        const Group::InjectionCMode& currentControl = well_state.currentInjectionGroupControl(Phase::GAS, group.name());
+        const auto& gconsale = schedule().gConSale(reportStepIdx).get(group.name(), summaryState);
+
+        double sales_rate = 0.0;
+        int gasPos = phase_usage_.phase_pos[BlackoilPhases::Vapour];
+        sales_rate += WellGroupHelpers::sumWellRates(group, schedule(), well_state, reportStepIdx, gasPos, /*isInjector*/false);
+        sales_rate -= WellGroupHelpers::sumWellRates(group, schedule(), well_state, reportStepIdx, gasPos, /*isInjector*/true);
+
+        // sum over all nodes
+        sales_rate = comm.sum(sales_rate);
+
+        // add import rate and substract consumption rate for group for gas
+        if (schedule().gConSump(reportStepIdx).has(group.name())) {
+            const auto& gconsump = schedule().gConSump(reportStepIdx).get(group.name(), summaryState);
+            if (phase_usage_.phase_used[BlackoilPhases::Vapour]) {
+                sales_rate += gconsump.import_rate;
+                sales_rate -= gconsump.consumption_rate;
+            }
+        }
+        if (sales_rate > gconsale.max_sales_rate) {
+            OPM_THROW(std::runtime_error, "Group " + group.name() + " has sale rate more then the maximum permitted value. Not implemented in Flow" );
+        }
+        if (sales_rate < gconsale.min_sales_rate) {
+            OPM_THROW(std::runtime_error, "Group " + group.name() + " has sale rate less then minimum permitted value. Not implemented in Flow" );
+        }
+        if (gconsale.sales_target < 0.0) {
+            OPM_THROW(std::runtime_error, "Group " + group.name() + " has sale rate target less then zero. Not implemented in Flow" );
+        }
+
+    }
+
 
     template<typename TypeTag>
     void

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -2176,14 +2176,8 @@ namespace Opm
             assert (phasePos == pu.phase_pos[BlackoilPhases::Vapour]);
 
             // Gas injection rate = Total gas production rate + gas import rate - gas consumption rate - sales rate;
+            // The import and consumption is already included in the REIN rates.
             double inj_rate = well_state.currentInjectionREINRates(group.name())[phasePos];
-            if (schedule.gConSump(current_step_).has(group.name())) {
-                const auto& gconsump = schedule.gConSump(current_step_).get(group.name(), summaryState);
-                if (pu.phase_used[BlackoilPhases::Vapour]) {
-                    inj_rate += gconsump.import_rate;
-                    inj_rate -= gconsump.consumption_rate;
-                }
-            }
             const auto& gconsale = schedule.gConSale(current_step_).get(group.name(), summaryState);
             inj_rate -= gconsale.sales_target;
 


### PR DESCRIPTION
1) Only check GCONSALE limits at the end of a timestep. NB. The simulator still throws if some of the limits are violated
2) BUGFIX: don't remove gas consumption twice

Tested on `9_3B_---_STW/MSW` and `9_3C_---_STW/MSW`