### PR TITLE
Do not include config.h in header (not even in *_impl.hpp)

### DIFF
--- a/opm/simulators/linalg/setupPropertyTree_impl.hpp
+++ b/opm/simulators/linalg/setupPropertyTree_impl.hpp
@@ -17,8 +17,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <config.h>
-
 #include <opm/simulators/linalg/setupPropertyTree.hpp>
 
 #include <boost/version.hpp>


### PR DESCRIPTION
I was getting warnings about redefined definitions (e.g. HAVE_PARMETIS).