### PR TITLE
[bugfix] Fix TRANXYZ for problems with less than 3 dimensions.

### DIFF
--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -530,7 +530,7 @@ private:
                 int gc1 = std::min(cartMapper.cartesianIndex(c1), cartMapper.cartesianIndex(c2));
                 int gc2 = std::max(cartMapper.cartesianIndex(c1), cartMapper.cartesianIndex(c2));
 
-                if (gc2 - gc1 == 1) {
+                if (gc2 - gc1 == 1 && cartDims[0] > 1) {
                     if (tranx_deckAssigned)
                         // set simulator internal transmissibilities to values from inputTranx
                         trans_[isId] = inputTranxData[c1];
@@ -538,7 +538,7 @@ private:
                         // Scale transmissibilities with scale factor from inputTranx
                         trans_[isId] *= inputTranxData[c1];
                 }
-                else if (gc2 - gc1 == cartDims[0]) {
+                else if (gc2 - gc1 == cartDims[0] && cartDims[1] > 1) {
                     if (trany_deckAssigned)
                         // set simulator internal transmissibilities to values from inputTrany
                         trans_[isId] = inputTranyData[c1];

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -552,12 +552,12 @@ private:
                 int gc1 = std::min(cartIdx1, cartIdx2);
                 int gc2 = std::max(cartIdx1, cartIdx2);
 
-                if (gc2 - gc1 == 1) {
+                if (gc2 - gc1 == 1 && cartDims[0] > 1 ) {
                     tranx.data[gc1] = globalTrans->transmissibility(c1, c2);
                     continue; // skip other if clauses as they are false, last one needs some computation
                 }
 
-                if (gc2 - gc1 == cartDims[0]) {
+                if (gc2 - gc1 == cartDims[0] && cartDims[1] > 1) {
                     trany.data[gc1] = globalTrans->transmissibility(c1, c2);
                     continue; // skipt next if clause as it needs some computation
                 }


### PR DESCRIPTION
Up to now We always assumed that cardDims[i]>1 holds. which it does for most of the cases. But when e.g. simulating a vertical stack of 5 cells flow would report the transmissibilities in the Z direction in TRANX and output TRANZ as zero. Similar problems should be there for 2D grids.

With this commit we actually check whether there can be neighbors in the X and Y direction to prevent this behavior.