### PR TITLE
Report Guiderates at Well and Group Levels

### DIFF
--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -261,6 +261,8 @@ namespace WellGroupHelpers
     GuideRate::RateVector
     getRateVector(const WellStateFullyImplicitBlackoil& well_state, const PhaseUsage& pu, const std::string& name);
 
+    GuideRate::RateVector
+    getProductionGroupRateVector(const WellStateFullyImplicitBlackoil& well_state, const PhaseUsage& pu, const std::string& group_name);
 
     double getGuideRate(const std::string& name,
                         const Schedule& schedule,
@@ -279,7 +281,6 @@ namespace WellGroupHelpers
                            const GuideRateModel::Target target,
                            const Phase& injectionPhase,
                            const PhaseUsage& pu);
-
 
     int groupControlledWells(const Schedule& schedule,
                              const WellStateFullyImplicitBlackoil& well_state,
@@ -314,7 +315,6 @@ namespace WellGroupHelpers
         PhaseUsage pu_;
     };
 
-    GuideRate::RateVector getGroupRateVector(const std::string& group_name);
 
 
     double fractionFromGuideRates(const std::string& name,

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -1066,9 +1066,9 @@ namespace Opm
             auto it = wellNameToGlobalIdx_.find(name);
 
             if (it == wellNameToGlobalIdx_.end())
-                OPM_THROW(std::logic_error, "Could not find global injection group for well" << name);
+                OPM_THROW(std::logic_error, "Could not find global injection group for well " << name);
 
-            return globalIsInjectionGrup_[it->second];
+            return globalIsInjectionGrup_[it->second] != 0;
         }
 
         bool isProductionGrup(const std::string& name) const {
@@ -1076,9 +1076,9 @@ namespace Opm
             auto it = wellNameToGlobalIdx_.find(name);
 
             if (it == wellNameToGlobalIdx_.end())
-                OPM_THROW(std::logic_error, "Could not find global injection group for well" << name);
+                OPM_THROW(std::logic_error, "Could not find global production group for well " << name);
 
-            return globalIsProductionGrup_[it->second];
+            return globalIsProductionGrup_[it->second] != 0;
         }
 
     private:

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -379,6 +379,10 @@ namespace Opm
             return it->second;
         }
 
+        bool hasWellRates(const std::string& wellName) const {
+            return this->well_rates.find(wellName) != this->well_rates.end();
+        }
+
         void setCurrentProductionGroupRates(const std::string& groupName, const std::vector<double>& rates ) {
             production_group_rates[groupName] = rates;
         }
@@ -390,6 +394,10 @@ namespace Opm
                 OPM_THROW(std::logic_error, "Could not find any rates for productino group  " << groupName);
 
             return it->second;
+        }
+
+        bool hasProductionGroupRates(const std::string& groupName) const {
+            return this->production_group_rates.find(groupName) != this->production_group_rates.end();
         }
         
         void setCurrentProductionGroupReductionRates(const std::string& groupName, const std::vector<double>& target ) {


### PR DESCRIPTION
This PR adds support for reporting the simulator's guiderate values at the well and group levels to the output layer through the `wellData()` and `groupData()` member functions.  We add several new member functions that collectively assemble the values and assign them to objects of type `Opm::data::GuideRateValue` (PR OPM/opm-common#1868) for subsequent output to the summary and restart files.

In particular
```
getGuideRateValues(const Well&) const
getGuideRateValues(const Group&) const
```
retrieve the guiderate values for all phases for those individual wells and groups for which the `guideRate_` data member defines a value.  The most complicated function of this PR is
```
calculateAllGroupGuideRates
```
which aggregates those individual contributions from the well (leaf) level up to the root of the group tree (the FIELD group).  This process uses an ancillary array (`up`) to keep track of the parent groups of all wells and all groups, and to ensure that we only visit each parent group once (`sort`+`unique` on subsets of the `up` array).

We do not currently support outputting guiderates for reservoir voidage volume (`GuideRateModel::Target::RES`).

We also add a few helper functions to the `WellGroupHelpers` and `WellStateFullyImplicitBlackoil` in order to simplify the implementation of `calculateAllGroupRates`.