### PR TITLE
Changed default for sched-restart to false

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -125,7 +125,7 @@ struct EclStrictParsing<TypeTag, TTag::EclBaseVanguard> {
 };
 template<class TypeTag>
 struct SchedRestart<TypeTag, TTag::EclBaseVanguard> {
-    static constexpr bool value = true;
+    static constexpr bool value = false;
 };
 template<class TypeTag>
 struct EdgeWeightsMethod<TypeTag, TTag::EclBaseVanguard> {


### PR DESCRIPTION
Any simulation without historic schedule will crash if this default is not changed. Maybe it is time to change default, and rather use the command line switch when we fail to initialize wells/groups from binary files.