### PR TITLE
fix insideCartElmIdx and outsideCartElmIdx order for faces in parallel (2)

### DIFF
--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -475,14 +475,11 @@ private:
         if (insideFaceIdx > 3) { // top or or bottom
             Scalar mult = 1e20;
             unsigned cartElemIdx = insideCartElemIdx;
+            assert(insideFaceIdx==5); // as insideCartElemIdx < outsideCartElemIdx holds
             // pick the smallest multiplier while looking down the pillar untill reaching the other end of the connection
             // for the inbetween cells we apply it from both sides
             while (cartElemIdx != outsideCartElemIdx) {
-                if (insideFaceIdx == 4 || cartElemIdx !=insideCartElemIdx )
-                    mult = std::min(mult, transMult.getMultiplier(cartElemIdx, Opm::FaceDir::ZMinus));
-                if (insideFaceIdx == 5 || cartElemIdx !=insideCartElemIdx)
-                    mult = std::min(mult, transMult.getMultiplier(cartElemIdx, Opm::FaceDir::ZPlus));
-
+                mult = std::min(mult, transMult.getMultiplier(cartElemIdx, Opm::FaceDir::ZPlus));
                 cartElemIdx += cartDims[0]*cartDims[1];
             }
             trans *= mult;

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -273,13 +273,13 @@ public:
                         A * (n*d)/(d*d);
                 }
 
-                // we only need to calculate a face's transmissibility
-                // once...
-                if (elemIdx > outsideElemIdx)
-                    continue;
-
                 unsigned insideCartElemIdx = cartMapper.cartesianIndex(elemIdx);
                 unsigned outsideCartElemIdx = cartMapper.cartesianIndex(outsideElemIdx);
+
+                // we only need to calculate a face's transmissibility
+                // once...
+                if (insideCartElemIdx > outsideCartElemIdx)
+                    continue;
 
                 // local indices of the faces of the inside and
                 // outside elements which contain the intersection


### PR DESCRIPTION
Alternative fix to #2766 that makes cartesian index usage consistent.

only e80a02cc7 is the fix. The rest is cleanup. the fix simply bases the processing of faces on the cartesian element indices to make each face processed only once. Previous we used the local element indices (the two approaches were consistent until #2220).

