### PR TITLE
Wellstate split

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -40,6 +40,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/utils/DeferredLogger.cpp
   opm/simulators/utils/gatherDeferredLogger.cpp
   opm/simulators/utils/ParallelRestart.cpp
+  opm/simulators/wells/GroupState.cpp
   opm/simulators/wells/ParallelWellInfo.cpp
   opm/simulators/wells/VFPProdProperties.cpp
   opm/simulators/wells/VFPInjProperties.cpp
@@ -106,6 +107,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_parallelwellinfo.cpp
   tests/test_glift1.cpp
   tests/test_keyword_validator.cpp
+  tests/test_GroupState.cpp
   )
 
 if(MPI_FOUND)
@@ -253,6 +255,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/TargetCalculator.hpp
   opm/simulators/wells/WellConnectionAuxiliaryModule.hpp
   opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+  opm/simulators/wells/GroupState.hpp
   opm/simulators/wells/VFPProperties.hpp
   opm/simulators/wells/VFPHelpers.hpp
   opm/simulators/wells/VFPInjProperties.hpp

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -33,7 +33,11 @@ namespace Opm {
     template<typename TypeTag>
     BlackoilWellModel<TypeTag>::
     BlackoilWellModel(Simulator& ebosSimulator)
-        : ebosSimulator_(ebosSimulator)
+        : ebosSimulator_(ebosSimulator),
+          phase_usage_(phaseUsageFromDeck(ebosSimulator_.vanguard().eclState())),
+          active_well_state_(phase_usage_.num_phases),
+          last_valid_well_state_(phase_usage_.num_phases),
+          nupcol_well_state_(phase_usage_.num_phases)
     {
         terminal_output_ = false;
         if (ebosSimulator.gridView().comm().rank() == 0)
@@ -75,12 +79,8 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     init()
     {
-        const Opm::EclipseState& eclState = ebosSimulator_.vanguard().eclState();
-
         extractLegacyCellPvtRegionIndex_();
         extractLegacyDepth_();
-
-        phase_usage_ = phaseUsageFromDeck(eclState);
 
         gravity_ = ebosSimulator_.problem().gravity()[2];
 

--- a/opm/simulators/wells/GroupState.cpp
+++ b/opm/simulators/wells/GroupState.cpp
@@ -1,0 +1,237 @@
+/*
+  Copyright 2021 Equinor
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+
+#include <opm/simulators/wells/GroupState.hpp>
+
+namespace Opm {
+
+GroupState::GroupState(std::size_t np) :
+    num_phases(np)
+{}
+
+bool GroupState::operator==(const GroupState& other) const {
+    return this->m_production_rates == other.m_production_rates &&
+           this->production_controls == other.production_controls &&
+           this->prod_red_rates == other.prod_red_rates &&
+           this->inj_red_rates == other.inj_red_rates &&
+           this->inj_resv_rates == other.inj_resv_rates &&
+           this->inj_potentials == other.inj_potentials &&
+           this->inj_rein_rates == other.inj_rein_rates &&
+           this->inj_vrep_rate == other.inj_vrep_rate &&
+           this->m_grat_sales_target == other.m_grat_sales_target &&
+           this->injection_controls == other.injection_controls;
+}
+
+//-------------------------------------------------------------------------
+
+bool GroupState::has_production_rates(const std::string& gname) const {
+    auto group_iter = this->m_production_rates.find(gname);
+    return (group_iter != this->m_production_rates.end());
+}
+
+void GroupState::update_production_rates(const std::string& gname, const std::vector<double>& rates) {
+    if (rates.size() != this->num_phases)
+        throw std::logic_error("Wrong number of phases");
+
+    this->m_production_rates[gname] = rates;
+}
+
+const std::vector<double>& GroupState::production_rates(const std::string& gname) const {
+    auto group_iter = this->m_production_rates.find(gname);
+    if (group_iter == this->m_production_rates.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+//-------------------------------------------------------------------------
+
+bool GroupState::has_production_reduction_rates(const std::string& gname) const {
+    auto group_iter = this->prod_red_rates.find(gname);
+    return (group_iter != this->prod_red_rates.end());
+}
+
+void GroupState::update_production_reduction_rates(const std::string& gname, const std::vector<double>& rates) {
+    if (rates.size() != this->num_phases)
+        throw std::logic_error("Wrong number of phases");
+
+    this->prod_red_rates[gname] = rates;
+}
+
+const std::vector<double>& GroupState::production_reduction_rates(const std::string& gname) const {
+    auto group_iter = this->prod_red_rates.find(gname);
+    if (group_iter == this->prod_red_rates.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+//-------------------------------------------------------------------------
+
+bool GroupState::has_injection_reduction_rates(const std::string& gname) const {
+    auto group_iter = this->inj_red_rates.find(gname);
+    return (group_iter != this->inj_red_rates.end());
+}
+
+void GroupState::update_injection_reduction_rates(const std::string& gname, const std::vector<double>& rates) {
+    if (rates.size() != this->num_phases)
+        throw std::logic_error("Wrong number of phases");
+
+    this->inj_red_rates[gname] = rates;
+}
+
+const std::vector<double>& GroupState::injection_reduction_rates(const std::string& gname) const {
+    auto group_iter = this->inj_red_rates.find(gname);
+    if (group_iter == this->inj_red_rates.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+//-------------------------------------------------------------------------
+
+bool GroupState::has_injection_reservoir_rates(const std::string& gname) const {
+    auto group_iter = this->inj_resv_rates.find(gname);
+    return (group_iter != this->inj_resv_rates.end());
+}
+
+void GroupState::update_injection_reservoir_rates(const std::string& gname, const std::vector<double>& rates) {
+    if (rates.size() != this->num_phases)
+        throw std::logic_error("Wrong number of phases");
+
+    this->inj_resv_rates[gname] = rates;
+}
+
+const std::vector<double>& GroupState::injection_reservoir_rates(const std::string& gname) const {
+    auto group_iter = this->inj_resv_rates.find(gname);
+    if (group_iter == this->inj_resv_rates.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+//-------------------------------------------------------------------------
+
+void GroupState::update_injection_rein_rates(const std::string& gname, const std::vector<double>& rates) {
+    if (rates.size() != this->num_phases)
+        throw std::logic_error("Wrong number of phases");
+
+    this->inj_rein_rates[gname] = rates;
+}
+
+const std::vector<double>& GroupState::injection_rein_rates(const std::string& gname) const {
+    auto group_iter = this->inj_rein_rates.find(gname);
+    if (group_iter == this->inj_rein_rates.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+//-------------------------------------------------------------------------
+
+void GroupState::update_injection_vrep_rate(const std::string& gname, double rate) {
+    this->inj_vrep_rate[gname] = rate;
+}
+
+double GroupState::injection_vrep_rate(const std::string& gname) const {
+    auto group_iter = this->inj_vrep_rate.find(gname);
+    if (group_iter == this->inj_vrep_rate.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+//-------------------------------------------------------------------------
+
+void GroupState::update_grat_sales_target(const std::string& gname, double target) {
+    this->m_grat_sales_target[gname] = target;
+}
+
+double GroupState::grat_sales_target(const std::string& gname) const {
+    auto group_iter = this->m_grat_sales_target.find(gname);
+    if (group_iter == this->m_grat_sales_target.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+bool GroupState::has_grat_sales_target(const std::string& gname) const {
+    return (this->m_grat_sales_target.count(gname) > 0);
+}
+
+//-------------------------------------------------------------------------
+
+void GroupState::update_injection_potentials(const std::string& gname, const std::vector<double>& potentials) {
+    if (potentials.size() != this->num_phases)
+        throw std::logic_error("Wrong number of phases");
+
+    this->inj_potentials[gname] = potentials;
+}
+
+const std::vector<double>& GroupState::injection_potentials(const std::string& gname) const {
+    auto group_iter = this->inj_potentials.find(gname);
+    if (group_iter == this->inj_potentials.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+//-------------------------------------------------------------------------
+
+bool GroupState::has_production_control(const std::string& gname) const {
+    auto group_iter = this->production_controls.find(gname);
+    if (group_iter == this->production_controls.end())
+        return false;
+
+    return true;
+}
+
+void GroupState::production_control(const std::string& gname, Group::ProductionCMode cmode) {
+    this->production_controls[gname] = cmode;
+}
+
+Group::ProductionCMode GroupState::production_control(const std::string& gname) const {
+    auto group_iter = this->production_controls.find(gname);
+    if (group_iter == this->production_controls.end())
+        throw std::logic_error("Could not find any control for production group: " + gname);
+
+    return group_iter->second;
+}
+
+//-------------------------------------------------------------------------
+
+bool GroupState::has_injection_control(const std::string& gname, Phase phase) const {
+    return this->injection_controls.count(std::make_pair(phase, gname)) > 0;
+}
+
+void GroupState::injection_control(const std::string& gname, Phase phase, Group::InjectionCMode cmode) {
+    this->injection_controls[ std::make_pair(phase, gname) ] = cmode;
+}
+
+Group::InjectionCMode GroupState::injection_control(const std::string& gname, Phase phase) const {
+    auto key = std::make_pair(phase, gname);
+    auto group_iter = this->injection_controls.find( key );
+    if (group_iter == this->injection_controls.end())
+        throw std::logic_error("Could not find ontrol for injection group: " + gname);
+
+    return group_iter->second;
+}
+}

--- a/opm/simulators/wells/GroupState.hpp
+++ b/opm/simulators/wells/GroupState.hpp
@@ -1,0 +1,168 @@
+/*
+  Copyright 2021 Equinor
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_GROUPSTATE_HEADER_INCLUDED
+#define OPM_GROUPSTATE_HEADER_INCLUDED
+
+#include <map>
+#include <vector>
+
+#include <opm/core/props/BlackoilPhases.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
+
+namespace Opm {
+
+class GroupState {
+public:
+    explicit GroupState(std::size_t num_phases);
+    bool operator==(const GroupState& other) const;
+
+    bool has_production_rates(const std::string& gname) const;
+    void update_production_rates(const std::string& gname, const std::vector<double>& rates);
+    const std::vector<double>& production_rates(const std::string& gname) const;
+
+    bool has_production_reduction_rates(const std::string& gname) const;
+    void update_production_reduction_rates(const std::string& gname, const std::vector<double>& rates);
+    const std::vector<double>& production_reduction_rates(const std::string& gname) const;
+
+    bool has_injection_reduction_rates(const std::string& gname) const;
+    void update_injection_reduction_rates(const std::string& gname, const std::vector<double>& rates);
+    const std::vector<double>& injection_reduction_rates(const std::string& gname) const;
+
+    bool has_injection_reservoir_rates(const std::string& gname) const;
+    void update_injection_reservoir_rates(const std::string& gname, const std::vector<double>& rates);
+    const std::vector<double>& injection_reservoir_rates(const std::string& gname) const;
+
+    void update_injection_rein_rates(const std::string& gname, const std::vector<double>& rates);
+    const std::vector<double>& injection_rein_rates(const std::string& gname) const;
+
+    void update_injection_potentials(const std::string& gname, const std::vector<double>& potentials);
+    const std::vector<double>& injection_potentials(const std::string& gname) const;
+
+    void update_injection_vrep_rate(const std::string& gname, double rate);
+    double injection_vrep_rate(const std::string& gname) const;
+
+    void update_grat_sales_target(const std::string& gname, double target);
+    double grat_sales_target(const std::string& gname) const;
+    bool has_grat_sales_target(const std::string& gname) const;
+
+    bool has_production_control(const std::string& gname) const;
+    void production_control(const std::string& gname, Group::ProductionCMode cmode);
+    Group::ProductionCMode production_control(const std::string& gname) const;
+
+    bool has_injection_control(const std::string& gname, Phase phase) const;
+    void injection_control(const std::string& gname, Phase phase, Group::InjectionCMode cmode);
+    Group::InjectionCMode injection_control(const std::string& gname, Phase phase) const;
+
+    std::size_t data_size() const;
+    std::size_t collect(double * data) const;
+    std::size_t distribute(const double * data);
+
+
+    template<class Comm>
+    void communicate_rates(const Comm& comm)
+    {
+        // Note that injection_group_vrep_rates is handled separate from
+        // the forAllGroupData() function, since it contains single doubles,
+        // not vectors.
+
+        // Create a function that calls some function
+        // for all the individual data items to simplify
+        // the further code.
+        auto iterateContainer = [](auto& container, auto& func) {
+            for (auto& x : container) {
+                func(x.second);
+            }
+        };
+
+
+        auto forAllGroupData = [&](auto& func) {
+            iterateContainer(m_production_rates, func);
+            iterateContainer(prod_red_rates, func);
+            iterateContainer(inj_red_rates, func);
+            iterateContainer(inj_resv_rates, func);
+            iterateContainer(inj_rein_rates, func);
+        };
+
+        // Compute the size of the data.
+        std::size_t sz = 0;
+        auto computeSize = [&sz](const auto& v) {
+            sz += v.size();
+        };
+        forAllGroupData(computeSize);
+        sz += this->inj_vrep_rate.size();
+
+        // Make a vector and collect all data into it.
+        std::vector<double> data(sz);
+        std::size_t pos = 0;
+
+
+
+        // That the collect function mutates the vector v is an artifact for
+        // testing.
+        auto collect = [&data, &pos](auto& v) {
+            for (auto& x : v) {
+                data[pos++] = x;
+                x = -1;
+            }
+        };
+        forAllGroupData(collect);
+        for (const auto& x : this->inj_vrep_rate) {
+            data[pos++] = x.second;
+        }
+        if (pos != sz)
+            throw std::logic_error("Internal size mismatch when collecting groupData");
+
+        // Communicate it with a single sum() call.
+        comm.sum(data.data(), data.size());
+
+        // Distribute the summed vector to the data items.
+        pos = 0;
+        auto distribute = [&data, &pos](auto& v) {
+            for (auto& x : v) {
+                x = data[pos++];
+            }
+        };
+        forAllGroupData(distribute);
+        for (auto& x : this->inj_vrep_rate) {
+            x.second = data[pos++];
+        }
+        if (pos != sz)
+            throw std::logic_error("Internal size mismatch when distributing groupData");
+    }
+
+private:
+    std::size_t num_phases;
+    std::map<std::string, std::vector<double>> m_production_rates;
+    std::map<std::string, Group::ProductionCMode> production_controls;
+    std::map<std::string, std::vector<double>> prod_red_rates;
+    std::map<std::string, std::vector<double>> inj_red_rates;
+    std::map<std::string, std::vector<double>> inj_resv_rates;
+    std::map<std::string, std::vector<double>> inj_potentials;
+    std::map<std::string, std::vector<double>> inj_rein_rates;
+    std::map<std::string, double> inj_vrep_rate;
+    std::map<std::string, double> m_grat_sales_target;
+
+
+    std::map<std::pair<Opm::Phase, std::string>, Group::InjectionCMode> injection_controls;
+};
+
+}
+
+#endif

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -46,6 +46,13 @@ namespace Opm
         typedef std::array< int, 3 >  mapentry_t;
         typedef std::map< std::string, mapentry_t > WellMapType;
 
+
+
+        explicit WellState(int num_phases) :
+            np_(num_phases)
+        {}
+
+
         /// Allocate and initialize if wells is non-null.
         /// Also tries to give useful initial values to the bhp() and
         /// wellRates() fields, depending on controls.  The
@@ -397,9 +404,8 @@ namespace Opm
 
             // Set default zero initial well rates.
             // May be overwritten below.
-            const int np = pu.num_phases;
-            for (int p = 0; p < np; ++p) {
-                wellrates_[np*w + p] = 0.0;
+            for (int p = 0; p < this->np_; ++p) {
+                wellrates_[this->np_*w + p] = 0.0;
             }
 
             if ( well.isInjector() ) { 
@@ -465,15 +471,15 @@ namespace Opm
                         switch (inj_controls.injector_type) {
                         case InjectorType::WATER:
                             assert(pu.phase_used[BlackoilPhases::Aqua]);
-                            wellrates_[np*w + pu.phase_pos[BlackoilPhases::Aqua]] = inj_surf_rate;
+                            wellrates_[this->np_*w + pu.phase_pos[BlackoilPhases::Aqua]] = inj_surf_rate;
                             break;
                         case InjectorType::GAS:
                             assert(pu.phase_used[BlackoilPhases::Vapour]);
-                            wellrates_[np*w + pu.phase_pos[BlackoilPhases::Vapour]] = inj_surf_rate;
+                            wellrates_[this->np_*w + pu.phase_pos[BlackoilPhases::Vapour]] = inj_surf_rate;
                             break;
                         case InjectorType::OIL:
                             assert(pu.phase_used[BlackoilPhases::Liquid]);
-                            wellrates_[np*w + pu.phase_pos[BlackoilPhases::Liquid]] = inj_surf_rate;
+                            wellrates_[this->np_*w + pu.phase_pos[BlackoilPhases::Liquid]] = inj_surf_rate;
                             break;
                         case InjectorType::MULTI:
                             // Not currently handled, keep zero init.
@@ -488,15 +494,15 @@ namespace Opm
                     switch (prod_controls.cmode) {
                     case Well::ProducerCMode::ORAT:
                         assert(pu.phase_used[BlackoilPhases::Liquid]);
-                        wellrates_[np*w + pu.phase_pos[BlackoilPhases::Liquid]] = -prod_controls.oil_rate;
+                        wellrates_[this->np_*w + pu.phase_pos[BlackoilPhases::Liquid]] = -prod_controls.oil_rate;
                         break;
                     case Well::ProducerCMode::WRAT:
                         assert(pu.phase_used[BlackoilPhases::Aqua]);
-                        wellrates_[np*w + pu.phase_pos[BlackoilPhases::Aqua]] = -prod_controls.water_rate;
+                        wellrates_[this->np_*w + pu.phase_pos[BlackoilPhases::Aqua]] = -prod_controls.water_rate;
                         break;
                     case Well::ProducerCMode::GRAT:
                         assert(pu.phase_used[BlackoilPhases::Vapour]);
-                        wellrates_[np*w + pu.phase_pos[BlackoilPhases::Vapour]] = -prod_controls.gas_rate;
+                        wellrates_[this->np_*w + pu.phase_pos[BlackoilPhases::Vapour]] = -prod_controls.gas_rate;
                         break;
                     default:
                         // Keep zero init.

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -68,6 +68,11 @@ namespace Opm
         using BaseType :: resetConnectionTransFactors;
         using BaseType :: updateStatus;
 
+        explicit WellStateFullyImplicitBlackoil(int num_phases) :
+            WellState(num_phases)
+        {}
+
+
         /// Allocate and initialize if wells is non-null.  Also tries
         /// to give useful initial values to the bhp(), wellRates()
         /// and perfPhaseRates() fields, depending on controls
@@ -105,7 +110,7 @@ namespace Opm
                 nperf += wpd.size();
             }
 
-            well_reservoir_rates_.resize(nw * np, 0.0);
+            well_reservoir_rates_.resize(nw * this->numPhases(), 0.0);
             well_dissolved_gas_rates_.resize(nw, 0.0);
             well_vaporized_oil_rates_.resize(nw, 0.0);
 
@@ -129,7 +134,7 @@ namespace Opm
 
             // Ensure that we start out with zero rates by default.
             perfphaserates_.clear();
-            perfphaserates_.resize(nperf * np, 0.0);
+            perfphaserates_.resize(nperf * this->numPhases(), 0.0);
 
             // these are only used to monitor the injectivity
             perf_water_throughput_.clear();
@@ -152,8 +157,8 @@ namespace Opm
 
                 for (int perf = connpos; perf < connpos + num_perf_this_well; ++perf) {
                     if (wells_ecl[w].getStatus() == Well::Status::OPEN) {
-                        for (int p = 0; p < np; ++p) {
-                            perfphaserates_[np*perf + p] = wellRates()[np*w + p] / double(global_num_perf_this_well);
+                        for (int p = 0; p < this->numPhases(); ++p) {
+                            perfphaserates_[this->numPhases()*perf + p] = wellRates()[this->numPhases()*w + p] / double(global_num_perf_this_well);
                         }
                     }
                     perfPress()[perf] = cellPressures[well_perf_data[w][perf-connpos].cell_index];
@@ -182,9 +187,9 @@ namespace Opm
 
             perfRateSolvent_.clear();
             perfRateSolvent_.resize(nperf, 0.0);
-            productivity_index_.resize(nw * np, 0.0);
-            conn_productivity_index_.resize(nperf * np, 0.0);
-            well_potentials_.resize(nw * np, 0.0);
+            productivity_index_.resize(nw * this->numPhases(), 0.0);
+            conn_productivity_index_.resize(nperf * this->numPhases(), 0.0);
+            well_potentials_.resize(nw * this->numPhases(), 0.0);
 
             perfRatePolymer_.clear();
             perfRatePolymer_.resize(nperf, 0.0);

--- a/tests/test_GroupState.cpp
+++ b/tests/test_GroupState.cpp
@@ -1,0 +1,69 @@
+/*
+  Copyright 2021 Equinor.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdexcept>
+
+#include <opm/simulators/wells/GroupState.hpp>
+
+#define BOOST_TEST_MODULE GroupStateTest
+#include <boost/test/unit_test.hpp>
+
+using namespace Opm;
+
+class TestCommunicator {
+public:
+    void sum(const double *, std::size_t) const {}
+};
+
+
+
+BOOST_AUTO_TEST_CASE(GroupStateCreate) {
+    std::size_t num_phases{3};
+    GroupState gs(num_phases);
+
+    BOOST_CHECK(!gs.has_production_rates("AGROUP"));
+    BOOST_CHECK_THROW( gs.update_production_rates("AGROUP", {0}), std::exception);
+
+    std::vector<double> rates{0,1,2};
+    gs.update_production_rates("AGROUP", rates);
+    BOOST_CHECK(gs.has_production_rates("AGROUP"));
+
+    BOOST_CHECK_THROW( gs.production_rates("NO_SUCH_GROUP"), std::exception );
+    auto r2 = gs.production_rates("AGROUP");
+    BOOST_CHECK( r2 == rates );
+
+    gs.update_injection_rein_rates("CGROUP", rates);
+
+
+    BOOST_CHECK(!gs.has_production_control("NO_SUCH_GROUP"));
+    BOOST_CHECK(!gs.has_production_control("AGROUP"));
+
+    gs.production_control("AGROUP", Group::ProductionCMode::GRAT);
+    BOOST_CHECK(gs.has_production_control("AGROUP"));
+    BOOST_CHECK(gs.production_control("AGROUP") == Group::ProductionCMode::GRAT);
+    BOOST_CHECK_THROW(gs.production_control("BGROUP"), std::exception);
+
+
+    auto gs2 = gs;
+    BOOST_CHECK(gs2 == gs);
+    TestCommunicator comm;
+    gs.communicate_rates(comm);
+    BOOST_CHECK(gs2 == gs);
+}
+

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -121,7 +121,7 @@ namespace {
     buildWellState(const Setup& setup, const std::size_t timeStep,
                    std::vector<Opm::ParallelWellInfo>& pinfos)
     {
-        auto state  = Opm::WellStateFullyImplicitBlackoil{};
+        auto state  = Opm::WellStateFullyImplicitBlackoil{setup.pu.num_phases};
 
         const auto cpress =
             std::vector<double>(setup.grid.c_grid()->number_of_cells,


### PR DESCRIPTION
I am working on restart. It is hard work. I think initializing the WellState correctly is an important part of this. The WellState class is large and a bit unwieldy - to get a better overview I have started to pull group related properties out of the wellstate and into a new `GroupState`. Posting this early to get comments right away if this is something the powers that be don't desire.; the second commit will be steadily expanded to include all the group related stuff from the existsing `WellState`


**Update**: This should be ready for review and merge now. This is not exactly pure gold, but at least pulling all group related stuff out from the `WellState` to the new `GroupState` class makes it slightly easier to have an overview. The `GroupState` implementation can certainly be improved. Right now there is no API change, but for a followup PR it might make sense to move the new `GroupState` member out from `WellState` and let it become a separate member of the `WellModel`? When this is merged I intend to continue to group parts of the wellstate (ALQ, segments, ...) into separate classes.