### PR TITLE
Implements a Python step() method.

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -308,6 +308,13 @@ namespace Opm
             return execute_(&FlowMainEbos::runSimulatorInit, /*cleanup=*/false);
         }
 
+        // Returns true unless "EXIT" was encountered in the schedule
+        //   section of the input datafile.
+        int executeStep()
+        {
+            return simulator_->runStep(*simtimer_);
+        }
+
         // Print an ASCII-art header to the PRT and DEBUG files.
         // \return Whether unkown keywords were seen during parsing.
         static void printPRTHeader(bool output_cout)

--- a/opm/simulators/flow/python/simulators.hpp
+++ b/opm/simulators/flow/python/simulators.hpp
@@ -34,6 +34,7 @@ private:
 public:
     BlackOilSimulator( const std::string &deckFilename);
     int run();
+    int step();
     int step_init();
 
 private:

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -28,6 +28,14 @@ int BlackOilSimulator::run()
     return mainObject.runDynamic();
 }
 
+int BlackOilSimulator::step()
+{
+    if (!hasRunInit_) {
+        throw std::logic_error("step() called before step_init()");
+    }
+    return mainEbos_->executeStep();
+}
+
 int BlackOilSimulator::step_init()
 {
 
@@ -56,5 +64,6 @@ PYBIND11_MODULE(simulators, m)
     py::class_<Opm::Pybind::BlackOilSimulator>(m, "BlackOilSimulator")
         .def(py::init< const std::string& >())
         .def("run", &Opm::Pybind::BlackOilSimulator::run)
+        .def("step", &Opm::Pybind::BlackOilSimulator::step)
         .def("step_init", &Opm::Pybind::BlackOilSimulator::step_init);
 }


### PR DESCRIPTION
A resubmission of commit 8e4f748 in PR #2403 and PR #2444 and continues the work in #2690 implementing Python bindings to the flow simulator.

The Python `step()` method advances the simulator one report step. Before calling `step()` for the first time, `step_init()` must have been called.