### PR TITLE
Always create proper case name.

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -268,8 +268,7 @@ public:
         edgeWeightsMethod_   = Dune::EdgeWeightMethod(EWOMS_GET_PARAM(TypeTag, int, EdgeWeightsMethod));
         ownersFirst_ = EWOMS_GET_PARAM(TypeTag, bool, OwnerCellsFirst);
 
-        // Skip processing of filename if external deck already exists.
-        if (!externalDeck_)
+        // Make proper case name.
         {
             if (fileName == "")
                 throw std::runtime_error("No input deck file has been specified as a command line argument,"


### PR DESCRIPTION
Without this, rank 0 gets an empty case name, resulting in buggy VTK output with filenames containing the genereric stem "sim" rather than the case name as stem.