### PR TITLE
Allow well operators with FlexibleSolver.

### DIFF
--- a/opm/simulators/linalg/FlexibleSolver_impl.hpp
+++ b/opm/simulators/linalg/FlexibleSolver_impl.hpp
@@ -39,23 +39,23 @@ namespace Dune
     /// Create a sequential solver.
     template <class MatrixType, class VectorType>
     FlexibleSolver<MatrixType, VectorType>::
-    FlexibleSolver(const MatrixType& matrix,
+    FlexibleSolver(AbstractOperatorType& op,
                    const boost::property_tree::ptree& prm,
                    const std::function<VectorType()>& weightsCalculator)
     {
-        init(matrix, Dune::Amg::SequentialInformation(), prm, weightsCalculator);
+        init(op, Dune::Amg::SequentialInformation(), prm, weightsCalculator);
     }
 
     /// Create a parallel solver (if Comm is e.g. OwnerOverlapCommunication).
     template <class MatrixType, class VectorType>
     template <class Comm>
     FlexibleSolver<MatrixType, VectorType>::
-    FlexibleSolver(const MatrixType& matrix,
+    FlexibleSolver(AbstractOperatorType& op,
                    const Comm& comm,
                    const boost::property_tree::ptree& prm,
                    const std::function<VectorType()>& weightsCalculator)
     {
-        init(matrix, comm, prm, weightsCalculator);
+        init(op, comm, prm, weightsCalculator);
     }
 
     template <class MatrixType, class VectorType>
@@ -88,7 +88,7 @@ namespace Dune
     FlexibleSolver<MatrixType, VectorType>::
     category() const
     {
-        return linearoperator_->category();
+        return linearoperator_for_solver_->category();
     }
 
     // Machinery for making sequential or parallel operators/preconditioners/scalar products.
@@ -96,56 +96,64 @@ namespace Dune
     template <class Comm>
     void
     FlexibleSolver<MatrixType, VectorType>::
-    initOpPrecSp(const MatrixType& matrix, const boost::property_tree::ptree& prm,
-                 const std::function<VectorType()> weightsCalculator, const Comm& comm)
+    initOpPrecSp(AbstractOperatorType& op,
+                 const boost::property_tree::ptree& prm,
+                 const std::function<VectorType()> weightsCalculator,
+                 const Comm& comm)
     {
         // Parallel case.
-        using ParOperatorType = Dune::OverlappingSchwarzOperator<MatrixType, VectorType, VectorType, Comm>;
         using pt = const boost::property_tree::ptree;
-        auto linop = std::make_shared<ParOperatorType>(matrix, comm);
-        linearoperator_ = linop;
+        using ParOperatorType = Dune::OverlappingSchwarzOperator<MatrixType, VectorType, VectorType, Comm>;
+        linearoperator_for_solver_ = &op;
+        auto op_prec = std::make_shared<ParOperatorType>(op.getmat(), comm);
         auto child = prm.get_child_optional("preconditioner");
-        preconditioner_
-            = Opm::PreconditionerFactory<ParOperatorType, Comm>::create(*linop, child? *child : pt(),
-                                                                        weightsCalculator, comm);
-        scalarproduct_ = Dune::createScalarProduct<VectorType, Comm>(comm, linearoperator_->category());
+        preconditioner_ = Opm::PreconditionerFactory<ParOperatorType, Comm>::create(*op_prec,
+                                                                                    child ? *child : pt(),
+                                                                                    weightsCalculator,
+                                                                                    comm);
+        scalarproduct_ = Dune::createScalarProduct<VectorType, Comm>(comm, op.category());
+        linearoperator_for_precond_ = op_prec;
     }
 
     template <class MatrixType, class VectorType>
     void
     FlexibleSolver<MatrixType, VectorType>::
-    initOpPrecSp(const MatrixType& matrix, const boost::property_tree::ptree& prm,
-                 const std::function<VectorType()> weightsCalculator, const Dune::Amg::SequentialInformation&)
+    initOpPrecSp(AbstractOperatorType& op,
+                 const boost::property_tree::ptree& prm,
+                 const std::function<VectorType()> weightsCalculator,
+                 const Dune::Amg::SequentialInformation&)
     {
         // Sequential case.
-        using SeqOperatorType = Dune::MatrixAdapter<MatrixType, VectorType, VectorType>;
         using pt = const boost::property_tree::ptree;
-        auto linop = std::make_shared<SeqOperatorType>(matrix);
-        linearoperator_ = linop;
+        using SeqOperatorType = Dune::MatrixAdapter<MatrixType, VectorType, VectorType>;
+        linearoperator_for_solver_ = &op;
+        auto op_prec = std::make_shared<SeqOperatorType>(op.getmat());
         auto child = prm.get_child_optional("preconditioner");
-        preconditioner_ = Opm::PreconditionerFactory<SeqOperatorType>::create(*linop, child? *child : pt(),
+        preconditioner_ = Opm::PreconditionerFactory<SeqOperatorType>::create(*op_prec,
+                                                                              child ? *child : pt(),
                                                                               weightsCalculator);
         scalarproduct_ = std::make_shared<Dune::SeqScalarProduct<VectorType>>();
+        linearoperator_for_precond_ = op_prec;
     }
 
     template <class MatrixType, class VectorType>
     void
     FlexibleSolver<MatrixType, VectorType>::
-    initSolver(const boost::property_tree::ptree& prm, bool isMaster)
+    initSolver(const boost::property_tree::ptree& prm, const bool is_iorank)
     {
         const double tol = prm.get<double>("tol", 1e-2);
         const int maxiter = prm.get<int>("maxiter", 200);
-        const int verbosity = isMaster? prm.get<int>("verbosity", 0) : 0;
+        const int verbosity = is_iorank ? prm.get<int>("verbosity", 0) : 0;
         const std::string solver_type = prm.get<std::string>("solver", "bicgstab");
         if (solver_type == "bicgstab") {
-            linsolver_.reset(new Dune::BiCGSTABSolver<VectorType>(*linearoperator_,
+            linsolver_.reset(new Dune::BiCGSTABSolver<VectorType>(*linearoperator_for_solver_,
                                                                   *scalarproduct_,
                                                                   *preconditioner_,
                                                                   tol, // desired residual reduction factor
                                                                   maxiter, // maximum number of iterations
                                                                   verbosity));
         } else if (solver_type == "loopsolver") {
-            linsolver_.reset(new Dune::LoopSolver<VectorType>(*linearoperator_,
+            linsolver_.reset(new Dune::LoopSolver<VectorType>(*linearoperator_for_solver_,
                                                               *scalarproduct_,
                                                               *preconditioner_,
                                                               tol, // desired residual reduction factor
@@ -153,7 +161,7 @@ namespace Dune
                                                               verbosity));
         } else if (solver_type == "gmres") {
             int restart = prm.get<int>("restart", 15);
-            linsolver_.reset(new Dune::RestartedGMResSolver<VectorType>(*linearoperator_,
+            linsolver_.reset(new Dune::RestartedGMResSolver<VectorType>(*linearoperator_for_solver_,
                                                                         *scalarproduct_,
                                                                         *preconditioner_,
                                                                         tol,
@@ -163,7 +171,7 @@ namespace Dune
 #if HAVE_SUITESPARSE_UMFPACK
         } else if (solver_type == "umfpack") {
             bool dummy = false;
-            linsolver_.reset(new Dune::UMFPack<MatrixType>(linearoperator_->getmat(), verbosity, dummy));
+            linsolver_.reset(new Dune::UMFPack<MatrixType>(linearoperator_for_solver_->getmat(), verbosity, dummy));
 #endif
         } else {
             OPM_THROW(std::invalid_argument, "Properties: Solver " << solver_type << " not known.");
@@ -177,13 +185,13 @@ namespace Dune
     template <class Comm>
     void
     FlexibleSolver<MatrixType, VectorType>::
-    init(const MatrixType& matrix,
+    init(AbstractOperatorType& op,
          const Comm& comm,
          const boost::property_tree::ptree& prm,
          const std::function<VectorType()> weightsCalculator)
     {
-        initOpPrecSp(matrix, prm, weightsCalculator, comm);
-        initSolver(prm, comm.communicator().rank()==0);
+        initOpPrecSp(op, prm, weightsCalculator, comm);
+        initSolver(prm, comm.communicator().rank() == 0);
     }
 
 } // namespace Dune
@@ -198,28 +206,33 @@ using BM = Dune::BCRSMatrix<Dune::FieldMatrix<double, N, N>>;
 template <int N>
 using OBM = Dune::BCRSMatrix<Opm::MatrixBlock<double, N, N>>;
 
-// INSTANTIATE_CONSTRUCTOR instantiates the constructor that is a template,
-// this is only needed in the MPI case, since otherwise the Comm type is
-// not a template argument but always SequentialInformation.
 #if HAVE_MPI
+
 using Comm = Dune::OwnerOverlapCopyCommunication<int, int>;
-#define INSTANTIATE_FLEXIBLESOLVER_CONSTRUCTOR(n) \
-template Dune::FlexibleSolver<OBM<n>, BV<n>>::FlexibleSolver(const MatrixType& matrix,                        \
+
+// Note: we must instantiate the constructor that is a template.
+// This is only needed in the parallel case, since otherwise the Comm type is
+// not a template argument but always SequentialInformation.
+
+#define INSTANTIATE_FLEXIBLESOLVER(N)                  \
+template class Dune::FlexibleSolver<BM<N>, BV<N>>;     \
+template class Dune::FlexibleSolver<OBM<N>, BV<N>>;    \
+template Dune::FlexibleSolver<BM<N>, BV<N>>::FlexibleSolver(AbstractOperatorType& op,                         \
+                                                            const Comm& comm,                                 \
+                                                            const boost::property_tree::ptree& prm,           \
+                                                            const std::function<BV<N>()>& weightsCalculator); \
+template Dune::FlexibleSolver<OBM<N>, BV<N>>::FlexibleSolver(AbstractOperatorType& op,                        \
                                                              const Comm& comm,                                \
                                                              const boost::property_tree::ptree& prm,          \
-                                                             const std::function<BV<n>()>& weightsCalculator);
-#else
-#define INSTANTIATE_FLEXIBLESOLVER_CONSTRUCTOR(n)
-#endif
+                                                             const std::function<BV<N>()>& weightsCalculator);
 
-// INSTANTIATE instantiates the class including any templated constructors if necessary.
-#define INSTANTIATE_FLEXIBLESOLVER(n)               \
-/* Variants using Dune::FieldMatrix blocks. */      \
-template class Dune::FlexibleSolver<BM<n>, BV<n>>;  \
-/* Variants using Opm::MatrixBlock blocks. */       \
-template class Dune::FlexibleSolver<OBM<n>, BV<n>>; \
-INSTANTIATE_FLEXIBLESOLVER_CONSTRUCTOR(n)
+#else // HAVE_MPI
 
+#define INSTANTIATE_FLEXIBLESOLVER(N)                  \
+template class Dune::FlexibleSolver<BM<N>, BV<N>>;     \
+template class Dune::FlexibleSolver<OBM<N>, BV<N>>;
+
+#endif // HAVE_MPI
 
 
 #endif // OPM_FLEXIBLE_SOLVER_IMPL_HEADER_INCLUDED

--- a/opm/simulators/linalg/PressureSolverPolicy.hpp
+++ b/opm/simulators/linalg/PressureSolverPolicy.hpp
@@ -25,6 +25,7 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <dune/istl/solver.hh>
+#include <dune/istl/owneroverlapcopy.hh>
 
 namespace Dune
 {
@@ -55,19 +56,24 @@ namespace Amg
          * The operator will use one step of AMG to approximately solve
          * the coarse level system.
          */
-        struct PressureInverseOperator : public Dune::InverseOperator<X, X> {
-            template <class Comm>
-            PressureInverseOperator(Operator& op, const boost::property_tree::ptree& prm, const Comm& comm)
+        struct PressureInverseOperator : public Dune::InverseOperator<X, X>
+        {
+            template <typename GlobalIndex, typename LocalIndex>
+            PressureInverseOperator(Operator& op,
+                                    const boost::property_tree::ptree& prm,
+                                    const Dune::OwnerOverlapCopyCommunication<GlobalIndex, LocalIndex>& comm)
                 : linsolver_()
             {
                 assert(op.category() == Dune::SolverCategory::overlapping);
-                linsolver_ = std::make_unique<Solver>(op.getmat(), comm, prm, std::function<X()>());
+                linsolver_ = std::make_unique<Solver>(op, comm, prm, std::function<X()>());
             }
-            PressureInverseOperator(Operator& op, const boost::property_tree::ptree& prm, const SequentialInformation&)
+            PressureInverseOperator(Operator& op,
+                                    const boost::property_tree::ptree& prm,
+                                    const SequentialInformation&)
                 : linsolver_()
             {
                 assert(op.category() != Dune::SolverCategory::overlapping);
-                linsolver_ = std::make_unique<Solver>(op.getmat(), prm, std::function<X()>());
+                linsolver_ = std::make_unique<Solver>(op, prm, std::function<X()>());
             }
 
 

--- a/tests/test_flexiblesolver.cpp
+++ b/tests/test_flexiblesolver.cpp
@@ -75,7 +75,9 @@ testSolver(const boost::property_tree::ptree& prm, const std::string& matrix_fil
                                                                 prm.get<int>("preconditioner.pressure_var_index"),
                                                                 transpose);
               };
-    Dune::FlexibleSolver<Matrix, Vector> solver(matrix, prm, wc);
+    using SeqOperatorType = Dune::MatrixAdapter<Matrix, Vector, Vector>;
+    SeqOperatorType op(matrix);
+    Dune::FlexibleSolver<Matrix, Vector> solver(op, prm, wc);
     Vector x(rhs.size());
     Dune::InverseOperatorResult res;
     solver.apply(x, rhs, res);


### PR DESCRIPTION
This changes the FlexibleSolver to be constructed using a `Dune::AssembledLinearOperator<Matrix, Vector, Vector>` instead of a `Matrix`. (The `Matrix` and `Vector` template arguments to the class are the same as before.)

The preconditioners will be constructed passing the operator's getmat() result, while the operator itself will be used in the iterative solvers. So the wells-as-operator approach can now be used. On Norne, I get bitwise identical results with ILU0 through FlexibleSolver as I get with the default solver (tested with 8 processes). For some preconditioners such as CPR, it looks as if it is still preferable to have --matrix-add-well-contributions=true, but at least the space of possibilities is now wider.