### PR TITLE
Assemble UDQState external to the vanguard

### DIFF
--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -141,6 +141,7 @@ public:
      */
     static void setExternalSummaryConfig(std::unique_ptr<SummaryConfig> summaryConfig);
 
+    static void setExternalUDQState(std::unique_ptr<UDQState> udqState);
     /*!
      * \brief Return a reference to the parsed ECL deck.
      */
@@ -277,6 +278,8 @@ protected:
     static std::unique_ptr<EclipseState> externalEclState_;
     static std::unique_ptr<Schedule> externalEclSchedule_;
     static std::unique_ptr<SummaryConfig> externalEclSummaryConfig_;
+    static std::unique_ptr<UDQState> externalUDQState_;
+
 
     std::string caseName_;
     std::string fileName_;

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -46,6 +46,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
 
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
@@ -461,7 +462,7 @@ namespace Opm
                 if (output_param >= 0)
                     outputInterval = output_param;
 
-                readDeck(mpiRank, deckFilename, deck_, eclipseState_, schedule_,
+                readDeck(mpiRank, deckFilename, deck_, eclipseState_, schedule_, udqState_,
                          summaryConfig_, nullptr, python, std::move(parseContext),
                          init_from_restart_file, outputCout_, outputInterval);
 
@@ -542,6 +543,7 @@ namespace Opm
         std::unique_ptr<Deck> deck_;
         std::unique_ptr<EclipseState> eclipseState_;
         std::unique_ptr<Schedule> schedule_;
+        std::unique_ptr<UDQState> udqState_;
         std::unique_ptr<SummaryConfig> summaryConfig_;
     };
 

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -46,6 +46,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
@@ -186,7 +187,7 @@ void setupMessageLimiter(const Opm::MessageLimits msgLimits,  const std::string&
 
 
 void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& deck, std::unique_ptr<Opm::EclipseState>& eclipseState,
-              std::unique_ptr<Opm::Schedule>& schedule, std::unique_ptr<Opm::SummaryConfig>& summaryConfig,
+              std::unique_ptr<Opm::Schedule>& schedule, std::unique_ptr<UDQState>& udqState, std::unique_ptr<Opm::SummaryConfig>& summaryConfig,
               std::unique_ptr<ErrorGuard> errorGuard, std::shared_ptr<Opm::Python>& python, std::unique_ptr<ParseContext> parseContext,
               bool initFromRestart, bool checkDeck, const std::optional<int>& outputInterval)
 {
@@ -243,11 +244,14 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
                 const auto rst_state = Opm::RestartIO::RstState::load(std::move(rst_view));
                 if (!schedule)
                     schedule = std::make_unique<Opm::Schedule>(*deck, *eclipseState, *parseContext, *errorGuard, python, outputInterval, &rst_state);
+                udqState = std::make_unique<Opm::UDQState>( schedule->operator[](0).udq().params().undefinedValue() );
             }
             else {
                 if (!schedule)
                     schedule = std::make_unique<Opm::Schedule>(*deck, *eclipseState, *parseContext, *errorGuard, python);
+                udqState = std::make_unique<Opm::UDQState>( schedule->operator[](0).udq().params().undefinedValue() );
             }
+
             if (Opm::OpmLog::hasBackend("STDOUT_LOGGER")) // loggers might not be set up!
             {
                 setupMessageLimiter(schedule->operator[](0).message_limits(), "STDOUT_LOGGER");

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -36,6 +36,7 @@ class ParseContext;
 class Python;
 class Schedule;
 class SummaryConfig;
+class UDQState;
 
 enum class FileOutputMode {
     //! \brief No output to files.
@@ -53,7 +54,7 @@ FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, con
 ///
 /// If pointers already contains objects then they are used otherwise they are created and can be used outside later.
 void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Deck>& deck, std::unique_ptr<EclipseState>& eclipseState,
-              std::unique_ptr<Schedule>& schedule, std::unique_ptr<SummaryConfig>& summaryConfig,
+              std::unique_ptr<Schedule>& schedule, std::unique_ptr<UDQState>& udqState, std::unique_ptr<SummaryConfig>& summaryConfig,
               std::unique_ptr<ErrorGuard> errorGuard, std::shared_ptr<Python>& python, std::unique_ptr<ParseContext> parseContext,
               bool initFromRestart, bool checkDeck, const std::optional<int>& outputInterval);
 } // end namespace Opm


### PR DESCRIPTION
With this PR the `UDQState` can be initialized external to the vanguard. This is necessary to enable restart from models with UDQ.

I will disavow the current code any day including Sundays, but I have tried to follow the existing pattern as close as possible - for all that is worth.