### PR TITLE
Add more AMG options to allow setting from JSON.

### DIFF
--- a/opm/simulators/linalg/PreconditionerFactory.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory.hpp
@@ -138,6 +138,11 @@ private:
         // graph might be unsymmetric and hence not supported by the PTScotch/ParMetis
         // calls in DUNE. Accumulating to 1 skips PTScotch/ParMetis
         criterion.setAccumulate(static_cast<Dune::Amg::AccumulationMode>(prm.get<int>("accumulate", 1)));
+        criterion.setProlongationDampingFactor(prm.get<double>("prolongationdamping", 1.6));
+        criterion.setMaxDistance(prm.get<int>("maxdistance", 2));
+        criterion.setMaxConnectivity(prm.get<int>("maxconnectivity", 15));
+        criterion.setMaxAggregateSize(prm.get<int>("maxaggsize", 6));
+        criterion.setMinAggregateSize(prm.get<int>("minaggsize", 4));
         return criterion;
     }
 

--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -65,6 +65,11 @@ setupCPR(const std::string& conf, const FlowLinearSolverParameters& p)
     // graph might be unsymmetric and hence not supported by the PTScotch/ParMetis
     // calls in DUNE. Accumulating to 1 skips PTScotch/ParMetis
     prm.put("preconditioner.coarsesolver.preconditioner.accumulate", 1);
+    prm.put("preconditioner.coarsesolver.preconditioner.prolongationdamping", 1.6);
+    prm.put("preconditioner.coarsesolver.preconditioner.maxdistance", 2);
+    prm.put("preconditioner.coarsesolver.preconditioner.maxconnectivity", 15);
+    prm.put("preconditioner.coarsesolver.preconditioner.maxaggsize", 6);
+    prm.put("preconditioner.coarsesolver.preconditioner.minaggsize", 4);
     return prm;
 }
 
@@ -93,6 +98,11 @@ setupAMG([[maybe_unused]] const std::string& conf, const FlowLinearSolverParamet
     // graph might be unsymmetric and hence not supported by the PTScotch/ParMetis
     // calls in DUNE. Accumulating to 1 skips PTScotch/ParMetis
     prm.put("preconditioner.accumulate", 1);
+    prm.put("preconditioner.prolongationdamping", 1.6);
+    prm.put("preconditioner.maxdistance", 2);
+    prm.put("preconditioner.maxconnectivity", 15);
+    prm.put("preconditioner.maxaggsize", 6);
+    prm.put("preconditioner.minaggsize", 4);
     return prm;
 }
 


### PR DESCRIPTION
This allows more flexibility to change AMG options from a JSON setup. In particular, the prolongationdamping parameter looks like it can significantly improve performance.

The below JSON setup can be used for experimentation. It sets "beta" to 0 and "prolongationdamping" to 1.0, otherwise it is just like the default `--linsolver=cpr` option. Save the file as (for example) "cpr-experiment.json" and use it with `--linsolver=cpr-experiment.json`.

When testing this (or CPR with other parameters) it is still recommended to add `--matrix-add-well-contributions=true`. For some cases such as model 2 it is also good to tighten the linear solver tolerance a little, to for example 5e-3.

Running on 8 processes, Norne runtimes with this is 15-20% faster than the default ILU0 option on my system. For model 2, the difference is greater.

```json
{
    "maxiter": "20",
    "tol": "0.01",
    "verbosity": "0",
    "solver": "bicgstab",
    "preconditioner": {
        "type": "cpr",
        "weight_type": "trueimpes",
        "finesmoother": {
            "type": "ParOverILU0",
            "relaxation": "1"
        },
        "pressure_var_index": "1",
        "verbosity": "0",
        "coarsesolver": {
            "maxiter": "1",
            "tol": "0.10000000000000001",
            "solver": "loopsolver",
            "verbosity": "0",
            "preconditioner": {
                "type": "amg",
                "alpha": "0.33333333333300003",
                "relaxation": "1",
                "iterations": "1",
                "coarsenTarget": "1200",
                "pre_smooth": "1",
                "post_smooth": "1",
                "prolongationdamping": "1.0",
                "beta": "0.0",
                "smoother": "ILU0",
                "verbosity": "0",
                "maxlevel": "15",
                "skip_isolated": "0",
                "accumulate": "1"
            }
        }
    }
}
```