### PR TITLE
Initial Implementation of WELPI Feature

### DIFF
--- a/opm/simulators/flow/MissingFeatures.cpp
+++ b/opm/simulators/flow/MissingFeatures.cpp
@@ -791,7 +791,6 @@ namespace MissingFeatures {
             "WELEVNT",
             "WELMOVEL"
             "WELOPENL"
-            "WELPI",
             "WELPRI",
             "WELSOMIN",
             "WELSPECL",

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -283,6 +283,9 @@ namespace Opm {
 
             void initializeWellProdIndCalculators();
             void initializeWellPerfData();
+            void initializeWellState(const int           timeStepIdx,
+                                     const int           globalNumWells,
+                                     const SummaryState& summaryState);
 
             // create the well container
             std::vector<WellInterfacePtr > createWellContainer(const int time_step);

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -215,6 +215,7 @@ namespace Opm {
                 auto wsrpt = well_state_.report(phase_usage_, Opm::UgGridHelpers::globalCell(grid()));
 
                 this->assignWellGuideRates(wsrpt);
+                this->assignShutConnections(wsrpt);
 
                 return wsrpt;
             }
@@ -468,6 +469,7 @@ namespace Opm {
             void setWsolvent(const Group& group, const Schedule& schedule, const int reportStepIdx, double wsolvent);
 
             void assignWellGuideRates(data::Wells& wsrpt) const;
+            void assignShutConnections(data::Wells& wsrpt) const;
             void assignGroupValues(const int                               reportStepIdx,
                                    const Schedule&                         sched,
                                    std::map<std::string, data::GroupData>& gvalues) const;

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -34,6 +34,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -322,6 +323,9 @@ namespace Opm {
             bool report_step_starts_;
             bool glift_debug = false;
             bool alternative_well_rate_init_;
+
+            std::optional<int> last_run_wellpi_{};
+
             std::unique_ptr<RateConverterType> rateConverter_;
             std::unique_ptr<VFPProperties<VFPInjProperties,VFPProdProperties>> vfp_properties_;
 
@@ -467,6 +471,8 @@ namespace Opm {
             void updateWsolvent(const Group& group, const Schedule& schedule, const int reportStepIdx, const WellStateFullyImplicitBlackoil& wellState);
 
             void setWsolvent(const Group& group, const Schedule& schedule, const int reportStepIdx, double wsolvent);
+
+            void runWellPIScaling(const int timeStepIdx, DeferredLogger& local_deferredLogger);
 
             void assignWellGuideRates(data::Wells& wsrpt) const;
             void assignShutConnections(data::Wells& wsrpt) const;

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -214,16 +214,7 @@ namespace Opm {
             {
                 auto wsrpt = well_state_.report(phase_usage_, Opm::UgGridHelpers::globalCell(grid()));
 
-                for (const auto& well : this->wells_ecl_) {
-                    auto xwPos = wsrpt.find(well.name());
-                    if (xwPos == wsrpt.end()) { // No well results.  Unexpected.
-                        continue;
-                    }
-
-                    auto& grval = xwPos->second.guide_rates;
-                    grval.clear();
-                    grval += this->getGuideRateValues(well);
-                }
+                this->assignWellGuideRates(wsrpt);
 
                 return wsrpt;
             }
@@ -473,6 +464,7 @@ namespace Opm {
 
             void setWsolvent(const Group& group, const Schedule& schedule, const int reportStepIdx, double wsolvent);
 
+            void assignWellGuideRates(data::Wells& wsrpt) const;
             void assignGroupValues(const int                               reportStepIdx,
                                    const Schedule&                         sched,
                                    std::map<std::string, data::GroupData>& gvalues) const;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2591,6 +2591,29 @@ namespace Opm {
         }
     }
 
+
+
+
+
+    template<typename TypeTag>
+    void
+    BlackoilWellModel<TypeTag>::
+    assignWellGuideRates(data::Wells& wsrpt) const
+    {
+        for (const auto& well : this->wells_ecl_) {
+            auto xwPos = wsrpt.find(well.name());
+            if (xwPos == wsrpt.end()) { // No well results.  Unexpected.
+                continue;
+            }
+
+            xwPos->second.guide_rates = this->getGuideRateValues(well);
+        }
+    }
+
+
+
+
+
     template <typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::

--- a/opm/simulators/wells/WellProdIndexCalculator.cpp
+++ b/opm/simulators/wells/WellProdIndexCalculator.cpp
@@ -96,6 +96,11 @@ Opm::WellProdIndexCalculator::WellProdIndexCalculator(const Well& well)
     : standardConnFactors_{ calculateStandardConnFactors(well) }
 {}
 
+void Opm::WellProdIndexCalculator::reInit(const Well& well)
+{
+    this->standardConnFactors_ = calculateStandardConnFactors(well);
+}
+
 double
 Opm::WellProdIndexCalculator::
 connectionProdIndStandard(const std::size_t connIdx,

--- a/opm/simulators/wells/WellProdIndexCalculator.hpp
+++ b/opm/simulators/wells/WellProdIndexCalculator.hpp
@@ -41,6 +41,16 @@ namespace Opm {
         ///   per-connection static data.
         explicit WellProdIndexCalculator(const Well& well);
 
+        /// Reinitialization operation
+        ///
+        /// Needed to repopulate the internal data members in case of
+        /// changes to the Well's properties, e.g., as a result of the
+        /// Well's CTFs being rescaled due to WELPI.
+        ///
+        /// \param[in] well Individual well for which to collect
+        ///   per-connection static data.
+        void reInit(const Well& well);
+
         /// Compute connection-level steady-state productivity index value
         /// using dynamic phase mobility.
         ///

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -64,6 +64,7 @@ namespace Opm
         using BaseType :: wellMap;
         using BaseType :: numWells;
         using BaseType :: numPhases;
+        using BaseType :: resetConnectionTransFactors;
 
         /// Allocate and initialize if wells is non-null.  Also tries
         /// to give useful initial values to the bhp(), wellRates()

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -270,6 +270,16 @@ namespace Opm
                                 }
                             }
                         }
+
+                        // Productivity index.
+                        {
+                            auto*       thisWellPI = &this     ->productivityIndex()[newIndex*np + 0];
+                            const auto* thatWellPI = &prevState->productivityIndex()[oldIndex*np + 0];
+
+                            for (int p = 0; p < np; ++p) {
+                                thisWellPI[p] = thatWellPI[p];
+                            }
+                        }
                     }
 
                     // If in the new step, there is no THP related target/limit anymore, its thp value should be


### PR DESCRIPTION
This PR adds an initial implementation of the `WELPI` feature.  At this time there are still issues that need ironing out, especially for injection wells, but I believe we're ready for more widespread testing.

We rely on actual PI values being calculated at the well level at the end of each time step and use those values, in the event of a `WELPI` request, to calculate CTF scaling factors and apply those factors to all subsequent editions of the well provided the connection factors are eligible for `WELPI`-based rescaling.

If we trigger a rescaling event we also reset the `WellState`'s internal copies of the CTFs and reinitialize the Well PI calculators to ensure the rescaling takes effect immediately.  Since we rely on PI values being available at the end of each time step we must also take care to forward those values from the `WellState` of one report step to the `WellState` of the next report step.

This PR depends on #2846 and must not be merged before that PR is merged into master.