### PR TITLE
Add command-line restarting functionality.

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -127,6 +127,11 @@ struct AllowDistributedWells {
     using type = UndefinedProperty;
 };
 
+template<class TypeTag, class MyTypeTag>
+struct Restart {
+    using type = UndefinedProperty;
+};
+
 template<class TypeTag>
 struct IgnoreKeywords<TypeTag, TTag::EclBaseVanguard> {
     static constexpr auto value = "";
@@ -173,6 +178,11 @@ struct ZoltanImbalanceTol<TypeTag, TTag::EclBaseVanguard> {
 template<class TypeTag>
 struct AllowDistributedWells<TypeTag, TTag::EclBaseVanguard> {
     static constexpr bool value = false;
+};
+
+template<class TypeTag>
+struct Restart<TypeTag, TTag::EclBaseVanguard> {
+    static constexpr auto value = "none";
 };
 
 template<class T1, class T2>
@@ -241,6 +251,9 @@ public:
                              "Tolerable imbalance of the loadbalancing provided by Zoltan (default: 1.1).");
         EWOMS_REGISTER_PARAM(TypeTag, bool, AllowDistributedWells,
                              "Allow the perforations of a well to be distributed to interior of multiple processes");
+        EWOMS_REGISTER_PARAM(TypeTag, std::string, Restart,
+                             "Restarting specification with the following syntax: "
+                             "<full path to base case name>:<report step to restart from>");
         // register here for the use in the tests without BlackoildModelParametersEbos
         EWOMS_REGISTER_PARAM(TypeTag, bool, UseMultisegmentWell, "Use the well model for multi-segment wells instead of the one for single-segment wells");
 
@@ -453,7 +466,8 @@ public:
         readDeck(myRank, fileName, deck_, eclState_, eclSchedule_,
                  eclSummaryConfig_, std::move(errorGuard), python,
                  std::move(parseContext_), /* initFromRestart = */ false,
-                 /* checkDeck = */ enableExperiments, outputInterval);
+                 /* checkDeck = */ enableExperiments, outputInterval,
+                 EWOMS_GET_PARAM(TypeTag, std::string, Restart));
 
         this->summaryState_ = std::make_unique<Opm::SummaryState>( Opm::TimeService::from_time_t(this->eclSchedule_->getStartTime() ));
         this->udqState_ = std::make_unique<Opm::UDQState>( this->eclSchedule_->getUDQConfig(0).params().undefinedValue() );

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -462,7 +462,8 @@ namespace Opm
 
                 readDeck(mpiRank, deckFilename, deck_, eclipseState_, schedule_,
                          summaryConfig_, nullptr, python, std::move(parseContext),
-                         init_from_restart_file, outputCout_, outputInterval);
+                         init_from_restart_file, outputCout_, outputInterval,
+                         EWOMS_GET_PARAM(PreTypeTag, std::string, Restart));
 
                 setupTime_ = externalSetupTimer.elapsed();
                 outputFiles_ = (outputMode != FileOutputMode::OUTPUT_NONE);

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -37,7 +37,7 @@
 #include <optional>
 #include <string>
 
-namespace Opm 
+namespace Opm
 {
 enum class FileOutputMode {
     //! \brief No output to files.
@@ -54,10 +54,19 @@ FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, con
 /// \brief Reads the deck and creates all necessary objects if needed
 ///
 /// If pointers already contains objects then they are used otherwise they are created and can be used outside later.
-void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& deck, std::unique_ptr<Opm::EclipseState>& eclipseState,
-              std::unique_ptr<Opm::Schedule>& schedule, std::unique_ptr<Opm::SummaryConfig>& summaryConfig,
-              std::unique_ptr<ErrorGuard> errorGuard, std::shared_ptr<Opm::Python>& python, std::unique_ptr<ParseContext> parseContext,
-              bool initFromRestart, bool checkDeck, const std::optional<int>& outputInterval);
+void readDeck(int rank,
+              std::string& deckFilename,
+              std::unique_ptr<Opm::Deck>& deck,
+              std::unique_ptr<Opm::EclipseState>& eclipseState,
+              std::unique_ptr<Opm::Schedule>& schedule,
+              std::unique_ptr<Opm::SummaryConfig>& summaryConfig,
+              std::unique_ptr<ErrorGuard> errorGuard,
+              std::shared_ptr<Opm::Python>& python,
+              std::unique_ptr<ParseContext> parseContext,
+              bool initFromRestart,
+              bool checkDeck,
+              const std::optional<int>& outputInterval,
+              const std::string& restartCommandLine);
 } // end namespace Opm
 
 #endif // OPM_READDECK_HEADER_INCLUDED


### PR DESCRIPTION
This adds the --restart parameter with the syntax proposed by Mr. Hove in the discussion of #2620, i.e. `--restart=path/to/CASENAME:46` to restart at step 46.

This is meant to replace #2620, and to partially be my "review" of that PR. There are a few open issues that should be resolved first, and I'll therefore consider this WIP for now:
 - Behaviour is not identical to what you get by restarting with the in-deck RESTART keyword.
 - Error message when you restart at a step for which you have no data in the UNRST file just complains about missing PRESSURE, not pointing to missing data for the particular step.
 - If wrong data (casename, step) is given in a parallel restart run, there is a deadlock instead of a graceful termination.