### PR TITLE
Wbp collect

### DIFF
--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -225,6 +225,11 @@ public:
             }
         }
 
+        for (const auto& global_index : wbp_index_list) {
+            if (collectToIORank.isCartIdxOnThisRank(global_index - 1))
+                this->wbpData_[global_index] = 0.0;
+        }
+
         forceDisableFipOutput_ = EWOMS_GET_PARAM(TypeTag, bool, ForceDisableFluidInPlaceOutput);
     }
 
@@ -837,6 +842,8 @@ public:
             if (gasConnectionSaturations_.count(cartesianIdx) > 0) {
                 gasConnectionSaturations_[cartesianIdx] = Opm::getValue(fs.saturation(gasPhaseIdx));
             }
+            if (this->wbpData_.count(cartesianIdx) > 0)
+                this->wbpData_[cartesianIdx] = Opm::getValue(fs.pressure(oilPhaseIdx));
 
             // tracers
             const auto& tracerModel = simulator_.problem().tracerModel();
@@ -1852,6 +1859,10 @@ public:
         return 0;
     }
 
+    const std::map<std::size_t, double>& getWBPData() const {
+        return this->wbpData_;
+    }
+
     const std::map<std::pair<std::string, int>, double>& getBlockData()
     { return blockData_; }
 
@@ -2365,6 +2376,7 @@ private:
     ScalarBuffer hydrocarbonPoreVolume_;
     ScalarBuffer pressureTimesPoreVolume_;
     ScalarBuffer pressureTimesHydrocarbonVolume_;
+    std::map<std::size_t , double> wbpData_;
     std::map<std::pair<std::string, int>, double> blockData_;
     std::map<size_t, Scalar> oilConnectionPressures_;
     std::map<size_t, Scalar> waterConnectionSaturations_;

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -195,7 +195,7 @@ class EclOutputBlackOilModule
 
 public:
     template<class CollectDataToIORankType>
-    EclOutputBlackOilModule(const Simulator& simulator, const CollectDataToIORankType& collectToIORank)
+    EclOutputBlackOilModule(const Simulator& simulator, const std::vector<std::size_t>& wbp_index_list, const CollectDataToIORankType& collectToIORank)
         : simulator_(simulator)
     {
         const Opm::SummaryConfig summaryConfig = simulator_.vanguard().summaryConfig();

--- a/tests/test_ecl_output.cc
+++ b/tests/test_ecl_output.cc
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(Summary)
     using Vanguard = Opm::GetPropType<TypeTag, Opm::Properties::Vanguard>;
     typedef Opm::CollectDataToIORank< Vanguard > CollectDataToIORankType;
     CollectDataToIORankType collectToIORank(simulator->vanguard());
-    Opm::EclOutputBlackOilModule<TypeTag> eclOutputModule(*simulator, collectToIORank);
+    Opm::EclOutputBlackOilModule<TypeTag> eclOutputModule(*simulator, {}, collectToIORank);
 
     typedef Opm::EclWriter<TypeTag> EclWriterType;
     // create the actual ECL writer


### PR DESCRIPTION
I have written some MPI stuff:

![image](https://user-images.githubusercontent.com/1321665/100714263-d0328100-33b5-11eb-8a01-daa352da26e8.png)

Thing goes as follows:

1. There is a family of summary keywords `WBP, WBP4, WBP5` and `WBP9`. These are different ways to calculate an average well pressure based on the completed cells and their neighbours. 
2. In opm-common there is a class [`PAvgCalculatorCollection`](https://github.com/OPM/opm-common/blob/master/opm/parser/eclipse/EclipseState/Schedule/Well/PAvgCalculatorCollection.hpp) which holds on to the wells which want to calculate the `WBPx` keywords. The most important method for the current PR is the `::index_list()` which returns all the global indices where we need the pressure.
3. This PR will distribute the `index_list` to all PE's and then assemble the requested pressures and update `PAvgCalculatorCollection` instance and pass it to the summary writer.

The actual calculation of WBP in opm-common is not yet complete; but that should be possible to complete only in opm-common with no coupling to opm-simulators.
