### PR TITLE
Chase Type Specific Aquifer Data API Change 

### DIFF
--- a/opm/simulators/aquifers/AquiferCarterTracy.hpp
+++ b/opm/simulators/aquifers/AquiferCarterTracy.hpp
@@ -81,15 +81,14 @@ public:
         }
         data.volume = this->W_flux_.value();
         data.initPressure = this->pa0_;
-        data.type = data::AquiferType::CarterTracy;
 
-        data.aquCT = std::make_shared<data::CarterTracyData>();
-        data.aquCT->timeConstant = this->aquct_data_.timeConstant();
-        data.aquCT->influxConstant = this->aquct_data_.influxConstant();
-        data.aquCT->waterDensity = this->aquct_data_.waterDensity();
-        data.aquCT->waterViscosity = this->aquct_data_.waterViscosity();
-        data.aquCT->dimensionless_time = this->dimensionless_time_;
-        data.aquCT->dimensionless_pressure = this->dimensionless_pressure_;
+        auto* aquCT = data.typeData.template create<data::AquiferType::CarterTracy>();
+        aquCT->timeConstant = this->aquct_data_.timeConstant();
+        aquCT->influxConstant = this->aquct_data_.influxConstant();
+        aquCT->waterDensity = this->aquct_data_.waterDensity();
+        aquCT->waterViscosity = this->aquct_data_.waterViscosity();
+        aquCT->dimensionless_time = this->dimensionless_time_;
+        aquCT->dimensionless_pressure = this->dimensionless_pressure_;
 
         return data;
     }

--- a/opm/simulators/aquifers/AquiferFetkovich.hpp
+++ b/opm/simulators/aquifers/AquiferFetkovich.hpp
@@ -27,6 +27,7 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <exception>
 #include <stdexcept>
+#include <utility>
 
 namespace Opm
 {
@@ -82,12 +83,11 @@ public:
                                         });
         data.volume = this->W_flux_.value();
         data.initPressure = this->pa0_;
-        data.type = data::AquiferType::Fetkovich;
 
-        data.aquFet = std::make_shared<data::FetkovichData>();
-        data.aquFet->initVolume = this->aqufetp_data_.initial_watvolume;
-        data.aquFet->prodIndex = this->aqufetp_data_.prod_index;
-        data.aquFet->timeConstant = this->aqufetp_data_.timeConstant();
+        auto* aquFet = data.typeData.template create<data::AquiferType::Fetkovich>();
+        aquFet->initVolume = this->aqufetp_data_.initial_watvolume;
+        aquFet->prodIndex = this->aqufetp_data_.prod_index;
+        aquFet->timeConstant = this->aqufetp_data_.timeConstant();
 
         return data;
     }
@@ -99,7 +99,7 @@ protected:
 
     void assignRestartData(const data::AquiferData& xaq) override
     {
-        if (xaq.type != data::AquiferType::Fetkovich) {
+        if (! xaq.typeData.is<data::AquiferType::Fetkovich>()) {
             throw std::invalid_argument {
                 "Analytic aquifer data for unexpected aquifer "
                 "type passed to Fetkovich aquifer"

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -83,14 +83,12 @@ BlackoilAquiferModel<TypeTag>::initFromRestart(const data::Aquifers& aquiferSoln
 template <typename TypeTag>
 void
 BlackoilAquiferModel<TypeTag>::beginEpisode()
-{
-}
+{}
 
 template <typename TypeTag>
 void
 BlackoilAquiferModel<TypeTag>::beginIteration()
-{
-}
+{}
 
 template <typename TypeTag>
 void
@@ -131,8 +129,7 @@ BlackoilAquiferModel<TypeTag>::addToSource(RateVector& rates,
 template <typename TypeTag>
 void
 BlackoilAquiferModel<TypeTag>::endIteration()
-{
-}
+{}
 
 template <typename TypeTag>
 void
@@ -155,11 +152,11 @@ BlackoilAquiferModel<TypeTag>::endTimeStep()
         }
     }
 }
+
 template <typename TypeTag>
 void
 BlackoilAquiferModel<TypeTag>::endEpisode()
-{
-}
+{}
 
 template <typename TypeTag>
 template <class Restarter>
@@ -215,12 +212,14 @@ BlackoilAquiferModel<TypeTag>::init()
         }
     }
 }
+
 template <typename TypeTag>
 bool
 BlackoilAquiferModel<TypeTag>::aquiferCarterTracyActive() const
 {
     return !aquifers_CarterTracy.empty();
 }
+
 template <typename TypeTag>
 bool
 BlackoilAquiferModel<TypeTag>::aquiferFetkovichActive() const
@@ -236,7 +235,8 @@ BlackoilAquiferModel<TypeTag>::aquiferNumericalActive() const
 }
 
 template<typename TypeTag>
-data::Aquifers BlackoilAquiferModel<TypeTag>::aquiferData() const {
+data::Aquifers BlackoilAquiferModel<TypeTag>::aquiferData() const
+{
     data::Aquifers data;
     if (this->aquiferCarterTracyActive()) {
         for (const auto& aqu : this->aquifers_CarterTracy) {

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -61,6 +61,7 @@ struct GroupData;
 struct GroupGuideRates;
 class GuideRateValue;
 struct NodeData;
+struct NumericAquiferData;
 class Rates;
 struct Segment;
 class Solution;
@@ -349,6 +350,7 @@ ADD_PACK_PROTOTYPES(data::GroupGuideRates)
 ADD_PACK_PROTOTYPES(data::GroupData)
 ADD_PACK_PROTOTYPES(data::NodeData)
 ADD_PACK_PROTOTYPES(data::GroupAndNetworkValues)
+ADD_PACK_PROTOTYPES(data::NumericAquiferData)
 ADD_PACK_PROTOTYPES(data::Well)
 ADD_PACK_PROTOTYPES(data::Wells)
 ADD_PACK_PROTOTYPES(RestartKey)

--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -265,14 +265,14 @@ Opm::data::NodeData getNodeData()
 Opm::data::AquiferData getFetkovichAquifer(const int aquiferID = 1)
 {
     auto aquifer = Opm::data::AquiferData {
-        aquiferID, 123.456, 56.78, 9.0e10, 290.0, 2515.5, Opm::data::AquiferType::Fetkovich
+        aquiferID, 123.456, 56.78, 9.0e10, 290.0, 2515.5
     };
 
-    aquifer.aquFet = std::make_shared<Opm::data::FetkovichData>();
+    auto* aquFet = aquifer.typeData.create<Opm::data::AquiferType::Fetkovich>();
 
-    aquifer.aquFet->initVolume = 1.23;
-    aquifer.aquFet->prodIndex = 45.67;
-    aquifer.aquFet->timeConstant = 890.123;
+    aquFet->initVolume = 1.23;
+    aquFet->prodIndex = 45.67;
+    aquFet->timeConstant = 890.123;
 
     return aquifer;
 }
@@ -280,17 +280,33 @@ Opm::data::AquiferData getFetkovichAquifer(const int aquiferID = 1)
 Opm::data::AquiferData getCarterTracyAquifer(const int aquiferID = 5)
 {
     auto aquifer = Opm::data::AquiferData {
-        aquiferID, 123.456, 56.78, 9.0e10, 290.0, 2515.5, Opm::data::AquiferType::CarterTracy
+        aquiferID, 123.456, 56.78, 9.0e10, 290.0, 2515.5
     };
 
-    aquifer.aquCT = std::make_shared<Opm::data::CarterTracyData>();
+    auto* aquCT = aquifer.typeData.create<Opm::data::AquiferType::CarterTracy>();
 
-    aquifer.aquCT->timeConstant = 987.65;
-    aquifer.aquCT->influxConstant = 43.21;
-    aquifer.aquCT->waterDensity = 1014.5;
-    aquifer.aquCT->waterViscosity = 0.00318;
-    aquifer.aquCT->dimensionless_time = 42.0;
-    aquifer.aquCT->dimensionless_pressure = 2.34;
+    aquCT->timeConstant = 987.65;
+    aquCT->influxConstant = 43.21;
+    aquCT->waterDensity = 1014.5;
+    aquCT->waterViscosity = 0.00318;
+    aquCT->dimensionless_time = 42.0;
+    aquCT->dimensionless_pressure = 2.34;
+
+    return aquifer;
+}
+
+Opm::data::AquiferData getNumericalAquifer(const int aquiferID = 2)
+{
+    auto aquifer = Opm::data::AquiferData {
+        aquiferID, 123.456, 56.78, 9.0e10, 290.0, 2515.5
+    };
+
+    auto* aquNum = aquifer.typeData.create<Opm::data::AquiferType::Numerical>();
+
+    aquNum->initPressure.push_back(1.234);
+    aquNum->initPressure.push_back(2.345);
+    aquNum->initPressure.push_back(3.4);
+    aquNum->initPressure.push_back(9.876);
 
     return aquifer;
 }
@@ -363,12 +379,21 @@ BOOST_AUTO_TEST_CASE(dataCarterTracyData)
     DO_CHECKS(data::CarterTracyData)
 }
 
+BOOST_AUTO_TEST_CASE(dataNumericAquiferData)
+{
+    const auto val1 = getNumericalAquifer();
+    const auto val2 = PackUnpack(val1);
+
+    DO_CHECKS(data::NumericAquiferData)
+}
+
 BOOST_AUTO_TEST_CASE(dataAquifers)
 {
     const auto val1 = Opm::data::Aquifers {
         { 1, getFetkovichAquifer(1) },
         { 4, getFetkovichAquifer(4) },
         { 5, getCarterTracyAquifer(5) },
+        { 9, getNumericalAquifer(9) },
     };
 
     const auto val2 = PackUnpack(val1);


### PR DESCRIPTION
This PR switches to using the new `typeData` interface for representing type-specific aquifer data items introduced in OPM/opm-common#2496.  In particular we use the new `typeData.is<>()` and `typeData.get<>()` member functions to query and access the data that is specific to each aquifer type (e.g., Carter-Tracy or numerical).

While here, also expand the reported data items for numerical aquifers to one initial pressure value for each aquifer cell.  This is needed for restart purposes.