### PR TITLE
add well_test_state to WGState

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1312,7 +1312,7 @@ assignShutConnections(data::Wells& wsrpt,
             return wellIsOpen && (conn.state() != Connection::State::SHUT);
         };
 
-        if (this->wellTestState_.hasWellClosed(well.name()) &&
+        if (this->wellTestState().hasWellClosed(well.name()) &&
             !this->wasDynamicallyShutThisTimeStep(wellID))
         {
             xwel.dynamicStatus = well.getAutomaticShutIn()
@@ -1581,7 +1581,7 @@ forceShutWellByNameIfPredictionMode(const std::string& wellname,
     for (const auto& well : well_container_generic_) {
         if (well->name() == wellname && !well->wellIsStopped()) {
             if (well->underPredictionMode()) {
-                wellTestState_.closeWell(wellname, WellTestConfig::Reason::PHYSICAL, simulation_time);
+                wellTestState().closeWell(wellname, WellTestConfig::Reason::PHYSICAL, simulation_time);
                 well_was_shut = 1;
             }
             break;

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1588,6 +1588,10 @@ forceShutWellByNameIfPredictionMode(const std::string& wellname,
         }
     }
 
+    // the wellTesteState is updated between timesteps and we also need to update the privous WGstate
+    if(well_was_shut)
+        this->commitWGState();
+
     // Communicate across processes if a well was shut.
     well_was_shut = comm_.max(well_was_shut);
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -116,6 +116,10 @@ public:
 
     GroupState& groupState() { return this->active_wgstate_.group_state; }
 
+    WellTestState& wellTestState() { return this->active_wgstate_.well_test_state; }
+
+    const WellTestState& wellTestState() const { return this->active_wgstate_.well_test_state; }
+
 
     double wellPI(const int well_index) const;
     double wellPI(const std::string& well_name) const;
@@ -405,7 +409,6 @@ protected:
 
     mutable std::unordered_set<std::string> closed_this_step_;
 
-    WellTestState wellTestState_{};
     GuideRate guideRate_;
     std::unique_ptr<VFPProperties> vfp_properties_{};
     std::map<std::string, double> node_pressures_; // Storing network pressures for output.

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -326,7 +326,7 @@ namespace Opm {
 
         // Close completions due to economical reasons
         for (auto& well : well_container_) {
-            well->closeCompletions(wellTestState_);
+            well->closeCompletions(wellTestState());
         }
 
         // calculate the well potentials
@@ -412,7 +412,7 @@ namespace Opm {
     {
         const auto& wtest_config = schedule()[timeStepIdx].wtest_config();
         if (wtest_config.size() != 0) { // there is a WTEST request
-            const auto wellsForTesting = wellTestState_
+            const auto wellsForTesting = wellTestState()
                 .updateWells(wtest_config, wells_ecl_, simulationTime);
 
             for (const auto& testWell : wellsForTesting) {
@@ -435,7 +435,7 @@ namespace Opm {
                 const WellTestConfig::Reason testing_reason = testWell.second;
 
                 well->wellTesting(ebosSimulator_, simulationTime, timeStepIdx,
-                                  testing_reason, this->wellState(), this->groupState(), wellTestState_, deferred_logger);
+                                  testing_reason, this->wellState(), this->groupState(), wellTestState(), deferred_logger);
             }
         }
     }
@@ -511,7 +511,7 @@ namespace Opm {
             local_deferredLogger.warning("WELL_POTENTIAL_CALCULATION_FAILED", msg);
         }
 
-        updateWellTestState(simulationTime, wellTestState_);
+        updateWellTestState(simulationTime, wellTestState());
 
         // check group sales limits at the end of the timestep
         checkGconsaleLimits(fieldGroup, this->wellState(),
@@ -634,28 +634,28 @@ namespace Opm {
                 }
 
                 // A new WCON keywords can re-open a well that was closed/shut due to Physical limit
-                if (this->wellTestState_.hasWellClosed(well_name)) {
+                if (this->wellTestState().hasWellClosed(well_name)) {
                     // TODO: more checking here, to make sure this standard more specific and complete
                     // maybe there is some WCON keywords will not open the well
                     auto& events = this->wellState().well(w).events;
                     if (events.hasEvent(WellState::event_mask)) {
-                        if (wellTestState_.lastTestTime(well_name) == ebosSimulator_.time()) {
+                        if (wellTestState().lastTestTime(well_name) == ebosSimulator_.time()) {
                             // The well was shut this timestep, we are most likely retrying
                             // a timestep without the well in question, after it caused
                             // repeated timestep cuts. It should therefore not be opened,
                             // even if it was new or received new targets this report step.
                             events.clearEvent(WellState::event_mask);
                         } else {
-                            wellTestState_.openWell(well_name);
+                            wellTestState().openWell(well_name);
                         }
                     }
                 }
 
                 // TODO: should we do this for all kinds of closing reasons?
-                // something like wellTestState_.hasWell(well_name)?
+                // something like wellTestState().hasWell(well_name)?
                 bool wellIsStopped = false;
-                if (wellTestState_.hasWellClosed(well_name, WellTestConfig::Reason::ECONOMIC) ||
-                    wellTestState_.hasWellClosed(well_name, WellTestConfig::Reason::PHYSICAL))
+                if (wellTestState().hasWellClosed(well_name, WellTestConfig::Reason::ECONOMIC) ||
+                    wellTestState().hasWellClosed(well_name, WellTestConfig::Reason::PHYSICAL))
                 {
                     if (well_ecl.getAutomaticShutIn()) {
                         // shut wells are not added to the well container

--- a/opm/simulators/wells/WGState.cpp
+++ b/opm/simulators/wells/WGState.cpp
@@ -24,7 +24,8 @@ namespace Opm {
 
 WGState::WGState(const PhaseUsage& pu) :
     well_state(pu),
-    group_state(pu.num_phases)
+    group_state(pu.num_phases),
+    well_test_state{}
 {}
 
 }

--- a/opm/simulators/wells/WGState.hpp
+++ b/opm/simulators/wells/WGState.hpp
@@ -22,11 +22,12 @@
 
 #include <opm/simulators/wells/WellState.hpp>
 #include <opm/simulators/wells/GroupState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp>
 
 namespace Opm {
 
 /*
-  Microscopic class to handle a pair of well and group state.
+  Microscopic class to handle well , group and well test state.
 */
 
 struct PhaseUsage;
@@ -36,6 +37,8 @@ struct WGState {
 
     WellState well_state;
     GroupState group_state;
+    WellTestState well_test_state;
+
 };
 
 }


### PR DESCRIPTION
If the simulator fails after a well opens due to well testing we want to also revert the wellTestState. Adding the wellTestState to the WGState class automatically includes it in the resetWGState and commitWGState logic. 