### PR TITLE
Remove superfluos function call

### DIFF
--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -264,9 +264,6 @@ public:
                 // not being able to create such cell-based result vectors.
                 should_write = 0;
             }
-            else {
-                should_write = schedule.rst_keyword(reportStepNum, keyword);
-            }
         }
 
         outputFipRestart_ = false;


### PR DESCRIPTION
When this is merged we can also remove a function from the `RestartConfig`class - simplifying that API will simplify the last pieces of the Schedule refactoring ....  