### PR TITLE
update well potentials in wellState along with alq and update guide rates accordingly

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -392,7 +392,7 @@ namespace Opm {
 
             void assembleWellEq(const double dt, DeferredLogger& deferred_logger);
 
-            void maybeDoGasLiftOptimize(DeferredLogger& deferred_logger);
+            bool maybeDoGasLiftOptimize(DeferredLogger& deferred_logger);
 
             void gasLiftOptimizationStage1(DeferredLogger& deferred_logger,
                 GLiftProdWells &prod_wells, GLiftOptWells &glift_wells,

--- a/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
@@ -65,12 +65,15 @@ public:
 
         GradInfo(double grad_, double new_oil_rate_, bool oil_is_limited_,
                  double new_gas_rate_, bool gas_is_limited_,
+                 double new_water_rate_, bool water_is_limited_,
                  double alq_, bool alq_is_limited_) :
             grad{grad_},
             new_oil_rate{new_oil_rate_},
             oil_is_limited{oil_is_limited_},
             new_gas_rate{new_gas_rate_},
             gas_is_limited{gas_is_limited_},
+            new_water_rate{new_water_rate_},
+            water_is_limited{water_is_limited_},
             alq{alq_},
             alq_is_limited{alq_is_limited_} {}
         double grad;
@@ -78,6 +81,8 @@ public:
         bool oil_is_limited;
         double new_gas_rate;
         bool gas_is_limited;
+        double new_water_rate;
+        bool water_is_limited;
         double alq;
         bool alq_is_limited;
     };

--- a/opm/simulators/wells/GasLiftStage2.cpp
+++ b/opm/simulators/wells/GasLiftStage2.cpp
@@ -115,8 +115,18 @@ addOrRemoveALQincrement_(GradMap &grad_map, const std::string& well_name, bool a
     }
     state.update(gi.new_oil_rate, gi.oil_is_limited,
         gi.new_gas_rate, gi.gas_is_limited,
-        gi.alq, gi.alq_is_limited, add);
-    this->well_state_.setALQ(well_name, gi.alq);
+        gi.alq, gi.alq_is_limited, gi.new_water_rate, add);
+        this->well_state_.setALQ(well_name, gi.alq);
+        const auto& pu = this->well_state_.phaseUsage();
+        std::vector<double> well_pot(pu.num_phases, 0.0);
+        if(pu.phase_used[BlackoilPhases::PhaseIndex::Liquid])
+            well_pot[pu.phase_pos[BlackoilPhases::PhaseIndex::Liquid]] = gi.new_oil_rate;
+        if(pu.phase_used[BlackoilPhases::PhaseIndex::Aqua])
+            well_pot[pu.phase_pos[BlackoilPhases::PhaseIndex::Aqua]] = gi.new_water_rate;
+        if(pu.phase_used[BlackoilPhases::PhaseIndex::Vapour])
+            well_pot[pu.phase_pos[BlackoilPhases::PhaseIndex::Vapour]] = gi.new_gas_rate;
+
+        this->well_state_[well_name].well_potentials = well_pot;
 }
 
 std::optional<GasLiftStage2::GradInfo>

--- a/opm/simulators/wells/GasLiftWellState.hpp
+++ b/opm/simulators/wells/GasLiftWellState.hpp
@@ -31,13 +31,14 @@ namespace Opm
         //GasLiftWellState() { }
         GasLiftWellState(double oil_rate, bool oil_is_limited,
                      double gas_rate, bool gas_is_limited,
-            double alq, bool alq_is_limited, std::optional<bool> increase) :
+            double alq, bool alq_is_limited, double water_rate, std::optional<bool> increase) :
                 oil_rate_{oil_rate},
                 oil_is_limited_{oil_is_limited},
                 gas_rate_{gas_rate},
                 gas_is_limited_{gas_is_limited},
                 alq_{alq},
                 alq_is_limited_{alq_is_limited},
+                water_rate_{water_rate},
                 increase_{increase}
         {}
         double alq() const { return alq_; }
@@ -49,9 +50,10 @@ namespace Opm
         std::optional<bool> increase() const { return increase_; }
         bool oilIsLimited() const { return oil_is_limited_; }
         double oilRate() const { return oil_rate_; }
+        double waterRate() const { return water_rate_; }
         void update(double oil_rate, bool oil_is_limited,
             double gas_rate, bool gas_is_limited,
-            double alq, bool alq_is_limited,
+            double alq, bool alq_is_limited, double water_rate,
             bool increase)
         {
             oil_rate_ = oil_rate;
@@ -60,6 +62,7 @@ namespace Opm
             gas_is_limited_ = gas_is_limited;
             alq_ = alq;
             alq_is_limited_ = alq_is_limited;
+            water_rate_ = water_rate;
             increase_ = increase;
         }
     private:
@@ -69,6 +72,7 @@ namespace Opm
         bool gas_is_limited_;
         double alq_;
         bool alq_is_limited_;
+        double water_rate_;
         std::optional<bool> increase_;
     };
 


### PR DESCRIPTION
This makes sure the guide rates (i.e. the distribution between wells/groups) are updated when gaslift changes during iterations.
(LIFTOPT item 4 = YES) and as a result reduce oscillations in the solution. 