### PR TITLE
Broadcast mult update

### DIFF
--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -330,7 +330,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doFilterConnection
     {
         // Broadcast another time to remove inactive peforations on
         // slave processors.
-        eclScheduleBroadcast(EclGenericVanguard::comm(), schedule);
+        eclBroadcast(EclGenericVanguard::comm(), schedule);
     }
     catch(const std::exception& broadcast_error)
     {

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -69,6 +69,7 @@
 #include <opm/core/props/satfunc/RelpermDiagnostics.hpp>
 
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+#include <opm/simulators/utils/ParallelSerialization.hpp>
 
 #include <opm/models/utils/pffgridvector.hh>
 #include <opm/models/blackoil/blackoilmodel.hh>
@@ -1023,7 +1024,9 @@ public:
             // has changed, the grid may need be re-created which has some serious
             // implications on e.g., the solution of the simulation.)
             const auto& miniDeck = schedule[episodeIdx].geo_keywords();
+            const auto& cc = simulator.vanguard().grid().comm();
             eclState.apply_schedule_keywords( miniDeck );
+            eclBroadcast(cc, eclState.getTransMult() );
 
             // re-compute all quantities which may possibly be affected.
             transmissibilities_.update(true);

--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -57,9 +57,15 @@ void eclStateBroadcast(Parallel::Communication comm, EclipseState& eclState, Sch
     ser.broadcast(wtestState);
 }
 
-void eclScheduleBroadcast(Parallel::Communication comm, Schedule& schedule)
+template <class T>
+void eclBroadcast(Parallel::Communication comm, T& data)
 {
     Opm::EclMpiSerializer ser(comm);
-    ser.broadcast(schedule);
+    ser.broadcast(data);
 }
+
+
+template void eclBroadcast<TransMult>(Parallel::Communication, TransMult&);
+template void eclBroadcast<Schedule>(Parallel::Communication, Schedule&);
+
 }

--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -34,6 +34,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WListManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
 
 #include <ebos/eclmpiserializer.hh>
 

--- a/opm/simulators/utils/ParallelSerialization.hpp
+++ b/opm/simulators/utils/ParallelSerialization.hpp
@@ -45,8 +45,10 @@ void eclStateBroadcast(Parallel::Communication  comm, EclipseState& eclState, Sc
                        Action::State& actionState,
                        WellTestState& wtestState);
 
-/// \brief Broadcasts an schedule from root node in parallel runs.
-void eclScheduleBroadcast(Parallel::Communication comm, Schedule& schedule);
+
+template <class T>
+void eclBroadcast(Parallel::Communication comm, T& );
+
 
 } // end namespace Opm
 

--- a/opm/simulators/utils/ParallelSerialization.hpp
+++ b/opm/simulators/utils/ParallelSerialization.hpp
@@ -28,6 +28,7 @@ class Schedule;
 class SummaryConfig;
 class UDQState;
 class WellTestState;
+class TransMult;
 
 namespace Action {
 class State;


### PR DESCRIPTION
When MULT? has been updated runtime in the SCHEDULE section we need to broadcast the updated `TransMult` container.

Depends on: https://github.com/OPM/opm-common/pull/2822