### PR TITLE
Well PI: Use Appropriate Calculator for Each Well

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1471,13 +1471,11 @@ namespace Opm {
             return;
         }
 
-        auto piCalc = this->prod_index_calc_.begin();
         for (const auto& wellPtr : this->well_container_) {
             wellPtr->updateProductivityIndex(this->ebosSimulator_,
-                                             *piCalc,
+                                             this->prod_index_calc_[wellPtr->indexOfWell()],
                                              this->well_state_,
                                              deferred_logger);
-            ++piCalc;
         }
     }
 


### PR DESCRIPTION
The original code assumed that
```C++
well_container_.size() == numLocalWells()
```
This assumption does not hold when wells open/shut dynamically in the context of `WECON` and/or `WTEST`.

Switch to indexing into the `prod_index_calc_` vector using the well's own linear index instead of manually advancing iterators.

Pointy Hat: [at]bska