### PR TITLE
fixed: add missing config.h include

### DIFF
--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
 #include <opm/simulators/wells/SingleWellState.hpp>
 #include <opm/simulators/wells/PerforationData.hpp>
 


### PR DESCRIPTION
config.h goes first in *all* compile units..

hopefully will fix odr violation reported here; 
https://launchpadlibrarian.net/598757949/buildlog_ubuntu-jammy-amd64.opm-simulators_2022.04-rc1-1~jammy_BUILDING.txt.gz