### PR TITLE
Add actionState argument also for non MPI branch

### DIFF
--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -851,7 +851,7 @@ RestartValue loadParallelRestart(const EclipseIO* eclIO, Action::State& actionSt
     return restartValues;
 #else
     (void) comm;
-    return eclIO->loadRestart(summaryState, solutionKeys, extraKeys);
+    return eclIO->loadRestart(actionState, summaryState, solutionKeys, extraKeys);
 #endif
 }
 


### PR DESCRIPTION
See: https://github.com/OPM/opm-common/pull/1823

This patch (from @bska) recovers serial build on my machine