### PR TITLE
Support external loadbalancers in EclCpGridVanguard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,18 @@ opm_add_test(flow_poly
   $<TARGET_OBJECTS:moduleVersion>)
 target_compile_definitions(flow_poly PRIVATE USE_POLYHEDRALGRID)
 
+# the production oriented general-purpose ECL simulator
+opm_add_test(flow_distribute_z
+  ONLY_COMPILE
+  ALWAYS_ENABLE
+  DEFAULT_ENABLE_IF ${FLOW_DEFAULT_ENABLE_IF}
+  DEPENDS opmsimulators
+  LIBRARIES opmsimulators
+  SOURCES
+  flow/flow_distribute_z.cpp
+  ${FLOW_TGTS}
+  $<TARGET_OBJECTS:moduleVersion>
+  )
 
 if (NOT BUILD_FLOW_VARIANTS)
   set(FLOW_VARIANTS_DEFAULT_ENABLE_IF "FALSE")

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -904,6 +904,14 @@ if(MPI_FOUND)
                                        REL_TOL ${rel_tol_parallel}
                                        TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
 
+  # A test for distributed standard wells. We load distribute only along the z-axis
+  add_test_compare_parallel_simulation(CASENAME spe9
+                                       FILENAME SPE9_CP_SHORT
+                                       SIMULATOR flow_distribute_z
+                                       ABS_TOL ${abs_tol_parallel}
+                                       REL_TOL ${rel_tol_parallel}
+                                       TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
+
   add_test_compare_parallel_simulation(CASENAME spe9group
                                        FILENAME SPE9_CP_GROUP
                                        SIMULATOR flow

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -175,6 +175,12 @@ template<class TypeTag>
 struct AllowDistributedWells<TypeTag, TTag::EclBaseVanguard> {
     static constexpr bool value = false;
 };
+
+// Same as in BlackoilModelParametersEbos.hpp but for here.
+template<class TypeTag>
+struct UseMultisegmentWell<TypeTag, TTag::EclBaseVanguard> {
+    static constexpr bool value = true;
+};
 } // namespace Opm::Properties
 
 namespace Opm {
@@ -232,6 +238,8 @@ public:
                              "Tolerable imbalance of the loadbalancing provided by Zoltan (default: 1.1).");
         EWOMS_REGISTER_PARAM(TypeTag, bool, AllowDistributedWells,
                              "Allow the perforations of a well to be distributed to interior of multiple processes");
+        // register here for the use in the tests without BlackoildModelParametersEbos
+        EWOMS_REGISTER_PARAM(TypeTag, bool, UseMultisegmentWell, "Use the well model for multi-segment wells instead of the one for single-segment wells");
 
     }
 
@@ -464,7 +472,7 @@ public:
         {
             int hasMsWell = false;
 
-            if (BlackoilModelParametersEbos<TypeTag>().use_multisegment_well_)
+            if (EWOMS_GET_PARAM(TypeTag, bool, UseMultisegmentWell))
             {
                 if (myRank == 0)
                 {

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -51,7 +51,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 
-#include <opm/simulators/flow/BlackoilModelParametersEbos.hpp>
 
 #include <opm/simulators/utils/readDeck.hpp>
 
@@ -175,6 +174,9 @@ template<class TypeTag>
 struct AllowDistributedWells<TypeTag, TTag::EclBaseVanguard> {
     static constexpr bool value = false;
 };
+
+template<class T1, class T2>
+struct UseMultisegmentWell;
 
 // Same as in BlackoilModelParametersEbos.hpp but for here.
 template<class TypeTag>

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -51,6 +51,8 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 
+#include <opm/simulators/flow/BlackoilModelParametersEbos.hpp>
+
 #include <opm/simulators/utils/readDeck.hpp>
 
 #if HAVE_MPI
@@ -121,6 +123,11 @@ struct ZoltanImbalanceTol {
     using type = UndefinedProperty;
 };
 
+template<class TypeTag, class MyTypeTag>
+struct AllowDistributedWells {
+    using type = UndefinedProperty;
+};
+
 template<class TypeTag>
 struct IgnoreKeywords<TypeTag, TTag::EclBaseVanguard> {
     static constexpr auto value = "";
@@ -164,6 +171,10 @@ struct ZoltanImbalanceTol<TypeTag, TTag::EclBaseVanguard> {
     static constexpr type value = 1.1;
 };
 
+template<class TypeTag>
+struct AllowDistributedWells<TypeTag, TTag::EclBaseVanguard> {
+    static constexpr bool value = false;
+};
 } // namespace Opm::Properties
 
 namespace Opm {
@@ -218,7 +229,9 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, bool, SerialPartitioning,
                              "Perform partitioning for parallel runs on a single process.");
         EWOMS_REGISTER_PARAM(TypeTag, Scalar, ZoltanImbalanceTol,
-                             "Perform partitioning for parallel runs on a single process.");
+                             "Tolerable imbalance of the loadbalancing provided by Zoltan (default: 1.1).");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, AllowDistributedWells,
+                             "Allow the perforations of a well to be distributed to interior of multiple processes");
 
     }
 
@@ -354,6 +367,7 @@ public:
         ownersFirst_ = EWOMS_GET_PARAM(TypeTag, bool, OwnerCellsFirst);
         serialPartitioning_ = EWOMS_GET_PARAM(TypeTag, bool, SerialPartitioning);
         zoltanImbalanceTol_ = EWOMS_GET_PARAM(TypeTag, Scalar, ZoltanImbalanceTol);
+        enableDistributedWells_ = EWOMS_GET_PARAM(TypeTag, bool, AllowDistributedWells);
 
         // Make proper case name.
         {
@@ -444,6 +458,45 @@ public:
             parallelWells_.emplace_back(well.name(), true);
         }
         std::sort(parallelWells_.begin(), parallelWells_.end());
+
+        // Check whether allowing distribute wells makes sense
+        if (enableDistributedWells() )
+        {
+            int hasMsWell = false;
+
+            if (BlackoilModelParametersEbos<TypeTag>().use_multisegment_well_)
+            {
+                if (myRank == 0)
+                {
+                    const auto& wells = this->schedule().getWellsatEnd();
+                    for ( const auto& well: wells)
+                    {
+                        hasMsWell = hasMsWell || well.isMultiSegment();
+                    }
+                }
+            }
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+            const auto& comm = Dune::MPIHelper::getCommunication();
+#else
+            const auto& comm = Dune::MPIHelper::getCollectiveCommunication();
+#endif
+            hasMsWell = comm.max(hasMsWell);
+
+            if (hasMsWell)
+            {
+                if (myRank == 0)
+                {
+                    std::string message = std::string("Option --allow-distributed-wells=true is only allowed ")
+                        + "if model only has only standard wells."
+                        + "You need to provide option "
+                        + " with --enable-multisegement-wells=false to treat "
+                        + "existing multisegment wells as standard wells.";
+                    OpmLog::error(message);
+                }
+                comm.barrier();
+                OPM_THROW(std::invalid_argument, "All wells need to be standard wells!");
+            }
+        }
     }
 
     /*!
@@ -559,6 +612,12 @@ public:
      */
     Scalar zoltanImbalanceTol() const
     { return zoltanImbalanceTol_; }
+
+    /*!
+     * \brief Whether perforations of a well might be distributed.
+     */
+    bool enableDistributedWells() const
+    { return enableDistributedWells_; }
 
     /*!
      * \brief Returns the name of the case.
@@ -813,6 +872,7 @@ private:
     bool ownersFirst_;
     bool serialPartitioning_;
     Scalar zoltanImbalanceTol_;
+    bool enableDistributedWells_;
 
 protected:
     /*! \brief The cell centroids after loadbalance was called.

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -175,6 +175,7 @@ public:
             Dune::EdgeWeightMethod edgeWeightsMethod = this->edgeWeightsMethod();
             bool ownersFirst = this->ownersFirst();
             bool serialPartitioning = this->serialPartitioning();
+            bool enableDistributedWells = this->enableDistributedWells();
             Scalar zoltanImbalanceTol = this->zoltanImbalanceTol();
 
             // convert to transmissibility for faces
@@ -222,7 +223,8 @@ public:
                     PropsCentroidsDataHandle<Dune::CpGrid> handle(*grid_, eclState, eclGrid, this->centroids_,
                                                                   cartesianIndexMapper());
                     this->parallelWells_ = std::get<1>(grid_->loadBalance(handle, edgeWeightsMethod, &wells, serialPartitioning,
-                                                                          faceTrans.data(), ownersFirst, false, 1, true, zoltanImbalanceTol));
+                                                                          faceTrans.data(), ownersFirst, false, 1, true, zoltanImbalanceTol,
+                                                                          enableDistributedWells));
                 }
                 catch(const std::bad_cast& e)
                 {

--- a/flow/flow_distribute_z.cpp
+++ b/flow/flow_distribute_z.cpp
@@ -1,0 +1,67 @@
+/*
+  Copyright 2013, 2014, 2015 SINTEF ICT, Applied Mathematics.
+  Copyright 2014 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015, 2017 IRIS AS
+  Copyright 2021 OPM-OP AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <opm/simulators/flow/Main.hpp>
+#include <ebos/eclcpgridvanguard.hh>
+
+std::vector<int> loadBalanceInZOnly(const Dune::CpGrid& grid)
+{
+    auto cartMapper = Dune::CartesianIndexMapper<Dune::CpGrid>(grid);
+    auto dims = cartMapper.cartesianDimensions();
+    std::vector<int> parts(grid.leafGridView().size(0));
+    auto numCellsPerProc = dims[2]/grid.comm().size();
+
+    if (grid.size(0)>0 && numCellsPerProc == 0)
+    {
+        OPM_THROW(std::logic_error,
+                  "cartesian grid must have more cells in z direction than number of processes.");
+    }
+
+    using ElementMapper =
+        Dune::MultipleCodimMultipleGeomTypeMapper<typename Dune::CpGrid::LeafGridView>;
+    const auto& gridView = grid.leafGridView();
+    const auto& idSet = grid.localIdSet();
+    ElementMapper elemMapper(gridView, Dune::mcmgElementLayout());
+
+    for( const auto &element : elements(gridView) )
+    {
+        const auto& id = idSet.id(element);
+        unsigned elemIdx = elemMapper.index(element);
+        const auto& cartIndex = cartMapper.cartesianIndex(elemIdx);
+        std::array<int,3> cartCoord;
+        cartMapper.cartesianCoordinate(cartIndex, cartCoord);
+        using std::min;
+        auto rank = min(grid.comm().size() -1, cartCoord[2] / numCellsPerProc);
+        parts[id] = rank;
+    }
+    return parts;
+}
+
+int main(int argc, char** argv)
+{
+    auto mainObject = Opm::Main(argc, argv);
+    Opm::EclCpGridVanguard<Opm::Properties::TTag::EclFlowProblem>::setExternalLoadBalancer(loadBalanceInZOnly);
+    return mainObject.runDynamic();
+}
+

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -23,6 +23,7 @@
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
 
+#include <ebos/eclbasevanguard.hh>
 #include <string>
 
 namespace Opm::Properties {
@@ -30,6 +31,10 @@ namespace Opm::Properties {
 namespace TTag {
 struct FlowModelParameters {};
 }
+
+// forward declaration to make this header usable from eclbasevanguard.hh
+template<class TypeTag, class MyTypeTag>
+struct EclDeckFileName;
 
 template<class TypeTag, class MyTypeTag>
 struct DbhpMaxRel {

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -32,10 +32,6 @@ namespace TTag {
 struct FlowModelParameters {};
 }
 
-// forward declaration to make this header usable from eclbasevanguard.hh
-template<class TypeTag, class MyTypeTag>
-struct EclDeckFileName;
-
 template<class TypeTag, class MyTypeTag>
 struct DbhpMaxRel {
     using type = UndefinedProperty;


### PR DESCRIPTION
Additionally adds a flow executable that only distributes cells in z-direction. Executable is named flow_distribute_z and uses the external load balancing information. It can be used to test the distributed standard wells on SPE9 with 4 or more processes.

Automatic test of this is still missing as I need to find how to best do this. Suggestions welcome.

Based on #3029  and hence needs OPM/opm-grid#511
