### PR TITLE
cusparseSolver can now handle MultisegmentWells

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -44,6 +44,7 @@ list (APPEND MAIN_SOURCE_FILES
 if(CUDA_FOUND)
   list (APPEND MAIN_SOURCE_FILES opm/simulators/linalg/bda/cusparseSolverBackend.cu)
   list (APPEND MAIN_SOURCE_FILES opm/simulators/linalg/bda/WellContributions.cu)
+  list (APPEND MAIN_SOURCE_FILES opm/simulators/linalg/bda/MultisegmentWellContribution.cpp)
   list (APPEND MAIN_SOURCE_FILES opm/simulators/linalg/bda/BdaBridge.cpp)
 endif()
 if(MPI_FOUND)
@@ -144,6 +145,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/linalg/bda/BdaResult.hpp
   opm/simulators/linalg/bda/cuda_header.hpp
   opm/simulators/linalg/bda/cusparseSolverBackend.hpp
+  opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
   opm/simulators/linalg/bda/WellContributions.hpp
   opm/simulators/linalg/BlackoilAmg.hpp
   opm/simulators/linalg/amgcpr.hh

--- a/opm/simulators/linalg/bda/MultisegmentWellContribution.cpp
+++ b/opm/simulators/linalg/bda/MultisegmentWellContribution.cpp
@@ -1,0 +1,138 @@
+/*
+  Copyright 2020 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <cstdlib>
+#include <cstring>
+#include <config.h> // CMake
+#include <fstream>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/ErrorMacros.hpp>
+
+#if HAVE_UMFPACK
+#include <dune/istl/umfpack.hh>
+#include <opm/simulators/linalg/bda/cuda_header.hpp>
+#endif // HAVE_UMFPACK
+
+#include <opm/simulators/linalg/bda/MultisegmentWellContribution.hpp>
+
+namespace Opm
+{
+
+        MultisegmentWellContribution::MultisegmentWellContribution(unsigned int dim_, unsigned int dim_wells_,
+            unsigned int Nb_, unsigned int Mb_,
+            unsigned int BnumBlocks_, double *Bvalues, unsigned int *BcolIndices, unsigned int *BrowPointers,
+            unsigned int DnumBlocks_, double *Dvalues, int *DcolPointers, int *DrowIndices,
+            double *Cvalues)
+            : dim(dim_), dim_wells(dim_wells_), N(Nb_*dim), Nb(Nb_), M(Mb_*dim_wells), Mb(Mb_), DnumBlocks(DnumBlocks_), BnumBlocks(BnumBlocks_)
+        {
+            Cvals.insert(Cvals.end(), Cvalues, Cvalues + BnumBlocks*dim*dim_wells);
+            Dvals.insert(Dvals.end(), Dvalues, Dvalues + DnumBlocks*dim_wells*dim_wells);
+            Bvals.insert(Bvals.end(), Bvalues, Bvalues + BnumBlocks*dim*dim_wells);
+            Ccols.insert(Ccols.end(), BcolIndices, BcolIndices + BnumBlocks);
+            Bcols.insert(Bcols.end(), BcolIndices, BcolIndices + BnumBlocks);
+            Crows.insert(Crows.end(), BrowPointers, BrowPointers + M + 1);
+            Brows.insert(Brows.end(), BrowPointers, BrowPointers + M + 1);
+
+            Dcols.insert(Dcols.end(), DcolPointers, DcolPointers + M + 1);
+            Drows.insert(Drows.end(), DrowIndices, DrowIndices + DnumBlocks*dim_wells*dim_wells);
+
+            z1.resize(Mb * dim_wells);
+            z2.resize(Mb * dim_wells);
+
+            // allocate pinned memory on host
+            cudaMallocHost(&h_x, sizeof(double) * N);
+            cudaMallocHost(&h_y, sizeof(double) * N);
+
+            umfpack_di_symbolic(M, M, Dcols.data(), Drows.data(), Dvals.data(), &UMFPACK_Symbolic, nullptr, nullptr);
+            umfpack_di_numeric(Dcols.data(), Drows.data(), Dvals.data(), UMFPACK_Symbolic, &UMFPACK_Numeric, nullptr, nullptr);
+        }
+
+        MultisegmentWellContribution::~MultisegmentWellContribution()
+        {
+            cudaFreeHost(h_x);
+            cudaFreeHost(h_y);
+
+            umfpack_di_free_symbolic(&UMFPACK_Symbolic);
+            umfpack_di_free_numeric(&UMFPACK_Numeric);
+        }
+
+
+        // Apply the MultisegmentWellContribution, similar to MultisegmentWell::apply()
+        // y -= (C^T * (D^-1 * (B * x)))
+        void MultisegmentWellContribution::apply(double *d_x, double *d_y)
+        {
+            // copy vectors x and y from GPU to CPU
+            cudaMemcpyAsync(h_x, d_x, sizeof(double) * N, cudaMemcpyDeviceToHost, stream);
+            cudaMemcpyAsync(h_y, d_y, sizeof(double) * N, cudaMemcpyDeviceToHost, stream);
+            cudaStreamSynchronize(stream);
+
+            // reset z1 and z2
+            std::fill(z1.begin(), z1.end(), 0.0);
+            std::fill(z2.begin(), z2.end(), 0.0);
+
+            // z1 = B * x
+            for (unsigned int row = 0; row < Mb; ++row) {
+                // for every block in the row
+                for (unsigned int blockID = Brows[row]; blockID < Brows[row+1]; ++blockID) {
+                    unsigned int colIdx = Bcols[blockID];
+                    for (unsigned int j = 0; j < dim_wells; ++j) {
+                        double temp = 0.0;
+                        for (unsigned int k = 0; k < dim; ++k) {
+                            temp += Bvals[blockID * dim * dim_wells + j * dim + k] * h_x[colIdx * dim + k];
+                        }
+                        z1[row * dim_wells + j] += temp;
+                    }
+                }
+            }
+
+            // z2 = D^-1 * (B * x)
+            // umfpack
+            umfpack_di_solve(UMFPACK_A, Dcols.data(), Drows.data(), Dvals.data(), z2.data(), z1.data(), UMFPACK_Numeric, nullptr, nullptr);
+
+            // y -= (C^T * z2)
+            // y -= (C^T * (D^-1 * (B * x)))
+            for (unsigned int row = 0; row < Mb; ++row) {
+                // for every block in the row
+                for (unsigned int blockID = Brows[row]; blockID < Brows[row+1]; ++blockID) {
+                    unsigned int colIdx = Bcols[blockID];
+                    for (unsigned int j = 0; j < dim; ++j) {
+                        double temp = 0.0;
+                        for (unsigned int k = 0; k < dim_wells; ++k) {
+                            temp += Cvals[blockID * dim * dim_wells + j + k * dim] * z2[row * dim_wells + k];
+                        }
+                        h_y[colIdx * dim + j] -= temp;
+                    }
+                }
+            }
+
+            // copy vector y from CPU to GPU
+            cudaMemcpyAsync(d_y, h_y, sizeof(double) * N, cudaMemcpyHostToDevice, stream);
+            cudaStreamSynchronize(stream);
+        }
+
+        void MultisegmentWellContribution::setCudaStream(cudaStream_t stream_)
+        {
+            stream = stream_;
+        }
+
+
+} //namespace Opm
+

--- a/opm/simulators/linalg/bda/MultisegmentWellContribution.cpp
+++ b/opm/simulators/linalg/bda/MultisegmentWellContribution.cpp
@@ -36,14 +36,14 @@ namespace Opm
             unsigned int DnumBlocks_, double *Dvalues, int *DcolPointers, int *DrowIndices,
             double *Cvalues)
         :
-            dim(dim_),
-            dim_wells(dim_wells_),
-            N(Nb_*dim),
-            Nb(Nb_),
-            M(Mb_*dim_wells),
-            Mb(Mb_),
-            DnumBlocks(DnumBlocks_),
-            BnumBlocks(BnumBlocks_)
+            dim(dim_),                // size of blockvectors in vectors x and y, equal to MultisegmentWell::numEq
+            dim_wells(dim_wells_),    // size of blocks in C, B and D, equal to MultisegmentWell::numWellEq
+            N(Nb_*dim),               // number of rows in vectors x and y, N == dim*Nb
+            Nb(Nb_),                  // number of blockrows in x and y
+            M(Mb_*dim_wells),         // number of rows, M == dim_wells*Mb
+            Mb(Mb_),                  // number of blockrows in C, D and B
+            DnumBlocks(DnumBlocks_),  // number of blocks in D
+            BnumBlocks(BnumBlocks_)   // number of blocks in C and B
         {
             Cvals.insert(Cvals.end(), Cvalues, Cvalues + BnumBlocks*dim*dim_wells);
             Dvals.insert(Dvals.end(), Dvalues, Dvalues + DnumBlocks*dim_wells*dim_wells);

--- a/opm/simulators/linalg/bda/MultisegmentWellContribution.cpp
+++ b/opm/simulators/linalg/bda/MultisegmentWellContribution.cpp
@@ -41,14 +41,20 @@ namespace Opm
             unsigned int BnumBlocks_, double *Bvalues, unsigned int *BcolIndices, unsigned int *BrowPointers,
             unsigned int DnumBlocks_, double *Dvalues, int *DcolPointers, int *DrowIndices,
             double *Cvalues)
-            : dim(dim_), dim_wells(dim_wells_), N(Nb_*dim), Nb(Nb_), M(Mb_*dim_wells), Mb(Mb_), DnumBlocks(DnumBlocks_), BnumBlocks(BnumBlocks_)
+        :
+            dim(dim_),
+            dim_wells(dim_wells_),
+            N(Nb_*dim),
+            Nb(Nb_),
+            M(Mb_*dim_wells),
+            Mb(Mb_),
+            DnumBlocks(DnumBlocks_),
+            BnumBlocks(BnumBlocks_)
         {
             Cvals.insert(Cvals.end(), Cvalues, Cvalues + BnumBlocks*dim*dim_wells);
             Dvals.insert(Dvals.end(), Dvalues, Dvalues + DnumBlocks*dim_wells*dim_wells);
             Bvals.insert(Bvals.end(), Bvalues, Bvalues + BnumBlocks*dim*dim_wells);
-            Ccols.insert(Ccols.end(), BcolIndices, BcolIndices + BnumBlocks);
             Bcols.insert(Bcols.end(), BcolIndices, BcolIndices + BnumBlocks);
-            Crows.insert(Crows.end(), BrowPointers, BrowPointers + M + 1);
             Brows.insert(Brows.end(), BrowPointers, BrowPointers + M + 1);
 
             Dcols.insert(Dcols.end(), DcolPointers, DcolPointers + M + 1);

--- a/opm/simulators/linalg/bda/MultisegmentWellContribution.cpp
+++ b/opm/simulators/linalg/bda/MultisegmentWellContribution.cpp
@@ -32,9 +32,9 @@ namespace Opm
 
         MultisegmentWellContribution::MultisegmentWellContribution(unsigned int dim_, unsigned int dim_wells_,
             unsigned int Nb_, unsigned int Mb_,
-            unsigned int BnumBlocks_, double *Bvalues, unsigned int *BcolIndices, unsigned int *BrowPointers,
+            unsigned int BnumBlocks_, std::vector<double> &Bvalues, std::vector<unsigned int> &BcolIndices, std::vector<unsigned int> &BrowPointers,
             unsigned int DnumBlocks_, double *Dvalues, int *DcolPointers, int *DrowIndices,
-            double *Cvalues)
+            std::vector<double> &Cvalues)
         :
             dim(dim_),                // size of blockvectors in vectors x and y, equal to MultisegmentWell::numEq
             dim_wells(dim_wells_),    // size of blocks in C, B and D, equal to MultisegmentWell::numWellEq
@@ -43,16 +43,16 @@ namespace Opm
             M(Mb_*dim_wells),         // number of rows, M == dim_wells*Mb
             Mb(Mb_),                  // number of blockrows in C, D and B
             DnumBlocks(DnumBlocks_),  // number of blocks in D
-            BnumBlocks(BnumBlocks_)   // number of blocks in C and B
+            BnumBlocks(BnumBlocks_),  // number of blocks in C and B
+            // copy data for matrix D into vectors to prevent it going out of scope
+            Dvals(Dvalues, Dvalues + DnumBlocks*dim_wells*dim_wells),
+            Dcols(DcolPointers, DcolPointers + M + 1),
+            Drows(DrowIndices, DrowIndices + DnumBlocks*dim_wells*dim_wells)
         {
-            Cvals.insert(Cvals.end(), Cvalues, Cvalues + BnumBlocks*dim*dim_wells);
-            Dvals.insert(Dvals.end(), Dvalues, Dvalues + DnumBlocks*dim_wells*dim_wells);
-            Bvals.insert(Bvals.end(), Bvalues, Bvalues + BnumBlocks*dim*dim_wells);
-            Bcols.insert(Bcols.end(), BcolIndices, BcolIndices + BnumBlocks);
-            Brows.insert(Brows.end(), BrowPointers, BrowPointers + M + 1);
-
-            Dcols.insert(Dcols.end(), DcolPointers, DcolPointers + M + 1);
-            Drows.insert(Drows.end(), DrowIndices, DrowIndices + DnumBlocks*dim_wells*dim_wells);
+            Cvals = std::move(Cvalues);
+            Bvals = std::move(Bvalues);
+            Bcols = std::move(BcolIndices);
+            Brows = std::move(BrowPointers);
 
             z1.resize(Mb * dim_wells);
             z2.resize(Mb * dim_wells);

--- a/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
+++ b/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
@@ -1,0 +1,114 @@
+/*
+  Copyright 2020 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MULTISEGMENTWELLCONTRIBUTION_HEADER_INCLUDED
+#define MULTISEGMENTWELLCONTRIBUTION_HEADER_INCLUDED
+
+#include <config.h>
+
+#include <vector>
+
+#include <cuda_runtime.h>
+
+namespace Opm
+{
+
+    /// This class serves to duplicate the functionality of the MultisegmentWell
+    /// A MultisegmentWell uses C, D and B and performs y -= (C^T * (D^-1 * (B*x)))
+    /// B and C are matrices, with M rows and N columns, where N is the size of the matrix. They contain blocks of MultisegmentWell::numEq by MultisegmentWell::numWellEq.
+    /// D is a MxM matrix, the square blocks have size MultisegmentWell::numWellEq. 
+    /// B*x and D*B*x are a vector with M*numWellEq doubles
+    /// C*D*B*x is a vector with N*numEq doubles.
+    ///
+    /// This class is used in 3 phases:
+    /// - get total size of all wellcontributions that must be stored here
+    /// - allocate memory
+    /// - copy data of wellcontributions
+    class MultisegmentWellContribution
+    {
+
+    private:
+        unsigned int dim;                        // number of columns of blocks in B and C, equal to MultisegmentWell::numEq
+        unsigned int dim_wells;                  // number of rows of blocks in B and C, equal to MultisegmentWell::numWellEq
+        unsigned int N;                          // number of rows in vectors x and y, N == dim*Nb
+        unsigned int Nb;                         // number of blockrows in x and y
+        unsigned int M;                          // number of rows, M == dim_wells*Mb
+        unsigned int Mb;                         // number of blockrows in C, D and B
+
+        cudaStream_t stream;
+        double *h_x = nullptr, *h_y = nullptr;  // CUDA pinned memory for GPU memcpy
+
+        // C and B are stored in BCRS format, D is stored in CSC format (Dune::UMFPack).
+        unsigned int DnumBlocks;
+        unsigned int BnumBlocks;
+        std::vector<double> Cvals;
+        std::vector<double> Dvals;
+        std::vector<double> Bvals;
+        std::vector<unsigned int> Ccols;
+        std::vector<int> Dcols;              // Columnpointers, contains M+1 entries
+        std::vector<unsigned int> Bcols;
+        std::vector<unsigned int> Crows;
+        std::vector<int> Drows;              // Rowindicies, contains DnumBlocks*dim*dim_wells entries
+        std::vector<unsigned int> Brows;
+        std::vector<double> z1;          // z1 = B * x
+        std::vector<double> z2;          // z2 = D^-1 * B * x
+        void *UMFPACK_Symbolic, *UMFPACK_Numeric;
+
+
+    public:
+
+        /// Set a cudaStream to be used
+        /// \param[in] stream           the cudaStream that is used
+        void setCudaStream(cudaStream_t stream);
+
+        /// Create a new MultisegmentWellContribution
+        /// Matrices C and B are passed in Blocked CSR, matrix D in CSC
+        /// \param[in] dim              size of blocks in vectors x and y, equal to MultisegmentWell::numEq
+        /// \param[in] dim_wells        size of blocks of C, B and D, equal to MultisegmentWell::numWellEq
+        /// \param[in] Nb               number of blocks in vectors x and y
+        /// \param[in] Mb               number of blockrows in C, B and D
+        /// \param[in] BnumBlocks       number of blocks in C and B
+        /// \param[in] Bvalues          nonzero values of matrix B
+        /// \param[in] BcolIndices      columnindices of blocks of matrix B
+        /// \param[in] BrowPointers     rowpointers of matrix B
+        /// \param[in] DnumBlocks       number of blocks in D
+        /// \param[in] Dvalues          nonzero values of matrix D
+        /// \param[in] DcolPointers     columnpointers of matrix D
+        /// \param[in] DrowIndices      rowindices of matrix D
+        /// \param[in] Cvalues          nonzero values of matrix C
+        MultisegmentWellContribution(unsigned int dim, unsigned int dim_wells,
+            unsigned int Nb, unsigned int Mb,
+            unsigned int BnumBlocks, double *Bvalues, unsigned int *BcolIndices, unsigned int *BrowPointers,
+            unsigned int DnumBlocks, double *Dvalues, int *DcolPointers, int *DrowIndices,
+            double *Cvalues);
+
+        /// Destroy a MultisegmentWellContribution, and free memory
+        ~MultisegmentWellContribution();
+
+        /// Apply the MultisegmentWellContribution on GPU
+        /// performs y -= (C^T * (D^-1 * (B*x))) for MultisegmentWell
+        /// \param[in] d_x          vector x, must be on GPU
+        /// \param[inout] d_y       vector y, must be on GPU
+        void apply(double *d_x, double *d_y);
+
+    };
+
+} //namespace Opm
+
+#endif

--- a/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
+++ b/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
@@ -73,6 +73,7 @@ namespace Opm
 
         /// Create a new MultisegmentWellContribution
         /// Matrices C and B are passed in Blocked CSR, matrix D in CSC
+        /// The variables representing C, B and D will go out of scope when MultisegmentWell::addWellContribution() ends
         /// \param[in] dim              size of blocks in blockvectors x and y, equal to MultisegmentWell::numEq
         /// \param[in] dim_wells        size of blocks of C, B and D, equal to MultisegmentWell::numWellEq
         /// \param[in] Nb               number of blocks in vectors x and y
@@ -88,9 +89,9 @@ namespace Opm
         /// \param[in] Cvalues          nonzero values of matrix C
         MultisegmentWellContribution(unsigned int dim, unsigned int dim_wells,
             unsigned int Nb, unsigned int Mb,
-            unsigned int BnumBlocks, double *Bvalues, unsigned int *BcolIndices, unsigned int *BrowPointers,
+            unsigned int BnumBlocks, std::vector<double> &Bvalues, std::vector<unsigned int> &BcolIndices, std::vector<unsigned int> &BrowPointers,
             unsigned int DnumBlocks, double *Dvalues, int *DcolPointers, int *DrowIndices,
-            double *Cvalues);
+            std::vector<double> &Cvalues);
 
         /// Destroy a MultisegmentWellContribution, and free memory
         ~MultisegmentWellContribution();

--- a/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
+++ b/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
@@ -40,8 +40,8 @@ namespace Opm
     {
 
     private:
-        unsigned int dim;                        // number of columns of blocks in B and C, equal to MultisegmentWell::numEq
-        unsigned int dim_wells;                  // number of rows of blocks in B and C, equal to MultisegmentWell::numWellEq
+        unsigned int dim;                        // size of blockvectors in vectors x and y, equal to MultisegmentWell::numEq
+        unsigned int dim_wells;                  // size of blocks in C, B and D, equal to MultisegmentWell::numWellEq
         unsigned int N;                          // number of rows in vectors x and y, N == dim*Nb
         unsigned int Nb;                         // number of blockrows in x and y
         unsigned int M;                          // number of rows, M == dim_wells*Mb
@@ -51,8 +51,8 @@ namespace Opm
 
         // C and B are stored in BCRS format, D is stored in CSC format (Dune::UMFPack)
         // Sparsity pattern for C is not stored, since it is the same as B
-        unsigned int DnumBlocks;
-        unsigned int BnumBlocks;
+        unsigned int DnumBlocks;             // number of blocks in D
+        unsigned int BnumBlocks;             // number of blocks in C and B
         std::vector<double> Cvals;
         std::vector<double> Dvals;
         std::vector<double> Bvals;
@@ -73,7 +73,7 @@ namespace Opm
 
         /// Create a new MultisegmentWellContribution
         /// Matrices C and B are passed in Blocked CSR, matrix D in CSC
-        /// \param[in] dim              size of blocks in vectors x and y, equal to MultisegmentWell::numEq
+        /// \param[in] dim              size of blocks in blockvectors x and y, equal to MultisegmentWell::numEq
         /// \param[in] dim_wells        size of blocks of C, B and D, equal to MultisegmentWell::numWellEq
         /// \param[in] Nb               number of blocks in vectors x and y
         /// \param[in] Mb               number of blockrows in C, B and D

--- a/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
+++ b/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
@@ -50,16 +50,15 @@ namespace Opm
         cudaStream_t stream;
         double *h_x = nullptr, *h_y = nullptr;  // CUDA pinned memory for GPU memcpy
 
-        // C and B are stored in BCRS format, D is stored in CSC format (Dune::UMFPack).
+        // C and B are stored in BCRS format, D is stored in CSC format (Dune::UMFPack)
+        // Sparsity pattern for C is not stored, since it is the same as B
         unsigned int DnumBlocks;
         unsigned int BnumBlocks;
         std::vector<double> Cvals;
         std::vector<double> Dvals;
         std::vector<double> Bvals;
-        std::vector<unsigned int> Ccols;
         std::vector<int> Dcols;              // Columnpointers, contains M+1 entries
         std::vector<unsigned int> Bcols;
-        std::vector<unsigned int> Crows;
         std::vector<int> Drows;              // Rowindicies, contains DnumBlocks*dim*dim_wells entries
         std::vector<unsigned int> Brows;
         std::vector<double> z1;          // z1 = B * x

--- a/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
+++ b/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
@@ -35,11 +35,7 @@ namespace Opm
     /// D is a MxM matrix, the square blocks have size MultisegmentWell::numWellEq. 
     /// B*x and D*B*x are a vector with M*numWellEq doubles
     /// C*D*B*x is a vector with N*numEq doubles.
-    ///
-    /// This class is used in 3 phases:
-    /// - get total size of all wellcontributions that must be stored here
-    /// - allocate memory
-    /// - copy data of wellcontributions
+    
     class MultisegmentWellContribution
     {
 

--- a/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
+++ b/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
@@ -47,8 +47,7 @@ namespace Opm
         unsigned int M;                          // number of rows, M == dim_wells*Mb
         unsigned int Mb;                         // number of blockrows in C, D and B
 
-        cudaStream_t stream;
-        double *h_x = nullptr, *h_y = nullptr;  // CUDA pinned memory for GPU memcpy
+        cudaStream_t stream; // not actually used yet, will be when MultisegmentWellContribution are applied on GPU
 
         // C and B are stored in BCRS format, D is stored in CSC format (Dune::UMFPack)
         // Sparsity pattern for C is not stored, since it is the same as B
@@ -96,11 +95,11 @@ namespace Opm
         /// Destroy a MultisegmentWellContribution, and free memory
         ~MultisegmentWellContribution();
 
-        /// Apply the MultisegmentWellContribution on GPU
+        /// Apply the MultisegmentWellContribution on CPU
         /// performs y -= (C^T * (D^-1 * (B*x))) for MultisegmentWell
-        /// \param[in] d_x          vector x, must be on GPU
-        /// \param[inout] d_y       vector y, must be on GPU
-        void apply(double *d_x, double *d_y);
+        /// \param[in] h_x          vector x, must be on CPU
+        /// \param[inout] h_y       vector y, must be on CPU
+        void apply(double *h_x, double *h_y);
 
     };
 

--- a/opm/simulators/linalg/bda/WellContributions.cu
+++ b/opm/simulators/linalg/bda/WellContributions.cu
@@ -128,27 +128,39 @@ namespace Opm
     }
 
 
-    void WellContributions::alloc(){
-        cudaMalloc((void**)&d_Cnnzs, sizeof(double) * num_blocks * dim * dim_wells);
-        cudaMalloc((void**)&d_Dnnzs, sizeof(double) * num_wells * dim_wells * dim_wells);
-        cudaMalloc((void**)&d_Bnnzs, sizeof(double) * num_blocks * dim * dim_wells);
-        cudaMalloc((void**)&d_Ccols, sizeof(int) * num_blocks);
-        cudaMalloc((void**)&d_Bcols, sizeof(int) * num_blocks);
-        val_pointers = new unsigned int[num_wells + 1];
-        cudaMalloc((void**)&d_val_pointers, sizeof(int) * (num_wells + 1));
-        cudaCheckLastError("apply_gpu malloc failed");
-        allocated = true;
+    void WellContributions::alloc()
+    {
+        if (num_std_wells > 0) {
+            cudaMalloc((void**)&d_Cnnzs, sizeof(double) * num_blocks * dim * dim_wells);
+            cudaMalloc((void**)&d_Dnnzs, sizeof(double) * num_std_wells * dim_wells * dim_wells);
+            cudaMalloc((void**)&d_Bnnzs, sizeof(double) * num_blocks * dim * dim_wells);
+            cudaMalloc((void**)&d_Ccols, sizeof(int) * num_blocks);
+            cudaMalloc((void**)&d_Bcols, sizeof(int) * num_blocks);
+            val_pointers = new unsigned int[num_std_wells + 1];
+            cudaMalloc((void**)&d_val_pointers, sizeof(int) * (num_std_wells + 1));
+            cudaCheckLastError("apply_gpu malloc failed");
+            allocated = true;
+        }
     }
 
     WellContributions::~WellContributions()
     {
-        cudaFree(d_Cnnzs);
-        cudaFree(d_Dnnzs);
-        cudaFree(d_Bnnzs);
-        cudaFree(d_Ccols);
-        cudaFree(d_Bcols);
-        delete[] val_pointers;
-        cudaFree(d_val_pointers);
+        // delete MultisegmentWellContributions
+        for (auto ms : multisegments) {
+            delete ms;
+        }
+        multisegments.clear();
+
+        // delete data for StandardWell
+        if (num_std_wells > 0) {
+            cudaFree(d_Cnnzs);
+            cudaFree(d_Dnnzs);
+            cudaFree(d_Bnnzs);
+            cudaFree(d_Ccols);
+            cudaFree(d_Bcols);
+            delete[] val_pointers;
+            cudaFree(d_val_pointers);
+        }
     }
 
 
@@ -156,8 +168,16 @@ namespace Opm
     // y -= (C^T *(D^-1*(   B*x)))
     void WellContributions::apply(double *d_x, double *d_y)
     {
-        int smem_size = 2 * sizeof(double) * dim_wells;
-        apply_well_contributions<<<num_wells, 32, smem_size, stream>>>(d_Cnnzs, d_Dnnzs, d_Bnnzs, d_Ccols, d_Bcols, d_x, d_y, dim, dim_wells, d_val_pointers);
+        // apply MultisegmentWells
+        for(MultisegmentWellContribution *well : multisegments){
+            well->apply(d_x, d_y);
+        }
+
+        // apply StandardWells
+        if (num_std_wells > 0) {
+            int smem_size = 2 * sizeof(double) * dim_wells;
+            apply_well_contributions<<<num_std_wells, 32, smem_size, stream>>>(d_Cnnzs, d_Dnnzs, d_Bnnzs, d_Ccols, d_Bcols, d_x, d_y, dim, dim_wells, d_val_pointers);
+        }
     }
 
 
@@ -173,16 +193,16 @@ namespace Opm
             cudaMemcpy(d_Ccols + num_blocks_so_far, colIndices, sizeof(int) * val_size, cudaMemcpyHostToDevice);
             break;
         case MatrixType::D:
-            cudaMemcpy(d_Dnnzs + num_wells_so_far * dim_wells * dim_wells, values, sizeof(double) * dim_wells * dim_wells, cudaMemcpyHostToDevice);
+            cudaMemcpy(d_Dnnzs + num_std_wells_so_far * dim_wells * dim_wells, values, sizeof(double) * dim_wells * dim_wells, cudaMemcpyHostToDevice);
             break;
         case MatrixType::B:
             cudaMemcpy(d_Bnnzs + num_blocks_so_far * dim * dim_wells, values, sizeof(double) * val_size * dim * dim_wells, cudaMemcpyHostToDevice);
             cudaMemcpy(d_Bcols + num_blocks_so_far, colIndices, sizeof(int) * val_size, cudaMemcpyHostToDevice);
-            val_pointers[num_wells_so_far] = num_blocks_so_far;
-            if(num_wells_so_far == num_wells - 1){
-                val_pointers[num_wells] = num_blocks;
+            val_pointers[num_std_wells_so_far] = num_blocks_so_far;
+            if(num_std_wells_so_far == num_std_wells - 1){
+                val_pointers[num_std_wells] = num_blocks;
             }
-            cudaMemcpy(d_val_pointers, val_pointers, sizeof(int) * (num_wells+1), cudaMemcpyHostToDevice);
+            cudaMemcpy(d_val_pointers, val_pointers, sizeof(int) * (num_std_wells+1), cudaMemcpyHostToDevice);
             break;
         default:
             OPM_THROW(std::logic_error,"Error unsupported matrix ID for WellContributions::addMatrix()");
@@ -190,13 +210,16 @@ namespace Opm
         cudaCheckLastError("WellContributions::addMatrix() failed");
         if (MatrixType::B == type) {
             num_blocks_so_far += val_size;
-            num_wells_so_far++;
+            num_std_wells_so_far++;
         }
     }
 
     void WellContributions::setCudaStream(cudaStream_t stream_)
     {
         this->stream = stream_;
+        for(MultisegmentWellContribution *well : multisegments){
+            well->setCudaStream(stream_);
+        }
     }
 
     void WellContributions::setBlockSize(unsigned int dim_, unsigned int dim_wells_)
@@ -211,7 +234,18 @@ namespace Opm
             OPM_THROW(std::logic_error,"Error cannot add more sizes after allocated in WellContributions");
         }
         num_blocks += nnz;
-        num_wells++;
+        num_std_wells++;
+    }
+
+    void WellContributions::addMultisegmentWellContribution(unsigned int dim, unsigned int dim_wells,
+        unsigned int Nb, unsigned int Mb,
+        unsigned int BnumBlocks, double *Bvalues, unsigned int *BcolIndices, unsigned int *BrowPointers,
+        unsigned int DnumBlocks, double *Dvalues, int *DcolPointers, int *DrowIndices,
+        double *Cvalues)
+    {
+        MultisegmentWellContribution *well = new MultisegmentWellContribution(dim, dim_wells, Nb, Mb, BnumBlocks, Bvalues, BcolIndices, BrowPointers, DnumBlocks, Dvalues, DcolPointers, DrowIndices, Cvalues);
+        multisegments.emplace_back(well);
+        ++num_ms_wells;
     }
 
 } //namespace Opm

--- a/opm/simulators/linalg/bda/WellContributions.cu
+++ b/opm/simulators/linalg/bda/WellContributions.cu
@@ -174,6 +174,10 @@ namespace Opm
     void WellContributions::apply(double *d_x, double *d_y)
     {
         // apply MultisegmentWells
+
+        // make sure the stream is empty if timing measurements are done
+        cudaStreamSynchronize(stream);
+
         if (num_ms_wells > 0) {
             // allocate pinned memory on host if not yet done
             if (h_x == nullptr) {
@@ -181,8 +185,6 @@ namespace Opm
                 cudaMallocHost(&h_y, sizeof(double) * N);
             }
 
-            // make sure the stream is empty to start timing
-            cudaStreamSynchronize(stream);
 
             // copy vectors x and y from GPU to CPU
             cudaMemcpyAsync(h_x, d_x, sizeof(double) * N, cudaMemcpyDeviceToHost, stream);

--- a/opm/simulators/linalg/bda/WellContributions.cu
+++ b/opm/simulators/linalg/bda/WellContributions.cu
@@ -267,9 +267,9 @@ namespace Opm
 
     void WellContributions::addMultisegmentWellContribution(unsigned int dim, unsigned int dim_wells,
         unsigned int Nb, unsigned int Mb,
-        unsigned int BnumBlocks, double *Bvalues, unsigned int *BcolIndices, unsigned int *BrowPointers,
+        unsigned int BnumBlocks, std::vector<double> &Bvalues, std::vector<unsigned int> &BcolIndices, std::vector<unsigned int> &BrowPointers,
         unsigned int DnumBlocks, double *Dvalues, int *DcolPointers, int *DrowIndices,
-        double *Cvalues)
+        std::vector<double> &Cvalues)
     {
         this->N = Nb * dim;
         MultisegmentWellContribution *well = new MultisegmentWellContribution(dim, dim_wells, Nb, Mb, BnumBlocks, Bvalues, BcolIndices, BrowPointers, DnumBlocks, Dvalues, DcolPointers, DrowIndices, Cvalues);

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -63,6 +63,7 @@ namespace Opm
         unsigned int num_blocks_so_far = 0;      // keep track of where next data is written
         unsigned int num_std_wells_so_far = 0;   // keep track of where next data is written
         unsigned int *val_pointers = nullptr;    // val_pointers[wellID] == index of first block for this well in Ccols and Bcols
+        unsigned int N;                          // number of rows (not blockrows) in vectors x and y
         bool allocated = false;
         std::vector<MultisegmentWellContribution*> multisegments;
         cudaStream_t stream;
@@ -76,6 +77,9 @@ namespace Opm
         double *d_z1 = nullptr;
         double *d_z2 = nullptr;
         unsigned int *d_val_pointers = nullptr;
+
+        double *h_x = nullptr, *h_y = nullptr;  // CUDA pinned memory for GPU memcpy
+
 
     public:
 
@@ -98,9 +102,9 @@ namespace Opm
 
         /// Apply all Wells in this object
         /// performs y -= (C^T * (D^-1 * (B*x))) for all Wells
-        /// \param[in] x          vector x
-        /// \param[inout] y       vector y
-        void apply(double *x, double *y);
+        /// \param[in] d_x        vector x, must be on GPU
+        /// \param[inout] d_y     vector y, must be on GPU
+        void apply(double *d_x, double *d_y);
 
         /// Allocate memory for the StandardWells
         void alloc();

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -28,6 +28,8 @@
 
 #include <vector>
 
+#include <opm/simulators/linalg/bda/MultisegmentWellContribution.hpp>
+
 #include <cuda_runtime.h>
 
 namespace Opm
@@ -35,6 +37,10 @@ namespace Opm
 
     /// This class serves to eliminate the need to include the WellContributions into the matrix (with --matrix-add-well-contributions=true) for the cusparseSolver
     /// If the --matrix-add-well-contributions commandline parameter is true, this class should not be used
+    /// So far, StandardWell and MultisegmentWell are supported
+    /// A single instance (or pointer) of this class is passed to the cusparseSolver.
+    /// For StandardWell, this class contains all the data and handles the computation. For MultisegmentWell, the vector 'multisegments' contains all the data. For more information, check the MultisegmentWellContribution class.
+
     /// A StandardWell uses C, D and B and performs y -= (C^T * (D^-1 * (B*x)))
     /// B and C are vectors, disguised as matrices and contain blocks of StandardWell::numEq by StandardWell::numStaticWellEq
     /// D is a block, disguised as matrix, the square block has size StandardWell::numStaticWellEq. D is actually stored as D^-1
@@ -50,14 +56,18 @@ namespace Opm
 
     private:
         unsigned int num_blocks = 0;             // total number of blocks in all wells
-        unsigned int dim;                        // number of columns of blocks in B and C, equal to StandardWell::numEq
-        unsigned int dim_wells;                  // number of rows of blocks in B and C, equal to StandardWell::numStaticWellEq
-        unsigned int num_wells = 0;              // number of wellcontributions in this object
+        unsigned int dim;                        // number of columns in blocks in B and C, equal to StandardWell::numEq
+        unsigned int dim_wells;                  // number of rows in blocks in B and C, equal to StandardWell::numStaticWellEq
+        unsigned int num_std_wells = 0;          // number of StandardWells in this object
+        unsigned int num_ms_wells = 0;           // number of MultisegmentWells in this object, must equal multisegments.size()
         unsigned int num_blocks_so_far = 0;      // keep track of where next data is written
-        unsigned int num_wells_so_far = 0;       // keep track of where next data is written
+        unsigned int num_std_wells_so_far = 0;   // keep track of where next data is written
         unsigned int *val_pointers = nullptr;    // val_pointers[wellID] == index of first block for this well in Ccols and Bcols
         bool allocated = false;
+        std::vector<MultisegmentWellContribution*> multisegments;
+        cudaStream_t stream;
 
+        // data for StandardWells, could remain nullptrs if not used
         double *d_Cnnzs = nullptr;
         double *d_Dnnzs = nullptr;
         double *d_Bnnzs = nullptr;
@@ -66,7 +76,7 @@ namespace Opm
         double *d_z1 = nullptr;
         double *d_z2 = nullptr;
         unsigned int *d_val_pointers = nullptr;
-        cudaStream_t stream;
+
     public:
 
         /// StandardWell has C, D and B matrices that need to be copied
@@ -86,22 +96,22 @@ namespace Opm
         /// Destroy a WellContributions, and free memory
         ~WellContributions();
 
-        /// Apply all wellcontributions in this object
-        /// performs y -= (C^T * (D^-1 * (B*x))) for StandardWell
+        /// Apply all Wells in this object
+        /// performs y -= (C^T * (D^-1 * (B*x))) for all Wells
         /// \param[in] x          vector x
         /// \param[inout] y       vector y
         void apply(double *x, double *y);
 
-        /// Allocate memory for the wellcontributions
+        /// Allocate memory for the StandardWells
         void alloc();
 
-        /// Indicate how large the blocks of the wellcontributions (C and B) are
+        /// Indicate how large the blocks of the StandardWell (C and B) are
         /// \param[in] dim         number of columns
         /// \param[in] dim_wells   number of rows
         void setBlockSize(unsigned int dim, unsigned int dim_wells);
 
-        /// Indicate how large the next wellcontribution is, this function cannot be called after alloc() is called
-        /// \param[in] numBlocks   number of blocks in C and B of next wellcontribution
+        /// Indicate how large the next StandardWell is, this function cannot be called after alloc() is called
+        /// \param[in] numBlocks   number of blocks in C and B of next StandardWell
         void addNumBlocks(unsigned int numBlocks);
 
         /// Store a matrix in this object, in blocked csr format, can only be called after alloc() is called
@@ -111,10 +121,31 @@ namespace Opm
         /// \param[in] val_size    number of blocks in C or B, ignored for D
         void addMatrix(MatrixType type, int *colIndices, double *values, unsigned int val_size);
 
+        /// Add a MultisegmentWellContribution, actually creates an object on heap that is destroyed in the destructor
+        /// Matrices C and B are passed in Blocked CSR, matrix D in CSC
+        /// \param[in] dim              size of blocks in vectors x and y, equal to MultisegmentWell::numEq
+        /// \param[in] dim_wells        size of blocks of C, B and D, equal to MultisegmentWell::numWellEq
+        /// \param[in] Nb               number of blocks in vectors x and y
+        /// \param[in] Mb               number of blockrows in C, B and D
+        /// \param[in] BnumBlocks       number of blocks in C and B
+        /// \param[in] Bvalues          nonzero values of matrix B
+        /// \param[in] BcolIndices      columnindices of blocks of matrix B
+        /// \param[in] BrowPointers     rowpointers of matrix B
+        /// \param[in] DnumBlocks       number of blocks in D
+        /// \param[in] Dvalues          nonzero values of matrix D
+        /// \param[in] DcolPointers     columnpointers of matrix D
+        /// \param[in] DrowIndices      rowindices of matrix D
+        /// \param[in] Cvalues          nonzero values of matrix C
+        void addMultisegmentWellContribution(unsigned int dim, unsigned int dim_wells,
+            unsigned int Nb, unsigned int Mb,
+            unsigned int BnumBlocks, double *Bvalues, unsigned int *BcolIndices, unsigned int *BrowPointers,
+            unsigned int DnumBlocks, double *Dvalues, int *DcolPointers, int *DrowIndices,
+            double *Cvalues);
+
         /// Return the number of wells added to this object
         /// \return the number of wells added to this object
         unsigned int getNumWells(){
-            return num_wells;
+            return num_std_wells + num_ms_wells;
         }
     };
 

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -142,9 +142,9 @@ namespace Opm
         /// \param[in] Cvalues          nonzero values of matrix C
         void addMultisegmentWellContribution(unsigned int dim, unsigned int dim_wells,
             unsigned int Nb, unsigned int Mb,
-            unsigned int BnumBlocks, double *Bvalues, unsigned int *BcolIndices, unsigned int *BrowPointers,
+            unsigned int BnumBlocks, std::vector<double> &Bvalues, std::vector<unsigned int> &BcolIndices, std::vector<unsigned int> &BrowPointers,
             unsigned int DnumBlocks, double *Dvalues, int *DcolPointers, int *DrowIndices,
-            double *Cvalues);
+            std::vector<double> &Cvalues);
 
         /// Return the number of wells added to this object
         /// \return the number of wells added to this object

--- a/opm/simulators/linalg/bda/cuda_header.hpp
+++ b/opm/simulators/linalg/bda/cuda_header.hpp
@@ -20,6 +20,7 @@
 #ifndef CUDA_HEADER_HEADER_INCLUDED
 #define CUDA_HEADER_HEADER_INCLUDED
 
+#include <cuda_runtime.h>
 #include <iostream>
 
 /// Runtime error checking of CUDA functions

--- a/opm/simulators/linalg/bda/cusparseSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/cusparseSolverBackend.hpp
@@ -74,9 +74,9 @@ private:
     void gpu_pbicgstab(WellContributions& wellContribs, BdaResult& res);
 
     /// Initialize GPU and allocate memory
-    /// \param[in] N         number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] nnz         number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] dim         size of block
+    /// \param[in] N                number of nonzeroes, divide by dim*dim to get number of blocks
+    /// \param[in] nnz              number of nonzeroes, divide by dim*dim to get number of blocks
+    /// \param[in] dim              size of block
     void initialize(int N, int nnz, int dim);
 
     /// Clean memory

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -135,6 +135,11 @@ namespace Opm
         /// r = r - C D^-1 Rw
         virtual void apply(BVector& r) const override;
 
+#if HAVE_CUDA
+        /// add the contribution (C, D, B matrices) of this Well to the WellContributions object
+        void addWellContribution(WellContributions& wellContribs) const;
+#endif
+
         /// using the solution x to recover the solution xw for wells and applying
         /// xw to update Well State
         virtual void recoverWellSolutionAndUpdateWellState(const BVector& x,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -639,6 +639,66 @@ namespace Opm
 
 
 
+#if HAVE_CUDA
+    template<typename TypeTag>
+    void
+    MultisegmentWell<TypeTag>::
+    addWellContribution(WellContributions& wellContribs) const
+    {
+        unsigned int Nb = duneB_.M();       // number of blockrows in matrix A
+        unsigned int Mb = duneB_.N();       // number of blockrows in duneB_, duneC_ and duneD_
+        unsigned int BnumBlocks = duneB_.nonzeroes();
+        unsigned int DnumBlocks = duneD_.nonzeroes();
+
+        // duneC
+        std::vector<unsigned int> Ccols;
+        std::vector<double> Cvals;
+        Ccols.reserve(BnumBlocks);
+        Cvals.reserve(BnumBlocks * numEq * numWellEq);
+        for (auto rowC = duneC_.begin(); rowC != duneC_.end(); ++rowC) {
+            for (auto colC = rowC->begin(), endC = rowC->end(); colC != endC; ++colC) {
+                Ccols.emplace_back(colC.index());
+                for (int i = 0; i < numWellEq; ++i) {
+                    for (int j = 0; j < numEq; ++j) {
+                        Cvals.emplace_back((*colC)[i][j]);
+                    }
+                }
+            }
+        }
+
+        // duneD
+        Dune::UMFPack<DiagMatWell> umfpackMatrix(duneD_, 0);
+        double *Dvals = umfpackMatrix.getInternalMatrix().getValues();
+        int *Dcols = umfpackMatrix.getInternalMatrix().getColStart();
+        int *Drows = umfpackMatrix.getInternalMatrix().getRowIndex();
+
+        // duneB
+        std::vector<unsigned int> Bcols;
+        std::vector<unsigned int> Brows;
+        std::vector<double> Bvals;
+        Bcols.reserve(BnumBlocks);
+        Brows.reserve(Mb+1);
+        Bvals.reserve(BnumBlocks * numEq * numWellEq);
+        Brows.emplace_back(0);
+        unsigned int sumBlocks = 0;
+        for (auto rowB = duneB_.begin(); rowB != duneB_.end(); ++rowB) {
+            int sizeRow = 0;
+            for (auto colB = rowB->begin(), endB = rowB->end(); colB != endB; ++colB) {
+                Bcols.emplace_back(colB.index());
+                for (int i = 0; i < numWellEq; ++i) {
+                    for (int j = 0; j < numEq; ++j) {
+                        Bvals.emplace_back((*colB)[i][j]);
+                    }
+                }
+                sizeRow++;
+            }
+            sumBlocks += sizeRow;
+            Brows.emplace_back(sumBlocks);
+        }
+
+        wellContribs.addMultisegmentWellContribution(numEq, numWellEq, Nb, Mb, BnumBlocks, Bvals.data(), Bcols.data(), Brows.data(), DnumBlocks, Dvals, Dcols, Drows, Cvals.data());
+    }
+#endif
 
 
     template <typename TypeTag>

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -696,7 +696,7 @@ namespace Opm
             Brows.emplace_back(sumBlocks);
         }
 
-        wellContribs.addMultisegmentWellContribution(numEq, numWellEq, Nb, Mb, BnumBlocks, Bvals.data(), Bcols.data(), Brows.data(), DnumBlocks, Dvals, Dcols, Drows, Cvals.data());
+        wellContribs.addMultisegmentWellContribution(numEq, numWellEq, Nb, Mb, BnumBlocks, Bvals, Bcols, Brows, DnumBlocks, Dvals, Dcols, Drows, Cvals);
     }
 #endif
 


### PR DESCRIPTION
The MultisegmentWells are actually applied on CPU via SuiteSparse/UMFPACK.


some notes:
- The MultisegmentWells are applied on the CPU, this involves copying vectors x and y to the CPU, applying C, applying D using UMFPACK, applying B, copying vector y to the GPU. This is done twice per linear iteration, and incurs huge transfer costs. Applying the MultisegmentWells fully on GPU can be done in a later PR.
- The cusparseSolver object receives a WellContributions object, this object contains the data for StandardWells, plus a vector with pointers to MultisegmentWellContribution objects. StandardWells are applied simultaneously on GPU, thus their data should be in 1 array. MultisegmentWells are applied sequentially on CPU.
- An OpmLog::warning is printed if BlackoilWellModel cannot determine if a well is either StandardWell or MultisegmentWell, then the well is not send to cusparseSolver. This could also be an error.
- The number of Newton Iterations for Dune seem to have decreased between March and May. However, it seems to have increased for the 2080Ti. The K40 has less iterations for the most recent version.
- The MultisegmentWellContribution constructor inserts its data in vectors. Instead of vectors, it could probably use the raw pointers, but the time to insert is quite small anyway.

Intel Xeon E5-2620 v3 @ 2.4 GHz
NVIDIA RTX 2080Ti, NVIDIA Tesla K40c

```
Based on master of March 23 2020 (3d04df97):
NORNE_1A_MSW:
	Dune:
		runtime: 2104 s
		Assembly time: 613 s
		Linear solve time: 1421 s
		Newton Iterations: 4019
		Linear Iterations: 71511
	cusparse + UMFPACK, 2080Ti:
		runtime: 1294 s
		Assembly time: 527 s
		Linear solve time: 701 s
		Newton Iterations: 3346
		Linear Iterations: 51353
		Accum DeviceToHost copy: 170 s, probably wrong measurement
		Accum HostToDevice copy: 98 s
Bigger testcase:
	Dune:
		runtime: 29814 s or 8h16m
		Assembly time: 12267 s
		Linear solve time: 16436 s
		Newton Iterations: 3553
		Linear Iterations: 25905
	cusparse + UMFPACK, 2080Ti:
		runtime: 24864 s or 6h54m
		Assembly time: 13941 s
		Linear solve time: 9591 s
		Newton Iterations: 3515
		Linear Iterations: 23878
		Accum DeviceToHost copy: 3525 s, probably wrong measurement
		Accum HostToDevice copy: 1918 s

Based on master of May 12 2020 (1f177b33):
NORNE_1A_MSW:
	Dune:
		runtime: 1764 s
		Assembly time: 532 s
		Linear solve time: 1165 s
		Newton Iterations: 3381
		Linear Iterations: 58574
	cusparse + UMFPACK, 2080Ti:
		runtime: 2008 s
		Assembly time: 868 s
		Linear solve time: 1047 s
		Newton Iterations: 5586
		Linear Iterations: 80504
		Accum DeviceToHost copy: 546 s, probably wrong measurement
		Accum HostToDevice copy: 152 s
	cusparse + UMFPACK, K40:
		runtime: 1360 s
		Assembly time: 401 s
		Linear solve time: 903 s
		Newton Iterations: 2663
		Linear Iterations: 45255
		Accum DeviceToHost copy: 590 s, probably wrong measurement
		Accum HostToDevice copy: 161 s
```