### PR TITLE
Allow processing emtpy grid partitions during parallel output writing.

### DIFF
--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -752,9 +752,6 @@ public:
         if (!isParallel())
             return true;
 
-        if (localIdxToGlobalIdx_.empty())
-            throw std::logic_error("index map is not created on this rank");
-
         return std::find(localIdxToGlobalIdx_.begin(), localIdxToGlobalIdx_.end(), globalIdx) != localIdxToGlobalIdx_.end();
     }
 


### PR DESCRIPTION
Empty grids result in  empty localIdxToGlobalIdx_ mapping of course. This is needed in parallel where empty partitions might occur. 

Note that we currently throw an exception if load balancing results in an empty partition for one process. This is one of the necessary steps to allow such partitions.

