### PR TITLE
Fix STOP in combination with inoperable/unsolvable

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -2067,7 +2067,7 @@ forceShutWellByName(const std::string& wellname,
     // process that owns it.
     int well_was_shut = 0;
     for (const auto& well : well_container_generic_) {
-        if (well->name() == wellname && !well->wellIsStopped()) {
+        if (well->name() == wellname) {
             wellTestState().close_well(wellname, WellTestConfig::Reason::PHYSICAL, simulation_time);
             well_was_shut = 1;
             break;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1223,7 +1223,7 @@ namespace Opm {
         ConvergenceReport local_report;
         const int iterationIdx = ebosSimulator_.model().newtonMethod().numIterations();
         for (const auto& well : well_container_) {
-            if (well->isOperableAndSolvable() ) {
+            if (well->isOperableAndSolvable() || well->wellIsStopped()) {
                 local_report += well->getWellConvergence(this->wellState(), B_avg, local_deferredLogger, iterationIdx > param_.strict_outer_iter_wells_ );
             } else {
                 ConvergenceReport report;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -449,7 +449,7 @@ namespace Opm
                       const GroupState& group_state,
                       DeferredLogger& deferred_logger)
     {
-        if (!this->isOperableAndSolvable())
+        if (!this->isOperableAndSolvable() && !this->wellIsStopped())
             return;
 
         // keep a copy of the original well state
@@ -510,6 +510,7 @@ namespace Opm
         }
         this->changed_to_open_this_step_ = false;
         const bool well_operable = this->operability_status_.isOperableAndSolvable();
+
         if (!well_operable && old_well_operable) {
             if (this->well_ecl_.getAutomaticShutIn()) {
                 deferred_logger.info(" well " + this->name() + " gets SHUT during iteration ");
@@ -539,7 +540,7 @@ namespace Opm
     void
     WellInterface<TypeTag>::addCellRates(RateVector& rates, int cellIdx) const
     {
-        if(!this->isOperableAndSolvable())
+        if(!this->isOperableAndSolvable() && !this->wellIsStopped())
             return;
 
         for (int perfIdx = 0; perfIdx < this->number_of_perforations_; ++perfIdx) {


### PR DESCRIPTION
Some fixups for combination STOP + shut_unsolvable_wells=true (default is false) 

This also change default behavior for wells with STOP that do not converge when time step is less than threshold. 

Tested on the norne prediction tests in opm-tests/norne