### PR TITLE
changed: special case no input deck given handling

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -423,6 +423,14 @@ namespace Opm
                 deckFilename = EWOMS_GET_PARAM(PreTypeTag, std::string, EclDeckFileName);
             }
 
+            if (deckFilename.empty()) {
+                if (mpiRank == 0) {
+                    std::cerr << "No input case given. Try '--help' for a usage description.\n";
+                }
+                exitCode = EXIT_FAILURE;
+                return false;
+            }
+
             using PreVanguard = GetPropType<PreTypeTag, Properties::Vanguard>;
             try {
                 deckFilename = PreVanguard::canonicalDeckPath(deckFilename);


### PR DESCRIPTION
we do not want to invoke MPI_Abort in this case

Current master:
```
/home/akva/kode/build/opm/d/opm-simulators/bin/flow 
Exception received: Cannot find input case ''. Try '--help' for a usage description.
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
with errorcode 1.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
--------------------------------------------------------------------------
```
which is not good.

If I return EXIT_FAILURE which would make more sense we still get
```
mpirun -np 2 /home/akva/kode/build/opm/d/opm-simulators/bin/flow 
No input deck given. Try '--help' for usage description.
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
mpirun detected that one or more processes exited with non-zero status, thus causing
the job to be terminated. The first process to do so was:

  Process name: [[3786,1],0]
  Exit code:    1
--------------------------------------------------------------------------
```

thus I chose the icky and return EXIT_SUCCESS to keep it silent.