### PR TITLE
Default two-step preconditioner to post-smoothing

### DIFF
--- a/opm/simulators/linalg/OwningTwoLevelPreconditioner.hpp
+++ b/opm/simulators/linalg/OwningTwoLevelPreconditioner.hpp
@@ -130,8 +130,8 @@ public:
                            finesmoother_,
                            levelTransferPolicy_,
                            coarseSolverPolicy_,
-                           prm.get<int>("pre_smooth", transpose? 1 : 0),
-                           prm.get<int>("post_smooth", transpose? 0 : 1))
+                           prm.get<int>("pre_smooth",  0),
+                           prm.get<int>("post_smooth", 1))
         , prm_(prm)
     {
         if (prm.get<int>("verbosity", 0) > 10 && comm.communicator().rank() == 0) {


### PR DESCRIPTION
A very small fix.

This changes nothing for the "built-in" options for --linsolver, namely "cpr"/"cpr_trueimpes" and "cpr_quasiimpes", since they already have the current behaviour.