### PR TITLE
Capture the variables argc, argv, outputCout, and outputFiles in Opm::FlowMainEbos

### DIFF
--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -47,7 +47,7 @@ void flowEbosBlackoilSetDeck(double setupTime, Deck *deck, EclipseState& eclStat
 }
 
 std::unique_ptr<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>
-flowEbosBlackoilMainInit(int argc, char** argv)
+flowEbosBlackoilMainInit(int argc, char** argv, bool outputCout, bool outputFiles)
 {
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
@@ -59,14 +59,15 @@ flowEbosBlackoilMainInit(int argc, char** argv)
     Dune::MPIHelper::instance(argc, argv);
 #endif
 
-    return std::make_unique<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>();
+    return std::make_unique<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>(
+        argc, argv, outputCout, outputFiles);
 }
 
 // ----------------- Main program -----------------
 int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {
-    auto mainfunc = flowEbosBlackoilMainInit(argc, argv);
-    return mainfunc->execute(argc, argv, outputCout, outputFiles);
+    auto mainfunc = flowEbosBlackoilMainInit(argc, argv, outputCout, outputFiles);
+    return mainfunc->execute();
 }
 
 }

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -63,8 +63,9 @@ int flowEbosBrineMain(int argc, char** argv, bool outputCout, bool outputFiles)
     Dune::MPIHelper::instance(argc, argv).rank();
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowBrineProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    Opm::FlowMainEbos<TTAG(EclFlowBrineProblem)>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
 }
 
 }

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -62,8 +62,9 @@ int flowEbosEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles)
     Dune::MPIHelper::instance(argc, argv).rank();
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowEnergyProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    Opm::FlowMainEbos<TTAG(EclFlowEnergyProblem)>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
 }
 
 }

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -63,8 +63,9 @@ int flowEbosFoamMain(int argc, char** argv, bool outputCout, bool outputFiles)
     Dune::MPIHelper::instance(argc, argv).rank();
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowFoamProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    Opm::FlowMainEbos<TTAG(EclFlowFoamProblem)>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
 }
 
 }

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -86,8 +86,9 @@ int flowEbosGasOilMain(int argc, char** argv, bool outputCout, bool outputFiles)
     Dune::MPIHelper::instance(argc, argv);
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowGasOilProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    Opm::FlowMainEbos<TTAG(EclFlowGasOilProblem)>
+        mainfunc {argc, argv, outputCout, outputFiles} ;
+    return mainfunc.execute();
 }
 
 }

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -85,8 +85,9 @@ int flowEbosOilWaterMain(int argc, char** argv, bool outputCout, bool outputFile
     Dune::MPIHelper::instance(argc, argv);
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowOilWaterProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    Opm::FlowMainEbos<TTAG(EclFlowOilWaterProblem)>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
 }
 
 }

--- a/flow/flow_ebos_oilwater_brine.cpp
+++ b/flow/flow_ebos_oilwater_brine.cpp
@@ -85,8 +85,9 @@ int flowEbosOilWaterBrineMain(int argc, char** argv, bool outputCout, bool outpu
     Dune::MPIHelper::instance(argc, argv);
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowOilWaterBrineProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    Opm::FlowMainEbos<TTAG(EclFlowOilWaterBrineProblem)>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
 }
 
 }

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -86,8 +86,9 @@ int flowEbosOilWaterPolymerMain(int argc, char** argv, bool outputCout, bool out
     Dune::MPIHelper::instance(argc, argv);
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowOilWaterPolymerProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    Opm::FlowMainEbos<TTAG(EclFlowOilWaterPolymerProblem)>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
 }
 
 }

--- a/flow/flow_ebos_oilwater_polymer_injectivity.cpp
+++ b/flow/flow_ebos_oilwater_polymer_injectivity.cpp
@@ -84,8 +84,9 @@ int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCou
     Dune::MPIHelper::instance(argc, argv);
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowOilWaterPolymerInjectivityProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    Opm::FlowMainEbos<TTAG(EclFlowOilWaterPolymerInjectivityProblem)>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
 }
 
 }

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -62,8 +62,9 @@ int flowEbosPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles
     Dune::MPIHelper::instance(argc, argv).rank();
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowPolymerProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    Opm::FlowMainEbos<TTAG(EclFlowPolymerProblem)>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
 }
 
 }

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -63,8 +63,9 @@ int flowEbosSolventMain(int argc, char** argv, bool outputCout, bool outputFiles
     Dune::MPIHelper::instance(argc, argv).rank();
 #endif
 
-    Opm::FlowMainEbos<TTAG(EclFlowSolventProblem)> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    Opm::FlowMainEbos<TTAG(EclFlowSolventProblem)>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
 }
 
 }

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -79,6 +79,13 @@ namespace Opm
 
         typedef Opm::SimulatorFullyImplicitBlackoilEbos<TypeTag> Simulator;
 
+        FlowMainEbos(int argc, char **argv, bool output_cout, bool output_files )
+            : argc_{argc}, argv_{argv},
+              output_cout_{output_cout}, output_files_{output_files}
+        {
+
+        }
+
         // Read the command line parameters. Throws an exception if something goes wrong.
         static int setupParameters_(int argc, char** argv)
         {
@@ -291,10 +298,9 @@ namespace Opm
         /// This is the main function of Flow.  It runs a complete simulation with the
         /// given grid and simulator classes, based on the user-specified command-line
         /// input.
-        int execute(int argc, char** argv, bool output_cout, bool output_to_files)
+        int execute()
         {
-            return execute_(argc, argv, output_cout, output_to_files,
-                &FlowMainEbos::runSimulator, /*cleanup=*/true);
+            return execute_(&FlowMainEbos::runSimulator, /*cleanup=*/true);
         }
 
         // Print an ASCII-art header to the PRT and DEBUG files.
@@ -343,25 +349,24 @@ namespace Opm
         }
     private:
         // called by execute() or executeInitStep()
-        int execute_(int argc, char** argv, bool output_cout, bool output_to_files,
-            int (FlowMainEbos::* runOrInitFunc)(bool), bool cleanup)
+        int execute_(int (FlowMainEbos::* runOrInitFunc)(), bool cleanup)
         {
             try {
                 // deal with some administrative boilerplate
 
-                int status = setupParameters_(argc, argv);
+                int status = setupParameters_(argc_, argv_);
                 if (status)
                     return status;
 
                 setupParallelism();
                 setupEbosSimulator();
-                runDiagnostics(output_cout);
+                runDiagnostics();
                 createSimulator();
 
                 // if run, do the actual work, else just initialize
-                int exitCode = (this->*runOrInitFunc)(output_cout);
+                int exitCode = (this->*runOrInitFunc)();
                 if (cleanup) {
-                    executeCleanup_(output_to_files);
+                    executeCleanup_();
                 }
                 return exitCode;
             }
@@ -369,7 +374,7 @@ namespace Opm
                 std::ostringstream message;
                 message  << "Program threw an exception: " << e.what();
 
-                if (output_cout) {
+                if (output_cout_) {
                     // in some cases exceptions are thrown before the logging system is set
                     // up.
                     if (OpmLog::hasBackend("STREAMLOG")) {
@@ -384,9 +389,9 @@ namespace Opm
             }
         }
 
-        void executeCleanup_(bool output_to_files) {
+        void executeCleanup_() {
             // clean up
-            mergeParallelLogFiles(output_to_files);
+            mergeParallelLogFiles();
         }
 
     protected:
@@ -415,12 +420,12 @@ namespace Opm
 
 
 
-        void mergeParallelLogFiles(bool output_to_files)
+        void mergeParallelLogFiles()
         {
             // force closing of all log files.
             OpmLog::removeAllBackends();
 
-            if (mpi_rank_ != 0 || mpi_size_ < 2 || !output_to_files) {
+            if (mpi_rank_ != 0 || mpi_size_ < 2 || !output_files_) {
                 return;
             }
 
@@ -497,9 +502,9 @@ namespace Opm
         // Run diagnostics.
         // Writes to:
         //   OpmLog singleton.
-        void runDiagnostics(bool output_cout)
+        void runDiagnostics()
         {
-            if (!output_cout) {
+            if (!output_cout_) {
                 return;
             }
 
@@ -523,24 +528,24 @@ namespace Opm
         }
 
         // Run the simulator.
-        int runSimulator(bool output_cout)
+        int runSimulator()
         {
-            return runSimulatorInitOrRun_(output_cout, &FlowMainEbos::runSimulatorRunCallback_);
+            return runSimulatorInitOrRun_(&FlowMainEbos::runSimulatorRunCallback_);
         }
 
     private:
         // Callback that will be called from runSimulatorInitOrRun_().
-        int runSimulatorRunCallback_(bool output_cout)
+        int runSimulatorRunCallback_()
         {
             SimulatorReport report = simulator_->run(*simtimer_);
-            runSimulatorAfterSim_(output_cout, report);
+            runSimulatorAfterSim_(report);
             return report.success.exit_status;
         }
 
         // Output summary after simulation has completed
-        void runSimulatorAfterSim_(bool output_cout, SimulatorReport &report)
+        void runSimulatorAfterSim_(SimulatorReport &report)
         {
-            if (output_cout) {
+            if (output_cout_) {
                 std::ostringstream ss;
                 ss << "\n\n================    End of simulation     ===============\n\n";
                 ss << "Number of MPI processes: " << std::setw(6) << mpi_size_ << "\n";
@@ -565,8 +570,7 @@ namespace Opm
         }
 
         // Run the simulator.
-        int runSimulatorInitOrRun_(
-             bool output_cout, int (FlowMainEbos::* initOrRunFunc)(bool))
+        int runSimulatorInitOrRun_(int (FlowMainEbos::* initOrRunFunc)())
         {
 
             const auto& schedule = this->schedule();
@@ -578,7 +582,7 @@ namespace Opm
             const auto& initConfig = eclState().getInitConfig();
             simtimer_->init(timeMap, (size_t)initConfig.getRestartStep());
 
-            if (output_cout) {
+            if (output_cout_) {
                 std::ostringstream oss;
 
                 // This allows a user to catch typos and misunderstandings in the
@@ -591,16 +595,16 @@ namespace Opm
             }
 
             if (!ioConfig.initOnly()) {
-                if (output_cout) {
+                if (output_cout_) {
                     std::string msg;
                     msg = "\n\n================ Starting main simulation loop ===============\n";
                     OpmLog::info(msg);
                 }
 
-                return (this->*initOrRunFunc)(output_cout);
+                return (this->*initOrRunFunc)();
             }
             else {
-                if (output_cout) {
+                if (output_cout_) {
                     std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;
                 }
                 return EXIT_SUCCESS;
@@ -637,6 +641,10 @@ namespace Opm
         std::any parallel_information_;
         std::unique_ptr<Simulator> simulator_;
         std::unique_ptr<SimulatorTimer> simtimer_;
+        int argc_;
+        char **argv_;
+        bool output_cout_;
+        bool output_files_;
     };
 } // namespace Opm
 

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -354,7 +354,7 @@ namespace Opm
             try {
                 // deal with some administrative boilerplate
 
-                int status = setupParameters_(argc_, argv_);
+                int status = setupParameters_(this->argc_, this->argv_);
                 if (status)
                     return status;
 
@@ -374,7 +374,7 @@ namespace Opm
                 std::ostringstream message;
                 message  << "Program threw an exception: " << e.what();
 
-                if (output_cout_) {
+                if (this->output_cout_) {
                     // in some cases exceptions are thrown before the logging system is set
                     // up.
                     if (OpmLog::hasBackend("STREAMLOG")) {
@@ -425,7 +425,7 @@ namespace Opm
             // force closing of all log files.
             OpmLog::removeAllBackends();
 
-            if (mpi_rank_ != 0 || mpi_size_ < 2 || !output_files_) {
+            if (mpi_rank_ != 0 || mpi_size_ < 2 || !this->output_files_) {
                 return;
             }
 
@@ -504,7 +504,7 @@ namespace Opm
         //   OpmLog singleton.
         void runDiagnostics()
         {
-            if (!output_cout_) {
+            if (!this->output_cout_) {
                 return;
             }
 
@@ -545,7 +545,7 @@ namespace Opm
         // Output summary after simulation has completed
         void runSimulatorAfterSim_(SimulatorReport &report)
         {
-            if (output_cout_) {
+            if (this->output_cout_) {
                 std::ostringstream ss;
                 ss << "\n\n================    End of simulation     ===============\n\n";
                 ss << "Number of MPI processes: " << std::setw(6) << mpi_size_ << "\n";
@@ -582,7 +582,7 @@ namespace Opm
             const auto& initConfig = eclState().getInitConfig();
             simtimer_->init(timeMap, (size_t)initConfig.getRestartStep());
 
-            if (output_cout_) {
+            if (this->output_cout_) {
                 std::ostringstream oss;
 
                 // This allows a user to catch typos and misunderstandings in the
@@ -595,7 +595,7 @@ namespace Opm
             }
 
             if (!ioConfig.initOnly()) {
-                if (output_cout_) {
+                if (this->output_cout_) {
                     std::string msg;
                     msg = "\n\n================ Starting main simulation loop ===============\n";
                     OpmLog::info(msg);
@@ -604,7 +604,7 @@ namespace Opm
                 return (this->*initOrRunFunc)();
             }
             else {
-                if (output_cout_) {
+                if (this->output_cout_) {
                     std::cout << "\n\n================ Simulation turned off ===============\n" << std::flush;
                 }
                 return EXIT_SUCCESS;

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -100,8 +100,8 @@ namespace Opm {
 # else
     Dune::MPIHelper::instance(argc, argv);
 # endif
-    Opm::FlowMainEbos<TypeTag> mainfunc;
-    return mainfunc.execute(argc, argv, outputCout, outputFiles);
+    Opm::FlowMainEbos<TypeTag> mainfunc(argc, argv, outputCout, outputFiles);
+    return mainfunc.execute();
   }
 }
 


### PR DESCRIPTION
Make `Opm::FlowMainEbos` capture the variables `argc`, `argv`, `outputCout`, and `outputFiles`. Passing the variables to the constructor and saving them as class variables in `Opm::FlowMainEbos` makes the implementation of the Python interface simpler. For example, the `step_init()` method (see PR #2690) does not need to ask `Opm::Main` about the values of the variables when it needs to run `execute()` in `FlowMainEbos`.

Another advantage of this refactoring could be that less variables needs to be passed around from `Opm::Main`, to the static flow modules `flow_ebos_xxx.cpp`, and then again to `FlowMainEbos`.