### PR TITLE
Address Static Code Analysis Warnings

### DIFF
--- a/tests/test_flexiblesolver.cpp
+++ b/tests/test_flexiblesolver.cpp
@@ -67,13 +67,11 @@ testSolver(const Opm::PropertyTree& prm, const std::string& matrix_filename, con
     if(prm.get<std::string>("preconditioner.type") == "cprt"){
         transpose = true;
     }
-    auto wc = [&matrix, &prm, transpose]()
-              {
-                  return Opm::Amg::getQuasiImpesWeights<Matrix,
-                                                        Vector>(matrix,
-                                                                1,
-                                                                transpose);
-              };
+    auto wc = [&matrix, transpose]()
+    {
+        return Opm::Amg::getQuasiImpesWeights<Matrix, Vector>(matrix, 1, transpose);
+    };
+
     using SeqOperatorType = Dune::MatrixAdapter<Matrix, Vector, Vector>;
     SeqOperatorType op(matrix);
     Dune::FlexibleSolver<Matrix, Vector> solver(op, prm, wc, 1);

--- a/tests/test_preconditionerfactory.cpp
+++ b/tests/test_preconditionerfactory.cpp
@@ -96,13 +96,11 @@ testPrec(const Opm::PropertyTree& prm, const std::string& matrix_filename, const
     if(prm.get<std::string>("preconditioner.type") == "cprt"){
         transpose = true;
     }
-    auto wc = [&matrix, &prm, transpose]()
-                    {
-                        return Opm::Amg::getQuasiImpesWeights<Matrix,
-                                                              Vector>(matrix,
-                                                                      1,
-                                                                      transpose);
-                    };
+    auto wc = [&matrix, transpose]()
+    {
+        return Opm::Amg::getQuasiImpesWeights<Matrix, Vector>(matrix, 1, transpose);
+    };
+
     auto prec = PrecFactory::create(op, prm.get_child("preconditioner"), wc, 1);
     Dune::BiCGSTABSolver<Vector> solver(op, *prec, prm.get<double>("tol"), prm.get<int>("maxiter"), prm.get<int>("verbosity"));
     Vector x(rhs.size());


### PR DESCRIPTION
In particular, don't print uninitialized memory (`Reorder.cpp:left`) and don't capture objects (`prm`) that aren't actually used.  While
here, refactor the initialization of the MT19937 random number generator.  Constructing this object is too expensive to do for each try, especially when we can just run the generator in place.