### PR TITLE
Simplify computation of connection pressure.

### DIFF
--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2201,28 +2201,14 @@ namespace Opm
         // the 'top' perforation is nearest to the surface topologically.
         // Our goal is to compute a pressure delta for each perforation.
 
-        // 1. Compute pressure differences between perforations.
-        //    dp_perf will contain the pressure difference between a
-        //    perforation and the one above it, except for the first
-        //    perforation for each well, for which it will be the
-        //    difference to the reference (bhp) depth.
-
         const int nperf = number_of_perforations_;
         perf_pressure_diffs_.resize(nperf, 0.0);
 
         for (int perf = 0; perf < nperf; ++perf) {
             const double z_above = perf == 0 ? ref_depth_ : perf_depth_[perf - 1];
-            const double dz = perf_depth_[perf] - z_above;
+            const double dz = perf_depth_[perf] - ref_depth_;
             perf_pressure_diffs_[perf] = dz * perf_densities_[perf] * gravity_;
         }
-
-        // 2. Compute pressure differences to the reference point (bhp) by
-        //    accumulating the already computed adjacent pressure
-        //    differences, storing the result in dp_perf.
-        //    This accumulation must be done per well.
-        const auto beg = perf_pressure_diffs_.begin();
-        const auto end = perf_pressure_diffs_.end();
-        std::partial_sum(beg, end, beg);
     }
 
 


### PR DESCRIPTION
Previously we did compute the delta between two perforations and then used a partial sum. That seemed to be a rather complex
algorithm to calculate the delta between a connection and the reference depth.
This commit now simply computes the latter without an intermediary step (difference between two perforations) and hopefully is more clear.

It is also more suitable for distributed wells.