### PR TITLE
 Add keyword validation using a predicate function

### DIFF
--- a/opm/simulators/flow/KeywordValidation.cpp
+++ b/opm/simulators/flow/KeywordValidation.cpp
@@ -109,6 +109,7 @@ namespace KeywordValidation
             // Otherwise, check all its items.
             validateKeywordItems(keyword, m_string_items, errors);
             validateKeywordItems(keyword, m_int_items, errors);
+            validateKeywordItems(keyword, m_double_items, errors);
         }
     }
 
@@ -152,8 +153,7 @@ namespace KeywordValidation
                                                const T& item_value,
                                                std::vector<ValidationError>& errors) const
     {
-        const auto& permitted = properties.permitted_values;
-        if (std::find(permitted.begin(), permitted.end(), item_value) == permitted.end()) {
+        if (!properties.validator(item_value)) {
             // If the value is not permitted, format the value to report it.
             std::string formatted_value;
             if constexpr (std::is_arithmetic<T>::value)

--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -19,32 +19,33 @@
 
 #include <opm/simulators/utils/PartiallySupportedFlowKeywords.hpp>
 
+using namespace Opm::KeywordValidation;
 namespace Opm::FlowKeywordValidation
 {
 
-template<>
-const KeywordValidation::PartiallySupportedKeywords<std::string>&
+template <>
+const PartiallySupportedKeywords<std::string>&
 partiallySupported()
 {
-    static const KeywordValidation::PartiallySupportedKeywords<std::string> partially_supported_keywords_strings = {
+    static const PartiallySupportedKeywords<std::string> partially_supported_keywords_strings = {
         {
             "COMPORD",
             {
-                {2, {false, {"INPUT"}, std::nullopt}}, // ORDER_TYPE
+                {2, {false, allow_values<std::string>{"INPUT"}, std::nullopt}}, // ORDER_TYPE
             },
         },
         {
             "ENDSCALE",
             {
-                {1, {false, {"NODIR"}, std::nullopt}}, // DIRECT
-                {2, {false, {"REVERS"}, std::nullopt}}, // IRREVERS
+                {1, {false, allow_values<std::string>{"NODIR"}, std::nullopt}}, // DIRECT
+                {2, {false, allow_values<std::string>{"REVERS"}, std::nullopt}}, // IRREVERS
             },
         },
         {
             "PINCH",
             {
-                {2, {false, {"GAP"}, std::nullopt}}, // GAP
-                {4, {false, {"TOPBOT"}, std::nullopt}}, // PINCHOUT_OPTION
+                {2, {false, allow_values<std::string>{"GAP"}, std::nullopt}}, // GAP
+                {4, {false, allow_values<std::string>{"TOPBOT"}, std::nullopt}}, // PINCHOUT_OPTION
             },
         },
     };
@@ -52,20 +53,29 @@ partiallySupported()
     return partially_supported_keywords_strings;
 }
 
-template<>
-const KeywordValidation::PartiallySupportedKeywords<int>&
+template <>
+const PartiallySupportedKeywords<int>&
 partiallySupported()
 {
-    static const KeywordValidation::PartiallySupportedKeywords<int> partially_supported_keywords_int = {
+    static const PartiallySupportedKeywords<int> partially_supported_keywords_int = {
         {
             "EHYSTR",
             {
-                {2, {false, {0}, std::nullopt}}, //relative_perm_hyst
+                {2, {false, allow_values<int>{0}, std::nullopt}}, // relative_perm_hyst
             },
         },
     };
 
     return partially_supported_keywords_int;
+}
+
+template <>
+const PartiallySupportedKeywords<double>&
+partiallySupported()
+{
+    static const PartiallySupportedKeywords<double> partially_supported_keywords_double = {};
+
+    return partially_supported_keywords_double;
 }
 
 } // namespace Opm::FlowKeywordValidation

--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.hpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.hpp
@@ -36,16 +36,17 @@
     This struct has the following fields:
 
     critical (bool) : if this is a critical error.
-    permitted_values (vector of strings) : the list of values that is allowed.
+    validator (function wrapper) : A function wrapper object that is used to test values.
     message (itemal string): an optional message to add to the error reported by flow.
 
-    Below is the set of partiall supported keywords, currently used by flow.
+    For convenience there is a small class KeywordValidation::allow_values which
+    can be initialized with a list of permitted values, and used as a validator.
 */
 
 namespace Opm::FlowKeywordValidation
 {
 
-template<typename T>
+template <typename T>
 const KeywordValidation::PartiallySupportedKeywords<T>& partiallySupported();
 
 } // namespace Opm::FlowKeywordValidation

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -210,7 +210,8 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
                 Opm::KeywordValidation::KeywordValidator keyword_validator(
                     Opm::FlowKeywordValidation::unsupportedKeywords(),
                     Opm::FlowKeywordValidation::partiallySupported<std::string>(),
-                    Opm::FlowKeywordValidation::partiallySupported<int>());
+                    Opm::FlowKeywordValidation::partiallySupported<int>(),
+                    Opm::FlowKeywordValidation::partiallySupported<double>());
                 keyword_validator.validateDeck(*deck, *parseContext, *errorGuard);
 
                 if ( checkDeck )


### PR DESCRIPTION
The recently added keyword validation code could only check values of items against a list of options. This pull request adds the option to call a predicate function to test the value of an item. This allows for a broad range of tests, such as checking the sign of a value, or for  a range of values. The cost in complications of the specification of the validations is minor: one field is added to the struct used to define a check.

A test has been added that demonstrates this approach using a lambda function as a predicate.

In addition to this improvement, checking of items with double value types has been added.

**EDIT:** Decided to go for the simpler solution. Everything is done via a validator function, and a small helper class was added to be able to easily define lists of permitted values. Small change to the keyword definition structures that the user needs to write, but they are also clearer. 