### PR TITLE
[python] Make sure Python files are installed similar to opm-common.

### DIFF
--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -23,7 +23,15 @@ target_sources(simulators
 
 target_link_libraries( simulators PRIVATE opmsimulators )
 
-set(PYTHON_PACKAGE_PATH "site-packages")
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import site, sys; sys.stdout.write(site.getsitepackages()[-1]);" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_PATH)
+if (PYTHON_SITE_PACKAGES_PATH MATCHES ".*/dist-packages/?" AND
+      CMAKE_INSTALL_PREFIX MATCHES "^/usr.*")
+  # dist-packages is only used if we install below /usr and python's site packages
+  # path matches dist-packages
+  set(PYTHON_PACKAGE_PATH "dist-packages")
+else()
+  set(PYTHON_PACKAGE_PATH "site-packages")
+endif()
 set(PYTHON_INSTALL_PREFIX "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/${PYTHON_PACKAGE_PATH}" CACHE STRING "Subdirectory to install Python modules in")
 
 install(TARGETS simulators DESTINATION ${DEST_PREFIX}${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_PREFIX}/opm)

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -23,7 +23,13 @@ target_sources(simulators
 
 target_link_libraries( simulators PRIVATE opmsimulators )
 
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import site, sys; sys.stdout.write(site.getsitepackages()[-1]);" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_PATH)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "
+import site, sys
+try:
+    sys.stdout.write(site.getsitepackages()[-1])
+except e:
+    sys.stdout.write('')" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_PATH)
+
 if (PYTHON_SITE_PACKAGES_PATH MATCHES ".*/dist-packages/?" AND
       CMAKE_INSTALL_PREFIX MATCHES "^/usr.*")
   # dist-packages is only used if we install below /usr and python's site packages


### PR DESCRIPTION
Instead of always using site-packages we query the sitepackages path from Python. If it matches dist-packages then we use dist-packages if we install below /usr, otherwise site-packages is used.

This will also make sure that the Python files end up in the same location as for the ones of opm-common. This should make using them easier.

The inconsistency before was that on Debian we install into dist-packages for opm-common and here we always into site-packages. This created quite some confusion (on all sides), see #3822. And does not work as expected.

BTW only 100% consistent if OPM/opm-common#2978 is also merged