### PR TITLE
Fix assert in relaxation factor in std well

### DIFF
--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -107,15 +107,18 @@ relaxationFactorFractionsProducer(const std::vector<double>& primary_variables,
             const double original_sum = primary_variables[WFrac] + primary_variables[GFrac];
             const double relaxed_update = (dwells[0][WFrac] + dwells[0][GFrac]) * relaxation_factor;
             const double possible_updated_sum = original_sum - relaxed_update;
-
-            if (possible_updated_sum > 1.0) {
+            // We only relax if fraction is above 1.
+            // The newton solver should handle the rest
+            const double epsilon = 0.001;
+            if (possible_updated_sum > 1.0 + epsilon) {
+                // since the orignal sum <= 1.0 the epsilon asserts that
+                // the relaxed_update is non trivial.
                 assert(relaxed_update != 0.);
 
                 const double further_relaxation_factor = std::abs((1. - original_sum) / relaxed_update) * 0.95;
                 relaxation_factor *= further_relaxation_factor;
             }
         }
-
         assert(relaxation_factor >= 0.0 && relaxation_factor <= 1.0);
     }
     return relaxation_factor;


### PR DESCRIPTION
If original sum ~ 1 and relaxed_update ~ 0 the factor could -> inf
and trigger the assert.
The 1.1. factor will make sure this does not happen