### PR TITLE
Always external

### DIFF
--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -261,7 +261,7 @@ void EclGenericVanguard::init()
 
     readDeck(myRank, fileName_, deck_, eclState_, eclSchedule_,
              eclSummaryConfig_, std::move(errorGuard), python,
-             std::move(parseContext_), /* initFromRestart = */ false,
+             *parseContext_, /* initFromRestart = */ false,
              /* checkDeck = */ enableExperiments_, outputInterval_);
 
     this->summaryState_ = std::make_unique<SummaryState>( TimeService::from_time_t(this->eclSchedule_->getStartTime() ));

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -441,14 +441,13 @@ namespace Opm
                                           outputDir,
                                           EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
                                           outputCout_, "STDOUT_LOGGER");
-                auto parseContext =
-                    std::make_unique<ParseContext>(std::vector<std::pair<std::string , InputError::Action>>
-                                                   {{ParseContext::PARSE_RANDOM_SLASH, InputError::IGNORE},
-                                                    {ParseContext::PARSE_MISSING_DIMS_KEYWORD, InputError::WARN},
-                                                    {ParseContext::SUMMARY_UNKNOWN_WELL, InputError::WARN},
-                                                    {ParseContext::SUMMARY_UNKNOWN_GROUP, InputError::WARN}});
+                ParseContext parseContext(std::vector<std::pair<std::string , InputError::Action>>
+                                          {{ParseContext::PARSE_RANDOM_SLASH, InputError::IGNORE},
+                                           {ParseContext::PARSE_MISSING_DIMS_KEYWORD, InputError::WARN},
+                                           {ParseContext::SUMMARY_UNKNOWN_WELL, InputError::WARN},
+                                           {ParseContext::SUMMARY_UNKNOWN_GROUP, InputError::WARN}});
                 if (EWOMS_GET_PARAM(PreTypeTag, bool, EclStrictParsing))
-                    parseContext->update(InputError::DELAYED_EXIT1);
+                    parseContext.update(InputError::DELAYED_EXIT1);
 
                 FlowMainEbos<PreTypeTag>::printPRTHeader(outputCout_);
 
@@ -462,7 +461,7 @@ namespace Opm
                     outputInterval = output_param;
 
                 readDeck(mpiRank, deckFilename, deck_, eclipseState_, schedule_,
-                         summaryConfig_, nullptr, python, std::move(parseContext),
+                         summaryConfig_, nullptr, python, parseContext,
                          init_from_restart_file, outputCout_, outputInterval);
 
                 setupTime_ = externalSetupTimer.elapsed();

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -54,7 +54,7 @@ FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, con
 /// If pointers already contains objects then they are used otherwise they are created and can be used outside later.
 void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Deck>& deck, std::unique_ptr<EclipseState>& eclipseState,
               std::unique_ptr<Schedule>& schedule, std::unique_ptr<SummaryConfig>& summaryConfig,
-              std::unique_ptr<ErrorGuard> errorGuard, std::shared_ptr<Python>& python, std::unique_ptr<ParseContext> parseContext,
+              std::unique_ptr<ErrorGuard> errorGuard, std::shared_ptr<Python>& python, const ParseContext& parseContext,
               bool initFromRestart, bool checkDeck, const std::optional<int>& outputInterval);
 } // end namespace Opm
 


### PR DESCRIPTION
The `readDeck()` function will *always* create `Deck, EclipseState` and friends - no need to check first. 