### PR TITLE
Move to more consistent ownership of ECL data in EclBaseVanguard

### DIFF
--- a/ebos/ebos_blackoil.cc
+++ b/ebos/ebos_blackoil.cc
@@ -89,18 +89,18 @@ std::unique_ptr<Opm::ParseContext> ebosBlackOilCreateParseContext(int argc, char
     return result;
 }
 
-void ebosBlackOilSetDeck(Opm::Deck* deck,
-                         Opm::ParseContext* parseContext,
-                         Opm::ErrorGuard* errorGuard,
+void ebosBlackOilSetDeck(std::unique_ptr<Opm::Deck> deck,
+                         std::unique_ptr<Opm::ParseContext> parseContext,
+                         std::unique_ptr<Opm::ErrorGuard> errorGuard,
                          double externalSetupTime)
 {
     typedef TTAG(EbosTypeTag) ProblemTypeTag;
     typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+    Vanguard::setExternalParseContext(std::move(parseContext));
+    Vanguard::setExternalErrorGuard(std::move(errorGuard));
+    Vanguard::setExternalDeck(std::move(deck));
 }
 
 int ebosBlackOilMain(int argc, char **argv)

--- a/ebos/ebos_blackoil.hh
+++ b/ebos/ebos_blackoil.hh
@@ -40,9 +40,9 @@ bool ebosBlackOilDeckFileNameIsSet(int argc, char** argv);
 std::string ebosBlackOilGetDeckFileName(int argc, char** argv);
 std::unique_ptr<Opm::ParseContext> ebosBlackOilCreateParseContext(int argc, char** argv);
 
-void ebosBlackOilSetDeck(Opm::Deck* deck,
-                         Opm::ParseContext* parseContext,
-                         Opm::ErrorGuard* errorGuard,
+void ebosBlackOilSetDeck(std::unique_ptr<Opm::Deck> deck,
+                         std::unique_ptr<Opm::ParseContext> parseContext,
+                         std::unique_ptr<Opm::ErrorGuard> errorGuard,
                          double externalSetupTime);
 
 int ebosBlackOilMain(int argc, char** argv);

--- a/ebos/ebos_brine.cc
+++ b/ebos/ebos_brine.cc
@@ -41,18 +41,18 @@ END_PROPERTIES
 
 namespace Opm {
 
-void ebosBrineSetDeck(Opm::Deck* deck,
-                     Opm::ParseContext* parseContext,
-                     Opm::ErrorGuard* errorGuard,
-                     double externalSetupTime)
+void ebosBrineSetDeck(std::unique_ptr<Opm::Deck> deck,
+                      std::unique_ptr<Opm::ParseContext> parseContext,
+                      std::unique_ptr<Opm::ErrorGuard> errorGuard,
+                      double externalSetupTime)
 {
     typedef TTAG(EbosBrineTypeTag) ProblemTypeTag;
     typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+    Vanguard::setExternalParseContext(std::move(parseContext));
+    Vanguard::setExternalErrorGuard(std::move(errorGuard));
+    Vanguard::setExternalDeck(std::move(deck));
 }
 
 int ebosBrineMain(int argc, char **argv)

--- a/ebos/ebos_foam.cc
+++ b/ebos/ebos_foam.cc
@@ -41,18 +41,18 @@ END_PROPERTIES
 
 namespace Opm {
 
-void ebosFoamSetDeck(Opm::Deck* deck,
-                     Opm::ParseContext* parseContext,
-                     Opm::ErrorGuard* errorGuard,
+void ebosFoamSetDeck(std::unique_ptr<Opm::Deck> deck,
+                     std::unique_ptr<Opm::ParseContext> parseContext,
+                     std::unique_ptr<Opm::ErrorGuard> errorGuard,
                      double externalSetupTime)
 {
     typedef TTAG(EbosFoamTypeTag) ProblemTypeTag;
     typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+    Vanguard::setExternalParseContext(std::move(parseContext));
+    Vanguard::setExternalErrorGuard(std::move(errorGuard));
+    Vanguard::setExternalDeck(std::move(deck));
 }
 
 int ebosFoamMain(int argc, char **argv)

--- a/ebos/ebos_foam.hh
+++ b/ebos/ebos_foam.hh
@@ -33,9 +33,9 @@
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Opm {
-void ebosFoamSetDeck(Opm::Deck* deck,
-                     Opm::ParseContext* parseContext,
-                     Opm::ErrorGuard* errorGuard,
+void ebosFoamSetDeck(std::unique_ptr<Opm::Deck> deck,
+                     std::unique_ptr<Opm::ParseContext> parseContext,
+                     std::unique_ptr<Opm::ErrorGuard> errorGuard,
                      double externalSetupTime);
 
 int ebosFoamMain(int argc, char** argv);

--- a/ebos/ebos_gasoil.cc
+++ b/ebos/ebos_gasoil.cc
@@ -57,18 +57,18 @@ END_PROPERTIES
 
 namespace Opm {
 
-void ebosGasOilSetDeck(Opm::Deck* deck,
-                       Opm::ParseContext* parseContext,
-                       Opm::ErrorGuard* errorGuard,
+void ebosGasOilSetDeck(std::unique_ptr<Opm::Deck> deck,
+                       std::unique_ptr<Opm::ParseContext> parseContext,
+                       std::unique_ptr<Opm::ErrorGuard> errorGuard,
                        double externalSetupTime)
 {
     typedef TTAG(EbosGasOilTypeTag) ProblemTypeTag;
     typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+    Vanguard::setExternalParseContext(std::move(parseContext));
+    Vanguard::setExternalErrorGuard(std::move(errorGuard));
+    Vanguard::setExternalDeck(std::move(deck));
 }
 
 int ebosGasOilMain(int argc, char **argv)

--- a/ebos/ebos_gasoil.hh
+++ b/ebos/ebos_gasoil.hh
@@ -33,9 +33,9 @@
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Opm {
-void ebosGasOilSetDeck(Opm::Deck* deck,
-                       Opm::ParseContext* parseContext,
-                       Opm::ErrorGuard* errorGuard,
+void ebosGasOilSetDeck(std::unique_ptr<Opm::Deck> deck,
+                       std::unique_ptr<Opm::ParseContext> parseContext,
+                       std::unique_ptr<Opm::ErrorGuard> errorGuard,
                        double externalSetupTime);
 
 int ebosGasOilMain(int argc, char** argv);

--- a/ebos/ebos_oilwater.cc
+++ b/ebos/ebos_oilwater.cc
@@ -57,18 +57,18 @@ END_PROPERTIES
 
 namespace Opm {
 
-void ebosOilWaterSetDeck(Opm::Deck* deck,
-                         Opm::ParseContext* parseContext,
-                         Opm::ErrorGuard* errorGuard,
+void ebosOilWaterSetDeck(std::unique_ptr<Opm::Deck> deck,
+                         std::unique_ptr<Opm::ParseContext> parseContext,
+                         std::unique_ptr<Opm::ErrorGuard> errorGuard,
                          double externalSetupTime)
 {
     typedef TTAG(EbosOilWaterTypeTag) ProblemTypeTag;
     typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+    Vanguard::setExternalParseContext(std::move(parseContext));
+    Vanguard::setExternalErrorGuard(std::move(errorGuard));
+    Vanguard::setExternalDeck(std::move(deck));
 }
 
 int ebosOilWaterMain(int argc, char **argv)

--- a/ebos/ebos_oilwater.hh
+++ b/ebos/ebos_oilwater.hh
@@ -33,9 +33,9 @@
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Opm {
-void ebosOilWaterSetDeck(Opm::Deck* deck,
-                         Opm::ParseContext* parseContext,
-                         Opm::ErrorGuard* errorGuard,
+void ebosOilWaterSetDeck(std::unique_ptr<Opm::Deck> deck,
+                         std::unique_ptr<Opm::ParseContext> parseContext,
+                         std::unique_ptr<Opm::ErrorGuard> errorGuard,
                          double externalSetupTime);
 
 int ebosOilWaterMain(int argc, char** argv);

--- a/ebos/ebos_oilwaterpolymer.cc
+++ b/ebos/ebos_oilwaterpolymer.cc
@@ -59,18 +59,18 @@ END_PROPERTIES
 
 namespace Opm {
 
-void ebosOilWaterPolymerSetDeck(Opm::Deck* deck,
-                                Opm::ParseContext* parseContext,
-                                Opm::ErrorGuard* errorGuard,
+void ebosOilWaterPolymerSetDeck(std::unique_ptr<Opm::Deck> deck,
+                                std::unique_ptr<Opm::ParseContext> parseContext,
+                                std::unique_ptr<Opm::ErrorGuard> errorGuard,
                                 double externalSetupTime)
 {
     typedef TTAG(EbosOilWaterPolymerTypeTag) ProblemTypeTag;
     typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+    Vanguard::setExternalParseContext(std::move(parseContext));
+    Vanguard::setExternalErrorGuard(std::move(errorGuard));
+    Vanguard::setExternalDeck(std::move(deck));
 }
 
 int ebosOilWaterPolymerMain(int argc, char **argv)

--- a/ebos/ebos_oilwaterpolymer.hh
+++ b/ebos/ebos_oilwaterpolymer.hh
@@ -33,9 +33,9 @@
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Opm {
-void ebosOilWaterPolymerSetDeck(Opm::Deck* deck,
-                                Opm::ParseContext* parseContext,
-                                Opm::ErrorGuard* errorGuard,
+void ebosOilWaterPolymerSetDeck(std::unique_ptr<Opm::Deck> deck,
+                                std::unique_ptr<Opm::ParseContext> parseContext,
+                                std::unique_ptr<Opm::ErrorGuard> errorGuard,
                                 double externalSetupTime);
 
 int ebosOilWaterPolymerMain(int argc, char** argv);

--- a/ebos/ebos_polymer.cc
+++ b/ebos/ebos_polymer.cc
@@ -41,18 +41,18 @@ END_PROPERTIES
 
 namespace Opm {
 
-void ebosPolymerSetDeck(Opm::Deck* deck,
-                        Opm::ParseContext* parseContext,
-                        Opm::ErrorGuard* errorGuard,
+void ebosPolymerSetDeck(std::unique_ptr<Opm::Deck> deck,
+                        std::unique_ptr<Opm::ParseContext> parseContext,
+                        std::unique_ptr<Opm::ErrorGuard> errorGuard,
                         double externalSetupTime)
 {
     typedef TTAG(EbosPolymerTypeTag) ProblemTypeTag;
     typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+    Vanguard::setExternalParseContext(std::move(parseContext));
+    Vanguard::setExternalErrorGuard(std::move(errorGuard));
+    Vanguard::setExternalDeck(std::move(deck));
 }
 
 int ebosPolymerMain(int argc, char **argv)

--- a/ebos/ebos_polymer.hh
+++ b/ebos/ebos_polymer.hh
@@ -33,9 +33,9 @@
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Opm {
-void ebosPolymerSetDeck(Opm::Deck* deck,
-                        Opm::ParseContext* parseContext,
-                        Opm::ErrorGuard* errorGuard,
+void ebosPolymerSetDeck(std::unique_ptr<Opm::Deck> deck,
+                        std::unique_ptr<Opm::ParseContext> parseContext,
+                        std::unique_ptr<Opm::ErrorGuard> errorGuard,
                         double externalSetupTime);
 
 int ebosPolymerMain(int argc, char** argv);

--- a/ebos/ebos_solvent.cc
+++ b/ebos/ebos_solvent.cc
@@ -41,18 +41,18 @@ END_PROPERTIES
 
 namespace Opm {
 
-void ebosSolventSetDeck(Opm::Deck* deck,
-                        Opm::ParseContext* parseContext,
-                        Opm::ErrorGuard* errorGuard,
+void ebosSolventSetDeck(std::unique_ptr<Opm::Deck> deck,
+                        std::unique_ptr<Opm::ParseContext> parseContext,
+                        std::unique_ptr<Opm::ErrorGuard> errorGuard,
                         double externalSetupTime)
 {
     typedef TTAG(EbosSolventTypeTag) ProblemTypeTag;
     typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+    Vanguard::setExternalParseContext(std::move(parseContext));
+    Vanguard::setExternalErrorGuard(std::move(errorGuard));
+    Vanguard::setExternalDeck(std::move(deck));
 }
 
 int ebosSolventMain(int argc, char **argv)

--- a/ebos/ebos_solvent.hh
+++ b/ebos/ebos_solvent.hh
@@ -33,9 +33,9 @@
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Opm {
-void ebosSolventSetDeck(Opm::Deck* deck,
-                        Opm::ParseContext* parseContext,
-                        Opm::ErrorGuard* errorGuard,
+void ebosSolventSetDeck(std::unique_ptr<Opm::Deck> deck,
+                        std::unique_ptr<Opm::ParseContext> parseContext,
+                        std::unique_ptr<Opm::ErrorGuard> errorGuard,
                         double externalSetupTime);
 
 int ebosSolventMain(int argc, char** argv);

--- a/ebos/ebos_thermal.cc
+++ b/ebos/ebos_thermal.cc
@@ -41,18 +41,18 @@ END_PROPERTIES
 
 namespace Opm {
 
-void ebosThermalSetDeck(Opm::Deck* deck,
-                        Opm::ParseContext* parseContext,
-                        Opm::ErrorGuard* errorGuard,
+void ebosThermalSetDeck(std::unique_ptr<Opm::Deck> deck,
+                        std::unique_ptr<Opm::ParseContext> parseContext,
+                        std::unique_ptr<Opm::ErrorGuard> errorGuard,
                         double externalSetupTime)
 {
     typedef TTAG(EbosThermalTypeTag) ProblemTypeTag;
     typedef GET_PROP_TYPE(ProblemTypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(externalSetupTime);
-    Vanguard::setExternalParseContext(parseContext);
-    Vanguard::setExternalErrorGuard(errorGuard);
-    Vanguard::setExternalDeck(deck);
+    Vanguard::setExternalParseContext(std::move(parseContext));
+    Vanguard::setExternalErrorGuard(std::move(errorGuard));
+    Vanguard::setExternalDeck(std::move(deck));
 }
 
 int ebosThermalMain(int argc, char **argv)

--- a/ebos/ebos_thermal.hh
+++ b/ebos/ebos_thermal.hh
@@ -33,9 +33,9 @@
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Opm {
-void ebosThermalSetDeck(Opm::Deck* deck,
-                        Opm::ParseContext* parseContext,
-                        Opm::ErrorGuard* errorGuard,
+void ebosThermalSetDeck(std::unique_ptr<Opm::Deck> deck,
+                        std::unique_ptr<Opm::ParseContext> parseContext,
+                        std::unique_ptr<Opm::ErrorGuard> errorGuard,
                         double externalSetupTime);
 
 int ebosThermalMain(int argc, char** argv);

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -351,8 +351,8 @@ public:
         }
         else
             eclSchedule_ = externalEclSchedule_.get();
-        this->summaryState_.reset( new Opm::SummaryState( std::chrono::system_clock::from_time_t(this->eclSchedule_->getStartTime() )));
-        this->actionState_.reset( new Opm::Action::State() );
+        this->summaryState_ = std::make_unique<Opm::SummaryState>( std::chrono::system_clock::from_time_t(this->eclSchedule_->getStartTime() ));
+        this->actionState_ = std::make_unique<Opm::Action::State>() ;
 
         if (!externalEclSummaryConfig_) {
             // create the schedule object. Note that if eclState is supposed to represent

--- a/ebos/mebos_main.cc
+++ b/ebos/mebos_main.cc
@@ -123,9 +123,9 @@ int main(int argc, char **argv)
         if (polymerActive && oilActive && waterActive) {
             if (myRank == 0)
                 std::cout << "Using oil-water-polymer mode" << std::endl;
-            Opm::ebosOilWaterPolymerSetDeck(deck.get(),
-                                            parseContext.get(),
-                                            errorGuard.get(),
+            Opm::ebosOilWaterPolymerSetDeck(std::move(deck),
+                                            std::move(parseContext),
+                                            std::move(errorGuard),
                                             externalSetupTimer.elapsed());
             return Opm::ebosOilWaterPolymerMain(argc, argv);
         }
@@ -154,9 +154,9 @@ int main(int argc, char **argv)
         if (oilActive && waterActive) {
             if (myRank == 0)
                 std::cout << "Using oil-water mode" << std::endl;
-            Opm::ebosOilWaterSetDeck(deck.get(),
-                                     parseContext.get(),
-                                     errorGuard.get(),
+            Opm::ebosOilWaterSetDeck(std::move(deck),
+                                     std::move(parseContext),
+                                     std::move(errorGuard),
                                      externalSetupTimer.elapsed());
             return Opm::ebosOilWaterMain(argc, argv);
         }
@@ -164,9 +164,9 @@ int main(int argc, char **argv)
             // run ebos_gasoil
             if (myRank == 0)
                 std::cout << "Using gas-oil mode" << std::endl;
-            Opm::ebosGasOilSetDeck(deck.get(),
-                                   parseContext.get(),
-                                   errorGuard.get(),
+            Opm::ebosGasOilSetDeck(std::move(deck),
+                                   std::move(parseContext),
+                                   std::move(errorGuard),
                                    externalSetupTimer.elapsed());
             return Opm::ebosGasOilMain(argc, argv);
         }
@@ -202,9 +202,9 @@ int main(int argc, char **argv)
         // run ebos_foam
         if (myRank == 0)
             std::cout << "Using foam mode" << std::endl;
-        Opm::ebosFoamSetDeck(deck.get(),
-                             parseContext.get(),
-                             errorGuard.get(),
+        Opm::ebosFoamSetDeck(std::move(deck),
+                             std::move(parseContext),
+                             std::move(errorGuard),
                              externalSetupTimer.elapsed());
         return Opm::ebosFoamMain(argc, argv);
     }
@@ -233,9 +233,9 @@ int main(int argc, char **argv)
         // run ebos_polymer
         if (myRank == 0)
             std::cout << "Using polymer mode" << std::endl;
-        Opm::ebosPolymerSetDeck(deck.get(),
-                                parseContext.get(),
-                                errorGuard.get(),
+        Opm::ebosPolymerSetDeck(std::move(deck),
+                                std::move(parseContext),
+                                std::move(errorGuard),
                                 externalSetupTimer.elapsed());
         return Opm::ebosPolymerMain(argc, argv);
     }
@@ -264,9 +264,9 @@ int main(int argc, char **argv)
         // run ebos_solvent
         if (myRank == 0)
             std::cout << "Using solvent mode" << std::endl;
-        Opm::ebosSolventSetDeck(deck.get(),
-                                parseContext.get(),
-                                errorGuard.get(),
+        Opm::ebosSolventSetDeck(std::move(deck),
+                                std::move(parseContext),
+                                std::move(errorGuard),
                                 externalSetupTimer.elapsed());
         return Opm::ebosSolventMain(argc, argv);
     }
@@ -295,18 +295,18 @@ int main(int argc, char **argv)
         // run ebos_thermal
         if (myRank == 0)
             std::cout << "Using thermal mode" << std::endl;
-        Opm::ebosThermalSetDeck(deck.get(),
-                                parseContext.get(),
-                                errorGuard.get(),
+        Opm::ebosThermalSetDeck(std::move(deck),
+                                std::move(parseContext),
+                                std::move(errorGuard),
                                 externalSetupTimer.elapsed());
         return Opm::ebosThermalMain(argc, argv);
     }
     else {
         if (myRank == 0)
             std::cout << "Using blackoil mode" << std::endl;
-        Opm::ebosBlackOilSetDeck(deck.get(),
-                                 parseContext.get(),
-                                 errorGuard.get(),
+        Opm::ebosBlackOilSetDeck(std::move(deck),
+                                 std::move(parseContext),
+                                 std::move(errorGuard),
                                  externalSetupTimer.elapsed());
         return Opm::ebosBlackOilMain(argc, argv);
     }

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -34,16 +34,19 @@
 
 namespace Opm {
 
-void flowEbosBlackoilSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosBlackoilSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                             std::unique_ptr<EclipseState> eclState,
+                             std::unique_ptr<Schedule> schedule,
+                             std::unique_ptr<SummaryConfig> summaryConfig)
 {
     typedef TTAG(EclFlowProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
-    Vanguard::setExternalEclState(&eclState);
-    Vanguard::setExternalSchedule(&schedule);
-    Vanguard::setExternalSummaryConfig(&summaryConfig);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 
 std::unique_ptr<Opm::FlowMainEbos<TTAG(EclFlowProblem)>>

--- a/flow/flow_ebos_blackoil.hpp
+++ b/flow/flow_ebos_blackoil.hpp
@@ -24,7 +24,10 @@
 #include <opm/simulators/flow/FlowMainEbos.hpp>
 
 namespace Opm {
-void flowEbosBlackoilSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosBlackoilSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                             std::unique_ptr<EclipseState> eclState,
+                             std::unique_ptr<Schedule> schedule,
+                             std::unique_ptr<SummaryConfig> summaryConfig);
 
 int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles);
 

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -36,16 +36,19 @@ SET_BOOL_PROP(EclFlowBrineProblem, EnableBrine, true);
 }}
 
 namespace Opm {
-void flowEbosBrineSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosBrineSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                          std::unique_ptr<EclipseState> eclState,
+                          std::unique_ptr<Schedule> schedule,
+                          std::unique_ptr<SummaryConfig> summaryConfig)
 {
     typedef TTAG(EclFlowBrineProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
-    Vanguard::setExternalEclState(&eclState);
-    Vanguard::setExternalSchedule(&schedule);
-    Vanguard::setExternalSummaryConfig(&summaryConfig);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 
 

--- a/flow/flow_ebos_brine.hpp
+++ b/flow/flow_ebos_brine.hpp
@@ -24,7 +24,10 @@
 
 
 namespace Opm {
-void flowEbosBrineSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosBrineSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                          std::unique_ptr<EclipseState> eclState,
+                          std::unique_ptr<Schedule> schedule,
+                          std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosBrineMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -36,16 +36,19 @@ SET_BOOL_PROP(EclFlowEnergyProblem, EnableEnergy, true);
 }}
 
 namespace Opm {
-void flowEbosEnergySetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosEnergySetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                          std::unique_ptr<EclipseState> eclState,
+                          std::unique_ptr<Schedule> schedule,
+                          std::unique_ptr<SummaryConfig> summaryConfig)
 {
     typedef TTAG(EclFlowEnergyProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
-    Vanguard::setExternalEclState(&eclState);
-    Vanguard::setExternalSchedule(&schedule);
-    Vanguard::setExternalSummaryConfig(&summaryConfig);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_energy.hpp
+++ b/flow/flow_ebos_energy.hpp
@@ -23,7 +23,10 @@
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
-void flowEbosEnergySetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosEnergySetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                           std::unique_ptr<EclipseState> eclState,
+                           std::unique_ptr<Schedule> schedule,
+                           std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -36,16 +36,19 @@ SET_BOOL_PROP(EclFlowFoamProblem, EnableFoam, true);
 }}
 
 namespace Opm {
-void flowEbosFoamSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosFoamSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                         std::unique_ptr<EclipseState> eclState,
+                         std::unique_ptr<Schedule> schedule,
+                         std::unique_ptr<SummaryConfig> summaryConfig)
 {
     typedef TTAG(EclFlowFoamProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
-    Vanguard::setExternalEclState(&eclState);
-    Vanguard::setExternalSchedule(&schedule);
-    Vanguard::setExternalSummaryConfig(&summaryConfig);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 
 

--- a/flow/flow_ebos_foam.hpp
+++ b/flow/flow_ebos_foam.hpp
@@ -24,7 +24,10 @@
 
 
 namespace Opm {
-void flowEbosFoamSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosFoamSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                         std::unique_ptr<EclipseState> eclState,
+                         std::unique_ptr<Schedule> schedule,
+                         std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosFoamMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -60,16 +60,19 @@ public:
 }}
 
 namespace Opm {
-void flowEbosGasOilSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosGasOilSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                           std::unique_ptr<EclipseState> eclState,
+                           std::unique_ptr<Schedule> schedule,
+                           std::unique_ptr<SummaryConfig> summaryConfig)
 {
     typedef TTAG(EclFlowGasOilProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
-    Vanguard::setExternalEclState(&eclState);
-    Vanguard::setExternalSchedule(&schedule);
-    Vanguard::setExternalSummaryConfig(&summaryConfig);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 
 

--- a/flow/flow_ebos_gasoil.hpp
+++ b/flow/flow_ebos_gasoil.hpp
@@ -23,7 +23,10 @@
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
-void flowEbosGasOilSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosGasOilSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                           std::unique_ptr<EclipseState> eclState,
+                           std::unique_ptr<Schedule> schedule,
+                           std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosGasOilMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -60,16 +60,19 @@ public:
 }}
 
 namespace Opm {
-void flowEbosOilWaterSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosOilWaterSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                             std::unique_ptr<EclipseState> eclState,
+                             std::unique_ptr<Schedule> schedule,
+                             std::unique_ptr<SummaryConfig> summaryConfig)
 {
     typedef TTAG(EclFlowOilWaterProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
-    Vanguard::setExternalEclState(&eclState);
-    Vanguard::setExternalSchedule(&schedule);
-    Vanguard::setExternalSummaryConfig(&summaryConfig);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_oilwater.hpp
+++ b/flow/flow_ebos_oilwater.hpp
@@ -23,7 +23,10 @@
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
-void flowEbosOilWaterSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosOilWaterSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                             std::unique_ptr<EclipseState> eclState,
+                             std::unique_ptr<Schedule> schedule,
+                             std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosOilWaterMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_oilwater_brine.cpp
+++ b/flow/flow_ebos_oilwater_brine.cpp
@@ -60,16 +60,19 @@ public:
 }}
 
 namespace Opm {
-void flowEbosOilWaterBrineSetDeck(double setupTime, Deck* deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosOilWaterBrineSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                                  std::unique_ptr<EclipseState> eclState,
+                                  std::unique_ptr<Schedule> schedule,
+                                  std::unique_ptr<SummaryConfig> summaryConfig)
 {
     typedef TTAG(EclFlowOilWaterBrineProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
-    Vanguard::setExternalEclState(&eclState);
-    Vanguard::setExternalSchedule(&schedule);
-    Vanguard::setExternalSummaryConfig(&summaryConfig);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_oilwater_brine.hpp
+++ b/flow/flow_ebos_oilwater_brine.hpp
@@ -23,7 +23,10 @@
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
-void flowEbosOilWaterBrineSetDeck(double setupTime, Deck* deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosOilWaterBrineSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                                  std::unique_ptr<EclipseState> eclState,
+                                  std::unique_ptr<Schedule> schedule,
+                                  std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosOilWaterBrineMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -61,16 +61,19 @@ public:
 }}
 
 namespace Opm {
-void flowEbosOilWaterPolymerSetDeck(double setupTime, Deck* deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosOilWaterPolymerSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                                    std::unique_ptr<EclipseState> eclState,
+                                    std::unique_ptr<Schedule> schedule,
+                                    std::unique_ptr<SummaryConfig> summaryConfig)
 {
     typedef TTAG(EclFlowOilWaterPolymerProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
-    Vanguard::setExternalEclState(&eclState);
-    Vanguard::setExternalSchedule(&schedule);
-    Vanguard::setExternalSummaryConfig(&summaryConfig);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_oilwater_polymer.hpp
+++ b/flow/flow_ebos_oilwater_polymer.hpp
@@ -23,7 +23,10 @@
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
-void flowEbosOilWaterPolymerSetDeck(double setupTime, Deck* deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosOilWaterPolymerSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                                    std::unique_ptr<EclipseState> eclState,
+                                    std::unique_ptr<Schedule> schedule,
+                                    std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosOilWaterPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_oilwater_polymer_injectivity.cpp
+++ b/flow/flow_ebos_oilwater_polymer_injectivity.cpp
@@ -68,7 +68,7 @@ namespace Opm {
     typedef TTAG(EclFlowOilWaterPolymerInjectivityProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
-    Vanguard::setExternalDeck(&deck, &eclState);
+    Vanguard::setExternalDeck(std::move(deck, &eclState));
 } */
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -36,16 +36,19 @@ SET_BOOL_PROP(EclFlowPolymerProblem, EnablePolymer, true);
 }}
 
 namespace Opm {
-void flowEbosPolymerSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosPolymerSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                            std::unique_ptr<EclipseState> eclState,
+                            std::unique_ptr<Schedule> schedule,
+                            std::unique_ptr<SummaryConfig> summaryConfig)
 {
     typedef TTAG(EclFlowPolymerProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
-    Vanguard::setExternalEclState(&eclState);
-    Vanguard::setExternalSchedule(&schedule);
-    Vanguard::setExternalSummaryConfig(&summaryConfig);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_polymer.hpp
+++ b/flow/flow_ebos_polymer.hpp
@@ -23,7 +23,10 @@
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
-void flowEbosPolymerSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosPolymerSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                            std::unique_ptr<EclipseState> eclState,
+                            std::unique_ptr<Schedule> schedule,
+                            std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles);
 }
 

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -36,16 +36,19 @@ SET_BOOL_PROP(EclFlowSolventProblem, EnableSolvent, true);
 }}
 
 namespace Opm {
-void flowEbosSolventSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+void flowEbosSolventSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                            std::unique_ptr<EclipseState> eclState,
+                            std::unique_ptr<Schedule> schedule,
+                            std::unique_ptr<SummaryConfig> summaryConfig)
 {
     typedef TTAG(EclFlowSolventProblem) TypeTag;
     typedef GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
 
     Vanguard::setExternalSetupTime(setupTime);
-    Vanguard::setExternalDeck(deck);
-    Vanguard::setExternalEclState(&eclState);
-    Vanguard::setExternalSchedule(&schedule);
-    Vanguard::setExternalSummaryConfig(&summaryConfig);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 
 

--- a/flow/flow_ebos_solvent.hpp
+++ b/flow/flow_ebos_solvent.hpp
@@ -24,7 +24,10 @@
 
 
 namespace Opm {
-void flowEbosSolventSetDeck(double setupTime, Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig);
+void flowEbosSolventSetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                            std::unique_ptr<EclipseState> eclState,
+                            std::unique_ptr<Schedule> schedule,
+                            std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosSolventMain(int argc, char** argv, bool outoutCout, bool outputFiles);
 }
 

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -78,13 +78,13 @@ END_PROPERTIES
 
 namespace Opm {
   template <class TypeTag>
-  void flowEbosSetDeck(Deck *deck, EclipseState& eclState, Schedule& schedule, SummaryConfig& summaryConfig)
+  void flowEbosSetDeck(std::unique_ptr<Deck> deck, std::unique_ptr<EclipseState> eclState, std::unique_ptr<Schedule> schedule, std::unique_ptr<SummaryConfig> summaryConfig)
   {
     using Vanguard = typename GET_PROP_TYPE(TypeTag, Vanguard);
-    Vanguard::setExternalDeck(deck);
-    Vanguard::setExternalEclState(&eclState);
-    Vanguard::setExternalSchedule(&schedule);
-    Vanguard::setExternalSummaryConfig(&summaryConfig);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
   }
 
 // ----------------- Main program -----------------
@@ -142,16 +142,16 @@ namespace Opm
 
         Main(int argc,
              char** argv,
-             std::shared_ptr<Opm::Deck> deck,
-             std::shared_ptr<Opm::EclipseState> eclipseState,
-             std::shared_ptr<Opm::Schedule> schedule,
-             std::shared_ptr<Opm::SummaryConfig> summaryConfig)
+             std::unique_ptr<Opm::Deck> deck,
+             std::unique_ptr<Opm::EclipseState> eclipseState,
+             std::unique_ptr<Opm::Schedule> schedule,
+             std::unique_ptr<Opm::SummaryConfig> summaryConfig)
             : argc_(argc)
             , argv_(argv)
-            , deck_(deck)
-            , eclipseState_(eclipseState)
-            , schedule_(schedule)
-            , summaryConfig_(summaryConfig)
+            , deck_(std::move(deck))
+            , eclipseState_(std::move(eclipseState))
+            , schedule_(std::move(schedule))
+            , summaryConfig_(std::move(summaryConfig))
         {
         }
 
@@ -188,10 +188,10 @@ namespace Opm
                 // case. E.g. check that number of phases == 3
                 Opm::flowEbosBlackoilSetDeck(
                     setupTime_,
-                    deck_.get(),
-                    *eclipseState_,
-                    *schedule_,
-                    *summaryConfig_);
+                    std::move(deck_),
+                    std::move(eclipseState_),
+                    std::move(schedule_),
+                    std::move(summaryConfig_));
                 return Opm::flowEbosBlackoilMainInit(
                     argc_, argv_, outputCout_, outputFiles_);
             } else {
@@ -215,12 +215,13 @@ namespace Opm
             else if( phases.size() == 2 ) {
                 // oil-gas
                 if (phases.active( Opm::Phase::GAS )) {
-                    Opm::flowEbosGasOilSetDeck(setupTime_, deck_.get(), *eclipseState_, *schedule_, *summaryConfig_);
+                    Opm::flowEbosGasOilSetDeck(setupTime_, std::move(deck_), std::move(eclipseState_),
+                                               std::move(schedule_), std::move(summaryConfig_));
                     return Opm::flowEbosGasOilMain(argc_, argv_, outputCout_, outputFiles_);
                 }
                 // oil-water
                 else if ( phases.active( Opm::Phase::WATER ) ) {
-                    Opm::flowEbosOilWaterSetDeck(setupTime_, deck_.get(), *eclipseState_, *schedule_, *summaryConfig_);
+                    Opm::flowEbosOilWaterSetDeck(setupTime_, std::move(deck_), std::move(eclipseState_), std::move(schedule_), std::move(summaryConfig_));
                     return Opm::flowEbosOilWaterMain(argc_, argv_, outputCout_, outputFiles_);
                 }
                 else {
@@ -247,16 +248,25 @@ namespace Opm
                 }
 
                 if ( phases.size() == 3 ) { // oil water polymer case
-                    Opm::flowEbosOilWaterPolymerSetDeck(setupTime_, deck_.get(), *eclipseState_, *schedule_, *summaryConfig_);
+                    Opm::flowEbosOilWaterPolymerSetDeck(setupTime_, std::move(deck_),
+                                                        std::move(eclipseState_),
+                                                        std::move(schedule_),
+                                                        std::move(summaryConfig_));
                     return Opm::flowEbosOilWaterPolymerMain(argc_, argv_, outputCout_, outputFiles_);
                 } else {
-                    Opm::flowEbosPolymerSetDeck(setupTime_, deck_.get(), *eclipseState_, *schedule_, *summaryConfig_);
+                    Opm::flowEbosPolymerSetDeck(setupTime_, std::move(deck_),
+                                                std::move(eclipseState_),
+                                                std::move(schedule_),
+                                                std::move(summaryConfig_));
                     return Opm::flowEbosPolymerMain(argc_, argv_, outputCout_, outputFiles_);
                 }
             }
             // Foam case
             else if ( phases.active( Opm::Phase::FOAM ) ) {
-                Opm::flowEbosFoamSetDeck(setupTime_, deck_.get(), *eclipseState_, *schedule_, *summaryConfig_);
+                Opm::flowEbosFoamSetDeck(setupTime_, std::move(deck_),
+                                         std::move(eclipseState_),
+                                         std::move(schedule_),
+                                         std::move(summaryConfig_));
                 return Opm::flowEbosFoamMain(argc_, argv_, outputCout_, outputFiles_);
             }
             // Brine case
@@ -268,27 +278,42 @@ namespace Opm
                     return EXIT_FAILURE;
                 }
                 if ( phases.size() == 3 ) { // oil water brine case
-                    Opm::flowEbosOilWaterBrineSetDeck(setupTime_, deck_.get(), *eclipseState_, *schedule_, *summaryConfig_);
+                    Opm::flowEbosOilWaterBrineSetDeck(setupTime_, std::move(deck_),
+                                                      std::move(eclipseState_),
+                                                      std::move(schedule_),
+                                                      std::move(summaryConfig_));
                     return Opm::flowEbosOilWaterBrineMain(argc_, argv_, outputCout_, outputFiles_);
                 } else {
-                    Opm::flowEbosBrineSetDeck(setupTime_, deck_.get(), *eclipseState_, *schedule_, *summaryConfig_);
+                    Opm::flowEbosBrineSetDeck(setupTime_, std::move(deck_),
+                                              std::move(eclipseState_),
+                                              std::move(schedule_),
+                                              std::move(summaryConfig_));
                     return Opm::flowEbosBrineMain(argc_, argv_, outputCout_, outputFiles_);
                 }
             }
             // Solvent case
             else if ( phases.active( Opm::Phase::SOLVENT ) ) {
-                Opm::flowEbosSolventSetDeck(setupTime_, deck_.get(), *eclipseState_, *schedule_, *summaryConfig_);
+                Opm::flowEbosSolventSetDeck(setupTime_, std::move(deck_),
+                                            std::move(eclipseState_),
+                                            std::move(schedule_),
+                                            std::move(summaryConfig_));
                 return Opm::flowEbosSolventMain(argc_, argv_, outputCout_, outputFiles_);
             }
             // Energy case
             else if (eclipseState_->getSimulationConfig().isThermal()) {
-                Opm::flowEbosEnergySetDeck(setupTime_, deck_.get(), *eclipseState_, *schedule_, *summaryConfig_);
+                Opm::flowEbosEnergySetDeck(setupTime_, std::move(deck_),
+                                           std::move(eclipseState_),
+                                           std::move(schedule_),
+                                           std::move(summaryConfig_));
                 return Opm::flowEbosEnergyMain(argc_, argv_, outputCout_, outputFiles_);
             }
 #endif // FLOW_BLACKOIL_ONLY
             // Blackoil case
             else if( phases.size() == 3 ) {
-                Opm::flowEbosBlackoilSetDeck(setupTime_, deck_.get(), *eclipseState_, *schedule_, *summaryConfig_);
+                Opm::flowEbosBlackoilSetDeck(setupTime_, std::move(deck_),
+                                             std::move(eclipseState_),
+                                             std::move(schedule_),
+                                             std::move(summaryConfig_));
                 return Opm::flowEbosBlackoilMain(argc_, argv_, outputCout_, outputFiles_);
             }
             else {
@@ -301,7 +326,10 @@ namespace Opm
         template <class TypeTag>
         int dispatchStatic_()
         {
-            Opm::flowEbosSetDeck<TypeTag>(deck_.get(), *eclipseState_, *schedule_, *summaryConfig_);
+            Opm::flowEbosSetDeck<TypeTag>(std::move(deck_),
+                                          std::move(eclipseState_),
+                                          std::move(schedule_),
+                                          std::move(summaryConfig_));
             return Opm::flowEbosMain<TypeTag>(argc_, argv_, outputCout_, outputFiles_);
         }
 
@@ -692,10 +720,10 @@ namespace Opm
         std::string deckFilename_;
         std::string flowProgName_;
         char *saveArgs_[2];
-        std::shared_ptr<Opm::Deck> deck_;
-        std::shared_ptr<Opm::EclipseState> eclipseState_;
-        std::shared_ptr<Opm::Schedule> schedule_;
-        std::shared_ptr<Opm::SummaryConfig> summaryConfig_;
+        std::unique_ptr<Opm::Deck> deck_;
+        std::unique_ptr<Opm::EclipseState> eclipseState_;
+        std::unique_ptr<Opm::Schedule> schedule_;
+        std::unique_ptr<Opm::SummaryConfig> summaryConfig_;
     };
 
 } // namespace Opm


### PR DESCRIPTION
We resort to consistently use unique_ptrs in EclBaseVanguard for the data read from ECL files or set externally. This means that
during the simulation EclBaseVanguard owns this data and not Main or the ebos setup functions. This ownership transfer becomes
transparent due to std::move. 

This came up when trying to fix the parallel runs of ebos and during that removing some code duplication. It seemed like a necessary step.