### PR TITLE
Fix stdwell_apply opencl kernel

### DIFF
--- a/opm/simulators/linalg/bda/cuWellContributions.cu
+++ b/opm/simulators/linalg/bda/cuWellContributions.cu
@@ -82,6 +82,12 @@ __global__ void apply_well_contributions(
         // merge all blocks into 1 dim*dim_wells block
         // since 3*4 blocks has give 2 parallel blocks, do not use a loop
         // 0x00ffffff contains 24 ones, representing the two blocks that are added
+        // block 1:     block 2:
+        //  0  1  2     12 13 14
+        //  3  4  5     15 16 17
+        //  6  7  8     18 19 20
+        //  9 10 11     21 22 23
+        // thread i will hold the sum of thread i and i + vals_per_block
         temp += __shfl_down_sync(0x00ffffff, temp, dim * dim_wells);
 
         // merge all (dim) columns of 1 block, results in a single 1*dim_wells vector, which is used to multiply with invD

--- a/opm/simulators/linalg/bda/cuWellContributions.cu
+++ b/opm/simulators/linalg/bda/cuWellContributions.cu
@@ -80,10 +80,9 @@ __global__ void apply_well_contributions(
         }
 
         // merge all blocks into 1 dim*dim_wells block
-        // since NORNE has only 2 parallel blocks, do not use a loop
+        // since 3*4 blocks has give 2 parallel blocks, do not use a loop
+        // 0x00ffffff contains 24 ones, representing the two blocks that are added
         temp += __shfl_down_sync(0x00ffffff, temp, dim * dim_wells);
-
-        b = idx_t / vals_per_block + val_pointers[idx_b];
 
         // merge all (dim) columns of 1 block, results in a single 1*dim_wells vector, which is used to multiply with invD
         if (idx_t < vals_per_block) {

--- a/opm/simulators/linalg/bda/openclKernels.cpp
+++ b/opm/simulators/linalg/bda/openclKernels.cpp
@@ -1103,15 +1103,17 @@ std::string OpenclKernels::get_matrix_operation_source(matrix_operation op, bool
                         b += numBlocksPerWarp;
                     }
 
+                    // merge all blocks in this workgroup into 1 block
+                    // if numBlocksPerWarp >= 3, should use loop
                     if(wiId < valsPerBlock){
-                        localSum[wiId] += localSum[wiId + valsPerBlock];
+                        for (int i = 1; i < numBlocksPerWarp; ++i) {
+                            localSum[wiId] += localSum[wiId + i*valsPerBlock];
+                        }
                     }
 
-                    b = wiId/valsPerBlock + val_pointers[wgId];
-
                     if(c == 0 && wiId < valsPerBlock){
-                        for(unsigned int stride = 2; stride > 0; stride >>= 1){
-                            localSum[wiId] += localSum[wiId + stride];
+                        for(unsigned int i = dim-1; i > 0; --i){
+                            localSum[wiId] += localSum[wiId + i];
                         }
                         z1[r] = localSum[wiId];
                     }

--- a/opm/simulators/linalg/bda/openclKernels.cpp
+++ b/opm/simulators/linalg/bda/openclKernels.cpp
@@ -1105,6 +1105,12 @@ std::string OpenclKernels::get_matrix_operation_source(matrix_operation op, bool
 
                     // merge all blocks in this workgroup into 1 block
                     // if numBlocksPerWarp >= 3, should use loop
+                    // block 1:     block 2:
+                    //  0  1  2     12 13 14
+                    //  3  4  5     15 16 17
+                    //  6  7  8     18 19 20
+                    //  9 10 11     21 22 23
+                    // workitem i will hold the sum of workitems i and i + valsPerBlock
                     if(wiId < valsPerBlock){
                         for (int i = 1; i < numBlocksPerWarp; ++i) {
                             localSum[wiId] += localSum[wiId + i*valsPerBlock];


### PR DESCRIPTION
This fixes the bug in the opencl kernel `stdwell_apply` and `stdwell_apply_no_reorder`.
Fixes https://github.com/OPM/opm-simulators/issues/3635.
Also removes unnecessary line in opencl and in cuda kernel.

```
Benchmarks for NORNE_ATW2013.DATA
Notation: A (B+C+D+E), F, G, I | J
A: Total time
B: Assembly time
C: Linear solve time
D: Update time
E: Pre/post step
F: Overall Linearizations
G: Overall New Iterations
I: Overall Linear Iterations
J: Number of times openclSolver failed to converge and Dune was used instead.
LS: level scheduling
GC: graph coloring

R5 2400G, NVIDIA GTX1050Ti:
--matrix-add-well-contributions=true, clear CPU:
LS: 620 (136+378+ 78+109), 1814, 1453, 21656 | 0
GC: 755 (170+345+103+117), 2384, 1996, 46638 | 0
--matrix-add-well-contributions=false, clear CPU:
LS: 656 (134+316+ 77+110), 1810, 1447, 20797 | 0
GC: 771 (172+359+101+118), 2309, 1920, 43975 | 0
```