### PR TITLE
Fix Gpu fallout pr 2612

### DIFF
--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -1137,6 +1137,11 @@ protected:
             return noGhostMat_ ? *noGhostMat_ : *matrix_;
         }
 
+        const Matrix& getMatrix() const
+        {
+            return noGhostMat_ ? *noGhostMat_ : *matrix_;
+        }
+
         const Simulator& simulator_;
         mutable int iterations_;
         mutable bool converged_;

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -616,7 +616,8 @@ protected:
                     if (!useWellConn_) {
                         simulator_.problem().wellModel().getWellContributions(wellContribs);
                     }
-                    bdaBridge->solve_system(&getMatrix(), istlb, wellContribs, result);
+                    // Const_cast needed since the CUDA stuff overwrites values for better matrix condition..
+                    bdaBridge->solve_system(const_cast<Matrix*>(&getMatrix()), istlb, wellContribs, result);
                     if (result.converged) {
                         // get result vector x from non-Dune backend, iff solve was successful
                         bdaBridge->get_result(x);

--- a/opm/simulators/linalg/bda/BdaBridge.cpp
+++ b/opm/simulators/linalg/bda/BdaBridge.cpp
@@ -194,55 +194,21 @@ void BdaBridge::get_result(BridgeVector &x OPM_UNUSED) {
     }
 }
 
-template void BdaBridge::solve_system<
-Dune::BCRSMatrix<Opm::MatrixBlock<double, 1, 1>, std::allocator<Opm::MatrixBlock<double, 1, 1> > > ,
-Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > >
-(Dune::BCRSMatrix<Opm::MatrixBlock<double, 1, 1>, std::allocator<Opm::MatrixBlock<double, 1, 1> > > *mat,
-    Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > &b,
-    WellContributions& wellContribs,
-    InverseOperatorResult &res);
+#define INSTANTIATE_BDA_FUNCTIONS(n)                                                                  \
+template void BdaBridge::solve_system                                                                 \
+(Dune::BCRSMatrix<Opm::MatrixBlock<double, n, n>, std::allocator<Opm::MatrixBlock<double, n, n> > >*, \
+    Dune::BlockVector<Dune::FieldVector<double, n>, std::allocator<Dune::FieldVector<double, n> > >&, \
+    WellContributions&, InverseOperatorResult&);                                                      \
+                                                                                                      \
+template void BdaBridge::get_result                                                                   \
+(Dune::BlockVector<Dune::FieldVector<double, n>, std::allocator<Dune::FieldVector<double, n> > >&);   \
 
-template void BdaBridge::solve_system<
-Dune::BCRSMatrix<Opm::MatrixBlock<double, 2, 2>, std::allocator<Opm::MatrixBlock<double, 2, 2> > > ,
-Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > >
-(Dune::BCRSMatrix<Opm::MatrixBlock<double, 2, 2>, std::allocator<Opm::MatrixBlock<double, 2, 2> > > *mat,
-    Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > &b,
-    WellContributions& wellContribs,
-    InverseOperatorResult &res);
+INSTANTIATE_BDA_FUNCTIONS(1);
+INSTANTIATE_BDA_FUNCTIONS(2);
+INSTANTIATE_BDA_FUNCTIONS(3);
+INSTANTIATE_BDA_FUNCTIONS(4);
 
-template void BdaBridge::solve_system<
-Dune::BCRSMatrix<Opm::MatrixBlock<double, 3, 3>, std::allocator<Opm::MatrixBlock<double, 3, 3> > > ,
-Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > >
-(Dune::BCRSMatrix<Opm::MatrixBlock<double, 3, 3>, std::allocator<Opm::MatrixBlock<double, 3, 3> > > *mat,
-    Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > &b,
-    WellContributions& wellContribs,
-    InverseOperatorResult &res);
-
-template void BdaBridge::solve_system<
-Dune::BCRSMatrix<Opm::MatrixBlock<double, 4, 4>, std::allocator<Opm::MatrixBlock<double, 4, 4> > > ,
-Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > >
-(Dune::BCRSMatrix<Opm::MatrixBlock<double, 4, 4>, std::allocator<Opm::MatrixBlock<double, 4, 4> > > *mat,
-    Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > &b,
-    WellContributions& wellContribs,
-    InverseOperatorResult &res);
-
-template void BdaBridge::get_result<
-Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > >
-(Dune::BlockVector<Dune::FieldVector<double, 1>, std::allocator<Dune::FieldVector<double, 1> > > &x);
-
-template void BdaBridge::get_result<
-Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > >
-(Dune::BlockVector<Dune::FieldVector<double, 2>, std::allocator<Dune::FieldVector<double, 2> > > &x);
-
-template void BdaBridge::get_result<
-Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > >
-(Dune::BlockVector<Dune::FieldVector<double, 3>, std::allocator<Dune::FieldVector<double, 3> > > &x);
-
-template void BdaBridge::get_result<
-Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > >
-(Dune::BlockVector<Dune::FieldVector<double, 4>, std::allocator<Dune::FieldVector<double, 4> > > &x);
-
-
+#undef INSTANTIATE_BDA_FUNCTIONS
 
 }
 

--- a/opm/simulators/linalg/bda/BdaBridge.hpp
+++ b/opm/simulators/linalg/bda/BdaBridge.hpp
@@ -58,6 +58,7 @@ public:
 
 
     /// Solve linear system, A*x = b
+    /// \warning Values of A might get overwritten!
     /// \param[in] mat          matrix A, should be of type Dune::BCRSMatrix
     /// \param[in] b            vector b, should be of type Dune::BlockVector
     /// \param[in] wellContribs contains all WellContributions, to apply them separately, instead of adding them to matrix A


### PR DESCRIPTION
Due to the changes in #2613 we experienced linker errors as the matrix passed to the `BdaBridge` was made const there and these functions have not been instantiated. But the bridge needs a mutable matrix as it overwriter zero diagonal values. This PR uses a const cast to pass a mutable matrix to the BdaBridge to fix this. In addition we simplify the explcite template instantiation a bit with a macro.