### PR TITLE
Specialize amgSmootherArgs() for ParallelOverlappingILU0

### DIFF
--- a/opm/simulators/linalg/PreconditionerFactory.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory.hpp
@@ -137,12 +137,41 @@ private:
         return criterion;
     }
 
+    /// Helper struct to explicitly overload amgSmootherArgs() version for
+    /// ParallelOverlappingILU0, since in-class specialization is not allowed.
+    template <typename X> struct Id { using Type = X; };
+
     template <typename Smoother>
     static auto amgSmootherArgs(const boost::property_tree::ptree& prm)
+    {
+        return amgSmootherArgs(prm, Id<Smoother>());
+    }
+
+    template <typename Smoother>
+    static auto amgSmootherArgs(const boost::property_tree::ptree& prm,
+                                Id<Smoother>)
     {
         using SmootherArgs = typename Dune::Amg::SmootherTraits<Smoother>::Arguments;
         SmootherArgs smootherArgs;
         smootherArgs.iterations = prm.get<int>("iterations", 1);
+        // smootherArgs.overlap=SmootherArgs::vertex;
+        // smootherArgs.overlap=SmootherArgs::none;
+        // smootherArgs.overlap=SmootherArgs::aggregate;
+        smootherArgs.relaxationFactor = prm.get<double>("relaxation", 0.9);
+        return smootherArgs;
+    }
+
+    static auto amgSmootherArgs(const boost::property_tree::ptree& prm,
+                                Id<Opm::ParallelOverlappingILU0<Matrix, Vector, Vector, Comm>>)
+    {
+        using Smoother = Opm::ParallelOverlappingILU0<Matrix, Vector, Vector, Comm>;
+        using SmootherArgs = typename Dune::Amg::SmootherTraits<Smoother>::Arguments;
+        SmootherArgs smootherArgs;
+        smootherArgs.iterations = prm.get<int>("iterations", 1);
+        const int iluwitdh = prm.get<int>("iluwidth", 0);
+        smootherArgs.setN(iluwitdh);
+        const MILU_VARIANT milu = convertString2Milu(prm.get<std::string>("milutype", std::string("ilu")));
+        smootherArgs.setMilu(milu);
         // smootherArgs.overlap=SmootherArgs::vertex;
         // smootherArgs.overlap=SmootherArgs::none;
         // smootherArgs.overlap=SmootherArgs::aggregate;

--- a/opm/simulators/linalg/PreconditionerFactory.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory.hpp
@@ -157,7 +157,7 @@ private:
         // smootherArgs.overlap=SmootherArgs::vertex;
         // smootherArgs.overlap=SmootherArgs::none;
         // smootherArgs.overlap=SmootherArgs::aggregate;
-        smootherArgs.relaxationFactor = prm.get<double>("relaxation", 0.9);
+        smootherArgs.relaxationFactor = prm.get<double>("relaxation", 1.0);
         return smootherArgs;
     }
 
@@ -175,7 +175,7 @@ private:
         // smootherArgs.overlap=SmootherArgs::vertex;
         // smootherArgs.overlap=SmootherArgs::none;
         // smootherArgs.overlap=SmootherArgs::aggregate;
-        smootherArgs.relaxationFactor = prm.get<double>("relaxation", 0.9);
+        smootherArgs.relaxationFactor = prm.get<double>("relaxation", 1.0);
         return smootherArgs;
     }
 


### PR DESCRIPTION
This allows us to set the ILU width and MILU variant. Some people experienced compile issues with this, let's see if Jenkins is ok.

I have also set the relaxation to 1.0 as discussed in #2601, now in a separate commit.