### PR TITLE
changed: do not set the ebos well model as default type

### DIFF
--- a/ebos/ebos_plain.cc
+++ b/ebos/ebos_plain.cc
@@ -28,6 +28,7 @@
 #include "config.h"
 
 #include "eclproblem.hh"
+#include "eclwellmanager.hh"
 
 #include <opm/models/utils/start.hh>
 
@@ -38,6 +39,11 @@ struct EbosPlainTypeTag {
     using InheritsFrom = std::tuple<EclBaseProblem, BlackOilModel>;
 };
 }
+
+template<class TypeTag>
+struct EclWellModel<TypeTag, TTag::EbosPlainTypeTag> {
+    using type = EclWellManager<TypeTag>;
+};
 
 } // namespace Opm::Properties
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -53,7 +53,6 @@
 #include "eclcpgridvanguard.hh"
 #endif
 
-#include "eclwellmanager.hh"
 #include "eclequilinitializer.hh"
 #include "eclwriter.hh"
 #include "ecloutputblackoilmodule.hh"
@@ -305,12 +304,6 @@ public:
 template<class TypeTag>
 struct EclAquiferModel<TypeTag, TTag::EclBaseProblem> {
     using type = EclBaseAquiferModel<TypeTag>;
-};
-
-// use the built-in proof of concept well model by default
-template<class TypeTag>
-struct EclWellModel<TypeTag, TTag::EclBaseProblem> {
-    using type = EclWellManager<TypeTag>;
 };
 
 // Enable aquifers by default in experimental mode

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -21,6 +21,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+#include <opm/simulators/wells/GroupState.hpp>
 #include <opm/simulators/wells/TargetCalculator.hpp>
 
 namespace Opm

--- a/tests/test_ecl_output.cc
+++ b/tests/test_ecl_output.cc
@@ -26,6 +26,7 @@
 
 #include <ebos/equil/equilibrationhelpers.hh>
 #include <ebos/eclproblem.hh>
+#include <ebos/eclwellmanager.hh>
 #include <opm/models/utils/start.hh>
 
 #include <opm/grid/UnstructuredGrid.h>
@@ -67,17 +68,25 @@
 
 namespace Opm::Properties {
 namespace TTag {
+
 struct TestEclOutputTypeTag {
     using InheritsFrom = std::tuple<EclBaseProblem, BlackOilModel>;
 };
 }
+
 template<class TypeTag>
 struct EnableGravity<TypeTag, TTag::TestEclOutputTypeTag> {
     static constexpr bool value = false;
 };
+
 template<class TypeTag>
 struct EnableAsyncEclOutput<TypeTag, TTag::TestEclOutputTypeTag> {
     static constexpr bool value = false;
+};
+
+template<class TypeTag>
+struct EclWellModel<TypeTag, TTag::TestEclOutputTypeTag> {
+    using type = EclWellManager<TypeTag>;
 };
 
 } // namespace Opm::Properties

--- a/tests/test_equil.cc
+++ b/tests/test_equil.cc
@@ -26,6 +26,7 @@
 
 #include <ebos/equil/equilibrationhelpers.hh>
 #include <ebos/eclproblem.hh>
+#include <ebos/eclwellmanager.hh>
 #include <opm/models/utils/start.hh>
 
 #include <opm/grid/UnstructuredGrid.h>
@@ -64,10 +65,17 @@
 
 namespace Opm::Properties {
 namespace TTag {
+
 struct TestEquilTypeTag {
     using InheritsFrom = std::tuple<EclBaseProblem, BlackOilModel>;
 };
 }
+
+template<class TypeTag>
+struct EclWellModel<TypeTag, TTag::TestEquilTypeTag> {
+    using type = EclWellManager<TypeTag>;
+};
+
 } // namespace Opm::Properties
 
 template <class TypeTag>


### PR DESCRIPTION
rather, only set it where we want to use it. this avoids including
eclwellmanager.hh and eclpeacemanwell.hh unnecessarily in
simulator objects (where BlackoilWellModel is used).