### PR TITLE
Report Group Level Injection Guide Rates if Present

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1633,16 +1633,22 @@ assignGroupGuideRates(const Group& group,
     auto& inj  = gdata.guideRates.injection;   inj .clear();
 
     auto xgrPos = groupGuideRates.find(group.name());
-    if ((xgrPos == groupGuideRates.end()) ||
-        !this->guideRate_.has(group.name()))
-    {
+    if (xgrPos == groupGuideRates.end()) {
         // No guiderates defined for this group.
         return;
     }
 
     const auto& xgr = xgrPos->second;
-    prod = xgr.production;
-    inj  = xgr.injection;
+
+    if (this->guideRate_.has(group.name())) {
+        prod = xgr.production;
+    }
+
+    if (this->guideRate_.has(group.name(), Phase::WATER) ||
+        this->guideRate_.has(group.name(), Phase::GAS))
+    {
+        inj = xgr.injection;
+    }
 }
 
 void


### PR DESCRIPTION
We used to tie reporting these quantities to whether or not a group had any guide rates for production ([`GuideRate::has()`](https://github.com/OPM/opm-common/blob/3b2d650f8d68d87cd41449bf796d0dfd7118cd52/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp#L193-L196)), but this is clearly insufficient for group-level injection guide rates.