### PR TITLE
Refactor runSimulator().

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -488,14 +488,58 @@ namespace Opm
         // Run the simulator.
         int runSimulator(bool output_cout)
         {
+            return runSimulatorInitOrRun_(output_cout, &FlowMainEbos::runSimulatorRunCallback_);
+        }
+
+    private:
+        // Callback that will be called from runSimulatorInitOrRun_().
+        int runSimulatorRunCallback_(bool output_cout)
+        {
+            SimulatorReport report = simulator_->run(*simtimer_);
+            runSimulatorAfterSim_(output_cout, report);
+            return report.success.exit_status;
+        }
+
+        // Output summary after simulation has completed
+        void runSimulatorAfterSim_(bool output_cout, SimulatorReport &report)
+        {
+            if (output_cout) {
+                std::ostringstream ss;
+                ss << "\n\n================    End of simulation     ===============\n\n";
+                ss << "Number of MPI processes: " << std::setw(6) << mpi_size_ << "\n";
+#if _OPENMP
+                int threads = omp_get_max_threads();
+#else
+                int threads = 1;
+#endif
+                ss << "Threads per MPI process:  " << std::setw(5) << threads << "\n";
+                report.reportFullyImplicit(ss);
+                OpmLog::info(ss.str());
+                const std::string dir = eclState().getIOConfig().getOutputDir();
+                namespace fs = Opm::filesystem;
+                fs::path output_dir(dir);
+                {
+                    std::string filename = eclState().getIOConfig().getBaseName() + ".INFOSTEP";
+                    fs::path fullpath = output_dir / filename;
+                    std::ofstream os(fullpath.string());
+                    report.fullReports(os);
+                }
+            }
+        }
+
+        // Run the simulator.
+        int runSimulatorInitOrRun_(
+             bool output_cout, int (FlowMainEbos::* initOrRunFunc)(bool))
+        {
+
             const auto& schedule = this->schedule();
             const auto& timeMap = schedule.getTimeMap();
             auto& ioConfig = eclState().getIOConfig();
-            SimulatorTimer simtimer;
+            simtimer_ = std::make_unique<SimulatorTimer>();
 
             // initialize variables
             const auto& initConfig = eclState().getInitConfig();
-            simtimer.init(timeMap, (size_t)initConfig.getRestartStep());
+            simtimer_->init(timeMap, (size_t)initConfig.getRestartStep());
 
             if (output_cout) {
                 std::ostringstream oss;
@@ -516,37 +560,17 @@ namespace Opm
                     OpmLog::info(msg);
                 }
 
-                SimulatorReport report = simulator_->run(simtimer);
-                if (output_cout) {
-                    std::ostringstream ss;
-                    ss << "\n\n================    End of simulation     ===============\n\n";
-                    ss << "Number of MPI processes: " << std::setw(6) << mpi_size_ << "\n";
-#if _OPENMP
-                    int threads = omp_get_max_threads();
-#else
-                    int threads = 1;
-#endif
-                    ss << "Threads per MPI process:  " << std::setw(5) << threads << "\n";
-                    report.reportFullyImplicit(ss);
-                    OpmLog::info(ss.str());
-                    const std::string dir = eclState().getIOConfig().getOutputDir();
-                    namespace fs = Opm::filesystem;
-                    fs::path output_dir(dir);
-                    {
-                        std::string filename = eclState().getIOConfig().getBaseName() + ".INFOSTEP";
-                        fs::path fullpath = output_dir / filename;
-                        std::ofstream os(fullpath.string());
-                        report.fullReports(os);
-                    }
-                }
-                return report.success.exit_status;
-            } else {
+                return (this->*initOrRunFunc)(output_cout);
+            }
+            else {
                 if (output_cout) {
                     std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;
                 }
                 return EXIT_SUCCESS;
             }
         }
+
+    protected:
 
         /// This is the main function of Flow.
         // Create simulator instance.
@@ -575,6 +599,7 @@ namespace Opm
         int  mpi_size_ = 1;
         std::any parallel_information_;
         std::unique_ptr<Simulator> simulator_;
+        std::unique_ptr<SimulatorTimer> simtimer_;
     };
 } // namespace Opm
 


### PR DESCRIPTION
A resubmission of commit b25f489 in PR #2403 and PR #2441 to work with the current master.

Continues the work in PR #2619 to refactor `FlowMainEbos.hpp` to work with the Python bindings.

We need to refactor `runSimulator()` to avoid code duplication when `executeStepInit()` is implemented (to be called from the Python interface and implemented in a upcoming PR). Here, `runSimulator()` is refactored into a `runSimulatorInitOrRun()` that takes a callback function. When `runSimulatorInit()` is implemented (upcoming PR) it will pass a different callback that only initializes the simulator. Currently, `runSimulator()` passes the callback `runSimulatorRunCallback_()` which runs the whole simulation. The code outputting the simulation summary in `runSimulator()` is also refactored into a `runSimulatorAfterSim_()` method.