### PR TITLE
Refactor well calculations

### DIFF
--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -68,6 +68,7 @@ namespace Opm
         using typename Base::RateConverterType;
         using typename Base::SparseMatrixAdapter;
         using typename Base::FluidState;
+        using typename Base::RateVector;
         using GasLiftHandler = Opm::GasLiftRuntime<TypeTag>;
 
         using Base::numEq;
@@ -511,6 +512,19 @@ namespace Opm
                                                     WellState& well_state,
                                                     Opm::DeferredLogger& deferred_logger) override;
 
+        void assembleWellEqWithoutIterationImpl(const Simulator& ebosSimulator,
+                                                const double dt,
+                                                WellState& well_state,
+                                                Opm::DeferredLogger& deferred_logger);
+
+        void calculateSinglePerf(const Simulator& ebosSimulator,
+                                 const int perf,
+                                 WellState& well_state,
+                                 std::vector<RateVector>& connectionRates,
+                                 std::vector<EvalWell>& cq_s,
+                                 EvalWell& water_flux_s,
+                                 Opm::DeferredLogger& deferred_logger) const;
+
         // check whether the well is operable under the current reservoir condition
         // mostly related to BHP limit and THP limit
         void updateWellOperability(const Simulator& ebos_simulator,
@@ -576,12 +590,17 @@ namespace Opm
                             const EvalWell& water_velocity,
                             Opm::DeferredLogger& deferred_logger) const;
 
+        // modify the water rate for polymer injectivity study
+        void handleInjectivityRate(const Simulator& ebosSimulator,
+                                   const int perf,
+                                   std::vector<EvalWell>& cq_s) const;
+
         // handle the extra equations for polymer injectivity study
-        void handleInjectivityRateAndEquations(const IntensiveQuantities& int_quants,
-                                               const WellState& well_state,
-                                               const int perf,
-                                               std::vector<EvalWell>& cq_s,
-                                               Opm::DeferredLogger& deferred_logger);
+        void handleInjectivityEquations(const Simulator& ebosSimulator,
+                                        const WellState& well_state,
+                                        const int perf,
+                                        const EvalWell& water_flux_s,
+                                        Opm::DeferredLogger& deferred_logger);
 
         virtual void updateWaterThroughput(const double dt, WellState& well_state) const override;
 
@@ -599,7 +618,8 @@ namespace Opm
                                         const IntensiveQuantities& int_quants,
                                         const WellState& well_state,
                                         const int perf,
-                                        DeferredLogger& deferred_logger);
+                                        std::vector<RateVector>& connectionRates,
+                                        DeferredLogger& deferred_logger) const;
 
 
         std::optional<double> computeBhpAtThpLimitProd(const WellState& well_state,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -511,13 +511,13 @@ namespace Opm
                                  const std::vector<double>& B_avg,
                                  Opm::DeferredLogger& deferred_logger);
 
-        void scaleProductivityIndex(const int perfIdx, double& productivity_index, const bool new_well, Opm::DeferredLogger& deferred_logger);
+        void scaleProductivityIndex(const int perfIdx, double& productivity_index, const bool new_well, Opm::DeferredLogger& deferred_logger) const;
 
         void initCompletions();
 
         // count the number of times an output log message is created in the productivity
         // index calculations
-        int well_productivity_index_logger_counter_;
+        mutable int well_productivity_index_logger_counter_;
 
         bool checkConstraints(WellState& well_state,
                               const Schedule& schedule,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1382,7 +1382,7 @@ namespace Opm
 
     template<typename TypeTag>
     void
-    WellInterface<TypeTag>::scaleProductivityIndex(const int perfIdx, double& productivity_index, const bool new_well, Opm::DeferredLogger& deferred_logger)
+    WellInterface<TypeTag>::scaleProductivityIndex(const int perfIdx, double& productivity_index, const bool new_well, Opm::DeferredLogger& deferred_logger) const
     {
         const auto& connection = well_ecl_.getConnections()[(*perf_data_)[perfIdx].ecl_index];
         if (well_ecl_.getDrainageRadius() < 0) {


### PR DESCRIPTION
This changes the innermost part of the well assembly to be a new function calculateSinglePerf(), that is const. Then all the code that modifies the residual and jacobians (or rather, the B, C and D matrices) is in a more compact location (lines 612-643 for per-perforation assembly and lines 649-674 for per-well assembly).

@blattms Hopefully this makes it easier to implement distributed wells. Note that this is still a bit of WIP, and will likely be squashed and modified before merging. Please give feedback on any changes you would like to see to make your job easier.