### PR TITLE
Use plain WellTestState::hasWellClosed() without reason

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -617,8 +617,7 @@ namespace Opm {
                 // TODO: should we do this for all kinds of closing reasons?
                 // something like wellTestState().hasWell(well_name)?
                 bool wellIsStopped = false;
-                if (wellTestState().hasWellClosed(well_name, WellTestConfig::Reason::ECONOMIC) ||
-                    wellTestState().hasWellClosed(well_name, WellTestConfig::Reason::PHYSICAL))
+                if (wellTestState().hasWellClosed(well_name))
                 {
                     if (well_ecl.getAutomaticShutIn()) {
                         // shut wells are not added to the well container

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -353,8 +353,7 @@ void WellInterfaceGeneric::updateWellTestStatePhysical(const double simulation_t
                                                        DeferredLogger& deferred_logger) const
 {
     if (!isOperableAndSolvable()) {
-        if (well_test_state.hasWellClosed(name(), WellTestConfig::Reason::ECONOMIC) ||
-            well_test_state.hasWellClosed(name(), WellTestConfig::Reason::PHYSICAL) ) {
+        if (well_test_state.hasWellClosed(name())) {
             // Already closed, do nothing.
         } else {
             well_test_state.closeWell(name(), WellTestConfig::Reason::PHYSICAL, simulation_time);


### PR DESCRIPTION
Small refactoring for WTEST restart