### PR TITLE
MSW: drop unused method

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -199,8 +199,6 @@ namespace Opm
         /// int number_of_segments_;
         int numberOfSegments() const;
 
-        int numberOfPerforations() const;
-
         virtual std::vector<double> computeCurrentWellRates(const Simulator& ebosSimulator,
                                                             DeferredLogger& deferred_logger) const override;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1097,18 +1097,6 @@ namespace Opm
 
 
     template <typename TypeTag>
-    int
-    MultisegmentWell<TypeTag>::
-    numberOfPerforations() const
-    {
-        return segmentSet().number_of_perforations_;
-    }
-
-
-
-
-
-    template <typename TypeTag>
     WellSegments::CompPressureDrop
     MultisegmentWell<TypeTag>::
     compPressureDrop() const


### PR DESCRIPTION
Unused which is a good thing since it does not compile if you instance it. No such member in segmentSet()