### PR TITLE
Opm restart

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -80,6 +80,9 @@ NEW_PROP_TAG(IgnoreKeywords);
 NEW_PROP_TAG(EnableExperiments);
 NEW_PROP_TAG(EdgeWeightsMethod);
 NEW_PROP_TAG(OwnerCellsFirst);
+NEW_PROP_TAG(OpmRestart);
+NEW_PROP_TAG(OpmRestartBase);
+NEW_PROP_TAG(OpmRestartStep);
 
 SET_STRING_PROP(EclBaseVanguard, IgnoreKeywords, "");
 SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "");
@@ -89,6 +92,10 @@ SET_BOOL_PROP(EclBaseVanguard, EclStrictParsing, false);
 SET_BOOL_PROP(EclBaseVanguard, SchedRestart, true);
 SET_INT_PROP(EclBaseVanguard, EdgeWeightsMethod, 1);
 SET_BOOL_PROP(EclBaseVanguard, OwnerCellsFirst, true);
+
+SET_BOOL_PROP(EclBaseVanguard,OpmRestart,false);
+SET_STRING_PROP(EclBaseVanguard,OpmRestartBase,"none");
+SET_INT_PROP(EclBaseVanguard,OpmRestartStep,-1);
 
 END_PROPERTIES
 
@@ -138,6 +145,10 @@ public:
                              "Choose edge-weighing strategy: 0=uniform, 1=trans, 2=log(trans).");
         EWOMS_REGISTER_PARAM(TypeTag, bool, OwnerCellsFirst,
                              "Order cells owned by rank before ghost/overlap cells.");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, OpmRestart, "Use opm restart feature");
+        EWOMS_REGISTER_PARAM(TypeTag, std::string, OpmRestartBase,"The base of previous run for OPM restart feature");
+        EWOMS_REGISTER_PARAM(TypeTag, int, OpmRestartStep,"Restart step for OPM restart feature");
+
     }
 
     /*!

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -418,15 +418,23 @@ namespace Opm
                           included here as a switch.
                         */
                         const bool init_from_restart_file = !EWOMS_GET_PARAM(PreTypeTag, bool, SchedRestart);
-                        const auto& init_config = eclipseState_->getInitConfig();
+                        auto& init_config = eclipseState_->getInitConfig();
+                        const bool opm_restart = EWOMS_GET_PARAM(PreTypeTag, bool, OpmRestart);
+			if( opm_restart ) {
+			    int report_step = EWOMS_GET_PARAM(PreTypeTag, int, OpmRestartStep);
+			    std::string preRunRestartBase = EWOMS_GET_PARAM(PreTypeTag, std::string, OpmRestartBase);
+			    init_config.setRestart(preRunRestartBase,report_step);
+			}
+			
                         if (init_config.restartRequested() && init_from_restart_file) {
                             int report_step = init_config.getRestartStep();
-                            const auto& rst_filename = eclipseState_->getIOConfig().getRestartFileName( init_config.getRestartRootName(), report_step, false );
+                            bool uniform = false;// this experimental feature only work with nonuniform output
+                            const auto& rst_filename = eclipseState_->getIOConfig().getRestartFileName( init_config.getRestartRootName(), report_step, uniform );
                             Opm::EclIO::ERst rst_file(rst_filename);
                             const auto& rst_state = Opm::RestartIO::RstState::load(rst_file, report_step);
                             if (!schedule_)
                                 schedule_.reset(new Opm::Schedule(*deck_, *eclipseState_, parseContext, errorGuard, python, &rst_state) );
-                        }
+			}
                         else {
                             if (!schedule_)
                                 schedule_.reset(new Opm::Schedule(*deck_, *eclipseState_, parseContext, errorGuard, python));

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -423,6 +423,8 @@ namespace Opm
 			if( opm_restart ) {
 			    int report_step = EWOMS_GET_PARAM(PreTypeTag, int, OpmRestartStep);
 			    std::string preRunRestartBase = EWOMS_GET_PARAM(PreTypeTag, std::string, OpmRestartBase);
+                            auto& io_config = eclipseState_->getIOConfig();
+                            io_config.consistentFileFlags();//make consistence between output and input names
 			    init_config.setRestart(preRunRestartBase,report_step);
 			}
 			


### PR DESCRIPTION
Change to make it simple to restart without file manipulations. This would be usefull at least for developers. It depend on pullrequest from opm-common. The intendend use is
```sh
flow SPE1CASE2.DATA --output-dir=spe1case2restart  \
    --opm-restart=true --opm-restart-step=60 \
    --opm-restart-base=fullpath/spe1_fullfowardrun/SPE1CASE2
```
- this is a draft due to changes in opm-common