### PR TITLE
Added Standard Well support for OpenCL solver backend

### DIFF
--- a/opm/simulators/linalg/bda/WellContributions.cpp
+++ b/opm/simulators/linalg/bda/WellContributions.cpp
@@ -24,6 +24,7 @@
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/simulators/linalg/bda/openclKernels.hpp>
 #include "opm/simulators/linalg/bda/WellContributions.hpp"
 
 namespace Opm
@@ -35,8 +36,15 @@ void WellContributions::alloc()
     if (num_std_wells > 0) {
 #if HAVE_CUDA
         allocStandardWells();
+#elif HAVE_OPENCL
+        d_Cnnzs = cl::Buffer(*context, CL_MEM_READ_ONLY, sizeof(double) * num_blocks * dim * dim_wells);
+        d_Dnnzs = cl::Buffer(*context, CL_MEM_READ_ONLY, sizeof(double) * num_std_wells * dim_wells * dim_wells);
+        d_Bnnzs = cl::Buffer(*context, CL_MEM_READ_ONLY, sizeof(double) * num_blocks * dim * dim_wells);
+        d_Ccols = cl::Buffer(*context, CL_MEM_READ_ONLY, sizeof(int) * num_blocks);
+        d_Bcols = cl::Buffer(*context, CL_MEM_READ_ONLY, sizeof(int) * num_blocks);
+        d_val_pointers = cl::Buffer(*context, CL_MEM_READ_ONLY, sizeof(double) * (num_std_wells + 1));
 #else
-        OPM_THROW(std::logic_error, "Error cannot allocate on GPU for StandardWells because CUDA was not found by cmake");
+        OPM_THROW(std::logic_error, "Error cannot allocate on GPU because neither CUDA nor OpenCL were found by cmake");
 #endif
     }
 }
@@ -56,6 +64,13 @@ WellContributions::~WellContributions()
 
 #if HAVE_CUDA
     freeStandardWells();
+#elif HAVE_OPENCL
+    cl::ReleaseMemObject(d_Cnnzs);
+    cl::ReleaseMemObject(d_Dnnzs);
+    cl::ReleaseMemObject(d_Bnnzs);
+    cl::ReleaseMemObject(d_Ccols);
+    cl::ReleaseMemObject(d_Bcols);
+    cl::ReleaseMemObject(d_val_pointers);
 #endif
 }
 
@@ -84,21 +99,58 @@ void WellContributions::apply(cl::Buffer& d_x, cl::Buffer& d_y) {
         queue->enqueueWriteBuffer(d_y, CL_TRUE, 0, sizeof(double) * N, h_y);
     }
 
+    queue->enqueueWriteBuffer(d_Cnnzs, CL_TRUE, 0, sizeof(double) * h_Cnnzs.size(), h_Cnnzs.data());
+    queue->enqueueWriteBuffer(d_Dnnzs, CL_TRUE, 0, sizeof(double) * h_Dnnzs.size(), h_Dnnzs.data());
+    queue->enqueueWriteBuffer(d_Bnnzs, CL_TRUE, 0, sizeof(double) * h_Bnnzs.size(), h_Bnnzs.data());
+    queue->enqueueWriteBuffer(d_Ccols, CL_TRUE, 0, sizeof(int) * h_Ccols.size(), h_Ccols.data());
+    queue->enqueueWriteBuffer(d_Bcols, CL_TRUE, 0, sizeof(int) * h_Bcols.size(), h_Bcols.data());
+    queue->enqueueWriteBuffer(d_val_pointers, CL_TRUE, 0, sizeof(int) * (num_std_wells + 1), val_pointers);
 
     // apply StandardWells
     if (num_std_wells > 0) {
-        OPM_THROW(std::logic_error, "Error StandardWells are not supported by openclSolver");
+        cl::Event event;
+        event = (*add_well_contributions)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items), cl::NDRange(work_group_size)), d_Cnnzs, d_Dnnzs, d_Bnnzs, d_Ccols, d_Bcols, d_x, d_y, dim, dim_wells, d_val_pointers, cl::Local(work_group_size*sizeof(double)), cl::Local(2*sizeof(double)*dim_wells), cl::Local(2*sizeof(double)*dim_wells));
     }
 }
 #endif
 
 void WellContributions::addMatrix(MatrixType type, int *colIndices, double *values, unsigned int val_size)
 {
+    if (!allocated) {
+        OPM_THROW(std::logic_error, "Error cannot add wellcontribution before allocating memory in WellContributions");
+    }
 #if HAVE_CUDA
-        addMatrixGpu(type, colIndices, values, val_size);
+    addMatrixGpu(type, colIndices, values, val_size);
+#elif HAVE_OPENCL
+    switch (type) {
+    case MatrixType::C:
+        h_Ccols.insert(h_Ccols.end(), colIndices, colIndices + val_size);
+        h_Cnnzs.insert(h_Cnnzs.end(), values, values + val_size*dim*dim_wells);
+        break;
+
+    case MatrixType::D:
+        h_Dnnzs.insert(h_Dnnzs.end(), values, values + val_size*dim_wells*dim_wells);
+        break;
+
+    case MatrixType::B:
+        h_Bcols.insert(h_Bcols.end(), colIndices, colIndices + val_size);
+        h_Bnnzs.insert(h_Bnnzs.end(), values, values + val_size*dim*dim_wells);
+        val_pointers[num_std_wells_so_far] = num_blocks_so_far;
+
+        if(num_std_wells_so_far == num_std_wells - 1){
+            val_pointers[num_std_wells] = num_blocks;
+        }
+        break;
+    default:
+        OPM_THROW(std::logic_error, "Error unsupported matrix ID for WellContributions::addMatrix()");
+    }   
 #else
-        OPM_THROW(std::logic_error, "Error cannot add StandardWell matrix on GPU because CUDA was not found by cmake");
+    OPM_THROW(std::logic_error, "Error cannot add StandardWell matrix on GPU because neither CUDA nor OpenCL were found by cmake");
 #endif
+    if (MatrixType::B == type) {
+        num_blocks_so_far += val_size;
+        num_std_wells_so_far++;
+    }
 }
 
 
@@ -140,9 +192,25 @@ void WellContributions::setReordering(int *toOrder_, bool reorder_)
 }
 
 #if HAVE_OPENCL
+void WellContributions::setOpenCLContext(cl::Context *context_)
+{
+    this->context = context_;
+}
+
 void WellContributions::setOpenCLQueue(cl::CommandQueue *queue_)
 {
     this->queue = queue_;
+}
+
+void WellContributions::setKernelParameters(const unsigned int work_group_size_, const unsigned int total_work_items_)
+{
+    this->work_group_size = work_group_size_;
+    this->total_work_items = total_work_items_;
+}
+
+void WellContributions::setKernel(cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, const unsigned int, cl::Buffer&, cl::LocalSpaceArg, cl::LocalSpaceArg, cl::LocalSpaceArg> *add_well_contributions_)
+{
+    this->add_well_contributions = add_well_contributions_;
 }
 #endif
 

--- a/opm/simulators/linalg/bda/WellContributions.cu
+++ b/opm/simulators/linalg/bda/WellContributions.cu
@@ -127,30 +127,24 @@ __global__ void apply_well_contributions(
 
 void WellContributions::allocStandardWells()
 {
-    if (num_std_wells > 0) {
-        cudaMalloc((void**)&d_Cnnzs, sizeof(double) * num_blocks * dim * dim_wells);
-        cudaMalloc((void**)&d_Dnnzs, sizeof(double) * num_std_wells * dim_wells * dim_wells);
-        cudaMalloc((void**)&d_Bnnzs, sizeof(double) * num_blocks * dim * dim_wells);
-        cudaMalloc((void**)&d_Ccols, sizeof(int) * num_blocks);
-        cudaMalloc((void**)&d_Bcols, sizeof(int) * num_blocks);
-        val_pointers = new unsigned int[num_std_wells + 1];
-        cudaMalloc((void**)&d_val_pointers, sizeof(int) * (num_std_wells + 1));
-        cudaCheckLastError("apply_gpu malloc failed");
-        allocated = true;
-    }
+    cudaMalloc((void**)&d_Cnnzs, sizeof(double) * num_blocks * dim * dim_wells);
+    cudaMalloc((void**)&d_Dnnzs, sizeof(double) * num_std_wells * dim_wells * dim_wells);
+    cudaMalloc((void**)&d_Bnnzs, sizeof(double) * num_blocks * dim * dim_wells);
+    cudaMalloc((void**)&d_Ccols, sizeof(int) * num_blocks);
+    cudaMalloc((void**)&d_Bcols, sizeof(int) * num_blocks);
+    val_pointers = new unsigned int[num_std_wells + 1];
+    cudaMalloc((void**)&d_val_pointers, sizeof(int) * (num_std_wells + 1));
+    cudaCheckLastError("apply_gpu malloc failed");
 }
 
 void WellContributions::freeStandardWells() {
     // delete data for StandardWell
-    if (num_std_wells > 0) {
-        cudaFree(d_Cnnzs);
-        cudaFree(d_Dnnzs);
-        cudaFree(d_Bnnzs);
-        cudaFree(d_Ccols);
-        cudaFree(d_Bcols);
-        delete[] val_pointers;
-        cudaFree(d_val_pointers);
-    }
+    cudaFree(d_Cnnzs);
+    cudaFree(d_Dnnzs);
+    cudaFree(d_Bnnzs);
+    cudaFree(d_Ccols);
+    cudaFree(d_Bcols);
+    cudaFree(d_val_pointers);
 }
 
 

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -83,7 +83,12 @@ private:
 #endif
 
 #if HAVE_OPENCL
-    cl::CommandQueue *queue = nullptr;
+    cl::Context *context;
+    cl::CommandQueue *queue;
+    cl::Buffer d_Cnnzs, d_Dnnzs, d_Bnnzs, d_Ccols, d_Bcols, d_val_pointers;
+    cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, const unsigned int, cl::Buffer&, cl::LocalSpaceArg, cl::LocalSpaceArg, cl::LocalSpaceArg> *add_well_contributions;
+    std::vector<double> h_Cnnzs, h_Dnnzs, h_Bnnzs;
+    std::vector<int> h_Ccols, h_Bcols;
 #endif
 
 #if HAVE_CUDA
@@ -140,7 +145,8 @@ public:
     void apply(double *d_x, double *d_y);
 #endif
 #if HAVE_OPENCL
-    void apply(cl::Buffer& x, cl::Buffer& y);
+    //void apply(cl::Buffer& x, cl::Buffer& y);
+    void apply(cl::Buffer x, cl::Buffer y);
 #endif
 
     /// Allocate memory for the StandardWells
@@ -200,6 +206,8 @@ public:
     /// This object copies some cl::Buffers, it requires a CommandQueue to do that
     /// \param[in] queue      the opencl commandqueue to be used
     void setOpenCLQueue(cl::CommandQueue *queue);
+    void setOpenCLContext(cl::Context *context);
+    void setKernel(cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, const unsigned int, cl::Buffer&, cl::LocalSpaceArg, cl::LocalSpaceArg, cl::LocalSpaceArg> *add_well_contributions_);
 #endif
 };
 

--- a/opm/simulators/linalg/bda/openclKernels.hpp
+++ b/opm/simulators/linalg/bda/openclKernels.hpp
@@ -23,7 +23,7 @@
 namespace bda
 {
 
-    const char* axpy_s  = R"(
+    inline const char* axpy_s  = R"(
     __kernel void axpy(
         __global double *in,
         const double a,
@@ -42,7 +42,7 @@ namespace bda
 
 
     // returns partial sums, instead of the final dot product
-    const char* dot_1_s = R"(
+    inline const char* dot_1_s = R"(
     __kernel void dot_1(
         __global double *in1,
         __global double *in2,
@@ -83,7 +83,7 @@ namespace bda
 
     // returns partial sums, instead of the final norm
     // the square root must be computed on CPU
-    const char* norm_s = R"(
+    inline const char* norm_s = R"(
     __kernel void norm(
         __global double *in,
         __global double *out,
@@ -122,7 +122,7 @@ namespace bda
 
 
     // p = (p - omega * v) * beta + r
-    const char* custom_s = R"(
+    inline const char* custom_s = R"(
     __kernel void custom(
         __global double *p,
         __global double *v,
@@ -150,7 +150,7 @@ namespace bda
     // algorithm based on:
     // Optimization of Block Sparse Matrix-Vector Multiplication on Shared-MemoryParallel Architectures,
     // Ryan Eberhardt, Mark Hoemmen, 2016, https://doi.org/10.1109/IPDPSW.2016.42
-    const char* spmv_blocked_s = R"(
+    inline const char* spmv_blocked_s = R"(
     __kernel void spmv_blocked(
         __global const double *vals,
         __global const int *cols,
@@ -220,7 +220,7 @@ namespace bda
 
     // ILU apply part 1: forward substitution
     // solves L*x=y where L is a lower triangular sparse blocked matrix
-    const char* ILU_apply1_s = R"(
+    inline const char* ILU_apply1_s = R"(
     __kernel void ILU_apply1(
         __global const double *Lvals,
         __global const unsigned int *Lcols,
@@ -290,7 +290,7 @@ namespace bda
 
     // ILU apply part 2: backward substitution
     // solves U*x=y where L is a lower triangular sparse blocked matrix
-    const char* ILU_apply2_s = R"(
+    inline const char* ILU_apply2_s = R"(
     __kernel void ILU_apply2(
         __global const double *Uvals,
         __global const int *Ucols,
@@ -366,7 +366,7 @@ namespace bda
     }
     )";
 
-    const char* add_well_contributions_s = R"(
+    inline const char* add_well_contributions_s = R"(
     #pragma OPENCL EXTENSION cl_khr_fp64: enable
     #pragma OPENCL EXTENSION cl_khr_int64_base_atomics: enable
 

--- a/opm/simulators/linalg/bda/openclKernels.hpp
+++ b/opm/simulators/linalg/bda/openclKernels.hpp
@@ -366,7 +366,99 @@ namespace bda
     }
     )";
 
+    const char* add_well_contributions_s = R"(
+    #pragma OPENCL EXTENSION cl_khr_fp64: enable
+    #pragma OPENCL EXTENSION cl_khr_int64_base_atomics: enable
 
+    void atomicAdd(volatile __global double *val, const double delta){
+        union{
+            double f;
+            ulong i;
+        } old;
+        
+        union{
+            double f;
+            ulong i;
+        } new;
+
+        do{
+            old.f = *val;
+            new.f = old.f + delta;
+        } while(atom_cmpxchg((volatile __global ulong *)val, old.i, new.i) != old.i);
+    }
+
+    __kernel void add_well_contributions(__global double *valsC,
+                                         __global double *valsD,
+                                         __global double *valsB,
+                                         __global const int *colsC,
+                                         __global const int *colsB,
+                                         __global double *x,
+                                         __global double *y,
+                                         const unsigned int blnc,
+                                         const unsigned int blnr,
+                                         __global const unsigned int *rowptr,
+                                         __local double *localSum,
+                                         __local double *z1,
+                                         __local double *z2){
+        int wgId = get_group_id(0);
+        int wiId = get_local_id(0);
+        int valSize = rowptr[wgId + 1] - rowptr[wgId];
+        int valsPerBlock = blnc*blnr;
+        int numActiveWorkItems = (32/valsPerBlock)*valsPerBlock;
+        int numBlocksPerWarp = 32/valsPerBlock;
+        int c = wiId % blnc;
+        int r = (wiId/blnc) % blnr;
+        double temp;
+
+        localSum[wiId] = 0;
+        if(wiId < numActiveWorkItems){
+            int b = wiId/valsPerBlock + rowptr[wgId];
+            while(b < valSize + rowptr[wgId]){
+                int colIdx = colsB[b];
+                localSum[wiId] += valsB[b*blnc*blnr + r*blnc + c]*x[colIdx*blnc + c];
+                b += numBlocksPerWarp;
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        int stride = valsPerBlock;
+        if(wiId < stride){
+            localSum[wiId] += localSum[wiId + stride];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        if(c == 0 && wiId < valsPerBlock){
+            for(stride = 2; stride > 0; stride /= 2){
+                localSum[wiId] += localSum[wiId + stride];
+            }
+            z1[r] = localSum[wiId];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        if(wiId < blnr){
+            temp = 0.0;
+            for(unsigned int i = 0; i < blnr; ++i){
+                temp += valsD[wgId*blnr*blnr + wiId*blnr + i]*z1[i];
+            }
+            z2[wiId] = temp;
+        }
+
+        barrier(CLK_GLOBAL_MEM_FENCE);
+
+        if(wiId < blnc*valSize){
+            temp = 0.0;
+            int bb = wiId/blnc + rowptr[wgId];
+            int colIdx = colsC[bb];
+            for (unsigned int j = 0; j < blnr; ++j){
+                temp += valsC[bb*blnc*blnr + j*blnc + c]*z2[j];
+            }
+            atomicAdd(&y[colIdx*blnc + c], temp);
+        }
+    }
+    )";
 
 } // end namespace bda
 

--- a/opm/simulators/linalg/bda/openclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/openclSolverBackend.hpp
@@ -140,7 +140,7 @@ private:
     /// \param[in] vals           array of nonzeroes, each block is stored row-wise and contiguous, contains nnz values
     /// \param[in] rows           array of rowPointers, contains N/dim+1 values
     /// \param[in] cols           array of columnIndices, contains nnz values
-    void initialize(int N, int nnz, int dim, double *vals, int *rows, int *cols);
+    void initialize(int N, int nnz, int dim, double *vals, int *rows, int *cols, WellContributions& wellContribs);
 
     /// Clean memory
     void finalize();

--- a/opm/simulators/linalg/bda/openclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/openclSolverBackend.hpp
@@ -74,6 +74,7 @@ private:
     std::unique_ptr<cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, cl::Buffer&, cl::Buffer&, const unsigned int, cl::LocalSpaceArg> > spmv_blocked_k;
     std::shared_ptr<cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, const unsigned int, cl::LocalSpaceArg> > ILU_apply1_k;
     std::shared_ptr<cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, const unsigned int, cl::LocalSpaceArg> > ILU_apply2_k;
+    std::shared_ptr<cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, const unsigned int, cl::Buffer&, cl::LocalSpaceArg, cl::LocalSpaceArg, cl::LocalSpaceArg> > add_well_contributions_k; 
 
     Preconditioner *prec = nullptr;                  // only supported preconditioner is BILU0
     int *toOrder = nullptr, *fromOrder = nullptr;    // BILU0 reorders rows of the matrix via these mappings


### PR DESCRIPTION
I'm trying to add Standard Well support for the OpenCL solver backend. I have written a kernel for this end based on the CUDA kernel from WellContributions.cu. 

The kernel works outside OPM (https://github.com/ducbueno/WellContributions), but when I call it from inside the simulation execution stalls in wellContribs.apply(...).

I'm currently trying to work this out.