### PR TITLE
Add diffusion in Flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,16 @@ opm_add_test(flow_co2
   DEPENDS opmsimulators
   LIBRARIES opmsimulators)
 
+opm_add_test(flow_bo_diffusion
+  ONLY_COMPILE
+  DEFAULT_ENABLE_IF ${FLOW_VARIANTS_DEFAULT_ENABLE_IF}
+  SOURCES
+  flow/flow_bo_diffusion.cpp
+  $<TARGET_OBJECTS:moduleVersion>
+  EXE_NAME flow_bo_diffusion
+  DEPENDS opmsimulators
+  LIBRARIES opmsimulators)
+
 opm_add_test(flow_onephase_energy
   ONLY_COMPILE
   DEFAULT_ENABLE_IF ${FLOW_VARIANTS_DEFAULT_ENABLE_IF}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,13 +339,13 @@ opm_add_test(flow_onephase
   DEPENDS opmsimulators
   LIBRARIES opmsimulators)
 
-opm_add_test(flow_co2
+opm_add_test(flow_co2_diffusion
   ONLY_COMPILE
   DEFAULT_ENABLE_IF ${FLOW_VARIANTS_DEFAULT_ENABLE_IF}
   SOURCES
   flow/flow_co2_diffusion.cpp
   $<TARGET_OBJECTS:moduleVersion>
-  EXE_NAME flow_co2
+  EXE_NAME flow_co2_diffusion
   DEPENDS opmsimulators
   LIBRARIES opmsimulators)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,6 +339,16 @@ opm_add_test(flow_onephase
   DEPENDS opmsimulators
   LIBRARIES opmsimulators)
 
+opm_add_test(flow_co2
+  ONLY_COMPILE
+  DEFAULT_ENABLE_IF ${FLOW_VARIANTS_DEFAULT_ENABLE_IF}
+  SOURCES
+  flow/flow_co2_diffusion.cpp
+  $<TARGET_OBJECTS:moduleVersion>
+  EXE_NAME flow_co2
+  DEPENDS opmsimulators
+  LIBRARIES opmsimulators)
+
 opm_add_test(flow_onephase_energy
   ONLY_COMPILE
   DEFAULT_ENABLE_IF ${FLOW_VARIANTS_DEFAULT_ENABLE_IF}

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -622,6 +622,7 @@ class EclProblem : public GetPropType<TypeTag, Properties::BaseProblem>
     enum { enableExtbo = getPropValue<TypeTag, Properties::EnableExtbo>() };
     enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    enum { enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>() };
     enum { enableThermalFluxBoundaries = getPropValue<TypeTag, Properties::EnableThermalFluxBoundaries>() };
     enum { enableApiTracking = getPropValue<TypeTag, Properties::EnableApiTracking>() };
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx };
@@ -1370,6 +1371,18 @@ public:
     {
         assert(fromDofLocalIdx == 0);
         return pffDofData_.get(context.element(), toDofLocalIdx).transmissibility;
+    }
+
+    /*!
+     * \copydoc EclTransmissiblity::diffusivity
+     */
+    template <class Context>
+    Scalar diffusivity(const Context& context,
+                       unsigned OPM_OPTIM_UNUSED fromDofLocalIdx,
+                       unsigned toDofLocalIdx) const
+    {
+        assert(fromDofLocalIdx == 0);
+        return *pffDofData_.get(context.element(), toDofLocalIdx).diffusivity;
     }
 
     /*!
@@ -3072,6 +3085,8 @@ private:
     struct PffDofData_
     {
         Opm::ConditionalStorage<enableEnergy, Scalar> thermalHalfTrans;
+        Opm::ConditionalStorage<enableDiffusion, Scalar> diffusivity;
+        //Scalar diffusivity;
         Scalar transmissibility;
     };
 
@@ -3093,6 +3108,8 @@ private:
 
                 if (enableEnergy)
                     *dofData.thermalHalfTrans = transmissibilities_.thermalHalfTrans(globalCenterElemIdx, globalElemIdx);
+                if (enableDiffusion)
+                    *dofData.diffusivity = transmissibilities_.diffusivity(globalCenterElemIdx, globalElemIdx);
             }
         };
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -3086,7 +3086,6 @@ private:
     {
         Opm::ConditionalStorage<enableEnergy, Scalar> thermalHalfTrans;
         Opm::ConditionalStorage<enableDiffusion, Scalar> diffusivity;
-        //Scalar diffusivity;
         Scalar transmissibility;
     };
 

--- a/flow/flow_bo_diffusion.cpp
+++ b/flow/flow_bo_diffusion.cpp
@@ -16,18 +16,17 @@
 */
 #include "config.h"
 #include <opm/simulators/flow/Main.hpp>
-#include <opm/models/blackoil/blackoiltwophaseindices.hh>
 
 namespace Opm {
 namespace Properties {
 namespace TTag {
-struct EclFlowCo2Problem {
+struct EclFlowDiffusionProblem {
     using InheritsFrom = std::tuple<EclFlowProblem>;
 };
 }
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::EclFlowProblem> {
+struct EnableDiffusion<TypeTag, TTag::EclFlowDiffusionProblem> {
     static constexpr bool value = true;
 };
 
@@ -38,7 +37,7 @@ struct EnableDiffusion<TypeTag, TTag::EclFlowProblem> {
 // ----------------- Main program -----------------
 int main(int argc, char** argv)
 {
-    using TypeTag = Opm::Properties::TTag::EclFlowCo2Problem;
+    using TypeTag = Opm::Properties::TTag::EclFlowDiffusionProblem;
     auto mainObject = Opm::Main(argc, argv);
     return mainObject.runStatic<TypeTag>();
 }

--- a/flow/flow_bo_diffusion.cpp
+++ b/flow/flow_bo_diffusion.cpp
@@ -1,0 +1,44 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/models/blackoil/blackoiltwophaseindices.hh>
+
+namespace Opm {
+namespace Properties {
+namespace TTag {
+struct EclFlowCo2Problem {
+    using InheritsFrom = std::tuple<EclFlowProblem>;
+};
+}
+
+template<class TypeTag>
+struct EnableDiffusion<TypeTag, TTag::EclFlowProblem> {
+    static constexpr bool value = true;
+};
+
+
+}}
+
+
+// ----------------- Main program -----------------
+int main(int argc, char** argv)
+{
+    using TypeTag = Opm::Properties::TTag::EclFlowCo2Problem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
+}

--- a/flow/flow_co2_diffusion.cpp
+++ b/flow/flow_co2_diffusion.cpp
@@ -27,7 +27,7 @@ struct EclFlowCo2Problem {
 }
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::EclFlowProblem> {
+struct EnableDiffusion<TypeTag, TTag::EclFlowCo2Problem> {
     static constexpr bool value = true;
 };
 

--- a/flow/flow_co2_diffusion.cpp
+++ b/flow/flow_co2_diffusion.cpp
@@ -1,0 +1,64 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/models/blackoil/blackoiltwophaseindices.hh>
+
+namespace Opm {
+namespace Properties {
+namespace TTag {
+struct EclFlowCo2Problem {
+    using InheritsFrom = std::tuple<EclFlowProblem>;
+};
+}
+
+template<class TypeTag>
+struct EnableDiffusion<TypeTag, TTag::EclFlowProblem> {
+    static constexpr bool value = true;
+};
+
+//! The indices required by the model
+template<class TypeTag>
+struct Indices<TypeTag, TTag::EclFlowCo2Problem>
+{
+private:
+    // it is unfortunately not possible to simply use 'TypeTag' here because this leads
+    // to cyclic definitions of some properties. if this happens the compiler error
+    // messages unfortunately are *really* confusing and not really helpful.
+    using BaseTypeTag = TTag::EclFlowProblem;
+    using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
+
+public:
+    typedef Opm::BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
+                                         getPropValue<TypeTag, Properties::EnableExtbo>(),
+                                         getPropValue<TypeTag, Properties::EnablePolymer>(),
+                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         getPropValue<TypeTag, Properties::EnableFoam>(),
+                                         getPropValue<TypeTag, Properties::EnableBrine>(),
+                                         /*PVOffset=*/0,
+                                         /*disabledCompIdx=*/FluidSystem::waterCompIdx> type;
+};
+}}
+
+
+// ----------------- Main program -----------------
+int main(int argc, char** argv)
+{
+    using TypeTag = Opm::Properties::TTag::EclFlowCo2Problem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
+}


### PR DESCRIPTION
This PR adds 
1) code to compute diffusivity in the eclTransmissibility class. Only called if diffusion is enabled. i.e. should not affect the standard Flow. 
2) Adds optional oil-gas-diffusion and bo-diffusion variants of Flow. 

Depends on OPM/opm-models#640