### PR TITLE
shut/stop unsolvable wells

### DIFF
--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -142,6 +142,10 @@ struct MaxNewtonIterationsWithInnerWellIterations  {
     using type = UndefinedProperty;
 };
 template<class TypeTag, class MyTypeTag>
+struct ShutUnsolvableWells {
+    using type = UndefinedProperty;
+};
+template<class TypeTag, class MyTypeTag>
 struct MaxInnerIterWells {
     using type = UndefinedProperty;
 };
@@ -251,6 +255,10 @@ struct MaxInnerIterWells<TypeTag, TTag::FlowModelParameters> {
     static constexpr int value = 50;
 };
 template<class TypeTag>
+struct ShutUnsolvableWells<TypeTag, TTag::FlowModelParameters> {
+    static constexpr bool value = false;
+};
+template<class TypeTag>
 struct AlternativeWellRateInit<TypeTag, TTag::FlowModelParameters> {
     static constexpr bool value = true;
 };
@@ -341,6 +349,9 @@ namespace Opm
         /// Maximum newton iterations with inner well iterations
         int max_niter_inner_well_iter_;
 
+        /// Whether to shut unsolvable well
+        bool shut_unsolvable_wells_;
+
         /// Maximum inner iteration number for standard wells
         int max_inner_iter_wells_;
 
@@ -398,6 +409,7 @@ namespace Opm
             strict_inner_iter_ms_wells_ = EWOMS_GET_PARAM(TypeTag, int, StrictInnerIterMsWells);
             regularization_factor_ms_wells_ = EWOMS_GET_PARAM(TypeTag, Scalar, RegularizationFactorMsw);
             max_niter_inner_well_iter_ = EWOMS_GET_PARAM(TypeTag, int, MaxNewtonIterationsWithInnerWellIterations);
+            shut_unsolvable_wells_ = EWOMS_GET_PARAM(TypeTag, bool, ShutUnsolvableWells);
             max_inner_iter_wells_ = EWOMS_GET_PARAM(TypeTag, int, MaxInnerIterWells);
             maxSinglePrecisionTimeStep_ = EWOMS_GET_PARAM(TypeTag, Scalar, MaxSinglePrecisionDays) *24*60*60;
             max_strict_iter_ = EWOMS_GET_PARAM(TypeTag, int, MaxStrictIter);
@@ -430,6 +442,7 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, int, MaxInnerIterMsWells, "Maximum number of inner iterations for multi-segment wells");
             EWOMS_REGISTER_PARAM(TypeTag, int, StrictInnerIterMsWells, "Number of inner iterations for multi-segment wells with strict tolerance");
             EWOMS_REGISTER_PARAM(TypeTag, int, MaxNewtonIterationsWithInnerWellIterations, "Maximum newton iterations with inner well iterations");
+            EWOMS_REGISTER_PARAM(TypeTag, bool, ShutUnsolvableWells, "Shut unsolvable wells");
             EWOMS_REGISTER_PARAM(TypeTag, int, MaxInnerIterWells, "Maximum number of inner iterations for standard wells");
             EWOMS_REGISTER_PARAM(TypeTag, bool, AlternativeWellRateInit, "Use alternative well rate initialization procedure");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, RegularizationFactorMsw, "Regularization factor for ms wells");

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -340,6 +340,8 @@ protected:
 
     void solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state, const GroupState& group_state,
                              DeferredLogger& deferred_logger);
+
+    bool shutUnsolvableWells() const;
 };
 
 }

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -177,7 +177,7 @@ protected:
     // definition of the struct OperabilityStatus
     struct OperabilityStatus {
         bool isOperable() const {
-            if (!operable_under_only_bhp_limit) {
+            if (!operable_under_only_bhp_limit || !solvable) {
                 return false;
             } else {
                 return ( (isOperableUnderBHPLimit() || isOperableUnderTHPLimit()) );
@@ -197,6 +197,7 @@ protected:
             obey_thp_limit_under_bhp_limit = true;
             can_obtain_bhp_with_thp_limit = true;
             obey_bhp_limit_with_thp_limit = true;
+            solvable = true;
         }
 
         // whether the well can be operated under bhp limit
@@ -210,6 +211,8 @@ protected:
         bool can_obtain_bhp_with_thp_limit = true;
         // whether the well obey bhp limit when operated under thp limit
         bool obey_bhp_limit_with_thp_limit = true;
+        // the well is solveable
+        bool solvable = true;
     };
 
     OperabilityStatus operability_status_;


### PR DESCRIPTION
This adds a check for solvability in the operability check. 
Since the checking for solvability involves a full inner iteration for each well, this PR also
makes the usage of inner iterations obligatory. Hence it removes the parameter that controls this. 

I have tested this on the Norne prediction family and also on some other prediction cases with good results in terms of avoiding oscillatory solutions and improved performance due to less convergence issues. 

Currently this feature only works for producers. Testing indicates that this also is beneficial for injectors, but it run into some MPI issues that I will need some more time to figure out. 