### PR TITLE
add support for POTN in WECON

### DIFF
--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -453,7 +453,7 @@ namespace Opm
         double wsalt() const;
 
         bool checkRateEconLimits(const WellEconProductionLimits& econ_production_limits,
-                                 const WellState& well_state,
+                                 const std::vector<double>& well_rates,
                                  Opm::DeferredLogger& deferred_logger) const;
 
         double getTHPConstraint(const SummaryState& summaryState) const;


### PR DESCRIPTION
This adds support for POTN (default is RATE) in WECON. 

