### PR TITLE
Switched time step control and changed damping factor for it

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -906,7 +906,7 @@ if(MPI_FOUND)
                                        FILENAME SPE1FOAM
                                        SIMULATOR flow
                                        ABS_TOL ${abs_tol}
-                                       REL_TOL ${rel_tol})
+                                       REL_TOL ${coarse_rel_tol_parallel})
 
   add_test_compare_parallel_simulation(CASENAME spe1_thermal
                                        FILENAME SPE1CASE2_THERMAL

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -906,8 +906,7 @@ if(MPI_FOUND)
                                        FILENAME SPE1FOAM
                                        SIMULATOR flow
                                        ABS_TOL ${abs_tol}
-                                       REL_TOL ${rel_tol}
-                                       TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
+                                       REL_TOL ${rel_tol})
 
   add_test_compare_parallel_simulation(CASENAME spe1_thermal
                                        FILENAME SPE1CASE2_THERMAL

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -162,7 +162,7 @@ struct TimeStepAfterEventInDays<TypeTag, TTag::FlowTimeSteppingParameters> {
 };
 template<class TypeTag>
 struct TimeStepControl<TypeTag, TTag::FlowTimeSteppingParameters> {
-    static constexpr auto value = "pid";
+    static constexpr auto value = "pid+newtoniteration";
 };
 template<class TypeTag>
 struct TimeStepControlTolerance<TypeTag, TTag::FlowTimeSteppingParameters> {
@@ -195,7 +195,7 @@ struct TimeStepControlDecayDampingFactor<TypeTag, TTag::FlowTimeSteppingParamete
 template<class TypeTag>
 struct TimeStepControlGrowthDampingFactor<TypeTag, TTag::FlowTimeSteppingParameters> {
     using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 1.0/1.2;
+    static constexpr type value = 1.0/0.2;
 };
 template<class TypeTag>
 struct TimeStepControlFileName<TypeTag, TTag::FlowTimeSteppingParameters> {

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -195,7 +195,7 @@ struct TimeStepControlDecayDampingFactor<TypeTag, TTag::FlowTimeSteppingParamete
 template<class TypeTag>
 struct TimeStepControlGrowthDampingFactor<TypeTag, TTag::FlowTimeSteppingParameters> {
     using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 5;
+    static constexpr type value = 3.2;
 };
 template<class TypeTag>
 struct TimeStepControlFileName<TypeTag, TTag::FlowTimeSteppingParameters> {
@@ -629,13 +629,13 @@ namespace Opm {
             else if (control == "pid+iteration") {
                 const int iterations =  EWOMS_GET_PARAM(TypeTag, int, TimeStepControlTargetIterations); // 30
                 const double decayDampingFactor = EWOMS_GET_PARAM(TypeTag, double, TimeStepControlDecayDampingFactor); // 1.0
-                const double growthDampingFactor = EWOMS_GET_PARAM(TypeTag, double, TimeStepControlGrowthDampingFactor); // 5
+                const double growthDampingFactor = EWOMS_GET_PARAM(TypeTag, double, TimeStepControlGrowthDampingFactor); // 3.2
                 timeStepControl_ = TimeStepControlType(new PIDAndIterationCountTimeStepControl(iterations, decayDampingFactor, growthDampingFactor, tol));
             }
             else if (control == "pid+newtoniteration") {
                 const int iterations =  EWOMS_GET_PARAM(TypeTag, int, TimeStepControlTargetNewtonIterations); // 8
                 const double decayDampingFactor = EWOMS_GET_PARAM(TypeTag, double, TimeStepControlDecayDampingFactor); // 1.0
-                const double growthDampingFactor = EWOMS_GET_PARAM(TypeTag, double, TimeStepControlGrowthDampingFactor); // 5
+                const double growthDampingFactor = EWOMS_GET_PARAM(TypeTag, double, TimeStepControlGrowthDampingFactor); // 3.2
                 timeStepControl_ = TimeStepControlType(new PIDAndIterationCountTimeStepControl(iterations, decayDampingFactor, growthDampingFactor, tol));
                 useNewtonIteration_ = true;
             }

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -195,7 +195,7 @@ struct TimeStepControlDecayDampingFactor<TypeTag, TTag::FlowTimeSteppingParamete
 template<class TypeTag>
 struct TimeStepControlGrowthDampingFactor<TypeTag, TTag::FlowTimeSteppingParameters> {
     using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 1.0/0.2;
+    static constexpr type value = 5;
 };
 template<class TypeTag>
 struct TimeStepControlFileName<TypeTag, TTag::FlowTimeSteppingParameters> {
@@ -629,13 +629,13 @@ namespace Opm {
             else if (control == "pid+iteration") {
                 const int iterations =  EWOMS_GET_PARAM(TypeTag, int, TimeStepControlTargetIterations); // 30
                 const double decayDampingFactor = EWOMS_GET_PARAM(TypeTag, double, TimeStepControlDecayDampingFactor); // 1.0
-                const double growthDampingFactor = EWOMS_GET_PARAM(TypeTag, double, TimeStepControlGrowthDampingFactor); // 1.0/1.2
+                const double growthDampingFactor = EWOMS_GET_PARAM(TypeTag, double, TimeStepControlGrowthDampingFactor); // 5
                 timeStepControl_ = TimeStepControlType(new PIDAndIterationCountTimeStepControl(iterations, decayDampingFactor, growthDampingFactor, tol));
             }
             else if (control == "pid+newtoniteration") {
                 const int iterations =  EWOMS_GET_PARAM(TypeTag, int, TimeStepControlTargetNewtonIterations); // 8
                 const double decayDampingFactor = EWOMS_GET_PARAM(TypeTag, double, TimeStepControlDecayDampingFactor); // 1.0
-                const double growthDampingFactor = EWOMS_GET_PARAM(TypeTag, double, TimeStepControlGrowthDampingFactor); // 1.0/1.2
+                const double growthDampingFactor = EWOMS_GET_PARAM(TypeTag, double, TimeStepControlGrowthDampingFactor); // 5
                 timeStepControl_ = TimeStepControlType(new PIDAndIterationCountTimeStepControl(iterations, decayDampingFactor, growthDampingFactor, tol));
                 useNewtonIteration_ = true;
             }


### PR DESCRIPTION
Our default time stepping routine is too aggressive, by in\creasing time step until convergence failure. By letting the next time step cut back a little when we exceed eight newton iterations, we can avoid many convergence problems while keeping numerical performance good. This is particularly beneficial in the prediction part of the simulation.