### PR TITLE
Use log mechanism for info output

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -412,10 +412,6 @@ namespace Opm
                 Opm::FlowMainEbos<PreTypeTag>::printBanner();
             }
             // Create Deck and EclipseState.
-            if (outputCout_) {
-                std::cout << "Reading deck file '" << deckFilename << "'\n";
-                std::cout.flush();
-            }
             try {
                 auto python = std::make_shared<Opm::Python>();
                 const bool init_from_restart_file = !EWOMS_GET_PARAM(PreTypeTag, bool, SchedRestart);
@@ -437,9 +433,18 @@ namespace Opm
 
                 Opm::FlowMainEbos<PreTypeTag>::printPRTHeader(outputCout_);
 
+                if (outputCout_) {
+                    OpmLog::info("Reading deck file '" + deckFilename + "'");
+                }
+
                 readDeck(mpiRank, deckFilename, deck_, eclipseState_, schedule_,
                          summaryConfig_, nullptr, python, std::move(parseContext),
                          init_from_restart_file, outputCout_);
+
+                if (outputCout_) {
+                    OpmLog::info("Done reading deck file.");
+                }
+
                 setupTime_ = externalSetupTimer.elapsed();
                 outputFiles_ = (outputMode != FileOutputMode::OUTPUT_NONE);
             }


### PR DESCRIPTION
…and tell the user the deck has been read.

This is a very minor improvement, but without it a user or developer can easily assume that the simulator hangs or spends excessive time on deck reading whereas it actually hangs or is slow in a later part of the initialization.