### PR TITLE
Remove 'MAXVALUE' From List of Missing Features

### DIFF
--- a/opm/simulators/flow/MissingFeatures.cpp
+++ b/opm/simulators/flow/MissingFeatures.cpp
@@ -450,7 +450,6 @@ namespace MissingFeatures {
             "MAPUNITS",
             "MASSFLOW",
             "MATCORR",
-            "MAXVALUE",
             "MEMORY",
             "MESSAGE",
             "MESSOPTS",


### PR DESCRIPTION
We've supported that operator for quite some time.