### PR TITLE
Well testing of gas lift wells

### DIFF
--- a/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.hpp
@@ -250,7 +250,8 @@ protected:
     bool checkInitialALQmodified_(double alq, double initial_alq) const;
     bool checkThpControl_() const;
     virtual std::optional<double> computeBhpAtThpLimit_(double alq) const = 0;
-    std::optional<BasicRates> computeInitialWellRates_() const;
+    std::pair<std::optional<double>,double> computeConvergedBhpAtThpLimitByMaybeIncreasingALQ_() const;
+    std::pair<std::optional<BasicRates>,double> computeInitialWellRates_() const;
     std::optional<LimitedRates> computeLimitedWellRatesWithALQ_(double alq) const;
     virtual BasicRates computeWellRates_(double bhp, bool bhp_is_limited,                                                             bool debug_output = true) const = 0;
     std::optional<BasicRates> computeWellRatesWithALQ_(double alq) const;
@@ -272,7 +273,7 @@ protected:
                            const BasicRates& rates) const;
     std::pair<double, bool> getGasRateWithGroupLimit_(
                            double new_gas_rate, double gas_rate) const;
-    std::optional<LimitedRates> getInitialRatesWithLimit_() const;
+    std::pair<std::optional<LimitedRates>,double> getInitialRatesWithLimit_() const;
     LimitedRates getLimitedRatesFromRates_(const BasicRates& rates) const;
     std::tuple<double,double,bool,bool> getLiquidRateWithGroupLimit_(
                            const double new_oil_rate, const double oil_rate,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -248,6 +248,10 @@ public:
 
     void checkWellOperability(const Simulator& ebos_simulator, const WellState& well_state, DeferredLogger& deferred_logger);
 
+    void gliftBeginTimeStepWellTestUpdateALQ(const Simulator& ebos_simulator,
+                                             WellState& well_state,
+                                             DeferredLogger& deferred_logger);
+
     // check whether the well is operable under the current reservoir condition
     // mostly related to BHP limit and THP limit
     void updateWellOperability(const Simulator& ebos_simulator,


### PR DESCRIPTION
Assigns a maximum ALQ value to each GLIFT producer when doing well testing in `beginTimeStep()`. This is done to allow the well to attain a positive potential and thereby be considered as open. Then, later in the timestep, when `assemble()` is called, the full gas lift optimization procedure can adjust the ALQ to its "correct" value.

It is also observed that in some cases when gas lift is switched off by setting ALQ to zero, and later in the schedule is switched back on again, it might not be possible to determine bhp from thp (the iteration fails to converge) for low small ALQ values. Instead of aborting the gas lift optimization, we should try increasing ALQ until we get convergence or until the maximum ALQ for the well is reached.

With this change to the code, test case [GASLIFT-02](https://github.com/OPM/opm-tests/blob/master/gaslift/GASLIFT-02.DATA) runs to completion and gives the following result for gas lift injection rate for group `PLAT-1`:

![image](https://user-images.githubusercontent.com/6708379/162488919-ef973bff-ff1d-46eb-9432-41efe6bcab8d.png)
