### PR TITLE
Prevent multiple *.?.dbg/prt files in production parallel runs.

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -440,11 +440,14 @@ private:
             const bool init_from_restart_file = !EWOMS_GET_PARAM(PreTypeTag, bool, SchedRestart);
             if (outputDir.empty())
                 outputDir = EWOMS_GET_PARAM(PreTypeTag, std::string, OutputDir);
+
+            const bool allRanksDbgPrtLog = EWOMS_GET_PARAM(PreTypeTag, bool,
+                                                      EnableLoggingFalloutWarning);
             outputMode = setupLogging(mpiRank,
                                       deckFilename,
                                       outputDir,
                                       EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
-                                      outputCout_, "STDOUT_LOGGER");
+                                      outputCout_, "STDOUT_LOGGER", allRanksDbgPrtLog);
             auto parseContext =
                 std::make_unique<ParseContext>(std::vector<std::pair<std::string , InputError::Action>>
                                                {{ParseContext::PARSE_RANDOM_SLASH, InputError::IGNORE},

--- a/opm/simulators/utils/ParallelFileMerger.cpp
+++ b/opm/simulators/utils/ParallelFileMerger.cpp
@@ -54,7 +54,7 @@ void ParallelFileMerger::operator()(const fs::path& file)
 
     if ( std::regex_match(filename, matches, fileWarningRegex_) )
     {
-        std::string rank = std::regex_replace(filename, fileWarningRegex_, "\\1");
+        std::string rank = std::regex_replace(filename, fileWarningRegex_, "$1");
 
         if( std::regex_match(filename, logFileRegex_) )
         {

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -343,7 +343,8 @@ Opm::setupLogging(const int          mpi_rank_,
                   const std::string& cmdline_output_dir,
                   const std::string& cmdline_output,
                   const bool         output_cout_,
-                  const std::string& stdout_log_id)
+                  const std::string& stdout_log_id,
+                  const bool         allRanksDbgLog)
 {
     if (!cmdline_output_dir.empty()) {
         ensureOutputDirExists_(cmdline_output_dir);
@@ -401,6 +402,10 @@ Opm::setupLogging(const int          mpi_rank_,
             output = FileOutputMode::OUTPUT_ALL;
             std::cerr << "Value " << cmdline_output
                       << " is not a recognized output mode. Using \"all\" instead.\n";
+        }
+        if (!allRanksDbgLog && mpi_rank_ != 0)
+        {
+            output = FileOutputMode::OUTPUT_NONE;
         }
     }
 

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -64,7 +64,8 @@ setupLogging(int                mpi_rank_,
              const std::string& cmdline_output_dir,
              const std::string& cmdline_output,
              bool               output_cout_,
-             const std::string& stdout_log_id);
+             const std::string& stdout_log_id,
+             const bool         allRanksDbgLog);
 
 /// \brief Reads the deck and creates all necessary objects if needed
 ///


### PR DESCRIPTION
There was a fallout when skipping concating these files to the default ones (PR #1708). We should also have deactivated creating these files at all. As a result these files appeared in all aborted parallel runs.

This change now prevents creating and logging to these files in parallel in a default run (--enable-parallel-logging-fallout-warning=false).

Developers can still activate logging and concating to see whether everything is only logged on the io process by passing --enable-parallel-logging-fallout-warning=true.

Alternative to #3725.
Closes #3709