### PR TITLE
Use target_link_libraries(... PUBLIC ...) to fix missing symbols.

### DIFF
--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -21,7 +21,7 @@ target_sources(simulators
   $<TARGET_OBJECTS:moduleVersion>
   $<TARGET_OBJECTS:flow_libblackoil>)
 
-target_link_libraries( simulators PRIVATE opmsimulators )
+target_link_libraries( simulators PUBLIC opmsimulators )
 
 set(PYTHON_PACKAGE_PATH "site-packages")
 set(PYTHON_INSTALL_PREFIX "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/${PYTHON_PACKAGE_PATH}" CACHE STRING "Subdirectory to install Python modules in")


### PR DESCRIPTION
When running the test (ctest -R ython --verbose) I would otherwise get

```
test 184
    Start 184: python_schedule

184: Test command: /usr/bin/cmake "-E" "env" "PYTHONPATH=/home/mblatt/src/dune/opm/opm-simulators/opts-gcc9.cmake/python:/home/mblatt/src/dune/opm/opm-common/opts-gcc9.cmake/python::/home/mblatt/src/django:/home/mblatt/opt/libecl/lib/python2.7/dist-packages:/home/mblatt/no-backup/HexaFEM:." "/usr/bin/python3.9" "-m" "unittest" "test/test_schedule.py"
184: Test timeout computed to be: 10000000
184: E
184: ======================================================================
184: ERROR: test_schedule (unittest.loader._FailedTest)
184: ----------------------------------------------------------------------
184: ImportError: Failed to import test module: test_schedule
184: Traceback (most recent call last):
184:   File "/usr/lib/python3.9/unittest/loader.py", line 154, in loadTestsFromName
184:     module = __import__(module_name)
184:   File "/home/mblatt/src/dune/opm-amg-opt/opm-simulators/opts-gcc9.cmake/python/test/test_schedule.py", line 6, in <module>
184:     from opm2.simulators import BlackOilSimulator
184: ImportError: /home/mblatt/src/dune/opm-amg-opt/opm-simulators/opts-gcc9.cmake/python/opm2/simulators.cpython-39-x86_64-linux-gnu.so: undefined symbol: _ZNK4Dune9Exception4whatEv
184:
184:
```

With this change the tests actually successfully.