### PR TITLE
changed: move Deck parameter to BlackoilModelParametersEbos

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -36,6 +36,7 @@
 #include <opm/grid/common/GridEnums.hpp>
 #include <opm/grid/common/CartesianIndexMapper.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
+#include <opm/simulators/flow/BlackoilModelParametersEbos.hpp>
 
 #include <array>
 #include <optional>
@@ -56,10 +57,6 @@ struct EclBaseVanguard {};
 // declare the properties required by the for the ecl simulator vanguard
 template<class TypeTag, class MyTypeTag>
 struct EquilGrid {
-    using type = UndefinedProperty;
-};
-template<class TypeTag, class MyTypeTag>
-struct EclDeckFileName {
     using type = UndefinedProperty;
 };
 template<class TypeTag, class MyTypeTag>

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -23,7 +23,6 @@
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
 
-#include <ebos/eclbasevanguard.hh>
 #include <string>
 
 namespace Opm::Properties {
@@ -32,6 +31,10 @@ namespace TTag {
 struct FlowModelParameters {};
 }
 
+template<class TypeTag, class MyTypeTag>
+struct EclDeckFileName {
+    using type = UndefinedProperty;
+};
 template<class TypeTag, class MyTypeTag>
 struct DbhpMaxRel {
     using type = UndefinedProperty;


### PR DESCRIPTION
it is used there. now eclbasevanguard.hh includes
BlackoilModelParametersEbos, instead of the other way around.