### PR TITLE
Delay the check for missing features to *after* state construction

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -192,7 +192,6 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
             {
                 Opm::Parser parser;
                 deck = std::make_unique<Opm::Deck>( parser.parseFile(deckFilename , *parseContext, *errorGuard));
-                Opm::MissingFeatures::checkKeywords(*deck, *parseContext, *errorGuard);
                 if ( checkDeck )
                     Opm::checkDeck(*deck, parser, *parseContext, *errorGuard);
             }
@@ -230,6 +229,7 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
                 summaryConfig = std::make_unique<Opm::SummaryConfig>(*deck, *schedule, eclipseState->getTableManager(), *parseContext, *errorGuard);
 
             Opm::checkConsistentArrayDimensions(*eclipseState, *schedule, *parseContext, *errorGuard);
+            Opm::MissingFeatures::checkKeywords(*deck, *parseContext, *errorGuard);
         }
         catch(const OpmInputError& input_error) {
             failureMessage = input_error.what();


### PR DESCRIPTION
This will move the check for missing features to the end of the input processing; the missing keywords is a sort of "ok - here comes the rest which has not processed/supported at all" - in my opinion it makes sense to have that *after* the messages with more context.