### PR TITLE
Fixes application of transmissibility modifiers from the edit section.

### DIFF
--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -390,7 +390,7 @@ public:
         }
 
         // potentially overwrite and/or modify  transmissibilities based on input from deck
-        updateFromEclState_();
+        updateFromEclState_(global);
 
         // Create mapping from global to local index
         const size_t cartesianSize = cartMapper.cartesianSize();
@@ -513,20 +513,48 @@ private:
         }
     }
 
-    void updateFromEclState_()
+    void updateFromEclState_(bool global)
+    {
+        const FieldPropsManager* fp =
+            (global) ? &(vanguard_.eclState().fieldProps()) :
+            &(vanguard_.eclState().globalFieldProps());
+
+        std::array<bool,3> is_tran {fp->tran_active("TRANX"),
+                                    fp->tran_active("TRANY"),
+                                    fp->tran_active("TRANZ")};
+
+        if( !(is_tran[0] ||is_tran[1] || is_tran[2]) )
+        {
+            // Skip unneeded expensive traversals
+            return;
+        }
+
+        std::array<std::string, 3> keywords {"TRANX", "TRANY", "TRANZ"};
+        std::array<std::vector<double>,3> trans = createTransmissibilityArrays(is_tran);
+        auto key = keywords.begin();
+        auto perform = is_tran.begin();
+
+        for (auto it = trans.begin(); it != trans.end(); ++it, ++key, ++perform)
+        {
+            if(perform)
+                fp->apply_tran(*key, *it);
+        }
+
+        resetTransmissibilityFromArrays(is_tran, trans);
+    }
+
+    /// \brief overwrites calculated transmissibilities
+    ///
+    /// \param is_tran Whether TRAN{XYZ} have been modified.
+    /// \param trans Arrays with modified transmissibilities TRAN{XYZ}
+    void resetTransmissibilityFromArrays(const std::array<bool,3>& is_tran,
+                                         const std::array<std::vector<double>,3>& trans)
     {
         const auto& gridView = vanguard_.gridView();
         const auto& cartMapper = vanguard_.cartesianIndexMapper();
         const auto& cartDims = cartMapper.cartesianDimensions();
         ElementMapper elemMapper(gridView, Dune::mcmgElementLayout());
 
-        const auto& fp = vanguard_.eclState().fieldProps();
-        const auto& inputTranxData = fp.get_double("TRANX");
-        const auto& inputTranyData = fp.get_double("TRANY");
-        const auto& inputTranzData = fp.get_double("TRANZ");
-        bool tranx_deckAssigned = false;                     // Ohh my ....
-        bool trany_deckAssigned = false;
-        bool tranz_deckAssigned = false;
         // compute the transmissibilities for all intersections
         auto elemIt = gridView.template begin</*codim=*/ 0>();
         const auto& elemEndIt = gridView.template end</*codim=*/ 0>();
@@ -541,44 +569,111 @@ private:
                 if (!intersection.neighbor())
                     continue; // intersection is on the domain boundary
 
+                // In the EclState TRANX[c1] is transmissibility in X+
+                // direction. Ordering of compressed (c1,c2) and cartesian index
+                // (gc1, gc2) is coherent (c1 < c2 <=> gc1 < gc2). This also
+                // holds for the global grid. While distributing changes the
+                // order of the local indices, the transmissibilities are still
+                // stored at the cell with the lower global cartesian index as
+                // the fieldprops are communicated by the grid.
                 unsigned c1 = elemMapper.index(intersection.inside());
                 unsigned c2 = elemMapper.index(intersection.outside());
-
-                if (c1 > c2)
+                int gc1 = cartMapper.cartesianIndex(c1);
+                int gc2 = cartMapper.cartesianIndex(c2);
+                if (gc1 > gc2)
                     continue; // we only need to handle each connection once, thank you.
 
                 auto isId = isId_(c1, c2);
 
-                int gc1 = std::min(cartMapper.cartesianIndex(c1), cartMapper.cartesianIndex(c2));
-                int gc2 = std::max(cartMapper.cartesianIndex(c1), cartMapper.cartesianIndex(c2));
-
                 if (gc2 - gc1 == 1 && cartDims[0] > 1) {
-                    if (tranx_deckAssigned)
+                    if (is_tran[0])
                         // set simulator internal transmissibilities to values from inputTranx
-                        trans_[isId] = inputTranxData[c1];
-                    else
-                        // Scale transmissibilities with scale factor from inputTranx
-                        trans_[isId] *= inputTranxData[c1];
+                        trans_[isId] = trans[0][c1];
                 }
                 else if (gc2 - gc1 == cartDims[0] && cartDims[1] > 1) {
-                    if (trany_deckAssigned)
+                    if (is_tran[1])
                         // set simulator internal transmissibilities to values from inputTrany
-                        trans_[isId] = inputTranyData[c1];
-                    else
-                        // Scale transmissibilities with scale factor from inputTrany
-                        trans_[isId] *= inputTranyData[c1];
+                        trans_[isId] = trans[1][c1];
                 }
                 else if (gc2 - gc1 == cartDims[0]*cartDims[1]) {
-                    if (tranz_deckAssigned)
+                    if (is_tran[2])
                         // set simulator internal transmissibilities to values from inputTranz
-                        trans_[isId] = inputTranzData[c1];
-                    else
-                        // Scale transmissibilities with scale factor from inputTranz
-                        trans_[isId] *= inputTranzData[c1];
+                        trans_[isId] = trans[2][c1];
                 }
                 //else.. We don't support modification of NNC at the moment.
             }
         }
+    }
+
+    /// \brief Creates TRANS{XYZ} arrays for modification by FieldProps data
+    ///
+    /// \param is_tran Whether TRAN{XYZ} will be modified. If entry is false the array will be empty
+    /// \returns an array of vector (TRANX, TRANY, TRANZ}
+    std::array<std::vector<double>,3>
+    createTransmissibilityArrays(const std::array<bool,3>& is_tran)
+    {
+        const auto& gridView = vanguard_.gridView();
+        const auto& cartMapper = vanguard_.cartesianIndexMapper();
+        const auto& cartDims = cartMapper.cartesianDimensions();
+        ElementMapper elemMapper(gridView, Dune::mcmgElementLayout());
+
+        auto numElem = vanguard_.gridView().size(/*codim=*/0);
+        std::array<std::vector<double>,3> trans =
+            { std::vector<double>(is_tran[0] ? numElem : 0, 0),
+              std::vector<double>(is_tran[1] ? numElem : 0, 0),
+              std::vector<double>(is_tran[2] ? numElem : 0, 0)};
+
+        // compute the transmissibilities for all intersections
+        auto elemIt = gridView.template begin</*codim=*/ 0>();
+        const auto& elemEndIt = gridView.template end</*codim=*/ 0>();
+
+        for (; elemIt != elemEndIt; ++elemIt) {
+            const auto& elem = *elemIt;
+            auto isIt = gridView.ibegin(elem);
+            const auto& isEndIt = gridView.iend(elem);
+            for (; isIt != isEndIt; ++ isIt) {
+                // store intersection, this might be costly
+                const auto& intersection = *isIt;
+                if (!intersection.neighbor())
+                    continue; // intersection is on the domain boundary
+
+                // In the EclState TRANX[c1] is transmissibility in X+
+                // direction. Ordering of compressed (c1,c2) and cartesian index
+                // (gc1, gc2) is coherent (c1 < c2 <=> gc1 < gc2). This also
+                // holds for the global grid. While distributing changes the
+                // order of the local indices, the transmissibilities are still
+                // stored at the cell with the lower global cartesian index as
+                // the fieldprops are communicated by the grid.
+                unsigned c1 = elemMapper.index(intersection.inside());
+                unsigned c2 = elemMapper.index(intersection.outside());
+                int gc1 = cartMapper.cartesianIndex(c1);
+                int gc2 = cartMapper.cartesianIndex(c2);
+
+                if (gc1 > gc2)
+                    continue; // we only need to handle each connection once, thank you.
+
+                auto isId = isId_(c1, c2);
+
+                if (gc2 - gc1 == 1 && cartDims[0] > 1) {
+                    if (is_tran[0])
+                        // set simulator internal transmissibilities to values from inputTranx
+                         trans[0][c1] = trans_[isId];
+                }
+                else if (gc2 - gc1 == cartDims[0] && cartDims[1] > 1) {
+                    if (is_tran[1])
+                        // set simulator internal transmissibilities to values from inputTrany
+                         trans[1][c1] = trans_[isId];
+                }
+                else if (gc2 - gc1 == cartDims[0]*cartDims[1]) {
+                    if (is_tran[2])
+                        // set simulator internal transmissibilities to values from inputTranz
+                         trans[2][c1] = trans_[isId];
+                }
+                //else.. We don't support modification of NNC at the moment.
+            }
+        }
+
+        return trans;
     }
 
 

--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -167,6 +167,17 @@ std::vector<double> ParallelFieldPropsManager::get_global_double(const std::stri
     return result;
 }
 
+bool ParallelFieldPropsManager::tran_active(const std::string& keyword) const
+{
+    auto calculator = m_tran.find(keyword);
+    return calculator != m_tran.end() && calculator->second.size();
+}
+
+void ParallelFieldPropsManager::apply_tran(const std::string& keyword,
+                                           std::vector<double>& data) const
+{
+    Opm::apply_tran(m_tran, m_doubleProps, m_activeSize(), keyword, data);
+}
 
 bool ParallelFieldPropsManager::has_int(const std::string& keyword) const
 {
@@ -174,6 +185,10 @@ bool ParallelFieldPropsManager::has_int(const std::string& keyword) const
     return it != m_intProps.end();
 }
 
+void ParallelFieldPropsManager::deserialize_tran(const std::vector<char>& buffer)
+{
+    Opm::deserialize_tran(m_tran, buffer);
+}
 
 bool ParallelFieldPropsManager::has_double(const std::string& keyword) const
 {

--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -68,17 +68,18 @@ const std::vector<int>& ParallelFieldPropsManager::get_int(const std::string& ke
         // Some of the keywords might be defaulted.
         // We will let rank 0 create them and distribute them using get_global_int
         auto data = get_global_int(keyword);
-        auto& local_data = const_cast<std::map<std::string, std::vector<int>>&>(m_intProps)[keyword];
-        local_data.resize(m_activeSize());
+        auto& local_data = const_cast<std::map<std::string, FieldData<int>>&>(m_intProps)[keyword];
+        local_data.data.resize(m_activeSize());
+        local_data.value_status.resize(m_activeSize());
 
         for (int i = 0; i < m_activeSize(); ++i)
         {
-            local_data[i] = data[m_local2Global(i)];
+            local_data.data[i] = data[m_local2Global(i)];
         }
-        return local_data;
+        return local_data.data;
     }
 
-    return it->second;
+    return it->second.data;
 }
 
 std::vector<int> ParallelFieldPropsManager::get_global_int(const std::string& keyword) const
@@ -121,16 +122,17 @@ const std::vector<double>& ParallelFieldPropsManager::get_double(const std::stri
         // Some of the keywords might be defaulted.
         // We will let rank 0 create them and distribute them using get_global_int
         auto data = get_global_double(keyword);
-        auto& local_data = const_cast<std::map<std::string, std::vector<double>>&>(m_doubleProps)[keyword];
-        local_data.resize(m_activeSize());
+        auto& local_data = const_cast<std::map<std::string, FieldData<double>>&>(m_doubleProps)[keyword];
+        local_data.data.resize(m_activeSize());
+        local_data.value_status.resize(m_activeSize());
         for (int i = 0; i < m_activeSize(); ++i)
         {
-            local_data[i] = data[m_local2Global(i)];
+            local_data.data[i] = data[m_local2Global(i)];
         }
-        return local_data;
+        return local_data.data;
     }
 
-    return it->second;
+    return it->second.data;
 }
 
 

--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -68,7 +68,7 @@ const std::vector<int>& ParallelFieldPropsManager::get_int(const std::string& ke
         // Some of the keywords might be defaulted.
         // We will let rank 0 create them and distribute them using get_global_int
         auto data = get_global_int(keyword);
-        auto& local_data = const_cast<std::map<std::string, FieldData<int>>&>(m_intProps)[keyword];
+        auto& local_data = const_cast<std::map<std::string, Fieldprops::FieldData<int>>&>(m_intProps)[keyword];
         local_data.data.resize(m_activeSize());
         local_data.value_status.resize(m_activeSize());
 
@@ -122,7 +122,7 @@ const std::vector<double>& ParallelFieldPropsManager::get_double(const std::stri
         // Some of the keywords might be defaulted.
         // We will let rank 0 create them and distribute them using get_global_int
         auto data = get_global_double(keyword);
-        auto& local_data = const_cast<std::map<std::string, FieldData<double>>&>(m_doubleProps)[keyword];
+        auto& local_data = const_cast<std::map<std::string, Fieldprops::FieldData<double>>&>(m_doubleProps)[keyword];
         local_data.data.resize(m_activeSize());
         local_data.value_status.resize(m_activeSize());
         for (int i = 0; i < m_activeSize(); ++i)

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -96,8 +96,8 @@ public:
                                    std::placeholders::_1);
     }
 protected:
-    std::map<std::string, std::vector<int>> m_intProps; //!< Map of integer properties in process-local compressed indices.
-    std::map<std::string, std::vector<double>> m_doubleProps; //!< Map of double properties in process-local compressed indices.
+    std::map<std::string, Opm::FieldData<int>> m_intProps; //!< Map of integer properties in process-local compressed indices.
+    std::map<std::string, Opm::FieldData<double>> m_doubleProps; //!< Map of double properties in process-local compressed indices.
     FieldPropsManager& m_manager; //!< Underlying field property manager (only used on root process).
     Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> m_comm; //!< Collective communication handler.
     std::function<int(void)> m_activeSize; //!< active size function of the grid

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -103,13 +103,13 @@ public:
 
     void deserialize_tran(const std::vector<char>& buffer) override;
 protected:
-    std::map<std::string, Opm::FieldData<int>> m_intProps; //!< Map of integer properties in process-local compressed indices.
-    std::map<std::string, Opm::FieldData<double>> m_doubleProps; //!< Map of double properties in process-local compressed indices.
+    std::map<std::string, Opm::Fieldprops::FieldData<int>> m_intProps; //!< Map of integer properties in process-local compressed indices.
+    std::map<std::string, Opm::Fieldprops::FieldData<double>> m_doubleProps; //!< Map of double properties in process-local compressed indices.
     FieldPropsManager& m_manager; //!< Underlying field property manager (only used on root process).
     Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> m_comm; //!< Collective communication handler.
     std::function<int(void)> m_activeSize; //!< active size function of the grid
     std::function<int(const int)> m_local2Global; //!< mapping from local to global cartesian indices
-    std::unordered_map<std::string, TranCalculator> m_tran; //!< calculators map
+    std::unordered_map<std::string, Fieldprops::TranCalculator> m_tran; //!< calculators map
 };
 
 

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -20,6 +20,7 @@
 #define PARALLEL_ECLIPSE_STATE_HPP
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp>
 #include <dune/common/parallel/mpihelper.hh>
 
 #include <functional>
@@ -95,6 +96,12 @@ public:
         m_local2Global = std::bind(&T::cartesianIndex, mapper,
                                    std::placeholders::_1);
     }
+
+    bool tran_active(const std::string& keyword) const override;
+
+    void apply_tran(const std::string& keyword, std::vector<double>& trans) const override;
+
+    void deserialize_tran(const std::vector<char>& buffer) override;
 protected:
     std::map<std::string, Opm::FieldData<int>> m_intProps; //!< Map of integer properties in process-local compressed indices.
     std::map<std::string, Opm::FieldData<double>> m_doubleProps; //!< Map of double properties in process-local compressed indices.
@@ -102,6 +109,7 @@ protected:
     Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> m_comm; //!< Collective communication handler.
     std::function<int(void)> m_activeSize; //!< active size function of the grid
     std::function<int(const int)> m_local2Global; //!< mapping from local to global cartesian indices
+    std::unordered_map<std::string, TranCalculator> m_tran; //!< calculators map
 };
 
 

--- a/opm/simulators/utils/PropsCentroidsDataHandle.hpp
+++ b/opm/simulators/utils/PropsCentroidsDataHandle.hpp
@@ -118,7 +118,10 @@ public:
 
                 for (const auto& doubleKey : m_doubleKeys)
                 {
-                    const auto& fieldData = globalProps.get_double_field_data(doubleKey);
+                    // We need to allow unsupported keywords to get the data
+                    // for TranCalculator, too.
+                    const auto& fieldData = globalProps.get_double_field_data(doubleKey,
+                                                                              /* allow_unsupported = */ true);
                     data.push_back(std::make_pair(fieldData.data[index],
                                                   static_cast<unsigned char>(fieldData.value_status[index])));
                 }

--- a/opm/simulators/utils/PropsCentroidsDataHandle.hpp
+++ b/opm/simulators/utils/PropsCentroidsDataHandle.hpp
@@ -81,6 +81,7 @@ public:
             int position = 0;
             Mpi::pack(m_intKeys, buffer, position, comm);
             Mpi::pack(m_doubleKeys, buffer, position, comm);
+            int calcStart = position;
             {
                 std::vector<char> tran_buffer = globalProps.serialize_tran();
                 position += tran_buffer.size();
@@ -88,6 +89,9 @@ public:
             }
             comm.broadcast(&position, 1, 0);
             comm.broadcast(buffer.data(), position, 0);
+
+            // Unpack Calculator as we need it here, too.
+            m_distributed_fieldProps.deserialize_tran( std::vector<char>(buffer.begin() + calcStart, buffer.end()) );
 
             // copy data to persistent map based on local id
             m_no_data = m_intKeys.size() + m_doubleKeys.size() +

--- a/opm/simulators/utils/PropsCentroidsDataHandle.hpp
+++ b/opm/simulators/utils/PropsCentroidsDataHandle.hpp
@@ -81,6 +81,11 @@ public:
             int position = 0;
             Mpi::pack(m_intKeys, buffer, position, comm);
             Mpi::pack(m_doubleKeys, buffer, position, comm);
+            {
+                std::vector<char> tran_buffer = globalProps.serialize_tran();
+                position += tran_buffer.size();
+                buffer.insert(buffer.end(), std::make_move_iterator(tran_buffer.begin()), std::make_move_iterator(tran_buffer.end()));
+            }
             comm.broadcast(&position, 1, 0);
             comm.broadcast(buffer.data(), position, 0);
 
@@ -121,6 +126,7 @@ public:
             int position{};
             Mpi::unpack(m_intKeys, buffer, position, comm);
             Mpi::unpack(m_doubleKeys, buffer, position, comm);
+            m_distributed_fieldProps.deserialize_tran( std::vector<char>(buffer.begin() + position, buffer.end()) );
             m_no_data = m_intKeys.size() + m_doubleKeys.size() +
                 Grid::dimensionworld;
         }

--- a/opm/simulators/utils/PropsCentroidsDataHandle.hpp
+++ b/opm/simulators/utils/PropsCentroidsDataHandle.hpp
@@ -112,8 +112,8 @@ public:
                 for (const auto& intKey : m_intKeys)
                 {
                     const auto& fieldData = globalProps.get_int_field_data(intKey);
-                    data.push_back(std::make_pair(fieldData.data[index],
-                                                  static_cast<unsigned char>(fieldData.value_status[index])));
+                    data.emplace_back(fieldData.data[index],
+                                      static_cast<unsigned char>(fieldData.value_status[index]));
                 }
 
                 for (const auto& doubleKey : m_doubleKeys)
@@ -122,14 +122,14 @@ public:
                     // for TranCalculator, too.
                     const auto& fieldData = globalProps.get_double_field_data(doubleKey,
                                                                               /* allow_unsupported = */ true);
-                    data.push_back(std::make_pair(fieldData.data[index],
-                                                  static_cast<unsigned char>(fieldData.value_status[index])));
+                    data.emplace_back(fieldData.data[index],
+                                      static_cast<unsigned char>(fieldData.value_status[index]));
                 }
 
                 auto cartIndex = cartMapper.cartesianIndex(index);
                 const auto& center = eclGridOnRoot->getCellCenter(cartIndex);
                 for (int dim = 0; dim < Grid::dimensionworld; ++dim)
-                    data.push_back(std::make_pair(center[dim], '1')); // write garbage for value_status
+                    data.emplace_back(center[dim], '1'); // write garbage for value_status
             }
         }
         else


### PR DESCRIPTION
These are the downstream changes from OPM/opm-common#1932.

We now communicate the complete FieldData during the load balancing as this is needed to correctly apply the modifications from the TranCalculator. Of course we also broadcasts its data and store in ParallelFieldPropsmanager. To apply then transmissibility modifications, we copy the calculated transmissibilities to appropriates arrays, apply the modifications using the calculator and afterwards copy them back.