### PR TITLE
Unconditionally Calculate PI at End of Timestep 

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -53,6 +53,7 @@
 #include <opm/simulators/wells/StandardWell.hpp>
 #include <opm/simulators/wells/MultisegmentWell.hpp>
 #include <opm/simulators/wells/WellGroupHelpers.hpp>
+#include <opm/simulators/wells/WellProdIndexCalculator.hpp>
 #include <opm/simulators/timestepping/gatherConvergenceReport.hpp>
 #include <dune/common/fmatrix.hh>
 #include <dune/istl/bcrsmatrix.hh>
@@ -268,6 +269,7 @@ namespace Opm {
 
             std::vector< Well > wells_ecl_;
             std::vector< std::vector<PerforationData> > well_perf_data_;
+            std::vector< WellProdIndexCalculator > prod_index_calc_;
 
             bool wells_active_;
 
@@ -281,6 +283,7 @@ namespace Opm {
 
             std::function<bool(const Well&)> is_shut_or_defunct_;
 
+            void initializeWellProdIndCalculators();
             void initializeWellPerfData();
 
             // create the well container
@@ -376,6 +379,8 @@ namespace Opm {
             const std::vector<double>& wellPerfEfficiencyFactors() const;
 
             void calculateEfficiencyFactors(const int reportStepIdx);
+
+            void calculateProductivityIndexValues(DeferredLogger& deferred_logger);
 
             // it should be able to go to prepareTimeStep(), however, the updateWellControls() and initPrimaryVariablesEvaluation()
             // makes it a little more difficult. unless we introduce if (iterationIdx != 0) to avoid doing the above functions

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -43,6 +43,7 @@ namespace Opm
         using typename Base::Indices;
         using typename Base::RateConverterType;
         using typename Base::SparseMatrixAdapter;
+        using typename Base::FluidState;
 
         /// the number of reservior equations
         using Base::numEq;
@@ -183,6 +184,17 @@ namespace Opm
         virtual std::vector<double> computeCurrentWellRates(const Simulator& ebosSimulator,
                                                             DeferredLogger& deferred_logger) const override;
 
+        void computeConnLevelProdInd(const FluidState& fs,
+                                     const std::function<double(const EvalWell&)>& connPICalc,
+                                     const std::vector<EvalWell>& mobility,
+                                     double* connPI) const;
+
+        void computeConnLevelInjInd(const FluidState& fs,
+                                    const std::function<double(const EvalWell&)>& connIICalc,
+                                    const std::vector<EvalWell>& mobility,
+                                    const int segIx,
+                                    double* connII,
+                                    DeferredLogger& deferred_logger) const;
     protected:
         int number_segments_;
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -22,8 +22,9 @@
 #ifndef OPM_MULTISEGMENTWELL_HEADER_INCLUDED
 #define OPM_MULTISEGMENTWELL_HEADER_INCLUDED
 
-
 #include <opm/simulators/wells/WellInterface.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
 namespace Opm
 {
@@ -185,14 +186,14 @@ namespace Opm
                                                             DeferredLogger& deferred_logger) const override;
 
         void computeConnLevelProdInd(const FluidState& fs,
-                                     const std::function<double(const EvalWell&)>& connPICalc,
+                                     const std::function<double(const double)>& connPICalc,
                                      const std::vector<EvalWell>& mobility,
                                      double* connPI) const;
 
         void computeConnLevelInjInd(const FluidState& fs,
-                                    const std::function<double(const EvalWell&)>& connIICalc,
+                                    const Phase preferred_phase,
+                                    const std::function<double(const double)>& connIICalc,
                                     const std::vector<EvalWell>& mobility,
-                                    const int segIx,
                                     double* connII,
                                     DeferredLogger& deferred_logger) const;
     protected:

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -44,7 +44,6 @@ namespace Opm
         using typename Base::RateConverterType;
         using typename Base::SparseMatrixAdapter;
 
-
         /// the number of reservior equations
         using Base::numEq;
 
@@ -167,6 +166,11 @@ namespace Opm
         virtual void calculateExplicitQuantities(const Simulator& ebosSimulator,
                                                  const WellState& well_state,
                                                  Opm::DeferredLogger& deferred_logger) override; // should be const?
+
+        virtual void updateProductivityIndex(const Simulator& ebosSimulator,
+                                             const WellProdIndexCalculator& wellPICalc,
+                                             WellState& well_state,
+                                             DeferredLogger& deferred_logger) const override;
 
         virtual void  addWellContributions(SparseMatrixAdapter& jacobian) const override;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1224,7 +1224,8 @@ namespace Opm
 
         const auto& allConn = this->well_ecl_.getConnections();
         const auto  nPerf   = allConn.size();
-        for (auto allPerfID = 0*nPerf, subsetPerfID = 0*nPerf; allPerfID < nPerf; ++allPerfID) {
+        auto subsetPerfID   = 0*nPerf;
+        for (auto allPerfID = 0*nPerf; allPerfID < nPerf; ++allPerfID) {
             if (allConn[allPerfID].state() == Connection::State::SHUT) {
                 continue;
             }
@@ -1259,6 +1260,9 @@ namespace Opm
             ++subsetPerfID;
             connPI += np;
         }
+
+        assert (static_cast<int>(subsetPerfID) == this->number_of_perforations_ &&
+                "Internal logic error in processing connections for PI/II");
     }
 
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1243,15 +1243,15 @@ namespace Opm
             setToZero(connPI);
 
             const auto segIx = this->segmentNumberToIndex(allConn[allPerfID].segment());
-            if (! isInjecting(fs, segIx, subsetPerfID)) {  // Production or zero flow rate
-                if (allow_xflow || this->isProducer()) {
-                    this->computeConnLevelProdInd(fs, connPICalc, mob, connPI);
-                }
-            }
-            else {              // Connection injects into reservoir
-                if (allow_xflow || this->isInjector()) {
+            if (isInjecting(fs, segIx, subsetPerfID)) { // Connection injects into reservoir
+                if (this->isInjector() || allow_xflow) {
                     this->computeConnLevelInjInd(fs, connPICalc, mob, segIx,
                                                  connPI, deferred_logger);
+                }
+            }
+            else {  // Production or zero flow rate
+                if (this->isProducer() || allow_xflow) {
+                    this->computeConnLevelProdInd(fs, connPICalc, mob, connPI);
                 }
             }
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -23,6 +23,8 @@
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
 
+#include <algorithm>
+
 namespace Opm
 {
 
@@ -1191,18 +1193,6 @@ namespace Opm
                .cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0)->fluidState();
         };
 
-        auto isInjecting = [this](const typename StandardWell<TypeTag>::FluidState& fs,
-                                  const int seg,
-                                  const int perf) -> bool
-        {
-            const auto pressure_cell = this->extendEval(fs.pressure(FluidSystem::oilPhaseIdx));
-            const auto perf_seg_press_diff = this->gravity_ * this->segment_densities_[seg] * this->perforation_segment_depth_diffs_[perf];
-            const auto cell_perf_press_diff = this->cell_perforation_pressure_diffs_[perf];
-            const auto drawdown = pressure_cell - cell_perf_press_diff - (this->getSegmentPressure(seg) + perf_seg_press_diff);
-
-            return drawdown.value() < 0.0;
-        };
-
         const int np = this->number_of_phases_;
         auto setToZero = [np](double* x) -> void
         {
@@ -1214,13 +1204,12 @@ namespace Opm
             std::transform(src, src + np, dest, dest, std::plus<>{});
         };
 
-        const auto allow_xflow = this->getAllowCrossFlow()
-            || this->openCrossFlowAvoidSingularity(ebosSimulator);
-
         auto* wellPI = &well_state.productivityIndex()[this->index_of_well_*np + 0];
         auto* connPI = &well_state.connectionProductivityIndex()[this->first_perf_*np + 0];
 
         setToZero(wellPI);
+
+        const auto preferred_phase = this->well_ecl_.getPreferredPhase();
 
         const auto& allConn = this->well_ecl_.getConnections();
         const auto  nPerf   = allConn.size();
@@ -1230,29 +1219,23 @@ namespace Opm
                 continue;
             }
 
+            auto connPICalc = [&wellPICalc, allPerfID](const double mobility) -> double
+            {
+                return wellPICalc.connectionProdIndStandard(allPerfID, mobility);
+            };
+
             std::vector<EvalWell> mob(this->num_components_, 0.0);
             getMobility(ebosSimulator, static_cast<int>(subsetPerfID), mob);
 
             const auto& fs = fluidState(subsetPerfID);
-
-            auto connPICalc = [&wellPICalc, allPerfID](const EvalWell& mobility) -> double
-            {
-                return wellPICalc.connectionProdIndStandard(allPerfID, mobility.value());
-            };
-
             setToZero(connPI);
 
-            const auto segIx = this->segmentNumberToIndex(allConn[allPerfID].segment());
-            if (isInjecting(fs, segIx, subsetPerfID)) { // Connection injects into reservoir
-                if (this->isInjector() || allow_xflow) {
-                    this->computeConnLevelInjInd(fs, connPICalc, mob, segIx,
-                                                 connPI, deferred_logger);
-                }
+            if (this->isInjector()) {
+                this->computeConnLevelInjInd(fs, preferred_phase, connPICalc,
+                                             mob, connPI, deferred_logger);
             }
             else {  // Production or zero flow rate
-                if (this->isProducer() || allow_xflow) {
-                    this->computeConnLevelProdInd(fs, connPICalc, mob, connPI);
-                }
+                this->computeConnLevelProdInd(fs, connPICalc, mob, connPI);
             }
 
             addVector(connPI, wellPI);
@@ -3992,7 +3975,7 @@ namespace Opm
     void
     MultisegmentWell<TypeTag>::
     computeConnLevelProdInd(const typename MultisegmentWell<TypeTag>::FluidState& fs,
-                            const std::function<double(const EvalWell&)>& connPICalc,
+                            const std::function<double(const double)>& connPICalc,
                             const std::vector<EvalWell>& mobility,
                             double* connPI) const
     {
@@ -4001,8 +3984,9 @@ namespace Opm
         for (int p = 0; p < np; ++p) {
             // Note: E100's notion of PI value phase mobility includes
             // the reciprocal FVF.
-            const auto connMob = mobility[ flowPhaseToEbosCompIdx(p) ]
-                * this->extendEval(fs.invB(p));
+            const auto connMob =
+                mobility[ flowPhaseToEbosCompIdx(p) ].value()
+                * fs.invB(p).value();
 
             connPI[p] = connPICalc(connMob);
         }
@@ -4029,72 +4013,36 @@ namespace Opm
     void
     MultisegmentWell<TypeTag>::
     computeConnLevelInjInd(const typename MultisegmentWell<TypeTag>::FluidState& fs,
-                           const std::function<double(const EvalWell&)>& connIICalc,
+                           const Phase preferred_phase,
+                           const std::function<double(const double)>& connIICalc,
                            const std::vector<EvalWell>& mobility,
-                           const int segIx,
                            double* connII,
                            DeferredLogger& deferred_logger) const
     {
+        // Assumes single phase injection
         const auto& pu = this->phaseUsage();
-        const int   np = this->number_of_phases_;
 
-        const auto zero = EvalWell { 0.0 };
-        const auto mt   = std::accumulate(mobility.begin(), mobility.end(), zero);
-
-        auto cmix_s = std::vector<EvalWell>(this->num_components_, zero);
-        for (auto componentIdx = 0*this->num_components_;
-             componentIdx < this->num_components_; ++componentIdx)
-        {
-            cmix_s[componentIdx] = this->surfaceVolumeFraction(segIx, componentIdx);
+        auto phase_pos = 0;
+        if (preferred_phase == Phase::GAS) {
+            phase_pos = pu.phase_pos[Gas];
         }
-
-        auto volumeRatio = zero;
-        if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
-            const auto waterCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx);
-            volumeRatio += cmix_s[waterCompIdx] / this->extendEval(fs.invB(pu.phase_pos[Water]));
+        else if (preferred_phase == Phase::OIL) {
+            phase_pos = pu.phase_pos[Oil];
         }
-
-        if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) &&
-            FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx))
-        {
-            const auto oilCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx);
-            const auto gasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);
-
-            const auto rs = this->extendEval(fs.Rs());
-            const auto rv = this->extendEval(fs.Rv());
-
-            // Incorporate RS/RV factors if both oil and gas active
-            const auto d = 1.0 - rv*rs;
-
-            if (d.value() == 0.0) {
-                OPM_DEFLOG_THROW(Opm::NumericalIssue,
-                                 "Zero d value obtained for well " << this->name()
-                                 << " during connection I.I. calculation"
-                                 << " with rs " << rs << " and rv " << rv,
-                                 deferred_logger);
-            }
-
-            const auto tmp_oil = (cmix_s[oilCompIdx] - rv*cmix_s[gasCompIdx]) / d;
-            volumeRatio += tmp_oil / this->extendEval(fs.invB(pu.phase_pos[Oil]));
-
-            const auto tmp_gas = (cmix_s[gasCompIdx] - rs*cmix_s[oilCompIdx]) / d;
-            volumeRatio += tmp_gas / this->extendEval(fs.invB(pu.phase_pos[Gas]));
+        else if (preferred_phase == Phase::WATER) {
+            phase_pos = pu.phase_pos[Water];
         }
         else {
-            if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
-                const auto oilCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx);
-                volumeRatio += cmix_s[oilCompIdx] / this->extendEval(fs.invB(pu.phase_pos[Oil]));
-            }
-
-            if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
-                const auto gasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);
-                volumeRatio += cmix_s[gasCompIdx] / this->extendEval(fs.invB(pu.phase_pos[Gas]));
-            }
+            OPM_DEFLOG_THROW(Opm::NotImplemented,
+                             "Unsupported Injector Type ("
+                             << static_cast<int>(preferred_phase)
+                             << ") for well " << this->name()
+                             << " during connection I.I. calculation",
+                             deferred_logger);
         }
 
-        const auto cqt_is = mt / volumeRatio;
-        for (int p = 0; p < np; ++p) {
-            connII[p] = connIICalc(cmix_s[ flowPhaseToEbosCompIdx(p) ] * cqt_is);
-        }
+        const auto zero   = EvalWell { 0.0 };
+        const auto mt     = std::accumulate(mobility.begin(), mobility.end(), zero);
+        connII[phase_pos] = connIICalc(mt.value() * fs.invB(phase_pos).value());
     }
 } // namespace Opm

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -27,9 +27,10 @@
 #include <opm/simulators/linalg/bda/WellContributions.hpp>
 #endif
 
+#include <opm/simulators/wells/GasLiftRuntime.hpp>
 #include <opm/simulators/wells/RateConverter.hpp>
 #include <opm/simulators/wells/WellInterface.hpp>
-#include <opm/simulators/wells/GasLiftRuntime.hpp>
+#include <opm/simulators/wells/WellProdIndexCalculator.hpp>
 
 #include <opm/models/blackoil/blackoilpolymermodules.hh>
 #include <opm/models/blackoil/blackoilsolventmodules.hh>
@@ -224,6 +225,11 @@ namespace Opm
                                                  const WellState& well_state,
                                                  Opm::DeferredLogger& deferred_logger) override; // should be const?
 
+        virtual void updateProductivityIndex(const Simulator& ebosSimulator,
+                                             const WellProdIndexCalculator& wellPICalc,
+                                             WellState& well_state,
+                                             DeferredLogger& deferred_logger) const override;
+
         virtual void  addWellContributions(SparseMatrixAdapter& mat) const override;
 
         // iterate well equations with the specified control until converged
@@ -315,7 +321,6 @@ namespace Opm
         using Base::wpolymer;
         using Base::wfoam;
         using Base::scalingFactor;
-        using Base::scaleProductivityIndex;
         using Base::mostStrictBhpFromBhpLimits;
 
         // protected member variables from the Base class

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -39,6 +39,7 @@
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
 
 #include <opm/material/densead/DynamicEvaluation.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
 
 #include <dune/common/dynvector.hh>
@@ -311,12 +312,13 @@ namespace Opm
                                                             DeferredLogger& deferred_logger) const override;
 
         void computeConnLevelProdInd(const FluidState& fs,
-                                     const std::function<double(const EvalWell&)>& connPICalc,
+                                     const std::function<double(const double)>& connPICalc,
                                      const std::vector<EvalWell>& mobility,
                                      double* connPI) const;
 
-        void computeConnLevelInjInd(const FluidState& fs,
-                                    const std::function<double(const EvalWell&)>& connIICalc,
+        void computeConnLevelInjInd(const typename StandardWell<TypeTag>::FluidState& fs,
+                                    const Phase preferred_phase,
+                                    const std::function<double(const double)>& connIICalc,
                                     const std::vector<EvalWell>& mobility,
                                     double* connII,
                                     DeferredLogger& deferred_logger) const;

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -310,8 +310,18 @@ namespace Opm
         virtual std::vector<double> computeCurrentWellRates(const Simulator& ebosSimulator,
                                                             DeferredLogger& deferred_logger) const override;
 
-    protected:
+        void computeConnLevelProdInd(const FluidState& fs,
+                                     const std::function<double(const EvalWell&)>& connPICalc,
+                                     const std::vector<EvalWell>& mobility,
+                                     double* connPI) const;
 
+        void computeConnLevelInjInd(const FluidState& fs,
+                                    const std::function<double(const EvalWell&)>& connIICalc,
+                                    const std::vector<EvalWell>& mobility,
+                                    double* connII,
+                                    DeferredLogger& deferred_logger) const;
+
+    protected:
         // protected functions from the Base class
         using Base::getAllowCrossFlow;
         using Base::flowPhaseToEbosCompIdx;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -24,6 +24,10 @@
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/simulators/linalg/MatrixBlock.hpp>
 
+#include <algorithm>
+#include <functional>
+#include <numeric>
+
 namespace Opm
 {
 
@@ -2288,42 +2292,41 @@ namespace Opm
                             WellState& well_state,
                             DeferredLogger& deferred_logger) const
     {
-        auto recipFVF = [&ebosSimulator, this](const int perf, const int p) -> double
+        auto fluidState = [&ebosSimulator, this](const int perf)
         {
             const auto cell_idx = this->well_cells_[perf];
-            const auto& fs = ebosSimulator.model()
+            return ebosSimulator.model()
                .cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0)->fluidState();
-
-            return fs.invB(p).value();
         };
 
-        auto Rs = [&ebosSimulator, this](const int perf) -> double
+        auto isInjecting = [this](const typename StandardWell<TypeTag>::FluidState& fs,
+                                  const int perf) -> bool
         {
-            const auto cell_idx = this->well_cells_[perf];
-            const auto& fs = ebosSimulator.model()
-               .cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0)->fluidState();
+            const auto cell_press = this->extendEval(this->getPerfCellPressure(fs));
+            const auto conn_press = this->getBhp() + this->perf_pressure_diffs_[perf];
+            const auto drawdown   = cell_press - conn_press;
 
-            return fs.Rs().value();
+            return drawdown.value() < 0.0;
         };
 
-        auto Rv = [&ebosSimulator, this](const int perf) -> double
+        const int np = this->number_of_phases_;
+        auto setToZero = [np](double* x) -> void
         {
-            const auto cell_idx = this->well_cells_[perf];
-            const auto& fs = ebosSimulator.model()
-               .cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0)->fluidState();
-
-            return fs.Rv().value();
+            std::fill_n(x, np, 0.0);
         };
 
-        const auto& pu = this->phaseUsage();
-        const int   np = this->number_of_phases_;
+        auto addVector = [np](const double* src, double* dest) -> void
+        {
+            std::transform(src, src + np, dest, dest, std::plus<>{});
+        };
+
+        const auto allow_xflow = this->getAllowCrossFlow()
+            || this->openCrossFlowAvoidSingularity(ebosSimulator);
 
         auto* wellPI = &well_state.productivityIndex()[this->index_of_well_*np + 0];
         auto* connPI = &well_state.connectionProductivityIndex()[this->first_perf_*np + 0];
 
-        for (int p = 0; p < np; ++p) {
-            wellPI[p] = 0.0;
-        }
+        setToZero(wellPI);
 
         const auto& allConn = this->well_ecl_.getConnections();
         const auto  nPerf   = allConn.size();
@@ -2335,29 +2338,27 @@ namespace Opm
             std::vector<EvalWell> mob(num_components_, {numWellEq_ + numEq, 0.0});
             getMobility(ebosSimulator, static_cast<int>(subsetPerfID), mob, deferred_logger);
 
-            for (int p = 0; p < np; ++p) {
-                // Note: E100's notion of PI value phase mobility includes
-                // the reciprocal FVF.
-                const auto connMob = mob[ flowPhaseToEbosCompIdx(p) ].value() * recipFVF(subsetPerfID, p);
-                connPI[p] = wellPICalc.connectionProdIndStandard(allPerfID, connMob);
-            }
+            const auto& fs = fluidState(subsetPerfID);
 
-            if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) &&
-                FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx))
+            auto connPICalc = [&wellPICalc, allPerfID](const EvalWell& mobility) -> double
             {
-                const auto io = pu.phase_pos[Oil];
-                const auto ig = pu.phase_pos[Gas];
+                return wellPICalc.connectionProdIndStandard(allPerfID, mobility.value());
+            };
 
-                const auto vapoil = connPI[ig] * Rv(subsetPerfID);
-                const auto disgas = connPI[io] * Rs(subsetPerfID);
-
-                connPI[io] += vapoil;
-                connPI[ig] += disgas;
+            setToZero(connPI);
+            if (! isInjecting(fs, subsetPerfID)) {  // Production or zero flow rate
+                if (allow_xflow || this->isProducer()) {
+                    this->computeConnLevelProdInd(fs, connPICalc, mob, connPI);
+                }
+            }
+            else {              // Connection injects into reservoir
+                if (allow_xflow || this->isInjector()) {
+                    this->computeConnLevelInjInd(fs, connPICalc, mob,
+                                                 connPI, deferred_logger);
+                }
             }
 
-            for (int p = 0; p < np; ++p) {
-                wellPI[p] += connPI[p];
-            }
+            addVector(connPI, wellPI);
 
             ++subsetPerfID;
             connPI += np;
@@ -4271,4 +4272,115 @@ namespace Opm
     }
 
 
+
+
+
+    template <typename TypeTag>
+    void
+    StandardWell<TypeTag>::
+    computeConnLevelProdInd(const typename StandardWell<TypeTag>::FluidState& fs,
+                            const std::function<double(const EvalWell&)>& connPICalc,
+                            const std::vector<EvalWell>& mobility,
+                            double* connPI) const
+    {
+        const auto& pu = this->phaseUsage();
+        const int   np = this->number_of_phases_;
+        for (int p = 0; p < np; ++p) {
+            // Note: E100's notion of PI value phase mobility includes
+            // the reciprocal FVF.
+            const auto connMob = mobility[ flowPhaseToEbosCompIdx(p) ]
+                * this->extendEval(fs.invB(p));
+
+            connPI[p] = connPICalc(connMob);
+        }
+
+        if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) &&
+            FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx))
+        {
+            const auto io = pu.phase_pos[Oil];
+            const auto ig = pu.phase_pos[Gas];
+
+            const auto vapoil = connPI[ig] * fs.Rv().value();
+            const auto disgas = connPI[io] * fs.Rs().value();
+
+            connPI[io] += vapoil;
+            connPI[ig] += disgas;
+        }
+    }
+
+
+
+
+
+    template <typename TypeTag>
+    void
+    StandardWell<TypeTag>::
+    computeConnLevelInjInd(const typename StandardWell<TypeTag>::FluidState& fs,
+                           const std::function<double(const EvalWell&)>& connIICalc,
+                           const std::vector<EvalWell>& mobility,
+                           double* connII,
+                           DeferredLogger& deferred_logger) const
+    {
+        const auto& pu = this->phaseUsage();
+        const int   np = this->number_of_phases_;
+
+        const auto zero = EvalWell { this->numWellEq_ + this->numEq, 0.0 };
+        const auto mt   = std::accumulate(mobility.begin(), mobility.end(), zero);
+
+        auto cmix_s = std::vector<EvalWell>(this->num_components_, zero);
+        for (auto componentIdx = 0*this->num_components_;
+             componentIdx < this->num_components_; ++componentIdx)
+        {
+            cmix_s[componentIdx] = this->wellSurfaceVolumeFraction(componentIdx);
+        }
+
+        auto volumeRatio = zero;
+        if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
+            const auto waterCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx);
+            volumeRatio += cmix_s[waterCompIdx] / this->extendEval(fs.invB(pu.phase_pos[Water]));
+        }
+
+        if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) &&
+            FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx))
+        {
+            const auto oilCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx);
+            const auto gasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);
+
+            const auto rs = this->extendEval(fs.Rs());
+            const auto rv = this->extendEval(fs.Rv());
+
+            // Incorporate RS/RV factors if both oil and gas active
+            const auto d = EvalWell { this->numWellEq_ + this->numEq, 1.0 } - rv*rs;
+
+            if (d.value() == 0.0) {
+                OPM_DEFLOG_THROW(Opm::NumericalIssue,
+                                 "Zero d value obtained for well " << this->name()
+                                 << " during connection I.I. calculation"
+                                 << " with rs " << rs << " and rv " << rv,
+                                 deferred_logger);
+            }
+
+            const auto tmp_oil = (cmix_s[oilCompIdx] - rv*cmix_s[gasCompIdx]) / d;
+            volumeRatio += tmp_oil / this->extendEval(fs.invB(pu.phase_pos[Oil]));
+
+            const auto tmp_gas = (cmix_s[gasCompIdx] - rs*cmix_s[oilCompIdx]) / d;
+            volumeRatio += tmp_gas / this->extendEval(fs.invB(pu.phase_pos[Gas]));
+        }
+        else {
+            if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
+                const auto oilCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx);
+                volumeRatio += cmix_s[oilCompIdx] / this->extendEval(fs.invB(pu.phase_pos[Oil]));
+            }
+
+            if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+                const auto gasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);
+                volumeRatio += cmix_s[gasCompIdx] / this->extendEval(fs.invB(pu.phase_pos[Gas]));
+            }
+        }
+
+        const auto cqt_is = mt / volumeRatio;
+        for (int p = 0; p < np; ++p) {
+            connII[p] = connIICalc(cmix_s[ flowPhaseToEbosCompIdx(p) ] * cqt_is);
+        }
+    }
 } // namespace Opm

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2330,7 +2330,8 @@ namespace Opm
 
         const auto& allConn = this->well_ecl_.getConnections();
         const auto  nPerf   = allConn.size();
-        for (auto allPerfID = 0*nPerf, subsetPerfID = 0*nPerf; allPerfID < nPerf; ++allPerfID) {
+        auto subsetPerfID   = 0*nPerf;
+        for (auto allPerfID = 0*nPerf; allPerfID < nPerf; ++allPerfID) {
             if (allConn[allPerfID].state() == Connection::State::SHUT) {
                 continue;
             }
@@ -2363,6 +2364,9 @@ namespace Opm
             ++subsetPerfID;
             connPI += np;
         }
+
+        assert (static_cast<int>(subsetPerfID) == this->number_of_perforations_ &&
+                "Internal logic error in processing connections for PI/II");
     }
 
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2347,15 +2347,15 @@ namespace Opm
             };
 
             setToZero(connPI);
-            if (! isInjecting(fs, subsetPerfID)) {  // Production or zero flow rate
-                if (allow_xflow || this->isProducer()) {
-                    this->computeConnLevelProdInd(fs, connPICalc, mob, connPI);
-                }
-            }
-            else {              // Connection injects into reservoir
-                if (allow_xflow || this->isInjector()) {
+            if (isInjecting(fs, subsetPerfID)) { // Connection injects into reservoir
+                if (this->isInjector() || allow_xflow) {
                     this->computeConnLevelInjInd(fs, connPICalc, mob,
                                                  connPI, deferred_logger);
+                }
+            }
+            else {  // Production or zero flow rate
+                if (this->isProducer() || allow_xflow) {
+                    this->computeConnLevelProdInd(fs, connPICalc, mob, connPI);
                 }
             }
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -39,6 +39,7 @@
 #include <opm/simulators/wells/VFPProperties.hpp>
 #include <opm/simulators/wells/WellHelpers.hpp>
 #include <opm/simulators/wells/WellGroupHelpers.hpp>
+#include <opm/simulators/wells/WellProdIndexCalculator.hpp>
 #include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/BlackoilModelParametersEbos.hpp>
 
@@ -220,6 +221,11 @@ namespace Opm
         virtual void calculateExplicitQuantities(const Simulator& ebosSimulator,
                                                  const WellState& well_state,
                                                  Opm::DeferredLogger& deferred_logger) = 0; // should be const?
+
+        virtual void updateProductivityIndex(const Simulator& ebosSimulator,
+                                             const WellProdIndexCalculator& wellPICalc,
+                                             WellState& well_state,
+                                             DeferredLogger& deferred_logger) const = 0;
 
         /// \brief Wether the Jacobian will also have well contributions in it.
         virtual bool jacobianContainsWellContributions() const
@@ -513,13 +519,7 @@ namespace Opm
                                  const std::vector<double>& B_avg,
                                  Opm::DeferredLogger& deferred_logger);
 
-        void scaleProductivityIndex(const int perfIdx, double& productivity_index, const bool new_well, Opm::DeferredLogger& deferred_logger) const;
-
         void initCompletions();
-
-        // count the number of times an output log message is created in the productivity
-        // index calculations
-        mutable int well_productivity_index_logger_counter_;
 
         bool checkConstraints(WellState& well_state,
                               const Schedule& schedule,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -85,8 +85,6 @@ namespace Opm
 
         connectionRates_.resize(number_of_perforations_);
 
-        well_productivity_index_logger_counter_ = 0;
-
         wellIsStopped_ = false;
         if (well.getStatus() == Well::Status::STOP) {
             wellIsStopped_ = true;
@@ -1378,40 +1376,6 @@ namespace Opm
                           + std::to_string(max_iter) + " iterations");
             well_state = well_state0;
         }
-    }
-
-    template<typename TypeTag>
-    void
-    WellInterface<TypeTag>::scaleProductivityIndex(const int perfIdx, double& productivity_index, const bool new_well, Opm::DeferredLogger& deferred_logger) const
-    {
-        const auto& connection = well_ecl_.getConnections()[(*perf_data_)[perfIdx].ecl_index];
-        if (well_ecl_.getDrainageRadius() < 0) {
-            if (new_well && perfIdx == 0) {
-                deferred_logger.warning("PRODUCTIVITY_INDEX_WARNING", "Negative drainage radius not supported. The productivity index is set to zero");
-            }
-            productivity_index = 0.0;
-            return;
-        }
-
-        if (connection.r0() > well_ecl_.getDrainageRadius()) {
-            if (new_well && well_productivity_index_logger_counter_ < 1) {
-                deferred_logger.info("PRODUCTIVITY_INDEX_INFO", "The effective radius is larger than the well drainage radius for well " + name() +
-                             " They are set to equal in the well productivity index calculations");
-                well_productivity_index_logger_counter_++;
-            }
-            return;
-        }
-
-        // For zero drainage radius the productivity index is just the transmissibility times the mobility
-        if (well_ecl_.getDrainageRadius() == 0) {
-            return;
-        }
-
-        // Scale the productivity index to account for the drainage radius.
-        // Assumes steady radial flow only valied for horizontal wells
-        productivity_index *=
-        (std::log(connection.r0() / connection.rw()) + connection.skinFactor()) /
-        (std::log(well_ecl_.getDrainageRadius() / connection.rw()) + connection.skinFactor());
     }
 
     template<typename TypeTag>


### PR DESCRIPTION
This PR ensures that we calculate the well and connection level per-phase steady-state productivity index (PI) at the end of a completed time step (triggered from `endTimeStep()`).

We add a new data member,
```
BlackoilWellModel<>::prod_index_calc_
```
which holds one `WellProdIndexCalculator` for each of the process' local wells and a new interface member function
```
WellInterface::updateProductivityIndex
```
which uses a per-well PI calculator to actually compute the PI values and store those in the `WellState`.  Implement this member function for both `StandardWell` and `MultisegmentWell`.  Were it not for `getMobility` existing only in the derived classes, the two equal implementations could be merged and moved to the interface.

We also add a new data member to the `WellStateFullyImplicitBlackoil` to hold the connection-level PI values.  Finally, remove the conditional PI calculation from `StandardWell`'s well equation assembly routine.