### PR TITLE
[testing] always using inner iterations for testing purpose.

### DIFF
--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -472,7 +472,7 @@ namespace Opm
 
         // only use inner well iterations for the first newton iterations.
         const int iteration_idx = ebosSimulator.model().newtonMethod().numIterations();
-        if (iteration_idx < param_.max_niter_inner_well_iter_) {
+        if (true) {
             this->operability_status_.solvable = true;
             bool converged = this->iterateWellEquations(ebosSimulator, dt, well_state, group_state, deferred_logger);
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -472,7 +472,7 @@ namespace Opm
 
         // only use inner well iterations for the first newton iterations.
         const int iteration_idx = ebosSimulator.model().newtonMethod().numIterations();
-        if (true) {
+        if (iteration_idx < param_.max_niter_inner_well_iter_ || this->well_ecl_.isMultiSegment()) {
             this->operability_status_.solvable = true;
             bool converged = this->iterateWellEquations(ebosSimulator, dt, well_state, group_state, deferred_logger);
 


### PR DESCRIPTION
Looks like it gives better results for some test cases. Creating this one for performance checking. 

Notably, I think inner iterations are more essential for multisegment wells. 