### PR TITLE
don't shut stopped wells

### DIFF
--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -926,7 +926,7 @@ namespace Opm
                                 WellTestState& well_test_state,
                                 Opm::DeferredLogger& deferred_logger) const
     {
-        if (!isOperable() || wellIsStopped_) {
+        if (!isOperable()) {
             if (well_test_state.hasWellClosed(name(), WellTestConfig::Reason::ECONOMIC) ||
                 well_test_state.hasWellClosed(name(), WellTestConfig::Reason::PHYSICAL) ) {
                 // Already closed, do nothing.


### PR DESCRIPTION
We don't want to automatically shut wells stopped by the user. 

Wells stopped due to issues with operability should be triggered by isOperable() if I read the code correctly. 