### PR TITLE
Add test of PINCH::ALL + MULTZ with a barrier

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -457,6 +457,13 @@ add_test_compareECLFiles(CASENAME pinch_multz_all
                          REL_TOL ${rel_tol}
                          DIR pinch)
 
+add_test_compareECLFiles(CASENAME pinch_multz_all_barrier
+                         FILENAME PINCH_MULTZ_ALL_BARRIER
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR pinch)
+
 if (opm-common_EMBEDDED_PYTHON)
   add_test_compareECLFiles(CASENAME udq_pyaction
                            FILENAME PYACTION_WCONPROD

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -131,6 +131,7 @@ tests[spe1_foam]="flow spe1_foam SPE1FOAM"
 tests[wsegsicd]="flow wsegsicd TEST_WSEGSICD"
 tests[bc_lab]="flow bc_lab BC_LAB"
 tests[pinch_multz_all]="flow pinch PINCH_MULTZ_ALL pinch_multz_all"
+tests[pinch_multz_all_barrier]="flow pinch PINCH_MULTZ_ALL_BARRIER pinch_multz_all_barrier"
 
 changed_tests=""
 


### PR DESCRIPTION
Add regression for [this](https://github.com/OPM/opm-tests/blob/master/pinch/PINCH_MULTZ_ALL_BARRIER.DATA) case. ~~Should be ready to be merged when https://github.com/OPM/opm-common/pull/1905 has been merged~~