### PR TITLE
Communicators2

### DIFF
--- a/ebos/collecttoiorank.cc
+++ b/ebos/collecttoiorank.cc
@@ -722,7 +722,7 @@ CollectDataToIORank(const Grid& grid, const EquilGrid* equilGrid,
                     const GridView& localGridView,
                     const Dune::CartesianIndexMapper<Grid>& cartMapper,
                     const Dune::CartesianIndexMapper<EquilGrid>* equilCartMapper)
-    : toIORankComm_()
+    : toIORankComm_(grid.comm())
 {
     // index maps only have to be build when reordering is needed
     if (!needsReordering && !isParallel())

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -230,7 +230,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Ecl
         OpmLog::info("\nProcessing grid");
     }
 
-    grid_.reset(new Dune::CpGrid());
+    grid_.reset(new Dune::CpGrid(EclGenericVanguard::comm()));
     const auto& removed_cells = grid_->processEclipseFormat(input_grid,
                                                             &eclState,
                                                             /*isPeriodic=*/false,

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -237,11 +237,12 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Ecl
         OpmLog::info("\nProcessing grid");
     }
 
-    #if HAVE_MPI
-        grid_.reset(new Dune::CpGrid(EclGenericVanguard::comm()));
-    #else
-        grid_.reset(new Dune::CpGrid());
-    #endif
+#if HAVE_MPI
+    grid_.reset(new Dune::CpGrid(EclGenericVanguard::comm()));
+#else
+    grid_.reset(new Dune::CpGrid());
+#endif
+
     const auto& removed_cells = grid_->processEclipseFormat(input_grid,
                                                             &eclState,
                                                             /*isPeriodic=*/false,

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -237,7 +237,11 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Ecl
         OpmLog::info("\nProcessing grid");
     }
 
-    grid_.reset(new Dune::CpGrid(EclGenericVanguard::comm()));
+    #if HAVE_MPI
+        grid_.reset(new Dune::CpGrid(EclGenericVanguard::comm()));
+    #else
+        grid_.reset(new Dune::CpGrid());
+    #endif
     const auto& removed_cells = grid_->processEclipseFormat(input_grid,
                                                             &eclState,
                                                             /*isPeriodic=*/false,

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -58,7 +58,7 @@ template<class ElementMapper, class GridView, class Scalar>
 EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::EclGenericCpGridVanguard()
 {
 #if HAVE_MPI
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_rank(EclGenericVanguard::comm(), &mpiRank);
 #else
   mpiRank = 0;
 #endif
@@ -85,7 +85,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doLoadBalance_(Dun
                                                                              EclGenericVanguard::ParallelWellStruct& parallelWells)
 {
     int mpiSize = 1;
-    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+    MPI_Comm_size(grid_->comm(), &mpiSize);
 
     if (mpiSize > 1) {
         // the CpGrid's loadBalance() method likes to have the transmissibilities as
@@ -188,7 +188,7 @@ template<class ElementMapper, class GridView, class Scalar>
 void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::distributeFieldProps_(EclipseState& eclState1)
 {
     int mpiSize = 1;
-    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+    MPI_Comm_size(grid_->comm(), &mpiSize);
 
     if (mpiSize > 1) {
         try
@@ -262,7 +262,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Ecl
     {
         const bool has_numerical_aquifer = eclState.aquifer().hasNumericalAquifer();
         int mpiSize = 1;
-        MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+        MPI_Comm_size(grid_->comm(), &mpiSize);
         // when there is numerical aquifers, new NNC are generated during grid processing
         // we need to pass the NNC from root process to other processes
         if (has_numerical_aquifer && mpiSize > 1) {
@@ -312,7 +312,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doFilterConnection
     {
         // Broadcast another time to remove inactive peforations on
         // slave processors.
-        eclScheduleBroadcast(schedule);
+        eclScheduleBroadcast(EclGenericVanguard::comm(), schedule);
     }
     catch(const std::exception& broadcast_error)
     {

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -61,7 +61,7 @@ std::unique_ptr<EclipseState> EclGenericVanguard::externalEclState_;
 std::unique_ptr<Schedule> EclGenericVanguard::externalEclSchedule_;
 std::unique_ptr<SummaryConfig> EclGenericVanguard::externalEclSummaryConfig_;
 std::unique_ptr<UDQState> EclGenericVanguard::externalUDQState_;
-std::unique_ptr<EclGenericVanguard::CommunicationType> EclGenericVanguard::comm_;
+std::unique_ptr<EclGenericVanguard::Communication> EclGenericVanguard::comm_;
 
 EclGenericVanguard::EclGenericVanguard()
     : python(std::make_shared<Python>())

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -48,6 +48,13 @@
 #include <mpi.h>
 #endif // HAVE_MPI
 
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>; 
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
+
 #include <stdexcept>
 
 namespace Opm {
@@ -304,11 +311,8 @@ void EclGenericVanguard::init()
                 }
             }
         }
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-        const auto& comm = Dune::MPIHelper::getCommunication();
-#else
-        const auto& comm = Dune::MPIHelper::getCollectiveCommunication();
-#endif
+
+        const auto& comm = Communication();
         hasMsWell = comm.max(hasMsWell);
 
         if (hasMsWell)

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -266,7 +266,7 @@ void EclGenericVanguard::init()
         parseContext_ = createParseContext(ignoredKeywords_, eclStrictParsing_);
     }
 
-    readDeck(myRank, fileName_, deck_, eclState_, eclSchedule_, udqState_,
+    readDeck(EclGenericVanguard::comm(), fileName_, deck_, eclState_, eclSchedule_, udqState_,
              eclSummaryConfig_, std::move(errorGuard), python,
              std::move(parseContext_), /* initFromRestart = */ false,
              /* checkDeck = */ enableExperiments_, outputInterval_);

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -60,12 +60,12 @@ class UDQState;
 
 class EclGenericVanguard {
 public:
-    using ParallelWellStruct = std::vector<std::pair<std::string,bool>>;
-
+   
+using ParallelWellStruct = std::vector<std::pair<std::string,bool>>;
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-    using CommunicationType = Dune::Communication<Dune::MPIHelper::MPICommunicator>;
+    using Communication = Dune::Communication<Dune::MPIHelper::MPICommunicator>;
 #else
-    using CommunicationType = Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator>;
+    using Communication = Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator>;
 #endif
 
     /*!
@@ -272,11 +272,11 @@ public:
     { return parallelWells_; }
 
     //! \brief Set global communication.
-    static void setCommunication(std::unique_ptr<CommunicationType> comm)
+    static void setCommunication(std::unique_ptr<Communication> comm)
     { comm_ = std::move(comm); }
 
     //! \brief Obtain global communicator.
-    static CommunicationType& comm()
+    static Communication& comm()
     {
         assert(comm_);
         return *comm_;
@@ -301,7 +301,7 @@ protected:
     static std::unique_ptr<Schedule> externalEclSchedule_;
     static std::unique_ptr<SummaryConfig> externalEclSummaryConfig_;
     static std::unique_ptr<UDQState> externalUDQState_;
-    static std::unique_ptr<CommunicationType> comm_;
+    static std::unique_ptr<Communication> comm_;
 
     std::string caseName_;
     std::string fileName_;

--- a/ebos/eclgenericwriter.cc
+++ b/ebos/eclgenericwriter.cc
@@ -505,11 +505,11 @@ evalSummary(int reportStepNum,
     if (collectToIORank_.isParallel()) {
 #ifdef HAVE_MPI
         unsigned long buffer_size = buffer.size();
-        MPI_Bcast(&buffer_size, 1, MPI_UNSIGNED_LONG, collectToIORank_.ioRank, MPI_COMM_WORLD);
+        MPI_Bcast(&buffer_size, 1, MPI_UNSIGNED_LONG, collectToIORank_.ioRank, grid_.comm());
         if (!collectToIORank_.isIORank())
             buffer.resize( buffer_size );
 
-        MPI_Bcast(buffer.data(), buffer_size, MPI_CHAR, collectToIORank_.ioRank, MPI_COMM_WORLD);
+        MPI_Bcast(buffer.data(), buffer_size, MPI_CHAR, collectToIORank_.ioRank, grid_.comm());
         if (!collectToIORank_.isIORank()) {
             SummaryState& st = summaryState;
             st.deserialize(buffer);

--- a/ebos/eclmpiserializer.hh
+++ b/ebos/eclmpiserializer.hh
@@ -21,9 +21,17 @@
 #ifndef ECL_MPI_SERIALIZER_HH
 #define ECL_MPI_SERIALIZER_HH
 
+#include <dune/common/version.hh>
 #include <opm/simulators/utils/ParallelRestart.hpp>
 #include <optional>
 #include <variant>
+
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>; 
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
 
 namespace Opm {
 
@@ -36,7 +44,7 @@ class EclMpiSerializer {
 public:
     //! \brief Constructor.
     //! \param comm The global communicator to broadcast using
-    explicit EclMpiSerializer(Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm) :
+    explicit EclMpiSerializer(Communication comm) :
         m_comm(comm)
     {}
 
@@ -476,7 +484,7 @@ protected:
         static constexpr bool value = sizeof(test<T>(0)) == sizeof(yes_type);
     };
 
-    Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> m_comm; //!< Communicator to broadcast using
+    Communication m_comm; //!< Communicator to broadcast using
 
     Operation m_op = Operation::PACKSIZE; //!< Current operation
     size_t m_packSize = 0; //!< Required buffer size after PACKSIZE has been done

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -488,7 +488,7 @@ namespace Opm
 
         void setupEbosSimulator()
         {
-            ebosSimulator_.reset(new EbosSimulator(/*verbose=*/false));
+            ebosSimulator_.reset(new EbosSimulator(EclGenericVanguard::comm(), /*verbose=*/false));
             ebosSimulator_->executionTimer().start();
             ebosSimulator_->model().applyInitialSolution();
 

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -392,7 +392,7 @@ namespace Opm
             using PreProblem = GetPropType<PreTypeTag, Properties::Problem>;
 
             PreProblem::setBriefDescription("Flow, an advanced reservoir simulator for ECL-decks provided by the Open Porous Media project.");
-            int status = FlowMainEbos<PreTypeTag>::setupParameters_(argc_, argv_);
+            int status = FlowMainEbos<PreTypeTag>::setupParameters_(argc_, argv_, EclGenericVanguard::comm());
             if (status != 0) {
                 // if setupParameters_ returns a value smaller than 0, there was no error, but
                 // the program should abort. This is the case e.g. for the --help and the
@@ -437,7 +437,7 @@ namespace Opm
                 return false;
             }
             if (outputCout_) {
-                FlowMainEbos<PreTypeTag>::printBanner();
+                FlowMainEbos<PreTypeTag>::printBanner(EclGenericVanguard::comm());
             }
             // Create Deck and EclipseState.
             try {

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -149,8 +149,27 @@ namespace Opm
           initMPI();
         }
 
+#define DEMONSTRATE_RUN_WITH_NONWORLD_COMM 1
+
         ~Main()
         {
+#if DEMONSTRATE_RUN_WITH_NONWORLD_COMM
+#if HAVE_MPI
+            // Cannot use EclGenericVanguard::comm()
+            // to get world size here, as it may be
+            // a split communication at this point.
+            int world_size;
+            MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+            if (world_size > 1) {
+                MPI_Comm new_comm = EclGenericVanguard::comm();
+                int result;
+                MPI_Comm_compare(MPI_COMM_WORLD, new_comm, &result);
+                assert(result == MPI_UNEQUAL);
+                MPI_Comm_free(&new_comm);
+            }
+#endif // HAVE_MPI
+#endif // DEMONSTRATE_RUN_WITH_NONWORLD_COMM
+
             EclGenericVanguard::setCommunication(nullptr);
 
 #if HAVE_MPI && !HAVE_DUNE_FEM
@@ -166,27 +185,42 @@ namespace Opm
             MPI_Init(&argc_, &argv_);
 #endif
             EclGenericVanguard::setCommunication(std::make_unique<EclGenericVanguard::CommunicationType>());
+
+#if DEMONSTRATE_RUN_WITH_NONWORLD_COMM
+#if HAVE_MPI
+            if (EclGenericVanguard::comm().size() > 1) {
+                int world_rank = EclGenericVanguard::comm().rank();
+                int color = (world_rank == 0);
+                MPI_Comm new_comm;
+                MPI_Comm_split(EclGenericVanguard::comm(), color, world_rank, &new_comm);
+                isSimulationRank_ = (world_rank > 0);
+                EclGenericVanguard::setCommunication(std::make_unique<EclGenericVanguard::CommunicationType>(new_comm));
+            }
+#endif // HAVE_MPI
+#endif // DEMONSTRATE_RUN_WITH_NONWORLD_COMM
         }
 
         int runDynamic()
         {
             int exitCode = EXIT_SUCCESS;
-            if (initialize_<Properties::TTag::FlowEarlyBird>(exitCode)) {
-                return dispatchDynamic_();
-            } else {
-                return exitCode;
+            if (isSimulationRank_) {
+                if (initialize_<Properties::TTag::FlowEarlyBird>(exitCode)) {
+                    return dispatchDynamic_();
+                }
             }
+            return exitCode;
         }
 
         template <class TypeTag>
         int runStatic()
         {
             int exitCode = EXIT_SUCCESS;
-            if (initialize_<TypeTag>(exitCode)) {
-                return dispatchStatic_<TypeTag>();
-            } else {
-                return exitCode;
+            if (isSimulationRank_) {
+                if (initialize_<TypeTag>(exitCode)) {
+                    return dispatchStatic_<TypeTag>();
+                }
             }
+            return exitCode;
         }
 
         // To be called from the Python interface code. Only do the
@@ -553,6 +587,7 @@ namespace Opm
         std::unique_ptr<Schedule> schedule_;
         std::unique_ptr<UDQState> udqState_;
         std::unique_ptr<SummaryConfig> summaryConfig_;
+        bool isSimulationRank_ = true;
     };
 
 } // namespace Opm

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -184,7 +184,7 @@ namespace Opm
 #elif HAVE_MPI
             MPI_Init(&argc_, &argv_);
 #endif
-            EclGenericVanguard::setCommunication(std::make_unique<EclGenericVanguard::CommunicationType>());
+            EclGenericVanguard::setCommunication(std::make_unique<EclGenericVanguard::Communication>());
 
 #if DEMONSTRATE_RUN_WITH_NONWORLD_COMM
 #if HAVE_MPI
@@ -194,7 +194,7 @@ namespace Opm
                 MPI_Comm new_comm;
                 MPI_Comm_split(EclGenericVanguard::comm(), color, world_rank, &new_comm);
                 isSimulationRank_ = (world_rank > 0);
-                EclGenericVanguard::setCommunication(std::make_unique<EclGenericVanguard::CommunicationType>(new_comm));
+                EclGenericVanguard::setCommunication(std::make_unique<EclGenericVanguard::Communication>(new_comm));
             }
 #endif // HAVE_MPI
 #endif // DEMONSTRATE_RUN_WITH_NONWORLD_COMM

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -504,7 +504,7 @@ namespace Opm
                 if (output_param >= 0)
                     outputInterval = output_param;
 
-                readDeck(mpiRank, deckFilename, deck_, eclipseState_, schedule_, udqState_,
+                readDeck(EclGenericVanguard::comm(), deckFilename, deck_, eclipseState_, schedule_, udqState_,
                          summaryConfig_, nullptr, python, std::move(parseContext),
                          init_from_restart_file, outputCout_, outputInterval);
 

--- a/opm/simulators/linalg/ParallelIstlInformation.hpp
+++ b/opm/simulators/linalg/ParallelIstlInformation.hpp
@@ -44,6 +44,16 @@
 #include <dune/common/enumset.hh>
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
+#include <dune/common/version.hh>
+#include <dune/common/parallel/mpihelper.hh>
+
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using CommunicationType = Dune::Communication<MPIComm>; 
+#else
+    using CommunicationType = Dune::CollectiveCommunication<MPIComm>;
+#endif
+
 namespace Opm
 {
 namespace
@@ -109,7 +119,7 @@ public:
         return remoteIndices_;
     }
     /// \brief Get the Collective MPI communicator that we use.
-    Dune::CollectiveCommunication<MPI_Comm> communicator() const
+    CommunicationType communicator() const
     {
         return communicator_;
     }

--- a/opm/simulators/timestepping/gatherConvergenceReport.cpp
+++ b/opm/simulators/timestepping/gatherConvergenceReport.cpp
@@ -167,7 +167,7 @@ namespace Opm
 
     /// Create a global convergence report combining local
     /// (per-process) reports.
-    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, MPI_Comm mpi_communicator)
+    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, Communication mpi_communicator)
     {
         // Pack local report.
         int message_size = messageSize(local_report, mpi_communicator);
@@ -202,7 +202,7 @@ namespace Opm
 
 namespace Opm
 {
-    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, MPIComm mpi_communicator)
+    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, Communication mpi_communicator)
     {
         return local_report;
     }

--- a/opm/simulators/timestepping/gatherConvergenceReport.cpp
+++ b/opm/simulators/timestepping/gatherConvergenceReport.cpp
@@ -202,7 +202,7 @@ namespace Opm
 
 namespace Opm
 {
-    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, Dune::MPIHelper::MPICommunicator mpi_communicator)
+    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, MPIComm mpi_communicator)
     {
         return local_report;
     }

--- a/opm/simulators/timestepping/gatherConvergenceReport.cpp
+++ b/opm/simulators/timestepping/gatherConvergenceReport.cpp
@@ -33,57 +33,57 @@ namespace
 
     void packReservoirFailure(const ConvergenceReport::ReservoirFailure& f,
                               std::vector<char>& buf,
-                              int& offset)
+                              int& offset, MPI_Comm mpi_communicator)
     {
         int type = static_cast<int>(f.type());
         int severity = static_cast<int>(f.severity());
         int phase = f.phase();
-        MPI_Pack(&type, 1, MPI_INT, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
-        MPI_Pack(&severity, 1, MPI_INT, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
-        MPI_Pack(&phase, 1, MPI_INT, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
+        MPI_Pack(&type, 1, MPI_INT, buf.data(), buf.size(), &offset, mpi_communicator);
+        MPI_Pack(&severity, 1, MPI_INT, buf.data(), buf.size(), &offset, mpi_communicator);
+        MPI_Pack(&phase, 1, MPI_INT, buf.data(), buf.size(), &offset, mpi_communicator);
     }
 
     void packWellFailure(const ConvergenceReport::WellFailure& f,
                          std::vector<char>& buf,
-                         int& offset)
+                         int& offset, MPI_Comm mpi_communicator)
     {
         int type = static_cast<int>(f.type());
         int severity = static_cast<int>(f.severity());
         int phase = f.phase();
-        MPI_Pack(&type, 1, MPI_INT, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
-        MPI_Pack(&severity, 1, MPI_INT, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
-        MPI_Pack(&phase, 1, MPI_INT, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
+        MPI_Pack(&type, 1, MPI_INT, buf.data(), buf.size(), &offset, mpi_communicator);
+        MPI_Pack(&severity, 1, MPI_INT, buf.data(), buf.size(), &offset, mpi_communicator);
+        MPI_Pack(&phase, 1, MPI_INT, buf.data(), buf.size(), &offset, mpi_communicator);
         int name_length = f.wellName().size() + 1; // Adding 1 for the null terminator.
-        MPI_Pack(&name_length, 1, MPI_INT, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
-        MPI_Pack(const_cast<char*>(f.wellName().c_str()), name_length, MPI_CHAR, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
+        MPI_Pack(&name_length, 1, MPI_INT, buf.data(), buf.size(), &offset, mpi_communicator);
+        MPI_Pack(const_cast<char*>(f.wellName().c_str()), name_length, MPI_CHAR, buf.data(), buf.size(), &offset, mpi_communicator);
     }
 
     void packConvergenceReport(const ConvergenceReport& local_report,
                                std::vector<char>& buf,
-                               int& offset)
+                               int& offset, MPI_Comm mpi_communicator)
     {
         // Pack the data.
         // Status will not be packed, it is possible to deduce from the other data.
         // Reservoir failures.
         const auto rf = local_report.reservoirFailures();
         int num_rf = rf.size();
-        MPI_Pack(&num_rf, 1, MPI_INT, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
+        MPI_Pack(&num_rf, 1, MPI_INT, buf.data(), buf.size(), &offset, mpi_communicator);
         for (const auto& f : rf) {
-            packReservoirFailure(f, buf, offset);
+            packReservoirFailure(f, buf, offset, mpi_communicator);
         }
         // Well failures.
         const auto wf = local_report.wellFailures();
         int num_wf = wf.size();
-        MPI_Pack(&num_wf, 1, MPI_INT, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
+        MPI_Pack(&num_wf, 1, MPI_INT, buf.data(), buf.size(), &offset, mpi_communicator);
         for (const auto& f : wf) {
-            packWellFailure(f, buf, offset);
+            packWellFailure(f, buf, offset, mpi_communicator);
         }
     }
 
-    int messageSize(const ConvergenceReport& local_report)
+    int messageSize(const ConvergenceReport& local_report, MPI_Comm mpi_communicator)
     {
         int int_pack_size = 0;
-        MPI_Pack_size(1, MPI_INT, MPI_COMM_WORLD, &int_pack_size);
+        MPI_Pack_size(1, MPI_INT, mpi_communicator, &int_pack_size);
         const int num_rf = local_report.reservoirFailures().size();
         const int num_wf = local_report.wellFailures().size();
         int wellnames_length = 0;
@@ -93,33 +93,33 @@ namespace
         return (2 + 3*num_rf + 4*num_wf) * int_pack_size + wellnames_length;
     }
 
-    ConvergenceReport::ReservoirFailure unpackReservoirFailure(const std::vector<char>& recv_buffer, int& offset)
+    ConvergenceReport::ReservoirFailure unpackReservoirFailure(const std::vector<char>& recv_buffer, int& offset, MPI_Comm mpi_communicator)
     {
         int type = -1;
         int severity = -1;
         int phase = -1;
         auto* data = const_cast<char*>(recv_buffer.data());
-        MPI_Unpack(data, recv_buffer.size(), &offset, &type, 1, MPI_INT, MPI_COMM_WORLD);
-        MPI_Unpack(data, recv_buffer.size(), &offset, &severity, 1, MPI_INT, MPI_COMM_WORLD);
-        MPI_Unpack(data, recv_buffer.size(), &offset, &phase, 1, MPI_INT, MPI_COMM_WORLD);
+        MPI_Unpack(data, recv_buffer.size(), &offset, &type, 1, MPI_INT, mpi_communicator);
+        MPI_Unpack(data, recv_buffer.size(), &offset, &severity, 1, MPI_INT, mpi_communicator);
+        MPI_Unpack(data, recv_buffer.size(), &offset, &phase, 1, MPI_INT, mpi_communicator);
         return ConvergenceReport::ReservoirFailure(static_cast<ConvergenceReport::ReservoirFailure::Type>(type),
                                                    static_cast<ConvergenceReport::Severity>(severity),
                                                    phase);
     }
 
-    ConvergenceReport::WellFailure unpackWellFailure(const std::vector<char>& recv_buffer, int& offset)
+    ConvergenceReport::WellFailure unpackWellFailure(const std::vector<char>& recv_buffer, int& offset, MPI_Comm mpi_communicator)
     {
         int type = -1;
         int severity = -1;
         int phase = -1;
         auto* data = const_cast<char*>(recv_buffer.data());
-        MPI_Unpack(data, recv_buffer.size(), &offset, &type, 1, MPI_INT, MPI_COMM_WORLD);
-        MPI_Unpack(data, recv_buffer.size(), &offset, &severity, 1, MPI_INT, MPI_COMM_WORLD);
-        MPI_Unpack(data, recv_buffer.size(), &offset, &phase, 1, MPI_INT, MPI_COMM_WORLD);
+        MPI_Unpack(data, recv_buffer.size(), &offset, &type, 1, MPI_INT, mpi_communicator);
+        MPI_Unpack(data, recv_buffer.size(), &offset, &severity, 1, MPI_INT, mpi_communicator);
+        MPI_Unpack(data, recv_buffer.size(), &offset, &phase, 1, MPI_INT, mpi_communicator);
         int name_length = -1;
-        MPI_Unpack(data, recv_buffer.size(), &offset, &name_length, 1, MPI_INT, MPI_COMM_WORLD);
+        MPI_Unpack(data, recv_buffer.size(), &offset, &name_length, 1, MPI_INT, mpi_communicator);
         std::vector<char> namechars(name_length);
-        MPI_Unpack(data, recv_buffer.size(), &offset, namechars.data(), name_length, MPI_CHAR, MPI_COMM_WORLD);
+        MPI_Unpack(data, recv_buffer.size(), &offset, namechars.data(), name_length, MPI_CHAR, mpi_communicator);
         std::string name(namechars.data());
         return ConvergenceReport::WellFailure(static_cast<ConvergenceReport::WellFailure::Type>(type),
                                               static_cast<ConvergenceReport::Severity>(severity),
@@ -127,33 +127,33 @@ namespace
                                               name);
     }
 
-    ConvergenceReport unpackSingleConvergenceReport(const std::vector<char>& recv_buffer, int& offset)
+    ConvergenceReport unpackSingleConvergenceReport(const std::vector<char>& recv_buffer, int& offset, MPI_Comm mpi_communicator)
     {
         ConvergenceReport cr;
         int num_rf = -1;
         auto* data = const_cast<char*>(recv_buffer.data());
-        MPI_Unpack(data, recv_buffer.size(), &offset, &num_rf, 1, MPI_INT, MPI_COMM_WORLD);
+        MPI_Unpack(data, recv_buffer.size(), &offset, &num_rf, 1, MPI_INT, mpi_communicator);
         for (int rf = 0; rf < num_rf; ++rf) {
-            ConvergenceReport::ReservoirFailure f = unpackReservoirFailure(recv_buffer, offset);
+            ConvergenceReport::ReservoirFailure f = unpackReservoirFailure(recv_buffer, offset, mpi_communicator);
             cr.setReservoirFailed(f);
         }
         int num_wf = -1;
-        MPI_Unpack(data, recv_buffer.size(), &offset, &num_wf, 1, MPI_INT, MPI_COMM_WORLD);
+        MPI_Unpack(data, recv_buffer.size(), &offset, &num_wf, 1, MPI_INT, mpi_communicator);
         for (int wf = 0; wf < num_wf; ++wf) {
-            ConvergenceReport::WellFailure f = unpackWellFailure(recv_buffer, offset);
+            ConvergenceReport::WellFailure f = unpackWellFailure(recv_buffer, offset, mpi_communicator);
             cr.setWellFailed(f);
         }
         return cr;
     }
 
     ConvergenceReport unpackConvergenceReports(const std::vector<char>& recv_buffer,
-                                               const std::vector<int>& displ)
+                                               const std::vector<int>& displ, MPI_Comm mpi_communicator)
     {
         ConvergenceReport cr;
         const int num_processes = displ.size() - 1;
         for (int process = 0; process < num_processes; ++process) {
             int offset = displ[process];
-            cr += unpackSingleConvergenceReport(recv_buffer, offset);
+            cr += unpackSingleConvergenceReport(recv_buffer, offset, mpi_communicator);
             assert(offset == displ[process + 1]);
         }
         return cr;
@@ -167,20 +167,20 @@ namespace Opm
 
     /// Create a global convergence report combining local
     /// (per-process) reports.
-    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report)
+    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, MPI_Comm mpi_communicator)
     {
         // Pack local report.
-        int message_size = messageSize(local_report);
+        int message_size = messageSize(local_report, mpi_communicator);
         std::vector<char> buffer(message_size);
         int offset = 0;
-        packConvergenceReport(local_report, buffer, offset);
+        packConvergenceReport(local_report, buffer, offset,mpi_communicator);
         assert(offset == message_size);
 
         // Get message sizes and create offset/displacement array for gathering.
         int num_processes = -1;
-        MPI_Comm_size(MPI_COMM_WORLD, &num_processes);
+        MPI_Comm_size(mpi_communicator, &num_processes);
         std::vector<int> message_sizes(num_processes);
-        MPI_Allgather(&message_size, 1, MPI_INT, message_sizes.data(), 1, MPI_INT, MPI_COMM_WORLD);
+        MPI_Allgather(&message_size, 1, MPI_INT, message_sizes.data(), 1, MPI_INT, mpi_communicator);
         std::vector<int> displ(num_processes + 1, 0);
         std::partial_sum(message_sizes.begin(), message_sizes.end(), displ.begin() + 1);
 
@@ -189,10 +189,10 @@ namespace Opm
         MPI_Allgatherv(buffer.data(), buffer.size(), MPI_PACKED,
                        const_cast<char*>(recv_buffer.data()), message_sizes.data(),
                        displ.data(), MPI_PACKED,
-                       MPI_COMM_WORLD);
+                       mpi_communicator);
 
         // Unpack.
-        ConvergenceReport global_report = unpackConvergenceReports(recv_buffer, displ);
+        ConvergenceReport global_report = unpackConvergenceReports(recv_buffer, displ, mpi_communicator);
         return global_report;
     }
 
@@ -202,7 +202,7 @@ namespace Opm
 
 namespace Opm
 {
-    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report)
+    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, Dune::MPIHelper::MPICommunicator mpi_communicator)
     {
         return local_report;
     }

--- a/opm/simulators/timestepping/gatherConvergenceReport.hpp
+++ b/opm/simulators/timestepping/gatherConvergenceReport.hpp
@@ -21,15 +21,18 @@
 #ifndef OPM_GATHERCONVERGENCEREPORT_HEADER_INCLUDED
 #define OPM_GATHERCONVERGENCEREPORT_HEADER_INCLUDED
 
+#include <dune/common/version.hh>
 #include <opm/simulators/timestepping/ConvergenceReport.hpp>
 #include <dune/common/parallel/mpihelper.hh>
+
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
 
 namespace Opm
 {
 
     /// Create a global convergence report combining local
     /// (per-process) reports.
-    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, Dune::MPIHelper::MPICommunicator communicator);
+    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, MPIComm communicator);
 
 } // namespace Opm
 

--- a/opm/simulators/timestepping/gatherConvergenceReport.hpp
+++ b/opm/simulators/timestepping/gatherConvergenceReport.hpp
@@ -26,13 +26,18 @@
 #include <dune/common/parallel/mpihelper.hh>
 
 using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>;
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
 
 namespace Opm
 {
 
     /// Create a global convergence report combining local
     /// (per-process) reports.
-    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, MPIComm communicator);
+    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, Communication communicator);
 
 } // namespace Opm
 

--- a/opm/simulators/timestepping/gatherConvergenceReport.hpp
+++ b/opm/simulators/timestepping/gatherConvergenceReport.hpp
@@ -22,13 +22,14 @@
 #define OPM_GATHERCONVERGENCEREPORT_HEADER_INCLUDED
 
 #include <opm/simulators/timestepping/ConvergenceReport.hpp>
+#include <dune/common/parallel/mpihelper.hh>
 
 namespace Opm
 {
 
     /// Create a global convergence report combining local
     /// (per-process) reports.
-    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report);
+    ConvergenceReport gatherConvergenceReport(const ConvergenceReport& local_report, Dune::MPIHelper::MPICommunicator communicator);
 
 } // namespace Opm
 

--- a/opm/simulators/utils/DeferredLogger.hpp
+++ b/opm/simulators/utils/DeferredLogger.hpp
@@ -88,8 +88,9 @@ enum ExcEnum {
 
     private:
         std::vector<Message> messages_;
+        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
         friend DeferredLogger gatherDeferredLogger(const DeferredLogger& local_deferredlogger,
-                                                   Dune::MPIHelper::MPICommunicator mpi_communicator);
+                                                   MPIComm mpi_communicator);
     };
 
 } // namespace Opm

--- a/opm/simulators/utils/DeferredLogger.hpp
+++ b/opm/simulators/utils/DeferredLogger.hpp
@@ -21,6 +21,8 @@
 #ifndef OPM_DEFERREDLOGGER_HEADER_INCLUDED
 #define OPM_DEFERREDLOGGER_HEADER_INCLUDED
 
+#include <dune/common/parallel/mpihelper.hh>
+
 #include <string>
 #include <vector>
 
@@ -86,7 +88,8 @@ enum ExcEnum {
 
     private:
         std::vector<Message> messages_;
-        friend DeferredLogger gatherDeferredLogger(const DeferredLogger& local_deferredlogger);
+        friend DeferredLogger gatherDeferredLogger(const DeferredLogger& local_deferredlogger,
+                                                   Dune::MPIHelper::MPICommunicator mpi_communicator);
     };
 
 } // namespace Opm

--- a/opm/simulators/utils/DeferredLogger.hpp
+++ b/opm/simulators/utils/DeferredLogger.hpp
@@ -21,6 +21,7 @@
 #ifndef OPM_DEFERREDLOGGER_HEADER_INCLUDED
 #define OPM_DEFERREDLOGGER_HEADER_INCLUDED
 
+#include <dune/common/version.hh>
 #include <dune/common/parallel/mpihelper.hh>
 
 #include <string>
@@ -89,8 +90,13 @@ enum ExcEnum {
     private:
         std::vector<Message> messages_;
         using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+            using Communication = Dune::Communication<MPIComm>; 
+        #else
+            using Communication = Dune::CollectiveCommunication<MPIComm>;
+        #endif
         friend DeferredLogger gatherDeferredLogger(const DeferredLogger& local_deferredlogger,
-                                                   MPIComm mpi_communicator);
+                                                   Communication mpi_communicator);
     };
 
 } // namespace Opm

--- a/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
+++ b/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
@@ -61,7 +61,7 @@ namespace {
 
 void _throw(Opm::ExceptionType::ExcEnum exc_type,
             const std::string& message,
-            Communication cc)
+            Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> cc)
 {
     auto global_exc = cc.max(exc_type);
 
@@ -89,7 +89,7 @@ void _throw(Opm::ExceptionType::ExcEnum exc_type,
 
 inline void checkForExceptionsAndThrow(Opm::ExceptionType::ExcEnum exc_type,
                                        const std::string& message,
-                                       Communication cc)
+                                       Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> cc)
 {
     _throw(exc_type, message, cc);
 }
@@ -98,7 +98,7 @@ inline void logAndCheckForExceptionsAndThrow(Opm::DeferredLogger& deferred_logge
                                              Opm::ExceptionType::ExcEnum exc_type,
                                              const std::string& message,
                                              const bool terminal_output,
-                                             Communication cc)
+                                             Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> cc)
 {
     Opm::DeferredLogger global_deferredLogger = gatherDeferredLogger(deferred_logger, cc);
 

--- a/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
+++ b/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
@@ -32,6 +32,13 @@
 #include <exception>
 #include <stdexcept>
 
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>; 
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
+
 // Macro to throw an exception.
 // Inspired by ErrorMacros.hpp in opm-common.
 // NOTE: For this macro to work, the
@@ -54,7 +61,7 @@ namespace {
 
 void _throw(Opm::ExceptionType::ExcEnum exc_type,
             const std::string& message,
-            Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> cc)
+            Communication cc)
 {
     auto global_exc = cc.max(exc_type);
 
@@ -82,7 +89,7 @@ void _throw(Opm::ExceptionType::ExcEnum exc_type,
 
 inline void checkForExceptionsAndThrow(Opm::ExceptionType::ExcEnum exc_type,
                                        const std::string& message,
-                                       Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> cc)
+                                       Communication cc)
 {
     _throw(exc_type, message, cc);
 }
@@ -91,7 +98,7 @@ inline void logAndCheckForExceptionsAndThrow(Opm::DeferredLogger& deferred_logge
                                              Opm::ExceptionType::ExcEnum exc_type,
                                              const std::string& message,
                                              const bool terminal_output,
-                                             Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> cc)
+                                             Communication cc)
 {
     Opm::DeferredLogger global_deferredLogger = gatherDeferredLogger(deferred_logger, cc);
 

--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -235,10 +235,10 @@ ParallelEclipseState::ParallelEclipseState(const Deck& deck, Dune::CollectiveCom
 
 const FieldPropsManager& ParallelEclipseState::fieldProps() const
 {
-    if (!m_parProps && Dune::MPIHelper::getCollectiveCommunication().rank() != 0)
+    if (!m_parProps && m_comm.rank() != 0)
         OPM_THROW(std::runtime_error, "Attempt to access field properties on no-root process before switch to parallel properties");
 
-    if (!m_parProps || Dune::MPIHelper::getCollectiveCommunication().size() == 1)
+    if (!m_parProps || m_comm.size() == 1)
         return this->EclipseState::fieldProps();
 
     return m_fieldProps;
@@ -247,7 +247,7 @@ const FieldPropsManager& ParallelEclipseState::fieldProps() const
 
 const FieldPropsManager& ParallelEclipseState::globalFieldProps() const
 {
-    if (Dune::MPIHelper::getCollectiveCommunication().rank() != 0)
+    if (m_comm.rank() != 0)
         OPM_THROW(std::runtime_error, "Attempt to access global field properties on non-root process");
     return this->EclipseState::globalFieldProps();
 }
@@ -255,7 +255,7 @@ const FieldPropsManager& ParallelEclipseState::globalFieldProps() const
 
 const EclipseGrid& ParallelEclipseState::getInputGrid() const
 {
-    if (Dune::MPIHelper::getCollectiveCommunication().rank() != 0)
+    if (m_comm.rank() != 0)
         OPM_THROW(std::runtime_error, "Attempt to access eclipse grid on non-root process");
     return this->EclipseState::getInputGrid();
 }
@@ -269,8 +269,7 @@ void ParallelEclipseState::switchToGlobalProps()
 
 void ParallelEclipseState::switchToDistributedProps()
 {
-    const auto& comm = Dune::MPIHelper::getCollectiveCommunication();
-    if (comm.size() == 1) // No need for the parallel frontend
+    if (m_comm.size() == 1) // No need for the parallel frontend
         return;
 
     m_parProps = true;

--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -27,12 +27,12 @@ namespace Opm {
 
 ParallelFieldPropsManager::ParallelFieldPropsManager(FieldPropsManager& manager)
     : m_manager(manager)
-    , m_comm(Dune::MPIHelper::getCollectiveCommunication())
+    , m_comm(Communication())
 {
 }
 
 // EXPERIMENTAL FUNCTION TO ADD COMM AS INPUT
-ParallelFieldPropsManager::ParallelFieldPropsManager(FieldPropsManager& manager, Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm)
+ParallelFieldPropsManager::ParallelFieldPropsManager(FieldPropsManager& manager, Communication comm)
     : m_manager(manager)
     , m_comm(comm)
 {
@@ -215,7 +215,7 @@ bool ParallelFieldPropsManager::has_double(const std::string& keyword) const
 }
 
 
-ParallelEclipseState::ParallelEclipseState(Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm)
+ParallelEclipseState::ParallelEclipseState(Communication comm)
     : m_fieldProps(field_props, comm)
     , m_comm(comm)
 {
@@ -228,7 +228,7 @@ ParallelEclipseState::ParallelEclipseState(const Deck& deck)
 {
 }
 
-ParallelEclipseState::ParallelEclipseState(const Deck& deck, Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm)
+ParallelEclipseState::ParallelEclipseState(const Deck& deck, Communication comm)
     : EclipseState(deck)
     , m_fieldProps(field_props, comm)
     , m_comm(comm)

--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -31,6 +31,13 @@ ParallelFieldPropsManager::ParallelFieldPropsManager(FieldPropsManager& manager)
 {
 }
 
+// EXPERIMENTAL FUNCTION TO ADD COMM AS INPUT
+ParallelFieldPropsManager::ParallelFieldPropsManager(FieldPropsManager& manager, Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm)
+    : m_manager(manager)
+    , m_comm(comm)
+{
+}
+
 
 std::vector<int> ParallelFieldPropsManager::actnum() const
 {
@@ -208,8 +215,8 @@ bool ParallelFieldPropsManager::has_double(const std::string& keyword) const
 }
 
 
-ParallelEclipseState::ParallelEclipseState()
-    : m_fieldProps(field_props)
+ParallelEclipseState::ParallelEclipseState(Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm)
+    : m_fieldProps(field_props, comm)
 {
 }
 
@@ -220,6 +227,11 @@ ParallelEclipseState::ParallelEclipseState(const Deck& deck)
 {
 }
 
+ParallelEclipseState::ParallelEclipseState(const Deck& deck, Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm)
+    : EclipseState(deck)
+    , m_fieldProps(field_props, comm)
+{
+}
 
 const FieldPropsManager& ParallelEclipseState::fieldProps() const
 {

--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -217,6 +217,7 @@ bool ParallelFieldPropsManager::has_double(const std::string& keyword) const
 
 ParallelEclipseState::ParallelEclipseState(Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm)
     : m_fieldProps(field_props, comm)
+    , m_comm(comm)
 {
 }
 
@@ -230,6 +231,7 @@ ParallelEclipseState::ParallelEclipseState(const Deck& deck)
 ParallelEclipseState::ParallelEclipseState(const Deck& deck, Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm)
     : EclipseState(deck)
     , m_fieldProps(field_props, comm)
+    , m_comm(comm)
 {
 }
 

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -47,6 +47,10 @@ public:
     //! \param manager The field property manager to wrap.
     ParallelFieldPropsManager(FieldPropsManager& manager);
 
+    //! \brief Constructor.
+    //! \param manager The field property manager to wrap.
+    ParallelFieldPropsManager(FieldPropsManager& manager, Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm);
+
     //! \brief Returns actnum vector.
     //! \details If called on non-root process an empty vector is returned
     std::vector<int> actnum() const override;
@@ -130,12 +134,18 @@ class ParallelEclipseState : public EclipseState {
     friend class PropsCentroidsDataHandle;
 public:
     //! \brief Default constructor.
-    ParallelEclipseState();
+    ParallelEclipseState(Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm);
 
     //! \brief Construct from a deck instance.
     //! \param deck The deck to construct from
     //! \details Only called on root process
     ParallelEclipseState(const Deck& deck);
+
+    //! EXPERIMENTAL FUNCTION TO ADD COMM AS INPUT.
+    //! \brief Construct from a deck instance.
+    //! \param deck The deck to construct from
+    //! \details Only called on root process
+    ParallelEclipseState(const Deck& deck, Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm);
 
     //! \brief Switch to global field properties.
     //! \details Called on root process to use the global field properties

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -19,11 +19,19 @@
 #ifndef PARALLEL_ECLIPSE_STATE_HPP
 #define PARALLEL_ECLIPSE_STATE_HPP
 
+#include <dune/common/version.hh>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp>
 #include <dune/common/parallel/mpihelper.hh>
 
 #include <functional>
+
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>;
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
 
 namespace Opm {
 
@@ -49,7 +57,7 @@ public:
 
     //! \brief Constructor.
     //! \param manager The field property manager to wrap.
-    ParallelFieldPropsManager(FieldPropsManager& manager, Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm);
+    ParallelFieldPropsManager(FieldPropsManager& manager, Communication comm);
 
     //! \brief Returns actnum vector.
     //! \details If called on non-root process an empty vector is returned
@@ -110,7 +118,7 @@ protected:
     std::map<std::string, Fieldprops::FieldData<int>> m_intProps; //!< Map of integer properties in process-local compressed indices.
     std::map<std::string, Fieldprops::FieldData<double>> m_doubleProps; //!< Map of double properties in process-local compressed indices.
     FieldPropsManager& m_manager; //!< Underlying field property manager (only used on root process).
-    Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> m_comm; //!< Collective communication handler.
+    Communication m_comm; //!< Collective communication handler.
     std::function<int(void)> m_activeSize; //!< active size function of the grid
     std::function<int(const int)> m_local2Global; //!< mapping from local to global cartesian indices
     std::unordered_map<std::string, Fieldprops::TranCalculator> m_tran; //!< calculators map
@@ -134,7 +142,7 @@ class ParallelEclipseState : public EclipseState {
     friend class PropsCentroidsDataHandle;
 public:
     //! \brief Default constructor.
-    ParallelEclipseState(Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm);
+    ParallelEclipseState(Communication comm);
 
     //! \brief Construct from a deck instance.
     //! \param deck The deck to construct from
@@ -145,7 +153,7 @@ public:
     //! \brief Construct from a deck instance.
     //! \param deck The deck to construct from
     //! \details Only called on root process
-    ParallelEclipseState(const Deck& deck, Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm);
+    ParallelEclipseState(const Deck& deck, Communication comm);
 
     //! \brief Switch to global field properties.
     //! \details Called on root process to use the global field properties
@@ -180,7 +188,7 @@ public:
 private:
     bool m_parProps = false; //! True to use distributed properties on root process
     ParallelFieldPropsManager m_fieldProps; //!< The parallel field properties
-    Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> m_comm; //!< Collective communication handler.
+    Communication m_comm; //!< Collective communication handler.
 };
 
 

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -179,8 +179,8 @@ public:
     }
 private:
     bool m_parProps = false; //! True to use distributed properties on root process
-    Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> m_comm; //!< Collective communication handler.
     ParallelFieldPropsManager m_fieldProps; //!< The parallel field properties
+    Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> m_comm; //!< Collective communication handler.
 };
 
 

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -179,6 +179,7 @@ public:
     }
 private:
     bool m_parProps = false; //! True to use distributed properties on root process
+    Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> m_comm; //!< Collective communication handler.
     ParallelFieldPropsManager m_fieldProps; //!< The parallel field properties
 };
 

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -26,6 +26,7 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/TimeService.hpp>
 
+#include <dune/common/version.hh>
 #include <dune/common/parallel/mpihelper.hh>
 
 #include <chrono>
@@ -38,6 +39,13 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>; 
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
 
 namespace Opm
 {
@@ -77,18 +85,18 @@ class State;
 namespace Mpi
 {
 template<class T>
-std::size_t packSize(const T*, std::size_t, Dune::MPIHelper::MPICommunicator,
+std::size_t packSize(const T*, std::size_t, MPIComm,
                      std::integral_constant<bool, false>);
 
 template<class T>
-std::size_t packSize(const T*, std::size_t l, Dune::MPIHelper::MPICommunicator comm,
+std::size_t packSize(const T*, std::size_t l, MPIComm comm,
                      std::integral_constant<bool, true>);
 
 template<class T>
-std::size_t packSize(const T* data, std::size_t l, Dune::MPIHelper::MPICommunicator comm);
+std::size_t packSize(const T* data, std::size_t l, MPIComm comm);
 
 template<class T>
-std::size_t packSize(const T&, Dune::MPIHelper::MPICommunicator,
+std::size_t packSize(const T&, MPIComm,
                      std::integral_constant<bool, false>)
 {
     std::string msg = std::string{"Packing not (yet) supported for non-pod type: "} + typeid(T).name();
@@ -96,7 +104,7 @@ std::size_t packSize(const T&, Dune::MPIHelper::MPICommunicator,
 }
 
 template<class T>
-std::size_t packSize(const T&, Dune::MPIHelper::MPICommunicator comm,
+std::size_t packSize(const T&, MPIComm comm,
                      std::integral_constant<bool, true>)
 {
 #if HAVE_MPI
@@ -110,69 +118,69 @@ std::size_t packSize(const T&, Dune::MPIHelper::MPICommunicator comm,
 }
 
 template<class T>
-std::size_t packSize(const T& data, Dune::MPIHelper::MPICommunicator comm)
+std::size_t packSize(const T& data, MPIComm comm)
 {
     return packSize(data, comm, typename std::is_pod<T>::type());
 }
 
 template<class T1, class T2>
-std::size_t packSize(const std::pair<T1,T2>& data, Dune::MPIHelper::MPICommunicator comm);
+std::size_t packSize(const std::pair<T1,T2>& data, MPIComm comm);
 
 template<class T>
-std::size_t packSize(const std::optional<T>& data, Dune::MPIHelper::MPICommunicator comm);
+std::size_t packSize(const std::optional<T>& data, MPIComm comm);
 
 template<class T, class A>
-std::size_t packSize(const std::vector<T,A>& data, Dune::MPIHelper::MPICommunicator comm);
+std::size_t packSize(const std::vector<T,A>& data, MPIComm comm);
 
 template<class K, class C, class A>
 std::size_t packSize(const std::set<K,C,A>& data,
-                     Dune::MPIHelper::MPICommunicator comm);
+                     MPIComm comm);
 
 template<class T, class H, class KE, class A>
 std::size_t packSize(const std::unordered_set<T,H,KE,A>& data,
-                     Dune::MPIHelper::MPICommunicator comm);
+                     MPIComm comm);
 
 template<class A>
-std::size_t packSize(const std::vector<bool,A>& data, Dune::MPIHelper::MPICommunicator comm);
+std::size_t packSize(const std::vector<bool,A>& data, MPIComm comm);
 
 template<class... Ts>
-std::size_t packSize(const std::tuple<Ts...>& data, Dune::MPIHelper::MPICommunicator comm);
+std::size_t packSize(const std::tuple<Ts...>& data, MPIComm comm);
 
 template<class T, std::size_t N>
-std::size_t packSize(const std::array<T,N>& data, Dune::MPIHelper::MPICommunicator comm);
+std::size_t packSize(const std::array<T,N>& data, MPIComm comm);
 
-std::size_t packSize(const char* str, Dune::MPIHelper::MPICommunicator comm);
+std::size_t packSize(const char* str, MPIComm comm);
 
 template<class T1, class T2, class C, class A>
-std::size_t packSize(const std::map<T1,T2,C,A>& data, Dune::MPIHelper::MPICommunicator comm);
+std::size_t packSize(const std::map<T1,T2,C,A>& data, MPIComm comm);
 
 template<class T1, class T2, class H, class P, class A>
-std::size_t packSize(const std::unordered_map<T1,T2,H,P,A>& data, Dune::MPIHelper::MPICommunicator comm);
+std::size_t packSize(const std::unordered_map<T1,T2,H,P,A>& data, MPIComm comm);
 
 ////// pack routines
 
 template<class T>
 void pack(const T*, std::size_t, std::vector<char>&, int&,
-          Dune::MPIHelper::MPICommunicator, std::integral_constant<bool, false>);
+          MPIComm, std::integral_constant<bool, false>);
 
 template<class T>
 void pack(const T* data, std::size_t l, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm, std::integral_constant<bool, true>);
+          MPIComm comm, std::integral_constant<bool, true>);
 
 template<class T>
 void pack(const T* data, std::size_t l, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 template<class T>
 void pack(const T&, std::vector<char>&, int&,
-          Dune::MPIHelper::MPICommunicator, std::integral_constant<bool, false>)
+          MPIComm, std::integral_constant<bool, false>)
 {
     OPM_THROW(std::logic_error, "Packing not (yet) supported for this non-pod type.");
 }
 
 template<class T>
 void pack(const T& data, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm, std::integral_constant<bool, true>)
+          MPIComm comm, std::integral_constant<bool, true>)
 {
 #if HAVE_MPI
     MPI_Pack(&data, 1, Dune::MPITraits<T>::getType(), buffer.data(),
@@ -187,81 +195,81 @@ void pack(const T& data, std::vector<char>& buffer, int& position,
 
 template<class T>
 void pack(const T& data, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm)
+          MPIComm comm)
 {
     pack(data, buffer, position, comm, typename std::is_pod<T>::type());
 }
 
 template<class T1, class T2>
 void pack(const std::pair<T1,T2>& data, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 template<class T>
 void pack(const std::optional<T>& data, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 template<class T, class A>
 void pack(const std::vector<T,A>& data, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 template<class A>
 void pack(const std::vector<bool,A>& data, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 template<class... Ts>
 void pack(const std::tuple<Ts...>& data, std::vector<char>& buffer,
-          int& position, Dune::MPIHelper::MPICommunicator comm);
+          int& position, MPIComm comm);
 
 template<class K, class C, class A>
 void pack(const std::set<K,C,A>& data,
           std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 template<class T, class H, class KE, class A>
 void pack(const std::unordered_set<T,H,KE,A>& data,
           std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 template<class T, size_t N>
 void pack(const std::array<T,N>& data, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 template<class T1, class T2, class C, class A>
 void pack(const std::map<T1,T2,C,A>& data, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 template<class T1, class T2, class H, class P, class A>
 void pack(const std::unordered_map<T1,T2,H,P,A>& data, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 void pack(const char* str, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 /// unpack routines
 
 template<class T>
 void unpack(T*, const std::size_t&, std::vector<char>&, int&,
-            Dune::MPIHelper::MPICommunicator, std::integral_constant<bool, false>);
+            MPIComm, std::integral_constant<bool, false>);
 
 template<class T>
 void unpack(T* data, const std::size_t& l, std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm,
+            MPIComm comm,
             std::integral_constant<bool, true>);
 
 template<class T>
 void unpack(T* data, const std::size_t& l, std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm);
+            MPIComm comm);
 
 template<class T>
 void unpack(T&, std::vector<char>&, int&,
-            Dune::MPIHelper::MPICommunicator, std::integral_constant<bool, false>)
+            MPIComm, std::integral_constant<bool, false>)
 {
     OPM_THROW(std::logic_error, "Packing not (yet) supported for this non-pod type.");
 }
 
 template<class T>
 void unpack(T& data, std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm, std::integral_constant<bool, true>)
+            MPIComm comm, std::integral_constant<bool, true>)
 {
 #if HAVE_MPI
     MPI_Unpack(buffer.data(), buffer.size(), &position, &data, 1,
@@ -276,64 +284,64 @@ void unpack(T& data, std::vector<char>& buffer, int& position,
 
 template<class T>
 void unpack(T& data, std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm)
+            MPIComm comm)
 {
     unpack(data, buffer, position, comm, typename std::is_pod<T>::type());
 }
 
 template<class T1, class T2>
 void unpack(std::pair<T1,T2>& data, std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm);
+            MPIComm comm);
 
 template<class T>
 void unpack(std::optional<T>& data, std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm);
+            MPIComm comm);
 
 template<class T, class A>
 void unpack(std::vector<T,A>& data, std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm);
+            MPIComm comm);
 
 template<class A>
 void unpack(std::vector<bool,A>& data, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 template<class... Ts>
 void unpack(std::tuple<Ts...>& data, std::vector<char>& buffer,
-            int& position, Dune::MPIHelper::MPICommunicator comm);
+            int& position, MPIComm comm);
 
 template<class K, class C, class A>
 void unpack(std::set<K,C,A>& data,
             std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm);
+            MPIComm comm);
 
 template<class T, class H, class KE, class A>
 void unpack(std::unordered_set<T,H,KE,A>& data,
             std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm);
+            MPIComm comm);
 
 template<class T, size_t N>
 void unpack(std::array<T,N>& data, std::vector<char>& buffer, int& position,
-          Dune::MPIHelper::MPICommunicator comm);
+          MPIComm comm);
 
 template<class T1, class T2, class C, class A>
 void unpack(std::map<T1,T2,C,A>& data, std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm);
+            MPIComm comm);
 
 template<class T1, class T2, class H, class P, class A>
 void unpack(std::unordered_map<T1,T2,H,P,A>& data, std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm);
+            MPIComm comm);
 
 void unpack(char* str, std::size_t length, std::vector<char>& buffer, int& position,
-            Dune::MPIHelper::MPICommunicator comm);
+            MPIComm comm);
 
 /// prototypes for complex types
 
 #define ADD_PACK_PROTOTYPES(T) \
-  std::size_t packSize(const T& data, Dune::MPIHelper::MPICommunicator comm); \
+  std::size_t packSize(const T& data, MPIComm comm); \
   void pack(const T& data, std::vector<char>& buffer, int& position, \
-          Dune::MPIHelper::MPICommunicator comm); \
+          MPIComm comm); \
   void unpack(T& data, std::vector<char>& buffer, int& position, \
-              Dune::MPIHelper::MPICommunicator comm);
+              MPIComm comm);
 
 ADD_PACK_PROTOTYPES(data::AquiferData)
 ADD_PACK_PROTOTYPES(data::CarterTracyData)
@@ -363,7 +371,7 @@ ADD_PACK_PROTOTYPES(time_point)
 RestartValue loadParallelRestart(const EclipseIO* eclIO, Action::State& actionState, SummaryState& summaryState,
                                  const std::vector<RestartKey>& solutionKeys,
                                  const std::vector<RestartKey>& extraKeys,
-                                 Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm);
+                                 Communication comm);
 
 } // end namespace Opm
 #endif // PARALLEL_RESTART_HPP

--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -39,18 +39,18 @@
 
 namespace Opm {
 
-void eclStateBroadcast(EclipseState& eclState, Schedule& schedule,
+void eclStateBroadcast(CollCommType comm, EclipseState& eclState, Schedule& schedule,
                        SummaryConfig& summaryConfig)
 {
-    Opm::EclMpiSerializer ser(Dune::MPIHelper::getCollectiveCommunication());
+    Opm::EclMpiSerializer ser(comm);
     ser.broadcast(eclState);
     ser.broadcast(schedule);
     ser.broadcast(summaryConfig);
 }
 
-void eclScheduleBroadcast(Schedule& schedule)
+void eclScheduleBroadcast(CollCommType comm, Schedule& schedule)
 {
-    Opm::EclMpiSerializer ser(Dune::MPIHelper::getCollectiveCommunication());
+    Opm::EclMpiSerializer ser(comm);
     ser.broadcast(schedule);
 }
 }

--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -39,7 +39,7 @@
 
 namespace Opm {
 
-void eclStateBroadcast(CollCommType comm, EclipseState& eclState, Schedule& schedule,
+void eclStateBroadcast(Communication comm, EclipseState& eclState, Schedule& schedule,
                        SummaryConfig& summaryConfig)
 {
     Opm::EclMpiSerializer ser(comm);
@@ -48,7 +48,7 @@ void eclStateBroadcast(CollCommType comm, EclipseState& eclState, Schedule& sche
     ser.broadcast(summaryConfig);
 }
 
-void eclScheduleBroadcast(CollCommType comm, Schedule& schedule)
+void eclScheduleBroadcast(Communication comm, Schedule& schedule)
 {
     Opm::EclMpiSerializer ser(comm);
     ser.broadcast(schedule);

--- a/opm/simulators/utils/ParallelSerialization.hpp
+++ b/opm/simulators/utils/ParallelSerialization.hpp
@@ -19,22 +19,25 @@
 #ifndef PARALLEL_SERIALIZATION_HPP
 #define PARALLEL_SERIALIZATION_HPP
 
+#include <dune/common/parallel/mpihelper.hh>
+
 namespace Opm {
 
 class EclipseState;
 class Schedule;
 class SummaryConfig;
 
+using CollCommType = Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator>;
 /*! \brief Broadcasts an eclipse state from root node in parallel runs.
  *! \param eclState EclipseState to broadcast
  *! \param schedule Schedule to broadcast
  *! \param summaryConfig SummaryConfig to broadcast
 */
-void eclStateBroadcast(EclipseState& eclState, Schedule& schedule,
+void eclStateBroadcast(CollCommType comm, EclipseState& eclState, Schedule& schedule,
                        SummaryConfig& summaryConfig);
 
 /// \brief Broadcasts an schedule from root node in parallel runs.
-void eclScheduleBroadcast(Schedule& schedule);
+void eclScheduleBroadcast(CollCommType comm, Schedule& schedule);
 
 } // end namespace Opm
 

--- a/opm/simulators/utils/ParallelSerialization.hpp
+++ b/opm/simulators/utils/ParallelSerialization.hpp
@@ -19,6 +19,7 @@
 #ifndef PARALLEL_SERIALIZATION_HPP
 #define PARALLEL_SERIALIZATION_HPP
 
+#include <dune/common/version.hh>
 #include <dune/common/parallel/mpihelper.hh>
 
 namespace Opm {
@@ -27,17 +28,22 @@ class EclipseState;
 class Schedule;
 class SummaryConfig;
 
-using CollCommType = Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator>;
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>; 
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
 /*! \brief Broadcasts an eclipse state from root node in parallel runs.
  *! \param eclState EclipseState to broadcast
  *! \param schedule Schedule to broadcast
  *! \param summaryConfig SummaryConfig to broadcast
 */
-void eclStateBroadcast(CollCommType comm, EclipseState& eclState, Schedule& schedule,
+void eclStateBroadcast(Communication comm, EclipseState& eclState, Schedule& schedule,
                        SummaryConfig& summaryConfig);
 
 /// \brief Broadcasts an schedule from root node in parallel runs.
-void eclScheduleBroadcast(CollCommType comm, Schedule& schedule);
+void eclScheduleBroadcast(Communication comm, Schedule& schedule);
 
 } // end namespace Opm
 

--- a/opm/simulators/utils/PropsCentroidsDataHandle.hpp
+++ b/opm/simulators/utils/PropsCentroidsDataHandle.hpp
@@ -69,7 +69,7 @@ public:
           m_centroids(centroids)
     {
         // Scatter the keys
-        const auto& comm = Dune::MPIHelper::getCollectiveCommunication();
+        const Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm = m_grid.comm();
         if (comm.rank() == 0)
         {
             const auto& globalProps = eclState.globalFieldProps();

--- a/opm/simulators/utils/PropsCentroidsDataHandle.hpp
+++ b/opm/simulators/utils/PropsCentroidsDataHandle.hpp
@@ -39,6 +39,13 @@
 namespace Opm
 {
 
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>; 
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
+
 /*!
  * \brief A Data handle to communicate the field properties and cell centroids during load balance.
  * \tparam Grid The type of grid where the load balancing is happening.
@@ -69,7 +76,7 @@ public:
           m_centroids(centroids)
     {
         // Scatter the keys
-        const Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> comm = m_grid.comm();
+        const Communication comm = m_grid.comm();
         if (comm.rank() == 0)
         {
             const auto& globalProps = eclState.globalFieldProps();

--- a/opm/simulators/utils/gatherDeferredLogger.cpp
+++ b/opm/simulators/utils/gatherDeferredLogger.cpp
@@ -32,7 +32,7 @@
 namespace
 {
 
-    void packMessages(const std::vector<Opm::DeferredLogger::Message>& local_messages, std::vector<char>& buf, int& offset, const MPI_Comm mpi_communicator)
+    void packMessages(const std::vector<Opm::DeferredLogger::Message>& local_messages, std::vector<char>& buf, int& offset, const Communication mpi_communicator)
     {
 
         int messagesize = local_messages.size();
@@ -106,7 +106,7 @@ namespace Opm
 
     /// combine (per-process) messages
     Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger,
-                                             MPI_Comm mpi_communicator)
+                                             Communication mpi_communicator)
     {
 
         int num_messages = local_deferredlogger.messages_.size();
@@ -166,7 +166,7 @@ namespace Opm
 namespace Opm
 {
     Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger,
-                                             MPIComm /* dummy communicator */)
+                                             Communication /* dummy communicator */)
     {
         return local_deferredlogger;
     }

--- a/opm/simulators/utils/gatherDeferredLogger.cpp
+++ b/opm/simulators/utils/gatherDeferredLogger.cpp
@@ -32,55 +32,55 @@
 namespace
 {
 
-    void packMessages(const std::vector<Opm::DeferredLogger::Message>& local_messages, std::vector<char>& buf, int& offset)
+    void packMessages(const std::vector<Opm::DeferredLogger::Message>& local_messages, std::vector<char>& buf, int& offset, const MPI_Comm mpi_communicator)
     {
 
         int messagesize = local_messages.size();
-        MPI_Pack(&messagesize, 1, MPI_UNSIGNED, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
+        MPI_Pack(&messagesize, 1, MPI_UNSIGNED, buf.data(), buf.size(), &offset, mpi_communicator);
 
         for (const auto& lm : local_messages) {
-            MPI_Pack(static_cast<void*>(const_cast<std::int64_t*>(&lm.flag)), 1, MPI_INT64_T, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
+            MPI_Pack(static_cast<void*>(const_cast<std::int64_t*>(&lm.flag)), 1, MPI_INT64_T, buf.data(), buf.size(), &offset, mpi_communicator);
             int tagsize = lm.tag.size();
-            MPI_Pack(&tagsize, 1, MPI_UNSIGNED, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
+            MPI_Pack(&tagsize, 1, MPI_UNSIGNED, buf.data(), buf.size(), &offset, mpi_communicator);
             if (tagsize>0) {
-                MPI_Pack(const_cast<char*>(lm.tag.c_str()), lm.tag.size(), MPI_CHAR, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
+                MPI_Pack(const_cast<char*>(lm.tag.c_str()), lm.tag.size(), MPI_CHAR, buf.data(), buf.size(), &offset, mpi_communicator);
             }
             int textsize = lm.text.size();
-            MPI_Pack(&textsize, 1, MPI_UNSIGNED, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
+            MPI_Pack(&textsize, 1, MPI_UNSIGNED, buf.data(), buf.size(), &offset, mpi_communicator);
             if (textsize>0) {
-                MPI_Pack(const_cast<char*>(lm.text.c_str()), lm.text.size(), MPI_CHAR, buf.data(), buf.size(), &offset, MPI_COMM_WORLD);
+                MPI_Pack(const_cast<char*>(lm.text.c_str()), lm.text.size(), MPI_CHAR, buf.data(), buf.size(), &offset, mpi_communicator);
             }
         }
     }
 
-    Opm::DeferredLogger::Message unpackSingleMessage(const std::vector<char>& recv_buffer, int& offset)
+    Opm::DeferredLogger::Message unpackSingleMessage(const std::vector<char>& recv_buffer, int& offset, const MPI_Comm mpi_communicator)
     {
         int64_t flag;
         auto* data = const_cast<char*>(recv_buffer.data());
-        MPI_Unpack(data, recv_buffer.size(), &offset, &flag, 1, MPI_INT64_T, MPI_COMM_WORLD);
+        MPI_Unpack(data, recv_buffer.size(), &offset, &flag, 1, MPI_INT64_T, mpi_communicator);
 
         // unpack tag
         unsigned int tagsize;
-        MPI_Unpack(data, recv_buffer.size(), &offset, &tagsize, 1, MPI_UNSIGNED, MPI_COMM_WORLD);
+        MPI_Unpack(data, recv_buffer.size(), &offset, &tagsize, 1, MPI_UNSIGNED, mpi_communicator);
         std::string tag;
         if (tagsize>0) {
             std::vector<char> tagchars(tagsize);
-            MPI_Unpack(data, recv_buffer.size(), &offset, tagchars.data(), tagsize, MPI_CHAR, MPI_COMM_WORLD);
+            MPI_Unpack(data, recv_buffer.size(), &offset, tagchars.data(), tagsize, MPI_CHAR, mpi_communicator);
             tag = std::string(tagchars.data(), tagsize);
         }
         // unpack text
         unsigned int textsize;
-        MPI_Unpack(data, recv_buffer.size(), &offset, &textsize, 1, MPI_UNSIGNED, MPI_COMM_WORLD);
+        MPI_Unpack(data, recv_buffer.size(), &offset, &textsize, 1, MPI_UNSIGNED, mpi_communicator);
         std::string text;
         if (textsize>0) {
             std::vector<char> textchars(textsize);
-            MPI_Unpack(data, recv_buffer.size(), &offset, textchars.data(), textsize, MPI_CHAR, MPI_COMM_WORLD);
+            MPI_Unpack(data, recv_buffer.size(), &offset, textchars.data(), textsize, MPI_CHAR, mpi_communicator);
             text = std::string (textchars.data(), textsize);
         }
         return Opm::DeferredLogger::Message({flag, tag, text});
     }
 
-    std::vector<Opm::DeferredLogger::Message> unpackMessages(const std::vector<char>& recv_buffer, const std::vector<int>& displ)
+    std::vector<Opm::DeferredLogger::Message> unpackMessages(const std::vector<char>& recv_buffer, const std::vector<int>& displ, const MPI_Comm mpi_communicator)
     {
         std::vector<Opm::DeferredLogger::Message> messages;
         const int num_processes = displ.size() - 1;
@@ -89,9 +89,9 @@ namespace
             int offset = displ[process];
             // unpack number of messages
             unsigned int messagesize;
-            MPI_Unpack(data, recv_buffer.size(), &offset, &messagesize, 1, MPI_UNSIGNED, MPI_COMM_WORLD);
+            MPI_Unpack(data, recv_buffer.size(), &offset, &messagesize, 1, MPI_UNSIGNED, mpi_communicator);
             for (unsigned int i=0; i<messagesize; i++) {
-                messages.push_back(unpackSingleMessage(recv_buffer, offset));
+                messages.push_back(unpackSingleMessage(recv_buffer, offset, mpi_communicator));
             }
             assert(offset == displ[process + 1]);
         }
@@ -105,15 +105,16 @@ namespace Opm
 {
 
     /// combine (per-process) messages
-    Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger)
+    Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger,
+                                             MPI_Comm mpi_communicator)
     {
 
         int num_messages = local_deferredlogger.messages_.size();
 
         int int64_mpi_pack_size;
-        MPI_Pack_size(1, MPI_INT64_T, MPI_COMM_WORLD, &int64_mpi_pack_size);
+        MPI_Pack_size(1, MPI_INT64_T, mpi_communicator, &int64_mpi_pack_size);
         int unsigned_int_mpi_pack_size;
-        MPI_Pack_size(1, MPI_UNSIGNED, MPI_COMM_WORLD, &unsigned_int_mpi_pack_size);
+        MPI_Pack_size(1, MPI_UNSIGNED, mpi_communicator, &unsigned_int_mpi_pack_size);
 
         // store number of messages;
         int message_size = unsigned_int_mpi_pack_size;
@@ -124,9 +125,9 @@ namespace Opm
 
         for (const auto& lm : local_deferredlogger.messages_) {
             int string_mpi_pack_size;
-            MPI_Pack_size(lm.tag.size(), MPI_CHAR, MPI_COMM_WORLD, &string_mpi_pack_size);
+            MPI_Pack_size(lm.tag.size(), MPI_CHAR, mpi_communicator, &string_mpi_pack_size);
             message_size += string_mpi_pack_size;
-            MPI_Pack_size(lm.text.size(), MPI_CHAR, MPI_COMM_WORLD, &string_mpi_pack_size);
+            MPI_Pack_size(lm.text.size(), MPI_CHAR, mpi_communicator, &string_mpi_pack_size);
             message_size += string_mpi_pack_size;
         }
 
@@ -134,14 +135,14 @@ namespace Opm
         std::vector<char> buffer(message_size);
 
         int offset = 0;
-        packMessages(local_deferredlogger.messages_, buffer, offset);
+        packMessages(local_deferredlogger.messages_, buffer, offset, mpi_communicator);
         assert(offset == message_size);
 
         // Get message sizes and create offset/displacement array for gathering.
         int num_processes = -1;
-        MPI_Comm_size(MPI_COMM_WORLD, &num_processes);
+        MPI_Comm_size(mpi_communicator, &num_processes);
         std::vector<int> message_sizes(num_processes);
-        MPI_Allgather(&message_size, 1, MPI_INT, message_sizes.data(), 1, MPI_INT, MPI_COMM_WORLD);
+        MPI_Allgather(&message_size, 1, MPI_INT, message_sizes.data(), 1, MPI_INT, mpi_communicator);
         std::vector<int> displ(num_processes + 1, 0);
         std::partial_sum(message_sizes.begin(), message_sizes.end(), displ.begin() + 1);
 
@@ -150,11 +151,11 @@ namespace Opm
         MPI_Allgatherv(buffer.data(), buffer.size(), MPI_PACKED,
                        const_cast<char*>(recv_buffer.data()), message_sizes.data(),
                        displ.data(), MPI_PACKED,
-                       MPI_COMM_WORLD);
+                       mpi_communicator);
 
         // Unpack.
         Opm::DeferredLogger global_deferredlogger;
-        global_deferredlogger.messages_ = unpackMessages(recv_buffer, displ);
+        global_deferredlogger.messages_ = unpackMessages(recv_buffer, displ, mpi_communicator);
         return global_deferredlogger;
     }
 
@@ -164,7 +165,8 @@ namespace Opm
 
 namespace Opm
 {
-    Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger)
+    Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger,
+                                             Dune::MPIHelper::MPICommunicator /* dummy communicator */)
     {
         return local_deferredlogger;
     }

--- a/opm/simulators/utils/gatherDeferredLogger.cpp
+++ b/opm/simulators/utils/gatherDeferredLogger.cpp
@@ -166,7 +166,7 @@ namespace Opm
 namespace Opm
 {
     Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger,
-                                             Dune::MPIHelper::MPICommunicator /* dummy communicator */)
+                                             MPIComm /* dummy communicator */)
     {
         return local_deferredlogger;
     }

--- a/opm/simulators/utils/gatherDeferredLogger.hpp
+++ b/opm/simulators/utils/gatherDeferredLogger.hpp
@@ -21,13 +21,14 @@
 #ifndef OPM_GATHERDEFERREDLOGGER_HEADER_INCLUDED
 #define OPM_GATHERDEFERREDLOGGER_HEADER_INCLUDED
 
+#include <dune/common/parallel/mpihelper.hh>
 #include <opm/simulators/utils/DeferredLogger.hpp>
 
 namespace Opm
 {
 
     /// Create a global log combining local logs
-    Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger);
+    Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger, Dune::MPIHelper::MPICommunicator communicator);
 
 } // namespace Opm
 

--- a/opm/simulators/utils/gatherDeferredLogger.hpp
+++ b/opm/simulators/utils/gatherDeferredLogger.hpp
@@ -26,12 +26,17 @@
 #include <dune/common/version.hh>
 
 using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>;
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
 
 namespace Opm
 {
 
     /// Create a global log combining local logs
-    Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger, MPIComm communicator);
+    Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger, Communication communicator);
 
 } // namespace Opm
 

--- a/opm/simulators/utils/gatherDeferredLogger.hpp
+++ b/opm/simulators/utils/gatherDeferredLogger.hpp
@@ -23,12 +23,15 @@
 
 #include <dune/common/parallel/mpihelper.hh>
 #include <opm/simulators/utils/DeferredLogger.hpp>
+#include <dune/common/version.hh>
+
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
 
 namespace Opm
 {
 
     /// Create a global log combining local logs
-    Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger, Dune::MPIHelper::MPICommunicator communicator);
+    Opm::DeferredLogger gatherDeferredLogger(const Opm::DeferredLogger& local_deferredlogger, MPIComm communicator);
 
 } // namespace Opm
 

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -190,7 +190,7 @@ void setupMessageLimiter(const Opm::MessageLimits msgLimits,  const std::string&
 }
 
 
-void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& deck, std::unique_ptr<Opm::EclipseState>& eclipseState,
+void readDeck(CollCommType comm, std::string& deckFilename, std::unique_ptr<Opm::Deck>& deck, std::unique_ptr<Opm::EclipseState>& eclipseState,
               std::unique_ptr<Opm::Schedule>& schedule, std::unique_ptr<UDQState>& udqState, std::unique_ptr<Opm::SummaryConfig>& summaryConfig,
               std::unique_ptr<ErrorGuard> errorGuard, std::shared_ptr<Opm::Python>& python, std::unique_ptr<ParseContext> parseContext,
               bool initFromRestart, bool checkDeck, const std::optional<int>& outputInterval)
@@ -202,6 +202,7 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
 
     int parseSuccess = 1; // > 0 is success
     std::string failureMessage;
+    int rank = comm.rank();
 
     if (rank==0) {
         try
@@ -352,7 +353,7 @@ void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Opm::Deck>& d
         errorGuard->clear();
     }
 
-    parseSuccess = Dune::MPIHelper::getCollectiveCommunication().min(parseSuccess);
+    parseSuccess = comm.min(parseSuccess);
 
     if (!parseSuccess)
     {

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -328,7 +328,6 @@ void readDeck(CollCommType comm, std::string& deckFilename, std::unique_ptr<Opm:
     // In case of parse errors eclipseState/schedule might be null
     // and trigger segmentation faults in parallel during broadcast
     // (e.g. when serializing the non-existent TableManager)
-    auto comm = Dune::MPIHelper::getCollectiveCommunication();
     parseSuccess = comm.min(parseSuccess);
     try
     {

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -334,7 +334,7 @@ void readDeck(CollCommType comm, std::string& deckFilename, std::unique_ptr<Opm:
     {
         if (parseSuccess)
         {
-            Opm::eclStateBroadcast(*eclipseState, *schedule, *summaryConfig);
+            Opm::eclStateBroadcast(comm, *eclipseState, *schedule, *summaryConfig);
         }
     }
     catch(const std::exception& broadcast_error)

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -233,7 +233,7 @@ void readDeck(CollCommType comm, std::string& deckFilename, std::unique_ptr<Opm:
 
             if (!eclipseState) {
 #if HAVE_MPI
-                eclipseState = std::make_unique<Opm::ParallelEclipseState>(*deck);
+                eclipseState = std::make_unique<Opm::ParallelEclipseState>(*deck,comm);
 #else
                 eclipseState = std::make_unique<Opm::EclipseState>(*deck);
 #endif
@@ -322,7 +322,7 @@ void readDeck(CollCommType comm, std::string& deckFilename, std::unique_ptr<Opm:
         if (!schedule)
             schedule = std::make_unique<Opm::Schedule>(python);
         if (!eclipseState)
-            eclipseState = std::make_unique<Opm::ParallelEclipseState>();
+            eclipseState = std::make_unique<Opm::ParallelEclipseState>(comm);
     }
 
     // In case of parse errors eclipseState/schedule might be null

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -233,7 +233,7 @@ void readDeck(CollCommType comm, std::string& deckFilename, std::unique_ptr<Opm:
 
             if (!eclipseState) {
 #if HAVE_MPI
-                eclipseState = std::make_unique<Opm::ParallelEclipseState>(*deck,comm);
+                eclipseState = std::make_unique<Opm::ParallelEclipseState>(*deck, comm);
 #else
                 eclipseState = std::make_unique<Opm::EclipseState>(*deck);
 #endif

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -190,7 +190,7 @@ void setupMessageLimiter(const Opm::MessageLimits msgLimits,  const std::string&
 }
 
 
-void readDeck(CollCommType comm, std::string& deckFilename, std::unique_ptr<Opm::Deck>& deck, std::unique_ptr<Opm::EclipseState>& eclipseState,
+void readDeck(Communication comm, std::string& deckFilename, std::unique_ptr<Opm::Deck>& deck, std::unique_ptr<Opm::EclipseState>& eclipseState,
               std::unique_ptr<Opm::Schedule>& schedule, std::unique_ptr<UDQState>& udqState, std::unique_ptr<Opm::SummaryConfig>& summaryConfig,
               std::unique_ptr<ErrorGuard> errorGuard, std::shared_ptr<Opm::Python>& python, std::unique_ptr<ParseContext> parseContext,
               bool initFromRestart, bool checkDeck, const std::optional<int>& outputInterval)
@@ -215,6 +215,7 @@ void readDeck(CollCommType comm, std::string& deckFilename, std::unique_ptr<Opm:
 
             if (!deck)
             {
+
 
                 deck = std::make_unique<Opm::Deck>( parser.parseFile(deckFilename , *parseContext, *errorGuard));
 

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -22,10 +22,18 @@
 #ifndef OPM_READDECK_HEADER_INCLUDED
 #define OPM_READDECK_HEADER_INCLUDED
 
+#include <dune/common/version.hh>
 #include <dune/common/parallel/mpihelper.hh>
 #include <memory>
 #include <optional>
 #include <string>
+
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>;
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
 
 namespace Opm 
 {
@@ -51,11 +59,10 @@ enum class FileOutputMode {
 // Setup the OpmLog backends
 FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, const std::string& cmdline_output_dir, const std::string& cmdline_output, bool output_cout_, const std::string& stdout_log_id);
 
-using CollCommType = Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator>;
 /// \brief Reads the deck and creates all necessary objects if needed
 ///
 /// If pointers already contains objects then they are used otherwise they are created and can be used outside later.
-void readDeck(CollCommType comm, std::string& deckFilename, std::unique_ptr<Deck>& deck, std::unique_ptr<EclipseState>& eclipseState,
+void readDeck(Communication comm, std::string& deckFilename, std::unique_ptr<Deck>& deck, std::unique_ptr<EclipseState>& eclipseState,
               std::unique_ptr<Schedule>& schedule, std::unique_ptr<UDQState>& udqState, std::unique_ptr<SummaryConfig>& summaryConfig,
               std::unique_ptr<ErrorGuard> errorGuard, std::shared_ptr<Python>& python, std::unique_ptr<ParseContext> parseContext,
               bool initFromRestart, bool checkDeck, const std::optional<int>& outputInterval);

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -22,6 +22,7 @@
 #ifndef OPM_READDECK_HEADER_INCLUDED
 #define OPM_READDECK_HEADER_INCLUDED
 
+#include <dune/common/parallel/mpihelper.hh>
 #include <memory>
 #include <optional>
 #include <string>
@@ -50,10 +51,11 @@ enum class FileOutputMode {
 // Setup the OpmLog backends
 FileOutputMode setupLogging(int mpi_rank_, const std::string& deck_filename, const std::string& cmdline_output_dir, const std::string& cmdline_output, bool output_cout_, const std::string& stdout_log_id);
 
+using CollCommType = Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator>;
 /// \brief Reads the deck and creates all necessary objects if needed
 ///
 /// If pointers already contains objects then they are used otherwise they are created and can be used outside later.
-void readDeck(int rank, std::string& deckFilename, std::unique_ptr<Deck>& deck, std::unique_ptr<EclipseState>& eclipseState,
+void readDeck(CollCommType comm, std::string& deckFilename, std::unique_ptr<Deck>& deck, std::unique_ptr<EclipseState>& eclipseState,
               std::unique_ptr<Schedule>& schedule, std::unique_ptr<UDQState>& udqState, std::unique_ptr<SummaryConfig>& summaryConfig,
               std::unique_ptr<ErrorGuard> errorGuard, std::shared_ptr<Python>& python, std::unique_ptr<ParseContext> parseContext,
               bool initFromRestart, bool checkDeck, const std::optional<int>& outputInterval);

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1805,7 +1805,7 @@ updateWellPotentials(const int reportStepIdx,
     }
     logAndCheckForExceptionsAndThrow(deferred_logger, exc_type,
                                      "computeWellPotentials() failed: " + exc_msg,
-                                     terminal_output_);
+                                     terminal_output_, comm_);
 
 }
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -49,7 +49,7 @@ BlackoilWellModelGeneric(Schedule& schedule,
                          const SummaryState& summaryState,
                          const EclipseState& eclState,
                          const PhaseUsage& phase_usage,
-                         const Comm& comm)
+                         const Communication& comm)
     : schedule_(schedule)
     , summaryState_(summaryState)
     , eclState_(eclState)
@@ -1016,7 +1016,7 @@ actionOnBrokenConstraints(const Group& group,
         throw("Invalid procedure for maximum rate limit selected for group" + group.name());
     }
 
-    auto cc = Dune::MPIHelper::getCollectiveCommunication();
+    Communication cc = comm_;
     if (!ss.str().empty() && cc.rank() == 0)
         deferred_logger.info(ss.str());
 }
@@ -1038,7 +1038,8 @@ actionOnBrokenConstraints(const Group& group,
            << " to " << Group::InjectionCMode2String(newControl);
         this->groupState().injection_control(group.name(), controlPhase, newControl);
     }
-    auto cc = Dune::MPIHelper::getCollectiveCommunication();
+
+    Communication cc = comm_;
     if (!ss.str().empty() && cc.rank() == 0)
         deferred_logger.info(ss.str());
 }

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -32,6 +32,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include <dune/common/version.hh>
 #include <opm/output/data/GuideRateValue.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp>
@@ -68,7 +69,12 @@ class BlackoilWellModelGeneric
 {
 public:
     // ---------      Types      ---------
-    using Comm = Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator>;
+    using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+    #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+        using Communication = Dune::Communication<MPIComm>; 
+    #else
+        using Communication = Dune::CollectiveCommunication<MPIComm>;
+    #endif
     using GLiftOptWells = std::map<std::string,std::unique_ptr<GasLiftSingleWellGeneric>>;
     using GLiftProdWells = std::map<std::string,const WellInterfaceGeneric*>;
     using GLiftWellStateMap = std::map<std::string,std::unique_ptr<GasLiftWellState>>;
@@ -77,7 +83,7 @@ public:
                              const SummaryState& summaryState,
                              const EclipseState& eclState,
                              const PhaseUsage& phase_usage,
-                             const Comm& comm);
+                             const Communication& comm);
 
     virtual ~BlackoilWellModelGeneric() = default;
 
@@ -372,7 +378,7 @@ protected:
     Schedule& schedule_;
     const SummaryState& summaryState_;
     const EclipseState& eclState_;
-    const Comm& comm_;
+    const Communication& comm_;
 
     PhaseUsage phase_usage_;
     bool terminal_output_{false};

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -32,6 +32,12 @@
 
 #include <fmt/format.h>
 
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>;
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
 
 namespace Opm {
     template<typename TypeTag>
@@ -290,13 +296,6 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-
-        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
-        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-            using Communication = Dune::Communication<MPIComm>;
-        #else
-            using Communication = Dune::CollectiveCommunication<MPIComm>;
-        #endif
           
         const Communication& cc = grid().comm();
         logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "beginTimeStep() failed: " + exc_msg, terminal_output_, cc);
@@ -503,13 +502,6 @@ namespace Opm {
 
         this->commitWGState();
  
-        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
-        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-            using Communication = Dune::Communication<MPIComm>;
-        #else
-            using Communication = Dune::CollectiveCommunication<MPIComm>;
-        #endif
-        
         const Communication& cc = grid().comm();
         DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger,cc);
         if (terminal_output_) {
@@ -718,12 +710,6 @@ namespace Opm {
         }
 
         // Collect log messages and print.
-        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
-        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-            using Communication = Dune::Communication<MPIComm>;
-        #else
-            using Communication = Dune::CollectiveCommunication<MPIComm>;
-        #endif
         
         const Communication& cc = grid().comm();
         DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger,cc);
@@ -869,14 +855,7 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-         
-        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
-        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-            using Communication = Dune::Communication<MPIComm>;
-        #else
-            using Communication = Dune::CollectiveCommunication<MPIComm>;
-        #endif
-        
+                 
         const Communication& cc = grid().comm();
         logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "assemble() failed: " + exc_msg, terminal_output_, cc);
         last_report_.converged = true;
@@ -1184,13 +1163,6 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-
-        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
-        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-            using Communication = Dune::Communication<MPIComm>;
-        #else
-            using Communication = Dune::CollectiveCommunication<MPIComm>;
-        #endif
         
         const Communication& cc = grid().comm();
         logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "recoverWellSolutionAndUpdateWellState() failed: " + exc_msg, terminal_output_,cc);
@@ -1229,13 +1201,6 @@ namespace Opm {
                 local_report += well->getWellConvergence(this->wellState(), B_avg, local_deferredLogger, iterationIdx > param_.strict_outer_iter_ms_wells_ );
             }
         }
-
-        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
-        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-            using Communication = Dune::Communication<MPIComm>;
-        #else
-            using Communication = Dune::CollectiveCommunication<MPIComm>;
-        #endif
         
         const Communication& cc = grid().comm();
         DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger, cc);
@@ -1357,14 +1322,7 @@ namespace Opm {
                 this->closed_this_step_.insert(well->name());
             }
         }
-        
-        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
-        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-            using Communication = Dune::Communication<MPIComm>;
-        #else
-            using Communication = Dune::CollectiveCommunication<MPIComm>;
-        #endif
-        
+               
         const Communication& cc = grid().comm();
         DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger, cc);
         if (terminal_output_) {
@@ -1529,14 +1487,7 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-        
-        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
-        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
-            using Communication = Dune::Communication<MPIComm>;
-        #else
-            using Communication = Dune::CollectiveCommunication<MPIComm>;
-        #endif
-        
+               
         const Communication& cc = grid().comm();
         logAndCheckForExceptionsAndThrow(deferred_logger, exc_type, "prepareTimestep() failed: " + exc_msg, terminal_output_, cc);
     }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -59,8 +59,10 @@ namespace Opm {
                                         cartDims[0] * cartDims[1] * cartDims[2]);
 
             auto& parallel_wells = ebosSimulator.vanguard().parallelWells();
-            this->parallel_well_info_.assign(parallel_wells.begin(),
-                                             parallel_wells.end());
+
+            for (const auto& wellinfo : parallel_wells) {                   
+                this->parallel_well_info_.emplace_back(wellinfo, grid.comm());         
+            }
         }
 
         this->alternative_well_rate_init_ =

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -32,6 +32,7 @@
 
 #include <fmt/format.h>
 
+
 namespace Opm {
     template<typename TypeTag>
     BlackoilWellModel<TypeTag>::
@@ -289,15 +290,16 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+
+        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
         #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
             using Communication = Dune::Communication<MPIComm>;
         #else
             using Communication = Dune::CollectiveCommunication<MPIComm>;
         #endif
-        
+          
         const Communication& cc = grid().comm();
-        logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "beginTimeStep() failed: " + exc_msg, terminal_output_, comm_);
+        logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "beginTimeStep() failed: " + exc_msg, terminal_output_, cc);
 
         for (auto& well : well_container_) {
             well->setVFPProperties(vfp_properties_.get());
@@ -501,7 +503,7 @@ namespace Opm {
 
         this->commitWGState();
  
-            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
         #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
             using Communication = Dune::Communication<MPIComm>;
         #else
@@ -716,7 +718,7 @@ namespace Opm {
         }
 
         // Collect log messages and print.
-            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
         #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
             using Communication = Dune::Communication<MPIComm>;
         #else
@@ -868,7 +870,7 @@ namespace Opm {
             exc_msg = e.what();
         }
          
-            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
         #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
             using Communication = Dune::Communication<MPIComm>;
         #else
@@ -1182,7 +1184,8 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+
+        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
         #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
             using Communication = Dune::Communication<MPIComm>;
         #else
@@ -1226,7 +1229,8 @@ namespace Opm {
                 local_report += well->getWellConvergence(this->wellState(), B_avg, local_deferredLogger, iterationIdx > param_.strict_outer_iter_ms_wells_ );
             }
         }
-            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+
+        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
         #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
             using Communication = Dune::Communication<MPIComm>;
         #else
@@ -1353,7 +1357,8 @@ namespace Opm {
                 this->closed_this_step_.insert(well->name());
             }
         }
-            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        
+        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
         #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
             using Communication = Dune::Communication<MPIComm>;
         #else
@@ -1524,7 +1529,8 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        
+        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
         #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
             using Communication = Dune::Communication<MPIComm>;
         #else

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -289,7 +289,14 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+            using Communication = Dune::Communication<MPIComm>;
+        #else
+            using Communication = Dune::CollectiveCommunication<MPIComm>;
+        #endif
+        
+        const Communication& cc = grid().comm();
         logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "beginTimeStep() failed: " + exc_msg, terminal_output_, comm_);
 
         for (auto& well : well_container_) {
@@ -494,7 +501,14 @@ namespace Opm {
 
         this->commitWGState();
  
-        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+            using Communication = Dune::Communication<MPIComm>;
+        #else
+            using Communication = Dune::CollectiveCommunication<MPIComm>;
+        #endif
+        
+        const Communication& cc = grid().comm();
         DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger,cc);
         if (terminal_output_) {
             global_deferredLogger.logMessages();
@@ -702,7 +716,14 @@ namespace Opm {
         }
 
         // Collect log messages and print.
-        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+            using Communication = Dune::Communication<MPIComm>;
+        #else
+            using Communication = Dune::CollectiveCommunication<MPIComm>;
+        #endif
+        
+        const Communication& cc = grid().comm();
         DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger,cc);
         if (terminal_output_) {
             global_deferredLogger.logMessages();
@@ -846,7 +867,15 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+         
+            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+            using Communication = Dune::Communication<MPIComm>;
+        #else
+            using Communication = Dune::CollectiveCommunication<MPIComm>;
+        #endif
+        
+        const Communication& cc = grid().comm();
         logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "assemble() failed: " + exc_msg, terminal_output_, cc);
         last_report_.converged = true;
         last_report_.assemble_time_well += perfTimer.stop();
@@ -1153,7 +1182,14 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+            using Communication = Dune::Communication<MPIComm>;
+        #else
+            using Communication = Dune::CollectiveCommunication<MPIComm>;
+        #endif
+        
+        const Communication& cc = grid().comm();
         logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "recoverWellSolutionAndUpdateWellState() failed: " + exc_msg, terminal_output_,cc);
     }
 
@@ -1190,7 +1226,14 @@ namespace Opm {
                 local_report += well->getWellConvergence(this->wellState(), B_avg, local_deferredLogger, iterationIdx > param_.strict_outer_iter_ms_wells_ );
             }
         }
-        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+            using Communication = Dune::Communication<MPIComm>;
+        #else
+            using Communication = Dune::CollectiveCommunication<MPIComm>;
+        #endif
+        
+        const Communication& cc = grid().comm();
         DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger, cc);
         if (terminal_output_) {
             global_deferredLogger.logMessages();
@@ -1310,7 +1353,14 @@ namespace Opm {
                 this->closed_this_step_.insert(well->name());
             }
         }
-        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+            using Communication = Dune::Communication<MPIComm>;
+        #else
+            using Communication = Dune::CollectiveCommunication<MPIComm>;
+        #endif
+        
+        const Communication& cc = grid().comm();
         DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger, cc);
         if (terminal_output_) {
             global_deferredLogger.logMessages();
@@ -1474,7 +1524,14 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+            using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+        #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+            using Communication = Dune::Communication<MPIComm>;
+        #else
+            using Communication = Dune::CollectiveCommunication<MPIComm>;
+        #endif
+        
+        const Communication& cc = grid().comm();
         logAndCheckForExceptionsAndThrow(deferred_logger, exc_type, "prepareTimestep() failed: " + exc_msg, terminal_output_, cc);
     }
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -237,7 +237,6 @@ namespace Opm {
     {
         updatePerforationIntensiveQuantities();
         updateAverageFormationFactor();
-
         DeferredLogger local_deferredLogger;
 
         this->resetWGState();
@@ -288,8 +287,8 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-
-        logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "beginTimeStep() failed: " + exc_msg, terminal_output_);
+        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+        logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "beginTimeStep() failed: " + exc_msg, terminal_output_, comm_);
 
         for (auto& well : well_container_) {
             well->setVFPProperties(vfp_properties_.get());
@@ -372,7 +371,7 @@ namespace Opm {
         }
 
         logAndCheckForExceptionsAndThrow(local_deferredLogger,
-            exc_type, "beginTimeStep() failed: " + exc_msg, terminal_output_);
+            exc_type, "beginTimeStep() failed: " + exc_msg, terminal_output_, cc);
 
     }
 
@@ -492,8 +491,9 @@ namespace Opm {
         this->calculateProductivityIndexValues(local_deferredLogger);
 
         this->commitWGState();
-
-        DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger);
+ 
+        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+        DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger,cc);
         if (terminal_output_) {
             global_deferredLogger.logMessages();
         }
@@ -700,7 +700,8 @@ namespace Opm {
         }
 
         // Collect log messages and print.
-        DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger);
+        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+        DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger,cc);
         if (terminal_output_) {
             global_deferredLogger.logMessages();
         }
@@ -843,7 +844,8 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-        logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "assemble() failed: " + exc_msg, terminal_output_);
+        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+        logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "assemble() failed: " + exc_msg, terminal_output_, cc);
         last_report_.converged = true;
         last_report_.assemble_time_well += perfTimer.stop();
     }
@@ -1126,6 +1128,7 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     recoverWellSolutionAndUpdateWellState(const BVector& x)
     {
+         
         DeferredLogger local_deferredLogger;
         auto exc_type = ExceptionType::NONE;
         std::string exc_msg;
@@ -1148,7 +1151,8 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-        logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "recoverWellSolutionAndUpdateWellState() failed: " + exc_msg, terminal_output_);
+        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+        logAndCheckForExceptionsAndThrow(local_deferredLogger, exc_type, "recoverWellSolutionAndUpdateWellState() failed: " + exc_msg, terminal_output_,cc);
     }
 
 
@@ -1184,12 +1188,13 @@ namespace Opm {
                 local_report += well->getWellConvergence(this->wellState(), B_avg, local_deferredLogger, iterationIdx > param_.strict_outer_iter_ms_wells_ );
             }
         }
-        DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger);
+        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+        DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger, cc);
         if (terminal_output_) {
             global_deferredLogger.logMessages();
         }
 
-        ConvergenceReport report = gatherConvergenceReport(local_report);
+        ConvergenceReport report = gatherConvergenceReport(local_report, cc);
 
         // Log debug messages for NaN or too large residuals.
         if (terminal_output_) {
@@ -1303,8 +1308,8 @@ namespace Opm {
                 this->closed_this_step_.insert(well->name());
             }
         }
-
-        DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger);
+        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+        DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger, cc);
         if (terminal_output_) {
             global_deferredLogger.logMessages();
         }
@@ -1467,7 +1472,8 @@ namespace Opm {
             exc_type = ExceptionType::DEFAULT;
             exc_msg = e.what();
         }
-        logAndCheckForExceptionsAndThrow(deferred_logger, exc_type, "prepareTimestep() failed: " + exc_msg, terminal_output_);
+        const Dune::MPIHelper::MPICommunicator& cc = grid().comm();
+        logAndCheckForExceptionsAndThrow(deferred_logger, exc_type, "prepareTimestep() failed: " + exc_msg, terminal_output_, cc);
     }
 
 

--- a/opm/simulators/wells/ParallelWellInfo.cpp
+++ b/opm/simulators/wells/ParallelWellInfo.cpp
@@ -357,7 +357,8 @@ ParallelWellInfo::ParallelWellInfo(const std::string& name,
       commAboveBelow_(new CommunicateAboveBelow(*comm_))
 {}
 
-ParallelWellInfo::ParallelWellInfo(const std::pair<std::string,bool>& well_info,
+
+ParallelWellInfo::ParallelWellInfo(const std::pair<std::string, bool>& well_info,
                                    [[maybe_unused]] Communication allComm)
     : name_(well_info.first), hasLocalCells_(well_info.second),
       rankWithFirstPerf_(-1)
@@ -373,6 +374,7 @@ ParallelWellInfo::ParallelWellInfo(const std::pair<std::string,bool>& well_info,
     commAboveBelow_.reset(new CommunicateAboveBelow(*comm_));
     isOwner_ = (comm_->rank() == 0);
 }
+
 
 void ParallelWellInfo::communicateFirstPerforation(bool hasFirst)
 {

--- a/opm/simulators/wells/ParallelWellInfo.hpp
+++ b/opm/simulators/wells/ParallelWellInfo.hpp
@@ -49,7 +49,8 @@ public:
       ownerAbove = 3,
       overlapAbove = 4
     };
-    using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
     using Communication = Dune::Communication<MPIComm>;
 #else

--- a/opm/simulators/wells/ParallelWellInfo.hpp
+++ b/opm/simulators/wells/ParallelWellInfo.hpp
@@ -269,7 +269,7 @@ public:
     /// \param allComm The communication object with all MPI ranks active in the simulation.
     ///                Default is the one with all ranks available.
     ParallelWellInfo(const std::pair<std::string,bool>& well_info,
-                     Communication allComm = Communication());
+                     Communication allComm);
 
     const Communication& communication() const
     {

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -85,7 +85,7 @@ protected:
     static const bool gasEnabled = Indices::gasEnabled;
     static const bool oilEnabled = Indices::oilEnabled;
 
-    static constexpr bool has_wfrac_variable = Indices::waterEnabled && Indices::oilEnabled;;
+    static constexpr bool has_wfrac_variable = Indices::waterEnabled && Indices::oilEnabled;
     static constexpr bool has_gfrac_variable = Indices::gasEnabled && Indices::numPhases > 1;
     static constexpr int WFrac = has_wfrac_variable ? 1 : -1000;
     static constexpr int GFrac = has_gfrac_variable ? has_wfrac_variable + 1 : -1000;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -183,7 +183,7 @@ namespace Opm
             changed = this->checkConstraints(well_state, group_state, schedule, summaryState, deferred_logger);
         }
 
-        auto cc = Dune::MPIHelper::getCollectiveCommunication();
+        Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> cc = ebos_simulator.vanguard().grid().comm();
 
         // checking whether control changed
         if (changed) {

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -24,6 +24,15 @@
 #include <opm/simulators/wells/GroupState.hpp>
 #include <opm/simulators/wells/TargetCalculator.hpp>
 
+#include <dune/common/version.hh>
+
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>; 
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
+
 namespace Opm
 {
 
@@ -183,8 +192,7 @@ namespace Opm
             changed = this->checkConstraints(well_state, group_state, schedule, summaryState, deferred_logger);
         }
 
-        Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator> cc = ebos_simulator.vanguard().grid().comm();
-
+        Communication cc = ebos_simulator.vanguard().grid().comm();
         // checking whether control changed
         if (changed) {
             std::string to;

--- a/tests/test_gatherconvergencereport.cpp
+++ b/tests/test_gatherconvergencereport.cpp
@@ -25,8 +25,16 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <dune/common/version.hh>
 #include <opm/simulators/timestepping/gatherConvergenceReport.hpp>
 #include <dune/common/parallel/mpihelper.hh>
+
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>; 
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
 
 #if HAVE_MPI
 struct MPIError

--- a/tests/test_gatherconvergencereport.cpp
+++ b/tests/test_gatherconvergencereport.cpp
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(AllHaveFailure)
     using CR = Opm::ConvergenceReport;
     CR cr;
     cr.setWellFailed({CR::WellFailure::Type::ControlBHP, CR::Severity::Normal, -1, name.str()});
-    CR global_cr = gatherConvergenceReport(cr);
+    CR global_cr = gatherConvergenceReport(cr, cc);
     BOOST_CHECK(global_cr.wellFailures().size() == std::size_t(cc.size()));
     BOOST_CHECK(global_cr.wellFailures()[cc.rank()] == cr.wellFailures()[0]);
     // Extra output for debugging.
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(EvenHaveFailure)
         name << "WellRank" << cc.rank() << std::flush;
         cr.setWellFailed({CR::WellFailure::Type::ControlBHP, CR::Severity::Normal, -1, name.str()});
     }
-    CR global_cr = gatherConvergenceReport(cr);
+    CR global_cr = gatherConvergenceReport(cr, cc);
     BOOST_CHECK(global_cr.wellFailures().size() == std::size_t((cc.size())+1) / 2);
     if (cc.rank() % 2 == 0) {
         BOOST_CHECK(global_cr.wellFailures()[cc.rank()/2] == cr.wellFailures()[0]);

--- a/tests/test_gatherdeferredlogger.cpp
+++ b/tests/test_gatherdeferredlogger.cpp
@@ -25,6 +25,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <dune/common/version.hh>
 #include <opm/simulators/utils/gatherDeferredLogger.hpp>
 #include <dune/common/parallel/mpihelper.hh>
 
@@ -34,6 +35,13 @@
 #include <opm/common/OpmLog/TimerLog.hpp>
 #include <opm/common/OpmLog/StreamLog.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
+
+using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+    using Communication = Dune::Communication<MPIComm>; 
+#else
+    using Communication = Dune::CollectiveCommunication<MPIComm>;
+#endif
 
 using namespace Opm;
 
@@ -80,7 +88,7 @@ void initLogger(std::ostringstream& log_stream) {
 
 BOOST_AUTO_TEST_CASE(NoMessages)
 {
-    auto cc = Dune::MPIHelper::getCollectiveCommunication();
+    const Communication& cc = Dune::MPIHelper::getCollectiveCommunication();
 
     std::ostringstream log_stream;
     initLogger(log_stream);
@@ -103,7 +111,7 @@ BOOST_AUTO_TEST_CASE(NoMessages)
 
 BOOST_AUTO_TEST_CASE(VariableNumberOfMessages)
 {
-    auto cc = Dune::MPIHelper::getCollectiveCommunication();
+    const Communication& cc = Dune::MPIHelper::getCollectiveCommunication();
 
     std::ostringstream log_stream;
     initLogger(log_stream);
@@ -141,7 +149,7 @@ BOOST_AUTO_TEST_CASE(VariableNumberOfMessages)
 
 BOOST_AUTO_TEST_CASE(AllHaveOneMessage)
 {
-    auto cc = Dune::MPIHelper::getCollectiveCommunication();
+    const Communication& cc = Dune::MPIHelper::getCollectiveCommunication();
 
     std::ostringstream log_stream;
     initLogger(log_stream);

--- a/tests/test_gatherdeferredlogger.cpp
+++ b/tests/test_gatherdeferredlogger.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(NoMessages)
 
     Opm::DeferredLogger local_deferredlogger;
 
-    Opm::DeferredLogger global_deferredlogger = gatherDeferredLogger(local_deferredlogger);
+    Opm::DeferredLogger global_deferredlogger = gatherDeferredLogger(local_deferredlogger, cc);
 
     if (cc.rank() == 0) {
 
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(VariableNumberOfMessages)
         local_deferredlogger.bug("tagme", "bug from rank " + std::to_string(cc.rank()));
     }
 
-    Opm::DeferredLogger global_deferredlogger = gatherDeferredLogger(local_deferredlogger);
+    Opm::DeferredLogger global_deferredlogger = gatherDeferredLogger(local_deferredlogger, cc);
 
     if (cc.rank() == 0) {
 
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(AllHaveOneMessage)
     Opm::DeferredLogger local_deferredlogger;
     local_deferredlogger.info("info from rank " + std::to_string(cc.rank()));
 
-    Opm::DeferredLogger global_deferredlogger = gatherDeferredLogger(local_deferredlogger);
+    Opm::DeferredLogger global_deferredlogger = gatherDeferredLogger(local_deferredlogger, cc);
 
     if (cc.rank() == 0) {
 

--- a/tests/test_parallelwellinfo.cpp
+++ b/tests/test_parallelwellinfo.cpp
@@ -113,7 +113,12 @@ BOOST_AUTO_TEST_CASE(ParallelWellComparison)
         pairs = {{"Test1", false},{"Test2", true}, {"Test1", true} };
 
     std::vector<Opm::ParallelWellInfo> well_info;
-    well_info.assign(pairs.begin(), pairs.end());
+    
+    for (const auto& wellinfo : pairs) {                   
+        well_info.emplace_back(wellinfo, MPI_COMM_WORLD);         
+    }
+
+    //well_info.assign(pairs.begin(), pairs.end());
 
     BOOST_CHECK_EQUAL_COLLECTIONS(pairs.begin(), pairs.end(),
                                   well_info.begin(), well_info.end());

--- a/tests/test_parallelwellinfo.cpp
+++ b/tests/test_parallelwellinfo.cpp
@@ -18,7 +18,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include<config.h>
+
 #include<opm/simulators/wells/ParallelWellInfo.hpp>
+
+#include <dune/common/version.hh>
 #include<vector>
 #include<string>
 #include<tuple>
@@ -106,6 +109,12 @@ BOOST_AUTO_TEST_CASE(ParallelWellComparison)
     int argc = 0;
     char** argv = nullptr;
     const auto& helper = Dune::MPIHelper::instance(argc, argv);
+        using MPIComm = typename Dune::MPIHelper::MPICommunicator;
+    #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+        using Communication = Dune::Communication<MPIComm>;
+    #else
+        using Communication = Dune::CollectiveCommunication<MPIComm>;
+    #endif
     std::vector<std::pair<std::string,bool>> pairs;
     if (helper.rank() == 0)
         pairs = {{"Test1", true},{"Test2", true}, {"Test1", false} };
@@ -115,7 +124,7 @@ BOOST_AUTO_TEST_CASE(ParallelWellComparison)
     std::vector<Opm::ParallelWellInfo> well_info;
     
     for (const auto& wellinfo : pairs) {                   
-        well_info.emplace_back(wellinfo, MPI_COMM_WORLD);         
+        well_info.emplace_back(wellinfo, Communication());         
     }
 
     //well_info.assign(pairs.begin(), pairs.end());

--- a/tests/test_wellmodel.cpp
+++ b/tests/test_wellmodel.cpp
@@ -102,7 +102,7 @@ struct GlobalFixture {
         Dune::MPIHelper::instance(argcDummy, argvDummy);
 #endif
 
-        Opm::FlowMainEbos<Opm::Properties::TTag::EclFlowProblem>::setupParameters_(argcDummy, argvDummy);
+        Opm::FlowMainEbos<Opm::Properties::TTag::EclFlowProblem>::setupParameters_(argcDummy, argvDummy, Dune::MPIHelper::getCollectiveCommunication());
     }
 };
 


### PR DESCRIPTION
The opm simulators support a variable communicator instead of the fixed MPI_COMM_WORLD. A demo code has been added to main to test the use of non-global communicators. The compilation was done with and without USE_MPI and the tests with mpirun also. 