### PR TITLE
bugfix: Detect exception during beginReportStep in parallel & abort

### DIFF
--- a/opm/simulators/utils/DeferredLogger.hpp
+++ b/opm/simulators/utils/DeferredLogger.hpp
@@ -46,6 +46,7 @@ enum ExcEnum {
     INVALID_ARGUMENT = 2,
     LOGIC_ERROR = 3,
     DEFAULT = 4,   // will throw std::logic_error()
+    NUMERICAL_ISSUE = 5
 };
 }
 

--- a/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
+++ b/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
@@ -23,6 +23,8 @@
 
 #include <opm/simulators/utils/DeferredLogger.hpp>
 
+#include <opm/material/common/Exceptions.hpp>
+
 #include <dune/common/version.hh>
 #include <dune/common/parallel/mpihelper.hh>
 
@@ -63,6 +65,9 @@ void _throw(Opm::ExceptionType::ExcEnum exc_type, const std::string& message) {
         break;
     case Opm::ExceptionType::INVALID_ARGUMENT:
         throw std::invalid_argument(message);
+        break;
+    case Opm::ExceptionType::NUMERICAL_ISSUE:
+        throw Opm::NumericalIssue(message);
         break;
     case Opm::ExceptionType::DEFAULT:
     case Opm::ExceptionType::LOGIC_ERROR:


### PR DESCRIPTION
Previously, exceptions happening at this stage have deadlocked flow. E.g.  `UniformTabulated2DFunction` in opm-material throws a `NumericalIssue` if the values passed are outside the tabulated reason. This function is e.g. called in 2-phase CO2-storage cases during `BlackoilModel::initializeWellState`.

BTW: This is only the first step as it is not very user friendly that a simulation aborts at this stage.