### PR TITLE
Reduce Aquifer Data Copying

### DIFF
--- a/opm/simulators/aquifers/AquiferCarterTracy.hpp
+++ b/opm/simulators/aquifers/AquiferCarterTracy.hpp
@@ -57,8 +57,7 @@ public:
                        const AquiferCT::AQUCT_data& aquct_data)
         : Base(aquct_data.aquiferID, connections, ebosSimulator)
         , aquct_data_(aquct_data)
-    {
-    }
+    {}
 
     void endTimeStep() override
     {
@@ -73,7 +72,7 @@ public:
     data::AquiferData aquiferData() const
     {
         data::AquiferData data;
-        data.aquiferID = this->aquiferID;
+        data.aquiferID = this->aquiferID();
         // TODO: not sure how to get this pressure value yet
         data.pressure = this->pa0_;
         data.fluxRate = 0.;

--- a/opm/simulators/aquifers/AquiferNumerical.hpp
+++ b/opm/simulators/aquifers/AquiferNumerical.hpp
@@ -104,6 +104,11 @@ public:
         this->cumulative_flux_ = 0.;
     }
 
+    int aquiferID() const
+    {
+        return static_cast<int>(this->id_);
+    }
+
 private:
     const size_t id_;
     const Simulator& ebos_simulator_;

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -237,23 +237,20 @@ template<typename TypeTag>
 data::Aquifers BlackoilAquiferModel<TypeTag>::aquiferData() const {
     data::Aquifers data;
     if (this->aquiferCarterTracyActive()) {
-        for (const auto& aqu : aquifers_CarterTracy) {
-            data::AquiferData aqu_data = aqu.aquiferData();
-            data[aqu_data.aquiferID] = aqu_data;
+        for (const auto& aqu : this->aquifers_CarterTracy) {
+            data.insert_or_assign(aqu.aquiferID(), aqu.aquiferData());
         }
     }
 
     if (this->aquiferFetkovichActive()) {
-        for (const auto& aqu : aquifers_Fetkovich) {
-            data::AquiferData aqu_data = aqu.aquiferData();
-            data[aqu_data.aquiferID] = aqu_data;
+        for (const auto& aqu : this->aquifers_Fetkovich) {
+            data.insert_or_assign(aqu.aquiferID(), aqu.aquiferData());
         }
     }
 
     if (this->aquiferNumericalActive()) {
         for (const auto& aqu : this->aquifers_numerical) {
-            data::AquiferData aqu_data = aqu.aquiferData();
-            data[aqu_data.aquiferID] = aqu_data;
+            data.insert_or_assign(aqu.aquiferID(), aqu.aquiferData());
         }
     }
 


### PR DESCRIPTION
This PR switches to using `map<>::insert_or_assign()` as the primary interface for collecting dynamic aquifer data.  In turn, this activates move semantics for the substructures and reduces the number of times the data is copied.

Insert_or_assign requires the key, so provide this value&mdash;i.e., the aquifer ID&mdash;as part of the `AquiferInterface`.