### PR TITLE
Create PhaseUsage constructor

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -32,6 +32,7 @@ list (APPEND MAIN_SOURCE_FILES
   ebos/eclgenericvanguard.cc
   ebos/eclgenericwriter.cc
   ebos/ecltransmissibility.cc
+  opm/core/props/BlackoilPhases.cpp
   opm/core/props/phaseUsageFromDeck.cpp
   opm/core/props/satfunc/RelpermDiagnostics.cpp
   opm/simulators/timestepping/SimulatorReport.cpp

--- a/opm/core/props/BlackoilPhases.cpp
+++ b/opm/core/props/BlackoilPhases.cpp
@@ -1,0 +1,53 @@
+/*
+  Copyright 2021 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <algorithm>
+#include <vector>
+
+#include <opm/core/props/BlackoilPhases.hpp>
+
+Opm::PhaseUsage::PhaseUsage(std::vector<BlackoilPhases::PhaseIndex> phases)
+{
+    std::sort(phases.begin(), phases.end());
+    this->phase_used.fill(0);
+    this->phase_pos.fill(-1);
+
+    std::size_t current_pos = 0;
+    for (const auto& phase : phases) {
+        this->phase_used[phase] = 1;
+        this->phase_pos[phase] = current_pos;
+
+        current_pos++;
+    }
+
+    this->num_phases = 0;
+    if (this->phase_used[BlackoilPhases::Aqua])
+        this->num_phases++;
+    if (this->phase_used[BlackoilPhases::Liquid])
+        this->num_phases++;
+    if (this->phase_used[BlackoilPhases::Vapour])
+        this->num_phases++;
+
+    this->has_solvent   = this->phase_used[BlackoilPhases::Solvent];
+    this->has_polymer   = this->phase_used[BlackoilPhases::Polymer];
+    this->has_energy    = this->phase_used[BlackoilPhases::Energy];
+    this->has_polymermw = this->phase_used[BlackoilPhases::PolymerMW];
+    this->has_foam      = this->phase_used[BlackoilPhases::Foam];
+    this->has_brine     = this->phase_used[BlackoilPhases::Brine];
+    this->has_zFraction = this->phase_used[BlackoilPhases::ZFraction];
+}

--- a/opm/core/props/BlackoilPhases.hpp
+++ b/opm/core/props/BlackoilPhases.hpp
@@ -63,43 +63,6 @@ namespace Opm
 
     };
 
-    /// Check or assign presence of a formed, free phase.  Limited to
-    /// the 'BlackoilPhases'.
-    ///
-    /// Use a std::vector<PhasePresence> to represent the conditions
-    /// in an entire model.
-    class PhasePresence
-    {
-    public:
-        PhasePresence()
-            : present_(0)
-        {}
-
-        bool hasFreeWater() const { return present(BlackoilPhases::Aqua  ); }
-        bool hasFreeOil  () const { return present(BlackoilPhases::Liquid); }
-        bool hasFreeGas  () const { return present(BlackoilPhases::Vapour); }
-
-        void setFreeWater() { insert(BlackoilPhases::Aqua  ); }
-        void setFreeOil  () { insert(BlackoilPhases::Liquid); }
-        void setFreeGas  () { insert(BlackoilPhases::Vapour); }
-
-        bool operator==(const PhasePresence& other) const { return present_ == other.present_; }
-        bool operator!=(const PhasePresence& other) const { return !this->operator==(other); }
-
-    private:
-        unsigned char present_;
-
-        bool present(const BlackoilPhases::PhaseIndex i) const
-        {
-            return present_ & (1 << i);
-        }
-
-        void insert(const BlackoilPhases::PhaseIndex i)
-        {
-            present_ |= (1 << i);
-        }
-    };
-
 } // namespace Opm
 
 #endif // OPM_BLACKOILPHASES_HEADER_INCLUDED

--- a/opm/core/props/BlackoilPhases.hpp
+++ b/opm/core/props/BlackoilPhases.hpp
@@ -21,6 +21,7 @@
 #define OPM_BLACKOILPHASES_HEADER_INCLUDED
 
 #include <array>
+#include <vector>
 
 namespace Opm
 {
@@ -43,6 +44,10 @@ namespace Opm
 
     struct PhaseUsage : public BlackoilPhases
     {
+        PhaseUsage() = default;
+        explicit PhaseUsage(std::vector<BlackoilPhases::PhaseIndex> phases);
+
+
         std::array<int, MaxNumPhases + NumCryptoPhases> phase_used;
         std::array<int, MaxNumPhases + NumCryptoPhases> phase_pos;
 

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -594,6 +594,27 @@ BOOST_AUTO_TEST_CASE(TestSingleWellState) {
 
 
 
+BOOST_AUTO_TEST_CASE(TestPU) {
+    Opm::PhaseUsage pu({Opm::BlackoilPhases::Polymer, Opm::BlackoilPhases::Solvent, Opm::BlackoilPhases::Aqua, Opm::BlackoilPhases::ZFraction});
+
+    BOOST_CHECK(pu.phase_used[Opm::BlackoilPhases::Aqua]);      BOOST_CHECK_EQUAL(pu.phase_pos[Opm::BlackoilPhases::Aqua], 0);
+    BOOST_CHECK(pu.phase_used[Opm::BlackoilPhases::Solvent]);   BOOST_CHECK_EQUAL(pu.phase_pos[Opm::BlackoilPhases::Solvent], 1);
+    BOOST_CHECK(pu.phase_used[Opm::BlackoilPhases::Polymer]);   BOOST_CHECK_EQUAL(pu.phase_pos[Opm::BlackoilPhases::Polymer], 2);
+    BOOST_CHECK(pu.phase_used[Opm::BlackoilPhases::ZFraction]); BOOST_CHECK_EQUAL(pu.phase_pos[Opm::BlackoilPhases::ZFraction], 3);
+
+    BOOST_CHECK(!pu.phase_used[Opm::BlackoilPhases::Liquid]);   BOOST_CHECK_EQUAL(pu.phase_pos[Opm::BlackoilPhases::Liquid], -1);
+    BOOST_CHECK(!pu.phase_used[Opm::BlackoilPhases::Energy]);   BOOST_CHECK_EQUAL(pu.phase_pos[Opm::BlackoilPhases::Energy], -1);
+
+    BOOST_CHECK_EQUAL(pu.num_phases, 1);  // Only Aqua counts as a phase.
+    BOOST_CHECK(pu.has_polymer);
+    BOOST_CHECK(pu.has_solvent);
+    BOOST_CHECK(pu.has_zFraction);
+
+    BOOST_CHECK(!pu.has_energy);
+    BOOST_CHECK(!pu.has_polymermw);
+    BOOST_CHECK(!pu.has_foam);
+    BOOST_CHECK(!pu.has_brine);
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add a constructor to enable creating `PhaseUsage` objects without a Deck. Good for testing at least.