### PR TITLE
Call MPI_Abort() in main catch all clause

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -431,7 +431,10 @@ namespace Opm
                         std::cout << message.str() << "\n";
                     }
                 }
-
+#if HAVE_MPI
+                if (this->mpi_size_ > 1)
+                    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+#endif
                 return EXIT_FAILURE;
             }
         }


### PR DESCRIPTION
In current master it is difficult to use exceptions in the simulator code, because when only when process throws an exception the other processes will quite quickly deadlock in a subsequent collective communication.

With this PR `MPI_Abort(MPI_COMM_WORLD)`will be called in the catch all clause of flow execution and we can safely use arbitrary `std::exceptions` in the simulator. (The simulator will come tumbling down in flames - but I consider that far superior to a deadlock).

Exactly how this should be done is maybe outside my MPI competence - but I *really* hope something like this can be merged. 