### PR TITLE
consindering the situation of single water phase for RateConverter

### DIFF
--- a/opm/simulators/wells/RateConverter.hpp
+++ b/opm/simulators/wells/RateConverter.hpp
@@ -521,10 +521,13 @@ namespace Opm {
                         if (Details::PhaseUsed::oil(pu)) {
                             attr.pressure += fs.pressure(FluidSystem::oilPhaseIdx).value() * pv_cell;
                             attr.temperature += fs.temperature(FluidSystem::oilPhaseIdx).value() * pv_cell;
-                        } else {
-                             assert(Details::PhaseUsed::gas(pu));
+                        } else if (Details::PhaseUsed::gas(pu)) {
                              attr.pressure += fs.pressure(FluidSystem::gasPhaseIdx).value() * pv_cell;
                              attr.temperature += fs.temperature(FluidSystem::gasPhaseIdx).value() * pv_cell;
+                        } else {
+                            assert(Details::PhaseUsed::water(pu));
+                            attr.pressure += fs.pressure(FluidSystem::waterPhaseIdx).value() * pv_cell;
+                            attr.temperature += fs.temperature(FluidSystem::waterPhaseIdx).value() * pv_cell;
                         }
                         attr.saltConcentration += fs.saltConcentration().value() * pv_cell;
                     }


### PR DESCRIPTION
an attempt to fix the failure https://ci.opm-project.org/job/opm-simulators-PR-builder/2766/testReport/junit/(root)/mpi/compareParallelSim_flow_onephase_energy_SPE1CASE2_THERMAL_ONEPHASE/ from https://github.com/OPM/opm-simulators/pull/3418#issuecomment-892716714

It is a bug introduced in https://github.com/OPM/opm-simulators/pull/3445 , not sure how it was missed from the jenkins test. 

And also, the current version is a quick attempt. I do not have the full knowledge about how the gas-water system is developed, the current version might introduce some inconsistency. 

Anyway, it is an attempt. 