### PR TITLE
Silence warnings from range-for.

### DIFF
--- a/opm/simulators/linalg/ParallelOverlappingILU0.hpp
+++ b/opm/simulators/linalg/ParallelOverlappingILU0.hpp
@@ -380,7 +380,7 @@ namespace Opm
                 }
             }
             // create the row
-            for(const auto entry: rowPattern)
+            for (const auto& entry : rowPattern)
             {
                 iluRow.insert(entry.first);
             }

--- a/opm/simulators/timestepping/ConvergenceReport.hpp
+++ b/opm/simulators/timestepping/ConvergenceReport.hpp
@@ -109,12 +109,12 @@ namespace Opm
             status_ = static_cast<Status>(status_ | WellFailed);
             well_failures_.push_back(wf);
         }
-        
+
         void setGroupConverged(const bool groupConverged)
         {
             groupConverged_ = groupConverged;
         }
-        
+
         ConvergenceReport& operator+=(const ConvergenceReport& other)
         {
             status_ = static_cast<Status>(status_ | other.status_);
@@ -159,7 +159,7 @@ namespace Opm
                 return s1 < s2 ? s2 : s1;
             };
             auto s = Severity::None;
-            for (const auto f : res_failures_) {
+            for (const auto& f : res_failures_) {
                 s = smax(s, f.severity());
             }
             for (const auto& f : well_failures_) {

--- a/opm/simulators/timestepping/gatherConvergenceReport.cpp
+++ b/opm/simulators/timestepping/gatherConvergenceReport.cpp
@@ -68,7 +68,7 @@ namespace
         const auto rf = local_report.reservoirFailures();
         int num_rf = rf.size();
         MPI_Pack(&num_rf, 1, MPI_INT, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
-        for (const auto f : rf) {
+        for (const auto& f : rf) {
             packReservoirFailure(f, buf, offset);
         }
         // Well failures.

--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -392,7 +392,7 @@ void pack(const std::vector<bool,A>& data, std::vector<char>& buffer, int& posit
           Dune::MPIHelper::MPICommunicator comm)
 {
     pack(data.size(), buffer, position, comm);
-    for (const auto& entry : data) {
+    for (const auto entry : data) { // Not a reference: vector<bool> range
         bool b = entry;
         pack(b, buffer, position, comm);
     }

--- a/opm/simulators/utils/gatherDeferredLogger.cpp
+++ b/opm/simulators/utils/gatherDeferredLogger.cpp
@@ -38,7 +38,7 @@ namespace
         int messagesize = local_messages.size();
         MPI_Pack(&messagesize, 1, MPI_UNSIGNED, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
 
-        for (const auto lm : local_messages) {
+        for (const auto& lm : local_messages) {
             MPI_Pack(static_cast<void*>(const_cast<std::int64_t*>(&lm.flag)), 1, MPI_INT64_T, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
             int tagsize = lm.tag.size();
             MPI_Pack(&tagsize, 1, MPI_UNSIGNED, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
@@ -122,7 +122,7 @@ namespace Opm
         // store 2 unsigned ints per message for length of tag and length of text
         message_size += num_messages*2*unsigned_int_mpi_pack_size;
 
-        for (const auto lm : local_deferredlogger.messages_) {
+        for (const auto& lm : local_deferredlogger.messages_) {
             int string_mpi_pack_size;
             MPI_Pack_size(lm.tag.size(), MPI_CHAR, MPI_COMM_WORLD, &string_mpi_pack_size);
             message_size += string_mpi_pack_size;


### PR DESCRIPTION
New clang version, new warnings...

This bunch is all about using references in range-for loops. Or not, for `vector<bool>`, of course!