### PR TITLE
Save two grid traversals and arrays for wells

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -303,7 +303,7 @@ namespace Opm {
             // the number of the cells in the local grid
             size_t local_num_cells_;
             double gravity_;
-            std::vector<double> depth_;
+            std::function<double (std::size_t)> depth_;
             bool initial_step_;
             bool report_step_starts_;
             bool glift_debug = false;

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -297,7 +297,7 @@ namespace Opm {
             bool terminal_output_;
             bool has_solvent_;
             bool has_polymer_;
-            std::vector<int> pvt_region_idx_;
+            std::function<std::size_t (std::size_t)> pvt_region_idx_;
             PhaseUsage phase_usage_;
             size_t global_num_cells_;
             // the number of the cells in the local grid

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1637,12 +1637,11 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::extractLegacyDepth_()
     {
         const auto& grid = ebosSimulator_.vanguard().grid();
-        const unsigned numCells = grid.size(/*codim=*/0);
 
-        depth_.resize(numCells);
-        for (unsigned cellIdx = 0; cellIdx < numCells; ++cellIdx) {
-            depth_[cellIdx] = Opm::UgGridHelpers::cellCenterDepth( grid, cellIdx );
-        }
+        depth_ = [&grid](std::size_t cellIdx)
+                 {
+                     return Opm::UgGridHelpers::cellCenterDepth( grid, cellIdx );
+                 };
     }
 
     template<typename TypeTag>

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -108,7 +108,7 @@ namespace Opm
                          const std::vector<PerforationData>& perf_data);
 
         virtual void init(const PhaseUsage* phase_usage_arg,
-                          const std::vector<double>& depth_arg,
+                          const std::function<double (std::size_t)>& depth_arg,
                           const double gravity_arg,
                           const int num_cells) override;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -128,7 +128,7 @@ namespace Opm
     void
     MultisegmentWell<TypeTag>::
     init(const PhaseUsage* phase_usage_arg,
-         const std::vector<double>& depth_arg,
+         const std::function<double (std::size_t)>& depth_arg,
          const double gravity_arg,
          const int num_cells)
     {
@@ -149,7 +149,7 @@ namespace Opm
         // calcuate the depth difference between the perforations and the perforated grid block
         for (int perf = 0; perf < number_of_perforations_; ++perf) {
             const int cell_idx = well_cells_[perf];
-            cell_perforation_depth_diffs_[perf] = depth_arg[cell_idx] - perf_depth_[perf];
+            cell_perforation_depth_diffs_[perf] = depth_arg(cell_idx) - perf_depth_[perf];
         }
     }
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -162,7 +162,7 @@ namespace Opm
                      const std::vector<PerforationData>& perf_data);
 
         virtual void init(const PhaseUsage* phase_usage_arg,
-                          const std::vector<double>& depth_arg,
+                          const std::function<double (std::size_t)>& depth_arg,
                           const double gravity_arg,
                           const int num_cells) override;
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -60,7 +60,7 @@ namespace Opm
     void
     StandardWell<TypeTag>::
     init(const PhaseUsage* phase_usage_arg,
-         const std::vector<double>& depth_arg,
+         const std::function<double (std::size_t)>& depth_arg,
          const double gravity_arg,
          const int num_cells)
     {
@@ -69,7 +69,7 @@ namespace Opm
         perf_depth_.resize(number_of_perforations_, 0.);
         for (int perf = 0; perf < number_of_perforations_; ++perf) {
             const int cell_idx = well_cells_[perf];
-            perf_depth_[perf] = depth_arg[cell_idx];
+            perf_depth_[perf] = depth_arg(cell_idx);
         }
 
         // counting/updating primary variable numbers

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -151,7 +151,7 @@ namespace Opm
         void setGuideRate(const GuideRate* guide_rate_arg);
 
         virtual void init(const PhaseUsage* phase_usage_arg,
-                          const std::vector<double>& depth_arg,
+                          const std::function<double(std::size_t)>& depth_arg,
                           const double gravity_arg,
                           const int num_cells);
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -124,7 +124,7 @@ namespace Opm
     void
     WellInterface<TypeTag>::
     init(const PhaseUsage* phase_usage_arg,
-         const std::vector<double>& /* depth_arg */,
+         const std::function<double (std::size_t)>& /* depth_arg */,
          const double gravity_arg,
          const int /* num_cells */)
     {


### PR DESCRIPTION
Both the cell depth and the pvt region are just queried for the well perforation. Yet we created two arrays storing the information for all cells. That seemed a bit of waste and this PR fixes this by using std::function instead.