### PR TITLE
Mark SuiteSparse as required.

### DIFF
--- a/opm-simulators-prereqs.cmake
+++ b/opm-simulators-prereqs.cmake
@@ -30,7 +30,7 @@ set (opm-simulators_DEPS
   # Look for MPI support
   "MPI"
   # Tim Davis' SuiteSparse archive
-  "SuiteSparse COMPONENTS umfpack"
+  "SuiteSparse REQUIRED COMPONENTS umfpack"
   # SuperLU direct solver
   "SuperLU"
   # OPM dependency


### PR DESCRIPTION
UMFPack is used unconditionally in the multisegment well code.
To fully work this also needs OPM/opm-common#1796