### PR TITLE
[bugfix] Make tracerConcentrations_ valid for non-restart writes.

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -670,6 +670,11 @@ assignToSolution(data::Solution& sol)
             std::string tmp = tracer.name + "F";
             sol.insert(tmp, UnitSystem::measure::identity, std::move(tracerConcentrations_[tracerIdx++]), data::TargetType::RESTART_SOLUTION);
         }
+        // We need put tracerConcentrations into a valid state.
+        // Otherwise next time we end up here outside of a restart write we will
+        // move invalidated data above (as it was moved away before and never
+        // reallocated)
+        tracerConcentrations_.resize(0);
     }
 }
 


### PR DESCRIPTION
We decide whether to write tracer concentrations based on the size of the tracerConcentrations_ container. Hence we need to make sure that its size is zero after the concentrations have been written and now resize the container to reflect that.

Before this change only the container inside tracerConcentrations_ were moved (and hence made empty) and next tiem we passed empty containers to the output writing functions (which in parallel triggered an assertion).