### PR TITLE
Use better-suited AMG criterion.

### DIFF
--- a/opm/simulators/linalg/PreconditionerFactory.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory.hpp
@@ -119,7 +119,7 @@ public:
 
 private:
     using CriterionBase
-        = Dune::Amg::AggregationCriterion<Dune::Amg::SymmetricMatrixDependency<Matrix, Dune::Amg::FirstDiagonal>>;
+        = Dune::Amg::AggregationCriterion<Dune::Amg::SymmetricDependency<Matrix, Dune::Amg::FirstDiagonal>>;
     using Criterion = Dune::Amg::CoarsenCriterion<CriterionBase>;
 
     // Helpers for creation of AMG preconditioner.


### PR DESCRIPTION
Use SymmetricDependency instead of SymmetricMatrixDependency. Our matrices are structurally symmetric, but not numerically symmetric.

This change reduces the number of linear iterations on Norne with CPR by more than 10%, and also reduces the nonlinear iterations by 5%. On model 2, linear iterations are down 20% and Newton iterations 5%.

To reproduce on Norne: use the options `--matrix-add-well-contributions=true --linsolver=cpr`.
To reproduce on model 2 (for best performance): additionally add `--linear-solver-max-iter=30 --linear-solver-reduction=5e-3`.

Change suggested by @hnil.