### PR TITLE
Make sure that flow is not compiled with -DNDEBUG

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -67,6 +67,15 @@
 #include <string>
 #include <type_traits>
 
+
+#ifdef NDEBUG
+static_assert(false, "In order to enforce assert(...) checks flow can *not* be compiled with -DNDEBUG");
+#endif
+
+
+
+
+
 namespace Opm::Properties {
 
 // this is a dummy type tag that is used to setup the parameters before the actual


### PR DESCRIPTION
Ensure that the `assert(....)` safety belt is always present.

flow is a complex piece of software, and the input format is quite complex - and not 100% understood. This implies that the distinction between pure programming errors which *should not happen* - and error conditions which can be traced to user input is not entirely clear. I have several times wasted quite some debugging time in a situation where I thought everything worked - to later discover that `assert( something )` has been broken when switching to debug mode.

Piggy back on: https://github.com/OPM/opm-common/pull/2594