### PR TITLE
Fix running in parallel with --owner-cells-first=false.

### DIFF
--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -393,23 +393,17 @@ protected:
             {
                 copyJacToNoGhost(M.istlMatrix(), *noGhostMat_);
             }
-            else
-            {
-                if (firstcall)
-                {
-                    // ebos will not change the matrix object. Hence simply store a pointer
-                    // to the original one with a deleter that does nothing.
-                    // Outch! We need to be able to scale the linear system! Hence const_cast
-                    matrix_ = const_cast<Matrix*>(&M.istlMatrix());
-                }
-                else
-                {
-                    // Pointers should not change
-                    if ( &(M.istlMatrix()) != matrix_ )
-                    {
-                        OPM_THROW(std::logic_error, "Matrix objects are expected to be reused when reassembling!"
-                                  <<" old pointer was " << matrix_ << ", new one is " << (&M.istlMatrix()) );
-                    }
+            if (firstcall) {
+                // ebos will not change the matrix object. Hence simply store a pointer
+                // to the original one with a deleter that does nothing.
+                // Outch! We need to be able to scale the linear system! Hence const_cast
+                matrix_ = const_cast<Matrix*>(&M.istlMatrix());
+            } else {
+                // Pointers should not change
+                if (&(M.istlMatrix()) != matrix_) {
+                    OPM_THROW(std::logic_error,
+                              "Matrix objects are expected to be reused when reassembling!"
+                                  << " old pointer was " << matrix_ << ", new one is " << (&M.istlMatrix()));
                 }
             }
             rhs_ = &b;


### PR DESCRIPTION
After seeing some troubles I could not understand trying to get `FlexibleSolver` to work with operators, I went back to the master branch for a sanity check, and discovered that the `--owner-cells-first=false` option does not seem to work.

It is a bit confusing, as I recall it is not that long ago the default was flipped to true! The bug was that `matrix_` would be a null pointer further down, since the initalization code would not be called.