### PR TITLE
Don't Capture Local Flux Data Unless Needed

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.hh
+++ b/ebos/eclgenericoutputblackoilmodule.hh
@@ -186,6 +186,11 @@ public:
         return 0;
     }
 
+    bool needInterfaceFluxes([[maybe_unused]] const bool isSubStep) const
+    {
+        return this->interRegionFlows_.wantInterRegflowSummary();
+    }
+
     const std::map<std::size_t, double>& getWBPData() const
     {
         return this->wbpData_;

--- a/ebos/eclinterregflows.hh
+++ b/ebos/eclinterregflows.hh
@@ -274,6 +274,11 @@ namespace Opm {
         /// Whether or not previous read() operation succeeded.
         bool readIsConsistent() const;
 
+        bool wantInterRegflowSummary() const
+        {
+            return !this->regionMaps_.empty();
+        }
+
         /// Serialise internal representation to MPI message buffer
         ///
         /// \tparam MessageBufferType Linear MPI message buffer.  API should

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -187,7 +187,9 @@ public:
         const auto localWellTestState = simulator_.problem().wellModel().wellTestState();
         this->prepareLocalCellData(isSubStep, reportStepNum);
 
-        this->captureLocalFluxData();
+        if (this->eclOutputModule_->needInterfaceFluxes(isSubStep)) {
+            this->captureLocalFluxData();
+        }
 
         if (this->collectToIORank_.isParallel()) {
             OPM_BEGIN_PARALLEL_TRY_CATCH()


### PR DESCRIPTION
This is a potentially expensive operation and so we should not run it unless such values are actually needed for output purposes (e.g., inter-region flow summary vectors).