### PR TITLE
fix deprecation warning with dune 2.7+

### DIFF
--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -30,7 +30,11 @@
 #include <opm/grid/common/GridEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp>
 #include <opm/simulators/utils/ParallelCommunication.hpp>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 7)
+#include <dune/common/parallel/communication.hh>
+#else
 #include <dune/common/parallel/collectivecommunication.hh>
+#endif
 
 #include <array>
 #include <cassert>


### PR DESCRIPTION
```
In file included from /var/lib/jenkins/post-builder/workspace/opm-models-PR-builder/deps/opm-simulators/ebos/eclgenericvanguard.hh:33,
                 from /var/lib/jenkins/post-builder/workspace/opm-models-PR-builder/deps/opm-simulators/ebos/eclbasevanguard.hh:34,
                 from /var/lib/jenkins/post-builder/workspace/opm-models-PR-builder/deps/opm-simulators/ebos/eclcpgridvanguard.hh:32,
                 from /var/lib/jenkins/post-builder/workspace/opm-models-PR-builder/deps/opm-simulators/ebos/eclproblem.hh:53,
                 from /var/lib/jenkins/post-builder/workspace/opm-models-PR-builder/deps/opm-simulators/opm/simulators/flow/BlackoilModelEbos.hpp:27,
                 from /var/lib/jenkins/post-builder/workspace/opm-models-PR-builder/deps/opm-simulators/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp:26,
                 from /var/lib/jenkins/post-builder/workspace/opm-models-PR-builder/deps/opm-simulators/opm/simulators/flow/FlowMainEbos.hpp:28,
                 from /var/lib/jenkins/post-builder/workspace/opm-models-PR-builder/deps/opm-simulators/opm/simulators/flow/Main.hpp:57,
                 from /var/lib/jenkins/post-builder/workspace/opm-models-PR-builder/deps/opm-simulators/flow/flow_blackoil_dunecpr.cpp:23:
/usr/include/dune/common/parallel/collectivecommunication.hh:2:2: warning: #warning "Deprecated header, use #include <dune/common/parallel/communication.hh> instead!" [-Wcpp]
    2 | #warning "Deprecated header, use #include <dune/common/parallel/communication.hh> instead!"
```