### PR TITLE
Write out the linear system when ultra high verbosity is requested.

### DIFF
--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -486,7 +486,7 @@ protected:
         }
 
         bool solve(Vector& x) {
-            const int verbosity = prm_.get<int>("verbosity");
+            const int verbosity = useFlexible_ ? prm_.get<int>("verbosity", 0) : parameters_.linear_solver_verbosity_;
             const bool write_matrix = verbosity > 10;
             // Solve system.
 


### PR DESCRIPTION
This added to ISTLSolverEbosFlexible in PRs #2593 and #2594  and should be available form ISTLSolverEbos for consistency reasons, too. Done with this commit.

