### PR TITLE
Don't Process Corner-Point Data If No Valid Cell Geometry

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -472,6 +472,8 @@ private:
                      summaryConfig_, nullptr, python, std::move(parseContext),
                      init_from_restart_file, outputCout_, outputInterval);
 
+            verifyValidCellGeometry(EclGenericVanguard::comm(), *this->eclipseState_);
+
             setupTime_ = externalSetupTimer.elapsed();
             outputFiles_ = (outputMode != FileOutputMode::OUTPUT_NONE);
         }

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -86,6 +86,9 @@ void readDeck(Parallel::Communication         comm,
               bool                            initFromRestart,
               bool                            checkDeck,
               const std::optional<int>&       outputInterval);
+
+void verifyValidCellGeometry(Parallel::Communication comm,
+                             const EclipseState&     eclipseState);
 } // end namespace Opm
 
 #endif // OPM_READDECK_HEADER_INCLUDED


### PR DESCRIPTION
If no cell has a valid corner-point geometry, typically caused by using `GDFILE` to read non-finite data such as all `ZCORN = -1.0E+20`, then we must not attempt to generate a grid structure.  If we do, we will typically just fail somewhere deep down in the corner-point processing code and generate a diagnostic message that's hard to decipher.

With this commit we instead output a diagnostic message of the form
```
Error: No active cell in input grid has valid/finite cell geometry
Please check geometry keywords, especially if grid is imported through GDFILE
Program threw an exception: Allocating the simulation vanguard failed: No active cell in input grid has valid/finite cell geometry
Please check geometry keywords, especially if grid is imported through GDFILE
```
This may not be a lot better than the original diagnostic
```
Processing grid
flow: ${ROOT}/opm-grid/opm/grid/cpgpreprocess/preprocess.c:768: is_lefthanded: Assertion `! searching' failed.
Aborted (core dumped)
```
but does at least suggest that the grid data may be faulty.