### PR TITLE
Add support for explicit guiderate for injection groups

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -501,6 +501,7 @@ namespace Opm {
             void assignGroupControl(const Group& group, data::GroupData& gdata) const;
             data::GuideRateValue getGuideRateValues(const Well& well) const;
             data::GuideRateValue getGuideRateValues(const Group& group) const;
+            data::GuideRateValue getGuideRateInjectionGroupValues(const Group& group) const;
             void getGuideRateValues(const GuideRate::RateVector& qs,
                                     const bool                   is_inj,
                                     const std::string&           wgname,

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -390,7 +390,7 @@ namespace Opm {
 
             void updateWellControls(Opm::DeferredLogger& deferred_logger, const bool checkGroupControls);
 
-            void updateAndCommunicateGroupData();
+            void updateAndCommunicateGroupData(Opm::DeferredLogger& deferred_logger);
             void updateNetworkPressures();
 
             // setting the well_solutions_ based on well_state.

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2972,12 +2972,10 @@ namespace Opm {
 
         const auto& gname = group.name();
         if (this->guideRate_->has(gname, Opm::Phase::GAS)) {
-            // No guiderates exist for 'gname'.
             grval.set(data::GuideRateValue::Item::Gas,
                       this->guideRate_->get(gname, Opm::Phase::GAS));
         }
         if (this->guideRate_->has(gname, Opm::Phase::WATER)) {
-            // No guiderates exist for 'gname'.
             grval.set(data::GuideRateValue::Item::Water,
                       this->guideRate_->get(gname, Opm::Phase::WATER));
         }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2831,7 +2831,7 @@ namespace Opm {
 
         for (const auto& wname : sched.wellNames(reportStepIdx)) {
             if (! (this->well_state_.hasWellRates(wname) &&
-                   this->guideRate_->hasProductionGroupOrWell(wname)))
+                   this->guideRate_->has(wname)))
             {
                 continue;
             }
@@ -2868,12 +2868,12 @@ namespace Opm {
                 const auto& gname = up[start + gi];
                 const auto& group = sched.getGroup(gname, reportStepIdx);
 
-                if (this->guideRate_->hasProductionGroupOrWell(gname)) {
+                if (this->guideRate_->has(gname)) {
                     gr[gname].production = this->getGuideRateValues(group);
                 }
 
-                if (this->guideRate_->hasInjectionGroup(::Opm::Phase::WATER, gname)
-                        || this->guideRate_->hasInjectionGroup(::Opm::Phase::GAS, gname)) {
+                if (this->guideRate_->has(gname, Opm::Phase::WATER)
+                        || this->guideRate_->has(gname, Opm::Phase::GAS)) {
                     gr[gname].injection = this->getGuideRateInjectionGroupValues(group);
                 }
 
@@ -2949,7 +2949,7 @@ namespace Opm {
             return grval;
         }
 
-        if (! this->guideRate_->hasProductionGroupOrWell(wname)) {
+        if (! this->guideRate_->has(wname)) {
             // No guiderates exist for 'wname'.
             return grval;
         }
@@ -2971,15 +2971,15 @@ namespace Opm {
         assert (this->guideRate_ != nullptr);
 
         const auto& gname = group.name();
-        if (this->guideRate_->hasInjectionGroup(Opm::Phase::GAS, gname)) {
+        if (this->guideRate_->has(gname, Opm::Phase::GAS)) {
             // No guiderates exist for 'gname'.
             grval.set(data::GuideRateValue::Item::Gas,
-                      this->guideRate_->getInjectionGroup(Opm::Phase::GAS, gname));
+                      this->guideRate_->get(gname, Opm::Phase::GAS));
         }
-        if (this->guideRate_->hasInjectionGroup(Opm::Phase::WATER, gname)) {
+        if (this->guideRate_->has(gname, Opm::Phase::WATER)) {
             // No guiderates exist for 'gname'.
             grval.set(data::GuideRateValue::Item::Water,
-                      this->guideRate_->getInjectionGroup(Opm::Phase::WATER, gname));
+                      this->guideRate_->get(gname, Opm::Phase::WATER));
         }
         return grval;
     }
@@ -3002,7 +3002,7 @@ namespace Opm {
             return grval;
         }
 
-        if (! this->guideRate_->hasProductionGroupOrWell(gname)) {
+        if (! this->guideRate_->has(gname)) {
             // No guiderates exist for 'gname'.
             return grval;
         }
@@ -3026,7 +3026,7 @@ namespace Opm {
     {
         auto getGR = [this, &wgname, &qs](const GuideRateModel::Target t)
         {
-            return this->guideRate_->getProductionGroupOrWell(wgname, t, qs);
+            return this->guideRate_->get(wgname, t, qs);
         };
 
         // Note: GuideRate does currently (2020-07-20) not support Target::RES.
@@ -3055,7 +3055,7 @@ namespace Opm {
 
         auto xgrPos = groupGuideRates.find(group.name());
         if ((xgrPos == groupGuideRates.end()) ||
-            !this->guideRate_->hasProductionGroupOrWell(group.name()))
+            !this->guideRate_->has(group.name()))
         {
             // No guiderates defined for this group.
             return;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -306,7 +306,7 @@ namespace Opm {
 
         well_state_ = previous_well_state_;
         well_state_.disableGliftOptimization();
-        updateAndCommunicateGroupData();
+        updateAndCommunicateGroupData(local_deferredLogger);
         const int reportStepIdx = ebosSimulator_.episodeIndex();
         const double simulationTime = ebosSimulator_.time();
         int exception_thrown = 0;
@@ -1225,7 +1225,7 @@ namespace Opm {
         // For no well active globally we simply return.
         if( !wellsActive() ) return ;
 
-        updateAndCommunicateGroupData();
+        updateAndCommunicateGroupData(deferred_logger);
 
         updateNetworkPressures();
 
@@ -1239,7 +1239,7 @@ namespace Opm {
             // Check group's constraints from higher levels.
             updateGroupHigherControls(deferred_logger, switched_groups);
 
-            updateAndCommunicateGroupData();
+            updateAndCommunicateGroupData(deferred_logger);
 
             // Check wells' group constraints and communicate.
             for (const auto& well : well_container_) {
@@ -1249,7 +1249,7 @@ namespace Opm {
                     switched_wells.insert(well->name());
                 }
             }
-            updateAndCommunicateGroupData();
+            updateAndCommunicateGroupData(deferred_logger);
         }
 
         // Check individual well constraints and communicate.
@@ -1260,7 +1260,7 @@ namespace Opm {
             const auto mode = WellInterface<TypeTag>::IndividualOrGroup::Individual;
             well->updateWellControl(ebosSimulator_, mode, well_state_, deferred_logger);
         }
-        updateAndCommunicateGroupData();
+        updateAndCommunicateGroupData(deferred_logger);
 
     }
 
@@ -1303,7 +1303,7 @@ namespace Opm {
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::
-    updateAndCommunicateGroupData()
+    updateAndCommunicateGroupData(Opm::DeferredLogger& deferred_logger)
     {
         const int reportStepIdx = ebosSimulator_.episodeIndex();
         const Group& fieldGroup = schedule().getGroup("FIELD", reportStepIdx);
@@ -1332,7 +1332,7 @@ namespace Opm {
         const double simulationTime = ebosSimulator_.time();
         std::vector<double> pot(numPhases(), 0.0);
         WellGroupHelpers::updateGuideRateForProductionGroups(fieldGroup, schedule(), phase_usage_, reportStepIdx, simulationTime, well_state_, comm, guideRate_.get(), pot);
-        WellGroupHelpers::updateGuideRatesForInjectionGroups(fieldGroup, schedule(), summaryState, phase_usage_, reportStepIdx, well_state_, guideRate_.get());
+        WellGroupHelpers::updateGuideRatesForInjectionGroups(fieldGroup, schedule(), summaryState, phase_usage_, reportStepIdx, well_state_, guideRate_.get(), deferred_logger);
 
         WellGroupHelpers::updateREINForGroups(fieldGroup, schedule(), reportStepIdx, phase_usage_, summaryState, well_state_nupcol_, well_state_);
         WellGroupHelpers::updateVREPForGroups(fieldGroup, schedule(), reportStepIdx, well_state_nupcol_, well_state_);

--- a/opm/simulators/wells/TargetCalculator.hpp
+++ b/opm/simulators/wells/TargetCalculator.hpp
@@ -169,13 +169,14 @@ namespace WellGroupHelpers
     class InjectionTargetCalculator
     {
     public:
-        InjectionTargetCalculator(const Group::InjectionCMode cmode,
+        InjectionTargetCalculator(const Group::InjectionCMode& cmode,
                                   const PhaseUsage& pu,
                                   const std::vector<double>& resv_coeff,
                                   const std::string& group_name,
                                   const double sales_target,
                                   const WellStateFullyImplicitBlackoil& well_state,
-                                  const Phase& injection_phase)
+                                  const Phase& injection_phase,
+                                  DeferredLogger& deferred_logger)
             : cmode_(cmode)
             , pu_(pu)
             , resv_coeff_(resv_coeff)
@@ -204,7 +205,9 @@ namespace WellGroupHelpers
                 break;
             }
             default:
-                assert(false);
+                OPM_DEFLOG_THROW(std::logic_error,
+                                 "Invalid injection phase in InjectionTargetCalculator",
+                                 deferred_logger);
             }
         }
 
@@ -215,7 +218,7 @@ namespace WellGroupHelpers
             return rates[pos_];
         }
 
-        double groupTarget(const Group::InjectionControls ctrl) const
+        double groupTarget(const Group::InjectionControls& ctrl, Opm::DeferredLogger& deferred_logger) const
         {
             switch (cmode_) {
             case Group::InjectionCMode::RATE:
@@ -253,8 +256,9 @@ namespace WellGroupHelpers
                 return inj_rate;
             }
             default:
-                // Should never be here.
-                assert(false);
+                OPM_DEFLOG_THROW(std::logic_error,
+                                 "Invalid Group::InjectionCMode in InjectionTargetCalculator",
+                                 deferred_logger);
                 return 0.0;
             }
         }

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -338,7 +338,7 @@ namespace WellGroupHelpers
                 const bool individual_control = (currentGroupControl != Group::ProductionCMode::FLD
                                                  && currentGroupControl != Group::ProductionCMode::NONE);
                 const int num_group_controlled_wells
-                    = groupControlledWells(schedule, wellStateNupcol, reportStepIdx, subGroupName, "", !isInjector, Phase::OIL);
+                    = groupControlledWells(schedule, wellStateNupcol, reportStepIdx, subGroupName, "", !isInjector, /*injectionPhaseNotUsed*/Phase::OIL);
                 if (individual_control || num_group_controlled_wells == 0) {
                     for (int phase = 0; phase < np; phase++) {
                         groupTargetReduction[phase]
@@ -1063,7 +1063,7 @@ namespace WellGroupHelpers
                 // the current well to be always included, because we
                 // want to know the situation that applied to the
                 // calculation of reductions.
-                const int num_gr_ctrl = groupControlledWells(schedule, wellState, reportStepIdx, chain[ii + 1], "", true, Phase::OIL);
+                const int num_gr_ctrl = groupControlledWells(schedule, wellState, reportStepIdx, chain[ii + 1], "", /*is_producer*/true, /*injectionPhaseNotUsed*/Phase::OIL);
                 if (num_gr_ctrl == 0) {
                     if (guideRate->has(chain[ii + 1])) {
                         target += localReduction(chain[ii + 1]);
@@ -1186,7 +1186,7 @@ namespace WellGroupHelpers
                 // the current well to be always included, because we
                 // want to know the situation that applied to the
                 // calculation of reductions.
-                const int num_gr_ctrl = groupControlledWells(schedule, wellState, reportStepIdx, chain[ii + 1], "", false, injectionPhase);
+                const int num_gr_ctrl = groupControlledWells(schedule, wellState, reportStepIdx, chain[ii + 1], "", /*is_producer*/false, injectionPhase);
                 if (num_gr_ctrl == 0) {
                     if (guideRate->has(chain[ii + 1], injectionPhase)) {
                         target += localReduction(chain[ii + 1]);

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -175,7 +175,7 @@ namespace WellGroupHelpers
         oilPot = comm.sum(oilPot);
         gasPot = comm.sum(gasPot);
         waterPot = comm.sum(waterPot);
-        guideRate->productionGroupCompute(group.name(), reportStepIdx, simTime, oilPot, gasPot, waterPot);
+        guideRate->compute(group.name(), reportStepIdx, simTime, oilPot, gasPot, waterPot);
     }
 
     template <class Comm>
@@ -213,7 +213,7 @@ namespace WellGroupHelpers
             oilpot = comm.sum(oilpot);
             gaspot = comm.sum(gaspot);
             waterpot = comm.sum(waterpot);
-            guideRate->wellCompute(well.name(), reportStepIdx, simTime, oilpot, gaspot, waterpot);
+            guideRate->compute(well.name(), reportStepIdx, simTime, oilpot, gaspot, waterpot);
         }
     }
 

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -223,7 +223,8 @@ namespace WellGroupHelpers
                                             const Opm::PhaseUsage& pu,
                                             const int reportStepIdx,
                                             const WellStateFullyImplicitBlackoil& wellState,
-                                            GuideRate* guideRate);
+                                            GuideRate* guideRate,
+                                            Opm::DeferredLogger& deferred_logger);
 
     void updateVREPForGroups(const Group& group,
                              const Schedule& schedule,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -597,7 +597,8 @@ namespace Opm
                                       const EvalWell& bhp,
                                       const EvalWell& injection_rate,
                                       EvalWell& control_eq,
-                                      double efficiencyFactor);
+                                      double efficiencyFactor,
+                                      Opm::DeferredLogger& deferred_logger);
 
         template <class EvalWell>
         void getGroupProductionControl(const Group& group,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -2244,7 +2244,7 @@ namespace Opm
         const size_t num_ancestors = chain.size() - 1;
         double target = orig_target;
         for (size_t ii = 0; ii < num_ancestors; ++ii) {
-            if ((ii == 0) || guide_rate_->hasInjectionGroup(injectionPhase, chain[ii])) {
+            if ((ii == 0) || guide_rate_->has(chain[ii], injectionPhase)) {
                 // Apply local reductions only at the control level
                 // (top) and for levels where we have a specified
                 // group guide rate.
@@ -2338,7 +2338,7 @@ namespace Opm
         const size_t num_ancestors = chain.size() - 1;
         double target = orig_target;
         for (size_t ii = 0; ii < num_ancestors; ++ii) {
-            if ((ii == 0) || guide_rate_->hasProductionGroupOrWell(chain[ii])) {
+            if ((ii == 0) || guide_rate_->has(chain[ii])) {
                 // Apply local reductions only at the control level
                 // (top) and for levels where we have a specified
                 // group guide rate.

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -2142,47 +2142,35 @@ namespace Opm
 
 
 
-
     template <typename TypeTag>
     template <class EvalWell>
     void
     WellInterface<TypeTag>::getGroupInjectionControl(const Group& group,
-                                                     const WellState& well_state,
-                                                     const Opm::Schedule& schedule,
-                                                     const SummaryState& summaryState,
-                                                     const InjectorType& injectorType,
-                                                     const EvalWell& bhp,
-                                                     const EvalWell& injection_rate,
-                                                     EvalWell& control_eq,
-                                                     double efficiencyFactor)
+                                                      const WellState& well_state,
+                                                      const Opm::Schedule& schedule,
+                                                      const SummaryState& summaryState,
+                                                      const InjectorType& injectorType,
+                                                      const EvalWell& bhp,
+                                                      const EvalWell& injection_rate,
+                                                      EvalWell& control_eq,
+                                                      double efficiencyFactor)
     {
-        const auto& well = well_ecl_;
-        const auto pu = phaseUsage();
-
         // Setting some defaults to silence warnings below.
         // Will be overwritten in the switch statement.
-        int phasePos = -1;
-        Well::GuideRateTarget wellTarget = Well::GuideRateTarget::UNDEFINED;
         Phase injectionPhase = Phase::WATER;
         switch (injectorType) {
         case InjectorType::WATER:
         {
-            phasePos = pu.phase_pos[BlackoilPhases::Aqua];
-            wellTarget = Well::GuideRateTarget::WAT;
             injectionPhase = Phase::WATER;
             break;
         }
         case InjectorType::OIL:
         {
-            phasePos = pu.phase_pos[BlackoilPhases::Liquid];
-            wellTarget = Well::GuideRateTarget::OIL;
             injectionPhase = Phase::OIL;
             break;
         }
         case InjectorType::GAS:
         {
-            phasePos = pu.phase_pos[BlackoilPhases::Vapour];
-            wellTarget = Well::GuideRateTarget::GAS;
             injectionPhase = Phase::GAS;
             break;
         }
@@ -2192,7 +2180,6 @@ namespace Opm
         }
 
         const Group::InjectionCMode& currentGroupControl = well_state.currentInjectionGroupControl(injectionPhase, group.name());
-
         if (currentGroupControl == Group::InjectionCMode::FLD ||
             currentGroupControl == Group::InjectionCMode::NONE) {
             if (!group.injectionGroupControlAvailable(injectionPhase)) {
@@ -2217,100 +2204,59 @@ namespace Opm
         }
 
         efficiencyFactor *= group.getGroupEfficiencyFactor();
-        assert(group.hasInjectionControl(injectionPhase));
-        const auto& groupcontrols = group.injectionControls(injectionPhase, summaryState);
+        const auto& well = well_ecl_;
+        const auto pu = phaseUsage();
 
-        const std::vector<double>& groupInjectionReductions = well_state.currentInjectionGroupReductionRates(group.name());
-        double groupTargetReduction = groupInjectionReductions[phasePos];
-        double fraction = WellGroupHelpers::fractionFromInjectionPotentials(well.name(),
-                                                                            group.name(),
-                                                                            schedule,
-                                                                            well_state,
-                                                                            current_step_,
-                                                                            guide_rate_,
-                                                                            GuideRateModel::convert_target(wellTarget),
-                                                                            pu,
-                                                                            injectionPhase,
-                                                                            false);
-        switch (currentGroupControl) {
-        case Group::InjectionCMode::NONE:
-        {
-            // The NONE case is handled earlier
-            assert(false);
-            break;
+        if (!group.isInjectionGroup()) {
+            // use bhp as control eq and let the updateControl code find a valid control
+            const auto& controls = well.injectionControls(summaryState);
+            control_eq = bhp - controls.bhp_limit;
+            return;
         }
-        case Group::InjectionCMode::RATE:
-        {
-            double target = std::max(0.0, (groupcontrols.surface_max_rate - groupTargetReduction)) / efficiencyFactor;
-            control_eq = injection_rate - fraction * target;
-            break;
-        }
-        case Group::InjectionCMode::RESV:
-        {
-            std::vector<double> convert_coeff(number_of_phases_, 1.0);
-            rateConverter_.calcCoeff(/*fipreg*/ 0, pvtRegionIdx_, convert_coeff);
-            double coeff = convert_coeff[phasePos];
-            double target = std::max(0.0, (groupcontrols.resv_max_rate/coeff - groupTargetReduction)) / efficiencyFactor;
-            control_eq = injection_rate - fraction * target;
-            break;
-        }
-        case Group::InjectionCMode::REIN:
-        {
-            double productionRate = well_state.currentInjectionREINRates(groupcontrols.reinj_group)[phasePos];
-            double target = std::max(0.0, (groupcontrols.target_reinj_fraction*productionRate - groupTargetReduction)) / efficiencyFactor;
-            control_eq = injection_rate - fraction * target;
-            break;
-        }
-        case Group::InjectionCMode::VREP:
-        {
-            std::vector<double> convert_coeff(number_of_phases_, 1.0);
-            rateConverter_.calcCoeff(/*fipreg*/ 0, pvtRegionIdx_, convert_coeff);
-            double coeff = convert_coeff[phasePos];
-            double voidageRate = well_state.currentInjectionVREPRates(groupcontrols.voidage_group)*groupcontrols.target_void_fraction;
 
-            double injReduction = 0.0;
-            std::vector<double> groupInjectionReservoirRates = well_state.currentInjectionGroupReservoirRates(group.name());
-            if (groupcontrols.phase != Phase::WATER)
-                injReduction += groupInjectionReservoirRates[pu.phase_pos[BlackoilPhases::Aqua]];
+        // If we are here, we are at the topmost group to be visited in the recursion.
+        // This is the group containing the control we will check against.
 
-            if (groupcontrols.phase != Phase::OIL)
-                injReduction += groupInjectionReservoirRates[pu.phase_pos[BlackoilPhases::Liquid]];
+        // Make conversion factors for RESV <-> surface rates.
+        std::vector<double> resv_coeff(phaseUsage().num_phases, 1.0);
+        rateConverter_.calcCoeff(0, pvtRegionIdx_, resv_coeff); // FIPNUM region 0 here, should use FIPNUM from WELSPECS.
 
-            if (groupcontrols.phase != Phase::GAS)
-                injReduction += groupInjectionReservoirRates[pu.phase_pos[BlackoilPhases::Vapour]];
-
-            voidageRate -= injReduction;
-
-            double target = std::max(0.0, ( voidageRate/coeff - groupTargetReduction)) / efficiencyFactor;
-            control_eq = injection_rate - fraction * target;
-            break;
-        }
-        case Group::InjectionCMode::FLD:
-        {
-            // The FLD case is handled earlier
-            assert(false);
-            break;
-        }
-        case Group::InjectionCMode::SALE:
-        {
-            // only for gas injectors
-            assert (phasePos == pu.phase_pos[BlackoilPhases::Vapour]);
-
-            // Gas injection rate = Total gas production rate + gas import rate - gas consumption rate - sales rate;
-            // The import and consumption is already included in the REIN rates.
-            double inj_rate = well_state.currentInjectionREINRates(group.name())[phasePos];
+        double sales_target = 0;
+        if (schedule[current_step_].gconsale().has(group.name())) {
             const auto& gconsale = schedule[current_step_].gconsale().get(group.name(), summaryState);
-            inj_rate -= gconsale.sales_target;
+            sales_target = gconsale.sales_target;
+        }
+        WellGroupHelpers::InjectionTargetCalculator tcalc(currentGroupControl, pu, resv_coeff, group.name(), sales_target, well_state, injectionPhase);
+        WellGroupHelpers::FractionCalculator fcalc(schedule, summaryState, well_state, current_step_, guide_rate_, tcalc.guideTargetMode(), pu, false, injectionPhase);
 
-            double target = std::max(0.0, (inj_rate - groupTargetReduction)) / efficiencyFactor;
-            control_eq = injection_rate - fraction * target;
-            break;
+        auto localFraction = [&](const std::string& child) {
+            return fcalc.localFraction(child, "");
+        };
+
+        auto localReduction = [&](const std::string& group_name) {
+            const std::vector<double>& groupTargetReductions = well_state.currentInjectionGroupReductionRates(group_name);
+            return tcalc.calcModeRateFromRates(groupTargetReductions);
+        };
+
+        const double orig_target = tcalc.groupTarget(group.injectionControls(injectionPhase, summaryState));
+        const auto chain = WellGroupHelpers::groupChainTopBot(name(), group.name(), schedule, current_step_);
+        // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
+        const size_t num_ancestors = chain.size() - 1;
+        double target = orig_target;
+        for (size_t ii = 0; ii < num_ancestors; ++ii) {
+            if ((ii == 0) || guide_rate_->hasInjectionGroup(injectionPhase, chain[ii])) {
+                // Apply local reductions only at the control level
+                // (top) and for levels where we have a specified
+                // group guide rate.
+                target -= localReduction(chain[ii]);
+            }
+            target *= localFraction(chain[ii+1]);
         }
-        // default:
-        //     OPM_DEFLOG_THROW(std::runtime_error, "Unvalid group control specified for group "  + well.groupName(), deferred_logger );
-        }
+        // Avoid negative target rates coming from too large local reductions.
+        const double target_rate = std::max(0.0, target / efficiencyFactor);
+        const auto current_rate = injection_rate; // Switch sign since 'rates' are negative for producers.
+        control_eq = current_rate - target_rate;
     }
-
 
 
 
@@ -2375,7 +2321,7 @@ namespace Opm
             gratTargetFromSales = well_state.currentGroupGratTargetFromSales(group.name());
 
         WellGroupHelpers::TargetCalculator tcalc(currentGroupControl, pu, resv_coeff, gratTargetFromSales);
-        WellGroupHelpers::FractionCalculator fcalc(schedule, well_state, current_step_, guide_rate_, tcalc.guideTargetMode(), pu);
+        WellGroupHelpers::FractionCalculator fcalc(schedule, summaryState, well_state, current_step_, guide_rate_, tcalc.guideTargetMode(), pu, true, Phase::OIL);
 
         auto localFraction = [&](const std::string& child) {
             return fcalc.localFraction(child, "");
@@ -2392,7 +2338,7 @@ namespace Opm
         const size_t num_ancestors = chain.size() - 1;
         double target = orig_target;
         for (size_t ii = 0; ii < num_ancestors; ++ii) {
-            if ((ii == 0) || guide_rate_->has(chain[ii])) {
+            if ((ii == 0) || guide_rate_->hasProductionGroupOrWell(chain[ii])) {
                 // Apply local reductions only at the control level
                 // (top) and for levels where we have a specified
                 // group guide rate.

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -449,6 +449,7 @@ namespace Opm
             return this->production_group_rates.find(groupName) != this->production_group_rates.end();
         }
 
+
         void setCurrentProductionGroupReductionRates(const std::string& groupName, const std::vector<double>& target ) {
             production_group_reduction_rates[groupName] = target;
         }


### PR DESCRIPTION
With this commit the guiderate logic used for the production groups is also used for injectors
This allows for setting guiderates explicit at different group levels
Only RATE, NETV and VOID guiderate type is supported.

Needs to be merged together with OPM/opm-common#2355
