### PR TITLE
always inner well iterations in prediction mode

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -217,7 +217,7 @@ namespace Opm
                                     DeferredLogger& deferred_logger) const;
 
         virtual bool useInnerIterations() const override {
-            return param_.use_inner_iterations_ms_wells_;
+            return param_.use_inner_iterations_ms_wells_ || this->underPredictionMode();
         }
     protected:
         int number_segments_;

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -325,7 +325,7 @@ namespace Opm
                                     DeferredLogger& deferred_logger) const;
 
         virtual bool useInnerIterations() const override {
-            return param_.use_inner_iterations_wells_;
+            return param_.use_inner_iterations_wells_ || this->underPredictionMode();
         }
 
     protected:


### PR DESCRIPTION
I had hoped to always force inner well iterations, but I have not been able to solve the issue with the model2 regression. This restrict the forcing to the predictive simulations where it is needed! 