### PR TITLE
Bug in wellstate handling for pressure drop in MSW wells?

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1921,19 +1921,20 @@ namespace Opm
 
         // for top segment, the well control equation will be used.
         EvalWell pressure_equation = getSegmentPressure(seg);
+        auto top_segment_index = well_state.topSegmentIndex(this->index_of_well_);
 
         // we need to handle the pressure difference between the two segments
         // we only consider the hydrostatic pressure loss first
         // TODO: we might be able to add member variables to store these values, then we update well state
         // after converged
         const auto hydro_pressure_drop = getHydroPressureLoss(seg);
-        well_state.segPressDropHydroStatic()[seg] = hydro_pressure_drop.value();
+        well_state.segPressDropHydroStatic()[top_segment_index + seg] = hydro_pressure_drop.value();
         pressure_equation -= hydro_pressure_drop;
 
         if (frictionalPressureLossConsidered()) {
             const auto friction_pressure_drop = getFrictionPressureLoss(seg);
             pressure_equation -= friction_pressure_drop;
-            well_state.segPressDropFriction()[seg] = friction_pressure_drop.value();
+            well_state.segPressDropFriction()[top_segment_index + seg] = friction_pressure_drop.value();
         }
 
         resWell_[seg][SPres] = pressure_equation.value();
@@ -2046,7 +2047,8 @@ namespace Opm
         const double sign = mass_rate < 0. ? 1.0 : - 1.0;
         accelerationPressureLoss *= sign;
 
-        well_state.segPressDropAcceleration()[seg] = accelerationPressureLoss.value();
+        auto top_segment_index = well_state.topSegmentIndex(this->index_of_well_);
+        well_state.segPressDropAcceleration()[top_segment_index + seg] = accelerationPressureLoss.value();
 
         resWell_[seg][SPres] -= accelerationPressureLoss.value();
         duneD_[seg][seg][SPres][SPres] -= accelerationPressureLoss.derivative(SPres + numEq);
@@ -2706,9 +2708,10 @@ namespace Opm
                 assemblePressureEq(seg, unit_system, well_state, deferred_logger);
             }
 
-            well_state.segPressDrop()[seg] = well_state.segPressDropHydroStatic()[seg] +
-                                             well_state.segPressDropFriction()[seg] +
-                                             well_state.segPressDropAcceleration()[seg];
+            auto top_segment_index = well_state.topSegmentIndex(index_of_well_);
+            well_state.segPressDrop()[top_segment_index + seg] = well_state.segPressDropHydroStatic()[top_segment_index + seg] +
+                                                                 well_state.segPressDropFriction()[top_segment_index + seg] +
+                                                                 well_state.segPressDropAcceleration()[top_segment_index + seg];
         }
     }
 
@@ -3262,7 +3265,8 @@ namespace Opm
             }
         }
         pressure_equation = pressure_equation - icd_pressure_drop;
-        well_state.segPressDropFriction()[seg] = icd_pressure_drop.value();
+        auto top_segment_index = well_state.topSegmentIndex(this->index_of_well_);
+        well_state.segPressDropFriction()[top_segment_index + seg] = icd_pressure_drop.value();
 
         const int seg_upwind = upwinding_segments_[seg];
         resWell_[seg][SPres] = pressure_equation.value();


### PR DESCRIPTION
I *think* there is a bug in the handling of the pressure drop terms in the `WellState` object for MSW wells. Typical code looks like this:
```C++
for (int seg=0; seg < numSegments(); seg++) {
     ...
     well_state.segPressDrop()[seg] = .....
}
```
the problem with this code is that the `seg` variable only runs over the number of segments for *this particular well*, whereas the `WellState::segment_pressure_drop_` vector expects an index in the range `[0, total_number_of_segments_in_reservoir>`. With this PR the segment index is offset by the index location of the top segment before the `WellState` array is accessed.

The code in question is only used for summary output, and should therefor not affect the calculations as such. I have stumbled upon this while working with #3296 - so it is not reported as a bug by anyone. I hope @GitPaean will have a look, and maybe also this can be tested with Eclipse. In case this indeed addresses a bug there will be updates to the reference solutions.
      