### PR TITLE
Fix some warnings in the OpenCl Solver.

### DIFF
--- a/opm/simulators/linalg/bda/WellContributions.cpp
+++ b/opm/simulators/linalg/bda/WellContributions.cpp
@@ -92,7 +92,7 @@ void WellContributions::apply(cl::Buffer& d_x, cl::Buffer& d_y) {
 }
 #endif
 
-void WellContributions::addMatrix(MatrixType type, int *colIndices, double *values, unsigned int val_size)
+void WellContributions::addMatrix([[maybe_unused]] MatrixType type, [[maybe_unused]]int *colIndices, [[maybe_unused]] double *values, [[maybe_unused]] unsigned int val_size)
 {
 #if HAVE_CUDA
         addMatrixGpu(type, colIndices, values, val_size);

--- a/opm/simulators/linalg/bda/WellContributions.cpp
+++ b/opm/simulators/linalg/bda/WellContributions.cpp
@@ -117,14 +117,14 @@ void WellContributions::addNumBlocks(unsigned int nnz)
     num_std_wells++;
 }
 
-void WellContributions::addMultisegmentWellContribution(unsigned int dim, unsigned int dim_wells,
+void WellContributions::addMultisegmentWellContribution(unsigned int dim_, unsigned int dim_wells_,
         unsigned int Nb, unsigned int Mb,
         unsigned int BnumBlocks, std::vector<double> &Bvalues, std::vector<unsigned int> &BcolIndices, std::vector<unsigned int> &BrowPointers,
         unsigned int DnumBlocks, double *Dvalues, int *DcolPointers, int *DrowIndices,
         std::vector<double> &Cvalues)
 {
-    this->N = Nb * dim;
-    MultisegmentWellContribution *well = new MultisegmentWellContribution(dim, dim_wells, Nb, Mb, BnumBlocks, Bvalues, BcolIndices, BrowPointers, DnumBlocks, Dvalues, DcolPointers, DrowIndices, Cvalues);
+    this->N = Nb * dim_;
+    MultisegmentWellContribution *well = new MultisegmentWellContribution(dim, dim_wells_, Nb, Mb, BnumBlocks, Bvalues, BcolIndices, BrowPointers, DnumBlocks, Dvalues, DcolPointers, DrowIndices, Cvalues);
     multisegments.emplace_back(well);
     ++num_ms_wells;
 }

--- a/opm/simulators/linalg/bda/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/openclSolverBackend.cpp
@@ -514,13 +514,13 @@ void openclSolverBackend<block_size>::initialize(int N_, int nnz_, int dim, doub
 
         prec->setKernels(ILU_apply1_k.get(), ILU_apply2_k.get());
 
-    } catch (cl::Error error) {
+    } catch (const cl::Error& error) {
         std::ostringstream oss;
         oss << "OpenCL Error: " << error.what() << "(" << error.err() << ")\n";
         oss << getErrorString(error.err());
         // rethrow exception
         OPM_THROW(std::logic_error, oss.str());
-    } catch (std::logic_error error) {
+    } catch (const std::logic_error& error) {
         // rethrow exception by OPM_THROW in the try{}, without this, a segfault occurs
         throw error;
     }
@@ -665,13 +665,13 @@ void openclSolverBackend<block_size>::solve_system(WellContributions& wellContri
     // actually solve
     try {
         gpu_pbicgstab(wellContribs, res);
-    } catch (cl::Error error) {
+    } catch (const cl::Error& error) {
         std::ostringstream oss;
         oss << "openclSolverBackend::solve_system error: " << error.what() << "(" << error.err() << ")\n";
         oss << getErrorString(error.err());
         // rethrow exception
         OPM_THROW(std::logic_error, oss.str());
-    } catch (std::logic_error error) {
+    } catch (const std::logic_error& error) {
         // rethrow exception by OPM_THROW in the try{}, without this, a segfault occurs
         throw error;
     }


### PR DESCRIPTION
PR #2682 introduced some new warnings (shadowing variables, and catching exceptions by value). This PR fixes them.

Would be nice if @Tongdongq would tell his 2 cents on this (especially the shadowed variables).