### PR TITLE
Sort local non-shut wells.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -219,6 +219,11 @@ namespace Opm {
         auto w = schedule().getWells(timeStepIdx);
         globalNumWells = w.size();
         w.erase(std::remove_if(w.begin(), w.end(), is_shut_or_defunct_), w.end());
+        // sort to speed lookup of accompanying parallel_well_info
+        std::sort(w.begin(), w.end(), [](const auto& w1, const auto& w2){
+                                          return w1.name() < w2.name();
+                                      });
+
         return w;
     }
 


### PR DESCRIPTION
This will change the order of applying wells. Most tests are unaffected by this (maybe because the wells are sorted anyway), others are (e.g. FAULTS_MODEL_1, and 9_4B_WINJ_VREP-W_STW, probably others, too).

This PR is there to demonstrate the minimal changes needed to change results