### PR TITLE
 WIP Add flow_dyn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
 set( USE_OPENMP_DEFAULT OFF ) # Use of OpenMP is considered experimental
 option(BUILD_FLOW "Build the production oriented flow simulator?" ON)
 option(BUILD_FLOW_BLACKOIL_ONLY "Build the production oriented flow simulator only supporting the blackoil model?" OFF)
+option(BUILD_FLOW_DYN "Build the flow simulator with dynamic indicies?" OFF)
 option(BUILD_FLOW_VARIANTS "Build the variants for flow by default?" OFF)
 option(BUILD_EBOS "Build the research oriented ebos simulator?" ON)
 option(BUILD_EBOS_EXTENSIONS "Build the variants for various extensions of ebos by default?" OFF)
@@ -292,6 +293,29 @@ opm_add_test(flow_blackoil_dunecpr
   EXE_NAME flow_blackoil_dunecpr
   DEPENDS opmsimulators
   LIBRARIES opmsimulators)
+
+if (NOT BUILD_FLOW_DYN)
+  set(FLOW_DYN_DEFAULT_ENABLE_IF "FALSE")
+else()
+  set(FLOW_DYN_DEFAULT_ENABLE_IF "TRUE")
+endif()
+
+# the production oriented general-purpose ECL simulator
+opm_add_test(flow_dyn
+  ONLY_COMPILE
+  ALWAYS_ENABLE
+  DEFAULT_ENABLE_IF ${FLOW_DYN_DEFAULT_ENABLE_IF}
+  DEPENDS opmsimulators
+  LIBRARIES opmsimulators
+  SOURCES
+  flow/flow.cpp
+  flow/flow_1.cpp
+  flow/flow_2.cpp
+  flow/flow_3.cpp
+  flow/flow_4.cpp
+  flow/flow_ebos_blackoil.cpp
+  $<TARGET_OBJECTS:moduleVersion>)
+target_compile_definitions(flow_dyn PRIVATE "FLOW_DYN")
 
 opm_add_test(flow_onephase
   ONLY_COMPILE

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -238,6 +238,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/MSWellHelpers.hpp
   opm/simulators/wells/BlackoilWellModel.hpp
   opm/simulators/wells/BlackoilWellModel_impl.hpp
+  opm/simulators/wells/WellIndices.hpp
   )
 
 list (APPEND EXAMPLE_SOURCE_FILES

--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -82,7 +82,7 @@ public:
                                     FluidSystem,
                                     enableTemperature,
                                     enableEnergy,
-                                    Indices::gasEnabled,
+                                    true,
                                     enableBrine,
                                     Indices::numPhases
                                     > ScalarFluidState;
@@ -116,18 +116,16 @@ public:
             for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 if (FluidSystem::phaseIsActive(phaseIdx))
                     fluidState.setSaturation(phaseIdx, initialState.saturation()[phaseIdx][elemIdx]);
-                else if (Indices::numPhases == 3)
-                    fluidState.setSaturation(phaseIdx, 0.0);
             }
 
             if (FluidSystem::enableDissolvedGas())
                 fluidState.setRs(initialState.rs()[elemIdx]);
-            else if (Indices::gasEnabled)
+            else if (Indices::gasIsActive() && Indices::oilIsActive())
                 fluidState.setRs(0.0);
 
             if (FluidSystem::enableVaporizedOil())
                 fluidState.setRv(initialState.rv()[elemIdx]);
-            else if (Indices::gasEnabled)
+            else if (Indices::gasIsActive() && Indices::oilIsActive())
                 fluidState.setRv(0.0);
 
 

--- a/ebos/eclfluxmodule.hh
+++ b/ebos/eclfluxmodule.hh
@@ -106,11 +106,11 @@ class EclTransExtensiveQuantities
     using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
     using GridView = GetPropType<TypeTag, Properties::GridView>;
     using MaterialLaw = GetPropType<TypeTag, Properties::MaterialLaw>;
+    using Indices = GetPropType<TypeTag, Properties::Indices>;
 
     enum { dimWorld = GridView::dimensionworld };
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx };
     enum { numPhases = FluidSystem::numPhases };
-    enum { enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>() };
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
 
     typedef Opm::MathToolbox<Evaluation> Toolbox;
@@ -438,7 +438,7 @@ protected:
                 volumeFlux_[phaseIdx] =
                     pressureDifference_[phaseIdx]*up.mobility(phaseIdx)*(-transModified/faceArea);
 
-                if (enableSolvent && phaseIdx == gasPhaseIdx)
+                if (Indices::solventIsActive() && phaseIdx == gasPhaseIdx)
                     asImp_().setSolventVolumeFlux( pressureDifference_[phaseIdx]*up.solventMobility()*(-transModified/faceArea));
             }
             else {
@@ -456,7 +456,7 @@ protected:
                     pressureDifference_[phaseIdx]*mob*(-transModified/faceArea);
 
                 // Solvent inflow is not yet supported
-                if (enableSolvent && phaseIdx == gasPhaseIdx)
+                if (Indices::solventIsActive() && phaseIdx == gasPhaseIdx)
                     asImp_().setSolventVolumeFlux(0.0);
             }
         }

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -94,6 +94,7 @@ class EclOutputBlackOilModule
     using MaterialLawParams = GetPropType<TypeTag, Properties::MaterialLawParams>;
     using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
     using GridView = GetPropType<TypeTag, Properties::GridView>;
+    using Indices = GetPropType<TypeTag, Properties::Indices>;
     using Element = typename GridView::template Codim<0>::Entity;
     using ElementIterator = typename GridView::template Codim<0>::Iterator;
 
@@ -388,7 +389,7 @@ public:
             rstKeywords["RV"] = 0;
         }
 
-        if (getPropValue<TypeTag, Properties::EnableSolvent>())
+        if (Indices::solventIsActive())
             sSol_.resize(bufferSize, 0.0);
         if (getPropValue<TypeTag, Properties::EnablePolymer>())
             cPolymer_.resize(bufferSize, 0.0);

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2182,16 +2182,16 @@ private:
                           << "conservation as a post processing step. This is currently unsupported, "
                           << "i.e., energy conservation is always handled fully implicitly." << std::endl;
 
-//            int numDeckPhases = FluidSystem::numActivePhases();
-//            if (numDeckPhases < Indices::numPhases)
-//                std::cerr << "WARNING: The number of active phases specified by the deck ("
-//                          << numDeckPhases << ") is smaller than the number of compiled-in phases ("
-//                          << Indices::numPhases << "). This usually results in a significant "
-//                          << "performance degradation compared to using a specialized simulator."  << std::endl;
-//            else if (numDeckPhases < Indices::numPhases)
-//                throw std::runtime_error("The deck enables "+std::to_string(numDeckPhases)+" phases "
-//                                         "while this simulator can only handle "+
-//                                         std::to_string(Indices::numPhases)+".");
+            int numDeckPhases = FluidSystem::numActivePhases();
+            if (numDeckPhases < Indices::numPhases)
+                std::cerr << "WARNING: The number of active phases specified by the deck ("
+                          << numDeckPhases << ") is smaller than the number of compiled-in phases ("
+                          << Indices::numPhases << "). This usually results in a significant "
+                          << "performance degradation compared to using a specialized simulator."  << std::endl;
+            else if (numDeckPhases < Indices::numPhases)
+                throw std::runtime_error("The deck enables "+std::to_string(numDeckPhases)+" phases "
+                                         "while this simulator can only handle "+
+                                         std::to_string(Indices::numPhases)+".");
 
             // make sure that the correct phases are active
             if (FluidSystem::phaseIsActive(oilPhaseIdx) && !Indices::oilIsActive())

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -166,6 +166,7 @@ class EclWriter
     using Scalar = GetPropType<TypeTag, Properties::Scalar>;
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
     using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+    using Indices = GetPropType<TypeTag, Properties::Indices>;
     using Element = typename GridView::template Codim<0>::Entity;
     using ElementIterator = typename GridView::template Codim<0>::Iterator;
 
@@ -174,7 +175,6 @@ class EclWriter
     typedef std::vector<Scalar> ScalarBuffer;
 
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
-    enum { enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>() };
 
 
 public:
@@ -396,7 +396,7 @@ public:
             {"SWAT", Opm::UnitSystem::measure::identity, static_cast<bool>(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx))},
             {"SGAS", Opm::UnitSystem::measure::identity, static_cast<bool>(FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx))},
             {"TEMP" , Opm::UnitSystem::measure::temperature, enableEnergy},
-            {"SSOLVENT" , Opm::UnitSystem::measure::identity, enableSolvent},
+            {"SSOLVENT" , Opm::UnitSystem::measure::identity, Indices::solventIsActive()},
             {"RS", Opm::UnitSystem::measure::gas_oil_ratio, FluidSystem::enableDissolvedGas()},
             {"RV", Opm::UnitSystem::measure::oil_gas_ratio, FluidSystem::enableVaporizedOil()},
             {"SOMAX", Opm::UnitSystem::measure::identity, simulator_.problem().vapparsActive()},

--- a/flow/flow_1.cpp
+++ b/flow/flow_1.cpp
@@ -1,0 +1,92 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#include <flow/flow_1.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoildynindices.hh>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
+#include <opm/simulators/flow/FlowMainEbos.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
+
+namespace Opm {
+namespace Properties {
+namespace TTag {
+struct EclFlow1Problem {
+    using InheritsFrom = std::tuple<EclFlowProblem>;
+};
+}
+
+//! The indices required by the model
+template<class TypeTag>
+struct Indices<TypeTag, TTag::EclFlow1Problem>
+{
+private:
+    // it is unfortunately not possible to simply use 'TypeTag' here because this leads
+    // to cyclic definitions of some properties. if this happens the compiler error
+    // messages unfortunately are *really* confusing and not really helpful.
+    using BaseTypeTag = TTag::EclFlowProblem;
+    using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
+
+public:
+    typedef Opm::BlackOilDynIndices<1,1> type;
+};
+}}
+
+namespace Opm {
+void flow1SetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                             std::unique_ptr<EclipseState> eclState,
+                             std::unique_ptr<Schedule> schedule,
+                             std::unique_ptr<SummaryConfig> summaryConfig)
+{
+    using TypeTag = Properties::TTag::EclFlow1Problem;
+    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
+
+    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+}
+
+// ----------------- Main program -----------------
+int flow1Main(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+#else
+    Dune::MPIHelper::instance(argc, argv);
+#endif
+
+    Opm::FlowMainEbos<Properties::TTag::EclFlow1Problem>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
+}
+
+}

--- a/flow/flow_1.hpp
+++ b/flow/flow_1.hpp
@@ -1,0 +1,33 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef FLOW_1_HPP
+#define FLOW_1_HPP
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+namespace Opm {
+void flow1SetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                             std::unique_ptr<EclipseState> eclState,
+                             std::unique_ptr<Schedule> schedule,
+                             std::unique_ptr<SummaryConfig> summaryConfig);
+int flow1Main(int argc, char** argv, bool outputCout, bool outputFiles);
+}
+
+#endif // FLOW_1_HPP

--- a/flow/flow_2.cpp
+++ b/flow/flow_2.cpp
@@ -1,0 +1,92 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#include <flow/flow_2.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoildynindices.hh>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
+#include <opm/simulators/flow/FlowMainEbos.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
+
+namespace Opm {
+namespace Properties {
+namespace TTag {
+struct EclFlow2Problem {
+    using InheritsFrom = std::tuple<EclFlowProblem>;
+};
+}
+
+//! The indices required by the model
+template<class TypeTag>
+struct Indices<TypeTag, TTag::EclFlow2Problem>
+{
+private:
+    // it is unfortunately not possible to simply use 'TypeTag' here because this leads
+    // to cyclic definitions of some properties. if this happens the compiler error
+    // messages unfortunately are *really* confusing and not really helpful.
+    using BaseTypeTag = TTag::EclFlowProblem;
+    using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
+
+public:
+    typedef Opm::BlackOilDynIndices<2,2> type;
+};
+}}
+
+namespace Opm {
+void flow2SetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                             std::unique_ptr<EclipseState> eclState,
+                             std::unique_ptr<Schedule> schedule,
+                             std::unique_ptr<SummaryConfig> summaryConfig)
+{
+    using TypeTag = Properties::TTag::EclFlow2Problem;
+    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
+
+    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+}
+
+// ----------------- Main program -----------------
+int flow2Main(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+#else
+    Dune::MPIHelper::instance(argc, argv);
+#endif
+
+    Opm::FlowMainEbos<Properties::TTag::EclFlow2Problem>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
+}
+
+}

--- a/flow/flow_2.hpp
+++ b/flow/flow_2.hpp
@@ -1,0 +1,33 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef FLOW_2_HPP
+#define FLOW_2_HPP
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+namespace Opm {
+void flow2SetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                             std::unique_ptr<EclipseState> eclState,
+                             std::unique_ptr<Schedule> schedule,
+                             std::unique_ptr<SummaryConfig> summaryConfig);
+int flow2Main(int argc, char** argv, bool outputCout, bool outputFiles);
+}
+
+#endif // FLOW_2_HPP

--- a/flow/flow_3.cpp
+++ b/flow/flow_3.cpp
@@ -1,0 +1,92 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#include <flow/flow_3.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoildynindices.hh>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
+#include <opm/simulators/flow/FlowMainEbos.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
+
+namespace Opm {
+namespace Properties {
+namespace TTag {
+struct EclFlow3Problem {
+    using InheritsFrom = std::tuple<EclFlowProblem>;
+};
+}
+
+//! The indices required by the model
+template<class TypeTag>
+struct Indices<TypeTag, TTag::EclFlow3Problem>
+{
+private:
+    // it is unfortunately not possible to simply use 'TypeTag' here because this leads
+    // to cyclic definitions of some properties. if this happens the compiler error
+    // messages unfortunately are *really* confusing and not really helpful.
+    using BaseTypeTag = TTag::EclFlowProblem;
+    using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
+
+public:
+    typedef Opm::BlackOilDynIndices<3,3> type;
+};
+}}
+
+namespace Opm {
+void flow3SetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                             std::unique_ptr<EclipseState> eclState,
+                             std::unique_ptr<Schedule> schedule,
+                             std::unique_ptr<SummaryConfig> summaryConfig)
+{
+    using TypeTag = Properties::TTag::EclFlow3Problem;
+    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
+
+    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+}
+
+// ----------------- Main program -----------------
+int flow3Main(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+#else
+    Dune::MPIHelper::instance(argc, argv);
+#endif
+
+    Opm::FlowMainEbos<Properties::TTag::EclFlow3Problem>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
+}
+
+}

--- a/flow/flow_3.hpp
+++ b/flow/flow_3.hpp
@@ -1,0 +1,33 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef FLOW_3_HPP
+#define FLOW_3_HPP
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+namespace Opm {
+void flow3SetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                             std::unique_ptr<EclipseState> eclState,
+                             std::unique_ptr<Schedule> schedule,
+                             std::unique_ptr<SummaryConfig> summaryConfig);
+int flow3Main(int argc, char** argv, bool outputCout, bool outputFiles);
+}
+
+#endif // FLOW_2_HPP

--- a/flow/flow_4.cpp
+++ b/flow/flow_4.cpp
@@ -54,6 +54,10 @@ public:
 #warning need to make a 4-3 variant for polymer++
     typedef Opm::BlackOilDynIndices<4,4> type;
 };
+template<class TypeTag>
+struct EnableSolvent<TypeTag, TTag::EclFlow4Problem> {
+    static constexpr bool value = true;
+};
 }}
 
 namespace Opm {

--- a/flow/flow_4.cpp
+++ b/flow/flow_4.cpp
@@ -1,0 +1,93 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#include <flow/flow_4.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoildynindices.hh>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
+#include <opm/simulators/flow/FlowMainEbos.hpp>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
+
+namespace Opm {
+namespace Properties {
+namespace TTag {
+struct EclFlow4Problem {
+    using InheritsFrom = std::tuple<EclFlowProblem>;
+};
+}
+
+//! The indices required by the model
+template<class TypeTag>
+struct Indices<TypeTag, TTag::EclFlow4Problem>
+{
+private:
+    // it is unfortunately not possible to simply use 'TypeTag' here because this leads
+    // to cyclic definitions of some properties. if this happens the compiler error
+    // messages unfortunately are *really* confusing and not really helpful.
+    using BaseTypeTag = TTag::EclFlowProblem;
+    using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
+
+public:
+#warning need to make a 4-3 variant for polymer++
+    typedef Opm::BlackOilDynIndices<4,4> type;
+};
+}}
+
+namespace Opm {
+void flow4SetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                             std::unique_ptr<EclipseState> eclState,
+                             std::unique_ptr<Schedule> schedule,
+                             std::unique_ptr<SummaryConfig> summaryConfig)
+{
+    using TypeTag = Properties::TTag::EclFlow4Problem;
+    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
+
+    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+}
+
+// ----------------- Main program -----------------
+int flow4Main(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    Opm::resetLocale();
+
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+#else
+    Dune::MPIHelper::instance(argc, argv);
+#endif
+
+    Opm::FlowMainEbos<Properties::TTag::EclFlow4Problem>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
+}
+
+}

--- a/flow/flow_4.hpp
+++ b/flow/flow_4.hpp
@@ -1,0 +1,33 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef FLOW_4_HPP
+#define FLOW_4_HPP
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+namespace Opm {
+void flow4SetDeck(double setupTime, std::unique_ptr<Deck> deck,
+                             std::unique_ptr<EclipseState> eclState,
+                             std::unique_ptr<Schedule> schedule,
+                             std::unique_ptr<SummaryConfig> summaryConfig);
+int flow4Main(int argc, char** argv, bool outputCout, bool outputFiles);
+}
+
+#endif // FLOW_4_HPP

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -50,24 +50,17 @@ public:
     using BlackoilIndices = GetPropType<TypeTag, Properties::Indices>;
     using RateVector = GetPropType<TypeTag, Properties::RateVector>;
     using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
+    using Eval = GetPropType<TypeTag, Properties::Evaluation>;
+    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
+
 
     enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     enum { enableBrine = getPropValue<TypeTag, Properties::EnableBrine>() };
 
     static const int numEq = BlackoilIndices::numEq;
-    typedef double Scalar;
 
-    typedef DenseAd::Evaluation<double, /*size=*/numEq> Eval;
-
-    typedef Opm::BlackOilFluidState<Eval,
-                                    FluidSystem,
-                                    enableTemperature,
-                                    enableEnergy,
-                                    BlackoilIndices::gasEnabled,
-                                    enableBrine,
-                                    BlackoilIndices::numPhases>
-        FluidState;
+    typedef typename BlackOilIntensiveQuantities<TypeTag>::FluidState FluidState;
 
     static const auto waterCompIdx = FluidSystem::waterCompIdx;
     static const auto waterPhaseIdx = FluidSystem::waterPhaseIdx;

--- a/opm/simulators/flow/BlackoilModelEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelEbos.hpp
@@ -440,17 +440,17 @@ namespace Opm {
                 const auto& priVarsNew = ebosSimulator_.model().solution(/*timeIdx=*/0)[globalElemIdx];
 
                 Scalar pressureNew;
-                pressureNew = priVarsNew[Indices::pressureSwitchIdx];
+                pressureNew = priVarsNew[Indices::activePressureSwitchIdx()];
 
                 Scalar saturationsNew[FluidSystem::numPhases] = { 0.0 };
                 Scalar oilSaturationNew = 1.0;
                 if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
-                    saturationsNew[FluidSystem::waterPhaseIdx] = priVarsNew[Indices::waterSaturationIdx];
+                    saturationsNew[FluidSystem::waterPhaseIdx] = priVarsNew[Indices::activeWaterSaturationIdx()];
                     oilSaturationNew -= saturationsNew[FluidSystem::waterPhaseIdx];
                 }
 
                 if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx) && priVarsNew.primaryVarsMeaning() == PrimaryVariables::Sw_po_Sg) {
-                    saturationsNew[FluidSystem::gasPhaseIdx] = priVarsNew[Indices::compositionSwitchIdx];
+                    saturationsNew[FluidSystem::gasPhaseIdx] = priVarsNew[Indices::activeCompositionSwitchIdx()];
                     oilSaturationNew -= saturationsNew[FluidSystem::gasPhaseIdx];
                 }
 
@@ -461,7 +461,7 @@ namespace Opm {
                 const auto& priVarsOld = ebosSimulator_.model().solution(/*timeIdx=*/1)[globalElemIdx];
 
                 Scalar pressureOld;
-                pressureOld = priVarsOld[Indices::pressureSwitchIdx];
+                pressureOld = priVarsOld[Indices::activePressureSwitchIdx()];
 
                 Scalar saturationsOld[FluidSystem::numPhases] = { 0.0 };
                 Scalar oilSaturationOld = 1.0;
@@ -473,14 +473,14 @@ namespace Opm {
 
                 if (FluidSystem::numActivePhases() > 1) {
                     if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
-                        saturationsOld[FluidSystem::waterPhaseIdx] = priVarsOld[Indices::waterSaturationIdx];
+                        saturationsOld[FluidSystem::waterPhaseIdx] = priVarsOld[Indices::activeWaterSaturationIdx()];
                         oilSaturationOld -= saturationsOld[FluidSystem::waterPhaseIdx];
                     }
 
                     if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx) &&
                         priVarsOld.primaryVarsMeaning() == PrimaryVariables::Sw_po_Sg)
                     {
-                        saturationsOld[FluidSystem::gasPhaseIdx] = priVarsOld[Indices::compositionSwitchIdx];
+                        saturationsOld[FluidSystem::gasPhaseIdx] = priVarsOld[Indices::activeCompositionSwitchIdx()];
                         oilSaturationOld -= saturationsOld[FluidSystem::gasPhaseIdx];
                     }
 
@@ -662,7 +662,7 @@ namespace Opm {
                     maxCoeff[ compIdx ] = std::max( maxCoeff[ compIdx ], std::abs( R2 ) / pvValue );
                 }
 
-                if ( has_solvent_ ) {
+                if ( Indices::solventIsActive() ) {
                     B_avg[ contiSolventEqIdx ] += 1.0 / intQuants.solventInverseFormationVolumeFactor().value();
                     const auto R2 = ebosResid[cell_idx][contiSolventEqIdx];
                     R_sum[ contiSolventEqIdx ] += R2;
@@ -801,7 +801,7 @@ namespace Opm {
                     const unsigned compIdx = Indices::canonicalToActiveComponentIndex(canonicalCompIdx);
                     compNames[compIdx] = FluidSystem::componentName(canonicalCompIdx);
                 }
-                if (has_solvent_) {
+                if (Indices::solventIsActive()) {
                     compNames[solventSaturationIdx] = "Solvent";
                 }
                 if (has_polymer_) {

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -24,7 +24,14 @@
 
 #include <flow/flow_ebos_blackoil.hpp>
 
-# ifndef FLOW_BLACKOIL_ONLY
+# ifdef FLOW_DYN
+# include <flow/flow_1.hpp>
+# include <flow/flow_2.hpp>
+# include <flow/flow_3.hpp>
+# include <flow/flow_4.hpp>
+# endif
+
+#if !defined(FLOW_BLACKOIL_ONLY) && !defined(FLOW_DYN)
 #  include <flow/flow_ebos_gasoil.hpp>
 #  include <flow/flow_ebos_oilwater.hpp>
 #  include <flow/flow_ebos_solvent.hpp>
@@ -203,8 +210,9 @@ namespace Opm
             //       requested.
 
             if ( false ) {}
-#ifndef FLOW_BLACKOIL_ONLY
             // Twophase cases
+#ifndef FLOW_BLACKOIL_ONLY
+#ifndef FLOW_DYN
             else if( phases.size() == 2 ) {
                 // oil-gas
                 if (phases.active( Opm::Phase::GAS )) {
@@ -300,7 +308,35 @@ namespace Opm
                                            std::move(summaryConfig_));
                 return Opm::flowEbosEnergyMain(argc_, argv_, outputCout_, outputFiles_);
             }
-#endif // FLOW_BLACKOIL_ONLY
+#endif // if NOT FLOW_DYN
+#ifdef FLOW_DYN
+            else if( phases.size() == 1 ) {
+                Opm::flow1SetDeck(setupTime_, std::move(deck_),
+                                             std::move(eclipseState_),
+                                             std::move(schedule_),
+                                             std::move(summaryConfig_));
+                return Opm::flow1Main(argc_, argv_, outputCout_, outputFiles_);
+            } else if( phases.size() == 2 ) {
+                Opm::flow2SetDeck(setupTime_, std::move(deck_),
+                                             std::move(eclipseState_),
+                                             std::move(schedule_),
+                                             std::move(summaryConfig_));
+                return Opm::flow2Main(argc_, argv_, outputCout_, outputFiles_);
+            } else if ( phases.size() == 3 ) {
+                Opm::flow3SetDeck(setupTime_, std::move(deck_),
+                                             std::move(eclipseState_),
+                                             std::move(schedule_),
+                                             std::move(summaryConfig_));
+                return Opm::flow3Main(argc_, argv_, outputCout_, outputFiles_);
+            } else if ( phases.size() == 4 ){
+                Opm::flow4SetDeck(setupTime_, std::move(deck_),
+                                             std::move(eclipseState_),
+                                             std::move(schedule_),
+                                             std::move(summaryConfig_));
+                return Opm::flow4Main(argc_, argv_, outputCout_, outputFiles_);
+            }
+#endif // FLOW_DYN
+#endif // ONLY_BLACKOIL
             // Blackoil case
             else if( phases.size() == 3 ) {
                 Opm::flowEbosBlackoilSetDeck(setupTime_, std::move(deck_),

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -49,6 +49,7 @@
 #include <opm/simulators/flow/countGlobalCells.hpp>
 #include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
 #include <opm/simulators/wells/RateConverter.hpp>
+#include <opm/simulators/wells/WellIndices.hpp>
 #include <opm/simulators/wells/WellInterface.hpp>
 #include <opm/simulators/wells/StandardWell.hpp>
 #include <opm/simulators/wells/MultisegmentWell.hpp>
@@ -95,7 +96,6 @@ namespace Opm {
             typedef typename Opm::BaseAuxiliaryModule<TypeTag>::NeighborSet NeighborSet;
 
             static const int numEq = Indices::numEq;
-            static const int solventSaturationIdx = Indices::solventSaturationIdx;
 
             // TODO: where we should put these types, WellInterface or Well Model?
             // or there is some other strategy, like TypeTag

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -86,6 +86,9 @@ namespace Opm {
         ebosSimulator_.model().addAuxiliaryModule(this);
 
         is_cell_perforated_.resize(local_num_cells_, false);
+
+        has_solvent_ = Indices::solventIsActive();
+
     }
 
     template<typename TypeTag>
@@ -266,10 +269,10 @@ namespace Opm {
             // copy of get perfpressure in Standard well
             // exept for value
             double perf_pressure = 0.0;
-            if (Indices::oilEnabled) {
+            if (Indices::oilIsActive()) {
                 perf_pressure = fs.pressure(FluidSystem::oilPhaseIdx).value();
             } else {
-                if (Indices::waterEnabled) {
+                if (Indices::waterIsActive()) {
                     perf_pressure = fs.pressure(FluidSystem::waterPhaseIdx).value();
                 } else {
                     perf_pressure = fs.pressure(FluidSystem::gasPhaseIdx).value();
@@ -1568,7 +1571,7 @@ namespace Opm {
             return numPhases();
         }
         int numComp = FluidSystem::numComponents;
-        if (has_solvent_) {
+        if (Indices::solventIsActive()) {
             numComp ++;
         }
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -62,11 +62,6 @@ namespace Opm
         static constexpr bool has_gas = (Indices::compositionSwitchIdx >= 0);
         static constexpr bool has_water = (Indices::waterSaturationIdx >= 0);
 
-        static constexpr int GTotal = 0;
-        static constexpr int WFrac = has_water ? 1: -1000;
-        static constexpr int GFrac = has_gas ? has_water + 1 : -1000;
-        static constexpr int SPres = has_gas + has_water + 1;
-
         //  the number of well equations  TODO: it should have a more general strategy for it
         static const int numWellEq = Indices::numWellEq;
 
@@ -107,7 +102,8 @@ namespace Opm
                          const int first_perf_index,
                          const std::vector<PerforationData>& perf_data);
 
-        virtual void init(const PhaseUsage* phase_usage_arg,
+        virtual void init(const Phases& phases,
+                          const PhaseUsage* phase_usage_arg,
                           const std::vector<double>& depth_arg,
                           const double gravity_arg,
                           const int num_cells) override;
@@ -216,6 +212,7 @@ namespace Opm
         using Base::ebosCompIdxToFlowCompIdx;
         using Base::getAllowCrossFlow;
         using Base::scalingFactor;
+        using Base::wellIndices;
         using Base::wellIsStopped_;
 
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -48,7 +48,7 @@ namespace Opm
         /// the number of reservior equations
         using Base::numEq;
 
-        using Base::has_solvent;
+        //using Base::has_solvent;
         using Base::has_polymer;
         using Base::Water;
         using Base::Oil;
@@ -68,7 +68,7 @@ namespace Opm
         static constexpr int SPres = has_gas + has_water + 1;
 
         //  the number of well equations  TODO: it should have a more general strategy for it
-        static const int numWellEq = getPropValue<TypeTag, Properties::EnablePolymer>() ? numEq : numEq + 1;
+        static const int numWellEq = Indices::numWellEq;
 
         using typename Base::Scalar;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -54,7 +54,7 @@ namespace Opm
     , segment_phase_viscosities_(numberOfSegments(), std::vector<EvalWell>(num_components_, 0.0)) // number of phase here?
     {
         // not handling solvent or polymer for now with multisegment well
-        if (has_solvent) {
+        if (Indices::solventIsActive()) {
             OPM_THROW(std::runtime_error, "solvent is not supported by multisegment well yet");
         }
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -72,7 +72,6 @@ namespace Opm
 
         using Base::numEq;
 
-        using Base::has_solvent;
         using Base::has_polymer;
         using Base::has_foam;
         using Base::has_brine;
@@ -83,14 +82,8 @@ namespace Opm
         using BrineModule = Opm::BlackOilBrineModule<TypeTag>;
 
         // polymer concentration and temperature are already known by the well, so
-        // polymer and energy conservation do not need to be considered explicitly
-        static const int numPolymerEq = Indices::numPolymers;
-        static const int numEnergyEq = Indices::numEnergy;
-        static const int numFoamEq = Indices::numFoam;
-        static const int numBrineEq = Indices::numBrine;
-
         // number of the conservation equations
-        static const int numWellConservationEq = numEq - numPolymerEq - numEnergyEq - numFoamEq - numBrineEq;
+        static const int numWellConservationEq = Indices::numWellEq;
         // number of the well control equations
         static const int numWellControlEq = 1;
         // number of the well equations that will always be used
@@ -106,11 +99,12 @@ namespace Opm
         // well control equation is always the last well equation.
         // TODO: in the current implementation, we use the well rate as the first primary variables for injectors,
         // instead of G_t.
-        static const bool gasoil = numEq == 2 && (Indices::compositionSwitchIdx >= 0);
+//        static const bool gasoil = numEq == 2 &gasoil? -1000: & (Indices::compositionSwitchIdx >= 0);
         static const int WQTotal = 0;
-        static const int WFrac = gasoil? -1000: 1;
-        static const int GFrac = gasoil? 1: 2;
-        static const int SFrac = !has_solvent ? -1000 : 3;
+        static const int WFrac =  1;
+        static const int GFrac = 2;
+        static const int SFrac = 3;
+#warning TODO make a dynamic maping
         // the index for Bhp in primary variables and also the index of well control equation
         // they both will be the last one in their respective system.
         // TODO: we should have indices for the well equations and well primary variables separately

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -91,24 +91,6 @@ namespace Opm
         static const int numStaticWellEq = numWellConservationEq + numWellControlEq;
 
         // the positions of the primary variables for StandardWell
-        // the first one is the weighted total rate (WQ_t), the second and the third ones are F_w and F_g,
-        // which represent the fraction of Water and Gas based on the weighted total rate, the last one is BHP.
-        // correspondingly, we have four well equations for blackoil model, the first three are mass
-        // converstation equations, and the last one is the well control equation.
-        // primary variables related to other components, will be before the Bhp and after F_g.
-        // well control equation is always the last well equation.
-        // TODO: in the current implementation, we use the well rate as the first primary variables for injectors,
-        // instead of G_t.
-//        static const bool gasoil = numEq == 2 &gasoil? -1000: & (Indices::compositionSwitchIdx >= 0);
-        static const int WQTotal = 0;
-        static const int WFrac =  1;
-        static const int GFrac = 2;
-        static const int SFrac = 3;
-#warning TODO make a dynamic maping
-        // the index for Bhp in primary variables and also the index of well control equation
-        // they both will be the last one in their respective system.
-        // TODO: we should have indices for the well equations and well primary variables separately
-        static const int Bhp = numStaticWellEq - numWellControlEq;
 
         using typename Base::Scalar;
 
@@ -155,7 +137,8 @@ namespace Opm
                      const int first_perf_index,
                      const std::vector<PerforationData>& perf_data);
 
-        virtual void init(const PhaseUsage* phase_usage_arg,
+        virtual void init(const Phases& phases,
+                          const PhaseUsage* phase_usage_arg,
                           const std::vector<double>& depth_arg,
                           const double gravity_arg,
                           const int num_cells) override;
@@ -303,6 +286,7 @@ namespace Opm
         using Base::scalingFactor;
         using Base::scaleProductivityIndex;
         using Base::mostStrictBhpFromBhpLimits;
+        using Base::wellIndices;
 
         // protected member variables from the Base class
         using Base::current_step_;
@@ -536,12 +520,12 @@ namespace Opm
 
         // calculate a relaxation factor to avoid overshoot of the fractions for producers
         // which might result in negative rates
-        static double relaxationFactorFractionsProducer(const std::vector<double>& primary_variables,
-                                                        const BVectorWell& dwells);
+        double relaxationFactorFractionsProducer(const std::vector<double>& primary_variables,
+                                                        const BVectorWell& dwells) const;
 
         // calculate a relaxation factor to avoid overshoot of total rates
-        static double relaxationFactorRate(const std::vector<double>& primary_variables,
-                                           const BVectorWell& dwells);
+        double relaxationFactorRate(const std::vector<double>& primary_variables,
+                                           const BVectorWell& dwells) const;
 
         virtual void wellTestingPhysical(const Simulator& simulator, const std::vector<double>& B_avg,
                                          const double simulation_time, const int report_step,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -82,16 +82,16 @@ namespace Opm
         using MaterialLaw = GetPropType<TypeTag, Properties::MaterialLaw>;
         using SparseMatrixAdapter = GetPropType<TypeTag, Properties::SparseMatrixAdapter>;
         using RateVector = GetPropType<TypeTag, Properties::RateVector>;
+        using Eval = GetPropType<TypeTag, Properties::Evaluation>;
+        using Scalar = GetPropType<TypeTag, Properties::Scalar>;
 
         static const int numEq = Indices::numEq;
-        typedef double Scalar;
 
         typedef Dune::FieldVector<Scalar, numEq    > VectorBlockType;
         typedef Dune::FieldMatrix<Scalar, numEq, numEq > MatrixBlockType;
         typedef Dune::BlockVector<VectorBlockType> BVector;
-        typedef DenseAd::Evaluation<double, /*size=*/numEq> Eval;
 
-        static const bool has_solvent = getPropValue<TypeTag, Properties::EnableSolvent>();
+        //static const bool has_solvent = getPropValue<TypeTag, Properties::EnableSolvent>();
         static const bool has_polymer = getPropValue<TypeTag, Properties::EnablePolymer>();
         static const bool has_energy = getPropValue<TypeTag, Properties::EnableEnergy>();
         static const bool has_temperature = getPropValue<TypeTag, Properties::EnableTemperature>();
@@ -109,14 +109,9 @@ namespace Opm
         // For the conversion between the surface volume rate and reservoir voidage rate
         using RateConverterType = RateConverter::
         SurfaceToReservoirVoidage<FluidSystem, std::vector<int> >;
-        static const bool compositionSwitchEnabled = Indices::gasEnabled;
-        using FluidState = Opm::BlackOilFluidState<Eval,
-                                                   FluidSystem,
-                                                   has_temperature,
-                                                   has_energy,
-                                                   compositionSwitchEnabled,
-                                                   has_brine,
-                                                   Indices::numPhases >;
+
+        typedef typename BlackOilIntensiveQuantities<TypeTag>::FluidState FluidState;
+
         /// Constructor
         WellInterface(const Well& well, const int time_step,
                       const ModelParameters& param,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -40,6 +40,7 @@
 #include <opm/simulators/wells/WellHelpers.hpp>
 #include <opm/simulators/wells/WellGroupHelpers.hpp>
 #include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/simulators/wells/WellIndices.hpp>
 #include <opm/simulators/flow/BlackoilModelParametersEbos.hpp>
 
 #include <opm/simulators/timestepping/ConvergenceReport.hpp>
@@ -145,7 +146,8 @@ namespace Opm
 
         void setGuideRate(const GuideRate* guide_rate_arg);
 
-        virtual void init(const PhaseUsage* phase_usage_arg,
+        virtual void init(const Phases& phases,
+                          const PhaseUsage* phase_usage_arg,
                           const std::vector<double>& depth_arg,
                           const double gravity_arg,
                           const int num_cells);
@@ -286,6 +288,8 @@ namespace Opm
 
     protected:
 
+        WellIndices well_indices_;
+
         // to indicate a invalid completion
         static const int INVALIDCOMPLETION = INT_MAX;
 
@@ -378,6 +382,8 @@ namespace Opm
         bool wellIsStopped_;
 
         double wsolvent_;
+
+        const WellIndices& wellIndices() const;
 
         const PhaseUsage& phaseUsage() const;
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -123,13 +123,15 @@ namespace Opm
     template<typename TypeTag>
     void
     WellInterface<TypeTag>::
-    init(const PhaseUsage* phase_usage_arg,
+    init(const Phases& phases,
+         const PhaseUsage* phase_usage_arg,
          const std::vector<double>& /* depth_arg */,
          const double gravity_arg,
          const int /* num_cells */)
     {
         phase_usage_ = phase_usage_arg;
         gravity_ = gravity_arg;
+        well_indices_.init(phases);
     }
 
 
@@ -254,6 +256,13 @@ namespace Opm
     }
 
 
+    template<typename TypeTag>
+    const WellIndices&
+    WellInterface<TypeTag>::
+    wellIndices() const
+    {
+        return well_indices_;
+    }
 
     template<typename TypeTag>
     const PhaseUsage&

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -99,7 +99,7 @@ namespace Opm
 
         wsolvent_ = 0.0;
 
-        if (has_solvent && well.isInjector()) {
+        if (Indices::solventIsActive() && well.isInjector()) {
             auto injectorType = well_ecl_.injectorType();
             if (injectorType == InjectorType::GAS) {
                 wsolvent_ = well_ecl_.getSolventFraction();
@@ -1229,7 +1229,7 @@ namespace Opm
             return 1.0;
         if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx) && pu.phase_pos[Gas] == phaseIdx)
             return 0.01;
-        if (has_solvent && phaseIdx == contiSolventEqIdx )
+        if (Indices::solventIsActive() && phaseIdx == contiSolventEqIdx )
             return 0.01;
 
         // we should not come this far


### PR DESCRIPTION
Adds a dynamic flow version that only takes number of equations as parameter

The goal is to reduce the number of flow versions i.e reduce compile time

The drawback is a slight overhead in the run time. Initial testing indicates
1) Extra cost of using dynamic mappings and if evaluations < 1% for norne
2) Extra cost of adding enableSolvent unconditionally for norne. ~5%. The solvent code is never called and the number of equation is still 3, but the intensive quantities size is increased to carry solvent related stuff. 
3) Extra cost of using dynamic flow for oil-water olympus. ~2%..  The dynamic flow currently always allocating three phases in the fluid state. 

This should neither alter the results nor the runtime for flow.

Some optimization could potentially further reduce the overhead associated with the dynamic blackoil indices code.

Depends on OPM/opm-models#631