### PR TITLE
Reinstate lost logging of header and parameters.

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -432,6 +432,10 @@ namespace Opm
                                                          {Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputError::WARN},
                                                          {Opm::ParseContext::SUMMARY_UNKNOWN_WELL, Opm::InputError::WARN},
                                                          {Opm::ParseContext::SUMMARY_UNKNOWN_GROUP, Opm::InputError::WARN}});
+                if (EWOMS_GET_PARAM(PreTypeTag, bool, EclStrictParsing))
+                    parseContext->update(Opm::InputError::DELAYED_EXIT1);
+
+                Opm::FlowMainEbos<PreTypeTag>::printPRTHeader(outputCout_);
 
                 readDeck(mpiRank, deckFilename, deck_, eclipseState_, schedule_,
                          summaryConfig_, nullptr, python, std::move(parseContext),


### PR DESCRIPTION
Also re-add the ability to do strict parsing.

I would add that there are some details of this code I still suspect may not be 100% correct after the summer's refactoring. For example, we pass a `nullptr` for the `unique_ptr<ErrorGuard>` argument of `readDeck()`, and construct a default one on the inside, not sure why?