### PR TITLE
update status after WTEST

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -369,7 +369,10 @@ namespace Opm {
 
                 const auto& events = schedule()[reportStepIdx].wellgroup_events();
                 const bool event = report_step_starts_ && events.hasEvent(well->name(), effective_events_mask);
-                if (event) {
+                const bool dyn_status_change = this->wellState().well(well->name()).status
+                        != this->prevWellState().well(well->name()).status;
+
+                if (event || dyn_status_change) {
                     try {
                         well->updateWellStateWithTarget(ebosSimulator_, this->groupState(), this->wellState(), local_deferredLogger);
                         well->calculateExplicitQuantities(ebosSimulator_, this->wellState(), local_deferredLogger);

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -62,6 +62,10 @@ void SingleWellState::stop() {
     this->status = Well::Status::STOP;
 }
 
+void SingleWellState::open() {
+    this->status = Well::Status::OPEN;
+}
+
 }
 
 

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -54,6 +54,7 @@ public:
     void init_timestep(const SingleWellState& other);
     void shut();
     void stop();
+    void open();
 };
 
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -298,6 +298,8 @@ namespace Opm
                     welltest_state.dropCompletion(this->name(), completion.first);
                 }
             }
+            // set the status of the well_state to open
+            ws.open();
             well_state = well_state_copy;
         }
     }
@@ -514,6 +516,8 @@ namespace Opm
             for (int p = 0; p < np; ++p) {
                 ws.well_potentials[p] = std::abs(potentials[p]);
             }
+            //set the status of the well_state to open
+            ws.open();
             well_state = well_state_copy;
         } else {
             const std::string msg = " well " + this->name() + " is not operable during well testing for physical reason";

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -770,6 +770,12 @@ void WellState::stopWell(int well_index)
     ws.stop();
 }
 
+void WellState::openWell(int well_index)
+{
+    auto& ws = this->well(well_index);
+    ws.open();
+}
+
 void WellState::shutWell(int well_index)
 {
     auto& ws = this->well(well_index);

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -217,10 +217,7 @@ public:
 
     void updateStatus(int well_index, Well::Status status);
 
-    void openWell(int well_index) {
-        this->wells_[well_index].status = Well::Status::OPEN;
-    }
-
+    void openWell(int well_index);
     void shutWell(int well_index);
     void stopWell(int well_index);
 


### PR DESCRIPTION
without this PR the well will open and be included in the well container, but the output will be trivial since the status is still SHUT. 