### PR TITLE
Suggestion: Remove enable switch for tracer support

### DIFF
--- a/ebos/eclgenerictracermodel.cc
+++ b/ebos/eclgenerictracermodel.cc
@@ -149,23 +149,13 @@ name(int tracerIdx) const
 
 template<class Grid,class GridView, class DofMapper, class Stencil, class Scalar>
 void EclGenericTracerModel<Grid,GridView,DofMapper,Stencil,Scalar>::
-doInit(bool enabled, bool rst, size_t numGridDof,
+doInit(bool rst, size_t numGridDof,
        size_t gasPhaseIdx, size_t oilPhaseIdx, size_t waterPhaseIdx)
 {
     const auto& tracers = eclState_.tracer();
 
     if (tracers.size() == 0)
         return; // tracer treatment is supposed to be disabled
-
-    if (!enabled) {
-        if (gridView_.comm().rank() == 0) {
-            OpmLog::warning("Keyword TRACERS has only experimental support, and is hence ignored.\n"
-                            "The experimental tracer model can still be used, but must be set explicitly.\n"
-                            "To use tracers, set the command line option: --enable-tracer-model=true"
-                            "\n");
-        }
-        return; // Tracer transport must be enabled by the user
-    }
 
     // retrieve the number of tracers from the deck
     const size_t numTracers = tracers.size();

--- a/ebos/eclgenerictracermodel.hh
+++ b/ebos/eclgenerictracermodel.hh
@@ -86,8 +86,7 @@ protected:
     /*!
      * \brief Initialize all internal data structures needed by the tracer module
      */
-    void doInit(bool enabled,
-                bool rst,
+    void doInit(bool rst,
                 size_t numGridDof,
                 size_t gasPhaseIdx,
                 size_t oilPhaseIdx,

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -551,11 +551,6 @@ struct EnableThermalFluxBoundaries<TypeTag, TTag::EclBaseProblem> {
     static constexpr bool value = false;
 };
 
-template<class TypeTag>
-struct EnableTracerModel<TypeTag, TTag::EclBaseProblem> {
-    static constexpr bool value = true;
-};
-
 // By default, simulators derived from the EclBaseProblem are production simulators,
 // i.e., experimental features must be explicitly enabled at compile time
 template<class TypeTag>
@@ -702,8 +697,6 @@ public:
                              "Tell the output writer to use double precision. Useful for 'perfect' restarts");
         EWOMS_REGISTER_PARAM(TypeTag, unsigned, RestartWritingInterval,
                              "The frequencies of which time steps are serialized to disk");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableTracerModel,
-                             "Transport tracers found in the deck.");
         EWOMS_REGISTER_PARAM(TypeTag, bool, EclEnableDriftCompensation,
                              "Enable partial compensation of systematic mass losses via the source term of the next time step");
         if constexpr (enableExperiments)

--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -105,8 +105,7 @@ public:
      */
     void init(bool rst)
     {
-        bool enabled = EWOMS_GET_PARAM(TypeTag, bool, EnableTracerModel);
-        this->doInit(enabled, rst, simulator_.model().numGridDof(),
+        this->doInit(rst, simulator_.model().numGridDof(),
                      gasPhaseIdx, oilPhaseIdx, waterPhaseIdx);
 
         prepareTracerBatches();


### PR DESCRIPTION
The tracer support is now enabled by default - I don't see many people running flow as:
```
flow --enable-tracer=false CASE.DATA
```
I therefor suggest just removing the switch.