### PR TITLE
added: 'update_data' custom target

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -1152,3 +1152,10 @@ endif()
                                        DIR udq_actionx
                                        TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
 endif()
+
+if(OPM_TESTS_ROOT)
+  add_custom_target(update_data
+                    COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR} --target check --parallel || exit 0
+                    COMMAND ${CMAKE_COMMAND} -E env "REASON=Local\ data\ update" ${PROJECT_SOURCE_DIR}/tests/update_reference_data.sh ${OPM_TESTS_ROOT} ${PROJECT_BINARY_DIR}
+                    COMMENT "Updating reference data")
+endif()


### PR DESCRIPTION
this allows updating opm-tests reference data repository
with the current results.

this is useful for devs as some of the tests only pass on the
CI system due to slight differences. you can now run this
before applying changes, and thus only reveal real regressions
introduced by your changes.

Downstream of https://github.com/OPM/opm-common/pull/2613

@joakim-hove took a while but here you go. please test.