### PR TITLE
Complete future-proofing ILU usage in the preconditioner factory.

### DIFF
--- a/opm/simulators/linalg/PreconditionerFactory.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory.hpp
@@ -318,7 +318,11 @@ private:
 	doAddCreator("kamg", [](const O& op, const P& prm, const std::function<Vector()>&) {
             const std::string smoother = prm.get<std::string>("smoother", "ParOverILU0");
             if (smoother == "ILU0" || smoother == "ParOverILU0") {
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 7)
+                using Smoother = SeqILU<M, V, V>;
+#else
                 using Smoother = SeqILU0<M, V, V>;
+#endif
                 return makeAmgPreconditioner<Smoother>(op, prm, true);
             } else if (smoother == "Jac") {
                 using Smoother = SeqJac<M, V, V>;
@@ -333,7 +337,11 @@ private:
                 using Smoother = SeqSSOR<M, V, V>;
                 return makeAmgPreconditioner<Smoother>(op, prm, true);
             } else if (smoother == "ILUn") {
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 7)
+                using Smoother = SeqILU<M, V, V>;
+#else
                 using Smoother = SeqILUn<M, V, V>;
+#endif
                 return makeAmgPreconditioner<Smoother>(op, prm, true);
             } else {
                 OPM_THROW(std::invalid_argument, "Properties: No smoother with name " << smoother <<".");


### PR DESCRIPTION
SeqILU0/SeqILU0 are removed in master and one should use SeqILU.
Closes #2568 