### PR TITLE
add options for timestepping

### DIFF
--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -106,6 +106,8 @@ namespace Opm
         ///                   in one time step (default is 1e-3)
         /// \param verbose    if true get some output (default = false)
         PIDAndIterationCountTimeStepControl( const int target_iterations = 20,
+                                             const double decayDampingFactor = 1.0,
+                                             const double growthDampingFactor = 1.0/1.2,
                                              const double tol = 1e-3,
                                              const bool verbose = false);
 
@@ -114,6 +116,8 @@ namespace Opm
 
     protected:
         const int     target_iterations_;
+        const double  decayDampingFactor_;
+        const double  growthDampingFactor_;
     };
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR adds

- a new timestepping options "newtoniterationcount" which increase(decrease) timestep if number of newton iterations is smaller(larger) than the target newton iterations. The increase and decrease is give by TimeStepControlGrowthRate and TimeStepControlDecayRate

- a option to control the damping of the pid+(newton)iteration control
TimeStepControlGrowthDampingFactor
TimeStepControlDecayDampingFactor  
can be used to damp the increase/decrease of the timestep based on iterations counts. 

Defaults stays the same --> does not change any results. 
