### PR TITLE
[bugfix] Fix sequential run after #979

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -352,7 +352,7 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
         errorGuard->clear();
     }
 
-    parseSuccess = comm.min(parseSuccess);
+    parseSuccess = Dune::MPIHelper::getCollectiveCommunication().min(parseSuccess);
 
     if (!parseSuccess)
     {


### PR DESCRIPTION
Defition of the communicator was moved inside a `#if HAVE_MPI` there. This commit queries the communicator again below to fix this.