### PR TITLE
Fixes compilation with dune-fem 2.8

### DIFF
--- a/ebos/collecttoiorank.cc
+++ b/ebos/collecttoiorank.cc
@@ -991,6 +991,13 @@ isCartIdxOnThisRank(int cartIdx) const
 template class CollectDataToIORank<Dune::CpGrid,
                                    Dune::CpGrid,
                                    Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>>;
+template class CollectDataToIORank<Dune::CpGrid,
+                                   Dune::CpGrid,
+                                   Dune::Fem::GridPart2GridViewImpl<
+                                       Dune::Fem::AdaptiveLeafGridPart<
+                                           Dune::CpGrid,
+                                           Dune::PartitionIteratorType(4),
+                                           false> > >;
 #else
 template class CollectDataToIORank<Dune::CpGrid,
                                    Dune::CpGrid,

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -397,6 +397,18 @@ template class EclGenericCpGridVanguard<Dune::MultipleCodimMultipleGeomTypeMappe
                                         Dune::Fem::AdaptiveLeafGridPart<
                                         Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,
                                         double>;
+template class EclGenericCpGridVanguard<Dune::MultipleCodimMultipleGeomTypeMapper<
+                                            Dune::Fem::GridPart2GridViewImpl<
+                                                Dune::Fem::AdaptiveLeafGridPart<
+                                                    Dune::CpGrid,
+                                                    Dune::PartitionIteratorType(4),
+                                                    false>>>,
+                                        Dune::Fem::GridPart2GridViewImpl<
+                                            Dune::Fem::AdaptiveLeafGridPart<
+                                                Dune::CpGrid,
+                                                Dune::PartitionIteratorType(4),
+                                                false> >,
+                                        double>;
 #else
 template class EclGenericCpGridVanguard<Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
                                         Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,

--- a/ebos/eclgenericproblem.cc
+++ b/ebos/eclgenericproblem.cc
@@ -720,6 +720,15 @@ initDRSDT_(size_t numDof,
 template class EclGenericProblem<Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,
                                  BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,
                                  double>;
+template class EclGenericProblem<Dune::Fem::GridPart2GridViewImpl<
+                                     Dune::Fem::AdaptiveLeafGridPart<
+                                         Dune::CpGrid,
+                                         Dune::PartitionIteratorType(4),
+                                         false>>,
+                                 Opm::BlackOilFluidSystem<
+                                     double,
+                                     Opm::BlackOilDefaultIndexTraits>,
+                                 double>;
 #else
 template class EclGenericProblem<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
                                  BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,

--- a/ebos/eclgenericthresholdpressure.cc
+++ b/ebos/eclgenericthresholdpressure.cc
@@ -250,6 +250,19 @@ template class EclGenericThresholdPressure<Dune::CpGrid,
                                            Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,
                                            Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>>,
                                            double>;
+template class EclGenericThresholdPressure<Dune::CpGrid,
+                                            Dune::Fem::GridPart2GridViewImpl<
+                                                Dune::Fem::AdaptiveLeafGridPart<
+                                                    Dune::CpGrid,
+                                                    Dune::PartitionIteratorType(4),
+                                                    false> >,
+                                            Dune::MultipleCodimMultipleGeomTypeMapper<
+                                                Dune::Fem::GridPart2GridViewImpl<
+                                                    Dune::Fem::AdaptiveLeafGridPart<
+                                                        Dune::CpGrid,
+                                                        Dune::PartitionIteratorType(4),
+                                                        false>>>,
+                                            double>;
 #else
 template class EclGenericThresholdPressure<Dune::CpGrid,
                                            Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,

--- a/ebos/eclgenerictracermodel.cc
+++ b/ebos/eclgenerictracermodel.cc
@@ -286,6 +286,15 @@ template class EclGenericTracerModel<Dune::CpGrid,
                                      Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>>,
                                      Opm::EcfvStencil<double,Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,false,false>,
                                      double>;
+template class EclGenericTracerModel<Dune::CpGrid,
+                                     Dune::Fem::GridPart2GridViewImpl<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, (Dune::PartitionIteratorType)4, false> >,
+                                     Dune::MultipleCodimMultipleGeomTypeMapper<
+                                         Dune::Fem::GridPart2GridViewImpl<
+                                             Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false> > >,
+                                     Opm::EcfvStencil<double, Dune::Fem::GridPart2GridViewImpl<
+                                                                  Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false> >,
+                                                      false, false>,
+                                     double>;
 #else
 template class EclGenericTracerModel<Dune::CpGrid,
                                      Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,

--- a/ebos/eclgenericwriter.cc
+++ b/ebos/eclgenericwriter.cc
@@ -540,6 +540,20 @@ template class EclGenericWriter<Dune::CpGrid,
                                 Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,
                                 Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>>,
                                 double>;
+template class EclGenericWriter<Dune::CpGrid,
+                                Dune::CpGrid,
+                                Dune::Fem::GridPart2GridViewImpl<
+                                    Dune::Fem::AdaptiveLeafGridPart<
+                                        Dune::CpGrid,
+                                        Dune::PartitionIteratorType(4),
+                                        false>>,
+                                Dune::MultipleCodimMultipleGeomTypeMapper<
+                                    Dune::Fem::GridPart2GridViewImpl<
+                                        Dune::Fem::AdaptiveLeafGridPart<
+                                            Dune::CpGrid,
+                                            Dune::PartitionIteratorType(4),
+                                            false>>>,
+                                double>;
 #else
 template class EclGenericWriter<Dune::CpGrid,
                                 Dune::CpGrid,

--- a/ebos/ecltransmissibility.cc
+++ b/ebos/ecltransmissibility.cc
@@ -1048,6 +1048,19 @@ template class EclTransmissibility<Dune::CpGrid,
                                    Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,
                                    Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>>,
                                    double>;
+template class EclTransmissibility<Dune::CpGrid,
+                                   Dune::Fem::GridPart2GridViewImpl<
+                                       Dune::Fem::AdaptiveLeafGridPart<
+                                           Dune::CpGrid,
+                                           Dune::PartitionIteratorType(4),
+                                           false> >,
+                                   Dune::MultipleCodimMultipleGeomTypeMapper<
+                                       Dune::Fem::GridPart2GridViewImpl<
+                                           Dune::Fem::AdaptiveLeafGridPart<
+                                               Dune::CpGrid,
+                                               Dune::PartitionIteratorType(4),
+                                               false> > >,
+                                   double>;
 #else
 template class EclTransmissibility<Dune::CpGrid,
                                    Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,

--- a/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosFlexible.hpp
@@ -108,7 +108,7 @@ public:
         // Set it up manually
         using ElementMapper =
             Dune::MultipleCodimMultipleGeomTypeMapper<GridView>;
-        ElementMapper elemMapper(simulator_.vanguard().grid().leafGridView(), Dune::mcmgElementLayout());
+        ElementMapper elemMapper(simulator_.gridView(), Dune::mcmgElementLayout());
         detail::findOverlapAndInterior(simulator_.vanguard().grid(), elemMapper, overlapRows_, interiorRows_);
 #if HAVE_MPI
         if (parallelInformation_.type() == typeid(ParallelISTLInformation)) {


### PR DESCRIPTION
by adding the missing needed explicit template instantiation and fixing how element mapper is instantiated.

@atgeirr Please backport to release.

Closes #3626