### PR TITLE
only compute Bavg once pr timestep

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -357,6 +357,8 @@ namespace Opm {
             // used to better efficiency of calcuation
             mutable BVector scaleAddRes_;
 
+            std::vector< Scalar > B_avg_;
+
             const Grid& grid() const
             { return ebosSimulator_.vanguard().grid(); }
 
@@ -409,7 +411,7 @@ namespace Opm {
             void setRepRadiusPerfLength();
 
 
-            void computeAverageFormationFactor(std::vector<Scalar>& B_avg) const;
+            void updateAverageFormationFactor();
 
             // Calculating well potentials for each well
             void computeWellPotentials(std::vector<double>& well_potentials, const int reportStepIdx, Opm::DeferredLogger& deferred_logger);
@@ -438,7 +440,7 @@ namespace Opm {
 
             int reportStepIndex() const;
 
-            void assembleWellEq(const std::vector<Scalar>& B_avg, const double dt, Opm::DeferredLogger& deferred_logger);
+            void assembleWellEq(const double dt, Opm::DeferredLogger& deferred_logger);
 
             // some preparation work, mostly related to group control and RESV,
             // at the beginning of each time step (Not report step)

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -129,7 +129,6 @@ namespace Opm
         }
 
         virtual void assembleWellEq(const Simulator& ebosSimulator,
-                                    const std::vector<Scalar>& B_avg,
                                     const double dt,
                                     WellState& well_state,
                                     Opm::DeferredLogger& deferred_logger) override;
@@ -160,7 +159,6 @@ namespace Opm
 
         /// computing the well potentials for group control
         virtual void computeWellPotentials(const Simulator& ebosSimulator,
-                                           const std::vector<Scalar>& B_avg,
                                            const WellState& well_state,
                                            std::vector<double>& well_potentials,
                                            Opm::DeferredLogger& deferred_logger) override;
@@ -402,19 +400,16 @@ namespace Opm
                          std::vector<EvalWell>& mob) const;
 
         void computeWellRatesAtBhpLimit(const Simulator& ebosSimulator,
-                                        const std::vector<Scalar>& B_avg,
                                         std::vector<double>& well_flux,
                                         Opm::DeferredLogger& deferred_logger) const;
 
         void computeWellRatesWithBhp(const Simulator& ebosSimulator,
-                                     const std::vector<Scalar>& B_avg,
                                      const Scalar bhp,
                                      std::vector<double>& well_flux,
                                      Opm::DeferredLogger& deferred_logger) const;
 
         std::vector<double>
         computeWellPotentialWithTHP(const Simulator& ebos_simulator,
-                                    const std::vector<Scalar>& B_avg,
                                     Opm::DeferredLogger& deferred_logger) const;
 
         void assembleControlEq(const WellState& well_state,
@@ -447,7 +442,6 @@ namespace Opm
         bool accelerationalPressureLossConsidered() const;
 
         virtual bool iterateWellEqWithControl(const Simulator& ebosSimulator,
-                                              const std::vector<Scalar>& B_avg,
                                               const double dt,
                                               const Well::InjectionControls& inj_controls,
                                               const Well::ProductionControls& prod_controls,
@@ -496,12 +490,10 @@ namespace Opm
 
 
         std::optional<double> computeBhpAtThpLimitProd(const Simulator& ebos_simulator,
-                                                       const std::vector<Scalar>& B_avg,
                                                        const SummaryState& summary_state,
                                                        DeferredLogger& deferred_logger) const;
 
         std::optional<double> computeBhpAtThpLimitInj(const Simulator& ebos_simulator,
-                                                      const std::vector<Scalar>& B_avg,
                                                       const SummaryState& summary_state,
                                                       DeferredLogger& deferred_logger) const;
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -176,7 +176,6 @@ namespace Opm
         virtual void initPrimaryVariablesEvaluation() const override;
 
         virtual void assembleWellEq(const Simulator& ebosSimulator,
-                                    const std::vector<Scalar>& B_avg,
                                     const double dt,
                                     WellState& well_state,
                                     Opm::DeferredLogger& deferred_logger) override;
@@ -212,7 +211,6 @@ namespace Opm
 
         /// computing the well potentials for group control
         virtual void computeWellPotentials(const Simulator& ebosSimulator,
-                                           const std::vector<Scalar>& B_avg,
                                            const WellState& well_state,
                                            std::vector<double>& well_potentials,
                                            Opm::DeferredLogger& deferred_logger) /* const */ override;
@@ -234,7 +232,6 @@ namespace Opm
 
         // iterate well equations with the specified control until converged
         bool iterateWellEqWithControl(const Simulator& ebosSimulator,
-                                      const std::vector<double>& B_avg,
                                       const double dt,
                                       const Well::InjectionControls& inj_controls,
                                       const Well::ProductionControls& prod_controls,
@@ -469,7 +466,6 @@ namespace Opm
                              Opm::DeferredLogger& deferred_logger) const;
 
         void computeWellRatesWithBhpPotential(const Simulator& ebosSimulator,
-                                              const std::vector<Scalar>& B_avg,
                                               const double& bhp,
                                               std::vector<double>& well_flux,
                                               Opm::DeferredLogger& deferred_logger);

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -169,7 +169,6 @@ namespace Opm
         virtual void solveEqAndUpdateWellState(WellState& well_state, Opm::DeferredLogger& deferred_logger) = 0;
 
         virtual void assembleWellEq(const Simulator& ebosSimulator,
-                                    const std::vector<Scalar>& B_avg,
                                     const double dt,
                                     WellState& well_state,
                                     Opm::DeferredLogger& deferred_logger
@@ -205,7 +204,6 @@ namespace Opm
 
         // TODO: before we decide to put more information under mutable, this function is not const
         virtual void computeWellPotentials(const Simulator& ebosSimulator,
-                                           const std::vector<Scalar>& B_avg,
                                            const WellState& well_state,
                                            std::vector<double>& well_potentials,
                                            Opm::DeferredLogger& deferred_logger) = 0;
@@ -265,7 +263,7 @@ namespace Opm
 
         // TODO: theoretically, it should be a const function
         // Simulator is not const is because that assembleWellEq is non-const Simulator
-        void wellTesting(const Simulator& simulator, const std::vector<double>& B_avg,
+        void wellTesting(const Simulator& simulator,
                          const double simulation_time, const int report_step,
                          const WellTestConfig::Reason testing_reason,
                          /* const */ WellState& well_state, WellTestState& welltest_state,
@@ -513,11 +511,11 @@ namespace Opm
         virtual void updateIPR(const Simulator& ebos_simulator, Opm::DeferredLogger& deferred_logger) const=0;
 
 
-        void wellTestingEconomic(const Simulator& simulator, const std::vector<double>& B_avg,
+        void wellTestingEconomic(const Simulator& simulator,
                                  const double simulation_time, const WellState& well_state,
                                  WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger);
 
-        void wellTestingPhysical(const Simulator& simulator, const std::vector<double>& B_avg,
+        void wellTestingPhysical(const Simulator& simulator,
                                  const double simulation_time, const int report_step,
                                  WellState& well_state, WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger);
 
@@ -531,7 +529,6 @@ namespace Opm
 
         // iterate well equations with the specified control until converged
         virtual bool iterateWellEqWithControl(const Simulator& ebosSimulator,
-                                              const std::vector<double>& B_avg,
                                               const double dt,
                                               const Well::InjectionControls& inj_controls,
                                               const Well::ProductionControls& prod_controls,
@@ -539,7 +536,6 @@ namespace Opm
                                               Opm::DeferredLogger& deferred_logger) = 0;
 
         bool iterateWellEquations(const Simulator& ebosSimulator,
-                                  const std::vector<double>& B_avg,
                                   const double dt,
                                   WellState& well_state,
                                   Opm::DeferredLogger& deferred_logger);
@@ -557,7 +553,6 @@ namespace Opm
                                          Opm::DeferredLogger& deferred_logger) const;
 
         void solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state,
-                                 const std::vector<double>& B_avg,
                                  Opm::DeferredLogger& deferred_logger);
 
         void initCompletions();


### PR DESCRIPTION
use the Bavg value stored in wellInterface class to avoid passing it round. 

This is a first step to align some of the interfaces to make it possible to use more of the same code for standard and multi-segmented wells. 