### PR TITLE
Implement addWellContributions() for multi-segment wells

### DIFF
--- a/opm/simulators/linalg/MatrixBlock.hpp
+++ b/opm/simulators/linalg/MatrixBlock.hpp
@@ -458,6 +458,37 @@ namespace Opm
 {
 namespace Detail
 {
+    //! calculates ret = A * B
+    template< class TA, class TB, class TC, class PositiveSign >
+    static inline void multMatrixImpl( const TA &A, // n x m
+                                       const TB &B, // n x p
+                                       TC &ret,     // m x p
+                                       const PositiveSign )
+    {
+        typedef typename TA :: size_type size_type;
+        typedef typename TA :: field_type K;
+        assert( A.N() == B.N() );
+        assert( A.M() == ret.N() );
+        assert( B.M() == ret.M() );
+
+        const size_type n = A.N();
+        const size_type m = ret.N();
+        const size_type p = B.M();
+        for( size_type i = 0; i < m; ++i )
+        {
+            for( size_type j = 0; j < p; ++j )
+            {
+                K sum = 0;
+                for( size_type k = 0; k < n; ++k )
+                {
+                    sum += A[ i ][ k ] * B[ k ][ j ];
+                }
+                // set value depending on given sign
+                ret[ i ][ j ] = PositiveSign::value ? sum : -sum;
+            }
+        }
+    }
+
     //! calculates ret = sign * (A^T * B)
     //! TA, TB, and TC are not necessarily FieldMatrix, but those should
     //! follow the Dune::DenseMatrix interface.

--- a/opm/simulators/wells/MSWellHelpers.hpp
+++ b/opm/simulators/wells/MSWellHelpers.hpp
@@ -72,7 +72,50 @@ namespace mswellhelpers
 #else
         // this is not thread safe
         OPM_THROW(std::runtime_error, "Cannot use applyUMFPack() without UMFPACK. "
-                  "Reconfigure opm-simulator with SuiteSparse/UMFPACK support and recompile.");
+                  "Reconfigure opm-simulators with SuiteSparse/UMFPACK support and recompile.");
+#endif // HAVE_UMFPACK
+    }
+
+
+
+    /// Applies umfpack and checks for singularity
+    template <typename MatrixType, typename VectorType>
+    MatrixType
+    invertWithUMFPack(const MatrixType& D, std::shared_ptr<Dune::UMFPack<MatrixType> >& linsolver)
+    {
+#if HAVE_UMFPACK
+        const int sz = D.M();
+        const int bsz = D[0][0].M();
+        VectorType e(sz);
+        e = 0.0;
+
+        // Make a block matrix with a full pattern.
+        MatrixType inv(sz, sz, sz*sz, MatrixType::row_wise);
+        for (auto row = inv.createbegin(); row != inv.createend(); ++row) {
+            for (int c = 0; c < sz; ++c) {
+                row.insert(c);
+            }
+        }
+
+        // Create inverse by passing basis vectors to the solver.
+        for (int ii = 0; ii < sz; ++ii) {
+            for (int jj = 0; jj < bsz; ++jj) {
+                e[ii][jj] = 1.0;
+                auto col = applyUMFPack(D, linsolver, e);
+                for (int cc = 0; cc < sz; ++cc) {
+                    for (int dd = 0; dd < bsz; ++dd) {
+                        inv[cc][ii][dd][jj] = col[cc][dd];
+                    }
+                }
+                e[ii][jj] = 0.0;
+            }
+        }
+
+        return inv;
+#else
+        // this is not thread safe
+        OPM_THROW(std::runtime_error, "Cannot use invertWithUMFPack() without UMFPACK. "
+                  "Reconfigure opm-simulators with SuiteSparse/UMFPACK support and recompile.");
 #endif // HAVE_UMFPACK
     }
 

--- a/opm/simulators/wells/MSWellHelpers.hpp
+++ b/opm/simulators/wells/MSWellHelpers.hpp
@@ -80,7 +80,7 @@ namespace mswellhelpers
 
     /// Applies umfpack and checks for singularity
     template <typename MatrixType, typename VectorType>
-    MatrixType
+    Dune::Matrix<typename MatrixType::block_type>
     invertWithUMFPack(const MatrixType& D, std::shared_ptr<Dune::UMFPack<MatrixType> >& linsolver)
     {
 #if HAVE_UMFPACK
@@ -89,13 +89,8 @@ namespace mswellhelpers
         VectorType e(sz);
         e = 0.0;
 
-        // Make a block matrix with a full pattern.
-        MatrixType inv(sz, sz, sz*sz, MatrixType::row_wise);
-        for (auto row = inv.createbegin(); row != inv.createend(); ++row) {
-            for (int c = 0; c < sz; ++c) {
-                row.insert(c);
-            }
-        }
+        // Make a full block matrix.
+        Dune::Matrix<typename MatrixType::block_type> inv(sz, sz);
 
         // Create inverse by passing basis vectors to the solver.
         for (int ii = 0; ii < sz; ++ii) {

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1188,7 +1188,9 @@ namespace Opm
         // D is a (nseg x nseg) block matrix with (4 x 4) blocks.
         // B and C are (nseg x ncells) block matrices with (4 x 4 blocks).
         // They have nonzeros at (i, j) only if this well has a
-        // perforation at cell j connected to segment i.
+        // perforation at cell j connected to segment i.  The code
+        // assumes that no cell is connected to more than one segment,
+        // i.e. the columns of B/C have no more than one nonzero.
         for (int rowC = 0; rowC < duneC_.N(); ++rowC) {
             for (auto colC = duneC_[rowC].begin(), endC = duneC_[rowC].end(); colC != endC; ++colC) {
                 const auto row_index = colC.index();


### PR DESCRIPTION
This allows the `--matrix-add-well-contributions=true` option for multisegment wells. However the implementation should be considered experimental for the following reasons:
 - Very limited testing so far (only small msw test cases from opm-tests, as well as the original "model 2").
 - In testing with "model 2" occasional linear solver failures happen, which could indicate either a problem with this code, or more broadly a problem with the MSW formulation itself, or a combination. However, similar solver failures happen also with `--matrix-add-well-contributions=false` when running with cpr, which makes it less likely that the new code is at fault.
 - The code inverts the D matrix, which is a square matrix with (4 * number of segments) rows and columns. Inverting a nontrivial matrix is of course quite suspect! The resulting matrix will be full and probably ill-conditioned.

Performance seems not to be impacted much, in the sense that the new code hardly shows up in the profiler. Adding extra nonzero elements to the system matrix, instead of applying the wells as operators, does cause a slowdown, just as observed with standard wells, the performance impact of the new code seems no different from that case.