### PR TITLE
Remove unused methods from wellmodel

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -199,11 +199,6 @@ namespace Opm {
                 timeStepSucceeded(ebosSimulator_.time(), ebosSimulator_.timeStepSize());
             }
 
-            void endEpisode()
-            {
-                endReportStep();
-            }
-
             template <class Context>
             void computeTotalRatesForDof(RateVector& rate,
                                          const Context& context,

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -493,21 +493,6 @@ namespace Opm {
 
 
 
-    // called at the end of a report step
-    template<typename TypeTag>
-    void
-    BlackoilWellModel<TypeTag>::
-    endReportStep()
-    {
-        // Clear the communication data structures for above values.
-        for (auto&& pinfo : local_parallel_well_info_)
-        {
-            pinfo->clear();
-        }
-    }
-
-
-
 
 
     // called at the end of a report step
@@ -515,8 +500,6 @@ namespace Opm {
     const SimulatorReportSingle&
     BlackoilWellModel<TypeTag>::
     lastReport() const {return last_report_; }
-
-
 
 
 


### PR DESCRIPTION
These methods are not called - removing.

Maybe they *should* have been called?