### PR TITLE
[testing] clearing well_container_ at timeStepSucceeded()

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -508,6 +508,8 @@ namespace Opm {
 
         previous_well_state_ = well_state_;
 
+        this->well_container_.clear();
+
         Opm::DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger);
         if (terminal_output_) {
             global_deferredLogger.logMessages();


### PR DESCRIPTION
it should not be usable for next time step. It caused confusion related to other development. 

Not sure it is doable, so it is testing.