### PR TITLE
StandardWell only assing primary_variables_[WQTotal] once.

### DIFF
--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2843,9 +2843,7 @@ namespace Opm
                 break;
             }
         } else {
-            for (int p = 0; p < np; ++p) {
                 primary_variables_[WQTotal] = total_well_rate;
-            }
         }
 
         if (std::abs(total_well_rate) > 0.) {


### PR DESCRIPTION
There seems to be no need to assign the same value consecutively as often as there are phases. To the very least it is confusing.