### PR TITLE
Option for continue on solver convergence failure

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -45,6 +45,10 @@ struct SolverMinTimeStep {
     using type = UndefinedProperty;
 };
 template<class TypeTag, class MyTypeTag>
+struct SolverContinueOnConvergenceFailure {
+    using type = UndefinedProperty;
+};
+template<class TypeTag, class MyTypeTag>
 struct SolverMaxRestarts {
     using type = UndefinedProperty;
 };
@@ -137,6 +141,10 @@ template<class TypeTag>
 struct SolverMinTimeStep<TypeTag, TTag::FlowTimeSteppingParameters> {
     using type = GetPropType<TypeTag, Scalar>;
     static constexpr type value = 1.0e-12;
+};
+template<class TypeTag>
+struct SolverContinueOnConvergenceFailure<TypeTag, TTag::FlowTimeSteppingParameters> {
+    static constexpr bool value = false;
 };
 template<class TypeTag>
 struct SolverMaxRestarts<TypeTag, TTag::FlowTimeSteppingParameters> {
@@ -262,6 +270,7 @@ namespace Opm {
             , maxGrowth_(EWOMS_GET_PARAM(TypeTag, double, SolverMaxGrowth)) // 3.0
             , maxTimeStep_(EWOMS_GET_PARAM(TypeTag, double, SolverMaxTimeStepInDays)*24*60*60) // 365.25
             , minTimeStep_(unitSystem.to_si(UnitSystem::measure::time, EWOMS_GET_PARAM(TypeTag, double, SolverMinTimeStep))) // 1e-12;
+            , ignoreConvergenceFailure_(EWOMS_GET_PARAM(TypeTag, bool, SolverContinueOnConvergenceFailure)) // false;
             , solverRestartMax_(EWOMS_GET_PARAM(TypeTag, int, SolverMaxRestarts)) // 10
             , solverVerbose_(EWOMS_GET_PARAM(TypeTag, int, SolverVerbosity) > 0 && terminalOutput) // 2
             , timestepVerbose_(EWOMS_GET_PARAM(TypeTag, int, TimeStepVerbosity) > 0 && terminalOutput) // 2
@@ -288,7 +297,8 @@ namespace Opm {
             , growthFactor_(tuning.TFDIFF)
             , maxGrowth_(tuning.TSFMAX)
             , maxTimeStep_(tuning.TSMAXZ) // 365.25
-            , minTimeStep_(unitSystem.to_si(UnitSystem::measure::time, EWOMS_GET_PARAM(TypeTag, double, SolverMinTimeStep))) // 1e-12;
+            , minTimeStep_(tuning.TSFMIN) // 0.1;
+            , ignoreConvergenceFailure_(true)
             , solverRestartMax_(EWOMS_GET_PARAM(TypeTag, int, SolverMaxRestarts)) // 10
             , solverVerbose_(EWOMS_GET_PARAM(TypeTag, int, SolverVerbosity) > 0 && terminalOutput) // 2
             , timestepVerbose_(EWOMS_GET_PARAM(TypeTag, int, TimeStepVerbosity) > 0 && terminalOutput) // 2
@@ -314,6 +324,8 @@ namespace Opm {
                                  "The maximum size of a time step in days");
             EWOMS_REGISTER_PARAM(TypeTag, double, SolverMinTimeStep,
                                  "The minimum size of a time step in days for field and metric and hours for lab. If a step cannot converge without getting cut below this step size the simulator will stop");
+            EWOMS_REGISTER_PARAM(TypeTag, bool, SolverContinueOnConvergenceFailure,
+                                 "Continue instead of stop when minimum solver time step is reached");
             EWOMS_REGISTER_PARAM(TypeTag, int, SolverMaxRestarts,
                                  "The maximum number of breakdowns before a substep is given up and the simulator is terminated");
             EWOMS_REGISTER_PARAM(TypeTag, int, SolverVerbosity,
@@ -444,7 +456,20 @@ namespace Opm {
 
                 report += substepReport;
 
-                if (substepReport.converged) {
+                bool continue_on_uncoverged_solution = ignoreConvergenceFailure_ && !substepReport.converged && dt <= minTimeStep_;
+
+                if (continue_on_uncoverged_solution) {
+                    const auto msg = std::string("Solver failed to converge but timestep ")
+                            + std::to_string(dt) + " is smaller or equal to "
+                            + std::to_string(minTimeStep_) + "\n which is the minimum threshold given"
+                            +  "by option --solver-min-time-step= \n";
+                    if (solverVerbose_) {
+                        OpmLog::error(msg);
+                    }
+                }
+
+                if (substepReport.converged || continue_on_uncoverged_solution) {
+
                     // advance by current dt
                     ++substepTimer;
 
@@ -736,6 +761,7 @@ namespace Opm {
         double maxGrowth_;                   //!< factor that limits the maximum growth of a time step
         double maxTimeStep_;                //!< maximal allowed time step size in days
         double minTimeStep_;                //!< minimal allowed time step size before throwing
+        bool ignoreConvergenceFailure_;     //!< continue instead of stop when minimum time step is reached
         int solverRestartMax_;        //!< how many restart of solver are allowed
         bool solverVerbose_;           //!< solver verbosity
         bool timestepVerbose_;         //!< timestep verbosity


### PR DESCRIPTION
Sometimes you just want you're simulation to run through. 

Note 1. It is false pr default. 
Note 2. It is set to true if TUNING is enabled

