### PR TITLE
Add check for group production control for LRAT and WRAT in the gasslift code

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -948,12 +948,15 @@ namespace Opm {
                 group_oil_rates.reserve(num_rates_to_sync);
                 std::vector<double> group_gas_rates;
                 group_gas_rates.reserve(num_rates_to_sync);
+                std::vector<double> group_water_rates;
+                group_water_rates.reserve(num_rates_to_sync);
                 if (comm.rank() == i) {
                     for (auto idx : groups_to_sync) {
-                        auto [oil_rate, gas_rate, alq] = group_info.getRates(idx);
+                        auto [oil_rate, gas_rate, water_rate, alq] = group_info.getRates(idx);
                         group_indexes.push_back(idx);
                         group_oil_rates.push_back(oil_rate);
                         group_gas_rates.push_back(gas_rate);
+                        group_water_rates.push_back(water_rate);
                         group_alq_rates.push_back(alq);
                     }
                 }
@@ -968,11 +971,12 @@ namespace Opm {
                 comm.broadcast(group_indexes.data(), num_rates_to_sync, i);
                 comm.broadcast(group_oil_rates.data(), num_rates_to_sync, i);
                 comm.broadcast(group_gas_rates.data(), num_rates_to_sync, i);
+                comm.broadcast(group_water_rates.data(), num_rates_to_sync, i);
                 comm.broadcast(group_alq_rates.data(), num_rates_to_sync, i);
                 if (comm.rank() != i) {
                     for (int j=0; j<num_rates_to_sync; j++) {
                         group_info.updateRate(group_indexes[j],
-                            group_oil_rates[j], group_gas_rates[j], group_alq_rates[j]);
+                            group_oil_rates[j], group_gas_rates[j], group_water_rates[j], group_alq_rates[j]);
                     }
                 }
             }

--- a/opm/simulators/wells/GasLiftGroupInfo.hpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.hpp
@@ -84,25 +84,28 @@ public:
     double alqRate(const std::string& group_name);
     double gasRate(const std::string& group_name);
     int getGroupIdx(const std::string& group_name);
-    std::tuple<double,double,double> getRates(int group_idx);
+    std::tuple<double,double,double,double> getRates(int group_idx);
     std::optional<double> gasTarget(const std::string& group_name);
     const std::string& groupIdxToName(int group_idx);
     bool hasWell(const std::string& well_name);
     void initialize();
     std::optional<double> maxAlq(const std::string& group_name);
     double oilRate(const std::string& group_name);
+    double waterRate(const std::string& group_name);
     std::optional<double> oilTarget(const std::string& group_name);
+    std::optional<double> waterTarget(const std::string& group_name);
+    std::optional<double> liquidTarget(const std::string& group_name);
     void update(const std::string& well_name,
-        double delta_oil, double delta_gas, double delta_alq);
-    void updateRate(int idx, double oil_rate, double gas_rate, double alq);
+        double delta_oil, double delta_gas, double delta_water, double delta_alq);
+    void updateRate(int idx, double oil_rate, double gas_rate, double water_rate, double alq);
     const Well2GroupMap& wellGroupMap() { return well_group_map_; }
 private:
     bool checkDoGasLiftOptimization_(const std::string& well_name);
     bool checkNewtonIterationIdxOk_(const std::string& well_name);
     void displayDebugMessage_(const std::string& msg);
     void displayDebugMessage_(const std::string& msg, const std::string& well_name);
-    std::pair<double, double> getProducerWellRates_(const int index);
-    std::tuple<double, double, double>
+    std::tuple<double, double, double> getProducerWellRates_(const int index);
+    std::tuple<double, double, double, double>
         initializeGroupRatesRecursive_(const Group &group);
     void initializeWell2GroupMapRecursive_(
         const Group& group, std::vector<std::string>& group_names,
@@ -112,44 +115,58 @@ private:
 
     class GroupRates {
     public:
-        GroupRates( double oil_rate, double gas_rate, double alq,
+        GroupRates( double oil_rate, double gas_rate, double water_rate, double alq,
             std::optional<double> oil_target,
             std::optional<double> gas_target,
+            std::optional<double> water_target,
+            std::optional<double> liquid_target,
             std::optional<double> total_gas,
             std::optional<double> max_alq
                   ) :
             oil_rate_{oil_rate},
             gas_rate_{gas_rate},
+            water_rate_{water_rate},
             alq_{alq},
             oil_target_{oil_target},
             gas_target_{gas_target},
+            water_target_{water_target},
+            liquid_target_{liquid_target},
             total_gas_{total_gas},
             max_alq_{max_alq}
         {}
         double alq() const { return alq_; }
-        void assign(double oil_rate, double gas_rate, double alq)
+        void assign(double oil_rate, double gas_rate, double water_rate, double alq)
         {
             oil_rate_ = oil_rate;
             gas_rate_ = gas_rate;
+            water_rate_ = water_rate;
             alq_ = alq;
         }
         double gasRate() const { return gas_rate_; }
+        double waterRate() const { return water_rate_; }
         std::optional<double> gasTarget() const { return gas_target_; }
+        std::optional<double> waterTarget() const { return water_target_; }
         std::optional<double> maxAlq() const { return max_alq_; }
         double oilRate() const { return oil_rate_; }
         std::optional<double> oilTarget() const { return oil_target_; }
-        void update(double delta_oil, double delta_gas, double delta_alq)
+        std::optional<double> liquidTarget() const { return liquid_target_; }
+
+        void update(double delta_oil, double delta_gas, double delta_water, double delta_alq)
         {
             oil_rate_ += delta_oil;
             gas_rate_ += delta_gas;
+            water_rate_ += delta_water;
             alq_ += delta_alq;
         }
     private:
         double oil_rate_;
         double gas_rate_;
+        double water_rate_;
         double alq_;
         std::optional<double> oil_target_;
         std::optional<double> gas_target_;
+        std::optional<double> water_target_;
+        std::optional<double> liquid_target_;
         std::optional<double> total_gas_;
         std::optional<double> max_alq_;
     };

--- a/opm/simulators/wells/GasLiftSingleWellGeneric.cpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.cpp
@@ -843,15 +843,15 @@ GasLiftSingleWellGeneric::
 runOptimize1_()
 {
     std::unique_ptr<GasLiftWellState> state;
-    auto inc_count = this->well_state_.gliftGetAlqIncreaseCount(this->well_name_);
-    auto dec_count = this->well_state_.gliftGetAlqDecreaseCount(this->well_name_);
+    int inc_count = this->well_state_.gliftGetAlqIncreaseCount(this->well_name_);
+    int dec_count = this->well_state_.gliftGetAlqDecreaseCount(this->well_name_);
     if (dec_count == 0 && inc_count == 0) {
         state = tryIncreaseLiftGas_();
-        if (!state && !state->alqChanged()) {
+        if (!state || !(state->alqChanged())) {
             state = tryDecreaseLiftGas_();
         }
     }
-    else if (dec_count == 0) {
+     else if (dec_count == 0) {
         assert(inc_count > 0);
         state = tryIncreaseLiftGas_();
     }

--- a/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
@@ -126,9 +126,9 @@ protected:
         bool checkAlqOutsideLimits(double alq, double oil_rate);
         bool checkEcoGradient(double gradient);
         bool checkGroupALQrateExceeded(double delta_alq);
-        bool checkGroupTargetsViolated(double delta_oil, double delta_gas);
-        std::tuple<double,double,double>
-          reduceALQtoGroupTarget(double alq, double oil_rate, double gas_rate, std::vector<double> &potentials);
+        bool checkGroupTargetsViolated(double delta_oil, double delta_gas, double delta_water);
+        std::tuple<double,double,double,double>
+          reduceALQtoGroupTarget(double alq, double oil_rate, double gas_rate, double water_rate, std::vector<double> &potentials);
         bool checkNegativeOilRate(double oil_rate);
         bool checkThpControl();
         bool checkOilRateExceedsTarget(double oil_rate);
@@ -137,7 +137,7 @@ protected:
         bool computeBhpAtThpLimit(double alq);
         void debugShowIterationInfo(double alq);
         double getBhpWithLimit();
-        void updateGroupRates(double delta_oil, double delta_gas, double delta_alq);
+        void updateGroupRates(double delta_oil, double delta_gas, double delta_water, double delta_alq);
         void warn_(std::string msg) {parent.displayWarning_(msg);}
     };
 
@@ -162,8 +162,9 @@ protected:
     bool computeInitialWellRates_(std::vector<double>& potentials);
 
     void debugCheckNegativeGradient_(double grad, double alq, double new_alq,
-                                     double oil_rate, double new_oil_rate, double gas_rate,
-                                     double new_gas_rate, bool increase) const;
+                                     double oil_rate, double new_oil_rate,
+                                     double gas_rate, double new_gas_rate,
+                                     bool increase) const;
 
     void debugShowAlqIncreaseDecreaseCounts_();
 
@@ -178,9 +179,16 @@ protected:
 
     std::pair<double, bool> getBhpWithLimit_(double bhp) const;
     std::pair<double, bool> getGasRateWithLimit_(const std::vector<double>& potentials) const;
-    std::tuple<double,double,bool,bool>
+    std::tuple<double,double,double,bool,bool,bool>
     getInitialRatesWithLimit_(const std::vector<double>& potentials);
     std::pair<double, bool> getOilRateWithLimit_(const std::vector<double>& potentials) const;
+    std::pair<double, bool> getWaterRateWithLimit_(const std::vector<double>& potentials) const;
+
+    std::pair<double, bool> getOilRateWithGroupLimit_(const double new_oil_rate, const double oil_rate) const;
+    std::pair<double, bool> getGasRateWithGroupLimit_(const double new_gas_rate, const double gas_rate) const;
+    std::pair<double, bool> getWaterRateWithGroupLimit_(const double new_water_rate, const double water_rate) const;
+    std::tuple<double,double,bool,bool> getLiquidRateWithGroupLimit_(double new_oil_rate, const double oil_rate,
+                                                                     double new_water_rate, const double water_rate) const;
 
     std::tuple<double,double,bool,bool,double>
     increaseALQtoPositiveOilRate_(double alq,
@@ -200,10 +208,10 @@ protected:
 
     void logSuccess_(double alq,
                      const int iteration_idx);
-    std::tuple<double,double,double,bool,bool>
+    std::tuple<double,double,double, double,bool,bool,bool>
       maybeAdjustALQbeforeOptimizeLoop_(
-          bool increase, double alq, double oil_rate, double gas_rate,
-          bool oil_is_limited, bool gas_is_limited, std::vector<double> &potentials);
+          bool increase, double alq, double oil_rate, double gas_rate, double water_rate,
+          bool oil_is_limited, bool gas_is_limited, bool water_is_limited, std::vector<double> &potentials);
     std::tuple<double,double,bool,bool,double>
       reduceALQtoOilTarget_(double alq, double oil_rate, double gas_rate,
           bool oil_is_limited, bool gas_is_limited, std::vector<double> &potentials);


### PR DESCRIPTION
Testing on modified versions of tests from model5. We are currently working on adding more tests for gasslift that should also cover LRAT and WRAT controlled groups. 

Note that the first commit is unrelated and fixes a bug in runOptimize1 that is not used by default. It is only triggered if compiled if line https://github.com/OPM/opm-simulators/blob/ad44564f277c7923960c43bba1295375aad24bb8/opm/simulators/wells/GasLiftSingleWellGeneric.cpp#L61 is set to true. 

