### PR TITLE
Scale well rates after group switching

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -286,10 +286,10 @@ protected:
                                const int reportStepIdx,
                                DeferredLogger& deferred_logger) const;
 
-    Group::InjectionCMode checkGroupInjectionConstraints(const Group& group,
+    std::pair<Group::InjectionCMode, double> checkGroupInjectionConstraints(const Group& group,
                                                          const int reportStepIdx,
                                                          const Phase& phase) const;
-    Group::ProductionCMode checkGroupProductionConstraints(const Group& group,
+    std::pair<Group::ProductionCMode, double> checkGroupProductionConstraints(const Group& group,
                                                            const int reportStepIdx,
                                                            DeferredLogger& deferred_logger) const;
 

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -423,6 +423,76 @@ namespace WellGroupHelpers
             group_state.update_production_reduction_rates(group.name(), groupTargetReduction);
     }
 
+    void updateWellRatesFromGroupTargetScale(const double scale,
+                                             const Group& group,
+                                             const Schedule& schedule,
+                                             const int reportStepIdx,
+                                             bool isInjector,
+                                             const GroupState& group_state,
+                                             WellState& wellState) {
+        for (const std::string& groupName : group.groups()) {
+            bool individual_control = false;
+            if (isInjector) {
+                const Phase all[] = {Phase::WATER, Phase::OIL, Phase::GAS};
+                for (Phase phase : all) {
+                    const Group::InjectionCMode& currentGroupControl
+                            = group_state.injection_control(groupName, phase);
+                    individual_control = individual_control || (currentGroupControl != Group::InjectionCMode::FLD
+                                                     && currentGroupControl != Group::InjectionCMode::NONE);
+                }
+            } else {
+                const Group::ProductionCMode& currentGroupControl = group_state.production_control(groupName);
+                individual_control = (currentGroupControl != Group::ProductionCMode::FLD
+                                                 && currentGroupControl != Group::ProductionCMode::NONE);
+            }
+            if (!individual_control) {
+                const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+                updateWellRatesFromGroupTargetScale(scale, groupTmp, schedule, reportStepIdx, isInjector, group_state, wellState);
+            }
+        }
+
+        const int np = wellState.numPhases();
+        for (const std::string& wellName : group.wells()) {
+            const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
+
+            if (wellTmp.isProducer() && isInjector)
+                continue;
+
+            if (wellTmp.isInjector() && !isInjector)
+                continue;
+
+            if (wellTmp.getStatus() == Well::Status::SHUT)
+                continue;
+
+            const auto& end = wellState.wellMap().end();
+            const auto& it = wellState.wellMap().find(wellName);
+            if (it == end) // the well is not found
+                continue;
+
+            int well_index = it->second[0];
+
+            if (! wellState.wellIsOwned(well_index, wellName) ) // Only sum once
+            {
+                continue;
+            }
+
+            // scale rates
+            if (isInjector) {
+                if (wellState.currentInjectionControl(well_index) == Well::InjectorCMode::GRUP)
+                    for (int phase = 0; phase < np; phase++) {
+                        wellState.wellRates(well_index)[phase] *= scale;
+                    }
+            } else {
+                if (wellState.currentProductionControl(well_index) == Well::ProducerCMode::GRUP)
+                    for (int phase = 0; phase < np; phase++) {
+                        wellState.wellRates(well_index)[phase] *= scale;
+                    }
+            }
+        }
+
+
+    }
+
 
     void updateVREPForGroups(const Group& group,
                              const Schedule& schedule,
@@ -1100,7 +1170,10 @@ namespace WellGroupHelpers
         }
         // Avoid negative target rates comming from too large local reductions.
         const double target_rate = std::max(1e-12, target / efficiencyFactorInclGroup);
-        return std::make_pair(current_rate > target_rate, target_rate / current_rate);
+        double scale = 1.0;
+        if (current_rate > 1e-12)
+            scale = target_rate / current_rate;
+        return std::make_pair(current_rate > target_rate, scale);
     }
 
     std::pair<bool, double> checkGroupConstraintsInj(const std::string& name,
@@ -1224,7 +1297,10 @@ namespace WellGroupHelpers
         }
         // Avoid negative target rates comming from too large local reductions.
         const double target_rate = std::max(1e-12, target / efficiencyFactorInclGroup);
-        return std::make_pair(current_rate > target_rate, target_rate / current_rate);
+        double scale = 1.0;
+        if (current_rate > 1e-12)
+            scale = target_rate / current_rate;
+        return std::make_pair(current_rate > target_rate, scale);
     }
 
     template <class Comm>

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -158,6 +158,14 @@ namespace WellGroupHelpers
                                     WellState& wellState,
                                     GroupState& group_state);
 
+    void updateWellRatesFromGroupTargetScale(const double scale,
+                                             const Group& group,
+                                             const Schedule& schedule,
+                                             const int reportStepIdx,
+                                             bool isInjector,
+                                             const GroupState& group_state,
+                                             WellState& wellState);
+
     void updateREINForGroups(const Group& group,
                              const Schedule& schedule,
                              const int reportStepIdx,


### PR DESCRIPTION
This PR does two things
1) It scales the well rates for wells under group control when its groups control changes
2) It adds an epsilon to avoid inf scales for wells with current rate zero. 

It still under testing. But I will make a draft PR to utilize our testing framework. 
