### PR TITLE
Modify cpr defaults (for better performance)

### DIFF
--- a/opm/simulators/linalg/setupPropertyTree_impl.hpp
+++ b/opm/simulators/linalg/setupPropertyTree_impl.hpp
@@ -101,9 +101,6 @@ setupPropertyTree(const FlowLinearSolverParameters& p)
             prm.put("preconditioner.coarsesolver.preconditioner.verbosity",0);
             prm.put("preconditioner.coarsesolver.preconditioner.maxlevel",15);
             prm.put("preconditioner.coarsesolver.preconditioner.skip_isolated",0);
-            if(p.linear_solver_configuration_ == "cpr_trueimpes"){
-                prm.put("preconditioner.weight_type","trueimpes");
-            }
         } else {
             if(conf != "ilu0"){
                 OPM_THROW(std::invalid_argument, conf  << "is not a valid setting for --linear-solver-configuration."

--- a/opm/simulators/linalg/setupPropertyTree_impl.hpp
+++ b/opm/simulators/linalg/setupPropertyTree_impl.hpp
@@ -59,7 +59,7 @@ setupPropertyTree(const FlowLinearSolverParameters& p)
         // Support old UseCpr if not configuration was set
         if (!EWOMS_PARAM_IS_SET(TypeTag, std::string, LinearSolverConfiguration) && p.use_cpr_)
         {
-            conf = "cpr_quasiimpes";
+            conf = "cpr_trueimpes";
         }
 
         if((conf == "cpr_trueimpes") || (conf == "cpr_quasiimpes")){

--- a/opm/simulators/linalg/setupPropertyTree_impl.hpp
+++ b/opm/simulators/linalg/setupPropertyTree_impl.hpp
@@ -92,7 +92,8 @@ setupPropertyTree(const FlowLinearSolverParameters& p)
             prm.put("preconditioner.coarsesolver.preconditioner.relaxation",1.0);
             if (EWOMS_PARAM_IS_SET(TypeTag, int, CprMaxEllIter))
                 prm.put("preconditioner.coarsesolver.preconditioner.iterations", p.cpr_max_ell_iter_);
-            prm.put("preconditioner.coarsesolver.preconditioner.iterations",1);
+            else
+                prm.put("preconditioner.coarsesolver.preconditioner.iterations",1);
             prm.put("preconditioner.coarsesolver.preconditioner.coarsenTarget",1200);
             prm.put("preconditioner.coarsesolver.preconditioner.pre_smooth",1);
             prm.put("preconditioner.coarsesolver.preconditioner.post_smooth",1);


### PR DESCRIPTION
Based on the config posted by @hnil in PR #2608, we use trueimpes as default. Still we only use 1 step of pre- and postsmoothing as this is faster for Norne than what was proposed. Added some more cleanups without any effects, tool

Total time
| trueimpes 2 steps | trueimpes 1 step | quasiimpes 1 step |
|---|---|---|
| 640 | 594 | 650 |