### PR TITLE
Restart summary only

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -82,14 +82,20 @@ endfunction()
 #   - This test class compares the output from a restarted simulation
 #     to that of a non-restarted simulation.
 function(add_test_compare_restarted_simulation)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR)
+  set(oneValueArgs CASENAME FILENAME SIMULATOR TEST_NAME ABS_TOL REL_TOL DIR)
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_DIR)
     set(PARAM_DIR ${PARAM_CASENAME})
   endif()
+  if (PARAM_TEST_NAME)
+    set(TEST_NAME ${PARAM_TEST_NAME})
+  else()
+    set(TEST_NAME compareRestartedSim_${PARAM_SIMULATOR}+${PARAM_FILENAME})
+  endif()
+
   set(RESULT_PATH ${BASE_RESULT_PATH}/restart/${PARAM_SIMULATOR}+${PARAM_CASENAME})
-  opm_add_test(compareRestartedSim_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
+  opm_add_test(${TEST_NAME} NO_COMPILE
                EXE_NAME ${PARAM_SIMULATOR}
                DRIVER_ARGS ${OPM_TESTS_ROOT}/${PARAM_DIR} ${RESULT_PATH}
                            ${PROJECT_BINARY_DIR}/bin

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -940,6 +940,20 @@ add_test_compare_restarted_simulation(CASENAME msw_3d_hfa
                                       REL_TOL ${rel_tol_restart_msw}
                                       TEST_ARGS --enable-adaptive-time-stepping=false --sched-restart=true)
 
+
+# Basic restart tests which only compare the summary output, this test driver should
+# only be used in situations where it is challenging to get agreement in the restart file.
+opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-summary-restart-regressionTest.sh "")
+
+add_test_compare_restarted_simulation(CASENAME spe1
+                                      FILENAME SPE1CASE2_ACTNUM
+                                      SIMULATOR flow
+                                      TEST_NAME restart_spe1_summary
+                                      ABS_TOL ${abs_tol_restart}
+                                      REL_TOL ${rel_tol_restart}
+                                      TEST_ARGS --sched-restart=false)
+
+
 # PORV test
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-porv-acceptanceTest.sh "")
 add_test_compareECLFiles(CASENAME norne

--- a/tests/run-summary-restart-regressionTest.sh
+++ b/tests/run-summary-restart-regressionTest.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# This runs a simulator from start to end, then a restarted run of the
+# simulator. Finally the *summary output* from the the two simulations is
+# compared. Primarily the driver 'run-restart-regressionTest.sh' should be used,
+# but in situations where it is difficult to get the restart files to agree this
+# script can be used as second-best alternative.
+
+INPUT_DATA_PATH="$1"
+RESULT_PATH="$2"
+BINPATH="$3"
+FILENAME="$4"
+ABS_TOL="$5"
+REL_TOL="$6"
+COMPARE_ECL_COMMAND="$7"
+OPM_PACK_COMMAND="$8"
+EXE_NAME="${9}"
+shift 9
+TEST_ARGS="$@"
+
+BASE_NAME=${FILENAME}_RESTART.DATA
+
+rm -Rf ${RESULT_PATH}
+mkdir -p ${RESULT_PATH}
+cd ${RESULT_PATH}
+${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
+
+test $? -eq 0 || exit 1
+
+${OPM_PACK_COMMAND} -o ${BASE_NAME} ${INPUT_DATA_PATH}/${FILENAME}_RESTART.DATA
+
+${BINPATH}/${EXE_NAME} ${BASE_NAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
+test $? -eq 0 || exit 1
+
+ecode=0
+echo "=== Executing comparison for summary file ==="
+${COMPARE_ECL_COMMAND} -R -t SMRY ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/${FILENAME}_RESTART ${ABS_TOL} ${REL_TOL}
+if [ $? -ne 0 ]
+then
+  ecode=1
+  ${COMPARE_ECL_COMMAND} -a -R -t SMRY ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/${FILENAME}_RESTART ${ABS_TOL} ${REL_TOL}
+fi
+
+exit $ecode


### PR DESCRIPTION
Add a test driver to run a restart test where only the summary results are compared. Suggested "improvement" for situations where it is not (yet) possible to achieve full restart capability.
