### PR TITLE
Fix d issues 

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -228,7 +228,8 @@ namespace Opm
 
         // compute the fluid properties, such as densities, viscosities, and so on, in the segments
         // They will be treated implicitly, so they need to be of Evaluation type
-        void computeSegmentFluidProperties(const Simulator& ebosSimulator);
+        void computeSegmentFluidProperties(const Simulator& ebosSimulator,
+                                           DeferredLogger& deferred_logger);
 
         // get the mobility for specific perforation
         void getMobilityEval(const Simulator& ebosSimulator,

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -1194,9 +1194,10 @@ getSegmentSurfaceVolume(const EvalWell& temperature,
             sstr << "Problematic d value " << d << " obtained for well " << baseif_.name()
                  << " during conversion to surface volume with rs " << rs
                  << ", rv " << rv << " and pressure " << seg_pressure
-                 << " obtaining d " << d;
+                 << " obtaining d " << d
+                 << " Continue without dissolution (rs = 0) and vaporization (rv = 0) "
+                 << " for this connection.";
             OpmLog::debug(sstr.str());
-            OPM_THROW_NOLOG(NumericalIssue, sstr.str());
         }
 
         if (rs > 0.0) { // rs > 0.0?

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -758,10 +758,10 @@ computeSegmentFluidProperties(const EvalWell& temperature,
 
             const EvalWell d = 1.0 - rs * rv;
 
-            if (rs != 0.0) { // rs > 0.0?
+            if (rs > 0.0 && d > 0.0) {
                 mix[gasCompIdx] = (mix_s[gasCompIdx] - mix_s[oilCompIdx] * rs) / d;
             }
-            if (rv != 0.0) { // rv > 0.0?
+            if (rv > 0.0 && d > 0.0) {
                 mix[oilCompIdx] = (mix_s[oilCompIdx] - mix_s[gasCompIdx] * rv) / d;
             }
         }

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -180,7 +180,8 @@ protected:
 
     void computeSegmentFluidProperties(const EvalWell& temperature,
                                        const EvalWell& saltConcentration,
-                                       int pvt_region_index);
+                                       int pvt_region_index,
+                                       DeferredLogger& deferred_logger);
 
     EvalWell getBhp() const;
     EvalWell getFrictionPressureLoss(const int seg) const;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1000,7 +1000,7 @@ namespace Opm
     template <typename TypeTag>
     void
     MultisegmentWell<TypeTag>::
-    computeSegmentFluidProperties(const Simulator& ebosSimulator)
+    computeSegmentFluidProperties(const Simulator& ebosSimulator, DeferredLogger& deferred_logger)
     {
         // TODO: the concept of phases and components are rather confusing in this function.
         // needs to be addressed sooner or later.
@@ -1029,7 +1029,8 @@ namespace Opm
 
         this->MSWEval::computeSegmentFluidProperties(temperature,
                                                      saltConcentration,
-                                                     pvt_region_index);
+                                                     pvt_region_index,
+                                                     deferred_logger);
     }
 
 
@@ -1494,7 +1495,7 @@ namespace Opm
         this->updateUpwindingSegments();
 
         // calculate the fluid properties needed.
-        computeSegmentFluidProperties(ebosSimulator);
+        computeSegmentFluidProperties(ebosSimulator, deferred_logger);
 
         // clear all entries
         this->duneB_ = 0.0;

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -264,10 +264,12 @@ namespace Opm
                                                     const std::vector<double>& b_perf,
                                                     const std::vector<double>& rsmax_perf,
                                                     const std::vector<double>& rvmax_perf,
-                                                    const std::vector<double>& surf_dens_perf);
+                                                    const std::vector<double>& surf_dens_perf,
+                                                    DeferredLogger& deferred_logger);
 
         void computeWellConnectionPressures(const Simulator& ebosSimulator,
-                                            const WellState& well_state);
+                                            const WellState& well_state,
+                                            DeferredLogger& deferred_logger);
 
         void computePerfRateEval(const IntensiveQuantities& intQuants,
                                  const std::vector<EvalWell>& mob,

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -950,13 +950,14 @@ computeConnectionDensities(const std::vector<double>& perfComponentRates,
             if (!rvmax_perf.empty() && mix[gaspos] > 1e-12) {
                 rv = std::min(mix[oilpos]/mix[gaspos], rvmax_perf[perf]);
             }
-            if (rs != 0.0) {
+            double d = 1.0 - rs*rv;
+            if (rs > 0.0 && d > 0.0) {
                 // Subtract gas in oil from gas mixture
-                x[gaspos] = (mix[gaspos] - mix[oilpos]*rs)/(1.0 - rs*rv);
+                x[gaspos] = (mix[gaspos] - mix[oilpos]*rs)/d;
             }
-            if (rv != 0.0) {
+            if (rv > 0.0 && d > 0.0) {
                 // Subtract oil in gas from oil mixture
-                x[oilpos] = (mix[oilpos] - mix[gaspos]*rv)/(1.0 - rs*rv);;
+                x[oilpos] = (mix[oilpos] - mix[gaspos]*rv)/d;
             }
         }
         double volrat = 0.0;

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -831,7 +831,8 @@ computeConnectionDensities(const std::vector<double>& perfComponentRates,
                            const std::vector<double>& b_perf,
                            const std::vector<double>& rsmax_perf,
                            const std::vector<double>& rvmax_perf,
-                           const std::vector<double>& surf_dens_perf)
+                           const std::vector<double>& surf_dens_perf,
+                           DeferredLogger& deferred_logger)
 {
     // Verify that we have consistent input.
     const int nperf = baseif_.numPerfs();
@@ -951,6 +952,18 @@ computeConnectionDensities(const std::vector<double>& perfComponentRates,
                 rv = std::min(mix[oilpos]/mix[gaspos], rvmax_perf[perf]);
             }
             double d = 1.0 - rs*rv;
+
+            if (d <= 0.0) {
+                std::ostringstream sstr;
+                sstr << "Problematic d value " << d << " obtained for well " << baseif_.name()
+                     << " during ccomputeConnectionDensities with rs " << rs
+                     << ", rv " << rv
+                     << " obtaining d " << d
+                     << " Continue as if no dissolution (rs = 0) and vaporization (rv = 0) "
+                     << " for this connection.";
+                deferred_logger.debug(sstr.str());
+            }
+
             if (rs > 0.0 && d > 0.0) {
                 // Subtract gas in oil from gas mixture
                 x[gaspos] = (mix[gaspos] - mix[oilpos]*rs)/d;

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -951,8 +951,7 @@ computeConnectionDensities(const std::vector<double>& perfComponentRates,
             if (!rvmax_perf.empty() && mix[gaspos] > 1e-12) {
                 rv = std::min(mix[oilpos]/mix[gaspos], rvmax_perf[perf]);
             }
-            double d = 1.0 - rs*rv;
-
+            const double d = 1.0 - rs*rv;
             if (d <= 0.0) {
                 std::ostringstream sstr;
                 sstr << "Problematic d value " << d << " obtained for well " << baseif_.name()
@@ -962,15 +961,15 @@ computeConnectionDensities(const std::vector<double>& perfComponentRates,
                      << " Continue as if no dissolution (rs = 0) and vaporization (rv = 0) "
                      << " for this connection.";
                 deferred_logger.debug(sstr.str());
-            }
-
-            if (rs > 0.0 && d > 0.0) {
-                // Subtract gas in oil from gas mixture
-                x[gaspos] = (mix[gaspos] - mix[oilpos]*rs)/d;
-            }
-            if (rv > 0.0 && d > 0.0) {
-                // Subtract oil in gas from oil mixture
-                x[oilpos] = (mix[oilpos] - mix[gaspos]*rv)/d;
+            } else {
+                if (rs > 0.0) {
+                    // Subtract gas in oil from gas mixture
+                    x[gaspos] = (mix[gaspos] - mix[oilpos]*rs)/d;
+                }
+                if (rv > 0.0) {
+                    // Subtract oil in gas from oil mixture
+                    x[oilpos] = (mix[oilpos] - mix[gaspos]*rv)/d;
+                }
             }
         }
         double volrat = 0.0;

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -144,7 +144,8 @@ protected:
                                     const std::vector<double>& b_perf,
                                     const std::vector<double>& rsmax_perf,
                                     const std::vector<double>& rvmax_perf,
-                                    const std::vector<double>& surf_dens_perf);
+                                    const std::vector<double>& surf_dens_perf,
+                                    DeferredLogger& deferred_logger);
 
     ConvergenceReport getWellConvergence(const WellState& well_state,
                                          const std::vector<double>& B_avg,

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -361,23 +361,20 @@ namespace Opm
                     const double d = 1.0 - getValue(rv) * getValue(rs);
 
                     if (d <= 0.0) {
-                    std::ostringstream sstr;
-                    sstr << "Problematic d value " << d << " obtained for well " << this->name()
-                         << " during computePerfRate calculations with rs " << rs
-                         << ", rv " << rv << " and pressure " << pressure
-                         << " obtaining d " << d
-                         << " Continue as if no dissolution (rs = 0) and vaporization (rv = 0) "
-                         << " for this connection.";
-                    deferred_logger.debug(sstr.str());
-                    }
-                    // vaporized oil into gas
-                    // rv * q_gr * b_g = rv * (q_gs - rs * q_os) / d
-                    if (d > 0.0) {
+                        std::ostringstream sstr;
+                        sstr << "Problematic d value " << d << " obtained for well " << this->name()
+                             << " during computePerfRate calculations with rs " << rs
+                            << ", rv " << rv << " and pressure " << pressure
+                            << " obtaining d " << d
+                            << " Continue as if no dissolution (rs = 0) and vaporization (rv = 0) "
+                            << " for this connection.";
+                        deferred_logger.debug(sstr.str());
+                    } else {
+                        // vaporized oil into gas
+                        // rv * q_gr * b_g = rv * (q_gs - rs * q_os) / d
                         perf_vap_oil_rate = getValue(rv) * (getValue(cq_s[gasCompIdx]) - getValue(rs) * getValue(cq_s[oilCompIdx])) / d;
-                    }
-                    // dissolved of gas in oil
-                    // rs * q_or * b_o = rs * (q_os - rv * q_gs) / d
-                    if (d > 0.0) {
+                        // dissolved of gas in oil
+                        // rs * q_or * b_o = rs * (q_os - rv * q_gs) / d
                         perf_dis_gas_rate = getValue(rs) * (getValue(cq_s[oilCompIdx]) - getValue(rv) * getValue(cq_s[gasCompIdx])) / d;
                     }
                 }
@@ -612,16 +609,14 @@ namespace Opm
                             << " Continue as if no dissolution (rs = 0) and vaporization (rv = 0) "
                             << " for this connection.";
                         deferred_logger.debug(sstr.str());
-                    }
-                    if(FluidSystem::gasPhaseIdx == phaseIdx && d > 0.0) {
-                        cq_r_thermal = (cq_s[gasCompIdx] - this->extendEval(fs.Rs()) * cq_s[oilCompIdx]) / (d * this->extendEval(fs.invB(phaseIdx)) );
-                    // q_or = 1 / (b_o * d) * (q_os - rv * q_gs)
-                    } else if(FluidSystem::oilPhaseIdx == phaseIdx && d > 0.0) {
-                        cq_r_thermal = (cq_s[oilCompIdx] - this->extendEval(fs.Rv()) * cq_s[gasCompIdx]) / (d * this->extendEval(fs.invB(phaseIdx)) );
-                    } else {
-                        assert(d <= 0.0);
-                        // for d <= 0.0 we continue as if rs = 0 and rv = 0
                         cq_r_thermal = cq_s[activeCompIdx] / this->extendEval(fs.invB(phaseIdx));
+                    } else {
+                        if(FluidSystem::gasPhaseIdx == phaseIdx) {
+                            cq_r_thermal = (cq_s[gasCompIdx] - this->extendEval(fs.Rs()) * cq_s[oilCompIdx]) / (d * this->extendEval(fs.invB(phaseIdx)) );
+                        } else if(FluidSystem::oilPhaseIdx == phaseIdx) {
+                            // q_or = 1 / (b_o * d) * (q_os - rv * q_gs)
+                            cq_r_thermal = (cq_s[oilCompIdx] - this->extendEval(fs.Rv()) * cq_s[gasCompIdx]) / (d * this->extendEval(fs.invB(phaseIdx)) );
+                        }
                     }
                 }
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -356,10 +356,14 @@ namespace Opm
                     const double d = 1.0 - getValue(rv) * getValue(rs);
                     // vaporized oil into gas
                     // rv * q_gr * b_g = rv * (q_gs - rs * q_os) / d
-                    perf_vap_oil_rate = getValue(rv) * (getValue(cq_s[gasCompIdx]) - getValue(rs) * getValue(cq_s[oilCompIdx])) / d;
+                    if (d > 0.0) {
+                        perf_vap_oil_rate = getValue(rv) * (getValue(cq_s[gasCompIdx]) - getValue(rs) * getValue(cq_s[oilCompIdx])) / d;
+                    }
                     // dissolved of gas in oil
                     // rs * q_or * b_o = rs * (q_os - rv * q_gs) / d
-                    perf_dis_gas_rate = getValue(rs) * (getValue(cq_s[oilCompIdx]) - getValue(rv) * getValue(cq_s[gasCompIdx])) / d;
+                    if (d > 0.0) {
+                        perf_dis_gas_rate = getValue(rs) * (getValue(cq_s[oilCompIdx]) - getValue(rv) * getValue(cq_s[gasCompIdx])) / d;
+                    }
                 }
             }
         }
@@ -580,8 +584,6 @@ namespace Opm
                     const unsigned gasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);
                     // q_os = q_or * b_o + rv * q_gr * b_g
                     // q_gs = q_gr * g_g + rs * q_or * b_o
-                    // d = 1.0 - rs * rv
-                    const EvalWell d = this->extendEval(1.0 - fs.Rv() * fs.Rs());
                     // q_gr = 1 / (b_g * d) * (q_gs - rs * q_os)
                     if(FluidSystem::gasPhaseIdx == phaseIdx)
                         cq_r_thermal = (cq_s[gasCompIdx] - this->extendEval(fs.Rs()) * cq_s[oilCompIdx]) / (d * this->extendEval(fs.invB(phaseIdx)) );


### PR DESCRIPTION
If d=1-rs*rv=0 we can not back-compute the surface volumes from the reservoir volumes. 

This PR consists of 2 commits. 
1) Avoid hard throw when d <=0 in MSW model and instead continue as if rs = rv = 0 for that connection. This fix is motivated by a field model and is sufficient for the simulator to finish the run. 
2) The second is still WIP in that it is not tested at all. When grabbing for "d = " I noticed that most places there was no guards for d = 0. The solution proposed for d<=0 is to continue as if rs = rv = 0. 