### PR TITLE
Simulator Group Data: Chase Upstream API Update

### DIFF
--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -562,7 +562,10 @@ public:
         return wellDat;
     }
 
-    Opm::data::Group groupData(const int /* reportStepIdx */, Opm::Schedule& /* sched */) const {
+    Opm::data::GroupValues
+    groupData(const int /* reportStepIdx */,
+              const Opm::Schedule& /* sched */) const
+    {
         return {};
     }
 

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -187,30 +187,19 @@ namespace Opm {
 
             void initFromRestartFile(const RestartValue& restartValues);
 
-            Opm::data::Group groupData(const int reportStepIdx, Opm::Schedule& sched) const
+            Opm::data::GroupValues
+            groupData(const int reportStepIdx, const Opm::Schedule& sched) const
             {
-                Opm::data::Group dw;
-                for (const std::string gname :  sched.groupNames(reportStepIdx))  {
+                auto gvalues = ::Opm::data::GroupValues{};
+
+                for (const auto& gname : sched.groupNames(reportStepIdx)) {
                     const auto& grup = sched.getGroup(gname, reportStepIdx);
-                    const auto& grup_type = grup.getGroupType();
-                    Opm::data::currentGroupConstraints cgc;
-                    cgc.currentProdConstraint =  Opm::Group::ProductionCMode::NONE;
-                    cgc.currentGasInjectionConstraint = Opm::Group::InjectionCMode::NONE;
-                    cgc.currentWaterInjectionConstraint = Opm::Group::InjectionCMode::NONE;
-                    if (this->well_state_.hasProductionGroupControl(gname)) {
-                        cgc.currentProdConstraint = this->well_state_.currentProductionGroupControl(gname);
-                    }
-                    if ((grup_type == Opm::Group::GroupType::INJECTION) || (grup_type == Opm::Group::GroupType::MIXED))  {
-                        if (this->well_state_.hasInjectionGroupControl(Opm::Phase::WATER, gname)) {
-                            cgc.currentWaterInjectionConstraint = this->well_state_.currentInjectionGroupControl(Opm::Phase::WATER, gname);
-                        }
-                        if (this->well_state_.hasInjectionGroupControl(Opm::Phase::GAS, gname)) {
-                            cgc.currentGasInjectionConstraint = this->well_state_.currentInjectionGroupControl(Opm::Phase::GAS, gname);
-                        }
-                    }
-                    dw.emplace(gname, cgc);
+
+                    auto& gdata = gvalues[gname];
+                    this->assignGroupControl(grup, gdata);
                 }
-                return dw;
+
+                return gvalues;
             }
 
             Opm::data::Wells wellData() const
@@ -443,8 +432,7 @@ namespace Opm {
 
             void setWsolvent(const Group& group, const Schedule& schedule, const int reportStepIdx, double wsolvent);
 
-
-
+            void assignGroupControl(const Group& group, data::GroupData& gdata) const;
         };
 
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2430,5 +2430,40 @@ namespace Opm {
         }
     }
 
+    template<typename TypeTag>
+    void
+    BlackoilWellModel<TypeTag>::
+    assignGroupControl(const Group& group, data::GroupData& gdata) const
+    {
+        const auto& gname     = group.name();
+        const auto  grup_type = group.getGroupType();
+        auto&       cgc       = gdata.currentControl;
+
+        cgc.currentProdConstraint =
+            ::Opm::Group::ProductionCMode::NONE;
+
+        cgc.currentGasInjectionConstraint =
+        cgc.currentWaterInjectionConstraint =
+            ::Opm::Group::InjectionCMode::NONE;
+
+        if (this->well_state_.hasProductionGroupControl(gname)) {
+            cgc.currentProdConstraint = this->well_state_
+                .currentProductionGroupControl(gname);
+        }
+
+        if ((grup_type == ::Opm::Group::GroupType::INJECTION) ||
+            (grup_type == ::Opm::Group::GroupType::MIXED))
+        {
+            if (this->well_state_.hasInjectionGroupControl(::Opm::Phase::WATER, gname)) {
+                cgc.currentWaterInjectionConstraint = this->well_state_
+                    .currentInjectionGroupControl(::Opm::Phase::WATER, gname);
+            }
+
+            if (this->well_state_.hasInjectionGroupControl(::Opm::Phase::GAS, gname)) {
+                cgc.currentGasInjectionConstraint = this->well_state_
+                    .currentInjectionGroupControl(::Opm::Phase::GAS, gname);
+            }
+        }
+    }
 
 } // namespace Opm


### PR DESCRIPTION
This commit makes the 'groupData()' function return a
```C++
map<string, Opm::data::GroupData>
```
object instead of a
```C++
map<string, Opm::data::GroupConstraints>
```
object.  The `GroupData` structure adds a level of indirection to the current per-group summary quantities that are directly assigned by the simulator.  While here, also move the assignment of the current group constraints/control values out to a separate helper to reduce the body of the per-group loop in `groupData()`.

This is in preparation of adding support for reporting group-level production/injection guiderates (`G[OGW][IP]GR`) to the summary file.

---

Note: This PR is the companion to upstream PR OPM/opm-common#1853.  This PR **must not** be merged without also merging the upstream PR lest there be a build break.