### PR TITLE
Add writing detailed performance report

### DIFF
--- a/opm/simulators/flow/BlackoilModelEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelEbos.hpp
@@ -229,12 +229,12 @@ namespace Opm {
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         template <class NonlinearSolverType>
-        SimulatorReport nonlinearIteration(const int iteration,
+        SimulatorReportBase nonlinearIteration(const int iteration,
                                            const SimulatorTimerInterface& timer,
                                            NonlinearSolverType& nonlinear_solver)
         {
-            SimulatorReport report;
-            failureReport_ = SimulatorReport();
+            SimulatorReportBase report;
+            failureReport_ = SimulatorReportBase();
             Dune::Timer perfTimer;
 
             perfTimer.start();
@@ -854,7 +854,7 @@ namespace Opm {
         { return ebosSimulator_; }
 
         /// return the statistics if the nonlinearIteration() method failed
-        const SimulatorReport& failureReport() const
+        const SimulatorReportBase& failureReport() const
         { return failureReport_; }
 
         struct StepReport
@@ -885,7 +885,7 @@ namespace Opm {
 	const bool has_brine_;
 
         ModelParameters                 param_;
-        SimulatorReport failureReport_;
+        SimulatorReportBase failureReport_;
 
         // Well Model
         BlackoilWellModel<TypeTag>& well_model_;

--- a/opm/simulators/flow/BlackoilModelEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelEbos.hpp
@@ -229,12 +229,12 @@ namespace Opm {
         /// \param[in, out] reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         template <class NonlinearSolverType>
-        SimulatorReportBase nonlinearIteration(const int iteration,
-                                           const SimulatorTimerInterface& timer,
-                                           NonlinearSolverType& nonlinear_solver)
+        SimulatorReportSingle nonlinearIteration(const int iteration,
+                                                 const SimulatorTimerInterface& timer,
+                                                 NonlinearSolverType& nonlinear_solver)
         {
-            SimulatorReportBase report;
-            failureReport_ = SimulatorReportBase();
+            SimulatorReportSingle report;
+            failureReport_ = SimulatorReportSingle();
             Dune::Timer perfTimer;
 
             perfTimer.start();
@@ -368,8 +368,8 @@ namespace Opm {
         /// \param[in]      reservoir_state   reservoir state variables
         /// \param[in, out] well_state        well state variables
         /// \param[in]      initial_assembly  pass true if this is the first call to assemble() in this timestep
-        SimulatorReport assembleReservoir(const SimulatorTimerInterface& /* timer */,
-                                          const int iterationIdx)
+        SimulatorReportSingle assembleReservoir(const SimulatorTimerInterface& /* timer */,
+                                                const int iterationIdx)
         {
             // -------- Mass balance equations --------
             ebosSimulator_.model().newtonMethod().setIterationIndex(iterationIdx);
@@ -854,7 +854,7 @@ namespace Opm {
         { return ebosSimulator_; }
 
         /// return the statistics if the nonlinearIteration() method failed
-        const SimulatorReportBase& failureReport() const
+        const SimulatorReportSingle& failureReport() const
         { return failureReport_; }
 
         struct StepReport
@@ -885,7 +885,7 @@ namespace Opm {
 	const bool has_brine_;
 
         ModelParameters                 param_;
-        SimulatorReportBase failureReport_;
+        SimulatorReportSingle failureReport_;
 
         // Well Model
         BlackoilWellModel<TypeTag>& well_model_;

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -521,7 +521,7 @@ namespace Opm
                     namespace fs = Opm::filesystem;
                     fs::path output_dir(dir);
                     {
-                        std::string filename = eclState().getIOConfig().getBaseName() + ".STEPINFO";
+                        std::string filename = eclState().getIOConfig().getBaseName() + ".INFOSTEP";
                         fs::path fullpath = output_dir / filename;
                         std::ofstream os(fullpath.string());
                         report.fullReports(os);

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -518,8 +518,21 @@ namespace Opm
                     ss << "Threads per MPI process:  " << std::setw(5) << threads << "\n";
                     successReport.reportFullyImplicit(ss, &failureReport);
                     OpmLog::info(ss.str());
+		    const std::string dir = eclState().getIOConfig().getOutputDir();
+		    namespace fs = Opm::filesystem;
+		    fs::path output_dir(dir);
+		    {
+			fs::path fullpath = output_dir / "successreports.txt";
+			std::ofstream os(fullpath.string());
+			successReport.fullReports(os);
+		    }
+		    {
+			fs::path fullpath = output_dir / "failedreports.txt";
+			std::ofstream os(fullpath.string());
+			failureReport.fullReports(os);
+		    }		    
                 }
-                return successReport.exit_status;
+	        return successReport.exit_status;
             } else {
                 if (output_cout) {
                     std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -517,16 +517,17 @@ namespace Opm
                     ss << "Threads per MPI process:  " << std::setw(5) << threads << "\n";
                     report.reportFullyImplicit(ss);
                     OpmLog::info(ss.str());
-		    const std::string dir = eclState().getIOConfig().getOutputDir();
-		    namespace fs = Opm::filesystem;
-		    fs::path output_dir(dir);
-		    {
-			fs::path fullpath = output_dir / "confreports.txt";
-			std::ofstream os(fullpath.string());
-			report.fullReports(os);
-		    }
+                    const std::string dir = eclState().getIOConfig().getOutputDir();
+                    namespace fs = Opm::filesystem;
+                    fs::path output_dir(dir);
+                    {
+                        std::string filename = eclState().getIOConfig().getBaseName() + ".ITERINFO";
+                        fs::path fullpath = output_dir / filename;
+                        std::ofstream os(fullpath.string());
+                        report.fullReports(os);
+                    }
                 }
-	        return report.success.exit_status;
+                return report.success.exit_status;
             } else {
                 if (output_cout) {
                     std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -504,8 +504,7 @@ namespace Opm
                     OpmLog::info(msg);
                 }
 
-                SimulatorReport successReport = simulator_->run(simtimer);
-                SimulatorReport failureReport = simulator_->failureReport();
+                SimulatorReport report = simulator_->run(simtimer);
                 if (output_cout) {
                     std::ostringstream ss;
                     ss << "\n\n================    End of simulation     ===============\n\n";
@@ -516,23 +515,18 @@ namespace Opm
                     int threads = 1;
 #endif
                     ss << "Threads per MPI process:  " << std::setw(5) << threads << "\n";
-                    successReport.reportFullyImplicit(ss, &failureReport);
+                    report.reportFullyImplicit(ss);
                     OpmLog::info(ss.str());
 		    const std::string dir = eclState().getIOConfig().getOutputDir();
 		    namespace fs = Opm::filesystem;
 		    fs::path output_dir(dir);
 		    {
-			fs::path fullpath = output_dir / "successreports.txt";
+			fs::path fullpath = output_dir / "confreports.txt";
 			std::ofstream os(fullpath.string());
-			successReport.fullReports(os);
+			report.fullReports(os);
 		    }
-		    {
-			fs::path fullpath = output_dir / "failedreports.txt";
-			std::ofstream os(fullpath.string());
-			failureReport.fullReports(os);
-		    }		    
                 }
-	        return successReport.exit_status;
+	        return report.success.exit_status;
             } else {
                 if (output_cout) {
                     std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -521,7 +521,7 @@ namespace Opm
                     namespace fs = Opm::filesystem;
                     fs::path output_dir(dir);
                     {
-                        std::string filename = eclState().getIOConfig().getBaseName() + ".ITERINFO";
+                        std::string filename = eclState().getIOConfig().getBaseName() + ".STEPINFO";
                         fs::path fullpath = output_dir / filename;
                         std::ofstream os(fullpath.string());
                         report.fullReports(os);

--- a/opm/simulators/flow/NonlinearSolverEbos.hpp
+++ b/opm/simulators/flow/NonlinearSolverEbos.hpp
@@ -151,10 +151,11 @@ namespace Opm {
 
         SimulatorReport step(const SimulatorTimerInterface& timer)
         {
-            SimulatorReport iterReport;
-            SimulatorReport report;
+            SimulatorReportBase iterReport;
+            SimulatorReportBase report;
+	    report.global_time = timer.simulationTimeElapsed();
             failureReport_ = SimulatorReport();
-
+	    failureReport_.global_time = timer.simulationTimeElapsed();
             // Do model-specific once-per-step calculations.
             model_->prepareStep(timer);
 
@@ -172,7 +173,7 @@ namespace Opm {
                     // model will usually do an early return without an expensive
                     // solve, unless the minIter() count has not been reached yet.
                     iterReport = model_->nonlinearIteration(iteration, timer, *this);
-
+		    iterReport.global_time = timer.simulationTimeElapsed();
                     report += iterReport;
                     report.converged = iterReport.converged;
 
@@ -199,8 +200,10 @@ namespace Opm {
             // Do model-specific post-step actions.
             model_->afterStep(timer);
             report.converged = true;
-
-            return report;
+	    SimulatorReport report_step;
+	    report_step += report;
+	    report_step.converged = true;
+            return report_step;
         }
 
         /// return the statistics if the step() method failed

--- a/opm/simulators/flow/NonlinearSolverEbos.hpp
+++ b/opm/simulators/flow/NonlinearSolverEbos.hpp
@@ -190,7 +190,7 @@ namespace Opm {
             while ( (!converged && (iteration <= maxIter())) || (iteration <= minIter()));
 
             if (!converged) {
-                failureReport_ += report;
+                failureReport_ = report;
 
                 std::string msg = "Solver convergence failure - Failed to complete a time step within " + std::to_string(maxIter()) + " iterations.";
                 OPM_THROW_NOLOG(Opm::TooManyIterations, msg);

--- a/opm/simulators/flow/NonlinearSolverEbos.hpp
+++ b/opm/simulators/flow/NonlinearSolverEbos.hpp
@@ -149,13 +149,13 @@ namespace Opm {
         }
 
 
-        SimulatorReport step(const SimulatorTimerInterface& timer)
+        SimulatorReportSingle step(const SimulatorTimerInterface& timer)
         {
-            SimulatorReportBase iterReport;
-            SimulatorReportBase report;
-	    report.global_time = timer.simulationTimeElapsed();
-            failureReport_ = SimulatorReport();
-	    failureReport_.global_time = timer.simulationTimeElapsed();
+            SimulatorReportSingle iterReport;
+            SimulatorReportSingle report;
+            report.global_time = timer.simulationTimeElapsed();
+            failureReport_ = SimulatorReportSingle();
+            failureReport_.global_time = timer.simulationTimeElapsed();
             // Do model-specific once-per-step calculations.
             model_->prepareStep(timer);
 
@@ -173,7 +173,7 @@ namespace Opm {
                     // model will usually do an early return without an expensive
                     // solve, unless the minIter() count has not been reached yet.
                     iterReport = model_->nonlinearIteration(iteration, timer, *this);
-		    iterReport.global_time = timer.simulationTimeElapsed();
+                    iterReport.global_time = timer.simulationTimeElapsed();
                     report += iterReport;
                     report.converged = iterReport.converged;
 
@@ -200,14 +200,11 @@ namespace Opm {
             // Do model-specific post-step actions.
             model_->afterStep(timer);
             report.converged = true;
-	    SimulatorReport report_step;
-	    report_step += report;
-	    report_step.converged = true;
-            return report_step;
+            return report;
         }
 
         /// return the statistics if the step() method failed
-        const SimulatorReport& failureReport() const
+        const SimulatorReportSingle& failureReport() const
         { return failureReport_; }
 
         /// Number of linearizations used in all calls to step().
@@ -356,7 +353,7 @@ namespace Opm {
 
     private:
         // ---------  Data members  ---------
-        SimulatorReport failureReport_;
+        SimulatorReportSingle failureReport_;
         SolverParameters param_;
         std::unique_ptr<PhysicalModel> model_;
         int linearizations_;

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -193,9 +193,9 @@ namespace Opm {
         */
         template <class Solver>
         SimulatorReport step(const SimulatorTimer& simulatorTimer,
-                                   Solver& solver,
-                                   const bool isEvent,
-                                   const std::vector<int>* fipnum = nullptr)
+                             Solver& solver,
+                             const bool isEvent,
+                             const std::vector<int>* fipnum = nullptr)
         {
             SimulatorReport report;
             const double timestep = simulatorTimer.currentStepLength();

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -249,40 +249,40 @@ namespace Opm {
                     }
                 }
                 catch (const Opm::TooManyIterations& e) {
-                    substepReport += solver.failureReport();
+                    substepReport = solver.failureReport();
                     causeOfFailure = "Solver convergence failure - Iteration limit reached";
 
                     logException_(e, solverVerbose_);
                     // since linearIterations is < 0 this will restart the solver
                 }
                 catch (const Opm::LinearSolverProblem& e) {
-                    substepReport += solver.failureReport();
+                    substepReport = solver.failureReport();
                     causeOfFailure = "Linear solver convergence failure";
 
                     logException_(e, solverVerbose_);
                     // since linearIterations is < 0 this will restart the solver
                 }
                 catch (const Opm::NumericalIssue& e) {
-                    substepReport += solver.failureReport();
+                    substepReport = solver.failureReport();
                     causeOfFailure = "Solver convergence failure - Numerical problem encountered";
 
                     logException_(e, solverVerbose_);
                     // since linearIterations is < 0 this will restart the solver
                 }
                 catch (const std::runtime_error& e) {
-                    substepReport += solver.failureReport();
+                    substepReport = solver.failureReport();
 
                     logException_(e, solverVerbose_);
                     // also catch linear solver not converged
                 }
                 catch (const Dune::ISTLError& e) {
-                    substepReport += solver.failureReport();
+                    substepReport = solver.failureReport();
 
                     logException_(e, solverVerbose_);
                     // also catch errors in ISTL AMG that occur when time step is too large
                 }
                 catch (const Dune::MatrixBlockError& e) {
-                    substepReport += solver.failureReport();
+                    substepReport = solver.failureReport();
 
                     logException_(e, solverVerbose_);
                     // this can be thrown by ISTL's ILU0 in block mode, yet is not an ISTLError

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -65,7 +65,7 @@ namespace Opm
         total_linearizations += sr.total_linearizations;
         total_newton_iterations += sr.total_newton_iterations;
         total_linear_iterations += sr.total_linear_iterations;
-        global_time = sr.global_time;
+        global_time = sr.global_time; // It makes no sense adding time points, so = not += here.
     }
 
 

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -188,13 +188,13 @@ namespace Opm
 
     void SimulatorReport::fullReports(std::ostream& os) const
     {
-        os << "  Time(sec)   Time(day)  Assembly    LSolve    LSetup    Update    Output WellIt Lins NewtIt LinIt Conv\n";
+        os << "  Time(day)  TStep(day) Assembly    LSolve    LSetup    Update    Output WellIt Lins NewtIt LinIt Conv\n";
         for (size_t i = 0; i < this->stepreports.size(); ++i) {
             const SimulatorReportSingle& sr = this->stepreports[i];
             os.precision(10);
             os << std::defaultfloat;
-            os << std::setw(11) << sr.global_time << " ";
             os << std::setw(11) << unit::convert::to(sr.global_time, unit::day) << " ";
+            os << std::setw(11) << unit::convert::to(sr.timestep_length, unit::day) << " ";
             os.precision(4);
             os << std::fixed;
             os << std::setw(9) << sr.assemble_time << " ";

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -29,7 +29,7 @@
 
 namespace Opm
 {
-    SimulatorReportBase::SimulatorReportBase(bool verbose)
+    SimulatorReportSingle::SimulatorReportSingle(bool verbose)
         : pressure_time(0.0),
           transport_time(0.0),
           total_time(0.0),
@@ -50,7 +50,7 @@ namespace Opm
     {
     }
 
-    void SimulatorReportBase::operator+=(const SimulatorReportBase& sr)
+    void SimulatorReportSingle::operator+=(const SimulatorReportSingle& sr)
     {
         pressure_time += sr.pressure_time;
         transport_time += sr.transport_time;
@@ -68,20 +68,8 @@ namespace Opm
         global_time = sr.global_time;
     }
 
-    // void SimulatorReportBase::report(std::ostream& os)
-    // {
-    //     if ( verbose_ )
-    //     {
-    //         os << "Total time taken: " << total_time
-    //            << "\n  Pressure time:  " << pressure_time
-    //            << "\n  Transport time: " << transport_time
-    //            << "\n  Overall Newton Iterations:  " << total_newton_iterations
-    //            << "\n  Overall Linear Iterations:  " << total_linear_iterations
-    //            << std::endl;
-    //     }
-    // }
 
-    void SimulatorReportBase::reportStep(std::ostringstream& ss)
+    void SimulatorReportSingle::reportStep(std::ostringstream& ss) const
     {
         if ( verbose_ )
         {
@@ -97,7 +85,7 @@ namespace Opm
         }
     }
 
-    void SimulatorReportBase::reportFullyImplicit(std::ostream& os, const SimulatorReportBase* failureReport)
+    void SimulatorReportSingle::reportFullyImplicit(std::ostream& os, const SimulatorReportSingle* failureReport) const
     {
         if ( verbose_ )
         {
@@ -182,13 +170,11 @@ namespace Opm
         }
     }
 
-    void SimulatorReport::fullReports(std::ostream& os)
+    void SimulatorReport::fullReports(std::ostream& os) const
     {
         os << "  Time(sec)   Time(day)  Assembly    LSolve    LSetup    Update    Output WellIt Lins NewtIt LinIt Conv\n";
-        SimulatorReportBase all;
-        for (size_t i = 0; i < stepreports.size(); ++i) {
-            SimulatorReportBase& sr = stepreports[i];
-            all += sr;
+        for (size_t i = 0; i < this->stepreports.size(); ++i) {
+            const SimulatorReportSingle& sr = this->stepreports[i];
             os.precision(10);
             os << std::defaultfloat;
             os << std::setw(11) << sr.global_time << " ";
@@ -207,9 +193,6 @@ namespace Opm
             os << std::setw(6) << sr.total_newton_iterations << " ";
             os << std::setw(5) << sr.total_linear_iterations << " ";
             os << std::setw(4) << sr.converged << "\n";
-        }
-        if (not(this->linear_solve_time == all.linear_solve_time)) {
-            OpmLog::debug("Inconsistency between timestep report and total report");
         }
     }
 

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -188,7 +188,7 @@ namespace Opm
 
     void SimulatorReport::fullReports(std::ostream& os) const
     {
-        os << "  Time(day)  TStep(day) Assembly    LSolve    LSetup    Update    Output WellIt Lins NewtIt LinIt Conv\n";
+        os << "  Time(day)  TStep(day)  Assembly    LSolve    LSetup    Update    Output WellIt Lins NewtIt LinIt Conv\n";
         for (size_t i = 0; i < this->stepreports.size(); ++i) {
             const SimulatorReportSingle& sr = this->stepreports[i];
             os.precision(10);

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -27,7 +27,7 @@
 
 namespace Opm
 {
-    SimulatorReport::SimulatorReport(bool verbose)
+    SimulatorReportBase::SimulatorReportBase(bool verbose)
         : pressure_time(0.0),
           transport_time(0.0),
           total_time(0.0),
@@ -43,11 +43,12 @@ namespace Opm
           total_linear_iterations( 0 ),
           converged(false),
           exit_status(EXIT_SUCCESS),
+	  global_time(0),
           verbose_(verbose)
     {
     }
 
-    void SimulatorReport::operator+=(const SimulatorReport& sr)
+    void SimulatorReportBase::operator+=(const SimulatorReportBase& sr)
     {
         pressure_time += sr.pressure_time;
         transport_time += sr.transport_time;
@@ -62,9 +63,10 @@ namespace Opm
         total_linearizations += sr.total_linearizations;
         total_newton_iterations += sr.total_newton_iterations;
         total_linear_iterations += sr.total_linear_iterations;
+	global_time = sr.global_time;
     }
 
-    void SimulatorReport::report(std::ostream& os)
+    void SimulatorReportBase::report(std::ostream& os)
     {
         if ( verbose_ )
         {
@@ -77,7 +79,7 @@ namespace Opm
         }
     }
 
-    void SimulatorReport::reportStep(std::ostringstream& ss)
+    void SimulatorReportBase::reportStep(std::ostringstream& ss)
     {
         if ( verbose_ )
         {
@@ -93,7 +95,7 @@ namespace Opm
         }
     }
 
-    void SimulatorReport::reportFullyImplicit(std::ostream& os, const SimulatorReport* failureReport)
+    void SimulatorReportBase::reportFullyImplicit(std::ostream& os, const SimulatorReportBase* failureReport)
     {
         if ( verbose_ )
         {
@@ -178,7 +180,7 @@ namespace Opm
         }
     }
 
-    void SimulatorReport::reportParam(std::ostream& os)
+    void SimulatorReportBase::reportParam(std::ostream& os)
     {
         if ( verbose_ )
         {
@@ -190,6 +192,32 @@ namespace Opm
                << std::endl;
         }
     }
-
-
+    void SimulatorReport::fullReports(std::ostream& os){
+	SimulatorReportBase all;
+	for(size_t i=0; i < stepreports.size(); ++i){
+	    SimulatorReportBase& sr = stepreports[i];
+	    all += sr;
+	    os << sr.global_time<< " ";
+	    //os << sr.pressure_time<< " ";
+	    //os << sr.transport_time<< " ";
+	    //os << sr.total_time<< " ";
+	    //os << sr.solver_time<< " ";
+	    os << sr.assemble_time<< " ";
+	    os << sr.linear_solve_setup_time<< " ";
+	    os << sr.linear_solve_time<< " ";
+	    os << sr.update_time<< " ";
+	    os << sr.output_write_time<< " ";
+	    os<<  sr.total_well_iterations<< " ";
+	    os << sr.total_linearizations<< " ";
+	    os << sr.total_newton_iterations<< " ";
+	    os << sr.total_linear_iterations<< " ";
+	    os << sr.converged<< " ";
+	    os << sr.exit_status<< " ";
+	    os << std::endl;
+	}
+	if(not(this->linear_solve_time == all.linear_solve_time)){
+	    Opm::debug("Inconsistency between timestep report and total report");
+	}
+    }
+    
 } // namespace Opm

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -47,7 +47,7 @@ namespace Opm
         bool converged;
         int exit_status;
 
-	double global_time;
+        double global_time;
         double timestep_length;
 
         /// Default constructor initializing all times to 0.0.

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -51,48 +51,51 @@ namespace Opm
         /// Default constructor initializing all times to 0.0.
         explicit SimulatorReportBase(bool verbose=true);
         /// Copy constructor
-        SimulatorReportBase(const SimulatorReportBase&) = default;
+        // SimulatorReportBase(const SimulatorReportBase&) = default;
         /// Increment this report's times by those in sr.
         void operator+=(const SimulatorReportBase& sr);
         /// Print a report to the given stream.
-        void report(std::ostream& os);
+        // void report(std::ostream& os);
         void reportStep(std::ostringstream& os);
         /// Print a report, leaving out the transport time.
         void reportFullyImplicit(std::ostream& os, const SimulatorReportBase* failedReport = nullptr);
-        void reportParam(std::ostream& os);
+        // void reportParam(std::ostream& os);
     private:
         // Whether to print statistics to std::cout
         bool verbose_;
     };
-    struct SimulatorReport: public SimulatorReportBase{
-	std::vector<SimulatorReportBase> stepreports;
-	explicit SimulatorReport(bool verbose=true) :
-	    SimulatorReportBase(verbose),
-	    stepreports()
-	{	    
-	}
-	void operator+=(const SimulatorReportBase& sr){
-	    SimulatorReportBase::operator+=(sr);
-	    // if(stepreports.size()>0){
-	    // 	assert(stepreports.back().global_time != sr.global_time);
-	    // }
-	    stepreports.push_back(sr);
-	}
-	void operator+=(const SimulatorReport& sr){
-	    SimulatorReportBase::operator+=(sr);
-	    // if(stepreports.size()>0){
-	    // 	assert(stepreports.back().global_time != sr.global_time);
-	    // }
-	    if(sr.stepreports.size()>0){
-		stepreports.insert(stepreports.end(),sr.stepreports.begin(),sr.stepreports.end());
-	    }else{
-		stepreports.push_back(sr);
-	    }
-	    //stepreports.push_back(sr);
-	}
-	void fullReports(std::ostream& os);
+
+    struct SimulatorReport : public SimulatorReportBase {
+        std::vector<SimulatorReportBase> stepreports;
+        explicit SimulatorReport(bool verbose = true)
+            : SimulatorReportBase(verbose)
+            , stepreports()
+        {
+        }
+        void operator+=(const SimulatorReportBase& sr)
+        {
+            SimulatorReportBase::operator+=(sr);
+            // if(stepreports.size()>0){
+            // 	assert(stepreports.back().global_time != sr.global_time);
+            // }
+            stepreports.push_back(sr);
+        }
+        void operator+=(const SimulatorReport& sr)
+        {
+            SimulatorReportBase::operator+=(sr);
+            // if(stepreports.size()>0){
+            // 	assert(stepreports.back().global_time != sr.global_time);
+            // }
+            if (sr.stepreports.size() > 0) {
+                stepreports.insert(stepreports.end(), sr.stepreports.begin(), sr.stepreports.end());
+            } else {
+                stepreports.push_back(sr);
+            }
+            // stepreports.push_back(sr);
+        }
+        void fullReports(std::ostream& os);
     };
-    
-} // namespace Opm
+
+    } // namespace Opm
 
 #endif // OPM_SIMULATORREPORT_HEADER_INCLUDED

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -19,14 +19,15 @@
 
 #ifndef OPM_SIMULATORREPORT_HEADER_INCLUDED
 #define OPM_SIMULATORREPORT_HEADER_INCLUDED
-
+#include <cassert>
 #include <iosfwd>
+#include <vector>
 
 namespace Opm
 {
 
     /// A struct for returning timing data from a simulator to its caller.
-    struct SimulatorReport
+    struct SimulatorReportBase
     {
         double pressure_time;
         double transport_time;
@@ -46,23 +47,52 @@ namespace Opm
         bool converged;
         int exit_status;
 
+	double global_time;
         /// Default constructor initializing all times to 0.0.
-        explicit SimulatorReport(bool verbose=true);
+        explicit SimulatorReportBase(bool verbose=true);
         /// Copy constructor
-        SimulatorReport(const SimulatorReport&) = default;
+        SimulatorReportBase(const SimulatorReportBase&) = default;
         /// Increment this report's times by those in sr.
-        void operator+=(const SimulatorReport& sr);
+        void operator+=(const SimulatorReportBase& sr);
         /// Print a report to the given stream.
         void report(std::ostream& os);
         void reportStep(std::ostringstream& os);
         /// Print a report, leaving out the transport time.
-        void reportFullyImplicit(std::ostream& os, const SimulatorReport* failedReport = nullptr);
+        void reportFullyImplicit(std::ostream& os, const SimulatorReportBase* failedReport = nullptr);
         void reportParam(std::ostream& os);
     private:
         // Whether to print statistics to std::cout
         bool verbose_;
     };
-
+    struct SimulatorReport: public SimulatorReportBase{
+	std::vector<SimulatorReportBase> stepreports;
+	explicit SimulatorReport(bool verbose=true) :
+	    SimulatorReportBase(verbose),
+	    stepreports()
+	{	    
+	}
+	void operator+=(const SimulatorReportBase& sr){
+	    SimulatorReportBase::operator+=(sr);
+	    // if(stepreports.size()>0){
+	    // 	assert(stepreports.back().global_time != sr.global_time);
+	    // }
+	    stepreports.push_back(sr);
+	}
+	void operator+=(const SimulatorReport& sr){
+	    SimulatorReportBase::operator+=(sr);
+	    // if(stepreports.size()>0){
+	    // 	assert(stepreports.back().global_time != sr.global_time);
+	    // }
+	    if(sr.stepreports.size()>0){
+		stepreports.insert(stepreports.end(),sr.stepreports.begin(),sr.stepreports.end());
+	    }else{
+		stepreports.push_back(sr);
+	    }
+	    //stepreports.push_back(sr);
+	}
+	void fullReports(std::ostream& os);
+    };
+    
 } // namespace Opm
 
 #endif // OPM_SIMULATORREPORT_HEADER_INCLUDED

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -48,17 +48,16 @@ namespace Opm
         int exit_status;
 
 	double global_time;
+        double timestep_length;
+
         /// Default constructor initializing all times to 0.0.
-        explicit SimulatorReportSingle(const bool verbose = true);
+        SimulatorReportSingle();
         /// Increment this report's times by those in sr.
         void operator+=(const SimulatorReportSingle& sr);
         /// Print a report suitable for a single simulation step.
         void reportStep(std::ostringstream& os) const;
         /// Print a report suitable for the end of a fully implicit case, leaving out the pressure/transport time.
         void reportFullyImplicit(std::ostream& os, const SimulatorReportSingle* failedReport = nullptr) const;
-    private:
-        // Whether to print statistics to std::cout
-        bool verbose_;
     };
 
     struct SimulatorReport
@@ -67,30 +66,9 @@ namespace Opm
         SimulatorReportSingle failure;
         std::vector<SimulatorReportSingle> stepreports;
 
-        explicit SimulatorReport(bool verbose = true)
-            : success(verbose)
-            , failure(verbose)
-        {
-        }
-        void operator+=(const SimulatorReportSingle& sr)
-        {
-            if (sr.converged) {
-                success += sr;
-            } else {
-                failure += sr;
-            }
-            stepreports.push_back(sr);
-        }
-        void operator+=(const SimulatorReport& sr)
-        {
-            success += sr.success;
-            failure += sr.failure;
-            stepreports.insert(stepreports.end(), sr.stepreports.begin(), sr.stepreports.end());
-        }
-        void reportFullyImplicit(std::ostream& os) const
-        {
-            success.reportFullyImplicit(os, &failure);
-        }
+        void operator+=(const SimulatorReportSingle& sr);
+        void operator+=(const SimulatorReport& sr);
+        void reportFullyImplicit(std::ostream& os) const;
         void fullReports(std::ostream& os) const;
     };
 

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -253,7 +253,7 @@ namespace Opm {
             // return the internal well state
             const WellState& wellState() const;
 
-            const SimulatorReport& lastReport() const;
+            const SimulatorReportSingle& lastReport() const;
 
             void addWellContributions(SparseMatrixAdapter& jacobian) const
             {
@@ -317,7 +317,7 @@ namespace Opm {
             std::unique_ptr<RateConverterType> rateConverter_;
             std::unique_ptr<VFPProperties<VFPInjProperties,VFPProdProperties>> vfp_properties_;
 
-            SimulatorReport last_report_;
+            SimulatorReportSingle last_report_;
 
             WellTestState wellTestState_;
             std::unique_ptr<GuideRate> guideRate_;
@@ -377,7 +377,7 @@ namespace Opm {
             /// at the beginning of the time step and no derivatives are included in these quantities
             void calculateExplicitQuantities(Opm::DeferredLogger& deferred_logger) const;
 
-            SimulatorReport solveWellEq(const std::vector<Scalar>& B_avg, const double dt, Opm::DeferredLogger& deferred_logger);
+            SimulatorReportSingle solveWellEq(const std::vector<Scalar>& B_avg, const double dt, Opm::DeferredLogger& deferred_logger);
 
             void initPrimaryVariablesEvaluation() const;
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -430,7 +430,7 @@ namespace Opm {
 
     // called at the end of a report step
     template<typename TypeTag>
-    const SimulatorReport&
+    const SimulatorReportSingle&
     BlackoilWellModel<TypeTag>::
     lastReport() const {return last_report_; }
 
@@ -809,7 +809,7 @@ namespace Opm {
              const double dt)
     {
 
-        last_report_ = SimulatorReport();
+        last_report_ = SimulatorReportSingle();
 
         if ( ! wellsActive() ) {
             return;
@@ -1027,7 +1027,7 @@ namespace Opm {
 
 
     template<typename TypeTag>
-    SimulatorReport
+    SimulatorReportSingle
     BlackoilWellModel<TypeTag>::
     solveWellEq(const std::vector<Scalar>& B_avg, const double dt, Opm::DeferredLogger& deferred_logger)
     {
@@ -1095,7 +1095,7 @@ namespace Opm {
 
         logAndCheckForExceptionsAndThrow(deferred_logger, exception_thrown, "solveWellEq() failed.", terminal_output_);
 
-        SimulatorReport report;
+        SimulatorReportSingle report;
         report.converged = converged;
         report.total_well_iterations = it;
         return report;


### PR DESCRIPTION
This started from, and replaces #2595.

The real changes I have made are (in addition to code formatting fixes such as tabs):
 - Refactor to not use inheritance. The proposed way was a bit hard to understand. As it stands now I think it is more straightforward.
 - Refactored how failure reports are treated. In the (new) SimulatorReport class (the old is now SimulatorReportSingle), as single reports are added they are both added to the vector of reports, and cumulated into either the `success` or `failure` member. This allowed to remove the explicit treatment of failures from two classes.
 - The performance report is written to `<CASENAME>.STEPINFO`.
 - Successful and failed steps are in the same report (distinguish with the converged flag).
 - The report is made more human-readable, in particular:
   - Time step length has been added to each line of the performance report.
   - Simulation times and time steps are given in days rather than seconds.
   - Data have been formatted to line up nicely.
   - A header line have been added with column titles. (This must be removed if you want to read the report directly into MATLAB or other tools.)

As an example, the first few lines of the Norne report file looks like this:
```
  Time(day)  TStep(day)  Assembly    LSolve    LSetup    Update    Output WellIt Lins NewtIt LinIt Conv
          0           1    0.1639    0.0140    0.1518    0.0083    0.0000      1    5      4    18    1
          1           3    0.1108    0.0128    0.2272    0.0060    0.0000      1    4      3    42    1
          4           4    0.0828    0.0084    0.1451    0.0047    0.0000      4    3      2    26    1
          8         8.5    0.1686    0.0208    0.4454    0.0096    0.0000      2    6      5    89    1
       16.5         8.5    0.0787    0.0079    0.2305    0.0043    0.0000      1    3      2    49    1
         25          16    0.1503    0.0171    0.3958    0.0083    0.0000      3    5      4    79    1
```

Since I have made so many changes this PR is more than just my review of #2595. It would therefore be appropriate to have a third party review before merging.