### PR TITLE
Use std::variant access to Segment::icd

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -3627,8 +3627,6 @@ namespace Opm
 
 
 
-
-
     template<typename TypeTag>
     double
     MultisegmentWell<TypeTag>::
@@ -3658,7 +3656,7 @@ namespace Opm
     pressureDropSpiralICD(const int seg) const
     {
         // TODO: We have to consider the upwinding here
-        const SICD& sicd = *segmentSet()[seg].spiralICD();
+        const SICD& sicd = segmentSet()[seg].spiralICD();
 
         const std::vector<EvalWell>& phase_fractions = segment_phase_fractions_[seg];
         const std::vector<EvalWell>& phase_viscosities = segment_phase_viscosities_[seg];
@@ -3722,7 +3720,7 @@ namespace Opm
     MultisegmentWell<TypeTag>::
     pressureDropValve(const int seg) const
     {
-        const Valve& valve = *segmentSet()[seg].valve();
+        const Valve& valve = segmentSet()[seg].valve();
 
         const EvalWell& mass_rate = segment_mass_rates_[seg];
         const EvalWell& visc = segment_viscosities_[seg];


### PR DESCRIPTION
Downstream of: https://github.com/OPM/opm-common/pull/1801

~~This code is not yet ready; while refactoring I discovered a method in the MSW implementation which actually mutated the `SpiralICD` instance held by the Schedule object - that was technically allowed in the previous api which had `const std::shared_ptr< mutable >` - but was it intentional - seems suspicious to me!̃~~


Hmmm: pack and unpack of std::variant<> - seems tricky?