### PR TITLE
make sure wells has valid controls

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -271,26 +271,6 @@ namespace Opm {
             well_state_.initWellStateMSWell(wells_ecl_, phase_usage_, &previous_well_state_);
         }
 
-        const int nw = wells_ecl_.size();
-        for (int w = 0; w <nw; ++w) {
-            const auto& well = wells_ecl_[w];
-            const uint64_t effective_events_mask = ScheduleEvents::WELL_STATUS_CHANGE
-                                                 + ScheduleEvents::PRODUCTION_UPDATE
-                                                 + ScheduleEvents::INJECTION_UPDATE
-                                                 + ScheduleEvents::NEW_WELL;
-
-            if(!schedule()[timeStepIdx].wellgroup_events().hasEvent(well.name(), effective_events_mask))
-                continue;
-
-            if (well.isProducer()) {
-                const auto controls = well.productionControls(summaryState);
-                well_state_.currentProductionControls()[w] = controls.cmode;
-            }
-            else {
-                const auto controls = well.injectionControls(summaryState);
-                well_state_.currentInjectionControls()[w] = controls.cmode;
-            }
-        }
         const Group& fieldGroup = schedule().getGroup("FIELD", timeStepIdx);
         WellGroupHelpers::setCmodeGroup(fieldGroup, schedule(), summaryState, timeStepIdx, well_state_);
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -383,10 +383,11 @@ namespace Opm {
         const auto& comm = ebosSimulator_.vanguard().grid().comm();
         WellGroupHelpers::updateGuideRatesForWells(schedule(), phase_usage_, reportStepIdx, simulationTime, well_state_, comm, guideRate_.get());
         try {
-            // Compute initial well solution for new wells
+            // Compute initial well solution for new wells and injectors that change injection type i.e. WAG.
             for (auto& well : well_container_) {
                 const uint64_t effective_events_mask = ScheduleEvents::WELL_STATUS_CHANGE
-                                                    + ScheduleEvents::NEW_WELL;
+                        + ScheduleEvents::INJECTION_TYPE_CHANGED
+                        + ScheduleEvents::NEW_WELL;
 
                 const auto& events = schedule()[reportStepIdx].wellgroup_events();
                 const bool event = report_step_starts_ && events.hasEvent(well->name(), effective_events_mask);

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -167,6 +167,16 @@ namespace Opm
 
             current_injection_controls_.resize(nw);
             current_production_controls_.resize(nw);
+            for (int w = 0; w < nw; ++w) {
+                if (wells_ecl[w].isProducer()) {
+                    const auto controls = wells_ecl[w].productionControls(summary_state);
+                    currentProductionControls()[w] = controls.cmode;
+                }
+                else {
+                    const auto controls = wells_ecl[w].injectionControls(summary_state);
+                    currentInjectionControls()[w] = controls.cmode;
+                }
+            }
 
             perfRateSolvent_.clear();
             perfRateSolvent_.resize(nperf, 0.0);
@@ -207,12 +217,8 @@ namespace Opm
                          //   continue;
                          //}
 
-                        // if there is no effective control event happens to the well, we use the current_injection/production_controls_ from prevState
-                        // otherwise, we use the control specified in the deck
-                        if (!effective_events_occurred_[w]) {
-                            current_injection_controls_[ newIndex ] = prevState->currentInjectionControls()[ oldIndex ];
-                            current_production_controls_[ newIndex ] = prevState->currentProductionControls()[ oldIndex ];
-                        }
+                        current_injection_controls_[ newIndex ] = prevState->currentInjectionControls()[ oldIndex ];
+                        current_production_controls_[ newIndex ] = prevState->currentProductionControls()[ oldIndex ];
 
                         // wellrates
                         for( int i=0, idx=newIndex*np, oldidx=oldIndex*np; i<np; ++i, ++idx, ++oldidx )

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -207,7 +207,7 @@ namespace Opm
                         }
 
                         if (is_producer_[newIndex] != prevState->is_producer_[oldIndex]) {
-                            // Well changed from injector from/to producer, do not use its privious values.
+                            // Well changed to/from injector from/to producer, do not use its privious values.
                             continue;
                         }
 

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -206,6 +206,11 @@ namespace Opm
                             continue;
                         }
 
+                        if (is_producer_[newIndex] != prevState->is_producer_[oldIndex]) {
+                            // Well changed from injector from/to producer, do not use its privious values.
+                            continue;
+                        }
+
                         // bhp
                         bhp()[ newIndex ] = prevState->bhp()[ oldIndex ];
 


### PR DESCRIPTION
This change the logic of the well control copying between episodes

The new logic 
1) Always initialize with valid control from eclipeState
2) Copy control from the last time step for existing wells. 

Note that the new logic is consistent with the rest of the initialization of the well state. 