### PR TITLE
Subdomain matrix for opencl ILU preconditioner

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -85,6 +85,10 @@ struct EdgeWeightsMethod {
     using type = UndefinedProperty;
 };
 template<class TypeTag, class MyTypeTag>
+struct NumJacobiBlocks {
+    using type = UndefinedProperty;
+};
+template<class TypeTag, class MyTypeTag>
 struct OwnerCellsFirst {
     using type = UndefinedProperty;
 };
@@ -131,6 +135,10 @@ struct SchedRestart<TypeTag, TTag::EclBaseVanguard> {
 template<class TypeTag>
 struct EdgeWeightsMethod<TypeTag, TTag::EclBaseVanguard> {
     static constexpr int value = 1;
+};
+template<class TypeTag>
+struct NumJacobiBlocks<TypeTag, TTag::EclBaseVanguard> {
+    static constexpr int value = 0;
 };
 template<class TypeTag>
 struct OwnerCellsFirst<TypeTag, TTag::EclBaseVanguard> {
@@ -211,6 +219,8 @@ public:
                              "When restarting: should we try to initialize wells and groups from historical SCHEDULE section.");
         EWOMS_REGISTER_PARAM(TypeTag, int, EdgeWeightsMethod,
                              "Choose edge-weighing strategy: 0=uniform, 1=trans, 2=log(trans).");
+        EWOMS_REGISTER_PARAM(TypeTag, int, NumJacobiBlocks,
+                             "Number of blocks to be created for the Block-Jacobi preconditioner.");
         EWOMS_REGISTER_PARAM(TypeTag, bool, OwnerCellsFirst,
                              "Order cells owned by rank before ghost/overlap cells.");
         EWOMS_REGISTER_PARAM(TypeTag, bool, SerialPartitioning,
@@ -235,6 +245,7 @@ public:
     {
         fileName_ = EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName);
         edgeWeightsMethod_   = Dune::EdgeWeightMethod(EWOMS_GET_PARAM(TypeTag, int, EdgeWeightsMethod));
+        numJacobiBlocks_ = EWOMS_GET_PARAM(TypeTag, int, NumJacobiBlocks);
         ownersFirst_ = EWOMS_GET_PARAM(TypeTag, bool, OwnerCellsFirst);
         serialPartitioning_ = EWOMS_GET_PARAM(TypeTag, bool, SerialPartitioning);
         zoltanImbalanceTol_ = EWOMS_GET_PARAM(TypeTag, double, ZoltanImbalanceTol);

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -192,7 +192,6 @@ protected:
     }
 
     std::unique_ptr<TransmissibilityType> globalTrans_;
-    //std::vector<int> cell_part_;
 };
 
 } // namespace Opm

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -136,7 +136,7 @@ public:
                              this->serialPartitioning(), this->enableDistributedWells(),
                              this->zoltanImbalanceTol(), this->gridView(),
                              this->schedule(), this->centroids_,
-                             this->eclState(), this->parallelWells_);
+                             this->eclState(), this->parallelWells_, this->numJacobiBlocks());
 #endif
 
         this->updateGridView_();
@@ -192,6 +192,7 @@ protected:
     }
 
     std::unique_ptr<TransmissibilityType> globalTrans_;
+    //std::vector<int> cell_part_;
 };
 
 } // namespace Opm

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -87,7 +87,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doLoadBalance_(Dun
 {
     int mpiSize = 1;
     MPI_Comm_size(grid_->comm(), &mpiSize);
-    
+
     if (mpiSize > 1 || numJacobiBlocks > 0) {
         // the CpGrid's loadBalance() method likes to have the transmissibilities as
         // its edge weights. since this is (kind of) a layering violation and
@@ -181,6 +181,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doLoadBalance_(Dun
         // cells that exist only on other ranks even in the case of distributed wells
         // But we need all connections to figure out the first cell of a well (e.g. for
         // pressure). Hence this is now skipped. Rank 0 had everything even before.
+
         if (numJacobiBlocks > 0 && mpiSize == 1) {
             const auto wells = schedule.getWellsatEnd();
             cell_part_.resize(grid_->numCells());

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -88,7 +88,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doLoadBalance_(Dun
     int mpiSize = 1;
     MPI_Comm_size(grid_->comm(), &mpiSize);
 
-    if (mpiSize > 1 || numJacobiBlocks > 0) {
+    if (mpiSize > 1 || numJacobiBlocks > 1) {
         // the CpGrid's loadBalance() method likes to have the transmissibilities as
         // its edge weights. since this is (kind of) a layering violation and
         // transmissibilities are relatively expensive to compute, we only do it if
@@ -182,7 +182,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doLoadBalance_(Dun
         // But we need all connections to figure out the first cell of a well (e.g. for
         // pressure). Hence this is now skipped. Rank 0 had everything even before.
 
-        if (numJacobiBlocks > 0 && mpiSize == 1) {
+        if (numJacobiBlocks > 1 && mpiSize == 1) {
             const auto wells = schedule.getWellsatEnd();
             cell_part_.resize(grid_->numCells());
             cell_part_ = grid_->zoltanPartitionWithoutScatter(&wells, faceTrans.data(), numJacobiBlocks, zoltanImbalanceTol);

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -82,12 +82,13 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doLoadBalance_(Dun
                                                                              const Schedule& schedule,
                                                                              std::vector<double>& centroids,
                                                                              EclipseState& eclState1,
-                                                                             EclGenericVanguard::ParallelWellStruct& parallelWells)
+                                                                             EclGenericVanguard::ParallelWellStruct& parallelWells,
+                                                                             int numJacobiBlocks)
 {
     int mpiSize = 1;
     MPI_Comm_size(grid_->comm(), &mpiSize);
-
-    if (mpiSize > 1) {
+    
+    if (mpiSize > 1 || numJacobiBlocks > 0) {
         // the CpGrid's loadBalance() method likes to have the transmissibilities as
         // its edge weights. since this is (kind of) a layering violation and
         // transmissibilities are relatively expensive to compute, we only do it if
@@ -131,53 +132,60 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doLoadBalance_(Dun
         }
 
         //distribute the grid and switch to the distributed view.
-        {
-            const auto wells = schedule.getWellsatEnd();
-
-            try
+        if (mpiSize > 1) {
             {
-                auto& eclState = dynamic_cast<ParallelEclipseState&>(eclState1);
-                const EclipseGrid* eclGrid = nullptr;
+                const auto wells = schedule.getWellsatEnd();
 
-                if (grid_->comm().rank() == 0)
+                try
                 {
-                    eclGrid = &eclState.getInputGrid();
-                }
+                    auto& eclState = dynamic_cast<ParallelEclipseState&>(eclState1);
+                    const EclipseGrid* eclGrid = nullptr;
 
-                PropsCentroidsDataHandle<Dune::CpGrid> handle(*grid_, eclState, eclGrid, centroids,
-                                                              cartesianIndexMapper());
-                if (loadBalancerSet)
-                {
-                    std::vector<int> parts;
                     if (grid_->comm().rank() == 0)
                     {
-                        parts =  (*externalLoadBalancer)(*grid_);
+                        eclGrid = &eclState.getInputGrid();
                     }
-                    parallelWells = std::get<1>(grid_->loadBalance(handle, parts, &wells, ownersFirst, false, 1));
-                }
-                else
-                {
-                    parallelWells =
-                        std::get<1>(grid_->loadBalance(handle, edgeWeightsMethod, &wells, serialPartitioning,
-                                                       faceTrans.data(), ownersFirst, false, 1, true, zoltanImbalanceTol,
-                                                       enableDistributedWells));
-                }
-            }
-            catch(const std::bad_cast& e)
-            {
-                std::ostringstream message;
-                message << "Parallel simulator setup is incorrect as it does not use ParallelEclipseState ("
-                        << e.what() <<")"<<std::flush;
-                OpmLog::error(message.str());
-                std::rethrow_exception(std::current_exception());
-            }
-        }
-        grid_->switchToDistributedView();
 
+                    PropsCentroidsDataHandle<Dune::CpGrid> handle(*grid_, eclState, eclGrid, centroids,
+                                                                  cartesianIndexMapper());
+                    if (loadBalancerSet)
+                    {
+                        std::vector<int> parts;
+                        if (grid_->comm().rank() == 0)
+                        {
+                         parts =  (*externalLoadBalancer)(*grid_);
+                        }
+                        parallelWells = std::get<1>(grid_->loadBalance(handle, parts, &wells, ownersFirst, false, 1));
+                    }
+                    else
+                    {
+                        parallelWells =
+                            std::get<1>(grid_->loadBalance(handle, edgeWeightsMethod, &wells, serialPartitioning,
+                                                           faceTrans.data(), ownersFirst, false, 1, true, zoltanImbalanceTol,
+                                                           enableDistributedWells));
+                    }
+                }
+                catch(const std::bad_cast& e)
+                {
+                    std::ostringstream message;
+                    message << "Parallel simulator setup is incorrect as it does not use ParallelEclipseState ("
+                            << e.what() <<")"<<std::flush;
+                    OpmLog::error(message.str());
+                    std::rethrow_exception(std::current_exception());
+                }
+            }
+            grid_->switchToDistributedView();
+        }
+        
         // Calling Schedule::filterConnections would remove any perforated
         // cells that exist only on other ranks even in the case of distributed wells
         // But we need all connections to figure out the first cell of a well (e.g. for
         // pressure). Hence this is now skipped. Rank 0 had everything even before.
+        if (numJacobiBlocks > 0 && mpiSize == 1) {
+            const auto wells = schedule.getWellsatEnd();
+            cell_part_.resize(grid_->numCells());
+            cell_part_ = grid_->zoltanPartitionWithoutScatter(&wells, faceTrans.data(), numJacobiBlocks, zoltanImbalanceTol);
+        }
     }
 }
 

--- a/ebos/eclgenericcpgridvanguard.hh
+++ b/ebos/eclgenericcpgridvanguard.hh
@@ -101,6 +101,10 @@ public:
      */
     const CartesianIndexMapper& equilCartesianIndexMapper() const;
 
+    std::vector<int> cellPartition() const
+    {
+        return cell_part_;
+    }
 protected:
     /*!
      * \brief Distribute the simulation grid over multiple processes
@@ -114,7 +118,8 @@ protected:
                         const GridView& gridv, const Schedule& schedule,
                         std::vector<double>& centroids,
                         EclipseState& eclState,
-                        EclGenericVanguard::ParallelWellStruct& parallelWells);
+                        EclGenericVanguard::ParallelWellStruct& parallelWells,
+                        int numJacobiBlocks);
 
     void distributeFieldProps_(EclipseState& eclState);
 #endif
@@ -137,6 +142,7 @@ protected:
     std::unique_ptr<CartesianIndexMapper> equilCartesianIndexMapper_;
 
     int mpiRank;
+    std::vector<int> cell_part_;
 };
 
 } // namespace Opm

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -250,6 +250,12 @@ public:
     { return edgeWeightsMethod_; }
 
     /*!
+     * \brief Number of blocks in the Block-Jacobi preconditioner.
+     */
+    int numJacobiBlocks() const
+    { return numJacobiBlocks_; }
+
+    /*!
      * \brief Parameter that decide if cells owned by rank are ordered before ghost cells.
      */
     bool ownersFirst() const
@@ -323,6 +329,7 @@ protected:
     std::string caseName_;
     std::string fileName_;
     Dune::EdgeWeightMethod edgeWeightsMethod_;
+    int numJacobiBlocks_;
     bool ownersFirst_;
     bool serialPartitioning_;
     double zoltanImbalanceTol_;

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -272,7 +272,7 @@ namespace Opm
             if (use_gpu || use_fpga) {
                 const std::string accelerator_mode = EWOMS_GET_PARAM(TypeTag, std::string, AcceleratorMode);
                 auto wellContribs = WellContributions::create(accelerator_mode, useWellConn_);
-                bdaBridge->initWellContributions(*wellContribs);
+                bdaBridge->initWellContributions(*wellContribs, x.N() * x[0].N());
 
                 // the WellContributions can only be applied separately with CUDA or OpenCL, not with an FPGA or amgcl
 #if HAVE_CUDA || HAVE_OPENCL

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -574,13 +574,18 @@ namespace Opm
             blockJacobiForGPUILU0_->endindices();
         }
 
-        void copyMatToBlockJac(Matrix& mat, Matrix& blockJac)
+        void copyMatToBlockJac(const Matrix& mat, Matrix& blockJac)
         {
             auto rbegin = blockJac.begin();
             auto rend = blockJac.end();
-            for (auto row = rbegin; row != rend; ++row) {
+            auto outerRow = mat.begin();
+            for (auto row = rbegin; row != rend; ++row, ++outerRow) {
+                auto outerCol = (*outerRow).begin();
                 for (auto col = (*row).begin(); col != (*row).end(); ++col) {
-                    blockJac[row.index()][col.index()] = mat[row.index()][col.index()];
+                    // outerRow is guaranteed to have all column entries that row has!
+                    while(outerCol.index() < col.index()) ++outerCol;
+                    assert(outerCol.index() == col.index());
+                    *col = *outerCol; // copy nonzero block
                 }
             }
         }

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -161,15 +161,15 @@ namespace Opm
             // Set it up manually
             ElementMapper elemMapper(simulator_.vanguard().gridView(), Dune::mcmgElementLayout());
             detail::findOverlapAndInterior(simulator_.vanguard().grid(), elemMapper, overlapRows_, interiorRows_);
-	    numJacobiBlocks_ = EWOMS_GET_PARAM(TypeTag, int, NumJacobiBlocks);
-	    useWellConn_ = EWOMS_GET_PARAM(TypeTag, bool, MatrixAddWellContributions);
-	    if (numJacobiBlocks_ > 1) {
-		const auto wellsForConn = simulator_.vanguard().schedule().getWellsatEnd();
-		detail::setWellConnections(simulator_.vanguard().grid(), wellsForConn, useWellConn_,
-					   wellConnectionsGraph_, numJacobiBlocks_);
-		std::cout << "Create block-Jacobi pattern" << std::endl;
-		blockJacobiAdjacency();
-	    }
+            numJacobiBlocks_ = EWOMS_GET_PARAM(TypeTag, int, NumJacobiBlocks);
+            useWellConn_ = EWOMS_GET_PARAM(TypeTag, bool, MatrixAddWellContributions);
+            if (numJacobiBlocks_ > 1) {
+                const auto wellsForConn = simulator_.vanguard().schedule().getWellsatEnd();
+                detail::setWellConnections(simulator_.vanguard().grid(), wellsForConn, useWellConn_,
+                                           wellConnectionsGraph_, numJacobiBlocks_);
+                std::cout << "Create block-Jacobi pattern" << std::endl;
+                blockJacobiAdjacency();
+            }
             useWellConn_ = EWOMS_GET_PARAM(TypeTag, bool, MatrixAddWellContributions);
 #if HAVE_FPGA
             // check usage of MatrixAddWellContributions: for FPGA they must be included
@@ -281,15 +281,15 @@ namespace Opm
                 }
 #endif
 
-		if (numJacobiBlocks_ > 1) {
-		    copyMatToBlockJac(getMatrix(), *blockJacobiForGPUILU0_);
+                if (numJacobiBlocks_ > 1) {
+                    copyMatToBlockJac(getMatrix(), *blockJacobiForGPUILU0_);
                 // Const_cast needed since the CUDA stuff overwrites values for better matrix condition..
-		    bdaBridge->solve_system(const_cast<Matrix*>(&getMatrix()), &*blockJacobiForGPUILU0_,
-					    numJacobiBlocks_, *rhs_, *wellContribs, result);
-		}
-		else
-		    bdaBridge->solve_system(const_cast<Matrix*>(&getMatrix()), const_cast<Matrix*>(&getMatrix()),
-					    numJacobiBlocks_, *rhs_, *wellContribs, result);
+                    bdaBridge->solve_system(const_cast<Matrix*>(&getMatrix()), &*blockJacobiForGPUILU0_,
+                                            numJacobiBlocks_, *rhs_, *wellContribs, result);
+                }
+                else
+                    bdaBridge->solve_system(const_cast<Matrix*>(&getMatrix()), const_cast<Matrix*>(&getMatrix()),
+                                            numJacobiBlocks_, *rhs_, *wellContribs, result);
                 if (result.converged) {
                     // get result vector x from non-Dune backend, iff solve was successful
                     bdaBridge->get_result(x);
@@ -512,78 +512,78 @@ namespace Opm
                 }
         }
 
-	/// Create sparsity pattern for block-Jacobi matrix based on partitioning of grid.
-	void blockJacobiAdjacency()
-	{
-	    const auto& grid = simulator_.vanguard().grid();
-	    std::vector<int> cell_part = simulator_.vanguard().cellPartition();
+        /// Create sparsity pattern for block-Jacobi matrix based on partitioning of grid.
+        void blockJacobiAdjacency()
+        {
+            const auto& grid = simulator_.vanguard().grid();
+            std::vector<int> cell_part = simulator_.vanguard().cellPartition();
 
-	    typedef typename Matrix::size_type size_type;
-	    size_type numCells = grid.size( 0 );
-	    blockJacobiForGPUILU0_.reset(new Matrix(numCells, numCells, Matrix::random));
+            typedef typename Matrix::size_type size_type;
+            size_type numCells = grid.size( 0 );
+            blockJacobiForGPUILU0_.reset(new Matrix(numCells, numCells, Matrix::random));
 
-	    std::vector<std::set<size_type>> pattern;
-	    pattern.resize(numCells);
+            std::vector<std::set<size_type>> pattern;
+            pattern.resize(numCells);
 
-	    const auto& lid = grid.localIdSet();
-	    const auto& gridView = grid.leafGridView();
-	    auto elemIt = gridView.template begin<0>();
-	    const auto& elemEndIt = gridView.template end<0>();
+            const auto& lid = grid.localIdSet();
+            const auto& gridView = grid.leafGridView();
+            auto elemIt = gridView.template begin<0>();
+            const auto& elemEndIt = gridView.template end<0>();
 
-	    //Loop over cells
-	    for (; elemIt != elemEndIt; ++elemIt)
+            //Loop over cells
+            for (; elemIt != elemEndIt; ++elemIt)
             {
 
-		const auto& elem = *elemIt;
-		size_type idx = lid.id(elem);
-		pattern[idx].insert(idx);
+                const auto& elem = *elemIt;
+                size_type idx = lid.id(elem);
+                pattern[idx].insert(idx);
 
-		// Add well non-zero connections
-		for (auto wc = wellConnectionsGraph_[idx].begin(); wc!=wellConnectionsGraph_[idx].end(); ++wc)
-		    pattern[idx].insert(*wc);
+                // Add well non-zero connections
+                for (auto wc = wellConnectionsGraph_[idx].begin(); wc!=wellConnectionsGraph_[idx].end(); ++wc)
+                    pattern[idx].insert(*wc);
 
-		int locPart = cell_part[idx];
+                int locPart = cell_part[idx];
 
-		//Add neighbor if it is on the same part
-		auto isend = gridView.iend(elem);
-		for (auto is = gridView.ibegin(elem); is!=isend; ++is)
+                //Add neighbor if it is on the same part
+                auto isend = gridView.iend(elem);
+                for (auto is = gridView.ibegin(elem); is!=isend; ++is)
                 {
-		    //check if face has neighbor
-		    if (is->neighbor())
+                    //check if face has neighbor
+                    if (is->neighbor())
                     {
-			size_type nid = lid.id(is->outside());
-			int nabPart = cell_part[nid];
-			if (locPart == nabPart) 
-			    pattern[idx].insert(nid);
-		    }
+                        size_type nid = lid.id(is->outside());
+                        int nabPart = cell_part[nid];
+                        if (locPart == nabPart) 
+                            pattern[idx].insert(nid);
+                    }
 
-		    blockJacobiForGPUILU0_->setrowsize(idx, pattern[idx].size());
-		}
-	    }
-	    blockJacobiForGPUILU0_->endrowsizes();
-	    for (size_type dofId = 0; dofId < numCells; ++dofId)
-	    {
-		auto nabIdx = pattern[dofId].begin();
-		auto endNab = pattern[dofId].end();
-		for (; nabIdx != endNab; ++nabIdx)
-		{
-		    blockJacobiForGPUILU0_->addindex(dofId, *nabIdx);
-		}
-	    }
+                    blockJacobiForGPUILU0_->setrowsize(idx, pattern[idx].size());
+                }
+            }
+            blockJacobiForGPUILU0_->endrowsizes();
+            for (size_type dofId = 0; dofId < numCells; ++dofId)
+            {
+                auto nabIdx = pattern[dofId].begin();
+                auto endNab = pattern[dofId].end();
+                for (; nabIdx != endNab; ++nabIdx)
+                {
+                    blockJacobiForGPUILU0_->addindex(dofId, *nabIdx);
+                }
+            }
 
-	    blockJacobiForGPUILU0_->endindices();
-	}
+            blockJacobiForGPUILU0_->endindices();
+        }
 
-	void copyMatToBlockJac(Matrix& mat, Matrix& blockJac)
-	{
-	    auto rbegin = blockJac.begin();
-	    auto rend = blockJac.end();
-	    for (auto row = rbegin; row != rend; ++row) {
-		for (auto col = (*row).begin(); col != (*row).end(); ++col) {
-		    blockJac[row.index()][col.index()] = mat[row.index()][col.index()];
-		}
-	    }
-	}
+        void copyMatToBlockJac(Matrix& mat, Matrix& blockJac)
+        {
+            auto rbegin = blockJac.begin();
+            auto rend = blockJac.end();
+            for (auto row = rbegin; row != rend; ++row) {
+                for (auto col = (*row).begin(); col != (*row).end(); ++col) {
+                    blockJac[row.index()][col.index()] = mat[row.index()][col.index()];
+                }
+            }
+        }
 
         Matrix& getMatrix()
         {
@@ -619,7 +619,7 @@ namespace Opm
         FlowLinearSolverParameters parameters_;
         PropertyTree prm_;
         bool scale_variables_;
-	int numJacobiBlocks_;
+        int numJacobiBlocks_;
 
         std::shared_ptr< CommunicationType > comm_;
     }; // end ISTLSolver

--- a/opm/simulators/linalg/bda/BdaBridge.cpp
+++ b/opm/simulators/linalg/bda/BdaBridge.cpp
@@ -285,7 +285,8 @@ void BdaBridge<BridgeMatrix, BridgeVector, block_size>::get_result([[maybe_unuse
 }
 
 template <class BridgeMatrix, class BridgeVector, int block_size>
-void BdaBridge<BridgeMatrix, BridgeVector, block_size>::initWellContributions([[maybe_unused]] WellContributions& wellContribs) {
+void BdaBridge<BridgeMatrix, BridgeVector, block_size>::initWellContributions([[maybe_unused]] WellContributions& wellContribs,
+                                                                              [[maybe_unused]] unsigned N) {
     if(accelerator_mode.compare("opencl") == 0){
 #if HAVE_OPENCL
         const auto openclBackend = static_cast<const Opm::Accelerator::openclSolverBackend<block_size>*>(backend.get());
@@ -294,6 +295,7 @@ void BdaBridge<BridgeMatrix, BridgeVector, block_size>::initWellContributions([[
         OPM_THROW(std::logic_error, "Error openclSolver was chosen, but OpenCL was not found by CMake");
 #endif
     }
+    wellContribs.setVectorSize(N);
 }
 
 // the tests use Dune::FieldMatrix, Flow uses Opm::MatrixBlock

--- a/opm/simulators/linalg/bda/BdaBridge.cpp
+++ b/opm/simulators/linalg/bda/BdaBridge.cpp
@@ -245,7 +245,7 @@ void BdaBridge<BridgeMatrix, BridgeVector, block_size>::solve_system([[maybe_unu
             static std::vector<int> bm_h_cols;
             const int bm_nnzb = (bm_h_rows.empty()) ? blockMat->nonzeroes() : bm_h_rows.back();
             const int bm_nnz = bm_nnzb * dim * dim;
-            
+
             if (bm_h_rows.capacity() == 0) {
                 bm_h_rows.reserve(Nb+1);
                 bm_h_cols.reserve(bm_nnzb);
@@ -258,7 +258,6 @@ void BdaBridge<BridgeMatrix, BridgeVector, block_size>::solve_system([[maybe_unu
                 out << "Checking zeros took: " << t_zeros.stop() << " s, found " << numZeros << " zeros";
                 OpmLog::info(out.str());
             }
-            
             status = backend->solve_system2(N, nnz, dim, static_cast<double*>(&(((*mat)[0][0][0][0]))), h_rows.data(), h_cols.data(), static_cast<double*>(&(b[0][0])),
                                             bm_nnz, static_cast<double*>(&(((*blockMat)[0][0][0][0]))), bm_h_rows.data(), bm_h_cols.data(),
                                             wellContribs, result);

--- a/opm/simulators/linalg/bda/BdaBridge.cpp
+++ b/opm/simulators/linalg/bda/BdaBridge.cpp
@@ -193,6 +193,8 @@ void BdaBridge<BridgeMatrix, BridgeVector, block_size>::copySparsityPatternFromI
 
 template <class BridgeMatrix, class BridgeVector, int block_size>
 void BdaBridge<BridgeMatrix, BridgeVector, block_size>::solve_system([[maybe_unused]] BridgeMatrix* mat,
+                                                                     [[maybe_unused]] BridgeMatrix* blockMat,
+                                                                     [[maybe_unused]] int numJacobiBlocks,
                                                                      [[maybe_unused]] BridgeVector& b,
                                                                      [[maybe_unused]] WellContributions& wellContribs,
                                                                      [[maybe_unused]] InverseOperatorResult& res)
@@ -209,6 +211,11 @@ void BdaBridge<BridgeMatrix, BridgeVector, block_size>::solve_system([[maybe_unu
         const int nnzb = (h_rows.empty()) ? mat->nonzeroes() : h_rows.back();
         const int nnz = nnzb * dim * dim;
 
+        static std::vector<int> bm_h_rows;
+        static std::vector<int> bm_h_cols;
+        const int bm_nnzb = (bm_h_rows.empty()) ? blockMat->nonzeroes() : bm_h_rows.back();
+        const int bm_nnz = bm_nnzb * dim * dim;
+        
         if (dim != 3) {
             OpmLog::warning("BdaSolver only accepts blocksize = 3 at this time, will use Dune for the remainder of the program");
             use_gpu = use_fpga = false;
@@ -221,8 +228,15 @@ void BdaBridge<BridgeMatrix, BridgeVector, block_size>::solve_system([[maybe_unu
             copySparsityPatternFromISTL(*mat, h_rows, h_cols);
         }
 
+        if (bm_h_rows.capacity() == 0) {
+            bm_h_rows.reserve(Nb+1);
+            bm_h_cols.reserve(bm_nnzb);
+            copySparsityPatternFromISTL(*blockMat, bm_h_rows, bm_h_cols);
+        }
+
         Dune::Timer t_zeros;
         int numZeros = checkZeroDiagonal(*mat);
+        int bm_numZeros = checkZeroDiagonal(*blockMat);
         if (verbosity >= 2) {
             std::ostringstream out;
             out << "Checking zeros took: " << t_zeros.stop() << " s, found " << numZeros << " zeros";
@@ -232,9 +246,17 @@ void BdaBridge<BridgeMatrix, BridgeVector, block_size>::solve_system([[maybe_unu
 
         /////////////////////////
         // actually solve
+        SolverStatus status; 
+        if (numJacobiBlocks > 1)
+            status = backend->solve_system2(N, nnz, dim, static_cast<double*>(&(((*mat)[0][0][0][0]))), h_rows.data(), h_cols.data(), static_cast<double*>(&(b[0][0])),
+                                            bm_nnz, static_cast<double*>(&(((*blockMat)[0][0][0][0]))), bm_h_rows.data(), bm_h_cols.data(),
+                                            wellContribs, result);
+        else
+            status = backend->solve_system(N, nnz, dim, static_cast<double*>(&(((*mat)[0][0][0][0]))), h_rows.data(), h_cols.data(), static_cast<double*>(&(b[0][0])), wellContribs, result);
 
+            
         // assume that underlying data (nonzeroes) from mat (Dune::BCRSMatrix) are contiguous, if this is not the case, the chosen BdaSolver is expected to perform undefined behaviour
-        SolverStatus status = backend->solve_system(N, nnz, dim, static_cast<double*>(&(((*mat)[0][0][0][0]))), h_rows.data(), h_cols.data(), static_cast<double*>(&(b[0][0])), wellContribs, result);
+        //SolverStatus status = backend->solve_system(N, nnz, dim, static_cast<double*>(&(((*mat)[0][0][0][0]))), h_rows.data(), h_cols.data(), static_cast<double*>(&(b[0][0])), wellContribs, result);
         switch(status) {
         case SolverStatus::BDA_SOLVER_SUCCESS:
             //OpmLog::info("BdaSolver converged");

--- a/opm/simulators/linalg/bda/BdaBridge.cpp
+++ b/opm/simulators/linalg/bda/BdaBridge.cpp
@@ -192,8 +192,8 @@ void BdaBridge<BridgeMatrix, BridgeVector, block_size>::copySparsityPatternFromI
 
 
 template <class BridgeMatrix, class BridgeVector, int block_size>
-void BdaBridge<BridgeMatrix, BridgeVector, block_size>::solve_system([[maybe_unused]] BridgeMatrix* mat,
-                                                                     [[maybe_unused]] BridgeMatrix* blockMat,
+void BdaBridge<BridgeMatrix, BridgeVector, block_size>::solve_system([[maybe_unused]] BridgeMatrix* bridgeMat,
+                                                                     [[maybe_unused]] BridgeMatrix* jacMat,
                                                                      [[maybe_unused]] int numJacobiBlocks,
                                                                      [[maybe_unused]] BridgeVector& b,
                                                                      [[maybe_unused]] WellContributions& wellContribs,
@@ -203,12 +203,10 @@ void BdaBridge<BridgeMatrix, BridgeVector, block_size>::solve_system([[maybe_unu
     if (use_gpu || use_fpga) {
         BdaResult result;
         result.converged = false;
-        static std::vector<int> h_rows;
-        static std::vector<int> h_cols;
-        const int dim = (*mat)[0][0].N();
-        const int Nb = mat->N();
+        const int dim = (*bridgeMat)[0][0].N();
+        const int Nb = bridgeMat->N();
         const int N = Nb * dim;
-        const int nnzb = (h_rows.empty()) ? mat->nonzeroes() : h_rows.back();
+        const int nnzb = bridgeMat->nonzeroes();
         const int nnz = nnzb * dim * dim;
 
         if (dim != 3) {
@@ -217,15 +215,16 @@ void BdaBridge<BridgeMatrix, BridgeVector, block_size>::solve_system([[maybe_unu
             return;
         }
 
-        if (h_rows.capacity() == 0) {
+        if (!matrix) {
             h_rows.reserve(Nb+1);
             h_cols.reserve(nnzb);
-            copySparsityPatternFromISTL(*mat, h_rows, h_cols);
+            copySparsityPatternFromISTL(*bridgeMat, h_rows, h_cols);
+            // assume that underlying data (nonzeroes) from mat (Dune::BCRSMatrix) are contiguous, if this is not the case, the chosen BdaSolver is expected to perform undefined behaviour
+            matrix = std::make_unique<Opm::Accelerator::BlockedMatrix>(Nb, nnzb, block_size, static_cast<double*>(&(((*bridgeMat)[0][0][0][0]))), h_cols.data(), h_rows.data());
         }
 
         Dune::Timer t_zeros;
-        int numZeros = checkZeroDiagonal(*mat);
-
+        int numZeros = checkZeroDiagonal(*bridgeMat);
         if (verbosity >= 2) {
             std::ostringstream out;
             out << "Checking zeros took: " << t_zeros.stop() << " s, found " << numZeros << " zeros";
@@ -238,28 +237,27 @@ void BdaBridge<BridgeMatrix, BridgeVector, block_size>::solve_system([[maybe_unu
         SolverStatus status; 
         if (numJacobiBlocks < 2) {
             // assume that underlying data (nonzeroes) from mat (Dune::BCRSMatrix) are contiguous, if this is not the case, the chosen BdaSolver is expected to perform undefined behaviour
-            status = backend->solve_system(N, nnz, dim, static_cast<double*>(&(((*mat)[0][0][0][0]))), h_rows.data(), h_cols.data(), static_cast<double*>(&(b[0][0])), wellContribs, result);
-        }
-        else {
-            static std::vector<int> bm_h_rows;
-            static std::vector<int> bm_h_cols;
-            const int bm_nnzb = (bm_h_rows.empty()) ? blockMat->nonzeroes() : bm_h_rows.back();
-            const int bm_nnz = bm_nnzb * dim * dim;
+            status = backend->solve_system(N, nnz, dim, static_cast<double*>(&(((*bridgeMat)[0][0][0][0]))), h_rows.data(), h_cols.data(), static_cast<double*>(&(b[0][0])), wellContribs, result);
+        } else {
+            const int jacNnzb = (h_jacRows.empty()) ? jacMat->nonzeroes() : h_jacRows.back();
+            const int jacNnz = jacNnzb * dim * dim;
 
-            if (bm_h_rows.capacity() == 0) {
-                bm_h_rows.reserve(Nb+1);
-                bm_h_cols.reserve(bm_nnzb);
-                copySparsityPatternFromISTL(*blockMat, bm_h_rows, bm_h_cols);
+            if (!jacMatrix) {
+                h_jacRows.reserve(Nb+1);
+                h_jacCols.reserve(jacNnzb);
+                copySparsityPatternFromISTL(*jacMat, h_jacRows, h_jacCols);
+                jacMatrix = std::make_unique<Opm::Accelerator::BlockedMatrix>(Nb, jacNnzb, block_size, static_cast<double*>(&(((*jacMat)[0][0][0][0]))), h_jacCols.data(), h_jacRows.data());
             }
 
-            int bm_numZeros = checkZeroDiagonal(*blockMat);
+            Dune::Timer t_zeros2;
+            int jacNumZeros = checkZeroDiagonal(*jacMat);
             if (verbosity >= 2) {
                 std::ostringstream out;
-                out << "Checking zeros took: " << t_zeros.stop() << " s, found " << numZeros << " zeros";
+                out << "Checking zeros for jacMat took: " << t_zeros2.stop() << " s, found " << jacNumZeros << " zeros";
                 OpmLog::info(out.str());
             }
-            status = backend->solve_system2(N, nnz, dim, static_cast<double*>(&(((*mat)[0][0][0][0]))), h_rows.data(), h_cols.data(), static_cast<double*>(&(b[0][0])),
-                                            bm_nnz, static_cast<double*>(&(((*blockMat)[0][0][0][0]))), bm_h_rows.data(), bm_h_cols.data(),
+            status = backend->solve_system2(N, nnz, dim, static_cast<double*>(&(((*bridgeMat)[0][0][0][0]))), h_rows.data(), h_cols.data(), static_cast<double*>(&(b[0][0])),
+                                            jacNnz, static_cast<double*>(&(((*jacMat)[0][0][0][0]))), h_jacRows.data(), h_jacCols.data(),
                                             wellContribs, result);
         }
 

--- a/opm/simulators/linalg/bda/BdaBridge.hpp
+++ b/opm/simulators/linalg/bda/BdaBridge.hpp
@@ -65,7 +65,7 @@ public:
     /// \param[in] b            vector b, should be of type Dune::BlockVector
     /// \param[in] wellContribs contains all WellContributions, to apply them separately, instead of adding them to matrix A
     /// \param[inout] result    summary of solver result
-    void solve_system(BridgeMatrix *mat, BridgeVector &b, WellContributions& wellContribs, InverseOperatorResult &result);
+    void solve_system(BridgeMatrix *mat, BridgeMatrix *blockMat, int numJacobiBlocks, BridgeVector &b, WellContributions& wellContribs, InverseOperatorResult &result);
 
     /// Get the resulting x vector
     /// \param[inout] x    vector x, should be of type Dune::BlockVector

--- a/opm/simulators/linalg/bda/BdaBridge.hpp
+++ b/opm/simulators/linalg/bda/BdaBridge.hpp
@@ -93,7 +93,8 @@ public:
     /// Initialize the WellContributions object with opencl context and queue
     /// those must be set before calling BlackOilWellModel::getWellContributions() in ISTL
     /// \param[in] wellContribs   container to hold all WellContributions
-    void initWellContributions(WellContributions& wellContribs);
+    /// \param[in] N              number of rows in scalar vector that wellContribs will be applied on
+    void initWellContributions(WellContributions& wellContribs, unsigned N);
 
     /// Return whether the BdaBridge will use the FPGA or not
     /// return whether the BdaBridge will use the FPGA or not

--- a/opm/simulators/linalg/bda/BdaSolver.hpp
+++ b/opm/simulators/linalg/bda/BdaSolver.hpp
@@ -86,12 +86,8 @@ namespace Accelerator {
         virtual ~BdaSolver() {};
 
         /// Define as pure virtual functions, so derivedclass must implement them
-        virtual SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix,
-            double *b, WellContributions& wellContribs, BdaResult &res) = 0;
-
-        virtual SolverStatus solve_system2(std::shared_ptr<BlockedMatrix> matrix, double *b,
-                                           std::shared_ptr<BlockedMatrix> jacMatrix,
-                                           WellContributions& wellContribs, BdaResult &res) = 0;
+        virtual SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b,
+            std::shared_ptr<BlockedMatrix> jacMatrix, WellContributions& wellContribs, BdaResult &res) = 0;
 
         virtual void get_result(double *x) = 0;
 

--- a/opm/simulators/linalg/bda/BdaSolver.hpp
+++ b/opm/simulators/linalg/bda/BdaSolver.hpp
@@ -89,10 +89,10 @@ namespace Accelerator {
             double *vals, int *rows, int *cols,
             double *b, WellContributions& wellContribs, BdaResult &res) = 0;
 
-	virtual SolverStatus solve_system2(int N_, int nnz_, int dim,
-					   double *vals, int *rows, int *cols, double *b,
-					   int nnz2, double *vals2, int *rows2, int *cols2,
-					   WellContributions& wellContribs, BdaResult &res) = 0;
+        virtual SolverStatus solve_system2(int N_, int nnz_, int dim,
+                                           double *vals, int *rows, int *cols, double *b,
+                                           int nnz2, double *vals2, int *rows2, int *cols2,
+                                           WellContributions& wellContribs, BdaResult &res) = 0;
 
         virtual void get_result(double *x) = 0;
 

--- a/opm/simulators/linalg/bda/BdaSolver.hpp
+++ b/opm/simulators/linalg/bda/BdaSolver.hpp
@@ -89,6 +89,11 @@ namespace Accelerator {
             double *vals, int *rows, int *cols,
             double *b, WellContributions& wellContribs, BdaResult &res) = 0;
 
+	virtual SolverStatus solve_system2(int N_, int nnz_, int dim,
+					   double *vals, int *rows, int *cols, double *b,
+					   int nnz2, double *vals2, int *rows2, int *cols2,
+					   WellContributions& wellContribs, BdaResult &res) = 0;
+
         virtual void get_result(double *x) = 0;
 
     }; // end class BdaSolver

--- a/opm/simulators/linalg/bda/BdaSolver.hpp
+++ b/opm/simulators/linalg/bda/BdaSolver.hpp
@@ -22,6 +22,7 @@
 
 
 #include <opm/simulators/linalg/bda/BdaResult.hpp>
+#include <opm/simulators/linalg/bda/BlockedMatrix.hpp>
 
 #include <string>
 
@@ -85,13 +86,11 @@ namespace Accelerator {
         virtual ~BdaSolver() {};
 
         /// Define as pure virtual functions, so derivedclass must implement them
-        virtual SolverStatus solve_system(int N, int nnz, int dim,
-            double *vals, int *rows, int *cols,
+        virtual SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix,
             double *b, WellContributions& wellContribs, BdaResult &res) = 0;
 
-        virtual SolverStatus solve_system2(int N_, int nnz_, int dim,
-                                           double *vals, int *rows, int *cols, double *b,
-                                           int nnz2, double *vals2, int *rows2, int *cols2,
+        virtual SolverStatus solve_system2(std::shared_ptr<BlockedMatrix> matrix, double *b,
+                                           std::shared_ptr<BlockedMatrix> jacMatrix,
                                            WellContributions& wellContribs, BdaResult &res) = 0;
 
         virtual void get_result(double *x) = 0;

--- a/opm/simulators/linalg/bda/BlockedMatrix.cpp
+++ b/opm/simulators/linalg/bda/BlockedMatrix.cpp
@@ -37,14 +37,12 @@ namespace Accelerator
 
 using Opm::OpmLog;
 
-/*Sort a row of matrix elements from a blocked CSR-format.*/
 
-void sortBlockedRow(int *colIndices, double *data, int left, int right, unsigned block_size) {
-    const unsigned int bs = block_size;
+
+void sortRow(int *colIndices, int *data, int left, int right) {
     int l = left;
     int r = right;
     int middle = colIndices[(l + r) >> 1];
-    double lDatum[bs * bs];
     do {
         while (colIndices[l] < middle)
             l++;
@@ -54,9 +52,9 @@ void sortBlockedRow(int *colIndices, double *data, int left, int right, unsigned
             int lColIndex = colIndices[l];
             colIndices[l] = colIndices[r];
             colIndices[r] = lColIndex;
-            memcpy(lDatum, data + l * bs * bs, sizeof(double) * bs * bs);
-            memcpy(data + l * bs * bs, data + r * bs * bs, sizeof(double) * bs * bs);
-            memcpy(data + r * bs * bs, lDatum, sizeof(double) * bs * bs);
+            int tmp = data[l];
+            data[l] = data[r];
+            data[r] = tmp;
 
             l++;
             r--;
@@ -64,10 +62,10 @@ void sortBlockedRow(int *colIndices, double *data, int left, int right, unsigned
     } while (l < r);
 
     if (left < r)
-        sortBlockedRow(colIndices, data, left, r, bs);
+        sortRow(colIndices, data, left, r);
 
     if (right > l)
-        sortBlockedRow(colIndices, data, l, right, bs);
+        sortRow(colIndices, data, l, right);
 }
 
 

--- a/opm/simulators/linalg/bda/BlockedMatrix.hpp
+++ b/opm/simulators/linalg/bda/BlockedMatrix.hpp
@@ -127,13 +127,13 @@ public:
 };
 
 
-/// Sort a row of matrix elements from a blocked CSR-format
-/// \param[inout] colIndices     
-/// \param[inout] data           
+/// Sort a row of matrix elements from a CSR-format, where the nonzeroes are ints
+/// These ints aren't actually nonzeroes, but represent a mapping used later
+/// \param[inout] colIndices     represent keys in sorting
+/// \param[inout] data           sorted according to the colIndices
 /// \param[in] left              lower index of data of row
 /// \param[in] right             upper index of data of row
-/// \param[in] block_size        size of blocks in the row
-void sortBlockedRow(int *colIndices, double *data, int left, int right, unsigned block_size);
+void sortRow(int *colIndices, int *data, int left, int right);
 
 /// Multiply and subtract blocks
 /// a = a - (b * c)

--- a/opm/simulators/linalg/bda/FPGASolverBackend.cpp
+++ b/opm/simulators/linalg/bda/FPGASolverBackend.cpp
@@ -225,7 +225,11 @@ void FpgaSolverBackend<block_size>::get_result(double *x_)
 
 
 template <unsigned int block_size>
-SolverStatus FpgaSolverBackend<block_size>::solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b, WellContributions&, BdaResult &res)
+SolverStatus FpgaSolverBackend<block_size>::solve_system(std::shared_ptr<BlockedMatrix> matrix,
+                                                         double *b,
+                                                         [[maybe_unused]] std::shared_ptr<BlockedMatrix> jacMatrix,
+                                                         WellContributions&,
+                                                         BdaResult &res)
 {
     if (initialized == false) {
         initialize(matrix->Nb, matrix->nnzbzs, matrix->nnzValues, matrix->rowPointers, matrix->colIndices);
@@ -250,15 +254,6 @@ SolverStatus FpgaSolverBackend<block_size>::solve_system(std::shared_ptr<Blocked
     return SolverStatus::BDA_SOLVER_SUCCESS;
 }
 
-template <unsigned int block_size>
-SolverStatus FpgaSolverBackend<block_size>::solve_system2(std::shared_ptr<BlockedMatrix> matrix,
-                                                          double *b,
-                                                          [[maybe_unused]] std::shared_ptr<BlockedMatrix> jacMatrix,
-                                                          WellContributions& wellContribs,
-                                                          BdaResult &res)
-{
-    return solve_system(matrix, b, wellContribs, res);
-}
 
 template <unsigned int block_size>
 void FpgaSolverBackend<block_size>::initialize(int Nb_, int nnzbs, double *vals, int *rows, int *cols)

--- a/opm/simulators/linalg/bda/FPGASolverBackend.cpp
+++ b/opm/simulators/linalg/bda/FPGASolverBackend.cpp
@@ -252,9 +252,9 @@ SolverStatus FpgaSolverBackend<block_size>::solve_system(int N_, int nnz_, int d
 
 template <unsigned int block_size>
 SolverStatus FpgaSolverBackend<block_size>::solve_system2(int N_, int nnz_, int dim,
-					   double *vals, int *rows, int *cols, double *b,
-					   int nnz2, double *vals2, int *rows2, int *cols2,
-					   WellContributions& wellContribs, BdaResult &res)
+                                           double *vals, int *rows, int *cols, double *b,
+                                           int nnz2, double *vals2, int *rows2, int *cols2,
+                                           WellContributions& wellContribs, BdaResult &res)
 {
     (void) nnz2; (void) vals2; (void) rows2; (void) cols2;
     return solve_system(N_, nnz_, dim, vals, rows, cols, b, wellContribs, res);

--- a/opm/simulators/linalg/bda/FPGASolverBackend.cpp
+++ b/opm/simulators/linalg/bda/FPGASolverBackend.cpp
@@ -223,6 +223,7 @@ void FpgaSolverBackend<block_size>::get_result(double *x_)
     }
 } // end get_result()
 
+
 template <unsigned int block_size>
 SolverStatus FpgaSolverBackend<block_size>::solve_system(int N_, int nnz_, int dim, double *vals, int *rows, int *cols, double *b, WellContributions&, BdaResult &res)
 {
@@ -255,7 +256,8 @@ SolverStatus FpgaSolverBackend<block_size>::solve_system2(int N_, int nnz_, int 
 					   int nnz2, double *vals2, int *rows2, int *cols2,
 					   WellContributions& wellContribs, BdaResult &res)
 {
-    return SolverStatus::BDA_SOLVER_ANALYSIS_FAILED;
+    (void) nnz2; (void) vals2; (void) rows2; (void) cols2;
+    return solve_system(N_, nnz_, dim, vals, rows, cols, b, wellContribs, res);
 }
 
 template <unsigned int block_size>

--- a/opm/simulators/linalg/bda/FPGASolverBackend.cpp
+++ b/opm/simulators/linalg/bda/FPGASolverBackend.cpp
@@ -223,7 +223,6 @@ void FpgaSolverBackend<block_size>::get_result(double *x_)
     }
 } // end get_result()
 
-
 template <unsigned int block_size>
 SolverStatus FpgaSolverBackend<block_size>::solve_system(int N_, int nnz_, int dim, double *vals, int *rows, int *cols, double *b, WellContributions&, BdaResult &res)
 {
@@ -250,6 +249,14 @@ SolverStatus FpgaSolverBackend<block_size>::solve_system(int N_, int nnz_, int d
     return SolverStatus::BDA_SOLVER_SUCCESS;
 }
 
+template <unsigned int block_size>
+SolverStatus FpgaSolverBackend<block_size>::solve_system2(int N_, int nnz_, int dim,
+					   double *vals, int *rows, int *cols, double *b,
+					   int nnz2, double *vals2, int *rows2, int *cols2,
+					   WellContributions& wellContribs, BdaResult &res)
+{
+    return SolverStatus::BDA_SOLVER_ANALYSIS_FAILED;
+}
 
 template <unsigned int block_size>
 void FpgaSolverBackend<block_size>::initialize(int N_, int nnz_, int dim, double *vals, int *rows, int *cols)

--- a/opm/simulators/linalg/bda/FPGASolverBackend.hpp
+++ b/opm/simulators/linalg/bda/FPGASolverBackend.hpp
@@ -256,9 +256,9 @@ public:
     SolverStatus solve_system(int N, int nnz, int dim, double *vals, int *rows, int *cols, double *b, WellContributions& wellContribs, BdaResult &res) override;
 
     SolverStatus solve_system2(int N_, int nnz_, int dim,
-			       double *vals, int *rows, int *cols, double *b,
-			       int nnz2, double *vals2, int *rows2, int *cols2,
-			       WellContributions& wellContribs, BdaResult &res) override;
+                               double *vals, int *rows, int *cols, double *b,
+                               int nnz2, double *vals2, int *rows2, int *cols2,
+                               WellContributions& wellContribs, BdaResult &res) override;
     
     /// Get result after linear solve, and peform postprocessing if necessary
     /// \param[inout] x           resulting x vector, caller must guarantee that x points to a valid array

--- a/opm/simulators/linalg/bda/FPGASolverBackend.hpp
+++ b/opm/simulators/linalg/bda/FPGASolverBackend.hpp
@@ -244,14 +244,12 @@ public:
     /// Solve linear system, A*x = b, matrix A must be in blocked-CSR format
     /// \param[in] matrix         matrix A
     /// \param[in] b              input vector, contains N values
+    /// \param[in] jacMatrix      matrix for preconditioner
     /// \param[in] wellContribs   WellContributions, not used in FPGA solver because it requires them already added to matrix A
     /// \param[inout] res         summary of solver result
     /// \return                   status code
-    SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b, WellContributions& wellContribs, BdaResult &res) override;
-
-    SolverStatus solve_system2(std::shared_ptr<BlockedMatrix> matrix, double *b,
-                               std::shared_ptr<BlockedMatrix> jacMatrix,
-                               WellContributions& wellContribs, BdaResult &res) override;
+    SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b,
+        std::shared_ptr<BlockedMatrix> jacMatrix, WellContributions& wellContribs, BdaResult &res) override;
     
     /// Get result after linear solve, and peform postprocessing if necessary
     /// \param[inout] x           resulting x vector, caller must guarantee that x points to a valid array

--- a/opm/simulators/linalg/bda/FPGASolverBackend.hpp
+++ b/opm/simulators/linalg/bda/FPGASolverBackend.hpp
@@ -201,13 +201,12 @@ private:
     unsigned short rst_settle_cycles = 0;
 
     /// Allocate host memory
-    /// \param[in] N              number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] nnz            number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] dim            size of block
+    /// \param[in] Nb             number of blockrows
+    /// \param[in] nnzbs          number of blocks
     /// \param[in] vals           array of nonzeroes, each block is stored row-wise and contiguous, contains nnz values
     /// \param[in] rows           array of rowPointers, contains N/dim+1 values
     /// \param[in] cols           array of columnIndices, contains nnz values
-    void initialize(int N, int nnz, int dim, double *vals, int *rows, int *cols);
+    void initialize(int Nb, int nnzbs, int dim, double *vals, int *rows, int *cols);
 
     /// Reorder the linear system so it corresponds with the coloring
     /// \param[in] vals           array of nonzeroes, each block is stored row-wise and contiguous, contains nnz values
@@ -243,21 +242,15 @@ public:
     ~FpgaSolverBackend();
 
     /// Solve linear system, A*x = b, matrix A must be in blocked-CSR format
-    /// \param[in] N              number of rows, divide by dim to get number of blockrows
-    /// \param[in] nnz            number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] dim            size of block
-    /// \param[in] vals           array of nonzeroes, each block is stored row-wise and contiguous, contains nnz values
-    /// \param[in] rows           array of rowPointers, contains N/dim+1 values
-    /// \param[in] cols           array of columnIndices, contains nnz values
+    /// \param[in] matrix         matrix A
     /// \param[in] b              input vector, contains N values
     /// \param[in] wellContribs   WellContributions, not used in FPGA solver because it requires them already added to matrix A
     /// \param[inout] res         summary of solver result
     /// \return                   status code
-    SolverStatus solve_system(int N, int nnz, int dim, double *vals, int *rows, int *cols, double *b, WellContributions& wellContribs, BdaResult &res) override;
+    SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b, WellContributions& wellContribs, BdaResult &res) override;
 
-    SolverStatus solve_system2(int N_, int nnz_, int dim,
-                               double *vals, int *rows, int *cols, double *b,
-                               int nnz2, double *vals2, int *rows2, int *cols2,
+    SolverStatus solve_system2(std::shared_ptr<BlockedMatrix> matrix, double *b,
+                               std::shared_ptr<BlockedMatrix> jacMatrix,
                                WellContributions& wellContribs, BdaResult &res) override;
     
     /// Get result after linear solve, and peform postprocessing if necessary

--- a/opm/simulators/linalg/bda/FPGASolverBackend.hpp
+++ b/opm/simulators/linalg/bda/FPGASolverBackend.hpp
@@ -255,6 +255,11 @@ public:
     /// \return                   status code
     SolverStatus solve_system(int N, int nnz, int dim, double *vals, int *rows, int *cols, double *b, WellContributions& wellContribs, BdaResult &res) override;
 
+    SolverStatus solve_system2(int N_, int nnz_, int dim,
+			       double *vals, int *rows, int *cols, double *b,
+			       int nnz2, double *vals2, int *rows2, int *cols2,
+			       WellContributions& wellContribs, BdaResult &res) override;
+    
     /// Get result after linear solve, and peform postprocessing if necessary
     /// \param[inout] x           resulting x vector, caller must guarantee that x points to a valid array
     void get_result(double *x) override;

--- a/opm/simulators/linalg/bda/Reorder.hpp
+++ b/opm/simulators/linalg/bda/Reorder.hpp
@@ -47,13 +47,22 @@ namespace Accelerator
 template <unsigned int block_size>
 int colorBlockedNodes(int rows, const int *CSRRowPointers, const int *CSRColIndices, const int *CSCColPointers, const int *CSCRowIndices, std::vector<int>& colors, int maxRowsPerColor, int maxColsPerColor);
 
-/// Reorder the rows of the matrix according to the mapping in toOrder and fromOrder
-/// rMat must be allocated already
-/// \param[in] mat           matrix to be reordered
-/// \param[in] toOrder       reorder pattern that lists for each index in the original order, to which index in the new order it should be moved
-/// \param[in] fromOrder     reorder pattern that lists for each index in the new order, from which index in the original order it was moved
-/// \param[inout] rMat       reordered Matrix
-void reorderBlockedMatrixByPattern(BlockedMatrix *mat, int *toOrder, int *fromOrder, BlockedMatrix *rmat);
+/// Reorder the sparsity pattern of the matrix according to the mapping in toOrder and fromOrder
+/// Also find mapping for nnz blocks
+/// rmat must be allocated already
+/// \param[in] mat                        matrix to be reordered
+/// \param[out] reordermapping_nonzeroes  contains new index for every nnz block
+/// \param[in] toOrder                    reorder pattern that lists for each index in the original order, to which index in the new order it should be moved
+/// \param[in] fromOrder                  reorder pattern that lists for each index in the new order, from which index in the original order it was moved
+/// \param[out] rmat                      reordered Matrix
+void reorderBlockedMatrixByPattern(BlockedMatrix *mat, std::vector<int>& reordermapping_nonzeroes, int *toOrder, int *fromOrder, BlockedMatrix *rmat);
+
+/// Write nnz blocks from mat to rmat, according to the mapping in reordermapping_nonzeroes
+/// rmat must be allocated already
+/// \param[in] mat                       matrix to be reordered
+/// \param[in] reordermapping_nonzeroes  contains old index for every nnz block, so rmat_nnz[i] == mat_nnz[mapping[i]]
+/// \param[inout] rmat                   reordered Matrix
+void reorderNonzeroes(BlockedMatrix *mat, std::vector<int>& reordermapping_nonzeroes, BlockedMatrix *rmat);
 
 /// Compute reorder mapping from the color that each node has received
 /// The toOrder, fromOrder and iters arrays must be allocated already

--- a/opm/simulators/linalg/bda/WellContributions.cpp
+++ b/opm/simulators/linalg/bda/WellContributions.cpp
@@ -101,6 +101,10 @@ void WellContributions::setBlockSize(unsigned int dim_, unsigned int dim_wells_)
     }
 }
 
+void WellContributions::setVectorSize(unsigned N_) {
+    N = N_;
+}
+
 void WellContributions::addNumBlocks(unsigned int numBlocks)
 {
     if (allocated) {

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -101,6 +101,10 @@ public:
     /// \param[in] dim_wells   number of rows
     void setBlockSize(unsigned int dim, unsigned int dim_wells);
 
+    /// Set size of vector that the wells are applied to
+    /// \param[in] N          size of vector
+    void setVectorSize(unsigned N);
+
     /// Store a matrix in this object, in blocked csr format, can only be called after alloc() is called
     /// \param[in] type        indicate if C, D or B is sent
     /// \param[in] colIndices  columnindices of blocks in C or B, ignored for D

--- a/opm/simulators/linalg/bda/amgclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/amgclSolverBackend.cpp
@@ -360,6 +360,15 @@ void amgclSolverBackend<block_size>::get_result(double *x_) {
 
 
 template <unsigned int block_size>
+SolverStatus amgclSolverBackend<block_size>::solve_system2(int N_, int nnz_, int dim,
+							   double *vals, int *rows, int *cols, double *b,
+							   int nnz2, double *vals2, int *rows2, int *cols2,
+							   WellContributions& wellContribs, BdaResult &res)
+{
+    return SolverStatus::BDA_SOLVER_ANALYSIS_FAILED;
+}
+    
+template <unsigned int block_size>
 SolverStatus amgclSolverBackend<block_size>::solve_system(int N_, int nnz_, int dim, double *vals, int *rows, int *cols, double *b, WellContributions&, BdaResult &res) {
     if (initialized == false) {
         initialize(N_, nnz_, dim);
@@ -369,6 +378,7 @@ SolverStatus amgclSolverBackend<block_size>::solve_system(int N_, int nnz_, int 
     solve_system(b, res);
     return SolverStatus::BDA_SOLVER_SUCCESS;
 }
+
 
 
 #define INSTANTIATE_BDA_FUNCTIONS(n)                                                                \

--- a/opm/simulators/linalg/bda/amgclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/amgclSolverBackend.cpp
@@ -360,17 +360,12 @@ void amgclSolverBackend<block_size>::get_result(double *x_) {
 
 
 template <unsigned int block_size>
-SolverStatus amgclSolverBackend<block_size>::solve_system2(std::shared_ptr<BlockedMatrix> matrix,
+SolverStatus amgclSolverBackend<block_size>::solve_system(std::shared_ptr<BlockedMatrix> matrix,
                                                            double *b,
                                                            [[maybe_unused]] std::shared_ptr<BlockedMatrix> jacMatrix,
-                                                           WellContributions& wellContribs,
+                                                           [[maybe_unused]] WellContributions& wellContribs,
                                                            BdaResult &res)
 {
-    return solve_system(matrix, b, wellContribs, res);
-}
-    
-template <unsigned int block_size>
-SolverStatus amgclSolverBackend<block_size>::solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b, WellContributions&, BdaResult &res) {
     if (initialized == false) {
         initialize(matrix->Nb, matrix->nnzbs);
         convert_sparsity_pattern(matrix->rowPointers, matrix->colIndices);

--- a/opm/simulators/linalg/bda/amgclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/amgclSolverBackend.cpp
@@ -52,14 +52,14 @@ amgclSolverBackend<block_size>::~amgclSolverBackend() {}
 
 
 template <unsigned int block_size>
-void amgclSolverBackend<block_size>::initialize(int N_, int nnz_, int dim) {
-    this->N = N_;
-    this->nnz = nnz_;
-    this->nnzb = nnz_ / block_size / block_size;
+void amgclSolverBackend<block_size>::initialize(int Nb_, int nnzbs) {
+    this->Nb = Nb_;
+    this->N = Nb * block_size;
+    this->nnzb = nnzbs;
+    this->nnz = nnzbs * block_size * block_size;
 
-    Nb = (N + dim - 1) / dim;
     std::ostringstream out;
-    out << "Initializing amgclSolverBackend, matrix size: " << N << " blocks, nnzb: " << nnzb << "\n";
+    out << "Initializing amgclSolverBackend, matrix size: " << Nb << " blockrows, nnzb: " << nnzb << " blocks\n";
     out << "Maxit: " << maxit << std::scientific << ", tolerance: " << tolerance << "\n";
     out << "DeviceID: " << deviceID << "\n";
     OpmLog::info(out.str());
@@ -360,22 +360,22 @@ void amgclSolverBackend<block_size>::get_result(double *x_) {
 
 
 template <unsigned int block_size>
-SolverStatus amgclSolverBackend<block_size>::solve_system2(int N_, int nnz_, int dim,
-                                                           double *vals, int *rows, int *cols, double *b,
-                                                           int nnz2, double *vals2, int *rows2, int *cols2,
-                                                           WellContributions& wellContribs, BdaResult &res)
+SolverStatus amgclSolverBackend<block_size>::solve_system2(std::shared_ptr<BlockedMatrix> matrix,
+                                                           double *b,
+                                                           [[maybe_unused]] std::shared_ptr<BlockedMatrix> jacMatrix,
+                                                           WellContributions& wellContribs,
+                                                           BdaResult &res)
 {
-    (void) nnz2; (void) vals2; (void) rows2; (void) cols2;
-    return solve_system(N_, nnz_, dim, vals, rows, cols, b, wellContribs, res);
+    return solve_system(matrix, b, wellContribs, res);
 }
     
 template <unsigned int block_size>
-SolverStatus amgclSolverBackend<block_size>::solve_system(int N_, int nnz_, int dim, double *vals, int *rows, int *cols, double *b, WellContributions&, BdaResult &res) {
+SolverStatus amgclSolverBackend<block_size>::solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b, WellContributions&, BdaResult &res) {
     if (initialized == false) {
-        initialize(N_, nnz_, dim);
-        convert_sparsity_pattern(rows, cols);
+        initialize(matrix->Nb, matrix->nnzbs);
+        convert_sparsity_pattern(matrix->rowPointers, matrix->colIndices);
     }
-    convert_data(vals, rows);
+    convert_data(matrix->nnzValues, matrix->rowPointers);
     solve_system(b, res);
     return SolverStatus::BDA_SOLVER_SUCCESS;
 }

--- a/opm/simulators/linalg/bda/amgclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/amgclSolverBackend.cpp
@@ -361,9 +361,9 @@ void amgclSolverBackend<block_size>::get_result(double *x_) {
 
 template <unsigned int block_size>
 SolverStatus amgclSolverBackend<block_size>::solve_system2(int N_, int nnz_, int dim,
-							   double *vals, int *rows, int *cols, double *b,
-							   int nnz2, double *vals2, int *rows2, int *cols2,
-							   WellContributions& wellContribs, BdaResult &res)
+                                                           double *vals, int *rows, int *cols, double *b,
+                                                           int nnz2, double *vals2, int *rows2, int *cols2,
+                                                           WellContributions& wellContribs, BdaResult &res)
 {
     (void) nnz2; (void) vals2; (void) rows2; (void) cols2;
     return solve_system(N_, nnz_, dim, vals, rows, cols, b, wellContribs, res);

--- a/opm/simulators/linalg/bda/amgclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/amgclSolverBackend.cpp
@@ -365,7 +365,8 @@ SolverStatus amgclSolverBackend<block_size>::solve_system2(int N_, int nnz_, int
 							   int nnz2, double *vals2, int *rows2, int *cols2,
 							   WellContributions& wellContribs, BdaResult &res)
 {
-    return SolverStatus::BDA_SOLVER_ANALYSIS_FAILED;
+    (void) nnz2; (void) vals2; (void) rows2; (void) cols2;
+    return solve_system(N_, nnz_, dim, vals, rows, cols, b, wellContribs, res);
 }
     
 template <unsigned int block_size>
@@ -378,7 +379,6 @@ SolverStatus amgclSolverBackend<block_size>::solve_system(int N_, int nnz_, int 
     solve_system(b, res);
     return SolverStatus::BDA_SOLVER_SUCCESS;
 }
-
 
 
 #define INSTANTIATE_BDA_FUNCTIONS(n)                                                                \

--- a/opm/simulators/linalg/bda/amgclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/amgclSolverBackend.hpp
@@ -145,6 +145,11 @@ public:
     /// \return                   status code
     SolverStatus solve_system(int N, int nnz, int dim, double *vals, int *rows, int *cols, double *b, WellContributions& wellContribs, BdaResult &res) override;
 
+    SolverStatus solve_system2(int N_, int nnz_, int dim,
+			       double *vals, int *rows, int *cols, double *b,
+			       int nnz2, double *vals2, int *rows2, int *cols2,
+			       WellContributions& wellContribs, BdaResult &res) override;
+    
     /// Get result after linear solve, and peform postprocessing if necessary
     /// \param[inout] x          resulting x vector, caller must guarantee that x points to a valid array
     void get_result(double *x) override;

--- a/opm/simulators/linalg/bda/amgclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/amgclSolverBackend.hpp
@@ -96,10 +96,9 @@ private:
     std::once_flag vexcl_initialize;
 #endif
     /// Initialize host memory and determine amgcl parameters
-    /// \param[in] N              number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] nnz            number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] dim            size of block
-    void initialize(int N, int nnz, int dim);
+    /// \param[in] Nb               number of blockrows
+    /// \param[in] nnzbs            number of blocks
+    void initialize(int Nb, int nnzbs);
 
     /// Convert the BCSR sparsity pattern to a CSR one
     /// \param[in] rows           array of rowPointers, contains N/dim+1 values
@@ -129,25 +128,15 @@ public:
     ~amgclSolverBackend();
 
     /// Solve linear system, A*x = b, matrix A must be in blocked-CSR format
-    /// \param[in] N              number of rows, divide by dim to get number of blockrows
-    /// \param[in] nnz            number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] nnz_prec       number of nonzeroes of matrix for ILU0, divide by dim*dim to get number of blocks
-    /// \param[in] dim            size of block
-    /// \param[in] vals           array of nonzeroes, each block is stored row-wise and contiguous, contains nnz values
-    /// \param[in] rows           array of rowPointers, contains N/dim+1 values
-    /// \param[in] cols           array of columnIndices, contains nnz values
-    /// \param[in] vals_prec      array of nonzeroes for preconditioner
-    /// \param[in] rows_prec      array of rowPointers for preconditioner
-    /// \param[in] cols_prec      array of columnIndices for preconditioner
+    /// \param[in] matrix         matrix A
     /// \param[in] b              input vector, contains N values
     /// \param[in] wellContribs   WellContributions, to apply them separately, instead of adding them to matrix A
     /// \param[inout] res         summary of solver result
     /// \return                   status code
-    SolverStatus solve_system(int N, int nnz, int dim, double *vals, int *rows, int *cols, double *b, WellContributions& wellContribs, BdaResult &res) override;
+    SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b, WellContributions& wellContribs, BdaResult &res) override;
 
-    SolverStatus solve_system2(int N_, int nnz_, int dim,
-                               double *vals, int *rows, int *cols, double *b,
-                               int nnz2, double *vals2, int *rows2, int *cols2,
+    SolverStatus solve_system2(std::shared_ptr<BlockedMatrix> matrix, double *b,
+                               std::shared_ptr<BlockedMatrix> jacMatrix,
                                WellContributions& wellContribs, BdaResult &res) override;
     
     /// Get result after linear solve, and peform postprocessing if necessary

--- a/opm/simulators/linalg/bda/amgclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/amgclSolverBackend.hpp
@@ -146,9 +146,9 @@ public:
     SolverStatus solve_system(int N, int nnz, int dim, double *vals, int *rows, int *cols, double *b, WellContributions& wellContribs, BdaResult &res) override;
 
     SolverStatus solve_system2(int N_, int nnz_, int dim,
-			       double *vals, int *rows, int *cols, double *b,
-			       int nnz2, double *vals2, int *rows2, int *cols2,
-			       WellContributions& wellContribs, BdaResult &res) override;
+                               double *vals, int *rows, int *cols, double *b,
+                               int nnz2, double *vals2, int *rows2, int *cols2,
+                               WellContributions& wellContribs, BdaResult &res) override;
     
     /// Get result after linear solve, and peform postprocessing if necessary
     /// \param[inout] x          resulting x vector, caller must guarantee that x points to a valid array

--- a/opm/simulators/linalg/bda/amgclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/amgclSolverBackend.hpp
@@ -130,14 +130,12 @@ public:
     /// Solve linear system, A*x = b, matrix A must be in blocked-CSR format
     /// \param[in] matrix         matrix A
     /// \param[in] b              input vector, contains N values
+    /// \param[in] jacMatrix      matrix for preconditioner
     /// \param[in] wellContribs   WellContributions, to apply them separately, instead of adding them to matrix A
     /// \param[inout] res         summary of solver result
     /// \return                   status code
-    SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b, WellContributions& wellContribs, BdaResult &res) override;
-
-    SolverStatus solve_system2(std::shared_ptr<BlockedMatrix> matrix, double *b,
-                               std::shared_ptr<BlockedMatrix> jacMatrix,
-                               WellContributions& wellContribs, BdaResult &res) override;
+    SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b,
+        std::shared_ptr<BlockedMatrix> jacMatrix, WellContributions& wellContribs, BdaResult &res) override;
     
     /// Get result after linear solve, and peform postprocessing if necessary
     /// \param[inout] x          resulting x vector, caller must guarantee that x points to a valid array

--- a/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.cu
+++ b/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.cu
@@ -478,7 +478,12 @@ void cusparseSolverBackend<block_size>::get_result(double *x) {
 
 
 template <unsigned int block_size>
-SolverStatus cusparseSolverBackend<block_size>::solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b, WellContributions& wellContribs, BdaResult &res) {
+SolverStatus cusparseSolverBackend<block_size>::solve_system(std::shared_ptr<BlockedMatrix> matrix,
+                                                              double *b,
+                                                              [[maybe_unused]] std::shared_ptr<BlockedMatrix> jacMatrix,
+                                                              WellContributions& wellContribs,
+                                                              BdaResult &res)
+{
     if (initialized == false) {
         initialize(matrix->Nb, matrix->nnzbs);
         copy_system_to_gpu(matrix->nnzValues, matrix->rowPointers, matrix->colIndices, b);
@@ -499,15 +504,6 @@ SolverStatus cusparseSolverBackend<block_size>::solve_system(std::shared_ptr<Blo
     return SolverStatus::BDA_SOLVER_SUCCESS;
 }
 
-template <unsigned int block_size>
-SolverStatus cusparseSolverBackend<block_size>::solve_system2(std::shared_ptr<BlockedMatrix> matrix,
-                                                              double *b,
-                                                              [[maybe_unused]] std::shared_ptr<BlockedMatrix> jacMatrix,
-                                                              WellContributions& wellContribs,
-                                                              BdaResult &res)
-{
-    return solve_system(matrix, b, wellContribs, res);
-}
 
 #define INSTANTIATE_BDA_FUNCTIONS(n)                                                       \
 template cusparseSolverBackend<n>::cusparseSolverBackend(int, int, double, unsigned int);  \

--- a/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.cu
+++ b/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.cu
@@ -502,9 +502,9 @@ SolverStatus cusparseSolverBackend<block_size>::solve_system(int N, int nnz, int
 }
 template <unsigned int block_size>
 SolverStatus cusparseSolverBackend<block_size>::solve_system2(int N_, int nnz_, int dim,
-					   double *vals, int *rows, int *cols, double *b,
-					   int nnz2, double *vals2, int *rows2, int *cols2,
-					   WellContributions& wellContribs, BdaResult &res)
+                                           double *vals, int *rows, int *cols, double *b,
+                                           int nnz2, double *vals2, int *rows2, int *cols2,
+                                           WellContributions& wellContribs, BdaResult &res)
 {
     (void) nnz2; (void) vals2; (void) rows2; (void) cols2;
     return solve_system(N_, nnz_, dim, vals, rows, cols, b, wellContribs, res);

--- a/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.cu
+++ b/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.cu
@@ -500,7 +500,14 @@ SolverStatus cusparseSolverBackend<block_size>::solve_system(int N, int nnz, int
     }
     return SolverStatus::BDA_SOLVER_SUCCESS;
 }
-
+template <unsigned int block_size>
+SolverStatus cusparseSolverBackend<block_size>::solve_system2(int N_, int nnz_, int dim,
+					   double *vals, int *rows, int *cols, double *b,
+					   int nnz2, double *vals2, int *rows2, int *cols2,
+					   WellContributions& wellContribs, BdaResult &res)
+{
+    return SolverStatus::BDA_SOLVER_ANALYSIS_FAILED;
+}
 
 #define INSTANTIATE_BDA_FUNCTIONS(n)                                                       \
 template cusparseSolverBackend<n>::cusparseSolverBackend(int, int, double, unsigned int);  \

--- a/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.cu
+++ b/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.cu
@@ -506,7 +506,8 @@ SolverStatus cusparseSolverBackend<block_size>::solve_system2(int N_, int nnz_, 
 					   int nnz2, double *vals2, int *rows2, int *cols2,
 					   WellContributions& wellContribs, BdaResult &res)
 {
-    return SolverStatus::BDA_SOLVER_ANALYSIS_FAILED;
+    (void) nnz2; (void) vals2; (void) rows2; (void) cols2;
+    return solve_system(N_, nnz_, dim, vals, rows, cols, b, wellContribs, res);
 }
 
 #define INSTANTIATE_BDA_FUNCTIONS(n)                                                       \

--- a/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.cu
+++ b/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.cu
@@ -104,10 +104,10 @@ void cusparseSolverBackend<block_size>::gpu_pbicgstab(WellContributions& wellCon
 
         // apply ilu0
         cusparseDbsrsv2_solve(cusparseHandle, order, \
-                              operation, Nb, nnzb, &one, \
+                              operation, Nb, nnzbs_prec, &one, \
                               descr_L, d_mVals, d_mRows, d_mCols, block_size, info_L, d_p, d_t, policy, d_buffer);
         cusparseDbsrsv2_solve(cusparseHandle, order, \
-                              operation, Nb, nnzb, &one, \
+                              operation, Nb, nnzbs_prec, &one, \
                               descr_U, d_mVals, d_mRows, d_mCols, block_size, info_U, d_t, d_pw, policy, d_buffer);
 
         // spmv
@@ -135,10 +135,10 @@ void cusparseSolverBackend<block_size>::gpu_pbicgstab(WellContributions& wellCon
 
         // apply ilu0
         cusparseDbsrsv2_solve(cusparseHandle, order, \
-                              operation, Nb, nnzb, &one, \
+                              operation, Nb, nnzbs_prec, &one, \
                               descr_L, d_mVals, d_mRows, d_mCols, block_size, info_L, d_r, d_t, policy, d_buffer);
         cusparseDbsrsv2_solve(cusparseHandle, order, \
-                              operation, Nb, nnzb, &one, \
+                              operation, Nb, nnzbs_prec, &one, \
                               descr_U, d_mVals, d_mRows, d_mCols, block_size, info_U, d_t, d_s, policy, d_buffer);
 
         // spmv
@@ -188,14 +188,24 @@ void cusparseSolverBackend<block_size>::gpu_pbicgstab(WellContributions& wellCon
 
 
 template <unsigned int block_size>
-void cusparseSolverBackend<block_size>::initialize(int Nb_, int nnzb) {
-    this->Nb = Nb_;
+void cusparseSolverBackend<block_size>::initialize(std::shared_ptr<BlockedMatrix> matrix, std::shared_ptr<BlockedMatrix> jacMatrix) {
+    this->Nb = matrix->Nb;
     this->N = Nb * block_size;
-    this->nnzb = nnzb;
+    this->nnzb = matrix->nnzbs;
     this->nnz = nnzb * block_size * block_size;
+
+    if (jacMatrix) {
+        useJacMatrix = true;
+        nnzbs_prec = jacMatrix->nnzbs;
+    } else {
+        nnzbs_prec = nnzb;
+    }
 
     std::ostringstream out;
     out << "Initializing GPU, matrix size: " << Nb << " blockrows, nnz: " << nnzb << " blocks\n";
+    if (useJacMatrix) {
+        out << "Blocks in ILU matrix: " << nnzbs_prec << "\n";
+    }
     out << "Maxit: " << maxit << std::scientific << ", tolerance: " << tolerance << "\n";
     OpmLog::info(out.str());
 
@@ -230,7 +240,15 @@ void cusparseSolverBackend<block_size>::initialize(int Nb_, int nnzb) {
     cudaMalloc((void**)&d_bVals, sizeof(double) * nnz);
     cudaMalloc((void**)&d_bCols, sizeof(int) * nnzb);
     cudaMalloc((void**)&d_bRows, sizeof(int) * (Nb + 1));
-    cudaMalloc((void**)&d_mVals, sizeof(double) * nnz);
+    if (useJacMatrix) {
+        cudaMalloc((void**)&d_mVals, sizeof(double) * nnzbs_prec * block_size * block_size);
+        cudaMalloc((void**)&d_mCols, sizeof(int) * nnzbs_prec);
+        cudaMalloc((void**)&d_mRows, sizeof(int) * (Nb + 1));
+    } else {
+        cudaMalloc((void**)&d_mVals, sizeof(double) * nnz);
+        d_mCols = d_bCols;
+        d_mRows = d_bRows;
+    }
     cudaCheckLastError("Could not allocate enough memory on GPU");
 
     cublasSetStream(cublasHandle, stream);
@@ -259,6 +277,10 @@ void cusparseSolverBackend<block_size>::finalize() {
         cudaFree(d_t);
         cudaFree(d_v);
         cudaFree(d_mVals);
+        if (useJacMatrix) {
+            cudaFree(d_mCols);
+            cudaFree(d_mRows);
+        }
         cudaFree(d_bVals);
         cudaFree(d_bCols);
         cudaFree(d_bRows);
@@ -281,23 +303,32 @@ void cusparseSolverBackend<block_size>::finalize() {
 
 
 template <unsigned int block_size>
-void cusparseSolverBackend<block_size>::copy_system_to_gpu(double *vals, int *rows, int *cols, double *b) {
+void cusparseSolverBackend<block_size>::copy_system_to_gpu(std::shared_ptr<BlockedMatrix> matrix, double *b, std::shared_ptr<BlockedMatrix> jacMatrix) {
     Timer t;
 
 #if COPY_ROW_BY_ROW
     int sum = 0;
     for (int i = 0; i < Nb; ++i) {
-        int size_row = rows[i + 1] - rows[i];
-        memcpy(vals_contiguous + sum, vals + sum, size_row * sizeof(double) * block_size * block_size);
+        int size_row = matrix->rowPointers[i + 1] - matrix->rowPointers[i];
+        memcpy(vals_contiguous + sum, matrix->nnzValues + sum, size_row * sizeof(double) * block_size * block_size);
         sum += size_row * block_size * block_size;
     }
     cudaMemcpyAsync(d_bVals, vals_contiguous, nnz * sizeof(double), cudaMemcpyHostToDevice, stream);
 #else
-    cudaMemcpyAsync(d_bVals, vals, nnz * sizeof(double), cudaMemcpyHostToDevice, stream);
+    cudaMemcpyAsync(d_bVals, matrix->nnzValues, nnz * sizeof(double), cudaMemcpyHostToDevice, stream);
+    if (useJacMatrix) {
+        cudaMemcpyAsync(d_mVals, jacMatrix->nnzValues, nnzbs_prec * block_size * block_size * sizeof(double), cudaMemcpyHostToDevice, stream);
+    } else {
+        cudaMemcpyAsync(d_mVals, d_bVals, nnz  * sizeof(double), cudaMemcpyDeviceToDevice, stream);
+    }
 #endif
 
-    cudaMemcpyAsync(d_bCols, cols, nnzb * sizeof(int), cudaMemcpyHostToDevice, stream);
-    cudaMemcpyAsync(d_bRows, rows, (Nb + 1) * sizeof(int), cudaMemcpyHostToDevice, stream);
+    cudaMemcpyAsync(d_bCols, matrix->colIndices, nnzb * sizeof(int), cudaMemcpyHostToDevice, stream);
+    cudaMemcpyAsync(d_bRows, matrix->rowPointers, (Nb + 1) * sizeof(int), cudaMemcpyHostToDevice, stream);
+    if (useJacMatrix) {
+        cudaMemcpyAsync(d_mCols, jacMatrix->colIndices, nnzbs_prec * sizeof(int), cudaMemcpyHostToDevice, stream);
+        cudaMemcpyAsync(d_mRows, jacMatrix->rowPointers, (Nb + 1) * sizeof(int), cudaMemcpyHostToDevice, stream);
+    }
     cudaMemcpyAsync(d_b, b, N * sizeof(double), cudaMemcpyHostToDevice, stream);
     cudaMemsetAsync(d_x, 0, sizeof(double) * N, stream);
 
@@ -312,19 +343,24 @@ void cusparseSolverBackend<block_size>::copy_system_to_gpu(double *vals, int *ro
 
 // don't copy rowpointers and colindices, they stay the same
 template <unsigned int block_size>
-void cusparseSolverBackend<block_size>::update_system_on_gpu(double *vals, int *rows, double *b) {
+void cusparseSolverBackend<block_size>::update_system_on_gpu(std::shared_ptr<BlockedMatrix> matrix, double *b, std::shared_ptr<BlockedMatrix> jacMatrix) {
     Timer t;
 
 #if COPY_ROW_BY_ROW
     int sum = 0;
     for (int i = 0; i < Nb; ++i) {
-        int size_row = rows[i + 1] - rows[i];
-        memcpy(vals_contiguous + sum, vals + sum, size_row * sizeof(double) * block_size * block_size);
+        int size_row = matrix->rowPointers[i + 1] - matrix->rowPointers[i];
+        memcpy(vals_contiguous + sum, matrix->nnzValues + sum, size_row * sizeof(double) * block_size * block_size);
         sum += size_row * block_size * block_size;
     }
     cudaMemcpyAsync(d_bVals, vals_contiguous, nnz * sizeof(double), cudaMemcpyHostToDevice, stream);
 #else
-    cudaMemcpyAsync(d_bVals, vals, nnz * sizeof(double), cudaMemcpyHostToDevice, stream);
+    cudaMemcpyAsync(d_bVals, matrix->nnzValues, nnz * sizeof(double), cudaMemcpyHostToDevice, stream);
+    if (useJacMatrix) {
+        cudaMemcpyAsync(d_mVals, jacMatrix->nnzValues, nnzbs_prec * block_size * block_size * sizeof(double), cudaMemcpyHostToDevice, stream);
+    } else {
+        cudaMemcpyAsync(d_mVals, d_bVals, nnz  * sizeof(double), cudaMemcpyDeviceToDevice, stream);
+    }
 #endif
 
     cudaMemcpyAsync(d_b, b, N * sizeof(double), cudaMemcpyHostToDevice, stream);
@@ -337,12 +373,6 @@ void cusparseSolverBackend<block_size>::update_system_on_gpu(double *vals, int *
         OpmLog::info(out.str());
     }
 } // end update_system_on_gpu()
-
-
-template <unsigned int block_size>
-void cusparseSolverBackend<block_size>::reset_prec_on_gpu() {
-    cudaMemcpyAsync(d_mVals, d_bVals, nnz  * sizeof(double), cudaMemcpyDeviceToDevice, stream);
-}
 
 
 template <unsigned int block_size>
@@ -378,12 +408,12 @@ bool cusparseSolverBackend<block_size>::analyse_matrix() {
     cusparseCreateBsrsv2Info(&info_U);
     cudaCheckLastError("Could not create analysis info");
 
-    cusparseDbsrilu02_bufferSize(cusparseHandle, order, Nb, nnzb,
-                                 descr_M, d_bVals, d_bRows, d_bCols, block_size, info_M, &d_bufferSize_M);
-    cusparseDbsrsv2_bufferSize(cusparseHandle, order, operation, Nb, nnzb,
-                               descr_L, d_bVals, d_bRows, d_bCols, block_size, info_L, &d_bufferSize_L);
-    cusparseDbsrsv2_bufferSize(cusparseHandle, order, operation, Nb, nnzb,
-                               descr_U, d_bVals, d_bRows, d_bCols, block_size, info_U, &d_bufferSize_U);
+    cusparseDbsrilu02_bufferSize(cusparseHandle, order, Nb, nnzbs_prec,
+                                 descr_M, d_mVals, d_mRows, d_mCols, block_size, info_M, &d_bufferSize_M);
+    cusparseDbsrsv2_bufferSize(cusparseHandle, order, operation, Nb, nnzbs_prec,
+                               descr_L, d_mVals, d_mRows, d_mCols, block_size, info_L, &d_bufferSize_L);
+    cusparseDbsrsv2_bufferSize(cusparseHandle, order, operation, Nb, nnzbs_prec,
+                               descr_U, d_mVals, d_mRows, d_mCols, block_size, info_U, &d_bufferSize_U);
     cudaCheckLastError();
     d_bufferSize = std::max(d_bufferSize_M, std::max(d_bufferSize_L, d_bufferSize_U));
 
@@ -391,7 +421,7 @@ bool cusparseSolverBackend<block_size>::analyse_matrix() {
 
     // analysis of ilu LU decomposition
     cusparseDbsrilu02_analysis(cusparseHandle, order, \
-                               Nb, nnzb, descr_B, d_bVals, d_bRows, d_bCols, \
+                               Nb, nnzbs_prec, descr_B, d_mVals, d_mRows, d_mCols, \
                                block_size, info_M, policy, d_buffer);
 
     int structural_zero;
@@ -402,11 +432,11 @@ bool cusparseSolverBackend<block_size>::analyse_matrix() {
 
     // analysis of ilu apply
     cusparseDbsrsv2_analysis(cusparseHandle, order, operation, \
-                             Nb, nnzb, descr_L, d_bVals, d_bRows, d_bCols, \
+                             Nb, nnzbs_prec, descr_L, d_mVals, d_mRows, d_mCols, \
                              block_size, info_L, policy, d_buffer);
 
     cusparseDbsrsv2_analysis(cusparseHandle, order, operation, \
-                             Nb, nnzb, descr_U, d_bVals, d_bRows, d_bCols, \
+                             Nb, nnzbs_prec, descr_U, d_mVals, d_mRows, d_mCols, \
                              block_size, info_U, policy, d_buffer);
     cudaCheckLastError("Could not analyse level information");
 
@@ -426,10 +456,8 @@ template <unsigned int block_size>
 bool cusparseSolverBackend<block_size>::create_preconditioner() {
     Timer t;
 
-    d_mCols = d_bCols;
-    d_mRows = d_bRows;
     cusparseDbsrilu02(cusparseHandle, order, \
-                      Nb, nnzb, descr_M, d_mVals, d_mRows, d_mCols, \
+                      Nb, nnzbs_prec, descr_M, d_mVals, d_mRows, d_mCols, \
                       block_size, info_M, policy, d_buffer);
     cudaCheckLastError("Could not perform ilu decomposition");
 
@@ -480,22 +508,21 @@ void cusparseSolverBackend<block_size>::get_result(double *x) {
 template <unsigned int block_size>
 SolverStatus cusparseSolverBackend<block_size>::solve_system(std::shared_ptr<BlockedMatrix> matrix,
                                                               double *b,
-                                                              [[maybe_unused]] std::shared_ptr<BlockedMatrix> jacMatrix,
+                                                              std::shared_ptr<BlockedMatrix> jacMatrix,
                                                               WellContributions& wellContribs,
                                                               BdaResult &res)
 {
     if (initialized == false) {
-        initialize(matrix->Nb, matrix->nnzbs);
-        copy_system_to_gpu(matrix->nnzValues, matrix->rowPointers, matrix->colIndices, b);
+        initialize(matrix, jacMatrix);
+        copy_system_to_gpu(matrix, b, jacMatrix);
     } else {
-        update_system_on_gpu(matrix->nnzValues, matrix->rowPointers, b);
+        update_system_on_gpu(matrix, b, jacMatrix);
     }
     if (analysis_done == false) {
         if (!analyse_matrix()) {
             return SolverStatus::BDA_SOLVER_ANALYSIS_FAILED;
         }
     }
-    reset_prec_on_gpu();
     if (create_preconditioner()) {
         solve_system(wellContribs, res);
     } else {

--- a/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.hpp
@@ -139,9 +139,9 @@ public:
     SolverStatus solve_system(int N, int nnz, int dim, double *vals, int *rows, int *cols, double *b, WellContributions& wellContribs, BdaResult &res) override;
 
     SolverStatus solve_system2(int N_, int nnz_, int dim,
-			       double *vals, int *rows, int *cols, double *b,
-			       int nnz2, double *vals2, int *rows2, int *cols2,
-			       WellContributions& wellContribs, BdaResult &res) override;
+                               double *vals, int *rows, int *cols, double *b,
+                               int nnz2, double *vals2, int *rows2, int *cols2,
+                               WellContributions& wellContribs, BdaResult &res) override;
     
     /// Get resulting vector x after linear solve, also includes post processing if necessary
     /// \param[inout] x        resulting x vector, caller must guarantee that x points to a valid array

--- a/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.hpp
@@ -138,6 +138,11 @@ public:
     /// \return                   status code
     SolverStatus solve_system(int N, int nnz, int dim, double *vals, int *rows, int *cols, double *b, WellContributions& wellContribs, BdaResult &res) override;
 
+    SolverStatus solve_system2(int N_, int nnz_, int dim,
+			       double *vals, int *rows, int *cols, double *b,
+			       int nnz2, double *vals2, int *rows2, int *cols2,
+			       WellContributions& wellContribs, BdaResult &res) override;
+    
     /// Get resulting vector x after linear solve, also includes post processing if necessary
     /// \param[inout] x        resulting x vector, caller must guarantee that x points to a valid array
     void get_result(double *x) override;

--- a/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.hpp
@@ -75,10 +75,9 @@ private:
     void gpu_pbicgstab(WellContributions& wellContribs, BdaResult& res);
 
     /// Initialize GPU and allocate memory
-    /// \param[in] N                number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] nnz              number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] dim              size of block
-    void initialize(int N, int nnz, int dim);
+    /// \param[in] Nb               number of blockrows
+    /// \param[in] nnzbs            number of blocks
+    void initialize(int Nb, int nnzbs);
 
     /// Clean memory
     void finalize();
@@ -126,21 +125,15 @@ public:
     ~cusparseSolverBackend();
 
     /// Solve linear system, A*x = b, matrix A must be in blocked-CSR format
-    /// \param[in] N              number of rows, divide by dim to get number of blockrows
-    /// \param[in] nnz            number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] dim            size of block
-    /// \param[in] vals           array of nonzeroes, each block is stored row-wise and contiguous, contains nnz values
-    /// \param[in] rows           array of rowPointers, contains N/dim+1 values
-    /// \param[in] cols           array of columnIndices, contains nnz values
+    /// \param[in] matrix         matrix A
     /// \param[in] b              input vector, contains N values
     /// \param[in] wellContribs   contains all WellContributions, to apply them separately, instead of adding them to matrix A
     /// \param[inout] res         summary of solver result
     /// \return                   status code
-    SolverStatus solve_system(int N, int nnz, int dim, double *vals, int *rows, int *cols, double *b, WellContributions& wellContribs, BdaResult &res) override;
+    SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b, WellContributions& wellContribs, BdaResult &res) override;
 
-    SolverStatus solve_system2(int N_, int nnz_, int dim,
-                               double *vals, int *rows, int *cols, double *b,
-                               int nnz2, double *vals2, int *rows2, int *cols2,
+    SolverStatus solve_system2(std::shared_ptr<BlockedMatrix> matrix, double *b,
+                               std::shared_ptr<BlockedMatrix> jacMatrix,
                                WellContributions& wellContribs, BdaResult &res) override;
     
     /// Get resulting vector x after linear solve, also includes post processing if necessary

--- a/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.hpp
@@ -127,14 +127,12 @@ public:
     /// Solve linear system, A*x = b, matrix A must be in blocked-CSR format
     /// \param[in] matrix         matrix A
     /// \param[in] b              input vector, contains N values
+    /// \param[in] jacMatrix      matrix for preconditioner
     /// \param[in] wellContribs   contains all WellContributions, to apply them separately, instead of adding them to matrix A
     /// \param[inout] res         summary of solver result
     /// \return                   status code
-    SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b, WellContributions& wellContribs, BdaResult &res) override;
-
-    SolverStatus solve_system2(std::shared_ptr<BlockedMatrix> matrix, double *b,
-                               std::shared_ptr<BlockedMatrix> jacMatrix,
-                               WellContributions& wellContribs, BdaResult &res) override;
+    SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b,
+        std::shared_ptr<BlockedMatrix> jacMatrix, WellContributions& wellContribs, BdaResult &res) override;
     
     /// Get resulting vector x after linear solve, also includes post processing if necessary
     /// \param[inout] x        resulting x vector, caller must guarantee that x points to a valid array

--- a/opm/simulators/linalg/bda/opencl/BILU0.cpp
+++ b/opm/simulators/linalg/bda/opencl/BILU0.cpp
@@ -191,7 +191,9 @@ bool BILU0<block_size>::create_preconditioner(BlockedMatrix *mat, BlockedMatrix 
 
     auto *matToDecompose = jacMat;
 
-    if (opencl_ilu_reorder != ILUReorder::NONE) {
+    if (opencl_ilu_reorder == ILUReorder::NONE) { // NONE should only be used in debug
+        matToDecompose = jacMat ? jacMat : mat;
+    } else {
         Timer t_reorder;
         if (jacMat) {
             matToDecompose = rJacMat.get();

--- a/opm/simulators/linalg/bda/opencl/BILU0.cpp
+++ b/opm/simulators/linalg/bda/opencl/BILU0.cpp
@@ -365,11 +365,11 @@ template <unsigned int block_size>
 bool BILU0<block_size>::create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat)
 {
     const unsigned int bs = block_size;
-    auto *m = mat;
+
     auto *jm = jacMat;
 
     if (opencl_ilu_reorder != ILUReorder::NONE) {
-        m = rmat.get();
+
         jm = rJacMat.get();
         Timer t_reorder;
         reorderBlockedMatrixByPattern(mat, toOrder.data(), fromOrder.data(), rmat.get());

--- a/opm/simulators/linalg/bda/opencl/BILU0.cpp
+++ b/opm/simulators/linalg/bda/opencl/BILU0.cpp
@@ -269,7 +269,7 @@ bool BILU0<block_size>::create_preconditioner(BlockedMatrix *mat, BlockedMatrix 
     for (int color = 0; color < numColors; ++color) {
         const unsigned int firstRow = rowsPerColorPrefix[color];
         const unsigned int lastRow = rowsPerColorPrefix[color+1];
-        if (verbosity >= 4) {
+        if (verbosity >= 5) {
             out << "color " << color << ": " << firstRow << " - " << lastRow << " = " << lastRow - firstRow << "\n";
         }
         OpenclKernels::ILU_decomp(firstRow, lastRow, s.LUvals, s.LUcols, s.LUrows, s.diagIndex, s.invDiagVals, Nb, block_size);

--- a/opm/simulators/linalg/bda/opencl/BILU0.cpp
+++ b/opm/simulators/linalg/bda/opencl/BILU0.cpp
@@ -52,103 +52,7 @@ BILU0<block_size>::BILU0(ILUReorder opencl_ilu_reorder_, int verbosity_) :
 template <unsigned int block_size>
 bool BILU0<block_size>::analyze_matrix(BlockedMatrix *mat)
 {
-    const unsigned int bs = block_size;
-
-    this->N = mat->Nb * block_size;
-    this->Nb = mat->Nb;
-    this->nnz = mat->nnzbs * block_size * block_size;
-    this->nnzb = mat->nnzbs;
-
-    std::vector<int> CSCRowIndices;
-    std::vector<int> CSCColPointers;
-
-    if (opencl_ilu_reorder == ILUReorder::NONE) {
-        LUmat = std::make_unique<BlockedMatrix>(*mat);
-    } else {
-        toOrder.resize(Nb);
-        fromOrder.resize(Nb);
-        CSCRowIndices.resize(nnzb);
-        CSCColPointers.resize(Nb + 1);
-        rmat = std::make_shared<BlockedMatrix>(mat->Nb, mat->nnzbs, block_size);
-        LUmat = std::make_unique<BlockedMatrix>(*rmat);
-
-        Timer t_convert;
-        csrPatternToCsc(mat->colIndices, mat->rowPointers, CSCRowIndices.data(), CSCColPointers.data(), mat->Nb);
-        if (verbosity >= 3) {
-            std::ostringstream out;
-            out << "BILU0 convert CSR to CSC: " << t_convert.stop() << " s";
-            OpmLog::info(out.str());
-        }
-    }
-
-    Timer t_analysis;
-    std::ostringstream out;
-    if (opencl_ilu_reorder == ILUReorder::LEVEL_SCHEDULING) {
-        out << "BILU0 reordering strategy: " << "level_scheduling\n";
-        findLevelScheduling(mat->colIndices, mat->rowPointers, CSCRowIndices.data(), CSCColPointers.data(), mat->Nb, &numColors, toOrder.data(), fromOrder.data(), rowsPerColor);
-    } else if (opencl_ilu_reorder == ILUReorder::GRAPH_COLORING) {
-        out << "BILU0 reordering strategy: " << "graph_coloring\n";
-        findGraphColoring<block_size>(mat->colIndices, mat->rowPointers, CSCRowIndices.data(), CSCColPointers.data(), mat->Nb, mat->Nb, mat->Nb, &numColors, toOrder.data(), fromOrder.data(), rowsPerColor);
-    } else if (opencl_ilu_reorder == ILUReorder::NONE) {
-        out << "BILU0 reordering strategy: none\n";
-        // numColors = 1;
-        // rowsPerColor.emplace_back(Nb);
-        numColors = Nb;
-        for (int i = 0; i < Nb; ++i) {
-            rowsPerColor.emplace_back(1);
-        }
-    } else {
-        OPM_THROW(std::logic_error, "Error ilu reordering strategy not set correctly\n");
-    }
-    if (verbosity >= 1) {
-        out << "BILU0 analysis took: " << t_analysis.stop() << " s, " << numColors << " colors\n";
-    }
-#if CHOW_PATEL
-    out << "BILU0 CHOW_PATEL: " << CHOW_PATEL << ", CHOW_PATEL_GPU: " << CHOW_PATEL_GPU;
-#endif
-    OpmLog::info(out.str());
-
-    diagIndex.resize(mat->Nb);
-    invDiagVals.resize(mat->Nb * bs * bs);
-
-#if CHOW_PATEL
-    Lmat = std::make_unique<BlockedMatrix>(mat->Nb, (mat->nnzbs - mat->Nb) / 2, bs);
-    Umat = std::make_unique<BlockedMatrix>(mat->Nb, (mat->nnzbs - mat->Nb) / 2, bs);
-#endif
-
-    s.invDiagVals = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(double) * bs * bs * mat->Nb);
-    s.rowsPerColor = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(int) * (numColors + 1));
-    s.diagIndex = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(int) * LUmat->Nb);
-#if CHOW_PATEL
-    s.Lvals = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(double) * bs * bs * Lmat->nnzbs);
-    s.Lcols = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(int) * Lmat->nnzbs);
-    s.Lrows = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(int) * (Lmat->Nb + 1));
-    s.Uvals = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(double) * bs * bs * Lmat->nnzbs);
-    s.Ucols = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(int) * Lmat->nnzbs);
-    s.Urows = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(int) * (Lmat->Nb + 1));
-#else
-    s.LUvals = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(double) * bs * bs * LUmat->nnzbs);
-    s.LUcols = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(int) * LUmat->nnzbs);
-    s.LUrows = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(int) * (LUmat->Nb + 1));
-#endif
-
-    events.resize(2);
-    err = queue->enqueueWriteBuffer(s.invDiagVals, CL_FALSE, 0, mat->Nb * sizeof(double) * bs * bs, invDiagVals.data(), nullptr, &events[0]);
-
-    rowsPerColorPrefix.resize(numColors + 1); // resize initializes value 0.0
-    for (int i = 0; i < numColors; ++i) {
-        rowsPerColorPrefix[i + 1] = rowsPerColorPrefix[i] + rowsPerColor[i];
-    }
-    err |= queue->enqueueWriteBuffer(s.rowsPerColor, CL_FALSE, 0, (numColors + 1) * sizeof(int), rowsPerColorPrefix.data(), nullptr, &events[1]);
-
-    cl::WaitForEvents(events);
-    events.clear();
-    if (err != CL_SUCCESS) {
-        // enqueueWriteBuffer is C and does not throw exceptions like C++ OpenCL
-        OPM_THROW(std::logic_error, "BILU0 OpenCL enqueueWriteBuffer error");
-    }
-
-    return true;
+    return analyze_matrix(mat, nullptr);
 }
 
 
@@ -162,25 +66,29 @@ bool BILU0<block_size>::analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat
     this->nnz = mat->nnzbs * block_size * block_size;
     this->nnzb = mat->nnzbs;
 
-    this->nnz_jm = jacMat->nnzbs * block_size * block_size;
-    this->nnzbs_jm = jacMat->nnzbs;
-
     std::vector<int> CSCRowIndices;
     std::vector<int> CSCColPointers;
+
+    auto *matToDecompose = jacMat ? jacMat : mat; // decompose jacMat if valid, otherwise decompose mat
 
     if (opencl_ilu_reorder == ILUReorder::NONE) {
         LUmat = std::make_unique<BlockedMatrix>(*mat);
     } else {
         toOrder.resize(Nb);
         fromOrder.resize(Nb);
-        CSCRowIndices.resize(nnzbs_jm);
+        CSCRowIndices.resize(matToDecompose->nnzbs);
         CSCColPointers.resize(Nb + 1);
         rmat = std::make_shared<BlockedMatrix>(mat->Nb, mat->nnzbs, block_size);
-        rJacMat = std::make_shared<BlockedMatrix>(jacMat->Nb, jacMat->nnzbs, block_size);
-        LUmat = std::make_unique<BlockedMatrix>(*rJacMat);
+
+        if (jacMat) {
+            rJacMat = std::make_shared<BlockedMatrix>(jacMat->Nb, jacMat->nnzbs, block_size);
+            LUmat = std::make_unique<BlockedMatrix>(*rJacMat);
+        } else {
+            LUmat = std::make_unique<BlockedMatrix>(*rmat);
+        }
 
         Timer t_convert;
-        csrPatternToCsc(jacMat->colIndices, jacMat->rowPointers, CSCRowIndices.data(), CSCColPointers.data(), jacMat->Nb);
+        csrPatternToCsc(matToDecompose->colIndices, matToDecompose->rowPointers, CSCRowIndices.data(), CSCColPointers.data(), Nb);
         if(verbosity >= 3){
             std::ostringstream out;
             out << "BILU0 convert CSR to CSC: " << t_convert.stop() << " s";
@@ -192,10 +100,10 @@ bool BILU0<block_size>::analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat
     std::ostringstream out;
     if (opencl_ilu_reorder == ILUReorder::LEVEL_SCHEDULING) {
         out << "BILU0 reordering strategy: " << "level_scheduling\n";
-        findLevelScheduling(jacMat->colIndices, jacMat->rowPointers, CSCRowIndices.data(), CSCColPointers.data(), jacMat->Nb, &numColors, toOrder.data(), fromOrder.data(), rowsPerColor);
+        findLevelScheduling(matToDecompose->colIndices, matToDecompose->rowPointers, CSCRowIndices.data(), CSCColPointers.data(), Nb, &numColors, toOrder.data(), fromOrder.data(), rowsPerColor);
     } else if (opencl_ilu_reorder == ILUReorder::GRAPH_COLORING) {
         out << "BILU0 reordering strategy: " << "graph_coloring\n";
-        findGraphColoring<block_size>(jacMat->colIndices, jacMat->rowPointers, CSCRowIndices.data(), CSCColPointers.data(), jacMat->Nb, jacMat->Nb, jacMat->Nb, &numColors, toOrder.data(), fromOrder.data(), rowsPerColor);
+        findGraphColoring<block_size>(matToDecompose->colIndices, matToDecompose->rowPointers, CSCRowIndices.data(), CSCColPointers.data(), Nb, Nb, Nb, &numColors, toOrder.data(), fromOrder.data(), rowsPerColor);
     } else if (opencl_ilu_reorder == ILUReorder::NONE) {
         out << "BILU0 reordering strategy: none\n";
         // numColors = 1;
@@ -223,8 +131,6 @@ bool BILU0<block_size>::analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat
     Lmat = std::make_unique<BlockedMatrix<block_size> >(mat->Nb, (mat->nnzbs - mat->Nb) / 2);
     Umat = std::make_unique<BlockedMatrix<block_size> >(mat->Nb, (mat->nnzbs - mat->Nb) / 2);
 #endif
-
-    LUmat->nnzValues = new double[jacMat->nnzbs * bs * bs];
 
     s.invDiagVals = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(double) * bs * bs * mat->Nb);
     s.rowsPerColor = cl::Buffer(*context, CL_MEM_READ_WRITE, sizeof(int) * (numColors + 1));
@@ -266,95 +172,8 @@ bool BILU0<block_size>::analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat
 template <unsigned int block_size>
 bool BILU0<block_size>::create_preconditioner(BlockedMatrix *mat)
 {
-    const unsigned int bs = block_size;
-    auto *m = mat;
-
-    if (opencl_ilu_reorder != ILUReorder::NONE) {
-        m = rmat.get();
-        Timer t_reorder;
-        reorderBlockedMatrixByPattern(mat, toOrder.data(), fromOrder.data(), rmat.get());
-
-        if (verbosity >= 3) {
-            std::ostringstream out;
-            out << "BILU0 reorder matrix: " << t_reorder.stop() << " s";
-            OpmLog::info(out.str());
-        }
-    }
-
-    // TODO: remove this copy by replacing inplace ilu decomp by out-of-place ilu decomp
-    // this copy can have mat or rmat ->nnzValues as origin, depending on the reorder strategy
-    Timer t_copy;
-    memcpy(LUmat->nnzValues, m->nnzValues, sizeof(double) * bs * bs * m->nnzbs);
-
-    if (verbosity >= 3) {
-        std::ostringstream out;
-        out << "BILU0 memcpy: " << t_copy.stop() << " s";
-        OpmLog::info(out.str());
-    }
-
-#if CHOW_PATEL
-    chowPatelIlu.decomposition(queue.get(), context.get(),
-                               LUmat.get(), Lmat.get(), Umat.get(),
-                               invDiagVals.data(), diagIndex,
-                               s.diagIndex, s.invDiagVals,
-                               s.Lvals, s.Lcols, s.Lrows,
-                               s.Uvals, s.Ucols, s.Urows);
-#else
-    Timer t_copyToGpu;
-
-    events.resize(1);
-    err = queue->enqueueWriteBuffer(s.LUvals, CL_FALSE, 0, LUmat->nnzbs * bs * bs * sizeof(double), LUmat->nnzValues, nullptr, &events[0]);
-
-    std::call_once(pattern_uploaded, [&]() {
-        // find the positions of each diagonal block
-        // must be done after reordering
-        for (int row = 0; row < Nb; ++row) {
-            int rowStart = LUmat->rowPointers[row];
-            int rowEnd = LUmat->rowPointers[row + 1];
-
-            auto candidate = std::find(LUmat->colIndices + rowStart, LUmat->colIndices + rowEnd, row);
-            assert(candidate != LUmat->colIndices + rowEnd);
-            diagIndex[row] = candidate - LUmat->colIndices;
-        }
-        events.resize(4);
-        err |= queue->enqueueWriteBuffer(s.diagIndex, CL_FALSE, 0, Nb * sizeof(int), diagIndex.data(), nullptr, &events[1]);
-        err |= queue->enqueueWriteBuffer(s.LUcols, CL_FALSE, 0, LUmat->nnzbs * sizeof(int), LUmat->colIndices, nullptr, &events[2]);
-        err |= queue->enqueueWriteBuffer(s.LUrows, CL_FALSE, 0, (LUmat->Nb + 1) * sizeof(int), LUmat->rowPointers, nullptr, &events[3]);
-    });
-
-    cl::WaitForEvents(events);
-    events.clear();
-    if (err != CL_SUCCESS) {
-        // enqueueWriteBuffer is C and does not throw exceptions like C++ OpenCL
-        OPM_THROW(std::logic_error, "BILU0 OpenCL enqueueWriteBuffer error");
-    }
-
-    if (verbosity >= 3) {
-        std::ostringstream out;
-        out << "BILU0 copy to GPU: " << t_copyToGpu.stop() << " s";
-        OpmLog::info(out.str());
-    }
-
-    Timer t_decomposition;
-    std::ostringstream out;
-    cl::Event event;
-    for (int color = 0; color < numColors; ++color) {
-        const unsigned int firstRow = rowsPerColorPrefix[color];
-        const unsigned int lastRow = rowsPerColorPrefix[color + 1];
-        if (verbosity >= 4) {
-            out << "color " << color << ": " << firstRow << " - " << lastRow << " = " << lastRow - firstRow << "\n";
-        }
-        OpenclKernels::ILU_decomp(firstRow, lastRow, s.LUvals, s.LUcols, s.LUrows, s.diagIndex, s.invDiagVals, Nb, block_size);
-    }
-
-    if (verbosity >= 3) {
-        out << "BILU0 decomposition: " << t_decomposition.stop() << " s";
-        OpmLog::info(out.str());
-    }
-#endif // CHOW_PATEL
-
-    return true;
-} // end create_preconditioner()
+    return create_preconditioner(mat, nullptr);
+}
 
 
 template <unsigned int block_size>
@@ -362,13 +181,18 @@ bool BILU0<block_size>::create_preconditioner(BlockedMatrix *mat, BlockedMatrix 
 {
     const unsigned int bs = block_size;
 
-    auto *jm = jacMat;
+    auto *matToDecompose = jacMat;
 
     if (opencl_ilu_reorder != ILUReorder::NONE) {
-        jm = rJacMat.get();
         Timer t_reorder;
-        reorderBlockedMatrixByPattern(mat, toOrder.data(), fromOrder.data(), rmat.get());
-        reorderBlockedMatrixByPattern(jacMat, toOrder.data(), fromOrder.data(), rJacMat.get());
+        if (jacMat) {
+            matToDecompose = rJacMat.get();
+            reorderBlockedMatrixByPattern(mat, toOrder.data(), fromOrder.data(), rmat.get());
+            reorderBlockedMatrixByPattern(jacMat, toOrder.data(), fromOrder.data(), rJacMat.get());
+        } else {
+            matToDecompose = rmat.get();
+            reorderBlockedMatrixByPattern(mat, toOrder.data(), fromOrder.data(), rmat.get());
+        }
 
         if (verbosity >= 3){
             std::ostringstream out;
@@ -380,7 +204,7 @@ bool BILU0<block_size>::create_preconditioner(BlockedMatrix *mat, BlockedMatrix 
     // TODO: remove this copy by replacing inplace ilu decomp by out-of-place ilu decomp
     // this copy can have mat or rmat ->nnzValues as origin, depending on the reorder strategy
     Timer t_copy;
-    memcpy(LUmat->nnzValues, jm->nnzValues, sizeof(double) * bs * bs * jm->nnzbs);
+    memcpy(LUmat->nnzValues, matToDecompose->nnzValues, sizeof(double) * bs * bs * matToDecompose->nnzbs);
 
     if (verbosity >= 3){
         std::ostringstream out;

--- a/opm/simulators/linalg/bda/opencl/BILU0.cpp
+++ b/opm/simulators/linalg/bda/opencl/BILU0.cpp
@@ -178,7 +178,7 @@ bool BILU0<block_size>::analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat
         rmat = std::make_shared<BlockedMatrix>(mat->Nb, mat->nnzbs, block_size);
         rJacMat = std::make_shared<BlockedMatrix>(jacMat->Nb, jacMat->nnzbs, block_size);
         LUmat = std::make_unique<BlockedMatrix>(*rJacMat);
-            
+
         Timer t_convert;
         csrPatternToCsc(jacMat->colIndices, jacMat->rowPointers, CSCRowIndices.data(), CSCColPointers.data(), jacMat->Nb);
         if(verbosity >= 3){
@@ -193,20 +193,16 @@ bool BILU0<block_size>::analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat
     if (opencl_ilu_reorder == ILUReorder::LEVEL_SCHEDULING) {
         out << "BILU0 reordering strategy: " << "level_scheduling\n";
         findLevelScheduling(jacMat->colIndices, jacMat->rowPointers, CSCRowIndices.data(), CSCColPointers.data(), jacMat->Nb, &numColors, toOrder.data(), fromOrder.data(), rowsPerColor);
-        for (int iii = 0; iii < numColors; ++iii) { out << "rpc: "<< rowsPerColor[iii] << "\n";} 
-        out << "numColors: "<< numColors << "\n";
     } else if (opencl_ilu_reorder == ILUReorder::GRAPH_COLORING) {
         out << "BILU0 reordering strategy: " << "graph_coloring\n";
         findGraphColoring<block_size>(jacMat->colIndices, jacMat->rowPointers, CSCRowIndices.data(), CSCColPointers.data(), jacMat->Nb, jacMat->Nb, jacMat->Nb, &numColors, toOrder.data(), fromOrder.data(), rowsPerColor);
-        for (int iii = 0; iii < numColors; ++iii) { out << "rpc: "<< rowsPerColor[iii] << "\n";} 
-        out << "numColors: "<< numColors << "\n";
     } else if (opencl_ilu_reorder == ILUReorder::NONE) {
         out << "BILU0 reordering strategy: none\n";
         // numColors = 1;
         // rowsPerColor.emplace_back(Nb);
         numColors = Nb;
         for(int i = 0; i < Nb; ++i){
-        rowsPerColor.emplace_back(1);
+            rowsPerColor.emplace_back(1);
         }
     } else {
         OPM_THROW(std::logic_error, "Error ilu reordering strategy not set correctly\n");
@@ -369,7 +365,6 @@ bool BILU0<block_size>::create_preconditioner(BlockedMatrix *mat, BlockedMatrix 
     auto *jm = jacMat;
 
     if (opencl_ilu_reorder != ILUReorder::NONE) {
-
         jm = rJacMat.get();
         Timer t_reorder;
         reorderBlockedMatrixByPattern(mat, toOrder.data(), fromOrder.data(), rmat.get());

--- a/opm/simulators/linalg/bda/opencl/BILU0.hpp
+++ b/opm/simulators/linalg/bda/opencl/BILU0.hpp
@@ -133,6 +133,10 @@ public:
 #endif
     }
 
+    BlockedMatrix* getRJacMat()
+    {
+        return rJacMat.get();
+    }
 };
 
 } // namespace Accelerator

--- a/opm/simulators/linalg/bda/opencl/BILU0.hpp
+++ b/opm/simulators/linalg/bda/opencl/BILU0.hpp
@@ -69,6 +69,9 @@ private:
 
     ILUReorder opencl_ilu_reorder;
 
+    std::vector<int> reordermappingNonzeroes;    // maps nonzero blocks to new location in reordered matrix
+    std::vector<int> jacReordermappingNonzeroes; // same but for jacMatrix
+
     typedef struct {
         cl::Buffer invDiagVals;
         cl::Buffer diagIndex;
@@ -117,6 +120,11 @@ public:
         return rmat.get();
     }
 
+    BlockedMatrix* getRJacMat()
+    {
+        return rJacMat.get();
+    }
+
     std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> get_preconditioner_structure()
     {
         return {{LUmat->rowPointers, LUmat->rowPointers + (Nb + 1)}, {LUmat->colIndices, LUmat->colIndices + nnzb}, diagIndex};
@@ -129,11 +137,6 @@ public:
 #else
         return std::make_pair(s.LUvals, s.invDiagVals);
 #endif
-    }
-
-    BlockedMatrix* getRJacMat()
-    {
-        return rJacMat.get();
     }
 };
 

--- a/opm/simulators/linalg/bda/opencl/BILU0.hpp
+++ b/opm/simulators/linalg/bda/opencl/BILU0.hpp
@@ -53,8 +53,6 @@ class BILU0 : public Preconditioner<block_size>
     using Base::err;
 
 private:
-    int nnz_jm;     // number of nonzeroes of the matrix (scalar)
-    int nnzbs_jm;   // number of blocks of the matrix
     std::unique_ptr<BlockedMatrix> LUmat = nullptr;
     std::shared_ptr<BlockedMatrix> rmat = nullptr; // only used with PAR_SIM
     std::shared_ptr<BlockedMatrix> rJacMat = nullptr; 
@@ -95,11 +93,11 @@ public:
 
     // analysis, find reordering if specified
     bool analyze_matrix(BlockedMatrix *mat) override;
-    bool analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat);
+    bool analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat) override;
 
     // ilu_decomposition
     bool create_preconditioner(BlockedMatrix *mat) override;
-    bool create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat);
+    bool create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat) override;
 
     // apply preconditioner, x = prec(y)
     void apply(const cl::Buffer& y, cl::Buffer& x) override;

--- a/opm/simulators/linalg/bda/opencl/BILU0.hpp
+++ b/opm/simulators/linalg/bda/opencl/BILU0.hpp
@@ -53,8 +53,11 @@ class BILU0 : public Preconditioner<block_size>
     using Base::err;
 
 private:
+    int nnz_jm;     // number of nonzeroes of the matrix (scalar)
+    int nnzbs_jm;   // number of blocks of the matrix
     std::unique_ptr<BlockedMatrix> LUmat = nullptr;
     std::shared_ptr<BlockedMatrix> rmat = nullptr; // only used with PAR_SIM
+    std::shared_ptr<BlockedMatrix> rJacMat = nullptr; 
 #if CHOW_PATEL
     std::unique_ptr<BlockedMatrix> Lmat = nullptr, Umat = nullptr;
 #endif
@@ -92,9 +95,11 @@ public:
 
     // analysis, find reordering if specified
     bool analyze_matrix(BlockedMatrix *mat) override;
+    bool analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat);
 
     // ilu_decomposition
     bool create_preconditioner(BlockedMatrix *mat) override;
+    bool create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat);
 
     // apply preconditioner, x = prec(y)
     void apply(const cl::Buffer& y, cl::Buffer& x) override;

--- a/opm/simulators/linalg/bda/opencl/BISAI.cpp
+++ b/opm/simulators/linalg/bda/opencl/BISAI.cpp
@@ -92,6 +92,12 @@ bool BISAI<block_size>::analyze_matrix(BlockedMatrix *mat)
 }
 
 template <unsigned int block_size>
+bool BISAI<block_size>::analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat)
+{
+    return analyze_matrix(mat);
+}
+
+template <unsigned int block_size>
 void BISAI<block_size>::buildLowerSubsystemsStructures(){
     lower.subsystemPointers.assign(Nb + 1, 0);
 
@@ -253,6 +259,11 @@ bool BISAI<block_size>::create_preconditioner(BlockedMatrix *mat)
     }
 
     return true;
+}
+template <unsigned int block_size>
+bool BISAI<block_size>::create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat)
+{
+    return create_preconditioner(mat);
 }
 
 template <unsigned int block_size>

--- a/opm/simulators/linalg/bda/opencl/BISAI.cpp
+++ b/opm/simulators/linalg/bda/opencl/BISAI.cpp
@@ -79,23 +79,29 @@ std::vector<int> buildCsrToCscOffsetMap(std::vector<int> colPointers, std::vecto
 template <unsigned int block_size>
 bool BISAI<block_size>::analyze_matrix(BlockedMatrix *mat)
 {
-    const unsigned int bs = block_size;
-
-    this->N = mat->Nb * bs;
-    this->Nb = mat->Nb;
-    this->nnz = mat->nnzbs * bs * bs;
-    this->nnzb = mat->nnzbs;
-
-    bilu0->analyze_matrix(mat);
-
-    return true;
+    return analyze_matrix(mat, nullptr);
 }
 
 template <unsigned int block_size>
 bool BISAI<block_size>::analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat)
 {
-    (void) jacMat;
-    return analyze_matrix(mat);
+    const unsigned int bs = block_size;
+    auto *m = mat;
+
+    if (jacMat) {
+        m = jacMat;
+    }
+
+    this->N = m->Nb * bs;
+    this->Nb = m->Nb;
+    this->nnz = m->nnzbs * bs * bs;
+    this->nnzb = m->nnzbs;
+
+    if (jacMat) {
+        return bilu0->analyze_matrix(mat, jacMat);
+    } else {
+        return bilu0->analyze_matrix(mat);
+    }
 }
 
 template <unsigned int block_size>
@@ -169,7 +175,7 @@ void BISAI<block_size>::buildUpperSubsystemsStructures(){
 }
 
 template <unsigned int block_size>
-bool BISAI<block_size>::create_preconditioner(BlockedMatrix *mat)
+bool BISAI<block_size>::create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat)
 {
     const unsigned int bs = block_size;
 
@@ -179,7 +185,11 @@ bool BISAI<block_size>::create_preconditioner(BlockedMatrix *mat)
 
     Dune::Timer t_preconditioner;
 
-    bilu0->create_preconditioner(mat);
+    if (jacMat) {
+        bilu0->create_preconditioner(mat, jacMat);
+    } else {
+        bilu0->create_preconditioner(mat);
+    }
 
     std::call_once(initialize, [&]() {
         std::tie(colPointers, rowIndices, diagIndex) = bilu0->get_preconditioner_structure();
@@ -261,11 +271,11 @@ bool BISAI<block_size>::create_preconditioner(BlockedMatrix *mat)
 
     return true;
 }
+
 template <unsigned int block_size>
-bool BISAI<block_size>::create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat)
+bool BISAI<block_size>::create_preconditioner(BlockedMatrix *mat)
 {
-    (void) jacMat;
-    return create_preconditioner(mat);
+    return create_preconditioner(mat, nullptr);
 }
 
 template <unsigned int block_size>

--- a/opm/simulators/linalg/bda/opencl/BISAI.cpp
+++ b/opm/simulators/linalg/bda/opencl/BISAI.cpp
@@ -94,6 +94,7 @@ bool BISAI<block_size>::analyze_matrix(BlockedMatrix *mat)
 template <unsigned int block_size>
 bool BISAI<block_size>::analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat)
 {
+    (void) jacMat;
     return analyze_matrix(mat);
 }
 
@@ -263,6 +264,7 @@ bool BISAI<block_size>::create_preconditioner(BlockedMatrix *mat)
 template <unsigned int block_size>
 bool BISAI<block_size>::create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat)
 {
+    (void) jacMat;
     return create_preconditioner(mat);
 }
 

--- a/opm/simulators/linalg/bda/opencl/BISAI.hpp
+++ b/opm/simulators/linalg/bda/opencl/BISAI.hpp
@@ -117,10 +117,13 @@ public:
 
     // analysis, find reordering if specified
     bool analyze_matrix(BlockedMatrix *mat) override;
-
+    
+    bool analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat) override;
     // ilu_decomposition
     bool create_preconditioner(BlockedMatrix *mat) override;
 
+    bool create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat) override;
+    
     // apply preconditioner, x = prec(y)
     void apply(const cl::Buffer& y, cl::Buffer& x) override;
 

--- a/opm/simulators/linalg/bda/opencl/BISAI.hpp
+++ b/opm/simulators/linalg/bda/opencl/BISAI.hpp
@@ -117,13 +117,12 @@ public:
 
     // analysis, find reordering if specified
     bool analyze_matrix(BlockedMatrix *mat) override;
-    
     bool analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat) override;
+
     // ilu_decomposition
     bool create_preconditioner(BlockedMatrix *mat) override;
-
     bool create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat) override;
-    
+
     // apply preconditioner, x = prec(y)
     void apply(const cl::Buffer& y, cl::Buffer& x) override;
 

--- a/opm/simulators/linalg/bda/opencl/CPR.cpp
+++ b/opm/simulators/linalg/bda/opencl/CPR.cpp
@@ -80,6 +80,10 @@ bool CPR<block_size>::analyze_matrix(BlockedMatrix *mat_) {
     return success;
 }
 
+template <unsigned int block_size>
+bool CPR<block_size>::analyze_matrix(BlockedMatrix *mat_, BlockedMatrix *jacMat) {
+    return analyze_matrix(mat_);
+}
 
 template <unsigned int block_size>
 bool CPR<block_size>::create_preconditioner(BlockedMatrix *mat_) {
@@ -101,6 +105,10 @@ bool CPR<block_size>::create_preconditioner(BlockedMatrix *mat_) {
     return result;
 }
 
+template <unsigned int block_size>
+bool CPR<block_size>::create_preconditioner(BlockedMatrix *mat_, BlockedMatrix *jacMat) {
+    return create_preconditioner(mat_);
+}
 // return the absolute value of the N elements for which the absolute value is highest
 double get_absmax(const double *data, const int N) {
     return std::abs(*std::max_element(data, data + N, [](double a, double b){return std::fabs(a) < std::fabs(b);}));

--- a/opm/simulators/linalg/bda/opencl/CPR.cpp
+++ b/opm/simulators/linalg/bda/opencl/CPR.cpp
@@ -82,6 +82,7 @@ bool CPR<block_size>::analyze_matrix(BlockedMatrix *mat_) {
 
 template <unsigned int block_size>
 bool CPR<block_size>::analyze_matrix(BlockedMatrix *mat_, BlockedMatrix *jacMat) {
+    (void) jacMat;
     return analyze_matrix(mat_);
 }
 
@@ -107,6 +108,7 @@ bool CPR<block_size>::create_preconditioner(BlockedMatrix *mat_) {
 
 template <unsigned int block_size>
 bool CPR<block_size>::create_preconditioner(BlockedMatrix *mat_, BlockedMatrix *jacMat) {
+    (void) jacMat;
     return create_preconditioner(mat_);
 }
 // return the absolute value of the N elements for which the absolute value is highest

--- a/opm/simulators/linalg/bda/opencl/CPR.hpp
+++ b/opm/simulators/linalg/bda/opencl/CPR.hpp
@@ -126,6 +126,7 @@ public:
 
     bool analyze_matrix(BlockedMatrix *mat) override;
 
+    bool analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat) override;
     // set own Opencl variables, but also that of the bilu0 preconditioner
     void setOpencl(std::shared_ptr<cl::Context>& context, std::shared_ptr<cl::CommandQueue>& queue) override;
 
@@ -135,6 +136,8 @@ public:
 
     bool create_preconditioner(BlockedMatrix *mat) override;
 
+    bool create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat) override;
+    
     int* getToOrder() override
     {
         return bilu0->getToOrder();

--- a/opm/simulators/linalg/bda/opencl/CPR.hpp
+++ b/opm/simulators/linalg/bda/opencl/CPR.hpp
@@ -125,8 +125,8 @@ public:
     CPR(int verbosity, ILUReorder opencl_ilu_reorder);
 
     bool analyze_matrix(BlockedMatrix *mat) override;
-
     bool analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat) override;
+
     // set own Opencl variables, but also that of the bilu0 preconditioner
     void setOpencl(std::shared_ptr<cl::Context>& context, std::shared_ptr<cl::CommandQueue>& queue) override;
 
@@ -135,7 +135,6 @@ public:
     void apply(const cl::Buffer& y, cl::Buffer& x) override;
 
     bool create_preconditioner(BlockedMatrix *mat) override;
-
     bool create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat) override;
     
     int* getToOrder() override

--- a/opm/simulators/linalg/bda/opencl/Preconditioner.cpp
+++ b/opm/simulators/linalg/bda/opencl/Preconditioner.cpp
@@ -52,10 +52,21 @@ std::unique_ptr<Preconditioner<block_size> > Preconditioner<block_size>::create(
     }
 }
 
+template <unsigned int block_size>
+bool Preconditioner<block_size>::analyze_matrix(BlockedMatrix *mat, [[maybe_unused]] BlockedMatrix *jacMat) {
+    return analyze_matrix(mat);
+}
+
+template <unsigned int block_size>
+bool Preconditioner<block_size>::create_preconditioner(BlockedMatrix *mat, [[maybe_unused]] BlockedMatrix *jacMat) {
+    return create_preconditioner(mat);
+}
 
 #define INSTANTIATE_BDA_FUNCTIONS(n)  \
-template std::unique_ptr<Preconditioner<n> > Preconditioner<n>::create(PreconditionerType, int, ILUReorder);  \
-template void Preconditioner<n>::setOpencl(std::shared_ptr<cl::Context>&, std::shared_ptr<cl::CommandQueue>&);
+template std::unique_ptr<Preconditioner<n> > Preconditioner<n>::create(PreconditionerType, int, ILUReorder);   \
+template void Preconditioner<n>::setOpencl(std::shared_ptr<cl::Context>&, std::shared_ptr<cl::CommandQueue>&); \
+template bool Preconditioner<n>::analyze_matrix(BlockedMatrix *, BlockedMatrix *);                             \
+template bool Preconditioner<n>::create_preconditioner(BlockedMatrix *, BlockedMatrix *);
 
 INSTANTIATE_BDA_FUNCTIONS(1);
 INSTANTIATE_BDA_FUNCTIONS(2);

--- a/opm/simulators/linalg/bda/opencl/Preconditioner.hpp
+++ b/opm/simulators/linalg/bda/opencl/Preconditioner.hpp
@@ -68,10 +68,14 @@ public:
 
     // analyze matrix, e.g. the sparsity pattern
     // probably only called once
+    // the version with two params can be overloaded, if not, it will default to using the one param version
     virtual bool analyze_matrix(BlockedMatrix *mat) = 0;
+    virtual bool analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat);
 
     // create/update preconditioner, probably used every linear solve
+    // the version with two params can be overloaded, if not, it will default to using the one param version
     virtual bool create_preconditioner(BlockedMatrix *mat) = 0;
+    virtual bool create_preconditioner(BlockedMatrix *mat, BlockedMatrix *jacMat);
 
     // get reordering mappings
     virtual int* getToOrder() = 0;

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
@@ -454,6 +454,7 @@ void openclSolverBackend<block_size>::initialize2(int N_, int nnz_, int dim, dou
     Nb = (N + dim - 1) / dim;
     std::ostringstream out;
     out << "Initializing GPU, matrix size: " << N << " blocks, nnzb: " << nnzb << "\n";
+    out << "Blocks in ILU matrix: " << jac_nnzb << "\n";
     out << "Maxit: " << maxit << std::scientific << ", tolerance: " << tolerance << "\n";
     out << "PlatformID: " << platformID << ", deviceID: " << deviceID << "\n";
     OpmLog::info(out.str());

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
@@ -393,15 +393,10 @@ void openclSolverBackend<block_size>::initialize(std::shared_ptr<BlockedMatrix> 
         useJacMatrix = true;
     }
 
-    if (useJacMatrix) {
-        this->jac_nnz = jacMatrix->nnzbs;
-        this->jac_nnzb = jac_nnz * block_size * block_size;
-    }
-
     std::ostringstream out;
     out << "Initializing GPU, matrix size: " << Nb << " blockrows, nnzb: " << nnzb << "\n";
     if (useJacMatrix) {
-        out << "Blocks in ILU matrix: " << jac_nnzb << "\n";
+        out << "Blocks in ILU matrix: " << jacMatrix->nnzbs << "\n";
     }
     out << "Maxit: " << maxit << std::scientific << ", tolerance: " << tolerance << "\n";
     out << "PlatformID: " << platformID << ", deviceID: " << deviceID << "\n";

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
@@ -399,7 +399,7 @@ void openclSolverBackend<block_size>::initialize(std::shared_ptr<BlockedMatrix> 
     }
 
     std::ostringstream out;
-    out << "Initializing GPU, matrix size: " << N << " blocks, nnzb: " << nnzb << "\n";
+    out << "Initializing GPU, matrix size: " << Nb << " blockrows, nnzb: " << nnzb << "\n";
     if (useJacMatrix) {
         out << "Blocks in ILU matrix: " << jac_nnzb << "\n";
     }

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
@@ -370,7 +370,7 @@ void openclSolverBackend<block_size>::gpu_pbicgstab(WellContributions& wellContr
             ", time per iteration: " << res.elapsed / it << ", iterations: " << it;
         OpmLog::info(out.str());
     }
-    if (verbosity >= 4) {
+    if (verbosity >= 3) {
         std::ostringstream out;
         out << "openclSolver::prec_apply:  " << t_prec.elapsed() << " s\n";
         out << "wellContributions::apply:  " << t_well.elapsed() << " s\n";

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
@@ -590,7 +590,11 @@ template <unsigned int block_size>
 bool openclSolverBackend<block_size>::analyze_matrix() {
     Timer t;
 
-    bool success = prec->analyze_matrix(mat.get(), jacMat.get());
+    bool success;
+    if (blockJacVersion)
+        success = prec->analyze_matrix(mat.get(), jacMat.get());
+    else
+        success = prec->analyze_matrix(mat.get());
 
     if (opencl_ilu_reorder == ILUReorder::NONE) {
         rmat = mat.get();
@@ -641,7 +645,11 @@ template <unsigned int block_size>
 bool openclSolverBackend<block_size>::create_preconditioner() {
     Timer t;
 
-    bool result = prec->create_preconditioner(mat.get(), jacMat.get());
+    bool result;
+    if (blockJacVersion)
+        result = prec->create_preconditioner(mat.get(), jacMat.get());
+    else
+        result = prec->create_preconditioner(mat.get());
 
     if (verbosity > 2) {
         std::ostringstream out;
@@ -730,6 +738,7 @@ SolverStatus openclSolverBackend<block_size>::solve_system2(int N_, int nnz_, in
                            WellContributions& wellContribs, BdaResult &res)
 {
     if (initialized == false) {
+        blockJacVersion = true;
         initialize2(N_, nnz_,  dim, vals, rows, cols, nnz2, vals2, rows2, cols2);
         if (analysis_done == false) {
             if (!analyze_matrix()) {

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.hpp
@@ -63,8 +63,6 @@ private:
 
     std::vector<cl::Device> devices;
 
-    int jac_nnz;
-    int jac_nnzb;
     bool useJacMatrix = false;
 
     std::unique_ptr<Preconditioner<block_size> > prec;

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.hpp
@@ -72,8 +72,8 @@ private:
     bool is_root;                                                 // allow for nested solvers, the root solver is called by BdaBridge
     int *toOrder = nullptr, *fromOrder = nullptr;                 // BILU0 reorders rows of the matrix via these mappings
     bool analysis_done = false;
-    std::unique_ptr<BlockedMatrix> mat = nullptr;                 // original matrix
-    std::unique_ptr<BlockedMatrix> jacMat = nullptr;              // matrix for preconditioner
+    std::shared_ptr<BlockedMatrix> mat = nullptr;                 // original matrix
+    std::shared_ptr<BlockedMatrix> jacMat = nullptr;              // matrix for preconditioner
     BlockedMatrix *rmat = nullptr;                                // reordered matrix (or original if no reordering), used for spmv
     ILUReorder opencl_ilu_reorder;                                // reordering strategy
     std::vector<cl::Event> events;
@@ -135,16 +135,10 @@ private:
     void gpu_pbicgstab(WellContributions& wellContribs, BdaResult& res);
 
     /// Initialize GPU and allocate memory
-    /// \param[in] N              number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] nnz            number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] dim            size of block
-    /// \param[in] vals           array of nonzeroes, each block is stored row-wise and contiguous, contains nnz values
-    /// \param[in] rows           array of rowPointers, contains N/dim+1 values
-    /// \param[in] cols           array of columnIndices, contains nnz values
-    void initialize(int N, int nnz, int dim, double *vals, int *rows, int *cols);
-
-    void initialize2(int N, int nnz, int dim, double *vals, int *rows, int *cols,
-                     int nnz2, double *vals2, int *rows2, int *cols2);
+    /// \param[in] matrix     matrix A
+    /// \param[in] jacMatrix  matrix for preconditioner
+    void initialize(std::shared_ptr<BlockedMatrix> matrix);
+    void initialize2(std::shared_ptr<BlockedMatrix> matrix, std::shared_ptr<BlockedMatrix> jacMatrix);
 
     /// Clean memory
     void finalize();
@@ -197,25 +191,16 @@ public:
     ~openclSolverBackend();
 
     /// Solve linear system, A*x = b, matrix A must be in blocked-CSR format
-    /// \param[in] N              number of rows, divide by dim to get number of blockrows
-    /// \param[in] nnz            number of nonzeroes, divide by dim*dim to get number of blocks
-    /// \param[in] nnz_prec       number of nonzeroes of matrix for ILU0, divide by dim*dim to get number of blocks
-    /// \param[in] dim            size of block
-    /// \param[in] vals           array of nonzeroes, each block is stored row-wise and contiguous, contains nnz values
-    /// \param[in] rows           array of rowPointers, contains N/dim+1 values
-    /// \param[in] cols           array of columnIndices, contains nnz values
-    /// \param[in] vals_prec      array of nonzeroes for preconditioner
-    /// \param[in] rows_prec      array of rowPointers for preconditioner
-    /// \param[in] cols_prec      array of columnIndices for preconditioner
+    /// \param[in] matrix         matrix A
     /// \param[in] b              input vector, contains N values
     /// \param[in] wellContribs   WellContributions, to apply them separately, instead of adding them to matrix A
     /// \param[inout] res         summary of solver result
     /// \return                   status code
-    SolverStatus solve_system(int N, int nnz, int dim, double *vals, int *rows, int *cols, double *b, WellContributions& wellContribs, BdaResult &res) override;
+    SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b, WellContributions& wellContribs, BdaResult &res) override;
 
-    SolverStatus solve_system2(int N_, int nnz_, int dim, double *vals, int *rows, int *cols, double *b,
-                   int nnz2, double *vals2, int *rows2, int *cols2,
-                   WellContributions& wellContribs, BdaResult &res) override;
+    SolverStatus solve_system2(std::shared_ptr<BlockedMatrix> matrix, double *b,
+                               std::shared_ptr<BlockedMatrix> jacMatrix,
+                               WellContributions& wellContribs, BdaResult &res) override;
 
     /// Solve scalar linear system, for example a coarse system of an AMG preconditioner
     /// Data is already on the GPU

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.hpp
@@ -144,7 +144,7 @@ private:
     void initialize(int N, int nnz, int dim, double *vals, int *rows, int *cols);
 
     void initialize2(int N, int nnz, int dim, double *vals, int *rows, int *cols,
-		     int nnz2, double *vals2, int *rows2, int *cols2);
+                     int nnz2, double *vals2, int *rows2, int *cols2);
 
     /// Clean memory
     void finalize();

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.hpp
@@ -65,7 +65,7 @@ private:
 
     int jac_nnz;
     int jac_nnzb;
-    bool blockJacVersion = false;
+    bool useJacMatrix = false;
 
     std::unique_ptr<Preconditioner<block_size> > prec;
                                                                   // can perform blocked ILU0 and AMG on pressure component
@@ -137,8 +137,7 @@ private:
     /// Initialize GPU and allocate memory
     /// \param[in] matrix     matrix A
     /// \param[in] jacMatrix  matrix for preconditioner
-    void initialize(std::shared_ptr<BlockedMatrix> matrix);
-    void initialize2(std::shared_ptr<BlockedMatrix> matrix, std::shared_ptr<BlockedMatrix> jacMatrix);
+    void initialize(std::shared_ptr<BlockedMatrix> matrix, std::shared_ptr<BlockedMatrix> jacMatrix);
 
     /// Clean memory
     void finalize();
@@ -193,14 +192,12 @@ public:
     /// Solve linear system, A*x = b, matrix A must be in blocked-CSR format
     /// \param[in] matrix         matrix A
     /// \param[in] b              input vector, contains N values
+    /// \param[in] jacMatrix      matrix for preconditioner
     /// \param[in] wellContribs   WellContributions, to apply them separately, instead of adding them to matrix A
     /// \param[inout] res         summary of solver result
     /// \return                   status code
-    SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b, WellContributions& wellContribs, BdaResult &res) override;
-
-    SolverStatus solve_system2(std::shared_ptr<BlockedMatrix> matrix, double *b,
-                               std::shared_ptr<BlockedMatrix> jacMatrix,
-                               WellContributions& wellContribs, BdaResult &res) override;
+    SolverStatus solve_system(std::shared_ptr<BlockedMatrix> matrix, double *b,
+        std::shared_ptr<BlockedMatrix> jacMatrix, WellContributions& wellContribs, BdaResult &res) override;
 
     /// Solve scalar linear system, for example a coarse system of an AMG preconditioner
     /// Data is already on the GPU

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.hpp
@@ -65,6 +65,8 @@ private:
 
     int jac_nnz;
     int jac_nnzb;
+    bool blockJacVersion = false;
+
     std::unique_ptr<Preconditioner<block_size> > prec;
                                                                   // can perform blocked ILU0 and AMG on pressure component
     bool is_root;                                                 // allow for nested solvers, the root solver is called by BdaBridge

--- a/opm/simulators/linalg/bda/opencl/openclWellContributions.cpp
+++ b/opm/simulators/linalg/bda/opencl/openclWellContributions.cpp
@@ -35,12 +35,6 @@ using Accelerator::OpenclKernels;
 void WellContributionsOCL::setOpenCLEnv(cl::Context* context_, cl::CommandQueue* queue_) {
     this->context = context_;
     this->queue = queue_;
- }
-
-void WellContributionsOCL::setKernel(Accelerator::stdwell_apply_kernel_type* kernel_,
-                                     Accelerator::stdwell_apply_no_reorder_kernel_type* kernel_no_reorder_) {
-    this->kernel = kernel_;
-    this->kernel_no_reorder = kernel_no_reorder_;
 }
 
 void WellContributionsOCL::setReordering(int* h_toOrder_, bool reorder_)

--- a/opm/simulators/linalg/bda/opencl/openclWellContributions.hpp
+++ b/opm/simulators/linalg/bda/opencl/openclWellContributions.hpp
@@ -35,8 +35,6 @@ namespace Opm
 class WellContributionsOCL : public WellContributions
 {
 public:
-    void setKernel(Opm::Accelerator::stdwell_apply_kernel_type *kernel_,
-                   Opm::Accelerator::stdwell_apply_no_reorder_kernel_type *kernel_no_reorder_);
     void setOpenCLEnv(cl::Context *context_, cl::CommandQueue *queue_);
 
     /// Since the rows of the matrix are reordered, the columnindices of the matrixdata is incorrect
@@ -56,8 +54,6 @@ protected:
 
     cl::Context* context;
     cl::CommandQueue* queue;
-    Opm::Accelerator::stdwell_apply_kernel_type* kernel;
-    Opm::Accelerator::stdwell_apply_no_reorder_kernel_type* kernel_no_reorder;
     std::vector<cl::Event> events;
 
     std::unique_ptr<cl::Buffer> d_Cnnzs_ocl, d_Dnnzs_ocl, d_Bnnzs_ocl;

--- a/opm/simulators/linalg/findOverlapRowsAndColumns.hpp
+++ b/opm/simulators/linalg/findOverlapRowsAndColumns.hpp
@@ -39,9 +39,9 @@ namespace detail
     /// \param useWellConn Boolean that is true when UseWellContribusion is true
     /// \param wellGraph Cell IDs of well cells stored in a graph.
     template<class Grid, class W>
-    void setWellConnections(const Grid& grid, const W& wells, bool useWellConn, std::vector<std::set<int>>& wellGraph)
+    void setWellConnections(const Grid& grid, const W& wells, bool useWellConn, std::vector<std::set<int>>& wellGraph, int numJacobiBlocks)
     {
-        if ( grid.comm().size() > 1)
+        if ( grid.comm().size() > 1 || numJacobiBlocks > 1)
         {
             Dune::CartesianIndexMapper< Grid > cartMapper( grid );
             const int numCells = cartMapper.compressedSize(); // grid.numCells()

--- a/tests/test_cusparseSolver.cpp
+++ b/tests/test_cusparseSolver.cpp
@@ -116,7 +116,7 @@ testCusparseSolver(const boost::property_tree::ptree& prm, Matrix<bz>& matrix, V
         bridge = std::make_unique<Opm::BdaBridge<Matrix<bz>, Vector<bz>, bz> >(accelerator_mode, fpga_bitstream, linear_solver_verbosity, maxit, tolerance, platformID, deviceID, opencl_ilu_reorder, linsolver);
         auto mat2 = matrix; // deep copy to make sure nnz values are in contiguous memory
                             // matrix created by readMatrixMarket() did not have contiguous memory
-        bridge->solve_system(&mat2, rhs, *wellContribs, result);
+        bridge->solve_system(&mat2, &mat2, /*numJacobiBlocks=*/0, rhs, *wellContribs, result);
         bridge->get_result(x);
 
         return x;

--- a/tests/test_openclSolver.cpp
+++ b/tests/test_openclSolver.cpp
@@ -118,7 +118,7 @@ testOpenclSolver(const boost::property_tree::ptree& prm, Matrix<bz>& matrix, Vec
     }
     auto mat2 = matrix; // deep copy to make sure nnz values are in contiguous memory
                         // matrix created by readMatrixMarket() did not have contiguous memory
-    bridge->solve_system(&mat2, &mat2, 0, rhs, *wellContribs, result);
+    bridge->solve_system(&mat2, &mat2, /*numJacobiBlocks=*/0, rhs, *wellContribs, result);
     bridge->get_result(x);
 
     return x;

--- a/tests/test_openclSolver.cpp
+++ b/tests/test_openclSolver.cpp
@@ -118,7 +118,7 @@ testOpenclSolver(const boost::property_tree::ptree& prm, Matrix<bz>& matrix, Vec
     }
     auto mat2 = matrix; // deep copy to make sure nnz values are in contiguous memory
                         // matrix created by readMatrixMarket() did not have contiguous memory
-    bridge->solve_system(&mat2, rhs, *wellContribs, result);
+    bridge->solve_system(&mat2, &mat2, 0, rhs, *wellContribs, result);
     bridge->get_result(x);
 
     return x;


### PR DESCRIPTION
Requires https://github.com/andrthu/opm-grid/tree/partition-without-scatter, works with masters of 2022-1-22 10:00.
Andreas has created branches that send 2 matrices to the openclSolver.
The original one is used for spmv, the other one is send to the ILU preconditioner and is dubbed jacobiMatrix. The jacobiMatrix contains less blocks (subset of sparsity pattern of original matrix) and therefore more parallelism can be extracted by the ILU preconditioner.
This jacobiMatrix is obtained by performed subdomain decomposition, similar to the partitioning that occurs when using multiple MPI processes. These partitions are then put back into this jacobiMatrix.
The jacobiMatrix can be configured using the runtime parameter `--num-jacobi-blocks`. Values 0 and 1 don't do anything, and the original matrix is used for both spmv and ILU.

The sparsity pattern for jacobiMatrix is calculated once, using the partition data. And the respective nonzero blocks are copied from the original matrix every linear solve.
The BILU0 object receives both the original and jacobiMatrix, and reorders then both. The reordered original is used in the spmv and AMG part of the CPR, and the jacobiMatrix stays private inside the BILU0 object.
The jacobiMatrix is exposed to the AMG part of the CPR in an unpublished commit for testing.
There are many merge conflicts because many opencl files where moved the `opencl/` folder.

@blattms @atgeirr @andrthu 
```
Benchmarks:
Notation:
X: A (B+C), D, E, F | G, H
X: Number of Jacobi blocks
A: Total time
B: Assembly time
C: Linear solve time
D: Overall Linearizations
E: Overall Newton Iterations
F: Overall Linear Iterations
G: Number of colors in BILU0
H: Number of fallbacks to Dune

AMD EPYC Milan 7763 + Tesla A100
opencl, level_scheduling, wellcontribs in matrix, no CPR
  0: 546 (142+215), 1810, 1447, 20797 | 194, 0
  1: 551 (144+216), 1810, 1447, 20797 | 194, 0
  4: 524 (145+189), 1826, 1466, 21392 | 132, 0
 32: 488 (142+157), 1787, 1430, 21867 |  92, 0
 64: 478 (143+148), 1796, 1440, 22353 |  75, 0
 80: 465 (141+137), 1783, 1426, 22536 |  62, 0
100: 467 (143+137), 1785, 1427, 22690 |  55, 0
128: 466 (142+136), 1777, 1420, 23215 |  55, 0
150: 454 (141+128), 1775, 1419, 24245 |  42, 0
200: 486 (150+141), 1841, 1476, 25094 |  55, 0

R5 2400G, GTX 1050Ti, using CPR, but AMG hierarchy uses original matrix
opencl, level_scheduling, wellcontribs in matrix
  0: 449 (104+166), 1442, 1097, 2768 | 194, 0
  4: 464 (107+177), 1447, 1104, 2787 | 132, 0
 16: 458 (105+172), 1443, 1100, 2885 |  91, 0
 32: 457 (104+174), 1435, 1093, 2952 |  92, 0
 64: 465 (106+178), 1456, 1111, 3139 |  75, 0
100: 462 (104+177), 1446, 1103, 3182 |  55, 0
150: 466 (106+179), 1447, 1104, 3311 |  42, 0
opencl, graph_coloring, wellcontribs in matrix
  0: 464 (107+175), 1470, 1126, 3555 | 32, 0
  4: 505 (112+208), 1505, 1160, 3914 | 31, 0
 16: 498 (109+205), 1497, 1151, 4009 | 30, 0
 32: 489 (108+198), 1487, 1144, 3761 | 31, 0
 64: 500 (110+205), 1514, 1167, 4048 | 29, 0
100: 535 (118+226), 1623, 1273, 4744 | 29, 0
150: 519 (114+218), 1587, 1238, 4577 | 31, 0

R5 2400G, GTX 1050Ti, using CPR, but AMG hierarchy uses jacobiMatrix
level_scheduling, wellcontribs in matrix, no runtimes reported:
  0: 1442, 1097,  2768 | 0
  4: 1501, 1155,  6030 | 0
 16: 1531, 1183,  6722 | 0
 64: 1596, 1247,  9394 | 0
100: 1703, 1345, 11729 | 0
150: 1917, 1551, 17316 | 0
200: 1988, 1617, 18961 | 0
256: 2044, 1669, 27859 | 1 fallback
ref: 1810, 1447, 20797 | 0, no CPR
```
Main takeaways:
- the jacobiMatrix speeds up computation a lot when using only the ILU preconditioner
- it does not when using the CPR preconditioner (although implementation error is always possible)
- the jacobiMatrix does not increase parallelism for graph_coloring
- the AMG part of the CPR should not use the jacobiMatrix
