### PR TITLE
fixing the failure that bhp could not be calculated with thp limit

### DIFF
--- a/opm/simulators/wells/MultisegmentWellGeneric.cpp
+++ b/opm/simulators/wells/MultisegmentWellGeneric.cpp
@@ -670,6 +670,8 @@ bisectBracket(const std::function<double(const double)>& eq,
                                          baseif_.name());
             }
         }
+    } else {
+        finding_bracket = true;
     }
     return finding_bracket;
 }

--- a/opm/simulators/wells/MultisegmentWellGeneric.hpp
+++ b/opm/simulators/wells/MultisegmentWellGeneric.hpp
@@ -76,10 +76,22 @@ protected:
                                                    const double rho,
                                                    DeferredLogger& deferred_logger) const;
 
-    bool bruteForcingBracket(const std::function<double(const double)>& eq,
-                             const std::array<double, 2>& range,
-                             double& low, double& high,
-                             DeferredLogger& deferred_logger) const;
+    std::optional<double> bhpMax(const std::function<double(const double)>& fflo,
+                                 const double bhp_limit,
+                                 const double maxPerfPress,
+                                 const double vfp_flo_front,
+                                 DeferredLogger& deferred_logger) const;
+
+    bool bruteForceBracket(const std::function<double(const double)>& eq,
+                           const std::array<double, 2>& range,
+                           double& low, double& high,
+                           DeferredLogger& deferred_logger) const;
+
+    bool bisectBracket(const std::function<double(const double)>& eq,
+                       const std::array<double, 2>& range,
+                       double& low, double& high,
+                       std::optional<double>& approximate_solution,
+                       DeferredLogger& deferred_logger) const;
 
     /// Detect oscillation or stagnation based on the residual measure history
     void detectOscillations(const std::vector<double>& measure_history,

--- a/opm/simulators/wells/MultisegmentWellGeneric.hpp
+++ b/opm/simulators/wells/MultisegmentWellGeneric.hpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <optional>
 #include <vector>
+#include <array>
 
 namespace Opm
 {
@@ -74,6 +75,11 @@ protected:
                                                    const double maxPerfPress,
                                                    const double rho,
                                                    DeferredLogger& deferred_logger) const;
+
+    bool bruteForcingBracket(const std::function<double(const double)>& eq,
+                             const std::array<double, 2>& range,
+                             double& low, double& high,
+                             DeferredLogger& deferred_logger) const;
 
     /// Detect oscillation or stagnation based on the residual measure history
     void detectOscillations(const std::vector<double>& measure_history,


### PR DESCRIPTION
The new functionality is `bruteForceBracket()`, which tries to find the bracket that contains the bhp solution in a brute force manner. 

The current approach is very supplemental, only trying to use this brute force method to handle the situation that the existing method fails.  There probably some room for optimize, while the current PR represents a quick solution for the problem with little risk of breaking existing successful running. 

Other parts in this PR are pure refactoring to make the function `computeBhpAtThpLimitProd()` more readable. 
