### PR TITLE
Use the event for swithing between producer and injector 

### DIFF
--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -251,10 +251,9 @@ public:
                     adaptiveTimeStepping_->updateTUNING(schedule()[timer.currentStepNum()].tuning());
                 }
             }
-
             bool event = events.hasEvent(ScheduleEvents::NEW_WELL) ||
-                events.hasEvent(ScheduleEvents::PRODUCTION_UPDATE) ||
-                events.hasEvent(ScheduleEvents::INJECTION_UPDATE) ||
+                events.hasEvent(ScheduleEvents::INJECTION_TYPE_CHANGED) ||
+                events.hasEvent(ScheduleEvents::WELL_SWITCHED_INJECTOR_PRODUCER) ||
                 events.hasEvent(ScheduleEvents::WELL_STATUS_CHANGE);
             auto stepReport = adaptiveTimeStepping_->step(timer, *solver, event, nullptr);
             report_ += stepReport;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -402,6 +402,7 @@ namespace Opm {
             for (auto& well : well_container_) {
                 const uint64_t effective_events_mask = ScheduleEvents::WELL_STATUS_CHANGE
                         + ScheduleEvents::INJECTION_TYPE_CHANGED
+                        + ScheduleEvents::WELL_SWITCHED_INJECTOR_PRODUCER
                         + ScheduleEvents::NEW_WELL;
 
                 const auto& events = schedule()[reportStepIdx].wellgroup_events();


### PR DESCRIPTION
Switching between injection and production is a big event that need some special case. 

Depens on OPM/opm-common#2431