### PR TITLE
Make ghost-last feature available in PreconditionerFactory.

### DIFF
--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -26,7 +26,6 @@
 
 #include <opm/simulators/wells/RateConverter.hpp>
 #include <opm/simulators/wells/WellInterface.hpp>
-#include <opm/simulators/linalg/ISTLSolverEbos.hpp>
 
 #include <opm/models/blackoil/blackoilpolymermodules.hh>
 #include <opm/models/blackoil/blackoilsolventmodules.hh>

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -22,6 +22,7 @@
 #include <opm/common/utility/numeric/RootFinders.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+#include <opm/simulators/linalg/MatrixBlock.hpp>
 
 namespace Opm
 {


### PR DESCRIPTION
The new constructor requires information that is available in the communicator, but not directly. I have not seen a performance loss compared to existing default. The necessary processing takes place only when constructing the preconditioner, not updating it, so when/if we move to update rather than recreate the preconditioner also for ILU0 there will be a small gain there.

If the required information (that the ordering is "ghost last") can be obtained in an easier way from the communication object I would be happy to change this! Unfortunately making a new communication subclass will not work due to some explicit specializations for OwnerOverlapCommunication in dune-istl. Other ways of passing "extra info" to the factory can also be considered. For now I think this is an acceptable solution though.