### PR TITLE
reset target from wconprod and wconinje

### DIFF
--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -218,13 +218,11 @@ namespace Opm
                         // thp
                         thp()[ newIndex ] = prevState->thp()[ oldIndex ];
 
-                         // Currently this is taken care of by updateWellStateFromTarge. Maybe we should just remove the initialization and just use updateWellStateFromTarget
-                         //if (effective_events_occurred_[w]) {
-                         //   continue;
-                         //}
-
-                        current_injection_controls_[ newIndex ] = prevState->currentInjectionControls()[ oldIndex ];
-                        current_production_controls_[ newIndex ] = prevState->currentProductionControls()[ oldIndex ];
+                        // If new target is set using WCONPROD, WCONINJE etc. we change to the new control.
+                        if (!effective_events_occurred_[w]) {
+                            current_injection_controls_[ newIndex ] = prevState->currentInjectionControls()[ oldIndex ];
+                            current_production_controls_[ newIndex ] = prevState->currentProductionControls()[ oldIndex ];
+                        }
 
                         // wellrates
                         for( int i=0, idx=newIndex*np, oldidx=oldIndex*np; i<np; ++i, ++idx, ++oldidx )


### PR DESCRIPTION
In eagerness to fix one issue I accidentally introduced another. Interesting that this did not surface during testing. Don't we have any test that start as history and move to prediction?

