### PR TITLE
Initialise Guide Rate Object From Restart File

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -307,6 +307,14 @@ protected:
     void loadRestartGroupData(const std::string&     group,
                               const data::GroupData& value);
 
+    void loadRestartGuideRates(const int                    report_step,
+                               const GuideRateModel::Target target,
+                               const data::Wells&           rst_wells);
+
+    void loadRestartGuideRates(const int                                     report_step,
+                               const GuideRateConfig&                        config,
+                               const std::map<std::string, data::GroupData>& rst_groups);
+
     std::unordered_map<std::string, data::GroupGuideRates>
     calculateAllGroupGuiderates(const int reportStepIdx) const;
 


### PR DESCRIPTION
This PR initialises the contained `GuideRate` object using guide rate values from the restart file.  This is necessary, but not quite sufficient, to restart models in prediction mode with group-level constraints.

As a means to an end also split the existing `loadRestartData()` function into separate stages with their own associate `loadRestart*Data()` functions to assist future maintenance.