### PR TITLE
GasLiftGroupInfo: use a array to allow for one sum call

### DIFF
--- a/opm/simulators/wells/GasLiftGroupInfo.cpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.cpp
@@ -346,10 +346,8 @@ std::tuple<double, double, double, double>
 GasLiftGroupInfo::
 initializeGroupRatesRecursive_(const Group &group)
 {
-    double oil_rate = 0.0;
-    double water_rate = 0.0;
-    double gas_rate = 0.0;
-    double alq = 0.0;
+    std::array<double,4> rates{};
+    auto& [oil_rate, water_rate, gas_rate, alq] = rates;
     if (group.wellgroup()) {
         for (const std::string& well_name : group.wells()) {
             // NOTE: we cannot simply use:
@@ -374,10 +372,7 @@ initializeGroupRatesRecursive_(const Group &group)
                 }
             }
         }
-        oil_rate = this->comm_.sum(oil_rate);
-        gas_rate = this->comm_.sum(gas_rate);
-        water_rate = this->comm_.sum(water_rate);
-        alq = this->comm_.sum(alq);
+        this->comm_.sum(rates.data(), rates.size());
     }
     else {
         for (const std::string& group_name : group.groups()) {

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -1480,21 +1480,18 @@ namespace WellGroupHelpers
             }
         }
 
-        double oilPot = 0.0;
+        std::array<double,3> potentials{};
+        auto& [oilPot, gasPot, waterPot] = potentials;
         if (pu.phase_used[BlackoilPhases::Liquid])
             oilPot = pot[pu.phase_pos[BlackoilPhases::Liquid]];
 
-        double gasPot = 0.0;
         if (pu.phase_used[BlackoilPhases::Vapour])
             gasPot = pot[pu.phase_pos[BlackoilPhases::Vapour]];
 
-        double waterPot = 0.0;
         if (pu.phase_used[BlackoilPhases::Aqua])
             waterPot = pot[pu.phase_pos[BlackoilPhases::Aqua]];
 
-        oilPot = comm.sum(oilPot);
-        gasPot = comm.sum(gasPot);
-        waterPot = comm.sum(waterPot);
+        comm.sum(potentials.data(), potentials.size());
         const UnitSystem& unit_system = schedule.getUnits();
         oilPot = unit_system.from_si(UnitSystem::measure::liquid_surface_rate, oilPot);
         waterPot = unit_system.from_si(UnitSystem::measure::liquid_surface_rate, waterPot);
@@ -1512,9 +1509,8 @@ namespace WellGroupHelpers
                                   GuideRate* guideRate)
     {
         for (const auto& well : schedule.getWells(reportStepIdx)) {
-            double oilpot = 0.0;
-            double gaspot = 0.0;
-            double waterpot = 0.0;
+            std::array<double,3> potentials{};
+            auto& [oilpot, gaspot, waterpot] = potentials;
 
             const auto& well_index = wellState.index(well.name());
             if (well_index.has_value() && wellState.wellIsOwned(well_index.value(), well.name()))
@@ -1531,9 +1527,7 @@ namespace WellGroupHelpers
                 if (pu.phase_used[BlackoilPhases::Aqua] > 0)
                     waterpot = wpot[pu.phase_pos[BlackoilPhases::Aqua]];
             }
-            oilpot = comm.sum(oilpot);
-            gaspot = comm.sum(gaspot);
-            waterpot = comm.sum(waterpot);
+            comm.sum(potentials.data(), potentials.size());
             const UnitSystem& unit_system = schedule.getUnits();
             oilpot = unit_system.from_si(UnitSystem::measure::liquid_surface_rate, oilpot);
             waterpot = unit_system.from_si(UnitSystem::measure::liquid_surface_rate, waterpot);


### PR DESCRIPTION
Slightly more efficient communication is good, no?