### PR TITLE
Reuse umfpack decomposition for multisegment wells.

### DIFF
--- a/opm/simulators/wells/MSWellHelpers.hpp
+++ b/opm/simulators/wells/MSWellHelpers.hpp
@@ -64,7 +64,7 @@ namespace mswellhelpers
         for (size_t i_block = 0; i_block < y.size(); ++i_block) {
             for (size_t i_elem = 0; i_elem < y[i_block].size(); ++i_elem) {
                 if (std::isinf(y[i_block][i_elem]) || std::isnan(y[i_block][i_elem]) ) {
-                    OPM_THROW(Opm::NumericalIssue, "nan or inf value found in invDXDirect due to singular matrix");
+                    OPM_THROW(Opm::NumericalIssue, "nan or inf value found after UMFPack solve due to singular matrix");
                 }
             }
         }

--- a/opm/simulators/wells/MSWellHelpers.hpp
+++ b/opm/simulators/wells/MSWellHelpers.hpp
@@ -71,7 +71,7 @@ namespace mswellhelpers
         return y;
 #else
         // this is not thread safe
-        OPM_THROW(std::runtime_error, "Cannot use aplyUMFPack() without UMFPACK. "
+        OPM_THROW(std::runtime_error, "Cannot use applyUMFPack() without UMFPACK. "
                   "Reconfigure opm-simulator with SuiteSparse/UMFPACK support and recompile.");
 #endif // HAVE_UMFPACK
     }

--- a/opm/simulators/wells/MSWellHelpers.hpp
+++ b/opm/simulators/wells/MSWellHelpers.hpp
@@ -38,12 +38,12 @@ namespace Opm {
 namespace mswellhelpers
 {
 
-#if HAVE_UMFPACK
     /// Applies umfpack and checks for singularity
     template <typename MatrixType, typename VectorType>
     VectorType
     applyUMFPack(const MatrixType& D, std::shared_ptr<Dune::UMFPack<MatrixType> >& linsolver, VectorType x)
     {
+#if HAVE_UMFPACK
         if (!linsolver)
         {
             linsolver.reset(new Dune::UMFPack<MatrixType>(D, 0));
@@ -69,25 +69,12 @@ namespace mswellhelpers
             }
         }
         return y;
-    }
-#endif
-
-    // obtain y = D^-1 * x with a direct solver
-    template <typename MatrixType, typename VectorType>
-    VectorType
-    invDXDirect(const MatrixType& D, VectorType x)
-    {
-#if HAVE_UMFPACK
-        std::shared_ptr<Dune::UMFPack<MatrixType> > linsolver;
-        return applyUMFPack(D, linsolver, x);
 #else
         // this is not thread safe
-        OPM_THROW(std::runtime_error, "Cannot use invDXDirect() without UMFPACK. "
+        OPM_THROW(std::runtime_error, "Cannot use aplyUMFPack() without UMFPACK. "
                   "Reconfigure opm-simulator with SuiteSparse/UMFPACK support and recompile.");
 #endif // HAVE_UMFPACK
     }
-
-
 
 
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -234,8 +234,12 @@ namespace Opm
         // two off-diagonal matrices
         mutable OffDiagMatWell duneB_;
         mutable OffDiagMatWell duneC_;
-        // diagonal matrix for the well
+        // "diagonal" matrix for the well. It has offdiagonal entries for inlets and outlets.
         mutable DiagMatWell duneD_;
+        /// \brief solver for diagonal matrix
+        ///
+        /// This is a shared_ptr as MultisegmentWell is copied in computeWellPotentials...
+        mutable std::shared_ptr<Dune::UMFPack<DiagMatWell> > duneDSolver_;
 
         // residuals of the well equations
         mutable BVectorWell resWell_;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1922,7 +1922,6 @@ namespace Opm
         for (int pv_idx = 0; pv_idx < numWellEq; ++pv_idx) {
             duneD_[0][0][SPres][pv_idx] = control_eq.derivative(pv_idx + numEq);
         }
-        duneDSolver_.reset();
     }
 
 
@@ -2087,7 +2086,6 @@ namespace Opm
         if (accelerationalPressureLossConsidered()) {
             handleAccelerationPressureLoss(seg, well_state);
         }
-        duneDSolver_.reset();
     }
 
 
@@ -2182,7 +2180,6 @@ namespace Opm
         duneD_[seg][seg][SPres][GTotal] -= accelerationPressureLoss.derivative(GTotal + numEq);
         duneD_[seg][seg_upwind][SPres][WFrac] -= accelerationPressureLoss.derivative(WFrac + numEq);
         duneD_[seg][seg_upwind][SPres][GFrac] -= accelerationPressureLoss.derivative(GFrac + numEq);
-        duneDSolver_.reset();
     }
 
 
@@ -2516,6 +2513,8 @@ namespace Opm
         duneD_ = 0.0;
         resWell_ = 0.0;
 
+        duneDSolver_.reset();
+
         well_state.wellVaporizedOilRates()[index_of_well_] = 0.;
         well_state.wellDissolvedGasRates()[index_of_well_] = 0.;
 
@@ -2659,7 +2658,6 @@ namespace Opm
                                              well_state.segPressDropFriction()[seg] +
                                              well_state.segPressDropAcceleration()[seg];
         }
-        duneDSolver_.reset();
     }
 
 
@@ -3211,7 +3209,6 @@ namespace Opm
             duneD_[seg][outlet_segment_index][SPres][pv_idx] = -outlet_pressure.derivative(pv_idx + numEq);
 
         }
-        duneDSolver_.reset();
     }
 
 
@@ -3253,7 +3250,6 @@ namespace Opm
         for (int pv_idx = 0; pv_idx < numWellEq; ++pv_idx) {
             duneD_[seg][outlet_segment_index][SPres][pv_idx] = -outlet_pressure.derivative(pv_idx + numEq);
         }
-        duneDSolver_.reset();
     }
 
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -624,7 +624,6 @@ namespace Opm
         duneB_.mv(x, Bx);
 
         // invDBx = duneD^-1 * Bx_
-        // const BVectorWell invDBx = mswellhelpers::invDXDirect(duneD_, Bx);
         const BVectorWell invDBx = mswellhelpers::applyUMFPack(duneD_, duneDSolver_, Bx);
 
         // Ax = Ax - duneC_^T * invDBx
@@ -1016,7 +1015,6 @@ namespace Opm
     {
         // We assemble the well equations, then we check the convergence,
         // which is why we do not put the assembleWellEq here.
-        //const BVectorWell dx_well = mswellhelpers::invDXDirect(duneD_, resWell_);
         const BVectorWell dx_well = mswellhelpers::applyUMFPack(duneD_, duneDSolver_, resWell_);
 
         updateWellState(dx_well, well_state, deferred_logger);
@@ -1114,14 +1112,12 @@ namespace Opm
         for (int seg = 0; seg < numberOfSegments(); ++seg) {
             if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
                 const int sign = dwells[seg][WFrac] > 0. ? 1 : -1;
-                // const double dx_limited = sign * std::min(std::abs(dwells[seg][WFrac]), relaxation_factor * dFLimit);
                 const double dx_limited = sign * std::min(std::abs(dwells[seg][WFrac]) * relaxation_factor, dFLimit);
                 primary_variables_[seg][WFrac] = old_primary_variables[seg][WFrac] - dx_limited;
             }
 
             if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
                 const int sign = dwells[seg][GFrac] > 0. ? 1 : -1;
-                // const double dx_limited = sign * std::min(std::abs(dwells[seg][GFrac]), relaxation_factor * dFLimit);
                 const double dx_limited = sign * std::min(std::abs(dwells[seg][GFrac]) * relaxation_factor, dFLimit);
                 primary_variables_[seg][GFrac] = old_primary_variables[seg][GFrac] - dx_limited;
             }
@@ -1132,7 +1128,6 @@ namespace Opm
             // update the segment pressure
             {
                 const int sign = dwells[seg][SPres] > 0.? 1 : -1;
-                //const double dx_limited = sign * std::min(std::abs(dwells[seg][SPres]), relaxation_factor * max_pressure_change);
                 const double dx_limited = sign * std::min(std::abs(dwells[seg][SPres]) * relaxation_factor, max_pressure_change);
                 primary_variables_[seg][SPres] = std::max( old_primary_variables[seg][SPres] - dx_limited, 1e5);
             }

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -640,7 +640,6 @@ namespace Opm
     apply(BVector& r) const
     {
         // invDrw_ = duneD^-1 * resWell_
-        // const BVectorWell invDrw = mswellhelpers::invDXDirect(duneD_, resWell_);
         const BVectorWell invDrw = mswellhelpers::applyUMFPack(duneD_, duneDSolver_, resWell_);
         // r = r - duneC_^T * invDrw
         duneC_.mmtv(invDrw, r);
@@ -1000,7 +999,6 @@ namespace Opm
         // resWell = resWell - B * x
         duneB_.mmv(x, resWell);
         // xw = D^-1 * resWell
-        //xw = mswellhelpers::invDXDirect(duneD_, resWell);
         xw = mswellhelpers::applyUMFPack(duneD_, duneDSolver_, resWell);
     }
 
@@ -2398,7 +2396,6 @@ namespace Opm
 
             assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, deferred_logger);
 
-            // const BVectorWell dx_well = mswellhelpers::invDXDirect(duneD_, resWell_);
             const BVectorWell dx_well = mswellhelpers::applyUMFPack(duneD_, duneDSolver_, resWell_);
 
             if (it > param_.strict_inner_iter_ms_wells_)


### PR DESCRIPTION
Currently, we decompose the diagonal matrix every time we apply the well equations. With this change we will store the decomoposition and reuse whenever possible. This will ease the fixing of #2654 and save an additional decomposition there.  But already now this speeds up computation by ~3%. 

Iteration counts stay exactly the same with this change.