### PR TITLE
Make --alternative-well-rate-init=true the default.

### DIFF
--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -256,7 +256,7 @@ struct MaxInnerIterWells<TypeTag, TTag::FlowModelParameters> {
 };
 template<class TypeTag>
 struct AlternativeWellRateInit<TypeTag, TTag::FlowModelParameters> {
-    static constexpr bool value = false;
+    static constexpr bool value = true;
 };
 template<class TypeTag>
 struct StrictInnerIterMsWells<TypeTag, TTag::FlowModelParameters> {

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -396,9 +396,14 @@ namespace Opm {
         }
 
         if (alternative_well_rate_init_) {
-            // Update the well rates to match state, if only single-phase rates.
+            // Update the well rates of well_state_, if only single-phase rates, to
+            // have proper multi-phase rates proportional to rates at bhp zero.
+            // This is done only for producers, as injectors will only have a single
+            // nonzero phase anyway.
             for (auto& well : well_container_) {
-                well->updateWellStateRates(ebosSimulator_, well_state_, local_deferredLogger);
+                if (well->isProducer()) {
+                    well->updateWellStateRates(ebosSimulator_, well_state_, local_deferredLogger);
+                }
             }
         }
 


### PR DESCRIPTION
This should improve initialization in general, and is required to successfully run some cases depending on the network option.

We should verify it does not break things before merging though.