### PR TITLE
Make critical errors prevent starting the simulator.

### DIFF
--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -37,7 +37,7 @@ partiallySupported()
          {
             "COMPORD",
             {
-               {2,{false, allow_values<std::string> {"INPUT", "TRACK"}, "COMPORD(COMPORD): only INPUT and TRACK options supported – will STOP"}}, // ORDER_TYPE
+               {2,{true, allow_values<std::string> {"INPUT", "TRACK"}, "COMPORD(COMPORD): only INPUT and TRACK options supported – will STOP"}}, // ORDER_TYPE
             },
          },
          {
@@ -50,7 +50,7 @@ partiallySupported()
          {
             "EHYSTR",
             {
-               {5,{false, allow_values<std::string> {"BOTH"}, "EHYSTR(HYSTOPT): only default value of BOTH is supported – will STOP"}}, // limiting_hyst_flag
+               {5,{true, allow_values<std::string> {"BOTH"}, "EHYSTR(HYSTOPT): only default value of BOTH is supported – will STOP"}}, // limiting_hyst_flag
                {6,{false, allow_values<std::string> {}, "EHYSTR(HYSTSCAN): Killough’s option not supported and is ignored"}}, // shape_cap_press_flag
                {7,{false, allow_values<std::string> {}, "EHYSTR(HYSTMOB): mobility option not supported and is ignored"}}, // init_fluid_mob_flag
                {8,{false, allow_values<std::string> {"OIL"}, "EHYSTR(HYSTWET): only OIL supported value is ignored"}}, // wetting_phase_flag
@@ -85,23 +85,23 @@ partiallySupported()
          {
             "GCONINJE",
             {
-               {10,{false, allow_values<std::string> {"RATE", "NETV", "RESV", "VOID"}, "GCONINJE(GUIPHASE): only RATE/NETV/VOID are supported - will STOP"}}, // GUIDE_RATE_DEF
+               {10,{true, allow_values<std::string> {"RATE", "NETV", "RESV", "VOID"}, "GCONINJE(GUIPHASE): only RATE/NETV/VOID are supported - will STOP"}}, // GUIDE_RATE_DEF
             },
          },
          {
             "GCONPROD",
             {
-               {2,{false, allow_values<std::string> {"NONE", "FLD", "ORAT", "WRAT", "GRAT", "LRAT", "RESV"}, "GCONPROD(TARGET): valid option should be FLD/ORAT/WRAT/GRAT/LRAT or RESV – will STOP"}}, // CONTROL_MODE
-               {11,{false, allow_values<std::string> {}, "GCONPROD(ACTWAT): water violation procedure not implemented – will STOP"}}, // WATER_EXCEED_PROCEDURE
-               {12,{false, allow_values<std::string> {}, "GCONPROD(ACTGAS): gas violation procedure not implemented – will STOP"}}, // GAS_EXCEED_PROCEDURE
-               {13,{false, allow_values<std::string> {}, "GCONPROD(ACTLIQ): liquid violation procedure not implemented – will STOP"}}, // LIQUID_EXCEED_PROCEDURE
+               {2,{true, allow_values<std::string> {"NONE", "FLD", "ORAT", "WRAT", "GRAT", "LRAT", "RESV"}, "GCONPROD(TARGET): valid option should be FLD/ORAT/WRAT/GRAT/LRAT or RESV – will STOP"}}, // CONTROL_MODE
+               {11,{true, allow_values<std::string> {}, "GCONPROD(ACTWAT): water violation procedure not implemented – will STOP"}}, // WATER_EXCEED_PROCEDURE
+               {12,{true, allow_values<std::string> {}, "GCONPROD(ACTGAS): gas violation procedure not implemented – will STOP"}}, // GAS_EXCEED_PROCEDURE
+               {13,{true, allow_values<std::string> {}, "GCONPROD(ACTLIQ): liquid violation procedure not implemented – will STOP"}}, // LIQUID_EXCEED_PROCEDURE
                {21,{false, allow_values<std::string> {}, "GCONPROD(COMBPROC): linearly combined procedure is not used and should be defaulted (1*) – will continue"}}, // LIN_TARGET_EXCEED_PROCEDURE
             },
          },
          {
             "GEFAC",
             {
-               {3,{false, allow_values<std::string> {"YES"}, "GEFAC(GRPNETWK): Extended Network Model efficiency NO option not implemented – will STOP"}}, // TRANSFER_EXT_NET
+               {3,{true, allow_values<std::string> {"YES"}, "GEFAC(GRPNETWK): Extended Network Model efficiency NO option not implemented – will STOP"}}, // TRANSFER_EXT_NET
             },
          },
          {
@@ -114,7 +114,7 @@ partiallySupported()
             "GUIDERAT",
             {
                {2,{true, allow_values<std::string> {"OIL", "LIQ", "GAS", "RES", "NONE"}, "GUIDERAT(PHASE): unsupported option must be OIL LIQ GAS RES or NONE – will STOP"}}, // NOMINATED_PHASE
-               {9,{false, allow_values<std::string> {"YES"}, "GUIDERAT(GROPT01): only the default option of YES supported – will STOP"}}, // ALLOW_INCREASE
+               {9,{true, allow_values<std::string> {"YES"}, "GUIDERAT(GROPT01): only the default option of YES supported – will STOP"}}, // ALLOW_INCREASE
             },
          },
          {
@@ -158,8 +158,8 @@ partiallySupported()
          {
             "RESTART",
             {
-               {3,{false, allow_values<std::string> {}, "RESTART(RSTYPE): restart from SAVE file not supported – will STOP"}}, // SAVEFILE
-               {4,{false, allow_values<std::string> {"UNFORMATTED"}, "RESTART(RSFORMAT): restart from SAVE file not supported – will STOP"}}, // SAVEFILE_FORMAT
+               {3,{true, allow_values<std::string> {}, "RESTART(RSTYPE): restart from SAVE file not supported – will STOP"}}, // SAVEFILE
+               {4,{true, allow_values<std::string> {"UNFORMATTED"}, "RESTART(RSFORMAT): restart from SAVE file not supported – will STOP"}}, // SAVEFILE_FORMAT
             },
          },
          {
@@ -188,7 +188,7 @@ partiallySupported()
          {
             "SPECGRID",
             {
-               {5,{false, allow_values<std::string> {"F"}, "SPECGRID(TYPE): only option F (Cartesian grids supported) supported – will STOP"}}, // COORD_TYPE
+               {5,{true, allow_values<std::string> {"F"}, "SPECGRID(TYPE): only option F (Cartesian grids supported) supported – will STOP"}}, // COORD_TYPE
             },
          },
          {
@@ -227,13 +227,13 @@ partiallySupported()
          {
             "WEFAC",
             {
-               {3,{false, allow_values<std::string> {"YES"}, "WEFAC(WELNETWK): only the YES option is supported – will STOP"}}, // EXTENDED_NETWORK_OPT
+               {3,{true, allow_values<std::string> {"YES"}, "WEFAC(WELNETWK): only the YES option is supported – will STOP"}}, // EXTENDED_NETWORK_OPT
             },
          },
          {
             "WELSPECS",
             {
-               {8,{false, allow_values<std::string> {"STD", "NO"}, "WELSPECS(WELNETWK): only the STD and NO options are supported – will STOP"}}, // INFLOW_EQ
+               {8,{true, allow_values<std::string> {"STD", "NO"}, "WELSPECS(WELNETWK): only the STD and NO options are supported – will STOP"}}, // INFLOW_EQ
                {12,{false, allow_values<std::string> {"SEG"}, "WELSPECS(DENOPT): only the SEG option is supported – will continue"}}, // DENSITY_CALC
                {14,{false, allow_values<std::string> {}, "WELSPECS(STRMLIN1): not used  – will continue"}}, // FRONTSIM1
                {15,{false, allow_values<std::string> {}, "WELSPECS(STRMLIN2): not used – will continue"}}, // FRONTSIM2
@@ -243,13 +243,13 @@ partiallySupported()
          {
             "WELTARG",
             {
-               {2,{false, allow_values<std::string> {"ORAT", "WRAT", "GRAT", "LRAT", "RESV", "BHP", "THP", "VFP", "LIFT", "GUID"}, "WELTARG(TARGET): invalid option – will STOP"}}, // CMODE
+               {2,{true, allow_values<std::string> {"ORAT", "WRAT", "GRAT", "LRAT", "RESV", "BHP", "THP", "VFP", "LIFT", "GUID"}, "WELTARG(TARGET): invalid option – will STOP"}}, // CMODE
             },
          },
          {
             "WGRUPCON",
             {
-               {4,{false, allow_values<std::string> {"OIL", "WAT", "GAS", "LIQ", "RES", "RAT"}, "WGRUPCON(TARGET): only OIL WAT GAS LIQ RES RAT options are supported – will STOP"}}, // PHASE
+               {4,{true, allow_values<std::string> {"OIL", "WAT", "GAS", "LIQ", "RES", "RAT"}, "WGRUPCON(TARGET): only OIL WAT GAS LIQ RES RAT options are supported – will STOP"}}, // PHASE
             },
          },
          {
@@ -320,7 +320,7 @@ partiallySupported()
          {
             "EQUIL",
             {
-               {9,{false, [](int x) { return x >= -20 && x <= 0; }, "EQUIL(EQLOPT3): only values less than or equal to zero are supported (default is -5) - will STOP"}}, // OIP_INIT
+               {9,{true, [](int x) { return x >= -20 && x <= 0; }, "EQUIL(EQLOPT3): only values less than or equal to zero are supported (default is -5) - will STOP"}}, // OIP_INIT
                {10,{false, allow_values<int> {}, "EQUIL(EQLOPT4): compositional option not used – will continue"}}, // EQLOPT4
                {11,{false, allow_values<int> {}, "EQUIL(EQLOPT5): compositional option not used – will continue"}}, // EQLOPT5
             },
@@ -368,7 +368,7 @@ partiallySupported()
          {
             "NUMRES",
             {
-               {1,{false, allow_values<int> {1}, "NUMRES(NUMRES): only a value of one is supported – will STOP"}}, // NUM
+               {1,{true, allow_values<int> {1}, "NUMRES(NUMRES): only a value of one is supported – will STOP"}}, // NUM
             },
          },
          {
@@ -452,7 +452,7 @@ partiallySupported()
          {
             "WELSPECS",
             {
-               {17,{false, allow_values<int> {0}, "WELSPECS(POLYTAB): only the default value of zero is supported – will STOP"}}, // POLYMER_TABLE
+               {17,{true, allow_values<int> {0}, "WELSPECS(POLYTAB): only the default value of zero is supported – will STOP"}}, // POLYMER_TABLE
             },
          },
    };
@@ -521,7 +521,7 @@ partiallySupported()
          {
             "GCONPROD",
             {
-               {15,{false, allow_values<double> {}, "GCONPROD(RESVFRAC): reservoir volume fraction is not supported and should be defaulted (1*) – will STOP"}}, // RESERVOIR_VOLUME_BALANCE
+               {15,{true, allow_values<double> {}, "GCONPROD(RESVFRAC): reservoir volume fraction is not supported and should be defaulted (1*) – will STOP"}}, // RESERVOIR_VOLUME_BALANCE
                {16,{false, allow_values<double> {}, "GCONPROD(WGASRATE): wet gas rate is not used and should be defaulted (1*) – will continue"}}, // WETGAS_TARGET
                {17,{false, allow_values<double> {}, "GCONPROD(CALRATE): calorific rate is not used and should be defaulted (1*) – will continue"}}, // CALORIFIC_TARGET
                {18,{false, allow_values<double> {}, "GCONPROD(GASFRAC): gas production fraction is not used and should be defaulted (1*) – will continue"}}, // SURFACE_GAS_FRACTION
@@ -532,7 +532,7 @@ partiallySupported()
          {
             "GUIDERAT",
             {
-               {10,{false, [](double x) { return x >= 0; }, "GUIDERAT(GROPT01): only only positive values allowed – will STOP"}}, // ALLOW_INCREASE
+               {10,{true, [](double x) { return x >= 0; }, "GUIDERAT(GROPT01): only only positive values allowed – will STOP"}}, // ALLOW_INCREASE
             },
          },
          {


### PR DESCRIPTION
Many critical errors, as indicated by saying "will STOP" in the message, were not actually set as critical in the corresponding flag.