### PR TITLE
Fixed unitialized value for ILU when using flexible solvers.

### DIFF
--- a/opm/simulators/linalg/ParallelOverlappingILU0.hpp
+++ b/opm/simulators/linalg/ParallelOverlappingILU0.hpp
@@ -80,7 +80,7 @@ class ParallelOverlappingILU0Args
 {
  public:
     ParallelOverlappingILU0Args(MILU_VARIANT milu = MILU_VARIANT::ILU )
-        : milu_(milu)
+        : milu_(milu), n_(0)
     {}
     void setMilu(MILU_VARIANT milu)
     {


### PR DESCRIPTION
If the user requested CPR/AMG with ILU0, the uninitialized valued caused an arbritrary (quite high) fill-in level to be used which stalled the computation and exhausted memory when running parallel.

Contains only the fix from PR #2601 