### PR TITLE
Writematrix

### DIFF
--- a/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
@@ -278,6 +278,7 @@ protected:
         return weights;
     }
     void writeMatrix(){
+#ifdef HAVE_MPI	
 	int verbosity = prm_.get<int>("verbosity");
 	if(verbosity > 10){
 	    using block_type = typename MatrixType::block_type;
@@ -288,8 +289,9 @@ protected:
 	    Opm::Helper::writeSystem(this->simulator_,//simulator is only used to get names
 				     *matrix,
 				     this->rhs_,
-		                     *comm_);
+		                     comm_.get());
 	}
+#endif	
     }
     
     const Simulator& simulator_;

--- a/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
@@ -280,7 +280,10 @@ protected:
     void writeMatrix(){
 #ifdef HAVE_MPI	
 	int verbosity = prm_.get<int>("verbosity");
-	if(verbosity > 10){
+	//int nit = this->simulator_.model().newtonMethod().numIterations();
+	//int iters = this->iterations()
+	bool write_matrix = verbosity>10;
+	if(write_matrix > 10){
 	    using block_type = typename MatrixType::block_type;
 	    using value_type = typename block_type::value_type;
 	    using BaseBlockType = Dune::FieldMatrix<value_type,block_type::rows,block_type::cols>;

--- a/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
@@ -278,11 +278,11 @@ protected:
     void writeMatrix(){
 	int verbosity = prm_.get<int>("verbosity");
 	if(verbosity > 10){
-	    using block_type = MatrixType::block_type;
-	    using BaseBlockType = Dune::FieldMatrix<
-		block_type::value_type,block_type::rows,block_type::cols>;
+	    using block_type = typename MatrixType::block_type;
+	    using value_type = typename block_type::value_type;
+	    using BaseBlockType = Dune::FieldMatrix<value_type,block_type::rows,block_type::cols>;
 	    using BaseMatrixType = Dune::BCRSMatrix<BaseBlockType>;
-	    const BaseMatrixType& matrix =  reinterp_cast<BaseMatrixType>(*this->matrix_);
+	    const BaseMatrixType& matrix =  reinterpret_cast<BaseMatrixType>(*this->matrix_);
 	    Opm::Helper::writeSystem(this->simulator_,
 				     matrix,
 				     *this->rhs_);

--- a/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
@@ -283,7 +283,7 @@ protected:
 	//int nit = this->simulator_.model().newtonMethod().numIterations();
 	//int iters = this->iterations()
 	bool write_matrix = verbosity>10;
-	if(write_matrix > 10){
+	if(write_matrix){
 	    using block_type = typename MatrixType::block_type;
 	    using value_type = typename block_type::value_type;
 	    using BaseBlockType = Dune::FieldMatrix<value_type,block_type::rows,block_type::cols>;

--- a/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
+++ b/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
@@ -39,8 +39,10 @@ namespace Opm{
 	    }
 	    // Combine and return.
 	    std::ostringstream oss;
-	    oss << "prob_" << simulator.episodeIndex() << "_";
+	    oss << "prob_" << simulator.episodeIndex() << "_time_";
 	    oss << simulator.time() << "_";
+	    int nit = simulator_.model().newtonMethod().numIterations();
+	    oss << "_nit_" << nit << "_";
 	    std::string output_file(oss.str());
 	    fs::path full_path = output_dir / output_file;
 	    std::string prefix = full_path.string();

--- a/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
+++ b/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
@@ -24,7 +24,7 @@ namespace Opm{
 	void writeSystem(const SimulatorType& simulator,
 			 const MatrixType& matrix,
 			 const VectorType& rhs,
-			 const Communicator& comm){
+			 const Communicator* comm){
 	    std::string dir = simulator.problem().outputDir();
 	    if (dir == ".")
 		dir = "";
@@ -47,12 +47,21 @@ namespace Opm{
 	    {
 		std::string filename = prefix + "matrix_istl";
 		//std::ofstream filem(filename);
-		Dune::storeMatrixMarket(matrix, filename, comm,true);
+		if(comm != nullptr){//comm is not set in serial runs
+		    Dune::storeMatrixMarket(matrix, filename, *comm,true);
+		}else{
+		    Dune::storeMatrixMarket(matrix, filename);
+		}
+		    
 	    }
 	    {		
 		std::string filename = prefix + "rhs_istl";
 		//std::ofstream fileb(filename);
-		Dune::storeMatrixMarket(rhs, filename, comm, true);// got compilation error for store
+		if(comm != nullptr){//comm is not set in serial runs
+		    Dune::storeMatrixMarket(rhs, filename, *comm, true);
+		}else{
+		    Dune::storeMatrixMarket(rhs, filename);
+		}
 	    }
 	}
 

--- a/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
+++ b/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
@@ -41,7 +41,7 @@ namespace Opm{
 	    std::ostringstream oss;
 	    oss << "prob_" << simulator.episodeIndex() << "_time_";
 	    oss << simulator.time() << "_";
-	    int nit = simulator_.model().newtonMethod().numIterations();
+	    int nit = simulator.model().newtonMethod().numIterations();
 	    oss << "_nit_" << nit << "_";
 	    std::string output_file(oss.str());
 	    fs::path full_path = output_dir / output_file;

--- a/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
+++ b/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
@@ -1,0 +1,60 @@
+/*
+  Copyright 2019 SINTEF AS
+  This file is part of the Open Porous Media project (OPM).
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_WRITESYSTEMMATRIXHELPER_HEADER_INCLUDED
+#define OPM_WRITESYSTEMMATRIXHELPER_HEADER_INCLUDED
+#include <dune/istl/matrixmarket.hh>
+#include <ewoms/linear/matrixblock.hh>
+namespace Opm{
+    namespace Helper {
+	template<class SimulatorType,
+		 class MatrixType,
+		 class VectorType>
+	void writeSystem(const SimulatorType& simulator,
+			 const MatrixType& matrix,
+			 const VectorType& rhs){
+	    std::string dir = simulator.problem().outputDir();
+	    if (dir == ".")
+		dir = "";
+	    else if (!dir.empty() && dir.back() != '/')
+		dir += "/";
+	    namespace fs = boost::filesystem;
+	    fs::path output_dir(dir);
+	    fs::path subdir("reports");
+	    output_dir = output_dir / subdir;
+	    if(!(fs::exists(output_dir))){
+		fs::create_directory(output_dir);
+	    }
+	    // Combine and return.
+	    std::ostringstream oss;
+	    oss << "prob_" << simulator.episodeIndex() << "_";
+	    oss << simulator.time() << "_";
+	    std::string output_file(oss.str());
+	    fs::path full_path = output_dir / output_file;
+	    std::string prefix = full_path.string();
+	    {
+		std::string filename = prefix + "matrix_istl";
+		std::ofstream filem(filename);
+		Dune::storeMatrixMarket(matrix, filem);
+	    }
+	    {		
+		std::string filename = prefix + "rhs_istl";
+		std::ofstream fileb(filename);
+		Dune::storeMatrixMarket(rhs, fileb);
+	    }
+	}
+
+	
+    } //namespace helper   
+}// namespace Opm

--- a/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
+++ b/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
@@ -19,10 +19,12 @@ namespace Opm{
     namespace Helper {
 	template<class SimulatorType,
 		 class MatrixType,
-		 class VectorType>
+		 class VectorType,
+		 class Communicator>
 	void writeSystem(const SimulatorType& simulator,
 			 const MatrixType& matrix,
-			 const VectorType& rhs){
+			 const VectorType& rhs,
+			 const Communicator& comm){
 	    std::string dir = simulator.problem().outputDir();
 	    if (dir == ".")
 		dir = "";
@@ -44,13 +46,13 @@ namespace Opm{
 	    std::string prefix = full_path.string();
 	    {
 		std::string filename = prefix + "matrix_istl";
-		std::ofstream filem(filename);
-		Dune::storeMatrixMarket(matrix, filem);
+		//std::ofstream filem(filename);
+		Dune::storeMatrixMarket(matrix, filename, comm,true);
 	    }
 	    {		
 		std::string filename = prefix + "rhs_istl";
-		std::ofstream fileb(filename);
-		Dune::storeMatrixMarket(rhs, fileb);
+		//std::ofstream fileb(filename);
+		Dune::storeMatrixMarket(rhs, filename, comm, true);// got compilation error for store
 	    }
 	}
 

--- a/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
+++ b/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
@@ -15,7 +15,6 @@
 #ifndef OPM_WRITESYSTEMMATRIXHELPER_HEADER_INCLUDED
 #define OPM_WRITESYSTEMMATRIXHELPER_HEADER_INCLUDED
 #include <dune/istl/matrixmarket.hh>
-#include <ewoms/linear/matrixblock.hh>
 namespace Opm{
     namespace Helper {
 	template<class SimulatorType,
@@ -29,7 +28,7 @@ namespace Opm{
 		dir = "";
 	    else if (!dir.empty() && dir.back() != '/')
 		dir += "/";
-	    namespace fs = boost::filesystem;
+	    namespace fs = Opm::filesystem;
 	    fs::path output_dir(dir);
 	    fs::path subdir("reports");
 	    output_dir = output_dir / subdir;
@@ -58,3 +57,4 @@ namespace Opm{
 	
     } //namespace helper   
 }// namespace Opm
+#endif


### PR DESCRIPTION
Added options for writing which the flexible solver solve on. To use it one have to run with optionfile and change the verbosity level in the file. example:
```sh
opm-simulators/bin/flow_blackoil_dunecpr SPE1CASE1.DATA --output-dir=test \
   --linear-solver-configuration-json-file=options.json --linear-solver-configuration=file
```
with `option.json: verbosity>10` will write out matrices
```json
{
    "tol": "0.01",
    "maxiter": "20",
    "verbosity": "20",
    "solver": "bicgstab",
    "preconditioner": {
        "type": "ParOverILU0",
	"relaxation": "1"
    }
}
```