### PR TITLE
remove template parameters for enableEnergy/Diffusion in transmissibility

### DIFF
--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -50,7 +50,7 @@ struct EclCpGridVanguard {
 // declare the properties
 template<class TypeTag>
 struct Vanguard<TypeTag, TTag::EclCpGridVanguard> {
-    using type = Opm::EclCpGridVanguard<TypeTag>;
+    using type = EclCpGridVanguard<TypeTag>;
 };
 template<class TypeTag>
 struct Grid<TypeTag, TTag::EclCpGridVanguard> {
@@ -89,9 +89,8 @@ public:
     using Grid = GetPropType<TypeTag, Properties::Grid>;
     using EquilGrid = GetPropType<TypeTag, Properties::EquilGrid>;
     using GridView = GetPropType<TypeTag, Properties::GridView>;
-    using TransmissibilityType = EclTransmissibility<Grid, GridView, ElementMapper, Scalar,
-                                                     getPropValue<TypeTag, Properties::EnableEnergy>(),
-                                                     getPropValue<TypeTag, Properties::EnableDiffusion>()>;
+    using TransmissibilityType = EclTransmissibility<Grid, GridView, ElementMapper, Scalar>;
+
 private:
     typedef Dune::CartesianIndexMapper<Grid> CartesianIndexMapper;
     using Element = typename GridView::template Codim<0>::Entity;
@@ -163,7 +162,9 @@ protected:
                                                     this->gridView(),
                                                     this->cartesianIndexMapper(),
                                                     this->grid(),
-                                                    this->cellCentroids()));
+                                                    this->cellCentroids(),
+                                                    getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                                    getPropValue<TypeTag, Properties::EnableDiffusion>()));
         globalTrans_->update(false);
     }
 

--- a/ebos/eclpolyhedralgridvanguard.hh
+++ b/ebos/eclpolyhedralgridvanguard.hh
@@ -86,9 +86,7 @@ public:
     using Grid = GetPropType<TypeTag, Properties::Grid>;
     using EquilGrid = GetPropType<TypeTag, Properties::EquilGrid>;
     using GridView = GetPropType<TypeTag, Properties::GridView>;
-    using TransmissibilityType = EclTransmissibility<Grid, GridView, ElementMapper, Scalar,
-                                                     getPropValue<TypeTag, Properties::EnableEnergy>(),
-                                                     getPropValue<TypeTag, Properties::EnableDiffusion>()>;
+    using TransmissibilityType = EclTransmissibility<Grid, GridView, ElementMapper, Scalar>;
 
 private:
     typedef Grid* GridPointer;

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -819,7 +819,9 @@ public:
                               simulator.vanguard().gridView(),
                               simulator.vanguard().cartesianIndexMapper(),
                               simulator.vanguard().grid(),
-                              simulator.vanguard().cellCentroids())
+                              simulator.vanguard().cellCentroids(),
+                              enableEnergy,
+                              enableDiffusion)
         , thresholdPressures_(simulator)
         , wellModel_(simulator)
         , aquiferModel_(simulator)

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -30,8 +30,6 @@
 
 #include <opm/grid/common/CartesianIndexMapper.hpp>
 
-#include <opm/material/common/ConditionalStorage.hpp>
-
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
 
@@ -47,8 +45,7 @@ class EclipseState;
 struct NNCdata;
 class TransMult;
 
-template<class Grid, class GridView, class ElementMapper,
-         class Scalar, bool enableEnergy, bool enableDiffusion>
+template<class Grid, class GridView, class ElementMapper, class Scalar>
 class EclTransmissibility {
     // Grid and world dimension
     enum { dimWorld = GridView::dimensionworld };
@@ -61,7 +58,9 @@ public:
                         const GridView& gridView,
                         const Dune::CartesianIndexMapper<Grid>& cartMapper,
                         const Grid& grid,
-                        const std::vector<double>& centroids);
+                        const std::vector<double>& centroids,
+                        bool enableEnergy,
+                        bool enableDiffusivity);
 
     /*!
      * \brief Return the permeability for an element.
@@ -241,10 +240,10 @@ protected:
     Scalar transmissibilityThreshold_;
     std::map<std::pair<unsigned, unsigned>, Scalar> transBoundary_;
     std::map<std::pair<unsigned, unsigned>, Scalar> thermalHalfTransBoundary_;
-    Opm::ConditionalStorage<enableEnergy,
-                            std::unordered_map<std::uint64_t, Scalar> > thermalHalfTrans_;
-    Opm::ConditionalStorage<enableDiffusion,
-                            std::unordered_map<std::uint64_t, Scalar> > diffusivity_;
+    bool enableEnergy_;
+    bool enableDiffusivity_;
+    std::unordered_map<std::uint64_t, Scalar> thermalHalfTrans_;
+    std::unordered_map<std::uint64_t, Scalar> diffusivity_;
 };
 
 } // namespace Opm


### PR DESCRIPTION
- the diffusion one is basically done on runtime anyways
- the energy one gives some small code elimination gains
  however, it complicates the writing of downstream templates.