### PR TITLE
Remove segment pressure drop as separate variable

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2701,14 +2701,6 @@ namespace Opm
                 const UnitSystem& unit_system = ebosSimulator.vanguard().eclState().getDeckUnitSystem();
                 assemblePressureEq(seg, unit_system, well_state, deferred_logger);
             }
-
-            auto seg_press_drop = well_state.segPressDrop(index_of_well_);
-            auto seg_press_friction = well_state.segPressDropFriction(index_of_well_);
-            auto seg_press_static = well_state.segPressDropHydroStatic(index_of_well_);
-            auto seg_press_accel = well_state.segPressDropAcceleration(index_of_well_);
-            seg_press_drop[seg] = seg_press_static[seg] +
-                                  seg_press_friction[seg] +
-                                  seg_press_accel[seg];
         }
     }
 

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -539,7 +539,6 @@ void WellState::init(const std::vector<double>& cellPressures,
         }
         //seg_rates_ = wellRates();
         seg_rates_.assign(nw*np, 0);
-        seg_pressdrop_.assign(nw, 0.);
         seg_pressdrop_hydorstatic_.assign(nw, 0.);
         seg_pressdrop_friction_.assign(nw, 0.);
         seg_pressdrop_acceleration_.assign(nw, 0.);
@@ -946,7 +945,6 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
     assert(int(seg_press_.size()) == nseg_);
     assert(int(seg_rates_.size()) == nseg_ * numPhases() );
 
-    seg_pressdrop_.assign(nseg_, 0.);
     seg_pressdrop_hydorstatic_.assign(nseg_, 0.);
     seg_pressdrop_friction_.assign(nseg_, 0.);
     seg_pressdrop_acceleration_.assign(nseg_, 0.);
@@ -1159,7 +1157,7 @@ WellState::reportSegmentResults(const PhaseUsage& pu,
         using Value = data::SegmentPressures::Value;
         auto& segpress = seg_res.pressures;
         segpress[Value::Pressure] = this->segPress(well_id)[seg_ix];
-        segpress[Value::PDrop] = this->segPressDrop(well_id)[seg_ix];
+        segpress[Value::PDrop] = this->segPressDrop(well_id, seg_ix);
         segpress[Value::PDropHydrostatic] = this->segPressDropHydroStatic(well_id)[seg_ix];
         segpress[Value::PDropFriction] = this->segPressDropFriction(well_id)[seg_ix];
         segpress[Value::PDropAccel] = this->segPressDropAcceleration(well_id)[seg_ix];

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -219,16 +219,12 @@ public:
         return &seg_press_[top_segment_index];
     }
 
-    double * segPressDrop(std::size_t well_index)
+    double segPressDrop(std::size_t well_index, std::size_t segment_index) const
     {
         const int top_segment_index = this->top_segment_index_[well_index];
-        return &seg_pressdrop_[top_segment_index];
-    }
-
-    const double * segPressDrop(std::size_t well_index) const
-    {
-        const int top_segment_index = this->top_segment_index_[well_index];
-        return &seg_pressdrop_[top_segment_index];
+        return this->seg_pressdrop_friction_[top_segment_index + segment_index] +
+               this->seg_pressdrop_hydorstatic_[top_segment_index + segment_index] +
+               this->seg_pressdrop_acceleration_[top_segment_index + segment_index];
     }
 
     double* segPressDropFriction(std::size_t well_index)
@@ -537,8 +533,6 @@ private:
     int nseg_; // total number of the segments
 
     // The following data are only recorded for output
-    // pressure drop
-    std::vector<double> seg_pressdrop_;
     // frictional pressure drop
     std::vector<double> seg_pressdrop_friction_;
     // hydrostatic pressure drop


### PR DESCRIPTION
The segment pressure drop is the sum of three terms - the pressure drop due to friction, acceleration and hydrostatic change. With this PR the segment pressure drop is implemented as a function instead of a seperate member.

This is an intermediate step on the way towards: #3297. 