### PR TITLE
fixed: do not assert conditions guaranteed by unsigned

### DIFF
--- a/ebos/eclfluxmodule.hh
+++ b/ebos/eclfluxmodule.hh
@@ -181,7 +181,7 @@ protected:
      */
     unsigned upstreamIndex_(unsigned phaseIdx) const
     {
-        assert(0 <= phaseIdx && phaseIdx < numPhases);
+        assert(phaseIdx < numPhases);
 
         return upIdx_[phaseIdx];
     }
@@ -195,7 +195,7 @@ protected:
      */
     unsigned downstreamIndex_(unsigned phaseIdx) const
     {
-        assert(0 <= phaseIdx && phaseIdx < numPhases);
+        assert(phaseIdx < numPhases);
 
         return dnIdx_[phaseIdx];
     }

--- a/opm/simulators/utils/DeferredLogger.cpp
+++ b/opm/simulators/utils/DeferredLogger.cpp
@@ -17,8 +17,9 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
+#include <config.h>
 #include <opm/simulators/utils/DeferredLogger.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
 
 namespace Opm
 {

--- a/opm/simulators/utils/DeferredLogger.hpp
+++ b/opm/simulators/utils/DeferredLogger.hpp
@@ -21,8 +21,6 @@
 #ifndef OPM_DEFERREDLOGGER_HEADER_INCLUDED
 #define OPM_DEFERREDLOGGER_HEADER_INCLUDED
 
-#include <opm/common/OpmLog/OpmLog.hpp>
-
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
It makes gcc10 emit a warning. Also a minor header cleanup.