### PR TITLE
Implements the Python step_init() function

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -303,6 +303,11 @@ namespace Opm
             return execute_(&FlowMainEbos::runSimulator, /*cleanup=*/true);
         }
 
+        int executeInitStep()
+        {
+            return execute_(&FlowMainEbos::runSimulatorInit, /*cleanup=*/false);
+        }
+
         // Print an ASCII-art header to the PRT and DEBUG files.
         // \return Whether unkown keywords were seen during parsing.
         static void printPRTHeader(bool output_cout)
@@ -533,6 +538,11 @@ namespace Opm
             return runSimulatorInitOrRun_(&FlowMainEbos::runSimulatorRunCallback_);
         }
 
+        int runSimulatorInit()
+        {
+            return runSimulatorInitOrRun_(&FlowMainEbos::runSimulatorInitCallback_);
+        }
+
     private:
         // Callback that will be called from runSimulatorInitOrRun_().
         int runSimulatorRunCallback_()
@@ -540,6 +550,13 @@ namespace Opm
             SimulatorReport report = simulator_->run(*simtimer_);
             runSimulatorAfterSim_(report);
             return report.success.exit_status;
+        }
+
+        // Callback that will be called from runSimulatorInitOrRun_().
+        int runSimulatorInitCallback_()
+        {
+            simulator_->init(*simtimer_);
+            return EXIT_SUCCESS;
         }
 
         // Output summary after simulation has completed

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -119,6 +119,7 @@ namespace Opm
     {
     private:
         using FlowMainEbosType = Opm::FlowMainEbos<TTAG(EclFlowProblem)>;
+
         enum class FileOutputMode {
             //! \brief No output to files.
             OUTPUT_NONE = 0,

--- a/opm/simulators/flow/python/simulators.hpp
+++ b/opm/simulators/flow/python/simulators.hpp
@@ -1,0 +1,47 @@
+/*
+  Copyright 2013, 2014, 2015 SINTEF ICT, Applied Mathematics.
+  Copyright 2014 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015 IRIS AS
+  Copyright 2014 STATOIL ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_SIMULATORS_HEADER_INCLUDED
+#define OPM_SIMULATORS_HEADER_INCLUDED
+
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/FlowMainEbos.hpp>
+
+namespace Opm::Pybind {
+class BlackOilSimulator
+{
+private:
+    using FlowMainEbosType = Opm::FlowMainEbos<TTAG(EclFlowProblem)>;
+
+public:
+    BlackOilSimulator( const std::string &deckFilename);
+    int run();
+    int step_init();
+
+private:
+    const std::string deckFilename_;
+    std::unique_ptr<FlowMainEbosType> mainEbos_;
+    std::unique_ptr<Opm::Main> main_;
+    bool hasRunInit_;
+};
+
+} // namespace Opm::Python
+#endif // OPM_SIMULATORS_HEADER_INCLUDED

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -4,6 +4,7 @@ set_target_properties( simulators PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_
 
 target_sources(simulators
   PRIVATE
+    ../../opm/simulators/utils/moduleVersion.cpp
     ../../flow/flow_ebos_blackoil.cpp)
 
 target_link_libraries( simulators PRIVATE opmsimulators )


### PR DESCRIPTION
Note: This PR depends on #2689 which should be merged first.

A resubmission of commit 11eaa3d7 in PR #2403 and PR #2443 and continues the work in #2555 implementing Python bindings to the flow simulator.

The step_init() method initializes the simulation. It is required for the Python script to run step_init() before calling the step() method (which will be implemented in the next commit).

