### PR TITLE
Move getPerfCellPressure to wellInterface

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -887,7 +887,7 @@ namespace Opm
     {
         const auto& fs = int_quants.fluidState();
 
-        const EvalWell pressure_cell = this->extendEval(fs.pressure(FluidSystem::oilPhaseIdx));
+        const EvalWell pressure_cell = this->extendEval(this->getPerfCellPressure(fs));
         const EvalWell rs = this->extendEval(fs.Rs());
         const EvalWell rv = this->extendEval(fs.Rv());
 
@@ -944,7 +944,7 @@ namespace Opm
     {
         const auto& fs = int_quants.fluidState();
 
-        const Scalar pressure_cell = getValue(fs.pressure(FluidSystem::oilPhaseIdx));
+        const Scalar pressure_cell = getValue(this->getPerfCellPressure(fs));
         const Scalar rs = getValue(fs.Rs());
         const Scalar rv = getValue(fs.Rv());
 
@@ -1225,7 +1225,7 @@ namespace Opm
             const double perf_seg_press_diff = this->gravity_ * this->segment_densities_[seg].value() * this->perforation_segment_depth_diffs_[perf];
             // pressure difference between the perforation and the grid cell
             const double cell_perf_press_diff = this->cell_perforation_pressure_diffs_[perf];
-            const double pressure_cell = fs.pressure(FluidSystem::oilPhaseIdx).value();
+            const double pressure_cell = this->getPerfCellPressure(fs).value();
 
             // calculating the b for the connection
             std::vector<double> b_perf(this->num_components_);
@@ -1674,7 +1674,7 @@ namespace Opm
                 // pressure difference between the perforation and the grid cell
                 const double cell_perf_press_diff = this->cell_perforation_pressure_diffs_[perf];
 
-                const double pressure_cell = (fs.pressure(FluidSystem::oilPhaseIdx)).value();
+                const double pressure_cell = this->getPerfCellPressure(fs).value();
                 const double perf_press = pressure_cell - cell_perf_press_diff;
                 // Pressure drawdown (also used to determine direction of flow)
                 // TODO: not 100% sure about the sign of the seg_perf_press_diff
@@ -1844,7 +1844,7 @@ namespace Opm
                 const int cell_idx = this->well_cells_[perf];
                 const auto& int_quants = *(ebos_simulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
                 const auto& fs = int_quants.fluidState();
-                double pressure_cell = fs.pressure(FluidSystem::oilPhaseIdx).value();
+                double pressure_cell = this->getPerfCellPressure(fs).value();
                 max_pressure = std::max(max_pressure, pressure_cell);
             }
         }

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -263,8 +263,6 @@ namespace Opm
 
 
     protected:
-        Eval getPerfCellPressure(const FluidState& fs) const;
-
         // xw = inv(D)*(rw - C*x)
         void recoverSolutionWell(const BVector& x, BVectorWell& xw) const;
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -332,6 +332,9 @@ protected:
     bool solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state, const GroupState& group_state,
                              DeferredLogger& deferred_logger);
 
+    Eval getPerfCellPressure(const FluidState& fs) const;
+
+
 };
 
 }

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1024,6 +1024,20 @@ namespace Opm
             }
         }
     }
-
-
+    template<typename TypeTag>
+    typename WellInterface<TypeTag>::Eval
+    WellInterface<TypeTag>::getPerfCellPressure(const typename WellInterface<TypeTag>::FluidState& fs) const
+    {
+        Eval pressure;
+        if (Indices::oilEnabled) {
+            pressure = fs.pressure(FluidSystem::oilPhaseIdx);
+        } else {
+            if (Indices::waterEnabled) {
+                pressure = fs.pressure(FluidSystem::waterPhaseIdx);
+            } else {
+                pressure = fs.pressure(FluidSystem::gasPhaseIdx);
+            }
+        }
+        return pressure;
+    }
 } // namespace Opm


### PR DESCRIPTION
The cell pressure is independent of well model and belongs to the interface.
This should move the MSW model one step closer to supporting GasWater cases.