### PR TITLE
Do not iterate when computing well potentials for standard wells

### DIFF
--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1760,13 +1760,13 @@ namespace Opm
             auto bhp_at_thp_limit = computeBhpAtThpLimitInj(ebos_simulator, summary_state, deferred_logger);
             if (bhp_at_thp_limit) {
                 const double bhp = std::min(*bhp_at_thp_limit, controls.bhp_limit);
-                computeWellRatesWithBhpIterations(ebos_simulator, bhp, potentials, deferred_logger);
+                computeWellRatesWithBhp(ebos_simulator, bhp, potentials, deferred_logger);
             } else {
                 deferred_logger.warning("FAILURE_GETTING_CONVERGED_POTENTIAL",
                                         "Failed in getting converged thp based potential calculation for well "
                                         + name() + ". Instead the bhp based value is used");
                 const double bhp = controls.bhp_limit;
-                computeWellRatesWithBhpIterations(ebos_simulator, bhp, potentials, deferred_logger);
+                computeWellRatesWithBhp(ebos_simulator, bhp, potentials, deferred_logger);
             }
         } else {
             computeWellRatesWithThpAlqProd(
@@ -1793,7 +1793,7 @@ namespace Opm
         if (bhp_at_thp_limit) {
             const auto& controls = this->well_ecl_.productionControls(summary_state);
             bhp = std::max(*bhp_at_thp_limit, controls.bhp_limit);
-            computeWellRatesWithBhpIterations(ebos_simulator, bhp, potentials, deferred_logger);
+            computeWellRatesWithBhp(ebos_simulator, bhp, potentials, deferred_logger);
         }
         else {
             deferred_logger.warning("FAILURE_GETTING_CONVERGED_POTENTIAL",
@@ -1801,7 +1801,7 @@ namespace Opm
                 + name() + ". Instead the bhp based value is used");
             const auto& controls = this->well_ecl_.productionControls(summary_state);
             bhp = controls.bhp_limit;
-            computeWellRatesWithBhpIterations(ebos_simulator, bhp, potentials, deferred_logger);
+            computeWellRatesWithBhp(ebos_simulator, bhp, potentials, deferred_logger);
         }
         return bhp;
     }


### PR DESCRIPTION
Resent testing indicates that we may not want to iterate when computing well potentials.  More testing it needed and I therefore make it a draft.  