### PR TITLE
Removed OPERATER and OPERNUM since they are supported.

### DIFF
--- a/opm/simulators/flow/MissingFeatures.cpp
+++ b/opm/simulators/flow/MissingFeatures.cpp
@@ -513,7 +513,6 @@ namespace MissingFeatures {
             "OLDTRAN",
             "OLDTRANR",
             "OPTIONS",
-            "OPTIONS",
             "OUTSOL",
             "PARAOPTS",
             "PCG32D",

--- a/opm/simulators/flow/MissingFeatures.cpp
+++ b/opm/simulators/flow/MissingFeatures.cpp
@@ -512,8 +512,6 @@ namespace MissingFeatures {
             "OILAPI",
             "OLDTRAN",
             "OLDTRANR",
-            "OPERATER",
-            "OPERNUM",
             "OPTIONS",
             "OPTIONS",
             "OUTSOL",


### PR DESCRIPTION
Updating the missing features list.