### PR TITLE
Create CASE_RESTART deck on the fly when restart testing

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -114,7 +114,6 @@ function(add_test_compare_restarted_simulation)
                            -a ${PARAM_ABS_TOL}
                            -t ${PARAM_REL_TOL}
                            -c ${COMPARE_ECL_COMMAND}
-                           -p ${OPM_PACK_COMMAND}
                            -d ${RST_DECK_COMMAND}
                            -s ${PARAM_RESTART_STEP}
                TEST_ARGS ${PARAM_TEST_ARGS})
@@ -184,8 +183,7 @@ function(add_test_compare_parallel_restarted_simulation)
                   -t ${PARAM_REL_TOL}
                   -c ${COMPARE_ECL_COMMAND}
                   -s ${PARAM_RESTART_STEP}
-                  -d ${RST_DECK_COMMAND}
-                  -p ${OPM_PACK_COMMAND})
+                  -d ${RST_DECK_COMMAND})
   if(PARAM_MPI_PROCS)
     list(APPEND DRIVER_ARGS -n ${PARAM_MPI_PROCS})
   endif()

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -92,7 +92,7 @@ endfunction()
 #   - This test class compares the output from a restarted simulation
 #     to that of a non-restarted simulation.
 function(add_test_compare_restarted_simulation)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR TEST_NAME ABS_TOL REL_TOL DIR)
+  set(oneValueArgs CASENAME FILENAME SIMULATOR TEST_NAME ABS_TOL REL_TOL DIR RESTART_STEP)
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_DIR)
@@ -115,6 +115,8 @@ function(add_test_compare_restarted_simulation)
                            -t ${PARAM_REL_TOL}
                            -c ${COMPARE_ECL_COMMAND}
                            -p ${OPM_PACK_COMMAND}
+                           -d ${RST_DECK_COMMAND}
+                           -s ${PARAM_RESTART_STEP}
                TEST_ARGS ${PARAM_TEST_ARGS})
 endfunction()
 
@@ -167,7 +169,7 @@ endfunction()
 #   - This test class compares the output from a restarted parallel simulation
 #     to that of a non-restarted parallel simulation.
 function(add_test_compare_parallel_restarted_simulation)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR MPI_PROCS)
+  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR MPI_PROCS RESTART_STEP)
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_DIR)
@@ -181,6 +183,8 @@ function(add_test_compare_parallel_restarted_simulation)
                   -a ${PARAM_ABS_TOL}
                   -t ${PARAM_REL_TOL}
                   -c ${COMPARE_ECL_COMMAND}
+                  -s ${PARAM_RESTART_STEP}
+                  -d ${RST_DECK_COMMAND}
                   -p ${OPM_PACK_COMMAND})
   if(PARAM_MPI_PROCS)
     list(APPEND DRIVER_ARGS -n ${PARAM_MPI_PROCS})
@@ -1027,12 +1031,15 @@ add_test_compare_restarted_simulation(CASENAME spe1
                                       SIMULATOR flow
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
+                                      RESTART_STEP 6
                                       TEST_ARGS --sched-restart=false)
+
 add_test_compare_restarted_simulation(CASENAME spe9
                                       FILENAME SPE9_CP_SHORT
                                       SIMULATOR flow
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
+                                      RESTART_STEP 15
                                       TEST_ARGS --sched-restart=false)
 
 add_test_compare_restarted_simulation(CASENAME ctaquifer_2d_oilwater
@@ -1041,6 +1048,7 @@ add_test_compare_restarted_simulation(CASENAME ctaquifer_2d_oilwater
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
                                       DIR aquifer-oilwater
+                                      RESTART_STEP 15
                                       TEST_ARGS --sched-restart=true)
 
 add_test_compare_restarted_simulation(CASENAME fetkovich_2d
@@ -1048,6 +1056,7 @@ add_test_compare_restarted_simulation(CASENAME fetkovich_2d
                                       SIMULATOR flow
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
+                                      RESTART_STEP 30
                                       DIR aquifer-fetkovich
                                       TEST_ARGS --sched-restart=true)
 
@@ -1056,6 +1065,7 @@ add_test_compare_restarted_simulation(CASENAME numerical_aquifer_3d_1aqu
                                       SIMULATOR flow
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
+                                      RESTART_STEP 3
                                       DIR aquifer-num
                                       TEST_ARGS --sched-restart=true --enable-tuning=true)
 
@@ -1064,6 +1074,7 @@ add_test_compare_restarted_simulation(CASENAME numerical_aquifer_3d_2aqu
                                       SIMULATOR flow
                                       ABS_TOL 0.4
                                       REL_TOL 4.0e-3
+                                      RESTART_STEP 3
                                       DIR aquifer-num
                                       TEST_ARGS --sched-restart=true --enable-tuning=true)
 
@@ -1079,6 +1090,7 @@ add_test_compare_restarted_simulation(CASENAME msw_3d_hfa
                                       SIMULATOR flow
                                       ABS_TOL ${abs_tol_restart_msw}
                                       REL_TOL ${rel_tol_restart_msw}
+                                      RESTART_STEP 10
                                       TEST_ARGS --enable-adaptive-time-stepping=false --sched-restart=true)
 
 
@@ -1092,6 +1104,7 @@ add_test_compare_restarted_simulation(CASENAME spe1
                                       TEST_NAME restart_spe1_summary
                                       ABS_TOL ${abs_tol_restart}
                                       REL_TOL ${rel_tol_restart}
+                                      RESTART_STEP 6
                                       TEST_ARGS --sched-restart=false)
 
 
@@ -1131,6 +1144,7 @@ if(MPI_FOUND)
                                                  SIMULATOR flow
                                                  ABS_TOL ${abs_tol_restart}
                                                  REL_TOL ${rel_tol_restart}
+                                                 RESTART_STEP 6
                                                  TEST_ARGS --sched-restart=false)
 
   add_test_compare_parallel_restarted_simulation(CASENAME ctaquifer_2d_oilwater
@@ -1138,6 +1152,7 @@ if(MPI_FOUND)
                                                  SIMULATOR flow
                                                  ABS_TOL ${abs_tol_restart}
                                                  REL_TOL ${rel_tol_restart}
+                                                 RESTART_STEP 15
                                                  DIR aquifer-oilwater
                                                  TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
 
@@ -1146,6 +1161,7 @@ if(MPI_FOUND)
                                                  SIMULATOR flow
                                                  ABS_TOL ${abs_tol_restart}
                                                  REL_TOL ${rel_tol_restart}
+                                                 RESTART_STEP 30
                                                  DIR aquifer-fetkovich
                                                  TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
 
@@ -1154,6 +1170,7 @@ if(MPI_FOUND)
                                                  SIMULATOR flow
                                                  ABS_TOL 0.12
                                                  REL_TOL 5.0e-2
+                                                 RESTART_STEP 3
                                                  DIR aquifer-num
                                                  TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linsolver=cpr)
 
@@ -1162,6 +1179,7 @@ if(MPI_FOUND)
                                                  SIMULATOR flow
                                                  ABS_TOL 0.12
                                                  REL_TOL 5.0e-2
+                                                 RESTART_STEP 3
                                                  DIR aquifer-num
                                                  TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linsolver=cpr)
 

--- a/tests/run-parallel-restart-regressionTest.sh
+++ b/tests/run-parallel-restart-regressionTest.sh
@@ -15,7 +15,6 @@ then
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
   echo -e "\t\t -c <path>     Path to comparison tool"
-  echo -e "\t\t -p <path>     Path to deck packing tool"
   echo -e "\t\t -e <filename> Simulator binary to use"
   echo -e "\t\t -s <step>     Step to do restart testing from"
   echo -e "\t\t -d <path>     Path to restart deck tool"
@@ -26,7 +25,7 @@ fi
 
 MPI_PROCS=4
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:p:e:n:d:s:" OPT
+while getopts "i:r:b:f:a:t:c:e:n:d:s:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -36,7 +35,6 @@ do
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
     c) COMPARE_ECL_COMMAND=${OPTARG} ;;
-    p) OPM_PACK_COMMAND=${OPTARG} ;;
     d) RST_DECK_COMMAND=${OPTARG} ;;
     s) RESTART_STEP=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;

--- a/tests/run-restart-regressionTest.sh
+++ b/tests/run-restart-regressionTest.sh
@@ -16,12 +16,14 @@ then
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
   echo -e "\t\t -c <path>     Path to comparison tool"
   echo -e "\t\t -p <path>     Path to deck packing tool"
+  echo -e "\t\t -d <path>     Path to restart deck tool"
   echo -e "\t\t -e <filename> Simulator binary to use"
+  echo -e "\t\t -s <step>     Step to do restart testing from"
   exit 1
 fi
 
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:p:e:" OPT
+while getopts "i:r:b:f:a:t:c:p:e:d:s:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -31,14 +33,16 @@ do
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
     c) COMPARE_ECL_COMMAND=${OPTARG} ;;
+    d) RST_DECK_COMMAND=${OPTARG} ;;
     p) OPM_PACK_COMMAND=${OPTARG} ;;
+    s) RESTART_STEP=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
 
-BASE_NAME=${FILENAME}_RESTART.DATA
+BASE_NAME=${FILENAME}_RESTART
 
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
@@ -47,7 +51,7 @@ ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH
 
 test $? -eq 0 || exit 1
 
-${OPM_PACK_COMMAND} -o ${BASE_NAME} ${INPUT_DATA_PATH}/${FILENAME}_RESTART.DATA
+${RST_DECK_COMMAND} ${INPUT_DATA_PATH}/${FILENAME}.DATA ${FILENAME}.UNRST:${RESTART_STEP} ${BASE_NAME}.DATA -m inline -s
 
 ${BINPATH}/${EXE_NAME} ${BASE_NAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
 test $? -eq 0 || exit 1

--- a/tests/run-restart-regressionTest.sh
+++ b/tests/run-restart-regressionTest.sh
@@ -15,7 +15,6 @@ then
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
   echo -e "\t\t -c <path>     Path to comparison tool"
-  echo -e "\t\t -p <path>     Path to deck packing tool"
   echo -e "\t\t -d <path>     Path to restart deck tool"
   echo -e "\t\t -e <filename> Simulator binary to use"
   echo -e "\t\t -s <step>     Step to do restart testing from"
@@ -23,7 +22,7 @@ then
 fi
 
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:p:e:d:s:" OPT
+while getopts "i:r:b:f:a:t:c:e:d:s:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -34,7 +33,6 @@ do
     t) REL_TOL=${OPTARG} ;;
     c) COMPARE_ECL_COMMAND=${OPTARG} ;;
     d) RST_DECK_COMMAND=${OPTARG} ;;
-    p) OPM_PACK_COMMAND=${OPTARG} ;;
     s) RESTART_STEP=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
   esac

--- a/tests/run-summary-restart-regressionTest.sh
+++ b/tests/run-summary-restart-regressionTest.sh
@@ -17,7 +17,6 @@ then
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
   echo -e "\t\t -c <path>     Path to comparison tool"
-  echo -e "\t\t -p <path>     Path to deck packing tool"
   echo -e "\t\t -d <path>     Path to restart deck tool"
   echo -e "\t\t -e <filename> Simulator binary to use"
   echo -e "\t\t -s <step>     Step to do restart testing from"
@@ -25,7 +24,7 @@ then
 fi
 
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:p:e:d:s:" OPT
+while getopts "i:r:b:f:a:t:c:e:d:s:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -36,7 +35,6 @@ do
     t) REL_TOL=${OPTARG} ;;
     c) COMPARE_ECL_COMMAND=${OPTARG} ;;
     d) RST_DECK_COMMAND=${OPTARG} ;;
-    p) OPM_PACK_COMMAND=${OPTARG} ;;
     s) RESTART_STEP=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
   esac

--- a/tests/run-summary-restart-regressionTest.sh
+++ b/tests/run-summary-restart-regressionTest.sh
@@ -18,12 +18,14 @@ then
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
   echo -e "\t\t -c <path>     Path to comparison tool"
   echo -e "\t\t -p <path>     Path to deck packing tool"
+  echo -e "\t\t -d <path>     Path to restart deck tool"
   echo -e "\t\t -e <filename> Simulator binary to use"
+  echo -e "\t\t -s <step>     Step to do restart testing from"
   exit 1
 fi
 
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:p:e:" OPT
+while getopts "i:r:b:f:a:t:c:p:e:d:s:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -33,14 +35,16 @@ do
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
     c) COMPARE_ECL_COMMAND=${OPTARG} ;;
+    d) RST_DECK_COMMAND=${OPTARG} ;;
     p) OPM_PACK_COMMAND=${OPTARG} ;;
+    s) RESTART_STEP=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
 
-BASE_NAME=${FILENAME}_RESTART.DATA
+BASE_NAME=${FILENAME}_RESTART
 
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
@@ -49,7 +53,7 @@ ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH
 
 test $? -eq 0 || exit 1
 
-${OPM_PACK_COMMAND} -o ${BASE_NAME} ${INPUT_DATA_PATH}/${FILENAME}_RESTART.DATA
+${RST_DECK_COMMAND} ${INPUT_DATA_PATH}/${FILENAME}.DATA ${FILENAME}.UNRST:${RESTART_STEP} ${BASE_NAME}.DATA -m inline -s
 
 ${BINPATH}/${EXE_NAME} ${BASE_NAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
 test $? -eq 0 || exit 1


### PR DESCRIPTION
Use the `rst_deck` application from opm-common to create the `CASE_RESTART.DATA` decks on the fly when restart testing. The advantage of this is that it is not necessary to create explicit restart decks like [SPE1CASE2_ACTNUM_RESTART](https://github.com/OPM/opm-tests/blob/master/spe1/SPE1CASE2_ACTNUM_RESTART.DATA) manually first to enable restart testing.