### PR TITLE
Fixing equilibration when having numerical aquifers.  

### DIFF
--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -1852,15 +1852,20 @@ private:
             const unsigned int elemIdx = elemMapper.index(element);
             cellCenterDepth_[elemIdx] = Details::cellCenterDepth(element);
             const auto cartIx = cartesianIndexMapper_.cartesianIndex(elemIdx);
+            cellZSpan_[elemIdx] = Details::cellZSpan(element);
+            cellZMinMax_[elemIdx] = Details::cellZMinMax(element);
             if (!num_aqu_cells.empty()) {
                 const auto search = num_aqu_cells.find(cartIx);
                 if (search != num_aqu_cells.end()) {
                     const auto* aqu_cell = num_aqu_cells.at(cartIx);
-                    cellCenterDepth_[elemIdx] = aqu_cell->depth;
+                    const double depth_change_num_aqu = aqu_cell->depth - cellCenterDepth_[elemIdx];
+                    cellCenterDepth_[elemIdx] += depth_change_num_aqu;
+                    cellZSpan_[elemIdx].first += depth_change_num_aqu;
+                    cellZSpan_[elemIdx].second += depth_change_num_aqu;
+                    cellZMinMax_[elemIdx].first += depth_change_num_aqu;
+                    cellZMinMax_[elemIdx].second += depth_change_num_aqu;
                 }
             }
-            cellZSpan_[elemIdx] = Details::cellZSpan(element);
-            cellZMinMax_[elemIdx] = Details::cellZMinMax(element);
         }
     }
 


### PR DESCRIPTION
With the targeting three phase black oil case, the reservoir ZCORN range is between 2000 and 1000, and numerical aquifer cell depth is 2400. 

For one of the equilibration regions, the reservoir `vspan` based on `cellZMinMax_`  is [2000, 2002],  water-oil contact depth is 2003, oil-gas contact depth is 1500.  At the end, the `vspan` used for `ptable` equilibration is [1500, 2003]. 

At the end, when `makeWatPressure`, ` this->value_[Direction::Down]` is a table between [2003, 2003]. As a result, for any depth bigger than 2003, the water pressure will be `nan` based on extrapolation. For example, the numerical aquifer cell has a depth 2040, it gets `nan` water pressure value. 


There are different ways to fix this. The equilibration code itself can be done differently when considering the depth range for the pressure table. 

The PR tries not to touch the general equilibration code and limit the impact within the numerical aquifer related cases. I think this can be the minimal change to tangle the problem while hopefully not introducing new problems. 