### PR TITLE
Fixes determining whether index of summary keyword is on process.

### DIFF
--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -309,7 +309,16 @@ public:
 
             typedef Dune::MultipleCodimMultipleGeomTypeMapper<LocalGridView> ElementMapper;
             ElementMapper elemMapper(localGridView, Dune::mcmgElementLayout());
+            const auto& cartMapper = vanguard.cartesianIndexMapper();
+            sortedCartesianIdx_.reserve(vanguard.gridView().size(0));
 
+            for(const auto& elem: elements(localGridView))
+            {
+                auto idx = elemMapper.index(elem);
+                sortedCartesianIdx_.push_back(cartMapper.cartesianIndex(idx));
+            }
+
+            std::sort(sortedCartesianIdx_.begin(), sortedCartesianIdx_.end());
             localIdxToGlobalIdx_.resize(localGridView.size(0), -1);
 
             // the I/O rank receives from all other ranks
@@ -747,15 +756,14 @@ public:
     const std::vector<int>& globalRanks() const
     { return globalRanks_; }
 
-    bool isGlobalIdxOnThisRank(unsigned globalIdx) const
+    bool isCartIdxOnThisRank(int cartIdx) const
     {
         if (!isParallel())
             return true;
 
-        if (localIdxToGlobalIdx_.empty())
-            throw std::logic_error("index map is not created on this rank");
-
-        return std::find(localIdxToGlobalIdx_.begin(), localIdxToGlobalIdx_.end(), globalIdx) != localIdxToGlobalIdx_.end();
+        assert(!needsReordering);
+        auto candidate = std::lower_bound(sortedCartesianIdx_.begin(), sortedCartesianIdx_.end(), cartIdx);
+        return (candidate != sortedCartesianIdx_.end() && *candidate == cartIdx);
     }
 
 protected:
@@ -769,6 +777,10 @@ protected:
     Opm::data::Wells globalWellData_;
     Opm::data::GroupValues globalGroupData_;
     std::vector<int> localIdxToGlobalIdx_;
+    /// \brief sorted list of cartesian indices present-
+    ///
+    /// non-empty only when running in parallel
+    std::vector<int> sortedCartesianIdx_;
 };
 
 } // end namespace Opm

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -194,7 +194,7 @@ public:
         // Initialize block output
         for (const auto& node: summaryConfig) {
             if (node.category() == SummaryConfigNode::Category::Block) {
-                if (collectToIORank.isGlobalIdxOnThisRank(node.number() - 1)) {
+                if (collectToIORank.isCartIdxOnThisRank(node.number() - 1)) {
                     std::pair<std::string, int> key = std::make_pair(node.keyword(), node.number());
                     blockData_[key] = 0.0;
                 }


### PR DESCRIPTION
We used a method isGlobalIdxOnThisRank to determine whether to write
an entry for a summary keyword (like BPR). Unfortunately, this did
exactly what the name suggested, but we actually passed a cartesian
index to it. That meant that a lower cartesian index might have found on
many processes (with different cartesian index and hence resulting in
wrong values), while higher for ones no process would have been found
with it (resulting in writing zeros).

With this commit we store a sorted list of cartesian indices and query
that in the renamed and restructured function isCartesianidxOnThisRank.

Most probably this broke during refactoring.

Closes #2665