### PR TITLE
WIP: Fix assertion error for GASLIFT-02

### DIFF
--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2388,6 +2388,7 @@ namespace Opm
             // solution
             std::vector<double> rates(3);
             computeWellRatesWithBhpIterations(ebos_simulator, bhp, rates, deferred_logger);
+            this->adaptRatesForVFP(rates);
             return rates;
         };
 


### PR DESCRIPTION
Currently [GASLIFT-02](https://github.com/OPM/opm-tests/blob/master/gaslift/GASLIFT-02.DATA) fails with an assertion error:
```
Starting time step 0, stepsize 16 days, at day 32/60, date = 01-Feb-2021
Restart file written for report step  1/58, date = 01-Feb-2021 00:00:00
flow: /home/hakon/test/opm/opm-simulators/opm/simulators/wells/WellInterfaceGeneric.cpp:655: Opm::WellInterfaceGeneric::computeBhpAtThpLimitProdCommon(const std::function<std::vector<double>(double)>&, const Opm::SummaryState&, double, double, double, Opm::DeferredLogger&) const::<lambda(const std::vector<double>&)>: Assertion `rates.size() == 3' failed.
[hakon-Precision-7530:716293] *** Process received signal ***
[hakon-Precision-7530:716293] Signal: Aborted (6)
```
VFP calculations for two phase gas lift does not work unless the rates are adapted to include a zero gas rate.

I'll mark this as WIP until the issue with the failed test for `compareParallelSim_flow+SPE1CASE1_BRINE` on the jenkins server has been resolved, see #3868 for more information.