### PR TITLE
Add a writeSystem() helper and use it to write system matrices.

### DIFF
--- a/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
+++ b/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
@@ -1,0 +1,78 @@
+/*
+  Copyright 2019 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_WRITESYSTEMMATRIXHELPER_HEADER_INCLUDED
+#define OPM_WRITESYSTEMMATRIXHELPER_HEADER_INCLUDED
+
+#include <dune/istl/matrixmarket.hh>
+
+namespace Opm
+{
+namespace Helper
+{
+    template <class SimulatorType, class MatrixType, class VectorType, class Communicator>
+    void writeSystem(const SimulatorType& simulator,
+                     const MatrixType& matrix,
+                     const VectorType& rhs,
+                     const Communicator* comm)
+    {
+        std::string dir = simulator.problem().outputDir();
+        if (dir == ".") {
+            dir = "";
+        } else if (!dir.empty() && dir.back() != '/') {
+            dir += "/";
+        }
+        namespace fs = Opm::filesystem;
+        fs::path output_dir(dir);
+        fs::path subdir("reports");
+        output_dir = output_dir / subdir;
+        if (!(fs::exists(output_dir))) {
+            fs::create_directory(output_dir);
+        }
+        // Combine and return.
+        std::ostringstream oss;
+        oss << "prob_" << simulator.episodeIndex() << "_time_";
+        oss << std::setprecision(15) << std::setw(12) << std::setfill('0') << simulator.time() << "_";
+        int nit = simulator.model().newtonMethod().numIterations();
+        oss << "_nit_" << nit << "_";
+        std::string output_file(oss.str());
+        fs::path full_path = output_dir / output_file;
+        std::string prefix = full_path.string();
+        {
+            std::string filename = prefix + "matrix_istl";
+            if (comm != nullptr) { // comm is not set in serial runs
+                Dune::storeMatrixMarket(matrix, filename, *comm, true);
+            } else {
+                Dune::storeMatrixMarket(matrix, filename);
+            }
+        }
+        {
+            std::string filename = prefix + "rhs_istl";
+            if (comm != nullptr) { // comm is not set in serial runs
+                Dune::storeMatrixMarket(rhs, filename, *comm, true);
+            } else {
+                Dune::storeMatrixMarket(rhs, filename);
+            }
+        }
+    }
+
+
+} // namespace Helper
+} // namespace Opm
+#endif


### PR DESCRIPTION
Triggered only when using the flexible solver and a solver verbosity > 10.

Compared to #2593, I have cleaned up whitespace (tabs->spaces) and some other minor changes. One behaviour change: I have made the time part of the filename longer (12 characters) and padded with zeros so that filenames are more similar and can be sorted.

I planned to use another mechanism than verbosity to control this, but decided that can wait. Contrary to what is written in #2593 one can get matrices written without using a JSON file for the linear solver config, by using the `--flow-linear-solver-verbosity` parameter.

I think this can be merged. In a way, it is my review of #2593... So unless there are objections, I'll self-merge it tomorrow. @hnil please check that you are ok with the changes.