### PR TITLE
Move to separate compilation units

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -23,6 +23,7 @@
 # originally generated with the command:
 # find opm -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND MAIN_SOURCE_FILES
+  opm/core/props/phaseUsageFromDeck.cpp
   opm/core/props/satfunc/RelpermDiagnostics.cpp
   opm/simulators/timestepping/SimulatorReport.cpp
   opm/simulators/flow/KeywordValidation.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -39,6 +39,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/timestepping/gatherConvergenceReport.cpp
   opm/simulators/utils/DeferredLogger.cpp
   opm/simulators/utils/gatherDeferredLogger.cpp
+  opm/simulators/utils/ParallelFileMerger.cpp
   opm/simulators/utils/ParallelRestart.cpp
   opm/simulators/wells/GroupState.cpp
   opm/simulators/wells/WGState.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -26,6 +26,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/core/props/phaseUsageFromDeck.cpp
   opm/core/props/satfunc/RelpermDiagnostics.cpp
   opm/simulators/timestepping/SimulatorReport.cpp
+  opm/simulators/flow/countGlobalCells.cpp
   opm/simulators/flow/KeywordValidation.cpp
   opm/simulators/linalg/ExtractParallelGridInformationToISTL.cpp
   opm/simulators/linalg/FlexibleSolver1.cpp

--- a/opm/core/props/phaseUsageFromDeck.cpp
+++ b/opm/core/props/phaseUsageFromDeck.cpp
@@ -1,0 +1,164 @@
+
+/*
+  Copyright 2012 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/core/props/phaseUsageFromDeck.hpp>
+
+#include <opm/common/ErrorMacros.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+
+
+namespace Opm
+{
+
+PhaseUsage phaseUsage(const Phases& phases)
+{
+    PhaseUsage pu;
+    pu.phase_used.fill(0);
+
+    // Discover phase usage.
+    pu.phase_used[BlackoilPhases::Aqua] = phases.active(Phase::WATER);
+    pu.phase_used[BlackoilPhases::Liquid] = phases.active(Phase::OIL);
+    pu.phase_used[BlackoilPhases::Vapour] = phases.active(Phase::GAS);
+
+    pu.num_phases = 0;
+    int numActivePhases = 0;
+    for (int phaseIdx = 0; phaseIdx < BlackoilPhases::MaxNumPhases; ++phaseIdx) {
+        if (!pu.phase_used[phaseIdx]) {
+            pu.phase_pos[phaseIdx] = -1;
+        }
+        else {
+            pu.phase_pos[phaseIdx] = numActivePhases;
+            ++ numActivePhases;
+            pu.num_phases = numActivePhases;
+        }
+    }
+
+    // We need oil systems, since we do not support the keywords needed for
+    // water-gas systems.
+    if (!pu.phase_used[BlackoilPhases::Liquid] && !(pu.num_phases == 1)) {
+        OPM_THROW(std::runtime_error, "Cannot handle cases with no OIL, i.e. water-gas systems.");
+    }
+
+    // Add solvent info
+    pu.has_solvent = phases.active(Phase::SOLVENT);
+    if (pu.has_solvent) {
+        // this is quite a hack: even though solvent is not considered as in
+        // MaxNumPhases and pu.num_phases because this would break a lot of
+        // assumptions in old code, it is nevertheless an index to be translated
+        // to. solvent and solvent are even larger hacks because not even this can be
+        // done for them.
+        pu.phase_pos[BlackoilPhases::Solvent] = numActivePhases;
+        ++ numActivePhases;
+    }
+    else
+        pu.phase_pos[BlackoilPhases::Solvent] = -1;
+
+    // Add polymer info
+    pu.has_polymer = phases.active(Phase::POLYMER);
+    if (pu.has_polymer) {
+        // this is quite a hack: even though polymer is not considered as in
+        // MaxNumPhases and pu.num_phases because this would break a lot of
+        // assumptions in old code, it is nevertheless an index to be translated
+        // to. polymer and solvent are even larger hacks because not even this can be
+        // done for them.
+        pu.phase_pos[BlackoilPhases::Polymer] = numActivePhases;
+        ++ numActivePhases;
+    }
+    else
+        pu.phase_pos[BlackoilPhases::Polymer] = -1;
+
+    // Add energy info
+    pu.has_energy = phases.active(Phase::ENERGY);
+    if (pu.has_energy) {
+        // this is quite a hack: even though energy is not considered as in
+        // MaxNumPhases and pu.num_phases because this would break a lot of
+        // assumptions in old code, it is nevertheless an index to be translated
+        // to. polymer and solvent are even larger hacks because not even this can be
+        // done for them.
+        pu.phase_pos[BlackoilPhases::Energy] = numActivePhases;
+        ++ numActivePhases;
+    }
+    else
+        pu.phase_pos[BlackoilPhases::Energy] = -1;
+
+    // Add polymer molecular weight related
+    pu.has_polymermw = phases.active(Phase::POLYMW);
+    if (pu.has_polymermw) {
+        if (!pu.has_polymer) {
+            OPM_THROW(std::runtime_error, "pu.has_polymermw is true while pu.has_polymer is false");
+        }
+        pu.phase_pos[BlackoilPhases::PolymerMW] = numActivePhases;
+        ++ numActivePhases;
+    }
+    else
+        pu.phase_pos[BlackoilPhases::PolymerMW] = -1;
+
+    // Add foam info
+    pu.has_foam = phases.active(Phase::FOAM);
+    if (pu.has_foam) {
+        pu.phase_pos[BlackoilPhases::Foam] = numActivePhases;
+        ++ numActivePhases;
+    }
+    else
+        pu.phase_pos[BlackoilPhases::Foam] = -1;
+
+    // Add brine info
+    pu.has_brine = phases.active(Phase::BRINE);
+    if (pu.has_brine) {
+        pu.phase_pos[BlackoilPhases::Brine] = numActivePhases;
+        ++ numActivePhases;
+    }
+    else
+        pu.phase_pos[BlackoilPhases::Brine] = -1;
+
+    // Add zFraction info
+    pu.has_zFraction = phases.active(Phase::ZFRACTION);
+    if (pu.has_zFraction) {
+        pu.phase_pos[BlackoilPhases::ZFraction] = numActivePhases;
+        ++ numActivePhases;
+    }
+    else
+        pu.phase_pos[BlackoilPhases::ZFraction] = -1;
+
+
+    return pu;
+}
+
+PhaseUsage phaseUsageFromDeck(const Opm::EclipseState& eclipseState)
+{
+    const auto& phases = eclipseState.runspec().phases();
+
+    return phaseUsage(phases);
+}
+
+/// Looks at presence of WATER, OIL and GAS keywords in deck
+/// to determine active phases.
+PhaseUsage phaseUsageFromDeck(const Opm::Deck& deck)
+{
+    Runspec runspec( deck );
+    const auto& phases = runspec.phases();
+
+    return phaseUsage(phases);
+}
+
+}

--- a/opm/core/props/phaseUsageFromDeck.hpp
+++ b/opm/core/props/phaseUsageFromDeck.hpp
@@ -22,148 +22,23 @@
 #define OPM_PHASEUSAGEFROMDECK_HEADER_INCLUDED
 
 #include <opm/core/props/BlackoilPhases.hpp>
-#include <opm/common/ErrorMacros.hpp>
-
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
-
 
 namespace Opm
 {
+    class Deck;
+    class EclipseState;
+    class Phases;
+
     /// Determine the active phases
-    inline PhaseUsage phaseUsage(const Phases& phases) {
-        PhaseUsage pu;
-        pu.phase_used.fill(0);
-
-        // Discover phase usage.
-        pu.phase_used[BlackoilPhases::Aqua] = phases.active(Phase::WATER);
-        pu.phase_used[BlackoilPhases::Liquid] = phases.active(Phase::OIL);
-        pu.phase_used[BlackoilPhases::Vapour] = phases.active(Phase::GAS);
-
-        pu.num_phases = 0;
-        int numActivePhases = 0;
-        for (int phaseIdx = 0; phaseIdx < BlackoilPhases::MaxNumPhases; ++phaseIdx) {
-            if (!pu.phase_used[phaseIdx]) {
-                pu.phase_pos[phaseIdx] = -1;
-            }
-            else {
-                pu.phase_pos[phaseIdx] = numActivePhases;
-                ++ numActivePhases;
-                pu.num_phases = numActivePhases;
-            }
-        }
-
-        // We need oil systems, since we do not support the keywords needed for
-        // water-gas systems.
-        if (!pu.phase_used[BlackoilPhases::Liquid] && !(pu.num_phases == 1)) {
-            OPM_THROW(std::runtime_error, "Cannot handle cases with no OIL, i.e. water-gas systems.");
-        }
-
-        // Add solvent info
-        pu.has_solvent = phases.active(Phase::SOLVENT);
-        if (pu.has_solvent) {
-            // this is quite a hack: even though solvent is not considered as in
-            // MaxNumPhases and pu.num_phases because this would break a lot of
-            // assumptions in old code, it is nevertheless an index to be translated
-            // to. solvent and solvent are even larger hacks because not even this can be
-            // done for them.
-            pu.phase_pos[BlackoilPhases::Solvent] = numActivePhases;
-            ++ numActivePhases;
-        }
-        else
-            pu.phase_pos[BlackoilPhases::Solvent] = -1;
-
-        // Add polymer info
-        pu.has_polymer = phases.active(Phase::POLYMER);
-        if (pu.has_polymer) {
-            // this is quite a hack: even though polymer is not considered as in
-            // MaxNumPhases and pu.num_phases because this would break a lot of
-            // assumptions in old code, it is nevertheless an index to be translated
-            // to. polymer and solvent are even larger hacks because not even this can be
-            // done for them.
-            pu.phase_pos[BlackoilPhases::Polymer] = numActivePhases;
-            ++ numActivePhases;
-        }
-        else
-            pu.phase_pos[BlackoilPhases::Polymer] = -1;
-
-        // Add energy info
-        pu.has_energy = phases.active(Phase::ENERGY);
-        if (pu.has_energy) {
-            // this is quite a hack: even though energy is not considered as in
-            // MaxNumPhases and pu.num_phases because this would break a lot of
-            // assumptions in old code, it is nevertheless an index to be translated
-            // to. polymer and solvent are even larger hacks because not even this can be
-            // done for them.
-            pu.phase_pos[BlackoilPhases::Energy] = numActivePhases;
-            ++ numActivePhases;
-        }
-        else
-            pu.phase_pos[BlackoilPhases::Energy] = -1;
-
-        // Add polymer molecular weight related
-        pu.has_polymermw = phases.active(Phase::POLYMW);
-        if (pu.has_polymermw) {
-            if (!pu.has_polymer) {
-                OPM_THROW(std::runtime_error, "pu.has_polymermw is true while pu.has_polymer is false");
-            }
-            pu.phase_pos[BlackoilPhases::PolymerMW] = numActivePhases;
-            ++ numActivePhases;
-        }
-        else
-            pu.phase_pos[BlackoilPhases::PolymerMW] = -1;
-
-        // Add foam info
-        pu.has_foam = phases.active(Phase::FOAM);
-        if (pu.has_foam) {
-            pu.phase_pos[BlackoilPhases::Foam] = numActivePhases;
-            ++ numActivePhases;
-        }
-        else
-            pu.phase_pos[BlackoilPhases::Foam] = -1;
-
-        // Add brine info
-        pu.has_brine = phases.active(Phase::BRINE);
-        if (pu.has_brine) {
-            pu.phase_pos[BlackoilPhases::Brine] = numActivePhases;
-            ++ numActivePhases;
-        }
-        else
-            pu.phase_pos[BlackoilPhases::Brine] = -1;
-
-        // Add zFraction info
-        pu.has_zFraction = phases.active(Phase::ZFRACTION);
-        if (pu.has_zFraction) {
-            pu.phase_pos[BlackoilPhases::ZFraction] = numActivePhases;
-            ++ numActivePhases;
-        }
-        else
-            pu.phase_pos[BlackoilPhases::ZFraction] = -1;
-
-
-        return pu;
-    }
+    PhaseUsage phaseUsage(const Phases& phases);
 
     /// Looks at presence of WATER, OIL and GAS keywords in state object
     /// to determine active phases.
-    inline PhaseUsage phaseUsageFromDeck(const Opm::EclipseState& eclipseState)
-    {
-        const auto& phases = eclipseState.runspec().phases();
-
-        return phaseUsage(phases);
-    }
+    PhaseUsage phaseUsageFromDeck(const Opm::EclipseState& eclipseState);
 
     /// Looks at presence of WATER, OIL and GAS keywords in deck
     /// to determine active phases.
-    inline PhaseUsage phaseUsageFromDeck(const Opm::Deck& deck)
-    {
-        Runspec runspec( deck );
-        const auto& phases = runspec.phases();
-
-        return phaseUsage(phases);
-    }
-
+    PhaseUsage phaseUsageFromDeck(const Opm::Deck& deck);
 }
 
 #endif // OPM_PHASEUSAGEFROMDECK_HEADER_INCLUDED

--- a/opm/simulators/flow/countGlobalCells.cpp
+++ b/opm/simulators/flow/countGlobalCells.cpp
@@ -1,0 +1,50 @@
+/*
+  Copyright 2013, 2015 SINTEF ICT, Applied Mathematics.
+  Copyright 2014, 2015 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2014, 2015 Statoil ASA.
+  Copyright 2015 NTNU
+  Copyright 2015 IRIS AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "countGlobalCells.hpp"
+
+#include <cassert>
+
+namespace Opm {
+namespace detail {
+
+std::vector<int> buildAllCells(const int nc) {
+    std::vector<int> all_cells(nc);
+    std::iota(all_cells.begin(), all_cells.end(), 0);
+    return all_cells;
+}
+
+double getGravity(const double* g, const int dim) {
+    double grav = 0.0;
+    if (g) {
+        // Guard against gravity in anything but last dimension.
+        for (int dd = 0; dd < dim - 1; ++dd) {
+            assert(g[dd] == 0.0);
+        }
+        grav = g[dim - 1];
+    }
+    return grav;
+}
+
+} // namespace detail
+} // namespace Opm

--- a/opm/simulators/flow/countGlobalCells.hpp
+++ b/opm/simulators/flow/countGlobalCells.hpp
@@ -21,28 +21,24 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef OPM_BLACKOILDETAILS_HEADER_INCLUDED
-#define OPM_BLACKOILDETAILS_HEADER_INCLUDED
+#ifndef OPM_COUNTGLOBALCELLS_HEADER_INCLUDED
+#define OPM_COUNTGLOBALCELLS_HEADER_INCLUDED
 
 #include <opm/simulators/linalg/ParallelIstlInformation.hpp>
 #include <opm/core/props/BlackoilPhases.hpp>
 
+#include <dune/grid/common/gridview.hh>
+
+#include <boost/range/iterator_range.hpp>
+
 #include <any>
+#include <vector>
 
 namespace Opm {
 namespace detail {
 
 
-    inline
-    std::vector<int>
-    buildAllCells(const int nc)
-    {
-        std::vector<int> all_cells(nc);
-
-        for (int c = 0; c < nc; ++c) { all_cells[c] = c; }
-
-        return all_cells;
-    }
+    std::vector<int> buildAllCells(const int nc);
 
 
 
@@ -80,18 +76,7 @@ namespace detail {
 
 
 
-    inline
-    double getGravity(const double* g, const int dim) {
-        double grav = 0.0;
-        if (g) {
-            // Guard against gravity in anything but last dimension.
-            for (int dd = 0; dd < dim - 1; ++dd) {
-                assert(g[dd] == 0.0);
-            }
-            grav = g[dim - 1];
-        }
-        return grav;
-    }
+    double getGravity(const double* g, const int dim);
 
 
         /// \brief Compute the Euclidian norm of a vector

--- a/opm/simulators/utils/ParallelFileMerger.cpp
+++ b/opm/simulators/utils/ParallelFileMerger.cpp
@@ -1,0 +1,113 @@
+/*
+  Copyright 2016 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2016 STATOIL AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/simulators/utils/ParallelFileMerger.hpp>
+#include <iostream>
+
+namespace Opm
+{
+namespace detail
+{
+
+ParallelFileMerger::ParallelFileMerger(const fs::path& output_dir,
+                                       const std::string& deckname,
+                                       bool show_fallout)
+    : debugFileRegex_(deckname+"\\.\\d+\\.DBG"),
+      logFileRegex_(deckname+"\\.\\d+\\.PRT"),
+      fileWarningRegex_(deckname+"\\.(\\d+)\\.[^.]+"),
+      show_fallout_(show_fallout)
+{
+    if ( show_fallout_ )
+    {
+        auto debugPath = output_dir;
+        debugPath /= (deckname + ".DBG");
+        debugStream_.reset(new std::ofstream(debugPath,
+                                             std::ofstream::app));
+        auto logPath = output_dir;
+        logPath /= ( deckname + ".PRT");
+        logStream_.reset(new std::ofstream(logPath,
+                                           std::ofstream::app));
+    }
+}
+
+void ParallelFileMerger::operator()(const fs::path& file)
+{
+    std::smatch matches;
+    std::string filename = file.filename().native();
+
+    if ( std::regex_match(filename, matches, fileWarningRegex_) )
+    {
+        std::string rank = std::regex_replace(filename, fileWarningRegex_, "\\1");
+
+        if( std::regex_match(filename, logFileRegex_) )
+        {
+            if ( show_fallout_ ){
+                appendFile(*logStream_, file, rank);
+            }else{
+                fs::remove(file);
+            }
+        }
+        else
+        {
+            if (std::regex_match(filename, debugFileRegex_)  )
+            {
+                if ( show_fallout_ ){
+                    appendFile(*debugStream_, file, rank);
+                }else{
+                    fs::remove(file);
+                }
+            }
+            else
+            {
+                if ( show_fallout_ ){
+                    std::cerr << "WARNING: Unrecognized file with name "
+                                  << filename
+                                  << " that might stem from a  parallel run."
+                                  << std::endl;
+                }
+            }
+        }
+    }
+}
+
+void ParallelFileMerger::appendFile(std::ofstream& of, const fs::path& file, const std::string& rank)
+{
+    if( fs::file_size(file) )
+    {
+        std::cerr << "WARNING: There has been logging to file "
+                      << file.string() <<" by process "
+                      << rank << std::endl;
+
+        std::ifstream in(file);
+        of<<std::endl<< std::endl;
+        of<<"=======================================================";
+        of<<std::endl<<std::endl;
+        of << " Output written by rank " << rank << " to file " << file.string();
+        of << ":" << std::endl << std::endl;
+        of << in.rdbuf() << std::endl << std::endl;
+        of << "======================== end output =====================";
+        of << std::endl;
+        in.close();
+    }
+    fs::remove(file);
+}
+
+} // end namespace detail
+} // end namespace Opm

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -27,6 +27,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>


### PR DESCRIPTION
Some small low-hanging fruits that can be moved to separate compilation units to avoid recompilation in each simulator object.