### PR TITLE
pass updated well rates totarget reduction not the nupcol ones 

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1525,19 +1525,19 @@ updateAndCommunicateGroupData(const int reportStepIdx,
     auto& well_state = this->wellState();
     const auto& well_state_nupcol = this->nupcolWellState();
     // the group target reduction rates needs to be update since wells may have switched to/from GRUP control
-    // Currently the group target reduction does not honor NUPCOL. TODO: is that true?
+    // The group target reduction does not honor NUPCOL.
     std::vector<double> groupTargetReduction(numPhases(), 0.0);
-    WellGroupHelpers::updateGroupTargetReduction(fieldGroup, schedule(), reportStepIdx, /*isInjector*/ false, phase_usage_, guideRate_, well_state_nupcol, well_state, this->groupState(), groupTargetReduction);
+    WellGroupHelpers::updateGroupTargetReduction(fieldGroup, schedule(), reportStepIdx, /*isInjector*/ false, phase_usage_, guideRate_, well_state, this->groupState(), groupTargetReduction);
     std::vector<double> groupTargetReductionInj(numPhases(), 0.0);
-    WellGroupHelpers::updateGroupTargetReduction(fieldGroup, schedule(), reportStepIdx, /*isInjector*/ true, phase_usage_, guideRate_, well_state_nupcol, well_state, this->groupState(), groupTargetReductionInj);
+    WellGroupHelpers::updateGroupTargetReduction(fieldGroup, schedule(), reportStepIdx, /*isInjector*/ true, phase_usage_, guideRate_, well_state, this->groupState(), groupTargetReductionInj);
 
-    WellGroupHelpers::updateREINForGroups(fieldGroup, schedule(), reportStepIdx, phase_usage_, summaryState_, well_state_nupcol, well_state, this->groupState());
-    WellGroupHelpers::updateVREPForGroups(fieldGroup, schedule(), reportStepIdx, well_state_nupcol, well_state, this->groupState());
+    WellGroupHelpers::updateREINForGroups(fieldGroup, schedule(), reportStepIdx, phase_usage_, summaryState_, well_state_nupcol, this->groupState());
+    WellGroupHelpers::updateVREPForGroups(fieldGroup, schedule(), reportStepIdx, well_state_nupcol, this->groupState());
 
-    WellGroupHelpers::updateReservoirRatesInjectionGroups(fieldGroup, schedule(), reportStepIdx, well_state_nupcol, well_state, this->groupState());
+    WellGroupHelpers::updateReservoirRatesInjectionGroups(fieldGroup, schedule(), reportStepIdx, well_state_nupcol, this->groupState());
     WellGroupHelpers::updateSurfaceRatesInjectionGroups(fieldGroup, schedule(), reportStepIdx, well_state_nupcol, this->groupState());
 
-    WellGroupHelpers::updateGroupProductionRates(fieldGroup, schedule(), reportStepIdx, well_state_nupcol, well_state, this->groupState());
+    WellGroupHelpers::updateGroupProductionRates(fieldGroup, schedule(), reportStepIdx, well_state_nupcol, this->groupState());
 
     // We use the rates from the previous time-step to reduce oscillations
     WellGroupHelpers::updateWellRates(fieldGroup, schedule(), reportStepIdx, this->prevWellState(), well_state);

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -92,8 +92,7 @@ namespace WellGroupHelpers
                                     const bool isInjector,
                                     const PhaseUsage& pu,
                                     const GuideRate& guide_rate,
-                                    const WellState& wellStateNupcol,
-                                    WellState& wellState,
+                                    const WellState& wellState,
                                     GroupState& group_state,
                                     std::vector<double>& groupTargetReduction);
 
@@ -145,21 +144,19 @@ namespace WellGroupHelpers
     void updateVREPForGroups(const Group& group,
                              const Schedule& schedule,
                              const int reportStepIdx,
-                             const WellState& wellStateNupcol,
-                             WellState& wellState,
+                             const WellState& wellState,
                              GroupState& group_state);
 
     void updateReservoirRatesInjectionGroups(const Group& group,
                                              const Schedule& schedule,
                                              const int reportStepIdx,
-                                             const WellState& wellStateNupcol,
-                                             WellState& wellState,
+                                             const WellState& wellState,
                                              GroupState& group_state);
 
     void updateSurfaceRatesInjectionGroups(const Group& group,
                                            const Schedule& schedule,
                                            const int reportStepIdx,
-                                           const WellState& wellStateNupcol,
+                                           const WellState& wellState,
                                            GroupState& group_state);
 
     void updateWellRates(const Group& group,
@@ -171,8 +168,7 @@ namespace WellGroupHelpers
     void updateGroupProductionRates(const Group& group,
                                     const Schedule& schedule,
                                     const int reportStepIdx,
-                                    const WellState& wellStateNupcol,
-                                    WellState& wellState,
+                                    const WellState& wellState,
                                     GroupState& group_state);
 
     void updateWellRatesFromGroupTargetScale(const double scale,
@@ -188,8 +184,7 @@ namespace WellGroupHelpers
                              const int reportStepIdx,
                              const PhaseUsage& pu,
                              const SummaryState& st,
-                             const WellState& wellStateNupcol,
-                             WellState& wellState,
+                             const WellState& wellState,
                              GroupState& group_state);
 
     template <class RegionalValues>


### PR DESCRIPTION
This PR also removes the passing of the non-constant wellState to the groupState update code since groupState is separated from the wellState now. 