### PR TITLE
avoid throw for nan residuals instead return well as unconverged

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -1619,10 +1619,10 @@ assemblePressureEq(const int seg,
 }
 
 template<typename FluidSystem, typename Indices, typename Scalar>
-std::vector<Scalar>
+std::pair<bool, std::vector<Scalar> >
 MultisegmentWellEval<FluidSystem,Indices,Scalar>::
-getWellResiduals(const std::vector<Scalar>& B_avg,
-                 DeferredLogger& deferred_logger) const
+getFiniteWellResiduals(const std::vector<Scalar>& B_avg,
+                       DeferredLogger& deferred_logger) const
 {
     assert(int(B_avg.size() ) == baseif_.numComponents());
     std::vector<Scalar> residuals(numWellEq + 1, 0.0);
@@ -1638,8 +1638,9 @@ getWellResiduals(const std::vector<Scalar>& B_avg,
                 }
             }
             if (std::isnan(residual) || std::isinf(residual)) {
-                OPM_DEFLOG_THROW(NumericalIssue, "nan or inf value for residal get for well " << baseif_.name()
-                                                << " segment " << seg << " eq_idx " << eq_idx, deferred_logger);
+                deferred_logger.debug("nan or inf value for residal get for well " + baseif_.name()
+                                      + " segment " + std::to_string(seg) + " eq_idx " + std::to_string(eq_idx));
+                return {false, residuals};
             }
 
             if (residual > residuals[eq_idx]) {
@@ -1652,12 +1653,13 @@ getWellResiduals(const std::vector<Scalar>& B_avg,
     {
         const double control_residual = std::abs(resWell_[0][numWellEq - 1]);
         if (std::isnan(control_residual) || std::isinf(control_residual)) {
-           OPM_DEFLOG_THROW(NumericalIssue, "nan or inf value for control residal get for well " << baseif_.name(), deferred_logger);
+           deferred_logger.debug("nan or inf value for control residal get for well " + baseif_.name());
+           return {false, residuals};
         }
         residuals[numWellEq] = control_residual;
     }
 
-    return residuals;
+    return {true, residuals};
 }
 
 template<typename FluidSystem, typename Indices, typename Scalar>

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -199,8 +199,9 @@ protected:
     EvalWell getWQTotal() const;
 
 
-    std::vector<Scalar> getWellResiduals(const std::vector<Scalar>& B_avg,
-                                         DeferredLogger& deferred_logger) const;
+    std::pair<bool, std::vector<Scalar> >
+    getFiniteWellResiduals(const std::vector<Scalar>& B_avg,
+                           DeferredLogger& deferred_logger) const;
 
     double getControlTolerance(const WellState& well_state,
                                const double tolerance_wells,


### PR DESCRIPTION
This should not change the behavior but avoid unexpected "errors"  counts in the error summary. 
Issue reported by @tskille 
 
![image](https://user-images.githubusercontent.com/3223024/162405368-942cefc2-98fe-4ef5-8d0a-5fba802c8467.png)
