### PR TITLE
Remove first perf member from Well classes

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -756,7 +756,6 @@ namespace Opm {
                                           this->numComponents(),
                                           this->numPhases(),
                                           wellID,
-                                          this->wellState().firstPerfIndex()[wellID],
                                           perf_data);
     }
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -129,7 +129,6 @@ namespace Opm
                          const int num_components,
                          const int num_phases,
                          const int index_of_well,
-                         const int first_perf_index,
                          const std::vector<PerforationData>& perf_data);
 
         virtual void init(const PhaseUsage* phase_usage_arg,
@@ -237,7 +236,6 @@ namespace Opm
         using Base::well_cells_;
         using Base::param_;
         using Base::well_index_;
-        using Base::first_perf_;
         using Base::saturation_table_number_;
         using Base::well_efficiency_factor_;
         using Base::gravity_;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -42,9 +42,8 @@ namespace Opm
                      const int num_components,
                      const int num_phases,
                      const int index_of_well,
-                     const int first_perf_index,
                      const std::vector<PerforationData>& perf_data)
-    : Base(well, pw_info, time_step, param, rate_converter, pvtRegionIdx, num_components, num_phases, index_of_well, first_perf_index, perf_data)
+    : Base(well, pw_info, time_step, param, rate_converter, pvtRegionIdx, num_components, num_phases, index_of_well, perf_data)
     , MultisegmentWellGeneric<Scalar>(static_cast<WellInterfaceGeneric&>(*this))
     , cell_perforation_depth_diffs_(number_of_perforations_, 0.0)
     , cell_perforation_pressure_diffs_(number_of_perforations_, 0.0)

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -155,7 +155,6 @@ namespace Opm
                      const int num_components,
                      const int num_phases,
                      const int index_of_well,
-                     const int first_perf_index,
                      const std::vector<PerforationData>& perf_data);
 
         virtual void init(const PhaseUsage* phase_usage_arg,
@@ -313,7 +312,6 @@ namespace Opm
         using Base::gravity_;
         using Base::param_;
         using Base::well_efficiency_factor_;
-        using Base::first_perf_;
         using Base::ref_depth_;
         using Base::perf_depth_;
         using Base::well_cells_;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -43,9 +43,8 @@ namespace Opm
                  const int num_components,
                  const int num_phases,
                  const int index_of_well,
-                 const int first_perf_index,
                  const std::vector<PerforationData>& perf_data)
-    : Base(well, pw_info, time_step, param, rate_converter, pvtRegionIdx, num_components, num_phases, index_of_well, first_perf_index, perf_data)
+    : Base(well, pw_info, time_step, param, rate_converter, pvtRegionIdx, num_components, num_phases, index_of_well, perf_data)
     , StandardWellGeneric<Scalar>(Bhp, pw_info, *this)
     , F0_(numWellConservationEq)
     {

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -138,7 +138,6 @@ public:
                   const int num_components,
                   const int num_phases,
                   const int index_of_well,
-                  const int first_perf_index,
                   const std::vector<PerforationData>& perf_data);
 
     /// Virtual destructor

--- a/opm/simulators/wells/WellInterfaceFluidSystem.cpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.cpp
@@ -50,11 +50,10 @@ WellInterfaceFluidSystem(const Well& well,
                          const int num_components,
                          const int num_phases,
                          const int index_of_well,
-                         const int first_perf_index,
                          const std::vector<PerforationData>& perf_data)
     : WellInterfaceGeneric(well, parallel_well_info, time_step,
                            pvtRegionIdx, num_components, num_phases,
-                           index_of_well, first_perf_index, perf_data)
+                           index_of_well, perf_data)
     , rateConverter_(rate_converter)
 {
 }

--- a/opm/simulators/wells/WellInterfaceFluidSystem.hpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.hpp
@@ -76,7 +76,6 @@ protected:
                              const int num_components,
                              const int num_phases,
                              const int index_of_well,
-                             const int first_perf_index,
                              const std::vector<PerforationData>& perf_data);
 
     // updating the voidage rates in well_state when requested

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -45,7 +45,6 @@ WellInterfaceGeneric::WellInterfaceGeneric(const Well& well,
                                            const int num_components,
                                            const int num_phases,
                                            const int index_of_well,
-                                           const int first_perf_index,
                                            const std::vector<PerforationData>& perf_data)
       : well_ecl_(well)
       , parallel_well_info_(pw_info)
@@ -54,7 +53,6 @@ WellInterfaceGeneric::WellInterfaceGeneric(const Well& well,
       , num_components_(num_components)
       , number_of_phases_(num_phases)
       , index_of_well_(index_of_well)
-      , first_perf_(first_perf_index)
       , perf_data_(&perf_data)
       , ipr_a_(number_of_phases_)
       , ipr_b_(number_of_phases_)

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -54,7 +54,6 @@ public:
                          const int num_components,
                          const int num_phases,
                          const int index_of_well,
-                         const int first_perf_index,
                          const std::vector<PerforationData>& perf_data);
 
     /// Well name.
@@ -227,10 +226,6 @@ protected:
 
     // the index of well in Wells struct
     int index_of_well_;
-
-    // record the index of the first perforation
-    // of states of individual well.
-    int first_perf_;
 
     const std::vector<PerforationData>* perf_data_;
 

--- a/opm/simulators/wells/WellInterfaceIndices.cpp
+++ b/opm/simulators/wells/WellInterfaceIndices.cpp
@@ -45,7 +45,6 @@ WellInterfaceIndices(const Well& well,
                      const int num_components,
                      const int num_phases,
                      const int index_of_well,
-                     const int first_perf_index,
                      const std::vector<PerforationData>& perf_data)
     : WellInterfaceFluidSystem<FluidSystem>(well,
                                             parallel_well_info,
@@ -55,7 +54,6 @@ WellInterfaceIndices(const Well& well,
                                             num_components,
                                             num_phases,
                                             index_of_well,
-                                            first_perf_index,
                                             perf_data)
     , WellInterfaceEval<FluidSystem>(static_cast<const WellInterfaceFluidSystem<FluidSystem>&>(*this))
 {

--- a/opm/simulators/wells/WellInterfaceIndices.hpp
+++ b/opm/simulators/wells/WellInterfaceIndices.hpp
@@ -47,7 +47,6 @@ protected:
                          const int num_components,
                          const int num_phases,
                          const int index_of_well,
-                         const int first_perf_index,
                          const std::vector<PerforationData>& perf_data);
 
     int flowPhaseToEbosCompIdx( const int phaseIdx ) const;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -39,7 +39,6 @@ namespace Opm
                   const int num_components,
                   const int num_phases,
                   const int index_of_well,
-                  const int first_perf_index,
                   const std::vector<PerforationData>& perf_data)
       : WellInterfaceIndices<FluidSystem,Indices,Scalar>(well,
                                                          pw_info,
@@ -49,7 +48,6 @@ namespace Opm
                                                          num_components,
                                                          num_phases,
                                                          index_of_well,
-                                                         first_perf_index,
                                                          perf_data)
       , param_(param)
     {

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -295,19 +295,15 @@ void WellState::init(const std::vector<double>& cellPressures,
         }
     }
 
-    first_perf_index_.resize(nw, 0);
-    first_perf_index_[0] = 0;
     for (int w = 0; w < nw; ++w) {
         // Initialize perfphaserates_ to well
         // rates divided by the number of perforations.
         const auto& wname = wells_ecl[w].name();
         const auto& well_info = this->wellMap().at(wname);
-        const int connpos = well_info[1];
         const int num_perf_this_well = well_info[2];
         const int global_num_perf_this_well = parallel_well_info[w]->communication().sum(num_perf_this_well);
         auto& perf_press = this->perfPress(w);
 
-        first_perf_index_[w] = connpos;
         auto& phase_rates = this->perfPhaseRates(w);
 
         for (int perf = 0; perf < num_perf_this_well; ++perf) {

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -153,11 +153,6 @@ public:
         return this->events_[well_index];
     }
 
-    const std::vector<int>& firstPerfIndex() const
-    {
-        return first_perf_index_;
-    }
-
     /// One rate pr well connection.
     std::vector<double>& perfRateSolvent(std::size_t well_index) {
         return this->perfRateSolvent_[well_index];
@@ -444,7 +439,6 @@ private:
     // vector with size number of wells +1.
     // iterate over all perforations of a given well
     // for (int perf = first_perf_index_[well_index]; perf < first_perf_index_[well_index] + num_perf_[well_index]; ++perf)
-    std::vector<int> first_perf_index_;
     WellContainer<Opm::Well::InjectorCMode> current_injection_controls_;
     WellContainer<Well::ProducerCMode> current_production_controls_;
 

--- a/tests/test_wellmodel.cpp
+++ b/tests/test_wellmodel.cpp
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(TestStandardWellInput) {
 
     Opm::ParallelWellInfo pinfo{well.name()};
 
-    BOOST_CHECK_THROW( StandardWell( well, pinfo, -1, param, *rateConverter, 0, 3, 3, 0, 0, pdata), std::invalid_argument);
+    BOOST_CHECK_THROW( StandardWell( well, pinfo, -1, param, *rateConverter, 0, 3, 3, 0, pdata), std::invalid_argument);
 }
 
 
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(TestBehavoir) {
             }
 
             Opm::ParallelWellInfo pinfo{wells_ecl[w].name()};
-            wells.emplace_back(new StandardWell(wells_ecl[w], pinfo, current_timestep, param, *rateConverter, 0, 3, 3, w, 0, pdata) );
+            wells.emplace_back(new StandardWell(wells_ecl[w], pinfo, current_timestep, param, *rateConverter, 0, 3, 3, w, pdata) );
         }
     }
 


### PR DESCRIPTION
The new perforation datastructeres in WellState do not need this any longer. 