### PR TITLE
Make AMG use the graph of the communication pattern for agglomeration.

### DIFF
--- a/opm-simulators-prereqs.cmake
+++ b/opm-simulators-prereqs.cmake
@@ -13,7 +13,20 @@ set (opm-simulators_CONFIG_VAR
   DUNE_ISTL_VERSION_MINOR
   DUNE_ISTL_VERSION_REVISION
   HAVE_SUITESPARSE_UMFPACK
+  AMG_REPART_ON_COMM_GRAPH
   )
+
+# the sparsity pattern of our matrix might be unsymmetric due to
+# not storing offdiagonals for the ghost rows. DUNE assumes a
+# symmetric sparsity pattern to prepare the graph for
+# PTScotch/ParMETIS. Hence our approach breaks the assumption and
+# PTScotch/ParMETIS might deadlock or MPI will error out
+# in some MPI_Allgatherv calls.
+# We define AMG_REPART_ON_COMM_GRAPH to instruct AMG to use
+# the graph of the communication patter (one vertex for each
+# MPI rank and edge between v and w exists if these exchange
+# messages)
+set(AMG_REPART_ON_COMM_GRAPH 1)
 
 # dependencies
 set (opm-simulators_DEPS


### PR DESCRIPTION
The default in DUNE is to use the graph of the matrix to compute a coarser partitioning when building the hierarchy of matrices.
(This done to keep the ratio of communication versus computation reasonable as the matrices get coarser and coarser).

The sparsity pattern of our matrix might be unsymmetric due to not storing offdiagonals for the ghost rows. DUNE assumes a
symmetric sparsity pattern to prepare the graph for PTScotch/ParMETIS (without too much communication/computation).
Hence our approach breaks the assumption and PTScotch/ParMETIS might deadlock or MPI will error out in some MPI_Allgatherv calls.

Fortunately, there is another approach implemented that uses the graph of the communication happening when applying the linear operator. In this graph there is one vertex for each MPI rank and an edge between v and w (and w and v) exists if these
exchange messages during the application of the operator. This graph is constructed within AMG and always symmetric.

With this commit our build system defines AMG_REPART_ON_COMM_GRAPH to instruct AMG to use the graph of the communication pattern for loadbalancing.

Closes #2894 
Might be a better alternative than #2898 