### PR TITLE
Refactor some methods in `GasLiftSingleWellGeneric.cpp`

### DIFF
--- a/opm/simulators/wells/GasLiftGroupInfo.cpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.cpp
@@ -106,7 +106,7 @@ getRate(Rate rate_type, const std::string& group_name)
 
 std::tuple<double, double, double, double>
 GasLiftGroupInfo::
-getRates(int group_idx)
+getRates(const int group_idx)
 {
     const auto& group_name = groupIdxToName(group_idx);
     auto& rates = this->group_rate_map_.at(group_name);

--- a/opm/simulators/wells/GasLiftGroupInfo.cpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.cpp
@@ -84,6 +84,26 @@ gasTarget(const std::string& group_name)
     return group_rate.gasTarget();
 }
 
+double
+GasLiftGroupInfo::
+getRate(Rate rate_type, const std::string& group_name)
+{
+    switch (rate_type) {
+    case Rate::oil:
+        return oilRate(group_name);
+    case Rate::gas:
+        return gasRate(group_name);
+    case Rate::water:
+        return waterRate(group_name);
+    case Rate::liquid:
+        return oilRate(group_name) + waterRate(group_name);
+    default:
+        // Need this to avoid compiler warning : control reaches end of non-void function
+        throw std::runtime_error("This should not happen");
+    }
+}
+
+
 std::tuple<double, double, double, double>
 GasLiftGroupInfo::
 getRates(int group_idx)
@@ -91,6 +111,25 @@ getRates(int group_idx)
     const auto& group_name = groupIdxToName(group_idx);
     auto& rates = this->group_rate_map_.at(group_name);
     return std::make_tuple(rates.oilRate(), rates.gasRate(), rates.waterRate(), rates.alq());
+}
+
+std::optional<double>
+GasLiftGroupInfo::
+getTarget(Rate rate_type, const std::string& group_name)
+{
+    switch (rate_type) {
+    case Rate::oil:
+        return oilTarget(group_name);
+    case Rate::gas:
+        return gasTarget(group_name);
+    case Rate::water:
+        return waterTarget(group_name);
+    case Rate::liquid:
+        return liquidTarget(group_name);
+    default:
+        // Need this to avoid compiler warning : control reaches end of non-void function
+        throw std::runtime_error("This should not happen");
+    }
 }
 
 std::vector<std::pair<std::string,double>>&
@@ -187,6 +226,23 @@ liquidTarget(const std::string &group_name)
 {
     auto& group_rate = this->group_rate_map_.at(group_name);
     return group_rate.liquidTarget();
+}
+
+const std::string
+GasLiftGroupInfo::
+rateToString(Rate rate) {
+    switch (rate) {
+    case Rate::oil:
+        return "oil";
+    case Rate::gas:
+        return "gas";
+    case Rate::water:
+        return "water";
+    case Rate::liquid:
+        return "liquid";
+    default:
+        throw std::runtime_error("This should not happen");
+    }
 }
 
 void

--- a/opm/simulators/wells/GasLiftGroupInfo.hpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.hpp
@@ -87,7 +87,7 @@ public:
     double gasRate(const std::string& group_name);
     int getGroupIdx(const std::string& group_name);
     double getRate(Rate rate_type, const std::string& group_name);
-    std::tuple<double,double,double,double> getRates(int group_idx);
+    std::tuple<double,double,double,double> getRates(const int group_idx);
     std::optional<double> gasTarget(const std::string& group_name);
     std::optional<double> getTarget(Rate rate_type, const std::string& group_name);
     const std::string& groupIdxToName(int group_idx);

--- a/opm/simulators/wells/GasLiftGroupInfo.hpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.hpp
@@ -67,6 +67,8 @@ class GasLiftGroupInfo
     static const int Oil = BlackoilPhases::Liquid;
     static const int Gas = BlackoilPhases::Vapour;
 public:
+    enum class Rate {oil, gas, water, liquid};
+
     using GLiftEclWells = std::map<std::string,std::pair<const Well *,int>>;
     GasLiftGroupInfo(
         GLiftEclWells& ecl_wells,
@@ -84,13 +86,16 @@ public:
     double alqRate(const std::string& group_name);
     double gasRate(const std::string& group_name);
     int getGroupIdx(const std::string& group_name);
+    double getRate(Rate rate_type, const std::string& group_name);
     std::tuple<double,double,double,double> getRates(int group_idx);
     std::optional<double> gasTarget(const std::string& group_name);
+    std::optional<double> getTarget(Rate rate_type, const std::string& group_name);
     const std::string& groupIdxToName(int group_idx);
     bool hasWell(const std::string& well_name);
     void initialize();
     std::optional<double> maxAlq(const std::string& group_name);
     double oilRate(const std::string& group_name);
+    static const std::string rateToString(Rate rate);
     double waterRate(const std::string& group_name);
     std::optional<double> oilTarget(const std::string& group_name);
     std::optional<double> waterTarget(const std::string& group_name);

--- a/opm/simulators/wells/GasLiftSingleWellGeneric.cpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.cpp
@@ -633,8 +633,8 @@ getWaterRateWithGroupLimit_(double new_water_rate, double water_rate) const
 
 std::tuple<double, double, bool, bool>
 GasLiftSingleWellGeneric::
-getLiquidRateWithGroupLimit_(double new_oil_rate, double oil_rate,
-                             double new_water_rate, double water_rate) const
+getLiquidRateWithGroupLimit_(const double new_oil_rate, const double oil_rate,
+                             const double new_water_rate, const double water_rate) const
 {
     auto liquid_rate = oil_rate + water_rate;
     auto new_liquid_rate = new_oil_rate + new_water_rate;
@@ -662,8 +662,9 @@ getLiquidRateWithGroupLimit_(double new_oil_rate, double oil_rate,
 
         double oil_fraction = new_gr_oil_rate / new_gr_liquid_rate;
         double delta_liquid = liquid_rate_limited - liquid_rate;
-        new_oil_rate = oil_rate + oil_fraction * delta_liquid;
-        new_water_rate = water_rate + (1.0 - oil_fraction) * delta_liquid;
+        auto limited_oil_rate = oil_rate + oil_fraction * delta_liquid;
+        auto limited_water_rate = water_rate + (1.0 - oil_fraction) * delta_liquid;
+        return {limited_oil_rate, limited_water_rate, limited, limited};
     }
     return {new_oil_rate, new_water_rate, limited, limited};
 }

--- a/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
@@ -57,6 +57,7 @@ protected:
 
 public:
     using GLiftSyncGroups = std::set<int>;
+    using Rate = GasLiftGroupInfo::Rate;
     struct GradInfo
     {
         GradInfo() { }
@@ -180,14 +181,20 @@ protected:
     std::pair<double, bool> getGasRateWithLimit_(const std::vector<double>& potentials) const;
     std::tuple<double,double,double,bool,bool,bool>
     getInitialRatesWithLimit_(const std::vector<double>& potentials);
+    std::tuple<double, const std::string*, double> getRateWithGroupLimit_(
+        Rate rate_type, const double new_rate, const double old_rate) const;
     std::pair<double, bool> getOilRateWithLimit_(const std::vector<double>& potentials) const;
     std::pair<double, bool> getWaterRateWithLimit_(const std::vector<double>& potentials) const;
 
-    std::pair<double, bool> getOilRateWithGroupLimit_(const double new_oil_rate, const double oil_rate) const;
-    std::pair<double, bool> getGasRateWithGroupLimit_(const double new_gas_rate, const double gas_rate) const;
-    std::pair<double, bool> getWaterRateWithGroupLimit_(const double new_water_rate, const double water_rate) const;
-    std::tuple<double,double,bool,bool> getLiquidRateWithGroupLimit_(double new_oil_rate, const double oil_rate,
-                                                                     double new_water_rate, const double water_rate) const;
+    std::pair<double, bool> getOilRateWithGroupLimit_(
+                           double new_oil_rate, double oil_rate) const;
+    std::pair<double, bool> getGasRateWithGroupLimit_(
+                           double new_gas_rate, double gas_rate) const;
+    std::pair<double, bool> getWaterRateWithGroupLimit_(
+                           double new_water_rate, double water_rate) const;
+    std::tuple<double,double,bool,bool> getLiquidRateWithGroupLimit_(
+                           double new_oil_rate, double oil_rate,
+                           double new_water_rate, double water_rate) const;
 
     std::tuple<double,double,bool,bool,double>
     increaseALQtoPositiveOilRate_(double alq,

--- a/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
@@ -182,9 +182,11 @@ protected:
     std::tuple<double,double,double,bool,bool,bool>
     getInitialRatesWithLimit_(const std::vector<double>& potentials);
     std::tuple<double, const std::string*, double> getRateWithGroupLimit_(
-        Rate rate_type, const double new_rate, const double old_rate) const;
-    std::pair<double, bool> getOilRateWithLimit_(const std::vector<double>& potentials) const;
-    std::pair<double, bool> getWaterRateWithLimit_(const std::vector<double>& potentials) const;
+                  Rate rate_type, const double new_rate, const double old_rate) const;
+    std::pair<double, bool> getOilRateWithLimit_(
+                  const std::vector<double>& potentials) const;
+    std::pair<double, bool> getWaterRateWithLimit_(
+                  const std::vector<double>& potentials) const;
 
     std::pair<double, bool> getOilRateWithGroupLimit_(
                            double new_oil_rate, double oil_rate) const;
@@ -193,8 +195,8 @@ protected:
     std::pair<double, bool> getWaterRateWithGroupLimit_(
                            double new_water_rate, double water_rate) const;
     std::tuple<double,double,bool,bool> getLiquidRateWithGroupLimit_(
-                           double new_oil_rate, double oil_rate,
-                           double new_water_rate, double water_rate) const;
+                           const double new_oil_rate, const double oil_rate,
+                           const double new_water_rate, const double water_rate) const;
 
     std::tuple<double,double,bool,bool,double>
     increaseALQtoPositiveOilRate_(double alq,


### PR DESCRIPTION
Note this PR builds on #3747 which should be merged first.

Continues the work in #3747 to fix up repetitive code in `GasLiftSingleWellGeneric.cpp`.  In this PR `getOilRateWithGroupLimit_()`, `getGasRateWithGroupLimit_()`, `getWaterRateWithGroupLimit_()`, and `getLiquidRateWithGroupLimit_()` is refactored into a single generic method called `getRateWithGroupLimit_()`. 

Note that this change also includes a bug fix, see [this comment](https://github.com/OPM/opm-simulators/pull/3673/files#r771027732) and I guess this could be a reason to why the solution for the case [`4_GLIFT_MODEL5`](https://github.com/OPM/opm-tests/blob/master/model5/4_GLIFT_MODEL5.DATA) changes:

![glift1](https://user-images.githubusercontent.com/6708379/146472019-8dd43a8a-c10e-4109-8b48-f17ef30fcb59.png)

here `4_GLIFT_MODEL5_F1` is with the code in the master branch, `4_GLIFT_MODEL5_F2` (which is identical to the curve for `4_GLIFT_MODEL5_F1`) is with the code in PR #3747,  and `4_GLIFT_MODEL5` is with the current PR.

