### PR TITLE
Serialize std::chrono::system_clock::time_point through std::time_t

### DIFF
--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include "ParallelRestart.hpp"
+#include <ctime>
 #include <dune/common/parallel/mpitraits.hh>
 
 #define HANDLE_AS_POD(T) \
@@ -281,6 +282,13 @@ std::size_t packSize(const RestartValue& data, Dune::MPIHelper::MPICommunicator 
         +  packSize(data.grp_nwrk, comm)
         +  packSize(data.extra, comm);
 }
+
+std::size_t packSize(const std::chrono::system_clock::time_point&, Dune::MPIHelper::MPICommunicator comm)
+{
+    std::time_t tp;
+    return packSize(tp, comm);
+}
+
 
 ////// pack routines
 
@@ -567,6 +575,13 @@ void pack(const RestartValue& data, std::vector<char>& buffer, int& position,
     pack(data.grp_nwrk, buffer, position, comm);
     pack(data.extra, buffer, position, comm);
 }
+
+void pack(const std::chrono::system_clock::time_point& data, std::vector<char>& buffer, int& position,
+          Dune::MPIHelper::MPICommunicator comm)
+{
+    pack(std::chrono::system_clock::to_time_t(data), buffer, position, comm);
+}
+
 
 /// unpack routines
 
@@ -871,6 +886,15 @@ void unpack(RestartValue& data, std::vector<char>& buffer, int& position,
     unpack(data.grp_nwrk, buffer, position, comm);
     unpack(data.extra, buffer, position, comm);
 }
+
+void unpack(std::chrono::system_clock::time_point& data, std::vector<char>& buffer, int& position,
+            Dune::MPIHelper::MPICommunicator comm)
+{
+    std::time_t tp;
+    unpack(tp, buffer, position, comm);
+    data = std::chrono::system_clock::from_time_t(tp);
+}
+
 
 #define INSTANTIATE_PACK_VECTOR(...) \
 template std::size_t packSize(const std::vector<__VA_ARGS__>& data, \

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -30,6 +30,7 @@
 
 #include <dune/common/parallel/mpihelper.hh>
 
+#include <chrono>
 #include <optional>
 #include <map>
 #include <set>
@@ -317,6 +318,7 @@ ADD_PACK_PROTOTYPES(data::WellRates)
 ADD_PACK_PROTOTYPES(RestartKey)
 ADD_PACK_PROTOTYPES(RestartValue)
 ADD_PACK_PROTOTYPES(std::string)
+ADD_PACK_PROTOTYPES(std::chrono::system_clock::time_point)
 
 } // end namespace Mpi
 


### PR DESCRIPTION
Basic serialization of `std::chrono::system_clock::time_point`- the current PR serializes through `std::time_t`, for general `std::chrono` time_points this will lead to a loss of precision. But since time is currently treated with `std::time_t` in opm this should be sufficient for now.

This PR is required to get https://github.com/OPM/opm-common/pull/2178 through. 