### PR TITLE
Always accumulates data in AMG to 1 process on coarse levels.

### DIFF
--- a/opm/simulators/linalg/PreconditionerFactory.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory.hpp
@@ -134,6 +134,10 @@ private:
         criterion.setNoPreSmoothSteps(prm.get<int>("pre_smooth", 1));
         criterion.setNoPostSmoothSteps(prm.get<int>("post_smooth", 1));
         criterion.setDebugLevel(prm.get<int>("verbosity", 0));
+        // As the default we request to accumulate data to 1 process always as our matrix
+        // graph might be unsymmetric and hence not supported by the PTScotch/ParMetis
+        // calls in DUNE. Accumulating to 1 skips PTScotch/ParMetis
+        criterion.setAccumulate(static_cast<Dune::Amg::AccumulationMode>(prm.get<int>("accumulate", 1)));
         return criterion;
     }
 

--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -61,6 +61,10 @@ setupCPR(const std::string& conf, const FlowLinearSolverParameters& p)
     prm.put("preconditioner.coarsesolver.preconditioner.verbosity", 0);
     prm.put("preconditioner.coarsesolver.preconditioner.maxlevel", 15);
     prm.put("preconditioner.coarsesolver.preconditioner.skip_isolated", 0);
+    // We request to accumulate data to 1 process always as our matrix
+    // graph might be unsymmetric and hence not supported by the PTScotch/ParMetis
+    // calls in DUNE. Accumulating to 1 skips PTScotch/ParMetis
+    prm.put("preconditioner.coarsesolver.preconditioner.accumulate", 1);
     return prm;
 }
 
@@ -85,6 +89,10 @@ setupAMG([[maybe_unused]] const std::string& conf, const FlowLinearSolverParamet
     prm.put("preconditioner.verbosity", 0);
     prm.put("preconditioner.maxlevel", 15);
     prm.put("preconditioner.skip_isolated", 0);
+    // We request to accumulate data to 1 process always as our matrix
+    // graph might be unsymmetric and hence not supported by the PTScotch/ParMetis
+    // calls in DUNE. Accumulating to 1 skips PTScotch/ParMetis
+    prm.put("preconditioner.accumulate", 1);
     return prm;
 }
 


### PR DESCRIPTION
In OPM the matrix graph might be unsymmetric as we do not store the full sparsity pattern for copy rows but only the diagonal.
Unfortunately, DUNE assumes that matrices from finite elements and finite volumes have a symmetric sparsity pattern for copy rows to and uses this assumption to create the graphs for PTScotch/ParMETIS more easily. But PTScotch/ParMetis assume a symmetric graph.

Closes #2894 for me.

There are other possible (and better) fixes mentioned in #2894. But this one seemed the quickest and should be good enough for the release (Reverting OPM/opm-common#2061 would not cut it for ParMETIS).