### PR TITLE
added absolute minim value for relaxed tolerance

### DIFF
--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -61,7 +61,7 @@ SET_SCALAR_PROP(FlowModelParameters, DwellFractionMax, 0.2);
 SET_SCALAR_PROP(FlowModelParameters, MaxResidualAllowed, 1e7);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceMb, 1e-6);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceCnv,1e-2);
-SET_SCALAR_PROP(FlowModelParameters, ToleranceCnvRelaxed, 1e9);
+SET_SCALAR_PROP(FlowModelParameters, ToleranceCnvRelaxed, 1e-1);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceWells, 1e-4);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceWellControl, 1e-7);
 SET_INT_PROP(FlowModelParameters, MaxWelleqIter, 30);


### PR DESCRIPTION
Changed relaxed tolerance to absolute minium which make sence. A better choice would be to tighten the normal tolerance to 1e-3 and putt the relaxed to 1e-2. Fully relaxed cnv and no projection of saturation is probably not a good choise for the default options.