### PR TITLE
Split file to ensure correct authorship and license is applied.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -156,6 +156,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/linalg/ISTLSolverEbos.hpp
   opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
   opm/simulators/linalg/MatrixBlock.hpp
+  opm/simulators/linalg/MatrixMarketSpecializations.hpp
   opm/simulators/linalg/OwningBlockPreconditioner.hpp
   opm/simulators/linalg/OwningTwoLevelPreconditioner.hpp
   opm/simulators/linalg/ParallelOverlappingILU0.hpp
@@ -165,6 +166,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/linalg/PressureTransferPolicy.hpp
   opm/simulators/linalg/PreconditionerFactory.hpp
   opm/simulators/linalg/PreconditionerWithUpdate.hpp
+  opm/simulators/linalg/WriteSystemMatrixHelper.hpp
   opm/simulators/linalg/findOverlapRowsAndColumns.hpp
   opm/simulators/linalg/getQuasiImpesWeights.hpp
   opm/simulators/linalg/setupPropertyTree.hpp

--- a/opm/simulators/linalg/MatrixMarketSpecializations.hpp
+++ b/opm/simulators/linalg/MatrixMarketSpecializations.hpp
@@ -1,0 +1,63 @@
+/*
+  The content of this file is based on the file dune/istl/matrixmarket.hh in
+  the Dune module dune-istl.
+
+  The license of this file is therefore the same as that of Dune, see
+  https://www.dune-project.org/about/license/
+*/
+
+#ifndef OPM_MATRIXMARKETSPECIALIZATIONS_HEADER_INCLUDED
+#define OPM_MATRIXMARKETSPECIALIZATIONS_HEADER_INCLUDED
+
+#include <dune/istl/matrixmarket.hh>
+
+namespace Opm
+{
+template<typename T, int i, int j>
+class MatrixBlock;
+}
+
+namespace Dune
+{
+
+namespace MatrixMarketImpl
+{
+
+    template <typename T, int i, int j, typename A>
+    struct mm_header_printer<BCRSMatrix<Opm::MatrixBlock<T,i,j>, A>>
+    {
+        static void print(std::ostream& os)
+        {
+            os << "%%MatrixMarket matrix coordinate ";
+            os << mm_numeric_type<T>::str() << " general" << std::endl;
+        }
+    };
+
+    template <typename T, int i, int j, typename A>
+    struct mm_block_structure_header<BCRSMatrix<Opm::MatrixBlock<T,i,j>, A>>
+    {
+        using M = BCRSMatrix<Opm::MatrixBlock<T,i,j>, A>;
+        static void print(std::ostream& os, const M&)
+        {
+            os << "% ISTL_STRUCT blocked ";
+            os << i << " " << j << std::endl;
+        }
+    };
+
+} // namespace MatrixMarketImpl
+
+template<class M>
+struct mm_multipliers;
+
+template <typename T, int i, int j, typename A>
+struct mm_multipliers<BCRSMatrix<Opm::MatrixBlock<T,i,j>, A>>
+{
+    enum {
+        rows = i,
+        cols = j
+    };
+};
+
+} // namespace Dune
+
+#endif

--- a/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
+++ b/opm/simulators/linalg/WriteSystemMatrixHelper.hpp
@@ -21,55 +21,8 @@
 #define OPM_WRITESYSTEMMATRIXHELPER_HEADER_INCLUDED
 
 #include <dune/istl/matrixmarket.hh>
+#include <opm/simulators/linalg/MatrixMarketSpecializations.hpp>
 
-namespace Opm
-{
-template<typename T, int i, int j>
-class MatrixBlock;
-}
-
-namespace Dune
-{
-
-namespace MatrixMarketImpl
-{
-
-    template <typename T, int i, int j, typename A>
-    struct mm_header_printer<BCRSMatrix<Opm::MatrixBlock<T,i,j>, A>>
-    {
-        static void print(std::ostream& os)
-        {
-            os << "%%MatrixMarket matrix coordinate ";
-            os << mm_numeric_type<T>::str() << " general" << std::endl;
-        }
-    };
-
-    template <typename T, int i, int j, typename A>
-    struct mm_block_structure_header<BCRSMatrix<Opm::MatrixBlock<T,i,j>, A>>
-    {
-        using M = BCRSMatrix<Opm::MatrixBlock<T,i,j>, A>;
-        static void print(std::ostream& os, const M&)
-        {
-            os << "% ISTL_STRUCT blocked ";
-            os << i << " " << j << std::endl;
-        }
-    };
-
-} // namespace MatrixMarketImpl
-
-template<class M>
-struct mm_multipliers;
-
-template <typename T, int i, int j, typename A>
-struct mm_multipliers<BCRSMatrix<Opm::MatrixBlock<T,i,j>, A>>
-{
-    enum {
-        rows = i,
-        cols = j
-    };
-};
-
-} // namespace Dune
 
 namespace Opm
 {


### PR DESCRIPTION
Code was copied from Dune and not placed in its own file. This is unfortunate, and muddles ownership and license issues, for which I apologize (I was the one who did this). The content in question has been placed in its own file, with a notice at the top about origin and license.

Turns out there was another issue: the WriteSystemMatrixHelper.hpp file was never added to the file list for installation, so it could presumably cause failures downstream. That has also been addressed here.

@blattms please indicate if you think this is a good way to handle the issue.