### PR TITLE
Re-add grid view argument to doLoadBalance_().

### DIFF
--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -134,7 +134,7 @@ public:
 #if HAVE_MPI
         this->doLoadBalance_(this->edgeWeightsMethod(), this->ownersFirst(),
                              this->serialPartitioning(), this->enableDistributedWells(),
-                             this->zoltanImbalanceTol(),
+                             this->zoltanImbalanceTol(), this->gridView(),
                              this->schedule(), this->centroids_,
                              this->eclState(), this->parallelWells_, this->numJacobiBlocks());
 #endif

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -78,6 +78,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doLoadBalance_(Dun
                                                                              bool serialPartitioning,
                                                                              bool enableDistributedWells,
                                                                              double zoltanImbalanceTol,
+                                                                             const GridView& gridView,
                                                                              const Schedule& schedule,
                                                                              std::vector<double>& centroids,
                                                                              EclipseState& eclState1,
@@ -100,7 +101,6 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doLoadBalance_(Dun
         // convert to transmissibility for faces
         // TODO: grid_->numFaces() is not generic. use grid_->size(1) instead? (might
         // not work)
-        const auto& gridView = grid_->leafGridView();
         unsigned numFaces = grid_->numFaces();
         std::vector<double> faceTrans;
         int loadBalancerSet = externalLoadBalancer.has_value();

--- a/ebos/eclgenericcpgridvanguard.hh
+++ b/ebos/eclgenericcpgridvanguard.hh
@@ -115,6 +115,7 @@ protected:
     void doLoadBalance_(Dune::EdgeWeightMethod edgeWeightsMethod,
                         bool ownersFirst, bool serialPartitioning,
                         bool enableDistributedWells, double zoltanImbalanceTol,
+                        const GridView& gridv,
                         const Schedule& schedule,
                         std::vector<double>& centroids,
                         EclipseState& eclState,


### PR DESCRIPTION
In #3927 an inconsistency was reported, and subsequently resolved in #3929. The issue was that one grid view was passed in as an argument, and another one was obtained from the grid, then both were used in the function. The previous fix removed the argument, and used always the one from the grid. The current fix does the opposite: re-instate the argument, and do not use the one from the grid.

The reason for this, is that if the GridView type used to instantiate the class (ultimately same as the TypeTag's GridView) is different from the grid's LeafGridView, this does not compile. This happens when dune-fem is found and used, then the view held by the vanguard is of a different type.

The current fix is therefore an improvement (as now it compiles...). But it points out that we may have many inconsistencies like this. A quick grep for `grid.leafGridView()` reveals a dozen or so cases. It may be fairly easy to (alternative A) ensure they all use the grid view from the vanguard instead, to ensure consistency. But maybe we should consider not doing this, instead (alternative B) removing it from the vanguard? Maybe someone can enlighten us on why another gridview class is preferred when available in dune-fem? I lean towards alternative A, but in any case following through on that is not within the scope of this PR.