### PR TITLE
remove 16 days restriction for timestep in predicition mode

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -329,13 +329,6 @@ void registerAdaptiveParameters();
                         restarts = 0;
                     }
 
-                    // Further restrict time step size if we are in
-                    // prediction mode with THP constraints.
-                    if (solver.model().wellModel().hasTHPConstraints()) {
-                        const double maxPredictionTHPTimestep = 16.0 * unit::day;
-                        dtEstimate = std::min(dtEstimate, maxPredictionTHPTimestep);
-                    }
-                    assert(dtEstimate > 0);
                     if (timestepVerbose_) {
                         std::ostringstream ss;
                         substepReport.reportStep(ss);


### PR DESCRIPTION
This PR is for testing. Both the time-stepping, convergence and well models has improved since this hard-coded limit was enforced. Is it time to remove it? The initial testing I have done indicates so, but more testing is needed. 