### PR TITLE
Create Action::State external to the vanguard

### DIFF
--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -153,6 +153,7 @@ public:
     static void setExternalSummaryConfig(std::unique_ptr<SummaryConfig> summaryConfig);
 
     static void setExternalUDQState(std::unique_ptr<UDQState> udqState);
+    static void setExternalActionState(std::unique_ptr<Action::State> actionState);
     /*!
      * \brief Return a reference to the parsed ECL deck.
      */
@@ -301,6 +302,7 @@ protected:
     static std::unique_ptr<Schedule> externalEclSchedule_;
     static std::unique_ptr<SummaryConfig> externalEclSummaryConfig_;
     static std::unique_ptr<UDQState> externalUDQState_;
+    static std::unique_ptr<Action::State> externalActionState_;
     static std::unique_ptr<CommunicationType> comm_;
 
     std::string caseName_;

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -47,6 +47,7 @@
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
@@ -470,7 +471,7 @@ namespace Opm
                 if (output_param >= 0)
                     outputInterval = output_param;
 
-                readDeck(mpiRank, deckFilename, deck_, eclipseState_, schedule_, udqState_,
+                readDeck(mpiRank, deckFilename, deck_, eclipseState_, schedule_, udqState_, actionState_,
                          summaryConfig_, nullptr, python, std::move(parseContext),
                          init_from_restart_file, outputCout_, outputInterval);
 
@@ -552,6 +553,7 @@ namespace Opm
         std::unique_ptr<EclipseState> eclipseState_;
         std::unique_ptr<Schedule> schedule_;
         std::unique_ptr<UDQState> udqState_;
+        std::unique_ptr<Action::State> actionState_;
         std::unique_ptr<SummaryConfig> summaryConfig_;
     };
 

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -48,6 +48,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
@@ -191,7 +192,7 @@ void setupMessageLimiter(const Opm::MessageLimits msgLimits,  const std::string&
 
 
 void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& deck, std::unique_ptr<Opm::EclipseState>& eclipseState,
-              std::unique_ptr<Opm::Schedule>& schedule, std::unique_ptr<UDQState>& udqState, std::unique_ptr<Opm::SummaryConfig>& summaryConfig,
+              std::unique_ptr<Opm::Schedule>& schedule, std::unique_ptr<UDQState>& udqState, std::unique_ptr<Action::State>& actionState, std::unique_ptr<Opm::SummaryConfig>& summaryConfig,
               std::unique_ptr<ErrorGuard> errorGuard, std::shared_ptr<Opm::Python>& python, std::unique_ptr<ParseContext> parseContext,
               bool initFromRestart, bool checkDeck, const std::optional<int>& outputInterval)
 {
@@ -280,6 +281,7 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
 
                 udqState = std::make_unique<UDQState>((*schedule)[0].udq().params().undefinedValue());
                 udqState->load_rst(rst_state);
+                actionState = std::make_unique<Action::State>();
             }
             else {
                 if (!schedule) {
@@ -289,6 +291,7 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
                 }
 
                 udqState = std::make_unique<UDQState>((*schedule)[0].udq().params().undefinedValue());
+                actionState = std::make_unique<Action::State>();
             }
 
 

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -38,6 +38,10 @@ class Schedule;
 class SummaryConfig;
 class UDQState;
 
+namespace Action {
+class State;
+}
+
 enum class FileOutputMode {
     //! \brief No output to files.
     OUTPUT_NONE = 0,
@@ -54,7 +58,7 @@ FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, con
 ///
 /// If pointers already contains objects then they are used otherwise they are created and can be used outside later.
 void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Deck>& deck, std::unique_ptr<EclipseState>& eclipseState,
-              std::unique_ptr<Schedule>& schedule, std::unique_ptr<UDQState>& udqState, std::unique_ptr<SummaryConfig>& summaryConfig,
+              std::unique_ptr<Schedule>& schedule, std::unique_ptr<UDQState>& udqState, std::unique_ptr<Action::State>& actionState, std::unique_ptr<SummaryConfig>& summaryConfig,
               std::unique_ptr<ErrorGuard> errorGuard, std::shared_ptr<Python>& python, std::unique_ptr<ParseContext> parseContext,
               bool initFromRestart, bool checkDeck, const std::optional<int>& outputInterval);
 } // end namespace Opm

--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -37,4 +37,5 @@ then
   ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -a  ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
+echo ">>> ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/${FILENAME} ${RESULT_PATH}/${FILENAME} ${ABS_TOL} ${REL_TOL}"
 exit $ecode


### PR DESCRIPTION
Create the `Action::State` external to the vanguard. This is a necessary step to load the action state variables from the restart file.