### PR TITLE
[refactor] Move cell centroid lookup magic to vanguard for reuse.

### DIFF
--- a/ebos/eclalugridvanguard.hh
+++ b/ebos/eclalugridvanguard.hh
@@ -102,7 +102,6 @@ public:
 
     ~EclAluGridVanguard()
     {
-        delete cartesianIndexMapper_;
         delete equilCartesianIndexMapper_;
         delete grid_;
         delete equilGrid_;
@@ -178,6 +177,18 @@ public:
     const EquilCartesianIndexMapper& equilCartesianIndexMapper() const
     { return *equilCartesianIndexMapper_; }
 
+    /*!
+     * \brief Get function to query cell centroids for a distributed grid.
+     *
+     * Currently this only non-empty for a loadbalanced CpGrid.
+     * It is a function return the centroid for the given element
+     * index.
+     */
+    std::function<std::array<double,dimensionworld>(int)>
+    cellCentroids() const
+    {
+        return this->cellCentroids_(cartesianIndexMapper_.get());
+    }
 protected:
     void createGrids_()
     {
@@ -210,7 +221,8 @@ protected:
         grid_ = factory.convert(*equilGrid_, cartesianCellId_);
 
         cartesianIndexMapper_ =
-            new CartesianIndexMapper(*grid_, cartesianDimension_, cartesianCellId_);
+            std::make_unique<CartesianIndexMapper>(*grid_, cartesianDimension_,
+                                                   cartesianCellId_);
     }
 
     void filterConnections_()
@@ -222,7 +234,7 @@ protected:
     EquilGrid* equilGrid_;
     std::vector<int> cartesianCellId_;
     std::array<int,dimension> cartesianDimension_;
-    CartesianIndexMapper* cartesianIndexMapper_;
+    std::unique_ptr<CartesianIndexMapper> cartesianIndexMapper_;
     EquilCartesianIndexMapper* equilCartesianIndexMapper_;
 };
 

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -90,6 +90,7 @@ public:
     using EquilGrid = GetPropType<TypeTag, Properties::EquilGrid>;
     using GridView = GetPropType<TypeTag, Properties::GridView>;
     using TransmissibilityType = EclTransmissibility<Grid, GridView, ElementMapper, Scalar>;
+    static const int dimensionworld = Grid::dimensionworld;
 
 private:
     typedef Dune::CartesianIndexMapper<Grid> CartesianIndexMapper;
@@ -138,7 +139,6 @@ public:
                              this->eclState(), this->parallelWells_);
 #endif
 
-        this->allocCartMapper();
         this->updateGridView_();
         this->updateCartesianToCompressedMapping_();
         this->updateCellDepths_();
@@ -149,6 +149,18 @@ public:
 #endif
     }
 
+    /*!
+     * \brief Get function to query cell centroids for a distributed grid.
+     *
+     * Currently this only non-empty for a loadbalanced CpGrid.
+     * It is a function return the centroid for the given element
+     * index.
+     */
+    std::function<std::array<double,dimensionworld>(int)>
+    cellCentroids() const
+    {
+        return this->cellCentroids_(this->cartesianIndexMapper());
+    }
 
 protected:
     void createGrids_()

--- a/ebos/ecltransmissibility.cc
+++ b/ebos/ecltransmissibility.cc
@@ -88,7 +88,7 @@ EclTransmissibility(const EclipseState& eclState,
                     const GridView& gridView,
                     const Dune::CartesianIndexMapper<Grid>& cartMapper,
                     const Grid& grid,
-                    const std::vector<double>& centroids,
+                    std::function<std::array<double,dimWorld>(int)> centroids,
                     bool enableEnergy,
                     bool enableDiffusivity)
       : eclState_(eclState)
@@ -174,15 +174,7 @@ update(bool global)
         // compute the axis specific "centroids" used for the transmissibilities. for
         // consistency with the flow simulator, we use the element centers as
         // computed by opm-parser's Opm::EclipseGrid class for all axes.
-        std::array<double, 3> centroid;
-        if (gridView_.comm().rank() == 0) {
-            const auto& eclGrid = eclState_.getInputGrid();
-            unsigned cartesianCellIdx = cartMapper_.cartesianIndex(elemIdx);
-            centroid = eclGrid.getCellCenter(cartesianCellIdx);
-        } else
-            std::copy(centroids_.begin() + centroidIdx * dimWorld,
-                      centroids_.begin() + (centroidIdx + 1) * dimWorld,
-                      centroid.begin());
+        std::array<double, dimWorld> centroid = centroids_(elemIdx);
 
         for (unsigned axisIdx = 0; axisIdx < dimWorld; ++axisIdx)
             for (unsigned dimIdx = 0; dimIdx < dimWorld; ++dimIdx)

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -38,6 +38,7 @@
 #include <tuple>
 #include <vector>
 #include <unordered_map>
+#include <functional>
 
 namespace Opm {
 
@@ -58,7 +59,7 @@ public:
                         const GridView& gridView,
                         const Dune::CartesianIndexMapper<Grid>& cartMapper,
                         const Grid& grid,
-                        const std::vector<double>& centroids,
+                        std::function<std::array<double,dimWorld>(int)> centroids,
                         bool enableEnergy,
                         bool enableDiffusivity);
 
@@ -236,7 +237,7 @@ protected:
     const GridView& gridView_;
     const Dune::CartesianIndexMapper<Grid>& cartMapper_;
     const Grid& grid_;
-    const std::vector<double>& centroids_;
+    std::function<std::array<double,dimWorld>(int)> centroids_;
     Scalar transmissibilityThreshold_;
     std::map<std::pair<unsigned, unsigned>, Scalar> transBoundary_;
     std::map<std::pair<unsigned, unsigned>, Scalar> thermalHalfTransBoundary_;


### PR DESCRIPTION
In addition to transmissibilities We will need this for the tracers,
too, and should prevent code duplication.