### PR TITLE
Fixes compilation of CUDA.

### DIFF
--- a/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
+++ b/opm/simulators/linalg/bda/MultisegmentWellContribution.hpp
@@ -26,7 +26,9 @@
 #include <cuda_runtime.h>
 #endif
 
-#include <dune/istl/umfpack.hh>
+#if HAVE_SUITESPARSE_UMFPACK
+#include<umfpack.h>
+#endif
 #include <dune/common/version.hh>
 
 namespace Opm
@@ -79,8 +81,7 @@ private:
 public:
 
 #if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 7)
-    using UMFPackIndex =
-        typename Dune::UMFPack<Dune::BCRSMatrix<Dune::FieldMatrix<double,1,1>>>::UMFPackMatrix::Index;
+    using UMFPackIndex = SuiteSparse_long;
 #else
     using UMFPackIndex = int;
 #endif

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -31,7 +31,9 @@
 #include <vector>
 
 #include <opm/simulators/linalg/bda/MultisegmentWellContribution.hpp>
-#include <dune/istl/umfpack.hh>
+#if HAVE_SUITESPARSE_UMFPACK
+#include<umfpack.h>
+#endif
 #include <dune/common/version.hh>
 
 namespace Opm
@@ -58,8 +60,7 @@ class WellContributions
 {
 public:
 #if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 7)
-    using UMFPackIndex =
-        typename Dune::UMFPack<Dune::BCRSMatrix<Dune::FieldMatrix<double,1,1>>>::UMFPackMatrix::Index;
+    using UMFPackIndex = SuiteSparse_long;
 #else
     using UMFPackIndex = int;
 #endif


### PR DESCRIPTION
nvcc exits compilation if the header dune/istl/basearray.hh (form DUNE 2.6) is included as it does not seem to understand the friend declaration there (friend class for a struct).

```
/usr/include/dune/istl/basearray.hh:101:49: error: ‘typename Dune::Imp::base_array_unmanaged<B, A>::RealIterator’ names ‘template<class B, class A> template<class T> struct Dune::Imp::base_array_unmanaged<B, A>::RealIterator’, which is not a type
       friend class RealIterator<const ValueType>;
                                                 ^
```