### PR TITLE
Add the option to include gas lift for network calculations.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1284,7 +1284,8 @@ namespace Opm {
         if (!network.active()) {
             return;
         }
-        node_pressures_ = WellGroupHelpers::computeNetworkPressures(network, well_state_, *(vfp_properties_->getProd()));
+        node_pressures_ = WellGroupHelpers::computeNetworkPressures(
+            network, well_state_, *(vfp_properties_->getProd()), schedule(), reportStepIdx);
 
         // Set the thp limits of wells
         for (auto& well : well_container_) {

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1347,6 +1347,16 @@ namespace Opm {
 
         // We use the rates from the privious time-step to reduce oscilations
         WellGroupHelpers::updateWellRates(fieldGroup, schedule(), reportStepIdx, previous_well_state_, well_state_);
+
+        // Set ALQ for off-process wells to zero
+        for (const auto& wname : schedule().wellNames(reportStepIdx)) {
+            const bool is_producer = schedule().getWell(wname, reportStepIdx).isProducer();
+            const bool not_on_this_process = well_state_.wellMap().count(wname) == 0;
+            if (is_producer && not_on_this_process) {
+                well_state_.setALQ(wname, 0.0);
+            }
+        }
+
         well_state_.communicateGroupRates(comm);
 
         // compute wsolvent fraction for REIN wells

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -264,7 +264,9 @@ namespace WellGroupHelpers
     std::map<std::string, double>
     computeNetworkPressures(const Opm::Network::ExtNetwork& network,
                             const WellStateFullyImplicitBlackoil& well_state,
-                            const VFPProdProperties& vfp_prod_props);
+                            const VFPProdProperties& vfp_prod_props,
+                            const Schedule& schedule,
+                            const int report_time_step);
 
     GuideRate::RateVector
     getRateVector(const WellStateFullyImplicitBlackoil& well_state, const PhaseUsage& pu, const std::string& name);

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -1042,7 +1042,7 @@ namespace Opm
                 iterateContainer(injection_group_reduction_rates, func);
                 iterateContainer(injection_group_reservoir_rates, func);
                 iterateContainer(production_group_rates, func);
-                iterateContainer(well_rates,func);
+                iterateContainer(well_rates, func);
             };
 
             // Compute the size of the data.
@@ -1052,6 +1052,7 @@ namespace Opm
             };
             forAllGroupData(computeSize);
             sz += injection_group_vrep_rates.size();
+            sz += current_alq_.size();
 
             // Make a vector and collect all data into it.
             std::vector<double> data(sz);
@@ -1063,6 +1064,9 @@ namespace Opm
             };
             forAllGroupData(collect);
             for (const auto& x : injection_group_vrep_rates) {
+                data[pos++] = x.second;
+            }
+            for (const auto& x : current_alq_) {
                 data[pos++] = x.second;
             }
             assert(pos == sz);
@@ -1079,6 +1083,9 @@ namespace Opm
             };
             forAllGroupData(distribute);
             for (auto& x : injection_group_vrep_rates) {
+                x.second = data[pos++];
+            }
+            for (auto& x : current_alq_) {
                 x.second = data[pos++];
             }
             assert(pos == sz);


### PR DESCRIPTION
This adds the gas lift rates (as ALQ) into the network calculations to determine pressure drops in the network.