### PR TITLE
Pass the temperature to the restart machinary if enableTemperature is true

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.hh
+++ b/ebos/eclgenericoutputblackoilmodule.hh
@@ -148,6 +148,7 @@ protected:
                                    const SummaryConfig& summaryConfig,
                                    const SummaryState& summaryState,
                                    bool enableEnergy,
+                                   bool enableTemperature,
                                    bool enableSolvent,
                                    bool enablePolymer,
                                    bool enableFoam,
@@ -297,6 +298,7 @@ protected:
     const SummaryConfig& summaryConfig_;
     const SummaryState& summaryState_;
     bool enableEnergy_;
+    bool enableTemperature_;
 
     bool enableSolvent_;
     bool enablePolymer_;

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -118,6 +118,7 @@ public:
                    simulator.vanguard().summaryConfig(),
                    simulator.vanguard().summaryState(),
                    getPropValue<TypeTag, Properties::EnableEnergy>(),
+                   getPropValue<TypeTag, Properties::EnableTemperature>(),
                    getPropValue<TypeTag, Properties::EnableSolvent>(),
                    getPropValue<TypeTag, Properties::EnablePolymer>(),
                    getPropValue<TypeTag, Properties::EnableFoam>(),

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -98,6 +98,7 @@ class EclWriter : public EclGenericWriter<GetPropType<TypeTag, Properties::Grid>
     using BaseType = EclGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>;
 
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
     enum { enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>() };
 
 public:
@@ -272,11 +273,13 @@ public:
     {
         bool enableHysteresis = simulator_.problem().materialLawManager()->enableHysteresis();
         bool enableSwatinit = simulator_.vanguard().eclState().fieldProps().has_double("SWATINIT");
+        bool opm_rst_file = EWOMS_GET_PARAM(TypeTag, bool, EnableOpmRstFile);
+        bool read_temp = enableEnergy || (opm_rst_file && enableTemperature);
         std::vector<RestartKey> solutionKeys{
             {"PRESSURE", UnitSystem::measure::pressure},
             {"SWAT", UnitSystem::measure::identity, static_cast<bool>(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx))},
             {"SGAS", UnitSystem::measure::identity, static_cast<bool>(FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx))},
-            {"TEMP" , UnitSystem::measure::temperature, enableEnergy},
+            {"TEMP" , UnitSystem::measure::temperature, read_temp},
             {"SSOLVENT" , UnitSystem::measure::identity, enableSolvent},
             {"RS", UnitSystem::measure::gas_oil_ratio, FluidSystem::enableDissolvedGas()},
             {"RV", UnitSystem::measure::oil_gas_ratio, FluidSystem::enableVaporizedOil()},


### PR DESCRIPTION
EnableTemperature is true as default, i.e. the temperature is now passed to the restart machinery as default.
It will however be ignored and not written to the restart file if the user does not specify --enable-opm-restart-file=true 