### PR TITLE
Access well state variables through accessor functions

### DIFF
--- a/ebos/eclpeacemanwell.hh
+++ b/ebos/eclpeacemanwell.hh
@@ -33,6 +33,7 @@
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/alignedallocator.hh>
 
+#include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/densead/Math.hpp>
@@ -1408,6 +1409,36 @@ protected:
                 reservoirRate[waterPhaseIdx]
                 * Toolbox::value(dofVars.density[waterPhaseIdx])
                 / rhoWaterSurface;
+    }
+
+    const WellStateFullyImplicitBlackoil& wellState() const
+    {
+        throw std::logic_error("wellState() method not implemented for class eclpeacemanwell");
+    }
+
+    WellStateFullyImplicitBlackoil& wellState()
+    {
+        throw std::logic_error("wellState() method not implemented for class eclpeacemanwell");
+    }
+
+    void commitWellState()
+    {
+        throw std::logic_error("commitWellState() method not implemented for class eclpeacemanwell");
+    }
+
+    void commitWellState(WellStateFullyImplicitBlackoil well_state)
+    {
+        throw std::logic_error("commitWellState() method not implemented for class eclpeacemanwell");
+    }
+
+    void resetWellState()
+    {
+        throw std::logic_error("resetWellState() method not implemented for class eclpeacemanwell");
+    }
+
+    void updateNupcolWellState()
+    {
+        throw std::logic_error("updateNupcolWellState() method not implemented for class eclpeacemanwell");
     }
 
     void

--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -36,6 +36,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
+#include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
@@ -619,6 +620,35 @@ public:
         // not implemented
     }
 
+    const WellStateFullyImplicitBlackoil& wellState() const
+    {
+        throw std::logic_error("wellState() method not implemented for class eclwellmanager");
+    }
+
+    WellStateFullyImplicitBlackoil& wellState()
+    {
+        throw std::logic_error("wellState() method not implemented for class eclwellmanager");
+    }
+
+    void commitWellState()
+    {
+        throw std::logic_error("commitWellState() method not implemented for class eclwellmanager");
+    }
+
+    void commitWellState(WellStateFullyImplicitBlackoil well_state)
+    {
+        throw std::logic_error("commitWellState() method not implemented for class eclwellmanager");
+    }
+
+    void resetWellState()
+    {
+        throw std::logic_error("resetWellState() method not implemented for class eclwellmanager");
+    }
+
+    void updateNupcolWellState()
+    {
+        throw std::logic_error("updateNupcolWellState() method not implemented for class eclwellmanager");
+    }
 
     void
     updateEclWell(int, int)


### PR DESCRIPTION
This is effectively no change - but for me it is easier to read; the motivation is https://github.com/OPM/opm-simulators/pull/3116 which needs an additional storing away of the previous well state. With this PR that can be implemented as:
```
well_model.commitWellState();
```
whereas the same functionality in current master must be implemented as:
```
well_model.prev_well_state_ = well_model.well_state_
```

That might be a bit into the future - but I would assume this was also a smell step in a direction to wrangle the mutable state object out of the model object.

Use of this PR is illustrated in the last commit of #3116

