### PR TITLE
Distribute events

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -813,14 +813,14 @@ namespace Opm {
                 if (this->wellTestState_.hasWellClosed(well_name)) {
                     // TODO: more checking here, to make sure this standard more specific and complete
                     // maybe there is some WCON keywords will not open the well
-                    auto& events = this->wellState().events();
-                    if (events.hasEvent(well_name, WellStateFullyImplicitBlackoil::event_mask)) {
+                    auto& events = this->wellState().events(w);
+                    if (events.hasEvent(WellStateFullyImplicitBlackoil::event_mask)) {
                         if (wellTestState_.lastTestTime(well_name) == ebosSimulator_.time()) {
                             // The well was shut this timestep, we are most likely retrying
                             // a timestep without the well in question, after it caused
                             // repeated timestep cuts. It should therefore not be opened,
                             // even if it was new or received new targets this report step.
-                            events.clearEvent(well_name, WellStateFullyImplicitBlackoil::event_mask);
+                            events.clearEvent(WellStateFullyImplicitBlackoil::event_mask);
                         } else {
                             wellTestState_.openWell(well_name);
                         }
@@ -1687,12 +1687,12 @@ namespace Opm {
                 const int w = well->indexOfWell();
                 if (!well->isOperable() ) continue;
 
-                auto& events = this->wellState().events();
-                if (events.hasEvent(well->name(), WellStateFullyImplicitBlackoil::event_mask)) {
+                auto& events = this->wellState().events(w);
+                if (events.hasEvent(WellStateFullyImplicitBlackoil::event_mask)) {
                     well->updateWellStateWithTarget(ebosSimulator_, this->wellState(), deferred_logger);
                     // There is no new well control change input within a report step,
                     // so next time step, the well does not consider to have effective events anymore.
-                    events.clearEvent(well->name(), WellStateFullyImplicitBlackoil::event_mask);
+                    events.clearEvent(WellStateFullyImplicitBlackoil::event_mask);
                 }
             }
             updatePrimaryVariables(deferred_logger);

--- a/opm/simulators/wells/WellContainer.hpp
+++ b/opm/simulators/wells/WellContainer.hpp
@@ -56,6 +56,14 @@ public:
         this->data.push_back(std::forward<T>(value));
     }
 
+    void add(const std::string& name, const T& value) {
+        if (index_map.count(name) != 0)
+            throw std::logic_error("An object with name: " + name + " already exists in container");
+
+        this->index_map.emplace(name, this->data.size());
+        this->data.push_back(value);
+    }
+
     bool has(const std::string& name) const {
         return (index_map.count(name) != 0);
     }
@@ -66,8 +74,17 @@ public:
         this->data[index] = std::forward<T>(value);
     }
 
+    void update(const std::string& name, const T& value) {
+        auto index = this->index_map.at(name);
+        this->data[index] = value;
+    }
+
     void update(std::size_t index, T&& value) {
         this->data.at(index) = std::forward<T>(value);
+    }
+
+    void update(std::size_t index, const T& value) {
+        this->data.at(index) = value;
     }
 
     /*


### PR DESCRIPTION
Use `WellContainer<Events>` to manage per well events.

Upstream: https://github.com/OPM/opm-common/pull/2463