### PR TITLE
Add report for pre/post time

### DIFF
--- a/opm/simulators/flow/BlackoilModelEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelEbos.hpp
@@ -226,8 +226,11 @@ namespace Opm {
 
         /// Called once before each time step.
         /// \param[in] timer                  simulation timer
-        void prepareStep(const SimulatorTimerInterface& timer)
+        SimulatorReportSingle prepareStep(const SimulatorTimerInterface& timer)
         {
+            SimulatorReportSingle report;
+            Dune::Timer perfTimer;
+            perfTimer.start();
             // update the solution variables in ebos
             if ( timer.lastStepFailed() ) {
                 ebosSimulator_.model().updateFailed();
@@ -251,6 +254,9 @@ namespace Opm {
                 std::cout << "equation scaling not suported yet" << std::endl;
                 //updateEquationsScaling();
             }
+            report.pre_post_time += perfTimer.stop();
+
+            return report;
         }
 
 
@@ -394,9 +400,14 @@ namespace Opm {
         /// Called once after each time step.
         /// In this class, this function does nothing.
         /// \param[in] timer                  simulation timer
-        void afterStep(const SimulatorTimerInterface& timer OPM_UNUSED)
+        SimulatorReportSingle afterStep(const SimulatorTimerInterface& timer OPM_UNUSED)
         {
+            SimulatorReportSingle report;
+            Dune::Timer perfTimer;
+            perfTimer.start();
             ebosSimulator_.problem().endTimeStep();
+            report.pre_post_time += perfTimer.stop();
+            return report;
         }
 
         /// Assemble the residual and Jacobian of the nonlinear system.

--- a/opm/simulators/flow/NonlinearSolverEbos.hpp
+++ b/opm/simulators/flow/NonlinearSolverEbos.hpp
@@ -183,7 +183,7 @@ namespace Opm {
             report.timestep_length = timer.currentStepLength();
 
             // Do model-specific once-per-step calculations.
-            model_->prepareStep(timer);
+            report += model_->prepareStep(timer);
 
             int iteration = 0;
 
@@ -224,7 +224,7 @@ namespace Opm {
             }
 
             // Do model-specific post-step actions.
-            model_->afterStep(timer);
+            report += model_->afterStep(timer);
             report.converged = true;
             return report;
         }

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -36,6 +36,7 @@ namespace Opm
           total_time(0.0),
           solver_time(0.0),
           assemble_time(0.0),
+          pre_post_time(0.0),
           assemble_time_well(0.0),
           linear_solve_setup_time(0.0),
           linear_solve_time(0.0),
@@ -60,6 +61,7 @@ namespace Opm
         linear_solve_time += sr.linear_solve_time;
         solver_time += sr.solver_time;
         assemble_time += sr.assemble_time;
+        pre_post_time += sr.pre_post_time;
         assemble_time_well += sr.assemble_time_well;
         update_time += sr.update_time;
         output_write_time += sr.output_write_time;
@@ -137,6 +139,14 @@ namespace Opm
               os << fmt::format(" (Failed: {:2.1f}; {:2.1f}%)",
                                 failureReport->update_time,
                                 100*failureReport->update_time/t);
+            }
+            os << std::endl;
+            t = pre_post_time + (failureReport ? failureReport->pre_post_time : 0.0);
+            os << fmt::format(" Pre/post step (seconds):     {:7.2f}", t);
+            if (failureReport) {
+              os << fmt::format(" (Failed: {:2.1f}; {:2.1f}%)",
+                                failureReport->pre_post_time,
+                                100*failureReport->pre_post_time/t);
             }
             os << std::endl;
 

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -34,6 +34,7 @@ namespace Opm
         double total_time;
         double solver_time;
         double assemble_time;
+        double pre_post_time;
         double assemble_time_well;
         double linear_solve_setup_time;
         double linear_solve_time;


### PR DESCRIPTION
For some MSW cases like MOD4_GRP 50% of the time is spend computing well potentials during pre/post processing. This just shows this to the user. With this the solver time almost equals the sum of its components. 

Dump from a MOD4_GRP run. Note that this is a local branch with several improvements, for master the pre/post step dominates even more.  
```
Number of MPI processes:         1
Threads per MPI process:         2
Total time (seconds):           23.14 
Solver time (seconds):          23.13 
 Assembly time (seconds):        6.22 (Failed: 0.8; 13.0%)
   Well assembly (seconds):      3.77 (Failed: 0.5; 14.2%)
 Linear solve time (seconds):    4.00 (Failed: 0.6; 15.1%)
   Linear setup (seconds):       0.88 (Failed: 0.1; 13.2%)
 Update time (seconds):          1.65 (Failed: 0.2; 12.7%)
 Pre/post step (seconds):       11.03 (Failed: 0.0; 0.1%)
 Output write time (seconds):    0.15
Overall Well Iterations:         0    (Failed:   0; -nan%)
Overall Linearizations:        794    (Failed:  84; 10.6%)
Overall Newton Iterations:     682    (Failed:  84; 12.3%)
Overall Linear Iterations:    2776    (Failed: 376; 13.5%)
```
