### PR TITLE
adapt to changes in the property system

### DIFF
--- a/ebos/eclbaseaquifermodel.hh
+++ b/ebos/eclbaseaquifermodel.hh
@@ -35,13 +35,6 @@
 #include <stdexcept>
 #include <vector>
 
-BEGIN_PROPERTIES
-
-NEW_PROP_TAG(Simulator);
-NEW_PROP_TAG(RateVector);
-
-END_PROPERTIES
-
 namespace Opm {
 
 /*!

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -30,6 +30,7 @@
 #include <opm/models/io/basevanguard.hh>
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
+#include <opm/models/discretization/common/fvbaseproperties.hh>
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/grid/cpgrid/GridHelpers.hpp>
@@ -67,17 +68,13 @@ BEGIN_PROPERTIES
 NEW_TYPE_TAG(EclBaseVanguard);
 
 // declare the properties required by the for the ecl simulator vanguard
-NEW_PROP_TAG(Grid);
 NEW_PROP_TAG(EquilGrid);
-NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(EclDeckFileName);
-NEW_PROP_TAG(OutputDir);
 NEW_PROP_TAG(EnableOpmRstFile);
 NEW_PROP_TAG(EclStrictParsing);
 NEW_PROP_TAG(SchedRestart);
 NEW_PROP_TAG(EclOutputInterval);
 NEW_PROP_TAG(IgnoreKeywords);
-NEW_PROP_TAG(EnableExperiments);
 NEW_PROP_TAG(EdgeWeightsMethod);
 NEW_PROP_TAG(OwnerCellsFirst);
 

--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -38,18 +38,6 @@
 
 #include <vector>
 
-BEGIN_PROPERTIES
-
-NEW_PROP_TAG(Simulator);
-NEW_PROP_TAG(FluidSystem);
-NEW_PROP_TAG(GridView);
-NEW_PROP_TAG(Scalar);
-NEW_PROP_TAG(MaterialLaw);
-NEW_PROP_TAG(EnableTemperature);
-NEW_PROP_TAG(EnableEnergy);
-
-END_PROPERTIES
-
 namespace Opm {
 
 /*!

--- a/ebos/eclfluxmodule.hh
+++ b/ebos/eclfluxmodule.hh
@@ -41,12 +41,6 @@
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
 
-BEGIN_PROPERTIES
-
-NEW_PROP_TAG(MaterialLaw);
-
-END_PROPERTIES
-
 namespace Opm {
 
 template <class TypeTag>

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -49,17 +49,6 @@
 #include <vector>
 #include <unordered_map>
 
-BEGIN_PROPERTIES
-
-NEW_PROP_TAG(Simulator);
-NEW_PROP_TAG(Scalar);
-NEW_PROP_TAG(Evaluation);
-NEW_PROP_TAG(ElementContext);
-NEW_PROP_TAG(FluidSystem);
-NEW_PROP_TAG(EnableExperiments);
-
-END_PROPERTIES
-
 namespace Opm {
 
 /*!

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -31,6 +31,7 @@
 #include <ebos/nncsorter.hpp>
 
 #include <opm/models/utils/propertysystem.hh>
+#include <opm/models/common/multiphasebaseproperties.hh>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
@@ -53,17 +54,6 @@
 #include <array>
 #include <vector>
 #include <unordered_map>
-
-BEGIN_PROPERTIES
-
-NEW_PROP_TAG(Scalar);
-NEW_PROP_TAG(Vanguard);
-NEW_PROP_TAG(Grid);
-NEW_PROP_TAG(GridView);
-NEW_PROP_TAG(ElementMapper);
-NEW_PROP_TAG(EnableEnergy);
-
-END_PROPERTIES
 
 namespace Opm {
 

--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -54,12 +54,6 @@
 #include <string>
 #include <vector>
 
-BEGIN_PROPERTIES
-
-NEW_PROP_TAG(Grid);
-
-END_PROPERTIES
-
 namespace Opm {
 
 /*!

--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -63,14 +63,6 @@
 #include <utility>
 #include <vector>
 
-BEGIN_PROPERTIES
-
-NEW_PROP_TAG(Simulator);
-NEW_PROP_TAG(Grid);
-NEW_PROP_TAG(FluidSystem);
-
-END_PROPERTIES
-
 namespace Opm {
 
 /**

--- a/ebos/startEbos.hh
+++ b/ebos/startEbos.hh
@@ -42,18 +42,6 @@
 
 #include <opm/common/utility/String.hpp>
 
-BEGIN_PROPERTIES
-
-// forward declaration of property tags
-NEW_PROP_TAG(Scalar);
-NEW_PROP_TAG(Simulator);
-NEW_PROP_TAG(ThreadManager);
-NEW_PROP_TAG(PrintProperties);
-NEW_PROP_TAG(PrintParameters);
-NEW_PROP_TAG(ParameterFile);
-NEW_PROP_TAG(Problem);
-END_PROPERTIES
-
 //! \cond SKIP_THIS
 
 namespace Opm {

--- a/ebos/vtkecltracermodule.hh
+++ b/ebos/vtkecltracermodule.hh
@@ -46,8 +46,6 @@ BEGIN_PROPERTIES
 NEW_TYPE_TAG(VtkEclTracer);
 
 // create the property tags needed for the tracer model
-NEW_PROP_TAG(EnableVtkOutput);
-NEW_PROP_TAG(VtkOutputFormat);
 NEW_PROP_TAG(VtkWriteEclTracerConcentration);
 
 // set default values for what quantities to output

--- a/flow/flow_blackoil_dunecpr.cpp
+++ b/flow/flow_blackoil_dunecpr.cpp
@@ -25,25 +25,6 @@
 
 BEGIN_PROPERTIES
 NEW_TYPE_TAG(EclFlowProblemSimple, INHERITS_FROM(EclFlowProblem));
-NEW_PROP_TAG(FluidState);
-//SET_TYPE_PROP(EclBaseProblem, Problem, Opm::EclProblem<TypeTag>);
-SET_PROP(EclFlowProblemSimple, FluidState)
-    {
-    private:
-      typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
-      typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
-      enum { enableTemperature = GET_PROP_VALUE(TypeTag, EnableTemperature) };
-      enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
-      enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
-      enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
-      typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-      typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
-      static const bool compositionSwitchEnabled = Indices::gasEnabled;
-
-    public:
-//typedef Opm::BlackOilFluidSystemSimple<Scalar> type;
-       typedef Opm::BlackOilFluidState<Evaluation, FluidSystem, enableTemperature, enableEnergy, compositionSwitchEnabled,  Indices::numPhases > type;
-};
 
 SET_BOOL_PROP(EclFlowProblemSimple, MatrixAddWellContributions, true);
 SET_INT_PROP(EclFlowProblemSimple, LinearSolverVerbosity,0);

--- a/flow/flow_onephase.cpp
+++ b/flow/flow_onephase.cpp
@@ -25,8 +25,6 @@
 
 BEGIN_PROPERTIES
 NEW_TYPE_TAG(EclFlowProblemSimple, INHERITS_FROM(EclFlowProblem));
-NEW_PROP_TAG(FluidState);
-NEW_PROP_TAG(FluidSystem);
 //! The indices required by the model
 SET_PROP(EclFlowProblemSimple, Indices)
 {
@@ -47,43 +45,6 @@ public:
                                          /*enebledCompIdx=*/FluidSystem::waterCompIdx>
         type;
 };
-SET_PROP(EclFlowProblemSimple, FluidState)
-{
-private:
-    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
-    typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
-    enum { enableTemperature = GET_PROP_VALUE(TypeTag, EnableTemperature) };
-    enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
-    enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
-    enum { enableBrine = GET_PROP_VALUE(TypeTag, EnableBrine) };
-    enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
-    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
-    static const bool compositionSwitchEnabled = Indices::gasEnabled;
-
-public:
-    // typedef Opm::BlackOilFluidSystemSimple<Scalar> type;
-    typedef Opm::BlackOilFluidState<Evaluation,
-                                    FluidSystem,
-                                    enableTemperature,
-                                    enableEnergy,
-                                    compositionSwitchEnabled,
-                                    enableBrine,
-                                    Indices::numPhases>
-        type;
-};
-
-// SET_PROP(EclFlowProblemSimple, FluidSystem)
-// {
-// private:
-//   //typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-//   typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-//   typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
-//   typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
-
-// public:
-//   typedef Opm::BlackOilFluidSystem<Scalar,Indices> type;
-// };
 END_PROPERTIES
 
 int main(int argc, char** argv)

--- a/flow/flow_onephase_energy.cpp
+++ b/flow/flow_onephase_energy.cpp
@@ -26,8 +26,6 @@
 BEGIN_PROPERTIES
 NEW_TYPE_TAG(EclFlowProblemSimple, INHERITS_FROM(EclFlowProblem));
 SET_BOOL_PROP(EclFlowProblemSimple, EnableEnergy, true);
-NEW_PROP_TAG(FluidState);
-NEW_PROP_TAG(FluidSystem);
 //! The indices required by the model
 SET_PROP(EclFlowProblemSimple, Indices)
 {
@@ -48,43 +46,6 @@ public:
                                          /*enebledCompIdx=*/FluidSystem::waterCompIdx>
         type;
 };
-SET_PROP(EclFlowProblemSimple, FluidState)
-{
-private:
-    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
-    typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
-    enum { enableTemperature = GET_PROP_VALUE(TypeTag, EnableTemperature) };
-    enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
-    enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
-    enum { enableBrine = GET_PROP_VALUE(TypeTag, EnableBrine) };
-    enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
-    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
-    static const bool compositionSwitchEnabled = Indices::gasEnabled;
-
-public:
-    // typedef Opm::BlackOilFluidSystemSimple<Scalar> type;
-    typedef Opm::BlackOilFluidState<Evaluation,
-                                    FluidSystem,
-                                    enableTemperature,
-                                    enableEnergy,
-                                    compositionSwitchEnabled,
-                                    enableBrine,
-                                    Indices::numPhases>
-        type;
-};
-
-// SET_PROP(EclFlowProblemSimple, FluidSystem)
-// {
-// private:
-//   //typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-//   typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-//   typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
-//   typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
-
-// public:
-//   typedef Opm::BlackOilFluidSystem<Scalar,Indices> type;
-// };
 END_PROPERTIES
 
 int main(int argc, char** argv)

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -29,9 +29,6 @@ BEGIN_PROPERTIES
 
 NEW_TYPE_TAG(FlowModelParameters);
 
-NEW_PROP_TAG(Scalar);
-NEW_PROP_TAG(EclDeckFileName);
-
 NEW_PROP_TAG(DbhpMaxRel);
 NEW_PROP_TAG(DwellFractionMax);
 NEW_PROP_TAG(MaxResidualAllowed);

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -52,7 +52,6 @@ BEGIN_PROPERTIES
 
 NEW_PROP_TAG(EnableDryRun);
 NEW_PROP_TAG(OutputInterval);
-NEW_PROP_TAG(UseAmg);
 NEW_PROP_TAG(EnableLoggingFalloutWarning);
 
 // TODO: enumeration parameters. we use strings for now.

--- a/opm/simulators/flow/NonlinearSolverEbos.hpp
+++ b/opm/simulators/flow/NonlinearSolverEbos.hpp
@@ -38,7 +38,6 @@ BEGIN_PROPERTIES
 
 NEW_TYPE_TAG(FlowNonLinearSolver);
 
-NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(NewtonMaxRelax);
 NEW_PROP_TAG(FlowNewtonMaxIterations);
 NEW_PROP_TAG(FlowNewtonMinIterations);

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -36,7 +36,6 @@
 
 BEGIN_PROPERTIES
 
-NEW_PROP_TAG(EnableTerminalOutput);
 NEW_PROP_TAG(EnableAdaptiveTimeStepping);
 NEW_PROP_TAG(EnableTuning);
 

--- a/opm/simulators/linalg/FlowLinearSolverParameters.hpp
+++ b/opm/simulators/linalg/FlowLinearSolverParameters.hpp
@@ -42,7 +42,6 @@ BEGIN_PROPERTIES
 
 NEW_TYPE_TAG(FlowIstlSolverParams);
 
-NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(LinearSolverReduction);
 NEW_PROP_TAG(IluRelaxation);
 NEW_PROP_TAG(LinearSolverMaxIter);
@@ -57,7 +56,6 @@ NEW_PROP_TAG(LinearSolverRequireFullSparsityPattern);
 NEW_PROP_TAG(LinearSolverIgnoreConvergenceFailure);
 NEW_PROP_TAG(UseAmg);
 NEW_PROP_TAG(UseCpr);
-NEW_PROP_TAG(LinearSolverBackend);
 NEW_PROP_TAG(PreconditionerAddWellContributions);
 NEW_PROP_TAG(SystemStrategy);
 NEW_PROP_TAG(ScaleLinearSystem);

--- a/opm/simulators/linalg/FlowLinearSolverParameters.hpp
+++ b/opm/simulators/linalg/FlowLinearSolverParameters.hpp
@@ -27,6 +27,7 @@
 #include <opm/common/utility/parameters/ParameterGroup.hpp>
 #include <opm/simulators/linalg/ParallelOverlappingILU0.hpp>
 
+#include <opm/simulators/linalg/linalgproperties.hh>
 #include <opm/models/utils/parametersystem.hh>
 
 #include <array>

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -57,12 +57,8 @@ BEGIN_PROPERTIES
 
 NEW_TYPE_TAG(FlowIstlSolver, INHERITS_FROM(FlowIstlSolverParams));
 
-NEW_PROP_TAG(Scalar);
-NEW_PROP_TAG(GlobalEqVector);
-NEW_PROP_TAG(SparseMatrixAdapter);
-NEW_PROP_TAG(Indices);
-NEW_PROP_TAG(Simulator);
-NEW_PROP_TAG(EclWellModel);
+template <class TypeTag, class MyTypeTag>
+struct EclWellModel;
 
 //! Set the type of a global jacobian matrix for linear solvers that are based on
 //! dune-istl.

--- a/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
@@ -37,10 +37,6 @@ BEGIN_PROPERTIES
 
 NEW_TYPE_TAG(FlowIstlSolverFlexible, INHERITS_FROM(FlowIstlSolverParams));
 
-NEW_PROP_TAG(GlobalEqVector);
-NEW_PROP_TAG(SparseMatrixAdapter);
-NEW_PROP_TAG(Simulator);
-
 END_PROPERTIES
 
 

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -21,8 +21,6 @@ BEGIN_PROPERTIES
 
 NEW_TYPE_TAG(FlowTimeSteppingParameters);
 
-NEW_PROP_TAG(Scalar);
-
 NEW_PROP_TAG(SolverRestartFactor);
 NEW_PROP_TAG(SolverGrowthFactor);
 NEW_PROP_TAG(SolverMaxGrowth);


### PR DESCRIPTION
`NEW_PROP_TAG` is now a definition and not just a declaration.
Eliminate superfluous declarations, include headers with definitions.
Make one necessary forward declaration explicit.

Has to be merged at the same time as OPM/opm-models#591