### PR TITLE
only output gaslift related output on rank 0

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -2189,7 +2189,7 @@ BlackoilWellModelGeneric::
 gliftDebug(const std::string& msg,
            DeferredLogger& deferred_logger) const
 {
-    if (this->glift_debug) {
+    if (this->glift_debug && comm_.rank() == 0 ) {
         const std::string message = fmt::format(
             "  GLIFT (DEBUG) : BlackoilWellModel : {}", msg);
         deferred_logger.info(message);

--- a/opm/simulators/wells/GasLiftGroupInfo.cpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.cpp
@@ -428,7 +428,7 @@ void
 GasLiftGroupInfo::
 displayDebugMessage_(const std::string &msg, const std::string &well_name)
 {
-    if (this->debug) {
+    if (this->debug && this->comm_.rank() == 0) {
         const std::string message = fmt::format(
              "  GLIFT (DEBUG) : Init group info : Well {} : {}",
              well_name, msg);

--- a/opm/simulators/wells/GasLiftStage2.cpp
+++ b/opm/simulators/wells/GasLiftStage2.cpp
@@ -251,7 +251,7 @@ void
 GasLiftStage2::
 displayDebugMessage_(const std::string &msg) const
 {
-    if (this->debug) {
+    if (this->debug  && this->comm_.rank() == 0) {
         const std::string message = fmt::format(
             "  GLIFT2 (DEBUG) : {}", msg);
         this->deferred_logger_.info(message);


### PR DESCRIPTION
The debugging gaslift output is not activated by default so this should not change any behavior of the simulator.