### PR TITLE
Remove unused variable groups from BlackoilWellModel::wellsToState.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -403,7 +403,6 @@ namespace Opm {
 
             // convert well data from opm-common to well state from opm-core
             void wellsToState( const data::Wells& wells,
-                               const data::GroupValues& groups,
                                const PhaseUsage& phases,
                                const bool handle_ms_well,
                                WellStateFullyImplicitBlackoil& state ) const;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -545,7 +545,7 @@ namespace Opm {
             const size_t numCells = Opm::UgGridHelpers::numCells(grid());
             const bool handle_ms_well = (param_.use_multisegment_well_ && anyMSWellOpenLocal());
             well_state_.resize(wells_ecl_, schedule(), handle_ms_well, numCells, phaseUsage, well_perf_data_, summaryState, globalNumWells); // Resize for restart step
-            wellsToState(restartValues.wells, restartValues.groups, phaseUsage, handle_ms_well, well_state_);
+            wellsToState(restartValues.wells, phaseUsage, handle_ms_well, well_state_);
         }
 
         previous_well_state_ = well_state_;
@@ -1597,7 +1597,6 @@ namespace Opm {
     void
     BlackoilWellModel<TypeTag>::
     wellsToState( const data::Wells& wells,
-                  const data::GroupValues& groups,
                   const PhaseUsage& phases,
                   const bool handle_ms_well,
                   WellStateFullyImplicitBlackoil& state) const


### PR DESCRIPTION
Alternatively it could be marked as [[maybe_unused]] if it will be used sometime in the future.