### PR TITLE
Report Well Level Injection Guide Rates if Group Controlled

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -230,15 +230,15 @@ namespace Opm {
             data::Wells wellData() const
             {
                 auto wsrpt = this->wellState()
-                    .report(UgGridHelpers::globalCell(grid()),
-                            [this](const int well_ndex) -> bool
+                    .report(UgGridHelpers::globalCell(this->grid()),
+                            [this](const int well_index) -> bool
                 {
-                    return this->wasDynamicallyShutThisTimeStep(well_ndex);
+                    return this->wasDynamicallyShutThisTimeStep(well_index);
                 });
 
                 this->assignWellTracerRates(wsrpt);
 
-                this->assignWellGuideRates(wsrpt);
+                this->assignWellGuideRates(wsrpt, this->reportStepIndex());
                 this->assignShutConnections(wsrpt, this->reportStepIndex());
 
                 return wsrpt;

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -122,8 +122,14 @@ namespace {
                                                  const Opm::Group&     group)
         : RetrieveWellGuideRate{ guideRate, group.name() }
     {
-        this->inj_water = this->inj_water || group.hasInjectionControl(Opm::Phase::WATER);
-        this->inj_gas   = this->inj_gas   || group.hasInjectionControl(Opm::Phase::GAS);
+        if (group.isProductionGroup()) {
+            this->prod = true;
+        }
+
+        if (group.isInjectionGroup()) {
+            this->inj_water = this->inj_water || group.hasInjectionControl(Opm::Phase::WATER);
+            this->inj_gas   = this->inj_gas   || group.hasInjectionControl(Opm::Phase::GAS);
+        }
     }
 
     class GroupTreeWalker

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -275,7 +275,8 @@ protected:
                             const std::string&           wgname,
                             data::GuideRateValue&        grval) const;
 
-    void assignWellGuideRates(data::Wells& wsrpt) const;
+    void assignWellGuideRates(data::Wells& wsrpt,
+                              const int reportStepIdx) const;
     void assignShutConnections(data::Wells& wsrpt,
                                const int reportStepIndex) const;
     void assignGroupControl(const Group& group,


### PR DESCRIPTION
This PR introduces a new helper class `GroupTreeWalker`, currently private to the `BlackWellModelGeneric.cpp` implementation file, that is based on the code in #3613 for accumulating group-level injection and production guide rate values.  The user can add visitor operations for wells and groups, typically with side effects, and then choose whether to run a preorder walk (visit groups before their children) or a post-order walk (visit children&mdash;especially wells&mdash;before their parents).

We use this helper class to ensure that we always extract and report pertinent injection guide rates at the well level (i.e., `WxIGR`) if at least one of the groups in the well's upline to the FIELD group has an entry for the corresponding phase in `GCONINJE`.  This is for increased compatibility with ECLIPSE.

Prior to this change we would report zero-valued `WWIGR` vectors on a real field case which made analysing simulation results needlessly difficult.