### PR TITLE
Make constants used in subclasses protected.

### DIFF
--- a/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
@@ -43,6 +43,7 @@ class WellState;
 
 class GasLiftSingleWellGeneric
 {
+protected:
     static const int Water = BlackoilPhases::Aqua;
     static const int Oil = BlackoilPhases::Liquid;
     static const int Gas = BlackoilPhases::Vapour;


### PR DESCRIPTION
Compile fix needed for clang.