### PR TITLE
Add GRAVITY keyword to UnsupportedFlowKeywords

### DIFF
--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -244,6 +244,7 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"GRAVDR", {false, std::nullopt}},
         {"GRAVDRB", {false, std::nullopt}},
         {"GRAVDRM", {false, std::nullopt}},
+        {"GRAVITY", {false, std::string{"Use the DENSITY keyword instead"}}},
         {"GRDREACH", {false, std::nullopt}},
         {"GRIDUNIT", {false, std::nullopt}},
         {"GRUPMAST", {false, std::nullopt}},


### PR DESCRIPTION
Add GRAVITY keyword to UnsupportedFlowKeywords with message to use DENSITY instead.