### PR TITLE
Switch to Passing VFP Wrapper Tables as References

### DIFF
--- a/opm/simulators/wells/VFPHelpers.cpp
+++ b/opm/simulators/wells/VFPHelpers.cpp
@@ -590,7 +590,7 @@ T getGFR(const VFPProdTable& table,
 }
 
 template <typename T>
-const T& getTable(const std::map<int, std::reference_wrapper<const T>> tables, int table_id)
+const T& getTable(const std::map<int, std::reference_wrapper<const T>>& tables, int table_id)
 {
     auto entry = tables.find(table_id);
     if (entry == tables.end()) {
@@ -628,8 +628,8 @@ VFPInjTable::FLO_TYPE getType(const VFPInjTable& table)
     return table.getFloType();
 }
 
-template const VFPInjTable& getTable<VFPInjTable>(const std::map<int, std::reference_wrapper<const VFPInjTable>>, int);
-template const VFPProdTable& getTable<VFPProdTable>(const std::map<int, std::reference_wrapper<const VFPProdTable>>, int);
+template const VFPInjTable& getTable<VFPInjTable>(const std::map<int, std::reference_wrapper<const VFPInjTable>>&, int);
+template const VFPProdTable& getTable<VFPProdTable>(const std::map<int, std::reference_wrapper<const VFPProdTable>>&, int);
 
 #define INSTANCE(...) \
     template __VA_ARGS__ getFlo(const VFPInjTable&, const __VA_ARGS__&, const __VA_ARGS__&, const __VA_ARGS__&); \

--- a/opm/simulators/wells/VFPHelpers.hpp
+++ b/opm/simulators/wells/VFPHelpers.hpp
@@ -149,13 +149,13 @@ VFPEvaluation bhp(const VFPInjTable& table,
  * Returns the table from the map if found, or throws an exception
  */
 template <typename T>
-const T& getTable(const std::map<int, std::reference_wrapper<const T>> tables, int table_id);
+const T& getTable(const std::map<int, std::reference_wrapper<const T>>& tables, int table_id);
 
 /**
  * Check whether we have a table with the table number
  */
 template <typename T>
-bool hasTable(const std::map<int, std::reference_wrapper<const T>> tables, int table_id) {
+bool hasTable(const std::map<int, std::reference_wrapper<const T>>& tables, int table_id) {
     const auto entry = tables.find(table_id);
     return (entry != tables.end() );
 }


### PR DESCRIPTION
We don't need to copy those mapping tables on each call.