### PR TITLE
Default to initialize from restart file in case of restarted run

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -86,7 +86,7 @@ SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "");
 SET_INT_PROP(EclBaseVanguard, EclOutputInterval, -1); // use the deck-provided value
 SET_BOOL_PROP(EclBaseVanguard, EnableOpmRstFile, false);
 SET_BOOL_PROP(EclBaseVanguard, EclStrictParsing, false);
-SET_BOOL_PROP(EclBaseVanguard, SchedRestart, true);
+SET_BOOL_PROP(EclBaseVanguard, SchedRestart, false);
 SET_INT_PROP(EclBaseVanguard, EdgeWeightsMethod, 1);
 SET_BOOL_PROP(EclBaseVanguard, OwnerCellsFirst, true);
 


### PR DESCRIPTION
See discussion here: https://github.com/OPM/opm-common/issues/1396

Since some time ago the basic initialize restarted run from the restart file has been merged, and it works for all the restart tests in our test-suite, and also two field cases from Equinor. *But* - it certainly will not work for a lot of models, so when this PR is merged people's restart cases might very well break. They can get the current working behavior back with `--sched-restart=True`. There will be many fallouts which must be fixed, I can certainly do my part in fixing these fallouts - but I it will be a large task and I can not do it alone. 

During the discussion as part of https://github.com/OPM/opm-common/issues/1396 it was agreed that initializing from the restart file was the correct way to go, if we are to eventually get there I see no alternative to merging this PR - but it will probably be painful. There might be reasons to postpone this, or there might be other approaches to get there, but if we do not make an active decision we will not get to the *initialize restarted runs from restart file* situation. 

![image](https://user-images.githubusercontent.com/1321665/82540858-d797e880-9b4f-11ea-94db-af01c0f6f781.png)
