### PR TITLE
Broken Constraints: Fix Diagnostic Message

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2184,7 +2184,7 @@ namespace Opm {
     actionOnBrokenConstraints(const Group& group, const Group::ExceedAction& exceed_action, const Group::ProductionCMode& newControl, Opm::DeferredLogger& deferred_logger) {
 
         auto& well_state = well_state_;
-        const Group::ProductionCMode& oldControl = well_state.currentProductionGroupControl(group.name());
+        const Group::ProductionCMode oldControl = well_state.currentProductionGroupControl(group.name());
 
         std::ostringstream ss;
 
@@ -2240,7 +2240,7 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     actionOnBrokenConstraints(const Group& group, const Group::InjectionCMode& newControl, const Phase& controlPhase, Opm::DeferredLogger& deferred_logger) {
         auto& well_state = well_state_;
-        const Group::InjectionCMode& oldControl = well_state.currentInjectionGroupControl(controlPhase, group.name());
+        const Group::InjectionCMode oldControl = well_state.currentInjectionGroupControl(controlPhase, group.name());
 
         std::ostringstream ss;
         if (oldControl != newControl) {


### PR DESCRIPTION
Especially, grab a copy of the "oldControl" to avoid reading through a reference for which the underlying object is reset in
```
setCurrent*GroupControl()
```
This in turn avoids generating confusing diagnostic messages of the form
```
Switching production control mode for group G from FLD to FLD
```