### PR TITLE
Well Model Test: Supply Valid 'ecl_index' Values

### DIFF
--- a/tests/test_wellmodel.cpp
+++ b/tests/test_wellmodel.cpp
@@ -127,6 +127,10 @@ BOOST_AUTO_TEST_CASE(TestStandardWellInput) {
 
     Opm::PerforationData dummy;
     std::vector<Opm::PerforationData> pdata(well.getConnections().size(), dummy);
+    for (auto c = 0*pdata.size(); c < pdata.size(); ++c) {
+        pdata[c].ecl_index = c;
+    }
+
     Opm::ParallelWellInfo pinfo{well.name()};
 
     BOOST_CHECK_THROW( StandardWell( well, pinfo, -1, param, *rateConverter, 0, 3, 3, 0, 0, pdata), std::invalid_argument);
@@ -158,6 +162,10 @@ BOOST_AUTO_TEST_CASE(TestBehavoir) {
                                              std::vector<int>(10, 0)));
             Opm::PerforationData dummy;
             std::vector<Opm::PerforationData> pdata(wells_ecl[w].getConnections().size(), dummy);
+            for (auto c = 0*pdata.size(); c < pdata.size(); ++c) {
+                pdata[c].ecl_index = c;
+            }
+
             Opm::ParallelWellInfo pinfo{wells_ecl[w].name()};
             wells.emplace_back(new StandardWell(wells_ecl[w], pinfo, current_timestep, param, *rateConverter, 0, 3, 3, w, 0, pdata) );
         }


### PR DESCRIPTION
The `WellInterface::initCompletions()` member function needs these.