### PR TITLE
Pass true to FieldPropertieManager::keys to include TRANS Modifiers.

### DIFF
--- a/opm/simulators/utils/PropsCentroidsDataHandle.hpp
+++ b/opm/simulators/utils/PropsCentroidsDataHandle.hpp
@@ -74,7 +74,7 @@ public:
         {
             const auto& globalProps = eclState.globalFieldProps();
             m_intKeys = globalProps.keys<int>();
-            m_doubleKeys = globalProps.keys<double>();
+            m_doubleKeys = globalProps.keys<double>(true);
             std::size_t packSize = Mpi::packSize(m_intKeys, comm) +
                 Mpi::packSize(m_doubleKeys,comm);
             std::vector<char> buffer(packSize);


### PR DESCRIPTION
These seem not be listed anymore by default and opm-common has changes to reallow listing them if true is passed.
Needs OPM/opm-common#2289 and closes OPM/opm-common#2282