### PR TITLE
Load Analytic Aquifers From Restart File

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2379,8 +2379,13 @@ private:
                     this->solventSaturation_[elemIdx] = ssol;
             }
 
-            this->lastRs_[elemIdx] = elemFluidState.Rs();
-            this->lastRv_[elemIdx] = elemFluidState.Rv();
+            if (! this->lastRs_.empty()) {
+                this->lastRs_[elemIdx] = elemFluidState.Rs();
+            }
+
+            if (! this->lastRv_.empty()) {
+                this->lastRv_[elemIdx] = elemFluidState.Rv();
+            }
 
             if constexpr (enablePolymer)
                  this->polymerConcentration_[elemIdx] = eclWriter_->eclOutputModule().getPolymerConcentration(elemIdx);

--- a/opm/simulators/aquifers/AquiferCarterTracy.hpp
+++ b/opm/simulators/aquifers/AquiferCarterTracy.hpp
@@ -104,10 +104,10 @@ protected:
     Scalar dimensionless_time_{0};
     Scalar dimensionless_pressure_{0};
 
-    void assignRestartData(const data::AquiferData& /* xaq */) override
+    void assignRestartData(const data::AquiferData& xaq) override
     {
-        throw std::runtime_error {"Restart-based initialization not currently supported "
-                                  "for Carter-Tracey analytic aquifers"};
+        this->fluxValue_ = xaq.volume;
+        this->rhow_ = this->aquct_data_.waterDensity();
     }
 
     std::pair<Scalar, Scalar>
@@ -176,6 +176,10 @@ protected:
 
     inline void calculateAquiferCondition() override
     {
+        if (this->solution_set_from_restart_) {
+            return;
+        }
+
         if (! this->aquct_data_.initial_pressure.has_value()) {
             this->aquct_data_.initial_pressure =
                 this->calculateReservoirEquilibrium();

--- a/opm/simulators/aquifers/AquiferFetkovich.hpp
+++ b/opm/simulators/aquifers/AquiferFetkovich.hpp
@@ -107,6 +107,7 @@ protected:
         }
 
         this->aquifer_pressure_ = xaq.pressure;
+        this->rhow_ = this->aqufetp_data_.waterDensity();
     }
 
     inline Eval dpai(int idx)


### PR DESCRIPTION
This PR activates restart support for analytical aquifers. Analytic aquifer keywords do not exist in the input file for restarted runs since the 'SOLUTION' section is empty apart from from the `RESTART` specification.

We use the `RestartIO::Aquifer` (OPM/opm-common#2526) class to load the information from the restart file and then assign this information to the `AquiferConfig` object hosted by the `EclipseState`.  Loading `Schedule` information from the restart file is still contingent on the `--sched-restart=false` command line setting.  We support all aquifer types currently supported by the simulator, namely

* Carter&ndash;Tracy
* Fetkovich
* Numerical

Numerical aquifer restart support is limited to restoring the cumulative water production and initial aquifer cell pressures from the `RAQN` vector.  On the other hand, numerical aquifers are specified in the `GRID` section so we always have access to that information in a restarted run.  Analytical aquifers must always be constructed purely from the restart file information in restarted runs.

We take some care to account for multiple processes sharing a single aquifer when restarting a simulation run.  In the case of analytical aquifers we apportion the cumulative production based on the fraction of the total inflow area that is "owned" by each MPI process.  This is, at best, a very crude approximation.  In the **very** special case that all aquifer connections produce the same flow rates then this will nevertheless be an okay approximation.  Full fidelity apportionment will require tracking the cumulative production at the connection level which in turn will probably entail relinquishing complete ECLIPSE compatibility in the aquifer restart vectors.