### PR TITLE
Skip previously shut wells in WellState init

### DIFF
--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -188,8 +188,12 @@ namespace Opm
                     auto it = prevState->wellMap().find(well.name());
                     if ( it != end )
                     {
-                        const int oldIndex = (*it).second[ 0 ];
                         const int newIndex = w;
+                        const int oldIndex = it->second[ 0 ];
+                        if (prevState->status_[oldIndex] == Well::Status::SHUT) {
+                            // Well was shut in previous state, do not use its values.
+                            continue;
+                        }
 
                         // bhp
                         bhp()[ newIndex ] = prevState->bhp()[ oldIndex ];


### PR DESCRIPTION
If the well was shut in the previous report step we should not use the previous `WellState` to initialize it for this report step. In the case of wells which have been shut dynamically (due to well testing or ACTIONX) we previously nevertheless initialized the well (with more or less stale values). With this PR we skip the initialization in this case. This will lead to a data update because result will not be identical due to different initialisation. 

When this has been merged - with the necessary data updates, #2936 should be ready directly green in Jenkins :crossed_fingers: 