### PR TITLE
Initial well rates with the well potentials and scale the segment rates

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -339,10 +339,8 @@ namespace Opm
                              const double relaxation_factor=1.0) const;
 
 
-        // initialize the segment rates with well rates
-        // when there is no more accurate way to initialize the segment rates, we initialize
-        // the segment rates based on well rates with a simple strategy
-        void initSegmentRatesWithWellRates(WellState& well_state) const;
+        // scale the segment rates and pressure based on well rates and bhp
+        void scaleSegmentRatesAndPressureWithWellRatesAndPressure(WellState& well_state) const;
 
         // computing the accumulation term for later use in well mass equations
         void computeInitialSegmentFluids(const Simulator& ebos_simulator);

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -340,7 +340,8 @@ namespace Opm
 
 
         // scale the segment rates and pressure based on well rates and bhp
-        void scaleSegmentRatesAndPressureWithWellRatesAndPressure(WellState& well_state) const;
+        void scaleSegmentRatesWithWellRates(WellState& well_state) const;
+        void scaleSegmentPressuresWithBhp(WellState& well_state) const;
 
         // computing the accumulation term for later use in well mass equations
         void computeInitialSegmentFluids(const Simulator& ebos_simulator);


### PR DESCRIPTION
Initialize the well rates with well potentials when computing rates from bhp or bhp(thp)
The bhp was already initialized.

Scale the segment rates and pressure to adapt to changes in well rate and bhp

Improves convergence of the well potential calculations

Gives significant speed up on the NORNE_X_MSW cases in https://github.com/OPM/opm-tests/norne