### PR TITLE
Replace DEMONSTRATE_RUN_WITH_NONWORLD_COMM macro with runtime bool.

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -196,6 +196,48 @@ function(add_test_compare_parallel_restarted_simulation)
                        PROPERTIES RUN_SERIAL 1)
 endfunction()
 
+
+###########################################################################
+# TEST: add_test_split_comm
+###########################################################################
+
+# Input:
+#   - casename: basename (no extension)
+#
+# Details:
+#   - This test class compares the output from a parallel simulation
+#     to that of a parallel simulation running with a custom communicator.
+function(add_test_split_comm)
+  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR)
+  set(multiValueArgs TEST_ARGS)
+  cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+  if(NOT PARAM_DIR)
+    set(PARAM_DIR ${PARAM_CASENAME})
+  endif()
+  set(RESULT_PATH ${BASE_RESULT_PATH}/parallelSplitComm/${PARAM_SIMULATOR}+${PARAM_CASENAME})
+  set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
+                  -r ${RESULT_PATH}
+                  -b ${PROJECT_BINARY_DIR}/bin
+                  -f ${PARAM_FILENAME}
+                  -a ${PARAM_ABS_TOL}
+                  -t ${PARAM_REL_TOL}
+                  -c ${COMPARE_ECL_COMMAND})
+  if(PARAM_MPI_PROCS)
+    list(APPEND DRIVER_ARGS -n ${PARAM_MPI_PROCS})
+  endif()
+
+  opm_add_test(compareParallelSplitComm_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
+               EXE_NAME ${PARAM_SIMULATOR}
+               DRIVER_ARGS ${DRIVER_ARGS}
+               TEST_ARGS ${PARAM_TEST_ARGS})
+  set_tests_properties(compareParallelSplitComm_${PARAM_SIMULATOR}+${PARAM_FILENAME}
+                       PROPERTIES RUN_SERIAL 1)
+endfunction()
+
+
+###########################################################################
+
+
 if(NOT TARGET test-suite)
   add_custom_target(test-suite)
 endif()
@@ -1187,6 +1229,15 @@ if(MPI_FOUND)
                                                  RESTART_STEP 3
                                                  DIR aquifer-num
                                                  TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linsolver=cpr)
+
+# Single test to verify that we treat custom communicators correctly.
+  opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-split-comm-test.sh "")
+  add_test_split_comm(CASENAME spe1
+                      FILENAME SPE1CASE2
+                      SIMULATOR flow
+                      ABS_TOL 0.0
+                      REL_TOL 0.0)
+
 
   opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-parallel-regressionTest.sh "")
 

--- a/tests/run-split-comm-test.sh
+++ b/tests/run-split-comm-test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# This runs two parallel cases, one of them with one more process
+# and the --test-split-communicator=true option,
+# then compares the summary and restart files from the two runs.
+# Meant to track regression of the treatment of MPI communicators.
+
+if test $# -eq 0
+then
+  echo -e "Usage:\t$0 <options> -- [additional simulator options]"
+  echo -e "\tMandatory options:"
+  echo -e "\t\t -i <path>     Path to read deck from"
+  echo -e "\t\t -r <path>     Path to store results in"
+  echo -e "\t\t -b <path>     Path to simulator binary"
+  echo -e "\t\t -f <filename> Deck file name"
+  echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
+  echo -e "\t\t -t <tol>      Relative tolerance in comparison"
+  echo -e "\t\t -c <path>     Path to comparison tool"
+  echo -e "\t\t -e <filename> Simulator binary to use"
+  exit 1
+fi
+
+BASE_MPI_PROCS=3
+TEST_MPI_PROCS=4 # should be 1 more than the base
+OPTIND=1
+while getopts "i:r:b:f:a:t:c:e:n:" OPT
+do
+  case "${OPT}" in
+    i) INPUT_DATA_PATH=${OPTARG} ;;
+    r) RESULT_PATH=${OPTARG} ;;
+    b) BINPATH=${OPTARG} ;;
+    f) FILENAME=${OPTARG} ;;
+    a) ABS_TOL=${OPTARG} ;;
+    t) REL_TOL=${OPTARG} ;;
+    c) COMPARE_ECL_COMMAND=${OPTARG} ;;
+    e) EXE_NAME=${OPTARG} ;;
+  esac
+done
+shift $(($OPTIND-1))
+TEST_ARGS="$@"
+
+rm -Rf ${RESULT_PATH}
+mkdir -p ${RESULT_PATH}
+
+echo mpirun -np ${BASE_MPI_PROCS} ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME}.DATA ${TEST_ARGS} --output-dir=${RESULT_PATH}/base
+mpirun -np ${BASE_MPI_PROCS} ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME}.DATA ${TEST_ARGS} --output-dir=${RESULT_PATH}/base
+test $? -eq 0 || exit 1
+
+echo mpirun -np ${TEST_MPI_PROCS} ${BINPATH}/${EXE_NAME} --test-split-communicator=true ${INPUT_DATA_PATH}/${FILENAME}.DATA ${TEST_ARGS} --output-dir=${RESULT_PATH}/test
+mpirun -np ${TEST_MPI_PROCS} ${BINPATH}/${EXE_NAME} --test-split-communicator=true ${INPUT_DATA_PATH}/${FILENAME}.DATA ${TEST_ARGS} --output-dir=${RESULT_PATH}/test
+test $? -eq 0 || exit 1
+
+ecode=0
+echo "=== Executing comparison for summary file ==="
+${COMPARE_ECL_COMMAND} -t SMRY -R ${RESULT_PATH}/base/${FILENAME} ${RESULT_PATH}/test/${FILENAME} ${ABS_TOL} ${REL_TOL}
+if [ $? -ne 0 ]
+then
+  ecode=1
+  ${COMPARE_ECL_COMMAND} -t SMRY -a -R ${RESULT_PATH}/base/${FILENAME} ${RESULT_PATH}/test/${FILENAME} ${ABS_TOL} ${REL_TOL}
+fi
+
+echo "=== Executing comparison for restart file ==="
+${COMPARE_ECL_COMMAND} -l -t UNRST ${RESULT_PATH}/base/${FILENAME} ${RESULT_PATH}/test/${FILENAME} ${ABS_TOL} ${REL_TOL}
+if [ $? -ne 0 ]
+then
+  ecode=1
+  ${COMPARE_ECL_COMMAND} -a -l -t UNRST ${RESULT_PATH}/base/${FILENAME} ${RESULT_PATH}/test/${FILENAME} ${ABS_TOL} ${REL_TOL}
+fi
+
+exit $ecode


### PR DESCRIPTION
This allows for testing the simulator with the artifically split communicator, in order to verify that there is no inappropriate usage of the world communicator.

@blattms this is not (yet) the test you asked for, but the code change that should allow the test to be writte easily (and without compiling an extra dozen flow binaries).

I have two questions:
 - Since the parameter system is not up at the time we initialize MPI, I had to write a special treatment. This is in the function handleTestSplitCommunicatorCmdLine_(), basically you put "--test-split-communicator=true" as the VERY FIRST argument to the program, then you activate the feature. Is this ok? It means it is easy to write a command line to test it, but on the other hand it is a bit of a hack. The argument only superficially looks like it uses the normal parameter system.
 - How do I actually add a test? Locally I have been doing this:
 ```
mpirun -np 4 ~/opm/build-releasempi/opm-simulators/bin/flow --test-split-communicator=true SPE1CASE2.DATA --output-dir=output_2021_12_10-testsplitcomm-np4
```
and
```
mpirun -np 3 ~/opm/build-releasempi/opm-simulators/bin/flow SPE1CASE2.DATA --output-dir=output_2021_12_10-np3
```
Then I compare the DBG files, and see that the only differences are in timing. Success! But how should we write the test?

