### PR TITLE
Use explicit instantiation for FlexibleSolver to reduce compile times.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -28,6 +28,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/timestepping/SimulatorReport.cpp
   opm/simulators/flow/MissingFeatures.cpp
   opm/simulators/linalg/ExtractParallelGridInformationToISTL.cpp
+  opm/simulators/linalg/FlexibleSolver.cpp
   opm/simulators/timestepping/TimeStepControl.cpp
   opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
   opm/simulators/timestepping/SimulatorTimer.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -28,7 +28,10 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/timestepping/SimulatorReport.cpp
   opm/simulators/flow/MissingFeatures.cpp
   opm/simulators/linalg/ExtractParallelGridInformationToISTL.cpp
-  opm/simulators/linalg/FlexibleSolver.cpp
+  opm/simulators/linalg/FlexibleSolver1.cpp
+  opm/simulators/linalg/FlexibleSolver2.cpp
+  opm/simulators/linalg/FlexibleSolver3.cpp
+  opm/simulators/linalg/FlexibleSolver4.cpp
   opm/simulators/timestepping/TimeStepControl.cpp
   opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
   opm/simulators/timestepping/SimulatorTimer.cpp

--- a/opm/simulators/linalg/FlexibleSolver.cpp
+++ b/opm/simulators/linalg/FlexibleSolver.cpp
@@ -36,32 +36,23 @@ namespace Dune
     /// Create a sequential solver.
     template <class MatrixType, class VectorType>
     FlexibleSolver<MatrixType, VectorType>::
-    FlexibleSolver(const boost::property_tree::ptree& prm, const MatrixType& matrix,
+    FlexibleSolver(const MatrixType& matrix,
+                   const boost::property_tree::ptree& prm,
                    const std::function<VectorType()>& weightsCalculator)
     {
-        init(prm, matrix, weightsCalculator, Dune::Amg::SequentialInformation());
+        init(matrix, Dune::Amg::SequentialInformation(), prm, weightsCalculator);
     }
 
     /// Create a parallel solver (if Comm is e.g. OwnerOverlapCommunication).
     template <class MatrixType, class VectorType>
     template <class Comm>
     FlexibleSolver<MatrixType, VectorType>::
-    FlexibleSolver(const boost::property_tree::ptree& prm,
-                   const MatrixType& matrix,
-                   // const Comm& comm)
-                   const typename std::enable_if<IsComm<Comm>::value, Comm>::type& comm)
+    FlexibleSolver(const MatrixType& matrix,
+                   const Comm& comm,
+                   const boost::property_tree::ptree& prm,
+                   const std::function<VectorType()>& weightsCalculator)
     {
-        init(prm, matrix, std::function<VectorType()>(), comm);
-    }
-
-    /// Create a parallel solver (if Comm is e.g. OwnerOverlapCommunication).
-    template <class MatrixType, class VectorType>
-    template <class Comm>
-    FlexibleSolver<MatrixType, VectorType>::
-    FlexibleSolver(const boost::property_tree::ptree& prm, const MatrixType& matrix,
-                   const std::function<VectorType()>& weightsCalculator, const Comm& comm)
-    {
-        init(prm, matrix, weightsCalculator, comm);
+        init(matrix, comm, prm, weightsCalculator);
     }
 
     template <class MatrixType, class VectorType>
@@ -183,8 +174,10 @@ namespace Dune
     template <class Comm>
     void
     FlexibleSolver<MatrixType, VectorType>::
-    init(const boost::property_tree::ptree& prm, const MatrixType& matrix,
-         const std::function<VectorType()> weightsCalculator, const Comm& comm)
+    init(const MatrixType& matrix,
+         const Comm& comm,
+         const boost::property_tree::ptree& prm,
+         const std::function<VectorType()> weightsCalculator)
     {
         initOpPrecSp(matrix, prm, weightsCalculator, comm);
         initSolver(prm, comm.communicator().rank()==0);
@@ -203,45 +196,36 @@ template <int N>
 using OBM = Dune::BCRSMatrix<Opm::MatrixBlock<double, N, N>>;
 
 // Variants using Dune::FieldMatrix blocks.
-// template class Dune::FlexibleSolver<BM<1>, BV<1>>;
-// template class Dune::FlexibleSolver<BM<2>, BV<2>>;
+template class Dune::FlexibleSolver<BM<1>, BV<1>>;
+template class Dune::FlexibleSolver<BM<2>, BV<2>>;
 template class Dune::FlexibleSolver<BM<3>, BV<3>>;
-// template class Dune::FlexibleSolver<BM<4>, BV<4>>;
-/*
+template class Dune::FlexibleSolver<BM<4>, BV<4>>;
+
 // Variants using Opm::MatrixBlock blocks.
 template class Dune::FlexibleSolver<OBM<1>, BV<1>>;
 template class Dune::FlexibleSolver<OBM<2>, BV<2>>;
 template class Dune::FlexibleSolver<OBM<3>, BV<3>>;
 template class Dune::FlexibleSolver<OBM<4>, BV<4>>;
 
+
 using Comm = Dune::OwnerOverlapCopyCommunication<int, int>;
 
-template Dune::FlexibleSolver<OBM<1>, BV<1>>::FlexibleSolver(const boost::property_tree::ptree& prm,
-                                                             const OBM<1>& matrix,
-                                                             const Comm&);
-template Dune::FlexibleSolver<OBM<1>, BV<1>>::FlexibleSolver(const boost::property_tree::ptree& prm,
-                                                             const MatrixType& matrix,
-                                                             const std::function<BV<1>()>& weightsCalculator,
-                                                             const Comm& comm);
-template Dune::FlexibleSolver<OBM<2>, BV<2>>::FlexibleSolver(const boost::property_tree::ptree& prm,
-                                                             const OBM<2>& matrix,
-                                                             const Comm&);
-template Dune::FlexibleSolver<OBM<2>, BV<2>>::FlexibleSolver(const boost::property_tree::ptree& prm,
-                                                             const MatrixType& matrix,
-                                                             const std::function<BV<2>()>& weightsCalculator,
-                                                             const Comm& comm);
-template Dune::FlexibleSolver<OBM<3>, BV<3>>::FlexibleSolver(const boost::property_tree::ptree& prm,
-                                                             const OBM<3>& matrix,
-                                                             const Comm&);
-template Dune::FlexibleSolver<OBM<3>, BV<3>>::FlexibleSolver(const boost::property_tree::ptree& prm,
-                                                             const MatrixType& matrix,
-                                                             const std::function<BV<3>()>& weightsCalculator,
-                                                             const Comm& comm);
-template Dune::FlexibleSolver<OBM<4>, BV<4>>::FlexibleSolver(const boost::property_tree::ptree& prm,
-                                                             const OBM<4>& matrix,
-                                                             const Comm&);
-template Dune::FlexibleSolver<OBM<4>, BV<4>>::FlexibleSolver(const boost::property_tree::ptree& prm,
-                                                             const MatrixType& matrix,
-                                                             const std::function<BV<4>()>& weightsCalculator,
-                                                             const Comm& comm);
-*/
+template Dune::FlexibleSolver<OBM<1>, BV<1>>::FlexibleSolver(const MatrixType& matrix,
+                                                             const Comm& comm,
+                                                             const boost::property_tree::ptree& prm,
+                                                             const std::function<BV<1>()>& weightsCalculator);
+
+template Dune::FlexibleSolver<OBM<2>, BV<2>>::FlexibleSolver(const MatrixType& matrix,
+                                                             const Comm& comm,
+                                                             const boost::property_tree::ptree& prm,
+                                                             const std::function<BV<2>()>& weightsCalculator);
+
+template Dune::FlexibleSolver<OBM<3>, BV<3>>::FlexibleSolver(const MatrixType& matrix,
+                                                             const Comm& comm,
+                                                             const boost::property_tree::ptree& prm,
+                                                             const std::function<BV<3>()>& weightsCalculator);
+
+template Dune::FlexibleSolver<OBM<4>, BV<4>>::FlexibleSolver(const MatrixType& matrix,
+                                                             const Comm& comm,
+                                                             const boost::property_tree::ptree& prm,
+                                                             const std::function<BV<4>()>& weightsCalculator);

--- a/opm/simulators/linalg/FlexibleSolver.cpp
+++ b/opm/simulators/linalg/FlexibleSolver.cpp
@@ -1,0 +1,247 @@
+/*
+  Copyright 2019, 2020 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <opm/simulators/linalg/FlexibleSolver.hpp>
+#include <opm/simulators/linalg/matrixblock.hh>
+
+#include <dune/common/fmatrix.hh>
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/solvers.hh>
+#include <dune/istl/umfpack.hh>
+#include <dune/istl/owneroverlapcopy.hh>
+#include <dune/istl/paamg/pinfo.hh>
+
+#include <boost/property_tree/ptree.hpp>
+
+namespace Dune
+{
+    /// Create a sequential solver.
+    template <class MatrixType, class VectorType>
+    FlexibleSolver<MatrixType, VectorType>::
+    FlexibleSolver(const boost::property_tree::ptree& prm, const MatrixType& matrix,
+                   const std::function<VectorType()>& weightsCalculator)
+    {
+        init(prm, matrix, weightsCalculator, Dune::Amg::SequentialInformation());
+    }
+
+    /// Create a parallel solver (if Comm is e.g. OwnerOverlapCommunication).
+    template <class MatrixType, class VectorType>
+    template <class Comm>
+    FlexibleSolver<MatrixType, VectorType>::
+    FlexibleSolver(const boost::property_tree::ptree& prm,
+                   const MatrixType& matrix,
+                   // const Comm& comm)
+                   const typename std::enable_if<IsComm<Comm>::value, Comm>::type& comm)
+    {
+        init(prm, matrix, std::function<VectorType()>(), comm);
+    }
+
+    /// Create a parallel solver (if Comm is e.g. OwnerOverlapCommunication).
+    template <class MatrixType, class VectorType>
+    template <class Comm>
+    FlexibleSolver<MatrixType, VectorType>::
+    FlexibleSolver(const boost::property_tree::ptree& prm, const MatrixType& matrix,
+                   const std::function<VectorType()>& weightsCalculator, const Comm& comm)
+    {
+        init(prm, matrix, weightsCalculator, comm);
+    }
+
+    template <class MatrixType, class VectorType>
+    void
+    FlexibleSolver<MatrixType, VectorType>::
+    apply(VectorType& x, VectorType& rhs, Dune::InverseOperatorResult& res)
+    {
+        linsolver_->apply(x, rhs, res);
+    }
+
+    template <class MatrixType, class VectorType>
+    void
+    FlexibleSolver<MatrixType, VectorType>::
+    apply(VectorType& x, VectorType& rhs, double reduction, Dune::InverseOperatorResult& res)
+    {
+        linsolver_->apply(x, rhs, reduction, res);
+    }
+
+    /// Access the contained preconditioner.
+    template <class MatrixType, class VectorType>
+    auto
+    FlexibleSolver<MatrixType, VectorType>::
+    preconditioner() -> AbstractPrecondType&
+    {
+        return *preconditioner_;
+    }
+
+    template <class MatrixType, class VectorType>
+    Dune::SolverCategory::Category
+    FlexibleSolver<MatrixType, VectorType>::
+    category() const
+    {
+        return linearoperator_->category();
+    }
+
+    // Machinery for making sequential or parallel operators/preconditioners/scalar products.
+    template <class MatrixType, class VectorType>
+    template <class Comm>
+    void
+    FlexibleSolver<MatrixType, VectorType>::
+    initOpPrecSp(const MatrixType& matrix, const boost::property_tree::ptree& prm,
+                 const std::function<VectorType()> weightsCalculator, const Comm& comm)
+    {
+        // Parallel case.
+        using ParOperatorType = Dune::OverlappingSchwarzOperator<MatrixType, VectorType, VectorType, Comm>;
+        using pt = const boost::property_tree::ptree;
+        auto linop = std::make_shared<ParOperatorType>(matrix, comm);
+        linearoperator_ = linop;
+        auto child = prm.get_child_optional("preconditioner");
+        preconditioner_
+            = Opm::PreconditionerFactory<ParOperatorType, Comm>::create(*linop, child? *child : pt(),
+                                                                        weightsCalculator, comm);
+        scalarproduct_ = Dune::createScalarProduct<VectorType, Comm>(comm, linearoperator_->category());
+    }
+
+    template <class MatrixType, class VectorType>
+    void
+    FlexibleSolver<MatrixType, VectorType>::
+    initOpPrecSp(const MatrixType& matrix, const boost::property_tree::ptree& prm,
+                 const std::function<VectorType()> weightsCalculator, const Dune::Amg::SequentialInformation&)
+    {
+        // Sequential case.
+        using SeqOperatorType = Dune::MatrixAdapter<MatrixType, VectorType, VectorType>;
+        using pt = const boost::property_tree::ptree;
+        auto linop = std::make_shared<SeqOperatorType>(matrix);
+        linearoperator_ = linop;
+        auto child = prm.get_child_optional("preconditioner");
+        preconditioner_ = Opm::PreconditionerFactory<SeqOperatorType>::create(*linop, child? *child : pt(),
+                                                                              weightsCalculator);
+        scalarproduct_ = std::make_shared<Dune::SeqScalarProduct<VectorType>>();
+    }
+
+    template <class MatrixType, class VectorType>
+    void
+    FlexibleSolver<MatrixType, VectorType>::
+    initSolver(const boost::property_tree::ptree& prm, bool isMaster)
+    {
+        const double tol = prm.get<double>("tol", 1e-2);
+        const int maxiter = prm.get<int>("maxiter", 200);
+        const int verbosity = isMaster? prm.get<int>("verbosity", 0) : 0;
+        const std::string solver_type = prm.get<std::string>("solver", "bicgstab");
+        if (solver_type == "bicgstab") {
+            linsolver_.reset(new Dune::BiCGSTABSolver<VectorType>(*linearoperator_,
+                                                                  *scalarproduct_,
+                                                                  *preconditioner_,
+                                                                  tol, // desired residual reduction factor
+                                                                  maxiter, // maximum number of iterations
+                                                                  verbosity));
+        } else if (solver_type == "loopsolver") {
+            linsolver_.reset(new Dune::LoopSolver<VectorType>(*linearoperator_,
+                                                              *scalarproduct_,
+                                                              *preconditioner_,
+                                                              tol, // desired residual reduction factor
+                                                              maxiter, // maximum number of iterations
+                                                              verbosity));
+        } else if (solver_type == "gmres") {
+            int restart = prm.get<int>("restart", 15);
+            linsolver_.reset(new Dune::RestartedGMResSolver<VectorType>(*linearoperator_,
+                                                                        *scalarproduct_,
+                                                                        *preconditioner_,
+                                                                        tol,
+                                                                        restart, // desired residual reduction factor
+                                                                        maxiter, // maximum number of iterations
+                                                                        verbosity));
+#if HAVE_SUITESPARSE_UMFPACK
+        } else if (solver_type == "umfpack") {
+            bool dummy = false;
+            linsolver_.reset(new Dune::UMFPack<MatrixType>(linearoperator_->getmat(), verbosity, dummy));
+#endif
+        } else {
+            OPM_THROW(std::invalid_argument, "Properties: Solver " << solver_type << " not known.");
+        }
+    }
+
+
+    // Main initialization routine.
+    // Call with Comm == Dune::Amg::SequentialInformation to get a serial solver.
+    template <class MatrixType, class VectorType>
+    template <class Comm>
+    void
+    FlexibleSolver<MatrixType, VectorType>::
+    init(const boost::property_tree::ptree& prm, const MatrixType& matrix,
+         const std::function<VectorType()> weightsCalculator, const Comm& comm)
+    {
+        initOpPrecSp(matrix, prm, weightsCalculator, comm);
+        initSolver(prm, comm.communicator().rank()==0);
+    }
+
+} // namespace Dune
+
+
+// Explicit instantiations of FlexibleSolver
+
+template <int N>
+using BV = Dune::BlockVector<Dune::FieldVector<double, N>>;
+template <int N>
+using BM = Dune::BCRSMatrix<Dune::FieldMatrix<double, N, N>>;
+template <int N>
+using OBM = Dune::BCRSMatrix<Opm::MatrixBlock<double, N, N>>;
+
+// Variants using Dune::FieldMatrix blocks.
+// template class Dune::FlexibleSolver<BM<1>, BV<1>>;
+// template class Dune::FlexibleSolver<BM<2>, BV<2>>;
+template class Dune::FlexibleSolver<BM<3>, BV<3>>;
+// template class Dune::FlexibleSolver<BM<4>, BV<4>>;
+/*
+// Variants using Opm::MatrixBlock blocks.
+template class Dune::FlexibleSolver<OBM<1>, BV<1>>;
+template class Dune::FlexibleSolver<OBM<2>, BV<2>>;
+template class Dune::FlexibleSolver<OBM<3>, BV<3>>;
+template class Dune::FlexibleSolver<OBM<4>, BV<4>>;
+
+using Comm = Dune::OwnerOverlapCopyCommunication<int, int>;
+
+template Dune::FlexibleSolver<OBM<1>, BV<1>>::FlexibleSolver(const boost::property_tree::ptree& prm,
+                                                             const OBM<1>& matrix,
+                                                             const Comm&);
+template Dune::FlexibleSolver<OBM<1>, BV<1>>::FlexibleSolver(const boost::property_tree::ptree& prm,
+                                                             const MatrixType& matrix,
+                                                             const std::function<BV<1>()>& weightsCalculator,
+                                                             const Comm& comm);
+template Dune::FlexibleSolver<OBM<2>, BV<2>>::FlexibleSolver(const boost::property_tree::ptree& prm,
+                                                             const OBM<2>& matrix,
+                                                             const Comm&);
+template Dune::FlexibleSolver<OBM<2>, BV<2>>::FlexibleSolver(const boost::property_tree::ptree& prm,
+                                                             const MatrixType& matrix,
+                                                             const std::function<BV<2>()>& weightsCalculator,
+                                                             const Comm& comm);
+template Dune::FlexibleSolver<OBM<3>, BV<3>>::FlexibleSolver(const boost::property_tree::ptree& prm,
+                                                             const OBM<3>& matrix,
+                                                             const Comm&);
+template Dune::FlexibleSolver<OBM<3>, BV<3>>::FlexibleSolver(const boost::property_tree::ptree& prm,
+                                                             const MatrixType& matrix,
+                                                             const std::function<BV<3>()>& weightsCalculator,
+                                                             const Comm& comm);
+template Dune::FlexibleSolver<OBM<4>, BV<4>>::FlexibleSolver(const boost::property_tree::ptree& prm,
+                                                             const OBM<4>& matrix,
+                                                             const Comm&);
+template Dune::FlexibleSolver<OBM<4>, BV<4>>::FlexibleSolver(const boost::property_tree::ptree& prm,
+                                                             const MatrixType& matrix,
+                                                             const std::function<BV<4>()>& weightsCalculator,
+                                                             const Comm& comm);
+*/

--- a/opm/simulators/linalg/FlexibleSolver.hpp
+++ b/opm/simulators/linalg/FlexibleSolver.hpp
@@ -1,5 +1,6 @@
 /*
-  Copyright 2019 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2019, 2020 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2020 Equinor.
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/simulators/linalg/FlexibleSolver.hpp
+++ b/opm/simulators/linalg/FlexibleSolver.hpp
@@ -21,7 +21,7 @@
 #ifndef OPM_FLEXIBLE_SOLVER_HEADER_INCLUDED
 #define OPM_FLEXIBLE_SOLVER_HEADER_INCLUDED
 
-#include <opm/simulators/linalg/PreconditionerFactory.hpp>
+#include <opm/simulators/linalg/PreconditionerWithUpdate.hpp>
 
 #include <dune/common/fmatrix.hh>
 #include <dune/istl/bcrsmatrix.hh>

--- a/opm/simulators/linalg/FlexibleSolver1.cpp
+++ b/opm/simulators/linalg/FlexibleSolver1.cpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2019, 2020 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <opm/simulators/linalg/FlexibleSolver_impl.hpp>
+#include <opm/simulators/linalg/matrixblock.hh>
+
+#include <dune/common/fmatrix.hh>
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/solvers.hh>
+#include <dune/istl/umfpack.hh>
+#include <dune/istl/owneroverlapcopy.hh>
+#include <dune/istl/paamg/pinfo.hh>
+
+// Explicit instantiations of FlexibleSolver
+
+template <int N>
+using BV = Dune::BlockVector<Dune::FieldVector<double, N>>;
+template <int N>
+using BM = Dune::BCRSMatrix<Dune::FieldMatrix<double, N, N>>;
+template <int N>
+using OBM = Dune::BCRSMatrix<Opm::MatrixBlock<double, N, N>>;
+
+// Variants using Dune::FieldMatrix blocks.
+template class Dune::FlexibleSolver<BM<1>, BV<1>>;
+
+// Variants using Opm::MatrixBlock blocks.
+template class Dune::FlexibleSolver<OBM<1>, BV<1>>;
+
+
+using Comm = Dune::OwnerOverlapCopyCommunication<int, int>;
+
+template Dune::FlexibleSolver<OBM<1>, BV<1>>::FlexibleSolver(const MatrixType& matrix,
+                                                             const Comm& comm,
+                                                             const boost::property_tree::ptree& prm,
+                                                             const std::function<BV<1>()>& weightsCalculator);
+

--- a/opm/simulators/linalg/FlexibleSolver1.cpp
+++ b/opm/simulators/linalg/FlexibleSolver1.cpp
@@ -44,6 +44,7 @@ template class Dune::FlexibleSolver<BM<1>, BV<1>>;
 // Variants using Opm::MatrixBlock blocks.
 template class Dune::FlexibleSolver<OBM<1>, BV<1>>;
 
+#if HAVE_MPI
 
 using Comm = Dune::OwnerOverlapCopyCommunication<int, int>;
 
@@ -52,3 +53,4 @@ template Dune::FlexibleSolver<OBM<1>, BV<1>>::FlexibleSolver(const MatrixType& m
                                                              const boost::property_tree::ptree& prm,
                                                              const std::function<BV<1>()>& weightsCalculator);
 
+#endif // HAVE_MPI

--- a/opm/simulators/linalg/FlexibleSolver2.cpp
+++ b/opm/simulators/linalg/FlexibleSolver2.cpp
@@ -44,6 +44,7 @@ template class Dune::FlexibleSolver<BM<2>, BV<2>>;
 // Variants using Opm::MatrixBlock blocks.
 template class Dune::FlexibleSolver<OBM<2>, BV<2>>;
 
+#if HAVE_MPI
 
 using Comm = Dune::OwnerOverlapCopyCommunication<int, int>;
 
@@ -52,3 +53,4 @@ template Dune::FlexibleSolver<OBM<2>, BV<2>>::FlexibleSolver(const MatrixType& m
                                                              const boost::property_tree::ptree& prm,
                                                              const std::function<BV<2>()>& weightsCalculator);
 
+#endif // HAVE_MPI

--- a/opm/simulators/linalg/FlexibleSolver2.cpp
+++ b/opm/simulators/linalg/FlexibleSolver2.cpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2019, 2020 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <opm/simulators/linalg/FlexibleSolver_impl.hpp>
+#include <opm/simulators/linalg/matrixblock.hh>
+
+#include <dune/common/fmatrix.hh>
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/solvers.hh>
+#include <dune/istl/umfpack.hh>
+#include <dune/istl/owneroverlapcopy.hh>
+#include <dune/istl/paamg/pinfo.hh>
+
+// Explicit instantiations of FlexibleSolver
+
+template <int N>
+using BV = Dune::BlockVector<Dune::FieldVector<double, N>>;
+template <int N>
+using BM = Dune::BCRSMatrix<Dune::FieldMatrix<double, N, N>>;
+template <int N>
+using OBM = Dune::BCRSMatrix<Opm::MatrixBlock<double, N, N>>;
+
+// Variants using Dune::FieldMatrix blocks.
+template class Dune::FlexibleSolver<BM<2>, BV<2>>;
+
+// Variants using Opm::MatrixBlock blocks.
+template class Dune::FlexibleSolver<OBM<2>, BV<2>>;
+
+
+using Comm = Dune::OwnerOverlapCopyCommunication<int, int>;
+
+template Dune::FlexibleSolver<OBM<2>, BV<2>>::FlexibleSolver(const MatrixType& matrix,
+                                                             const Comm& comm,
+                                                             const boost::property_tree::ptree& prm,
+                                                             const std::function<BV<2>()>& weightsCalculator);
+

--- a/opm/simulators/linalg/FlexibleSolver3.cpp
+++ b/opm/simulators/linalg/FlexibleSolver3.cpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2019, 2020 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <opm/simulators/linalg/FlexibleSolver_impl.hpp>
+#include <opm/simulators/linalg/matrixblock.hh>
+
+#include <dune/common/fmatrix.hh>
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/solvers.hh>
+#include <dune/istl/umfpack.hh>
+#include <dune/istl/owneroverlapcopy.hh>
+#include <dune/istl/paamg/pinfo.hh>
+
+// Explicit instantiations of FlexibleSolver
+
+template <int N>
+using BV = Dune::BlockVector<Dune::FieldVector<double, N>>;
+template <int N>
+using BM = Dune::BCRSMatrix<Dune::FieldMatrix<double, N, N>>;
+template <int N>
+using OBM = Dune::BCRSMatrix<Opm::MatrixBlock<double, N, N>>;
+
+// Variants using Dune::FieldMatrix blocks.
+template class Dune::FlexibleSolver<BM<3>, BV<3>>;
+
+// Variants using Opm::MatrixBlock blocks.
+template class Dune::FlexibleSolver<OBM<3>, BV<3>>;
+
+
+using Comm = Dune::OwnerOverlapCopyCommunication<int, int>;
+
+template Dune::FlexibleSolver<OBM<3>, BV<3>>::FlexibleSolver(const MatrixType& matrix,
+                                                             const Comm& comm,
+                                                             const boost::property_tree::ptree& prm,
+                                                             const std::function<BV<3>()>& weightsCalculator);
+

--- a/opm/simulators/linalg/FlexibleSolver3.cpp
+++ b/opm/simulators/linalg/FlexibleSolver3.cpp
@@ -44,6 +44,7 @@ template class Dune::FlexibleSolver<BM<3>, BV<3>>;
 // Variants using Opm::MatrixBlock blocks.
 template class Dune::FlexibleSolver<OBM<3>, BV<3>>;
 
+#if HAVE_MPI
 
 using Comm = Dune::OwnerOverlapCopyCommunication<int, int>;
 
@@ -52,3 +53,4 @@ template Dune::FlexibleSolver<OBM<3>, BV<3>>::FlexibleSolver(const MatrixType& m
                                                              const boost::property_tree::ptree& prm,
                                                              const std::function<BV<3>()>& weightsCalculator);
 
+#endif // HAVE_MPI

--- a/opm/simulators/linalg/FlexibleSolver4.cpp
+++ b/opm/simulators/linalg/FlexibleSolver4.cpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2019, 2020 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <opm/simulators/linalg/FlexibleSolver_impl.hpp>
+#include <opm/simulators/linalg/matrixblock.hh>
+
+#include <dune/common/fmatrix.hh>
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/solvers.hh>
+#include <dune/istl/umfpack.hh>
+#include <dune/istl/owneroverlapcopy.hh>
+#include <dune/istl/paamg/pinfo.hh>
+
+// Explicit instantiations of FlexibleSolver
+
+template <int N>
+using BV = Dune::BlockVector<Dune::FieldVector<double, N>>;
+template <int N>
+using BM = Dune::BCRSMatrix<Dune::FieldMatrix<double, N, N>>;
+template <int N>
+using OBM = Dune::BCRSMatrix<Opm::MatrixBlock<double, N, N>>;
+
+// Variants using Dune::FieldMatrix blocks.
+template class Dune::FlexibleSolver<BM<4>, BV<4>>;
+
+// Variants using Opm::MatrixBlock blocks.
+template class Dune::FlexibleSolver<OBM<4>, BV<4>>;
+
+
+using Comm = Dune::OwnerOverlapCopyCommunication<int, int>;
+
+template Dune::FlexibleSolver<OBM<4>, BV<4>>::FlexibleSolver(const MatrixType& matrix,
+                                                             const Comm& comm,
+                                                             const boost::property_tree::ptree& prm,
+                                                             const std::function<BV<4>()>& weightsCalculator);
+

--- a/opm/simulators/linalg/FlexibleSolver4.cpp
+++ b/opm/simulators/linalg/FlexibleSolver4.cpp
@@ -44,6 +44,7 @@ template class Dune::FlexibleSolver<BM<4>, BV<4>>;
 // Variants using Opm::MatrixBlock blocks.
 template class Dune::FlexibleSolver<OBM<4>, BV<4>>;
 
+#if HAVE_MPI
 
 using Comm = Dune::OwnerOverlapCopyCommunication<int, int>;
 
@@ -52,3 +53,4 @@ template Dune::FlexibleSolver<OBM<4>, BV<4>>::FlexibleSolver(const MatrixType& m
                                                              const boost::property_tree::ptree& prm,
                                                              const std::function<BV<4>()>& weightsCalculator);
 
+#endif // HAVE_MPI

--- a/opm/simulators/linalg/FlexibleSolver_impl.hpp
+++ b/opm/simulators/linalg/FlexibleSolver_impl.hpp
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include <opm/simulators/linalg/FlexibleSolver.hpp>
+#include <opm/simulators/linalg/PreconditionerFactory.hpp>
 #include <opm/simulators/linalg/matrixblock.hh>
 
 #include <dune/common/fmatrix.hh>
@@ -184,48 +185,3 @@ namespace Dune
     }
 
 } // namespace Dune
-
-
-// Explicit instantiations of FlexibleSolver
-
-template <int N>
-using BV = Dune::BlockVector<Dune::FieldVector<double, N>>;
-template <int N>
-using BM = Dune::BCRSMatrix<Dune::FieldMatrix<double, N, N>>;
-template <int N>
-using OBM = Dune::BCRSMatrix<Opm::MatrixBlock<double, N, N>>;
-
-// Variants using Dune::FieldMatrix blocks.
-template class Dune::FlexibleSolver<BM<1>, BV<1>>;
-template class Dune::FlexibleSolver<BM<2>, BV<2>>;
-template class Dune::FlexibleSolver<BM<3>, BV<3>>;
-template class Dune::FlexibleSolver<BM<4>, BV<4>>;
-
-// Variants using Opm::MatrixBlock blocks.
-template class Dune::FlexibleSolver<OBM<1>, BV<1>>;
-template class Dune::FlexibleSolver<OBM<2>, BV<2>>;
-template class Dune::FlexibleSolver<OBM<3>, BV<3>>;
-template class Dune::FlexibleSolver<OBM<4>, BV<4>>;
-
-
-using Comm = Dune::OwnerOverlapCopyCommunication<int, int>;
-
-template Dune::FlexibleSolver<OBM<1>, BV<1>>::FlexibleSolver(const MatrixType& matrix,
-                                                             const Comm& comm,
-                                                             const boost::property_tree::ptree& prm,
-                                                             const std::function<BV<1>()>& weightsCalculator);
-
-template Dune::FlexibleSolver<OBM<2>, BV<2>>::FlexibleSolver(const MatrixType& matrix,
-                                                             const Comm& comm,
-                                                             const boost::property_tree::ptree& prm,
-                                                             const std::function<BV<2>()>& weightsCalculator);
-
-template Dune::FlexibleSolver<OBM<3>, BV<3>>::FlexibleSolver(const MatrixType& matrix,
-                                                             const Comm& comm,
-                                                             const boost::property_tree::ptree& prm,
-                                                             const std::function<BV<3>()>& weightsCalculator);
-
-template Dune::FlexibleSolver<OBM<4>, BV<4>>::FlexibleSolver(const MatrixType& matrix,
-                                                             const Comm& comm,
-                                                             const boost::property_tree::ptree& prm,
-                                                             const std::function<BV<4>()>& weightsCalculator);

--- a/opm/simulators/linalg/FlexibleSolver_impl.hpp
+++ b/opm/simulators/linalg/FlexibleSolver_impl.hpp
@@ -1,5 +1,6 @@
 /*
   Copyright 2019, 2020 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2020 Equinor.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -17,7 +18,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "config.h"
+#ifndef OPM_FLEXIBLE_SOLVER_IMPL_HEADER_INCLUDED
+#define OPM_FLEXIBLE_SOLVER_IMPL_HEADER_INCLUDED
 
 #include <opm/simulators/linalg/FlexibleSolver.hpp>
 #include <opm/simulators/linalg/PreconditionerFactory.hpp>
@@ -185,3 +187,5 @@ namespace Dune
     }
 
 } // namespace Dune
+
+#endif // OPM_FLEXIBLE_SOLVER_IMPL_HEADER_INCLUDED

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -905,10 +905,10 @@ protected:
                 if (isParallel()) {
 #if HAVE_MPI
                     assert(noGhostMat_);
-                    flexibleSolver_.reset(new FlexibleSolverType(prm_, *noGhostMat_, weightsCalculator, *comm_));
+                    flexibleSolver_.reset(new FlexibleSolverType(*noGhostMat_, *comm_, prm_, weightsCalculator));
 #endif
                 } else {
-                    flexibleSolver_.reset(new FlexibleSolverType(prm_, *matrix_, weightsCalculator));
+                    flexibleSolver_.reset(new FlexibleSolverType(*matrix_, prm_, weightsCalculator));
                 }
             }
             else

--- a/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
@@ -199,11 +199,11 @@ public:
             if (isParallel()) {
 #if HAVE_MPI
                 matrix_ = &mat.istlMatrix();
-                solver_.reset(new SolverType(prm_, mat.istlMatrix(), weightsCalculator, *comm_));
+                solver_.reset(new SolverType(mat.istlMatrix(), *comm_, prm_, weightsCalculator));
 #endif
             } else {
                 matrix_ = &mat.istlMatrix();
-                solver_.reset(new SolverType(prm_, mat.istlMatrix(), weightsCalculator));
+                solver_.reset(new SolverType(mat.istlMatrix(), prm_, weightsCalculator));
             }
             rhs_ = b;
         } else {

--- a/opm/simulators/linalg/PressureSolverPolicy.hpp
+++ b/opm/simulators/linalg/PressureSolverPolicy.hpp
@@ -61,9 +61,9 @@ namespace Amg
                 : linsolver_()
             {
                 if (op.category() == Dune::SolverCategory::overlapping) {
-                    linsolver_.reset(new Solver(prm, op.getmat(), std::function<X()>(), comm));
+                    linsolver_.reset(new Solver(op.getmat(), comm, prm, std::function<X()>()));
                 } else {
-                    linsolver_.reset(new Solver(prm, op.getmat(), std::function<X()>()));
+                    linsolver_.reset(new Solver(op.getmat(), prm, std::function<X()>()));
                 }
             }
 

--- a/opm/simulators/linalg/PressureSolverPolicy.hpp
+++ b/opm/simulators/linalg/PressureSolverPolicy.hpp
@@ -60,12 +60,16 @@ namespace Amg
             PressureInverseOperator(Operator& op, const boost::property_tree::ptree& prm, const Comm& comm)
                 : linsolver_()
             {
-                if (op.category() == Dune::SolverCategory::overlapping) {
-                    linsolver_.reset(new Solver(op.getmat(), comm, prm, std::function<X()>()));
-                } else {
-                    linsolver_.reset(new Solver(op.getmat(), prm, std::function<X()>()));
-                }
+                assert(op.category() == Dune::SolverCategory::overlapping);
+                linsolver_.reset(new Solver(op.getmat(), comm, prm, std::function<X()>()));
             }
+            PressureInverseOperator(Operator& op, const boost::property_tree::ptree& prm, const SequentialInformation&)
+                : linsolver_()
+            {
+                assert(op.category() != Dune::SolverCategory::overlapping);
+                linsolver_.reset(new Solver(op.getmat(), prm, std::function<X()>()));
+            }
+
 
             Dune::SolverCategory::Category category() const override
             {

--- a/tests/test_flexiblesolver.cpp
+++ b/tests/test_flexiblesolver.cpp
@@ -29,6 +29,7 @@
     BOOST_VERSION / 100 % 1000 > 48
 
 #include <opm/simulators/linalg/FlexibleSolver.hpp>
+#include <opm/simulators/linalg/getQuasiImpesWeights.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/tests/test_flexiblesolver.cpp
+++ b/tests/test_flexiblesolver.cpp
@@ -70,7 +70,7 @@ testSolver(const boost::property_tree::ptree& prm, const std::string& matrix_fil
                                                                 prm.get<int>("preconditioner.pressure_var_index"),
                                                                 transpose);
               };
-    Dune::FlexibleSolver<Matrix, Vector> solver(prm, matrix, wc);
+    Dune::FlexibleSolver<Matrix, Vector> solver(matrix, prm, wc);
     Vector x(rhs.size());
     Dune::InverseOperatorResult res;
     solver.apply(x, rhs, res);


### PR DESCRIPTION
This is a sketch of an attempt to reduce compile times related to the linear solver subsystems. The code right here successfully compiles and links the test_flexiblesolver.cpp unit test, but not Flow. However, but exchanging which lines are commented in/out in the "explicit instantiations" section, *and* changing the signature of one of the constructors to avoid using `enable_if` I get Flow to link. My immediate concerns are:
 - Is there a way to get things to link properly without changing any of the FlexibleSolver interface? (Constructor signature issue.)
 - Is there a robust way to keep all the code in the usual header file, for clients that do not want to or cannot link to a pre-instantiated target, while at the same time avoiding that code being used to instantiate for Flow? I can only get part of the way by using a forward declaration of the class, since you cannot forward-declare class member functions, the complete class must be defined when I call its members.
 - Are there peculiarities related to gcc/clang that require special treatment?

When that has been figured out, the explicit instantiations should be split into several compile units (one for each dimension?) to enable them to be compiled in parallel.

Further on, an additional concern for the future:
 - How does this change when/if we move towards making the FlexibleSolver take a `LinearOperatorType` rather than a `MatrixType` and `VectorType` as template arguments?

Any comments appreciated!