### PR TITLE
fixed: use const refs in foreach constructs

### DIFF
--- a/opm/simulators/timestepping/ConvergenceReport.hpp
+++ b/opm/simulators/timestepping/ConvergenceReport.hpp
@@ -162,7 +162,7 @@ namespace Opm
             for (const auto f : res_failures_) {
                 s = smax(s, f.severity());
             }
-            for (const auto f : well_failures_) {
+            for (const auto& f : well_failures_) {
                 s = smax(s, f.severity());
             }
             return s;

--- a/opm/simulators/timestepping/gatherConvergenceReport.cpp
+++ b/opm/simulators/timestepping/gatherConvergenceReport.cpp
@@ -75,7 +75,7 @@ namespace
         const auto wf = local_report.wellFailures();
         int num_wf = wf.size();
         MPI_Pack(&num_wf, 1, MPI_INT, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
-        for (const auto f : wf) {
+        for (const auto& f : wf) {
             packWellFailure(f, buf, offset);
         }
     }
@@ -87,7 +87,7 @@ namespace
         const int num_rf = local_report.reservoirFailures().size();
         const int num_wf = local_report.wellFailures().size();
         int wellnames_length = 0;
-        for (const auto f : local_report.wellFailures()) {
+        for (const auto& f : local_report.wellFailures()) {
             wellnames_length += (f.wellName().size() + 1);
         }
         return (2 + 3*num_rf + 4*num_wf) * int_pack_size + wellnames_length;

--- a/opm/simulators/wells/WellConnectionAuxiliaryModule.hpp
+++ b/opm/simulators/wells/WellConnectionAuxiliaryModule.hpp
@@ -62,7 +62,7 @@ public:
         wells_.reserve(schedule_wells.size());
 
         // initialize the additional cell connections introduced by wells.
-        for ( const auto well : schedule_wells )
+        for ( const auto& well : schedule_wells )
         {
             std::vector<int> compressed_well_perforations;
             // All possible completions of the well
@@ -102,7 +102,7 @@ public:
 
     void addNeighbors(std::vector<NeighborSet>& neighbors) const
     {
-        for(const auto well_perforations : wells_)
+        for(const auto& well_perforations : wells_)
         {
             for(const auto& perforation : well_perforations)
                 neighbors[perforation].insert(well_perforations.begin(),

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -74,7 +74,7 @@ namespace Opm
 
             int all_perf = 0;
             originalConnectionIndex_.reserve(perf_data.size());
-            for (const auto connection : well.getConnections()) {
+            for (const auto& connection : well.getConnections()) {
                 if (connection.state() == Connection::State::OPEN) {
                     originalConnectionIndex_.push_back(all_perf);
                 }


### PR DESCRIPTION
avoids unnecessary copies.

quells some clang(-10) warnings.