### PR TITLE
Chase Restart File Output Time Decision API Change

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.hh
+++ b/ebos/eclgenericoutputblackoilmodule.hh
@@ -28,6 +28,7 @@
 #define EWOMS_ECL_GENERIC_OUTPUT_BLACK_OIL_MODULE_HH
 
 #include <array>
+#include <cstddef>
 #include <map>
 #include <numeric>
 #include <optional>
@@ -231,14 +232,15 @@ protected:
         static constexpr int numWCNames = 3;
     };
 
-    void doAllocBuffers(unsigned bufferSize,
-                        unsigned reportStepNum,
-                        const bool substep,
-                        const bool log,
-                        const bool isRestart,
-                        const bool vapparsActive,
-                        const bool enableHysteresis,
-                        unsigned numTracers);
+    void doAllocBuffers(const unsigned    bufferSize,
+                        const unsigned    reportStepNum,
+                        const std::size_t previousRestartOutputStep,
+                        const bool        substep,
+                        const bool        log,
+                        const bool        isRestart,
+                        const bool        vapparsActive,
+                        const bool        enableHysteresis,
+                        const unsigned    numTracers);
 
     void fipUnitConvert_(std::unordered_map<Inplace::Phase, Scalar>& fip) const;
 

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -27,6 +27,7 @@
 #ifndef EWOMS_ECL_OUTPUT_BLACK_OIL_MODULE_HH
 #define EWOMS_ECL_OUTPUT_BLACK_OIL_MODULE_HH
 
+#include <cstddef>
 #include <array>
 #include <numeric>
 #include <optional>
@@ -161,19 +162,27 @@ public:
      * \brief Allocate memory for the scalar fields we would like to
      *        write to ECL output files
      */
-    void allocBuffers(unsigned bufferSize, unsigned reportStepNum, const bool substep, const bool log, const bool isRestart)
+    void allocBuffers(const unsigned    bufferSize,
+                      const unsigned    reportStepNum,
+                      const std::size_t previousRestartOutputStep,
+                      const bool        substep,
+                      const bool        log,
+                      const bool        isRestart)
     {
         if (!std::is_same<Discretization, EcfvDiscretization<TypeTag> >::value)
             return;
 
+        const auto& problem = this->simulator_.problem();
+
         this->doAllocBuffers(bufferSize,
                              reportStepNum,
+                             previousRestartOutputStep,
                              substep,
                              log,
                              isRestart,
-                             simulator_.problem().vapparsActive(std::max(simulator_.episodeIndex(), 0)),
-                             simulator_.problem().materialLawManager()->enableHysteresis(),
-                             simulator_.problem().tracerModel().numTracers());
+                             problem.vapparsActive(std::max(simulator_.episodeIndex(), 0)),
+                             problem.materialLawManager()->enableHysteresis(),
+                             problem.tracerModel().numTracers());
     }
 
     /*!

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1020,7 +1020,7 @@ public:
         bool tuningEvent = this->beginEpisode_(enableExperiments, this->episodeIndex());
 
         // set up the wells for the next episode.
-        wellModel_.beginEpisode();
+        this->wellModel_.beginEpisode(this->eclWriter_->previousRestartOutput());
 
         // set up the aquifers for the next episode.
         if (enableAquifers_)

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -215,7 +215,7 @@ public:
             ebosSimulator_.setEpisodeLength(0.0);
             ebosSimulator_.setTimeStepSize(0.0);
 
-            wellModel_().beginReportStep(timer.currentStepNum());
+            wellModel_().beginReportStep(timer.currentStepNum(), 0);
             ebosSimulator_.problem().writeOutput();
 
             report_.success.output_write_time += perfTimer.stop();

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -28,6 +28,7 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <cassert>
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <optional>
@@ -176,9 +177,10 @@ namespace Opm {
                 // TODO (?)
             }
 
-            void beginEpisode()
+            void beginEpisode(const std::size_t previousRestartOutput)
             {
-                beginReportStep(ebosSimulator_.episodeIndex());
+                this->beginReportStep(ebosSimulator_.episodeIndex(),
+                                      previousRestartOutput);
             }
 
             void beginTimeStep();
@@ -264,7 +266,8 @@ namespace Opm {
             }
 
             // called at the beginning of a report step
-            void beginReportStep(const int time_step);
+            void beginReportStep(const int         time_step,
+                                 const std::size_t previousRestartOutput);
 
             void updatePerforationIntensiveQuantities();
             // it should be able to go to prepareTimeStep(), however, the updateWellControls() and initPrimaryVariablesEvaluation()
@@ -308,12 +311,13 @@ namespace Opm {
 
 
             const ModelParameters param_;
-            size_t global_num_cells_{};
+            std::size_t global_num_cells_{};
             // the number of the cells in the local grid
-            size_t local_num_cells_{};
+            std::size_t local_num_cells_{};
             double gravity_{};
             std::vector<double> depth_{};
             bool alternative_well_rate_init_{};
+            std::size_t previousRestartOutput_{};
 
             std::unique_ptr<RateConverterType> rateConverter_{};
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -182,7 +182,7 @@ loadRestartData(const data::Wells& rst_wells,
             well_state.currentInjectionControl(well_index, rst_well.current_control.inj);
         }
 
-        for( size_t i = 0; i < phs.size(); ++i ) {
+        for (std::size_t i = 0; i < phs.size(); ++i) {
             assert( rst_well.rates.has( phs[ i ] ) );
             well_state.wellRates(well_index)[i] = rst_well.rates.get(phs[i]);
         }
@@ -254,7 +254,7 @@ loadRestartData(const data::Wells& rst_wells,
 void
 BlackoilWellModelGeneric::
 initFromRestartFile(const RestartValue& restartValues,
-                    const size_t numCells,
+                    const std::size_t numCells,
                     bool handle_ms_well)
 {
     // The restart step value is used to identify wells present at the given
@@ -1731,16 +1731,17 @@ gasLiftOptimizationStage2(DeferredLogger& deferred_logger,
 void
 BlackoilWellModelGeneric::
 updateWellPotentials(const int reportStepIdx,
+                     const std::size_t previousRestartOutput,
                      const bool onlyAfterEvent,
                      const SummaryConfig& summaryConfig,
                      DeferredLogger& deferred_logger)
 {
     auto well_state_copy = this->wellState();
 
-    const bool write_restart_file = schedule().write_rst_file(reportStepIdx);
+    const bool write_restart_file = schedule().write_rst_file(reportStepIdx, previousRestartOutput);
     auto exc_type = ExceptionType::NONE;
     std::string exc_msg;
-    size_t widx = 0;
+    std::size_t widx = 0;
     for (const auto& well : well_container_generic_) {
         const bool needed_for_summary =
                 ((summaryConfig.hasSummaryKey( "WWPI:" + well->name()) ||
@@ -1782,12 +1783,13 @@ updateWellPotentials(const int reportStepIdx,
         {
             this->computePotentials(widx, well_state_copy, exc_msg, exc_type, deferred_logger);
         }
+
         ++widx;
     }
+
     logAndCheckForExceptionsAndThrow(deferred_logger, exc_type,
                                      "computeWellPotentials() failed: " + exc_msg,
                                      terminal_output_);
-
 }
 
 void

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -24,14 +24,6 @@
 #ifndef OPM_BLACKOILWELLMODEL_GENERIC_HEADER_INCLUDED
 #define OPM_BLACKOILWELLMODEL_GENERIC_HEADER_INCLUDED
 
-#include <functional>
-#include <map>
-#include <memory>
-#include <string>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
-
 #include <opm/output/data/GuideRateValue.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp>
@@ -42,6 +34,15 @@
 #include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 #include <opm/simulators/wells/WellProdIndexCalculator.hpp>
 #include <opm/simulators/wells/WGState.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace Opm {
 
@@ -131,7 +132,7 @@ public:
                          WellState& well_state);
 
     void initFromRestartFile(const RestartValue& restartValues,
-                             const size_t numCells,
+                             const std::size_t numCells,
                              bool handle_ms_well);
 
     void setWellsActive(const bool wells_active);
@@ -354,6 +355,7 @@ protected:
 
     // Calculating well potentials for each well
     void updateWellPotentials(const int reportStepIdx,
+                              const std::size_t previousRestartOutput,
                               const bool onlyAfterEvent,
                               const SummaryConfig& summaryConfig,
                               DeferredLogger& deferred_logger);

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -124,7 +124,7 @@ namespace Opm {
             const auto& connectionSet = well.getConnections();
             wellCells.reserve(connectionSet.size());
 
-            for ( size_t c=0; c < connectionSet.size(); c++ )
+            for (std::size_t c=0; c < connectionSet.size(); ++c)
             {
                 const auto& connection = connectionSet.get(c);
                 int compressed_idx = cartesian_to_compressed_
@@ -173,10 +173,13 @@ namespace Opm {
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::
-    beginReportStep(const int timeStepIdx)
+    beginReportStep(const int timeStepIdx,
+                    const std::size_t previousRestartOutput)
     {
         DeferredLogger local_deferredLogger;
         report_step_starts_ = true;
+
+        this->previousRestartOutput_ = previousRestartOutput;
 
         const Grid& grid = ebosSimulator_.vanguard().grid();
         const auto& summaryState = ebosSimulator_.vanguard().summaryState();
@@ -297,6 +300,7 @@ namespace Opm {
         // calculate the well potentials
         try {
             updateWellPotentials(reportStepIdx,
+                                 this->previousRestartOutput_,
                                  /*onlyAfterEvent*/true,
                                  ebosSimulator_.vanguard().summaryConfig(),
                                  local_deferredLogger);
@@ -462,6 +466,7 @@ namespace Opm {
         // calculate the well potentials
         try {
             updateWellPotentials(reportStepIdx,
+                                 this->previousRestartOutput_,
                                  /*onlyAfterEvent*/false,
                                  ebosSimulator_.vanguard().summaryConfig(),
                                  local_deferredLogger);

--- a/opm/simulators/wells/GlobalWellInfo.hpp
+++ b/opm/simulators/wells/GlobalWellInfo.hpp
@@ -62,7 +62,7 @@ public:
         auto size = this->m_in_injecting_group.size();
         comm.sum( this->m_in_injecting_group.data(), size);
         comm.sum( this->m_in_producing_group.data(), size);
-    };
+    }
 
 
 

--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -89,6 +89,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WList.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WListManager.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/WriteRestartFileEvents.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
@@ -673,6 +674,7 @@ TEST_FOR_TYPE(WellSegments)
 TEST_FOR_TYPE(WellTestConfig)
 TEST_FOR_TYPE(WellType)
 TEST_FOR_TYPE(WListManager)
+TEST_FOR_TYPE(WriteRestartFileEvents)
 
 
 bool init_unit_test_func()

--- a/tests/test_glift1.cpp
+++ b/tests/test_glift1.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(G1)
     simulator->model().newtonMethod().setIterationIndex(0);
     WellModel& well_model = simulator->problem().wellModel();
     int report_step_idx = 0;
-    well_model.beginReportStep(report_step_idx);
+    well_model.beginReportStep(report_step_idx, report_step_idx);
     well_model.beginTimeStep();
     well_model.updatePerforationIntensiveQuantities();
     Opm::DeferredLogger deferred_logger;


### PR DESCRIPTION
The `Schedule::write_rst_file()` function now takes the time of the previous restart output as a parameter in order to properly account for combinations of `RPTRST`'s `BASIC=4`/`BASIC=5` and `FREQ>1` settings.