### PR TITLE
Use Consistent Grid Views for Transmissibility Calculation

### DIFF
--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -134,7 +134,7 @@ public:
 #if HAVE_MPI
         this->doLoadBalance_(this->edgeWeightsMethod(), this->ownersFirst(),
                              this->serialPartitioning(), this->enableDistributedWells(),
-                             this->zoltanImbalanceTol(), this->gridView(),
+                             this->zoltanImbalanceTol(),
                              this->schedule(), this->centroids_,
                              this->eclState(), this->parallelWells_, this->numJacobiBlocks());
 #endif

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -78,7 +78,6 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doLoadBalance_(Dun
                                                                              bool serialPartitioning,
                                                                              bool enableDistributedWells,
                                                                              double zoltanImbalanceTol,
-                                                                             const GridView& gridv,
                                                                              const Schedule& schedule,
                                                                              std::vector<double>& centroids,
                                                                              EclipseState& eclState1,
@@ -108,7 +107,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doLoadBalance_(Dun
         grid_->comm().broadcast(&loadBalancerSet, 1, 0);
         if (!loadBalancerSet){
             faceTrans.resize(numFaces, 0.0);
-            ElementMapper elemMapper(gridv, Dune::mcmgElementLayout());
+            ElementMapper elemMapper(gridView, Dune::mcmgElementLayout());
             auto elemIt = gridView.template begin</*codim=*/0>();
             const auto& elemEndIt = gridView.template end</*codim=*/0>();
             for (; elemIt != elemEndIt; ++ elemIt) {

--- a/ebos/eclgenericcpgridvanguard.hh
+++ b/ebos/eclgenericcpgridvanguard.hh
@@ -115,7 +115,7 @@ protected:
     void doLoadBalance_(Dune::EdgeWeightMethod edgeWeightsMethod,
                         bool ownersFirst, bool serialPartitioning,
                         bool enableDistributedWells, double zoltanImbalanceTol,
-                        const GridView& gridv, const Schedule& schedule,
+                        const Schedule& schedule,
                         std::vector<double>& centroids,
                         EclipseState& eclState,
                         EclGenericVanguard::ParallelWellStruct& parallelWells,


### PR DESCRIPTION
Commit 5067ce2f27e64c05c04a634de93b91aee6685afa (initially OPM/opm-models@e22366d4a, PR https://github.com/OPM/opm-models/pull/103) implicitly assumed that the `gridv` parameter would coincide with `grid_->leafGridView()`.  Make this assumption explicit.

Resolves #3927.