### PR TITLE
Change default MaxNewtonIterationsWithInnerWellIterations to 8

### DIFF
--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -244,7 +244,7 @@ struct MaxPressureChangeMsWells<TypeTag, TTag::FlowModelParameters> {
 };
 template<class TypeTag>
 struct MaxNewtonIterationsWithInnerWellIterations<TypeTag, TTag::FlowModelParameters> {
-    static constexpr int value = 3;
+    static constexpr int value = 8;
 };
 template<class TypeTag>
 struct MaxInnerIterMsWells<TypeTag, TTag::FlowModelParameters> {


### PR DESCRIPTION
More testing indicates that 3 is too small. In particular for challenging cases. It will slightly increase the simulation time for one of the model we test in benchmark, but for many other it will give both better performance and also sometimes more accurate results since premature shutting of wells are avoided. 8 seems to be a good compromise. Always applying inner iterations sometimes gives unwanted oscillation and non-converged solutions. 