### PR TITLE
using addition to update segment pressure when bhp is changed

### DIFF
--- a/opm/simulators/wells/SegmentState.cpp
+++ b/opm/simulators/wells/SegmentState.cpp
@@ -60,15 +60,16 @@ std::size_t SegmentState::size() const {
 }
 
 
-void SegmentState::scale_pressure(double bhp) {
+void SegmentState::scale_pressure(const double bhp) {
     if (this->empty())
         throw std::logic_error("Tried to pressure scale empty SegmentState");
 
-    auto scale_factor = bhp / this->pressure[0];
+    const auto pressure_change = bhp - this->pressure[0];
+
     std::transform(this->pressure.begin(),
                    this->pressure.end(),
                    this->pressure.begin(),
-                   [scale_factor] (const double& p) { return p*scale_factor;});
+                   [pressure_change] (const double& p) { return p + pressure_change;});
 }
 
 const std::vector<int>& SegmentState::segment_number() const {

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -539,7 +539,7 @@ BOOST_AUTO_TEST_CASE(TESTSegmentState2) {
     segments.scale_pressure(bhp);
 
     for (std::size_t i=0; i < segments.pressure.size(); i++)
-        BOOST_CHECK_EQUAL(segments.pressure[i], 2*(i+1));
+        BOOST_CHECK_EQUAL(segments.pressure[i], 1.+(i+1));
 
     BOOST_CHECK_EQUAL( segments.size(), well.getSegments().size() );
 }


### PR DESCRIPTION
when bhp is changed. It is much safer and more reasonable.

using multiplication is more likely to have dramatic values.