### PR TITLE
Use WellInterface::perf_data_ to calculate PI.

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1210,14 +1210,10 @@ namespace Opm
         setToZero(wellPI);
 
         const auto preferred_phase = this->well_ecl_.getPreferredPhase();
+        auto subsetPerfID   = 0;
 
-        const auto& allConn = this->well_ecl_.getConnections();
-        const auto  nPerf   = allConn.size();
-        auto subsetPerfID   = 0*nPerf;
-        for (auto allPerfID = 0*nPerf; allPerfID < nPerf; ++allPerfID) {
-            if (allConn[allPerfID].state() == Connection::State::SHUT) {
-                continue;
-            }
+        for ( const auto& perf : *this->perf_data_){
+            auto allPerfID = perf.ecl_index;
 
             auto connPICalc = [&wellPICalc, allPerfID](const double mobility) -> double
             {

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2316,14 +2316,10 @@ namespace Opm
         setToZero(wellPI);
 
         const auto preferred_phase = this->well_ecl_.getPreferredPhase();
+        auto subsetPerfID   = 0;
 
-        const auto& allConn = this->well_ecl_.getConnections();
-        const auto  nPerf   = allConn.size();
-        auto subsetPerfID   = 0*nPerf;
-        for (auto allPerfID = 0*nPerf; allPerfID < nPerf; ++allPerfID) {
-            if (allConn[allPerfID].state() == Connection::State::SHUT) {
-                continue;
-            }
+        for ( const auto& perf : *this->perf_data_){
+            auto allPerfID = perf.ecl_index;
 
             auto connPICalc = [&wellPICalc, allPerfID](const double mobility) -> double
             {


### PR DESCRIPTION
This simplifies the code a bit and will work with distributed wells. Previously, we assumed that all non-shut perforations are stored locally. That does not hold any more.