### PR TITLE
Do not iterate inside computeBhpFromThp in MSW

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -206,9 +206,6 @@ namespace Opm
                                    const Scalar& segment_pressure,
                                    const bool& allow_cf,
                                    std::vector<Scalar>& cq_s,
-                                   Scalar& perf_press,
-                                   double& perf_dis_gas_rate,
-                                   double& perf_vap_oil_rate,
                                    DeferredLogger& deferred_logger) const;
 
         void computePerfRateEval(const IntensiveQuantities& int_quants,
@@ -261,9 +258,14 @@ namespace Opm
                                         DeferredLogger& deferred_logger) const;
 
         void computeWellRatesWithBhp(const Simulator& ebosSimulator,
-                                     const Scalar bhp,
+                                     const Scalar& bhp,
                                      std::vector<double>& well_flux,
                                      DeferredLogger& deferred_logger) const;
+
+        void computeWellRatesWithBhpIterations(const Simulator& ebosSimulator,
+                                               const Scalar& bhp,
+                                               std::vector<double>& well_flux,
+                                               DeferredLogger& deferred_logger) const;
 
         std::vector<double>
         computeWellPotentialWithTHP(const Simulator& ebos_simulator,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1743,22 +1743,20 @@ namespace Opm
             return rates;
         };
 
-        auto bhp = this->MultisegmentWellGeneric<Scalar>::
+        auto bhpAtLimit = this->MultisegmentWellGeneric<Scalar>::
                computeBhpAtThpLimitProd(frates,
                                         summary_state,
                                         maxPerfPress(ebos_simulator),
                                         getRefDensity(),
                                         deferred_logger);
 
-       if(bhp)
-           return bhp;
+       if(bhpAtLimit)
+           return bhpAtLimit;
 
        auto fratesIter = [this, &ebos_simulator, &deferred_logger](const double bhp) {
-           // Not solving the well equations here, which means we are
-           // calculating at the current Fg/Fw values of the
-           // well. This does not matter unless the well is
-           // crossflowing, and then it is likely still a good
-           // approximation.
+           // Solver the well iterations to see if we are
+           // able to get a solution with an update
+           // solution
            std::vector<double> rates(3);
            computeWellRatesWithBhpIterations(ebos_simulator, bhp, rates, deferred_logger);
            return rates;
@@ -1795,21 +1793,19 @@ namespace Opm
             return rates;
         };
 
-        auto bhp = this->MultisegmentWellGeneric<Scalar>::
+        auto bhpAtLimit = this->MultisegmentWellGeneric<Scalar>::
                 computeBhpAtThpLimitInj(frates,
                                         summary_state,
                                         getRefDensity(),
                                         deferred_logger);
 
-        if(bhp)
-            return bhp;
+        if(bhpAtLimit)
+            return bhpAtLimit;
 
        auto fratesIter = [this, &ebos_simulator, &deferred_logger](const double bhp) {
-           // Not solving the well equations here, which means we are
-           // calculating at the current Fg/Fw values of the
-           // well. This does not matter unless the well is
-           // crossflowing, and then it is likely still a good
-           // approximation.
+           // Solver the well iterations to see if we are
+           // able to get a solution with an update
+           // solution
            std::vector<double> rates(3);
            computeWellRatesWithBhpIterations(ebos_simulator, bhp, rates, deferred_logger);
            return rates;

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -327,7 +327,7 @@ namespace Opm
                              double& perf_vap_oil_rate,
                              DeferredLogger& deferred_logger) const;
 
-        void computeWellRatesWithBhpPotential(const Simulator& ebosSimulator,
+        void computeWellRatesWithBhpIterations(const Simulator& ebosSimulator,
                                               const double& bhp,
                                               std::vector<double>& well_flux,
                                               DeferredLogger& deferred_logger) const;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1674,10 +1674,10 @@ namespace Opm
     template<typename TypeTag>
     void
     StandardWell<TypeTag>::
-    computeWellRatesWithBhpPotential(const Simulator& ebosSimulator,
-                            const double& bhp,
-                            std::vector<double>& well_flux,
-                            DeferredLogger& deferred_logger) const
+    computeWellRatesWithBhpIterations(const Simulator& ebosSimulator,
+                                      const double& bhp,
+                                      std::vector<double>& well_flux,
+                                      DeferredLogger& deferred_logger) const
     {
 
         // iterate to get a more accurate well density
@@ -1739,13 +1739,13 @@ namespace Opm
             auto bhp_at_thp_limit = computeBhpAtThpLimitInj(ebos_simulator, summary_state, deferred_logger);
             if (bhp_at_thp_limit) {
                 const double bhp = std::min(*bhp_at_thp_limit, controls.bhp_limit);
-                computeWellRatesWithBhpPotential(ebos_simulator, bhp, potentials, deferred_logger);
+                computeWellRatesWithBhpIterations(ebos_simulator, bhp, potentials, deferred_logger);
             } else {
                 deferred_logger.warning("FAILURE_GETTING_CONVERGED_POTENTIAL",
                                         "Failed in getting converged thp based potential calculation for well "
                                         + name() + ". Instead the bhp based value is used");
                 const double bhp = controls.bhp_limit;
-                computeWellRatesWithBhpPotential(ebos_simulator, bhp, potentials, deferred_logger);
+                computeWellRatesWithBhpIterations(ebos_simulator, bhp, potentials, deferred_logger);
             }
         } else {
             computeWellRatesWithThpAlqProd(
@@ -1772,7 +1772,7 @@ namespace Opm
         if (bhp_at_thp_limit) {
             const auto& controls = this->well_ecl_.productionControls(summary_state);
             bhp = std::max(*bhp_at_thp_limit, controls.bhp_limit);
-            computeWellRatesWithBhpPotential(ebos_simulator, bhp, potentials, deferred_logger);
+            computeWellRatesWithBhpIterations(ebos_simulator, bhp, potentials, deferred_logger);
         }
         else {
             deferred_logger.warning("FAILURE_GETTING_CONVERGED_POTENTIAL",
@@ -1780,7 +1780,7 @@ namespace Opm
                 + name() + ". Instead the bhp based value is used");
             const auto& controls = this->well_ecl_.productionControls(summary_state);
             bhp = controls.bhp_limit;
-            computeWellRatesWithBhpPotential(ebos_simulator, bhp, potentials, deferred_logger);
+            computeWellRatesWithBhpIterations(ebos_simulator, bhp, potentials, deferred_logger);
         }
         return bhp;
     }
@@ -1891,7 +1891,7 @@ namespace Opm
             // get the bhp value based on the bhp constraints
             const double bhp = this->mostStrictBhpFromBhpLimits(summaryState);
             assert(std::abs(bhp) != std::numeric_limits<double>::max());
-            computeWellRatesWithBhpPotential(ebosSimulator, bhp, well_potentials, deferred_logger);
+            computeWellRatesWithBhpIterations(ebosSimulator, bhp, well_potentials, deferred_logger);
         } else {
             // the well has a THP related constraint
             well_potentials = computeWellPotentialWithTHP(ebosSimulator, deferred_logger, well_state);


### PR DESCRIPTION
Note 1. For stw this is just a rename to make the naming consistent with MSW.

Gives significant speed up, especially in parallel where the well potential calculations  for MSW used to take up most of the simulation time. 

Moreover the change avoids too early closing of wells due to issues with the operability check. 