### PR TITLE
Use Main::runStatic in PyBlackoilSimulator

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -24,21 +24,19 @@
 
 #include <flow/flow_ebos_blackoil.hpp>
 
-# ifndef FLOW_BLACKOIL_ONLY
-#  include <flow/flow_ebos_gasoil.hpp>
-#  include <flow/flow_ebos_oilwater.hpp>
-#  include <flow/flow_ebos_gaswater.hpp>
-#  include <flow/flow_ebos_solvent.hpp>
-#  include <flow/flow_ebos_polymer.hpp>
-#  include <flow/flow_ebos_extbo.hpp>
-#  include <flow/flow_ebos_foam.hpp>
-#  include <flow/flow_ebos_brine.hpp>
-#  include <flow/flow_ebos_oilwater_brine.hpp>
-#  include <flow/flow_ebos_energy.hpp>
-#  include <flow/flow_ebos_oilwater_polymer.hpp>
-#  include <flow/flow_ebos_oilwater_polymer_injectivity.hpp>
-#  include <flow/flow_ebos_micp.hpp>
-# endif
+#include <flow/flow_ebos_gasoil.hpp>
+#include <flow/flow_ebos_oilwater.hpp>
+#include <flow/flow_ebos_gaswater.hpp>
+#include <flow/flow_ebos_solvent.hpp>
+#include <flow/flow_ebos_polymer.hpp>
+#include <flow/flow_ebos_extbo.hpp>
+#include <flow/flow_ebos_foam.hpp>
+#include <flow/flow_ebos_brine.hpp>
+#include <flow/flow_ebos_oilwater_brine.hpp>
+#include <flow/flow_ebos_energy.hpp>
+#include <flow/flow_ebos_oilwater_polymer.hpp>
+#include <flow/flow_ebos_oilwater_polymer_injectivity.hpp>
+#include <flow/flow_ebos_micp.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
@@ -288,11 +286,8 @@ namespace Opm
             // TODO: make sure that no illegal combinations like thermal and
             //       twophase are requested.
 
-            if (false) {}
-
-#ifndef FLOW_BLACKOIL_ONLY
             // Single-phase case
-            else if (rspec.micp()) {
+            if (rspec.micp()) {
                 return this->runMICP(phases);
             }
 
@@ -330,7 +325,6 @@ namespace Opm
             else if (eclipseState_->getSimulationConfig().isThermal()) {
                 return this->runThermal();
             }
-#endif // FLOW_BLACKOIL_ONLY
 
             // Blackoil case
             else if (phases.size() == 3) {
@@ -546,7 +540,6 @@ namespace Opm
             }
         }
 
-#ifndef FLOW_BLACKOIL_ONLY
         int runMICP(const Phases& phases)
         {
             if (!phases.active(Phase::WATER) || (phases.size() > 2)) {
@@ -684,7 +677,6 @@ namespace Opm
 
             return flowEbosEnergyMain(argc_, argv_, outputCout_, outputFiles_);
         }
-#endif  // FLOW_BLACKOIL_ONLY
 
         int runBlackOil()
         {

--- a/python/simulators/PyBlackOilSimulator.cpp
+++ b/python/simulators/PyBlackOilSimulator.cpp
@@ -75,7 +75,7 @@ py::array_t<double> PyBlackOilSimulator::getPorosity()
 int PyBlackOilSimulator::run()
 {
     auto mainObject = Opm::Main( deckFilename_ );
-    return mainObject.runDynamic();
+    return mainObject.runStatic<Opm::Properties::TTag::EclFlowProblem>();
 }
 
 void PyBlackOilSimulator::setPorosity( py::array_t<double,

--- a/python/simulators/PyBlackOilSimulator.cpp
+++ b/python/simulators/PyBlackOilSimulator.cpp
@@ -22,7 +22,6 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#define FLOW_BLACKOIL_ONLY
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/simulators/flow/FlowMainEbos.hpp>
 // NOTE: EXIT_SUCCESS, EXIT_FAILURE is defined in cstdlib

--- a/python/simulators/simulators.cpp
+++ b/python/simulators/simulators.cpp
@@ -22,7 +22,6 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#define FLOW_BLACKOIL_ONLY
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/simulators/flow/FlowMainEbos.hpp>
 #include <opm/simulators/flow/python/PyMaterialState.hpp>


### PR DESCRIPTION
Motivation is getting rid of the FLOW_BLACKOIL_ONLY hack.