### PR TITLE
Update guiderates after with new rates from newly opened wells

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -396,7 +396,7 @@ protected:
                               const SummaryConfig& summaryConfig,
                               DeferredLogger& deferred_logger);
 
-    bool guideRateUpdateIsNeeded() const;
+    bool guideRateUpdateIsNeeded(const int reportStepIdx) const;
 
     // create the well container
     virtual void createWellContainer(const int time_step) = 0;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -842,8 +842,8 @@ namespace Opm {
                                        terminal_output_, grid().comm());
 
         //update guide rates
-        if (guideRateUpdateIsNeeded()) {
-            const int reportStepIdx = ebosSimulator_.episodeIndex();
+        const int reportStepIdx = ebosSimulator_.episodeIndex();
+        if (guideRateUpdateIsNeeded(reportStepIdx)) {
             const double simulationTime = ebosSimulator_.time();
             const auto& comm = ebosSimulator_.vanguard().grid().comm();
             const auto& summaryState = ebosSimulator_.vanguard().summaryState();


### PR DESCRIPTION
The guide rates needs updated rates to be accurate while the initial well rates for newly opened well needs the guiderates to get good estimates. Adding an extra update on the guiderate during the first iterations thus improves the accuracy of the simulator.