### PR TITLE
Report Guiderate Values in Strict SI Units

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1202,7 +1202,7 @@ getGuideRateValues(const GuideRate::RateVector& qs,
 {
     auto getGR = [this, &wgname, &qs](const GuideRateModel::Target t)
     {
-        return this->guideRate_.get(wgname, t, qs);
+        return this->guideRate_.getSI(wgname, t, qs);
     };
 
     // Note: GuideRate does currently (2020-07-20) not support Target::RES.


### PR DESCRIPTION
The output layer expects its input values to be strictly SI, but we know that the `GuideRate` container's values are in output units.

This PR uses an API that was introduced in OPM/opm-common#2605.