### PR TITLE
Record the correct simulation time in ActionState

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1381,7 +1381,7 @@ public:
         }
 
         bool commit_wellstate = false;
-        auto simTime = schedule.simTime(reportStep);
+        auto simTime = Opm::asTimeT(now);
         for (const auto& action : actions.pending(actionState, simTime)) {
             auto actionResult = action->eval(context);
             if (actionResult) {


### PR DESCRIPTION
The Actionx machinery records the simulation time when an action has evaluated to true. This PR fixes the recording time - which was locked to report_step time in master, instead of actual simulation time.