### PR TITLE
Use enum Well::Status for well status in WellState

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -748,7 +748,7 @@ namespace Opm {
                         continue;
                     } else {
                         // stopped wells are added to the container but marked as stopped
-                        well_state_.thp()[w] = 0.;
+                        well_state_.stopWell(w);
                         wellIsStopped = true;
                     }
                 }
@@ -795,7 +795,7 @@ namespace Opm {
                 }
 
                 if (well_status == Well::Status::STOP) {
-                    well_state_.thp()[w] = 0.;
+                    well_state_.stopWell(w);
                     wellIsStopped = true;
                 }
 

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -225,6 +225,10 @@ namespace Opm
                 this->wellrates_[np * well_index + p] = 0;
         }
 
+        virtual void stopWell(int well_index) {
+            this->status_[well_index] = Well::Status::STOP;
+            this->thp_[well_index] = 0;
+        }
 
         virtual data::Wells report(const PhaseUsage& pu, const int* globalCellIdxMap) const
         {

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -69,7 +69,7 @@ namespace Opm
                 // const int np = wells->number_of_phases;
                 const int np = pu.num_phases;
                 np_ = np;
-                open_for_output_.assign(nw, true);
+                status_.assign(nw, Well::Status::OPEN);
                 bhp_.resize(nw, 0.0);
                 thp_.resize(nw, 0.0);
                 temperature_.resize(nw, 273.15 + 15.56); // standard condition temperature
@@ -212,9 +212,12 @@ namespace Opm
             return np_;
         }
 
+        void openWell(int well_index) {
+            this->status_[well_index] = Well::Status::OPEN;
+        }
 
         virtual void shutWell(int well_index) {
-            this->open_for_output_[well_index] = false;
+            this->status_[well_index] = Well::Status::SHUT;
             this->thp_[well_index] = 0;
             this->bhp_[well_index] = 0;
             const int np = numPhases();
@@ -230,7 +233,7 @@ namespace Opm
             data::Wells dw;
             for( const auto& itr : this->wellMap_ ) {
                 const auto well_index = itr.second[ 0 ];
-                if (!this->open_for_output_[well_index])
+                if (this->status_[well_index] != Well::Status::OPEN)
                     continue;
 
                 const auto& pwinfo = *parallel_well_info_[well_index];
@@ -307,7 +310,7 @@ namespace Opm
         std::vector<double> perfpress_;
         int np_;
     protected:
-        std::vector<bool>   open_for_output_;
+        std::vector<Well::Status> status_;
     private:
 
         WellMapType wellMap_;

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -559,7 +559,7 @@ namespace Opm
             for( const auto& wt : this->wellMap() ) {
                 const auto w = wt.second[ 0 ];
                 const auto& pwinfo = *parallel_well_info_[w];
-                if (!this->open_for_output_[w] || !pwinfo.isOwner())
+                if ((this->status_[w] != Well::Status::OPEN) || !pwinfo.isOwner())
                     continue;
 
                 auto& well = res.at( wt.first );
@@ -1178,7 +1178,7 @@ namespace Opm
                 if (it != end) {
                     // ... set the GRUP/not GRUP states.
                     const int well_index = it->second[0];
-                    if (!this->open_for_output_[well_index]) {
+                    if (this->status_[well_index] != Well::Status::OPEN) {
                         // Well is shut.
                         if (well.isInjector()) {
                             globalIsInjectionGrup_[global_well_index] = 0;

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -1075,6 +1075,10 @@ namespace Opm
                 this->well_reservoir_rates_[np * well_index + p] = 0;
         }
 
+        virtual void stopWell(int well_index) override {
+            WellState::stopWell(well_index);
+        }
+
         template<class Comm>
         void communicateGroupRates(const Comm& comm)
         {


### PR DESCRIPTION
In order to fully support #2936 we need to differentiate between `SHUT` wells and `STOP` wells - this is a step on the way. 

Mel: Long and winding road

