### PR TITLE
update primary variables in prepareTimeStep after updating the well target

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1492,6 +1492,8 @@ namespace Opm {
             auto& events = this->wellState().well(well->indexOfWell()).events;
             if (events.hasEvent(WellState::event_mask)) {
                 well->updateWellStateWithTarget(ebosSimulator_, this->groupState(), this->wellState(), deferred_logger);
+                well->updatePrimaryVariables(this->wellState(), deferred_logger);
+                well->initPrimaryVariablesEvaluation();
                 // There is no new well control change input within a report step,
                 // so next time step, the well does not consider to have effective events anymore.
                 events.clearEvent(WellState::event_mask);


### PR DESCRIPTION
In `BlackoilWellModel<TypeTag>::prepareTimeStep(DeferredLogger& deferred_logger)`, when some well event happen, we update the well state to match the new control type. 

Before we use the well for well solving, we need to update the primary variables and Evaluation related to wells. 

