### PR TITLE
Wellmodel manage group state

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -599,7 +599,7 @@ namespace Opm {
 
             void actionOnBrokenConstraints(const Group& group, const Group::InjectionCMode& newControl, const Phase& topUpPhase, Opm::DeferredLogger& deferred_logger);
 
-            void updateWsolvent(const Group& group, const Schedule& schedule, const int reportStepIdx, const WellStateFullyImplicitBlackoil& wellState);
+            void updateWsolvent(const Group& group, const Schedule& schedule, const int reportStepIdx, const WellStateFullyImplicitBlackoil& wellState, const GroupState& group_state);
 
             void setWsolvent(const Group& group, const Schedule& schedule, const int reportStepIdx, double wsolvent);
 

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -574,10 +574,11 @@ namespace Opm {
 
             // convert well data from opm-common to well state from opm-core
             void loadRestartData( const data::Wells& wells,
-                               const data::GroupAndNetworkValues& grpNwrkValues,
-                               const PhaseUsage& phases,
-                               const bool handle_ms_well,
-                               WellStateFullyImplicitBlackoil& state ) const;
+                                  const data::GroupAndNetworkValues& grpNwrkValues,
+                                  const PhaseUsage& phases,
+                                  const bool handle_ms_well,
+                                  WellStateFullyImplicitBlackoil& well_state,
+                                  GroupState& group_state) const;
 
             // whether there exists any multisegment well open on this process
             bool anyMSWellOpenLocal() const;
@@ -589,7 +590,7 @@ namespace Opm {
             bool checkGroupConstraints(const Group& group, Opm::DeferredLogger& deferred_logger) const;
             Group::ProductionCMode checkGroupProductionConstraints(const Group& group, Opm::DeferredLogger& deferred_logger) const;
             Group::InjectionCMode checkGroupInjectionConstraints(const Group& group, const Phase& phase) const;
-            void checkGconsaleLimits(const Group& group, WellState& well_state, Opm::DeferredLogger& deferred_logger ) const;
+            void checkGconsaleLimits(const Group& group, const WellState& well_state, GroupState& group_state, Opm::DeferredLogger& deferred_logger ) const;
 
             void updateGroupHigherControls(Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
             void checkGroupHigherConstraints(const Group& group, Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -327,6 +327,10 @@ namespace Opm {
                 this->nupcol_well_state_ = this->active_well_state_;
             }
 
+            const GroupState& groupState() const {
+                return this->group_state;
+            }
+
             Opm::data::Wells wellData() const
             {
                 auto wsrpt = this->wellState().report(phase_usage_, Opm::UgGridHelpers::globalCell(grid()),
@@ -577,8 +581,7 @@ namespace Opm {
                                   const data::GroupAndNetworkValues& grpNwrkValues,
                                   const PhaseUsage& phases,
                                   const bool handle_ms_well,
-                                  WellStateFullyImplicitBlackoil& well_state,
-                                  GroupState& group_state) const;
+                                  WellStateFullyImplicitBlackoil& well_state);
 
             // whether there exists any multisegment well open on this process
             bool anyMSWellOpenLocal() const;
@@ -590,7 +593,7 @@ namespace Opm {
             bool checkGroupConstraints(const Group& group, Opm::DeferredLogger& deferred_logger) const;
             Group::ProductionCMode checkGroupProductionConstraints(const Group& group, Opm::DeferredLogger& deferred_logger) const;
             Group::InjectionCMode checkGroupInjectionConstraints(const Group& group, const Phase& phase) const;
-            void checkGconsaleLimits(const Group& group, const WellState& well_state, GroupState& group_state, Opm::DeferredLogger& deferred_logger ) const;
+            void checkGconsaleLimits(const Group& group, const WellState& well_state, Opm::DeferredLogger& deferred_logger );
 
             void updateGroupHigherControls(Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
             void checkGroupHigherConstraints(const Group& group, Opm::DeferredLogger& deferred_logger, std::set<std::string>& switched_groups);
@@ -599,7 +602,7 @@ namespace Opm {
 
             void actionOnBrokenConstraints(const Group& group, const Group::InjectionCMode& newControl, const Phase& topUpPhase, Opm::DeferredLogger& deferred_logger);
 
-            void updateWsolvent(const Group& group, const Schedule& schedule, const int reportStepIdx, const WellStateFullyImplicitBlackoil& wellState, const GroupState& group_state);
+            void updateWsolvent(const Group& group, const Schedule& schedule, const int reportStepIdx, const WellStateFullyImplicitBlackoil& wellState);
 
             void setWsolvent(const Group& group, const Schedule& schedule, const int reportStepIdx, double wsolvent);
 
@@ -642,6 +645,8 @@ namespace Opm {
             WellState active_well_state_;
             WellState last_valid_well_state_;
             WellState nupcol_well_state_;
+
+            GroupState group_state;
         };
 
 

--- a/opm/simulators/wells/GroupState.cpp
+++ b/opm/simulators/wells/GroupState.cpp
@@ -230,7 +230,7 @@ Group::InjectionCMode GroupState::injection_control(const std::string& gname, Ph
     auto key = std::make_pair(phase, gname);
     auto group_iter = this->injection_controls.find( key );
     if (group_iter == this->injection_controls.end())
-        throw std::logic_error("Could not find ontrol for injection group: " + gname);
+        throw std::logic_error("Could not find control for injection group: " + gname);
 
     return group_iter->second;
 }

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -138,6 +138,7 @@ namespace Opm
         virtual void assembleWellEq(const Simulator& ebosSimulator,
                                     const double dt,
                                     WellState& well_state,
+                                    const GroupState& group_state,
                                     Opm::DeferredLogger& deferred_logger) override;
 
         /// updating the well state based the current control mode
@@ -420,6 +421,7 @@ namespace Opm
                                     Opm::DeferredLogger& deferred_logger) const;
 
         void assembleControlEq(const WellState& well_state,
+                               const GroupState& group_state,
                                const Opm::Schedule& schedule,
                                const SummaryState& summaryState,
                                const Well::InjectionControls& inj_controls,
@@ -453,14 +455,16 @@ namespace Opm
                                               const Well::InjectionControls& inj_controls,
                                               const Well::ProductionControls& prod_controls,
                                               WellState& well_state,
+                                              const GroupState& group_state,
                                               Opm::DeferredLogger& deferred_logger) override;
 
         virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
-                                    const double dt,
-                                    const Well::InjectionControls& inj_controls,
-                                    const Well::ProductionControls& prod_controls,
-                                    WellState& well_state,
-                                    Opm::DeferredLogger& deferred_logger) override;
+                                                    const double dt,
+                                                    const Well::InjectionControls& inj_controls,
+                                                    const Well::ProductionControls& prod_controls,
+                                                    WellState& well_state,
+                                                    const GroupState& group_state,
+                                                    Opm::DeferredLogger& deferred_logger) override;
 
         virtual void updateWaterThroughput(const double dt, WellState& well_state) const override;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -263,6 +263,7 @@ namespace Opm
     assembleWellEq(const Simulator& ebosSimulator,
                    const double dt,
                    WellState& well_state,
+                   const GroupState& group_state,
                    Opm::DeferredLogger& deferred_logger)
     {
 
@@ -270,13 +271,13 @@ namespace Opm
 
         const bool use_inner_iterations = param_.use_inner_iterations_ms_wells_;
         if (use_inner_iterations) {
-            this->iterateWellEquations(ebosSimulator, dt, well_state, deferred_logger);
+            this->iterateWellEquations(ebosSimulator, dt, well_state, group_state, deferred_logger);
         }
 
         const auto& summary_state = ebosSimulator.vanguard().summaryState();
         const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
         const auto prod_controls = well_ecl_.isProducer() ? well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
-        assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, deferred_logger);
+        assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
     }
 
 
@@ -861,6 +862,7 @@ namespace Opm
 
         // store a copy of the well state, we don't want to update the real well state
         WellState well_state_copy = ebosSimulator.problem().wellModel().wellState();
+        const auto& group_state = ebosSimulator.problem().wellModel().wellState().groupState();
 
         // Get the current controls.
         const auto& summary_state = ebosSimulator.vanguard().summaryState();
@@ -894,7 +896,7 @@ namespace Opm
         well_copy.calculateExplicitQuantities(ebosSimulator, well_state_copy, deferred_logger);
         const double dt = ebosSimulator.timeStepSize();
         // iterate to get a solution at the given bhp.
-        well_copy.iterateWellEqWithControl(ebosSimulator, dt, inj_controls, prod_controls, well_state_copy,
+        well_copy.iterateWellEqWithControl(ebosSimulator, dt, inj_controls, prod_controls, well_state_copy, group_state,
                                            deferred_logger);
 
         // compute the potential and store in the flux vector.
@@ -2000,6 +2002,7 @@ namespace Opm
     void
     MultisegmentWell<TypeTag>::
     assembleControlEq(const WellState& well_state,
+                      const GroupState& group_state,
                       const Opm::Schedule& schedule,
                       const SummaryState& summaryState,
                       const Well::InjectionControls& inj_controls,
@@ -2058,7 +2061,7 @@ namespace Opm
                 return calculateBhpFromThp(rates, well, summaryState, deferred_logger);
             };
             // Call generic implementation.
-            Base::assembleControlEqInj(well_state, schedule, summaryState, inj_controls, getBhp(), injection_rate, bhp_from_thp, control_eq, deferred_logger);
+            Base::assembleControlEqInj(well_state, group_state, schedule, summaryState, inj_controls, getBhp(), injection_rate, bhp_from_thp, control_eq, deferred_logger);
         } else {
             // Find rates.
             const auto rates = getRates();
@@ -2067,7 +2070,7 @@ namespace Opm
                 return calculateBhpFromThp(rates, well, summaryState, deferred_logger);
             };
             // Call generic implementation.
-            Base::assembleControlEqProd(well_state, schedule, summaryState, prod_controls, getBhp(), rates, bhp_from_thp, control_eq, deferred_logger);
+            Base::assembleControlEqProd(well_state, group_state, schedule, summaryState, prod_controls, getBhp(), rates, bhp_from_thp, control_eq, deferred_logger);
         }
 
         // using control_eq to update the matrix and residuals
@@ -2708,6 +2711,7 @@ namespace Opm
                              const Well::InjectionControls& inj_controls,
                              const Well::ProductionControls& prod_controls,
                              WellState& well_state,
+                             const GroupState& group_state,
                              Opm::DeferredLogger& deferred_logger)
     {
         if (!this->isOperable() && !this->wellIsStopped()) return true;
@@ -2726,7 +2730,7 @@ namespace Opm
         bool relax_convergence = false;
         for (; it < max_iter_number; ++it, ++debug_cost_counter_) {
 
-            assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, deferred_logger);
+            assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
 
             const BVectorWell dx_well = mswellhelpers::applyUMFPack(duneD_, duneDSolver_, resWell_);
 
@@ -2826,6 +2830,7 @@ namespace Opm
                                    const Well::InjectionControls& inj_controls,
                                    const Well::ProductionControls& prod_controls,
                                    WellState& well_state,
+                                   const GroupState& group_state,
                                    Opm::DeferredLogger& deferred_logger)
     {
 
@@ -2979,7 +2984,7 @@ namespace Opm
             if (seg == 0) { // top segment, pressure equation is the control equation
                 const auto& summaryState = ebosSimulator.vanguard().summaryState();
                 const Opm::Schedule& schedule = ebosSimulator.vanguard().schedule();
-                assembleControlEq(well_state, schedule, summaryState, inj_controls, prod_controls, deferred_logger);
+                assembleControlEq(well_state, group_state, schedule, summaryState, inj_controls, prod_controls, deferred_logger);
             } else {
                 const UnitSystem& unit_system = ebosSimulator.vanguard().eclState().getDeckUnitSystem();
                 assemblePressureEq(seg, unit_system, well_state, deferred_logger);

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -862,7 +862,7 @@ namespace Opm
 
         // store a copy of the well state, we don't want to update the real well state
         WellState well_state_copy = ebosSimulator.problem().wellModel().wellState();
-        const auto& group_state = ebosSimulator.problem().wellModel().wellState().groupState();
+        const auto& group_state = ebosSimulator.problem().wellModel().groupState();
 
         // Get the current controls.
         const auto& summary_state = ebosSimulator.vanguard().summaryState();

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -184,6 +184,7 @@ namespace Opm
         virtual void assembleWellEq(const Simulator& ebosSimulator,
                                     const double dt,
                                     WellState& well_state,
+                                    const GroupState& group_state,
                                     Opm::DeferredLogger& deferred_logger) override;
 
         virtual void updateWellStateWithTarget(const Simulator& ebos_simulator,
@@ -242,6 +243,7 @@ namespace Opm
                                       const Well::InjectionControls& inj_controls,
                                       const Well::ProductionControls& prod_controls,
                                       WellState& well_state,
+                                      const GroupState& group_state,
                                       Opm::DeferredLogger& deferred_logger) override;
 
         /// \brief Wether the Jacobian will also have well contributions in it.
@@ -518,6 +520,7 @@ namespace Opm
         double getALQ(const WellState& well_state) const;
 
         void assembleControlEq(const WellState& well_state,
+                               const GroupState& group_state,
                                const Opm::Schedule& schedule,
                                const SummaryState& summaryState,
                                Opm::DeferredLogger& deferred_logger);
@@ -531,11 +534,13 @@ namespace Opm
                                                     const Well::InjectionControls& inj_controls,
                                                     const Well::ProductionControls& prod_controls,
                                                     WellState& well_state,
+                                                    const GroupState& group_state,
                                                     Opm::DeferredLogger& deferred_logger) override;
 
         void assembleWellEqWithoutIterationImpl(const Simulator& ebosSimulator,
                                                 const double dt,
                                                 WellState& well_state,
+                                                const GroupState& group_state,
                                                 Opm::DeferredLogger& deferred_logger);
 
         void calculateSinglePerf(const Simulator& ebosSimulator,

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2610,7 +2610,7 @@ namespace Opm
         // create a copy of the well_state to use. If the operability checking is sucessful, we use this one
         // to replace the original one
         WellState well_state_copy = ebosSimulator.problem().wellModel().wellState();
-        const auto& group_state = ebosSimulator.problem().wellModel().wellState().groupState();
+        const auto& group_state = ebosSimulator.problem().wellModel().groupState();
 
         //  Set current control to bhp, and bhp value in state, modify bhp limit in control object.
         if (well_ecl_.isInjector()) {

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -988,7 +988,7 @@ namespace WellGroupHelpers
 
 
 
-    std::pair<bool, double> checkGroupConstraintsProd(const std::string& name,
+    std::pair<bool, double> checkGroupConstraintsProd(const std::string& wgname,
                                                       const std::string& parent,
                                                       const Group& group,
                                                       const WellStateFullyImplicitBlackoil& wellState,
@@ -1003,7 +1003,7 @@ namespace WellGroupHelpers
                                                       const std::vector<double>& resv_coeff,
                                                       DeferredLogger& deferred_logger)
     {
-        // When called for a well ('name' is a well name), 'parent'
+        // When called for a well ('wgname' is a well name), 'parent'
         // will be the name of 'group'. But if we recurse, 'name' and
         // 'parent' will stay fixed while 'group' will be higher up
         // in the group tree.
@@ -1020,7 +1020,7 @@ namespace WellGroupHelpers
             }
             // Otherwise: check production share of parent's control.
             const auto& parentGroup = schedule.getGroup(group.parent(), reportStepIdx);
-            return checkGroupConstraintsProd(name,
+            return checkGroupConstraintsProd(wgname,
                                              parent,
                                              parentGroup,
                                              wellState,
@@ -1054,7 +1054,7 @@ namespace WellGroupHelpers
         TargetCalculator tcalc(currentGroupControl, pu, resv_coeff, gratTargetFromSales);
         FractionCalculator fcalc(schedule, summaryState, wellState, group_state, reportStepIdx, guideRate, tcalc.guideTargetMode(), pu, true, Phase::OIL);
 
-        auto localFraction = [&](const std::string& child) { return fcalc.localFraction(child, name); };
+        auto localFraction = [&](const std::string& child) { return fcalc.localFraction(child, wgname); };
 
         auto localReduction = [&](const std::string& group_name) {
             const std::vector<double>& groupTargetReductions
@@ -1068,7 +1068,7 @@ namespace WellGroupHelpers
         // TODO finish explanation.
         const double current_rate
             = -tcalc.calcModeRateFromRates(rates); // Switch sign since 'rates' are negative for producers.
-        const auto chain = groupChainTopBot(name, group.name(), schedule, reportStepIdx);
+        const auto chain = groupChainTopBot(wgname, group.name(), schedule, reportStepIdx);
         // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
         const size_t num_ancestors = chain.size() - 1;
         // we need to find out the level where the current well is applied to the local reduction 
@@ -1113,7 +1113,7 @@ namespace WellGroupHelpers
         return std::make_pair(current_rate > target_rate, target_rate / current_rate);
     }
 
-    std::pair<bool, double> checkGroupConstraintsInj(const std::string& name,
+    std::pair<bool, double> checkGroupConstraintsInj(const std::string& wgname,
                                                      const std::string& parent,
                                                      const Group& group,
                                                      const WellStateFullyImplicitBlackoil& wellState,
@@ -1129,7 +1129,7 @@ namespace WellGroupHelpers
                                                      const std::vector<double>& resv_coeff,
                                                      DeferredLogger& deferred_logger)
     {
-        // When called for a well ('name' is a well name), 'parent'
+        // When called for a well ('wgname' is a well name), 'parent'
         // will be the name of 'group'. But if we recurse, 'name' and
         // 'parent' will stay fixed while 'group' will be higher up
         // in the group tree.
@@ -1146,7 +1146,7 @@ namespace WellGroupHelpers
             }
             // Otherwise: check production share of parent's control.
             const auto& parentGroup = schedule.getGroup(group.parent(), reportStepIdx);
-            return checkGroupConstraintsInj(name,
+            return checkGroupConstraintsInj(wgname,
                                             parent,
                                             parentGroup,
                                             wellState,
@@ -1179,7 +1179,7 @@ namespace WellGroupHelpers
         InjectionTargetCalculator tcalc(currentGroupControl, pu, resv_coeff, group.name(), sales_target, wellState, group_state, injectionPhase, deferred_logger);
         FractionCalculator fcalc(schedule, summaryState, wellState, group_state, reportStepIdx, guideRate, tcalc.guideTargetMode(), pu, false, injectionPhase);
 
-        auto localFraction = [&](const std::string& child) { return fcalc.localFraction(child, name); };
+        auto localFraction = [&](const std::string& child) { return fcalc.localFraction(child, wgname); };
 
         auto localReduction = [&](const std::string& group_name) {
             const std::vector<double>& groupTargetReductions
@@ -1193,8 +1193,8 @@ namespace WellGroupHelpers
         // TODO finish explanation.
         const double current_rate
             = tcalc.calcModeRateFromRates(rates); // Switch sign since 'rates' are negative for producers.
-        const auto chain = groupChainTopBot(name, group.name(), schedule, reportStepIdx);
-        // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
+        const auto chain = groupChainTopBot(wgname, group.name(), schedule, reportStepIdx);
+        // Because 'wgname' is the last of the elements, and not an ancestor, we subtract one below.
         const size_t num_ancestors = chain.size() - 1;
         // we need to find out the level where the current well is applied to the local reduction
         size_t local_reduction_level = 0;

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -894,15 +894,14 @@ namespace WellGroupHelpers
     }
     double FractionCalculator::guideRateSum(const Group& group, const std::string& always_included_child)
     {
-        const auto& group_state = this->well_state_.groupState();
         double total_guide_rate = 0.0;
         for (const std::string& child_group : group.groups()) {
             bool included = (child_group == always_included_child);
             if (is_producer_) {
-                const auto ctrl = group_state.production_control(child_group);
+                const auto ctrl = this->group_state_.production_control(child_group);
                 included = included || (ctrl == Group::ProductionCMode::FLD) || (ctrl == Group::ProductionCMode::NONE);
             } else {
-                const auto ctrl = group_state.injection_control(child_group, injection_phase_);
+                const auto ctrl = this->group_state_.injection_control(child_group, injection_phase_);
                 included = included || (ctrl == Group::InjectionCMode::FLD) || (ctrl == Group::InjectionCMode::NONE);
             }
             if (included) {
@@ -948,8 +947,7 @@ namespace WellGroupHelpers
     int FractionCalculator::groupControlledWells(const std::string& group_name,
                                                  const std::string& always_included_child)
     {
-        const auto& group_state = well_state_.groupState();
-        return ::Opm::WellGroupHelpers::groupControlledWells(schedule_, well_state_, group_state, report_step_, group_name, always_included_child, is_producer_, injection_phase_);
+        return ::Opm::WellGroupHelpers::groupControlledWells(schedule_, well_state_, this->group_state_, report_step_, group_name, always_included_child, is_producer_, injection_phase_);
     }
 
     GuideRate::RateVector FractionCalculator::getGroupRateVector(const std::string& group_name)

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -28,6 +28,7 @@
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/simulators/wells/VFPProdProperties.hpp>
 #include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/simulators/wells/GroupState.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -49,7 +50,7 @@ namespace WellGroupHelpers
                        const Schedule& schedule,
                        const SummaryState& summaryState,
                        const int reportStepIdx,
-                       WellStateFullyImplicitBlackoil& wellState);
+                       GroupState& groupState);
 
     void accumulateGroupEfficiencyFactor(const Group& group,
                                          const Schedule& schedule,
@@ -91,8 +92,8 @@ namespace WellGroupHelpers
                                     const PhaseUsage& pu,
                                     const GuideRate& guide_rate,
                                     const WellStateFullyImplicitBlackoil& wellStateNupcol,
-                                    WellStateFullyImplicitBlackoil& wellState,
-                                    std::vector<double>& groupTargetReduction);
+                                    const WellStateFullyImplicitBlackoil& wellState,
+                                    GroupState& group_state);
 
     template <class Comm>
     void updateGuideRateForProductionGroups(const Group& group,
@@ -230,13 +231,15 @@ namespace WellGroupHelpers
                              const Schedule& schedule,
                              const int reportStepIdx,
                              const WellStateFullyImplicitBlackoil& wellStateNupcol,
-                             WellStateFullyImplicitBlackoil& wellState);
+                             const WellStateFullyImplicitBlackoil& wellState,
+                             GroupState& group_state);
 
     void updateReservoirRatesInjectionGroups(const Group& group,
                                              const Schedule& schedule,
                                              const int reportStepIdx,
                                              const WellStateFullyImplicitBlackoil& wellStateNupcol,
-                                             WellStateFullyImplicitBlackoil& wellState);
+                                             const WellStateFullyImplicitBlackoil& wellState,
+                                             GroupState& group_state);
 
     void updateWellRates(const Group& group,
                          const Schedule& schedule,
@@ -248,7 +251,8 @@ namespace WellGroupHelpers
                                     const Schedule& schedule,
                                     const int reportStepIdx,
                                     const WellStateFullyImplicitBlackoil& wellStateNupcol,
-                                    WellStateFullyImplicitBlackoil& wellState);
+                                    const WellStateFullyImplicitBlackoil& wellState,
+                                    GroupState& group_state);
 
     void updateREINForGroups(const Group& group,
                              const Schedule& schedule,
@@ -256,7 +260,8 @@ namespace WellGroupHelpers
                              const PhaseUsage& pu,
                              const SummaryState& st,
                              const WellStateFullyImplicitBlackoil& wellStateNupcol,
-                             WellStateFullyImplicitBlackoil& wellState);
+                             const WellStateFullyImplicitBlackoil& wellState,
+                             GroupState& group_state);
 
     std::map<std::string, double>
     computeNetworkPressures(const Opm::Network::ExtNetwork& network,

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -102,6 +102,7 @@ namespace WellGroupHelpers
                                             const int reportStepIdx,
                                             const double& simTime,
                                             WellStateFullyImplicitBlackoil& wellState,
+                                            const GroupState& group_state,
                                             const Comm& comm,
                                             GuideRate* guideRate,
                                             std::vector<double>& pot)
@@ -112,11 +113,10 @@ namespace WellGroupHelpers
             const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
 
             // Note that group effiency factors for groupTmp are applied in updateGuideRateForGroups
-            updateGuideRateForProductionGroups(
-                        groupTmp, schedule, pu, reportStepIdx, simTime, wellState, comm, guideRate, thisPot);
+            updateGuideRateForProductionGroups(groupTmp, schedule, pu, reportStepIdx, simTime, wellState, group_state, comm, guideRate, thisPot);
 
             // accumulate group contribution from sub group unconditionally
-            const Group::ProductionCMode& currentGroupControl = wellState.currentProductionGroupControl(groupName);
+            const Group::ProductionCMode& currentGroupControl = group_state.production_control(group.name());
             if (currentGroupControl != Group::ProductionCMode::FLD
                     && currentGroupControl != Group::ProductionCMode::NONE) {
                 continue;
@@ -224,6 +224,7 @@ namespace WellGroupHelpers
                                             const Opm::PhaseUsage& pu,
                                             const int reportStepIdx,
                                             const WellStateFullyImplicitBlackoil& wellState,
+                                            const GroupState& group_state,
                                             GuideRate* guideRate,
                                             Opm::DeferredLogger& deferred_logger);
 
@@ -266,6 +267,7 @@ namespace WellGroupHelpers
     std::map<std::string, double>
     computeNetworkPressures(const Opm::Network::ExtNetwork& network,
                             const WellStateFullyImplicitBlackoil& well_state,
+                            const GroupState& group_state,
                             const VFPProdProperties& vfp_prod_props,
                             const Schedule& schedule,
                             const int report_time_step);
@@ -274,7 +276,7 @@ namespace WellGroupHelpers
     getWellRateVector(const WellStateFullyImplicitBlackoil& well_state, const PhaseUsage& pu, const std::string& name);
 
     GuideRate::RateVector
-    getProductionGroupRateVector(const WellStateFullyImplicitBlackoil& well_state, const PhaseUsage& pu, const std::string& group_name);
+    getProductionGroupRateVector(const GroupState& group_state, const PhaseUsage& pu, const std::string& group_name);
 
     double getGuideRate(const std::string& name,
                         const Schedule& schedule,
@@ -296,6 +298,7 @@ namespace WellGroupHelpers
 
     int groupControlledWells(const Schedule& schedule,
                              const WellStateFullyImplicitBlackoil& well_state,
+                             const GroupState& group_state,
                              const int report_step,
                              const std::string& group_name,
                              const std::string& always_included_child,
@@ -309,6 +312,7 @@ namespace WellGroupHelpers
         FractionCalculator(const Schedule& schedule,
                            const SummaryState& summary_state,
                            const WellStateFullyImplicitBlackoil& well_state,
+                           const GroupState& group_state,
                            const int report_step,
                            const GuideRate* guide_rate,
                            const GuideRateModel::Target target,
@@ -327,6 +331,7 @@ namespace WellGroupHelpers
         const Schedule& schedule_;
         const SummaryState& summary_state_;
         const WellStateFullyImplicitBlackoil& well_state_;
+        const GroupState& group_state_;
         int report_step_;
         const GuideRate* guide_rate_;
         GuideRateModel::Target target_;
@@ -340,6 +345,7 @@ namespace WellGroupHelpers
                                                      const std::string& parent,
                                                      const Group& group,
                                                      const WellStateFullyImplicitBlackoil& wellState,
+                                                     const GroupState& group_state,
                                                      const int reportStepIdx,
                                                      const GuideRate* guideRate,
                                                      const double* rates,
@@ -368,6 +374,7 @@ namespace WellGroupHelpers
                                                       const std::string& parent,
                                                       const Group& group,
                                                       const WellStateFullyImplicitBlackoil& wellState,
+                                                      const GroupState& group_state,
                                                       const int reportStepIdx,
                                                       const GuideRate* guideRate,
                                                       const double* rates,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -41,6 +41,7 @@
 #include <opm/simulators/wells/WellGroupHelpers.hpp>
 #include <opm/simulators/wells/WellProdIndexCalculator.hpp>
 #include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/simulators/wells/GroupState.hpp>
 // NOTE: GasLiftSingleWell.hpp includes StandardWell.hpp which includes ourself
 //   (WellInterface.hpp), so we need to forward declare GasLiftSingleWell
 //   for it to be defined in this file. Similar for BlackoilWellModel
@@ -185,6 +186,7 @@ namespace Opm
         virtual void assembleWellEq(const Simulator& ebosSimulator,
                                     const double dt,
                                     WellState& well_state,
+                                    const GroupState& group_state,
                                     Opm::DeferredLogger& deferred_logger
                                     ) = 0;
 
@@ -233,6 +235,7 @@ namespace Opm
         bool updateWellControl(const Simulator& ebos_simulator,
                                const IndividualOrGroup iog,
                                WellState& well_state,
+                               const GroupState& group_state,
                                Opm::DeferredLogger& deferred_logger) /* const */;
 
         virtual void updatePrimaryVariables(const WellState& well_state, Opm::DeferredLogger& deferred_logger) const = 0;
@@ -283,7 +286,9 @@ namespace Opm
         void wellTesting(const Simulator& simulator,
                          const double simulation_time, const int report_step,
                          const WellTestConfig::Reason testing_reason,
-                         /* const */ WellState& well_state, WellTestState& welltest_state,
+                         /* const */ WellState& well_state,
+                         const GroupState& group_state,
+                         WellTestState& welltest_state,
                          Opm::DeferredLogger& deferred_logger);
 
         void updatePerforatedCell(std::vector<bool>& is_cell_perforated);
@@ -339,6 +344,7 @@ namespace Opm
 
         void solveWellEquation(const Simulator& ebosSimulator,
                                WellState& well_state,
+                               const GroupState& group_state,
                                Opm::DeferredLogger& deferred_logger);
 
         const PhaseUsage& phaseUsage() const;
@@ -528,12 +534,15 @@ namespace Opm
 
 
         void wellTestingEconomic(const Simulator& simulator,
-                                 const double simulation_time, const WellState& well_state,
+                                 const double simulation_time, const WellState& well_state, const GroupState& group_state,
                                  WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger);
 
         void wellTestingPhysical(const Simulator& simulator,
                                  const double simulation_time, const int report_step,
-                                 WellState& well_state, WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger);
+                                 WellState& well_state,
+                                 const GroupState& group_state,
+                                 WellTestState& welltest_state,
+                                 Opm::DeferredLogger& deferred_logger);
 
 
         virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
@@ -541,6 +550,7 @@ namespace Opm
                                                     const Well::InjectionControls& inj_controls,
                                                     const Well::ProductionControls& prod_controls,
                                                     WellState& well_state,
+                                                    const GroupState& group_state,
                                                     Opm::DeferredLogger& deferred_logger) = 0;
 
         // iterate well equations with the specified control until converged
@@ -549,11 +559,13 @@ namespace Opm
                                               const Well::InjectionControls& inj_controls,
                                               const Well::ProductionControls& prod_controls,
                                               WellState& well_state,
+                                              const GroupState& group_state,
                                               Opm::DeferredLogger& deferred_logger) = 0;
 
         bool iterateWellEquations(const Simulator& ebosSimulator,
                                   const double dt,
                                   WellState& well_state,
+                                  const GroupState& group_state,
                                   Opm::DeferredLogger& deferred_logger);
 
         void updateWellTestStateEconomic(const WellState& well_state,
@@ -568,12 +580,13 @@ namespace Opm
                                          WellTestState& well_test_state,
                                          Opm::DeferredLogger& deferred_logger) const;
 
-        void solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state,
+        void solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state, const GroupState& group_state,
                                  Opm::DeferredLogger& deferred_logger);
 
         void initCompletions();
 
         bool checkConstraints(WellState& well_state,
+                              const GroupState& group_state,
                               const Schedule& schedule,
                               const SummaryState& summaryState,
                               DeferredLogger& deferred_logger) const;
@@ -582,27 +595,31 @@ namespace Opm
                                         const SummaryState& summaryState) const;
 
         bool checkGroupConstraints(WellState& well_state,
+                                   const GroupState& group_state,
                                    const Schedule& schedule,
                                    const SummaryState& summaryState,
                                    DeferredLogger& deferred_logger) const;
 
         std::pair<bool, double> checkGroupConstraintsProd(const Group& group,
-                                       const WellState& well_state,
-                                       const double efficiencyFactor,
-                                       const Schedule& schedule,
-                                       const SummaryState& summaryState,
-                                       DeferredLogger& deferred_logger) const;
+                                                          const WellState& well_state,
+                                                          const GroupState& group_state,
+                                                          const double efficiencyFactor,
+                                                          const Schedule& schedule,
+                                                          const SummaryState& summaryState,
+                                                          DeferredLogger& deferred_logger) const;
 
         std::pair<bool, double> checkGroupConstraintsInj(const Group& group,
-                                      const WellState& well_state,
-                                      const double efficiencyFactor,
-                                      const Schedule& schedule,
-                                      const SummaryState& summaryState,
-                                      DeferredLogger& deferred_logger) const;
+                                                         const WellState& well_state,
+                                                         const GroupState& group_state,
+                                                         const double efficiencyFactor,
+                                                         const Schedule& schedule,
+                                                         const SummaryState& summaryState,
+                                                         DeferredLogger& deferred_logger) const;
 
         template <class EvalWell>
         void getGroupInjectionControl(const Group& group,
                                       const WellState& well_state,
+                                      const GroupState& group_state,
                                       const Opm::Schedule& schedule,
                                       const SummaryState& summaryState,
                                       const InjectorType& injectorType,
@@ -615,6 +632,7 @@ namespace Opm
         template <class EvalWell>
         void getGroupProductionControl(const Group& group,
                                        const WellState& well_state,
+                                       const GroupState& group_state,
                                        const Opm::Schedule& schedule,
                                        const SummaryState& summaryState,
                                        const EvalWell& bhp,
@@ -624,6 +642,7 @@ namespace Opm
 
         template <class EvalWell, class BhpFromThpFunc>
         void assembleControlEqInj(const WellState& well_state,
+                                  const GroupState& group_state,
                                   const Opm::Schedule& schedule,
                                   const SummaryState& summaryState,
                                   const Well::InjectionControls& controls,
@@ -635,6 +654,7 @@ namespace Opm
 
         template <class EvalWell, class BhpFromThpFunc>
         void assembleControlEqProd(const WellState& well_state,
+                                   const GroupState& group_state,
                                    const Opm::Schedule& schedule,
                                    const SummaryState& summaryState,
                                    const Well::ProductionControls& controls,

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -413,22 +413,6 @@ namespace Opm
         std::vector<Well::ProducerCMode>& currentProductionControls() { return current_production_controls_; }
         const std::vector<Well::ProducerCMode>& currentProductionControls() const { return current_production_controls_; }
 
-        bool hasProductionGroupControl(const std::string& groupName) const {
-            return this->group_state.has_production_control(groupName);
-        }
-
-        bool hasInjectionGroupControl(const Opm::Phase& phase, const std::string& groupName) const {
-            return this->group_state.has_injection_control(groupName, phase);
-        }
-
-        Group::ProductionCMode currentProductionGroupControl(const std::string& groupName) const {
-            return this->group_state.production_control(groupName);
-        }
-
-        Group::InjectionCMode currentInjectionGroupControl(const Opm::Phase& phase, const std::string& groupName) const {
-            return this->group_state.injection_control(groupName, phase);
-        }
-
         void setCurrentWellRates(const std::string& wellName, const std::vector<double>& rates ) {
             well_rates[wellName].second = rates;
         }
@@ -444,46 +428,6 @@ namespace Opm
 
         bool hasWellRates(const std::string& wellName) const {
             return this->well_rates.find(wellName) != this->well_rates.end();
-        }
-
-        const std::vector<double>& currentProductionGroupRates(const std::string& groupName) const {
-            return this->group_state.production_rates(groupName);
-        }
-
-        bool hasProductionGroupRates(const std::string& groupName) const {
-            return this->group_state.has_production_rates(groupName);
-        }
-
-        const std::vector<double>& currentProductionGroupReductionRates(const std::string& groupName) const {
-            return this->group_state.production_reduction_rates(groupName);
-        }
-
-        const std::vector<double>& currentInjectionGroupReductionRates(const std::string& groupName) const {
-            return this->group_state.injection_reduction_rates(groupName);
-        }
-
-        const std::vector<double>& currentInjectionGroupReservoirRates(const std::string& groupName) const {
-            return this->group_state.injection_reservoir_rates(groupName);
-        }
-
-        double currentInjectionVREPRates(const std::string& groupName) const {
-            return this->group_state.injection_vrep_rate(groupName);
-        }
-
-        const std::vector<double>& currentInjectionREINRates(const std::string& groupName) const {
-            return this->group_state.injection_rein_rates(groupName);
-        }
-
-        bool hasGroupGratTargetFromSales(const std::string& groupName) const {
-            return this->group_state.has_grat_sales_target(groupName);
-        }
-
-        double currentGroupGratTargetFromSales(const std::string& groupName) const {
-            return this->group_state.grat_sales_target(groupName);
-        }
-
-        const std::vector<double>& currentGroupInjectionPotentials(const std::string& groupName) const {
-            return this->group_state.injection_potentials(groupName);
         }
 
         data::Wells
@@ -1260,6 +1204,10 @@ namespace Opm
 
 
         GroupState& groupState() {
+            return this->group_state;
+        }
+
+        const GroupState& groupState() const {
             return this->group_state;
         }
 

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -421,18 +421,8 @@ namespace Opm
             return this->group_state.has_injection_control(groupName, phase);
         }
 
-        /// One current control per group.
-        void setCurrentProductionGroupControl(const std::string& groupName, const Group::ProductionCMode& groupControl ) {
-            this->group_state.production_control(groupName, groupControl);
-        }
-
         Group::ProductionCMode currentProductionGroupControl(const std::string& groupName) const {
             return this->group_state.production_control(groupName);
-        }
-
-        /// One current control per group.
-        void setCurrentInjectionGroupControl(const Opm::Phase& phase, const std::string& groupName, const Group::InjectionCMode& groupControl ) {
-            this->group_state.injection_control(groupName, phase, groupControl);
         }
 
         Group::InjectionCMode currentInjectionGroupControl(const Opm::Phase& phase, const std::string& groupName) const {
@@ -456,10 +446,6 @@ namespace Opm
             return this->well_rates.find(wellName) != this->well_rates.end();
         }
 
-        void setCurrentProductionGroupRates(const std::string& groupName, const std::vector<double>& rates ) {
-            this->group_state.update_production_rates(groupName, rates);
-        }
-
         const std::vector<double>& currentProductionGroupRates(const std::string& groupName) const {
             return this->group_state.production_rates(groupName);
         }
@@ -468,49 +454,24 @@ namespace Opm
             return this->group_state.has_production_rates(groupName);
         }
 
-
-        void setCurrentProductionGroupReductionRates(const std::string& groupName, const std::vector<double>& target ) {
-            this->group_state.update_production_reduction_rates(groupName, target);
-        }
-
         const std::vector<double>& currentProductionGroupReductionRates(const std::string& groupName) const {
             return this->group_state.production_reduction_rates(groupName);
-        }
-
-        void setCurrentInjectionGroupReductionRates(const std::string& groupName, const std::vector<double>& target ) {
-            this->group_state.update_injection_reduction_rates(groupName, target);
         }
 
         const std::vector<double>& currentInjectionGroupReductionRates(const std::string& groupName) const {
             return this->group_state.injection_reduction_rates(groupName);
         }
 
-        void setCurrentInjectionGroupReservoirRates(const std::string& groupName, const std::vector<double>& target ) {
-            this->group_state.update_injection_reservoir_rates(groupName, target);
-        }
-
         const std::vector<double>& currentInjectionGroupReservoirRates(const std::string& groupName) const {
             return this->group_state.injection_reservoir_rates(groupName);
-        }
-
-        void setCurrentInjectionVREPRates(const std::string& groupName, const double& target ) {
-            this->group_state.update_injection_vrep_rate(groupName, target);
         }
 
         double currentInjectionVREPRates(const std::string& groupName) const {
             return this->group_state.injection_vrep_rate(groupName);
         }
 
-        void setCurrentInjectionREINRates(const std::string& groupName, const std::vector<double>& target ) {
-            this->group_state.update_injection_rein_rates(groupName, target);
-        }
-
         const std::vector<double>& currentInjectionREINRates(const std::string& groupName) const {
             return this->group_state.injection_rein_rates(groupName);
-        }
-
-        void setCurrentGroupGratTargetFromSales(const std::string& groupName, const double& target ) {
-            this->group_state.update_grat_sales_target(groupName, target);
         }
 
         bool hasGroupGratTargetFromSales(const std::string& groupName) const {
@@ -519,10 +480,6 @@ namespace Opm
 
         double currentGroupGratTargetFromSales(const std::string& groupName) const {
             return this->group_state.grat_sales_target(groupName);
-        }
-
-        void setCurrentGroupInjectionPotentials(const std::string& groupName, const std::vector<double>& pot ) {
-            this->group_state.update_injection_potentials(groupName, pot);
         }
 
         const std::vector<double>& currentGroupInjectionPotentials(const std::string& groupName) const {
@@ -1299,6 +1256,11 @@ namespace Opm
                 OPM_THROW(std::logic_error, "Could not find well name for global idx " << index);
             }
             return it->first;
+        }
+
+
+        GroupState& groupState() {
+            return this->group_state;
         }
 
     private:

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -70,8 +70,7 @@ namespace Opm
         using BaseType :: updateStatus;
 
         explicit WellStateFullyImplicitBlackoil(int num_phases) :
-            WellState(num_phases),
-            group_state(num_phases)
+            WellState(num_phases)
         {}
 
 
@@ -1048,8 +1047,6 @@ namespace Opm
                 x.second = data[pos++];
             }
             assert(pos == sz);
-
-            this->group_state.communicate_rates(comm);
         }
 
         template<class Comm>
@@ -1203,14 +1200,6 @@ namespace Opm
         }
 
 
-        GroupState& groupState() {
-            return this->group_state;
-        }
-
-        const GroupState& groupState() const {
-            return this->group_state;
-        }
-
     private:
         std::vector<double> perfphaserates_;
         std::vector<bool> is_producer_; // Size equal to number of local wells.
@@ -1227,8 +1216,6 @@ namespace Opm
         std::vector<int> globalIsProductionGrup_;
         std::map<std::string, int> wellNameToGlobalIdx_;
         std::map<std::string, std::pair<bool, std::vector<double>>> well_rates;
-
-        GroupState group_state;
 
         std::map<std::string, double> current_alq_;
         std::map<std::string, double> default_alq_;


### PR DESCRIPTION
On top of #3171

The WellState object no langer manages the GroupState.

This might not be the final destination (probaly not), but on the refactoring journey to Good Enough&trade; I see it as essential to have more explicit datastructures.