### PR TITLE
only compute guiderates at the beginning of a timestep

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -391,7 +391,7 @@ namespace Opm {
 
             void updateWellControls(Opm::DeferredLogger& deferred_logger, const bool checkGroupControls);
 
-            void updateAndCommunicateGroupData(Opm::DeferredLogger& deferred_logger);
+            void updateAndCommunicateGroupData();
             void updateNetworkPressures();
 
             // setting the well_solutions_ based on well_state.


### PR DESCRIPTION
This will need some more testing before it can be considered for merging. 