### PR TITLE
Extract Correct Connection-Level Rates

### DIFF
--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -616,13 +616,13 @@ namespace Opm
                         comp.rates.set( phs[ i ], *(rates + i) );
                     }
                     if ( pu.has_polymer ) {
-                        comp.rates.set( rt::polymer, this->perfRatePolymer()[local_comp_index]);
+                        comp.rates.set( rt::polymer, this->perfRatePolymer()[wt.second[1] + local_comp_index]);
                     }
                     if ( pu.has_brine ) {
-                        comp.rates.set( rt::brine, this->perfRateBrine()[local_comp_index]);
+                        comp.rates.set( rt::brine, this->perfRateBrine()[wt.second[1] + local_comp_index]);
                     }
                     if ( pu.has_solvent ) {
-                        comp.rates.set( rt::solvent, this->perfRateSolvent()[local_comp_index]);
+                        comp.rates.set( rt::solvent, this->perfRateSolvent()[wt.second[1] + local_comp_index]);
                     }
 
                     ++local_comp_index;


### PR DESCRIPTION
The Polymer, Brine, and Solvent quantities would be extracted from elements `0..#perf-1` of their pertinent container rather than from the elements associated to the particular well.