### PR TITLE
Correct messages for group control switching.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2181,7 +2181,7 @@ namespace Opm {
         switch(exceed_action) {
         case Group::ExceedAction::NONE: {
             if (oldControl != newControl && oldControl != Group::ProductionCMode::NONE) {
-                ss << "Group production exceed limit is NONE for group " + group.name() + ". Nothing happens";
+                ss << "Group production exceed action is NONE for group " + group.name() + ". Nothing happens.";
             }
             break;
         }
@@ -2204,7 +2204,9 @@ namespace Opm {
         case Group::ExceedAction::RATE: {
             if (oldControl != newControl) {
                 well_state.setCurrentProductionGroupControl(group.name(), newControl);
-                ss << "Switching control mode for group "<< group.name() << " to " << Group::ProductionCMode2String(newControl);
+                ss << "Switching production control mode for group "<< group.name()
+                   << " from " << Group::ProductionCMode2String(oldControl)
+                   << " to " << Group::ProductionCMode2String(newControl);
             }
             break;
         }
@@ -2233,9 +2235,9 @@ namespace Opm {
         std::ostringstream ss;
         if (oldControl != newControl) {
             const std::string from = Group::InjectionCMode2String(oldControl);
-            ss << "Group " << group.name() << " exceeding "
-               << from << " limit \n";
-            ss << "Switching control mode for group "<< group.name() << " to " << Group::InjectionCMode2String(newControl);
+            ss << "Switching injection control mode for group "<< group.name()
+               << " from " << Group::InjectionCMode2String(oldControl)
+               << " to " << Group::InjectionCMode2String(newControl);
             auto cc = Dune::MPIHelper::getCollectiveCommunication();
             if (cc.size() > 1) {
                 ss << " on rank " << cc.rank();


### PR DESCRIPTION
This writes a single message about switching for groups, including what it is switching from and to, which is consistent for injectors and producers. The master is wrong for injectors, where it will print "Group X exceeding RATE..." if it is RATE it is switching *from* (not to).