### PR TITLE
Prepare to Save/Restore Richer Set of Aquifer Values

### DIFF
--- a/ebos/eclbaseaquifermodel.hh
+++ b/ebos/eclbaseaquifermodel.hh
@@ -72,7 +72,7 @@ public:
      *        aquifer pressure and the base run's total produced liquid
      *        volume from the model's aquifers.
      */
-    void initFromRestart(const std::vector<data::AquiferData>& aquiferSoln OPM_UNUSED)
+    void initFromRestart(const data::Aquifers& aquiferSoln OPM_UNUSED)
     {
         throw std::logic_error {
             "Initialization from restart data not supported "

--- a/ebos/eclgenericwriter.cc
+++ b/ebos/eclgenericwriter.cc
@@ -392,6 +392,7 @@ doWriteOutput(const int                     reportStepNum,
               data::Solution&&              localCellData,
               data::Wells&&                 localWellData,
               data::GroupAndNetworkValues&& localGroupAndNetworkData,
+              data::Aquifers&&              localAquiferData,
               const Action::State& actionState,
               const UDQState& udqState,
               const SummaryState& summaryState,
@@ -410,7 +411,10 @@ doWriteOutput(const int                     reportStepNum,
                    : std::move(localWellData),
 
         isParallel ? this->collectToIORank_.globalGroupAndNetworkData()
-                   : std::move(localGroupAndNetworkData)
+                   : std::move(localGroupAndNetworkData),
+
+        isParallel ? this->collectToIORank_.globalAquiferData()
+                   : std::move(localAquiferData)
     };
 
     if (eclState_.getSimulationConfig().useThresholdPressure()) {

--- a/ebos/eclgenericwriter.hh
+++ b/ebos/eclgenericwriter.hh
@@ -82,6 +82,7 @@ protected:
                        data::Solution&&              localCellData,
                        data::Wells&&                 localWellData,
                        data::GroupAndNetworkValues&& localGroupAndNetworkData,
+                       data::Aquifers&&              localAquiferData,
                        const Action::State& actionState,
                        const UDQState& udqState,
                        const SummaryState& summaryState,

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1885,6 +1885,9 @@ public:
     EclWellModel& wellModel()
     { return wellModel_; }
 
+    const EclAquiferModel& aquiferModel() const
+    { return aquiferModel_; }
+
     EclAquiferModel& mutableAquiferModel()
     { return aquiferModel_; }
 

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -141,7 +141,6 @@ public:
     /*!
      * \brief collect and pass data and pass it to eclIO writer
      */
-
     void evalSummaryState(bool isSubStep)
     {
         const int reportStepNum = simulator_.episodeIndex() + 1;
@@ -176,7 +175,7 @@ public:
             .groupAndNetworkData(reportStepNum, simulator_.vanguard().schedule());
 
 
-        const auto localAquiferData = simulator_.problem().mutableAquiferModel().aquiferData();
+        const auto localAquiferData = simulator_.problem().aquiferModel().aquiferData();
 
         this->prepareLocalCellData(isSubStep, reportStepNum);
 
@@ -221,7 +220,6 @@ public:
                           eclOutputModule_->initialInplace());
     }
 
-
     void writeOutput(bool isSubStep)
     {
         const int reportStepNum = simulator_.episodeIndex() + 1;
@@ -233,6 +231,8 @@ public:
         auto localWellData = simulator_.problem().wellModel().wellData();
         auto localGroupAndNetworkData = simulator_.problem().wellModel()
             .groupAndNetworkData(reportStepNum, simulator_.vanguard().schedule());
+
+        auto localAquiferData = simulator_.problem().aquiferModel().aquiferData();
 
         data::Solution localCellData = {};
         if (! isSubStep) {
@@ -248,7 +248,7 @@ public:
                                            eclOutputModule_->getWBPData(),
                                            localWellData,
                                            localGroupAndNetworkData,
-                                           {});
+                                           localAquiferData);
         }
 
         if (this->collectToIORank_.isIORank()) {
@@ -258,6 +258,7 @@ public:
                                 std::move(localCellData),
                                 std::move(localWellData),
                                 std::move(localGroupAndNetworkData),
+                                std::move(localAquiferData),
                                 this->actionState(),
                                 this->udqState(),
                                 this->summaryState(),

--- a/opm/simulators/aquifers/AquiferFetkovich.hpp
+++ b/opm/simulators/aquifers/AquiferFetkovich.hpp
@@ -83,8 +83,9 @@ public:
         data.volume = this->W_flux_.value();
         data.initPressure = this->pa0_;
         data.type = data::AquiferType::Fetkovich;
-        // Not handling std::shared_ptr<FetkovichData> aquFet for now,
-        // because we do not need it yet
+
+        data.aquFet = std::make_shared<data::FetkovichData>();
+
         return data;
     }
 

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -88,19 +88,16 @@ public:
     {
     }
 
-    void initFromRestart(const std::vector<data::AquiferData>& aquiferSoln)
+    void initFromRestart(const data::Aquifers& aquiferSoln)
     {
-        auto xaqPos
-            = std::find_if(aquiferSoln.begin(), aquiferSoln.end(), [this](const data::AquiferData& xaq) -> bool {
-                   return xaq.aquiferID == this->aquiferID();
-              });
-
+        auto xaqPos = aquiferSoln.find(this->aquiferID());
         if (xaqPos == aquiferSoln.end())
             return;
 
-        this->assignRestartData(*xaqPos);
-        this->W_flux_ = xaqPos->volume;
-        this->pa0_ = xaqPos->initPressure;
+        this->assignRestartData(xaqPos->second);
+
+        this->W_flux_ = xaqPos->second.volume;
+        this->pa0_ = xaqPos->second.initPressure;
         this->solution_set_from_restart_ = true;
     }
 

--- a/opm/simulators/aquifers/AquiferNumerical.hpp
+++ b/opm/simulators/aquifers/AquiferNumerical.hpp
@@ -72,7 +72,7 @@ public:
         }
     }
 
-    void initFromRestart([[maybe_unused]]const std::vector<data::AquiferData>& aquiferSoln)
+    void initFromRestart([[maybe_unused]]const data::Aquifers& aquiferSoln)
     {
         // NOT handling Restart for now
     }

--- a/opm/simulators/aquifers/BlackoilAquiferModel.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel.hpp
@@ -87,7 +87,7 @@ public:
     explicit BlackoilAquiferModel(Simulator& simulator);
 
     void initialSolutionApplied();
-    void initFromRestart(const std::vector<data::AquiferData>& aquiferSoln);
+    void initFromRestart(const data::Aquifers& aquiferSoln);
 
     void beginEpisode();
     void beginTimeStep();

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -59,19 +59,21 @@ BlackoilAquiferModel<TypeTag>::initialSolutionApplied()
 
 template <typename TypeTag>
 void
-BlackoilAquiferModel<TypeTag>::initFromRestart(const std::vector<data::AquiferData>& aquiferSoln)
+BlackoilAquiferModel<TypeTag>::initFromRestart(const data::Aquifers& aquiferSoln)
 {
-    if (aquiferCarterTracyActive()) {
-        for (auto& aquifer : aquifers_CarterTracy) {
+    if (this->aquiferCarterTracyActive()) {
+        for (auto& aquifer : this->aquifers_CarterTracy) {
             aquifer.initFromRestart(aquiferSoln);
         }
     }
-    if (aquiferFetkovichActive()) {
-        for (auto& aquifer : aquifers_Fetkovich) {
+
+    if (this->aquiferFetkovichActive()) {
+        for (auto& aquifer : this->aquifers_Fetkovich) {
             aquifer.initFromRestart(aquiferSoln);
         }
     }
-    if (aquiferNumericalActive()) {
+
+    if (this->aquiferNumericalActive()) {
         for (auto& aquifer : this->aquifers_numerical) {
             aquifer.initFromRestart(aquiferSoln);
         }

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -49,9 +49,12 @@ class RestartValue;
 
 namespace data
 {
+struct AquiferData;
+struct CarterTracyData;
 struct CellData;
 struct Connection;
 struct CurrentControl;
+struct FetkovichData;
 class GroupAndNetworkValues;
 struct GroupConstraints;
 struct GroupData;
@@ -331,9 +334,12 @@ void unpack(char* str, std::size_t length, std::vector<char>& buffer, int& posit
   void unpack(T& data, std::vector<char>& buffer, int& position, \
               Dune::MPIHelper::MPICommunicator comm);
 
+ADD_PACK_PROTOTYPES(data::AquiferData)
+ADD_PACK_PROTOTYPES(data::CarterTracyData)
 ADD_PACK_PROTOTYPES(data::CellData)
 ADD_PACK_PROTOTYPES(data::Connection)
 ADD_PACK_PROTOTYPES(data::CurrentControl)
+ADD_PACK_PROTOTYPES(data::FetkovichData)
 ADD_PACK_PROTOTYPES(data::Rates)
 ADD_PACK_PROTOTYPES(data::Segment)
 ADD_PACK_PROTOTYPES(data::Solution)


### PR DESCRIPTION
This PR adds logic to communicate more dynamic aquifer values between the simulation and I/O layers.  In particular, we ensure that we allocate the `aquFet` and `aquCT` substructures of the dynamic aquifer data as appropriate and that we collect this information on the I/O rank as part of the restart output process. We furthermore make the `ParallelRestart` facility aware of dynamic aquifer data in preparation of loading these values from the restart file.