### PR TITLE
Broadcast UDQState and Action state after restart loading

### DIFF
--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -26,7 +26,8 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WList.hpp>
@@ -40,12 +41,16 @@
 namespace Opm {
 
 void eclStateBroadcast(EclipseState& eclState, Schedule& schedule,
-                       SummaryConfig& summaryConfig)
+                       SummaryConfig& summaryConfig,
+                       UDQState& udqState,
+                       Action::State& actionState)
 {
     Opm::EclMpiSerializer ser(Dune::MPIHelper::getCollectiveCommunication());
     ser.broadcast(eclState);
     ser.broadcast(schedule);
     ser.broadcast(summaryConfig);
+    ser.broadcast(udqState);
+    ser.broadcast(actionState);
 }
 
 void eclScheduleBroadcast(Schedule& schedule)

--- a/opm/simulators/utils/ParallelSerialization.hpp
+++ b/opm/simulators/utils/ParallelSerialization.hpp
@@ -24,6 +24,12 @@ namespace Opm {
 class EclipseState;
 class Schedule;
 class SummaryConfig;
+class UDQState;
+
+namespace Action {
+class State;
+}
+
 
 /*! \brief Broadcasts an eclipse state from root node in parallel runs.
  *! \param eclState EclipseState to broadcast
@@ -31,7 +37,9 @@ class SummaryConfig;
  *! \param summaryConfig SummaryConfig to broadcast
 */
 void eclStateBroadcast(EclipseState& eclState, Schedule& schedule,
-                       SummaryConfig& summaryConfig);
+                       SummaryConfig& summaryConfig,
+                       UDQState& udqState,
+                       Action::State& actionState);
 
 /// \brief Broadcasts an schedule from root node in parallel runs.
 void eclScheduleBroadcast(Schedule& schedule);

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -280,8 +280,8 @@ void readDeck(int rank, std::string& deckFilename, std::shared_ptr<Opm::Deck>& d
                 }
 
                 udqState = std::make_unique<UDQState>((*schedule)[0].udq().params().undefinedValue());
-                udqState->load_rst(rst_state);
                 actionState = std::make_unique<Action::State>();
+                udqState->load_rst(rst_state);
                 actionState->load_rst(schedule->operator[](report_step).actions(), rst_state);
             }
             else {
@@ -290,7 +290,6 @@ void readDeck(int rank, std::string& deckFilename, std::shared_ptr<Opm::Deck>& d
                                                           *parseContext, *errorGuard,
                                                           python);
                 }
-
                 udqState = std::make_unique<UDQState>((*schedule)[0].udq().params().undefinedValue());
                 actionState = std::make_unique<Action::State>();
             }
@@ -326,6 +325,10 @@ void readDeck(int rank, std::string& deckFilename, std::shared_ptr<Opm::Deck>& d
             schedule = std::make_unique<Opm::Schedule>(python);
         if (!eclipseState)
             eclipseState = std::make_unique<Opm::ParallelEclipseState>();
+        if (!udqState)
+            udqState = std::make_unique<UDQState>(0);
+        if (!actionState)
+            actionState = std::make_unique<Action::State>();
     }
 
     // In case of parse errors eclipseState/schedule might be null
@@ -337,7 +340,7 @@ void readDeck(int rank, std::string& deckFilename, std::shared_ptr<Opm::Deck>& d
     {
         if (parseSuccess)
         {
-            Opm::eclStateBroadcast(*eclipseState, *schedule, *summaryConfig);
+            Opm::eclStateBroadcast(*eclipseState, *schedule, *summaryConfig, *udqState, *actionState);
         }
     }
     catch(const std::exception& broadcast_error)


### PR DESCRIPTION
To ensure that the UDQState and ActionState are broadcasted for a restart run