### PR TITLE
Create and use scale kernel for relaxation of ILU

### DIFF
--- a/opm/simulators/linalg/bda/BILU0.cpp
+++ b/opm/simulators/linalg/bda/BILU0.cpp
@@ -584,7 +584,7 @@ BILU0<block_size>::~BILU0()
             if (verbosity >= 4) {
                 out << "color " << color << ": " << firstRow << " - " << lastRow << " = " << lastRow - firstRow << "\n";
             }
-            event = (*ilu_decomp_k)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items2), cl::NDRange(work_group_size2)), firstRow, lastRow, s.LUvals, s.LUcols, s.LUrows, s.invDiagVals, s.diagIndex, LUmat->Nb, cl::Local(lmem_per_work_group2));
+            event = (*ilu_decomp)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items2), cl::NDRange(work_group_size2)), firstRow, lastRow, s.LUvals, s.LUcols, s.LUrows, s.invDiagVals, s.diagIndex, LUmat->Nb, cl::Local(lmem_per_work_group2));
             event.wait();
         }
 
@@ -601,28 +601,33 @@ BILU0<block_size>::~BILU0()
     // however, if individual kernel calls are timed, waiting for events is needed
     // behavior on other GPUs is untested
     template <unsigned int block_size>
-    void BILU0<block_size>::apply(cl::Buffer& x, cl::Buffer& y)
+    void BILU0<block_size>::apply(cl::Buffer& y, cl::Buffer& x)
     {
+        const double relaxation = 0.9;
         cl::Event event;
         Timer t_apply;
 
         for(int color = 0; color < numColors; ++color){
 #if CHOW_PATEL
-            event = (*ILU_apply1)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items), cl::NDRange(work_group_size)), s.Lvals, s.Lcols, s.Lrows, s.diagIndex, x, y, s.rowsPerColor, color, block_size, cl::Local(lmem_per_work_group));
+            event = (*ILU_apply1)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items), cl::NDRange(work_group_size)), s.Lvals, s.Lcols, s.Lrows, s.diagIndex, y, x, s.rowsPerColor, color, block_size, cl::Local(lmem_per_work_group));
 #else
-            event = (*ILU_apply1)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items), cl::NDRange(work_group_size)), s.LUvals, s.LUcols, s.LUrows, s.diagIndex, x, y, s.rowsPerColor, color, block_size, cl::Local(lmem_per_work_group));
+            event = (*ILU_apply1)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items), cl::NDRange(work_group_size)), s.LUvals, s.LUcols, s.LUrows, s.diagIndex, y, x, s.rowsPerColor, color, block_size, cl::Local(lmem_per_work_group));
 #endif
             // event.wait();
         }
 
         for(int color = numColors-1; color >= 0; --color){
 #if CHOW_PATEL
-            event = (*ILU_apply2)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items), cl::NDRange(work_group_size)), s.Uvals, s.Ucols, s.Urows, s.diagIndex, s.invDiagVals, y, s.rowsPerColor, color, block_size, cl::Local(lmem_per_work_group));
+            event = (*ILU_apply2)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items), cl::NDRange(work_group_size)), s.Uvals, s.Ucols, s.Urows, s.diagIndex, s.invDiagVals, x, s.rowsPerColor, color, block_size, cl::Local(lmem_per_work_group));
 #else
-            event = (*ILU_apply2)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items), cl::NDRange(work_group_size)), s.LUvals, s.LUcols, s.LUrows, s.diagIndex, s.invDiagVals, y, s.rowsPerColor, color, block_size, cl::Local(lmem_per_work_group));
+            event = (*ILU_apply2)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items), cl::NDRange(work_group_size)), s.LUvals, s.LUcols, s.LUrows, s.diagIndex, s.invDiagVals, x, s.rowsPerColor, color, block_size, cl::Local(lmem_per_work_group));
 #endif
             // event.wait();
         }
+
+        // apply relaxation
+        event = (*scale)(cl::EnqueueArgs(*queue, cl::NDRange(total_work_items), cl::NDRange(work_group_size)), x, relaxation, N);
+        event.wait();
 
         if (verbosity >= 4) {
             event.wait();
@@ -651,11 +656,13 @@ template <unsigned int block_size>
 void BILU0<block_size>::setKernels(
     cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, const unsigned int, cl::LocalSpaceArg> *ILU_apply1_,
     cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, const unsigned int, cl::LocalSpaceArg> *ILU_apply2_,
-    cl::make_kernel<const unsigned int, const unsigned int, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const int, cl::LocalSpaceArg> *ilu_decomp_k_
+    cl::make_kernel<cl::Buffer&, const double, const unsigned int> *scale_,
+    cl::make_kernel<const unsigned int, const unsigned int, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const int, cl::LocalSpaceArg> *ilu_decomp_
 ){
     this->ILU_apply1 = ILU_apply1_;
     this->ILU_apply2 = ILU_apply2_;
-    this->ilu_decomp_k = ilu_decomp_k_;
+    this->scale = scale_;
+    this->ilu_decomp = ilu_decomp_;
 }
 
 
@@ -672,7 +679,8 @@ template void BILU0<n>::setKernelParameters(unsigned int, unsigned int, unsigned
 template void BILU0<n>::setKernels(                                                      \
     cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, const unsigned int, cl::LocalSpaceArg> *, \
     cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, const unsigned int, cl::LocalSpaceArg> *, \
-    cl::make_kernel<const unsigned int, const unsigned int, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const int, cl::LocalSpaceArg> *                 \
+    cl::make_kernel<cl::Buffer&, const double, const unsigned int> *, \
+    cl::make_kernel<const unsigned int, const unsigned int, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const int, cl::LocalSpaceArg> * \
     );
 
 INSTANTIATE_BDA_FUNCTIONS(1);

--- a/opm/simulators/linalg/bda/BILU0.hpp
+++ b/opm/simulators/linalg/bda/BILU0.hpp
@@ -85,9 +85,10 @@ namespace bda
 
         ilu_apply1_kernel_type *ILU_apply1;
         ilu_apply2_kernel_type *ILU_apply2;
+        cl::make_kernel<cl::Buffer&, const double, const unsigned int> *scale;
         cl::make_kernel<const unsigned int, const unsigned int, cl::Buffer&, cl::Buffer&, cl::Buffer&,
                                         cl::Buffer&, cl::Buffer&,
-                                        const int, cl::LocalSpaceArg> *ilu_decomp_k;
+                                        const int, cl::LocalSpaceArg> *ilu_decomp;
 
         GPU_storage s;
         cl::Context *context;
@@ -114,8 +115,8 @@ namespace bda
         // ilu_decomposition
         bool create_preconditioner(BlockedMatrix<block_size> *mat);
 
-        // apply preconditioner, y = prec(x)
-        void apply(cl::Buffer& x, cl::Buffer& y);
+        // apply preconditioner, x = prec(y)
+        void apply(cl::Buffer& y, cl::Buffer& x);
 
         void setOpenCLContext(cl::Context *context);
         void setOpenCLQueue(cl::CommandQueue *queue);
@@ -123,7 +124,8 @@ namespace bda
         void setKernels(
             cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, const unsigned int, cl::LocalSpaceArg> *ILU_apply1,
             cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, const unsigned int, cl::LocalSpaceArg> *ILU_apply2,
-            cl::make_kernel<const unsigned int, const unsigned int, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const int, cl::LocalSpaceArg> *ilu_decomp_k
+            cl::make_kernel<cl::Buffer&, const double, const unsigned int> *scale,
+            cl::make_kernel<const unsigned int, const unsigned int, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, cl::Buffer&, const int, cl::LocalSpaceArg> *ilu_decomp
             );
 
         int* getToOrder()

--- a/opm/simulators/linalg/bda/openclKernels.hpp
+++ b/opm/simulators/linalg/bda/openclKernels.hpp
@@ -48,6 +48,10 @@ using ilu_decomp_kernel_type = cl::make_kernel<const unsigned int, const unsigne
     /// a = a + alpha * b
     std::string get_axpy_string();
 
+    /// Generate string with scale kernel
+    /// a = a * alpha
+    std::string get_scale_string();
+
     /// returns partial sums, instead of the final dot product
     /// partial sums are added on CPU
     std::string get_dot_1_string();

--- a/opm/simulators/linalg/bda/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/openclSolverBackend.cpp
@@ -509,7 +509,7 @@ void openclSolverBackend<block_size>::initialize(int N_, int nnz_, int dim, doub
 
         get_opencl_kernels();
 
-        prec->setKernels(ILU_apply1_k.get(), ILU_apply2_k.get(), ilu_decomp_k.get());
+        prec->setKernels(ILU_apply1_k.get(), ILU_apply2_k.get(), scale_k.get(), ilu_decomp_k.get());
 
     } catch (const cl::Error& error) {
         std::ostringstream oss;
@@ -535,6 +535,8 @@ void openclSolverBackend<block_size>::get_opencl_kernels() {
         cl::Program::Sources sources;
         std::string axpy_s = get_axpy_string();
         add_kernel_string(sources, axpy_s);
+        std::string scale_s = get_scale_string();
+        add_kernel_string(sources, scale_s);
         std::string dot_1_s = get_dot_1_string();
         add_kernel_string(sources, dot_1_s);
         std::string norm_s = get_norm_string();
@@ -569,6 +571,7 @@ void openclSolverBackend<block_size>::get_opencl_kernels() {
         dot_k.reset(new cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, cl::LocalSpaceArg>(cl::Kernel(program, "dot_1")));
         norm_k.reset(new cl::make_kernel<cl::Buffer&, cl::Buffer&, const unsigned int, cl::LocalSpaceArg>(cl::Kernel(program, "norm")));
         axpy_k.reset(new cl::make_kernel<cl::Buffer&, const double, cl::Buffer&, const unsigned int>(cl::Kernel(program, "axpy")));
+        scale_k.reset(new cl::make_kernel<cl::Buffer&, const double, const unsigned int>(cl::Kernel(program, "scale")));
         custom_k.reset(new cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, const double, const double, const unsigned int>(cl::Kernel(program, "custom")));
         spmv_blocked_k.reset(new spmv_kernel_type(cl::Kernel(program, "spmv_blocked")));
         ILU_apply1_k.reset(new ilu_apply1_kernel_type(cl::Kernel(program, "ILU_apply1")));

--- a/opm/simulators/linalg/bda/openclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/openclSolverBackend.hpp
@@ -68,6 +68,7 @@ private:
     std::unique_ptr<cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, const unsigned int, cl::LocalSpaceArg> > dot_k;
     std::unique_ptr<cl::make_kernel<cl::Buffer&, cl::Buffer&, const unsigned int, cl::LocalSpaceArg> > norm_k;
     std::unique_ptr<cl::make_kernel<cl::Buffer&, const double, cl::Buffer&, const unsigned int> > axpy_k;
+    std::unique_ptr<cl::make_kernel<cl::Buffer&, const double, const unsigned int> > scale_k;
     std::unique_ptr<cl::make_kernel<cl::Buffer&, cl::Buffer&, cl::Buffer&, const double, const double, const unsigned int> > custom_k;
     std::unique_ptr<spmv_kernel_type> spmv_blocked_k;
     std::shared_ptr<ilu_apply1_kernel_type> ILU_apply1_k;
@@ -110,6 +111,11 @@ private:
     /// \param[in] a          scalar value to multiply input vector
     /// \param[inout] out     output vector
     void axpy_w(cl::Buffer in, const double a, cl::Buffer out);
+
+    /// Perform scale: vec *= a
+    /// \param[inout] vec     vector to scale
+    /// \param[in] a          scalar value to multiply vector
+    void scale_w(cl::Buffer vec, const double a);
 
     /// Custom function that combines scale, axpy and add functions in bicgstab
     /// p = (p - omega * v) * beta + r


### PR DESCRIPTION
The relaxation after the ILU application (multiplying with 0.9) was done inside the `ILU_apply2()` kernel, which performs backsubstitution, solving `Ux=y`. However since colors depend on previous colors, the input of many colors was already multiplied by 0.9, causing most colors to be 'too relaxed'.

This is solved by splitting the kernel: first U is applied completely, and then the output vector is multiplied by the relaxationfactor.

Also renamed `ilu_decomp_k` to `ilu_decomp` in `BILU0`, and swapped names of `x` and `y` in `BILU0::apply()`.

This change only affects `openclSolver`.

```
Benchmarks on R5 2400G, NVIDIA 1050Ti
LS: level_scheduling
GC: graph_coloring
dune: 569 (142+237+72+101), 1851, 1483, 21898
pre fix:
LS: 829 (146+495+71+100), 1794, 1431, 21612 | 0
GC: 817 (189+401+98+111), 2441, 2044, 44425 | 0
post fix:
LS: 789 (132+476+66+ 98), 1806, 1444, 20648 | 0
GC: 755 (162+388+85+103), 2301, 1913, 43778 | 0
```