### PR TITLE
Fix CMake variable case bug.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ if(OpenCL_FOUND)
   else()
     message(WARNING " OpenCL was found, but this version of opm-simulators relies on CL/cl.hpp, which implements OpenCL 1.0, 1.1 and 1.2.\n Deactivating OpenCL")
     set(OpenCL_FOUND OFF)
+    set(OPENCL_FOUND OFF)
   endif()
 endif()
 


### PR DESCRIPTION
This caused compile failure on a system without the c++ OpenCL binding header cl.hpp.

I will self-merge when green since it is an obvious bug, and since it is critical for me (causes build failure).