### PR TITLE
Make sure all wells are added to the well_rates map

### DIFF
--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -236,9 +236,13 @@ void WellState::init(const std::vector<double>& cellPressures,
     // call init on base class
     this->base_init(cellPressures, wells_ecl, parallel_well_info, well_perf_data, summary_state);
     this->global_well_info = std::make_optional<GlobalWellInfo>( schedule, report_step, wells_ecl );
+    for (const auto& wname : schedule.wellNames(report_step))
+    {
+        well_rates.insert({wname, std::make_pair(false, std::vector<double>(this->numPhases()))});
+    }
     for (const auto& winfo: parallel_well_info)
     {
-        well_rates.insert({winfo->name(), std::make_pair(winfo->isOwner(), std::vector<double>(this->numPhases()))});
+        well_rates[winfo->name()].first = winfo->isOwner();
     }
 
     const int nw = wells_ecl.size();

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -110,8 +110,10 @@ public:
     Well::ProducerCMode currentProductionControl(std::size_t well_index) const { return current_production_controls_[well_index]; }
     void currentProductionControl(std::size_t well_index, Well::ProducerCMode cmode) { current_production_controls_[well_index] = cmode; }
 
-    void setCurrentWellRates(const std::string& wellName, const std::vector<double>& rates ) {
-        well_rates.at(wellName).second = rates;
+    void setCurrentWellRates(const std::string& wellName, const std::vector<double>& new_rates ) {
+        auto& [owner, rates] = this->well_rates.at(wellName);
+        if (owner)
+            rates = new_rates;
     }
 
     const std::vector<double>& currentWellRates(const std::string& wellName) const;

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -111,7 +111,7 @@ public:
     void currentProductionControl(std::size_t well_index, Well::ProducerCMode cmode) { current_production_controls_[well_index] = cmode; }
 
     void setCurrentWellRates(const std::string& wellName, const std::vector<double>& rates ) {
-        well_rates[wellName].second = rates;
+        well_rates.at(wellName).second = rates;
     }
 
     const std::vector<double>& currentWellRates(const std::string& wellName) const;
@@ -470,6 +470,9 @@ private:
     WellContainer<Opm::Well::InjectorCMode> current_injection_controls_;
     WellContainer<Well::ProducerCMode> current_production_controls_;
 
+    // The well_rates variable is defined for all wells on all processors. The
+    // bool in the value pair is whether the current process owns the well or
+    // not.
     std::map<std::string, std::pair<bool, std::vector<double>>> well_rates;
 
 


### PR DESCRIPTION
`<Disclaimer>`
I might have misunderstood the intended content of the `WellState::well_rates` member
`</Disclaimer>`

The `well_rates` member of the `WellState`object is a map over all wells, where a bool element indicates whether the well is owned by the current process. In current master this is only explicitly initialized for the local wells, and then the structure is subsequently updated (by accident ??) when the rate is assigned with `operator[]` - however the bool part of the `std::pair<bool, std::vector<double>>` is not explicitly assigned this way.

With this PR the `well_rates`member is explicitly assigned for *all* wells, and then the rate update is done with `at( wname )` instead of `operator[](wname)`