### PR TITLE
Use groupstate2

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -41,6 +41,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/utils/gatherDeferredLogger.cpp
   opm/simulators/utils/ParallelRestart.cpp
   opm/simulators/wells/GroupState.cpp
+  opm/simulators/wells/WGState.cpp
   opm/simulators/wells/ParallelWellInfo.cpp
   opm/simulators/wells/VFPProdProperties.cpp
   opm/simulators/wells/VFPInjProperties.cpp
@@ -256,6 +257,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/WellConnectionAuxiliaryModule.hpp
   opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
   opm/simulators/wells/GroupState.hpp
+  opm/simulators/wells/WGState.hpp
   opm/simulators/wells/VFPProperties.hpp
   opm/simulators/wells/VFPHelpers.hpp
   opm/simulators/wells/VFPInjProperties.hpp

--- a/ebos/eclpeacemanwell.hh
+++ b/ebos/eclpeacemanwell.hh
@@ -34,6 +34,7 @@
 #include <opm/models/utils/alignedallocator.hh>
 
 #include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/simulators/wells/WGState.hpp>
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/densead/Math.hpp>
@@ -1422,22 +1423,22 @@ protected:
         throw std::logic_error("wellState() method not implemented for class eclpeacemanwell");
     }
 
-    void commitWellState()
+    void commitWGState()
     {
         throw std::logic_error("commitWellState() method not implemented for class eclpeacemanwell");
     }
 
-    void commitWellState(WellStateFullyImplicitBlackoil well_state)
+    void commitWGState(WGState wgstate)
     {
         throw std::logic_error("commitWellState() method not implemented for class eclpeacemanwell");
     }
 
-    void resetWellState()
+    void resetWGState()
     {
         throw std::logic_error("resetWellState() method not implemented for class eclpeacemanwell");
     }
 
-    void updateNupcolWellState()
+    void updateNupcolWGState()
     {
         throw std::logic_error("updateNupcolWellState() method not implemented for class eclpeacemanwell");
     }

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1414,7 +1414,7 @@ public:
           the next timestep we must commit it.
         */
         if (commit_wellstate)
-            this->wellModel_.commitWellState();
+            this->wellModel_.commitWGState();
     }
 
 

--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -37,6 +37,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
 #include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/simulators/wells/WGState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
@@ -631,24 +632,24 @@ public:
         throw std::logic_error("wellState() method not implemented for class eclwellmanager");
     }
 
-    void commitWellState()
+    void commitWGState()
     {
         throw std::logic_error("commitWellState() method not implemented for class eclwellmanager");
     }
 
-    void commitWellState(WellStateFullyImplicitBlackoil well_state)
+    void commitWGState(WGState)
     {
-        throw std::logic_error("commitWellState() method not implemented for class eclwellmanager");
+        throw std::logic_error("commitWGState() method not implemented for class eclwellmanager");
     }
 
-    void resetWellState()
+    void resetWGState()
     {
-        throw std::logic_error("resetWellState() method not implemented for class eclwellmanager");
+        throw std::logic_error("resetWGState() method not implemented for class eclwellmanager");
     }
 
-    void updateNupcolWellState()
+    void updateNupcolWGState()
     {
-        throw std::logic_error("updateNupcolWellState() method not implemented for class eclwellmanager");
+        throw std::logic_error("updateNupcolWGState() method not implemented for class eclwellmanager");
     }
 
     void

--- a/opm/simulators/wells/GroupState.hpp
+++ b/opm/simulators/wells/GroupState.hpp
@@ -25,6 +25,7 @@
 
 #include <opm/core/props/BlackoilPhases.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
 namespace Opm {
 
@@ -163,7 +164,7 @@ private:
     std::map<std::string, double> m_grat_sales_target;
 
 
-    std::map<std::pair<Opm::Phase, std::string>, Group::InjectionCMode> injection_controls;
+    std::map<std::pair<Phase, std::string>, Group::InjectionCMode> injection_controls;
 };
 
 }

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -138,6 +138,7 @@ namespace Opm
         virtual void assembleWellEq(const Simulator& ebosSimulator,
                                     const double dt,
                                     WellState& well_state,
+                                    const GroupState& group_state,
                                     Opm::DeferredLogger& deferred_logger) override;
 
         /// updating the well state based the current control mode
@@ -420,6 +421,7 @@ namespace Opm
                                     Opm::DeferredLogger& deferred_logger) const;
 
         void assembleControlEq(const WellState& well_state,
+                               const GroupState& group_state,
                                const Opm::Schedule& schedule,
                                const SummaryState& summaryState,
                                const Well::InjectionControls& inj_controls,
@@ -453,14 +455,16 @@ namespace Opm
                                               const Well::InjectionControls& inj_controls,
                                               const Well::ProductionControls& prod_controls,
                                               WellState& well_state,
+                                              const GroupState& group_state,
                                               Opm::DeferredLogger& deferred_logger) override;
 
         virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
-                                    const double dt,
-                                    const Well::InjectionControls& inj_controls,
-                                    const Well::ProductionControls& prod_controls,
-                                    WellState& well_state,
-                                    Opm::DeferredLogger& deferred_logger) override;
+                                                    const double dt,
+                                                    const Well::InjectionControls& inj_controls,
+                                                    const Well::ProductionControls& prod_controls,
+                                                    WellState& well_state,
+                                                    const GroupState& group_state,
+                                                    Opm::DeferredLogger& deferred_logger) override;
 
         virtual void updateWaterThroughput(const double dt, WellState& well_state) const override;
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -184,6 +184,7 @@ namespace Opm
         virtual void assembleWellEq(const Simulator& ebosSimulator,
                                     const double dt,
                                     WellState& well_state,
+                                    const GroupState& group_state,
                                     Opm::DeferredLogger& deferred_logger) override;
 
         virtual void updateWellStateWithTarget(const Simulator& ebos_simulator,
@@ -242,6 +243,7 @@ namespace Opm
                                       const Well::InjectionControls& inj_controls,
                                       const Well::ProductionControls& prod_controls,
                                       WellState& well_state,
+                                      const GroupState& group_state,
                                       Opm::DeferredLogger& deferred_logger) override;
 
         /// \brief Wether the Jacobian will also have well contributions in it.
@@ -518,6 +520,7 @@ namespace Opm
         double getALQ(const WellState& well_state) const;
 
         void assembleControlEq(const WellState& well_state,
+                               const GroupState& group_state,
                                const Opm::Schedule& schedule,
                                const SummaryState& summaryState,
                                Opm::DeferredLogger& deferred_logger);
@@ -531,11 +534,13 @@ namespace Opm
                                                     const Well::InjectionControls& inj_controls,
                                                     const Well::ProductionControls& prod_controls,
                                                     WellState& well_state,
+                                                    const GroupState& group_state,
                                                     Opm::DeferredLogger& deferred_logger) override;
 
         void assembleWellEqWithoutIterationImpl(const Simulator& ebosSimulator,
                                                 const double dt,
                                                 WellState& well_state,
+                                                const GroupState& group_state,
                                                 Opm::DeferredLogger& deferred_logger);
 
         void calculateSinglePerf(const Simulator& ebosSimulator,

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -544,20 +544,21 @@ namespace Opm
     assembleWellEq(const Simulator& ebosSimulator,
                    const double dt,
                    WellState& well_state,
+                   const GroupState& group_state,
                    Opm::DeferredLogger& deferred_logger)
     {
         checkWellOperability(ebosSimulator, well_state, deferred_logger);
 
         const bool use_inner_iterations = param_.use_inner_iterations_wells_;
         if (use_inner_iterations) {
-            this->iterateWellEquations(ebosSimulator, dt, well_state, deferred_logger);
+            this->iterateWellEquations(ebosSimulator, dt, well_state, group_state, deferred_logger);
         }
 
         // TODO: inj_controls and prod_controls are not used in the following function for now
         const auto& summary_state = ebosSimulator.vanguard().summaryState();
         const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
         const auto prod_controls = well_ecl_.isProducer() ? well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
-        assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, deferred_logger);
+        assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
     }
 
 
@@ -571,6 +572,7 @@ namespace Opm
                                    const Well::InjectionControls& /*inj_controls*/,
                                    const Well::ProductionControls& /*prod_controls*/,
                                    WellState& well_state,
+                                   const GroupState& group_state,
                                    Opm::DeferredLogger& deferred_logger)
     {
         // TODO: only_wells should be put back to save some computation
@@ -583,7 +585,7 @@ namespace Opm
         invDuneD_ = 0.0;
         resWell_ = 0.0;
 
-        assembleWellEqWithoutIterationImpl(ebosSimulator, dt, well_state, deferred_logger);
+        assembleWellEqWithoutIterationImpl(ebosSimulator, dt, well_state, group_state, deferred_logger);
     }
 
 
@@ -595,6 +597,7 @@ namespace Opm
     assembleWellEqWithoutIterationImpl(const Simulator& ebosSimulator,
                                        const double dt,
                                        WellState& well_state,
+                                       const GroupState& group_state,
                                        Opm::DeferredLogger& deferred_logger)
     {
 
@@ -678,7 +681,7 @@ namespace Opm
 
         const auto& summaryState = ebosSimulator.vanguard().summaryState();
         const Opm::Schedule& schedule = ebosSimulator.vanguard().schedule();
-        assembleControlEq(well_state, schedule, summaryState, deferred_logger);
+        assembleControlEq(well_state, group_state, schedule, summaryState, deferred_logger);
 
 
         // do the local inversion of D.
@@ -869,6 +872,7 @@ namespace Opm
     template <typename TypeTag>
     void
     StandardWell<TypeTag>::assembleControlEq(const WellState& well_state,
+                                             const GroupState& group_state,
                                              const Opm::Schedule& schedule,
                                              const SummaryState& summaryState,
                                              Opm::DeferredLogger& deferred_logger)
@@ -903,7 +907,7 @@ namespace Opm
             };
             // Call generic implementation.
             const auto& inj_controls = well.injectionControls(summaryState);
-            Base::assembleControlEqInj(well_state, schedule, summaryState, inj_controls, getBhp(), injection_rate, bhp_from_thp, control_eq, deferred_logger);
+            Base::assembleControlEqInj(well_state, group_state, schedule, summaryState, inj_controls, getBhp(), injection_rate, bhp_from_thp, control_eq, deferred_logger);
         } else {
             // Find rates.
             const auto rates = getRates();
@@ -913,7 +917,7 @@ namespace Opm
             };
             // Call generic implementation.
             const auto& prod_controls = well.productionControls(summaryState);
-            Base::assembleControlEqProd(well_state, schedule, summaryState, prod_controls, getBhp(), rates, bhp_from_thp, control_eq, deferred_logger);
+            Base::assembleControlEqProd(well_state, group_state, schedule, summaryState, prod_controls, getBhp(), rates, bhp_from_thp, control_eq, deferred_logger);
         }
 
         // using control_eq to update the matrix and residuals
@@ -2601,6 +2605,7 @@ namespace Opm
         // create a copy of the well_state to use. If the operability checking is sucessful, we use this one
         // to replace the original one
         WellState well_state_copy = ebosSimulator.problem().wellModel().wellState();
+        const auto& group_state  = ebosSimulator.problem().wellModel().groupState();
 
         //  Set current control to bhp, and bhp value in state, modify bhp limit in control object.
         if (well_ecl_.isInjector()) {
@@ -2611,7 +2616,7 @@ namespace Opm
         well_state_copy.bhp()[index_of_well_] = bhp;
 
         const double dt = ebosSimulator.timeStepSize();
-        bool converged = this->iterateWellEquations(ebosSimulator, dt, well_state_copy, deferred_logger);
+        bool converged = this->iterateWellEquations(ebosSimulator, dt, well_state_copy, group_state, deferred_logger);
         if (!converged) {
             const std::string msg = " well " + name() + " did not get converged during well potential calculations "
                                                         "returning zero values for the potential";
@@ -4092,13 +4097,14 @@ namespace Opm
                              const Well::InjectionControls& inj_controls,
                              const Well::ProductionControls& prod_controls,
                              WellState& well_state,
+                             const GroupState& group_state,
                              Opm::DeferredLogger& deferred_logger)
     {
         const int max_iter = param_.max_inner_iter_wells_;
         int it = 0;
         bool converged;
         do {
-            assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, deferred_logger);
+            assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
 
             auto report = getWellConvergence(well_state, Base::B_avg_, deferred_logger);
 

--- a/opm/simulators/wells/TargetCalculator.hpp
+++ b/opm/simulators/wells/TargetCalculator.hpp
@@ -175,6 +175,7 @@ namespace WellGroupHelpers
                                   const std::string& group_name,
                                   const double sales_target,
                                   const WellStateFullyImplicitBlackoil& well_state,
+                                  const GroupState& group_state,
                                   const Phase& injection_phase,
                                   DeferredLogger& deferred_logger)
             : cmode_(cmode)
@@ -183,6 +184,7 @@ namespace WellGroupHelpers
             , group_name_(group_name)
             , sales_target_(sales_target)
             , well_state_(well_state)
+            , group_state_(group_state)
         {
             // initialize to avoid warning
             pos_ = pu.phase_pos[BlackoilPhases::Aqua];
@@ -226,14 +228,12 @@ namespace WellGroupHelpers
             case Group::InjectionCMode::RESV:
                 return ctrl.resv_max_rate;
             case Group::InjectionCMode::REIN: {
-                double production_rate = well_state_.currentInjectionREINRates(ctrl.reinj_group)[pos_];
+                double production_rate = this->group_state_.injection_rein_rates(ctrl.reinj_group)[pos_];
                 return ctrl.target_reinj_fraction * production_rate;
             }
             case Group::InjectionCMode::VREP: {
-                const std::vector<double>& group_injection_reductions
-                    = well_state_.currentInjectionGroupReductionRates(group_name_);
-                double voidage_rate
-                        = well_state_.currentInjectionVREPRates(ctrl.voidage_group) * ctrl.target_void_fraction;
+                const std::vector<double>& group_injection_reductions = this->group_state_.injection_reduction_rates(this->group_name_);
+                double voidage_rate = group_state_.injection_vrep_rate(ctrl.voidage_group) * ctrl.target_void_fraction;
                 double inj_reduction = 0.0;
                 if (ctrl.phase != Phase::WATER)
                     inj_reduction += group_injection_reductions[pu_.phase_pos[BlackoilPhases::Aqua]]
@@ -251,7 +251,7 @@ namespace WellGroupHelpers
                 assert(pos_ == pu_.phase_pos[BlackoilPhases::Vapour]);
                 // Gas injection rate = Total gas production rate + gas import rate - gas consumption rate - sales rate;
                 // Gas import and consumption is already included in the REIN rates
-                double inj_rate = well_state_.currentInjectionREINRates(group_name_)[pos_];
+                double inj_rate = group_state_.injection_rein_rates(this->group_name_)[pos_];
                 inj_rate -= sales_target_;
                 return inj_rate;
             }
@@ -283,6 +283,7 @@ namespace WellGroupHelpers
         const std::string& group_name_;
         double sales_target_;
         const WellStateFullyImplicitBlackoil& well_state_;
+        const GroupState& group_state_;
         int pos_;
         GuideRateModel::Target target_;
 

--- a/opm/simulators/wells/WGState.cpp
+++ b/opm/simulators/wells/WGState.cpp
@@ -1,0 +1,30 @@
+/*
+  Copyright 2021 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/core/props/BlackoilPhases.hpp>
+#include <opm/simulators/wells/WGState.hpp>
+
+namespace Opm {
+
+WGState::WGState(const PhaseUsage& pu) :
+    well_state(pu),
+    group_state(pu.num_phases)
+{}
+
+}

--- a/opm/simulators/wells/WGState.hpp
+++ b/opm/simulators/wells/WGState.hpp
@@ -1,0 +1,43 @@
+/*
+  Copyright 2021 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_WGSTATE_HEADER_INCLUDED
+#define OPM_WGSTATE_HEADER_INCLUDED
+
+#include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/simulators/wells/GroupState.hpp>
+
+namespace Opm {
+
+/*
+  Microscopic class to handle a pair of well and group state.
+*/
+
+class PhaseUsage;
+
+struct WGState {
+    WGState(const PhaseUsage& pu);
+
+    WellStateFullyImplicitBlackoil well_state;
+    GroupState group_state;
+};
+
+}
+
+#endif

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -28,6 +28,7 @@
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/simulators/wells/VFPProdProperties.hpp>
 #include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
+#include <opm/simulators/wells/GroupState.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -49,7 +50,8 @@ namespace WellGroupHelpers
                        const Schedule& schedule,
                        const SummaryState& summaryState,
                        const int reportStepIdx,
-                       WellStateFullyImplicitBlackoil& wellState);
+                       WellStateFullyImplicitBlackoil& wellState,
+                       GroupState& group_state);
 
     void accumulateGroupEfficiencyFactor(const Group& group,
                                          const Schedule& schedule,
@@ -92,6 +94,7 @@ namespace WellGroupHelpers
                                     const GuideRate& guide_rate,
                                     const WellStateFullyImplicitBlackoil& wellStateNupcol,
                                     WellStateFullyImplicitBlackoil& wellState,
+                                    GroupState& group_state,
                                     std::vector<double>& groupTargetReduction);
 
     template <class Comm>
@@ -101,6 +104,7 @@ namespace WellGroupHelpers
                                             const int reportStepIdx,
                                             const double& simTime,
                                             WellStateFullyImplicitBlackoil& wellState,
+                                            const GroupState& group_state,
                                             const Comm& comm,
                                             GuideRate* guideRate,
                                             std::vector<double>& pot)
@@ -111,11 +115,10 @@ namespace WellGroupHelpers
             const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
 
             // Note that group effiency factors for groupTmp are applied in updateGuideRateForGroups
-            updateGuideRateForProductionGroups(
-                        groupTmp, schedule, pu, reportStepIdx, simTime, wellState, comm, guideRate, thisPot);
+            updateGuideRateForProductionGroups(groupTmp, schedule, pu, reportStepIdx, simTime, wellState, group_state, comm, guideRate, thisPot);
 
             // accumulate group contribution from sub group unconditionally
-            const Group::ProductionCMode& currentGroupControl = wellState.currentProductionGroupControl(groupName);
+            const auto currentGroupControl = group_state.production_control(groupName);
             if (currentGroupControl != Group::ProductionCMode::FLD
                     && currentGroupControl != Group::ProductionCMode::NONE) {
                 continue;
@@ -223,6 +226,7 @@ namespace WellGroupHelpers
                                             const Opm::PhaseUsage& pu,
                                             const int reportStepIdx,
                                             const WellStateFullyImplicitBlackoil& wellState,
+                                            const GroupState& group_state,
                                             GuideRate* guideRate,
                                             Opm::DeferredLogger& deferred_logger);
 
@@ -230,13 +234,15 @@ namespace WellGroupHelpers
                              const Schedule& schedule,
                              const int reportStepIdx,
                              const WellStateFullyImplicitBlackoil& wellStateNupcol,
-                             WellStateFullyImplicitBlackoil& wellState);
+                             WellStateFullyImplicitBlackoil& wellState,
+                             GroupState& group_state);
 
     void updateReservoirRatesInjectionGroups(const Group& group,
                                              const Schedule& schedule,
                                              const int reportStepIdx,
                                              const WellStateFullyImplicitBlackoil& wellStateNupcol,
-                                             WellStateFullyImplicitBlackoil& wellState);
+                                             WellStateFullyImplicitBlackoil& wellState,
+                                             GroupState& group_state);
 
     void updateWellRates(const Group& group,
                          const Schedule& schedule,
@@ -248,7 +254,8 @@ namespace WellGroupHelpers
                                     const Schedule& schedule,
                                     const int reportStepIdx,
                                     const WellStateFullyImplicitBlackoil& wellStateNupcol,
-                                    WellStateFullyImplicitBlackoil& wellState);
+                                    WellStateFullyImplicitBlackoil& wellState,
+                                    GroupState& group_state);
 
     void updateREINForGroups(const Group& group,
                              const Schedule& schedule,
@@ -256,11 +263,13 @@ namespace WellGroupHelpers
                              const PhaseUsage& pu,
                              const SummaryState& st,
                              const WellStateFullyImplicitBlackoil& wellStateNupcol,
-                             WellStateFullyImplicitBlackoil& wellState);
+                             WellStateFullyImplicitBlackoil& wellState,
+                             GroupState& group_state);
 
     std::map<std::string, double>
     computeNetworkPressures(const Opm::Network::ExtNetwork& network,
                             const WellStateFullyImplicitBlackoil& well_state,
+                            const GroupState& group_state,
                             const VFPProdProperties& vfp_prod_props,
                             const Schedule& schedule,
                             const int report_time_step);
@@ -269,11 +278,12 @@ namespace WellGroupHelpers
     getWellRateVector(const WellStateFullyImplicitBlackoil& well_state, const PhaseUsage& pu, const std::string& name);
 
     GuideRate::RateVector
-    getProductionGroupRateVector(const WellStateFullyImplicitBlackoil& well_state, const PhaseUsage& pu, const std::string& group_name);
+    getProductionGroupRateVector(const GroupState& group_state, const PhaseUsage& pu, const std::string& group_name);
 
     double getGuideRate(const std::string& name,
                         const Schedule& schedule,
                         const WellStateFullyImplicitBlackoil& wellState,
+                        const GroupState& group_state,
                         const int reportStepIdx,
                         const GuideRate* guideRate,
                         const GuideRateModel::Target target,
@@ -283,6 +293,7 @@ namespace WellGroupHelpers
     double getGuideRateInj(const std::string& name,
                            const Schedule& schedule,
                            const WellStateFullyImplicitBlackoil& wellState,
+                           const GroupState& group_state,
                            const int reportStepIdx,
                            const GuideRate* guideRate,
                            const GuideRateModel::Target target,
@@ -291,6 +302,7 @@ namespace WellGroupHelpers
 
     int groupControlledWells(const Schedule& schedule,
                              const WellStateFullyImplicitBlackoil& well_state,
+                             const GroupState& group_state,
                              const int report_step,
                              const std::string& group_name,
                              const std::string& always_included_child,
@@ -304,6 +316,7 @@ namespace WellGroupHelpers
         FractionCalculator(const Schedule& schedule,
                            const SummaryState& summary_state,
                            const WellStateFullyImplicitBlackoil& well_state,
+                           const GroupState& group_state,
                            const int report_step,
                            const GuideRate* guide_rate,
                            const GuideRateModel::Target target,
@@ -322,6 +335,7 @@ namespace WellGroupHelpers
         const Schedule& schedule_;
         const SummaryState& summary_state_;
         const WellStateFullyImplicitBlackoil& well_state_;
+        const GroupState& group_state_;
         int report_step_;
         const GuideRate* guide_rate_;
         GuideRateModel::Target target_;
@@ -335,6 +349,7 @@ namespace WellGroupHelpers
                                                      const std::string& parent,
                                                      const Group& group,
                                                      const WellStateFullyImplicitBlackoil& wellState,
+                                                     const GroupState& group_state,
                                                      const int reportStepIdx,
                                                      const GuideRate* guideRate,
                                                      const double* rates,
@@ -363,6 +378,7 @@ namespace WellGroupHelpers
                                                       const std::string& parent,
                                                       const Group& group,
                                                       const WellStateFullyImplicitBlackoil& wellState,
+                                                      const GroupState& group_state,
                                                       const int reportStepIdx,
                                                       const GuideRate* guideRate,
                                                       const double* rates,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -185,6 +185,7 @@ namespace Opm
         virtual void assembleWellEq(const Simulator& ebosSimulator,
                                     const double dt,
                                     WellState& well_state,
+                                    const GroupState& group_state,
                                     Opm::DeferredLogger& deferred_logger
                                     ) = 0;
 
@@ -233,6 +234,7 @@ namespace Opm
         bool updateWellControl(const Simulator& ebos_simulator,
                                const IndividualOrGroup iog,
                                WellState& well_state,
+                               const GroupState& group_state,
                                Opm::DeferredLogger& deferred_logger) /* const */;
 
         virtual void updatePrimaryVariables(const WellState& well_state, Opm::DeferredLogger& deferred_logger) const = 0;
@@ -283,7 +285,7 @@ namespace Opm
         void wellTesting(const Simulator& simulator,
                          const double simulation_time, const int report_step,
                          const WellTestConfig::Reason testing_reason,
-                         /* const */ WellState& well_state, WellTestState& welltest_state,
+                         /* const */ WellState& well_state, const GroupState& group_state, WellTestState& welltest_state,
                          Opm::DeferredLogger& deferred_logger);
 
         void updatePerforatedCell(std::vector<bool>& is_cell_perforated);
@@ -339,6 +341,7 @@ namespace Opm
 
         void solveWellEquation(const Simulator& ebosSimulator,
                                WellState& well_state,
+                               const GroupState& group_state,
                                Opm::DeferredLogger& deferred_logger);
 
         const PhaseUsage& phaseUsage() const;
@@ -528,12 +531,14 @@ namespace Opm
 
 
         void wellTestingEconomic(const Simulator& simulator,
-                                 const double simulation_time, const WellState& well_state,
+                                 const double simulation_time, const WellState& well_state, const GroupState& group_state,
                                  WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger);
 
         void wellTestingPhysical(const Simulator& simulator,
                                  const double simulation_time, const int report_step,
-                                 WellState& well_state, WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger);
+                                 WellState& well_state,
+                                 const GroupState& group_state,
+                                 WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger);
 
 
         virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
@@ -541,6 +546,7 @@ namespace Opm
                                                     const Well::InjectionControls& inj_controls,
                                                     const Well::ProductionControls& prod_controls,
                                                     WellState& well_state,
+                                                    const GroupState& group_state,
                                                     Opm::DeferredLogger& deferred_logger) = 0;
 
         // iterate well equations with the specified control until converged
@@ -549,11 +555,13 @@ namespace Opm
                                               const Well::InjectionControls& inj_controls,
                                               const Well::ProductionControls& prod_controls,
                                               WellState& well_state,
+                                              const GroupState& group_state,
                                               Opm::DeferredLogger& deferred_logger) = 0;
 
         bool iterateWellEquations(const Simulator& ebosSimulator,
                                   const double dt,
                                   WellState& well_state,
+                                  const GroupState& group_state,
                                   Opm::DeferredLogger& deferred_logger);
 
         void updateWellTestStateEconomic(const WellState& well_state,
@@ -568,12 +576,13 @@ namespace Opm
                                          WellTestState& well_test_state,
                                          Opm::DeferredLogger& deferred_logger) const;
 
-        void solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state,
+        void solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state, const GroupState& group_state,
                                  Opm::DeferredLogger& deferred_logger);
 
         void initCompletions();
 
         bool checkConstraints(WellState& well_state,
+                              const GroupState& group_state,
                               const Schedule& schedule,
                               const SummaryState& summaryState,
                               DeferredLogger& deferred_logger) const;
@@ -582,12 +591,14 @@ namespace Opm
                                         const SummaryState& summaryState) const;
 
         bool checkGroupConstraints(WellState& well_state,
+                                   const GroupState& group_state,
                                    const Schedule& schedule,
                                    const SummaryState& summaryState,
                                    DeferredLogger& deferred_logger) const;
 
         std::pair<bool, double> checkGroupConstraintsProd(const Group& group,
                                        const WellState& well_state,
+                                                          const GroupState& group_state,
                                        const double efficiencyFactor,
                                        const Schedule& schedule,
                                        const SummaryState& summaryState,
@@ -595,6 +606,7 @@ namespace Opm
 
         std::pair<bool, double> checkGroupConstraintsInj(const Group& group,
                                       const WellState& well_state,
+                                                         const GroupState& group_state,
                                       const double efficiencyFactor,
                                       const Schedule& schedule,
                                       const SummaryState& summaryState,
@@ -603,6 +615,7 @@ namespace Opm
         template <class EvalWell>
         void getGroupInjectionControl(const Group& group,
                                       const WellState& well_state,
+                                      const GroupState& group_state,
                                       const Opm::Schedule& schedule,
                                       const SummaryState& summaryState,
                                       const InjectorType& injectorType,
@@ -615,6 +628,7 @@ namespace Opm
         template <class EvalWell>
         void getGroupProductionControl(const Group& group,
                                        const WellState& well_state,
+                                       const GroupState& group_state,
                                        const Opm::Schedule& schedule,
                                        const SummaryState& summaryState,
                                        const EvalWell& bhp,
@@ -624,6 +638,7 @@ namespace Opm
 
         template <class EvalWell, class BhpFromThpFunc>
         void assembleControlEqInj(const WellState& well_state,
+                                  const GroupState& group_state,
                                   const Opm::Schedule& schedule,
                                   const SummaryState& summaryState,
                                   const Well::InjectionControls& controls,
@@ -635,6 +650,7 @@ namespace Opm
 
         template <class EvalWell, class BhpFromThpFunc>
         void assembleControlEqProd(const WellState& well_state,
+                                   const GroupState& group_state,
                                    const Opm::Schedule& schedule,
                                    const SummaryState& summaryState,
                                    const Well::ProductionControls& controls,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -514,6 +514,7 @@ namespace Opm
     updateWellControl(const Simulator& ebos_simulator,
                       const IndividualOrGroup iog,
                       WellState& well_state,
+                      const GroupState& group_state,
                       Opm::DeferredLogger& deferred_logger) /* const */
     {
         if (this->wellIsStopped()) {
@@ -534,10 +535,10 @@ namespace Opm
         if (iog == IndividualOrGroup::Individual) {
             changed = checkIndividualConstraints(well_state, summaryState);
         } else if (iog == IndividualOrGroup::Group) {
-            changed = checkGroupConstraints(well_state, schedule, summaryState, deferred_logger);
+            changed = checkGroupConstraints(well_state, group_state, schedule, summaryState, deferred_logger);
         } else {
             assert(iog == IndividualOrGroup::Both);
-            changed = checkConstraints(well_state, schedule, summaryState, deferred_logger);
+            changed = checkConstraints(well_state, group_state, schedule, summaryState, deferred_logger);
         }
 
         auto cc = Dune::MPIHelper::getCollectiveCommunication();
@@ -1113,17 +1114,18 @@ namespace Opm
                 const double simulation_time, const int report_step,
                 const WellTestConfig::Reason testing_reason,
                 /* const */ WellState& well_state,
+                const GroupState& group_state,
                 WellTestState& well_test_state,
                 Opm::DeferredLogger& deferred_logger)
     {
         if (testing_reason == WellTestConfig::Reason::PHYSICAL) {
             wellTestingPhysical(simulator, simulation_time, report_step,
-                                well_state, well_test_state, deferred_logger);
+                                well_state, group_state, well_test_state, deferred_logger);
         }
 
         if (testing_reason == WellTestConfig::Reason::ECONOMIC) {
             wellTestingEconomic(simulator, simulation_time,
-                                well_state, well_test_state, deferred_logger);
+                                well_state, group_state, well_test_state, deferred_logger);
         }
     }
 
@@ -1135,7 +1137,7 @@ namespace Opm
     void
     WellInterface<TypeTag>::
     wellTestingEconomic(const Simulator& simulator,
-                        const double simulation_time, const WellState& well_state,
+                        const double simulation_time, const WellState& well_state, const GroupState& group_state,
                         WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger)
     {
         deferred_logger.info(" well " + name() + " is being tested for economic limits");
@@ -1155,7 +1157,7 @@ namespace Opm
         // untill the number of closed completions do not increase anymore.
         while (testWell) {
             const size_t original_number_closed_completions = welltest_state_temp.sizeCompletions();
-            solveWellForTesting(simulator, well_state_copy, deferred_logger);
+            solveWellForTesting(simulator, well_state_copy, group_state, deferred_logger);
             updateWellTestState(well_state_copy, simulation_time, /*writeMessageToOPMLog=*/ false, welltest_state_temp, deferred_logger);
             closeCompletions(welltest_state_temp);
 
@@ -1299,13 +1301,14 @@ namespace Opm
     iterateWellEquations(const Simulator& ebosSimulator,
                          const double dt,
                          WellState& well_state,
+                         const GroupState& group_state,
                          Opm::DeferredLogger& deferred_logger)
     {
         const auto& summary_state = ebosSimulator.vanguard().summaryState();
         const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
         const auto prod_controls = well_ecl_.isProducer() ? well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
 
-        return this->iterateWellEqWithControl(ebosSimulator, dt, inj_controls, prod_controls, well_state, deferred_logger);
+        return this->iterateWellEqWithControl(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
     }
 
 
@@ -1352,13 +1355,13 @@ namespace Opm
     template<typename TypeTag>
     void
     WellInterface<TypeTag>::
-    solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state,
+    solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state, const GroupState& group_state,
                         Opm::DeferredLogger& deferred_logger)
     {
         // keep a copy of the original well state
         const WellState well_state0 = well_state;
         const double dt = ebosSimulator.timeStepSize();
-        const bool converged = iterateWellEquations(ebosSimulator, dt, well_state, deferred_logger);
+        const bool converged = iterateWellEquations(ebosSimulator, dt, well_state, group_state, deferred_logger);
         if (converged) {
             deferred_logger.debug("WellTest: Well equation for well " + name() +  " converged");
         } else {
@@ -1374,6 +1377,7 @@ namespace Opm
     WellInterface<TypeTag>::
     solveWellEquation(const Simulator& ebosSimulator,
                       WellState& well_state,
+                      const GroupState& group_state,
                       Opm::DeferredLogger& deferred_logger)
     {
         if (!this->isOperable())
@@ -1382,7 +1386,7 @@ namespace Opm
         // keep a copy of the original well state
         const WellState well_state0 = well_state;
         const double dt = ebosSimulator.timeStepSize();
-        const bool converged = iterateWellEquations(ebosSimulator, dt, well_state, deferred_logger);
+        const bool converged = iterateWellEquations(ebosSimulator, dt, well_state, group_state, deferred_logger);
         if (converged) {
             deferred_logger.debug("Compute initial well solution for well " + name() +  ". Converged");
         } else {
@@ -1427,7 +1431,9 @@ namespace Opm
     WellInterface<TypeTag>::
     wellTestingPhysical(const Simulator& ebos_simulator,
                         const double /* simulation_time */, const int /* report_step */,
-                        WellState& well_state, WellTestState& welltest_state,
+                        WellState& well_state,
+                        const GroupState& group_state,
+                        WellTestState& welltest_state,
                         Opm::DeferredLogger& deferred_logger)
     {
         deferred_logger.info(" well " + name() + " is being tested for physical limits");
@@ -1462,7 +1468,7 @@ namespace Opm
         calculateExplicitQuantities(ebos_simulator, well_state_copy, deferred_logger);
 
         const double dt = ebos_simulator.timeStepSize();
-        const bool converged = this->iterateWellEquations(ebos_simulator, dt, well_state_copy, deferred_logger);
+        const bool converged = this->iterateWellEquations(ebos_simulator, dt, well_state_copy, group_state, deferred_logger);
 
         if (!converged) {
             const std::string msg = " well " + name() + " did not get converged during well testing for physical reason";
@@ -1574,6 +1580,7 @@ namespace Opm
     template <typename TypeTag>
     bool
     WellInterface<TypeTag>::checkConstraints(WellState& well_state,
+                                             const GroupState& group_state,
                                              const Schedule& schedule,
                                              const SummaryState& summaryState,
                                              DeferredLogger& deferred_logger) const
@@ -1582,7 +1589,7 @@ namespace Opm
         if (ind_broken) {
             return true;
         } else {
-            return checkGroupConstraints(well_state, schedule, summaryState, deferred_logger);
+            return checkGroupConstraints(well_state, group_state, schedule, summaryState, deferred_logger);
         }
     }
 
@@ -1788,6 +1795,7 @@ namespace Opm
     template <typename TypeTag>
     bool
     WellInterface<TypeTag>::checkGroupConstraints(WellState& well_state,
+                                                  const GroupState& group_state,
                                                   const Schedule& schedule,
                                                   const SummaryState& summaryState,
                                                   DeferredLogger& deferred_logger) const
@@ -1808,7 +1816,7 @@ namespace Opm
                 const auto& group = schedule.getGroup( well.groupName(), current_step_ );
                 const double efficiencyFactor = well.getEfficiencyFactor();
                 const std::pair<bool, double> group_constraint = checkGroupConstraintsInj(
-                    group, well_state, efficiencyFactor, schedule, summaryState, deferred_logger);
+                                                                                          group, well_state, group_state, efficiencyFactor, schedule, summaryState, deferred_logger);
                 // If a group constraint was broken, we set the current well control to
                 // be GRUP.
                 if (group_constraint.first) {
@@ -1835,7 +1843,7 @@ namespace Opm
                 const auto& group = schedule.getGroup( well.groupName(), current_step_ );
                 const double efficiencyFactor = well.getEfficiencyFactor();
                 const std::pair<bool, double> group_constraint = checkGroupConstraintsProd(
-                    group, well_state, efficiencyFactor, schedule, summaryState, deferred_logger);
+                                                                                           group, well_state, group_state, efficiencyFactor, schedule, summaryState, deferred_logger);
                 // If a group constraint was broken, we set the current well control to
                 // be GRUP.
                 if (group_constraint.first) {
@@ -1860,6 +1868,7 @@ namespace Opm
     std::pair<bool, double>
     WellInterface<TypeTag>::checkGroupConstraintsInj(const Group& group,
                                                      const WellState& well_state,
+                                                     const GroupState& group_state,
                                                      const double efficiencyFactor,
                                                      const Schedule& schedule,
                                                      const SummaryState& summaryState,
@@ -1898,6 +1907,7 @@ namespace Opm
                                                           well_ecl_.groupName(),
                                                           group,
                                                           well_state,
+                                                          group_state,
                                                           current_step_,
                                                           guide_rate_,
                                                           well_state.wellRates().data() + index_of_well_ * phaseUsage().num_phases,
@@ -1918,6 +1928,7 @@ namespace Opm
     std::pair<bool, double>
     WellInterface<TypeTag>::checkGroupConstraintsProd(const Group& group,
                                                       const WellState& well_state,
+                                                      const GroupState& group_state,
                                                       const double efficiencyFactor,
                                                       const Schedule& schedule,
                                                       const SummaryState& summaryState,
@@ -1931,6 +1942,7 @@ namespace Opm
                                                            well_ecl_.groupName(),
                                                            group,
                                                            well_state,
+                                                           group_state,
                                                            current_step_,
                                                            guide_rate_,
                                                            well_state.wellRates().data() + index_of_well_ * phaseUsage().num_phases,
@@ -1950,6 +1962,7 @@ namespace Opm
     template <class EvalWell, class BhpFromThpFunc>
     void
     WellInterface<TypeTag>::assembleControlEqInj(const WellState& well_state,
+                                                 const GroupState& group_state,
                                                  const Opm::Schedule& schedule,
                                                  const SummaryState& summaryState,
                                                  const Well::InjectionControls& controls,
@@ -2008,6 +2021,7 @@ namespace Opm
             const auto& group = schedule.getGroup(well_ecl_.groupName(), current_step_);
             getGroupInjectionControl(group,
                                      well_state,
+                                     group_state,
                                      schedule,
                                      summaryState,
                                      injectorType,
@@ -2031,6 +2045,7 @@ namespace Opm
     template <class EvalWell, class BhpFromThpFunc>
     void
     WellInterface<TypeTag>::assembleControlEqProd(const WellState& well_state,
+                                                  const GroupState& group_state,
                                                   const Opm::Schedule& schedule,
                                                   const SummaryState& summaryState,
                                                   const Well::ProductionControls& controls,
@@ -2127,7 +2142,7 @@ namespace Opm
                     active_rates[pu.phase_pos[canonical_phase]] = rates[canonical_phase];
                 }
             }
-            getGroupProductionControl(group, well_state, schedule, summaryState, bhp, active_rates, control_eq, efficiencyFactor);
+            getGroupProductionControl(group, well_state, group_state, schedule, summaryState, bhp, active_rates, control_eq, efficiencyFactor);
             break;
         }
         case Well::ProducerCMode::CMODE_UNDEFINED: {
@@ -2146,6 +2161,7 @@ namespace Opm
     void
     WellInterface<TypeTag>::getGroupInjectionControl(const Group& group,
                                                       const WellState& well_state,
+                                                     const GroupState& group_state,
                                                       const Opm::Schedule& schedule,
                                                       const SummaryState& summaryState,
                                                       const InjectorType& injectorType,
@@ -2179,7 +2195,7 @@ namespace Opm
             assert(false);
         }
 
-        const Group::InjectionCMode& currentGroupControl = well_state.currentInjectionGroupControl(injectionPhase, group.name());
+        auto currentGroupControl = group_state.injection_control(group.name(), injectionPhase);
         if (currentGroupControl == Group::InjectionCMode::FLD ||
             currentGroupControl == Group::InjectionCMode::NONE) {
             if (!group.injectionGroupControlAvailable(injectionPhase)) {
@@ -2198,7 +2214,7 @@ namespace Opm
                 // Inject share of parents control
                 const auto& parent = schedule.getGroup( group.parent(), current_step_ );
                 efficiencyFactor *= group.getGroupEfficiencyFactor();
-                getGroupInjectionControl(parent, well_state, schedule, summaryState, injectorType, bhp, injection_rate, control_eq, efficiencyFactor, deferred_logger);
+                getGroupInjectionControl(parent, well_state, group_state, schedule, summaryState, injectorType, bhp, injection_rate, control_eq, efficiencyFactor, deferred_logger);
                 return;
             }
         }
@@ -2226,15 +2242,15 @@ namespace Opm
             const auto& gconsale = schedule[current_step_].gconsale().get(group.name(), summaryState);
             sales_target = gconsale.sales_target;
         }
-        WellGroupHelpers::InjectionTargetCalculator tcalc(currentGroupControl, pu, resv_coeff, group.name(), sales_target, well_state, injectionPhase, deferred_logger);
-        WellGroupHelpers::FractionCalculator fcalc(schedule, summaryState, well_state, current_step_, guide_rate_, tcalc.guideTargetMode(), pu, false, injectionPhase);
+        WellGroupHelpers::InjectionTargetCalculator tcalc(currentGroupControl, pu, resv_coeff, group.name(), sales_target, well_state, group_state, injectionPhase, deferred_logger);
+        WellGroupHelpers::FractionCalculator fcalc(schedule, summaryState, well_state, group_state, current_step_, guide_rate_, tcalc.guideTargetMode(), pu, false, injectionPhase);
 
         auto localFraction = [&](const std::string& child) {
             return fcalc.localFraction(child, "");
         };
 
         auto localReduction = [&](const std::string& group_name) {
-            const std::vector<double>& groupTargetReductions = well_state.currentInjectionGroupReductionRates(group_name);
+            const std::vector<double>& groupTargetReductions = group_state.injection_reduction_rates(group_name);
             return tcalc.calcModeRateFromRates(groupTargetReductions);
         };
 
@@ -2265,6 +2281,7 @@ namespace Opm
     void
     WellInterface<TypeTag>::getGroupProductionControl(const Group& group,
                                                       const WellState& well_state,
+                                                      const GroupState& group_state,
                                                       const Opm::Schedule& schedule,
                                                       const SummaryState& summaryState,
                                                       const EvalWell& bhp,
@@ -2272,7 +2289,7 @@ namespace Opm
                                                       EvalWell& control_eq,
                                                       double efficiencyFactor)
     {
-        const Group::ProductionCMode& currentGroupControl = well_state.currentProductionGroupControl(group.name());
+        const Group::ProductionCMode& currentGroupControl = group_state.production_control(group.name());
         if (currentGroupControl == Group::ProductionCMode::FLD ||
             currentGroupControl == Group::ProductionCMode::NONE) {
             if (!group.productionGroupControlAvailable()) {
@@ -2291,7 +2308,7 @@ namespace Opm
                 // Produce share of parents control
                 const auto& parent = schedule.getGroup( group.parent(), current_step_ );
                 efficiencyFactor *= group.getGroupEfficiencyFactor();
-                getGroupProductionControl(parent, well_state, schedule, summaryState, bhp, rates, control_eq, efficiencyFactor);
+                getGroupProductionControl(parent, well_state, group_state, schedule, summaryState, bhp, rates, control_eq, efficiencyFactor);
                 return;
             }
         }
@@ -2317,18 +2334,18 @@ namespace Opm
         // gconsale may adjust the grat target.
         // the adjusted rates is send to the targetCalculator
         double gratTargetFromSales = 0.0;
-        if (well_state.hasGroupGratTargetFromSales(group.name()))
-            gratTargetFromSales = well_state.currentGroupGratTargetFromSales(group.name());
+        if (group_state.has_grat_sales_target(group.name()))
+            gratTargetFromSales = group_state.grat_sales_target(group.name());
 
         WellGroupHelpers::TargetCalculator tcalc(currentGroupControl, pu, resv_coeff, gratTargetFromSales);
-        WellGroupHelpers::FractionCalculator fcalc(schedule, summaryState, well_state, current_step_, guide_rate_, tcalc.guideTargetMode(), pu, true, Phase::OIL);
+        WellGroupHelpers::FractionCalculator fcalc(schedule, summaryState, well_state, group_state, current_step_, guide_rate_, tcalc.guideTargetMode(), pu, true, Phase::OIL);
 
         auto localFraction = [&](const std::string& child) {
             return fcalc.localFraction(child, "");
         };
 
         auto localReduction = [&](const std::string& group_name) {
-            const std::vector<double>& groupTargetReductions = well_state.currentProductionGroupReductionRates(group_name);
+            const std::vector<double>& groupTargetReductions = group_state.production_reduction_rates(group_name);
             return tcalc.calcModeRateFromRates(groupTargetReductions);
         };
 

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -22,7 +22,6 @@
 #define OPM_WELLSTATEFULLYIMPLICITBLACKOIL_HEADER_INCLUDED
 
 #include <opm/simulators/wells/WellState.hpp>
-#include <opm/simulators/wells/GroupState.hpp>
 #include <opm/core/props/BlackoilPhases.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
@@ -70,9 +69,9 @@ namespace Opm
         using BaseType :: updateStatus;
 
         explicit WellStateFullyImplicitBlackoil(const PhaseUsage& pu) :
-            WellState(pu),
-            group_state(pu.num_phases)
-        {}
+            WellState(pu)
+        {
+        }
 
 
         /// Allocate and initialize if wells is non-null.  Also tries
@@ -412,32 +411,6 @@ namespace Opm
         std::vector<Well::ProducerCMode>& currentProductionControls() { return current_production_controls_; }
         const std::vector<Well::ProducerCMode>& currentProductionControls() const { return current_production_controls_; }
 
-        bool hasProductionGroupControl(const std::string& groupName) const {
-            return this->group_state.has_production_control(groupName);
-        }
-
-        bool hasInjectionGroupControl(const Opm::Phase& phase, const std::string& groupName) const {
-            return this->group_state.has_injection_control(groupName, phase);
-        }
-
-        /// One current control per group.
-        void setCurrentProductionGroupControl(const std::string& groupName, const Group::ProductionCMode& groupControl ) {
-            this->group_state.production_control(groupName, groupControl);
-        }
-
-        Group::ProductionCMode currentProductionGroupControl(const std::string& groupName) const {
-            return this->group_state.production_control(groupName);
-        }
-
-        /// One current control per group.
-        void setCurrentInjectionGroupControl(const Opm::Phase& phase, const std::string& groupName, const Group::InjectionCMode& groupControl ) {
-            this->group_state.injection_control(groupName, phase, groupControl);
-        }
-
-        Group::InjectionCMode currentInjectionGroupControl(const Opm::Phase& phase, const std::string& groupName) const {
-            return this->group_state.injection_control(groupName, phase);
-        }
-
         void setCurrentWellRates(const std::string& wellName, const std::vector<double>& rates ) {
             well_rates[wellName].second = rates;
         }
@@ -455,78 +428,7 @@ namespace Opm
             return this->well_rates.find(wellName) != this->well_rates.end();
         }
 
-        void setCurrentProductionGroupRates(const std::string& groupName, const std::vector<double>& rates ) {
-            this->group_state.update_production_rates(groupName, rates);
-        }
 
-        const std::vector<double>& currentProductionGroupRates(const std::string& groupName) const {
-            return this->group_state.production_rates(groupName);
-        }
-
-        bool hasProductionGroupRates(const std::string& groupName) const {
-            return this->group_state.has_production_rates(groupName);
-        }
-
-
-        void setCurrentProductionGroupReductionRates(const std::string& groupName, const std::vector<double>& target ) {
-            this->group_state.update_production_reduction_rates(groupName, target);
-        }
-
-        const std::vector<double>& currentProductionGroupReductionRates(const std::string& groupName) const {
-            return this->group_state.production_reduction_rates(groupName);
-        }
-
-        void setCurrentInjectionGroupReductionRates(const std::string& groupName, const std::vector<double>& target ) {
-            this->group_state.update_injection_reduction_rates(groupName, target);
-        }
-
-        const std::vector<double>& currentInjectionGroupReductionRates(const std::string& groupName) const {
-            return this->group_state.injection_reduction_rates(groupName);
-        }
-
-        void setCurrentInjectionGroupReservoirRates(const std::string& groupName, const std::vector<double>& target ) {
-            this->group_state.update_injection_reservoir_rates(groupName, target);
-        }
-
-        const std::vector<double>& currentInjectionGroupReservoirRates(const std::string& groupName) const {
-            return this->group_state.injection_reservoir_rates(groupName);
-        }
-
-        void setCurrentInjectionVREPRates(const std::string& groupName, const double& target ) {
-            this->group_state.update_injection_vrep_rate(groupName, target);
-        }
-
-        double currentInjectionVREPRates(const std::string& groupName) const {
-            return this->group_state.injection_vrep_rate(groupName);
-        }
-
-        void setCurrentInjectionREINRates(const std::string& groupName, const std::vector<double>& target ) {
-            this->group_state.update_injection_rein_rates(groupName, target);
-        }
-
-        const std::vector<double>& currentInjectionREINRates(const std::string& groupName) const {
-            return this->group_state.injection_rein_rates(groupName);
-        }
-
-        void setCurrentGroupGratTargetFromSales(const std::string& groupName, const double& target ) {
-            this->group_state.update_grat_sales_target(groupName, target);
-        }
-
-        bool hasGroupGratTargetFromSales(const std::string& groupName) const {
-            return this->group_state.has_grat_sales_target(groupName);
-        }
-
-        double currentGroupGratTargetFromSales(const std::string& groupName) const {
-            return this->group_state.grat_sales_target(groupName);
-        }
-
-        void setCurrentGroupInjectionPotentials(const std::string& groupName, const std::vector<double>& pot ) {
-            this->group_state.update_injection_potentials(groupName, pot);
-        }
-
-        const std::vector<double>& currentGroupInjectionPotentials(const std::string& groupName) const {
-            return this->group_state.injection_potentials(groupName);
-        }
 
         data::Wells
         report(const int* globalCellIdxMap,
@@ -1145,8 +1047,6 @@ namespace Opm
                 x.second = data[pos++];
             }
             assert(pos == sz);
-
-            this->group_state.communicate_rates(comm);
         }
 
         template<class Comm>
@@ -1299,6 +1199,7 @@ namespace Opm
             return it->first;
         }
 
+
     private:
         std::vector<double> perfphaserates_;
         std::vector<bool> is_producer_; // Size equal to number of local wells.
@@ -1315,8 +1216,6 @@ namespace Opm
         std::vector<int> globalIsProductionGrup_;
         std::map<std::string, int> wellNameToGlobalIdx_;
         std::map<std::string, std::pair<bool, std::vector<double>>> well_rates;
-
-        GroupState group_state;
 
         std::map<std::string, double> current_alq_;
         std::map<std::string, double> default_alq_;


### PR DESCRIPTION
This is a second attempt at #3171 and #3173 combined.

This PR will remove the `GroupState` member from the `WellStateFullyIMplicitBlackOil` and create a microscopic class `WGState`which handles the well state and group state together as a pair. I am not saying that this very good, or the final destination for this refactoring, but the current code is more explicit, and that is in my opinion a step in the right direction.

The commits Step 1, Step 2, ... is just the way I organized the work. Will squash everything before merge. 

This quite banal refactoring was really hard work; when such conceptually simple refactorings are so hard I think that is the code trying to tell you something. 
