### PR TITLE
Save space for cartesianToCompressed mapping.

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -297,8 +297,11 @@ public:
      */
     int compressedIndex(int cartesianCellIdx) const
     {
-        int index = cartesianToCompressed_[cartesianCellIdx];
-        return index;
+        auto index_pair = cartesianToCompressed_.find(cartesianCellIdx);
+        if (index_pair!=cartesianToCompressed_.end())
+            return index_pair->second;
+        else
+            return -1;
     }
 
     /*!
@@ -399,7 +402,6 @@ protected:
     void updateCartesianToCompressedMapping_()
     {
         size_t num_cells = asImp_().grid().leafGridView().size(0);
-        cartesianToCompressed_.resize(cartesianSize(), -1);
         for (unsigned i = 0; i < num_cells; ++i) {
             unsigned cartesianCellIdx = cartesianIndex(i);
             cartesianToCompressed_[cartesianCellIdx] = i;
@@ -482,7 +484,7 @@ protected:
     /*! \brief Mapping between cartesian and compressed cells.
      *  It is initialized the first time it is called
      */
-    std::vector<int> cartesianToCompressed_;
+    std::unordered_map<int,int> cartesianToCompressed_;
 
     /*! \brief Cell center depths
      */

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -194,10 +194,10 @@ protected:
      *         inactive cells are omitted in these vectors.
      */
     std::tuple<std::vector<NNCdata>, std::vector<NNCdata>>
-    applyNncToGridTrans_(const std::vector<int>& cartesianToCompressed);
+    applyNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianToCompressed);
 
     /// \brief Multiplies the grid transmissibilities according to EDITNNC.
-    void applyEditNncToGridTrans_(const std::vector<int>& globalToLocal);
+    void applyEditNncToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal);
 
     void extractPermeability_();
 


### PR DESCRIPTION
For 10 Million cell problems my compute server (128 RAM) starts to swap, when I use debugging tools in parallel runs. I assume that this might get an issue for others, too.

Now we consistently use unordered_map for the mapping.

Not in it's final state, yet. There already are mappings in the vanguard that we might be able to reuse.