### PR TITLE
[feature] Adds support for computing tracers in parallel runs.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -310,6 +310,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/utils/ParallelEclipseState.hpp
   opm/simulators/utils/ParallelRestart.hpp
   opm/simulators/utils/PropsCentroidsDataHandle.hpp
+  opm/simulators/utils/VectorVectorDataHandle.hpp
   opm/simulators/wells/PerfData.hpp
   opm/simulators/wells/PerforationData.hpp
   opm/simulators/wells/RateConverter.hpp

--- a/ebos/eclgenerictracermodel.cc
+++ b/ebos/eclgenerictracermodel.cc
@@ -102,14 +102,6 @@ doInit(bool enabled, size_t numGridDof,
         return; // Tracer transport must be enabled by the user
     }
 
-    if (comm.size() > 1) {
-        tracerNames_.resize(0);
-        if (comm.rank() == 0)
-            std::cout << "Warning: The tracer model currently does not work for parallel runs\n"
-                      << std::flush;
-        return;
-    }
-
     // retrieve the number of tracers from the deck
     const size_t numTracers = tracers.size();
     tracerNames_.resize(numTracers);

--- a/ebos/eclgenerictracermodel.cc
+++ b/ebos/eclgenerictracermodel.cc
@@ -131,7 +131,6 @@ doInit(bool enabled, size_t numGridDof,
        size_t gasPhaseIdx, size_t oilPhaseIdx, size_t waterPhaseIdx)
 {
     const auto& tracers = eclState_.tracer();
-    const auto& comm = gridView_.comm();
 
     if (tracers.size() == 0)
         return; // tracer treatment is supposed to be disabled

--- a/ebos/eclgenerictracermodel.hh
+++ b/ebos/eclgenerictracermodel.hh
@@ -51,7 +51,7 @@ public:
     using TracerMatrix = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, 1, 1>>;
     using TracerVector = Dune::BlockVector<Dune::FieldVector<Scalar,1>>;
     using CartesianIndexMapper = Dune::CartesianIndexMapper<Grid>;
-
+    static const int dimWorld = Grid::dimensionworld;
     /*!
      * \brief Return the number of tracers considered by the tracerModel.
      */
@@ -78,7 +78,8 @@ protected:
     EclGenericTracerModel(const GridView& gridView,
                           const EclipseState& eclState,
                           const CartesianIndexMapper& cartMapper,
-                          const DofMapper& dofMapper);
+                          const DofMapper& dofMapper,
+                          const std::function<std::array<double,dimWorld>(int)> centroids);
 
     /*!
      * \brief Initialize all internal data structures needed by the tracer module
@@ -109,7 +110,8 @@ protected:
 
     // <wellName, tracerIdx> -> wellRate
     std::map<std::pair<std::string, std::string>, double> wellTracerRate_;
-
+    /// \brief Function returning the cell centers
+    std::function<std::array<double,dimWorld>(int)> centroids_;
 };
 
 } // namespace Opm

--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -31,6 +31,7 @@
 #include <ebos/eclgenerictracermodel.hh>
 
 #include <opm/models/utils/propertysystem.hh>
+#include <opm/simulators/utils/VectorVectorDataHandle.hpp>
 
 #include <string>
 #include <vector>
@@ -235,6 +236,15 @@ protected:
         for (; elemIt != elemEndIt; ++ elemIt) {
             elemCtx.updateAll(*elemIt);
 
+            size_t I = elemCtx.globalSpaceIndex(/*dofIdx=*/ 0, /*timIdx=*/0);
+
+            if (elemIt->partitionType() != Dune::InteriorEntity)
+            {
+                // Dirichlet boundary conditions needed for the parallel matrix
+                (*this->tracerMatrix_)[I][I][0][0] = 1.;
+                continue;
+            }
+
             Scalar extrusionFactor =
                     elemCtx.intensiveQuantities(/*dofIdx=*/ 0, /*timeIdx=*/0).extrusionFactor();
             Valgrind::CheckDefined(extrusionFactor);
@@ -245,7 +255,6 @@ protected:
                     * extrusionFactor;
             Scalar dt = elemCtx.simulator().timeStepSize();
 
-            size_t I = elemCtx.globalSpaceIndex(/*dofIdx=*/ 0, /*timIdx=*/0);
             size_t I1 = elemCtx.globalSpaceIndex(/*dofIdx=*/ 0, /*timIdx=*/1);
 
             std::vector<Scalar> storageOfTimeIndex1(tr.numTracer());
@@ -323,6 +332,12 @@ protected:
                 }
             }
         }
+
+        // Communicate overlap using grid Communication
+        auto handle = VectorVectorDataHandle<GridView, std::vector<TracerVector>>(tr.residual_,
+                                                                                  simulator_.gridView());
+        simulator_.gridView().communicate(handle, Dune::InteriorBorder_All_Interface,
+                                          Dune::ForwardCommunication);
     }
 
     template <class TrRe>

--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -90,7 +90,8 @@ public:
         : BaseType(simulator.vanguard().gridView(),
                    simulator.vanguard().eclState(),
                    simulator.vanguard().cartesianIndexMapper(),
-                   simulator.model().dofMapper())
+                   simulator.model().dofMapper(),
+                   simulator.vanguard().cellCentroids())
         , simulator_(simulator)
         , wat_(TracerBatch<TracerVector>(waterPhaseIdx))
         , oil_(TracerBatch<TracerVector>(oilPhaseIdx))

--- a/opm/simulators/utils/VectorVectorDataHandle.hpp
+++ b/opm/simulators/utils/VectorVectorDataHandle.hpp
@@ -1,0 +1,102 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi: set et ts=4 sw=2 sts=4:
+/*
+  Copyright 2021 Equinor AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/**
+ * \file
+ * \brief A datahandle sending data located in multiple vectors
+ * \author Markus Blatt, OPM-OP AS
+ */
+
+namespace Opm
+{
+
+/// \brief A data handle sending multiple data store in vectors attached
+///        to cells.
+///
+/// Each data is assumed to a container with operator[] and the
+/// class operates on a vector of these.
+/// \tparam GridView the type of the grid view the data associated with
+/// \tparam The type of the vector of vectors.
+template<class GridView, class Vector>
+class VectorVectorDataHandle
+  : public Dune::CommDataHandleIF<VectorVectorDataHandle<GridView,Vector>,
+                                  std::decay_t<decltype(Vector()[0][0])>>
+{
+public:
+
+  /// \brief the data type we send
+  using DataType = std::decay_t<decltype(Vector()[0][0])>;
+
+  /// \brief Constructor
+  /// \param data The vector of data vectors
+  /// \param gridView The gridview the data is attached to.
+  VectorVectorDataHandle(Vector& data, const GridView& gridView)
+    : data_(data), gridView_(gridView)
+  {}
+
+  bool contains(int /* dim */, int codim) const
+  {
+    return codim == 0;
+  }
+
+  bool fixedsize(int /* dim */, int /* codim */) const
+  {
+    return true;
+  }
+  bool fixedSize(int /* dim */, int /* codim */) const
+  {
+    return true;
+  }
+
+  template<class EntityType>
+  std::size_t size(const EntityType /* entity */) const
+  {
+    return data_.size();
+  }
+
+
+  template<class BufferType, class EntityType>
+  void gather(BufferType& buffer, const EntityType& e) const
+  {
+    for(const auto& vec: data_)
+    {
+      buffer.write(vec[gridView_.indexSet().index(e)]);
+    }
+  }
+
+  template<class BufferType, class EntityType>
+  void scatter(BufferType& buffer, const EntityType& e, std::size_t n)
+  {
+    assert(n == data_.size());
+    for(auto& vec: data_)
+    {
+      buffer.read(vec[gridView_.indexSet().index(e)]);
+    }
+  }
+private:
+  Vector& data_;
+  const GridView& gridView_;
+};
+
+} // end namespace Opm


### PR DESCRIPTION
Needs OPM/opm-grid#552

Marking as WIP as it not perfect yet:

- There are deviations in a parallel run that seem to add up during the run (A few percent difference). I am a bit unsure whether this is to be expected or still a bug.
- Did not check restart output, but I am silently assuming that this wrong in parallel (albeit for the wells it magically worked out of the box)
- Distributed wells have not been checked yet. Might be broken, too.

Is there a tool to inspect the binary restart file?