### PR TITLE
Fixed time step chopping with OpenCL Standard Well kernel

### DIFF
--- a/opm/simulators/linalg/bda/WellContributions.cpp
+++ b/opm/simulators/linalg/bda/WellContributions.cpp
@@ -101,37 +101,8 @@ WellContributions::~WellContributions()
 #endif
 }
 
+/*
 #if HAVE_OPENCL
-void WellContributions::setOpenCLContext(cl::Context *context_){
-    this->context = context_;
-}
-
-void WellContributions::setOpenCLQueue(cl::CommandQueue *queue_){
-    this->queue = queue_;
-}
-
-void WellContributions::setKernel(kernel_type *stdwell_apply_){
-    this->stdwell_apply = stdwell_apply_;
-}
-
-void WellContributions::init(){
-    if(num_std_wells > 0){
-        d_Cnnzs_ocl = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(double) * num_blocks * dim * dim_wells);
-        d_Dnnzs_ocl = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(double) * num_std_wells * dim_wells * dim_wells);
-        d_Bnnzs_ocl = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(double) * num_blocks * dim * dim_wells);
-        d_Ccols_ocl = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(int) * num_blocks);
-        d_Bcols_ocl = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(int) * num_blocks);
-        d_val_pointers_ocl = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(unsigned int) * (num_std_wells + 1));
-
-        queue->enqueueWriteBuffer(d_Cnnzs_ocl, CL_TRUE, 0, sizeof(double) * num_blocks * dim * dim_wells, h_Cnnzs_ocl);
-        queue->enqueueWriteBuffer(d_Dnnzs_ocl, CL_TRUE, 0, sizeof(double) * num_std_wells * dim_wells * dim_wells, h_Dnnzs_ocl);
-        queue->enqueueWriteBuffer(d_Bnnzs_ocl, CL_TRUE, 0, sizeof(double) * num_blocks * dim * dim_wells, h_Bnnzs_ocl);
-        queue->enqueueWriteBuffer(d_Ccols_ocl, CL_TRUE, 0, sizeof(int) * num_blocks, h_Ccols_ocl);
-        queue->enqueueWriteBuffer(d_Bcols_ocl, CL_TRUE, 0, sizeof(int) * num_blocks, h_Bcols_ocl);
-        queue->enqueueWriteBuffer(d_val_pointers_ocl, CL_TRUE, 0, sizeof(unsigned int) * (num_std_wells + 1), val_pointers);
-    }
-}
-
 void WellContributions::applyMSWell(cl::Buffer& d_x, cl::Buffer& d_y) {
     // apply MultisegmentWells
     if (num_ms_wells > 0) {
@@ -154,30 +125,8 @@ void WellContributions::applyMSWell(cl::Buffer& d_x, cl::Buffer& d_y) {
         queue->enqueueWriteBuffer(d_y, CL_TRUE, 0, sizeof(double) * N, h_y_ocl);
     }
 }
-
-void WellContributions::applyStdWell(cl::Buffer& d_x, cl::Buffer& d_y){
-    const unsigned int work_group_size = 32;
-    const unsigned int total_work_items = num_std_wells * work_group_size;
-    const unsigned int lmem1 = sizeof(double) * work_group_size;
-    const unsigned int lmem2 = sizeof(double) * dim_wells;
-
-    cl::Event event;
-    event = (*stdwell_apply)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items), cl::NDRange(work_group_size)),
-                             d_Cnnzs_ocl, d_Dnnzs_ocl, d_Bnnzs_ocl, d_Ccols_ocl, d_Bcols_ocl, d_x, d_y, dim, dim_wells,
-                             d_val_pointers_ocl, cl::Local(lmem1), cl::Local(lmem2), cl::Local(lmem2));
-}
-
-void WellContributions::apply(cl::Buffer& d_x, cl::Buffer& d_y){
-    if(num_std_wells > 0){
-        applyStdWell(d_x, d_y);
-    }
-
-    if(num_ms_wells > 0){
-        applyMSWell(d_x, d_y);
-    }
-}
-
 #endif
+*/
 
 void WellContributions::addMatrix([[maybe_unused]] MatrixType type, [[maybe_unused]] int *colIndices, [[maybe_unused]] double *values, [[maybe_unused]] unsigned int val_size)
 {

--- a/opm/simulators/linalg/bda/openclKernels.hpp
+++ b/opm/simulators/linalg/bda/openclKernels.hpp
@@ -455,7 +455,7 @@ namespace bda
             for (unsigned int j = 0; j < blnr; ++j){
                 temp += valsC[bb*blnc*blnr + j*blnc + c]*z2[j];
             }
-            atomicAdd(&y[colIdx*blnc + c], temp);
+            atomicAdd(&y[colIdx*blnc + c], -temp);
         }
     }
     )";

--- a/opm/simulators/linalg/bda/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/openclSolverBackend.cpp
@@ -710,7 +710,6 @@ template <unsigned int block_size>
 SolverStatus openclSolverBackend<block_size>::solve_system(int N_, int nnz_, int dim, double *vals, int *rows, int *cols, double *b, WellContributions& wellContribs, BdaResult &res) {
     if (initialized == false) {
         initialize(N_, nnz_,  dim, vals, rows, cols);
-        initialize_wellContribs(wellContribs);
         if (analysis_done == false) {
             if (!analyse_matrix()) {
                 return SolverStatus::BDA_SOLVER_ANALYSIS_FAILED;
@@ -723,12 +722,12 @@ SolverStatus openclSolverBackend<block_size>::solve_system(int N_, int nnz_, int
         copy_system_to_gpu();
     } else {
         update_system(vals, b);
-        initialize_wellContribs(wellContribs);
         if (!create_preconditioner()) {
             return SolverStatus::BDA_SOLVER_CREATE_PRECONDITIONER_FAILED;
         }
         update_system_on_gpu();
     }
+    initialize_wellContribs(wellContribs);
     solve_system(wellContribs, res);
     return SolverStatus::BDA_SOLVER_SUCCESS;
 }

--- a/opm/simulators/linalg/bda/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/openclSolverBackend.cpp
@@ -254,7 +254,9 @@ void openclSolverBackend<block_size>::gpu_pbicgstab(BdaResult& res) {
 
         // apply wellContributions
         t_well.start();
-        stdwell_w(d_Cnnzs, d_Dnnzs, d_Bnnzs, d_Ccols, d_Bcols, d_pw, d_v, d_val_pointers);
+        if(num_std_wells > 0){
+            stdwell_w(d_Cnnzs, d_Dnnzs, d_Bnnzs, d_Ccols, d_Bcols, d_pw, d_v, d_val_pointers);
+        }
         t_well.stop();
 
         t_rest.start();
@@ -283,7 +285,9 @@ void openclSolverBackend<block_size>::gpu_pbicgstab(BdaResult& res) {
 
         // apply wellContributions
         t_well.start();
-        stdwell_w(d_Cnnzs, d_Dnnzs, d_Bnnzs, d_Ccols, d_Bcols, d_s, d_t, d_val_pointers);
+        if(num_std_wells > 0){
+            stdwell_w(d_Cnnzs, d_Dnnzs, d_Bnnzs, d_Ccols, d_Bcols, d_s, d_t, d_val_pointers);
+        }
         t_well.stop();
 
         t_rest.start();


### PR DESCRIPTION
 - Fixed kernel: added missing minus sign;
 - Fixed constant setting and resetting of OpenCL's context, queue and kernel in WellContributions.

These changes seem to have eliminated the time step chopping problem that was happening when including the `add_well_contributions` kernel before.

I had to remove the multisegment wells contribution functions to re-write my code. I already have a local branch where I'm trying to re-include the multisegment wells. For some reason, when I try to re-add the multisegment wells in a similar fashion to current standard wells I get some (but much much less) time step chopping.   
  