### PR TITLE
Invalidate and update the intensive quantities at the same time

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1059,9 +1059,8 @@ public:
             // if TUNING is enabled, also limit the time step size after a tuning event to TSINIT
             dt = std::min(dt, initialTimeStepSize_);
         simulator.setTimeStepSize(dt);
-
         if (doInvalidate)
-            this->model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
+            this->model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0);
     }
 
     /*!
@@ -1104,7 +1103,7 @@ public:
         invalidateIntensiveQuantities = invalidateFromMaxWaterSat || invalidateFromMinPressure;
 
         if (invalidateIntensiveQuantities)
-            this->model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
+            this->model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0);
 
         wellModel_.beginTimeStep();
         if (enableAquifers_)

--- a/opm/simulators/flow/BlackoilModelEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelEbos.hpp
@@ -554,7 +554,7 @@ namespace Opm {
                                                     // residual
 
             // if the solution is updated, the intensive quantities need to be recalculated
-            ebosSimulator_.model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
+            ebosSimulator_.model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0);
         }
 
         /// Return true if output to cout is wanted.


### PR DESCRIPTION
1) This makes sure that the intensive quantities is always available i.e. we can quarry them directly from the cache. 
2) It make sure that the update of the intensive quantities are done at a reasonable place. I.e. currently it is most often done in the assembly of the well model -> strange timing 
3) Update of the intensive quantities is expensive. This make sure it is done using OPENMP. Since this is currently done in a loop in the well model that is not parallel. This gives a speed up if more than 1 tread is used. 

Depends on OPM/opm-models#626