### PR TITLE
Segment state2

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -60,6 +60,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/wells/GlobalWellInfo.cpp
   opm/simulators/wells/GroupState.cpp
   opm/simulators/wells/ParallelWellInfo.cpp
+  opm/simulators/wells/SegmentState.cpp
   opm/simulators/wells/TargetCalculator.cpp
   opm/simulators/wells/VFPHelpers.cpp
   opm/simulators/wells/VFPProdProperties.cpp
@@ -205,6 +206,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/core/props/phaseUsageFromDeck.hpp
   opm/core/props/satfunc/RelpermDiagnostics.hpp
   opm/simulators/timestepping/SimulatorReport.hpp
+  opm/simulators/wells/SegmentState.hpp
   opm/simulators/wells/WellContainer.hpp
   opm/simulators/aquifers/AquiferInterface.hpp
   opm/simulators/aquifers/AquiferCarterTracy.hpp

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2023,7 +2023,7 @@ namespace Opm {
 
                 auto& segments = well_state.segments(well_index);
                 auto& segment_pressure = segments.pressure;
-                auto segment_rates  = well_state.segRates(well_index);
+                auto& segment_rates  = segments.rates;
                 for (const auto& rst_segment : rst_segments) {
                     const int segment_index = segment_set.segmentNumberToIndex(rst_segment.first);
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2021,7 +2021,8 @@ namespace Opm {
                 // \Note: eventually we need to hanlde the situations that some segments are shut
                 assert(0u + segment_set.size() == rst_segments.size());
 
-                auto segment_pressure = well_state.segPress(well_index);
+                auto& segments = well_state.segments(well_index);
+                auto& segment_pressure = segments.pressure;
                 auto segment_rates  = well_state.segRates(well_index);
                 for (const auto& rst_segment : rst_segments) {
                     const int segment_index = segment_set.segmentNumberToIndex(rst_segment.first);

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2043,7 +2043,7 @@ namespace Opm
         const double sign = mass_rate < 0. ? 1.0 : - 1.0;
         accelerationPressureLoss *= sign;
 
-        well_state.segPressDropAcceleration(index_of_well_)[seg] = accelerationPressureLoss.value();
+        well_state.segments(this->index_of_well_).pressure_drop_accel[seg] = accelerationPressureLoss.value();
 
         resWell_[seg][SPres] -= accelerationPressureLoss.value();
         duneD_[seg][seg][SPres][SPres] -= accelerationPressureLoss.derivative(SPres + numEq);

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1924,12 +1924,13 @@ namespace Opm
         // after converged
         const auto hydro_pressure_drop = getHydroPressureLoss(seg);
         well_state.segPressDropHydroStatic(index_of_well_)[seg] = hydro_pressure_drop.value();
+        auto& segments = well_state.segments(this->index_of_well_);
         pressure_equation -= hydro_pressure_drop;
 
         if (frictionalPressureLossConsidered()) {
             const auto friction_pressure_drop = getFrictionPressureLoss(seg);
             pressure_equation -= friction_pressure_drop;
-            well_state.segPressDropFriction(index_of_well_)[seg] = friction_pressure_drop.value();
+            segments.pressure_drop_friction[seg] = friction_pressure_drop.value();
         }
 
         resWell_[seg][SPres] = pressure_equation.value();
@@ -3254,7 +3255,7 @@ namespace Opm
             }
         }
         pressure_equation = pressure_equation - icd_pressure_drop;
-        well_state.segPressDropFriction(index_of_well_)[seg] = icd_pressure_drop.value();
+        well_state.segments(this->index_of_well_).pressure_drop_friction[seg] = icd_pressure_drop.value();
 
         const int seg_upwind = upwinding_segments_[seg];
         resWell_[seg][SPres] = pressure_equation.value();

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1923,8 +1923,8 @@ namespace Opm
         // TODO: we might be able to add member variables to store these values, then we update well state
         // after converged
         const auto hydro_pressure_drop = getHydroPressureLoss(seg);
-        well_state.segPressDropHydroStatic(index_of_well_)[seg] = hydro_pressure_drop.value();
         auto& segments = well_state.segments(this->index_of_well_);
+        segments.pressure_drop_hydrostatic[seg] = hydro_pressure_drop.value();
         pressure_equation -= hydro_pressure_drop;
 
         if (frictionalPressureLossConsidered()) {

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -315,12 +315,12 @@ namespace Opm
     scaleSegmentPressuresWithBhp(WellState& well_state) const
     {
         //scale segment pressures
+        auto& segments = well_state.segments(this->index_of_well_);
         const double bhp = well_state.bhp(index_of_well_);
-        auto segment_pressure = well_state.segPress(index_of_well_);
-        const double unscaled_top_seg_pressure = segment_pressure[0];
-        for (int seg = 0; seg < numberOfSegments(); ++seg) {
-            segment_pressure[seg] *= bhp/unscaled_top_seg_pressure;
-        }
+        const double unscaled_top_seg_pressure = segments.pressure[0];
+        const double scale_factor = bhp / unscaled_top_seg_pressure;
+
+        std::transform(segments.pressure.begin(), segments.pressure.end(), segments.pressure.begin(), [scale_factor](const double& p) { return p*scale_factor;} );
     }
 
 
@@ -719,8 +719,9 @@ namespace Opm
         const Well& well = Base::wellEcl();
 
         // the index of the top segment in the WellState
+        const auto& segments = well_state.segments(this->index_of_well_);
         const auto segment_rates = well_state.segRates(index_of_well_);
-        const auto segment_pressure = well_state.segPress(index_of_well_);
+        const auto& segment_pressure = segments.pressure;
         const PhaseUsage& pu = phaseUsage();
 
         for (int seg = 0; seg < numberOfSegments(); ++seg) {
@@ -2337,8 +2338,9 @@ namespace Opm
         assert( FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) );
         const int oil_pos = pu.phase_pos[Oil];
 
+        auto& segments = well_state.segments(this->index_of_well_);
         auto segment_rates = well_state.segRates(this->index_of_well_);
-        auto segment_pressure = well_state.segPress(this->index_of_well_);
+        auto& segment_pressure = segments.pressure;
         for (int seg = 0; seg < numberOfSegments(); ++seg) {
             std::vector<double> fractions(number_of_phases_, 0.0);
             fractions[oil_pos] = 1.0;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -278,7 +278,8 @@ namespace Opm
     MultisegmentWell<TypeTag>::
     scaleSegmentRatesWithWellRates(WellState& well_state) const
     {
-        auto segment_rates = well_state.segRates(index_of_well_);
+        auto& segments = well_state.segments(this->index_of_well_);
+        auto& segment_rates = segments.rates;
         for (int phase = 0; phase < number_of_phases_; ++phase) {
             const double unscaled_top_seg_rate = segment_rates[phase];
             const double well_phase_rate = well_state.wellRates(index_of_well_)[phase];
@@ -302,9 +303,8 @@ namespace Opm
                 }
 
                 std::vector<double> rates;
-                WellState::calculateSegmentRates(segment_inlets_, segment_perforations_, perforation_rates, number_of_phases_,
-                                                 0, rates);
-                std::copy(rates.begin(), rates.end(), segment_rates);
+                WellState::calculateSegmentRates(segment_inlets_, segment_perforations_, perforation_rates, number_of_phases_, 0, rates);
+                std::copy(rates.begin(), rates.end(), segment_rates.begin());
             }
         }
     }
@@ -716,7 +716,7 @@ namespace Opm
 
         // the index of the top segment in the WellState
         const auto& segments = well_state.segments(this->index_of_well_);
-        const auto segment_rates = well_state.segRates(index_of_well_);
+        const auto& segment_rates = segments.rates;
         const auto& segment_pressure = segments.pressure;
         const PhaseUsage& pu = phaseUsage();
 
@@ -2335,7 +2335,7 @@ namespace Opm
         const int oil_pos = pu.phase_pos[Oil];
 
         auto& segments = well_state.segments(this->index_of_well_);
-        auto segment_rates = well_state.segRates(this->index_of_well_);
+        auto& segment_rates = segments.rates;
         auto& segment_pressure = segments.pressure;
         for (int seg = 0; seg < numberOfSegments(); ++seg) {
             std::vector<double> fractions(number_of_phases_, 0.0);

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -265,8 +265,8 @@ namespace Opm
         Base::updateWellStateWithTarget(ebos_simulator, well_state, deferred_logger);
         // scale segment rates based on the wellRates
         // and segment pressure based on bhp
-        scaleSegmentPressuresWithBhp(well_state);
         scaleSegmentRatesWithWellRates(well_state);
+        scaleSegmentPressuresWithBhp(well_state);
     }
 
 
@@ -314,13 +314,9 @@ namespace Opm
     MultisegmentWell<TypeTag>::
     scaleSegmentPressuresWithBhp(WellState& well_state) const
     {
-        //scale segment pressures
         auto& segments = well_state.segments(this->index_of_well_);
-        const double bhp = well_state.bhp(index_of_well_);
-        const double unscaled_top_seg_pressure = segments.pressure[0];
-        const double scale_factor = bhp / unscaled_top_seg_pressure;
-
-        std::transform(segments.pressure.begin(), segments.pressure.end(), segments.pressure.begin(), [scale_factor](const double& p) { return p*scale_factor;} );
+        auto bhp = well_state.bhp(this->index_of_well_);
+        segments.scale_pressure(bhp);
     }
 
 

--- a/opm/simulators/wells/SegmentState.cpp
+++ b/opm/simulators/wells/SegmentState.cpp
@@ -16,6 +16,8 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <algorithm>
+#include <stdexcept>
 
 #include <opm/simulators/wells/SegmentState.hpp>
 
@@ -42,6 +44,17 @@ double SegmentState::pressure_drop(std::size_t index) const {
 
 bool SegmentState::empty() const {
     return this->rates.empty();
+}
+
+void SegmentState::scale_pressure(double bhp) {
+    if (this->empty())
+        throw std::logic_error("Tried to pressure scale empty SegmentState");
+
+    auto scale_factor = bhp / this->pressure[0];
+    std::transform(this->pressure.begin(),
+                   this->pressure.end(),
+                   this->pressure.begin(),
+                   [scale_factor] (const double& p) { return p*scale_factor;});
 }
 
 }

--- a/opm/simulators/wells/SegmentState.cpp
+++ b/opm/simulators/wells/SegmentState.cpp
@@ -1,0 +1,47 @@
+/*
+  Copyright Equinor ASA 2021
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/simulators/wells/SegmentState.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp>
+
+namespace Opm
+{
+
+SegmentState::SegmentState(int num_phases, const WellSegments& segments) :
+    rates(segments.size() * num_phases),
+    pressure(segments.size()),
+    pressure_drop_friction(segments.size()),
+    pressure_drop_hydrostatic(segments.size()),
+    pressure_drop_accel(segments.size())
+{
+
+}
+
+double SegmentState::pressure_drop(std::size_t index) const {
+    return this->pressure_drop_friction[index] + this->pressure_drop_hydrostatic[index] + this->pressure_drop_accel[index];
+}
+
+
+bool SegmentState::empty() const {
+    return this->rates.empty();
+}
+
+}

--- a/opm/simulators/wells/SegmentState.cpp
+++ b/opm/simulators/wells/SegmentState.cpp
@@ -55,6 +55,11 @@ bool SegmentState::empty() const {
     return this->rates.empty();
 }
 
+std::size_t SegmentState::size() const {
+    return this->pressure.size();
+}
+
+
 void SegmentState::scale_pressure(double bhp) {
     if (this->empty())
         throw std::logic_error("Tried to pressure scale empty SegmentState");

--- a/opm/simulators/wells/SegmentState.cpp
+++ b/opm/simulators/wells/SegmentState.cpp
@@ -27,14 +27,23 @@
 namespace Opm
 {
 
+namespace {
+std::vector<int> make_segment_number( const WellSegments& segments ) {
+    std::vector<int> segment_number;
+    std::transform(segments.begin(), segments.end(), std::back_insert_iterator(segment_number), [](const Segment& segment) { return segment.segmentNumber(); });
+    return segment_number;
+}
+
+}
+
 SegmentState::SegmentState(int num_phases, const WellSegments& segments) :
     rates(segments.size() * num_phases),
     pressure(segments.size()),
     pressure_drop_friction(segments.size()),
     pressure_drop_hydrostatic(segments.size()),
-    pressure_drop_accel(segments.size())
+    pressure_drop_accel(segments.size()),
+    m_segment_number(make_segment_number(segments))
 {
-
 }
 
 double SegmentState::pressure_drop(std::size_t index) const {
@@ -55,6 +64,10 @@ void SegmentState::scale_pressure(double bhp) {
                    this->pressure.end(),
                    this->pressure.begin(),
                    [scale_factor] (const double& p) { return p*scale_factor;});
+}
+
+const std::vector<int>& SegmentState::segment_number() const {
+    return this->m_segment_number;
 }
 
 }

--- a/opm/simulators/wells/SegmentState.hpp
+++ b/opm/simulators/wells/SegmentState.hpp
@@ -36,6 +36,8 @@ public:
     SegmentState(int num_phases, const WellSegments& segments);
     double pressure_drop(std::size_t index) const;
     bool empty() const;
+    void scale_pressure(double bhp);
+
 
     std::vector<double> rates;
     std::vector<double> pressure;

--- a/opm/simulators/wells/SegmentState.hpp
+++ b/opm/simulators/wells/SegmentState.hpp
@@ -1,0 +1,49 @@
+/*
+  Copyright Equinor ASA 2021
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_SEGMENTSTATE_HEADER_INCLUDED
+#define OPM_SEGMENTSTATE_HEADER_INCLUDED
+
+#include <vector>
+
+namespace Opm
+{
+
+class WellSegments;
+class WellConnections;
+
+
+class SegmentState
+{
+public:
+    SegmentState() = default;
+    SegmentState(int num_phases, const WellSegments& segments);
+    double pressure_drop(std::size_t index) const;
+    bool empty() const;
+
+    std::vector<double> rates;
+    std::vector<double> pressure;
+    std::vector<double> pressure_drop_friction;
+    std::vector<double> pressure_drop_hydrostatic;
+    std::vector<double> pressure_drop_accel;
+};
+
+}
+
+#endif

--- a/opm/simulators/wells/SegmentState.hpp
+++ b/opm/simulators/wells/SegmentState.hpp
@@ -38,6 +38,7 @@ public:
     bool empty() const;
     void scale_pressure(double bhp);
     const std::vector<int>& segment_number() const;
+    std::size_t size() const;
 
     std::vector<double> rates;
     std::vector<double> pressure;

--- a/opm/simulators/wells/SegmentState.hpp
+++ b/opm/simulators/wells/SegmentState.hpp
@@ -37,13 +37,15 @@ public:
     double pressure_drop(std::size_t index) const;
     bool empty() const;
     void scale_pressure(double bhp);
-
+    const std::vector<int>& segment_number() const;
 
     std::vector<double> rates;
     std::vector<double> pressure;
     std::vector<double> pressure_drop_friction;
     std::vector<double> pressure_drop_hydrostatic;
     std::vector<double> pressure_drop_accel;
+private:
+    std::vector<int>    m_segment_number;
 };
 
 }

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -49,6 +49,7 @@ void WellState::base_init(const std::vector<double>& cellPressures,
     this->bhp_.clear();
     this->thp_.clear();
     this->temperature_.clear();
+    this->segment_state.clear();
     {
         // const int nw = wells->number_of_wells;
         const int nw = wells_ecl.size();
@@ -97,6 +98,7 @@ void WellState::initSingleWell(const std::vector<double>& cellPressures,
     this->wellrates_.add(well.name(), std::vector<double>(np, 0));
 
     const int num_perf_this_well = well_info->communication().sum(well_perf_data_[w].size());
+    this->segment_state.add(well.name(), SegmentState{});
     this->perfpress_.add(well.name(), std::vector<double>(num_perf_this_well, -1e100));
     this->perfrates_.add(well.name(), std::vector<double>(num_perf_this_well, 0));
     this->bhp_.add(well.name(), 0.0);
@@ -851,6 +853,7 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
             // assuming the order of the perforations in well_ecl is the same with Wells
             const WellConnections& completion_set = well_ecl.getConnections();
             // number of segment for this single well
+            this->segment_state.update(w, SegmentState{np, segment_set});
             const int well_nseg = segment_set.size();
             int n_activeperf = 0;
             nseg_ += well_nseg;

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -535,7 +535,6 @@ void WellState::init(const std::vector<double>& cellPressures,
         }
         //seg_rates_ = wellRates();
         seg_rates_.assign(nw*np, 0);
-        seg_pressdrop_acceleration_.assign(nw, 0.);
     }
 
     updateWellsDefaultALQ(wells_ecl);
@@ -940,7 +939,6 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
     assert(int(seg_press_.size()) == nseg_);
     assert(int(seg_rates_.size()) == nseg_ * numPhases() );
 
-    seg_pressdrop_acceleration_.assign(nseg_, 0.);
 
     if (prev_well_state && !prev_well_state->wellMap().empty()) {
         const auto& end = prev_well_state->wellMap().end();
@@ -1155,9 +1153,9 @@ WellState::reportSegmentResults(const PhaseUsage& pu,
         auto& segpress = seg_res.pressures;
         segpress[Value::Pressure] = this->segPress(well_id)[seg_ix];
         segpress[Value::PDrop] = this->segPressDrop(well_id, seg_ix);
-        segpress[Value::PDropAccel] = this->segPressDropAcceleration(well_id)[seg_ix];
         segpress[Value::PDropHydrostatic] = segments.pressure_drop_hydrostatic[seg_ix];
         segpress[Value::PDropFriction] = segments.pressure_drop_friction[seg_ix];
+        segpress[Value::PDropAccel] = segments.pressure_drop_accel[seg_ix];
     }
 
     const auto segment_rates = this->segRates(well_id);

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -536,7 +536,6 @@ void WellState::init(const std::vector<double>& cellPressures,
         //seg_rates_ = wellRates();
         seg_rates_.assign(nw*np, 0);
         seg_pressdrop_hydorstatic_.assign(nw, 0.);
-        seg_pressdrop_friction_.assign(nw, 0.);
         seg_pressdrop_acceleration_.assign(nw, 0.);
     }
 
@@ -943,7 +942,6 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
     assert(int(seg_rates_.size()) == nseg_ * numPhases() );
 
     seg_pressdrop_hydorstatic_.assign(nseg_, 0.);
-    seg_pressdrop_friction_.assign(nseg_, 0.);
     seg_pressdrop_acceleration_.assign(nseg_, 0.);
 
     if (prev_well_state && !prev_well_state->wellMap().empty()) {
@@ -1149,6 +1147,10 @@ WellState::reportSegmentResults(const PhaseUsage& pu,
                                                      const int         seg_ix,
                                                      const int         seg_no) const
 {
+    const auto& segments = this->segments(well_id);
+    if (segments.empty())
+        return {};
+
     auto seg_res = data::Segment{};
     {
         using Value = data::SegmentPressures::Value;
@@ -1156,8 +1158,8 @@ WellState::reportSegmentResults(const PhaseUsage& pu,
         segpress[Value::Pressure] = this->segPress(well_id)[seg_ix];
         segpress[Value::PDrop] = this->segPressDrop(well_id, seg_ix);
         segpress[Value::PDropHydrostatic] = this->segPressDropHydroStatic(well_id)[seg_ix];
-        segpress[Value::PDropFriction] = this->segPressDropFriction(well_id)[seg_ix];
         segpress[Value::PDropAccel] = this->segPressDropAcceleration(well_id)[seg_ix];
+        segpress[Value::PDropFriction] = segments.pressure_drop_friction[seg_ix];
     }
 
     const auto segment_rates = this->segRates(well_id);

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -531,7 +531,6 @@ void WellState::init(const std::vector<double>& cellPressures,
         for (int w = 0; w < nw; ++w) {
             top_segment_index_[w] = w;
             seg_number_[w] = 1; // Top segment is segment #1
-            this->seg_press_[w] = this->bhp(w);
         }
         //seg_rates_ = wellRates();
         seg_rates_.assign(nw*np, 0);
@@ -841,7 +840,7 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
         if ( !well_ecl.isMultiSegment() ) { // not multi-segment well
             nseg_ += 1;
             seg_number_.push_back(1); // Assign single segment (top) as number 1.
-            seg_press_.push_back(bhp(w));
+            seg_press_.push_back(0);
             for (int p = 0; p < np; ++p) {
                 seg_rates_.push_back(rates[p]);
             }

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -526,10 +526,8 @@ void WellState::init(const std::vector<double>& cellPressures,
         // multi-segment wells added later.
         nseg_ = nw;
         top_segment_index_.resize(nw);
-        seg_number_.resize(nw);
         for (int w = 0; w < nw; ++w) {
             top_segment_index_[w] = w;
-            seg_number_[w] = 1; // Top segment is segment #1
         }
     }
 
@@ -818,7 +816,6 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
     const int np = pu.num_phases;
 
     top_segment_index_.clear();
-    seg_number_.clear();
     nseg_ = 0;
 
     // in the init function, the well rates and perforation rates have been initialized or copied from prevState
@@ -833,7 +830,6 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
         top_segment_index_.push_back(nseg_);
         if ( !well_ecl.isMultiSegment() ) { // not multi-segment well
             nseg_ += 1;
-            seg_number_.push_back(1); // Assign single segment (top) as number 1.
         } else { // it is a multi-segment well
             const WellSegments& segment_set = well_ecl.getSegments();
             // assuming the order of the perforations in well_ecl is the same with Wells
@@ -843,9 +839,6 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
             const int well_nseg = segment_set.size();
             int n_activeperf = 0;
             nseg_ += well_nseg;
-            for (auto segID = 0*well_nseg; segID < well_nseg; ++segID) {
-                this->seg_number_.push_back(segment_set[segID].segmentNumber());
-            }
 
             // we need to know for each segment, how many perforation it has and how many segments using it as outlet_segment
             // that is why I think we should use a well model to initialize the WellState here
@@ -1175,9 +1168,8 @@ int WellState::numSegments(const int well_id) const
 
 int WellState::segmentNumber(const int well_id, const int seg_id) const
 {
-    const auto top_offset = this->topSegmentIndex(well_id);
-
-    return this->seg_number_[top_offset + seg_id];
+    const auto& segments = this->segment_state[well_id];
+    return segments.segment_number[seg_id];
 }
 
 void WellState::updateWellsDefaultALQ( const std::vector<Well>& wells_ecl )

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -524,7 +524,6 @@ void WellState::init(const std::vector<double>& cellPressures,
     {
         // we need to create a trival segment related values to avoid there will be some
         // multi-segment wells added later.
-        nseg_ = nw;
         top_segment_index_.resize(nw);
         for (int w = 0; w < nw; ++w) {
             top_segment_index_[w] = w;
@@ -816,10 +815,10 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
     const int np = pu.num_phases;
 
     top_segment_index_.clear();
-    nseg_ = 0;
 
     // in the init function, the well rates and perforation rates have been initialized or copied from prevState
     // what we do here, is to set the segment rates and perforation rates
+    int nseg_ = 0;
     for (int w = 0; w < nw; ++w) {
         const auto& well_ecl = wells_ecl[w];
         const auto& wname = wells_ecl[w].name();
@@ -915,8 +914,6 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
             }
         }
     }
-    assert(int(seg_press_.size()) == nseg_);
-    assert(int(seg_rates_.size()) == nseg_ * numPhases() );
 
 
     if (prev_well_state) {
@@ -1159,17 +1156,14 @@ bool WellState::wellIsOwned(const std::string& wellName) const
 
 int WellState::numSegments(const int well_id) const
 {
-    const auto topseg = this->topSegmentIndex(well_id);
-
-    return (well_id + 1 == this->numWells()) // Last well?
-            ? (this->numSegment() - topseg)
-            : (this->topSegmentIndex(well_id + 1) - topseg);
+    const auto& segments = this->segments(well_id);
+    return segments.size();
 }
 
 int WellState::segmentNumber(const int well_id, const int seg_id) const
 {
     const auto& segments = this->segment_state[well_id];
-    return segments.segment_number[seg_id];
+    return segments.segment_number()[seg_id];
 }
 
 void WellState::updateWellsDefaultALQ( const std::vector<Well>& wells_ecl )

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -1152,14 +1152,13 @@ WellState::reportSegmentResults(const PhaseUsage& pu,
         using Value = data::SegmentPressures::Value;
         auto& segpress = seg_res.pressures;
         segpress[Value::Pressure] = this->segPress(well_id)[seg_ix];
-        segpress[Value::PDrop] = this->segPressDrop(well_id, seg_ix);
+        segpress[Value::PDrop] = segments.pressure_drop(seg_ix);
         segpress[Value::PDropHydrostatic] = segments.pressure_drop_hydrostatic[seg_ix];
         segpress[Value::PDropFriction] = segments.pressure_drop_friction[seg_ix];
         segpress[Value::PDropAccel] = segments.pressure_drop_accel[seg_ix];
     }
 
-    const auto segment_rates = this->segRates(well_id);
-    const auto rate = &segment_rates[seg_ix * this->numPhases()];
+    const auto rate = &this->segRates(well_id)[seg_ix * pu.num_phases];
     if (pu.phase_used[Water]) {
         seg_res.rates.set(data::Rates::opt::wat,
                           rate[pu.phase_pos[Water]]);

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -945,6 +945,7 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
             if ( !well.isMultiSegment() )
                 continue;
 
+            const auto& wname = well.name();
             const auto& it = prev_well_state->wellMap().find( wells_ecl[w].name() );
             if (it != end) { // the well is found in the prev_well_state
                 // TODO: the well with same name can change a lot, like they might not have same number of segments
@@ -965,17 +966,18 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
                     number_of_segment = topSegmentIndex(new_index_well + 1) - new_top_segment_index;
                 }
 
-                auto segment_rates = this->segRates(w);
-                auto segment_pressure = this->segPress(w);
 
+                auto& segments = this->segments(wname);
+                const auto& prev_segments = prev_well_state->segments(wname);
+
+                segments.pressure = prev_segments.pressure;
+
+                auto segment_rates = this->segRates(w);
                 const auto prev_segment_rates = prev_well_state->segRates(old_index_well);
-                const auto prev_segment_pressure = prev_well_state->segPress(old_index_well);
 
                 for (int seg=0; seg < number_of_segment; ++seg) {
                     for (int p = 0; p < np; ++p)
                         segment_rates[seg*np + p] = prev_segment_rates[seg*np + p];
-
-                    segment_pressure[seg] = prev_segment_pressure[seg];
                 }
             }
         }
@@ -1149,7 +1151,7 @@ WellState::reportSegmentResults(const PhaseUsage& pu,
     {
         using Value = data::SegmentPressures::Value;
         auto& segpress = seg_res.pressures;
-        segpress[Value::Pressure] = this->segPress(well_id)[seg_ix];
+        segpress[Value::Pressure] = segments.pressure[seg_ix];
         segpress[Value::PDrop] = segments.pressure_drop(seg_ix);
         segpress[Value::PDropHydrostatic] = segments.pressure_drop_hydrostatic[seg_ix];
         segpress[Value::PDropFriction] = segments.pressure_drop_friction[seg_ix];

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -535,7 +535,6 @@ void WellState::init(const std::vector<double>& cellPressures,
         }
         //seg_rates_ = wellRates();
         seg_rates_.assign(nw*np, 0);
-        seg_pressdrop_hydorstatic_.assign(nw, 0.);
         seg_pressdrop_acceleration_.assign(nw, 0.);
     }
 
@@ -941,7 +940,6 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
     assert(int(seg_press_.size()) == nseg_);
     assert(int(seg_rates_.size()) == nseg_ * numPhases() );
 
-    seg_pressdrop_hydorstatic_.assign(nseg_, 0.);
     seg_pressdrop_acceleration_.assign(nseg_, 0.);
 
     if (prev_well_state && !prev_well_state->wellMap().empty()) {
@@ -1157,8 +1155,8 @@ WellState::reportSegmentResults(const PhaseUsage& pu,
         auto& segpress = seg_res.pressures;
         segpress[Value::Pressure] = this->segPress(well_id)[seg_ix];
         segpress[Value::PDrop] = this->segPressDrop(well_id, seg_ix);
-        segpress[Value::PDropHydrostatic] = this->segPressDropHydroStatic(well_id)[seg_ix];
         segpress[Value::PDropAccel] = this->segPressDropAcceleration(well_id)[seg_ix];
+        segpress[Value::PDropHydrostatic] = segments.pressure_drop_hydrostatic[seg_ix];
         segpress[Value::PDropFriction] = segments.pressure_drop_friction[seg_ix];
     }
 

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -220,14 +220,6 @@ public:
         return &seg_press_[top_segment_index];
     }
 
-    double segPressDrop(std::size_t well_index, std::size_t segment_index) const
-    {
-        const auto& segments = this->segments(well_index);
-        return segments.pressure_drop_friction[segment_index] +
-               segments.pressure_drop_hydrostatic[segment_index] +
-               segments.pressure_drop_accel[segment_index];
-    }
-
 
     int numSegment() const
     {

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -210,14 +210,14 @@ public:
 
     double * segPress(std::size_t well_index)
     {
-        const int top_segment_index = this->top_segment_index_[well_index];
-        return &seg_press_[top_segment_index];
+        auto& segment = this->segments(well_index);
+        return segment.pressure.data();
     }
 
     const double * segPress(std::size_t well_index) const
     {
-        const int top_segment_index = this->top_segment_index_[well_index];
-        return &seg_press_[top_segment_index];
+        const auto& segment = this->segments(well_index);
+        return segment.pressure.data();
     }
 
 
@@ -503,7 +503,6 @@ private:
     // MS well related
     // for StandardWell, the number of segments will be one
     std::vector<double> seg_rates_;
-    std::vector<double> seg_press_;
     // the index of the top segments, which is used to locate the
     // multisegment well related information in WellState
     std::vector<int> top_segment_index_;

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -197,8 +197,6 @@ public:
 
 
 
-    int topSegmentIndex(const int w) const;
-
 
     const SegmentState& segments(const std::size_t well_index) const {
         return this->segment_state[well_index];
@@ -471,11 +469,6 @@ private:
     WellContainer<Events> events_;
 
     WellContainer<SegmentState> segment_state;
-    // the index of the top segments, which is used to locate the
-    // multisegment well related information in WellState
-    std::vector<int> top_segment_index_;
-
-    // The following data are only recorded for output
 
     // Productivity Index
     std::vector<double> productivity_index_;

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -196,19 +196,6 @@ public:
     }
 
 
-    const double * segRates(std::size_t well_index) const
-    {
-        const int top_segment_index = this->top_segment_index_[well_index];
-        return &this->seg_rates_[top_segment_index * this->phase_usage_.num_phases];
-    }
-
-    double * segRates(std::size_t well_index)
-    {
-        const int top_segment_index = this->top_segment_index_[well_index];
-        return &this->seg_rates_[top_segment_index * this->phase_usage_.num_phases];
-    }
-
-
     int numSegment() const
     {
         return nseg_;
@@ -488,9 +475,6 @@ private:
     WellContainer<Events> events_;
 
     WellContainer<SegmentState> segment_state;
-    // MS well related
-    // for StandardWell, the number of segments will be one
-    std::vector<double> seg_rates_;
     // the index of the top segments, which is used to locate the
     // multisegment well related information in WellState
     std::vector<int> top_segment_index_;

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -208,18 +208,6 @@ public:
         return &this->seg_rates_[top_segment_index * this->phase_usage_.num_phases];
     }
 
-    double * segPress(std::size_t well_index)
-    {
-        auto& segment = this->segments(well_index);
-        return segment.pressure.data();
-    }
-
-    const double * segPress(std::size_t well_index) const
-    {
-        const auto& segment = this->segments(well_index);
-        return segment.pressure.data();
-    }
-
 
     int numSegment() const
     {

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -196,10 +196,6 @@ public:
     }
 
 
-    int numSegment() const
-    {
-        return nseg_;
-    }
 
     int topSegmentIndex(const int w) const;
 
@@ -478,7 +474,6 @@ private:
     // the index of the top segments, which is used to locate the
     // multisegment well related information in WellState
     std::vector<int> top_segment_index_;
-    int nseg_; // total number of the segments
 
     // The following data are only recorded for output
 

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -491,14 +491,6 @@ private:
     // Well potentials
     std::vector<double> well_potentials_;
 
-    /// Map segment index to segment number, mostly for MS wells.
-    ///
-    /// Segment number (one-based) of j-th segment in i-th well is
-    /// \code
-    ///    const auto top    = topSegmentIndex(i);
-    ///    const auto seg_No = seg_number_[top + j];
-    /// \end
-    std::vector<int> seg_number_;
 
     data::Segment
     reportSegmentResults(const PhaseUsage& pu,

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -237,6 +237,14 @@ public:
         return this->segment_state[well_index];
     }
 
+    const SegmentState& segments(const std::string& wname) const {
+        return this->segment_state[wname];
+    }
+
+    SegmentState& segments(const std::string& wname) {
+        return this->segment_state[wname];
+    }
+
     std::vector<double>& productivityIndex() {
         return productivity_index_;
     }

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -222,22 +222,11 @@ public:
 
     double segPressDrop(std::size_t well_index, std::size_t segment_index) const
     {
+        const auto& segments = this->segments(well_index);
         const int top_segment_index = this->top_segment_index_[well_index];
-        return this->seg_pressdrop_friction_[top_segment_index + segment_index] +
+        return segments.pressure_drop_friction[segment_index] +
                this->seg_pressdrop_hydorstatic_[top_segment_index + segment_index] +
                this->seg_pressdrop_acceleration_[top_segment_index + segment_index];
-    }
-
-    double* segPressDropFriction(std::size_t well_index)
-    {
-        const int top_segment_index = this->top_segment_index_[well_index];
-        return &seg_pressdrop_friction_[top_segment_index];
-    }
-
-    const double* segPressDropFriction(std::size_t well_index) const
-    {
-        const int top_segment_index = this->top_segment_index_[well_index];
-        return &seg_pressdrop_friction_[top_segment_index];
     }
 
     double* segPressDropHydroStatic(std::size_t well_index)
@@ -545,8 +534,6 @@ private:
     int nseg_; // total number of the segments
 
     // The following data are only recorded for output
-    // frictional pressure drop
-    std::vector<double> seg_pressdrop_friction_;
     // hydrostatic pressure drop
     std::vector<double> seg_pressdrop_hydorstatic_;
     // accelerational pressure drop

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -23,6 +23,7 @@
 
 #include <opm/simulators/wells/ALQState.hpp>
 #include <opm/simulators/wells/GlobalWellInfo.hpp>
+#include <opm/simulators/wells/SegmentState.hpp>
 #include <opm/simulators/wells/WellContainer.hpp>
 #include <opm/core/props/BlackoilPhases.hpp>
 #include <opm/simulators/wells/PerforationData.hpp>
@@ -269,6 +270,15 @@ public:
     }
 
     int topSegmentIndex(const int w) const;
+
+
+    const SegmentState& segments(const std::size_t well_index) const {
+        return this->segment_state[well_index];
+    }
+
+    SegmentState& segments(const std::size_t well_index) {
+        return this->segment_state[well_index];
+    }
 
     std::vector<double>& productivityIndex() {
         return productivity_index_;
@@ -524,6 +534,7 @@ private:
     // \Note: for now, only WCON* keywords, and well status change is considered
     WellContainer<Events> events_;
 
+    WellContainer<SegmentState> segment_state;
     // MS well related
     // for StandardWell, the number of segments will be one
     std::vector<double> seg_rates_;

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -225,20 +225,8 @@ public:
         const auto& segments = this->segments(well_index);
         const int top_segment_index = this->top_segment_index_[well_index];
         return segments.pressure_drop_friction[segment_index] +
-               this->seg_pressdrop_hydorstatic_[top_segment_index + segment_index] +
+               segments.pressure_drop_hydrostatic[segment_index] +
                this->seg_pressdrop_acceleration_[top_segment_index + segment_index];
-    }
-
-    double* segPressDropHydroStatic(std::size_t well_index)
-    {
-        const int top_segment_index = this->top_segment_index_[well_index];
-        return &seg_pressdrop_hydorstatic_[top_segment_index];
-    }
-
-    const double* segPressDropHydroStatic(std::size_t well_index) const
-    {
-        const int top_segment_index = this->top_segment_index_[well_index];
-        return &seg_pressdrop_hydorstatic_[top_segment_index];
     }
 
     double * segPressDropAcceleration(std::size_t well_index)
@@ -534,8 +522,6 @@ private:
     int nseg_; // total number of the segments
 
     // The following data are only recorded for output
-    // hydrostatic pressure drop
-    std::vector<double> seg_pressdrop_hydorstatic_;
     // accelerational pressure drop
     std::vector<double> seg_pressdrop_acceleration_;
 

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -223,23 +223,11 @@ public:
     double segPressDrop(std::size_t well_index, std::size_t segment_index) const
     {
         const auto& segments = this->segments(well_index);
-        const int top_segment_index = this->top_segment_index_[well_index];
         return segments.pressure_drop_friction[segment_index] +
                segments.pressure_drop_hydrostatic[segment_index] +
-               this->seg_pressdrop_acceleration_[top_segment_index + segment_index];
+               segments.pressure_drop_accel[segment_index];
     }
 
-    double * segPressDropAcceleration(std::size_t well_index)
-    {
-        const int top_segment_index = this->top_segment_index_[well_index];
-        return &seg_pressdrop_acceleration_[top_segment_index];
-    }
-
-    const double* segPressDropAcceleration(std::size_t well_index) const
-    {
-        const int top_segment_index = this->top_segment_index_[well_index];
-        return &seg_pressdrop_acceleration_[top_segment_index];
-    }
 
     int numSegment() const
     {
@@ -522,8 +510,6 @@ private:
     int nseg_; // total number of the segments
 
     // The following data are only recorded for output
-    // accelerational pressure drop
-    std::vector<double> seg_pressdrop_acceleration_;
 
     // Productivity Index
     std::vector<double> productivity_index_;

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -26,6 +26,7 @@
 #include <opm/simulators/wells/GlobalWellInfo.hpp>
 #include <opm/simulators/wells/ParallelWellInfo.hpp>
 #include <opm/simulators/wells/WellState.hpp>
+#include <opm/simulators/wells/SegmentState.hpp>
 #include <opm/simulators/wells/WellContainer.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
 
@@ -520,6 +521,21 @@ BOOST_AUTO_TEST_CASE(TESTWellContainer) {
 
     auto wx = wci.well_index("WX");
     BOOST_CHECK(!wx.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(TESTSegmentState) {
+    const Setup setup{ "msw.data" };
+    const auto& well = setup.sched.getWell("PROD01", 0);
+    const auto& segments = well.getSegments();
+    Opm::SegmentState ss1(3, segments);
+    Opm::SegmentState ss2;
+
+
+    ss1.pressure_drop_hydrostatic[0] = 1;
+    ss1.pressure_drop_friction[0] = 2;
+    ss1.pressure_drop_accel[0] = 3;
+
+    BOOST_CHECK_EQUAL(ss1.pressure_drop(0), 6);
 }
 
 

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -168,15 +168,13 @@ namespace {
 
         for (auto wellID = 0*nWell; wellID < nWell; ++wellID) {
             const auto& well     = wells[wellID];
-            const auto  pressTop = 100.0 * wellID;
-
-            auto* press = wstate.segPress(wellID);
-
-            press[0] = pressTop;
-
             if (! well.isMultiSegment()) {
                 continue;
             }
+
+            const auto  pressTop = 100.0 * wellID;
+            auto* press = wstate.segPress(wellID);
+            press[0] = pressTop;
 
             const auto& segSet = well.getSegments();
             const auto  nSeg   = segSet.size();
@@ -210,16 +208,16 @@ namespace {
 
         for (auto wellID = 0*nWell; wellID < nWell; ++wellID) {
             const auto& well     = wells[wellID];
+            if (! well.isMultiSegment()) {
+                continue;
+            }
+
             const auto  rateTop  = 1000.0 * wellID;
             auto segRates = wstate.segRates(wellID);
 
             if (wat) { segRates[iw] = rateTop; }
             if (oil) { segRates[io] = rateTop; }
             if (gas) { segRates[ig] = rateTop; }
-
-            if (! well.isMultiSegment()) {
-                continue;
-            }
 
             const auto& segSet = well.getSegments();
             const auto  nSeg   = segSet.size();
@@ -280,18 +278,6 @@ BOOST_AUTO_TEST_CASE(Pressure)
     const auto rpt = wstate.report(setup.grid.c_grid()->global_cell, [](const int){return false;});
 
     {
-        const auto& xw = rpt.at("INJE01");
-
-        BOOST_CHECK_EQUAL(xw.segments.size(), 1); // Top Segment
-
-        const auto& xseg = xw.segments.at(1);
-
-        BOOST_CHECK_EQUAL(xseg.segNumber, 1);
-        const auto pres_idx = Opm::data::SegmentPressures::Value::Pressure;
-        BOOST_CHECK_CLOSE(xseg.pressures[pres_idx], prod01_first ? 100.0 : 0.0, 1.0e-10);
-    }
-
-    {
         const auto expect_nSeg = 6;
         const auto& xw = rpt.at("PROD01");
 
@@ -333,26 +319,6 @@ BOOST_AUTO_TEST_CASE(Rates)
     const auto gas = pu.phase_used[Opm::BlackoilPhases::Vapour];
 
     BOOST_CHECK(wat && oil && gas);
-
-    {
-        const auto rateTop = prod01_first ? 1000.0 : 0.0;
-
-        const auto& xw = rpt.at("INJE01");
-
-        BOOST_CHECK_EQUAL(xw.segments.size(), 1); // Top Segment
-
-        const auto& xseg = xw.segments.at(1);
-
-        BOOST_CHECK_EQUAL(xseg.segNumber, 1);
-        BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::wat),
-                          rateTop, 1.0e-10);
-
-        BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::oil),
-                          rateTop, 1.0e-10);
-
-        BOOST_CHECK_CLOSE(xseg.rates.get(Opm::data::Rates::opt::gas),
-                          rateTop, 1.0e-10);
-    }
 
     {
         const auto expect_nSeg = 6;

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -519,6 +519,16 @@ BOOST_AUTO_TEST_CASE(TESTSegmentState2) {
     segments.pressure_drop_hydrostatic[0] = 4;
 
     BOOST_CHECK_EQUAL(segments.pressure_drop(0), 7);
+
+
+    for (std::size_t i=0; i < segments.pressure.size(); i++)
+        segments.pressure[i] = (i + 1);
+
+    const double bhp = 2.0;
+    segments.scale_pressure(bhp);
+
+    for (std::size_t i=0; i < segments.pressure.size(); i++)
+        BOOST_CHECK_EQUAL(segments.pressure[i], 2*(i+1));
 }
 
 

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -538,5 +538,23 @@ BOOST_AUTO_TEST_CASE(TESTSegmentState) {
     BOOST_CHECK_EQUAL(ss1.pressure_drop(0), 6);
 }
 
+BOOST_AUTO_TEST_CASE(TESTSegmentState2) {
+    const Setup setup{ "msw.data" };
+    std::vector<Opm::ParallelWellInfo> pinfo;
+    const auto wstate = buildWellState(setup, 0, pinfo);
+    const auto& well = setup.sched.getWell("PROD01", 0);
+
+    BOOST_CHECK_THROW(wstate.segments(100), std::exception);
+    auto segments = wstate.segments(1);   // PROD01 is well 1
+    BOOST_CHECK_EQUAL(segments.pressure.size(), well.getSegments().size());
+
+    segments.pressure_drop_friction[0] = 1;
+    segments.pressure_drop_accel[0] = 2;
+    segments.pressure_drop_hydrostatic[0] = 4;
+
+    BOOST_CHECK_EQUAL(segments.pressure_drop(0), 7);
+}
+
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -249,16 +249,10 @@ BOOST_AUTO_TEST_CASE(Linearisation)
     std::vector<Opm::ParallelWellInfo> pinfos;
     const auto wstate = buildWellState(setup, tstep, pinfos);
 
-    BOOST_CHECK_EQUAL(wstate.numSegment(), 6 + 1);
+    BOOST_CHECK_EQUAL(wstate.segments("PROD01").size(), 6);
 
     const auto& wells = setup.sched.getWellsatEnd();
     BOOST_CHECK_EQUAL(wells.size(), 2);
-
-    const auto prod01_first = wells[0].name() == "PROD01";
-
-    BOOST_CHECK_EQUAL(wstate.topSegmentIndex(0), 0);
-    BOOST_CHECK_EQUAL(wstate.topSegmentIndex(1),
-                      prod01_first ? 6 : 1);
 }
 
 // ---------------------------------------------------------------------

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -530,6 +530,8 @@ BOOST_AUTO_TEST_CASE(TESTSegmentState2) {
 
     for (std::size_t i=0; i < segments.pressure.size(); i++)
         BOOST_CHECK_EQUAL(segments.pressure[i], 2*(i+1));
+
+    BOOST_CHECK_EQUAL( segments.size(), well.getSegments().size() );
 }
 
 

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -213,7 +213,8 @@ namespace {
             }
 
             const auto  rateTop  = 1000.0 * wellID;
-            auto segRates = wstate.segRates(wellID);
+            auto& segments = wstate.segments(wellID);
+            auto& segRates = segments.rates;
 
             if (wat) { segRates[iw] = rateTop; }
             if (oil) { segRates[io] = rateTop; }

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -173,8 +173,8 @@ namespace {
             }
 
             const auto  pressTop = 100.0 * wellID;
-            auto* press = wstate.segPress(wellID);
-            press[0] = pressTop;
+            auto& segments = wstate.segments(wellID);
+            segments.pressure[0] = pressTop;
 
             const auto& segSet = well.getSegments();
             const auto  nSeg   = segSet.size();
@@ -182,7 +182,7 @@ namespace {
             for (auto segID = 0*nSeg + 1; segID < nSeg; ++segID) {
                 // One-based numbering scheme for segments.
                 const auto segNo = segSet[segID].segmentNumber();
-                press[segNo - 1] = pressTop + 1.0*(segNo - 1);
+                segments.pressure[segNo - 1] = pressTop + 1.0*(segNo - 1);
             }
         }
     }


### PR DESCRIPTION
This is an alternative to #3297.

Implement a small class `SegmentState` to manage the MSW properties of the WellState object.

This PR is complete; but there are also two partial PRs which can be reviewed & merged separately. 

Part1: #3324 

Part2: #3329


