### PR TITLE
[backport] Spelling fix geomtry -> geometry.

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -365,7 +365,7 @@ namespace {
 
         if (status != MPI_SUCCESS) {
             throw std::invalid_argument {
-                "Unable to establish cell geomtry validity across MPI ranks"
+                "Unable to establish cell geometry validity across MPI ranks"
             };
         }
 #endif  // HAVE_MPI


### PR DESCRIPTION
Actually one should rename the function used from opm-common, too.
But that is for later...

Backport of #3895 to release.