### PR TITLE
Reorder variables and remove .reserve() calls

### DIFF
--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.cpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.cpp
@@ -537,21 +537,18 @@ void WellStateFullyImplicitBlackoil::initWellStateMSWell(const std::vector<Well>
 {
     // still using the order in wells
     const int nw = wells_ecl.size();
-    const auto& pu = this->phaseUsage();
-    const int np = pu.num_phases;
     if (nw == 0) {
         return;
     }
+    const auto& pu = this->phaseUsage();
+    const int np = pu.num_phases;
 
     top_segment_index_.clear();
-    top_segment_index_.reserve(nw);
     seg_press_.clear();
-    seg_press_.reserve(nw);
     seg_rates_.clear();
-    seg_rates_.reserve(nw * numPhases());
     seg_number_.clear();
-
     nseg_ = 0;
+
     // in the init function, the well rates and perforation rates have been initialized or copied from prevState
     // what we do here, is to set the segment rates and perforation rates
     for (int w = 0; w < nw; ++w) {

--- a/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
+++ b/opm/simulators/wells/WellStateFullyImplicitBlackoil.hpp
@@ -424,6 +424,11 @@ private:
     // for StandardWell, the number of segments will be one
     std::vector<double> seg_rates_;
     std::vector<double> seg_press_;
+    // the index of the top segments, which is used to locate the
+    // multisegment well related information in WellState
+    std::vector<int> top_segment_index_;
+    int nseg_; // total number of the segments
+
     // The following data are only recorded for output
     // pressure drop
     std::vector<double> seg_pressdrop_;
@@ -433,10 +438,6 @@ private:
     std::vector<double> seg_pressdrop_hydorstatic_;
     // accelerational pressure drop
     std::vector<double> seg_pressdrop_acceleration_;
-    // the index of the top segments, which is used to locate the
-    // multisegment well related information in WellState
-    std::vector<int> top_segment_index_;
-    int nseg_; // total number of the segments
 
     // Productivity Index
     std::vector<double> productivity_index_;


### PR DESCRIPTION
Veeery small trivial changes in MSW WellState code - just to start warming up there. 