### PR TITLE
Multiple restart tests

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -1024,6 +1024,14 @@ add_test_compareECLFiles(CASENAME 0b_rocktab_model6
                          REL_TOL ${rel_tol}
                          DIR model6)
 
+add_test_compareECLFiles(CASENAME base_wt_tracer
+                         FILENAME BASE_WT_TRACER
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR tracer
+			 RESTART_STEP 1,3,7)
+
 # Restart tests
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-restart-regressionTest.sh "")
 

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -58,6 +58,7 @@ declare -A tests
 # The key in the dictionary must agree with the name given to the test when
 # registering it with cmake in compareEclFiles.cmake. The SIMULATION_CASE should
 # be the basename of the .DATA file used for the simulation.
+
 tests[spe1]="flow spe1 SPE1CASE1"
 tests[spe12]="flow spe1 SPE1CASE2"
 tests[spe1_2p]="flow spe1 SPE1CASE2_2P"
@@ -171,6 +172,7 @@ tests[micp]="flow micp MICP"
 tests[0_base_model6]="flow model6 0_BASE_MODEL6"
 tests[0a_aquct_model6]="flow model6 0A_AQUCT_MODEL6"
 tests[0b_rocktab_model6]="flow model6 0B_ROCKTAB_MODEL6"
+tests[base_wt_tracer]="flow tracer BASE_WT_TRACER"
 
 changed_tests=""
 
@@ -198,12 +200,20 @@ do
 
       if [ -d $configuration/build-opm-simulators/tests/results/$binary+$test_name/restart ]
       then
-        copyToReferenceDir \
-            $BUILD_DIR/tests/results/$binary+$test_name/restart/ \
-            $OPM_TESTS_ROOT/$dirname/opm-simulation-reference/$binary/restart \
-            ${casename}_RESTART \
-            EGRID INIT RFT SMSPEC UNRST UNSMRY
-        test $? -eq 0 && changed_tests="$changed_tests $test_name(restart)"
+
+        RSTEPS=`ls -1 $BUILD_DIR/tests/results/$binary+$test_name/restart/*.UNRST | sed -e 's/.*RESTART_*//' | sed 's/[.].*//' `
+        result=0
+        for RSTEP in $RSTEPS
+        do
+          copyToReferenceDir \
+              $BUILD_DIR/tests/results/$binary+$test_name/restart/ \
+              $OPM_TESTS_ROOT/$dirname/opm-simulation-reference/$binary/restart \
+              ${casename}_RESTART_${RSTEP} \
+              EGRID INIT RFT SMSPEC UNRST UNSMRY
+          res=$?
+          test $result -eq 0 || result=$res
+        done
+        test $result -eq 0 && changed_tests="$changed_tests $test_name(restart)"
       fi
     fi
   done


### PR DESCRIPTION
I'm missing the possibility to specify more that one restart step when adding a new teset with **add_test_compareECLFiles** in **compareECLFiles.cmake**.  I would suggest that we allow for specifying more that one step by separating these with a comma (as shown below)
```CMake
add_test_compareECLFiles(CASENAME base_wt_tracer
                         FILENAME BASE_WT_TRACER
                         SIMULATOR flow
                         ABS_TOL ${abs_tol}
                         REL_TOL ${rel_tol}
                         DIR tracer
			 RESTART_STEP 1,3,7)
```
I have updated the script tests/run-regressionTest.sh in this PR to support this, and there is not much needed. Notice that the reference solutions for restarts need to be renamed 

example  in **opm-tests/spe1/opm-simulation-reference/flow/restart**
```
SPE1CASE2_RESTART.INIT -> SPE1CASE2_RESTART_60.INIT
SPE1CASE2_RESTART.SMSPEC -> SPE1CASE2_RESTART_60.SMSPEC
SPE1CASE2_RESTART.UNRST -> SPE1CASE2_RESTART_60.UNRST 
SPE1CASE2_RESTART.UNSMRY -> SPE1CASE2_RESTART_60.UNSMRY
```
I also believe that we need updates on the script for updating reference solutions.

@joakim-hove and @akva2, do you believe that this is possible to do ? 

From my perspective as a reservoir engineer who has been working a lot with restart over the last years, I would say that we really need this functionality for regression testing of flow-flow restart. 