### PR TITLE
Suggestion: Rename restart case to ${CASE}_RESTART in regression test

### DIFF
--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -71,21 +71,21 @@ then
   echo "=== Executing restart run ==="
   mkdir -p ${RESULT_PATH}/restart
   cp -f ${RESULT_PATH}/${FILENAME}.UNRST ${RESULT_PATH}/restart
-  ${RST_DECK_COMMAND}  ${INPUT_DATA_PATH}/${FILENAME}.DATA ${FILENAME}:${RESTART_STEP} -m inline -s > ${RESULT_PATH}/restart/${FILENAME}.DATA
+  ${RST_DECK_COMMAND}  ${INPUT_DATA_PATH}/${FILENAME}.DATA ${FILENAME}:${RESTART_STEP} -m inline -s > ${RESULT_PATH}/restart/${FILENAME}_RESTART.DATA
   cd ${RESULT_PATH}/restart
   if test -n "$RESTART_SCHED"
   then
     sched_rst="--sched-restart=${RESTART_SCHED}"
   fi
-  ${BINPATH}/${EXE_NAME} ${TEST_ARGS} ${sched_rst} --output-dir=${RESULT_PATH}/restart ${FILENAME}
+  ${BINPATH}/${EXE_NAME} ${TEST_ARGS} ${sched_rst} --output-dir=${RESULT_PATH}/restart ${FILENAME}_RESTART
   test $? -eq 0 || exit 1
 
   echo "=== Executing comparison for EGRID, INIT, UNRST and RFT files for restarted run ==="
-  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/restart/${FILENAME} ${RESULT_PATH}/restart/${FILENAME} ${ABS_TOL} ${REL_TOL}
+  ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/restart/${FILENAME}_RESTART ${RESULT_PATH}/restart/${FILENAME}_RESTART ${ABS_TOL} ${REL_TOL}
   if [ $? -ne 0 ]
   then
     ecode=1
-    ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -a  ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/restart/${FILENAME} ${RESULT_PATH}/restart/${FILENAME} ${ABS_TOL} ${REL_TOL}
+    ${COMPARE_ECL_COMMAND} ${ignore_extra_kw} -a  ${INPUT_DATA_PATH}/opm-simulation-reference/${EXE_NAME}/restart/${FILENAME}_RESTART ${RESULT_PATH}/restart/${FILENAME}_RESTART ${ABS_TOL} ${REL_TOL}
   fi
 fi
 

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -200,7 +200,7 @@ do
         copyToReferenceDir \
             $BUILD_DIR/tests/results/$binary+$test_name/restart/ \
             $OPM_TESTS_ROOT/$dirname/opm-simulation-reference/$binary/restart \
-            $casename \
+            ${casename}_RESTART \
             EGRID INIT RFT SMSPEC UNRST UNSMRY
         test $? -eq 0 && changed_tests="$changed_tests $test_name(restart)"
       fi


### PR DESCRIPTION
When the restart test option is invoked for the regression tests currently the equivalent of these shell commands are invoked:
```bash
mkdir $RESULT_PATH/restart
cp $RESULT_PATH/$CASE.UNRST $RESULT_PATH/restart
cd $RESULT_PATH/restart
flow $CASE --sched-restart ....
```

The important point is that the name `$CASE` is used both for the initial simulation and the restarted simulation, and in particular the result file `restart/$CASE.UNRST` will contain a mix of the base case simulation and the restarted simulation. In this PR I suggest renaming the restarted simulation `${CASE}_RESTART` - discovered while debugging the failure of #3694

Will require a data update.