### PR TITLE
[refactor] Use well_container and PerforationData for tracers

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -292,6 +292,12 @@ namespace Opm {
 
             void initGliftEclWellMap(GLiftEclWells &ecl_well_map);
 
+            /// \brief Get list of local nonshut wells
+            const std::vector<WellInterfacePtr>& localNonshutWells()
+            {
+                return well_container_;
+            }
+
         protected:
             Simulator& ebosSimulator_;
 

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -98,6 +98,11 @@ WellInterfaceGeneric::WellInterfaceGeneric(const Well& well,
     wsolvent_ = 0.0;
 }
 
+const std::vector<PerforationData>& WellInterfaceGeneric::perforationData() const
+{
+    return *perf_data_;
+}
+
 const std::string& WellInterfaceGeneric::name() const
 {
     return well_ecl_.name();

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -60,6 +60,9 @@ public:
                          const int index_of_well,
                          const std::vector<PerforationData>& perf_data);
 
+    /// \brief Get the perforations of the well
+    const std::vector<PerforationData>& perforationData() const;
+
     /// Well name.
     const std::string& name() const;
 


### PR DESCRIPTION
This saves some (expensive?) lookup (already done for us in the well model). We had to make the well_container accessible from the well model for this.

Using the perforation data will automatically make sure that the perforation are not shut and on this process in a parallel run.

The recent refactoring of the well code is quite handy :+1: 

