### PR TITLE
support none trivial item 3 in LIFTOPT.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -460,6 +460,8 @@ protected:
 
     bool glift_debug = false;
 
+    double last_glift_opt_time_ = -1.0;
+
 private:
     WellInterfaceGeneric* getGenWell(const std::string& well_name);
 };

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -861,7 +861,19 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     maybeDoGasLiftOptimize(DeferredLogger& deferred_logger)
     {
-        const bool do_glift_optimization = true;
+        bool do_glift_optimization = false;
+
+        const double simulation_time = ebosSimulator_.time();
+        const double min_wait = ebosSimulator_.vanguard().schedule().glo(ebosSimulator_.episodeIndex()).min_wait();
+        // We only optimize if a min_wait time has past.
+        // If all_newton is true we still want to optimize several times pr timestep
+        // i.e. we also optimize if check simulation_time == last_glift_opt_time_
+        // that is when the last_glift_opt_time is already updated with the current time step
+        if ( simulation_time == last_glift_opt_time_  || simulation_time >= (last_glift_opt_time_ + min_wait)) {
+            do_glift_optimization = true;
+            last_glift_opt_time_ = simulation_time;
+        }
+
         if (do_glift_optimization) {
             GLiftOptWells glift_wells;
             GLiftProdWells prod_wells;


### PR DESCRIPTION
Item 3 in liftopt sets a delay time between each gaslift optimization

LIFTOPT item 3 = 15 is used in GLIFTOPT_9.DATA in gaslift and with this change the simulator behave as expected. 