### PR TITLE
fixed: insideCartElmIdx and outsideCartElmIdx order in parallel

### DIFF
--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -344,9 +344,12 @@ public:
                 // apply the full face transmissibility multipliers
                 // for the inside ...
 
-                if (useSmallestMultiplier)
-                    applyAllZMultipliers_(trans, insideFaceIdx, insideCartElemIdx, outsideCartElemIdx, transMult, cartDims);
-                else
+                if (useSmallestMultiplier) {
+                    applyAllZMultipliers_(trans, insideFaceIdx,
+                                          std::min(insideCartElemIdx, outsideCartElemIdx),
+                                          std::max(insideCartElemIdx, outsideCartElemIdx),
+                                          transMult, cartDims);
+                } else
                     applyMultipliers_(trans, insideFaceIdx, insideCartElemIdx, transMult);
                 // ... and outside elements
                 applyMultipliers_(trans, outsideFaceIdx, outsideCartElemIdx, transMult);


### PR DESCRIPTION
in parallel the intersections point in the opposite
direction. this leads to inside > outside, and then the code in
applyAllZMultipliers_ blows up.

Note I'm not at all sure about this, but this is what happens according to my debugger.
Context is https://github.com/OPM/opm-simulators/pull/2765

It runs with this change and applies the same multipliers. Whether or not this is a workaround for another bug or not is up in the air..