### PR TITLE
Restore Debug Build

### DIFF
--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -821,7 +821,7 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
             // for the seg_rates_, now it becomes a recursive solution procedure.
             {
                 // make sure the information from wells_ecl consistent with wells
-                assert((n_activeperf == num_perf_this_well) &&
+                assert((n_activeperf == this->wellMap().at(well_ecl.name())[2]) &&
                        "Inconsistent number of reservoir connections in well");
 
                 if (pu.phase_used[Gas]) {


### PR DESCRIPTION
Commit 6a21371b5 (PR #3344) removed `num_perf_this_well` but did not make all requisite changes.  Fix an accompanying `assert` to restore builds that do not define `NDEBUG`.

Supersedes and closes #3356.