### PR TITLE
Forward Potential Rates to Next Report Step

### DIFF
--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -264,6 +264,12 @@ namespace Opm
                             wellReservoirRates()[ idx ] = prevState->wellReservoirRates()[ oldidx ];
                         }
 
+                        // Well potentials
+                        for( int i=0, idx=newIndex*np, oldidx=oldIndex*np; i<np; ++i, ++idx, ++oldidx )
+                        {
+                            wellPotentials()[ idx ] = prevState->wellPotentials()[ oldidx ];
+                        }
+
                         // perfPhaseRates
                         const int oldPerf_idx_beg = (*it).second[ 1 ];
                         const int num_perf_old_well = (*it).second[ 2 ];


### PR DESCRIPTION
These are used as part of calculating the BHP/THP when computing new potential rates in models that feature VFP tables and must therefore be properly initialised in the next report step's well state object.