### PR TITLE
fixed: make some indices constexpr

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -59,13 +59,13 @@ namespace Opm
         // TODO: we need to have order for the primary variables and also the order for the well equations.
         // sometimes, they are similar, while sometimes, they can have very different forms.
 
-        static const bool has_gas = (Indices::compositionSwitchIdx >= 0);
-        static const bool has_water = (Indices::waterSaturationIdx >= 0);
+        static constexpr bool has_gas = (Indices::compositionSwitchIdx >= 0);
+        static constexpr bool has_water = (Indices::waterSaturationIdx >= 0);
 
-        static const int GTotal = 0;
-        static const int WFrac = has_water? 1: -1000;
-        static const int GFrac = has_gas? has_water + 1 : -1000;
-        static const int SPres = has_gas + has_water + 1;
+        static constexpr int GTotal = 0;
+        static constexpr int WFrac = has_water ? 1: -1000;
+        static constexpr int GFrac = has_gas ? has_water + 1 : -1000;
+        static constexpr int SPres = has_gas + has_water + 1;
 
         //  the number of well equations  TODO: it should have a more general strategy for it
         static const int numWellEq = getPropValue<TypeTag, Properties::EnablePolymer>() ? numEq : numEq + 1;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -944,11 +944,11 @@ namespace Opm
 
             primary_variables_[seg][GTotal] = total_seg_rate;
             if (std::abs(total_seg_rate) > 0.) {
-                if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
+                if (has_water) {
                     const int water_pos = pu.phase_pos[Water];
                     primary_variables_[seg][WFrac] = scalingFactor(water_pos) * segment_rates[number_of_phases_ * seg_index + water_pos] / total_seg_rate;
                 }
-                if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+                if (has_gas) {
                     const int gas_pos = pu.phase_pos[Gas];
                     primary_variables_[seg][GFrac] = scalingFactor(gas_pos) * segment_rates[number_of_phases_ * seg_index + gas_pos] / total_seg_rate;
                 }
@@ -957,7 +957,7 @@ namespace Opm
                     // only single phase injection handled
                     auto phase = well.getInjectionProperties().injectorType;
 
-                    if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
+                    if (has_water) {
                         if (phase == InjectorType::WATER) {
                             primary_variables_[seg][WFrac] = 1.0;
                         } else {
@@ -965,7 +965,7 @@ namespace Opm
                         }
                     }
 
-                    if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+                    if (has_gas) {
                         if (phase == InjectorType::GAS) {
                             primary_variables_[seg][GFrac] = 1.0;
                         } else {
@@ -974,11 +974,11 @@ namespace Opm
                     }
 
                 } else if (this->isProducer()) { // producers
-                    if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
+                    if (has_water) {
                         primary_variables_[seg][WFrac] = 1.0 / number_of_phases_;
                     }
 
-                    if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+                    if (has_gas) {
                         primary_variables_[seg][GFrac] = 1.0 / number_of_phases_;
                     }
                 }
@@ -1108,13 +1108,13 @@ namespace Opm
         const std::vector<std::array<double, numWellEq> > old_primary_variables = primary_variables_;
 
         for (int seg = 0; seg < numberOfSegments(); ++seg) {
-            if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
+            if (has_water) {
                 const int sign = dwells[seg][WFrac] > 0. ? 1 : -1;
                 const double dx_limited = sign * std::min(std::abs(dwells[seg][WFrac]) * relaxation_factor, dFLimit);
                 primary_variables_[seg][WFrac] = old_primary_variables[seg][WFrac] - dx_limited;
             }
 
-            if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+            if (has_gas) {
                 const int sign = dwells[seg][GFrac] > 0. ? 1 : -1;
                 const double dx_limited = sign * std::min(std::abs(dwells[seg][GFrac]) * relaxation_factor, dFLimit);
                 primary_variables_[seg][GFrac] = old_primary_variables[seg][GFrac] - dx_limited;
@@ -1251,21 +1251,21 @@ namespace Opm
     volumeFraction(const int seg, const unsigned compIdx) const
     {
 
-        if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx) && compIdx == Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx)) {
+        if (has_water && compIdx == Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx)) {
             return primary_variables_evaluation_[seg][WFrac];
         }
 
-        if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx) && compIdx == Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx)) {
+        if (has_gas && compIdx == Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx)) {
             return primary_variables_evaluation_[seg][GFrac];
         }
 
         // Oil fraction
         EvalWell oil_fraction = 1.0;
-        if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
+        if (has_water) {
             oil_fraction -= primary_variables_evaluation_[seg][WFrac];
         }
 
-        if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+        if (has_gas) {
             oil_fraction -= primary_variables_evaluation_[seg][GFrac];
         }
         /* if (has_solvent) {
@@ -2069,10 +2069,10 @@ namespace Opm
         const int seg_upwind = upwinding_segments_[seg];
         duneD_[seg][seg][SPres][SPres] += pressure_equation.derivative(SPres + numEq);
         duneD_[seg][seg][SPres][GTotal] += pressure_equation.derivative(GTotal + numEq);
-        if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
+        if (has_water) {
             duneD_[seg][seg_upwind][SPres][WFrac] += pressure_equation.derivative(WFrac + numEq);
         }
-        if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+        if (has_gas) {
             duneD_[seg][seg_upwind][SPres][GFrac] += pressure_equation.derivative(GFrac + numEq);
         }
 
@@ -2180,10 +2180,10 @@ namespace Opm
         resWell_[seg][SPres] -= accelerationPressureLoss.value();
         duneD_[seg][seg][SPres][SPres] -= accelerationPressureLoss.derivative(SPres + numEq);
         duneD_[seg][seg][SPres][GTotal] -= accelerationPressureLoss.derivative(GTotal + numEq);
-        if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
+        if (has_water) {
             duneD_[seg][seg_upwind][SPres][WFrac] -= accelerationPressureLoss.derivative(WFrac + numEq);
         }
-        if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+        if (has_gas) {
             duneD_[seg][seg_upwind][SPres][GFrac] -= accelerationPressureLoss.derivative(GFrac + numEq);
         }
     }


### PR DESCRIPTION
also use the bool conditions for conditional deref'ing with the indices.
this helps avoid maybe uninitialized warnings with gcc.

please review carefully, but i think this should be equivalent.