### PR TITLE
added end_step, usefull for investigating cases for developers

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -54,12 +54,14 @@ NEW_PROP_TAG(EnableDryRun);
 NEW_PROP_TAG(OutputInterval);
 NEW_PROP_TAG(UseAmg);
 NEW_PROP_TAG(EnableLoggingFalloutWarning);
+NEW_PROP_TAG(EndStep);
 
 // TODO: enumeration parameters. we use strings for now.
 SET_STRING_PROP(EclFlowProblem, EnableDryRun, "auto");
 // Do not merge parallel output files or warn about them
 SET_BOOL_PROP(EclFlowProblem, EnableLoggingFalloutWarning, false);
 SET_INT_PROP(EclFlowProblem, OutputInterval, 1);
+SET_INT_PROP(EclFlowProblem, EndStep, std::numeric_limits<int>::max());
 
 END_PROPERTIES
 
@@ -98,6 +100,8 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, std::string, EnableDryRun,
                                  "Specify if the simulation ought to be actually run, or just pretended to be");
             EWOMS_REGISTER_PARAM(TypeTag, int, OutputInterval,
+                                 "Specify the number of report steps between two consecutive writes of restart data");
+            EWOMS_REGISTER_PARAM(TypeTag, int, EndStep,
                                  "Specify the number of report steps between two consecutive writes of restart data");
             EWOMS_REGISTER_PARAM(TypeTag, bool, EnableLoggingFalloutWarning,
                                  "Developer option to see whether logging was on non-root processors. In that case it will be appended to the *.DBG or *.PRT files");
@@ -480,10 +484,10 @@ namespace Opm
             const auto& timeMap = schedule.getTimeMap();
             auto& ioConfig = eclState().getIOConfig();
             SimulatorTimer simtimer;
-
+            size_t end_step = EWOMS_GET_PARAM(TypeTag, int, EndStep);
             // initialize variables
             const auto& initConfig = eclState().getInitConfig();
-            simtimer.init(timeMap, (size_t)initConfig.getRestartStep());
+            simtimer.init(timeMap, (size_t)initConfig.getRestartStep(), end_step);
 
             if (output_cout) {
                 std::ostringstream oss;

--- a/opm/simulators/timestepping/SimulatorTimer.cpp
+++ b/opm/simulators/timestepping/SimulatorTimer.cpp
@@ -31,6 +31,7 @@ namespace Opm
     SimulatorTimer::SimulatorTimer()
         : current_step_(0),
           current_time_(0.0),
+          end_step_(std::numeric_limits<size_t>::max()),
           start_date_(2012,1,1)    // A really arbitrary default starting value?!
     {
     }
@@ -42,6 +43,7 @@ namespace Opm
     {
         const int num_psteps = param.getDefault("num_psteps", 1);
         const double stepsize_days = param.getDefault("stepsize_days", 1.0);
+        const double end_step_ = std::numeric_limits<size_t>::max();
         const double stepsize = Opm::unit::convert::from(stepsize_days, Opm::unit::day);
         timesteps_.clear();
         timesteps_.resize(num_psteps, stepsize);
@@ -49,7 +51,7 @@ namespace Opm
     }
 
     /// Use the SimulatorTimer as a shim around opm-parser's Opm::TimeMap
-    void SimulatorTimer::init(const TimeMap& timeMap, size_t report_step)
+    void SimulatorTimer::init(const TimeMap& timeMap, size_t report_step, size_t end_step)
     {
         total_time_ = timeMap.getTotalTime();
         timesteps_.resize(timeMap.numTimesteps());
@@ -58,6 +60,7 @@ namespace Opm
         }
 
         setCurrentStepNum(report_step);
+        end_step_ = end_step;
         start_date_ = boost::posix_time::from_time_t( timeMap.getStartTime(0)).date();
     }
 
@@ -158,7 +161,7 @@ namespace Opm
     /// Return true if op++() has been called numSteps() times.
     bool SimulatorTimer::done() const
     {
-        return int(timesteps_.size()) == current_step_;
+        return int(timesteps_.size()) == current_step_ || (current_step_ == end_step_);
     }
 
     /// return copy of object

--- a/opm/simulators/timestepping/SimulatorTimer.hpp
+++ b/opm/simulators/timestepping/SimulatorTimer.hpp
@@ -47,7 +47,7 @@ namespace Opm
         void init(const ParameterGroup& param);
 
         /// Use the SimulatorTimer as a shim around opm-parser's Opm::TimeMap
-        void init(const TimeMap& timeMap, size_t report_step = 0);
+        void init(const TimeMap& timeMap, size_t report_step, size_t end_step);
 
         /// Whether the current step is the first step.
         bool initialStep() const;
@@ -121,6 +121,7 @@ namespace Opm
         std::vector<double> timesteps_;
         int current_step_;
         double current_time_;
+        double end_step_;
         double total_time_;
         boost::gregorian::date start_date_;
     };

--- a/tests/test_timer.cpp
+++ b/tests/test_timer.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(CreateTimer)
     boost::gregorian::date defaultStartDate( 2012, 1, 1);
     BOOST_CHECK_EQUAL(  boost::posix_time::ptime(defaultStartDate), simtimer.currentDateTime() );
 
-    simtimer.init(timeMap);
+    simtimer.init(timeMap,0,std::numeric_limits<int>::max());
     boost::gregorian::date startDate( 2014, 3, 26);
     BOOST_CHECK_EQUAL(  boost::posix_time::ptime(startDate), simtimer.currentDateTime() );
 


### PR DESCRIPTION
Added option to set the end step of a simulation. Together with the restart pull request this make it possible for developers to run and compare sections of previous run. A lot of development aim at fixing issues happening at some small part of the simulation period. 