### PR TITLE
Wtest control

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -776,8 +776,7 @@ namespace Opm {
                 // TODO: should we do this for all kinds of closing reasons?
                 // something like wellTestState_.hasWell(well_name)?
                 bool wellIsStopped = false;
-                if ( wellTestState_.hasWellClosed(well_name, WellTestConfig::Reason::ECONOMIC) ||
-                    wellTestState_.hasWellClosed(well_name, WellTestConfig::Reason::PHYSICAL) ) {
+                if ( wellTestState_.hasWellClosed(well_name)) {
                     if( well_ecl.getAutomaticShutIn() ) {
                         // shut wells are not added to the well container
                         well_state_.shutWell(w);

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -279,16 +279,16 @@ namespace Opm {
                                                  + ScheduleEvents::INJECTION_UPDATE
                                                  + ScheduleEvents::NEW_WELL;
 
-            if(!schedule()[timeStepIdx].wellgroup_events().hasEvent(well.name(), effective_events_mask))
-                continue;
-
-            if (well.isProducer()) {
-                const auto controls = well.productionControls(summaryState);
-                well_state_.currentProductionControls()[w] = controls.cmode;
-            }
-            else {
-                const auto controls = well.injectionControls(summaryState);
-                well_state_.currentInjectionControls()[w] = controls.cmode;
+            const auto& events = schedule()[timeStepIdx].wellgroup_events();
+            if(events.hasEvent(well.name(), effective_events_mask) || this->wellTestState_.hasWellClosed(well.name())) {
+                if (well.isProducer()) {
+                    const auto controls = well.productionControls(summaryState);
+                    well_state_.currentProductionControls()[w] = controls.cmode;
+                }
+                else {
+                    const auto controls = well.injectionControls(summaryState);
+                    well_state_.currentInjectionControls()[w] = controls.cmode;
+                }
             }
         }
         const Group& fieldGroup = schedule().getGroup("FIELD", timeStepIdx);

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -944,8 +944,7 @@ namespace Opm
                                 Opm::DeferredLogger& deferred_logger) const
     {
         if (!isOperable()) {
-            if (well_test_state.hasWellClosed(name(), WellTestConfig::Reason::ECONOMIC) ||
-                well_test_state.hasWellClosed(name(), WellTestConfig::Reason::PHYSICAL) ) {
+            if (well_test_state.hasWellClosed(name())) {
                 // Already closed, do nothing.
             } else {
                 well_test_state.closeWell(name(), WellTestConfig::Reason::PHYSICAL, simulation_time);


### PR DESCRIPTION
Ensure that controls are set for wells before WTEST reopen attempt 

This is an alternative to: #3082 

On my machine it will get past a crash this way - but later convergence is abmyssal.