### PR TITLE
Change default max number of newton iterations to 8

### DIFF
--- a/opm/simulators/flow/NonlinearSolverEbos.hpp
+++ b/opm/simulators/flow/NonlinearSolverEbos.hpp
@@ -65,7 +65,7 @@ struct NewtonMaxRelax<TypeTag, TTag::FlowNonLinearSolver> {
 };
 template<class TypeTag>
 struct FlowNewtonMaxIterations<TypeTag, TTag::FlowNonLinearSolver> {
-    static constexpr int value = 20;
+    static constexpr int value = 8;
 };
 template<class TypeTag>
 struct FlowNewtonMinIterations<TypeTag, TTag::FlowNonLinearSolver> {


### PR DESCRIPTION
Changing the maximum number of newton iterations has positive performance impact on some models. The purpose of this PR is to test the effect using benchmark