### PR TITLE
Make only rank zero honor verbosity in flexible solvers.

### DIFF
--- a/opm/simulators/linalg/FlexibleSolver.hpp
+++ b/opm/simulators/linalg/FlexibleSolver.hpp
@@ -143,11 +143,11 @@ private:
         scalarproduct_ = std::make_shared<Dune::SeqScalarProduct<VectorType>>();
     }
 
-    void initSolver(const boost::property_tree::ptree& prm)
+    void initSolver(const boost::property_tree::ptree& prm, bool isMaster)
     {
         const double tol = prm.get<double>("tol", 1e-2);
         const int maxiter = prm.get<int>("maxiter", 200);
-        const int verbosity = prm.get<int>("verbosity", 0);
+        const int verbosity = isMaster? prm.get<int>("verbosity", 0) : 0;
         const std::string solver_type = prm.get<std::string>("solver", "bicgstab");
         if (solver_type == "bicgstab") {
             linsolver_.reset(new Dune::BiCGSTABSolver<VectorType>(*linearoperator_,
@@ -190,7 +190,7 @@ private:
               const std::function<VectorTypeT()> weightsCalculator, const Comm& comm)
     {
         initOpPrecSp(matrix, prm, weightsCalculator, comm);
-        initSolver(prm);
+        initSolver(prm, comm.communicator().rank()==0);
     }
 
     std::shared_ptr<AbstractOperatorType> linearoperator_;


### PR DESCRIPTION
Previously all the ranks print linear solver statistics in verbose mode which cluttered the output in parallel runs. Now only rank 0 will print like it should be.