### PR TITLE
make sure wells has valid controls

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -279,16 +279,19 @@ namespace Opm {
                                                  + ScheduleEvents::INJECTION_UPDATE
                                                  + ScheduleEvents::NEW_WELL;
 
-            if(!schedule()[timeStepIdx].wellgroup_events().hasEvent(well.name(), effective_events_mask))
-                continue;
-
             if (well.isProducer()) {
                 const auto controls = well.productionControls(summaryState);
-                well_state_.currentProductionControls()[w] = controls.cmode;
+
+                if (well_state_.currentProductionControls()[w] == Well::ProducerCMode::NONE ||
+                        schedule()[timeStepIdx].wellgroup_events().hasEvent(well.name(), effective_events_mask)) {
+                    well_state_.currentProductionControls()[w] = controls.cmode;
+                }
             }
             else {
-                const auto controls = well.injectionControls(summaryState);
-                well_state_.currentInjectionControls()[w] = controls.cmode;
+                if (schedule()[timeStepIdx].wellgroup_events().hasEvent(well.name(), effective_events_mask)) {
+                    const auto controls = well.injectionControls(summaryState);
+                    well_state_.currentInjectionControls()[w] = controls.cmode;
+                }
             }
         }
         const Group& fieldGroup = schedule().getGroup("FIELD", timeStepIdx);

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -207,12 +207,8 @@ namespace Opm
                          //   continue;
                          //}
 
-                        // if there is no effective control event happens to the well, we use the current_injection/production_controls_ from prevState
-                        // otherwise, we use the control specified in the deck
-                        if (!effective_events_occurred_[w]) {
-                            current_injection_controls_[ newIndex ] = prevState->currentInjectionControls()[ oldIndex ];
-                            current_production_controls_[ newIndex ] = prevState->currentProductionControls()[ oldIndex ];
-                        }
+                        current_injection_controls_[ newIndex ] = prevState->currentInjectionControls()[ oldIndex ];
+                        current_production_controls_[ newIndex ] = prevState->currentProductionControls()[ oldIndex ];
 
                         // wellrates
                         for( int i=0, idx=newIndex*np, oldidx=oldIndex*np; i<np; ++i, ++idx, ++oldidx )


### PR DESCRIPTION
I don't understand why and when `Well::ProducerCMode::NONE` started appearing as a control. This is a band-aid type solution that fixes an urgent issue, but I would very much like to understand how a well production control can be NONE. I think it is related to recent changes in how we handle open/shut wells. 
