### PR TITLE
Fix Debug Build

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1150,7 +1150,7 @@ public:
     void endTimeStep()
     {
 #ifndef NDEBUG
-        if (getPropValue<(TypeTag, Properties::EnableDebuggingChecks>()) {
+        if (getPropValue<TypeTag, Properties::EnableDebuggingChecks>()) {
             // in debug mode, we don't care about performance, so we check if the model does
             // the right thing (i.e., the mass change inside the whole reservoir must be
             // equivalent to the fluxes over the grid's boundaries plus the source rates


### PR DESCRIPTION
Remove left parenthesis character left over from transitioning to the type-based parameter system.  The `'('` produced a build failure which only manifested in debug builds.

Thanks to Håkon Hægland for bringing the issue to our attention.

Fixes #2747.