### PR TITLE
Made some methods in GasLiftGroupInfo const

### DIFF
--- a/opm/simulators/wells/GasLiftGroupInfo.cpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.cpp
@@ -70,7 +70,7 @@ getGroupIdx(const std::string& group_name)
 
 double
 GasLiftGroupInfo::
-gasRate(const std::string& group_name)
+gasRate(const std::string& group_name) const
 {
     auto& group_rate = this->group_rate_map_.at(group_name);
     return group_rate.gasRate();
@@ -78,7 +78,7 @@ gasRate(const std::string& group_name)
 
 std::optional<double>
 GasLiftGroupInfo::
-gasTarget(const std::string& group_name)
+gasTarget(const std::string& group_name) const
 {
     auto& group_rate = this->group_rate_map_.at(group_name);
     return group_rate.gasTarget();
@@ -86,7 +86,7 @@ gasTarget(const std::string& group_name)
 
 double
 GasLiftGroupInfo::
-getRate(Rate rate_type, const std::string& group_name)
+getRate(Rate rate_type, const std::string& group_name) const
 {
     switch (rate_type) {
     case Rate::oil:
@@ -106,7 +106,7 @@ getRate(Rate rate_type, const std::string& group_name)
 
 std::tuple<double, double, double, double>
 GasLiftGroupInfo::
-getRates(const int group_idx)
+getRates(const int group_idx) const
 {
     const auto& group_name = groupIdxToName(group_idx);
     auto& rates = this->group_rate_map_.at(group_name);
@@ -115,7 +115,7 @@ getRates(const int group_idx)
 
 std::optional<double>
 GasLiftGroupInfo::
-getTarget(Rate rate_type, const std::string& group_name)
+getTarget(Rate rate_type, const std::string& group_name) const
 {
     switch (rate_type) {
     case Rate::oil:
@@ -142,7 +142,7 @@ getWellGroups(const std::string& well_name)
 
 const std::string&
 GasLiftGroupInfo::
-groupIdxToName(int group_idx)
+groupIdxToName(int group_idx) const
 {
     const std::string *group_name = nullptr;
     // TODO:  An alternative to the below loop is to set up a reverse map from idx ->
@@ -182,6 +182,14 @@ initialize()
 
 std::optional<double>
 GasLiftGroupInfo::
+liquidTarget(const std::string &group_name) const
+{
+    auto& group_rate = this->group_rate_map_.at(group_name);
+    return group_rate.liquidTarget();
+}
+
+std::optional<double>
+GasLiftGroupInfo::
 maxAlq(const std::string& group_name)
 {
     auto& group_rate = this->group_rate_map_.at(group_name);
@@ -190,7 +198,7 @@ maxAlq(const std::string& group_name)
 
 double
 GasLiftGroupInfo::
-oilRate(const std::string &group_name)
+oilRate(const std::string &group_name) const
 {
     auto& group_rate = this->group_rate_map_.at(group_name);
     return group_rate.oilRate();
@@ -198,34 +206,10 @@ oilRate(const std::string &group_name)
 
 std::optional<double>
 GasLiftGroupInfo::
-oilTarget(const std::string &group_name)
+oilTarget(const std::string &group_name) const
 {
     auto& group_rate = this->group_rate_map_.at(group_name);
     return group_rate.oilTarget();
-}
-
-double
-GasLiftGroupInfo::
-waterRate(const std::string &group_name)
-{
-    auto& group_rate = this->group_rate_map_.at(group_name);
-    return group_rate.waterRate();
-}
-
-std::optional<double>
-GasLiftGroupInfo::
-waterTarget(const std::string &group_name)
-{
-    auto& group_rate = this->group_rate_map_.at(group_name);
-    return group_rate.waterTarget();
-}
-
-std::optional<double>
-GasLiftGroupInfo::
-liquidTarget(const std::string &group_name)
-{
-    auto& group_rate = this->group_rate_map_.at(group_name);
-    return group_rate.liquidTarget();
 }
 
 const std::string
@@ -243,6 +227,22 @@ rateToString(Rate rate) {
     default:
         throw std::runtime_error("This should not happen");
     }
+}
+
+double
+GasLiftGroupInfo::
+waterRate(const std::string &group_name) const
+{
+    auto& group_rate = this->group_rate_map_.at(group_name);
+    return group_rate.waterRate();
+}
+
+std::optional<double>
+GasLiftGroupInfo::
+waterTarget(const std::string &group_name) const
+{
+    auto& group_rate = this->group_rate_map_.at(group_name);
+    return group_rate.waterTarget();
 }
 
 void

--- a/opm/simulators/wells/GasLiftGroupInfo.hpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.hpp
@@ -84,22 +84,23 @@ public:
         const std::string& well_name);
 
     double alqRate(const std::string& group_name);
-    double gasRate(const std::string& group_name);
+    double gasRate(const std::string& group_name) const;
     int getGroupIdx(const std::string& group_name);
-    double getRate(Rate rate_type, const std::string& group_name);
-    std::tuple<double,double,double,double> getRates(const int group_idx);
-    std::optional<double> gasTarget(const std::string& group_name);
-    std::optional<double> getTarget(Rate rate_type, const std::string& group_name);
-    const std::string& groupIdxToName(int group_idx);
+    double getRate(Rate rate_type, const std::string& group_name) const;
+    std::tuple<double,double,double,double> getRates(const int group_idx) const;
+    std::optional<double> gasTarget(const std::string& group_name) const;
+    std::optional<double> getTarget(
+        Rate rate_type, const std::string& group_name) const;
+    const std::string& groupIdxToName(int group_idx) const;
     bool hasWell(const std::string& well_name);
     void initialize();
+    std::optional<double> liquidTarget(const std::string& group_name) const;
     std::optional<double> maxAlq(const std::string& group_name);
-    double oilRate(const std::string& group_name);
+    double oilRate(const std::string& group_name) const;
+    std::optional<double> oilTarget(const std::string& group_name) const;
     static const std::string rateToString(Rate rate);
-    double waterRate(const std::string& group_name);
-    std::optional<double> oilTarget(const std::string& group_name);
-    std::optional<double> waterTarget(const std::string& group_name);
-    std::optional<double> liquidTarget(const std::string& group_name);
+    double waterRate(const std::string& group_name) const;
+    std::optional<double> waterTarget(const std::string& group_name) const;
     void update(const std::string& well_name,
         double delta_oil, double delta_gas, double delta_water, double delta_alq);
     void updateRate(int idx, double oil_rate, double gas_rate, double water_rate, double alq);


### PR DESCRIPTION
This is in agreement with [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#con2-by-default-make-member-functions-const): _A member function should be marked `const` unless it changes the object’s observable state. This gives a more precise statement of design intent, better readability, more errors caught by the compiler, and sometimes more optimization opportunities_.