### PR TITLE
Enable usage of fmtlib on the system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,8 +161,10 @@ macro (config_hook)
   endif()
   opm_need_version_of ("opm-models")
 
-  add_definitions(-DFMT_HEADER_ONLY)
-  list(APPEND EXTRA_INCLUDES SYSTEM ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
+  if(NOT fmt_FOUND)
+    add_definitions(-DFMT_HEADER_ONLY)
+    list(APPEND EXTRA_INCLUDES SYSTEM ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
+  endif()
   include_directories(${EXTRA_INCLUDES})
 endmacro (config_hook)
 


### PR DESCRIPTION
If fmtlib is present on the system we used that one in the normal mode (not header only). Otherwise we fallback to the embedded one header only. Searching for the library is done on opm-common.

Replacement of #3058. Needs OPM/opm-common#2348