### PR TITLE
Simplify the error message on invalid item values for keywords with only a single record

### DIFF
--- a/opm/simulators/flow/KeywordValidation.hpp
+++ b/opm/simulators/flow/KeywordValidation.hpp
@@ -106,6 +106,7 @@ namespace KeywordValidation
         template <typename T>
         void validateKeywordItem(const DeckKeyword& keyword,
                                  const PartiallySupportedKeywordProperties<T>& properties,
+                                 const bool multiple_records,
                                  const size_t record_number,
                                  const size_t item_number,
                                  const T& item_value,

--- a/tests/test_keyword_validator.cpp
+++ b/tests/test_keyword_validator.cpp
@@ -279,7 +279,7 @@ PINCH
     const auto report = get_error_report(errors, false);
     BOOST_CHECK(report
                 == "Unsupported keywords or keyword items:\n\n"
-                   "  PINCH: invalid value 'FOO' in record 1 for item 2\n"
+                   "  PINCH: invalid value 'FOO' for item 2\n"
                    "  In file: <memory string>, line 2");
 }
 
@@ -339,7 +339,7 @@ ENDSCALE
     const auto report = get_error_report(errors, false);
     BOOST_CHECK(report
                 == "Unsupported keywords or keyword items:\n\n"
-                   "  ENDSCALE: invalid value '0' in record 1 for item 3\n"
+                   "  ENDSCALE: invalid value '0' for item 3\n"
                    "  In file: <memory string>, line 2");
 }
 
@@ -374,7 +374,7 @@ ENDSCALE
     const auto report = get_error_report(errors, true);
     BOOST_CHECK(report
                 == "Unsupported keywords or keyword items:\n\n"
-                   "  ENDSCALE: invalid value '0' in record 1 for item 4\n"
+                   "  ENDSCALE: invalid value '0' for item 4\n"
                    "  In file: <memory string>, line 2");
 }
 
@@ -422,7 +422,7 @@ ENDSCALE
                    "  ECHO: keyword not supported\n"
                    "  In file: <memory string>, line 2\n"
                    "  This is not a critical error\n\n"
-                   "  ENDSCALE: invalid value '0' in record 1 for item 3\n"
+                   "  ENDSCALE: invalid value '0' for item 3\n"
                    "  In file: <memory string>, line 6");
 }
 
@@ -452,7 +452,7 @@ ENDSCALE
                 == "Unsupported keywords or keyword items:\n\n"
                    "  NOECHO: keyword not supported\n"
                    "  In file: <memory string>, line 3\n\n"
-                   "  PINCH: invalid value 'FOO' in record 1 for item 4\n"
+                   "  PINCH: invalid value 'FOO' for item 4\n"
                    "  In file: <memory string>, line 4\n"
                    "  This is a critical error");
 }


### PR DESCRIPTION
This pull request implements a very small improvement in the reporting of invalid item values. The current behavior is to always print the record number, even if there is only a single record. This changes the behavior to only include the record number if there is more than one record.
