### PR TITLE
Remove unused restart (de)serialize methods in aquifer/tracer models.

### DIFF
--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -133,23 +133,6 @@ public:
         advanceTracerFields(gas_);
     }
 
-    /*!
-     * \brief This method writes the complete state of all tracer
-     *        to the hard disk.
-     */
-    template <class Restarter>
-    void serialize(Restarter&)
-    { /* not implemented */ }
-
-    /*!
-     * \brief This method restores the complete state of the tracer
-     *        from disk.
-     *
-     * It is the inverse of the serialize() method.
-     */
-    template <class Restarter>
-    void deserialize(Restarter&)
-    { /* not implemented */ }
 
 protected:
 

--- a/opm/simulators/aquifers/BlackoilAquiferModel.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel.hpp
@@ -101,12 +101,6 @@ public:
 
     data::Aquifers aquiferData() const;
 
-    template <class Restarter>
-    void serialize(Restarter& res);
-
-    template <class Restarter>
-    void deserialize(Restarter& res);
-
 protected:
     // ---------      Types      ---------
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -158,24 +158,6 @@ void
 BlackoilAquiferModel<TypeTag>::endEpisode()
 {}
 
-template <typename TypeTag>
-template <class Restarter>
-void
-BlackoilAquiferModel<TypeTag>::serialize(Restarter& /* res */)
-{
-    // TODO (?)
-    throw std::logic_error("BlackoilAquiferModel::serialize() is not yet implemented");
-}
-
-template <typename TypeTag>
-template <class Restarter>
-void
-BlackoilAquiferModel<TypeTag>::deserialize(Restarter& /* res */)
-{
-    // TODO (?)
-    throw std::logic_error("BlackoilAquiferModel::deserialize() is not yet implemented");
-}
-
 // Initialize the aquifers in the deck
 template <typename TypeTag>
 void


### PR DESCRIPTION
The methods either throw or do nothing. Apparently they are not used by any code and just add to some developer's confusion. Hence I propose to remove them.

I might be wrong here and there is a purpose that I fail to see. Maybe @GitPaean and @osae should double check.