### PR TITLE
Remove extra MPI initialization.

### DIFF
--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -22,12 +22,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 
 void flowEbosBlackoilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
@@ -57,12 +51,6 @@ flowEbosBlackoilMainInit(int argc, char** argv, bool outputCout, bool outputFile
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv);
-#endif
 
     return std::make_unique<FlowMainEbos<Properties::TTag::EclFlowProblem>>(
         argc, argv, outputCout, outputFiles);

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -23,12 +23,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -65,13 +59,6 @@ int flowEbosBrineMain(int argc, char** argv, bool outputCout, bool outputFiles)
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-    // initialize MPI, finalize is done automatically on exit
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv).rank();
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowBrineProblem>
         mainfunc {argc, argv, outputCout, outputFiles};

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -23,12 +23,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -64,13 +58,6 @@ int flowEbosEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles)
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-    // initialize MPI, finalize is done automatically on exit
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv).rank();
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowEnergyProblem>
         mainfunc {argc, argv, outputCout, outputFiles};

--- a/flow/flow_ebos_extbo.cpp
+++ b/flow/flow_ebos_extbo.cpp
@@ -23,12 +23,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -64,13 +58,6 @@ int flowEbosExtboMain(int argc, char** argv, bool outputCout, bool outputFiles)
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-    // initialize MPI, finalize is done automatically on exit
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv).rank();
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowExtboProblem>
         mainfunc {argc, argv, outputCout, outputFiles};

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -23,12 +23,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -65,13 +59,6 @@ int flowEbosFoamMain(int argc, char** argv, bool outputCout, bool outputFiles)
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-    // initialize MPI, finalize is done automatically on exit
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv).rank();
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowFoamProblem>
         mainfunc {argc, argv, outputCout, outputFiles};

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -25,12 +25,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -86,12 +80,6 @@ int flowEbosGasOilMain(int argc, char** argv, bool outputCout, bool outputFiles)
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv);
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowGasOilProblem>
         mainfunc {argc, argv, outputCout, outputFiles} ;

--- a/flow/flow_ebos_gaswater.cpp
+++ b/flow/flow_ebos_gaswater.cpp
@@ -28,12 +28,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -89,12 +83,6 @@ int flowEbosGasWaterMain(int argc, char** argv, bool outputCout, bool outputFile
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv);
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowGasWaterProblem>
         mainfunc {argc, argv, outputCout, outputFiles} ;

--- a/flow/flow_ebos_micp.cpp
+++ b/flow/flow_ebos_micp.cpp
@@ -25,12 +25,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -88,12 +82,6 @@ int flowEbosMICPMain(int argc, char** argv, bool outputCout, bool outputFiles)
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv);
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowMICPProblem>
         mainfunc {argc, argv, outputCout, outputFiles};

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -25,12 +25,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -85,12 +79,6 @@ int flowEbosOilWaterMain(int argc, char** argv, bool outputCout, bool outputFile
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv);
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowOilWaterProblem>
         mainfunc {argc, argv, outputCout, outputFiles};

--- a/flow/flow_ebos_oilwater_brine.cpp
+++ b/flow/flow_ebos_oilwater_brine.cpp
@@ -25,12 +25,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -88,12 +82,6 @@ int flowEbosOilWaterBrineMain(int argc, char** argv, bool outputCout, bool outpu
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv);
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowOilWaterBrineProblem>
         mainfunc {argc, argv, outputCout, outputFiles};

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -25,12 +25,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -88,12 +82,6 @@ int flowEbosOilWaterPolymerMain(int argc, char** argv, bool outputCout, bool out
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv);
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowOilWaterPolymerProblem>
         mainfunc {argc, argv, outputCout, outputFiles};

--- a/flow/flow_ebos_oilwater_polymer_injectivity.cpp
+++ b/flow/flow_ebos_oilwater_polymer_injectivity.cpp
@@ -25,12 +25,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -87,12 +81,6 @@ int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCou
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv);
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowOilWaterPolymerInjectivityProblem>
         mainfunc {argc, argv, outputCout, outputFiles};

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -23,12 +23,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -64,13 +58,6 @@ int flowEbosPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-    // initialize MPI, finalize is done automatically on exit
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv).rank();
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowPolymerProblem>
         mainfunc {argc, argv, outputCout, outputFiles};

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -23,14 +23,6 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
-#if HAVE_DUNE_FEM
-#include <dune/fem/misc/mpimanager.hh>
-#else
-#include <dune/common/parallel/mpihelper.hh>
-#endif
-
-#include <filesystem>
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -67,13 +59,6 @@ int flowEbosSolventMain(int argc, char** argv, bool outputCout, bool outputFiles
     // we always want to use the default locale, and thus spare us the trouble
     // with incorrect locale settings.
     resetLocale();
-
-    // initialize MPI, finalize is done automatically on exit
-#if HAVE_DUNE_FEM
-    Dune::Fem::MPIManager::initialize(argc, argv);
-#else
-    Dune::MPIHelper::instance(argc, argv).rank();
-#endif
 
     FlowMainEbos<Properties::TTag::EclFlowSolventProblem>
         mainfunc {argc, argv, outputCout, outputFiles};


### PR DESCRIPTION
Initialization is now done in the Main::initMPI() method. For configurations with dune-fem, this also caused crashes
with dune-fem versions prior to 2.8.