### PR TITLE
Fixes compilation of WellContributions with deactivated OpenCL.

### DIFF
--- a/opm/simulators/linalg/bda/WellContributions.cpp
+++ b/opm/simulators/linalg/bda/WellContributions.cpp
@@ -23,13 +23,14 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/ErrorMacros.hpp>
 
-#include <opm/simulators/linalg/bda/openclKernels.hpp>
 #include <opm/simulators/linalg/bda/WellContributions.hpp>
 
 namespace Opm
 {
 
+#if HAVE_OPENCL
 using Opm::Accelerator::OpenclKernels;
+#endif
 
 WellContributions::WellContributions(std::string accelerator_mode, bool useWellConn){
     if(accelerator_mode.compare("cusparse") == 0){


### PR DESCRIPTION
OpenCL header was included and OpenclKernels used unconditionally in WellContributions.cpp. As this file is also compiled if CUDA is found, it lead to undefined references for e.g. cl::CommandQueue if opencl headers were there and compile error if not.

The header is included (if needed) and appropriately guarded in WellContributions.hpp, already.