### PR TITLE
Only check operable wells for wecon

### DIFF
--- a/opm/simulators/wells/WellInterfaceFluidSystem.cpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.cpp
@@ -790,8 +790,9 @@ updateWellTestState(const SingleWellState& ws,
     // updating well test state based on physical (THP/BHP) limits.
     updateWellTestStatePhysical(simulationTime, writeMessageToOPMLog, wellTestState, deferred_logger);
 
-    // updating well test state based on Economic limits.
-    updateWellTestStateEconomic(ws, simulationTime, writeMessageToOPMLog, wellTestState, deferred_logger);
+    // updating well test state based on Economic limits for operable wells
+    if (this->isOperableAndSolvable())
+        updateWellTestStateEconomic(ws, simulationTime, writeMessageToOPMLog, wellTestState, deferred_logger);
 
     // TODO: well can be shut/closed due to other reasons
 }


### PR DESCRIPTION
Only relevant is non default parameters are used
```
--shut-unsolvable-wells = true
```
or
```
--enable-well-operabilty-check-iter=true
```
that shuts wells during time-step