### PR TITLE
Make sure potentials are computed in some corner cases

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -454,7 +454,6 @@ namespace Opm {
                 well->updateWaterThroughput(dt, this->wellState());
             }
         }
-        updateWellTestState(simulationTime, wellTestState_);
 
         // update the rate converter with current averages pressures etc in
         rateConverter_->template defineState<ElementContext>(ebosSimulator_);
@@ -469,6 +468,8 @@ namespace Opm {
             const std::string msg = "A zero well potential is returned for output purposes. ";
             local_deferredLogger.warning("WELL_POTENTIAL_CALCULATION_FAILED", msg);
         }
+
+        updateWellTestState(simulationTime, wellTestState_);
 
         // check group sales limits at the end of the timestep
         const Group& fieldGroup = schedule().getGroup("FIELD", reportStepIdx);

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1536,25 +1536,40 @@ namespace Opm
         }
 
         // If the well is pressure controlled the potential equals the rate.
-        bool pressure_controlled_well = false;
+        bool thp_controlled_well = false;
+        bool bhp_controlled_well = false;
         if (this->isInjector()) {
             const Well::InjectorCMode& current = well_state.currentInjectionControl(index_of_well_);
-            if (current == Well::InjectorCMode::BHP || current == Well::InjectorCMode::THP) {
-                pressure_controlled_well = true;
+            if (current == Well::InjectorCMode::THP) {
+                thp_controlled_well = true;
+            }
+            if (current == Well::InjectorCMode::BHP) {
+                bhp_controlled_well = true;
             }
         } else {
             const Well::ProducerCMode& current = well_state.currentProductionControl(index_of_well_);
-            if (current == Well::ProducerCMode::BHP || current == Well::ProducerCMode::THP) {
-                pressure_controlled_well = true;
+            if (current == Well::ProducerCMode::THP) {
+                thp_controlled_well = true;
+            }
+            if (current == Well::ProducerCMode::BHP) {
+                bhp_controlled_well = true;
             }
         }
-        if (pressure_controlled_well) {
-            // initialized the well rates with the potentials i.e. the well rates based on bhp
-            const double sign = this->well_ecl_.isInjector() ? 1.0 : -1.0;
+        if (thp_controlled_well || bhp_controlled_well) {
+
+            double total_rate = 0.0;
             for (int phase = 0; phase < np; ++phase){
-                well_potentials[phase] = sign * well_state.wellRates(index_of_well_)[phase];
+                total_rate += well_state.wellRates(index_of_well_)[phase];
             }
-            return;
+            // for pressure controlled wells the well rates are the potentials
+            // if the rates are trivial we are most probably looking at the newly
+            // opened well and we therefore make the affort of computing the potentials anyway.
+            if (std::abs(total_rate) > 0) {
+                for (int phase = 0; phase < np; ++phase){
+                    well_potentials[phase] = well_state.wellRates(index_of_well_)[phase];
+                }
+                return;
+            }
         }
 
         // creating a copy of the well itself, to avoid messing up the explicit informations
@@ -1564,7 +1579,7 @@ namespace Opm
 
         // does the well have a THP related constraint?
         const auto& summaryState = ebosSimulator.vanguard().summaryState();
-        if (!well.Base::wellHasTHPConstraints(summaryState)) {
+        if (!well.Base::wellHasTHPConstraints(summaryState) || bhp_controlled_well) {
             // get the bhp value based on the bhp constraints
             const double bhp = well.mostStrictBhpFromBhpLimits(summaryState);
             assert(std::abs(bhp) != std::numeric_limits<double>::max());


### PR DESCRIPTION
1) potentials are computed before the WECON test are done. Relevant if potentials are used in WECON
2) re-compute potentials for pressure controlled wells if the rates are trivial. 