### PR TITLE
Use new VFPProdTable constructor 

### DIFF
--- a/tests/test_vfpproperties.cpp
+++ b/tests/test_vfpproperties.cpp
@@ -593,7 +593,8 @@ VFPPROD \n\
     auto units = Opm::UnitSystem::newFIELD();
     Opm::Parser parser;
     auto deck = parser.parseString(table_str);
-    Opm::VFPProdTable table(deck["VFPPROD"].front(), units);
+    bool gaslift_active = false;
+    Opm::VFPProdTable table(deck["VFPPROD"].front(), gaslift_active, units);
     Opm::VFPProdProperties properties;
     properties.addTable( table );
 
@@ -653,7 +654,8 @@ BOOST_AUTO_TEST_CASE(ParseInterpolateRealisticVFPPROD)
     BOOST_REQUIRE(deck.hasKeyword("VFPPROD"));
     BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
 
-    Opm::VFPProdTable table(deck["VFPPROD"].front(), units);
+    bool gaslift_active = false;
+    Opm::VFPProdTable table(deck["VFPPROD"].front(), gaslift_active, units);
     Opm::VFPProdProperties properties;
     properties.addTable(table);
 


### PR DESCRIPTION
Refer to https://github.com/OPM/opm-common/pull/2971. In order to use the new constructor proposed in that PR, the constructor must now be passed a boolean variable signalling if gaslift is active.