### PR TITLE
Well debug log

### DIFF
--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -52,10 +52,14 @@
 #include <opm/material/densead/Math.hpp>
 #include <opm/material/densead/Evaluation.hpp>
 
-#include <string>
-#include <memory>
-#include <vector>
+#include <iostream>
+#include <fstream>
+
 #include <cassert>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 namespace Opm
 {
@@ -384,6 +388,8 @@ namespace Opm
 
         double wsolvent_;
 
+        mutable std::shared_ptr<std::ofstream> debug_stream_;
+
         const PhaseUsage& phaseUsage() const;
 
         int flowPhaseToEbosCompIdx( const int phaseIdx ) const;
@@ -503,6 +509,9 @@ namespace Opm
         // count the number of times an output log message is created in the productivity
         // index calculations
         int well_productivity_index_logger_counter_;
+        void debugControls(const WellState& well_state) const;
+        void debugControl(const std::string& name, double current_value, double limit, bool upper_limit = false) const;
+        void debugIndividualConstraints(const WellState& well_state) const;
 
         bool checkConstraints(WellState& well_state,
                               const Schedule& schedule,
@@ -618,7 +627,6 @@ namespace Opm
         bool can_obtain_bhp_with_thp_limit = true;
         // whether the well obey bhp limit when operated under thp limit
         bool obey_bhp_limit_with_thp_limit = true;
-
     };
 
 


### PR DESCRIPTION
I need something like this for the restart work; and since I am quite ordinary developer it might be valuable for others as well?

This PR adds a very basic start for logging of well changes/updates. Currently the code is very basic and not by any means complete, but I post it here early so that it can be shot down and buried right away if this is not a wanted feature. Personally I like it of course.

I tried to strike a balance between zero (or veeery low) overhead in the default no-logging case, and not polluting the main code path too much. The intention is that developers working on this type of code should set a boolean flag in the code to `true` and recompile; in addition users can set the environment variable `OPM_DEBUG_WELLS="pattern"` - and the debugging will be turned on for all wells matching `pattern` - I think that could be a valuable tool for remote debugging assistance?

Feel free to slaughter the implementation all the way to minced meat - but fcous on the main question: "Do we want to merge something like this in the future - when the implementation has been fixed?" 