### PR TITLE
changed: delay deck dereference

### DIFF
--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -279,7 +279,6 @@ private:
         const auto& gridView = vanguard.gridView();
         const auto& elementMapper = simulator_.model().elementMapper();
         const auto& eclState = simulator_.vanguard().eclState();
-        const auto& deck = simulator_.vanguard().deck();
         const Opm::SimulationConfig& simConfig = eclState.getSimulationConfig();
         const auto& thpres = simConfig.getThresholdPressure();
 
@@ -334,6 +333,7 @@ private:
 
         if (enableExperiments) {
             // apply threshold pressures accross faults (experimental!)
+            const auto& deck = simulator_.vanguard().deck();
             if (deck.hasKeyword("THPRESFT"))
                 extractThpresft_(deck.getKeyword("THPRESFT"));
         }


### PR DESCRIPTION
this was harmless unless enableExperiments was given, since
the deck ref is not used otherwise, but it caused an UBSAN issue
when run in parallel.