### PR TITLE
Small cleanups in WellInterface

### DIFF
--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -27,6 +27,7 @@
 #include <opm/simulators/linalg/bda/WellContributions.hpp>
 #endif
 
+#include <opm/simulators/timestepping/ConvergenceReport.hpp>
 #include <opm/simulators/wells/RateConverter.hpp>
 #include <opm/simulators/wells/VFPInjProperties.hpp>
 #include <opm/simulators/wells/VFPProdProperties.hpp>

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -98,12 +98,12 @@ namespace Opm
 
         static const int numEq = Indices::numEq;
         static const int numPhases = Indices::numPhases;
-        typedef double Scalar;
+        using Scalar = GetPropType<TypeTag, Properties::Scalar>;
 
         typedef Dune::FieldVector<Scalar, numEq    > VectorBlockType;
         typedef Dune::FieldMatrix<Scalar, numEq, numEq > MatrixBlockType;
         typedef Dune::BlockVector<VectorBlockType> BVector;
-        typedef DenseAd::Evaluation<double, /*size=*/numEq> Eval;
+        typedef DenseAd::Evaluation<Scalar, /*size=*/numEq> Eval;
 
         static constexpr bool has_solvent = getPropValue<TypeTag, Properties::EnableSolvent>();
         static constexpr bool has_zFraction = getPropValue<TypeTag, Properties::EnableExtbo>();

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -90,11 +90,11 @@ namespace Opm
         using MaterialLaw = GetPropType<TypeTag, Properties::MaterialLaw>;
         using SparseMatrixAdapter = GetPropType<TypeTag, Properties::SparseMatrixAdapter>;
         using RateVector = GetPropType<TypeTag, Properties::RateVector>;
-        using GasLiftSingleWell = Opm::GasLiftSingleWell<TypeTag>;
-        using GLiftOptWells = typename Opm::BlackoilWellModel<TypeTag>::GLiftOptWells;
-        using GLiftProdWells = typename Opm::BlackoilWellModel<TypeTag>::GLiftProdWells;
+        using GasLiftSingleWell = ::Opm::GasLiftSingleWell<TypeTag>;
+        using GLiftOptWells = typename BlackoilWellModel<TypeTag>::GLiftOptWells;
+        using GLiftProdWells = typename BlackoilWellModel<TypeTag>::GLiftProdWells;
         using GLiftWellStateMap =
-            typename Opm::BlackoilWellModel<TypeTag>::GLiftWellStateMap;
+            typename BlackoilWellModel<TypeTag>::GLiftWellStateMap;
 
         static const int numEq = Indices::numEq;
         static const int numPhases = Indices::numPhases;
@@ -126,13 +126,13 @@ namespace Opm
         using RateConverterType = RateConverter::
         SurfaceToReservoirVoidage<FluidSystem, std::vector<int> >;
         static const bool compositionSwitchEnabled = Indices::gasEnabled;
-        using FluidState = Opm::BlackOilFluidState<Eval,
-                                                   FluidSystem,
-                                                   has_temperature,
-                                                   has_energy,
-                                                   compositionSwitchEnabled,
-                                                   has_brine,
-                                                   Indices::numPhases >;
+        using FluidState = BlackOilFluidState<Eval,
+                                              FluidSystem,
+                                              has_temperature,
+                                              has_energy,
+                                              compositionSwitchEnabled,
+                                              has_brine,
+                                              Indices::numPhases >;
         /// Constructor
         WellInterface(const Well& well,
                       const ParallelWellInfo& pw_info,
@@ -176,15 +176,15 @@ namespace Opm
 
         virtual void initPrimaryVariablesEvaluation() const = 0;
 
-        virtual ConvergenceReport getWellConvergence(const WellState& well_state, const std::vector<double>& B_avg, Opm::DeferredLogger& deferred_logger, const bool relax_tolerance = false) const = 0;
+        virtual ConvergenceReport getWellConvergence(const WellState& well_state, const std::vector<double>& B_avg, DeferredLogger& deferred_logger, const bool relax_tolerance = false) const = 0;
 
-        virtual void solveEqAndUpdateWellState(WellState& well_state, Opm::DeferredLogger& deferred_logger) = 0;
+        virtual void solveEqAndUpdateWellState(WellState& well_state, DeferredLogger& deferred_logger) = 0;
 
         void assembleWellEq(const Simulator& ebosSimulator,
                             const double dt,
                             WellState& well_state,
                             const GroupState& group_state,
-                            Opm::DeferredLogger& deferred_logger);
+                            DeferredLogger& deferred_logger);
 
         virtual void gasLiftOptimizationStage1 (
             WellState& well_state,
@@ -199,7 +199,7 @@ namespace Opm
                                  const double& simulationTime,
                                  const bool& writeMessageToOPMLog,
                                  WellTestState& wellTestState,
-                                 Opm::DeferredLogger& deferred_logger) const;
+                                 DeferredLogger& deferred_logger) const;
 
         void setWellEfficiencyFactor(const double efficiency_factor);
 
@@ -209,7 +209,7 @@ namespace Opm
         /// xw to update Well State
         virtual void recoverWellSolutionAndUpdateWellState(const BVector& x,
                                                            WellState& well_state,
-                                                           Opm::DeferredLogger& deferred_logger) const = 0;
+                                                           DeferredLogger& deferred_logger) const = 0;
 
         /// Ax = Ax - C D^-1 B x
         virtual void apply(const BVector& x, BVector& Ax) const = 0;
@@ -221,24 +221,24 @@ namespace Opm
         virtual void computeWellPotentials(const Simulator& ebosSimulator,
                                            const WellState& well_state,
                                            std::vector<double>& well_potentials,
-                                           Opm::DeferredLogger& deferred_logger) = 0;
+                                           DeferredLogger& deferred_logger) = 0;
 
         void updateWellStateWithTarget(const Simulator& ebos_simulator,
                                        WellState& well_state,
-                                       Opm::DeferredLogger& deferred_logger) const;
+                                       DeferredLogger& deferred_logger) const;
 
         enum class IndividualOrGroup { Individual, Group, Both };
         bool updateWellControl(const Simulator& ebos_simulator,
                                const IndividualOrGroup iog,
                                WellState& well_state,
                                const GroupState& group_state,
-                               Opm::DeferredLogger& deferred_logger) /* const */;
+                               DeferredLogger& deferred_logger) /* const */;
 
-        virtual void updatePrimaryVariables(const WellState& well_state, Opm::DeferredLogger& deferred_logger) const = 0;
+        virtual void updatePrimaryVariables(const WellState& well_state, DeferredLogger& deferred_logger) const = 0;
 
         virtual void calculateExplicitQuantities(const Simulator& ebosSimulator,
                                                  const WellState& well_state,
-                                                 Opm::DeferredLogger& deferred_logger) = 0; // should be const?
+                                                 DeferredLogger& deferred_logger) = 0; // should be const?
 
         virtual void updateProductivityIndex(const Simulator& ebosSimulator,
                                              const WellProdIndexCalculator& wellPICalc,
@@ -283,17 +283,17 @@ namespace Opm
                          const double simulation_time, const int report_step,
                          const WellTestConfig::Reason testing_reason,
                          /* const */ WellState& well_state, const GroupState& group_state, WellTestState& welltest_state,
-                         Opm::DeferredLogger& deferred_logger);
+                         DeferredLogger& deferred_logger);
 
         void updatePerforatedCell(std::vector<bool>& is_cell_perforated);
 
-        void checkWellOperability(const Simulator& ebos_simulator, const WellState& well_state, Opm::DeferredLogger& deferred_logger);
+        void checkWellOperability(const Simulator& ebos_simulator, const WellState& well_state, DeferredLogger& deferred_logger);
 
         // check whether the well is operable under the current reservoir condition
         // mostly related to BHP limit and THP limit
         void updateWellOperability(const Simulator& ebos_simulator,
                                    const WellState& well_state,
-                                   Opm::DeferredLogger& deferred_logger);
+                                   DeferredLogger& deferred_logger);
 
 
         // whether the well is operable
@@ -339,7 +339,7 @@ namespace Opm
         void solveWellEquation(const Simulator& ebosSimulator,
                                WellState& well_state,
                                const GroupState& group_state,
-                               Opm::DeferredLogger& deferred_logger);
+                               DeferredLogger& deferred_logger);
 
         const PhaseUsage& phaseUsage() const;
 
@@ -471,12 +471,12 @@ namespace Opm
 
         bool checkRateEconLimits(const WellEconProductionLimits& econ_production_limits,
                                  const std::vector<double>& well_rates,
-                                 Opm::DeferredLogger& deferred_logger) const;
+                                 DeferredLogger& deferred_logger) const;
 
         double getTHPConstraint(const SummaryState& summaryState) const;
 
         template <class ValueType>
-        ValueType calculateBhpFromThp(const WellState& well_state, const std::vector<ValueType>& rates, const Well& well, const SummaryState& summaryState, Opm::DeferredLogger& deferred_logger) const;
+        ValueType calculateBhpFromThp(const WellState& well_state, const std::vector<ValueType>& rates, const Well& well, const SummaryState& summaryState, DeferredLogger& deferred_logger) const;
 
         double getALQ(const WellState& well_state) const;
 
@@ -504,7 +504,7 @@ namespace Opm
         void checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
                                   const WellState& well_state,
                                   RatioLimitCheckReport& report,
-                                  Opm::DeferredLogger& deferred_logger) const;
+                                  DeferredLogger& deferred_logger) const;
 
 
         template <typename RatioFunc>
@@ -523,30 +523,30 @@ namespace Opm
         std::vector<double> initialWellRateFrations(const Simulator& ebosSimulator, const std::vector<double>& potentials) const;
 
         // whether a well is specified with a non-zero and valid VFP table number
-        bool isVFPActive(Opm::DeferredLogger& deferred_logger) const;
+        bool isVFPActive(DeferredLogger& deferred_logger) const;
 
         struct OperabilityStatus;
 
         OperabilityStatus operability_status_;
 
         // check whether the well is operable under BHP limit with current reservoir condition
-        virtual void checkOperabilityUnderBHPLimitProducer(const WellState& well_state, const Simulator& ebos_simulator, Opm::DeferredLogger& deferred_logger) =0;
+        virtual void checkOperabilityUnderBHPLimitProducer(const WellState& well_state, const Simulator& ebos_simulator, DeferredLogger& deferred_logger) =0;
 
         // check whether the well is operable under THP limit with current reservoir condition
-        virtual void checkOperabilityUnderTHPLimitProducer(const Simulator& ebos_simulator, const WellState& well_state, Opm::DeferredLogger& deferred_logger) =0;
+        virtual void checkOperabilityUnderTHPLimitProducer(const Simulator& ebos_simulator, const WellState& well_state, DeferredLogger& deferred_logger) =0;
 
-        virtual void updateIPR(const Simulator& ebos_simulator, Opm::DeferredLogger& deferred_logger) const=0;
+        virtual void updateIPR(const Simulator& ebos_simulator, DeferredLogger& deferred_logger) const=0;
 
 
         void wellTestingEconomic(const Simulator& simulator,
                                  const double simulation_time, const WellState& well_state, const GroupState& group_state,
-                                 WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger);
+                                 WellTestState& welltest_state, DeferredLogger& deferred_logger);
 
         void wellTestingPhysical(const Simulator& simulator,
                                  const double simulation_time, const int report_step,
                                  WellState& well_state,
                                  const GroupState& group_state,
-                                 WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger);
+                                 WellTestState& welltest_state, DeferredLogger& deferred_logger);
 
 
         virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
@@ -555,7 +555,7 @@ namespace Opm
                                                     const Well::ProductionControls& prod_controls,
                                                     WellState& well_state,
                                                     const GroupState& group_state,
-                                                    Opm::DeferredLogger& deferred_logger) = 0;
+                                                    DeferredLogger& deferred_logger) = 0;
 
         // iterate well equations with the specified control until converged
         virtual bool iterateWellEqWithControl(const Simulator& ebosSimulator,
@@ -564,28 +564,28 @@ namespace Opm
                                               const Well::ProductionControls& prod_controls,
                                               WellState& well_state,
                                               const GroupState& group_state,
-                                              Opm::DeferredLogger& deferred_logger) = 0;
+                                              DeferredLogger& deferred_logger) = 0;
 
         bool iterateWellEquations(const Simulator& ebosSimulator,
                                   const double dt,
                                   WellState& well_state,
                                   const GroupState& group_state,
-                                  Opm::DeferredLogger& deferred_logger);
+                                  DeferredLogger& deferred_logger);
 
         void updateWellTestStateEconomic(const WellState& well_state,
                                          const double simulation_time,
                                          const bool write_message_to_opmlog,
                                          WellTestState& well_test_state,
-                                         Opm::DeferredLogger& deferred_logger) const;
+                                         DeferredLogger& deferred_logger) const;
 
         void updateWellTestStatePhysical(const WellState& well_state,
                                          const double simulation_time,
                                          const bool write_message_to_opmlog,
                                          WellTestState& well_test_state,
-                                         Opm::DeferredLogger& deferred_logger) const;
+                                         DeferredLogger& deferred_logger) const;
 
         void solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state, const GroupState& group_state,
-                                 Opm::DeferredLogger& deferred_logger);
+                                 DeferredLogger& deferred_logger);
 
         void initCompletions();
 
@@ -624,20 +624,20 @@ namespace Opm
         void getGroupInjectionControl(const Group& group,
                                       const WellState& well_state,
                                       const GroupState& group_state,
-                                      const Opm::Schedule& schedule,
+                                      const Schedule& schedule,
                                       const SummaryState& summaryState,
                                       const InjectorType& injectorType,
                                       const EvalWell& bhp,
                                       const EvalWell& injection_rate,
                                       EvalWell& control_eq,
                                       double efficiencyFactor,
-                                      Opm::DeferredLogger& deferred_logger);
+                                      DeferredLogger& deferred_logger);
 
         template <class EvalWell>
         void getGroupProductionControl(const Group& group,
                                        const WellState& well_state,
                                        const GroupState& group_state,
-                                       const Opm::Schedule& schedule,
+                                       const Schedule& schedule,
                                        const SummaryState& summaryState,
                                        const EvalWell& bhp,
                                        const std::vector<EvalWell>& rates,
@@ -647,26 +647,26 @@ namespace Opm
         template <class EvalWell, class BhpFromThpFunc>
         void assembleControlEqInj(const WellState& well_state,
                                   const GroupState& group_state,
-                                  const Opm::Schedule& schedule,
+                                  const Schedule& schedule,
                                   const SummaryState& summaryState,
                                   const Well::InjectionControls& controls,
                                   const EvalWell& bhp,
                                   const EvalWell& injection_rate,
                                   BhpFromThpFunc bhp_from_thp,
                                   EvalWell& control_eq,
-                                  Opm::DeferredLogger& deferred_logger);
+                                  DeferredLogger& deferred_logger);
 
         template <class EvalWell, class BhpFromThpFunc>
         void assembleControlEqProd(const WellState& well_state,
                                    const GroupState& group_state,
-                                   const Opm::Schedule& schedule,
+                                   const Schedule& schedule,
                                    const SummaryState& summaryState,
                                    const Well::ProductionControls& controls,
                                    const EvalWell& bhp,
                                    const std::vector<EvalWell>& rates, // Always 3 canonical rates.
                                    BhpFromThpFunc bhp_from_thp,
                                    EvalWell& control_eq,
-                                   Opm::DeferredLogger& deferred_logger);
+                                   DeferredLogger& deferred_logger);
     };
 
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -725,8 +725,6 @@ namespace Opm
         double violation_extent = 0.0;
     };
 
-    const std::string modestring[4] = { "BHP", "THP", "RESERVOIR_RATE", "SURFACE_RATE" };
-
 }
 
 #include "WellInterface_impl.hpp"

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -33,7 +33,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp>
 
 #include <opm/core/props/BlackoilPhases.hpp>
-#include <opm/simulators/timestepping/SimulatorReport.hpp>
 
 #include <opm/simulators/wells/RateConverter.hpp>
 #include <opm/simulators/wells/VFPProperties.hpp>
@@ -52,7 +51,6 @@ namespace Opm {
 #include <opm/simulators/wells/BlackoilWellModel.hpp>
 #include <opm/simulators/flow/BlackoilModelParametersEbos.hpp>
 
-#include <opm/simulators/timestepping/ConvergenceReport.hpp>
 #include <opm/simulators/utils/DeferredLogger.hpp>
 
 #include<dune/common/fmatrix.hh>

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -520,7 +520,7 @@ namespace Opm
 
         double scalingFactor(const int comp_idx) const;
 
-        std::vector<double> initialWellRateFrations(const Simulator& ebosSimulator, const std::vector<double>& potentials) const;
+        std::vector<double> initialWellRateFractions(const Simulator& ebosSimulator, const std::vector<double>& potentials) const;
 
         // whether a well is specified with a non-zero and valid VFP table number
         bool isVFPActive(DeferredLogger& deferred_logger) const;

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -76,7 +76,7 @@ namespace Opm
 
         using WellState = WellStateFullyImplicitBlackoil;
 
-        typedef BlackoilModelParametersEbos<TypeTag> ModelParameters;
+        using ModelParameters = BlackoilModelParametersEbos<TypeTag>;
 
         static const int Water = BlackoilPhases::Aqua;
         static const int Oil = BlackoilPhases::Liquid;
@@ -100,10 +100,10 @@ namespace Opm
         static const int numPhases = Indices::numPhases;
         using Scalar = GetPropType<TypeTag, Properties::Scalar>;
 
-        typedef Dune::FieldVector<Scalar, numEq    > VectorBlockType;
-        typedef Dune::FieldMatrix<Scalar, numEq, numEq > MatrixBlockType;
-        typedef Dune::BlockVector<VectorBlockType> BVector;
-        typedef DenseAd::Evaluation<Scalar, /*size=*/numEq> Eval;
+        using VectorBlockType = Dune::FieldVector<Scalar, numEq>;
+        using MatrixBlockType = Dune::FieldMatrix<Scalar, numEq, numEq>;
+        using BVector = Dune::BlockVector<VectorBlockType>;
+        using Eval = DenseAd::Evaluation<Scalar, /*size=*/numEq>;
 
         static constexpr bool has_solvent = getPropValue<TypeTag, Properties::EnableSolvent>();
         static constexpr bool has_zFraction = getPropValue<TypeTag, Properties::EnableExtbo>();

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -517,7 +517,7 @@ namespace Opm
                       const IndividualOrGroup iog,
                       WellState& well_state,
                       const GroupState& group_state,
-                      Opm::DeferredLogger& deferred_logger) /* const */
+                      DeferredLogger& deferred_logger) /* const */
     {
         if (this->wellIsStopped()) {
             return false;
@@ -589,9 +589,9 @@ namespace Opm
     WellInterface<TypeTag>::
     checkRateEconLimits(const WellEconProductionLimits& econ_production_limits,
                         const std::vector<double>& well_rates,
-                        Opm::DeferredLogger& deferred_logger) const
+                        DeferredLogger& deferred_logger) const
     {
-        const Opm::PhaseUsage& pu = phaseUsage();
+        const PhaseUsage& pu = phaseUsage();
         const int np = number_of_phases_;
 
         if (econ_production_limits.onMinOilRate()) {
@@ -641,7 +641,7 @@ namespace Opm
                         const std::vector<ValueType>& rates,
                         const Well& well,
                         const SummaryState& summaryState,
-                        Opm::DeferredLogger& deferred_logger) const
+                        DeferredLogger& deferred_logger) const
     {
         // TODO: when well is under THP control, the BHP is dependent on the rates,
         // the well rates is also dependent on the BHP, so it might need to do some iteration.
@@ -843,7 +843,7 @@ namespace Opm
     checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
                          const WellState& well_state,
                          RatioLimitCheckReport& report,
-                         Opm::DeferredLogger& deferred_logger) const
+                         DeferredLogger& deferred_logger) const
     {
         // TODO: not sure how to define the worst-offending completion when more than one
         //       ratio related limit is violated.
@@ -965,7 +965,7 @@ namespace Opm
                         const double& simulationTime,
                         const bool& writeMessageToOPMLog,
                         WellTestState& wellTestState,
-                        Opm::DeferredLogger& deferred_logger) const
+                        DeferredLogger& deferred_logger) const
     {
 
         // currently, we only updateWellTestState for producers
@@ -999,7 +999,7 @@ namespace Opm
                                 const double simulation_time,
                                 const bool write_message_to_opmlog,
                                 WellTestState& well_test_state,
-                                Opm::DeferredLogger& deferred_logger) const
+                                DeferredLogger& deferred_logger) const
     {
         if (!isOperable()) {
             if (well_test_state.hasWellClosed(name(), WellTestConfig::Reason::ECONOMIC) ||
@@ -1029,7 +1029,7 @@ namespace Opm
                                 const double simulation_time,
                                 const bool write_message_to_opmlog,
                                 WellTestState& well_test_state,
-                                Opm::DeferredLogger& deferred_logger) const
+                                DeferredLogger& deferred_logger) const
     {
         if (this->wellIsStopped())
             return;
@@ -1173,7 +1173,7 @@ namespace Opm
                 /* const */ WellState& well_state,
                 const GroupState& group_state,
                 WellTestState& well_test_state,
-                Opm::DeferredLogger& deferred_logger)
+                DeferredLogger& deferred_logger)
     {
         if (testing_reason == WellTestConfig::Reason::PHYSICAL) {
             wellTestingPhysical(simulator, simulation_time, report_step,
@@ -1195,7 +1195,7 @@ namespace Opm
     WellInterface<TypeTag>::
     wellTestingEconomic(const Simulator& simulator,
                         const double simulation_time, const WellState& well_state, const GroupState& group_state,
-                        WellTestState& welltest_state, Opm::DeferredLogger& deferred_logger)
+                        WellTestState& welltest_state, DeferredLogger& deferred_logger)
     {
         deferred_logger.info(" well " + name() + " is being tested for economic limits");
 
@@ -1314,7 +1314,7 @@ namespace Opm
 
     template<typename TypeTag>
     bool
-    WellInterface<TypeTag>::isVFPActive(Opm::DeferredLogger& deferred_logger) const
+    WellInterface<TypeTag>::isVFPActive(DeferredLogger& deferred_logger) const
     {
         // since the well_controls only handles the VFP number when THP constraint/target is there.
         // we need to get the table number through the parser, in case THP constraint/target is not there.
@@ -1359,7 +1359,7 @@ namespace Opm
                          const double dt,
                          WellState& well_state,
                          const GroupState& group_state,
-                         Opm::DeferredLogger& deferred_logger)
+                         DeferredLogger& deferred_logger)
     {
         const auto& summary_state = ebosSimulator.vanguard().summaryState();
         const auto inj_controls = well_ecl_.isInjector() ? well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
@@ -1413,7 +1413,7 @@ namespace Opm
     void
     WellInterface<TypeTag>::
     solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state, const GroupState& group_state,
-                        Opm::DeferredLogger& deferred_logger)
+                        DeferredLogger& deferred_logger)
     {
         // keep a copy of the original well state
         const WellState well_state0 = well_state;
@@ -1435,7 +1435,7 @@ namespace Opm
     solveWellEquation(const Simulator& ebosSimulator,
                       WellState& well_state,
                       const GroupState& group_state,
-                      Opm::DeferredLogger& deferred_logger)
+                      DeferredLogger& deferred_logger)
     {
         if (!this->isOperable())
             return;
@@ -1517,7 +1517,7 @@ namespace Opm
                         WellState& well_state,
                         const GroupState& group_state,
                         WellTestState& welltest_state,
-                        Opm::DeferredLogger& deferred_logger)
+                        DeferredLogger& deferred_logger)
     {
         deferred_logger.info(" well " + name() + " is being tested for physical limits");
 
@@ -1577,7 +1577,7 @@ namespace Opm
     WellInterface<TypeTag>::
     checkWellOperability(const Simulator& ebos_simulator,
                          const WellState& well_state,
-                         Opm::DeferredLogger& deferred_logger)
+                         DeferredLogger& deferred_logger)
     {
 
         const bool checkOperability = EWOMS_GET_PARAM(TypeTag, bool, EnableWellOperabilityCheck);
@@ -1630,7 +1630,7 @@ namespace Opm
     WellInterface<TypeTag>::
     updateWellOperability(const Simulator& ebos_simulator,
                           const WellState& well_state,
-                          Opm::DeferredLogger& deferred_logger)
+                          DeferredLogger& deferred_logger)
     {
         this->operability_status_.reset();
 
@@ -1653,7 +1653,7 @@ namespace Opm
     WellInterface<TypeTag>::
     updateWellStateWithTarget(const Simulator& ebos_simulator,
                               WellState& well_state,
-                              Opm::DeferredLogger& deferred_logger) const
+                              DeferredLogger& deferred_logger) const
     {
 
         // only bhp and wellRates are used to initilize the primaryvariables for standard wells
@@ -1697,7 +1697,7 @@ namespace Opm
                 OPM_DEFLOG_THROW(std::runtime_error, "Expected WATER, OIL or GAS as type for injectors "  + name(), deferred_logger );
             }
 
-            const Opm::Well::InjectorCMode& current = well_state.currentInjectionControls()[well_index];
+            const Well::InjectorCMode& current = well_state.currentInjectionControls()[well_index];
 
             switch(current) {
             case Well::InjectorCMode::RATE:
@@ -2047,7 +2047,7 @@ namespace Opm
 
         if (well.isInjector()) {
             const auto controls = well.injectionControls(summaryState);
-            Opm::Well::InjectorCMode& currentControl = well_state.currentInjectionControls()[well_index];
+            Well::InjectorCMode& currentControl = well_state.currentInjectionControls()[well_index];
 
             if (controls.hasControl(Well::InjectorCMode::BHP) && currentControl != Well::InjectorCMode::BHP)
             {
@@ -2242,7 +2242,7 @@ namespace Opm
         const int well_index = index_of_well_;
 
         if (well.isInjector()) {
-            Opm::Well::InjectorCMode& currentControl = well_state.currentInjectionControls()[well_index];
+            Well::InjectorCMode& currentControl = well_state.currentInjectionControls()[well_index];
 
             if (currentControl != Well::InjectorCMode::GRUP) {
                 // This checks only the first encountered group limit,
@@ -2401,16 +2401,16 @@ namespace Opm
     void
     WellInterface<TypeTag>::assembleControlEqInj(const WellState& well_state,
                                                  const GroupState& group_state,
-                                                 const Opm::Schedule& schedule,
+                                                 const Schedule& schedule,
                                                  const SummaryState& summaryState,
                                                  const Well::InjectionControls& controls,
                                                  const EvalWell& bhp,
                                                  const EvalWell& injection_rate,
                                                  BhpFromThpFunc bhp_from_thp,
                                                  EvalWell& control_eq,
-                                                 Opm::DeferredLogger& deferred_logger)
+                                                 DeferredLogger& deferred_logger)
     {
-        const Opm::Well::InjectorCMode& current = well_state.currentInjectionControls()[index_of_well_];
+        const Well::InjectorCMode& current = well_state.currentInjectionControls()[index_of_well_];
         const InjectorType injectorType = controls.injector_type;
         const auto& pu = phaseUsage();
         const double efficiencyFactor = well_ecl_.getEfficiencyFactor();
@@ -2484,14 +2484,14 @@ namespace Opm
     void
     WellInterface<TypeTag>::assembleControlEqProd(const WellState& well_state,
                                                   const GroupState& group_state,
-                                                  const Opm::Schedule& schedule,
+                                                  const Schedule& schedule,
                                                   const SummaryState& summaryState,
                                                   const Well::ProductionControls& controls,
                                                   const EvalWell& bhp,
                                                   const std::vector<EvalWell>& rates, // Always 3 canonical rates.
                                                   BhpFromThpFunc bhp_from_thp,
                                                   EvalWell& control_eq,
-                                                  Opm::DeferredLogger& deferred_logger)
+                                                  DeferredLogger& deferred_logger)
     {
         const Well::ProducerCMode& current = well_state.currentProductionControls()[index_of_well_];
         const auto& pu = phaseUsage();
@@ -2600,14 +2600,14 @@ namespace Opm
     WellInterface<TypeTag>::getGroupInjectionControl(const Group& group,
                                                       const WellState& well_state,
                                                      const GroupState& group_state,
-                                                      const Opm::Schedule& schedule,
+                                                      const Schedule& schedule,
                                                       const SummaryState& summaryState,
                                                       const InjectorType& injectorType,
                                                       const EvalWell& bhp,
                                                       const EvalWell& injection_rate,
                                                       EvalWell& control_eq,
                                                       double efficiencyFactor,
-                                                      Opm::DeferredLogger& deferred_logger)
+                                                      DeferredLogger& deferred_logger)
     {
         // Setting some defaults to silence warnings below.
         // Will be overwritten in the switch statement.
@@ -2720,7 +2720,7 @@ namespace Opm
     WellInterface<TypeTag>::getGroupProductionControl(const Group& group,
                                                       const WellState& well_state,
                                                       const GroupState& group_state,
-                                                      const Opm::Schedule& schedule,
+                                                      const Schedule& schedule,
                                                       const SummaryState& summaryState,
                                                       const EvalWell& bhp,
                                                       const std::vector<EvalWell>& rates,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1780,7 +1780,7 @@ namespace Opm
                         well_state.wellRates()[well_index*np + p] *= controls.oil_rate/current_rate;
                     }
                 } else {
-                    const std::vector<double> fractions = initialWellRateFrations(ebos_simulator, well_state.wellPotentials());
+                    const std::vector<double> fractions = initialWellRateFractions(ebos_simulator, well_state.wellPotentials());
                     double control_fraction = fractions[pu.phase_pos[Oil]];
                     if (control_fraction != 0.0) {
                         for (int p = 0; p<np; ++p) {
@@ -1800,7 +1800,7 @@ namespace Opm
                         well_state.wellRates()[well_index*np + p] *= controls.water_rate/current_rate;
                     }
                 } else {
-                    const std::vector<double> fractions = initialWellRateFrations(ebos_simulator, well_state.wellPotentials());
+                    const std::vector<double> fractions = initialWellRateFractions(ebos_simulator, well_state.wellPotentials());
                     double control_fraction = fractions[pu.phase_pos[Water]];
                     if (control_fraction != 0.0) {
                         for (int p = 0; p<np; ++p) {
@@ -1820,7 +1820,7 @@ namespace Opm
                         well_state.wellRates()[well_index*np + p] *= controls.gas_rate/current_rate;
                     }
                 } else {
-                    const std::vector<double> fractions = initialWellRateFrations(ebos_simulator, well_state.wellPotentials());
+                    const std::vector<double> fractions = initialWellRateFractions(ebos_simulator, well_state.wellPotentials());
                     double control_fraction = fractions[pu.phase_pos[Gas]];
                     if (control_fraction != 0.0) {
                         for (int p = 0; p<np; ++p) {
@@ -1843,7 +1843,7 @@ namespace Opm
                         well_state.wellRates()[well_index*np + p] *= controls.liquid_rate/current_rate;
                     }
                 } else {
-                    const std::vector<double> fractions = initialWellRateFrations(ebos_simulator, well_state.wellPotentials());
+                    const std::vector<double> fractions = initialWellRateFractions(ebos_simulator, well_state.wellPotentials());
                     double control_fraction = fractions[pu.phase_pos[Water]] + fractions[pu.phase_pos[Oil]];
                     if (control_fraction != 0.0) {
                         for (int p = 0; p<np; ++p) {
@@ -1873,7 +1873,7 @@ namespace Opm
                             well_state.wellRates()[well_index*np + p] *= controls.resv_rate/total_res_rate;
                         }
                     } else {
-                        const std::vector<double> fractions = initialWellRateFrations(ebos_simulator, well_state.wellPotentials());
+                        const std::vector<double> fractions = initialWellRateFractions(ebos_simulator, well_state.wellPotentials());
                         for (int p = 0; p<np; ++p) {
                             well_state.wellRates()[well_index*np + p] = - fractions[p] * controls.resv_rate / convert_coeff[p];
                         }
@@ -1899,7 +1899,7 @@ namespace Opm
                             well_state.wellRates()[well_index*np + p] *= target/total_res_rate;
                         }
                     } else {
-                        const std::vector<double> fractions = initialWellRateFrations(ebos_simulator, well_state.wellPotentials());
+                        const std::vector<double> fractions = initialWellRateFractions(ebos_simulator, well_state.wellPotentials());
                         for (int p = 0; p<np; ++p) {
                             well_state.wellRates()[well_index*np + p] = - fractions[p] * target / convert_coeff[p];
                         }
@@ -1964,7 +1964,7 @@ namespace Opm
     template<typename TypeTag>
     std::vector<double>
     WellInterface<TypeTag>::
-    initialWellRateFrations(const Simulator& ebosSimulator, const std::vector<double>& potentials) const
+    initialWellRateFractions(const Simulator& ebosSimulator, const std::vector<double>& potentials) const
     {
         const int np = number_of_phases_;
         std::vector<double> scaling_factor(np);


### PR DESCRIPTION
The only commit I'm unsure about is https://github.com/OPM/opm-simulators/commit/ab4772aba8c5f62810a7da060520e75e73dedf1b as I'm getting mixed messages whether the intention is to hardcode the well code to double precision or not. If that is the intention, we should use double instead of Scalar to avoid confusion.