### PR TITLE
regularize MSW equation when iter > strict_inner_iter

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -162,6 +162,9 @@ namespace Opm
     protected:
         int number_segments_;
 
+        // regularize msw equation
+        bool regularize_;
+
         // components of the pressure drop to be included
         WellSegments::CompPressureDrop compPressureDrop() const;
         // multi-phase flow model


### PR DESCRIPTION
Attempt to improve convergence for problematic MSW wells. With default parameters i.e. 
regularization_factor_ms_wells_ = 1.0 this PR does not have any effect. 
The idea is to increase the default regularization factor to > 1.0 in later PR. 