### PR TITLE
Add json dump to GroupState

### DIFF
--- a/opm/simulators/wells/GroupState.cpp
+++ b/opm/simulators/wells/GroupState.cpp
@@ -17,7 +17,9 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <iterator>
 
+#include <opm/json/JsonObject.hpp>
 
 #include <opm/simulators/wells/GroupState.hpp>
 
@@ -234,4 +236,72 @@ Group::InjectionCMode GroupState::injection_control(const std::string& gname, Ph
 
     return group_iter->second;
 }
+
+//-------------------------------------------------------------------------
+
+namespace {
+
+template <typename T>
+void dump_vector(Json::JsonObject& root, const std::string& key, const std::vector<T>& data) {
+    auto data_obj = root.add_array(key);
+    for (const auto& rate : data)
+        data_obj.add(rate);
+}
+
+
+template <typename T>
+void dump_groupmap(Json::JsonObject& root, const std::string& key, const std::map<std::string, std::vector<T>>& group_data) {
+    auto map_obj = root.add_object(key);
+    for (const auto& [gname, data] : group_data)
+        dump_vector(map_obj, gname, data);
+}
+
+
+template <typename T>
+void dump_groupmap(Json::JsonObject& root, const std::string& key, const std::map<std::string, T>& group_data) {
+    auto map_obj = root.add_object(key);
+    for (const auto& [gname, value] : group_data)
+        map_obj.add_item(gname, value);
+}
+
+}
+
+std::string GroupState::dump() const
+{
+    Json::JsonObject root;
+    dump_groupmap(root, "production_rates", this->m_production_rates);
+    dump_groupmap(root, "prod_red_rates", this->prod_red_rates);
+    dump_groupmap(root, "inj_red_rates", this->inj_red_rates);
+    dump_groupmap(root, "inj_resv_rates", this->inj_resv_rates);
+    dump_groupmap(root, "inj_potentials", this->inj_potentials);
+    dump_groupmap(root, "inj_rein_rates", this->inj_rein_rates);
+    dump_groupmap(root, "vrep_rate", this->inj_vrep_rate);
+    dump_groupmap(root, "grat_sales_target", this->m_grat_sales_target);
+    {
+        std::map<std::string, int> int_controls;
+        for (const auto& [gname, control] : this->production_controls)
+            int_controls.insert({gname, static_cast<int>(control)});
+        dump_groupmap(root, "production_controls", int_controls);
+    }
+    {
+        std::map<std::string, std::vector<std::pair<Opm::Phase, Group::InjectionCMode>>> inj_cntrl;
+        for (const auto& [phase_name, cmode] : this->injection_controls) {
+            const auto& [phase, gname] = phase_name;
+            inj_cntrl[gname].emplace_back(phase, cmode);
+        }
+
+        auto map_obj = root.add_object("injection_controls");
+        for (const auto& [gname, phase_cmode] : inj_cntrl) {
+            auto group_array = map_obj.add_array(gname);
+            for (const auto& [phase, cmode] : phase_cmode) {
+                auto control_pair = group_array.add_array();
+                control_pair.add(static_cast<int>(phase));
+                control_pair.add(static_cast<int>(cmode));
+            }
+        }
+    }
+    return root.to_string();
+}
+
+
 }

--- a/opm/simulators/wells/GroupState.hpp
+++ b/opm/simulators/wells/GroupState.hpp
@@ -147,6 +147,9 @@ public:
             throw std::logic_error("Internal size mismatch when distributing groupData");
     }
 
+    std::string dump() const;
+
+
 private:
     std::size_t num_phases;
     std::map<std::string, std::vector<double>> m_production_rates;

--- a/tests/test_GroupState.cpp
+++ b/tests/test_GroupState.cpp
@@ -20,6 +20,8 @@
 #include <stdexcept>
 
 #include <opm/simulators/wells/GroupState.hpp>
+#include <opm/json/JsonObject.hpp>
+
 
 #define BOOST_TEST_MODULE GroupStateTest
 #include <boost/test/unit_test.hpp>
@@ -67,3 +69,16 @@ BOOST_AUTO_TEST_CASE(GroupStateCreate) {
     BOOST_CHECK(gs2 == gs);
 }
 
+
+BOOST_AUTO_TEST_CASE(GroupStateDump) {
+    std::size_t num_phases{3};
+    GroupState gs(num_phases);
+    std::vector<double> rates{0,1,2};
+    gs.update_production_rates("AGROUP", rates);
+    gs.update_injection_rein_rates("CGROUP", rates);
+    gs.injection_control("AGROUP", Phase::WATER, Group::InjectionCMode::RATE);
+    gs.injection_control("AGROUP", Phase::GAS, Group::InjectionCMode::RATE);
+
+    auto json_string = gs.dump();
+    Json::JsonObject json_gs(json_string);
+}


### PR DESCRIPTION
Add functionality to create a json dump of the GroupState object. Initially created to debug: #3174, but code on My machine indicates that this will also be valuable when debugging the restart capabilities.