### PR TITLE
quell dune2.7+ warning

### DIFF
--- a/ebos/collecttoiorank.cc
+++ b/ebos/collecttoiorank.cc
@@ -28,6 +28,7 @@
 #include <opm/grid/CpGrid.hpp>
 #include <opm/grid/polyhedralgrid.hh>
 
+#include <dune/common/version.hh>
 #include <dune/grid/common/gridenums.hh>
 #include <dune/grid/common/mcmgmapper.hh>
 #if HAVE_DUNE_FEM
@@ -197,7 +198,11 @@ public:
         : sendMapper_(sendMapper), recvMapper_(recvMapper), elementIndices_(elementIndices)
     {}
     using DataType = int;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int /*dim*/, int /*codim*/)
+#else
     bool fixedsize(int /*dim*/, int /*codim*/)
+#endif
     {
         return true;
     }
@@ -237,7 +242,11 @@ public:
         : mapper_(mapper), elementIndices_(elementIndices)
     {}
     using DataType = int;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    bool fixedSize(int /*dim*/, int /*codim*/)
+#else
     bool fixedsize(int /*dim*/, int /*codim*/)
+#endif
     {
         return true;
     }

--- a/ebos/eclgenericoutputblackoilmodule.hh
+++ b/ebos/eclgenericoutputblackoilmodule.hh
@@ -39,7 +39,12 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
-#include <dune/common/parallel/mpicollectivecommunication.hh>
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+#include <dune/common/parallel/communication.hh>
+#else
+#include <dune/common/parallel/collectivecommunication.hh>
+#endif
 #include <dune/common/parallel/mpihelper.hh>
 
 namespace Opm {


### PR DESCRIPTION
Debian 11 is near, and then ci will move to 2.7. Let us be ready.