### PR TITLE
Prevent Cmake error for CUDA with incompatible c++ compiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ include ("${project}-prereqs")
 # Make sure we are using the same compiler underneath
 # NVCC as for the rest. In the case that NVCC does not support
 # that compiler it will error out. Unfortunately this will only
-# work CMake >= 3.8. We found no way to make FindCUDA.cmake error
+# work for CMake >= 3.8. We found no way to make FindCUDA.cmake error
 # out. It seems to ignore CMAKE_NVCC_FLAGS and CMAKE. Additionally
 # our way of specifying cuda source files never worked for CMake
 # version < 3.8. Hence we deactivate cuda for these versions.
@@ -102,23 +102,18 @@ if(NOT CMAKE_DISABLE_FIND_PACKAGE_CUDA AND
       "prevent incompatibilities. Note that this might report that there "
       "is not CUDA compiler if your system's CUDA compiler does not support "
       "${CMAKE_CXX_COMPILER}.")
-    # set(CMAKE_CUDA_FLAGS "-ccbin ${CMAKE_CXX_COMPILER} ${CMAKE_CUDA_FLAGS}")
-    # check_language does not seem to care about ${CMAKE_CUDA_FLAGS}.
-    # Hence set(CMAKE_CUDA_FLAGS$(_flags_suffix) "-ccbin ${CMAKE_CXX_COMPILER} ${CMAKE_CUDA_FLAGS${_flags_suffix}}")
-    # would have no effect. We need to set the environment variable ENV{CUDAHOSTCXX} such
-    # that cuda picks up the correct compiler during check_language.
-    # In check_language(CUDA) we will get and error if we set and put
-    # "-ccbin ${CMAKE_CXX_COMPILER}" into the CMAKE_CUDA_FLAGS as this results
+    # check_language does not seem to care about ${CMAKE_CUDA_FLAGS} or $(CUDA_NVCC_FLAGS}.
+    # Hence we set CMAKE_CUDA_HOST_COMPILER to our C++ compiler.
+    # In check_language(CUDA) we will get an error if we in addition put
+    # "-ccbin ${CMAKE_CXX_COMPILER}" into CMAKE_CUDA_FLAGS. It results
     # in "${NVCC} -ccbin=${CMAKE_CXX_COMPILER}   -ccbin ${CMAKE_CXX_COMPILER}"
+    # which causes nvcc to abort
     set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
   endif()
   include(CheckLanguage)
-  # Unfortunately check_language(CUDA) will only check whether there is
-  # a nvcc compiler. It will not check whether compilation with the above
-  # option works. Since the OPTIONAL flag of enable_language is currently
-  # ignored CMake will error out below if the options do not work.
   check_language(CUDA)
   if(CMAKE_CUDA_COMPILER)
+    # OPTIONAL is ignored. Hence the magic above to check whether enabling CUDA works
     enable_language(CUDA OPTIONAL)
     # While the documentation says that it is deprecated, FindCUDA seems the
     # only easy way to determine the cublas and cusparse libraries.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,9 @@ if(NOT CMAKE_DISABLE_FIND_PACKAGE_CUDA AND
   if(CMAKE_BUILD_TYPE)
     set(_flags_suffix "_${CMAKE_BUILD_TYPE}")
   endif()
-  if(NOT DEFINED ENV{CUDAHOSTCXX} AND
+  if(NOT DEFINED ENV{CUDAHOSTCXX} AND NOT DEFINED CMAKE_CUDA_HOST_COMPILER AND
       (NOT CMAKE_CUDA_FLAGS${_flags_suffix} OR NOT CMAKE_CUDA_FLAGS${_flags_suffix} MATCHES ".*-ccbin .*"))
-    message(STATUS "Setting CUDA host compiler to ${CMAKE_CXX_COMPILER} to "
+    message(STATUS "Setting CUDA host compiler CMAKE_CUDA_HOST_COMPILER to ${CMAKE_CXX_COMPILER} to "
       "prevent incompatibilities. Note that this might report that there "
       "is not CUDA compiler if your system's CUDA compiler does not support "
       "${CMAKE_CXX_COMPILER}.")
@@ -110,7 +110,7 @@ if(NOT CMAKE_DISABLE_FIND_PACKAGE_CUDA AND
     # In check_language(CUDA) we will get and error if we set and put
     # "-ccbin ${CMAKE_CXX_COMPILER}" into the CMAKE_CUDA_FLAGS as this results
     # in "${NVCC} -ccbin=${CMAKE_CXX_COMPILER}   -ccbin ${CMAKE_CXX_COMPILER}"
-    set(ENV{CUDAHOSTCXX} ${CMAKE_CXX_COMPILER})
+    set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
   endif()
   include(CheckLanguage)
   # Unfortunately check_language(CUDA) will only check whether there is

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,15 +93,18 @@ include ("${project}-prereqs")
 # compatibility to cmake 3.6 and lower.
 if(NOT CMAKE_DISABLE_FIND_PACKAGE_CUDA AND
     CMAKE_VERSION VERSION_GREATER 3.7.9)
+  if(CMAKE_BUILD_TYPE)
+    set(_flags_suffix "_${CMAKE_BUILD_TYPE}")
+  endif()
   if(NOT DEFINED ENV{CUDAHOSTCXX} AND
-      (NOT CMAKE_CUDA_FLAGS OR NOT CMAKE_CUDA_FLAGS MATCHES ".*-ccbin .*"))
+      (NOT CMAKE_CUDA_FLAGS${_flags_suffix} OR NOT CMAKE_CUDA_FLAGS${_flags_suffix} MATCHES ".*-ccbin .*"))
     message(STATUS "Setting CUDA host compiler to ${CMAKE_CXX_COMPILER} to "
       "prevent incompatibilities. Note that this might report that there "
       "is not CUDA compiler if your system's CUDA compiler does not support "
       "${CMAKE_CXX_COMPILER}.")
     # set(CMAKE_CUDA_FLAGS "-ccbin ${CMAKE_CXX_COMPILER} ${CMAKE_CUDA_FLAGS}")
     # check_language does not seem to care about ${CMAKE_CUDA_FLAGS}.
-    # Hence set(CMAKE_CUDA_FLAGS "-ccbin ${CMAKE_CXX_COMPILER} ${CMAKE_CUDA_FLAGS}")
+    # Hence set(CMAKE_CUDA_FLAGS$(_flags_suffix) "-ccbin ${CMAKE_CXX_COMPILER} ${CMAKE_CUDA_FLAGS${_flags_suffix}}")
     # would have no effect. We need to set the environment variable ENV{CUDAHOSTCXX} such
     # that cuda picks up the correct compiler during check_language.
     # In check_language(CUDA) we will get and error if we set and put

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,15 @@ if(NOT CMAKE_DISABLE_FIND_PACKAGE_CUDA AND
     CMAKE_VERSION VERSION_GREATER 3.7.9)
   if(NOT DEFINED ENV{CUDAHOSTCXX} AND
       (NOT CMAKE_CUDA_FLAGS OR NOT CMAKE_CUDA_FLAGS MATCHES ".*-ccbin .*"))
+    message(STATUS "Setting CUDA host compiler to ${CMAKE_CXX_COMPILER} to "
+      "prevent incompatibilities. Note that this might report that there "
+      "is not CUDA compiler if your system's CUDA compiler does not support "
+      "${CMAKE_CXX_COMPILER}.")
     set(CMAKE_CUDA_FLAGS "-ccbin ${CMAKE_CXX_COMPILER} ${CMAKE_CUDA_FLAGS}")
+    # check_language does not seem to care about ${CMAKE_CUDA_FLAGS}, we
+    # need to set the environment variable CUDAHOSTCXX such that cuda
+    # picks up the correct compiler.
+    set(ENV{CUDAHOSTCXX} ${CMAKE_CXX_COMPILER})
   endif()
   include(CheckLanguage)
   # Unfortunately check_language(CUDA) will only check whether there is
@@ -105,12 +113,12 @@ if(NOT CMAKE_DISABLE_FIND_PACKAGE_CUDA AND
   check_language(CUDA)
   if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA OPTIONAL)
+    # While the documentation says that it is deprecated, FindCUDA seems the
+    # only easy way to determine the cublas and cusparse libraries.
+    # Hence we call it unconditionally
+    # The WellContributions kernel uses __shfl_down_sync, which was introduced in CUDA 9.0
+    find_package(CUDA)
   endif()
-  # While the documentation says that it is deprecated, FindCUDA seems the
-  # only easy way to determine the cublas and cusparse libraries.
-  # Hence we call it unconditionally
-  # The WellContributions kernel uses __shfl_down_sync, which was introduced in CUDA 9.0
-  find_package(CUDA)
   if(CUDA_FOUND AND CUDA_VERSION VERSION_LESS "9.0")
     set(CUDA_FOUND OFF)
     message(WARNING "Deactivating CUDA as we require version 9.0 or newer."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ if(NOT CMAKE_DISABLE_FIND_PACKAGE_CUDA AND
     # in "${NVCC} -ccbin=${CMAKE_CXX_COMPILER}   -ccbin ${CMAKE_CXX_COMPILER}"
     # which causes nvcc to abort
     set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
+    set(ENV{CUDAHOSTCXX} ${CMAKE_CUDA_HOST_COMPILER}) # The only thing honored by check_language(CUDA)!
   endif()
   include(CheckLanguage)
   check_language(CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,10 +99,14 @@ if(NOT CMAKE_DISABLE_FIND_PACKAGE_CUDA AND
       "prevent incompatibilities. Note that this might report that there "
       "is not CUDA compiler if your system's CUDA compiler does not support "
       "${CMAKE_CXX_COMPILER}.")
-    set(CMAKE_CUDA_FLAGS "-ccbin ${CMAKE_CXX_COMPILER} ${CMAKE_CUDA_FLAGS}")
-    # check_language does not seem to care about ${CMAKE_CUDA_FLAGS}, we
-    # need to set the environment variable CUDAHOSTCXX such that cuda
-    # picks up the correct compiler.
+    # set(CMAKE_CUDA_FLAGS "-ccbin ${CMAKE_CXX_COMPILER} ${CMAKE_CUDA_FLAGS}")
+    # check_language does not seem to care about ${CMAKE_CUDA_FLAGS}.
+    # Hence set(CMAKE_CUDA_FLAGS "-ccbin ${CMAKE_CXX_COMPILER} ${CMAKE_CUDA_FLAGS}")
+    # would have no effect. We need to set the environment variable ENV{CUDAHOSTCXX} such
+    # that cuda picks up the correct compiler during check_language.
+    # In check_language(CUDA) we will get and error if we set and put
+    # "-ccbin ${CMAKE_CXX_COMPILER}" into the CMAKE_CUDA_FLAGS as this results
+    # in "${NVCC} -ccbin=${CMAKE_CXX_COMPILER}   -ccbin ${CMAKE_CXX_COMPILER}"
     set(ENV{CUDAHOSTCXX} ${CMAKE_CXX_COMPILER})
   endif()
   include(CheckLanguage)


### PR DESCRIPTION
At least on Debian 10 the standard c++ compiler is g++-8, but CUDA only supports g++-7 and our test for CUDA in cmake did send an error in that case/combination which is quite annoying.

The reason was that check_language(CUDA) did not honor the CMAKE_CUDA_FLAGS variable and always used the default g++7, but enable_language(CUDA) did honor it. As we do set the underlying host compiler the fromer reported that CUDA is available while the latter marked the CUDA compiler as broken.

With this commit we work around this by setting the environment variable ENV{CUDAHOSTCXX} which nvcc will use. Hence now we only try to enable CUDA if it is compatible with the C++ compiler