### PR TITLE
fixed: include required headers where needed

### DIFF
--- a/examples/printvfp.cpp
+++ b/examples/printvfp.cpp
@@ -22,6 +22,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>

--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -20,6 +20,8 @@
 
 #include "ParallelEclipseState.hpp"
 
+#include <opm/common/ErrorMacros.hpp>
+
 namespace Opm {
 
 

--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -24,6 +24,7 @@
 #include "ParallelRestart.hpp"
 #include <ctime>
 #include <dune/common/parallel/mpitraits.hh>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 
 #define HANDLE_AS_POD(T) \
   std::size_t packSize(const T& data, Dune::MPIHelper::MPICommunicator comm) \

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -23,6 +23,7 @@
 #include <mpi.h>
 #endif
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/output/eclipse/RestartValue.hpp>
 #include <opm/output/eclipse/EclipseIO.hpp>
 #include <opm/output/eclipse/Summary.hpp>

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -28,6 +28,7 @@
 
 #include <opm/common/utility/String.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
+#include <opm/common/ErrorMacros.hpp>
 
 #include <opm/io/eclipse/EclIOdata.hpp>
 

--- a/tests/test_stoppedwells.cpp
+++ b/tests/test_stoppedwells.cpp
@@ -24,6 +24,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>

--- a/tests/test_vfpproperties.cpp
+++ b/tests/test_vfpproperties.cpp
@@ -34,6 +34,7 @@
 #include <opm/common/utility/FileSystem.hpp>
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/simulators/wells/VFPHelpers.hpp>

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -30,6 +30,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/common/utility/TimeService.hpp>
 


### PR DESCRIPTION
Due to changes upstream.