### PR TITLE
dynamically set zoltan imbalance tolerance

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -116,6 +116,11 @@ struct SerialPartitioning {
     using type = UndefinedProperty;
 };
 
+template<class TypeTag, class MyTypeTag>
+struct ZoltanImbalanceTol {
+    using type = UndefinedProperty;
+};
+
 template<class TypeTag>
 struct IgnoreKeywords<TypeTag, TTag::EclBaseVanguard> {
     static constexpr auto value = "";
@@ -151,6 +156,12 @@ struct OwnerCellsFirst<TypeTag, TTag::EclBaseVanguard> {
 template<class TypeTag>
 struct SerialPartitioning<TypeTag, TTag::EclBaseVanguard> {
     static constexpr bool value = false;
+};
+
+template<class TypeTag>
+struct ZoltanImbalanceTol<TypeTag, TTag::EclBaseVanguard> {
+    using type = GetPropType<TypeTag, Scalar>;
+    static constexpr type value = 1.1;
 };
 
 } // namespace Opm::Properties
@@ -206,6 +217,9 @@ public:
                              "Order cells owned by rank before ghost/overlap cells.");
         EWOMS_REGISTER_PARAM(TypeTag, bool, SerialPartitioning,
                              "Perform partitioning for parallel runs on a single process.");
+        EWOMS_REGISTER_PARAM(TypeTag, Scalar, ZoltanImbalanceTol,
+                             "Perform partitioning for parallel runs on a single process.");
+
     }
 
     /*!
@@ -339,6 +353,7 @@ public:
         edgeWeightsMethod_   = Dune::EdgeWeightMethod(EWOMS_GET_PARAM(TypeTag, int, EdgeWeightsMethod));
         ownersFirst_ = EWOMS_GET_PARAM(TypeTag, bool, OwnerCellsFirst);
         serialPartitioning_ = EWOMS_GET_PARAM(TypeTag, bool, SerialPartitioning);
+        zoltanImbalanceTol_ = EWOMS_GET_PARAM(TypeTag, Scalar, ZoltanImbalanceTol);
 
         // Make proper case name.
         {
@@ -538,6 +553,12 @@ public:
      */
     bool serialPartitioning() const
     { return serialPartitioning_; }
+
+    /*!
+     * \brief Parameter that sets the zoltan imbalance tolarance.
+     */
+    Scalar zoltanImbalanceTol() const
+    { return zoltanImbalanceTol_; }
 
     /*!
      * \brief Returns the name of the case.
@@ -791,6 +812,7 @@ private:
     Dune::EdgeWeightMethod edgeWeightsMethod_;
     bool ownersFirst_;
     bool serialPartitioning_;
+    Scalar zoltanImbalanceTol_;
 
 protected:
     /*! \brief The cell centroids after loadbalance was called.

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -175,6 +175,7 @@ public:
             Dune::EdgeWeightMethod edgeWeightsMethod = this->edgeWeightsMethod();
             bool ownersFirst = this->ownersFirst();
             bool serialPartitioning = this->serialPartitioning();
+            Scalar zoltanImbalanceTol = this->zoltanImbalanceTol();
 
             // convert to transmissibility for faces
             // TODO: grid_->numFaces() is not generic. use grid_->size(1) instead? (might
@@ -220,7 +221,8 @@ public:
 
                     PropsCentroidsDataHandle<Dune::CpGrid> handle(*grid_, eclState, eclGrid, this->centroids_,
                                                                   cartesianIndexMapper());
-                    this->parallelWells_ = std::get<1>(grid_->loadBalance(handle, edgeWeightsMethod, &wells, serialPartitioning, faceTrans.data(), ownersFirst));
+                    this->parallelWells_ = std::get<1>(grid_->loadBalance(handle, edgeWeightsMethod, &wells, serialPartitioning,
+                                                                          faceTrans.data(), ownersFirst, false, 1, true, zoltanImbalanceTol));
                 }
                 catch(const std::bad_cast& e)
                 {


### PR DESCRIPTION
Gives the user a hint and a way to fix the empty partition issue by using a stricter imbalance tolerance. 

Depends on OPM/opm-grid#507

