### PR TITLE
change default MinTimeStepBeforeShuttingProblematicWellsInDays to 0.01

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -204,7 +204,7 @@ struct TimeStepControlFileName<TypeTag, TTag::FlowTimeSteppingParameters> {
 template<class TypeTag>
 struct MinTimeStepBeforeShuttingProblematicWellsInDays<TypeTag, TTag::FlowTimeSteppingParameters> {
     using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 0.001;
+    static constexpr type value = 0.01;
 };
 
 } // namespace Opm::Properties


### PR DESCRIPTION
With the recent improvements in the convergence of the well model the simulator is able to keep alive wells that needs to die. Increasing this parameter will help them die a bit earlier. 

It goes without saying that this needs proper testing before it can be merged. I have tested it on the norne family where it shows good improvement on some of the cases. 