### PR TITLE
Add support for regression restart tests

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -28,7 +28,7 @@ function(add_test_runSimulator)
     set(PARAM_DIR ${PARAM_CASENAME})
   endif()
   set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${PARAM_SIMULATOR}+${PARAM_CASENAME})
-  set(TEST_ARGS ${OPM_TESTS_ROOT}/${PARAM_DIR}/${PARAM_FILENAME} ${PARAM_TEST_ARGS})
+  set(TEST_ARGS ${PARAM_TEST_ARGS})
   opm_add_test(runSimulator/${PARAM_CASENAME} NO_COMPILE
                EXE_NAME ${PARAM_SIMULATOR}
                DRIVER_ARGS ${OPM_TESTS_ROOT}/${PARAM_DIR}
@@ -50,7 +50,7 @@ endfunction()
 # Details:
 #   - This test class compares output from a simulation to reference files.
 function(add_test_compareECLFiles)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR DIR_PREFIX PREFIX)
+  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR DIR_PREFIX PREFIX RESTART_STEP)
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_DIR)
@@ -59,8 +59,11 @@ function(add_test_compareECLFiles)
   if(NOT PARAM_PREFIX)
     set(PARAM_PREFIX compareECLFiles)
   endif()
+  if(NOT PARAM_RESTART_STEP)
+    set(PARAM_RESTART_STEP 0)
+  endif()
   set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${PARAM_SIMULATOR}+${PARAM_CASENAME})
-  set(TEST_ARGS ${OPM_TESTS_ROOT}/${PARAM_DIR}/${PARAM_FILENAME} ${PARAM_TEST_ARGS})
+  set(TEST_ARGS ${PARAM_TEST_ARGS})
   opm_add_test(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
                EXE_NAME ${PARAM_SIMULATOR}
                DRIVER_ARGS ${OPM_TESTS_ROOT}/${PARAM_DIR} ${RESULT_PATH}
@@ -68,6 +71,8 @@ function(add_test_compareECLFiles)
                            ${PARAM_FILENAME}
                            ${PARAM_ABS_TOL} ${PARAM_REL_TOL}
                            ${COMPARE_ECL_COMMAND}
+                           ${RST_DECK_COMMAND}
+                           ${PARAM_RESTART_STEP}
                TEST_ARGS ${TEST_ARGS})
 endfunction()
 

--- a/tests/run-init-regressionTest.sh
+++ b/tests/run-init-regressionTest.sh
@@ -13,14 +13,15 @@ FILENAME="$4"
 ABS_TOL="$5"
 REL_TOL="$6"
 COMPARE_ECL_COMMAND="$7"
-EXE_NAME="${8}"
-shift 8
+# param 8 and 9 ignored, only used with regression tests
+EXE_NAME="${10}"
+shift 10
 TEST_ARGS="$@"
 
 rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_PATH}
+${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_PATH} ${INPUT_DATA_PATH}/${FILENAME}
 cd ..
 
 ecode=0

--- a/tests/run-porv-acceptanceTest.sh
+++ b/tests/run-porv-acceptanceTest.sh
@@ -13,16 +13,16 @@ FILENAME="$4"
 ABS_TOL="$5"
 REL_TOL="$6"
 COMPARE_ECL_COMMAND="$7"
-EXE_NAME="${8}"
-shift 8
+# param 8 and 9 ignored, only used with regression tests
+EXE_NAME="${10}"
+shift 10
 TEST_ARGS="$@"
 
 rm -Rf  ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_PATH}
+${BINPATH}/${EXE_NAME} ${TEST_ARGS} --enable-dry-run=true --output-dir=${RESULT_PATH} ${INPUT_DATA_PATH}/${FILENAME}
 cd ..
-
 
 ecode=0
 ${COMPARE_ECL_COMMAND} -t INIT -k PORV ${RESULT_PATH}/${FILENAME} ${INPUT_DATA_PATH}/opm-porevolume-reference/${EXE_NAME}/${FILENAME} ${ABS_TOL} ${REL_TOL}

--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -10,13 +10,15 @@ FILENAME="$4"
 ABS_TOL="$5"
 REL_TOL="$6"
 COMPARE_ECL_COMMAND="$7"
-EXE_NAME="${8}"
-shift 8
+RST_DECK_COMMAND="$8"
+RESTART_STEP="${9}"
+EXE_NAME="${10}"
+shift 10
 TEST_ARGS="$@"
 
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-${BINPATH}/${EXE_NAME} ${TEST_ARGS} --output-dir=${RESULT_PATH}
+${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} ${TEST_ARGS} --output-dir=${RESULT_PATH}
 test $? -eq 0 || exit 1
 cd ..
 
@@ -37,5 +39,24 @@ then
   ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -a  ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
-echo ">>> ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}"
+if test $RESTART_STEP -ne 0
+then
+  echo "=== Executing restart run ==="
+  mkdir -p ${RESULT_PATH}/restart
+  cp -f ${RESULT_PATH}/${FILENAME}.UNRST ${RESULT_PATH}/restart
+  ${RST_DECK_COMMAND}  ${INPUT_DATA_PATH}/${FILENAME}.DATA ${FILENAME}:${RESTART_STEP} -m inline -s > ${RESULT_PATH}/restart/${FILENAME}.DATA
+  cd ${RESULT_PATH}/restart
+  echo ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --output-dir=${RESULT_PATH}/restart ${FILENAME}
+  ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --output-dir=${RESULT_PATH}/restart ${FILENAME}
+  test $? -eq 0 || exit 1
+
+  echo "=== Executing comparison for EGRID, INIT, UNRST and RFT files for restarted run ==="
+  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/restart/${FILENAME} ${RESULT_PATH}/restart/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  if [ $? -ne 0 ]
+  then
+    ecode=1
+    ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -a  ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/restart/${FILENAME} ${RESULT_PATH}/restart/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  fi
+fi
+
 exit $ecode

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -183,6 +183,16 @@ do
           $casename \
           EGRID INIT RFT SMSPEC UNRST UNSMRY
       test $? -eq 0 && changed_tests="$changed_tests $test_name"
+
+      if [ -d $configuration/build-opm-simulators/tests/results/$binary+$test_name/restart ]
+      then
+        copyToReferenceDir \
+            $BUILD_DIR/tests/results/$binary+$test_name/restart/ \
+            $OPM_TESTS_ROOT/$dirname/opm-simulation-reference/$binary/restart \
+            $casename \
+            EGRID INIT RFT SMSPEC UNRST UNSMRY
+        test $? -eq 0 && changed_tests="$changed_tests $test_name(restart)"
+      fi
     fi
   done
 done


### PR DESCRIPTION
This restarts the simulation at a specified step. It then compares the results from this run to a separate,
existing regression data set.

By request from @alfbr 

It includes a rebased version of https://github.com/OPM/opm-simulators/pull/3072 as I rely on this functionality.

Still somewhat drafty, I need to test it on the CI system..