### PR TITLE
Always print CHOW_PATEL info if used

### DIFF
--- a/opm/simulators/linalg/bda/BILU0.cpp
+++ b/opm/simulators/linalg/bda/BILU0.cpp
@@ -103,12 +103,12 @@ namespace bda
         } else {
             OPM_THROW(std::logic_error, "Error ilu reordering strategy not set correctly\n");
         }
-        if(verbosity >= 3){
+        if(verbosity >= 1){
             out << "BILU0 analysis took: " << t_analysis.stop() << " s, " << numColors << " colors\n";
         }
-        if(verbosity >= 2){
-            out << "BILU0 CHOW_PATEL: " << CHOW_PATEL << ", CHOW_PATEL_GPU: " << CHOW_PATEL_GPU;
-        }
+#if CHOW_PATEL
+        out << "BILU0 CHOW_PATEL: " << CHOW_PATEL << ", CHOW_PATEL_GPU: " << CHOW_PATEL_GPU;
+#endif
         OpmLog::info(out.str());
 
         if (opencl_ilu_reorder != ILUReorder::NONE) {

--- a/opm/simulators/linalg/bda/ChowPatelIlu.cpp
+++ b/opm/simulators/linalg/bda/ChowPatelIlu.cpp
@@ -534,11 +534,9 @@ void ChowPatelIlu::decomposition(
                 out << "ChowPatelIlu copy sparsity pattern time: " << t_copy_pattern.stop() << " s";
                 OpmLog::info(out.str());
             }
-            if (verbosity >= 2){
-                std::ostringstream out;
-                out << "ChowPatelIlu PARALLEL: " << PARALLEL;
-                OpmLog::info(out.str());
-            }
+            std::ostringstream out;
+            out << "ChowPatelIlu PARALLEL: " << PARALLEL;
+            OpmLog::info(out.str());
         });
 
 


### PR DESCRIPTION
As CHOW_PATEL usage will be very rare, it's info is only printed when enabled.
Printing the number of colors found is printed more often, as that info is generally interesting.
`BILU0 reordering strategy: level_scheduling` is always printed, with the chosen reordering.
