### PR TITLE
Revert "Use fmt::format() for two messages"

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1376,7 +1376,7 @@ public:
                         wells_string += matching_wells[iw] + ", ";
                     wells_string += matching_wells.back();
                 }
-                std::string msg = fmt::format("The action: {} evaluated to true at {} wells: {}", action->name(), ts, wells_string);
+                std::string msg = "The action: " + action->name() + " evaluated to true at " + ts + " wells: " + wells_string;
                 Opm::OpmLog::info(msg);
 
                 const auto& wellpi = this->fetchWellPI(reportStep, *action, schedule, matching_wells);
@@ -1390,7 +1390,7 @@ public:
                         this->wellModel_.updateEclWell(reportStep, wname);
                 }
             } else {
-                std::string msg = fmt::format("The action: {} evaluated to false at {}", action->name(), ts);
+                std::string msg = "The action: " + action->name() + " evaluated to false at " + ts;
                 Opm::OpmLog::info(msg);
             }
         }


### PR DESCRIPTION
Reverts OPM/opm-simulators#3085

As [pointed out](https://github.com/OPM/opm-simulators/pull/3085#issuecomment-787941326) this introduces `fmtlib`usage in a header. Sorry. Reverting