### PR TITLE
Push 'corners' Object into Assert

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -892,7 +892,7 @@ private:
         static constexpr int zCoord = Element::dimension - 1;
         Scalar zz = 0.0;
 
-        const Geometry geometry = element.geometry();
+        const Geometry& geometry = element.geometry();
         const int corners = geometry.corners();
         for (int i=0; i < corners; ++i)
             zz += geometry.corner(i)[zCoord];

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -414,14 +414,13 @@ protected:
         Scalar zz1 = 0.0;
         Scalar zz2 = 0.0;
 
-        const Geometry geometry = element.geometry();
-        const int corners = geometry.corners();
+        const Geometry& geometry = element.geometry();
         // This code only works with CP-grid where the
         // number of corners are 8 and
         // also assumes that the first
         // 4 corners are the top surface and
         // the 4 next are the bottomn.
-        assert(corners == 8);
+        assert(geometry.corners() == 8);
         for (int i=0; i < 4; ++i){
             zz1 += geometry.corner(i)[zCoord];
             zz2 += geometry.corner(i+4)[zCoord];


### PR DESCRIPTION
That way we don't get "unused variable" warnings when someone defines `NDEBUG`.  While here, also switch to using `Geometry` references where appropriate to avoid needlessly copying `Geometry` objects.