### PR TITLE
changed: build separate simulator binaries for flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ cmake_minimum_required (VERSION 3.10)
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
 set( USE_OPENMP_DEFAULT OFF ) # Use of OpenMP is considered experimental
 option(BUILD_FLOW "Build the production oriented flow simulator?" ON)
-option(BUILD_FLOW_BLACKOIL_ONLY "Build the production oriented flow simulator only supporting the blackoil model?" OFF)
 option(BUILD_FLOW_VARIANTS "Build the variants for flow by default?" OFF)
 option(BUILD_EBOS "Build the research oriented ebos simulator?" ON)
 option(BUILD_EBOS_EXTENSIONS "Build the variants for various extensions of ebos by default?" OFF)
@@ -349,22 +348,28 @@ add_dependencies(moduleVersion opmsimulators)
 
 set(COMMON_MODELS brine energy extbo foam gasoil gaswater oilwater oilwater_polymer polymer solvent)
 set(FLOW_MODELS   blackoil oilwater_brine oilwater_polymer_injectivity micp)
+set(FLOW_VARIANT_MODELS brine_energy onephase onephase_energy)
 
 set(FLOW_TGTS)
-foreach(OBJ ${COMMON_MODELS} ${FLOW_MODELS})
+foreach(OBJ ${COMMON_MODELS} ${FLOW_MODELS} ${FLOW_VARIANT_MODELS})
   add_library(flow_lib${OBJ} OBJECT flow/flow_ebos_${OBJ}.cpp)
   list(APPEND FLOW_TGTS $<TARGET_OBJECTS:flow_lib${OBJ}>)
   if(TARGET fmt::fmt)
     target_link_libraries(flow_lib${OBJ} fmt::fmt)
   endif()
+  opm_add_test(flow_${OBJ}
+               ONLY_COMPILE
+               SOURCES
+               flow/flow_${OBJ}.cpp
+               $<TARGET_OBJECTS:moduleVersion>
+               $<TARGET_OBJECTS:flow_lib${OBJ}>
+               EXE_NAME flow_${OBJ}
+               DEPENDS opmsimulators
+               LIBRARIES opmsimulators)
 endforeach()
 set_property(TARGET flow_libblackoil PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-foreach(OBJ brine_energy onephase onephase_energy)
-  add_library(flow_lib${OBJ} OBJECT flow/flow_ebos_${OBJ}.cpp)
-  if(TARGET fmt::fmt)
-    target_link_libraries(flow_lib${OBJ} fmt::fmt)
-  endif()
+foreach(OBJ ${FLOW_VARIANT_MODELS})
   set_property(TARGET flow_lib${OBJ} PROPERTY EXCLUDE_FROM_ALL ${FLOW_VARIANTS_DEFAULT_ENABLE_IF})
 endforeach()
 
@@ -386,26 +391,6 @@ opm_add_test(flow
   ${FLOW_TGTS}
   $<TARGET_OBJECTS:moduleVersion>
   )
-
-
-if (NOT BUILD_FLOW_BLACKOIL_ONLY)
-  set(FLOW_BLACKOIL_ONLY_DEFAULT_ENABLE_IF "FALSE")
-else()
-  set(FLOW_BLACKOIL_ONLY_DEFAULT_ENABLE_IF "TRUE")
-endif()
-
-# the production oriented general-purpose ECL simulator
-opm_add_test(flow_blackoil
-  ONLY_COMPILE
-  ALWAYS_ENABLE
-  DEFAULT_ENABLE_IF ${FLOW_BLACKOIL_ONLY_DEFAULT_ENABLE_IF}
-  DEPENDS opmsimulators
-  LIBRARIES opmsimulators
-  SOURCES
-  flow/flow.cpp
-  $<TARGET_OBJECTS:flow_libblackoil>
-  $<TARGET_OBJECTS:moduleVersion>)
-target_compile_definitions(flow_blackoil PRIVATE "FLOW_BLACKOIL_ONLY")
 
 # the production oriented general-purpose ECL simulator
 opm_add_test(flow_poly
@@ -442,39 +427,6 @@ opm_add_test(flow_blackoil_dunecpr
   $<TARGET_OBJECTS:moduleVersion>
   EXE_NAME flow_blackoil_dunecpr
   DEPENDS opmsimulators
-  LIBRARIES opmsimulators)
-
-opm_add_test(flow_brine_energy
-  ONLY_COMPILE
-  DEFAULT_ENABLE_IF ${FLOW_VARIANTS_DEFAULT_ENABLE_IF}
-  SOURCES
-  flow/flow_brine_energy.cpp
-  $<TARGET_OBJECTS:moduleVersion>
-  $<TARGET_OBJECTS:flow_libbrine_energy>
-  EXE_NAME flow_brine_energy
-  DEPENDS opmsimulators
-  LIBRARIES opmsimulators)
-
-opm_add_test(flow_onephase
-  ONLY_COMPILE
-  DEFAULT_ENABLE_IF ${FLOW_VARIANTS_DEFAULT_ENABLE_IF}
-  SOURCES
-  flow/flow_onephase.cpp
-  $<TARGET_OBJECTS:moduleVersion>
-  $<TARGET_OBJECTS:flow_libonephase>
-  EXE_NAME flow_onephase
-  DEPENDS opmsimulators
-  LIBRARIES opmsimulators)
-
-opm_add_test(flow_onephase_energy
-  ONLY_COMPILE
-  DEFAULT_ENABLE_IF ${FLOW_VARIANTS_DEFAULT_ENABLE_IF}
-  SOURCES
-  flow/flow_onephase_energy.cpp
-  $<TARGET_OBJECTS:moduleVersion>
-  $<TARGET_OBJECTS:flow_libonephase_energy>
-  EXE_NAME flow_onephase_energy
-  DEPENDS opmsimulators flow_libonephase_energy
   LIBRARIES opmsimulators)
 
 if (BUILD_FLOW)

--- a/flow/flow_blackoil.cpp
+++ b/flow/flow_blackoil.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_blackoil.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosBlackoilMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_brine.cpp
+++ b/flow/flow_brine.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_brine.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosBrineMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -20,7 +20,7 @@
 
 #include <opm/material/common/ResetLocale.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -73,6 +73,13 @@ int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFile
 {
     auto mainfunc = flowEbosBlackoilMainInit(argc, argv, outputCout, outputFiles);
     return mainfunc->execute();
+}
+
+int flowEbosBlackoilMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_blackoil.hpp
+++ b/flow/flow_ebos_blackoil.hpp
@@ -41,10 +41,16 @@ void flowEbosBlackoilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
                              std::unique_ptr<WellTestState> wtestState,
                              std::shared_ptr<SummaryConfig> summaryConfig);
 
+//! \brief Main function used in flow binary.
 int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles);
 
+//! \brief Initialization function used in flow binary and python simulator.
 std::unique_ptr<FlowMainEbos<Properties::TTag::EclFlowProblem>>
     flowEbosBlackoilMainInit(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_blackoil binary.
+int flowEbosBlackoilMainStandalone(int argc, char** argv);
+
 }
 
 #endif // FLOW_EBOS_BLACKOIL_HPP

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -21,7 +21,7 @@
 #include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -76,6 +76,13 @@ int flowEbosBrineMain(int argc, char** argv, bool outputCout, bool outputFiles)
     FlowMainEbos<Properties::TTag::EclFlowBrineProblem>
         mainfunc {argc, argv, outputCout, outputFiles};
     return mainfunc.execute();
+}
+
+int flowEbosBrineMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowBrineProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_brine.hpp
+++ b/flow/flow_ebos_brine.hpp
@@ -30,7 +30,13 @@ void flowEbosBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
                           std::shared_ptr<EclipseState> eclState,
                           std::shared_ptr<Schedule> schedule,
                           std::shared_ptr<SummaryConfig> summaryConfig);
+
+//! \brief Main function used in flow binary.
 int flowEbosBrineMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_brine binary.
+int flowEbosBrineMainStandalone(int argc, char** argv);
+
 }
 
 #endif // FLOW_EBOS_BRINE_HPP

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -21,7 +21,7 @@
 #include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -75,6 +75,13 @@ int flowEbosEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles)
     FlowMainEbos<Properties::TTag::EclFlowEnergyProblem>
         mainfunc {argc, argv, outputCout, outputFiles};
     return mainfunc.execute();
+}
+
+int flowEbosEnergyMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowEnergyProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_energy.hpp
+++ b/flow/flow_ebos_energy.hpp
@@ -30,7 +30,12 @@ void flowEbosEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
                            std::shared_ptr<EclipseState> eclState,
                            std::shared_ptr<Schedule> schedule,
                            std::shared_ptr<SummaryConfig> summaryConfig);
+
+//! \brief Main function used in flow binary.
 int flowEbosEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_energy binary.
+int flowEbosEnergyMainStandalone(int argc, char** argv);
 
 }
 

--- a/flow/flow_ebos_extbo.cpp
+++ b/flow/flow_ebos_extbo.cpp
@@ -21,7 +21,7 @@
 #include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -75,6 +75,13 @@ int flowEbosExtboMain(int argc, char** argv, bool outputCout, bool outputFiles)
     FlowMainEbos<Properties::TTag::EclFlowExtboProblem>
         mainfunc {argc, argv, outputCout, outputFiles};
     return mainfunc.execute();
+}
+
+int flowEbosExtboMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowExtboProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_extbo.hpp
+++ b/flow/flow_ebos_extbo.hpp
@@ -30,7 +30,12 @@ void flowEbosExtboSetDeck(double setupTime, std::shared_ptr<Deck> deck,
                             std::shared_ptr<EclipseState> eclState,
                             std::shared_ptr<Schedule> schedule,
                             std::shared_ptr<SummaryConfig> summaryConfig);
+
+//! \brief Main function used in flow binary.
 int flowEbosExtboMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_extbo binary.
+int flowEbosExtboMainStandalone(int argc, char** argv);
 
 }
 

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -21,7 +21,7 @@
 #include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -76,6 +76,13 @@ int flowEbosFoamMain(int argc, char** argv, bool outputCout, bool outputFiles)
     FlowMainEbos<Properties::TTag::EclFlowFoamProblem>
         mainfunc {argc, argv, outputCout, outputFiles};
     return mainfunc.execute();
+}
+
+int flowEbosFoamMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowFoamProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_foam.hpp
+++ b/flow/flow_ebos_foam.hpp
@@ -30,7 +30,12 @@ void flowEbosFoamSetDeck(double setupTime, std::shared_ptr<Deck> deck,
                          std::shared_ptr<EclipseState> eclState,
                          std::shared_ptr<Schedule> schedule,
                          std::shared_ptr<SummaryConfig> summaryConfig);
+
+//! \brief Main function used in flow binary.
 int flowEbosFoamMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_foam binary.
+int flowEbosFoamMainStandalone(int argc, char** argv);
 
 }
 

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -23,7 +23,7 @@
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -96,6 +96,13 @@ int flowEbosGasOilMain(int argc, char** argv, bool outputCout, bool outputFiles)
     FlowMainEbos<Properties::TTag::EclFlowGasOilProblem>
         mainfunc {argc, argv, outputCout, outputFiles} ;
     return mainfunc.execute();
+}
+
+int flowEbosGasOilMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowGasOilProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_gasoil.hpp
+++ b/flow/flow_ebos_gasoil.hpp
@@ -30,7 +30,12 @@ void flowEbosGasOilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
                            std::shared_ptr<EclipseState> eclState,
                            std::shared_ptr<Schedule> schedule,
                            std::shared_ptr<SummaryConfig> summaryConfig);
+
+//! \brief Main function used in flow binary.
 int flowEbosGasOilMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_gasoil binary.
+int flowEbosGasOilMainStandalone(int argc, char** argv);
 
 }
 

--- a/flow/flow_ebos_gaswater.cpp
+++ b/flow/flow_ebos_gaswater.cpp
@@ -26,7 +26,7 @@
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -99,6 +99,13 @@ int flowEbosGasWaterMain(int argc, char** argv, bool outputCout, bool outputFile
     FlowMainEbos<Properties::TTag::EclFlowGasWaterProblem>
         mainfunc {argc, argv, outputCout, outputFiles} ;
     return mainfunc.execute();
+}
+
+int flowEbosGasWaterMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowGasWaterProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_gaswater.hpp
+++ b/flow/flow_ebos_gaswater.hpp
@@ -30,7 +30,12 @@ void flowEbosGasWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
                            std::shared_ptr<EclipseState> eclState,
                            std::shared_ptr<Schedule> schedule,
                            std::shared_ptr<SummaryConfig> summaryConfig);
+
+//! \brief Main function used in flow binary.
 int flowEbosGasWaterMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_gaswater binary.
+int flowEbosGasWaterMainStandalone(int argc, char** argv);
 
 }
 

--- a/flow/flow_ebos_micp.cpp
+++ b/flow/flow_ebos_micp.cpp
@@ -23,7 +23,7 @@
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -98,6 +98,13 @@ int flowEbosMICPMain(int argc, char** argv, bool outputCout, bool outputFiles)
     FlowMainEbos<Properties::TTag::EclFlowMICPProblem>
         mainfunc {argc, argv, outputCout, outputFiles};
     return mainfunc.execute();
+}
+
+int flowEbosMICPMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowMICPProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_micp.hpp
+++ b/flow/flow_ebos_micp.hpp
@@ -30,7 +30,12 @@ void flowEbosMICPSetDeck(double setupTime, std::shared_ptr<Deck> deck,
                                     std::shared_ptr<EclipseState> eclState,
                                     std::shared_ptr<Schedule> schedule,
                                     std::shared_ptr<SummaryConfig> summaryConfig);
+
+//! \brief Main function used in flow binary.
 int flowEbosMICPMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_micp binary.
+int flowEbosMICPMainStandalone(int argc, char** argv);
 
 }
 

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -23,7 +23,7 @@
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -95,6 +95,13 @@ int flowEbosOilWaterMain(int argc, char** argv, bool outputCout, bool outputFile
     FlowMainEbos<Properties::TTag::EclFlowOilWaterProblem>
         mainfunc {argc, argv, outputCout, outputFiles};
     return mainfunc.execute();
+}
+
+int flowEbosOilWaterMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowOilWaterProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_oilwater.hpp
+++ b/flow/flow_ebos_oilwater.hpp
@@ -30,7 +30,12 @@ void flowEbosOilWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
                              std::shared_ptr<EclipseState> eclState,
                              std::shared_ptr<Schedule> schedule,
                              std::shared_ptr<SummaryConfig> summaryConfig);
+
+//! \brief Main functon used in main flow binary.
 int flowEbosOilWaterMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_oilwater binary.
+int flowEbosOilWaterMainStandalone(int argc, char** argv);
 
 }
 

--- a/flow/flow_ebos_oilwater_brine.cpp
+++ b/flow/flow_ebos_oilwater_brine.cpp
@@ -23,7 +23,7 @@
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -98,6 +98,13 @@ int flowEbosOilWaterBrineMain(int argc, char** argv, bool outputCout, bool outpu
     FlowMainEbos<Properties::TTag::EclFlowOilWaterBrineProblem>
         mainfunc {argc, argv, outputCout, outputFiles};
     return mainfunc.execute();
+}
+
+int flowEbosOilWaterBrineMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowOilWaterBrineProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_oilwater_brine.hpp
+++ b/flow/flow_ebos_oilwater_brine.hpp
@@ -30,7 +30,12 @@ void flowEbosOilWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
                                   std::shared_ptr<EclipseState> eclState,
                                   std::shared_ptr<Schedule> schedule,
                                   std::shared_ptr<SummaryConfig> summaryConfig);
+
+//! \brief Main function used in flow binary.
 int flowEbosOilWaterBrineMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_oilwater_brine binary.
+int flowEbosOilWaterBrineMainStandalone(int argc, char** argv);
 
 }
 

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -23,7 +23,7 @@
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -98,6 +98,13 @@ int flowEbosOilWaterPolymerMain(int argc, char** argv, bool outputCout, bool out
     FlowMainEbos<Properties::TTag::EclFlowOilWaterPolymerProblem>
         mainfunc {argc, argv, outputCout, outputFiles};
     return mainfunc.execute();
+}
+
+int flowEbosOilWaterPolymerMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowOilWaterPolymerProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_oilwater_polymer.hpp
+++ b/flow/flow_ebos_oilwater_polymer.hpp
@@ -30,7 +30,12 @@ void flowEbosOilWaterPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck
                                     std::shared_ptr<EclipseState> eclState,
                                     std::shared_ptr<Schedule> schedule,
                                     std::shared_ptr<SummaryConfig> summaryConfig);
+
+//! \brief Main functon used in main flow binary.
 int flowEbosOilWaterPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_oilwater_polymer binary.
+int flowEbosOilWaterPolymerMainStandalone(int argc, char** argv);
 
 }
 

--- a/flow/flow_ebos_oilwater_polymer_injectivity.cpp
+++ b/flow/flow_ebos_oilwater_polymer_injectivity.cpp
@@ -23,7 +23,7 @@
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -97,6 +97,13 @@ int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCou
     FlowMainEbos<Properties::TTag::EclFlowOilWaterPolymerInjectivityProblem>
         mainfunc {argc, argv, outputCout, outputFiles};
     return mainfunc.execute();
+}
+
+int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowOilWaterPolymerInjectivityProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -21,7 +21,7 @@
 #include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -75,6 +75,13 @@ int flowEbosPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles
     FlowMainEbos<Properties::TTag::EclFlowPolymerProblem>
         mainfunc {argc, argv, outputCout, outputFiles};
     return mainfunc.execute();
+}
+
+int flowEbosPolymerMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowPolymerProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_polymer.hpp
+++ b/flow/flow_ebos_polymer.hpp
@@ -30,7 +30,12 @@ void flowEbosPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck,
                             std::shared_ptr<EclipseState> eclState,
                             std::shared_ptr<Schedule> schedule,
                             std::shared_ptr<SummaryConfig> summaryConfig);
+
+//! \brief Main function used in flow binary.
 int flowEbosPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_polymer binary.
+int flowEbosPolymerMainStandalone(int argc, char** argv);
 
 }
 

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -21,7 +21,7 @@
 #include <opm/material/common/ResetLocale.hpp>
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
-#include <opm/simulators/flow/FlowMainEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -76,6 +76,13 @@ int flowEbosSolventMain(int argc, char** argv, bool outputCout, bool outputFiles
     FlowMainEbos<Properties::TTag::EclFlowSolventProblem>
         mainfunc {argc, argv, outputCout, outputFiles};
     return mainfunc.execute();
+}
+
+int flowEbosSolventMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowSolventProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
 }
 
 }

--- a/flow/flow_ebos_solvent.hpp
+++ b/flow/flow_ebos_solvent.hpp
@@ -30,7 +30,12 @@ void flowEbosSolventSetDeck(double setupTime, std::shared_ptr<Deck> deck,
                             std::shared_ptr<EclipseState> eclState,
                             std::shared_ptr<Schedule> schedule,
                             std::shared_ptr<SummaryConfig> summaryConfig);
+
+//! \brief Main function used in flow binary.
 int flowEbosSolventMain(int argc, char** argv, bool outoutCout, bool outputFiles);
+
+//! \brief Main function used in flow_solvent binary.
+int flowEbosSolventMainStandalone(int argc, char** argv);
 
 }
 

--- a/flow/flow_energy.cpp
+++ b/flow/flow_energy.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_energy.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosEnergyMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_extbo.cpp
+++ b/flow/flow_extbo.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_extbo.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosExtboMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_foam.cpp
+++ b/flow/flow_foam.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_foam.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosFoamMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_gasoil.cpp
+++ b/flow/flow_gasoil.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_gasoil.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosGasOilMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_gaswater.cpp
+++ b/flow/flow_gaswater.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_gaswater.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosGasWaterMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_micp.cpp
+++ b/flow/flow_micp.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_micp.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosMICPMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_oilwater.cpp
+++ b/flow/flow_oilwater.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_oilwater.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosOilWaterMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_oilwater_brine.cpp
+++ b/flow/flow_oilwater_brine.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_oilwater_brine.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosOilWaterBrineMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_oilwater_polymer.cpp
+++ b/flow/flow_oilwater_polymer.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_oilwater_polymer.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosOilWaterPolymerMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_oilwater_polymer_injectivity.cpp
+++ b/flow/flow_oilwater_polymer_injectivity.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_oilwater_polymer_injectivity.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosOilWaterPolymerInjectivityMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_polymer.cpp
+++ b/flow/flow_polymer.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_polymer.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosPolymerMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP

--- a/flow/flow_solvent.cpp
+++ b/flow/flow_solvent.cpp
@@ -14,17 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
-#define FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP
+#include "config.h"
+#include <flow/flow_ebos_solvent.hpp>
 
-namespace Opm {
 
-//! \brief Main function used in flow binary.
-int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCout, bool outputFiles);
-
-//! \brief Main function used in flow_oilwater_polymer_injectivity binary.
-int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv);
-
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosSolventMainStandalone(argc, argv);
 }
-
-#endif // FLOW_EBOS_OILWATER_POLYMER_INJECTIVITY_HPP


### PR DESCRIPTION
this is very convenient during development.
we can then remove the FLOW_BLACKOIL_ONLY option,
as it is no longer needed - use the flow_blackoil binary instead.
however we need to keep this support in Main.hpp due to the python
bindings relying on it.

this is in preparation for the removal of the ebos binaries.