### PR TITLE
Fixes issue #3200 : boost 1.74 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ endif()
 
 opm_set_test_driver(${CMAKE_CURRENT_SOURCE_DIR}/tests/run-parallel-unitTest.sh "")
 
-add_compile_definitions(BOOST_BIND_GLOBAL_PLACEHOLDERS)
+add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 opm_add_test(test_gatherconvergencereport
   DEPENDS "opmsimulators"
   LIBRARIES opmsimulators ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ endif()
 
 opm_set_test_driver(${CMAKE_CURRENT_SOURCE_DIR}/tests/run-parallel-unitTest.sh "")
 
+add_compile_definitions(BOOST_BIND_GLOBAL_PLACEHOLDERS)
 opm_add_test(test_gatherconvergencereport
   DEPENDS "opmsimulators"
   LIBRARIES opmsimulators ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}


### PR DESCRIPTION
Silences the warning

> The practice of declaring the Bind placeholders (`_1`, `_2`, ...) in the global namespace is deprecated.