### PR TITLE
[GPU] Tweak BiCGStab

### DIFF
--- a/opm/simulators/linalg/bda/openclKernels.hpp
+++ b/opm/simulators/linalg/bda/openclKernels.hpp
@@ -440,6 +440,71 @@ namespace bda
     }
     )";
 
+    inline const char* blockscaleadd_s = R"(
+    __kernel void blockscaleadd(__global const double *vals,
+                                __global const int *cols,
+                                __global const int *rows,
+                                __global const double *x,
+                                __global const double *b,
+                                __global double *ar,
+                                const unsigned int Nb,
+                                const unsigned int block_size,
+                                __local double *tmp){
+        const unsigned int warpsize = 32;
+        const unsigned int bsize = get_local_size(0);
+        const unsigned int idx_r = get_global_id(0) / bsize;
+        const unsigned int idx_t = get_local_id(0);
+        unsigned int idx = idx_r * bsize + idx_t;
+        const unsigned int bs = block_size;
+        const unsigned int num_active_threads = (warpsize/bs/bs)*bs*bs;
+        const unsigned int num_blocks_per_warp = warpsize/bs/bs;
+        const unsigned int NUM_THREADS = get_global_size(0);
+        const unsigned int num_warps_in_grid = NUM_THREADS / warpsize;
+        unsigned int target_block_row = idx / warpsize;
+        const unsigned int lane = idx_t % warpsize;
+        const unsigned int c = (lane / bs) % bs;
+        const unsigned int r = lane % bs;
+
+        // for 3x3 blocks:
+        // num_active_threads: 27
+        // num_blocks_per_warp: 3
+
+        while(target_block_row < Nb){
+            unsigned int first_block = rows[target_block_row];
+            unsigned int last_block = rows[target_block_row+1];
+            unsigned int block = first_block + lane / (bs*bs);
+            double local_out = 0.0;
+
+            if(lane < num_active_threads){
+                for(; block < last_block; block += num_blocks_per_warp){
+                    double x_elem = x[cols[block]*bs + c];
+                    double A_elem = vals[block*bs*bs + c + r*bs];
+                    local_out += x_elem * A_elem;
+                }
+            }
+
+            // do reduction in shared mem
+            tmp[lane] = local_out;
+            barrier(CLK_LOCAL_MEM_FENCE);
+
+            for(unsigned int offset = 3; offset <= 24; offset <<= 1)
+            {
+                if (lane + offset < warpsize)
+                {
+                    tmp[lane] += tmp[lane + offset];
+                }
+                barrier(CLK_LOCAL_MEM_FENCE);
+            }
+
+            if(lane < bs){
+                unsigned int row = target_block_row*bs + lane;
+                ar[row] = b[row] - tmp[lane];
+            }
+            target_block_row += num_warps_in_grid;
+        }
+    }
+    )";
+
 } // end namespace bda
 
 #endif

--- a/opm/simulators/linalg/bda/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/openclSolverBackend.cpp
@@ -209,9 +209,6 @@ void openclSolverBackend<block_size>::gpu_pbicgstab(BdaResult& res) {
 
     Timer t_total, t_prec(false), t_spmv(false), t_well(false), t_rest(false);
 
-    // set r to the initial residual
-    // if initial x guess is not 0, must call applyblockedscaleadd(), not implemented
-    //applyblockedscaleadd(-1.0, mat, x, r);
 
     // set initial values
     cl::Event event;
@@ -222,6 +219,8 @@ void openclSolverBackend<block_size>::gpu_pbicgstab(BdaResult& res) {
     alpha = 1.0;
     omega = 1.0;
 
+    // x = 0 only on first run, therefore r = b
+    // On subsequent runs x = x_prev and r = b - A*x_prev
     if(first_run){
         queue->enqueueCopyBuffer(d_b, d_r, 0, 0, sizeof(double) * N, nullptr, &event);
         event.wait();

--- a/opm/simulators/linalg/bda/openclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/openclSolverBackend.hpp
@@ -54,6 +54,7 @@ private:
     double *vals_contiguous = nullptr;    // only used if COPY_ROW_BY_ROW is true in openclSolverBackend.cpp
 
     bool analysis_done = false;
+    bool first_run = true;
 
     // OpenCL variables must be reusable, they are initialized in initialize()
     cl::Buffer d_Avals, d_Acols, d_Arows;        // (reordered) matrix in BSR format on GPU
@@ -77,6 +78,9 @@ private:
                                     cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&,
                                     const unsigned int, const unsigned int, cl::Buffer&,
                                     cl::LocalSpaceArg, cl::LocalSpaceArg, cl::LocalSpaceArg> > stdwell_apply_k;
+    std::unique_ptr<cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&,
+                                    cl::Buffer&, cl::Buffer&, cl::Buffer&,
+                                    const unsigned int, const unsigned int, cl::LocalSpaceArg> > blockscaleadd_k;
 
     Preconditioner *prec = nullptr;                               // only supported preconditioner is BILU0
     WContainer *wcontainer = nullptr;
@@ -128,6 +132,8 @@ private:
     /// \param[in] x        input vector
     /// \param[out] b       output vector
     void spmv_blocked_w(cl::Buffer vals, cl::Buffer cols, cl::Buffer rows, cl::Buffer x, cl::Buffer b);
+
+    void blockscaleadd_w(cl::Buffer vals, cl::Buffer cols, cl::Buffer rows, cl::Buffer x, cl::Buffer b, cl::Buffer r);
 
     /// Solve linear system using ilu0-bicgstab
     /// \param[in] wellContribs   WellContributions, to apply them separately, instead of adding them to matrix A


### PR DESCRIPTION
Wrote a small change to the BiCGStab algorithm in the OpenCL backend, in order to tackle issue https://github.com/OPM/opm-simulators/issues/2822.

The initial solution for the algorithm is set to the solution obtained in the previous iteration, instead of being set to the zero vector at every iteration.

Still haven't run extensive tests. However the number of linear iterations for the 'SPE1CASE2.DATA' have reduced to ~13000 (~18% reduction).