### PR TITLE
Activate distributed wells in the simulator

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -175,6 +175,12 @@ template<class TypeTag>
 struct AllowDistributedWells<TypeTag, TTag::EclBaseVanguard> {
     static constexpr bool value = false;
 };
+
+// Same as in BlackoilModelParametersEbos.hpp but for here.
+template<class TypeTag>
+struct UseMultisegmentWell<TypeTag, TTag::EclBaseVanguard> {
+    static constexpr bool value = true;
+};
 } // namespace Opm::Properties
 
 namespace Opm {
@@ -232,6 +238,8 @@ public:
                              "Tolerable imbalance of the loadbalancing provided by Zoltan (default: 1.1).");
         EWOMS_REGISTER_PARAM(TypeTag, bool, AllowDistributedWells,
                              "Allow the perforations of a well to be distributed to interior of multiple processes");
+        // register here for the use in the tests without BlackoildModelParametersEbos
+        EWOMS_REGISTER_PARAM(TypeTag, bool, UseMultisegmentWell, "Use the well model for multi-segment wells instead of the one for single-segment wells");
 
     }
 
@@ -464,7 +472,7 @@ public:
         {
             int hasMsWell = false;
 
-            if (BlackoilModelParametersEbos<TypeTag>().use_multisegment_well_)
+            if (EWOMS_GET_PARAM(TypeTag, bool, UseMultisegmentWell))
             {
                 if (myRank == 0)
                 {

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -494,11 +494,11 @@ public:
             {
                 if (myRank == 0)
                 {
-                    std::string message = std::string("Option --allow-distributed-wells=true is only allowed ")
-                        + "if model only has only standard wells."
-                        + "You need to provide option "
-                        + " with --enable-multisegement-wells=false to treat "
-                        + "existing multisegment wells as standard wells.";
+                    std::string message =
+                        std::string("Option --allow-distributed-wells=true is only allowed if model\n")
+                        + "only has only standard wells. You need to provide option \n"
+                        + " with --enable-multisegement-wells=false to treat existing \n"
+                        + "multisegment wells as standard wells.";
                     OpmLog::error(message);
                 }
                 comm.barrier();

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -51,6 +51,8 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 
+#include <opm/simulators/flow/BlackoilModelParametersEbos.hpp>
+
 #include <opm/simulators/utils/readDeck.hpp>
 
 #if HAVE_MPI
@@ -121,6 +123,11 @@ struct ZoltanImbalanceTol {
     using type = UndefinedProperty;
 };
 
+template<class TypeTag, class MyTypeTag>
+struct AllowDistributedWells {
+    using type = UndefinedProperty;
+};
+
 template<class TypeTag>
 struct IgnoreKeywords<TypeTag, TTag::EclBaseVanguard> {
     static constexpr auto value = "";
@@ -164,6 +171,10 @@ struct ZoltanImbalanceTol<TypeTag, TTag::EclBaseVanguard> {
     static constexpr type value = 1.1;
 };
 
+template<class TypeTag>
+struct AllowDistributedWells<TypeTag, TTag::EclBaseVanguard> {
+    static constexpr bool value = false;
+};
 } // namespace Opm::Properties
 
 namespace Opm {
@@ -218,7 +229,9 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, bool, SerialPartitioning,
                              "Perform partitioning for parallel runs on a single process.");
         EWOMS_REGISTER_PARAM(TypeTag, Scalar, ZoltanImbalanceTol,
-                             "Perform partitioning for parallel runs on a single process.");
+                             "Tolerable imbalance of the loadbalancing provided by Zoltan (default: 1.1).");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, AllowDistributedWells,
+                             "Allow the perforations of a well to be distributed to interior of multiple processes");
 
     }
 
@@ -354,6 +367,7 @@ public:
         ownersFirst_ = EWOMS_GET_PARAM(TypeTag, bool, OwnerCellsFirst);
         serialPartitioning_ = EWOMS_GET_PARAM(TypeTag, bool, SerialPartitioning);
         zoltanImbalanceTol_ = EWOMS_GET_PARAM(TypeTag, Scalar, ZoltanImbalanceTol);
+        enableDistributedWells_ = EWOMS_GET_PARAM(TypeTag, bool, AllowDistributedWells);
 
         // Make proper case name.
         {
@@ -444,6 +458,45 @@ public:
             parallelWells_.emplace_back(well.name(), true);
         }
         std::sort(parallelWells_.begin(), parallelWells_.end());
+
+        // Check whether allowing distribute wells makes sense
+        if (enableDistributedWells() )
+        {
+            int hasMsWell = false;
+
+            if (BlackoilModelParametersEbos<TypeTag>().use_multisegment_well_)
+            {
+                if (myRank == 0)
+                {
+                    const auto& wells = this->schedule().getWellsatEnd();
+                    for ( const auto& well: wells)
+                    {
+                        hasMsWell = hasMsWell || well.isMultiSegment();
+                    }
+                }
+            }
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+            const auto& comm = Dune::MPIHelper::getCommunication();
+#else
+            const auto& comm = Dune::MPIHelper::getCollectiveCommunication();
+#endif
+            hasMsWell = comm.max(hasMsWell);
+
+            if (hasMsWell)
+            {
+                if (myRank == 0)
+                {
+                    std::string message = std::string("Option --allow-distributed-wells=true is only allowed ")
+                        + "if model only has only standard wells."
+                        + "You need to provide option "
+                        + " with --enable-multisegement-wells=false to treat "
+                        + "existing multisegment wells as standard wells.";
+                    OpmLog::error(message);
+                }
+                comm.barrier();
+                OPM_THROW(std::invalid_argument, "All wells need to be standard wells!");
+            }
+        }
     }
 
     /*!
@@ -559,6 +612,12 @@ public:
      */
     Scalar zoltanImbalanceTol() const
     { return zoltanImbalanceTol_; }
+
+    /*!
+     * \brief Whether perforations of a well might be distributed.
+     */
+    bool enableDistributedWells() const
+    { return enableDistributedWells_; }
 
     /*!
      * \brief Returns the name of the case.
@@ -813,6 +872,7 @@ private:
     bool ownersFirst_;
     bool serialPartitioning_;
     Scalar zoltanImbalanceTol_;
+    bool enableDistributedWells_;
 
 protected:
     /*! \brief The cell centroids after loadbalance was called.

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -175,6 +175,7 @@ public:
             Dune::EdgeWeightMethod edgeWeightsMethod = this->edgeWeightsMethod();
             bool ownersFirst = this->ownersFirst();
             bool serialPartitioning = this->serialPartitioning();
+            bool enableDistributedWells = this->enableDistributedWells();
             Scalar zoltanImbalanceTol = this->zoltanImbalanceTol();
 
             // convert to transmissibility for faces
@@ -222,7 +223,8 @@ public:
                     PropsCentroidsDataHandle<Dune::CpGrid> handle(*grid_, eclState, eclGrid, this->centroids_,
                                                                   cartesianIndexMapper());
                     this->parallelWells_ = std::get<1>(grid_->loadBalance(handle, edgeWeightsMethod, &wells, serialPartitioning,
-                                                                          faceTrans.data(), ownersFirst, false, 1, true, zoltanImbalanceTol));
+                                                                          faceTrans.data(), ownersFirst, false, 1, true, zoltanImbalanceTol,
+                                                                          enableDistributedWells));
                 }
                 catch(const std::bad_cast& e)
                 {

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -23,6 +23,7 @@
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
 
+#include <ebos/eclbasevanguard.hh>
 #include <string>
 
 namespace Opm::Properties {
@@ -30,6 +31,10 @@ namespace Opm::Properties {
 namespace TTag {
 struct FlowModelParameters {};
 }
+
+// forward declaration to make this header usable from eclbasevanguard.hh
+template<class TypeTag, class MyTypeTag>
+struct EclDeckFileName;
 
 template<class TypeTag, class MyTypeTag>
 struct DbhpMaxRel {


### PR DESCRIPTION
We introduce a new parameter --enable-distributed-wells=<true|false> for this. During startup we check that the model either only has standard wells or that multisegement wells are actively interpreted as standard wells (by way of passing --enable-multisegment-wells=false as an option).

Note that the typetag property `UseMultisegmentWells` is now there twice once for `TypeTag` of `EclBaseVanguard` as template parameter and once for `TTag::FlowModelParameters` as template parameter. If there is a better way, please let me know. This drove me crazy and it seemed the only way to make all tests compile.

Needs OPM/opm-grid#511