### PR TITLE
added: use extern template for opm-material types

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -56,6 +56,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/timestepping/gatherConvergenceReport.cpp
   opm/simulators/utils/DeferredLogger.cpp
   opm/simulators/utils/gatherDeferredLogger.cpp
+  opm/simulators/utils/OpmMaterialTypes.cpp
   opm/simulators/utils/ParallelFileMerger.cpp
   opm/simulators/utils/ParallelRestart.cpp
   opm/simulators/wells/ALQState.cpp

--- a/ebos/ebos.hh
+++ b/ebos/ebos.hh
@@ -28,6 +28,8 @@
 #ifndef EBOS_HH
 #define EBOS_HH
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
+
 #include "eclproblem.hh"
 
 #include <opm/simulators/wells/BlackoilWellModel.hpp>

--- a/flow/flow_blackoil_dunecpr.cpp
+++ b/flow/flow_blackoil_dunecpr.cpp
@@ -20,6 +20,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <opm/simulators/flow/Main.hpp>
 #include  <opm/simulators/linalg/ISTLSolverEbosFlexible.hpp>
 

--- a/flow/flow_blackoil_poly.cpp
+++ b/flow/flow_blackoil_poly.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "config.h"
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
 namespace Opm::Properties {

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -16,6 +16,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_blackoil.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -16,6 +16,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_brine.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -16,6 +16,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_energy.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_ebos_extbo.cpp
+++ b/flow/flow_ebos_extbo.cpp
@@ -16,6 +16,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_extbo.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -16,6 +16,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_foam.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -16,6 +16,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_gasoil.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_ebos_gaswater.cpp
+++ b/flow/flow_ebos_gaswater.cpp
@@ -19,6 +19,7 @@
 // Define making clear that the simulator supports AMG
 #define FLOW_SUPPORT_AMG 1
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_gaswater.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -16,6 +16,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_oilwater.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_ebos_oilwater_brine.cpp
+++ b/flow/flow_ebos_oilwater_brine.cpp
@@ -16,6 +16,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_oilwater_brine.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -16,6 +16,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_oilwater_polymer.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_ebos_oilwater_polymer_injectivity.cpp
+++ b/flow/flow_ebos_oilwater_polymer_injectivity.cpp
@@ -16,6 +16,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_oilwater_polymer_injectivity.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -16,6 +16,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_polymer.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -16,6 +16,7 @@
 */
 #include "config.h"
 
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <flow/flow_ebos_solvent.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>

--- a/flow/flow_onephase.cpp
+++ b/flow/flow_onephase.cpp
@@ -18,7 +18,9 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "config.h"
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/models/blackoil/blackoilonephaseindices.hh>
 

--- a/flow/flow_onephase_energy.cpp
+++ b/flow/flow_onephase_energy.cpp
@@ -18,7 +18,9 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "config.h"
+#include <opm/simulators/utils/OpmMaterialTypes.hpp>
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/models/blackoil/blackoilonephaseindices.hh>
 

--- a/opm/simulators/utils/OpmMaterialTypes.cpp
+++ b/opm/simulators/utils/OpmMaterialTypes.cpp
@@ -1,0 +1,115 @@
+/*
+  Copyright 2021 Equinor AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#include <opm/material/common/Tabulated1DFunction.hpp>
+#include <opm/material/common/UniformTabulated2DFunction.hpp>
+#include <opm/material/common/UniformXTabulated2DFunction.hpp>
+
+#include <opm/material/densead/Evaluation1.hpp>
+#include <opm/material/densead/Evaluation2.hpp>
+#include <opm/material/densead/Evaluation3.hpp>
+#include <opm/material/densead/Evaluation4.hpp>
+#include <opm/material/densead/Evaluation5.hpp>
+#include <opm/material/densead/Evaluation6.hpp>
+#include <opm/material/densead/Evaluation7.hpp>
+#include <opm/material/densead/Evaluation8.hpp>
+#include <opm/material/densead/Evaluation9.hpp>
+#include <opm/material/densead/Evaluation10.hpp>
+#include <opm/material/densead/Evaluation11.hpp>
+#include <opm/material/densead/Evaluation12.hpp>
+
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/SolventPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp>
+
+#include <opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp>
+
+#include <opm/material/constraintsolvers/NcpFlash.hpp>
+
+namespace Opm {
+
+template class Tabulated1DFunction<double>;
+template class UniformTabulated2DFunction<double>;
+template class UniformXTabulated2DFunction<double>;
+
+template class DenseAd::Evaluation<double,1>;
+template class DenseAd::Evaluation<double,2>;
+template class DenseAd::Evaluation<double,3>;
+template class DenseAd::Evaluation<double,4>;
+template class DenseAd::Evaluation<double,5>;
+template class DenseAd::Evaluation<double,6>;
+template class DenseAd::Evaluation<double,7>;
+template class DenseAd::Evaluation<double,8>;
+template class DenseAd::Evaluation<double,9>;
+template class DenseAd::Evaluation<double,10>;
+template class DenseAd::Evaluation<double,11>;
+template class DenseAd::Evaluation<double,12>;
+
+template class DenseAd::Evaluation<double,-1,4u>;
+template class DenseAd::Evaluation<double,-1,5u>;
+template class DenseAd::Evaluation<double,-1,6u>;
+template class DenseAd::Evaluation<double,-1,7u>;
+template class DenseAd::Evaluation<double,-1,8u>;
+template class DenseAd::Evaluation<double,-1,9u>;
+template class DenseAd::Evaluation<double,-1,10u>;
+
+template class BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>;
+
+template class BrineCo2Pvt<double>;
+template class Co2GasPvt<double>;
+template class ConstantCompressibilityBrinePvt<double>;
+template class ConstantCompressibilityOilPvt<double>;
+template class ConstantCompressibilityWaterPvt<double>;
+template class DeadOilPvt<double>;
+template class DryGasPvt<double>;
+template class GasPvtThermal<double>;
+template class LiveOilPvt<double>;
+template class OilPvtThermal<double>;
+template class SolventPvt<double>;
+template class WaterPvtThermal<double>;
+template class WetGasPvt<double>;
+
+template class GasPvtMultiplexer<double, false>;
+template class GasPvtMultiplexer<double, true>;
+template class OilPvtMultiplexer<double, false>;
+template class OilPvtMultiplexer<double, true>;
+template class WaterPvtMultiplexer<double, false>;
+template class WaterPvtMultiplexer<double, true>;
+
+template class EclEpsScalingPoints<double>;
+
+template class NcpFlash<double, BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>>;
+
+}

--- a/opm/simulators/utils/OpmMaterialTypes.hpp
+++ b/opm/simulators/utils/OpmMaterialTypes.hpp
@@ -1,0 +1,119 @@
+/*
+  Copyright 2021 Equinor AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_MATERIAL_TYPES_HPP
+#define OPM_MATERIAL_TYPES_HPP
+
+#include <opm/material/common/IntervalTabulated2DFunction.hpp>
+#include <opm/material/common/Tabulated1DFunction.hpp>
+#include <opm/material/common/UniformTabulated2DFunction.hpp>
+#include <opm/material/common/UniformXTabulated2DFunction.hpp>
+
+#include <opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp>
+
+#include <opm/material/densead/Evaluation1.hpp>
+#include <opm/material/densead/Evaluation2.hpp>
+#include <opm/material/densead/Evaluation3.hpp>
+#include <opm/material/densead/Evaluation4.hpp>
+#include <opm/material/densead/Evaluation5.hpp>
+#include <opm/material/densead/Evaluation6.hpp>
+#include <opm/material/densead/Evaluation7.hpp>
+#include <opm/material/densead/Evaluation8.hpp>
+#include <opm/material/densead/Evaluation9.hpp>
+#include <opm/material/densead/Evaluation10.hpp>
+#include <opm/material/densead/Evaluation11.hpp>
+#include <opm/material/densead/Evaluation12.hpp>
+
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/SolventPvt.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp>
+#include <opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp>
+
+#include <opm/material/constraintsolvers/NcpFlash.hpp>
+
+namespace Opm {
+
+extern template class IntervalTabulated2DFunction<double>;
+extern template class Tabulated1DFunction<double>;
+extern template class UniformTabulated2DFunction<double>;
+extern template class UniformXTabulated2DFunction<double>;
+
+extern template class DenseAd::Evaluation<double,1>;
+extern template class DenseAd::Evaluation<double,2>;
+extern template class DenseAd::Evaluation<double,3>;
+extern template class DenseAd::Evaluation<double,4>;
+extern template class DenseAd::Evaluation<double,5>;
+extern template class DenseAd::Evaluation<double,6>;
+extern template class DenseAd::Evaluation<double,7>;
+extern template class DenseAd::Evaluation<double,8>;
+extern template class DenseAd::Evaluation<double,9>;
+extern template class DenseAd::Evaluation<double,10>;
+extern template class DenseAd::Evaluation<double,11>;
+extern template class DenseAd::Evaluation<double,12>;
+
+extern template class DenseAd::Evaluation<double,-1,4u>;
+extern template class DenseAd::Evaluation<double,-1,5u>;
+extern template class DenseAd::Evaluation<double,-1,6u>;
+extern template class DenseAd::Evaluation<double,-1,7u>;
+extern template class DenseAd::Evaluation<double,-1,8u>;
+extern template class DenseAd::Evaluation<double,-1,9u>;
+extern template class DenseAd::Evaluation<double,-1,10u>;
+
+extern template class BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>;
+
+extern template class BrineCo2Pvt<double>;
+extern template class Co2GasPvt<double>;
+extern template class ConstantCompressibilityBrinePvt<double>;
+extern template class ConstantCompressibilityOilPvt<double>;
+extern template class ConstantCompressibilityWaterPvt<double>;
+extern template class DeadOilPvt<double>;
+extern template class DryGasPvt<double>;
+extern template class GasPvtThermal<double>;
+extern template class LiveOilPvt<double>;
+extern template class OilPvtThermal<double>;
+extern template class SolventPvt<double>;
+extern template class WaterPvtThermal<double>;
+extern template class WetGasPvt<double>;
+
+extern template class GasPvtMultiplexer<double, false>;
+extern template class GasPvtMultiplexer<double, true>;
+extern template class OilPvtMultiplexer<double, false>;
+extern template class OilPvtMultiplexer<double, true>;
+extern template class WaterPvtMultiplexer<double, false>;
+extern template class WaterPvtMultiplexer<double, true>;
+
+extern template class EclEpsScalingPoints<double>;
+
+extern template class NcpFlash<double, BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>>;
+
+}
+
+#endif


### PR DESCRIPTION
use this to build instances in a separate compile unit.

This yields a small speedup on my machine, but also has the potential to reduce inlining a little, so I'm not sure if the tradeoff is worth it.