### PR TITLE
fix insideCartElmIdx and outsideCartElmIdx order for faces in parallel (2) 

### DIFF
--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -475,14 +475,13 @@ private:
         if (insideFaceIdx > 3) { // top or or bottom
             Scalar mult = 1e20;
             unsigned cartElemIdx = insideCartElemIdx;
-            // pick the smallest multiplier while looking down the pillar untill reaching the other end of the connection
-            // for the inbetween cells we apply it from both sides
+            assert(insideFaceIdx==5); // as insideCartElemIdx < outsideCartElemIdx holds for the Z column
+            // pick the smallest multiplier for Z+ while looking down the pillar untill reaching the other end of the connection
+            // While Z- is not all used here. There is a call after this function that does
+            // applyMultipliers_(trans, outsideFaceIdx, outsideCartElemIdx, transMult)
+            // and hence treats the other direction
             while (cartElemIdx != outsideCartElemIdx) {
-                if (insideFaceIdx == 4 || cartElemIdx !=insideCartElemIdx )
-                    mult = std::min(mult, transMult.getMultiplier(cartElemIdx, Opm::FaceDir::ZMinus));
-                if (insideFaceIdx == 5 || cartElemIdx !=insideCartElemIdx)
-                    mult = std::min(mult, transMult.getMultiplier(cartElemIdx, Opm::FaceDir::ZPlus));
-
+                mult = std::min(mult, transMult.getMultiplier(cartElemIdx, Opm::FaceDir::ZPlus));
                 cartElemIdx += cartDims[0]*cartDims[1];
             }
             trans *= mult;

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -273,13 +273,13 @@ public:
                         A * (n*d)/(d*d);
                 }
 
-                // we only need to calculate a face's transmissibility
-                // once...
-                if (elemIdx > outsideElemIdx)
-                    continue;
-
                 unsigned insideCartElemIdx = cartMapper.cartesianIndex(elemIdx);
                 unsigned outsideCartElemIdx = cartMapper.cartesianIndex(outsideElemIdx);
+
+                // we only need to calculate a face's transmissibility
+                // once...
+                if (insideCartElemIdx > outsideCartElemIdx)
+                    continue;
 
                 // local indices of the faces of the inside and
                 // outside elements which contain the intersection


### PR DESCRIPTION
It really fixes only this and tries to make the code simpler and less opaque.

There are still other bugs in the pinch treatment, tough (see #2776). But these will need some update_data and are more risky. One should consider merging this before