### PR TITLE
Remove WSEGAICD from missing features

### DIFF
--- a/opm/simulators/flow/MissingFeatures.cpp
+++ b/opm/simulators/flow/MissingFeatures.cpp
@@ -824,7 +824,6 @@ namespace MissingFeatures {
             "WSCCLEAN",
             "WSCCLENL",
             "WSCTAB",
-            "WSEGAICD",
             "WSEGDFIN",
             "WSEGDFMD",
             "WSEGDFPA",


### PR DESCRIPTION
Seems we forgot to remove this when it got implemented.