### PR TITLE
Include limits header where needed for g++-11

### DIFF
--- a/opm/simulators/linalg/GraphColoring.hpp
+++ b/opm/simulators/linalg/GraphColoring.hpp
@@ -26,6 +26,7 @@
 #include <numeric>
 #include <queue>
 #include <cstddef>
+#include <limits>
 
 namespace Opm
 {

--- a/opm/simulators/timestepping/AdaptiveSimulatorTimer.hpp
+++ b/opm/simulators/timestepping/AdaptiveSimulatorTimer.hpp
@@ -22,7 +22,7 @@
 #include <cassert>
 #include <iostream>
 #include <vector>
-
+#include <limits>
 #include <algorithm>
 #include <memory>
 #include <numeric>


### PR DESCRIPTION
Without this compilation fails on Debian unstable.