### PR TITLE
Fixes and removes deprecation warnings for Dune 2.8

### DIFF
--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -380,7 +380,7 @@ template class EclGenericCpGridVanguard<Dune::MultipleCodimMultipleGeomTypeMappe
                                         Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,
                                         double>;
 #else
-template class EclGenericCpGridVanguard<Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,Dune::Impl::MCMGFailLayout>,
+template class EclGenericCpGridVanguard<Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
                                         Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
                                         double>;
 #endif

--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -1631,10 +1631,10 @@ updateSummaryRegionValues(const Inplace& inplace,
     // support the RPR__xxx summary keywords.
     {
         auto get_vector = [&inplace]
-            (const auto&          node,
-             const Inplace::Phase phase)
+            (const auto&          node_,
+             const Inplace::Phase phase_)
         {
-            return inplace.get_vector(node.fip_region(), phase);
+            return inplace.get_vector(node_.fip_region(), phase_);
         };
 
         for (const auto& phase : Inplace::phases()) {

--- a/ebos/eclgenericthresholdpressure.cc
+++ b/ebos/eclgenericthresholdpressure.cc
@@ -253,13 +253,13 @@ template class EclGenericThresholdPressure<Dune::CpGrid,
 #else
 template class EclGenericThresholdPressure<Dune::CpGrid,
                                            Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
-                                           Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,Dune::Impl::MCMGFailLayout>,
+                                           Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
                                            double>;
 #endif
 
 template class EclGenericThresholdPressure<Dune::PolyhedralGrid<3,3,double>,
                                            Dune::GridView<Dune::PolyhedralGridViewTraits<3,3,double,Dune::PartitionIteratorType(4)>>,
-                                           Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::PolyhedralGridViewTraits<3,3,double,Dune::PartitionIteratorType(4)>>, Dune::Impl::MCMGFailLayout>,
+                                           Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::PolyhedralGridViewTraits<3,3,double,Dune::PartitionIteratorType(4)>>>,
                                            double>;
 
 } // namespace Opm

--- a/ebos/eclgenerictracermodel.cc
+++ b/ebos/eclgenerictracermodel.cc
@@ -289,14 +289,14 @@ template class EclGenericTracerModel<Dune::CpGrid,
 #else
 template class EclGenericTracerModel<Dune::CpGrid,
                                      Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
-                                     Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,Dune::Impl::MCMGFailLayout>,
+                                     Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
                                      Opm::EcfvStencil<double,Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,false,false>,
                                      double>;
 #endif
 
 template class EclGenericTracerModel<Dune::PolyhedralGrid<3,3,double>,
                                      Dune::GridView<Dune::PolyhedralGridViewTraits<3,3,double,Dune::PartitionIteratorType(4)>>,
-                                     Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::PolyhedralGridViewTraits<3,3,double,Dune::PartitionIteratorType(4)>>,Dune::Impl::MCMGFailLayout>,
+                                     Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::PolyhedralGridViewTraits<3,3,double,Dune::PartitionIteratorType(4)>>>,
                                      Opm::EcfvStencil<double, Dune::GridView<Dune::PolyhedralGridViewTraits<3,3,double,Dune::PartitionIteratorType(4)>>,false,false>,
                                      double>;
 

--- a/ebos/eclgenericwriter.cc
+++ b/ebos/eclgenericwriter.cc
@@ -537,14 +537,14 @@ template class EclGenericWriter<Dune::CpGrid,
 template class EclGenericWriter<Dune::CpGrid,
                                 Dune::CpGrid,
                                 Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
-                                Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>, Dune::Impl::MCMGFailLayout>,
+                                Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
                                 double>;
 #endif
 
 template class EclGenericWriter<Dune::PolyhedralGrid<3,3,double>,
                                 Dune::PolyhedralGrid<3,3,double>,
                                 Dune::GridView<Dune::PolyhedralGridViewTraits<3, 3, double, Dune::PartitionIteratorType(4)>>,
-                                Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::PolyhedralGridViewTraits<3,3,double,Dune::PartitionIteratorType(4)>>, Dune::Impl::MCMGFailLayout>,
+                                Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::PolyhedralGridViewTraits<3,3,double,Dune::PartitionIteratorType(4)>>>,
                                 double>;
 
 } // namespace Opm

--- a/ebos/eclmpiserializer.hh
+++ b/ebos/eclmpiserializer.hh
@@ -168,7 +168,7 @@ public:
                              m_packSize += Mpi::packSize(d, m_comm);
                          };
 
-        auto pack = [&](auto& d) {
+        auto packer = [&](auto& d) {
                           Mpi::pack(d, m_buffer, m_position, m_comm);
                       };
 
@@ -177,7 +177,7 @@ public:
             std::visit( [&] (auto& arg) { pack_size(arg); }, data);
         } else if (m_op == Operation::PACK) {
             Mpi::pack(data.index(), m_buffer, m_position, m_comm);
-            std::visit([&](auto& arg) { pack(arg); }, data);
+            std::visit([&](auto& arg) { packer(arg); }, data);
         } else if (m_op == Operation::UNPACK) {
             size_t index;
             std::variant<T0,T1>& mutable_data = const_cast<std::variant<T0,T1>&>(data);

--- a/ebos/ecltransmissibility.cc
+++ b/ebos/ecltransmissibility.cc
@@ -1049,13 +1049,13 @@ template class EclTransmissibility<Dune::CpGrid,
 #else
 template class EclTransmissibility<Dune::CpGrid,
                                    Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
-                                   Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>, Dune::Impl::MCMGFailLayout>,
+                                   Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
                                    double>;
 #endif
 
 template class EclTransmissibility<Dune::PolyhedralGrid<3,3,double>,
                                    Dune::GridView<Dune::PolyhedralGridViewTraits<3, 3, double, Dune::PartitionIteratorType(4)>>,
-                                   Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::PolyhedralGridViewTraits<3,3,double,Dune::PartitionIteratorType(4)>>, Dune::Impl::MCMGFailLayout>,
+                                   Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::PolyhedralGridViewTraits<3,3,double,Dune::PartitionIteratorType(4)>>>,
                                    double>;
 
 } // namespace Opm

--- a/opm/simulators/linalg/FlexibleSolver_impl.hpp
+++ b/opm/simulators/linalg/FlexibleSolver_impl.hpp
@@ -21,9 +21,10 @@
 #ifndef OPM_FLEXIBLE_SOLVER_IMPL_HEADER_INCLUDED
 #define OPM_FLEXIBLE_SOLVER_IMPL_HEADER_INCLUDED
 
+#include <opm/simulators/linalg/matrixblock.hh>
+#include <opm/simulators/linalg/ilufirstelement.hh>
 #include <opm/simulators/linalg/FlexibleSolver.hpp>
 #include <opm/simulators/linalg/PreconditionerFactory.hpp>
-#include <opm/simulators/linalg/matrixblock.hh>
 
 #include <dune/common/fmatrix.hh>
 #include <dune/istl/bcrsmatrix.hh>

--- a/opm/simulators/linalg/ParallelOverlappingILU0.hpp
+++ b/opm/simulators/linalg/ParallelOverlappingILU0.hpp
@@ -25,6 +25,7 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <dune/common/version.hh>
 #include <dune/istl/preconditioner.hh>
+#include <dune/istl/ilu.hh>
 #include <dune/istl/paamg/smoother.hh>
 #include <dune/istl/paamg/graph.hh>
 #include <dune/istl/paamg/pinfo.hh>
@@ -430,7 +431,11 @@ namespace Opm
                                           detail::IsPositiveFunctor() );
             break;
         default:
+#if DUNE_VERSION_LT(DUNE_GRID, 2, 8)
             bilu0_decomposition( ILU );
+#else
+            Dune::ILU::blockILU0Decomposition( ILU );
+#endif
             break;
         }
     }
@@ -1022,7 +1027,11 @@ public:
                     break;
                 default:
                     if (interiorSize_ == A_->N())
+#if DUNE_VERSION_LT(DUNE_GRID, 2, 8)
                         bilu0_decomposition( *ILU );
+#else
+                        Dune::ILU::blockILU0Decomposition( *ILU );
+#endif
                     else
                         detail::ghost_last_bilu0_decomposition(*ILU, interiorSize_);
                     break;

--- a/tests/test_milu.cpp
+++ b/tests/test_milu.cpp
@@ -85,7 +85,11 @@ void test_milu0(M& A)
 
     // Test that (LU)^-1Ae=e
     A.mv(e, x1);
+#if DUNE_VERSION_GTE(DUNE_ISTL, 2, 8)
+    Dune::ILU::blockILUBacksolve(ILU, x2, x1);
+#else
     bilu_backsolve(ILU, x2, x1);
+#endif
     diff = x2;
     diff -= e;
 


### PR DESCRIPTION
Fixes:
- The layout parameter of MultipleCodimMultipleGeomTypeMapper was deprecated for a long time and removed in DUNE 2.8
- bilu_backsolve is deprecated and one should use Dune::ILU::blockILU0Decomposition.
- Compilation was broken due to inclusion order problems with our firstmatrixelement method (that is now CamelCase).

needs OPM/opm-models#668