### PR TITLE
Prevent another copy of cell to region mapping in RateConverter.

### DIFF
--- a/opm/simulators/wells/RateConverter.hpp
+++ b/opm/simulators/wells/RateConverter.hpp
@@ -435,7 +435,6 @@ namespace Opm {
 
                 // create map from cell to region
                 // and set all attributes to zero
-                const auto& grid = simulator.vanguard().grid();
                 for (const auto& reg : rmap_.activeRegions()) {
                     auto& ra = attr_.attributes(reg);
                     ra.pressure = 0.0;

--- a/opm/simulators/wells/RateConverter.hpp
+++ b/opm/simulators/wells/RateConverter.hpp
@@ -436,12 +436,7 @@ namespace Opm {
                 // create map from cell to region
                 // and set all attributes to zero
                 const auto& grid = simulator.vanguard().grid();
-                const unsigned numCells = grid.size(/*codim=*/0);
-                std::vector<int> cell2region(numCells, -1);
                 for (const auto& reg : rmap_.activeRegions()) {
-                    for (const auto& cell : rmap_.cells(reg)) {
-                        cell2region[cell] = reg;
-                    }
                     auto& ra = attr_.attributes(reg);
                     ra.pressure = 0.0;
                     ra.temperature = 0.0;
@@ -483,7 +478,7 @@ namespace Opm {
                         hydrocarbon -= fs.saturation(FluidSystem::waterPhaseIdx).value();
                     }
 
-                    int reg = cell2region[cellIdx];
+                    int reg = rmap_.region(cellIdx);
                     assert(reg >= 0);
                     auto& ra = attr_.attributes(reg);
                     auto& p  = ra.pressure;


### PR DESCRIPTION
RateConverter itself already copies this and offers the mapping.
With this commit we just use that.