### PR TITLE
removing unused well_state0 in iterateWellEqWithControl for MSW

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1369,7 +1369,6 @@ namespace Opm
         if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return true;
 
         const int max_iter_number = this->param_.max_inner_iter_ms_wells_;
-        const WellState well_state0 = well_state;
 
         {
             // getWellFiniteResiduals returns false for nan/inf residuals


### PR DESCRIPTION
It is possible we actually need it to recover when the iteration not converged, but it is not used in the current form and not sure the usage of this variable was deleted intentionally or unintentionally. 