### PR TITLE
Switch default for restarting to read historic schedule

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -138,7 +138,7 @@ struct EclStrictParsing<TypeTag, TTag::EclBaseVanguard> {
 };
 template<class TypeTag>
 struct SchedRestart<TypeTag, TTag::EclBaseVanguard> {
-    static constexpr bool value = false;
+    static constexpr bool value = true;
 };
 template<class TypeTag>
 struct EdgeWeightsMethod<TypeTag, TTag::EclBaseVanguard> {


### PR DESCRIPTION
Unfortunately restarting without reading historic schedule is a long term effort. In order to avoid excessive problems for users, I suggest we switch the default until we are closer to support restarting without historic schedule available.