### PR TITLE
Make consistent use of const for alq-related state.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -212,9 +212,8 @@ namespace Opm {
                         continue;
                     }
 
-                    xwPos->second.current_control.isProducer = well.isProducer();
-
-                    auto& grval = xwPos->second.guide_rates;  grval.clear();
+                    auto& grval = xwPos->second.guide_rates;
+                    grval.clear();
                     grval += this->getGuideRateValues(well);
                 }
 

--- a/opm/simulators/wells/GasLiftRuntime.hpp
+++ b/opm/simulators/wells/GasLiftRuntime.hpp
@@ -67,7 +67,7 @@ namespace Opm
             const Simulator &ebos_simulator,
             const SummaryState &summary_state,
             DeferredLogger &deferred_logger,
-            const WellState &well_state,
+            WellState &well_state,
             const Well::ProductionControls &controls
         );
         void runOptimize();
@@ -97,7 +97,7 @@ namespace Opm
         std::vector<double> potentials_;
         const StdWell &std_well_;
         const SummaryState &summary_state_;
-        const WellState &well_state_;
+        WellState &well_state_;
         std::string well_name_;
         bool debug;  // extra debug output
 

--- a/opm/simulators/wells/GasLiftRuntime_impl.hpp
+++ b/opm/simulators/wells/GasLiftRuntime_impl.hpp
@@ -35,7 +35,7 @@ GasLiftRuntime(
     const Simulator &ebos_simulator,
     const SummaryState &summary_state,
     DeferredLogger &deferred_logger,
-    const WellState &well_state,
+    WellState &well_state,
     const Well::ProductionControls &controls
 ) :
     controls_{controls},

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -116,7 +116,7 @@ namespace Opm
         virtual void initPrimaryVariablesEvaluation() const override;
 
         virtual void maybeDoGasLiftOptimization (
-            const WellState&,
+            WellState&,
             const Simulator&,
             DeferredLogger&
         ) const override {

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -248,7 +248,7 @@ namespace Opm
         ) const;
 
         virtual void maybeDoGasLiftOptimization (
-            const WellState& well_state,
+            WellState& well_state,
             const Simulator& ebosSimulator,
             DeferredLogger& deferred_logger
         ) const override;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2822,7 +2822,7 @@ namespace Opm
     void
     StandardWell<TypeTag>::
     maybeDoGasLiftOptimization(
-                          const WellState& well_state,
+                          WellState& well_state,
                           const Simulator& ebos_simulator,
                           Opm::DeferredLogger& deferred_logger) const
     {

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -171,7 +171,7 @@ namespace Opm
                                     ) = 0;
 
         virtual void maybeDoGasLiftOptimization (
-            const WellState& well_state,
+            WellState& well_state,
             const Simulator& ebosSimulator,
             DeferredLogger& deferred_logger
         ) const = 0;

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -1135,25 +1135,15 @@ namespace Opm
             return globalIsProductionGrup_[it->second] != 0;
         }
 
-        void updateALQ( const WellStateFullyImplicitBlackoil &copy ) const
-        {
-            this->current_alq_ = copy.getCurrentALQ();
-        }
-
-        std::map<std::string, double> getCurrentALQ() const
-        {
-            return current_alq_;
-        }
-
         double getALQ( const std::string& name) const
         {
             if (this->current_alq_.count(name) == 0) {
-                this->current_alq_[name] = this->default_alq_[name];
+                return this->default_alq_.at(name);
             }
-            return this->current_alq_[name];
+            return this->current_alq_.at(name);
         }
 
-        void setALQ( const std::string& name, double value) const
+        void setALQ( const std::string& name, double value)
         {
             this->current_alq_[name] = value;
         }
@@ -1162,11 +1152,11 @@ namespace Opm
             return do_glift_optimization_;
         }
 
-        void disableGliftOptimization() const {
+        void disableGliftOptimization() {
             do_glift_optimization_ = false;
         }
 
-        void enableGliftOptimization() const {
+        void enableGliftOptimization() {
             do_glift_optimization_ = true;
         }
 
@@ -1197,9 +1187,9 @@ namespace Opm
         std::map<std::string, double> injection_group_vrep_rates;
         std::map<std::string, std::vector<double>> injection_group_rein_rates;
         std::map<std::string, double> group_grat_target_from_sales;
-        mutable std::map<std::string, double> current_alq_;
-        mutable std::map<std::string, double> default_alq_;
-        mutable bool do_glift_optimization_;
+        std::map<std::string, double> current_alq_;
+        std::map<std::string, double> default_alq_;
+        bool do_glift_optimization_;
 
         std::vector<double> perfRateSolvent_;
 

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -150,6 +150,11 @@ namespace Opm
                 first_perf_index_[w+1] = connpos;
             }
 
+            is_producer_.resize(nw, false);
+            for (int w = 0; w < nw; ++w) {
+                is_producer_[w] = wells_ecl[w].isProducer();
+            }
+
             current_injection_controls_.resize(nw);
             current_production_controls_.resize(nw);
 
@@ -587,7 +592,7 @@ namespace Opm
                     well.rates.set( rt::brine, brineWellRate(w) );
                 }
 
-                if ( well.current_control.isProducer ) {
+                if ( is_producer_[w] ) {
                     well.rates.set( rt::alq, getALQ(/*wellName=*/wt.first) );
                 }
                 else {
@@ -600,6 +605,7 @@ namespace Opm
                 {
                     auto& curr = well.current_control;
 
+                    curr.isProducer = this->is_producer_[w];
                     curr.prod = this->currentProductionControls()[w];
                     curr.inj  = this->currentInjectionControls() [w];
                 }
@@ -1162,6 +1168,7 @@ namespace Opm
 
     private:
         std::vector<double> perfphaserates_;
+        std::vector<bool> is_producer_; // Size equal to number of local wells.
 
         // vector with size number of wells +1.
         // iterate over all perforations of a given well


### PR DESCRIPTION
A const well state was passed to functions that were modifying it by calling setALQ(). Now the setALQ() method is made non-const, mutable references to the well state are passed where sensible. The getALQ() method uses map::at() instead of map::operator[] and no longer modifies current_alq_. Removed two unused functions.

With this, it is now easy to see which methods modify the well state and which don't. The alq-related members in the WellStateFullyImplicitBlackoil class are no longer 'mutable'-qualified.

Please verify that the gas lift feature still works with this, I think there is no test for it in jenkins currently? @totto82 @hakonhagland 