### PR TITLE
Communicate Inter-Region Flows to I/O Rank

### DIFF
--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -28,9 +28,12 @@
 #include <opm/output/data/Solution.hpp>
 #include <opm/output/data/Wells.hpp>
 #include <opm/output/data/Groups.hpp>
+
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 
 #include <opm/grid/common/p2pcommunicator.hh>
+
+#include <ebos/eclinterregflows.hh>
 
 #include <map>
 #include <utility>
@@ -62,7 +65,8 @@ public:
                         const EquilGrid* equilGrid,
                         const GridView& gridView,
                         const Dune::CartesianIndexMapper<Grid>& cartMapper,
-                        const Dune::CartesianIndexMapper<EquilGrid>* equilCartMapper);
+                        const Dune::CartesianIndexMapper<EquilGrid>* equilCartMapper,
+                        const std::set<std::string>& fipRegionsInterregFlow = {});
 
     // gather solution to rank 0 for EclipseWriter
     void collect(const data::Solution& localCellData,
@@ -71,7 +75,8 @@ public:
                  const data::Wells& localWellData,
                  const data::GroupAndNetworkValues& localGroupAndNetworkData,
                  const data::Aquifers& localAquiferData,
-                 const WellTestState& localWellTestState);
+                 const WellTestState& localWellTestState,
+                 const EclInterRegFlowMap& interRegFlows);
 
     const std::map<std::size_t, double>& globalWBPData() const
     { return this->globalWBPData_; }
@@ -94,6 +99,12 @@ public:
     const data::Aquifers& globalAquiferData() const
     { return globalAquiferData_; }
 
+    EclInterRegFlowMap& globalInterRegFlows()
+    { return this->globalInterRegFlows_; }
+
+    const EclInterRegFlowMap& globalInterRegFlows() const
+    { return this->globalInterRegFlows_; }
+
     bool isIORank() const
     { return toIORankComm_.rank() == ioRank; }
 
@@ -112,6 +123,7 @@ public:
 
 protected:
     P2PCommunicatorType toIORankComm_;
+    EclInterRegFlowMap globalInterRegFlows_;
     IndexMapType globalCartesianIndex_;
     IndexMapType localIndexMap_;
     IndexMapStorageType indexMaps_;

--- a/ebos/eclgenericwriter.hh
+++ b/ebos/eclgenericwriter.hh
@@ -42,15 +42,23 @@
 
 namespace Opm {
 
-namespace Action { class State; }
 class EclipseIO;
 class EclipseState;
+class EclInterRegFlowMap;
 class Inplace;
 struct NNCdata;
 class Schedule;
 class SummaryConfig;
 class SummaryState;
 class UDQState;
+
+} // namespace Opm
+
+namespace Opm { namespace Action {
+class State;
+}} // namespace Opm::Action
+
+namespace Opm {
 
 template <class Grid, class EquilGrid, class GridView, class ElementMapper, class Scalar>
 class EclGenericWriter
@@ -119,10 +127,11 @@ protected:
                      const std::map<std::pair<std::string, int>, double>& blockData,
                      const std::map<std::string, double>& miscSummaryData,
                      const std::map<std::string, std::vector<double>>& regionData,
-                     SummaryState& summaryState,
-                     UDQState& udqState,
                      const Inplace& inplace,
-                     const Inplace& initialInPlace);
+                     const Inplace& initialInPlace,
+                     const EclInterRegFlowMap& interRegionFlowMap,
+                     SummaryState& summaryState,
+                     UDQState& udqState);
 
     CollectDataToIORankType collectToIORank_;
     const Grid& grid_;

--- a/ebos/eclinterregflows.cc
+++ b/ebos/eclinterregflows.cc
@@ -111,6 +111,17 @@ assignGlobalMaxRegionID(const std::size_t regID)
 //
 // =====================================================================
 
+Opm::EclInterRegFlowMap
+Opm::EclInterRegFlowMap::createMapFromNames(std::vector<std::string> names)
+{
+    auto map = EclInterRegFlowMap{};
+
+    map.names_ = std::move(names);
+    map.regionMaps_.resize(map.names_.size(), EclInterRegFlowMapSingleFIP{});
+
+    return map;
+}
+
 Opm::EclInterRegFlowMap::
 EclInterRegFlowMap(const std::size_t                numCells,
                    const std::vector<SingleRegion>& regions)

--- a/ebos/eclinterregflows.hh
+++ b/ebos/eclinterregflows.hh
@@ -38,6 +38,8 @@
 
 namespace Opm {
 
+    class EclInterRegFlowMap;
+
     /// Form CSR adjacency matrix representation of inter-region flow rate
     /// graph provided as a list of connections between regions on local MPI
     /// rank.  Pertains to a single FIP definition array (e.g., FIPNUM).
@@ -55,6 +57,8 @@ namespace Opm {
             /// Whether or not cell is interior to local rank.
             bool isInterior{true};
         };
+
+        friend class EclInterRegFlowMap;
 
         /// Constructor
         ///
@@ -165,6 +169,9 @@ namespace Opm {
         /// Whether or not this object contains contributions deserialised
         /// from a stream.  For error detection.
         bool isReadFromStream_{false};
+
+        /// Default constructor.
+        EclInterRegFlowMapSingleFIP() = default;
     };
 
     /// Inter-region flow accumulation maps for all region definition arrays
@@ -187,6 +194,15 @@ namespace Opm {
 
         /// Default constructor.
         EclInterRegFlowMap() = default;
+
+        /// Special purpose constructor for global object being collected on
+        /// the I/O rank.
+        ///
+        /// Only knows about the FIP region set names.
+        ///
+        /// \param[in] names Sorted sequence of FIP region names.
+        static EclInterRegFlowMap
+        createMapFromNames(std::vector<std::string> names);
 
         /// Constructor.
         ///


### PR DESCRIPTION
This PR ensures that compute inter-region flow rates on all ranks and collect those on the I/O rank using `CollectDataToIORank`.

We add a trivial `EclInterRegFlowMap` data member to the communication object.  This data member only knows the pertinent FIP region array names, but uses existing read/write support to collect contributions from all ranks into this "global" object.  We then pass this global object on to the summary evaluation routine.