### PR TITLE
Suggestion: Simplify check for number of perforations

### DIFF
--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -396,11 +396,7 @@ void WellState::init(const std::vector<double>& cellPressures,
                 }
 
                 const int num_perf_this_well = new_iter->second[2];
-
-                const int num_perf_changed = parallel_well_info[w]->communication()
-                    .sum(static_cast<int>(num_perf_old_well != num_perf_this_well));
-                const bool global_num_perf_same = num_perf_changed == 0;
-
+                const bool global_num_perf_same = (num_perf_this_well == num_perf_old_well);
 
                 // copy perforation rates when the number of
                 // perforations is equal, otherwise initialize


### PR DESCRIPTION
I might very well have misunderstood something here, but my understanding goes as follows:

1. We copy the state of the perforation rates from the previous step - this is good for convergence, but not essential for correctness.
2. If the number of the perforations have changed - either because new perforations have been specified in the input, or alternatively due to loadbalancing - we do not copy the previous perforation rates but rather initialize with an average rate.

In current master the check for change in perforation numbers is global - taking all processers into account, whereas I with this PR suggest checking just the local process for changes in number of perforations. I realize that this *can* optionally lead to a situation where perforations on process 1 get initialized by copying from previous state, whereas perforations on process 2 are initialized with an average rate - but as long as this is "just for convergence" I would say that was totally OK?