### PR TITLE
Avoid code duplication

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -136,12 +136,6 @@ namespace Opm
             // Not implemented yet
         }
 
-        virtual void assembleWellEq(const Simulator& ebosSimulator,
-                                    const double dt,
-                                    WellState& well_state,
-                                    const GroupState& group_state,
-                                    DeferredLogger& deferred_logger) override;
-
         /// updating the well state based the current control mode
         void updateWellStateWithTarget(const Simulator& ebos_simulator,
                                        WellState& well_state,
@@ -207,6 +201,10 @@ namespace Opm
                                     const std::vector<EvalWell>& mobility,
                                     double* connII,
                                     DeferredLogger& deferred_logger) const;
+
+        virtual bool useInnerIterations() const override {
+            return param_.use_inner_iterations_ms_wells_;
+        }
     protected:
         int number_segments_;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -255,35 +255,6 @@ namespace Opm
 
 
 
-
-
-    template <typename TypeTag>
-    void
-    MultisegmentWell<TypeTag>::
-    assembleWellEq(const Simulator& ebosSimulator,
-                   const double dt,
-                   WellState& well_state,
-                   const GroupState& group_state,
-                   DeferredLogger& deferred_logger)
-    {
-
-        checkWellOperability(ebosSimulator, well_state, deferred_logger);
-
-        const bool use_inner_iterations = param_.use_inner_iterations_ms_wells_;
-        if (use_inner_iterations) {
-            this->iterateWellEquations(ebosSimulator, dt, well_state, group_state, deferred_logger);
-        }
-
-        const auto& summary_state = ebosSimulator.vanguard().summaryState();
-        const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
-        const auto prod_controls = well_ecl_.isProducer() ? well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
-        assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
-    }
-
-
-
-
-
     template <typename TypeTag>
     void
     MultisegmentWell<TypeTag>::

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -181,12 +181,6 @@ namespace Opm
 
         virtual void initPrimaryVariablesEvaluation() const override;
 
-        virtual void assembleWellEq(const Simulator& ebosSimulator,
-                                    const double dt,
-                                    WellState& well_state,
-                                    const GroupState& group_state,
-                                    Opm::DeferredLogger& deferred_logger) override;
-
         void updateWellStateWithTarget(const Simulator& ebos_simulator,
                                        WellState& well_state,
                                        Opm::DeferredLogger& deferred_logger) const;
@@ -329,6 +323,10 @@ namespace Opm
                                     const std::vector<EvalWell>& mobility,
                                     double* connII,
                                     DeferredLogger& deferred_logger) const;
+
+        virtual bool useInnerIterations() const override {
+            return param_.use_inner_iterations_wells_;
+        }
 
     protected:
         // protected functions from the Base class

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -537,33 +537,6 @@ namespace Opm
 
 
 
-
-    template<typename TypeTag>
-    void
-    StandardWell<TypeTag>::
-    assembleWellEq(const Simulator& ebosSimulator,
-                   const double dt,
-                   WellState& well_state,
-                   const GroupState& group_state,
-                   Opm::DeferredLogger& deferred_logger)
-    {
-        checkWellOperability(ebosSimulator, well_state, deferred_logger);
-
-        const bool use_inner_iterations = param_.use_inner_iterations_wells_;
-        if (use_inner_iterations) {
-            this->iterateWellEquations(ebosSimulator, dt, well_state, group_state, deferred_logger);
-        }
-
-        // TODO: inj_controls and prod_controls are not used in the following function for now
-        const auto& summary_state = ebosSimulator.vanguard().summaryState();
-        const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
-        const auto prod_controls = well_ecl_.isProducer() ? well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
-        assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
-    }
-
-
-
-
     template<typename TypeTag>
     void
     StandardWell<TypeTag>::

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -182,12 +182,11 @@ namespace Opm
 
         virtual void solveEqAndUpdateWellState(WellState& well_state, Opm::DeferredLogger& deferred_logger) = 0;
 
-        virtual void assembleWellEq(const Simulator& ebosSimulator,
-                                    const double dt,
-                                    WellState& well_state,
-                                    const GroupState& group_state,
-                                    Opm::DeferredLogger& deferred_logger
-                                    ) = 0;
+        void assembleWellEq(const Simulator& ebosSimulator,
+                            const double dt,
+                            WellState& well_state,
+                            const GroupState& group_state,
+                            Opm::DeferredLogger& deferred_logger);
 
         virtual void gasLiftOptimizationStage1 (
             WellState& well_state,
@@ -345,6 +344,8 @@ namespace Opm
                                Opm::DeferredLogger& deferred_logger);
 
         const PhaseUsage& phaseUsage() const;
+
+        virtual bool useInnerIterations() const = 0;
 
     protected:
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1452,6 +1452,32 @@ namespace Opm
         }
     }
 
+
+
+    template <typename TypeTag>
+    void
+    WellInterface<TypeTag>::
+    assembleWellEq(const Simulator& ebosSimulator,
+                   const double dt,
+                   WellState& well_state,
+                   const GroupState& group_state,
+                   DeferredLogger& deferred_logger)
+    {
+
+        checkWellOperability(ebosSimulator, well_state, deferred_logger);
+
+        if (this->useInnerIterations()) {
+            this->iterateWellEquations(ebosSimulator, dt, well_state, group_state, deferred_logger);
+        }
+
+        const auto& summary_state = ebosSimulator.vanguard().summaryState();
+        const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
+        const auto prod_controls = well_ecl_.isProducer() ? well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
+        assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
+    }
+
+
+
     template<typename TypeTag>
     void
     WellInterface<TypeTag>::addCellRates(RateVector& rates, int cellIdx) const


### PR DESCRIPTION
add useInnerIteration method and move assembleWellEq to the well interface to avoid code duplication. 
These changes are cherry-picked from #3158 and should not change any results. 