### PR TITLE
eclwriter: fix regression in parallel

### DIFF
--- a/ebos/eclgenericwriter.hh
+++ b/ebos/eclgenericwriter.hh
@@ -69,14 +69,20 @@ public:
                      const GridView& gridView,
                      const Dune::CartesianIndexMapper<Grid>& cartMapper,
                      const Dune::CartesianIndexMapper<EquilGrid>* equilCartMapper,
-                     const TransmissibilityType& globalTrans,
                      bool enableAsyncOutput);
 
     const EclipseIO& eclIO() const;
 
     void writeInit();
 
+    void setTransmissibilities(const TransmissibilityType* globalTrans)
+    {
+        globalTrans_ = globalTrans;
+    }
+
 protected:
+    const TransmissibilityType& globalTrans() const;
+
     void doWriteOutput(const int                     reportStepNum,
                        const bool                    isSubStep,
                        data::Solution&&              localCellData,
@@ -114,7 +120,7 @@ protected:
     std::unique_ptr<EclipseIO> eclIO_;
     std::unique_ptr<TaskletRunner> taskletRunner_;
     Scalar restartTimeStepSize_;
-    const TransmissibilityType& globalTrans_;
+    const TransmissibilityType* globalTrans_ = nullptr;
     const Dune::CartesianIndexMapper<Grid>& cartMapper_;
     const Dune::CartesianIndexMapper<EquilGrid>* equilCartMapper_;
     const EquilGrid* equilGrid_;

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -791,7 +791,7 @@ public:
         ExtboModule::initFromState(vanguard.eclState());
 
         // create the ECL writer
-        eclWriter_.reset(new EclWriterType(simulator, *this));
+        eclWriter_.reset(new EclWriterType(simulator));
 
         enableDriftCompensation_ = EWOMS_GET_PARAM(TypeTag, bool, EclEnableDriftCompensation);
 
@@ -926,8 +926,15 @@ public:
         }
 
         // write the static output files (EGRID, INIT, SMSPEC, etc.)
-        if (enableEclOutput_)
+        if (enableEclOutput_) {
+            if (simulator.vanguard().grid().comm().size() > 1) {
+                if (simulator.vanguard().grid().comm().rank() == 0)
+                    eclWriter_->setTransmissibilities(&simulator.vanguard().globalTransmissibility());
+            } else
+                eclWriter_->setTransmissibilities(&simulator.problem().eclTransmissibilities());
+
             eclWriter_->writeInit();
+        }
 
         simulator.vanguard().releaseGlobalTransmissibilities();
 

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -112,8 +112,7 @@ public:
     // The Simulator object should preferably have been const - the
     // only reason that is not the case is due to the SummaryState
     // object owned deep down by the vanguard.
-    template<class Problem>
-    EclWriter(Simulator& simulator, const Problem& problem)
+    EclWriter(Simulator& simulator)
         : BaseType(simulator.vanguard().schedule(),
                    simulator.vanguard().eclState(),
                    simulator.vanguard().summaryConfig(),
@@ -122,7 +121,6 @@ public:
                    simulator.vanguard().gridView(),
                    simulator.vanguard().cartesianIndexMapper(),
                    simulator.vanguard().grid().comm().rank() == 0 ? &simulator.vanguard().equilCartesianIndexMapper() : nullptr,
-                   simulator.vanguard().grid().comm().size() > 1 ? simulator.vanguard().globalTransmissibility() : problem.eclTransmissibilities(),
                    EWOMS_GET_PARAM(TypeTag, bool, EnableAsyncEclOutput))
         , simulator_(simulator)
     {

--- a/tests/test_ecl_output.cc
+++ b/tests/test_ecl_output.cc
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(Summary)
 
     typedef Opm::EclWriter<TypeTag> EclWriterType;
     // create the actual ECL writer
-    std::unique_ptr<EclWriterType> eclWriter = std::unique_ptr<EclWriterType>(new EclWriterType(*simulator, simulator->problem()));
+    std::unique_ptr<EclWriterType> eclWriter = std::unique_ptr<EclWriterType>(new EclWriterType(*simulator));
 
     simulator->model().applyInitialSolution();
     Opm::data::Wells dw;


### PR DESCRIPTION
order of constructing and obtaining global transmissibilities
was off. replace constructor argument with a setter so it can be
set at the appropriate time.

closes #3328 