### PR TITLE
Implements a Python step_cleanup() method.

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -335,6 +335,15 @@ namespace Opm
             return simulator_->runStep(*simtimer_);
         }
 
+        // Called from Python to cleanup after having executed the last
+        // executeStep()
+        int executeStepsCleanup()
+        {
+            SimulatorReport report = simulator_->finalize();
+            runSimulatorAfterSim_(report);
+            return report.success.exit_status;
+        }
+
         // Print an ASCII-art header to the PRT and DEBUG files.
         // \return Whether unkown keywords were seen during parsing.
         static void printPRTHeader(bool output_cout)

--- a/opm/simulators/flow/python/simulators.hpp
+++ b/opm/simulators/flow/python/simulators.hpp
@@ -35,13 +35,16 @@ public:
     BlackOilSimulator( const std::string &deckFilename);
     int run();
     int step();
-    int step_init();
+    int stepInit();
+    int stepCleanup();
 
 private:
     const std::string deckFilename_;
+    bool hasRunInit_;
+    bool hasRunCleanup_;
+
     std::unique_ptr<FlowMainEbosType> mainEbos_;
     std::unique_ptr<Opm::Main> main_;
-    bool hasRunInit_;
 };
 
 } // namespace Opm::Python

--- a/opm/simulators/flow/python/simulators.hpp
+++ b/opm/simulators/flow/python/simulators.hpp
@@ -40,12 +40,12 @@ public:
 
 private:
     const std::string deckFilename_;
-    bool hasRunInit_;
-    bool hasRunCleanup_;
+    bool hasRunInit_ = false;
+    bool hasRunCleanup_ = false;
 
     std::unique_ptr<FlowMainEbosType> mainEbos_;
     std::unique_ptr<Opm::Main> main_;
 };
 
-} // namespace Opm::Python
+} // namespace Opm::Pybind
 #endif // OPM_SIMULATORS_HEADER_INCLUDED

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -18,7 +18,7 @@ namespace py = pybind11;
 
 namespace Opm::Pybind {
 BlackOilSimulator::BlackOilSimulator( const std::string &deckFilename)
-    : deckFilename_{deckFilename}, hasRunInit_{false}, hasRunCleanup_{false}
+    : deckFilename_{deckFilename}
 {
 }
 

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -18,7 +18,7 @@ namespace py = pybind11;
 
 namespace Opm::Pybind {
 BlackOilSimulator::BlackOilSimulator( const std::string &deckFilename)
-    : deckFilename_(deckFilename), hasRunInit_(false)
+    : deckFilename_{deckFilename}, hasRunInit_{false}, hasRunCleanup_{false}
 {
 }
 
@@ -33,16 +33,29 @@ int BlackOilSimulator::step()
     if (!hasRunInit_) {
         throw std::logic_error("step() called before step_init()");
     }
+    if (hasRunCleanup_) {
+        throw std::logic_error("step() called after step_cleanup()");
+    }
     return mainEbos_->executeStep();
 }
 
-int BlackOilSimulator::step_init()
+int BlackOilSimulator::stepCleanup()
+{
+    hasRunCleanup_ = true;
+    return mainEbos_->executeStepsCleanup();
+}
+
+int BlackOilSimulator::stepInit()
 {
 
     if (hasRunInit_) {
         // Running step_init() multiple times is not implemented yet,
-        // currently we just do nothing and return
-        return EXIT_SUCCESS;
+        if (hasRunCleanup_) {
+            throw std::logic_error("step_init() called again");
+        }
+        else {
+            return EXIT_SUCCESS;
+        }
     }
     main_ = std::make_unique<Opm::Main>( deckFilename_ );
     int exitCode = EXIT_SUCCESS;
@@ -65,5 +78,6 @@ PYBIND11_MODULE(simulators, m)
         .def(py::init< const std::string& >())
         .def("run", &Opm::Pybind::BlackOilSimulator::run)
         .def("step", &Opm::Pybind::BlackOilSimulator::step)
-        .def("step_init", &Opm::Pybind::BlackOilSimulator::step_init);
+        .def("step_init", &Opm::Pybind::BlackOilSimulator::stepInit)
+        .def("step_cleanup", &Opm::Pybind::BlackOilSimulator::stepCleanup);
 }


### PR DESCRIPTION
Implements a Python `step_cleanup()` method.

Continues the work in #2735 on implementing Python bindings for `flow`. The `step_cleanup()` method should be called after the last `step()` call to finalize the simulation.