### PR TITLE
Update rates after actionx

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1317,7 +1317,7 @@ public:
                 const auto& wellpi = this->fetchWellPI(reportStep, *action, schedule, matching_wells);
 
                 auto affected_wells = schedule.applyAction(reportStep, TimeService::from_time_t(simTime), *action, actionResult, wellpi);
-                this->wellModel_.updateEclWells(reportStep, affected_wells);
+                this->wellModel_.updateEclWells(reportStep, affected_wells, summaryState);
                 if (!affected_wells.empty())
                     commit_wellstate = true;
                 actionState.add_run(*action, simTime, std::move(actionResult));

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1447,7 +1447,8 @@ actionOnBrokenConstraints(const Group& group,
 void
 BlackoilWellModelGeneric::
 updateEclWells(const int timeStepIdx,
-               const std::unordered_set<std::string>& wells)
+               const std::unordered_set<std::string>& wells,
+               const SummaryState& st)
 {
     for (const auto& wname : wells) {
         auto well_iter = std::find_if(this->wells_ecl_.begin(), this->wells_ecl_.end(),
@@ -1476,6 +1477,7 @@ updateEclWells(const int timeStepIdx,
 
         ws.updateStatus( well.getStatus() );
         ws.reset_connection_factors(pd);
+        ws.update_targets(well, st);
         this->prod_index_calc_[well_index].reInit(well);
     }
 }

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -128,7 +128,8 @@ public:
     double wellPI(const std::string& well_name) const;
 
     void updateEclWells(const int timeStepIdx,
-                        const std::unordered_set<std::string>& wells);
+                        const std::unordered_set<std::string>& wells,
+                        const SummaryState& st);
 
 
     void loadRestartData(const data::Wells& rst_wells,

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -251,6 +251,14 @@ void SingleWellState::update_injector_targets(const Well& ecl_well, const Summar
     else
         this->bhp = this->perf_data.pressure_first_connection * bhp_safety_factor;
 }
+
+void SingleWellState::update_targets(const Well& ecl_well, const SummaryState& st) {
+    if (this->producer)
+        this->update_producer_targets(ecl_well, st);
+    else
+        this->update_injector_targets(ecl_well, st);
+}
+
 }
 
 

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -76,6 +76,7 @@ public:
     void reset_connection_factors(const std::vector<PerforationData>& new_perf_data);
     void update_producer_targets(const Well& ecl_well, const SummaryState& st);
     void update_injector_targets(const Well& ecl_well, const SummaryState& st);
+    void update_targets(const Well& ecl_well, const SummaryState& st);
     void updateStatus(Well::Status status);
     void init_timestep(const SingleWellState& other);
     void shut();


### PR DESCRIPTION
In the case an ACTIONX block has keywords affecting wellrates - e.g. `WCONPROD` we need to force an update of the wellrates used in the simulator. This PR is mainly a refactoring to extract the functionality to update rates out from the `WellState::init()` - so that it can be called halways through a report step. The actual change is in the last commit. Must be combined with: https://github.com/OPM/opm-common/pull/2801 to produce correct results.

The essence of the refactoring is:

1. Functionality is moved from `WellState` to `SingleWellState`
2. Code is split in an injector function and a producer function.
3. The pressure in the first connection which can be used as BHP limit is assigned to the `PerfData` structure at construction time.

The refactoring in the first N -1 commits can very well be squashed together to one commit.

The pure refactoring (i.e. the 12 first commits) have been transferred to a separate pr: https://github.com/OPM/opm-simulators/pull/3659
 