### PR TITLE
Refactor some methods in `GasLiftSingleWellGeneric.cpp` (part 2)

### DIFF
--- a/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
@@ -178,25 +178,30 @@ protected:
     void displayWarning_(const std::string& warning);
 
     std::pair<double, bool> getBhpWithLimit_(double bhp) const;
-    std::pair<double, bool> getGasRateWithLimit_(const std::vector<double>& potentials) const;
-    std::tuple<double,double,double,bool,bool,bool>
-    getInitialRatesWithLimit_(const std::vector<double>& potentials);
-    std::tuple<double, const std::string*, double> getRateWithGroupLimit_(
-                  Rate rate_type, const double new_rate, const double old_rate) const;
-    std::pair<double, bool> getOilRateWithLimit_(
-                  const std::vector<double>& potentials) const;
-    std::pair<double, bool> getWaterRateWithLimit_(
-                  const std::vector<double>& potentials) const;
-
-    std::pair<double, bool> getOilRateWithGroupLimit_(
-                           double new_oil_rate, double oil_rate) const;
+    std::pair<double, bool> getGasRateWithLimit_(
+                           const std::vector<double>& potentials) const;
     std::pair<double, bool> getGasRateWithGroupLimit_(
                            double new_gas_rate, double gas_rate) const;
-    std::pair<double, bool> getWaterRateWithGroupLimit_(
-                           double new_water_rate, double water_rate) const;
+    std::tuple<double,double,double,bool,bool,bool> getInitialRatesWithLimit_(
+                           const std::vector<double>& potentials);
     std::tuple<double,double,bool,bool> getLiquidRateWithGroupLimit_(
                            const double new_oil_rate, const double oil_rate,
                            const double new_water_rate, const double water_rate) const;
+    std::pair<double, bool> getOilRateWithGroupLimit_(
+                           double new_oil_rate, double oil_rate) const;
+    std::pair<double, bool> getOilRateWithLimit_(
+                           const std::vector<double>& potentials) const;
+    double getProductionTarget_(Rate rate) const;
+    double getRate_(Rate rate_type, const std::vector<double>& potentials) const;
+    std::pair<double, bool> getRateWithLimit_(
+                           Rate rate_type, const std::vector<double>& potentials) const;
+    std::tuple<double, const std::string*, double> getRateWithGroupLimit_(
+                 Rate rate_type, const double new_rate, const double old_rate) const;
+    std::pair<double, bool> getWaterRateWithGroupLimit_(
+                           double new_water_rate, double water_rate) const;
+    std::pair<double, bool> getWaterRateWithLimit_(
+                           const std::vector<double>& potentials) const;
+    bool hasProductionControl_(Rate rate) const;
 
     std::tuple<double,double,bool,bool,double>
     increaseALQtoPositiveOilRate_(double alq,


### PR DESCRIPTION
Note this PR includes #3748 which should be merged first. 

Continues the work in #3748 of cleaning up some methods in `GasLiftSingleWellGeneric.cpp` to get rid of repetitive code and make it easier to maintain the code in the future.
    
This last commit refactors `getOilRateWithLimit_()`, `getGasRateWithLimit_()`, and  `getWaterRateWithLimit_()`. The common part of the methods is split out into a new method called `getRateWithLimit_()`.

I have tested this PR with the case [`4_GLIFT_MODEL5`](https://github.com/OPM/opm-tests/blob/master/model5/4_GLIFT_MODEL5.DATA) and there was no difference in the solution for FGLIR (field gas lift injection rate) compared to the solution for #3748 which indicates that the numerical solution is not affected by this commit.