### PR TITLE
use nupcol to avoid oscillation between group controls

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1741,6 +1741,14 @@ namespace Opm {
     updateGroupIndividualControls(Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups)
     {
         const int reportStepIdx = ebosSimulator_.episodeIndex();
+
+        const int nupcol = schedule().getNupcol(reportStepIdx);
+        const int iterationIdx = ebosSimulator_.model().newtonMethod().numIterations();
+        // don't switch group control when iterationIdx > nupcol
+        // to avoid oscilations between group controls
+        if (iterationIdx > nupcol)
+            return;
+
         const Group& fieldGroup = schedule().getGroup("FIELD", reportStepIdx);
         updateGroupIndividualControl(fieldGroup, deferred_logger, switched_groups);
     }


### PR DESCRIPTION
This is sufficient to run the 9_4[B,C,D] test cases in opm-tests/model2.  