### PR TITLE
Wellcontainer perforations

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1970,7 +1970,7 @@ namespace Opm {
                 well_state.wellRates()[ wellrate_index + i ] = rst_well.rates.get( phs[ i ] );
             }
 
-            auto * perf_pressure = well_state.perfPress().data() + wm.second[1];
+            auto& perf_pressure = well_state.perfPress(well_index);
             auto * perf_rates = well_state.perfRates().data() + wm.second[1];
             auto * perf_phase_rates = well_state.mutable_perfPhaseRates().data() + wm.second[1]*np;
             const auto& perf_data = this->well_perf_data_[well_index];

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1971,7 +1971,7 @@ namespace Opm {
             }
 
             auto& perf_pressure = well_state.perfPress(well_index);
-            auto * perf_rates = well_state.perfRates().data() + wm.second[1];
+            auto& perf_rates = well_state.perfRates(well_index);
             auto * perf_phase_rates = well_state.mutable_perfPhaseRates().data() + wm.second[1]*np;
             const auto& perf_data = this->well_perf_data_[well_index];
 

--- a/opm/simulators/wells/GlobalWellInfo.cpp
+++ b/opm/simulators/wells/GlobalWellInfo.cpp
@@ -56,7 +56,7 @@ bool GlobalWellInfo::in_producing_group(const std::string& wname) const {
 }
 
 
-void GlobalWellInfo::update_group(const std::vector<Well::Status>& well_status, const std::vector<Well::InjectorCMode>& injection_cmode, const std::vector<Well::ProducerCMode>& production_cmode) {
+void GlobalWellInfo::update_group(const WellContainer<Well::Status>& well_status, const std::vector<Well::InjectorCMode>& injection_cmode, const std::vector<Well::ProducerCMode>& production_cmode) {
     if (well_status.size() != this->local_map.size())
         throw std::logic_error("Size mismatch");
 

--- a/opm/simulators/wells/GlobalWellInfo.hpp
+++ b/opm/simulators/wells/GlobalWellInfo.hpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/simulators/wells/WellContainer.hpp>
 
 namespace Opm {
 
@@ -69,7 +70,7 @@ public:
     GlobalWellInfo(const Schedule& sched, std::size_t report_step, const std::vector<Well>& local_wells);
     bool in_producing_group(const std::string& wname) const;
     bool in_injecting_group(const std::string& wname) const;
-    void update_group(const std::vector<Well::Status>& well_status, const std::vector<Well::InjectorCMode>& injection_cmode, const std::vector<Well::ProducerCMode>& production_cmode);
+    void update_group(const WellContainer<Well::Status>& well_status, const std::vector<Well::InjectorCMode>& injection_cmode, const std::vector<Well::ProducerCMode>& production_cmode);
     std::size_t well_index(const std::string& wname) const;
     const std::string& well_name(std::size_t well_index) const;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2644,7 +2644,7 @@ namespace Opm
             const EvalWell seg_pressure = getSegmentPressure(seg);
             const int rate_start_offset = first_perf_ * number_of_phases_;
             auto * perf_rates = &well_state.mutable_perfPhaseRates()[rate_start_offset];
-            auto * perf_press_state = &well_state.perfPress()[first_perf_];
+            auto& perf_press_state = well_state.perfPress(this->index_of_well_);
             for (const int perf : segment_perforations_[seg]) {
                 const int cell_idx = well_cells_[perf];
                 const auto& int_quants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -838,7 +838,7 @@ namespace Opm
         }
 
         // Store the perforation pressure for later usage.
-        auto * perf_press = &well_state.perfPress()[first_perf_];
+        auto& perf_press = well_state.perfPress(index_of_well_);
         perf_press[perf] = well_state.bhp()[index_of_well_] + perf_pressure_diffs_[perf];
     }
 
@@ -1647,9 +1647,9 @@ namespace Opm
         }
 
         // Compute the average pressure in each well block
-        const auto * perf_press = &well_state.perfPress()[first_perf_];
+        const auto& perf_press = well_state.perfPress(w);
         auto p_above =  this->parallel_well_info_.communicateAboveValues(well_state.bhp()[w],
-                                                                         perf_press,
+                                                                         perf_press.data(),
                                                                          nperf);
 
         for (int perf = 0; perf < nperf; ++perf) {

--- a/opm/simulators/wells/WellContainer.hpp
+++ b/opm/simulators/wells/WellContainer.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_WELL_CONTAINER_HEADER_INCLUDED
 #define OPM_WELL_CONTAINER_HEADER_INCLUDED
 
+#include <initializer_list>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -43,6 +44,15 @@ namespace Opm {
 template <class T>
 class WellContainer {
 public:
+
+    WellContainer() = default;
+
+
+    WellContainer(const std::initializer_list<std::pair<std::string,T>>& init_list) {
+        for (const auto& [name, value] : init_list)
+            this->add(name, value);
+    }
+
 
     std::size_t size() const {
         return this->data.size();

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -72,12 +72,12 @@ namespace Opm
             parallel_well_info_ = parallel_well_info;
             perfpress_.clear();
             perfrates_.clear();
+            status_.clear();
             {
                 // const int nw = wells->number_of_wells;
                 const int nw = wells_ecl.size();
                 const int np = this->phase_usage_.num_phases;
                 // const int np = wells->number_of_phases;
-                status_.assign(nw, Well::Status::OPEN);
                 bhp_.resize(nw, 0.0);
                 thp_.resize(nw, 0.0);
                 temperature_.resize(nw, 273.15 + 15.56); // standard condition temperature
@@ -348,7 +348,7 @@ namespace Opm
         WellContainer<std::vector<double>> perfrates_;
         WellContainer<std::vector<double>> perfpress_;
     protected:
-        std::vector<Well::Status> status_;
+        WellContainer<Well::Status> status_;
     private:
 
         WellMapType wellMap_;
@@ -398,6 +398,7 @@ namespace Opm
             if ( well.isInjector() ) { 
                 temperature_[w] = well.injectionControls(summary_state).temperature;
             }
+            this->status_.add(well.name(), Well::Status::OPEN);
 
             const int num_perf_this_well = well_info.communication().sum(well_perf_data_[w].size());
             this->perfpress_.add(well.name(), std::vector<double>(num_perf_this_well, -1e100));

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -150,7 +150,7 @@ namespace Opm
                 const int connpos = well_info[1];
                 const int num_perf_this_well = well_info[2];
                 const int global_num_perf_this_well = parallel_well_info[w]->communication().sum(num_perf_this_well);
-                auto * perf_press = &this->perfPress()[connpos];
+                auto& perf_press = this->perfPress(w);
                 auto * phase_rates = &this->mutable_perfPhaseRates()[connpos * this->numPhases()];
 
                 for (int perf = 0; perf < num_perf_this_well; ++perf) {
@@ -311,8 +311,8 @@ namespace Opm
                         // perfPressures
                         if (global_num_perf_same)
                         {
-                            auto * target_press = &perfPress()[connpos];
-                            const auto * src_press = &prevState->perfPress()[oldPerf_idx_beg];
+                            auto& target_press = perfPress(w);
+                            const auto& src_press = prevState->perfPress(well.name());
                             for (int perf = 0; perf < num_perf_this_well; ++perf)
                             {
                                 target_press[perf] = src_press[perf];
@@ -714,8 +714,7 @@ namespace Opm
                         // top segment is always the first one, and its pressure is the well bhp
                         seg_press_.push_back(bhp()[w]);
                         const int top_segment = top_segment_index_[w];
-                        const int start_perf = connpos;
-                        const auto * perf_press = &this->perfPress()[start_perf];
+                        const auto& perf_press = this->perfPress(w);
                         for (int seg = 1; seg < well_nseg; ++seg) {
                             if ( !segment_perforations[seg].empty() ) {
                                 const int first_perf = segment_perforations[seg][0];

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -483,6 +483,13 @@ BOOST_AUTO_TEST_CASE(TESTWellContainer) {
     BOOST_CHECK_EQUAL(vec_copy.size(), wc3.size());
     for (std::size_t i = 0; i < wc3.size(); i++)
         BOOST_CHECK_EQUAL(vec_copy[i], wc3[i]);
+
+
+    Opm::WellContainer<int> wci({{"W1", 1}, {"W2", 2}, {"W3", 3}});
+    BOOST_CHECK_EQUAL(wci.size(), 3);
+    BOOST_CHECK(wci.has("W1"));
+    BOOST_CHECK_EQUAL(wci[1], 2);
+    BOOST_CHECK_EQUAL(wci["W3"], 3);
 }
 
 

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -391,8 +391,10 @@ BOOST_AUTO_TEST_CASE(STOP_well)
 
     std::vector<Opm::ParallelWellInfo> pinfos;
     auto wstate = buildWellState(setup, 0, pinfos);
-    for (const auto& p : wstate.perfPress())
-        BOOST_CHECK(p > 0);
+    for (std::size_t well_index = 0; well_index < setup.sched.numWells(0); well_index++) {
+        for (const auto& p : wstate.perfPress(well_index))
+            BOOST_CHECK(p > 0);
+    }
 }
 
 

--- a/tests/test_wellstatefullyimplicitblackoil.cpp
+++ b/tests/test_wellstatefullyimplicitblackoil.cpp
@@ -404,6 +404,7 @@ BOOST_AUTO_TEST_CASE(GlobalWellInfo_TEST) {
     const Setup setup{ "msw.data" };
     std::vector<Opm::Well> local_wells = { setup.sched.getWell("PROD01", 1) };
     Opm::GlobalWellInfo gwi(setup.sched, 1, local_wells);
+    Opm::WellContainer<Opm::Well::Status> status({{"PROD01", Opm::Well::Status::OPEN}});
 
     BOOST_CHECK(!gwi.in_injecting_group("INJE01"));
     BOOST_CHECK(!gwi.in_injecting_group("PROD01"));
@@ -416,11 +417,11 @@ BOOST_AUTO_TEST_CASE(GlobalWellInfo_TEST) {
 
     BOOST_CHECK_THROW( gwi.update_group( {}, {}, {} ), std::exception);
 
-    gwi.update_group( {Opm::Well::Status::OPEN}, {Opm::Well::InjectorCMode::CMODE_UNDEFINED}, {Opm::Well::ProducerCMode::GRUP} );
+    gwi.update_group( status, {Opm::Well::InjectorCMode::CMODE_UNDEFINED}, {Opm::Well::ProducerCMode::GRUP} );
     BOOST_CHECK(!gwi.in_producing_group("INJE01"));
     BOOST_CHECK(gwi.in_producing_group("PROD01"));
 
-    gwi.update_group( {Opm::Well::Status::OPEN}, {Opm::Well::InjectorCMode::CMODE_UNDEFINED}, {Opm::Well::ProducerCMode::NONE} );
+    gwi.update_group( status, {Opm::Well::InjectorCMode::CMODE_UNDEFINED}, {Opm::Well::ProducerCMode::NONE} );
     BOOST_CHECK(!gwi.in_producing_group("INJE01"));
     BOOST_CHECK(!gwi.in_producing_group("PROD01"));
 }


### PR DESCRIPTION
Use `WellContainer<std::vector<double>>` to manage perforation data.

Sits on top of #3222 