### PR TITLE
fix trivial group target

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -669,7 +669,6 @@ namespace Opm {
                     case Well::ProducerCMode::RESV:
                         zero_rate_control = is_zero(prod_controls.resv_rate);
                         break;
-
                     default:
                         // Might still have zero rate controls, but is pressure controlled.
                         zero_rate_control = false;

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -39,6 +39,7 @@ SingleWellState::SingleWellState(const std::string& name_,
     , surface_rates(pu_.num_phases)
     , reservoir_rates(pu_.num_phases)
     , perf_data(perf_input.size(), pressure_first_connection, !is_producer, pu_.num_phases)
+    , trivial_target(false)
 {
     for (std::size_t perf = 0; perf < perf_input.size(); perf++) {
         this->perf_data.cell_index[perf] = perf_input[perf].cell_index;

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -61,6 +61,7 @@ public:
     std::vector<double> surface_rates;
     std::vector<double> reservoir_rates;
     PerfData perf_data;
+    bool trivial_target;
     SegmentState segments;
     Events events;
     Well::InjectorCMode injection_cmode{Well::InjectorCMode::CMODE_UNDEFINED};

--- a/opm/simulators/wells/WellInterfaceFluidSystem.cpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.cpp
@@ -163,7 +163,7 @@ activeProductionConstraint(const SingleWellState& ws,
     if (controls.hasControl(Well::ProducerCMode::THP) && currentControl != Well::ProducerCMode::THP) {
         const auto& thp = getTHPConstraint(summaryState);
         double current_thp = ws.thp;
-        if (thp > current_thp) {
+        if (thp > current_thp && !ws.trivial_target) {
             // If WVFPEXP item 4 is set to YES1 or YES2
             // switching to THP is prevented if the well will
             // produce at a higher rate with THP control
@@ -1120,6 +1120,10 @@ getGroupProductionTargetRate(const Group& group,
     const auto& rates = ws.surface_rates;
     const auto current_rate = -tcalc.calcModeRateFromRates(rates); // Switch sign since 'rates' are negative for producers.
     double scale = 1.0;
+    if (target_rate == 0.0) {
+        return 0.0;
+    }
+
     if (current_rate > 1e-14)
         scale = target_rate/current_rate;
     return scale;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -981,6 +981,9 @@ namespace Opm
                     for (int p = 0; p<np; ++p) {
                         ws.surface_rates[p] *= scale;
                     }
+                    ws.trivial_target = false;
+                } else {
+                    ws.trivial_target = true;
                 }
                 break;
             }


### PR DESCRIPTION
This fixes another fallout related to trivial group rates. See #3887 This time the well control starts oscillating between group (with target 0) and THP. This PR explicitly prevent switching to THP control if the target is zero. 

At the current stage only the case where the group target is zero is flagged, we may want to consider also flagging cases where the well has trivial target.  