### PR TITLE
Remove VISCREF from MissingFeatures

### DIFF
--- a/opm/simulators/flow/MissingFeatures.cpp
+++ b/opm/simulators/flow/MissingFeatures.cpp
@@ -769,7 +769,6 @@ namespace MissingFeatures {
             "VFPTABL",
             "VISAGE",
             "VISCD",
-            "VISCREF",
             "VISDATES",
             "VISOPTS",
             "WAGHYSTR",


### PR DESCRIPTION
The `VISCREF`keyword is supported.