### PR TITLE
Do not filter connections on the schedule of the loadbalanced grid.

### DIFF
--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -234,9 +234,9 @@ public:
 
             cartesianIndexMapper_.reset();
 
-            // Calling Schedule::filterConnectins would remove any perforated
-            // cells that exist on other ranks in the case of distributed wells
-            // But we need them to figure out the first cell of a well (e.g. for
+            // Calling Schedule::filterConnections would remove any perforated
+            // cells that exist only on other ranks even in the case of distributed wells
+            // But we need all connections to figure out the first cell of a well (e.g. for
             // pressure). Hence this is now skipped. Rank 0 had everything even before.
         }
 #endif

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -234,15 +234,10 @@ public:
 
             cartesianIndexMapper_.reset();
 
-            if ( ! equilGrid_ )
-            {
-                // for processes that do not hold the global grid we filter here using the local grid.
-                // If we would filter in filterConnection_ our partition would be empty and the connections of all
-                // wells would be removed.
-                ActiveGridCells activeCells(grid().logicalCartesianSize(),
-                                            grid().globalCell().data(), grid().size(0));
-                this->schedule().filterConnections(activeCells);
-            }
+            // Calling Schedule::filterConnectins would remove any perforated
+            // cells that exist on other ranks in the case of distributed wells
+            // But we need them to figure out the first cell of a well (e.g. for
+            // pressure). Hence this is now skipped. Rank 0 had everything even before.
         }
 #endif
 

--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -49,4 +49,9 @@ void eclStateBroadcast(EclipseState& eclState, Schedule& schedule,
     ser.broadcast(summaryConfig);
 }
 
+void eclScheduleBroadcast(Schedule& schedule)
+{
+    Opm::EclMpiSerializer ser(Dune::MPIHelper::getCollectiveCommunication());
+    ser.broadcast(schedule);
+}
 }

--- a/opm/simulators/utils/ParallelSerialization.hpp
+++ b/opm/simulators/utils/ParallelSerialization.hpp
@@ -33,6 +33,9 @@ class SummaryConfig;
 void eclStateBroadcast(EclipseState& eclState, Schedule& schedule,
                        SummaryConfig& summaryConfig);
 
+/// \brief Broadcasts an schedule from root node in parallel runs.
+void eclScheduleBroadcast(Schedule& schedule);
+
 } // end namespace Opm
 
 #endif // PARALLEL_SERIALIZATION_HPP


### PR DESCRIPTION
It would remove perforated cells from wells that cross the local domain's border. That would make it impossible to figure out the
first connection. In addition we would not be able to check that the connections exist (as rank 0 would have the complete information -> inconsistency).

This is cherry-picked from the work on distributed wells.

The filtering removes all connections from wells in the schedule that are not in the local domain of the process. It is only performed on processes with rank greater than zero (as zero needs all the information for output?). As currently a process either has all or no possible connections of a well in it's domain and the wells that have none are not treated anyway, this change should have no effect.