### PR TITLE
Improve convergence msw

### DIFF
--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -81,7 +81,7 @@ SET_SCALAR_PROP(FlowModelParameters, MaxPressureChangeMsWells, 10*1e5);
 SET_BOOL_PROP(FlowModelParameters, UseInnerIterationsMsWells, true);
 SET_INT_PROP(FlowModelParameters, MaxInnerIterMsWells, 100);
 SET_INT_PROP(FlowModelParameters, StrictInnerIterMsWells, 40);
-SET_SCALAR_PROP(FlowModelParameters, RegularizationFactorMsw, 10);
+SET_SCALAR_PROP(FlowModelParameters, RegularizationFactorMsw, 1);
 SET_BOOL_PROP(FlowModelParameters, EnableWellOperabilityCheck, true);
 
 SET_SCALAR_PROP(FlowModelParameters, RelaxedFlowTolInnerIterMsw, 1);

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -55,6 +55,10 @@ NEW_PROP_TAG(TolerancePressureMsWells);
 NEW_PROP_TAG(MaxPressureChangeMsWells);
 NEW_PROP_TAG(UseInnerIterationsMsWells);
 NEW_PROP_TAG(MaxInnerIterMsWells);
+NEW_PROP_TAG(StrictInnerIterMsWells);
+NEW_PROP_TAG(RelaxedFlowTolInnerIterMsw);
+NEW_PROP_TAG(RelaxedPressureTolInnerIterMsw);
+NEW_PROP_TAG(RegularizationFactorMsw);
 
 SET_SCALAR_PROP(FlowModelParameters, DbhpMaxRel, 1.0);
 SET_SCALAR_PROP(FlowModelParameters, DwellFractionMax, 0.2);
@@ -76,7 +80,12 @@ SET_SCALAR_PROP(FlowModelParameters, TolerancePressureMsWells, 0.01*1e5);
 SET_SCALAR_PROP(FlowModelParameters, MaxPressureChangeMsWells, 10*1e5);
 SET_BOOL_PROP(FlowModelParameters, UseInnerIterationsMsWells, true);
 SET_INT_PROP(FlowModelParameters, MaxInnerIterMsWells, 100);
+SET_INT_PROP(FlowModelParameters, StrictInnerIterMsWells, 40);
+SET_SCALAR_PROP(FlowModelParameters, RegularizationFactorMsw, 10);
 SET_BOOL_PROP(FlowModelParameters, EnableWellOperabilityCheck, true);
+
+SET_SCALAR_PROP(FlowModelParameters, RelaxedFlowTolInnerIterMsw, 1);
+SET_SCALAR_PROP(FlowModelParameters, RelaxedPressureTolInnerIterMsw, 0.5e5);
 
 // if openMP is available, determine the number threads per process automatically.
 #if _OPENMP
@@ -114,6 +123,12 @@ namespace Opm
         double tolerance_well_control_;
         /// Tolerance for the pressure equations for multisegment wells
         double tolerance_pressure_ms_wells_;
+
+        /// Relaxed tolerance for the inner iteration for the MSW flow solution
+        double relaxed_inner_tolerance_flow_ms_well_;
+        /// Relaxed tolerance for the inner iteration for the MSW pressure solution
+        double relaxed_inner_tolerance_pressure_ms_well_;
+
         /// Maximum pressure change over an iteratio for ms wells
         double max_pressure_change_ms_wells_;
 
@@ -122,6 +137,12 @@ namespace Opm
 
         /// Maximum inner iteration number for ms wells
         int max_inner_iter_ms_wells_;
+
+        /// Strict inner iteration number for ms wells
+        int strict_inner_iter_ms_wells_;
+
+        /// Regularization factor for ms wells
+        int regularization_factor_ms_wells_;
 
         /// Maximum iteration number of the well equation solution
         int max_welleq_iter_;
@@ -169,9 +190,13 @@ namespace Opm
             max_welleq_iter_ = EWOMS_GET_PARAM(TypeTag, int, MaxWelleqIter);
             use_multisegment_well_ = EWOMS_GET_PARAM(TypeTag, bool, UseMultisegmentWell);
             tolerance_pressure_ms_wells_ = EWOMS_GET_PARAM(TypeTag, Scalar, TolerancePressureMsWells);
+            relaxed_inner_tolerance_flow_ms_well_ = EWOMS_GET_PARAM(TypeTag, Scalar, RelaxedFlowTolInnerIterMsw);
+            relaxed_inner_tolerance_pressure_ms_well_ = EWOMS_GET_PARAM(TypeTag, Scalar, RelaxedPressureTolInnerIterMsw);
             max_pressure_change_ms_wells_ = EWOMS_GET_PARAM(TypeTag, Scalar, MaxPressureChangeMsWells);
             use_inner_iterations_ms_wells_ = EWOMS_GET_PARAM(TypeTag, bool, UseInnerIterationsMsWells);
             max_inner_iter_ms_wells_ = EWOMS_GET_PARAM(TypeTag, int, MaxInnerIterMsWells);
+            strict_inner_iter_ms_wells_ = EWOMS_GET_PARAM(TypeTag, int, StrictInnerIterMsWells);
+            regularization_factor_ms_wells_ = EWOMS_GET_PARAM(TypeTag, Scalar, RegularizationFactorMsw);
             maxSinglePrecisionTimeStep_ = EWOMS_GET_PARAM(TypeTag, Scalar, MaxSinglePrecisionDays) *24*60*60;
             max_strict_iter_ = EWOMS_GET_PARAM(TypeTag, int, MaxStrictIter);
             solve_welleq_initially_ = EWOMS_GET_PARAM(TypeTag, bool, SolveWelleqInitially);
@@ -195,9 +220,13 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, int, MaxWelleqIter, "Maximum number of iterations to determine solution the  well equations");
             EWOMS_REGISTER_PARAM(TypeTag, bool, UseMultisegmentWell, "Use the well model for multi-segment wells instead of the one for single-segment wells");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, TolerancePressureMsWells, "Tolerance for the pressure equations for multi-segment wells");
+            EWOMS_REGISTER_PARAM(TypeTag, Scalar, RelaxedFlowTolInnerIterMsw, "Relaxed tolerance for the inner iteration for the MSW flow solution");
+            EWOMS_REGISTER_PARAM(TypeTag, Scalar, RelaxedPressureTolInnerIterMsw, "Relaxed tolerance for the inner iteration for the MSW pressure solution");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, MaxPressureChangeMsWells, "Maximum relative pressure change for a single iteration of the multi-segment well model");
             EWOMS_REGISTER_PARAM(TypeTag, bool, UseInnerIterationsMsWells, "Use nested iterations for multi-segment wells");
             EWOMS_REGISTER_PARAM(TypeTag, int, MaxInnerIterMsWells, "Maximum number of inner iterations for multi-segment wells");
+            EWOMS_REGISTER_PARAM(TypeTag, int, StrictInnerIterMsWells, "Number of inner iterations for multi-segment wells with strict tolerance");
+            EWOMS_REGISTER_PARAM(TypeTag, Scalar, RegularizationFactorMsw, "Regularization factor for ms wells");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, MaxSinglePrecisionDays, "Maximum time step size where single precision floating point arithmetic can be used solving for the linear systems of equations");
             EWOMS_REGISTER_PARAM(TypeTag, int, MaxStrictIter, "Maximum number of Newton iterations before relaxed tolerances are used for the CNV convergence criterion");
             EWOMS_REGISTER_PARAM(TypeTag, bool, SolveWelleqInitially, "Fully solve the well equations before each iteration of the reservoir model");

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -128,7 +128,7 @@ namespace Opm
                                                Opm::DeferredLogger& deferred_logger) const override;
 
         /// check whether the well equations get converged for this well
-        virtual ConvergenceReport getWellConvergence(const WellState& well_state, const std::vector<double>& B_avg, Opm::DeferredLogger& deferred_logger) const override;
+        virtual ConvergenceReport getWellConvergence(const WellState& well_state, const std::vector<double>& B_avg, Opm::DeferredLogger& deferred_logger, const bool relax_tolerance = false) const override;
 
         /// Ax = Ax - C D^-1 B x
         virtual void apply(const BVector& x, BVector& Ax) const override;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2832,8 +2832,8 @@ namespace Opm
             vol_ratio += mix[comp_idx] / b[comp_idx];
         }
 
-        // segment volume
-        const double volume = segmentSet()[seg_idx].volume();
+        // We increase the segment volume with a factor 10 to stabilize the system.
+        const double volume = segmentSet()[seg_idx].volume() * 10;
 
         return volume / vol_ratio;
     }

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1126,8 +1126,8 @@ namespace Opm
             // update the segment pressure
             {
                 const int sign = dwells[seg][SPres] > 0.? 1 : -1;
-                const double dx_limited = sign * std::min(std::abs(dwells[seg][SPres]), relaxation_factor * max_pressure_change);
-                // const double dx_limited = sign * std::min(std::abs(dwells[seg][SPres]) * relaxation_factor, max_pressure_change);
+                //const double dx_limited = sign * std::min(std::abs(dwells[seg][SPres]), relaxation_factor * max_pressure_change);
+                const double dx_limited = sign * std::min(std::abs(dwells[seg][SPres]) * relaxation_factor, max_pressure_change);
                 primary_variables_[seg][SPres] = std::max( old_primary_variables[seg][SPres] - dx_limited, 1e5);
             }
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2445,7 +2445,7 @@ namespace Opm
             std::ostringstream sstr;
             sstr << " well " << name() << " manage to get converged within " << it << " inner iterations \n";
             if (relax_convergence)
-                sstr << "A relaxed tolerance is used after 40 iterations";
+                sstr << "A relaxed tolerance is used after "<< param_.strict_inner_iter_ms_wells_ << " iterations";
             deferred_logger.debug(sstr.str());
         } else {
             std::ostringstream sstr;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -536,7 +536,7 @@ namespace Opm
     template <typename TypeTag>
     ConvergenceReport
     MultisegmentWell<TypeTag>::
-    getWellConvergence(const WellState& well_state, const std::vector<double>& B_avg, Opm::DeferredLogger& deferred_logger) const
+    getWellConvergence(const WellState& well_state, const std::vector<double>& B_avg, Opm::DeferredLogger& deferred_logger, const bool relax_tolerance) const
     {
         assert(int(B_avg.size()) == num_components_);
 
@@ -577,21 +577,28 @@ namespace Opm
             if (eq_idx < num_components_) { // phase or component mass equations
                 const double flux_residual = maximum_residual[eq_idx];
                 // TODO: the report can not handle the segment number yet.
+
+                double relax_factor = 1.0;
+                if (relax_tolerance)
+                    relax_factor = 1.e4;
                 if (std::isnan(flux_residual)) {
                     report.setWellFailed({CR::WellFailure::Type::MassBalance, CR::Severity::NotANumber, eq_idx, name()});
                 } else if (flux_residual > param_.max_residual_allowed_) {
                     report.setWellFailed({CR::WellFailure::Type::MassBalance, CR::Severity::TooLarge, eq_idx, name()});
-                } else if (flux_residual > param_.tolerance_wells_) {
+                } else if (flux_residual > param_.tolerance_wells_ * relax_factor) {
                     report.setWellFailed({CR::WellFailure::Type::MassBalance, CR::Severity::Normal, eq_idx, name()});
                 }
             } else { // pressure equation
                 const double pressure_residual = maximum_residual[eq_idx];
                 const int dummy_component = -1;
+                double relax_factor = 1.0;
+                if (relax_tolerance)
+                    relax_factor = 50;
                 if (std::isnan(pressure_residual)) {
                     report.setWellFailed({CR::WellFailure::Type::Pressure, CR::Severity::NotANumber, dummy_component, name()});
                 } else if (std::isinf(pressure_residual)) {
                     report.setWellFailed({CR::WellFailure::Type::Pressure, CR::Severity::TooLarge, dummy_component, name()});
-                } else if (pressure_residual > param_.tolerance_pressure_ms_wells_) {
+                } else if (pressure_residual > param_.tolerance_pressure_ms_wells_ * relax_factor) {
                     report.setWellFailed({CR::WellFailure::Type::Pressure, CR::Severity::Normal, dummy_component, name()});
                 }
             }
@@ -2369,17 +2376,20 @@ namespace Opm
         int it = 0;
         // relaxation factor
         double relaxation_factor = 1.;
-        const double min_relaxation_factor = 0.2;
+        const double min_relaxation_factor = 0.6;
         bool converged = false;
         int stagnate_count = 0;
+        bool relax_convergence = false;
         for (; it < max_iter_number; ++it, ++debug_cost_counter_) {
 
             assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, deferred_logger);
 
             const BVectorWell dx_well = mswellhelpers::invDXDirect(duneD_, resWell_);
 
+            if (it > 40)
+                relax_convergence = true;
 
-            const auto report = getWellConvergence(well_state, B_avg, deferred_logger);
+            const auto report = getWellConvergence(well_state, B_avg, deferred_logger, relax_convergence);
             if (report.converged()) {
                 converged = true;
                 break;
@@ -2395,19 +2405,22 @@ namespace Opm
             // TODO: maybe we should have more sophiscated strategy to recover the relaxation factor,
             // for example, to recover it to be bigger
 
-            if (!is_stagnate) {
-                stagnate_count = 0;
-            }
             if (is_oscillate || is_stagnate) {
                 // HACK!
-                if (is_stagnate && relaxation_factor == min_relaxation_factor) {
+                std::ostringstream sstr;
+                if (relaxation_factor == min_relaxation_factor) {
                     // Still stagnating, terminate iterations if 5 iterations pass.
                     ++stagnate_count;
-                    if (stagnate_count == 5) {
-                        // break;
+                    if (stagnate_count == 6) {
+                        sstr << " well " << name() << " observes sever stagnation and/or oscillation. We relax the tolerance and check for convergence. \n";
+                        const auto reportStag = getWellConvergence(well_state, B_avg, deferred_logger, true);
+                        if (reportStag.converged()) {
+                            converged = true;
+                            sstr << " well " << name() << " manage to get converged with relaxed tolerances in " << it << " inner iterations";
+                            deferred_logger.debug(sstr.str());
+                            return;
+                        }
                     }
-                } else {
-                    stagnate_count = 0;
                 }
 
                 // a factor value to reduce the relaxation_factor
@@ -2415,7 +2428,6 @@ namespace Opm
                 relaxation_factor = std::max(relaxation_factor * reduction_mutliplier, min_relaxation_factor);
 
                 // debug output
-                std::ostringstream sstr;
                 if (is_stagnate) {
                     sstr << " well " << name() << " observes stagnation in inner iteration " << it << "\n";
 
@@ -2433,7 +2445,9 @@ namespace Opm
         // TODO: we should decide whether to keep the updated well_state, or recover to use the old well_state
         if (converged) {
             std::ostringstream sstr;
-            sstr << " well " << name() << " manage to get converged within " << it << " inner iterations";
+            sstr << " well " << name() << " manage to get converged within " << it << " inner iterations \n";
+            if (relax_convergence)
+                sstr << "A relaxed tolerance is used after 40 iterations";
             deferred_logger.debug(sstr.str());
         } else {
             std::ostringstream sstr;

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -177,7 +177,8 @@ namespace Opm
         /// check whether the well equations get converged for this well
         virtual ConvergenceReport getWellConvergence(const WellState& well_state,
                                                      const std::vector<double>& B_avg,
-                                                     Opm::DeferredLogger& deferred_logger) const override;
+                                                     Opm::DeferredLogger& deferred_logger,
+                                                     const bool relax_tolerance = false) const override;
 
         /// Ax = Ax - C D^-1 B x
         virtual void apply(const BVector& x, BVector& Ax) const override;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2088,7 +2088,7 @@ namespace Opm
     getWellConvergence(const WellState& well_state,
                        const std::vector<double>& B_avg,
                        Opm::DeferredLogger& deferred_logger,
-                       const bool relax_tolerance) const
+                       const bool /*relax_tolerance*/) const
     {
         // the following implementation assume that the polymer is always after the w-o-g phases
         // For the polymer, energy and foam cases, there is one more mass balance equations of reservoir than wells

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2087,7 +2087,8 @@ namespace Opm
     StandardWell<TypeTag>::
     getWellConvergence(const WellState& well_state,
                        const std::vector<double>& B_avg,
-                       Opm::DeferredLogger& deferred_logger) const
+                       Opm::DeferredLogger& deferred_logger,
+                       const bool relax_tolerance) const
     {
         // the following implementation assume that the polymer is always after the w-o-g phases
         // For the polymer, energy and foam cases, there is one more mass balance equations of reservoir than wells

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -157,7 +157,7 @@ namespace Opm
 
         virtual void initPrimaryVariablesEvaluation() const = 0;
 
-        virtual ConvergenceReport getWellConvergence(const WellState& well_state, const std::vector<double>& B_avg, Opm::DeferredLogger& deferred_logger) const = 0;
+        virtual ConvergenceReport getWellConvergence(const WellState& well_state, const std::vector<double>& B_avg, Opm::DeferredLogger& deferred_logger, const bool relax_tolerance = false) const = 0;
 
         virtual void solveEqAndUpdateWellState(WellState& well_state, Opm::DeferredLogger& deferred_logger) = 0;
 


### PR DESCRIPTION
The motivation for this PR is to improve the convergence on the 9_4E_..MSW test case in opm-models. The number of convergence failures for the well goes from 7466 in master to 0. (with enable-tuning=true)  Needs testing no bigger models. 