### PR TITLE
Explicitly zero well potentials at the start of report step

### DIFF
--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -337,17 +337,13 @@ void WellState::init(const std::vector<double>& cellPressures,
         }
     }
 
-    perfRateSolvent_.clear();
-    perfRateSolvent_.resize(nperf, 0.0);
-    productivity_index_.resize(nw * this->numPhases(), 0.0);
-    conn_productivity_index_.resize(nperf * this->numPhases(), 0.0);
-    well_potentials_.resize(nw * this->numPhases(), 0.0);
+    perfRateSolvent_.assign(nperf, 0.0);
+    productivity_index_.assign(nw * this->numPhases(), 0.0);
+    conn_productivity_index_.assign(nperf * this->numPhases(), 0.0);
+    well_potentials_.assign(nw * this->numPhases(), 0.0);
 
-    perfRatePolymer_.clear();
-    perfRatePolymer_.resize(nperf, 0.0);
-
-    perfRateBrine_.clear();
-    perfRateBrine_.resize(nperf, 0.0);
+    perfRatePolymer_.assign(nperf, 0.0);
+    perfRateBrine_.assign(nperf, 0.0);
 
     for (int w = 0; w < nw; ++w) {
         switch (wells_ecl[w].getStatus()) {


### PR DESCRIPTION
This is more of a question than an actual PR. In current master the well potentials can carry over to the next report step; the logic is quite complex with respect to previous step closed or not .... I have not gone through it in all detail.


Point is that with: #3336 the wellpotensials are explicitly cleared at the start of the report step (and then fetched from previous if there is a relevant previous!). If this PR is correct there will be a data update.