### PR TITLE
Accumulate Dissolved Gas and Vaporized Oil Flow Rates Across Ranks

### DIFF
--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -467,6 +467,14 @@ namespace Opm
         // Update the connection
         this->connectionRates_ = connectionRates;
 
+        // Accumulate dissolved gas and vaporized oil flow rates across all
+        // ranks sharing this well (this->index_of_well_).
+        {
+            const auto& comm = this->parallel_well_info_.communication();
+            ws.dissolved_gas_rate = comm.sum(ws.dissolved_gas_rate);
+            ws.vaporized_oil_rate = comm.sum(ws.vaporized_oil_rate);
+        }
+
         // accumulate resWell_ and invDuneD_ in parallel to get effects of all perforations (might be distributed)
         wellhelpers::sumDistributedWellEntries(this->invDuneD_[0][0], this->resWell_[0],
                                                this->parallel_well_info_.communication());


### PR DESCRIPTION
This is needed to get consistent estimates for the summary vectors

  * `{F,G,W}OP{R,T}{F,S}` &mdash; Free/Vaporized Oil Production Rate/Cumulative Volume
  * `{F,G,W}GP{R,T}{F,S}` &mdash; Free/Dissolved Gas Production Rate/Cumulative Volume

in the case of distributed wells.

Thanks to [at]blattms for the suggested fix.