### PR TITLE
Avoid switching to thp control if production is decreasing or injection is increasing

### DIFF
--- a/opm/simulators/wells/WellInterfaceFluidSystem.hpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.hpp
@@ -83,13 +83,16 @@ protected:
     void calculateReservoirRates(SingleWellState& ws) const;
 
     bool checkIndividualConstraints(SingleWellState& ws,
-                                    const SummaryState& summaryState) const;
+                                    const SummaryState& summaryState,
+                                    DeferredLogger& deferred_logger) const;
 
     Well::InjectorCMode activeInjectionConstraint(const SingleWellState& ws,
-                                                  const SummaryState& summaryState) const;
+                                                  const SummaryState& summaryState,
+                                                  DeferredLogger& deferred_logger) const;
 
     Well::ProducerCMode activeProductionConstraint(const SingleWellState& ws,
-                                                   const SummaryState& summaryState) const;
+                                                   const SummaryState& summaryState,
+                                                   DeferredLogger& deferred_logger) const;
 
     std::pair<bool, double> checkGroupConstraintsInj(const Group& group,
                                                      const WellState& well_state,

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -262,6 +262,8 @@ protected:
         bool solvable = true;
         // the well have non positive potentials
         bool has_negative_potentials = false;
+        //thp limit violated but not switched
+        mutable bool thp_limit_violated_but_not_switched = false;
     };
 
     OperabilityStatus operability_status_;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -262,7 +262,7 @@ namespace Opm
         }
         bool changed = false;
         if (iog == IndividualOrGroup::Individual) {
-            changed = this->checkIndividualConstraints(ws, summaryState);
+            changed = this->checkIndividualConstraints(ws, summaryState, deferred_logger);
         } else if (iog == IndividualOrGroup::Group) {
             changed = this->checkGroupConstraints(well_state, group_state, schedule, summaryState, deferred_logger);
         } else {
@@ -600,7 +600,8 @@ namespace Opm
 
         // Operability checking is not free
         // Only check wells under BHP and THP control
-        if(bhp_controled || thp_controled) {
+        bool check_thp = thp_controled || this->operability_status_.thp_limit_violated_but_not_switched;
+        if (check_thp || bhp_controled) {
             updateIPR(ebos_simulator, deferred_logger);
             checkOperabilityUnderBHPLimit(well_state, ebos_simulator, deferred_logger);
         }


### PR DESCRIPTION
This means that we may temporary allow a producer to operate with thp below its limit if that gives a higher production. The operability of these wells will be tested along with wells under thp and bhp control.  