### PR TITLE
Some janitoring

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -673,6 +673,8 @@ private:
                 setupTime_, deck_, eclipseState_, schedule_, summaryConfig_);
             return flowEbosBrineMain(argc_, argv_, outputCout_, outputFiles_);
         }
+
+        return EXIT_FAILURE;
     }
 
     int runSolvent()

--- a/tests/test_solvetransposed3x3.cpp
+++ b/tests/test_solvetransposed3x3.cpp
@@ -21,7 +21,12 @@
 
 #define BOOST_TEST_MODULE SolveTransposed3x3
 #include <boost/test/unit_test.hpp>
+
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 #include <dune/istl/bcrsmatrix.hh>
 


### PR DESCRIPTION
Quells two warnings, a boost deprecation warning and a control reaches end of non-void function warning.