### PR TITLE
Update well rates from target during well/group control update

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -282,6 +282,11 @@ namespace Opm {
             void prepareTimeStep(DeferredLogger& deferred_logger);
             void initPrimaryVariablesEvaluation() const;
             void updateWellControls(DeferredLogger& deferred_logger, const bool checkGroupControls);
+
+            void updateAndCommunicate(const int reportStepIdx,
+                                      const int iterationIdx,
+                                      DeferredLogger& deferred_logger);
+
             WellInterfacePtr getWell(const std::string& well_name) const;
             bool hasWell(const std::string& well_name) const;
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -300,22 +300,22 @@ protected:
                              const int reportStepIdx,
                              DeferredLogger& deferred_logger);
 
-    void checkGroupHigherConstraints(const Group& group,
+    bool checkGroupHigherConstraints(const Group& group,
                                      DeferredLogger& deferred_logger,
                                      const int reportStepIdx,
                                      std::set<std::string>& switched_groups);
 
-    void updateGroupIndividualControl(const Group& group,
+    bool updateGroupIndividualControl(const Group& group,
                                       DeferredLogger& deferred_logger,
                                       const int reportStepIdx,
                                       std::set<std::string>& switched_groups);
 
-    void updateGroupIndividualControls(DeferredLogger& deferred_logger,
+    bool updateGroupIndividualControls(DeferredLogger& deferred_logger,
                                        std::set<std::string>& switched_groups,
                                        const int reportStepIdx,
                                        const int iterationIdx);
 
-    void updateGroupHigherControls(DeferredLogger& deferred_logger,
+    bool updateGroupHigherControls(DeferredLogger& deferred_logger,
                                    const int reportStepIdx,
                                    std::set<std::string>& switched_groups);
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -608,11 +608,12 @@ namespace Opm
         const auto& summaryState = ebos_simulator.vanguard().summaryState();
         const auto& schedule = ebos_simulator.vanguard().schedule();
 
-        if (this->wellIsStopped()) {
+        if (this->wellIsStopped() || !this->isOperable()) {
             for (int p = 0; p<np; ++p) {
-                ws.surface_rates[p] = 0;
+                ws.surface_rates[p] = 0.0;
+                ws.well_potentials[p] = 0.0;
             }
-            ws.thp = 0;
+            ws.thp = 0.0;
             return;
         }
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -608,12 +608,11 @@ namespace Opm
         const auto& summaryState = ebos_simulator.vanguard().summaryState();
         const auto& schedule = ebos_simulator.vanguard().schedule();
 
-        if (this->wellIsStopped() || !this->isOperable()) {
+        if (this->wellIsStopped()) {
             for (int p = 0; p<np; ++p) {
-                ws.surface_rates[p] = 0.0;
-                ws.well_potentials[p] = 0.0;
+                ws.surface_rates[p] = 0;
             }
-            ws.thp = 0.0;
+            ws.thp = 0;
             return;
         }
 


### PR DESCRIPTION
If a well/group control change all wells belonging to the same group are potentially affected. Calling updateWellStateFromTarget between every update makes the rates more consistent and thus avoids oscillations.  