### PR TITLE
Finally fix selection for relaxed tolerance.

### DIFF
--- a/opm/simulators/flow/BlackoilModelEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelEbos.hpp
@@ -729,7 +729,11 @@ namespace Opm {
             cnvErrorPvFraction /= pvSum;
 
             const double tol_mb  = param_.tolerance_mb_;
-            const bool use_relaxed = cnvErrorPvFraction < param_.relaxed_max_pv_fraction_ || iteration >= param_.max_strict_iter_;                                              
+            // Default value of relaxed_max_pv_fraction_ is 1 and
+            // max_strict_iter_ is 8. Hence only iteration chooses
+            // whether to use relaxed or not.
+            // To activate only fraction use fraction below 1 and iter 0.
+            const bool use_relaxed = cnvErrorPvFraction < param_.relaxed_max_pv_fraction_ && iteration >= param_.max_strict_iter_;                                              
             const double tol_cnv = use_relaxed ? param_.tolerance_cnv_relaxed_ :  param_.tolerance_cnv_;
 
             // Finish computation

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -63,7 +63,7 @@ NEW_PROP_TAG(MaxInnerIterWells);
 SET_SCALAR_PROP(FlowModelParameters, DbhpMaxRel, 1.0);
 SET_SCALAR_PROP(FlowModelParameters, DwellFractionMax, 0.2);
 SET_SCALAR_PROP(FlowModelParameters, MaxResidualAllowed, 1e7);
-SET_SCALAR_PROP(FlowModelParameters, RelaxedMaxPvFraction, .0);
+SET_SCALAR_PROP(FlowModelParameters, RelaxedMaxPvFraction, 1.0);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceMb, 1e-6);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceCnv,1e-2);
 SET_SCALAR_PROP(FlowModelParameters, ToleranceCnvRelaxed, 1e9);


### PR DESCRIPTION
Default values are MaxStrictIter=8 and RelaxedPvFraction=1.0.
To activate relaxed pv fraction set MaxStrictIter to 0 and
fraction below 1.