### PR TITLE
Make a flow version that uses the polyhedreal grid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ option(BUILD_FLOW_VARIANTS "Build the variants for flow by default?" OFF)
 option(BUILD_EBOS "Build the research oriented ebos simulator?" ON)
 option(BUILD_EBOS_EXTENSIONS "Build the variants for various extensions of ebos by default?" OFF)
 option(BUILD_EBOS_DEBUG_EXTENSIONS "Build the ebos variants which are purely for debugging by default?" OFF)
-
+option(BUILD_FLOW_POLY_GRID "Build flow blackoil with polyhedral grid" OFF)
 option(ENABLE_3DPROPS_TESTING "Build and use the new experimental 3D properties" OFF)
 if (ENABLE_3DPROPS_TESTING)
   add_definitions(-DENABLE_3DPROPS_TESTING)
@@ -270,6 +270,25 @@ opm_add_test(flow_blackoil
   $<TARGET_OBJECTS:flow_libblackoil>
   $<TARGET_OBJECTS:moduleVersion>)
 target_compile_definitions(flow_blackoil PRIVATE "FLOW_BLACKOIL_ONLY")
+
+if (NOT BUILD_FLOW_POLY_GRID)
+  set(FLOW_POLY_ONLY_DEFAULT_ENABLE_IF "FALSE")
+else()
+  set(FLOW_POLY_ONLY_DEFAULT_ENABLE_IF "TRUE")
+endif()
+
+# the production oriented general-purpose ECL simulator
+opm_add_test(flow_poly
+  ONLY_COMPILE
+  ALWAYS_ENABLE
+  DEFAULT_ENABLE_IF ${FLOW_POLY_ONLY_DEFAULT_ENABLE_IF}
+  DEPENDS opmsimulators
+  LIBRARIES opmsimulators
+  SOURCES
+  flow/flow_blackoil_poly.cpp
+  $<TARGET_OBJECTS:moduleVersion>)
+target_compile_definitions(flow_poly PRIVATE USE_POLYHEDRALGRID)
+
 
 if (NOT BUILD_FLOW_VARIANTS)
   set(FLOW_VARIANTS_DEFAULT_ENABLE_IF "FALSE")

--- a/ebos/eclpolyhedralgridvanguard.hh
+++ b/ebos/eclpolyhedralgridvanguard.hh
@@ -183,10 +183,7 @@ public:
 protected:
     void createGrids_()
     {
-        const auto& gridProps = this->eclState().get3DProperties();
-        const std::vector<double>& porv = gridProps.getDoubleGridProperty("PORV").getData();
-
-        grid_ = new Grid(this->deck(), porv);
+        grid_ = new Grid(this->eclState().getInputGrid(), this->eclState().fieldProps().porv(true));
         cartesianIndexMapper_ = new CartesianIndexMapper(*grid_);
     }
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -47,10 +47,12 @@
 
 #if EBOS_USE_ALUGRID
 #include "eclalugridvanguard.hh"
+#elif USE_POLYHEDRALGRID
+#include "eclpolyhedralgridvanguard.hh"
 #else
-//#include "eclpolyhedralgridvanguard.hh"
 #include "eclcpgridvanguard.hh"
 #endif
+
 #include "eclwellmanager.hh"
 #include "eclequilinitializer.hh"
 #include "eclwriter.hh"
@@ -124,13 +126,14 @@ namespace TTag {
 struct EclBaseProblem {
   using InheritstFrom = std::tuple<VtkEclTracer, EclOutputBlackOil, EclAluGridVanguard>;
 };
+#elif USE_POLYHEDRALGRID
+struct EclBaseProblem {
+  using InheritsFrom = std::tuple<VtkEclTracer, EclOutputBlackOil, EclPolyhedralGridVanguard>;
+};
 #else
 struct EclBaseProblem {
   using InheritsFrom = std::tuple<VtkEclTracer, EclOutputBlackOil, EclCpGridVanguard>;
 };
-//struct EclBaseProblem {
-//    using InheritsFrom = std::tuple<VtkEclTracer, EclOutputBlackOil, EclPolyhedralGridVanguard>;
-//};
 #endif
 }
 

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -427,7 +427,6 @@ public:
             Opm::Action::State& actionState = simulator_.vanguard().actionState();
             auto restartValues = loadParallelRestart(eclIO_.get(), actionState, summaryState, solutionKeys, extraKeys,
                                                      gridView.grid().comm());
-
             for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
                 unsigned globalIdx = collectToIORank_.localIdxToGlobalIdx(elemIdx);
                 eclOutputModule_.setRestart(restartValues.solution, elemIdx, globalIdx);

--- a/flow/flow_blackoil_poly.cpp
+++ b/flow/flow_blackoil_poly.cpp
@@ -1,0 +1,35 @@
+/*
+  Copyright 2020, NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+#include <opm/simulators/flow/Main.hpp>
+
+namespace Opm::Properties {
+    namespace TTag {
+        struct EclFlowProblemPoly {
+            using InheritsFrom = std::tuple<EclFlowProblem>;
+        };
+    }
+}
+
+int main(int argc, char** argv)
+{
+    using TypeTag = Opm::Properties::TTag::EclFlowProblemPoly;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
+}

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -19,7 +19,6 @@
 #include <flow/flow_ebos_blackoil.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>
-#include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/FlowMainEbos.hpp>
 

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -30,6 +30,7 @@
 #include <opm/simulators/utils/ParallelFileMerger.hpp>
 #include <opm/simulators/utils/moduleVersion.hpp>
 #include <opm/simulators/linalg/ExtractParallelGridInformationToISTL.hpp>
+#include <opm/simulators/utils/ParallelEclipseState.hpp>
 
 #include <opm/core/props/satfunc/RelpermDiagnostics.hpp>
 

--- a/opm/simulators/linalg/findOverlapRowsAndColumns.hpp
+++ b/opm/simulators/linalg/findOverlapRowsAndColumns.hpp
@@ -121,7 +121,7 @@ namespace detail
     {
         size_t numInterior = 0;
         if (!ownerFirst || grid.comm().size()==1)
-            return grid.numCells();
+            return grid.leafGridView().size(0);
         const auto& gridView = grid.leafGridView();
         auto elemIt = gridView.template begin<0>();
         const auto& elemEndIt = gridView.template end<0>();


### PR DESCRIPTION
Currently the simulator creates the polyhedreal grid from an eclGrid from opm-common

TODO (but not in this PR)
 - make it possible to create the grid directly from DGF or MRST format
 - fix issue on norne.
 - add a test case to make sure this continues to work

Depends on OPM/opm-grid#500