### PR TITLE
BUG? Make sure WellState injection control is updated

### DIFF
--- a/opm/simulators/wells/WellInterfaceFluidSystem.cpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.cpp
@@ -93,7 +93,7 @@ checkIndividualConstraints(WellState& well_state,
 
     if (well.isInjector()) {
         const auto controls = well.injectionControls(summaryState);
-        auto currentControl = well_state.currentInjectionControl(well_index);
+        const auto currentControl = well_state.currentInjectionControl(well_index);
 
         if (controls.hasControl(Well::InjectorCMode::BHP) && currentControl != Well::InjectorCMode::BHP)
         {
@@ -150,7 +150,7 @@ checkIndividualConstraints(WellState& well_state,
                 current_rate += well_state.wellReservoirRates(well_index)[ pu.phase_pos[BlackoilPhases::Vapour] ];
 
             if (controls.reservoir_rate < current_rate) {
-                currentControl = Well::InjectorCMode::RESV;
+                well_state.currentInjectionControl(well_index, Well::InjectorCMode::RESV);
                 return true;
             }
         }
@@ -160,7 +160,7 @@ checkIndividualConstraints(WellState& well_state,
             const auto& thp = getTHPConstraint(summaryState);
             double current_thp = well_state.thp(well_index);
             if (thp < current_thp) {
-                currentControl = Well::InjectorCMode::THP;
+                well_state.currentInjectionControl(well_index, Well::InjectorCMode::THP);
                 return true;
             }
         }


### PR DESCRIPTION
Discovered while working on: #3451 

To me it looks like a bug in current master - where only a local variable is updated, instead of updating the shared `WellState`object.

This is also fixed in #3451 - but there in different implementation.