### PR TITLE
Don't Initialize Well State for Shut Wells

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -301,7 +301,7 @@ namespace Opm {
 
             std::vector<bool> is_cell_perforated_;
 
-            std::function<bool(const Well&)> is_shut_or_defunct_;
+            std::function<bool(const Well&)> not_on_process_;
 
             void initializeWellProdIndCalculators();
             void initializeWellPerfData();
@@ -373,8 +373,8 @@ namespace Opm {
             /// \brief Get the wells of our partition that are not shut.
             /// \param timeStepIdx The index of the time step.
             /// \param[out] globalNumWells the number of wells globally.
-            std::vector< Well > getLocalNonshutWells(const int timeStepIdx,
-                                                     int& globalNumWells) const;
+            std::vector< Well > getLocalWells(const int timeStepIdx,
+                                              int& globalNumWells) const;
 
             /// \brief Create the parallel well information
             /// \param localWells The local wells from ECL schedule

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -244,7 +244,7 @@ namespace Opm
         using Base::ebosCompIdxToFlowCompIdx;
         using Base::getAllowCrossFlow;
         using Base::scalingFactor;
-        using Base::wellIsStopped_;
+        using Base::wellIsStopped;
         using Base::updateWellOperability;
         using Base::checkWellOperability;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -302,7 +302,7 @@ namespace Opm
         const int np = well_state.numPhases();
         const auto& summaryState = ebos_simulator.vanguard().summaryState();
 
-        if (wellIsStopped_) {
+        if (this->wellIsStopped()) {
             for (int p = 0; p<np; ++p) {
                 well_state.wellRates()[well_index*np + p] = 0.0;
             }
@@ -2030,7 +2030,7 @@ namespace Opm
             return rates;
         };
 
-        if (wellIsStopped_) {
+        if (this->wellIsStopped()) {
             control_eq = getWQTotal();
         } else if (this->isInjector() ) {
             // Find scaling factor to get injection rate,

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -336,6 +336,7 @@ namespace Opm
         using Base::mostStrictBhpFromBhpLimits;
         using Base::updateWellOperability;
         using Base::checkWellOperability;
+        using Base::wellIsStopped;
 
         // protected member variables from the Base class
         using Base::current_step_;
@@ -362,7 +363,6 @@ namespace Opm
         using Base::ipr_b_;
         using Base::changed_to_stopped_this_step_;
 
-        using Base::wellIsStopped_;
 
         // total number of the well equations and primary variables
         // there might be extra equations be used, numWellEq will be updated during the initialization

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -892,7 +892,7 @@ namespace Opm
             return rates;
         };
 
-        if (wellIsStopped_) {
+        if (this->wellIsStopped()) {
             control_eq = getWQTotal();
         } else if (this->isInjector()) {
             // Find injection rate.
@@ -1365,7 +1365,7 @@ namespace Opm
         const int np = well_state.numPhases();
         const auto& summaryState = ebos_simulator.vanguard().summaryState();
 
-        if (wellIsStopped_) {
+        if (this->wellIsStopped()) {
             for (int p = 0; p<np; ++p) {
                 well_state.wellRates()[well_index*np + p] = 0.0;
             }
@@ -3490,7 +3490,7 @@ namespace Opm
         CR::WellFailure::Type ctrltype = CR::WellFailure::Type::Invalid;
 
         const int well_index = index_of_well_;
-        if (wellIsStopped_) {
+        if (this->wellIsStopped()) {
             ctrltype = CR::WellFailure::Type::ControlRate;
             control_tolerance = 1.e-6; // use smaller tolerance for zero control?
         }

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -307,14 +307,15 @@ namespace Opm
                                   DeferredLogger& deferred_logger) const;
 
         void stopWell() {
-            wellIsStopped_ = true;
+            this->wellStatus_ = Well::Status::STOP;
         }
+
         void openWell() {
-            wellIsStopped_ = false;
+            this->wellStatus_ = Well::Status::OPEN;
         }
 
         bool wellIsStopped() const {
-            return wellIsStopped_;
+            return this->wellStatus_ == Well::Status::STOP;
         }
 
         void setWsolvent(const double wsolvent);
@@ -419,7 +420,7 @@ namespace Opm
 
         std::vector<RateVector> connectionRates_;
 
-        bool wellIsStopped_;
+        Well::Status wellStatus_;
 
         double wsolvent_;
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -90,9 +90,9 @@ namespace Opm
 
         connectionRates_.resize(number_of_perforations_);
 
-        wellIsStopped_ = false;
+        this->wellStatus_ = Well::Status::OPEN;
         if (well.getStatus() == Well::Status::STOP) {
-            wellIsStopped_ = true;
+            this->wellStatus_ = Well::Status::STOP;
         }
 
         wsolvent_ = 0.0;
@@ -973,7 +973,7 @@ namespace Opm
                                 WellTestState& well_test_state,
                                 Opm::DeferredLogger& deferred_logger) const
     {
-        if (wellIsStopped_)
+        if (this->wellIsStopped())
             return;
 
         const WellEconProductionLimits& econ_production_limits = well_ecl_.getEconLimits();

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -398,9 +398,15 @@ namespace Opm
                 : (prod_controls.cmode == Well::ProducerCMode::GRUP);
 
             const double inj_surf_rate = well.isInjector() ? inj_controls.surface_rate : 0.0; // To avoid a "maybe-uninitialized" warning.
+
             const double local_pressure = well_perf_data_[w].empty() ?
                 0 : cellPressures[well_perf_data_[w][0].cell_index];
             const double global_pressure = well_info.broadcastFirstPerforationValue(local_pressure);
+
+            if (well.getStatus() == Well::Status::OPEN) {
+                this->openWell(w);
+            }
+
             if (well.getStatus() == Well::Status::STOP) {
                 // Stopped well:
                 // 1. Rates: zero well rates.

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -213,6 +213,10 @@ namespace Opm
                 auto end = prevState->wellMap().end();
                 for (int w = 0; w < nw; ++w) {
                     const Well& well = wells_ecl[w];
+                    if (well.getStatus() == Well::Status::SHUT) {
+                        continue;
+                    }
+
                     auto it = prevState->wellMap().find(well.name());
                     if ( it != end )
                     {

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -190,6 +190,23 @@ namespace Opm
 
             perfRateBrine_.clear();
             perfRateBrine_.resize(nperf, 0.0);
+
+            for (int w = 0; w < nw; ++w) {
+                switch (wells_ecl[w].getStatus()) {
+                case Well::Status::SHUT:
+                    this->shutWell(w);
+                    break;
+
+                case Well::Status::STOP:
+                    this->stopWell(w);
+                    break;
+
+                default:
+                    this->openWell(w);
+                    break;
+                }
+            }
+
             // intialize wells that have been there before
             // order may change so the mapping is based on the well name
             if (prevState && !prevState->wellMap().empty()) {


### PR DESCRIPTION
This is a rebased and trimmed-down version of the earlier PR #2936.  In particular, this PR prepares for the case of having the well state incorporate all wells on a process, not just the open/active ones.

This supersedes and closes #2936.