### PR TITLE
Include config.h in clSources.cpp to include correct openCL header.

### DIFF
--- a/opencl-source-provider.cmake
+++ b/opencl-source-provider.cmake
@@ -13,7 +13,8 @@ endif()
 
 set(CL_SRC_FILE ${PROJECT_BINARY_DIR}/clSources.cpp)
 file(WRITE ${CL_SRC_FILE} "// This file is auto-generated. Do not edit!\n\n")
-file(APPEND ${CL_SRC_FILE} "#include \"${BDA_DIR}/openclKernels.hpp\"\n\n")
+file(APPEND ${CL_SRC_FILE} "#include <config.h>\n\n")
+file(APPEND ${CL_SRC_FILE} "#include <${BDA_DIR}/openclKernels.hpp>\n\n")
 file(APPEND ${CL_SRC_FILE} "namespace Opm\{\n\n")
 file(APPEND ${CL_SRC_FILE} "namespace Accelerator\{\n\n")
 


### PR DESCRIPTION
Otherwise the definitions determined by CMake are not available to opm/simulators/linalg/bda/opencl.hpp and choosing the correct header might fail.

On my system this at least fixes a warning.

Fallout from #3749