### PR TITLE
communicate inj_resv/surface_rates

### DIFF
--- a/opm/simulators/wells/GroupState.cpp
+++ b/opm/simulators/wells/GroupState.cpp
@@ -35,7 +35,6 @@ bool GroupState::operator==(const GroupState& other) const {
            this->prod_red_rates == other.prod_red_rates &&
            this->inj_red_rates == other.inj_red_rates &&
            this->inj_resv_rates == other.inj_resv_rates &&
-           this->inj_potentials == other.inj_potentials &&
            this->inj_rein_rates == other.inj_rein_rates &&
            this->inj_vrep_rate == other.inj_vrep_rate &&
            this->inj_surface_rates == other.inj_surface_rates &&
@@ -203,23 +202,6 @@ bool GroupState::has_grat_sales_target(const std::string& gname) const {
 
 //-------------------------------------------------------------------------
 
-void GroupState::update_injection_potentials(const std::string& gname, const std::vector<double>& potentials) {
-    if (potentials.size() != this->num_phases)
-        throw std::logic_error("Wrong number of phases");
-
-    this->inj_potentials[gname] = potentials;
-}
-
-const std::vector<double>& GroupState::injection_potentials(const std::string& gname) const {
-    auto group_iter = this->inj_potentials.find(gname);
-    if (group_iter == this->inj_potentials.end())
-        throw std::logic_error("No such group");
-
-    return group_iter->second;
-}
-
-//-------------------------------------------------------------------------
-
 bool GroupState::has_production_control(const std::string& gname) const {
     auto group_iter = this->production_controls.find(gname);
     if (group_iter == this->production_controls.end())
@@ -322,7 +304,6 @@ std::string GroupState::dump() const
     dump_groupmap(root, "prod_red_rates", this->prod_red_rates);
     dump_groupmap(root, "inj_red_rates", this->inj_red_rates);
     dump_groupmap(root, "inj_resv_rates", this->inj_resv_rates);
-    dump_groupmap(root, "inj_potentials", this->inj_potentials);
     dump_groupmap(root, "inj_rein_rates", this->inj_rein_rates);
     dump_groupmap(root, "vrep_rate", this->inj_vrep_rate);
     dump_groupmap(root, "grat_sales_target", this->m_grat_sales_target);

--- a/opm/simulators/wells/GroupState.hpp
+++ b/opm/simulators/wells/GroupState.hpp
@@ -60,9 +60,6 @@ public:
     void update_injection_rein_rates(const std::string& gname, const std::vector<double>& rates);
     const std::vector<double>& injection_rein_rates(const std::string& gname) const;
 
-    void update_injection_potentials(const std::string& gname, const std::vector<double>& potentials);
-    const std::vector<double>& injection_potentials(const std::string& gname) const;
-
     void update_injection_vrep_rate(const std::string& gname, double rate);
     double injection_vrep_rate(const std::string& gname) const;
 
@@ -173,7 +170,6 @@ private:
     std::map<std::string, std::vector<double>> inj_red_rates;
     std::map<std::string, std::vector<double>> inj_surface_rates;
     std::map<std::string, std::vector<double>> inj_resv_rates;
-    std::map<std::string, std::vector<double>> inj_potentials;
     std::map<std::string, std::vector<double>> inj_rein_rates;
     std::map<std::string, double> inj_vrep_rate;
     std::map<std::string, double> m_grat_sales_target;


### PR DESCRIPTION
~~This unexpectedly changes results in parallel for cases where inj_resv_rates and inj_surface_rates are not used. They are only used for some of the GPMAINT versions.~~

~~I therefore mark it as draft, but would very much like some help in finding out.~~ 


I also mark it with release since it is a bug fix if we are officially supporting GPMAINT See #3636 