### PR TITLE
Apply gefac also on topmost VREP controlled group

### DIFF
--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -194,8 +194,7 @@ namespace WellGroupHelpers
         double rate = 0.0;
         for (const std::string& groupName : group.groups()) {
             const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            rate += groupTmp.getGroupEfficiencyFactor()
-                * sumSolventRates(groupTmp, schedule, wellState, reportStepIdx, injector);
+            rate += sumSolventRates(groupTmp, schedule, wellState, reportStepIdx, injector);
         }
         const auto& end = wellState.wellMap().end();
         for (const std::string& wellName : group.wells()) {
@@ -224,7 +223,8 @@ namespace WellGroupHelpers
             else
                 rate -= factor * wellState.solventWellRate(well_index);
         }
-        return rate;
+        const auto& gefac = group.getGroupEfficiencyFactor();
+        return gefac * rate;
     }
 
     void updateGroupTargetReduction(const Group& group,

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -1017,6 +1017,9 @@ namespace WellGroupHelpers
         // will be the name of 'group'. But if we recurse, 'name' and
         // 'parent' will stay fixed while 'group' will be higher up
         // in the group tree.
+        // efficiency factor is the well efficiency factor for the first group the well is
+        // part of. Later it is the accumulated factor including the group efficiency factor
+        // of the child of group.
 
         const Group::InjectionCMode& currentGroupControl
             = wellState.currentInjectionGroupControl(injectionPhase, group.name());
@@ -1237,6 +1240,9 @@ namespace WellGroupHelpers
         // will be the name of 'group'. But if we recurse, 'name' and
         // 'parent' will stay fixed while 'group' will be higher up
         // in the group tree.
+        // efficiencyfactor is the well efficiency factor for the first group the well is
+        // part of. Later it is the accumulated factor including the group efficiency factor
+        // of the child of group.
 
         const Group::ProductionCMode& currentGroupControl = wellState.currentProductionGroupControl(group.name());
 

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -128,10 +128,10 @@ namespace WellGroupHelpers
         double rate = 0.0;
         for (const std::string& groupName : group.groups()) {
             const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            rate += groupTmp.getGroupEfficiencyFactor()
-                * sumWellPhaseRates(rates, groupTmp, schedule, wellState, reportStepIdx, phasePos, injector);
+            rate += sumWellPhaseRates(rates, groupTmp, schedule, wellState, reportStepIdx, phasePos, injector);
         }
         const auto& end = wellState.wellMap().end();
+
         for (const std::string& wellName : group.wells()) {
             const auto& it = wellState.wellMap().find(wellName);
             if (it == end) // the well is not found
@@ -159,7 +159,8 @@ namespace WellGroupHelpers
             else
                 rate -= factor * rates[wellrate_index + phasePos];
         }
-        return rate;
+        const auto& gefac = group.getGroupEfficiencyFactor();
+        return gefac * rate;
     }
 
     double sumWellRates(const Group& group,

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -110,10 +110,10 @@ namespace WellGroupHelpers
         for (const std::string& groupName : group.groups()) {
             std::vector<double> thisPot(np, 0.0);
             const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+
+            // Note that group effiency factors for groupTmp are applied in updateGuideRateForGroups
             updateGuideRateForGroups(
                 groupTmp, schedule, pu, reportStepIdx, simTime, isInjector, wellState, comm, guideRate, thisPot);
-
-            const auto gefac = groupTmp.getGroupEfficiencyFactor();
 
             // accumulate group contribution from sub group unconditionally
             if (isInjector) {
@@ -129,7 +129,7 @@ namespace WellGroupHelpers
                     else
                         continue;
 
-                    pot[phasePos] += gefac * thisPot[phasePos];
+                    pot[phasePos] += thisPot[phasePos];
                 }
             } else {
                 const Group::ProductionCMode& currentGroupControl = wellState.currentProductionGroupControl(groupName);
@@ -138,7 +138,7 @@ namespace WellGroupHelpers
                     continue;
                 }
                 for (int phase = 0; phase < np; phase++) {
-                    pot[phase] += gefac * thisPot[phase];
+                    pot[phase] += thisPot[phase];
                 }
             }
         }
@@ -171,6 +171,13 @@ namespace WellGroupHelpers
             for (int phase = 0; phase < np; phase++) {
                 pot[phase] += wefac * wellState.wellPotentials()[wellrate_index + phase];
             }
+        }
+
+        // Apply group efficiency factor for this goup
+        auto gefac = group.getGroupEfficiencyFactor();
+
+        for (int phase = 0; phase < np; phase++) {
+            pot[phase] *= gefac;
         }
 
         double oilPot = 0.0;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -2220,6 +2220,7 @@ namespace Opm
             }
         }
 
+        efficiencyFactor *= group.getGroupEfficiencyFactor();
         assert(group.hasInjectionControl(injectionPhase));
         const auto& groupcontrols = group.injectionControls(injectionPhase, summaryState);
 
@@ -2353,6 +2354,7 @@ namespace Opm
             }
         }
 
+        efficiencyFactor *= group.getGroupEfficiencyFactor();
         const auto& well = well_ecl_;
         const auto pu = phaseUsage();
 


### PR DESCRIPTION
We have a model that has a tree of groups (three levels of groups below the topmost group F(topmost)->G1->G2->G3, wells only below G3). When we have a VREP constraint target on G1 and a group efficiency factor g1<1 results are wrong (We actually sometimes inject more than we should and there is a lot of switching in the group control modes). If on the other hand g1 is applied to G2 and G1 has group efficiency factor 1, the results are (nearly) correct.

~This is my rather naive attempt to always apply g1 to the topmost group G1. It does not really work and even worse injection drops to zero at some stage and has problems coming up again.~

~1ce5c598 is how I understood @atgeirr's private comment. (I also tested it standalone and it lead to injection dropping way below production and even production becoming 0 at some time).~

~I need to go back to my desk and rethink what might be happening here (maybe at some occasions applying the group efficiency factor of the VREP controlled group is actually wrong). But if anybody has some hints then they are highly welcome.~

I missed on spot. Fixed in d1f6545 and now reproducing results.