### PR TITLE
Handle empty region in average calculator

### DIFF
--- a/opm/simulators/wells/RegionAverageCalculator.hpp
+++ b/opm/simulators/wells/RegionAverageCalculator.hpp
@@ -185,10 +185,11 @@ namespace Opm {
                           // using the pore volume to do the averaging
                           const auto& attri_pv = attributes_pv[reg];
                           const double pv_sum = comm.sum(attri_pv.pv);
-                          assert(pv_sum > 0.);
-                          const double p_pv_sum = comm.sum(attri_pv.pressure);
-                          ra.pressure = p_pv_sum / pv_sum;
-
+                          // pore volums can be zero if a fipnum region is empty
+                          if (pv_sum > 0) {
+                            const double p_pv_sum = comm.sum(attri_pv.pressure);
+                            ra.pressure = p_pv_sum / pv_sum;
+                          }
                       }
                 }
             }


### PR DESCRIPTION
This should fix model 2 regression. 
A more elegant solution would be to make the RegionMapping.hpp parallel aware. But that is a task for another time and person. @bska or @blattms Cool if one of you could take a look at this some time.  