### PR TITLE
Silence reorder warning in GasLiftCommon

### DIFF
--- a/opm/simulators/wells/GasLiftCommon.hpp
+++ b/opm/simulators/wells/GasLiftCommon.hpp
@@ -41,9 +41,10 @@ protected:
     );
     int debugUpdateGlobalCounter_() const;
     virtual void displayDebugMessage_(const std::string& msg) const = 0;
-    bool debug;
-    DeferredLogger &deferred_logger_;
+
     WellState &well_state_;
+    DeferredLogger &deferred_logger_;
+    bool debug;
 };
 
 } // namespace Opm


### PR DESCRIPTION
The order of the initialization of member variables in the constructor should match the order in which the variables are declared in the class.