### PR TITLE
Use empty string for buildtime if BUILD_TIMESTAMP is not set.

### DIFF
--- a/opm/simulators/utils/moduleVersion.cpp
+++ b/opm/simulators/utils/moduleVersion.cpp
@@ -51,7 +51,11 @@ namespace Opm
     /// the binary was compiled.
     std::string compileTimestamp()
     {
+#ifdef BUILD_TIMESTAMP
         return BUILD_TIMESTAMP;
+#else
+        return "";
+#endif
     }
 
 } // namespace Opm


### PR DESCRIPTION
In combination with the relevant changes in opm-common this prevent flow in binary Linux packages from having a timestamp in the executable that changes with every rebuild.

With the changes in opm-common  one can now set the variable OPM_BINARY_PACKAGE_VERSION to a meaningful version string (Debian 11.2: 2021.10-4). If that is done and flow is built from tarballs it will now not have a time stamp and print the package version to the PRT file. E.g.

```
Flow Version     =  2021.10 (Debian 11.2: 2021.10-1)
```

Note that without setting the variable or when building from a git repository there is no change.

Downstream of OPM/opm-common#2980
Closes #3832 