### PR TITLE
Cleanup gaslift debugging output code

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -2189,12 +2189,13 @@ BlackoilWellModelGeneric::
 gliftDebug(const std::string& msg,
            DeferredLogger& deferred_logger) const
 {
-    if (this->glift_debug) {
+    if (this->glift_debug && this->terminal_output_) {
         const std::string message = fmt::format(
             "  GLIFT (DEBUG) : BlackoilWellModel : {}", msg);
         deferred_logger.info(message);
     }
 }
+
 
 void
 BlackoilWellModelGeneric::

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -909,8 +909,7 @@ namespace Opm {
             if (this->glift_debug) gliftDebugShowALQ(deferred_logger);
             num_wells_changed = glift_wells.size();
         }
-        auto comm = ebosSimulator_.vanguard().grid().comm();
-        num_wells_changed = comm.sum(num_wells_changed);
+        num_wells_changed = this->comm_.sum(num_wells_changed);
         return num_wells_changed > 0;
     }
 
@@ -1043,7 +1042,7 @@ namespace Opm {
             = std::make_unique<GasLiftSingleWell>(
                 *well, ebosSimulator_, summary_state,
                 deferred_logger, this->wellState(), this->groupState(),
-                group_info, sync_groups, this->glift_debug);
+                group_info, sync_groups, this->comm_, this->glift_debug);
         auto state = glift->runOptimize(
             ebosSimulator_.model().newtonMethod().numIterations());
         if (state) {

--- a/opm/simulators/wells/GasLiftCommon.hpp
+++ b/opm/simulators/wells/GasLiftCommon.hpp
@@ -37,14 +37,28 @@ protected:
     GasLiftCommon(
         WellState &well_state,
         DeferredLogger &deferred_logger,
+        const Parallel::Communication& comm,
         bool debug
     );
+    enum class MessageType { INFO, WARNING };
+
     int debugUpdateGlobalCounter_() const;
     virtual void displayDebugMessage_(const std::string& msg) const = 0;
+    void displayDebugMessageOnRank0_(const std::string &msg) const;
+    void logMessage_(
+        const std::string& prefix,
+        const std::string& msg,
+        MessageType msg_type = MessageType::INFO) const;
 
     WellState &well_state_;
     DeferredLogger &deferred_logger_;
+    const Parallel::Communication& comm_;
     bool debug;
+    // By setting this variable to true we restrict some debug output
+    // to only be printed for rank 0. By setting this variable to false we keep
+    // the output on all ranks. This can in some cases be helpful as a debugging
+    // aid to check that the output is in fact identical over all ranks
+    bool debug_output_only_on_rank0 = false;
 };
 
 } // namespace Opm

--- a/opm/simulators/wells/GasLiftGroupInfo.cpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.cpp
@@ -293,7 +293,7 @@ checkDoGasLiftOptimization_(const std::string &well_name)
     auto itr = this->ecl_wells_.find(well_name);
     if (itr == this->ecl_wells_.end()) {
         // well_name is not present in the well_model's well container
-        displayDebugMessage_("Could not find well in ecl_wells. Skipping.", well_name);
+        //displayDebugMessage_("Could not find well in ecl_wells. Skipping.", well_name);
         return false;
     }
     const Well *well = (itr->second).first;

--- a/opm/simulators/wells/GasLiftGroupInfo.hpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.hpp
@@ -202,7 +202,6 @@ protected:
     const int report_step_idx_;
     const int iteration_idx_;
     const PhaseUsage &phase_usage_;
-    const Parallel::Communication &comm_;
     const GasLiftOpt& glo_;
     GroupRateMap group_rate_map_;
     Well2GroupMap well_group_map_;

--- a/opm/simulators/wells/GasLiftSingleWell.hpp
+++ b/opm/simulators/wells/GasLiftSingleWell.hpp
@@ -50,6 +50,7 @@ namespace Opm
             const GroupState& group_state,
             GasLiftGroupInfo &group_info,
             GLiftSyncGroups &sync_groups,
+            const Parallel::Communication& comm,
             bool glift_debug
         );
         const WellInterfaceGeneric &getWell() const override { return well_; }

--- a/opm/simulators/wells/GasLiftSingleWellGeneric.cpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.cpp
@@ -48,9 +48,10 @@ GasLiftSingleWellGeneric::GasLiftSingleWellGeneric(
     const Schedule& schedule,
     const int report_step_idx,
     GLiftSyncGroups& sync_groups,
+    const Parallel::Communication& comm,
     bool glift_debug
 ) :
-    GasLiftCommon(well_state, deferred_logger, glift_debug)
+    GasLiftCommon(well_state, deferred_logger, comm, glift_debug)
     , group_state_{group_state}
     , ecl_well_{ecl_well}
     , summary_state_{summary_state}
@@ -495,9 +496,8 @@ displayDebugMessage_(const std::string& msg) const
 {
 
     if (this->debug) {
-        const std::string message = fmt::format(
-            "  GLIFT (DEBUG) : Well {} : {}", this->well_name_, msg);
-        this->deferred_logger_.info(message);
+        const std::string message = fmt::format("Well {} : {}", this->well_name_, msg);
+        logMessage_(/*prefix=*/"GLIFT", message);
     }
 }
 
@@ -505,9 +505,8 @@ void
 GasLiftSingleWellGeneric::
 displayWarning_(const std::string& msg)
 {
-    const std::string message = fmt::format(
-        "GAS LIFT OPTIMIZATION, WELL {} : {}", this->well_name_, msg);
-    this->deferred_logger_.warning("WARNING", message);
+    const std::string message = fmt::format("WELL {} : {}", this->well_name_, msg);
+    logMessage_(/*prefix=*/"GLIFT", msg, MessageType::WARNING);
 }
 
 std::pair<double, bool>

--- a/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
@@ -111,6 +111,7 @@ protected:
         const Schedule& schedule,
         const int report_step_idx,
         GLiftSyncGroups& sync_groups,
+        const Parallel::Communication& comm,
         bool glift_debug
     );
 

--- a/opm/simulators/wells/GasLiftSingleWell_impl.hpp
+++ b/opm/simulators/wells/GasLiftSingleWell_impl.hpp
@@ -29,6 +29,7 @@ GasLiftSingleWell(const WellInterface<TypeTag> &well,
                   const GroupState &group_state,
                   GasLiftGroupInfo &group_info,
                   GLiftSyncGroups &sync_groups,
+                  const Parallel::Communication& comm,
                   bool glift_debug
                  )
     // The parent class GasLiftSingleWellGeneric contains all stuff
@@ -44,6 +45,7 @@ GasLiftSingleWell(const WellInterface<TypeTag> &well,
         ebos_simulator.vanguard().schedule(),
         ebos_simulator.episodeIndex(),
         sync_groups,
+        comm,
         glift_debug
     )
    , ebos_simulator_{ebos_simulator}

--- a/opm/simulators/wells/GasLiftStage2.hpp
+++ b/opm/simulators/wells/GasLiftStage2.hpp
@@ -130,7 +130,6 @@ protected:
     const SummaryState& summary_state_;
     const Schedule& schedule_;
     const GasLiftOpt& glo_;
-    const Parallel::Communication& comm_;
     GradMap inc_grads_;
     GradMap dec_grads_;
     int max_iterations_ = 1000;

--- a/tests/test_glift1.cpp
+++ b/tests/test_glift1.cpp
@@ -172,6 +172,7 @@ BOOST_AUTO_TEST_CASE(G1)
     GLiftEclWells ecl_well_map;
     well_model.initGliftEclWellMap(ecl_well_map);
     const int iteration_idx = simulator->model().newtonMethod().numIterations();
+    const auto& comm = simulator->vanguard().grid().comm();
     GasLiftGroupInfo group_info {
         ecl_well_map,
         schedule,
@@ -181,13 +182,13 @@ BOOST_AUTO_TEST_CASE(G1)
         well_model.phaseUsage(),
         deferred_logger,
         well_state,
-        simulator->vanguard().grid().comm(),
+        comm,
         /*glift_debug=*/false
     };
     GLiftSyncGroups sync_groups;
     GasLiftSingleWell glift {*std_well, *(simulator.get()), summary_state,
         deferred_logger, well_state, group_state, group_info, sync_groups,
-        /*glift_debug=*/false
+        comm, /*glift_debug=*/false
     };
     group_info.initialize();
     auto state = glift.runOptimize(iteration_idx);


### PR DESCRIPTION
Some of the gas lift debugging output code outputs identical messages for all ranks. In some cases this is probably not desirable, in other cases it can be desirable if the output is prefixed by the rank number. Then it can be used as a debugging aid to verify that all ranks outputs identical messages.

This PR also cleans up the code by moving common parts of code to the common base class `GasLiftCommon`.

See also #3842.