### PR TITLE
Improves error handling and reporting in parallel.

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -224,6 +224,7 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
             if (!summaryConfig)
                 summaryConfig = std::make_unique<Opm::SummaryConfig>(*deck, *schedule, eclipseState->getTableManager(), *parseContext, *errorGuard);
 
+            Opm::checkConsistentArrayDimensions(*eclipseState, *schedule, *parseContext, *errorGuard);
         }
         catch(const std::exception& e)
         {
@@ -272,7 +273,6 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
 #if HAVE_MPI
         Opm::eclStateBroadcast(*eclipseState, *schedule, *summaryConfig);
 #endif
-        Opm::checkConsistentArrayDimensions(*eclipseState, *schedule, *parseContext, *errorGuard);
     }
     catch(const std::exception& e)
     {

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -274,7 +274,7 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
 #if HAVE_MPI
         MPI_Finalize();
 #endif
-        exit(1);
+        std::exit(EXIT_FAILURE);
     }
 }
 } // end namespace Opm

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -42,6 +42,8 @@
 #include <opm/simulators/utils/ParallelEclipseState.hpp>
 #include <opm/simulators/utils/ParallelSerialization.hpp>
 
+#include <cstdlib>
+
 namespace Opm
 {
 
@@ -297,7 +299,7 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
 #if HAVE_MPI
         MPI_Finalize();
 #endif
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 }
 } // end namespace Opm


### PR DESCRIPTION
As the ErrorGuard also dumps warnings we now always dump it (previously only on error) to get these messages in the
console.

If there are error encountered, we log a meaningful error message (the real cause was missing previously) and do a
graceful exit after MPI_Finalize.

Close #2764 