### PR TITLE
Fix well operability

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1169,12 +1169,13 @@ namespace Opm
         if ( bhp_limit_not_defaulted || !this->wellHasTHPConstraints(summaryState) ) {
             // if the BHP limit is not defaulted or the well does not have a THP limit
             // we need to check the BHP limit
-
-            double ipr_rate = 0;
+            double total_ipr_mass_rate = 0.0;
             for (int p = 0; p < this->number_of_phases_; ++p) {
-                ipr_rate += this->ipr_a_[p] - this->ipr_b_[p] * bhp_limit;
+                const double ipr_rate = this->ipr_a_[p] - this->ipr_b_[p] * bhp_limit;
+                const double rho = FluidSystem::referenceDensity( p, Base::pvtRegionIdx() );
+                total_ipr_mass_rate += ipr_rate * rho;
             }
-            if ( (this->isProducer() && ipr_rate < 0.) || (this->isInjector() && ipr_rate > 0.) ) {
+            if ( (this->isProducer() && total_ipr_mass_rate < 0.) || (this->isInjector() && total_ipr_mass_rate > 0.) ) {
                 this->operability_status_.operable_under_only_bhp_limit = false;
             }
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1170,9 +1170,16 @@ namespace Opm
             // if the BHP limit is not defaulted or the well does not have a THP limit
             // we need to check the BHP limit
             double total_ipr_mass_rate = 0.0;
-            for (int p = 0; p < this->number_of_phases_; ++p) {
-                const double ipr_rate = this->ipr_a_[p] - this->ipr_b_[p] * bhp_limit;
-                const double rho = FluidSystem::referenceDensity( p, Base::pvtRegionIdx() );
+            for (unsigned phaseIdx = 0; phaseIdx < FluidSystem::numPhases; ++phaseIdx)
+            {
+                if (!FluidSystem::phaseIsActive(phaseIdx)) {
+                    continue;
+                }
+
+                const unsigned compIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::solventComponentIndex(phaseIdx));
+                const double ipr_rate = this->ipr_a_[compIdx] - this->ipr_b_[compIdx] * bhp_limit;
+
+                const double rho = FluidSystem::referenceDensity( phaseIdx, Base::pvtRegionIdx() );
                 total_ipr_mass_rate += ipr_rate * rho;
             }
             if ( (this->isProducer() && total_ipr_mass_rate < 0.) || (this->isInjector() && total_ipr_mass_rate > 0.) ) {
@@ -1267,15 +1274,12 @@ namespace Opm
             // the well index associated with the connection
             const double tw_perf = this->well_index_[perf]*ebos_simulator.problem().template rockCompTransMultiplier<double>(int_quantities, cell_idx);
 
-            // TODO: there might be some indices related problems here
-            // phases vs components
-            // ipr values for the perforation
             std::vector<double> ipr_a_perf(this->ipr_a_.size());
             std::vector<double> ipr_b_perf(this->ipr_b_.size());
-            for (int p = 0; p < this->number_of_phases_; ++p) {
-                const double tw_mob = tw_perf * mob[p] * b_perf[p];
-                ipr_a_perf[p] += tw_mob * pressure_diff;
-                ipr_b_perf[p] += tw_mob;
+            for (int comp_idx = 0; comp_idx < this->num_components_; ++comp_idx) {
+                const double tw_mob = tw_perf * mob[comp_idx] * b_perf[comp_idx];
+                ipr_a_perf[comp_idx] += tw_mob * pressure_diff;
+                ipr_b_perf[comp_idx] += tw_mob;
             }
 
             // we need to handle the rs and rv when both oil and gas are present
@@ -1298,10 +1302,9 @@ namespace Opm
                 ipr_b_perf[oil_comp_idx] += vap_oil_b;
             }
 
-            for (int p = 0; p < this->number_of_phases_; ++p) {
-                // TODO: double check the indices here
-                this->ipr_a_[this->ebosCompIdxToFlowCompIdx(p)] += ipr_a_perf[p];
-                this->ipr_b_[this->ebosCompIdxToFlowCompIdx(p)] += ipr_b_perf[p];
+            for (size_t comp_idx = 0; comp_idx < ipr_a_perf.size(); ++comp_idx) {
+                this->ipr_a_[comp_idx] += ipr_a_perf[comp_idx];
+                this->ipr_b_[comp_idx] += ipr_b_perf[comp_idx];
             }
             }
         }

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1100,13 +1100,14 @@ namespace Opm
         if ( bhp_limit_not_defaulted || !this->wellHasTHPConstraints(summaryState) ) {
             // if the BHP limit is not defaulted or the well does not have a THP limit
             // we need to check the BHP limit
-
+            double total_ipr_mass_rate = 0.0;
             for (int p = 0; p < this->number_of_phases_; ++p) {
                 const double ipr_rate = this->ipr_a_[p] - this->ipr_b_[p] * bhp_limit;
-                if ( (this->isProducer() && ipr_rate < 0.) || (this->isInjector() && ipr_rate > 0.) ) {
-                    this->operability_status_.operable_under_only_bhp_limit = false;
-                    break;
-                }
+                const double rho = FluidSystem::referenceDensity( p, Base::pvtRegionIdx() );
+                total_ipr_mass_rate += ipr_rate * rho;
+            }
+            if ( (this->isProducer() && total_ipr_mass_rate < 0.) || (this->isInjector() && total_ipr_mass_rate > 0.) ) {
+                this->operability_status_.operable_under_only_bhp_limit = false;
             }
 
             // checking whether running under BHP limit will violate THP limit

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -55,8 +55,8 @@ WellInterfaceGeneric::WellInterfaceGeneric(const Well& well,
       , number_of_phases_(num_phases)
       , index_of_well_(index_of_well)
       , perf_data_(&perf_data)
-      , ipr_a_(number_of_phases_)
-      , ipr_b_(number_of_phases_)
+      , ipr_a_(num_components)
+      , ipr_b_(num_components)
 {
     assert(well.name()==pw_info.name());
     assert(std::is_sorted(perf_data.begin(), perf_data.end(),


### PR DESCRIPTION
The current check for operability using IPR is different between STW and MSW. STW return inoperable if at one of the components has negative(for producers) IPR. For MSW it checks if the sum is negative. This PR changes both so that only well where all components have negative IPRs are inoperable. I mark it as WIP and draft since I still don't understand how the well operability differs between the components. 