### PR TITLE
Changes in running of restart regression tests

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -96,7 +96,6 @@ function(add_test_compare_restarted_simulation)
                            ${PARAM_ABS_TOL} ${PARAM_REL_TOL}
                            ${COMPARE_ECL_COMMAND}
                            ${OPM_PACK_COMMAND}
-                           0
                TEST_ARGS ${PARAM_TEST_ARGS})
 endfunction()
 
@@ -161,7 +160,6 @@ function(add_test_compare_parallel_restarted_simulation)
                            ${PARAM_ABS_TOL} ${PARAM_REL_TOL}
                            ${COMPARE_ECL_COMMAND}
                            ${OPM_PACK_COMMAND}
-                           1
                TEST_ARGS ${PARAM_TEST_ARGS})
   set_tests_properties(compareParallelRestartedSim_${PARAM_SIMULATOR}+${PARAM_FILENAME}
                        PROPERTIES RUN_SERIAL 1)
@@ -749,7 +747,7 @@ add_test_compare_restarted_simulation(CASENAME msw_3d_hfa
                                       SIMULATOR flow
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
-                                      TEST_ARGS --sched-restart=false)
+                                      TEST_ARGS --enable-adaptive-time-stepping=false --sched-restart=false)
 
 # PORV test
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-porv-acceptanceTest.sh "")
@@ -774,7 +772,7 @@ add_test_compareECLFiles(CASENAME norne
 
 # Parallel tests
 if(MPI_FOUND)
-  opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-restart-regressionTest.sh "")
+  opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-parallel-restart-regressionTest.sh "")
   add_test_compare_parallel_restarted_simulation(CASENAME spe1
                                                  FILENAME SPE1CASE2_ACTNUM
                                                  SIMULATOR flow

--- a/tests/run-parallel-restart-regressionTest.sh
+++ b/tests/run-parallel-restart-regressionTest.sh
@@ -21,13 +21,13 @@ BASE_NAME=${FILENAME}_RESTART.DATA
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
+mpirun -np 4 ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --enable-adaptive-time-stepping=false --output-dir=${RESULT_PATH} ${TEST_ARGS}
 
 test $? -eq 0 || exit 1
 
 ${OPM_PACK_COMMAND} -o ${BASE_NAME} ${INPUT_DATA_PATH}/${FILENAME}_RESTART.DATA
 
-${BINPATH}/${EXE_NAME} ${BASE_NAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
+mpirun -np 4 ${BINPATH}/${EXE_NAME} ${BASE_NAME} --enable-adaptive-time-stepping=false --output-dir=${RESULT_PATH} ${TEST_ARGS}
 test $? -eq 0 || exit 1
 
 ecode=0


### PR DESCRIPTION
 - The parallel test gets a designated driver
 - The serial test is run with default adpative timestepping

The main point about these changes is to enable the base run to go with `--enable-adaptive-time-stepping=true` - which is required to get the the base run of: #2658 through 