### PR TITLE
Restart sched flag

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -50,7 +50,7 @@ endfunction()
 # Details:
 #   - This test class compares output from a simulation to reference files.
 function(add_test_compareECLFiles)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR DIR_PREFIX PREFIX RESTART_STEP)
+  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR DIR_PREFIX PREFIX RESTART_STEP RESTART_SCHED)
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_DIR)
@@ -61,6 +61,11 @@ function(add_test_compareECLFiles)
   endif()
   if(NOT PARAM_RESTART_STEP)
     set(PARAM_RESTART_STEP 0)
+  endif()
+  if(NOT DEFINED PARAM_RESTART_SCHED)
+    set(sched_restart "--")
+  else()
+    set(sched_restart "--sched-restart=${PARAM_RESTART_SCHED}")
   endif()
   set(RESULT_PATH ${BASE_RESULT_PATH}${PARAM_DIR_PREFIX}/${PARAM_SIMULATOR}+${PARAM_CASENAME})
   set(TEST_ARGS ${PARAM_TEST_ARGS})
@@ -73,6 +78,7 @@ function(add_test_compareECLFiles)
                            ${COMPARE_ECL_COMMAND}
                            ${RST_DECK_COMMAND}
                            ${PARAM_RESTART_STEP}
+                           ${sched_restart}
                TEST_ARGS ${TEST_ARGS})
 endfunction()
 
@@ -209,6 +215,7 @@ add_test_compareECLFiles(CASENAME spe12
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol}
+                         RESTART_SCHED false
                          DIR spe1)
 
 add_test_compareECLFiles(CASENAME spe1_2p

--- a/tests/run-init-regressionTest.sh
+++ b/tests/run-init-regressionTest.sh
@@ -13,9 +13,9 @@ FILENAME="$4"
 ABS_TOL="$5"
 REL_TOL="$6"
 COMPARE_ECL_COMMAND="$7"
-# param 8 and 9 ignored, only used with regression tests
-EXE_NAME="${10}"
-shift 10
+# param 8, 9 and 10 ignored, only used with regression tests
+EXE_NAME="${11}"
+shift 11
 TEST_ARGS="$@"
 
 rm -Rf  ${RESULT_PATH}

--- a/tests/run-porv-acceptanceTest.sh
+++ b/tests/run-porv-acceptanceTest.sh
@@ -13,9 +13,9 @@ FILENAME="$4"
 ABS_TOL="$5"
 REL_TOL="$6"
 COMPARE_ECL_COMMAND="$7"
-# param 8 and 9 ignored, only used with regression tests
-EXE_NAME="${10}"
-shift 10
+# param 8, 9 and 10 ignored, only used with regression tests
+EXE_NAME="${11}"
+shift 11
 TEST_ARGS="$@"
 
 rm -Rf  ${RESULT_PATH}

--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -12,8 +12,9 @@ REL_TOL="$6"
 COMPARE_ECL_COMMAND="$7"
 RST_DECK_COMMAND="$8"
 RESTART_STEP="${9}"
-EXE_NAME="${10}"
-shift 10
+RESTART_SCHED="${10}"
+EXE_NAME="${11}"
+shift 11
 TEST_ARGS="$@"
 
 mkdir -p ${RESULT_PATH}
@@ -42,12 +43,18 @@ fi
 if test $RESTART_STEP -ne 0
 then
   echo "=== Executing restart run ==="
+  if [ "$RESTART_SCHED" = "--" ]; then
+      sched_rst=""
+  else
+      sched_rst="${RESTART_SCHED}"
+  fi
+
   mkdir -p ${RESULT_PATH}/restart
   cp -f ${RESULT_PATH}/${FILENAME}.UNRST ${RESULT_PATH}/restart
   ${RST_DECK_COMMAND}  ${INPUT_DATA_PATH}/${FILENAME}.DATA ${FILENAME}:${RESTART_STEP} -m inline -s > ${RESULT_PATH}/restart/${FILENAME}.DATA
   cd ${RESULT_PATH}/restart
-  echo ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --output-dir=${RESULT_PATH}/restart ${FILENAME}
-  ${BINPATH}/${EXE_NAME} ${TEST_ARGS} --output-dir=${RESULT_PATH}/restart ${FILENAME}
+  echo ${BINPATH}/${EXE_NAME} ${TEST_ARGS} ${sched_rst} --output-dir=${RESULT_PATH}/restart ${FILENAME}
+  ${BINPATH}/${EXE_NAME} ${TEST_ARGS} ${sched_rst} --output-dir=${RESULT_PATH}/restart ${FILENAME}
   test $? -eq 0 || exit 1
 
   echo "=== Executing comparison for EGRID, INIT, UNRST and RFT files for restarted run ==="


### PR DESCRIPTION
Add test flag `RESTART_SCHED`when registering a restart test. The purpose of this switch is to be able to pass `--sched-restart=true` or `--sched-restart=false` to the restarted run. If the `RESTART_SCHED`argument is not supplied flow will restart with whatever is default behavior.