### PR TITLE
fixed: do not build test_parallelwellinfo.cpp twice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,14 +279,13 @@ opm_add_test(test_gatherdeferredlogger
 )
 
 opm_add_test(test_parallelwellinfo_mpi
-  DEPENDS "opmsimulators"
-  LIBRARIES opmsimulators ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
-  SOURCES
-    tests/test_parallelwellinfo.cpp
+  EXE_NAME
+    test_parallelwellinfo
   CONDITION
     MPI_FOUND AND Boost_UNIT_TEST_FRAMEWORK_FOUND
   DRIVER_ARGS
     4 ${PROJECT_BINARY_DIR}
+  NO_COMPILE
     )
 
 include(OpmBashCompletion)


### PR DESCRIPTION
mark the parallel test NO_COMPILE and specify the binary