### PR TITLE
removed dissolved gas and vapporized oil from RESV injection rates

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -373,6 +373,10 @@ namespace Opm {
                            const int pvtreg,
                            std::vector<double>& resv_coeff) override;
 
+            void calcInjRates(const int fipnum,
+                           const int pvtreg,
+                           std::vector<double>& resv_coeff) override;
+
              void computeWellTemperature();
 
         private:

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -253,6 +253,9 @@ protected:
     virtual void calcRates(const int fipnum,
                            const int pvtreg,
                            std::vector<double>& resv_coeff) = 0;
+    virtual void calcInjRates(const int fipnum,
+                           const int pvtreg,
+                           std::vector<double>& resv_coeff) = 0;
 
     data::GuideRateValue getGuideRateValues(const Group& group) const;
     data::GuideRateValue getGuideRateValues(const Well& well) const;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1497,6 +1497,16 @@ namespace Opm {
         rateConverter_->calcCoeff(fipnum, pvtreg, resv_coeff);
     }
 
+    template<typename TypeTag>
+    void
+    BlackoilWellModel<TypeTag>::
+    calcInjRates(const int fipnum,
+              const int pvtreg,
+              std::vector<double>& resv_coeff)
+    {
+        rateConverter_->calcInjCoeff(fipnum, pvtreg, resv_coeff);
+    }
+
 
     template <typename TypeTag>
     void

--- a/opm/simulators/wells/WellInterfaceEval.cpp
+++ b/opm/simulators/wells/WellInterfaceEval.cpp
@@ -132,7 +132,7 @@ getGroupInjectionControl(const Group& group,
 
     // Make conversion factors for RESV <-> surface rates.
     std::vector<double> resv_coeff(pu.num_phases, 1.0);
-    baseif_.rateConverter().calcCoeff(0, baseif_.pvtRegionIdx(), resv_coeff); // FIPNUM region 0 here, should use FIPNUM from WELSPECS.
+    baseif_.rateConverter().calcInjCoeff(0, baseif_.pvtRegionIdx(), resv_coeff); // FIPNUM region 0 here, should use FIPNUM from WELSPECS.
 
     double sales_target = 0;
     if (schedule[baseif_.currentStep()].gconsale().has(group.name())) {
@@ -406,7 +406,7 @@ assembleControlEqInj_(const WellState& well_state,
     }
     case Well::InjectorCMode::RESV: {
         std::vector<double> convert_coeff(baseif_.numPhases(), 1.0);
-        baseif_.rateConverter().calcCoeff(/*fipreg*/ 0, baseif_.pvtRegionIdx(), convert_coeff);
+        baseif_.rateConverter().calcInjCoeff(/*fipreg*/ 0, baseif_.pvtRegionIdx(), convert_coeff);
 
         double coeff = 1.0;
 

--- a/opm/simulators/wells/WellInterfaceFluidSystem.cpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.cpp
@@ -308,7 +308,7 @@ checkGroupConstraintsInj(const Group& group,
 
     // Make conversion factors for RESV <-> surface rates.
     std::vector<double> resv_coeff(phaseUsage().num_phases, 1.0);
-    rateConverter_.calcCoeff(0, pvtRegionIdx_, resv_coeff); // FIPNUM region 0 here, should use FIPNUM from WELSPECS.
+    rateConverter_.calcInjCoeff(0, pvtRegionIdx_, resv_coeff); // FIPNUM region 0 here, should use FIPNUM from WELSPECS.
 
     // Call check for the well's injection phase.
     return WellGroupHelpers::checkGroupConstraintsInj(name(),


### PR DESCRIPTION
The standard RESV coefficients use the average RS and RV values from the reservoir. For injection we assume no dissolved gas or vaporized oil. This is supposed to fix the issue reported by @bska in #3349 