### PR TITLE
fixed: double call to MPI_Finalize

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -385,9 +385,7 @@ namespace Opm
                 // the program should abort. This is the case e.g. for the --help and the
                 // --print-properties parameters.
 #if HAVE_MPI
-                if (status < 0)
-                    MPI_Finalize(); // graceful stop for --help or --print-properties command line.
-                else
+                if (status >= 0)
                     MPI_Abort(MPI_COMM_WORLD, status);
 #endif
                 exitCode = (status > 0) ? status : EXIT_SUCCESS;


### PR DESCRIPTION
I missed this one when moving the MPI handling into RAII style.

Closes #3529 