### PR TITLE
adding timing for the well assembly

### DIFF
--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -35,6 +35,7 @@ namespace Opm
           total_time(0.0),
           solver_time(0.0),
           assemble_time(0.0),
+          assemble_time_well(0.0),
           linear_solve_setup_time(0.0),
           linear_solve_time(0.0),
           update_time(0.0),
@@ -58,6 +59,7 @@ namespace Opm
         linear_solve_time += sr.linear_solve_time;
         solver_time += sr.solver_time;
         assemble_time += sr.assemble_time;
+        assemble_time_well += sr.assemble_time_well;
         update_time += sr.update_time;
         output_write_time += sr.output_write_time;
         total_time += sr.total_time;
@@ -101,6 +103,14 @@ namespace Opm
             }
             os << std::endl;
 
+            t = assemble_time_well + (failureReport ? failureReport->assemble_time_well : 0.0);
+            os << "   Well assembly time (seconds): " << t;
+            if (failureReport) {
+                os << " (Failed: " << failureReport->assemble_time_well << "; "
+                   << 100*failureReport->assemble_time_well/t << "%)";
+            }
+            os << std::endl;
+
             t = linear_solve_time + (failureReport ? failureReport->linear_solve_time : 0.0);
             os << " Linear solve time (seconds): " << t;
             if (failureReport) {
@@ -110,7 +120,7 @@ namespace Opm
             os << std::endl;
 
             t = linear_solve_setup_time + (failureReport ? failureReport->linear_solve_setup_time : 0.0);
-            os << " Linear solve setup time (seconds): " << t;
+            os << "   Linear solve setup time (seconds): " << t;
             if (failureReport) {
                 os << " (Failed: " << failureReport->linear_solve_setup_time << "; "
                    << 100*failureReport->linear_solve_setup_time/t << "%)";

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -34,6 +34,7 @@ namespace Opm
         double total_time;
         double solver_time;
         double assemble_time;
+        double assemble_time_well;
         double linear_solve_setup_time;
         double linear_solve_time;
         double update_time;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -809,6 +809,8 @@ namespace Opm {
     {
 
         last_report_ = SimulatorReportSingle();
+        Dune::Timer perfTimer;
+        perfTimer.start();
 
         if ( ! wellsActive() ) {
             return;
@@ -857,6 +859,7 @@ namespace Opm {
         logAndCheckForExceptionsAndThrow(local_deferredLogger, exception_thrown, "assemble() failed.", terminal_output_);
 
         last_report_.converged = true;
+        last_report_.assemble_time_well += perfTimer.stop();
     }
 
     template<typename TypeTag>


### PR DESCRIPTION
And changes the indentation of the linear solver setup time a little to show it is part of the linear solve time.

Basically, we want to monitor how costly the well related code. 

The summary of the timing looks like the following with this PR for SPE1 case running. 
```
Number of MPI processes:      1
Threads per MPI process:      2
Total time (seconds):         14.6889
Solver time (seconds):        14.6547
 Assembly time (seconds):     4.83799 (Failed: 0; 0%)
   Well assembly time (seconds): 1.33701 (Failed: 0; 0%)
 Linear solve time (seconds): 9.04144 (Failed: 0; 0%)
   Linear solve setup time (seconds): 0.000130328 (Failed: 0; 0%)
 Update time (seconds):       0.242177 (Failed: 0; 0%)
 Output write time (seconds): 0.0977013
Overall Well Iterations:      0 (Failed: 0; -nan%)
Overall Linearizations:       397 (Failed: 0; 0%)
Overall Newton Iterations:    310 (Failed: 0; 0%)
Overall Linear Iterations:    2564 (Failed: 0; 0%)
```