### PR TITLE
Use single well state

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1323,12 +1323,13 @@ namespace Opm {
     {
         DeferredLogger local_deferredLogger;
         for (const auto& well : well_container_) {
-            const auto wasClosed = wellTestState.hasWellClosed(well->name());
+            const auto& wname = well->name();
+            const auto wasClosed = wellTestState.hasWellClosed(wname);
 
-            well->updateWellTestState(this->wellState(), simulationTime, /*writeMessageToOPMLog=*/ true, wellTestState, local_deferredLogger);
+            well->updateWellTestState(this->wellState().well(wname), simulationTime, /*writeMessageToOPMLog=*/ true, wellTestState, local_deferredLogger);
 
-            if (!wasClosed && wellTestState.hasWellClosed(well->name())) {
-                this->closed_this_step_.insert(well->name());
+            if (!wasClosed && wellTestState.hasWellClosed(wname)) {
+                this->closed_this_step_.insert(wname);
             }
         }
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -588,7 +588,7 @@ namespace Opm
                                        max_pressure_change);
 
         this->updateWellStateFromPrimaryVariables(well_state, getRefDensity(), deferred_logger);
-        Base::calculateReservoirRates(well_state);
+        Base::calculateReservoirRates(well_state.well(this->index_of_well_));
     }
 
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -857,7 +857,7 @@ namespace Opm
         updatePrimaryVariablesNewton(dwells, well_state);
 
         updateWellStateFromPrimaryVariables(well_state, deferred_logger);
-        Base::calculateReservoirRates(well_state);
+        Base::calculateReservoirRates(well_state.well(this->index_of_well_));
     }
 
 

--- a/opm/simulators/wells/WellInterfaceFluidSystem.cpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.cpp
@@ -824,7 +824,7 @@ updateWellTestState(const SingleWellState& ws,
     }
 
     // updating well test state based on physical (THP/BHP) limits.
-    updateWellTestStatePhysical(ws, simulationTime, writeMessageToOPMLog, wellTestState, deferred_logger);
+    updateWellTestStatePhysical(simulationTime, writeMessageToOPMLog, wellTestState, deferred_logger);
 
     // updating well test state based on Economic limits.
     updateWellTestStateEconomic(ws, simulationTime, writeMessageToOPMLog, wellTestState, deferred_logger);

--- a/opm/simulators/wells/WellInterfaceFluidSystem.hpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.hpp
@@ -40,6 +40,7 @@ class Group;
 class GroupState;
 class Schedule;
 class WellState;
+class SingleWellState;
 
 template<class FluidSystem>
 class WellInterfaceFluidSystem : public WellInterfaceGeneric {
@@ -50,7 +51,7 @@ protected:
     static constexpr int INVALIDCOMPLETION = std::numeric_limits<int>::max();
 
 public:
-    void updateWellTestState(const WellState& well_state,
+    void updateWellTestState(const SingleWellState& ws,
                              const double& simulationTime,
                              const bool& writeMessageToOPMLog,
                              WellTestState& wellTestState,
@@ -79,15 +80,15 @@ protected:
                              const std::vector<PerforationData>& perf_data);
 
     // updating the voidage rates in well_state when requested
-    void calculateReservoirRates(WellState& well_state) const;
+    void calculateReservoirRates(SingleWellState& ws) const;
 
-    bool checkIndividualConstraints(WellState& well_state,
+    bool checkIndividualConstraints(SingleWellState& ws,
                                     const SummaryState& summaryState) const;
 
-    Well::InjectorCMode activeInjectionConstraint(const WellState& well_state,
+    Well::InjectorCMode activeInjectionConstraint(const SingleWellState& ws,
                                                   const SummaryState& summaryState) const;
 
-    Well::ProducerCMode activeProductionConstraint(const WellState& well_state,
+    Well::ProducerCMode activeProductionConstraint(const SingleWellState& ws,
                                                    const SummaryState& summaryState) const;
 
     std::pair<bool, double> checkGroupConstraintsInj(const Group& group,
@@ -129,23 +130,23 @@ protected:
     };
 
     void checkMaxWaterCutLimit(const WellEconProductionLimits& econ_production_limits,
-                               const WellState& well_state,
+                               const SingleWellState& ws,
                                RatioLimitCheckReport& report) const;
 
     void checkMaxGORLimit(const WellEconProductionLimits& econ_production_limits,
-                          const WellState& well_state,
+                          const SingleWellState& ws,
                           RatioLimitCheckReport& report) const;
 
     void checkMaxWGRLimit(const WellEconProductionLimits& econ_production_limits,
-                          const WellState& well_state,
+                          const SingleWellState& ws,
                           RatioLimitCheckReport& report) const;
 
     void checkRatioEconLimits(const WellEconProductionLimits& econ_production_limits,
-                              const WellState& well_state,
+                              const SingleWellState& ws,
                               RatioLimitCheckReport& report,
                               DeferredLogger& deferred_logger) const;
 
-    void updateWellTestStateEconomic(const WellState& well_state,
+    void updateWellTestStateEconomic(const SingleWellState& ws,
                                      const double simulation_time,
                                      const bool write_message_to_opmlog,
                                      WellTestState& well_test_state,
@@ -174,13 +175,13 @@ protected:
 
 private:
     template <typename RatioFunc>
-    void checkMaxRatioLimitCompletions(const WellState& well_state,
+    void checkMaxRatioLimitCompletions(const SingleWellState& ws,
                                        const double max_ratio_limit,
                                        const RatioFunc& ratioFunc,
                                        RatioLimitCheckReport& report) const;
 
     template<typename RatioFunc>
-    bool checkMaxRatioLimitWell(const WellState& well_state,
+    bool checkMaxRatioLimitWell(const SingleWellState& well_state,
                                 const double max_ratio_limit,
                                 const RatioFunc& ratioFunc) const;
 };

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -347,8 +347,7 @@ bool WellInterfaceGeneric::isVFPActive(DeferredLogger& deferred_logger) const
     }
 }
 
-void WellInterfaceGeneric::updateWellTestStatePhysical(const SingleWellState& /* well_state */,
-                                                       const double simulation_time,
+void WellInterfaceGeneric::updateWellTestStatePhysical(const double simulation_time,
                                                        const bool write_message_to_opmlog,
                                                        WellTestState& well_test_state,
                                                        DeferredLogger& deferred_logger) const

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -347,7 +347,7 @@ bool WellInterfaceGeneric::isVFPActive(DeferredLogger& deferred_logger) const
     }
 }
 
-void WellInterfaceGeneric::updateWellTestStatePhysical(const WellState& /* well_state */,
+void WellInterfaceGeneric::updateWellTestStatePhysical(const SingleWellState& /* well_state */,
                                                        const double simulation_time,
                                                        const bool write_message_to_opmlog,
                                                        WellTestState& well_test_state,

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -172,8 +172,7 @@ public:
 protected:
     bool getAllowCrossFlow() const;
     double mostStrictBhpFromBhpLimits(const SummaryState& summaryState) const;
-    void updateWellTestStatePhysical(const SingleWellState& ws,
-                                     const double simulation_time,
+    void updateWellTestStatePhysical(const double simulation_time,
                                      const bool write_message_to_opmlog,
                                      WellTestState& well_test_state,
                                      DeferredLogger& deferred_logger) const;

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -43,6 +43,7 @@ class SummaryState;
 class VFPProperties;
 class WellTestState;
 class WellState;
+class SingleWellState;
 class GroupState;
 class Group;
 class Schedule;
@@ -171,7 +172,7 @@ public:
 protected:
     bool getAllowCrossFlow() const;
     double mostStrictBhpFromBhpLimits(const SummaryState& summaryState) const;
-    void updateWellTestStatePhysical(const WellState& well_state,
+    void updateWellTestStatePhysical(const SingleWellState& ws,
                                      const double simulation_time,
                                      const bool write_message_to_opmlog,
                                      WellTestState& well_test_state,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -175,7 +175,7 @@ namespace Opm
 
         bool changed = false;
         if (iog == IndividualOrGroup::Individual) {
-            changed = this->checkIndividualConstraints(well_state, summaryState);
+            changed = this->checkIndividualConstraints(ws, summaryState);
         } else if (iog == IndividualOrGroup::Group) {
             changed = this->checkGroupConstraints(well_state, group_state, schedule, summaryState, deferred_logger);
         } else {
@@ -273,7 +273,7 @@ namespace Opm
             for (int p = 0; p < np; ++p) {
                 ws.well_potentials[p] = std::abs(potentials[p]);
             }
-            this->updateWellTestState(well_state_copy, simulation_time, /*writeMessageToOPMLog=*/ false, welltest_state_temp, deferred_logger);
+            this->updateWellTestState(well_state_copy.well(this->indexOfWell()), simulation_time, /*writeMessageToOPMLog=*/ false, welltest_state_temp, deferred_logger);
             this->closeCompletions(welltest_state_temp);
 
             // Stop testing if the well is closed or shut due to all completions shut


### PR DESCRIPTION
Use class `SingleWellState` instead of full `WellState` container in some locations. More to come.