### PR TITLE
Disable python tests in debian packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ option(BUILD_EBOS "Build the research oriented ebos simulator?" ON)
 option(BUILD_EBOS_EXTENSIONS "Build the variants for various extensions of ebos by default?" OFF)
 option(BUILD_EBOS_DEBUG_EXTENSIONS "Build the ebos variants which are purely for debugging by default?" OFF)
 option(BUILD_FLOW_POLY_GRID "Build flow blackoil with polyhedral grid" OFF)
+option(OPM_ENABLE_PYTHON "Enable python bindings?" OFF)
+option(OPM_ENABLE_PYTHON_TESTS "Enable tests for the python bindings?" ON)
 
 if(SIBLING_SEARCH AND NOT opm-common_DIR)
   # guess the sibling dir

--- a/debian/rules
+++ b/debian/rules
@@ -21,7 +21,7 @@ override_dh_auto_build:
 
 # consider using -DUSE_VERSIONED_DIR=ON if backporting
 override_dh_auto_configure:
-	dh_auto_configure --buildsystem=cmake -- -DCMAKE_BUILD_TYPE=Release -DUSE_MPI=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libopm-simulators1 -DWHOLE_PROG_OPTIM=OFF -DUSE_RUNPATH=OFF -DWITH_NATIVE=OFF -DUSE_QUADMATH=0 -DOPM_ENABLE_PYTHON=1 -DOPM_INSTALL_PYTHON=1 -DPYTHON_EXECUTABLE=/usr/bin/python3
+	dh_auto_configure --buildsystem=cmake -- -DCMAKE_BUILD_TYPE=Release -DUSE_MPI=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libopm-simulators1 -DWHOLE_PROG_OPTIM=OFF -DUSE_RUNPATH=OFF -DWITH_NATIVE=OFF -DUSE_QUADMATH=0 -DOPM_ENABLE_PYTHON=1 -DOPM_INSTALL_PYTHON=1 -DPYTHON_EXECUTABLE=/usr/bin/python3 -DOPM_ENABLE_PYTHON_TESTS=0
 
 override_dh_auto_install:
 	dh_auto_install -- install-html

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -25,8 +25,10 @@ file( COPY ${PROJECT_SOURCE_DIR}/python/test
 file( COPY ${PROJECT_SOURCE_DIR}/python/test_data
       DESTINATION ${PROJECT_BINARY_DIR}/python)
 
-add_test(NAME python_tests
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python
-    COMMAND ${CMAKE_COMMAND}
-          -E env PYTHONPATH=${PROJECT_BINARY_DIR}/python:$ENV{PYTHONPATH}
-          ${PYTHON_EXECUTABLE} -m unittest )
+if(OPM_ENABLE_PYTHON_TESTS)
+  add_test(NAME python_tests
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python
+      COMMAND ${CMAKE_COMMAND}
+            -E env PYTHONPATH=${PROJECT_BINARY_DIR}/python:$ENV{PYTHONPATH}
+            ${PYTHON_EXECUTABLE} -m unittest )
+endif()


### PR DESCRIPTION
add cmake option to disable the python tests
    
Due to bugs in the openmpi on bionic, this test fails to execute properly in pbuilder environments. 
Instead of rebuilding openmpi without dynamic loading (which is the suggested fix) and potentially break users
systems, this is a non-intrusive workaround to be used for packaging.
    
Also add explicit option for python support to make it visible in cmake frontends.
