### PR TITLE
Support Calculating Phase Pressures for Water/Gas at Block Level

### DIFF
--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -551,6 +551,10 @@ public:
                         val.second = getValue(fs.pressure(oilPhaseIdx)) - getValue(fs.pressure(waterPhaseIdx));
                     else if (key.first == "BGPC")
                         val.second = getValue(fs.pressure(gasPhaseIdx)) - getValue(fs.pressure(oilPhaseIdx));
+                    else if (key.first == "BWPR")
+                        val.second = getValue(fs.pressure(waterPhaseIdx));
+                    else if (key.first == "BGPR")
+                        val.second = getValue(fs.pressure(gasPhaseIdx));
                     else if (key.first == "BVWAT" || key.first == "BWVIS")
                         val.second = getValue(fs.viscosity(waterPhaseIdx));
                     else if (key.first == "BVGAS" || key.first == "BGVIS")


### PR DESCRIPTION
This PR adds support for calculating/extracting the block-level phase pressures for water (`BWPR`) and gas (`BGPR`) for summary output purposes.