### PR TITLE
fixed: do not take reference to a temporary

### DIFF
--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -105,9 +105,10 @@ public:
         const Schedule& deckSchedule = simulator_.vanguard().schedule();
         const auto& summaryState = simulator_.vanguard().summaryState();
         // create the wells which intersect with the current process' grid
+        const auto wellsatEnd = deckSchedule.getWellsatEnd();
         for (size_t deckWellIdx = 0; deckWellIdx < deckSchedule.numWells(); ++deckWellIdx)
         {
-            const auto& deckWell = deckSchedule.getWellsatEnd()[deckWellIdx];
+            const auto& deckWell = wellsatEnd[deckWellIdx];
             const std::string& wellName = deckWell.name();
             Scalar wellTemperature = 273.15 + 15.56; // [K]
             if (deckWell.isInjector())


### PR DESCRIPTION
getWellsatEnd returns a temporary vector. it goes out of
scope on the line, thus the reference taken is dangling.

@joakim-hove I think this randomly bit and is what broke the post-builder.