### PR TITLE
Use forwarding where possible in some headers

### DIFF
--- a/ebos/ebos_blackoil.hh
+++ b/ebos/ebos_blackoil.hh
@@ -28,14 +28,15 @@
 #ifndef EBOS_BLACK_OIL_HH
 #define EBOS_BLACK_OIL_HH
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
-
 #include <memory>
 #include <string>
 
 namespace Opm {
+
+class Deck;
+class ErrorGuard;
+class ParseContext;
+
 bool ebosBlackOilDeckFileNameIsSet(int argc, char** argv);
 std::string ebosBlackOilGetDeckFileName(int argc, char** argv);
 std::unique_ptr<Opm::ParseContext> ebosBlackOilCreateParseContext(int argc, char** argv);

--- a/ebos/ebos_brine.hh
+++ b/ebos/ebos_brine.hh
@@ -28,15 +28,16 @@
 #ifndef EBOS_BRINE_HH
 #define EBOS_BRINE_HH
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
-
 namespace Opm {
+
+class Deck;
+class ErrorGuard;
+class ParseContext;
+
 void ebosBrineSetDeck(Opm::Deck* deck,
-                     Opm::ParseContext* parseContext,
-                     Opm::ErrorGuard* errorGuard,
-                     double externalSetupTime);
+                      Opm::ParseContext* parseContext,
+                      Opm::ErrorGuard* errorGuard,
+                      double externalSetupTime);
 
 int ebosBrineMain(int argc, char** argv);
 }

--- a/ebos/ebos_energy.hh
+++ b/ebos/ebos_energy.hh
@@ -28,11 +28,14 @@
 #ifndef EBOS_ENERGY_HH
 #define EBOS_ENERGY_HH
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class ErrorGuard;
+class ParseContext;
+
 void ebosEnergySetDeck(std::unique_ptr<Opm::Deck> deck,
                        std::unique_ptr<Opm::ParseContext> parseContext,
                        std::unique_ptr<Opm::ErrorGuard> errorGuard,

--- a/ebos/ebos_extbo.hh
+++ b/ebos/ebos_extbo.hh
@@ -28,15 +28,16 @@
 #ifndef EBOS_EXTBO_HH
 #define EBOS_EXTBO_HH
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
-
 namespace Opm {
+
+class Deck;
+class ErrorGuard;
+class ParseContext;
+
 void ebosExtboSetDeck(Opm::Deck* deck,
-                        Opm::ParseContext* parseContext,
-                        Opm::ErrorGuard* errorGuard,
-                        double externalSetupTime);
+                      Opm::ParseContext* parseContext,
+                      Opm::ErrorGuard* errorGuard,
+                      double externalSetupTime);
 
 int ebosExtboMain(int argc, char** argv);
 }

--- a/ebos/ebos_foam.hh
+++ b/ebos/ebos_foam.hh
@@ -28,11 +28,14 @@
 #ifndef EBOS_FOAM_HH
 #define EBOS_FOAM_HH
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class ErrorGuard;
+class ParseContext;
+
 void ebosFoamSetDeck(std::unique_ptr<Opm::Deck> deck,
                      std::unique_ptr<Opm::ParseContext> parseContext,
                      std::unique_ptr<Opm::ErrorGuard> errorGuard,

--- a/ebos/ebos_gasoil.hh
+++ b/ebos/ebos_gasoil.hh
@@ -28,11 +28,14 @@
 #ifndef EBOS_GAS_OIL_HH
 #define EBOS_GAS_OIL_HH
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class ErrorGuard;
+class ParseContext;
+
 void ebosGasOilSetDeck(std::unique_ptr<Opm::Deck> deck,
                        std::unique_ptr<Opm::ParseContext> parseContext,
                        std::unique_ptr<Opm::ErrorGuard> errorGuard,

--- a/ebos/ebos_gaswater.hh
+++ b/ebos/ebos_gaswater.hh
@@ -28,15 +28,18 @@
 #ifndef EBOS_GAS_WATER_HH
 #define EBOS_GAS_WATER_HH
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class ErrorGuard;
+class ParseContext;
+
 void ebosGasWaterSetDeck(std::unique_ptr<Opm::Deck> deck,
-                       std::unique_ptr<Opm::ParseContext> parseContext,
-                       std::unique_ptr<Opm::ErrorGuard> errorGuard,
-                       double externalSetupTime);
+                         std::unique_ptr<Opm::ParseContext> parseContext,
+                         std::unique_ptr<Opm::ErrorGuard> errorGuard,
+                         double externalSetupTime);
 
 int ebosGasWaterMain(int argc, char** argv);
 }

--- a/ebos/ebos_oilwater.hh
+++ b/ebos/ebos_oilwater.hh
@@ -28,11 +28,14 @@
 #ifndef EBOS_OIL_WATER_HH
 #define EBOS_OIL_WATER_HH
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class ErrorGuard;
+class ParseContext;
+
 void ebosOilWaterSetDeck(std::unique_ptr<Opm::Deck> deck,
                          std::unique_ptr<Opm::ParseContext> parseContext,
                          std::unique_ptr<Opm::ErrorGuard> errorGuard,

--- a/ebos/ebos_oilwater_polymer.hh
+++ b/ebos/ebos_oilwater_polymer.hh
@@ -28,11 +28,14 @@
 #ifndef EBOS_OIL_WATER_POLYMER_HH
 #define EBOS_OIL_WATER_POLYMER_HH
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class ErrorGuard;
+class ParseContext;
+
 void ebosOilWaterPolymerSetDeck(std::unique_ptr<Opm::Deck> deck,
                                 std::unique_ptr<Opm::ParseContext> parseContext,
                                 std::unique_ptr<Opm::ErrorGuard> errorGuard,

--- a/ebos/ebos_polymer.hh
+++ b/ebos/ebos_polymer.hh
@@ -28,11 +28,14 @@
 #ifndef EBOS_POLYMER_HH
 #define EBOS_POLYMER_HH
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class ParseContext;
+class ErrorGuard;
+
 void ebosPolymerSetDeck(std::unique_ptr<Opm::Deck> deck,
                         std::unique_ptr<Opm::ParseContext> parseContext,
                         std::unique_ptr<Opm::ErrorGuard> errorGuard,

--- a/ebos/ebos_solvent.hh
+++ b/ebos/ebos_solvent.hh
@@ -28,11 +28,14 @@
 #ifndef EBOS_SOLVENT_HH
 #define EBOS_SOLVENT_HH
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class ErrorGuard;
+class ParseContext;
+
 void ebosSolventSetDeck(std::unique_ptr<Opm::Deck> deck,
                         std::unique_ptr<Opm::ParseContext> parseContext,
                         std::unique_ptr<Opm::ErrorGuard> errorGuard,

--- a/flow/flow_ebos_blackoil.hpp
+++ b/flow/flow_ebos_blackoil.hpp
@@ -17,13 +17,17 @@
 #ifndef FLOW_EBOS_BLACKOIL_HPP
 #define FLOW_EBOS_BLACKOIL_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class EclipseState;
+template<class TypeTag> class FlowMainEbos;
+class Schedule;
+class SummaryConfig;
+namespace Properties { namespace TTag { struct EclFlowProblem; } }
+
 void flowEbosBlackoilSetDeck(double setupTime, std::unique_ptr<Deck> deck,
                              std::unique_ptr<EclipseState> eclState,
                              std::unique_ptr<Schedule> schedule,

--- a/flow/flow_ebos_brine.hpp
+++ b/flow/flow_ebos_brine.hpp
@@ -17,13 +17,15 @@
 #ifndef FLOW_EBOS_BRINE_HPP
 #define FLOW_EBOS_BRINE_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class EclipseState;
+class Schedule;
+class SummaryConfig;
+
 void flowEbosBrineSetDeck(double setupTime, std::unique_ptr<Deck> deck,
                           std::unique_ptr<EclipseState> eclState,
                           std::unique_ptr<Schedule> schedule,

--- a/flow/flow_ebos_energy.hpp
+++ b/flow/flow_ebos_energy.hpp
@@ -17,17 +17,21 @@
 #ifndef FLOW_EBOS_ENERGY_HPP
 #define FLOW_EBOS_ENERGY_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class EclipseState;
+class Schedule;
+class SummaryConfig;
+
 void flowEbosEnergySetDeck(double setupTime, std::unique_ptr<Deck> deck,
                            std::unique_ptr<EclipseState> eclState,
                            std::unique_ptr<Schedule> schedule,
                            std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
 }
 
 #endif // FLOW_EBOS_ENERGY_HPP

--- a/flow/flow_ebos_extbo.hpp
+++ b/flow/flow_ebos_extbo.hpp
@@ -17,17 +17,21 @@
 #ifndef FLOW_EBOS_EXTBO_HPP
 #define FLOW_EBOS_EXTBO_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class EclipseState;
+class Schedule;
+class SummaryConfig;
+
 void flowEbosExtboSetDeck(double setupTime, std::unique_ptr<Deck> deck,
                             std::unique_ptr<EclipseState> eclState,
                             std::unique_ptr<Schedule> schedule,
                             std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosExtboMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
 }
 
 #endif // FLOW_EBOS_EXTBO_HPP

--- a/flow/flow_ebos_foam.hpp
+++ b/flow/flow_ebos_foam.hpp
@@ -17,18 +17,21 @@
 #ifndef FLOW_EBOS_FOAM_HPP
 #define FLOW_EBOS_FOAM_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class EclipseState;
+class Schedule;
+class SummaryConfig;
+
 void flowEbosFoamSetDeck(double setupTime, std::unique_ptr<Deck> deck,
                          std::unique_ptr<EclipseState> eclState,
                          std::unique_ptr<Schedule> schedule,
                          std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosFoamMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
 }
 
 #endif // FLOW_EBOS_FOAM_HPP

--- a/flow/flow_ebos_gasoil.hpp
+++ b/flow/flow_ebos_gasoil.hpp
@@ -17,17 +17,21 @@
 #ifndef FLOW_EBOS_GASOIL_HPP
 #define FLOW_EBOS_GASOIL_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class EclipseState;
+class Schedule;
+class SummaryConfig;
+
 void flowEbosGasOilSetDeck(double setupTime, std::unique_ptr<Deck> deck,
                            std::unique_ptr<EclipseState> eclState,
                            std::unique_ptr<Schedule> schedule,
                            std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosGasOilMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
 }
 
 #endif // FLOW_EBOS_GASOIL_HPP

--- a/flow/flow_ebos_gaswater.hpp
+++ b/flow/flow_ebos_gaswater.hpp
@@ -17,17 +17,21 @@
 #ifndef FLOW_EBOS_GASWATER_HPP
 #define FLOW_EBOS_GASWATER_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class EclipseState;
+class Schedule;
+class SummaryConfig;
+
 void flowEbosGasWaterSetDeck(double setupTime, std::unique_ptr<Deck> deck,
                            std::unique_ptr<EclipseState> eclState,
                            std::unique_ptr<Schedule> schedule,
                            std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosGasWaterMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
 }
 
 #endif // FLOW_EBOS_GASWATER_HPP

--- a/flow/flow_ebos_oilwater.hpp
+++ b/flow/flow_ebos_oilwater.hpp
@@ -17,17 +17,21 @@
 #ifndef FLOW_EBOS_OILWATER_HPP
 #define FLOW_EBOS_OILWATER_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class EclipseState;
+class Schedule;
+class SummaryConfig;
+
 void flowEbosOilWaterSetDeck(double setupTime, std::unique_ptr<Deck> deck,
                              std::unique_ptr<EclipseState> eclState,
                              std::unique_ptr<Schedule> schedule,
                              std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosOilWaterMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
 }
 
 #endif // FLOW_EBOS_OILWATER_HPP

--- a/flow/flow_ebos_oilwater_brine.hpp
+++ b/flow/flow_ebos_oilwater_brine.hpp
@@ -17,17 +17,21 @@
 #ifndef FLOW_EBOS_OILWATER_BRINE_HPP
 #define FLOW_EBOS_OILWATER_BRINE_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class EclipseState;
+class Schedule;
+class SummaryConfig;
+
 void flowEbosOilWaterBrineSetDeck(double setupTime, std::unique_ptr<Deck> deck,
                                   std::unique_ptr<EclipseState> eclState,
                                   std::unique_ptr<Schedule> schedule,
                                   std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosOilWaterBrineMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
 }
 
 #endif // FLOW_EBOS_OILWATER_BRINE_HPP

--- a/flow/flow_ebos_oilwater_polymer.hpp
+++ b/flow/flow_ebos_oilwater_polymer.hpp
@@ -17,17 +17,21 @@
 #ifndef FLOW_EBOS_OILWATER_POLYMER_HPP
 #define FLOW_EBOS_OILWATER_POLYMER_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class EclipseState;
+class Schedule;
+class SummaryConfig;
+
 void flowEbosOilWaterPolymerSetDeck(double setupTime, std::unique_ptr<Deck> deck,
                                     std::unique_ptr<EclipseState> eclState,
                                     std::unique_ptr<Schedule> schedule,
                                     std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosOilWaterPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
 }
 
 #endif // FLOW_EBOS_OILWATER_POLYMER_HPP

--- a/flow/flow_ebos_oilwater_polymer_injectivity.hpp
+++ b/flow/flow_ebos_oilwater_polymer_injectivity.hpp
@@ -17,12 +17,11 @@
 #ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
 #define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-
 namespace Opm {
+
   // void flowEbosOilWaterPolymerInjectivitySetDeck(Deck& deck, EclipseState& eclState);
 int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
 }
 
 #endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_ebos_polymer.hpp
+++ b/flow/flow_ebos_polymer.hpp
@@ -17,17 +17,21 @@
 #ifndef FLOW_EBOS_POLYMER_HPP
 #define FLOW_EBOS_POLYMER_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class EclipseState;
+class Schedule;
+class SummaryConfig;
+
 void flowEbosPolymerSetDeck(double setupTime, std::unique_ptr<Deck> deck,
                             std::unique_ptr<EclipseState> eclState,
                             std::unique_ptr<Schedule> schedule,
                             std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
 }
 
 #endif // FLOW_EBOS_POLYMER_HPP

--- a/flow/flow_ebos_solvent.hpp
+++ b/flow/flow_ebos_solvent.hpp
@@ -17,18 +17,21 @@
 #ifndef FLOW_EBOS_SOLVENT_HPP
 #define FLOW_EBOS_SOLVENT_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-
+#include <memory>
 
 namespace Opm {
+
+class Deck;
+class EclipseState;
+class Schedule;
+class SummaryConfig;
+
 void flowEbosSolventSetDeck(double setupTime, std::unique_ptr<Deck> deck,
                             std::unique_ptr<EclipseState> eclState,
                             std::unique_ptr<Schedule> schedule,
                             std::unique_ptr<SummaryConfig> summaryConfig);
 int flowEbosSolventMain(int argc, char** argv, bool outoutCout, bool outputFiles);
+
 }
 
 #endif // FLOW_EBOS_SOLVENT_HPP

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -25,22 +25,14 @@
 
 #include <sys/utsname.h>
 
-#include <opm/simulators/flow/BlackoilModelEbos.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/utils/ParallelFileMerger.hpp>
 #include <opm/simulators/utils/moduleVersion.hpp>
-#include <opm/simulators/linalg/ExtractParallelGridInformationToISTL.hpp>
 #include <opm/simulators/utils/ParallelEclipseState.hpp>
 
-#include <opm/core/props/satfunc/RelpermDiagnostics.hpp>
-
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/common/utility/String.hpp>
 
 #include <fmt/format.h>
@@ -85,6 +77,9 @@ struct OutputInterval<TypeTag, TTag::EclFlowProblem> {
 
 namespace Opm
 {
+
+    class Deck;
+
     // The FlowMain class is the ebos based black-oil simulator.
     template <class TypeTag>
     class FlowMainEbos

--- a/opm/simulators/flow/KeywordValidation.cpp
+++ b/opm/simulators/flow/KeywordValidation.cpp
@@ -24,6 +24,8 @@
 #include <fmt/format.h>
 
 #include <opm/common/utility/OpmInputError.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/simulators/flow/KeywordValidation.hpp>

--- a/opm/simulators/flow/KeywordValidation.hpp
+++ b/opm/simulators/flow/KeywordValidation.hpp
@@ -21,7 +21,6 @@
 #define OPM_KEYWORDVALIDATION_HEADER_INCLUDED
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 
 #include <optional>
 #include <string>
@@ -30,6 +29,8 @@
 namespace Opm
 {
 
+class Deck;
+class DeckKeyword;
 class ErrorGuard;
 class ParseContext;
 

--- a/opm/simulators/linalg/ExtractParallelGridInformationToISTL.cpp
+++ b/opm/simulators/linalg/ExtractParallelGridInformationToISTL.cpp
@@ -22,6 +22,8 @@
 #include <opm/simulators/linalg/ParallelIstlInformation.hpp>
 #include <dune/common/version.hh>
 #include <dune/common/shared_ptr.hh>
+#include <opm/grid/CpGrid.hpp>
+
  namespace Opm
 {
 #if defined(HAVE_OPM_GRID)

--- a/opm/simulators/linalg/ExtractParallelGridInformationToISTL.hpp
+++ b/opm/simulators/linalg/ExtractParallelGridInformationToISTL.hpp
@@ -21,8 +21,9 @@
 #define OPM_EXTRACTPARALLELGRIDINFORMATIONTOISTL_HEADER_INCLUDED
 #ifdef HAVE_OPM_GRID
 
-#include<opm/grid/CpGrid.hpp>
 #include <any>
+
+namespace Dune { class CpGrid; }
 
 namespace Opm
 {

--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -25,6 +25,13 @@
 #include <ctime>
 #include <cstring>
 #include <dune/common/parallel/mpitraits.hh>
+#include <opm/output/data/Cells.hpp>
+#include <opm/output/data/Groups.hpp>
+#include <opm/output/data/GuideRateValue.hpp>
+#include <opm/output/data/Solution.hpp>
+#include <opm/output/data/Wells.hpp>
+#include <opm/output/eclipse/EclipseIO.hpp>
+#include <opm/output/eclipse/RestartValue.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 
 #define HANDLE_AS_POD(T) \

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -24,10 +24,6 @@
 #endif
 
 #include <opm/common/ErrorMacros.hpp>
-#include <opm/output/eclipse/RestartValue.hpp>
-#include <opm/output/eclipse/EclipseIO.hpp>
-#include <opm/output/eclipse/Summary.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 #include <opm/common/utility/TimeService.hpp>
 
 #include <dune/common/parallel/mpihelper.hh>
@@ -40,10 +36,39 @@
 #include <tuple>
 #include <typeinfo>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace Opm
 {
+
+class EclipseIO;
+class SummaryState;
+class RestartKey;
+class RestartValue;
+
+namespace data
+{
+class CellData;
+class Connection;
+class CurrentControl;
+class GroupAndNetworkValues;
+class GroupConstraints;
+class GroupData;
+class GroupGuideRates;
+class GuideRateValue;
+class NodeData;
+class Rates;
+class Segment;
+class Solution;
+class Well;
+class WellRates;
+}
+
+namespace Action
+{
+class State;
+}
 
 namespace Mpi
 {

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -26,9 +26,11 @@
 #endif
 #include "readDeck.hpp"
 
+#include <opm/common/OpmLog/EclipsePRTLog.hpp>
 #include <opm/common/utility/String.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/common/utility/FileSystem.hpp>
 
 #include <opm/io/eclipse/EclIOdata.hpp>
 
@@ -38,6 +40,10 @@
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 #include "UnsupportedFlowKeywords.hpp"

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -37,6 +37,7 @@
 #include <opm/output/eclipse/RestartIO.hpp>
 #include <opm/io/eclipse/rst/state.hpp>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -22,23 +22,21 @@
 #ifndef OPM_READDECK_HEADER_INCLUDED
 #define OPM_READDECK_HEADER_INCLUDED
 
-#include <opm/common/OpmLog/OpmLog.hpp>
-#include <opm/common/OpmLog/EclipsePRTLog.hpp>
-#include <opm/common/OpmLog/LogUtil.hpp>
-
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/Python/Python.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp>
-
 #include <memory>
 #include <optional>
 #include <string>
 
 namespace Opm 
 {
+
+class Deck;
+class EclipseState;
+class ErrorGuard;
+class ParseContext;
+class Python;
+class Schedule;
+class SummaryConfig;
+
 enum class FileOutputMode {
     //! \brief No output to files.
     OUTPUT_NONE = 0,

--- a/opm/simulators/wells/ParallelWellInfo.cpp
+++ b/opm/simulators/wells/ParallelWellInfo.cpp
@@ -18,7 +18,9 @@
 */
 #include <config.h>
 #include <opm/simulators/wells/ParallelWellInfo.hpp>
+
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 
 namespace Dune
 {

--- a/opm/simulators/wells/ParallelWellInfo.hpp
+++ b/opm/simulators/wells/ParallelWellInfo.hpp
@@ -25,7 +25,6 @@
 #include <dune/istl/owneroverlapcopy.hh>
 
 #include <opm/common/ErrorMacros.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 
 #include <memory>
 #include <iterator>
@@ -33,6 +32,8 @@
 
 namespace Opm
 {
+
+class Well;
 
 /// \brief Class to facilitate getting values associated with the above/below perforation
 ///

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -20,9 +20,13 @@
 
 #include <config.h>
 #include <opm/simulators/wells/WellGroupHelpers.hpp>
-#include <opm/simulators/wells/TargetCalculator.hpp>
+
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GConSump.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GConSale.hpp>
+#include <opm/simulators/utils/DeferredLogger.hpp>
+#include <opm/simulators/wells/GroupState.hpp>
+#include <opm/simulators/wells/TargetCalculator.hpp>
+#include <opm/simulators/wells/VFPProdProperties.hpp>
 #include <algorithm>
 #include <stack>
 #include <vector>

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -24,9 +24,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/simulators/utils/DeferredLogger.hpp>
-#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
-#include <opm/simulators/wells/VFPProdProperties.hpp>
 #include <opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp>
 #include <opm/simulators/wells/GroupState.hpp>
 
@@ -39,6 +36,9 @@
 
 namespace Opm
 {
+
+class DeferredLogger;
+class VFPProdProperties;
 
 
 namespace WellGroupHelpers

--- a/tests/test_keyword_validator.cpp
+++ b/tests/test_keyword_validator.cpp
@@ -19,6 +19,7 @@
 
 #include <string>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/simulators/flow/KeywordValidation.hpp>
 


### PR DESCRIPTION
I don't really think this has a big real-world impact due to the huge compilation units, but at least it's a small contribution towards clarifying real dependencies.