### PR TITLE
[bugfix] Fix deadlocks because of parallel try-catch for some CO2 storage cases

### DIFF
--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -38,6 +38,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
 #include <opm/simulators/wells/WellState.hpp>
 #include <opm/simulators/wells/WGState.hpp>
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 #include <opm/output/eclipse/RestartValue.hpp>
@@ -407,6 +408,7 @@ public:
         const auto gridView = simulator_.vanguard().gridView();
         auto elemIt = gridView.template begin</*codim=*/0>();
         const auto& elemEndIt = gridView.template end</*codim=*/0>();
+        OPM_BEGIN_PARALLEL_TRY_CATCH();
         for (; elemIt != elemEndIt; ++elemIt) {
             const Element& elem = *elemIt;
             if (elem.partitionType() != Dune::InteriorEntity)
@@ -418,6 +420,7 @@ public:
             for (size_t wellIdx = 0; wellIdx < wellSize; ++wellIdx)
                 wells_[wellIdx]->beginIterationAccumulate(elemCtx, /*timeIdx=*/0);
         }
+        OPM_END_PARALLEL_TRY_CATCH("EclWellManager::beginIteration() failed: ");
 
         // call the postprocessing routines
         for (size_t wellIdx = 0; wellIdx < wellSize; ++wellIdx)

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -34,6 +34,7 @@
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/simulators/utils/ParallelRestart.hpp>
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 
 #include <ebos/eclgenericwriter.hh>
 
@@ -379,6 +380,7 @@ private:
         ElementIterator elemIt = gridView.template begin</*codim=*/0>();
 
         const ElementIterator& elemEndIt = gridView.template end</*codim=*/0>();
+        OPM_BEGIN_PARALLEL_TRY_CATCH();
         for (; elemIt != elemEndIt; ++elemIt) {
             const Element& elem = *elemIt;
 
@@ -387,6 +389,7 @@ private:
 
             eclOutputModule_->processElement(elemCtx);
         }
+        OPM_END_PARALLEL_TRY_CATCH("EclWriter::prepareLocalCellData() failed: ")
     }
 
     Simulator& simulator_;

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -27,6 +27,8 @@
 
 #include <opm/output/data/Aquifer.hpp>
 
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/densead/Math.hpp>
@@ -110,6 +112,8 @@ public:
         ElementContext elemCtx(ebos_simulator_);
         auto elemIt = ebos_simulator_.gridView().template begin<0>();
         const auto& elemEndIt = ebos_simulator_.gridView().template end<0>();
+        OPM_BEGIN_PARALLEL_TRY_CATCH();
+
         for (; elemIt != elemEndIt; ++elemIt) {
             const auto& elem = *elemIt;
 
@@ -124,6 +128,7 @@ public:
             const auto& iq = elemCtx.intensiveQuantities(0, 0);
             pressure_previous_[idx] = getValue(iq.fluidState().pressure(phaseIdx_()));
         }
+        OPM_END_PARALLEL_TRY_CATCH("AquiferInterface::beginTimeStep() failed: ");
     }
 
     template <class Context>

--- a/opm/simulators/aquifers/AquiferNumerical.hpp
+++ b/opm/simulators/aquifers/AquiferNumerical.hpp
@@ -25,6 +25,8 @@
 
 #include <opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp>
 
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -193,6 +195,8 @@ private:
         const auto& gridView = this->ebos_simulator_.gridView();
         auto elemIt = gridView.template begin</*codim=*/0>();
         const auto& elemEndIt = gridView.template end</*codim=*/0>();
+        OPM_BEGIN_PARALLEL_TRY_CATCH();
+
         for (; elemIt != elemEndIt; ++elemIt) {
             const auto& elem = *elemIt;
             if (elem.partitionType() != Dune::InteriorEntity) {
@@ -225,6 +229,7 @@ private:
             cell_pressure[idx] = water_pressure_reservoir;
         }
 
+        OPM_END_PARALLEL_TRY_CATCH("AquiferNumerical::calculateAquiferPressure() failed: ");
         const auto& comm = this->ebos_simulator_.vanguard().grid().comm();
         comm.sum(&sum_pressure_watervolume, 1);
         comm.sum(&sum_watervolume, 1);

--- a/opm/simulators/linalg/getQuasiImpesWeights.hpp
+++ b/opm/simulators/linalg/getQuasiImpesWeights.hpp
@@ -22,6 +22,8 @@
 
 #include <dune/common/fvector.hh>
 
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+
 #include <algorithm>
 #include <cmath>
 
@@ -100,6 +102,7 @@ namespace Amg
         int index = 0;
         auto elemIt = gridView.template begin</*codim=*/0>();
         const auto& elemEndIt = gridView.template end</*codim=*/0>();
+        OPM_BEGIN_PARALLEL_TRY_CATCH();
         for (; elemIt != elemEndIt; ++elemIt) {
             elemCtx.updatePrimaryStencil(*elemIt);
             elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
@@ -125,6 +128,7 @@ namespace Amg
             weights[index] = bweights;
             ++index;
         }
+        OPM_END_PARALLEL_TRY_CATCH("getTrueImpesWeights() failed: ");
     }
 } // namespace Amg
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1405,48 +1405,43 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     prepareTimeStep(DeferredLogger& deferred_logger)
     {
-        OPM_BEGIN_PARALLEL_TRY_CATCH();
-        {
-            for (const auto& well : well_container_) {
-                const bool old_well_operable = well->isOperable();
-                well->checkWellOperability(ebosSimulator_, this->wellState(), deferred_logger);
+        for (const auto& well : well_container_) {
+            const bool old_well_operable = well->isOperable();
+            well->checkWellOperability(ebosSimulator_, this->wellState(), deferred_logger);
 
-                if (!well->isOperable() ) continue;
+            if (!well->isOperable() ) continue;
 
-                auto& events = this->wellState().well(well->indexOfWell()).events;
-                if (events.hasEvent(WellState::event_mask)) {
-                    well->updateWellStateWithTarget(ebosSimulator_, this->groupState(), this->wellState(), deferred_logger);
-                    // There is no new well control change input within a report step,
-                    // so next time step, the well does not consider to have effective events anymore.
-                    events.clearEvent(WellState::event_mask);
-                }
+            auto& events = this->wellState().well(well->indexOfWell()).events;
+            if (events.hasEvent(WellState::event_mask)) {
+                well->updateWellStateWithTarget(ebosSimulator_, this->groupState(), this->wellState(), deferred_logger);
+                // There is no new well control change input within a report step,
+                // so next time step, the well does not consider to have effective events anymore.
+                events.clearEvent(WellState::event_mask);
+            }
 
-                // solve the well equation initially to improve the initial solution of the well model
-                if (param_.solve_welleq_initially_) {
-                    well->solveWellEquation(ebosSimulator_, this->wellState(), this->groupState(), deferred_logger);
-                }
+            // solve the well equation initially to improve the initial solution of the well model
+            if (param_.solve_welleq_initially_) {
+                well->solveWellEquation(ebosSimulator_, this->wellState(), this->groupState(), deferred_logger);
+            }
 
-                const bool well_operable = well->isOperable();
-                if (!well_operable && old_well_operable) {
-                    const Well& well_ecl = getWellEcl(well->name());
-                    if (well_ecl.getAutomaticShutIn()) {
-                        deferred_logger.info(" well " + well->name() + " gets SHUT at the beginning of the time step ");
-                    } else {
-                        if (!well->wellIsStopped()) {
-                            deferred_logger.info(" well " + well->name() + " gets STOPPED at the beginning of the time step ");
-                            well->stopWell();
-                        }
+            const bool well_operable = well->isOperable();
+            if (!well_operable && old_well_operable) {
+                const Well& well_ecl = getWellEcl(well->name());
+                if (well_ecl.getAutomaticShutIn()) {
+                    deferred_logger.info(" well " + well->name() + " gets SHUT at the beginning of the time step ");
+                } else {
+                    if (!well->wellIsStopped()) {
+                        deferred_logger.info(" well " + well->name() + " gets STOPPED at the beginning of the time step ");
+                        well->stopWell();
                     }
-                } else if (well_operable && !old_well_operable) {
-                    deferred_logger.info(" well " + well->name() + " gets REVIVED at the beginning of the time step ");
-                    well->openWell();
                 }
+            } else if (well_operable && !old_well_operable) {
+                deferred_logger.info(" well " + well->name() + " gets REVIVED at the beginning of the time step ");
+                well->openWell();
+            }
 
-             }  // end of for (const auto& well : well_container_)
-            updatePrimaryVariables(deferred_logger);
-        }
-        OPM_END_PARALLEL_TRY_CATCH_LOG(deferred_logger, "prepareTimestep() failed: ",
-                                       terminal_output_);
+        }  // end of for (const auto& well : well_container_)
+        updatePrimaryVariables(deferred_logger);
     }
 
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -527,6 +527,8 @@ namespace Opm {
 
         const auto& gridView = ebosSimulator_.vanguard().gridView();
         const auto& elemEndIt = gridView.template end</*codim=*/0>();
+        OPM_BEGIN_PARALLEL_TRY_CATCH();
+
         for (auto elemIt = gridView.template begin</*codim=*/0>();
              elemIt != elemEndIt;
              ++elemIt)
@@ -549,6 +551,7 @@ namespace Opm {
                 perf_pressure = fs.pressure(FluidSystem::gasPhaseIdx).value();
             }
         }
+        OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel::initializeWellState() failed: ");
 
         this->wellState().init(cellPressures, schedule(), wells_ecl_, local_parallel_well_info_, timeStepIdx,
                                &this->prevWellState(), well_perf_data_,
@@ -1486,6 +1489,7 @@ namespace Opm {
         const auto& gridView = grid.leafGridView();
         ElementContext elemCtx(ebosSimulator_);
         const auto& elemEndIt = gridView.template end</*codim=*/0, Dune::Interior_Partition>();
+        OPM_BEGIN_PARALLEL_TRY_CATCH();
 
         for (auto elemIt = gridView.template begin</*codim=*/0, Dune::Interior_Partition>();
              elemIt != elemEndIt; ++elemIt)
@@ -1512,6 +1516,7 @@ namespace Opm {
                 B += 1 / intQuants.solventInverseFormationVolumeFactor().value();
             }
         }
+        OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel::updateAverageFormationFactor() failed: ")
 
         // compute global average
         grid.comm().sum(B_avg.data(), B_avg.size());
@@ -1587,6 +1592,7 @@ namespace Opm {
         ElementContext elemCtx(ebosSimulator_);
         const auto& gridView = ebosSimulator_.gridView();
         const auto& elemEndIt = gridView.template end</*codim=*/0, Dune::Interior_Partition>();
+        OPM_BEGIN_PARALLEL_TRY_CATCH();
         for (auto elemIt = gridView.template begin</*codim=*/0, Dune::Interior_Partition>();
              elemIt != elemEndIt;
              ++elemIt)
@@ -1600,6 +1606,7 @@ namespace Opm {
             }
             elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
         }
+        OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel::updatePerforationIntensiveQuantities() failed: ");
     }
 
 

--- a/opm/simulators/wells/RateConverter.hpp
+++ b/opm/simulators/wells/RateConverter.hpp
@@ -26,6 +26,7 @@
 #include <opm/grid/utility/RegionMapping.hpp>
 #include <opm/simulators/linalg/ParallelIstlInformation.hpp>
 #include <opm/simulators/wells/RegionAttributeHelpers.hpp>
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <dune/grid/common/gridenums.hh>
 #include <algorithm>
 #include <cmath>
@@ -121,6 +122,7 @@ namespace Opm {
                 ElementContext elemCtx( simulator );
                 const auto& gridView = simulator.gridView();
                 const auto& comm = gridView.comm();
+                OPM_BEGIN_PARALLEL_TRY_CATCH();
 
                 const auto& elemEndIt = gridView.template end</*codim=*/0>();
                 for (auto elemIt = gridView.template begin</*codim=*/0>();
@@ -193,6 +195,8 @@ namespace Opm {
                         attr.saltConcentration += fs.saltConcentration().value() * pv_cell;
                     }
                 }
+
+                OPM_END_PARALLEL_TRY_CATCH("SurfaceToReservoirVoidage::defineState() failed: ");
 
                 for (const auto& reg : rmap_.activeRegions()) {
                       auto& ra = attr_.attributes(reg);

--- a/opm/simulators/wells/RegionAverageCalculator.hpp
+++ b/opm/simulators/wells/RegionAverageCalculator.hpp
@@ -23,6 +23,7 @@
 #include <opm/core/props/BlackoilPhases.hpp>
 #include <opm/simulators/wells/RegionAttributeHelpers.hpp>
 #include <opm/simulators/linalg/ParallelIstlInformation.hpp>
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 
 #include <dune/grid/common/gridenums.hh>
 #include <algorithm>
@@ -116,7 +117,9 @@ namespace Opm {
                 }
 
                 ElementContext elemCtx( simulator );
-                 const auto& elemEndIt = gridView.template end</*codim=*/0>();
+                const auto& elemEndIt = gridView.template end</*codim=*/0>();
+                OPM_BEGIN_PARALLEL_TRY_CATCH();
+
                 for (auto elemIt = gridView.template begin</*codim=*/0>();
                      elemIt != elemEndIt;
                      ++elemIt)
@@ -172,6 +175,7 @@ namespace Opm {
                         }
                     }
                 }
+                OPM_END_PARALLEL_TRY_CATCH("AverageRegionalPressure::defineState(): ");
 
                 for (int reg = 1; reg <= numRegions ; ++ reg) {
                       auto& ra = attr_.attributes(reg);


### PR DESCRIPTION
For a CO2 storage case excpeptions are thrown in opm-material because the passed parameters are unreasonable. Unfortunately, this made the models deadlock because there were problems in the exception handling:

- collective communication happened in the try-catch clause. As we also perform collective communication in/after the catch, processes were waiting at different collective communication calls forever
- Each try-catch had its own exceptions that were catched and only these. If there was an unknown exception it simply was not caught which also cause a deadlock if the exception only happened on a few processes. Those never reached the collective communication after the catch.

This PR introduces macros for the parallel-try-catch statements to make sure that the list of exceptions caught is consistent, it also
has a catch clause that will catch anything, and it makes the model with the problems abort (with signal 6 now) instead of running into a deadlock:
```
terminate called after throwing an instance of 'Opm::NumericalIssue'
  what():  Attempt to get tabulated value for (336.650000, 81706.071880) on a table of extend 280.000000 to 400.000000 times 100000.000000 to 100000000.000000
[smaug:90429] *** Process received signal ***
```
Interestingly this happens at an earlier report step than the deadlock before.
