### PR TITLE
fixed: use the --porcelain option when parsing git status

### DIFF
--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -262,7 +262,7 @@ then
 fi
 
 # Add potential new files
-untracked=`git status | sed '1,/Untracked files/d' | tail -n +3 | head -n -2`
+untracked=`git status --porcelain | awk '$1~/\?/{print $2}'`
 if [ -n "$untracked" ]
 then
   git add $untracked


### PR DESCRIPTION
the formatting for the standard git status output is unstable,
and has changed in newer versions of the git client. this lead
to missing lines in untracked files.