### PR TITLE
correcting the output of the number of threads

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -307,6 +307,11 @@ namespace Opm
                 threads =  omp_get_max_threads();
             else
                 threads = std::min(2, omp_get_max_threads());
+
+            const int input_threads = EWOMS_GET_PARAM(TypeTag, int, ThreadsPerProcess);
+
+            if (input_threads > 0)
+                threads = std::min(input_threads, omp_get_max_threads());
 #endif
 
 #if HAVE_MPI


### PR DESCRIPTION
Currently, when running flow, no matter what number you set to `--threads-per-process`, you always get two threads for output,  unless you have a single-core machine. 

```
Using 1 MPI processes with 2 OMP threads on each 
```

This PR is purely for correcting above output. 

At the same time, in the file `FlowMainEbos.hpp` and `threadmanager.hh`, there are multiple places dealing with the nubmer of threads, even with slightly different algorithm, which is not easy to follow, even it should be a simple thing. 

Some refactoring should be done regarding to this.  Maybe let `ThreadManager` deal with it only can be a solution,  then we need to set it up before we `printBanner`. 