### PR TITLE
drop aliases for Indices entries

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1050,7 +1050,7 @@ namespace Opm {
     getWellContributions(WellContributions& wellContribs) const
     {
         // prepare for StandardWells
-        wellContribs.setBlockSize(StandardWell<TypeTag>::numEq, StandardWell<TypeTag>::numStaticWellEq);
+        wellContribs.setBlockSize(StandardWell<TypeTag>::Indices::numEq, StandardWell<TypeTag>::numStaticWellEq);
 
         for(unsigned int i = 0; i < well_container_.size(); i++){
             auto& well = well_container_[i];

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -58,10 +58,6 @@ namespace Opm
         using typename Base::GLiftWellStateMap;
         using typename Base::GLiftSyncGroups;
 
-        /// the number of reservior equations
-        using Base::numEq;
-        using Base::numPhases;
-
         using Base::has_solvent;
         using Base::has_polymer;
         using Base::Water;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1219,7 +1219,7 @@ namespace Opm
 
                     this->resWell_[seg][comp_idx] += accumulation_term.value();
                     for (int pv_idx = 0; pv_idx < numWellEq; ++pv_idx) {
-                        this->duneD_[seg][seg][comp_idx][pv_idx] += accumulation_term.derivative(pv_idx + numEq);
+                        this->duneD_[seg][seg][comp_idx][pv_idx] += accumulation_term.derivative(pv_idx + Indices::numEq);
                     }
                 }
             }
@@ -1232,12 +1232,12 @@ namespace Opm
                     // segment_rate contains the derivatives with respect to GTotal in seg,
                     // and WFrac and GFrac in seg_upwind
                     this->resWell_[seg][comp_idx] -= segment_rate.value();
-                    this->duneD_[seg][seg][comp_idx][GTotal] -= segment_rate.derivative(GTotal + numEq);
+                    this->duneD_[seg][seg][comp_idx][GTotal] -= segment_rate.derivative(GTotal + Indices::numEq);
                     if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
-                        this->duneD_[seg][seg_upwind][comp_idx][WFrac] -= segment_rate.derivative(WFrac + numEq);
+                        this->duneD_[seg][seg_upwind][comp_idx][WFrac] -= segment_rate.derivative(WFrac + Indices::numEq);
                     }
                     if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
-                        this->duneD_[seg][seg_upwind][comp_idx][GFrac] -= segment_rate.derivative(GFrac + numEq);
+                        this->duneD_[seg][seg_upwind][comp_idx][GFrac] -= segment_rate.derivative(GFrac + Indices::numEq);
                     }
                     // pressure derivative should be zero
                 }
@@ -1253,12 +1253,12 @@ namespace Opm
                         // inlet_rate contains the derivatives with respect to GTotal in inlet,
                         // and WFrac and GFrac in inlet_upwind
                         this->resWell_[seg][comp_idx] += inlet_rate.value();
-                        this->duneD_[seg][inlet][comp_idx][GTotal] += inlet_rate.derivative(GTotal + numEq);
+                        this->duneD_[seg][inlet][comp_idx][GTotal] += inlet_rate.derivative(GTotal + Indices::numEq);
                         if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
-                            this->duneD_[seg][inlet_upwind][comp_idx][WFrac] += inlet_rate.derivative(WFrac + numEq);
+                            this->duneD_[seg][inlet_upwind][comp_idx][WFrac] += inlet_rate.derivative(WFrac + Indices::numEq);
                         }
                         if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
-                            this->duneD_[seg][inlet_upwind][comp_idx][GFrac] += inlet_rate.derivative(GFrac + numEq);
+                            this->duneD_[seg][inlet_upwind][comp_idx][GFrac] += inlet_rate.derivative(GFrac + Indices::numEq);
                         }
                         // pressure derivative should be zero
                     }
@@ -1308,13 +1308,13 @@ namespace Opm
                     for (int pv_idx = 0; pv_idx < numWellEq; ++pv_idx) {
 
                         // also need to consider the efficiency factor when manipulating the jacobians.
-                        this->duneC_[seg][cell_idx][pv_idx][comp_idx] -= cq_s_effective.derivative(pv_idx + numEq); // intput in transformed matrix
+                        this->duneC_[seg][cell_idx][pv_idx][comp_idx] -= cq_s_effective.derivative(pv_idx + Indices::numEq); // intput in transformed matrix
 
                         // the index name for the D should be eq_idx / pv_idx
-                        this->duneD_[seg][seg][comp_idx][pv_idx] += cq_s_effective.derivative(pv_idx + numEq);
+                        this->duneD_[seg][seg][comp_idx][pv_idx] += cq_s_effective.derivative(pv_idx + Indices::numEq);
                     }
 
-                    for (int pv_idx = 0; pv_idx < numEq; ++pv_idx) {
+                    for (int pv_idx = 0; pv_idx < Indices::numEq; ++pv_idx) {
                         // also need to consider the efficiency factor when manipulating the jacobians.
                         this->duneB_[seg][cell_idx][comp_idx][pv_idx] += cq_s_effective.derivative(pv_idx);
                     }

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -88,9 +88,6 @@ namespace Opm
         using typename Base::GLiftWellStateMap;
         using typename Base::GLiftSyncGroups;
 
-        using Base::numEq;
-        using Base::numPhases;
-
         using Base::has_solvent;
         using Base::has_zFraction;
         using Base::has_polymer;
@@ -103,20 +100,18 @@ namespace Opm
         using FoamModule = BlackOilFoamModule<TypeTag>;
         using BrineModule = BlackOilBrineModule<TypeTag>;
 
-        static const int numSolventEq = Indices::numSolvents;
-
         // number of the conservation equations
-        static const int numWellConservationEq = numPhases + numSolventEq;
+        static constexpr int numWellConservationEq = Indices::numPhases + Indices::numSolvents;
         // number of the well control equations
-        static const int numWellControlEq = 1;
+        static constexpr int numWellControlEq = 1;
         // number of the well equations that will always be used
         // based on the solution strategy, there might be other well equations be introduced
-        static const int numStaticWellEq = numWellConservationEq + numWellControlEq;
+        static constexpr int numStaticWellEq = numWellConservationEq + numWellControlEq;
 
         // the index for Bhp in primary variables and also the index of well control equation
         // they both will be the last one in their respective system.
         // TODO: we should have indices for the well equations and well primary variables separately
-        static const int Bhp = numStaticWellEq - numWellControlEq;
+        static constexpr int Bhp = numStaticWellEq - numWellControlEq;
 
         using typename Base::Scalar;
 
@@ -131,13 +126,6 @@ namespace Opm
         using Eval = typename StdWellEval::Eval;
         using EvalWell = typename StdWellEval::EvalWell;
         using BVectorWell = typename StdWellEval::BVectorWell;
-
-        using Base::contiSolventEqIdx;
-        using Base::contiZfracEqIdx;
-        using Base::contiPolymerEqIdx;
-        using Base::contiFoamEqIdx;
-        using Base::contiBrineEqIdx;
-        static const int contiEnergyEqIdx = Indices::contiEnergyEqIdx;
 
         StandardWell(const Well& well,
                      const ParallelWellInfo& pw_info,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -88,14 +88,12 @@ public:
         typename BlackoilWellModel<TypeTag>::GLiftWellStateMap;
     using GLiftSyncGroups = typename GasLiftSingleWellGeneric::GLiftSyncGroups;
 
-    static const int numEq = Indices::numEq;
-    static const int numPhases = Indices::numPhases;
     using Scalar = GetPropType<TypeTag, Properties::Scalar>;
 
-    using VectorBlockType = Dune::FieldVector<Scalar, numEq>;
-    using MatrixBlockType = Dune::FieldMatrix<Scalar, numEq, numEq>;
+    using VectorBlockType = Dune::FieldVector<Scalar, Indices::numEq>;
+    using MatrixBlockType = Dune::FieldMatrix<Scalar, Indices::numEq, Indices::numEq>;
     using BVector = Dune::BlockVector<VectorBlockType>;
-    using Eval = DenseAd::Evaluation<Scalar, /*size=*/numEq>;
+    using Eval = DenseAd::Evaluation<Scalar, /*size=*/Indices::numEq>;
 
     using RateConverterType =
     typename WellInterfaceFluidSystem<FluidSystem>::RateConverterType;
@@ -114,21 +112,13 @@ public:
     static constexpr bool has_polymermw = getPropValue<TypeTag, Properties::EnablePolymerMW>();
     static constexpr bool has_foam = getPropValue<TypeTag, Properties::EnableFoam>();
     static constexpr bool has_brine = getPropValue<TypeTag, Properties::EnableBrine>();
-    static const int contiSolventEqIdx = Indices::contiSolventEqIdx;
-    static const int contiZfracEqIdx = Indices::contiZfracEqIdx;
-    static const int contiPolymerEqIdx = Indices::contiPolymerEqIdx;
-    // index for the polymer molecular weight continuity equation
-    static const int contiPolymerMWEqIdx = Indices::contiPolymerMWEqIdx;
-    static const int contiFoamEqIdx = Indices::contiFoamEqIdx;
-    static const int contiBrineEqIdx = Indices::contiBrineEqIdx;
-    static const bool compositionSwitchEnabled = Indices::compositionSwitchIdx >= 0;
 
     // For the conversion between the surface volume rate and reservoir voidage rate 
     using FluidState = BlackOilFluidState<Eval,
                                           FluidSystem,
                                           has_temperature,
                                           has_energy,
-                                          compositionSwitchEnabled,
+                                          Indices::compositionSwitchIdx >= 0,
                                           has_brine,
                                           Indices::numPhases >;
     /// Constructor
@@ -235,7 +225,7 @@ public:
     {
         Eval out = 0.0;
         out.setValue(in.value());
-        for(int eqIdx = 0; eqIdx < numEq;++eqIdx) {
+        for (int eqIdx = 0; eqIdx < Indices::numEq; ++eqIdx) {
             out.setDerivative(eqIdx, in.derivative(eqIdx));
         }
         return out;

--- a/tests/test_wellmodel.cpp
+++ b/tests/test_wellmodel.cpp
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(TestBehavoir) {
         const auto& well = wells[0];
         BOOST_CHECK_EQUAL(well->name(), "PROD1");
         BOOST_CHECK(well->isProducer());
-        BOOST_CHECK(well->numEq == 3);
+        BOOST_CHECK(StandardWell::Indices::numEq == 3);
         BOOST_CHECK(well->numStaticWellEq== 4);
     }
 
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(TestBehavoir) {
         const auto& well = wells[1];
         BOOST_CHECK_EQUAL(well->name(), "INJE1");
         BOOST_CHECK(well->isInjector());
-        BOOST_CHECK(well->numEq == 3);
+        BOOST_CHECK(StandardWell::Indices::numEq == 3);
         BOOST_CHECK(well->numStaticWellEq== 4);      
     }
 }


### PR DESCRIPTION
using Indices directly more clearly shows where the data comes
from without having to hop through hoops to do so.

This is a style thing more than anything else so personal preferences play a big role. Feel free to reject.