### PR TITLE
[bugfix] Do not iterate pass end of perf_data_ in initCompletions

### DIFF
--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -142,6 +142,10 @@ namespace Opm
         int num_active_connections = 0;
         auto my_next_perf = perf_data_->begin();
         for (std::size_t c = 0; c < num_conns; ++c) {
+            if (my_next_perf == perf_data_->end())
+            {
+                break;
+            }
             if (my_next_perf->ecl_index > c)
             {
                 continue;


### PR DESCRIPTION
IMHO this might have happened if perf_data_ is empty or if the last connection is closed. (Discovered while working on distributed wells but might happen already before!)