### PR TITLE
quell deprecation warnings with boost 1.71

### DIFF
--- a/tests/test_milu.cpp
+++ b/tests/test_milu.cpp
@@ -12,7 +12,12 @@
 #include<opm/simulators/linalg/ParallelOverlappingILU0.hpp>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 template<class M>
 void test_milu0(M& A)

--- a/tests/test_norne_pvt.cpp
+++ b/tests/test_norne_pvt.cpp
@@ -23,7 +23,12 @@
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <sstream>

--- a/tests/test_relpermdiagnostics.cpp
+++ b/tests/test_relpermdiagnostics.cpp
@@ -26,7 +26,12 @@
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/CounterLog.hpp>


### PR DESCRIPTION
header was relocated.