### PR TITLE
use alternative init for wells with all rates less than eps

### DIFF
--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1053,8 +1053,9 @@ namespace Opm
         // if more than one nonzero rate.
         auto& ws = well_state.well(this->index_of_well_);
         int nonzero_rate_index = -1;
+        const double floating_point_error_epsilon = 1e-14;
         for (int p = 0; p < this->number_of_phases_; ++p) {
-            if (ws.surface_rates[p] != 0.0) {
+            if (std::abs(ws.surface_rates[p]) > floating_point_error_epsilon) {
                 if (nonzero_rate_index == -1) {
                     nonzero_rate_index = p;
                 } else {


### PR DESCRIPTION
This fixes (avoids premature shutting of a well) a corner case where a well is controlled by a group that has zero rate. Due to numerical instability the well still gets an epsilon rate and skip the improved initialization used for wells with trivial rate. Adding an epsilon in the check is sufficient to keep the well open and ready for production when the group gets a non-trivial target.  