### PR TITLE
Emit Actual Message on Input Failure

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -548,7 +548,7 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
 
     if (! parseSuccess) {
         if (comm.rank() == 0) {
-            OpmLog::error("Unrecoverable errors were encountered while loading input");
+            OpmLog::error(fmt::format("Unrecoverable errors while loading input: {}", failureMessage));
         }
 
 #if HAVE_MPI


### PR DESCRIPTION
This gives more information to the user and hopefully aids them in resolving the underlying issue.