### PR TITLE
Fix MPI issues in the well model

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -326,9 +326,9 @@ namespace Opm {
 
         well_state_ = previous_well_state_;
         well_state_.disableGliftOptimization();
+        updateAndCommunicateGroupData();
         const int reportStepIdx = ebosSimulator_.episodeIndex();
         const double simulationTime = ebosSimulator_.time();
-
         int exception_thrown = 0;
         try {
             // test wells
@@ -403,7 +403,6 @@ namespace Opm {
         const auto& comm = ebosSimulator_.vanguard().grid().comm();
         WellGroupHelpers::updateGuideRatesForWells(schedule(), phase_usage_, reportStepIdx, simulationTime, well_state_, comm, guideRate_.get());
         try {
-            updateAndCommunicateGroupData();
             // Compute initial well solution for new wells
             for (auto& well : well_container_) {
                 const uint64_t effective_events_mask = ScheduleEvents::WELL_STATUS_CHANGE

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -465,7 +465,8 @@ namespace Opm
 
         EvalWell getSegmentSurfaceVolume(const Simulator& ebos_simulator, const int seg_idx) const;
 
-        std::vector<Scalar> getWellResiduals(const std::vector<Scalar>& B_avg) const;
+        std::vector<Scalar> getWellResiduals(const std::vector<Scalar>& B_avg,
+                                             DeferredLogger& deferred_logger) const;
 
         void detectOscillations(const std::vector<double>& measure_history,
                                 const int it, bool& oscillate, bool& stagnate) const;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2720,7 +2720,7 @@ namespace Opm
 
         const int max_iter_number = param_.max_inner_iter_ms_wells_;
         const WellState well_state0 = well_state;
-        const std::vector<Scalar> residuals0 = getWellResiduals(B_avg);
+        const std::vector<Scalar> residuals0 = getWellResiduals(B_avg, deferred_logger);
         std::vector<std::vector<Scalar> > residual_history;
         std::vector<double> measure_history;
         int it = 0;
@@ -2745,7 +2745,7 @@ namespace Opm
                 break;
             }
 
-            residual_history.push_back(getWellResiduals(B_avg));
+            residual_history.push_back(getWellResiduals(B_avg, deferred_logger));
             measure_history.push_back(getResidualMeasureValue(well_state, residual_history[it], deferred_logger) );
 
             bool is_oscillate = false;
@@ -3222,7 +3222,8 @@ namespace Opm
     template<typename TypeTag>
     std::vector<typename MultisegmentWell<TypeTag>::Scalar>
     MultisegmentWell<TypeTag>::
-    getWellResiduals(const std::vector<Scalar>& B_avg) const
+    getWellResiduals(const std::vector<Scalar>& B_avg,
+                     DeferredLogger& deferred_logger) const
     {
         assert(int(B_avg.size() ) == num_components_);
         std::vector<Scalar> residuals(numWellEq + 1, 0.0);
@@ -3238,8 +3239,8 @@ namespace Opm
                     }
                 }
                 if (std::isnan(residual) || std::isinf(residual)) {
-                    OPM_THROW(Opm::NumericalIssue, "nan or inf value for residal get for well " << name()
-                                                    << " segment " << seg << " eq_idx " << eq_idx);
+                    OPM_DEFLOG_THROW(Opm::NumericalIssue, "nan or inf value for residal get for well " << name()
+                                                    << " segment " << seg << " eq_idx " << eq_idx, deferred_logger);
                 }
 
                 if (residual > residuals[eq_idx]) {
@@ -3252,7 +3253,7 @@ namespace Opm
         {
             const double control_residual = std::abs(resWell_[0][numWellEq - 1]);
             if (std::isnan(control_residual) || std::isinf(control_residual)) {
-               OPM_THROW(Opm::NumericalIssue, "nan or inf value for control residal get for well " << name());
+               OPM_DEFLOG_THROW(Opm::NumericalIssue, "nan or inf value for control residal get for well " << name(), deferred_logger);
             }
             residuals[numWellEq] = control_residual;
         }


### PR DESCRIPTION
The first commit makes some throws in `getWellResiduals` thread safe. 
The second make sure that the group related quantities are communicated before the wellTest