### PR TITLE
Check production and injection constraints separately

### DIFF
--- a/opm/simulators/wells/WellInterfaceFluidSystem.hpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.hpp
@@ -84,6 +84,12 @@ protected:
     bool checkIndividualConstraints(WellState& well_state,
                                     const SummaryState& summaryState) const;
 
+    Well::InjectorCMode activeInjectionConstraint(const WellState& well_state,
+                                                  const SummaryState& summaryState) const;
+
+    Well::ProducerCMode activeProductionConstraint(const WellState& well_state,
+                                                   const SummaryState& summaryState) const;
+
     std::pair<bool, double> checkGroupConstraintsInj(const Group& group,
                                                      const WellState& well_state,
                                                      const GroupState& group_state,


### PR DESCRIPTION
This is a first step towards being able to check constraints with a `const WellState` argument. Lost steam halfways.

As part of the work a bug (I think) was discovered - that will be highlighted in a separate PR against master (#3452)
.