### PR TITLE
extrapolate saltvd table

### DIFF
--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -1762,7 +1762,7 @@ private:
                 const auto& cells = reg.cells(i);
                 for (const auto& cell : cells) {
                     const double depth = cellCenterDepth_[cell];
-                    this->saltConcentration_[cell] = saltVdTable_[i].eval(depth);
+                    this->saltConcentration_[cell] = saltVdTable_[i].eval(depth, /*extrapolate=*/true);
                 }
             }
         }


### PR DESCRIPTION
When reading the release 2020.10 announcement I came over issue #2889. 
This is a fix. 