### PR TITLE
Fixes related to GEFAC

### DIFF
--- a/opm/simulators/wells/WellInterfaceEval.cpp
+++ b/opm/simulators/wells/WellInterfaceEval.cpp
@@ -114,7 +114,6 @@ getGroupInjectionControl(const Group& group,
         }
     }
 
-    efficiencyFactor *= group.getGroupEfficiencyFactor();
     const auto& well = baseif_.wellEcl();
     const auto pu = baseif_.phaseUsage();
 
@@ -165,7 +164,8 @@ getGroupInjectionControl(const Group& group,
     }
     // Avoid negative target rates coming from too large local reductions.
     const double target_rate = std::max(0.0, target / efficiencyFactor);
-    const auto current_rate = injection_rate; // Switch sign since 'rates' are negative for producers.
+    const auto current_rate = injection_rate;
+
     control_eq = current_rate - target_rate;
 }
 
@@ -207,7 +207,6 @@ getGroupProductionControl(const Group& group,
         }
     }
 
-    efficiencyFactor *= group.getGroupEfficiencyFactor();
     const auto& well = baseif_.wellEcl();
     const auto pu = baseif_.phaseUsage();
 

--- a/opm/simulators/wells/WellInterfaceFluidSystem.cpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.cpp
@@ -982,7 +982,6 @@ getGroupInjectionTargetRate(const Group& group,
         }
     }
 
-    efficiencyFactor *= group.getGroupEfficiencyFactor();
     const auto pu = phaseUsage();
 
     if (!group.isInjectionGroup()) {
@@ -1027,7 +1026,6 @@ getGroupInjectionTargetRate(const Group& group,
         }
         target *= localFraction(chain[ii+1]);
     }
-    // Avoid negative target rates coming from too large local reductions.
     return std::max(0.0, target / efficiencyFactor);
 }
 template<typename FluidSystem>
@@ -1053,7 +1051,6 @@ getGroupProductionTargetRate(const Group& group,
         }
     }
 
-    efficiencyFactor *= group.getGroupEfficiencyFactor();
     const auto pu = phaseUsage();
 
     if (!group.isProductionGroup()) {


### PR DESCRIPTION
This basically reverts changes applied in PR #3095.

With this gefac is only applied while accumulating rates from the level below.

