### PR TITLE
Fix bug in well closing, and allow more chopping by default.

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -59,7 +59,7 @@ SET_INT_PROP(FlowTimeSteppingParameters, TimeStepControlTargetNewtonIterations, 
 SET_SCALAR_PROP(FlowTimeSteppingParameters, TimeStepControlDecayRate, 0.75);
 SET_SCALAR_PROP(FlowTimeSteppingParameters, TimeStepControlGrowthRate, 1.25);
 SET_STRING_PROP(FlowTimeSteppingParameters, TimeStepControlFileName, "timesteps");
-SET_SCALAR_PROP(FlowTimeSteppingParameters, MinTimeStepBeforeShuttingProblematicWellsInDays, 0.25);
+SET_SCALAR_PROP(FlowTimeSteppingParameters, MinTimeStepBeforeShuttingProblematicWellsInDays, 0.001);
 
 
 END_PROPERTIES
@@ -533,10 +533,10 @@ namespace Opm {
             const int rep_step = sr.back().report_step;
             const int sub_step = sr.back().current_step;
             const int sr_size = sr.size();
-            for (const auto& wf : wfs) {
-                failing_wells.insert(wf.wellName());
-            }
             if (sr_size >= num_steps) {
+                for (const auto& wf : wfs) {
+                    failing_wells.insert(wf.wellName());
+                }
                 for (int s = 1; s < num_steps; ++s) {
                     const auto& srep = sr[sr_size - 1 - s];
                     // Report must be from same report step and substep, otherwise we have


### PR DESCRIPTION
This fixes a bug that would tag a well as consistently failing (i.e. for three chops) even if it had only caused chopping once. Also reduces the default minimum timestep reached before we check for consistently failing wells, as the existing default was deemed too strict and close down wells earlier than necessary. This could have some performance penalty, in that we might waste more iterations only to drop a well and restart the step, but as well closures are relatively speaking uncommon events, it is not likely to be noticeable.