### PR TITLE
Dunify aquifers

### DIFF
--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -244,6 +244,10 @@ public:
 
         cartesianIndexMapper_.reset(new CartesianIndexMapper(*grid_));
         this->updateGridView_();
+        this->updateCartesianToCompressedMapping_();
+        this->updateCellDepths_();
+
+
 #if HAVE_MPI
         if (mpiSize > 1) {
             try

--- a/ebos/eclpolyhedralgridvanguard.hh
+++ b/ebos/eclpolyhedralgridvanguard.hh
@@ -185,6 +185,8 @@ protected:
     {
         grid_ = new Grid(this->eclState().getInputGrid(), this->eclState().fieldProps().porv(true));
         cartesianIndexMapper_ = new CartesianIndexMapper(*grid_);
+        this->updateCartesianToCompressedMapping_();
+        this->updateCellDepths_();
     }
 
     void filterConnections_()

--- a/opm/simulators/aquifers/AquiferCarterTracy.hpp
+++ b/opm/simulators/aquifers/AquiferCarterTracy.hpp
@@ -46,6 +46,7 @@ public:
     using typename Base::RateVector;
     using typename Base::Scalar;
     using typename Base::Simulator;
+    using typename Base::ElementMapper;
 
     using Base::waterCompIdx;
     using Base::waterPhaseIdx;
@@ -92,16 +93,12 @@ protected:
     inline void initializeConnections() override
     {
         const auto& eclState = this->ebos_simulator_.vanguard().eclState();
-        const auto& ugrid = this->ebos_simulator_.vanguard().grid();
         const auto& grid = eclState.getInputGrid();
 
         // We hack the cell depth values for now. We can actually get it from elementcontext pos
         this->cell_depth_.resize(this->size(), this->aquiferDepth());
         this->alphai_.resize(this->size(), 1.0);
         this->faceArea_connected_.resize(this->size(), 0.0);
-
-        auto cell2Faces = Opm::UgGridHelpers::cell2Faces(ugrid);
-        auto faceCells = Opm::UgGridHelpers::faceCells(ugrid);
 
         // Translate the C face tag into the enum used by opm-parser's TransMult class
         Opm::FaceDir::DirEnum faceDirection;
@@ -110,18 +107,38 @@ protected:
         Scalar denom_face_areas = 0.;
         this->cellToConnectionIdx_.resize(this->ebos_simulator_.gridView().size(/*codim=*/0), -1);
         for (size_t idx = 0; idx < this->size(); ++idx) {
-            const int cell_index = this->cartesian_to_compressed_.at(this->connections_[idx].global_index);
+            const auto global_index = this->connections_[idx].global_index;
+            const int cell_index = this->cartesian_to_compressed_.at(global_index);
             this->cellToConnectionIdx_[cell_index] = idx;
+            const auto cellCenter = grid.getCellCenter(global_index);
+            this->cell_depth_.at(idx) = cellCenter[2];
+        }
+        // get default areas for all intersections
+        const auto& gridView = this->ebos_simulator_.vanguard().gridView();
+        ElementMapper elemMapper(gridView, Dune::mcmgElementLayout());
+        auto elemIt = gridView.template begin</*codim=*/ 0>();
+        const auto& elemEndIt = gridView.template end</*codim=*/ 0>();
+        for (; elemIt != elemEndIt; ++elemIt) {
+            const auto& elem = *elemIt;
+            unsigned cell_index = elemMapper.index(elem);
+            int idx = this->cellToConnectionIdx_[cell_index];
 
-            const auto cellFacesRange = cell2Faces[cell_index];
-            for (auto cellFaceIter = cellFacesRange.begin(); cellFaceIter != cellFacesRange.end(); ++cellFaceIter) {
-                // The index of the face in the compressed grid
-                const int faceIdx = *cellFaceIter;
+            // only deal with connections given by the aquifer
+            if( idx < 0)
+                continue;
 
-                // the logically-Cartesian direction of the face
-                const int faceTag = Opm::UgGridHelpers::faceTag(ugrid, cellFaceIter);
+            auto isIt = gridView.ibegin(elem);
+            const auto& isEndIt = gridView.iend(elem);
+            for (; isIt != isEndIt; ++ isIt) {
+                // store intersection, this might be costly
+                const auto& intersection = *isIt;
 
-                switch (faceTag) {
+                // only deal with grid boundaries
+                if (!intersection.boundary())
+                    continue;
+
+                int insideFaceIdx  = intersection.indexInInside();
+                switch (insideFaceIdx) {
                 case 0:
                     faceDirection = Opm::FaceDir::XMinus;
                     break;
@@ -146,12 +163,10 @@ protected:
                 }
 
                 if (faceDirection == this->connections_[idx].face_dir) {
-                    this->faceArea_connected_.at(idx) = this->getFaceArea(faceCells, ugrid, faceIdx, idx);
+                    this->faceArea_connected_[idx] = this->getFaceArea(intersection, idx);
                     denom_face_areas += (this->connections_[idx].influx_mult * this->faceArea_connected_.at(idx));
                 }
             }
-            auto cellCenter = grid.getCellCenter(this->connections_[idx].global_index);
-            this->cell_depth_.at(idx) = cellCenter[2];
         }
 
         const double eps_sqrt = std::sqrt(std::numeric_limits<double>::epsilon());

--- a/opm/simulators/aquifers/AquiferFetkovich.hpp
+++ b/opm/simulators/aquifers/AquiferFetkovich.hpp
@@ -47,6 +47,7 @@ public:
     using typename Base::RateVector;
     using typename Base::Scalar;
     using typename Base::Simulator;
+    using typename Base::ElementMapper;
 
     using Base::waterCompIdx;
     using Base::waterPhaseIdx;
@@ -95,16 +96,12 @@ protected:
     inline void initializeConnections() override
     {
         const auto& eclState = this->ebos_simulator_.vanguard().eclState();
-        const auto& ugrid = this->ebos_simulator_.vanguard().grid();
         const auto& grid = eclState.getInputGrid();
 
         // We hack the cell depth values for now. We can actually get it from elementcontext pos
         this->cell_depth_.resize(this->size(), this->aquiferDepth());
         this->alphai_.resize(this->size(), 1.0);
         this->faceArea_connected_.resize(this->size(), 0.0);
-
-        auto cell2Faces = Opm::UgGridHelpers::cell2Faces(ugrid);
-        auto faceCells = Opm::UgGridHelpers::faceCells(ugrid);
 
         // Translate the C face tag into the enum used by opm-parser's TransMult class
         Opm::FaceDir::DirEnum faceDirection;
@@ -115,21 +112,37 @@ protected:
         for (size_t idx = 0; idx < this->size(); ++idx) {
             const auto global_index = this->connections_[idx].global_index;
             const int cell_index = this->cartesian_to_compressed_.at(global_index);
-
             this->cellToConnectionIdx_[cell_index] = idx;
             const auto cellCenter = grid.getCellCenter(global_index);
             this->cell_depth_.at(idx) = cellCenter[2];
+        }
+        // get areas for all connections
+        const auto& gridView = this->ebos_simulator_.vanguard().gridView();
+        ElementMapper elemMapper(gridView, Dune::mcmgElementLayout());
+        auto elemIt = gridView.template begin</*codim=*/ 0>();
+        const auto& elemEndIt = gridView.template end</*codim=*/ 0>();
+        for (; elemIt != elemEndIt; ++elemIt) {
+            const auto& elem = *elemIt;
+            unsigned cell_index = elemMapper.index(elem);
+            int idx = this->cellToConnectionIdx_[cell_index];
+
+            // only deal with connections given by the aquifer
+            if( idx < 0)
+                continue;
 
             if (!this->connections_[idx].influx_coeff.first) { // influx_coeff is defaulted
-                const auto cellFacesRange = cell2Faces[cell_index];
-                for (auto cellFaceIter = cellFacesRange.begin(); cellFaceIter != cellFacesRange.end(); ++cellFaceIter) {
-                    // The index of the face in the compressed grid
-                    const int faceIdx = *cellFaceIter;
+                auto isIt = gridView.ibegin(elem);
+                const auto& isEndIt = gridView.iend(elem);
+                for (; isIt != isEndIt; ++ isIt) {
+                    // store intersection, this might be costly
+                    const auto& intersection = *isIt;
 
-                    // the logically-Cartesian direction of the face
-                    const int faceTag = Opm::UgGridHelpers::faceTag(ugrid, cellFaceIter);
+                    // only deal with grid boundaries
+                    if (!intersection.boundary())
+                        continue;
 
-                    switch (faceTag) {
+                    int insideFaceIdx  = intersection.indexInInside();
+                    switch (insideFaceIdx) {
                     case 0:
                         faceDirection = Opm::FaceDir::XMinus;
                         break;
@@ -150,11 +163,11 @@ protected:
                         break;
                     default:
                         OPM_THROW(Opm::NumericalIssue,
-                                  "Initialization of Aquifer problem. Make sure faceTag is correctly defined");
-                    }
+                            "Initialization of Aquifer Fetkovich problem. Make sure faceTag is correctly defined");                }
+
 
                     if (faceDirection == this->connections_[idx].face_dir) {
-                        this->faceArea_connected_[idx] = this->getFaceArea(faceCells, ugrid, faceIdx, idx);
+                        this->faceArea_connected_[idx] = this->getFaceArea(intersection, idx);
                         break;
                     }
                 }

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -76,12 +76,10 @@ public:
     // Constructor
     AquiferInterface(int aqID,
                      const std::vector<Aquancon::AquancCell>& connections,
-                     const std::unordered_map<int, int>& cartesian_to_compressed,
                      const Simulator& ebosSimulator)
         : aquiferID(aqID)
         , connections_(connections)
         , ebos_simulator_(ebosSimulator)
-        , cartesian_to_compressed_(cartesian_to_compressed)
     {
     }
 
@@ -216,7 +214,6 @@ protected:
     const int aquiferID;
     const std::vector<Aquancon::AquancCell> connections_;
     const Simulator& ebos_simulator_;
-    const std::unordered_map<int, int> cartesian_to_compressed_;
 
     // Grid variables
     std::vector<Scalar> faceArea_connected_;

--- a/opm/simulators/aquifers/BlackoilAquiferModel.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel.hpp
@@ -83,7 +83,6 @@ protected:
 
     Simulator& simulator_;
 
-    std::unordered_map<int, int> cartesian_to_compressed_;
     // TODO: probably we can use one variable to store both types of aquifers, because
     // they share the base class
     mutable std::vector<AquiferCarterTracy_object> aquifers_CarterTracy;

--- a/opm/simulators/aquifers/BlackoilAquiferModel.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel.hpp
@@ -35,6 +35,12 @@
 #include <opm/simulators/aquifers/AquiferCarterTracy.hpp>
 #include <opm/simulators/aquifers/AquiferFetkovich.hpp>
 
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/polyhedralgrid.hh>
+#if HAVE_DUNE_ALUGRID
+#include <dune/alugrid/grid.hh>
+#endif
+
 #include <opm/material/densead/Math.hpp>
 
 #include <vector>
@@ -48,6 +54,14 @@ class BlackoilAquiferModel
 {
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
     using RateVector = GetPropType<TypeTag, Properties::RateVector>;
+
+    constexpr bool supportsFaceTag(const Dune::CpGrid&){ return true;}
+    constexpr bool supportsFaceTag(const Dune::PolyhedralGrid<3, 3>&){ return true;}
+#if HAVE_DUNE_ALUGRID
+    constexpr bool supportsFaceTag(const Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming>&){ return true;}
+#endif
+    template<class G>
+    constexpr bool supportsFaceTag(const G&){ return false;}
 
 public:
     explicit BlackoilAquiferModel(Simulator& simulator);

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -18,7 +18,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <opm/grid/utility/cartesianToCompressed.hpp>
 namespace Opm
 {
 
@@ -170,20 +169,15 @@ BlackoilAquiferModel<TypeTag>::init()
         throw std::runtime_error("Aquifers currently do not work in parallel.");
 
     // Get all the carter tracy aquifer properties data and put it in aquifers vector
-    const int number_of_cells = simulator_.gridView().size(0);
-
-    cartesian_to_compressed_ = cartesianToCompressed(number_of_cells,
-                                                     this->simulator_.vanguard().grid().globalCell().data());
-
     const auto& connections = aquifer.connections();
     for (const auto& aq : aquifer.ct()) {
         aquifers_CarterTracy.emplace_back(connections[aq.aquiferID],
-                                          cartesian_to_compressed_, this->simulator_, aq);
+                                          this->simulator_, aq);
     }
 
     for (const auto& aq : aquifer.fetp()) {
         aquifers_Fetkovich.emplace_back(connections[aq.aquiferID],
-                                        cartesian_to_compressed_, this->simulator_, aq);
+                                        this->simulator_, aq);
     }
 }
 template <typename TypeTag>

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -170,11 +170,10 @@ BlackoilAquiferModel<TypeTag>::init()
         throw std::runtime_error("Aquifers currently do not work in parallel.");
 
     // Get all the carter tracy aquifer properties data and put it in aquifers vector
-    const auto& ugrid = simulator_.vanguard().grid();
     const int number_of_cells = simulator_.gridView().size(0);
 
     cartesian_to_compressed_ = cartesianToCompressed(number_of_cells,
-                                                     Opm::UgGridHelpers::globalCell(ugrid));
+                                                     this->simulator_.vanguard().grid().globalCell().data());
 
     const auto& connections = aquifer.connections();
     for (const auto& aq : aquifer.ct()) {

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -25,6 +25,9 @@ template <typename TypeTag>
 BlackoilAquiferModel<TypeTag>::BlackoilAquiferModel(Simulator& simulator)
     : simulator_(simulator)
 {
+    // Grid needs to support Facetag
+    assert(supportsFaceTag(simulator.vanguard().grid()));
+
     init();
 }
 


### PR DESCRIPTION
This PR modifies the aquifer model to use the dune interface. Similar to what is done for the initialization code in https://github.com/OPM/opm-simulators/pull/2941 

I have also removed the usage of the inputGrid since this will not be available in a partitioned grid. 


