### PR TITLE
Remove unused query/switch code for GLO - it is always on

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -387,8 +387,6 @@ namespace Opm {
 
             void maybeDoGasLiftOptimize(DeferredLogger& deferred_logger);
 
-            bool checkDoGasLiftOptimization(DeferredLogger& deferred_logger);
-
             void gasLiftOptimizationStage1(DeferredLogger& deferred_logger,
                 GLiftProdWells &prod_wells, GLiftOptWells &glift_wells,
                 GasLiftGroupInfo &group_info, GLiftWellStateMap &state_map);

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -845,7 +845,8 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     maybeDoGasLiftOptimize(DeferredLogger& deferred_logger)
     {
-        if (checkDoGasLiftOptimization(deferred_logger)) {
+        const bool do_glift_optimization = true;
+        if (do_glift_optimization) {
             GLiftOptWells glift_wells;
             GLiftProdWells prod_wells;
             GLiftWellStateMap state_map;
@@ -985,27 +986,6 @@ namespace Opm {
         }
     }
 
-    template<typename TypeTag>
-    bool
-    BlackoilWellModel<TypeTag>::
-    checkDoGasLiftOptimization(Opm::DeferredLogger& deferred_logger)
-    {
-        gliftDebug("checking if GLIFT should be done..", deferred_logger);
-        /*
-        std::size_t num_procs = ebosSimulator_.gridView().comm().size();
-        if (num_procs > 1u) {
-            const std::string msg = fmt::format("  GLIFT: skipping optimization. "
-                "Parallel run not supported yet: num procs = {}", num_procs);
-            deferred_logger.warning(msg);
-            return false;
-        }
-        */
-        if (!(this->wellState().gliftOptimizationEnabled())) {
-            gliftDebug("Optimization disabled in WellState", deferred_logger);
-            return false;
-        }
-        return true;
-    }
 
     template<typename TypeTag>
     void

--- a/opm/simulators/wells/StandardWellGeneric.cpp
+++ b/opm/simulators/wells/StandardWellGeneric.cpp
@@ -253,11 +253,6 @@ doGasLiftOptimize(const WellState &well_state,
                   const Schedule& schedule,
                   DeferredLogger& deferred_logger) const
 {
-    gliftDebug("checking if GLIFT should be done..", deferred_logger);
-    if (!well_state.gliftOptimizationEnabled()) {
-        gliftDebug("Optimization disabled in WellState", deferred_logger);
-        return false;
-    }
     if (well_state.gliftCheckAlqOscillation(baseif_.name())) {
         gliftDebug("further optimization skipped due to oscillation in ALQ",
                    deferred_logger);

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -216,8 +216,6 @@ void WellState::init(const std::vector<double>& cellPressures,
 
     const int nw = wells_ecl.size();
 
-    do_glift_optimization_ = true;
-
     if( nw == 0 ) return ;
 
     // Initialize perfphaserates_, which must be done here.

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -182,10 +182,6 @@ public:
         this->alq_state.update_count(name, increase);
     }
 
-    bool gliftOptimizationEnabled() const {
-        return do_glift_optimization_;
-    }
-
     void gliftTimeStepInit() {
         this->alq_state.reset_count();
     }
@@ -269,7 +265,6 @@ private:
     // whereas the GlobalWellInfo is not.
     std::optional<GlobalWellInfo> global_well_info;
     ALQState alq_state;
-    bool do_glift_optimization_;
     PhaseUsage phase_usage_;
 
     WellContainer<SingleWellState> wells_;


### PR DESCRIPTION
The `WellState` class had a `bool` switch whether to perform gas lift optimization - it was always on. Just removed with this PR in the long time quest of simplifying the `WellState` class. If runtime switching of the GLO should be brought back in, I don't think the `WellState`is the correct home for such a future variable? 