### PR TITLE
Add restart test of UDQ_WCONPROD

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -926,6 +926,13 @@ add_test_compare_restarted_simulation(CASENAME spe9
                                       REL_TOL ${rel_tol_restart}
                                       TEST_ARGS --sched-restart=false)
 
+add_test_compare_restarted_simulation(CASENAME udq_actionx
+                                      FILENAME UDQ_M1
+                                      SIMULATOR flow
+                                      ABS_TOL ${abs_tol_restart}
+                                      REL_TOL ${rel_tol_restart}
+                                      TEST_ARGS --sched-restart=false)
+
 # The dynamic MSW data is not written to /read from the restart file
 # We therefore accept significant deviation in the results.
 # Note also that we use --sched-restart=true since some necessary

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -960,6 +960,13 @@ add_test_compare_restarted_simulation(CASENAME spe1
                                       REL_TOL ${rel_tol_restart}
                                       TEST_ARGS --sched-restart=false)
 
+add_test_compare_restarted_simulation(CASENAME udq_actionx
+                                      FILENAME UDQ_M1
+                                      SIMULATOR flow
+                                      TEST_NAME restart_udq_m1_summary
+                                      ABS_TOL ${abs_tol_restart}
+                                      REL_TOL ${rel_tol_restart}
+                                      TEST_ARGS --sched-restart=false --solver-max-time-step-in-days=1.0)
 
 # PORV test
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-porv-acceptanceTest.sh "")


### PR DESCRIPTION
Add restart test for case with UDQ / UDA data. Testadata here: https://github.com/OPM/opm-tests/pull/327

~~The restarted case must be run with the non default option `--sched-restart=True` - it was not clear to me how to add that argument driver; last time I tried editing that stuff I spent considerable time - and ended up getting it all wrong. Seems maybe like the `run-restart-regressionTest.sh` script treats treats the arguments a bit haphazardly?~~

My fault: I started with a git ref from last year.

https://github.com/OPM/opm-common/pull/1861