### PR TITLE
Remove support for internal simulator configuration

### DIFF
--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -55,9 +55,9 @@ std::shared_ptr<Deck> EclGenericVanguard::deck_;
 std::shared_ptr<EclipseState> EclGenericVanguard::eclState_;
 std::shared_ptr<Schedule> EclGenericVanguard::eclSchedule_;
 std::shared_ptr<SummaryConfig> EclGenericVanguard::eclSummaryConfig_;
-std::unique_ptr<UDQState> EclGenericVanguard::externalUDQState_;
-std::unique_ptr<Action::State> EclGenericVanguard::externalActionState_;
-std::unique_ptr<WellTestState> EclGenericVanguard::externalWTestState_;
+std::unique_ptr<UDQState> EclGenericVanguard::udqState_;
+std::unique_ptr<Action::State> EclGenericVanguard::actionState_;
+std::unique_ptr<WellTestState> EclGenericVanguard::wtestState_;
 std::unique_ptr<Parallel::Communication> EclGenericVanguard::comm_;
 
 EclGenericVanguard::EclGenericVanguard()
@@ -67,61 +67,23 @@ EclGenericVanguard::EclGenericVanguard()
 
 EclGenericVanguard::~EclGenericVanguard() = default;
 
-void EclGenericVanguard::setSchedule(std::shared_ptr<Schedule> schedule)
+void EclGenericVanguard::setParams(double setupTime,
+                                   std::shared_ptr<Deck> deck,
+                                   std::shared_ptr<EclipseState> eclState,
+                                   std::shared_ptr<Schedule> schedule,
+                                   std::unique_ptr<UDQState> udqState,
+                                   std::unique_ptr<Action::State> actionState,
+                                   std::unique_ptr<WellTestState> wtestState,
+                                   std::shared_ptr<SummaryConfig> summaryConfig)
 {
-    eclSchedule_ = std::move(schedule);
-}
-
-void EclGenericVanguard::setSchedule(std::unique_ptr<Schedule> schedule)
-{
-    eclSchedule_ = std::move(schedule);
-}
-
-void EclGenericVanguard::setSummaryConfig(
-    std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    eclSummaryConfig_ = std::move(summaryConfig);
-}
-
-void EclGenericVanguard::setSummaryConfig(
-    std::unique_ptr<SummaryConfig> summaryConfig)
-{
-    eclSummaryConfig_ = std::move(summaryConfig);
-}
-
-void EclGenericVanguard::setDeck(std::shared_ptr<Deck> deck)
-{
-    deck_ = std::move(deck);
-}
-
-void EclGenericVanguard::setDeck(std::unique_ptr<Deck> deck)
-{
-    deck_ = std::move(deck);
-}
-
-void EclGenericVanguard::setEclState(std::shared_ptr<EclipseState> eclState)
-{
-    eclState_ = std::move(eclState);
-}
-
-void EclGenericVanguard::setEclState(std::unique_ptr<EclipseState> eclState)
-{
-    eclState_ = std::move(eclState);
-}
-
-void EclGenericVanguard::setExternalUDQState(std::unique_ptr<UDQState> udqState)
-{
-    externalUDQState_ = std::move(udqState);
-}
-
-void EclGenericVanguard::setExternalActionState(std::unique_ptr<Action::State> actionState)
-{
-    externalActionState_ = std::move(actionState);
-}
-
-void EclGenericVanguard::setExternalWTestState(std::unique_ptr<WellTestState> wtestState)
-{
-    externalWTestState_ = std::move(wtestState);
+    EclGenericVanguard::setupTime_ = setupTime;
+    EclGenericVanguard::deck_ = std::move(deck);
+    EclGenericVanguard::eclState_ = std::move(eclState);
+    EclGenericVanguard::eclSchedule_ = std::move(schedule);
+    EclGenericVanguard::udqState_ = std::move(udqState);
+    EclGenericVanguard::actionState_ = std::move(actionState);
+    EclGenericVanguard::wtestState_ = std::move(wtestState);
+    EclGenericVanguard::eclSummaryConfig_ = std::move(summaryConfig);
 }
 
 std::string EclGenericVanguard::canonicalDeckPath(const std::string& caseName)
@@ -209,21 +171,6 @@ void EclGenericVanguard::init()
         caseName_ = rawCaseName;
         std::transform(caseName_.begin(), caseName_.end(), caseName_.begin(), ::toupper);
     }
-
-    if (EclGenericVanguard::externalUDQState_)
-        this->udqState_ = std::move(EclGenericVanguard::externalUDQState_);
-    else
-        this->udqState_ = std::make_unique<UDQState>( this->eclSchedule_->getUDQConfig(0).params().undefinedValue() );
-
-    if (EclGenericVanguard::externalActionState_)
-        this->actionState_ = std::move(EclGenericVanguard::externalActionState_);
-    else
-        this->actionState_ = std::make_unique<Action::State>();
-
-    if (EclGenericVanguard::externalWTestState_)
-        this->wtestState_ = std::move(EclGenericVanguard::externalWTestState_);
-    else
-        this->wtestState_ = std::make_unique<WellTestState>();
 
     this->summaryState_ = std::make_unique<SummaryState>( TimeService::from_time_t(this->eclSchedule_->getStartTime() ));
 

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -56,7 +56,7 @@ double EclGenericVanguard::setupTime_ = 0.0;
 std::shared_ptr<Deck> EclGenericVanguard::deck_;
 std::unique_ptr<ParseContext> EclGenericVanguard::externalParseContext_;
 std::unique_ptr<ErrorGuard> EclGenericVanguard::externalErrorGuard_;
-std::shared_ptr<EclipseState> EclGenericVanguard::externalEclState_;
+std::shared_ptr<EclipseState> EclGenericVanguard::eclState_;
 std::shared_ptr<Schedule> EclGenericVanguard::externalEclSchedule_;
 std::shared_ptr<SummaryConfig> EclGenericVanguard::externalEclSummaryConfig_;
 std::unique_ptr<UDQState> EclGenericVanguard::externalUDQState_;
@@ -113,14 +113,14 @@ void EclGenericVanguard::setDeck(std::unique_ptr<Deck> deck)
     deck_ = std::move(deck);
 }
 
-void EclGenericVanguard::setExternalEclState(std::shared_ptr<EclipseState> eclState)
+void EclGenericVanguard::setEclState(std::shared_ptr<EclipseState> eclState)
 {
-    externalEclState_ = std::move(eclState);
+    eclState_ = std::move(eclState);
 }
 
-void EclGenericVanguard::setExternalEclState(std::unique_ptr<EclipseState> eclState)
+void EclGenericVanguard::setEclState(std::unique_ptr<EclipseState> eclState)
 {
-    externalEclState_ = std::move(eclState);
+    eclState_ = std::move(eclState);
 }
 
 void EclGenericVanguard::setExternalUDQState(std::unique_ptr<UDQState> udqState)
@@ -269,9 +269,8 @@ void EclGenericVanguard::init()
             parseContext_ = std::move(externalParseContext_);
             errorGuard = std::move(externalErrorGuard_);
         }
-        else if(externalEclState_ && externalEclSchedule_ && externalEclSummaryConfig_)
+        else if(externalEclSchedule_ && externalEclSummaryConfig_)
         {
-            eclState_ = std::move(externalEclState_);
             eclSchedule_ = std::move(externalEclSchedule_);
             eclSummaryConfig_ = std::move(externalEclSummaryConfig_);
         }

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -58,7 +58,7 @@ std::unique_ptr<ParseContext> EclGenericVanguard::externalParseContext_;
 std::unique_ptr<ErrorGuard> EclGenericVanguard::externalErrorGuard_;
 std::shared_ptr<EclipseState> EclGenericVanguard::eclState_;
 std::shared_ptr<Schedule> EclGenericVanguard::eclSchedule_;
-std::shared_ptr<SummaryConfig> EclGenericVanguard::externalEclSummaryConfig_;
+std::shared_ptr<SummaryConfig> EclGenericVanguard::eclSummaryConfig_;
 std::unique_ptr<UDQState> EclGenericVanguard::externalUDQState_;
 std::unique_ptr<Action::State> EclGenericVanguard::externalActionState_;
 std::unique_ptr<WellTestState> EclGenericVanguard::externalWTestState_;
@@ -91,16 +91,16 @@ void EclGenericVanguard::setSchedule(std::unique_ptr<Schedule> schedule)
     eclSchedule_ = std::move(schedule);
 }
 
-void EclGenericVanguard::setExternalSummaryConfig(
+void EclGenericVanguard::setSummaryConfig(
     std::shared_ptr<SummaryConfig> summaryConfig)
 {
-    externalEclSummaryConfig_ = std::move(summaryConfig);
+    eclSummaryConfig_ = std::move(summaryConfig);
 }
 
-void EclGenericVanguard::setExternalSummaryConfig(
+void EclGenericVanguard::setSummaryConfig(
     std::unique_ptr<SummaryConfig> summaryConfig)
 {
-    externalEclSummaryConfig_ = std::move(summaryConfig);
+    eclSummaryConfig_ = std::move(summaryConfig);
 }
 
 void EclGenericVanguard::setDeck(std::shared_ptr<Deck> deck)
@@ -268,10 +268,6 @@ void EclGenericVanguard::init()
         {
             parseContext_ = std::move(externalParseContext_);
             errorGuard = std::move(externalErrorGuard_);
-        }
-        else if(externalEclSummaryConfig_)
-        {
-            eclSummaryConfig_ = std::move(externalEclSummaryConfig_);
         }
         else
         {

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -36,7 +36,6 @@
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>
 
@@ -55,7 +54,6 @@ namespace Opm {
 double EclGenericVanguard::setupTime_ = 0.0;
 std::shared_ptr<Deck> EclGenericVanguard::deck_;
 std::unique_ptr<ParseContext> EclGenericVanguard::externalParseContext_;
-std::unique_ptr<ErrorGuard> EclGenericVanguard::externalErrorGuard_;
 std::shared_ptr<EclipseState> EclGenericVanguard::eclState_;
 std::shared_ptr<Schedule> EclGenericVanguard::eclSchedule_;
 std::shared_ptr<SummaryConfig> EclGenericVanguard::eclSummaryConfig_;
@@ -74,11 +72,6 @@ EclGenericVanguard::~EclGenericVanguard() = default;
 void EclGenericVanguard::setExternalParseContext(std::unique_ptr<ParseContext> parseContext)
 {
     externalParseContext_ = std::move(parseContext);
-}
-
-void EclGenericVanguard::setExternalErrorGuard(std::unique_ptr<ErrorGuard> errorGuard)
-{
-    externalErrorGuard_ = std::move(errorGuard);
 }
 
 void EclGenericVanguard::setSchedule(std::shared_ptr<Schedule> schedule)
@@ -258,16 +251,13 @@ void EclGenericVanguard::init()
         std::transform(caseName_.begin(), caseName_.end(), caseName_.begin(), ::toupper);
     }
 
-    std::unique_ptr<ErrorGuard> errorGuard = nullptr;
-
     // Check that we are in one of the known configurations for external variables
     // and move them to internal
     if (true)
     {
-        if (externalParseContext_ && externalErrorGuard_ )
+        if (externalParseContext_ )
         {
             parseContext_ = std::move(externalParseContext_);
-            errorGuard = std::move(externalErrorGuard_);
         }
         else
         {

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -39,7 +39,6 @@
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>
-#include <opm/simulators/utils/readDeck.hpp>
 
 #include <dune/common/version.hh>
 #include <dune/common/parallel/mpihelper.hh>
@@ -54,10 +53,9 @@
 namespace Opm {
 
 double EclGenericVanguard::setupTime_ = 0.0;
+std::shared_ptr<Deck> EclGenericVanguard::deck_;
 std::unique_ptr<ParseContext> EclGenericVanguard::externalParseContext_;
 std::unique_ptr<ErrorGuard> EclGenericVanguard::externalErrorGuard_;
-std::shared_ptr<Deck> EclGenericVanguard::externalDeck_;
-bool EclGenericVanguard::externalDeckSet_ = false;
 std::shared_ptr<EclipseState> EclGenericVanguard::externalEclState_;
 std::shared_ptr<Schedule> EclGenericVanguard::externalEclSchedule_;
 std::shared_ptr<SummaryConfig> EclGenericVanguard::externalEclSummaryConfig_;
@@ -105,16 +103,14 @@ void EclGenericVanguard::setExternalSummaryConfig(
     externalEclSummaryConfig_ = std::move(summaryConfig);
 }
 
-void EclGenericVanguard::setExternalDeck(std::shared_ptr<Deck> deck)
+void EclGenericVanguard::setDeck(std::shared_ptr<Deck> deck)
 {
-    externalDeck_ = std::move(deck);
-    externalDeckSet_ = true;
+    deck_ = std::move(deck);
 }
 
-void EclGenericVanguard::setExternalDeck(std::unique_ptr<Deck> deck)
+void EclGenericVanguard::setDeck(std::unique_ptr<Deck> deck)
 {
-    externalDeck_ = std::move(deck);
-    externalDeckSet_ = true;
+    deck_ = std::move(deck);
 }
 
 void EclGenericVanguard::setExternalEclState(std::shared_ptr<EclipseState> eclState)
@@ -266,10 +262,8 @@ void EclGenericVanguard::init()
 
     // Check that we are in one of the known configurations for external variables
     // and move them to internal
-    if (externalDeck_)
+    if (true)
     {
-        deck_ = std::move(externalDeck_);
-
         if (externalParseContext_ && externalErrorGuard_ )
         {
             parseContext_ = std::move(externalParseContext_);
@@ -295,11 +289,6 @@ void EclGenericVanguard::init()
     {
         parseContext_ = createParseContext(ignoredKeywords_, eclStrictParsing_);
     }
-
-    readDeck(EclGenericVanguard::comm(), fileName_, deck_, eclState_, eclSchedule_, udqState_, actionState_, wtestState_,
-             eclSummaryConfig_, std::move(errorGuard), python,
-             std::move(parseContext_), /* initFromRestart = */ false,
-             /* checkDeck = */ enableExperiments_, outputInterval_);
 
     if (EclGenericVanguard::externalUDQState_)
         this->udqState_ = std::move(EclGenericVanguard::externalUDQState_);

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -53,7 +53,7 @@
 
 namespace Opm {
 
-double EclGenericVanguard::externalSetupTime_ = 0.0;
+double EclGenericVanguard::setupTime_ = 0.0;
 std::unique_ptr<ParseContext> EclGenericVanguard::externalParseContext_;
 std::unique_ptr<ErrorGuard> EclGenericVanguard::externalErrorGuard_;
 std::shared_ptr<Deck> EclGenericVanguard::externalDeck_;

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -57,7 +57,7 @@ std::shared_ptr<Deck> EclGenericVanguard::deck_;
 std::unique_ptr<ParseContext> EclGenericVanguard::externalParseContext_;
 std::unique_ptr<ErrorGuard> EclGenericVanguard::externalErrorGuard_;
 std::shared_ptr<EclipseState> EclGenericVanguard::eclState_;
-std::shared_ptr<Schedule> EclGenericVanguard::externalEclSchedule_;
+std::shared_ptr<Schedule> EclGenericVanguard::eclSchedule_;
 std::shared_ptr<SummaryConfig> EclGenericVanguard::externalEclSummaryConfig_;
 std::unique_ptr<UDQState> EclGenericVanguard::externalUDQState_;
 std::unique_ptr<Action::State> EclGenericVanguard::externalActionState_;
@@ -81,14 +81,14 @@ void EclGenericVanguard::setExternalErrorGuard(std::unique_ptr<ErrorGuard> error
     externalErrorGuard_ = std::move(errorGuard);
 }
 
-void EclGenericVanguard::setExternalSchedule(std::shared_ptr<Schedule> schedule)
+void EclGenericVanguard::setSchedule(std::shared_ptr<Schedule> schedule)
 {
-    externalEclSchedule_ = std::move(schedule);
+    eclSchedule_ = std::move(schedule);
 }
 
-void EclGenericVanguard::setExternalSchedule(std::unique_ptr<Schedule> schedule)
+void EclGenericVanguard::setSchedule(std::unique_ptr<Schedule> schedule)
 {
-    externalEclSchedule_ = std::move(schedule);
+    eclSchedule_ = std::move(schedule);
 }
 
 void EclGenericVanguard::setExternalSummaryConfig(
@@ -269,9 +269,8 @@ void EclGenericVanguard::init()
             parseContext_ = std::move(externalParseContext_);
             errorGuard = std::move(externalErrorGuard_);
         }
-        else if(externalEclSchedule_ && externalEclSummaryConfig_)
+        else if(externalEclSummaryConfig_)
         {
-            eclSchedule_ = std::move(externalEclSchedule_);
             eclSummaryConfig_ = std::move(externalEclSummaryConfig_);
         }
         else

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -133,12 +133,9 @@ public:
 
     /*!
      * \brief Set the schedule object.
-     *
-     * The lifetime of this object is not managed by the vanguard, i.e., the object must
-     * stay valid until after the vanguard gets destroyed.
      */
-    static void setExternalSchedule(std::shared_ptr<Schedule> schedule);
-    static void setExternalSchedule(std::unique_ptr<Schedule> schedule);
+    static void setSchedule(std::shared_ptr<Schedule> schedule);
+    static void setSchedule(std::unique_ptr<Schedule> schedule);
 
     /*!
      * \brief Set the summary configuration object.
@@ -315,7 +312,6 @@ protected:
     static std::unique_ptr<ErrorGuard> externalErrorGuard_;
 
     // These variables may be owned by both Python and the simulator
-    static std::shared_ptr<Schedule> externalEclSchedule_;
     static std::shared_ptr<SummaryConfig> externalEclSummaryConfig_;
 
     static std::unique_ptr<UDQState> externalUDQState_;
@@ -359,7 +355,7 @@ protected:
     // These variables may be owned by both Python and the simulator
     static std::shared_ptr<Deck> deck_;
     static std::shared_ptr<EclipseState> eclState_;
-    std::shared_ptr<Schedule> eclSchedule_;
+    static std::shared_ptr<Schedule> eclSchedule_;
     std::shared_ptr<SummaryConfig> eclSummaryConfig_;
 
     /*! \brief Information about wells in parallel

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -96,16 +96,16 @@ public:
     /*!
      * \brief Set the wall time which was spend externally to set up the external data structures
      *
-     * i.e., the objects specified via the other setExternal*() methods.
+     * i.e., the objects specified via the other set*() methods.
      */
-    static void setExternalSetupTime(double t)
-    { externalSetupTime_ = t; }
+    static void setSetupTime(double t)
+    { setupTime_ = t; }
 
     /*!
      * \brief Returns the wall time required to set up the simulator before it was born.
      */
-    static double externalSetupTime()
-    { return externalSetupTime_; }
+    static double setupTime()
+    { return setupTime_; }
 
     /*!
      * \brief Set the Opm::ParseContext object which ought to be used for parsing the deck and creating the Opm::EclipseState object.
@@ -316,7 +316,7 @@ protected:
 
     void init();
 
-    static double externalSetupTime_;
+    static double setupTime_;
     static std::unique_ptr<ParseContext> externalParseContext_;
     static std::unique_ptr<ErrorGuard> externalErrorGuard_;
 

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -88,12 +88,6 @@ public:
     static std::string canonicalDeckPath(const std::string& caseName);
 
     /*!
-     * \brief Creates an Opm::parseContext object assuming that the parameters are ready.
-     */
-    static std::unique_ptr<ParseContext> createParseContext(const std::string& ignoredKeywords,
-                                                            bool eclStrictParsing);
-
-    /*!
      * \brief Set the wall time which was spend externally to set up the external data structures
      *
      * i.e., the objects specified via the other set*() methods.
@@ -106,11 +100,6 @@ public:
      */
     static double setupTime()
     { return setupTime_; }
-
-    /*!
-     * \brief Set the Opm::ParseContext object which ought to be used for parsing the deck and creating the Opm::EclipseState object.
-     */
-    static void setExternalParseContext(std::unique_ptr<ParseContext> parseContext);
 
     /*!
      * \brief Set the Opm::Deck object which ought to be used when the simulator vanguard
@@ -300,7 +289,6 @@ protected:
     void init();
 
     static double setupTime_;
-    static std::unique_ptr<ParseContext> externalParseContext_;
 
     // These variables may be owned by both Python and the simulator
     static std::unique_ptr<UDQState> externalUDQState_;
@@ -338,7 +326,6 @@ protected:
 
     // these attributes point  either to the internal  or to the external version of the
     // parser objects.
-    std::unique_ptr<ParseContext> parseContext_;
     std::shared_ptr<Python> python;
     // These variables may be owned by both Python and the simulator
     static std::shared_ptr<Deck> deck_;

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -94,6 +94,12 @@ public:
     { return setupTime_; }
 
     /*!
+     * \brief Read a deck.
+     * \param filename file to read
+     */
+    static void readDeck(const std::string& filename);
+
+    /*!
      * \brief Set the simulation configuration objects.
      */
     static void setParams(double setupTime,

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -139,12 +139,9 @@ public:
 
     /*!
      * \brief Set the summary configuration object.
-     *
-     * The lifetime of this object is not managed by the vanguard, i.e., the object must
-     * stay valid until after the vanguard gets destroyed.
      */
-    static void setExternalSummaryConfig(std::shared_ptr<SummaryConfig> summaryConfig);
-    static void setExternalSummaryConfig(std::unique_ptr<SummaryConfig> summaryConfig);
+    static void setSummaryConfig(std::shared_ptr<SummaryConfig> summaryConfig);
+    static void setSummaryConfig(std::unique_ptr<SummaryConfig> summaryConfig);
 
     static void setExternalUDQState(std::unique_ptr<UDQState> udqState);
     static void setExternalActionState(std::unique_ptr<Action::State> actionState);
@@ -312,8 +309,6 @@ protected:
     static std::unique_ptr<ErrorGuard> externalErrorGuard_;
 
     // These variables may be owned by both Python and the simulator
-    static std::shared_ptr<SummaryConfig> externalEclSummaryConfig_;
-
     static std::unique_ptr<UDQState> externalUDQState_;
     static std::unique_ptr<Action::State> externalActionState_;
     static std::unique_ptr<WellTestState> externalWTestState_;
@@ -356,7 +351,7 @@ protected:
     static std::shared_ptr<Deck> deck_;
     static std::shared_ptr<EclipseState> eclState_;
     static std::shared_ptr<Schedule> eclSchedule_;
-    std::shared_ptr<SummaryConfig> eclSummaryConfig_;
+    static std::shared_ptr<SummaryConfig> eclSummaryConfig_;
 
     /*! \brief Information about wells in parallel
      *

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -88,49 +88,22 @@ public:
     static std::string canonicalDeckPath(const std::string& caseName);
 
     /*!
-     * \brief Set the wall time which was spend externally to set up the external data structures
-     *
-     * i.e., the objects specified via the other set*() methods.
-     */
-    static void setSetupTime(double t)
-    { setupTime_ = t; }
-
-    /*!
      * \brief Returns the wall time required to set up the simulator before it was born.
      */
     static double setupTime()
     { return setupTime_; }
 
     /*!
-     * \brief Set the Opm::Deck object which ought to be used when the simulator vanguard
-     *        is instantiated.
+     * \brief Set the simulation configuration objects.
      */
-    static void setDeck(std::shared_ptr<Deck> deck);
-    static void setDeck(std::unique_ptr<Deck> deck);
-
-    /*!
-     * \brief Set the Opm::EclipseState object which ought to be used when the simulator
-     *        vanguard is instantiated.
-     */
-    static void setEclState(std::shared_ptr<EclipseState> eclState);
-    static void setEclState(std::unique_ptr<EclipseState> eclState);
-
-    /*!
-     * \brief Set the schedule object.
-     */
-    static void setSchedule(std::shared_ptr<Schedule> schedule);
-    static void setSchedule(std::unique_ptr<Schedule> schedule);
-
-    /*!
-     * \brief Set the summary configuration object.
-     */
-    static void setSummaryConfig(std::shared_ptr<SummaryConfig> summaryConfig);
-    static void setSummaryConfig(std::unique_ptr<SummaryConfig> summaryConfig);
-
-    static void setExternalUDQState(std::unique_ptr<UDQState> udqState);
-    static void setExternalActionState(std::unique_ptr<Action::State> actionState);
-    static void setExternalWTestState(std::unique_ptr<WellTestState> wtestState);
-
+    static void setParams(double setupTime,
+                          std::shared_ptr<Deck> deck,
+                          std::shared_ptr<EclipseState> eclState,
+                          std::shared_ptr<Schedule> schedule,
+                          std::unique_ptr<UDQState> udqState,
+                          std::unique_ptr<Action::State> actionState,
+                          std::unique_ptr<WellTestState> wtestState,
+                          std::shared_ptr<SummaryConfig> summaryConfig);
 
     /*!
      * \brief Return a reference to the parsed ECL deck.
@@ -291,9 +264,6 @@ protected:
     static double setupTime_;
 
     // These variables may be owned by both Python and the simulator
-    static std::unique_ptr<UDQState> externalUDQState_;
-    static std::unique_ptr<Action::State> externalActionState_;
-    static std::unique_ptr<WellTestState> externalWTestState_;
     static std::unique_ptr<Parallel::Communication> comm_;
 
     std::string caseName_;
@@ -315,14 +285,14 @@ protected:
     bool enableExperiments_;
 
     std::unique_ptr<SummaryState> summaryState_;
-    std::unique_ptr<UDQState> udqState_;
-    std::unique_ptr<Action::State> actionState_;
+    static std::unique_ptr<UDQState> udqState_;
+    static std::unique_ptr<Action::State> actionState_;
 
     // Observe that this instance is handled differently from the other state
     // variables, it will only be initialized for a restart run. While
     // initializing a restarted run this instance is transferred to the WGState
     // member in the well model.
-    std::unique_ptr<WellTestState> wtestState_;
+    static std::unique_ptr<WellTestState> wtestState_;
 
     // these attributes point  either to the internal  or to the external version of the
     // parser objects.

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -128,8 +128,8 @@ public:
      * \brief Set the Opm::EclipseState object which ought to be used when the simulator
      *        vanguard is instantiated.
      */
-    static void setExternalEclState(std::shared_ptr<EclipseState> eclState);
-    static void setExternalEclState(std::unique_ptr<EclipseState> eclState);
+    static void setEclState(std::shared_ptr<EclipseState> eclState);
+    static void setEclState(std::unique_ptr<EclipseState> eclState);
 
     /*!
      * \brief Set the schedule object.
@@ -315,7 +315,6 @@ protected:
     static std::unique_ptr<ErrorGuard> externalErrorGuard_;
 
     // These variables may be owned by both Python and the simulator
-    static std::shared_ptr<EclipseState> externalEclState_;
     static std::shared_ptr<Schedule> externalEclSchedule_;
     static std::shared_ptr<SummaryConfig> externalEclSummaryConfig_;
 
@@ -359,7 +358,7 @@ protected:
     std::shared_ptr<Python> python;
     // These variables may be owned by both Python and the simulator
     static std::shared_ptr<Deck> deck_;
-    std::shared_ptr<EclipseState> eclState_;
+    static std::shared_ptr<EclipseState> eclState_;
     std::shared_ptr<Schedule> eclSchedule_;
     std::shared_ptr<SummaryConfig> eclSummaryConfig_;
 

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -113,11 +113,6 @@ public:
     static void setExternalParseContext(std::unique_ptr<ParseContext> parseContext);
 
     /*!
-     * \brief Set the Opm::ErrorGuard object which ought to be used for parsing the deck and creating the Opm::EclipseState object.
-     */
-    static void setExternalErrorGuard(std::unique_ptr<ErrorGuard> errorGuard);
-
-    /*!
      * \brief Set the Opm::Deck object which ought to be used when the simulator vanguard
      *        is instantiated.
      */
@@ -306,7 +301,6 @@ protected:
 
     static double setupTime_;
     static std::unique_ptr<ParseContext> externalParseContext_;
-    static std::unique_ptr<ErrorGuard> externalErrorGuard_;
 
     // These variables may be owned by both Python and the simulator
     static std::unique_ptr<UDQState> externalUDQState_;
@@ -345,7 +339,6 @@ protected:
     // these attributes point  either to the internal  or to the external version of the
     // parser objects.
     std::unique_ptr<ParseContext> parseContext_;
-    std::unique_ptr<ErrorGuard> errorGuard_;
     std::shared_ptr<Python> python;
     // These variables may be owned by both Python and the simulator
     static std::shared_ptr<Deck> deck_;

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -120,15 +120,9 @@ public:
     /*!
      * \brief Set the Opm::Deck object which ought to be used when the simulator vanguard
      *        is instantiated.
-     *
-     * This is basically an optimization: In cases where the ECL input deck must be
-     * examined to decide which simulator ought to be used, this avoids having to parse
-     * the input twice. When this method is used, the caller is responsible for lifetime
-     * management of these two objects, i.e., they are not allowed to be deleted as long
-     * as the simulator vanguard object is alive.
      */
-    static void setExternalDeck(std::shared_ptr<Deck> deck);
-    static void setExternalDeck(std::unique_ptr<Deck> deck);
+    static void setDeck(std::shared_ptr<Deck> deck);
+    static void setDeck(std::unique_ptr<Deck> deck);
 
     /*!
      * \brief Set the Opm::EclipseState object which ought to be used when the simulator
@@ -321,12 +315,10 @@ protected:
     static std::unique_ptr<ErrorGuard> externalErrorGuard_;
 
     // These variables may be owned by both Python and the simulator
-    static std::shared_ptr<Deck> externalDeck_;
     static std::shared_ptr<EclipseState> externalEclState_;
     static std::shared_ptr<Schedule> externalEclSchedule_;
     static std::shared_ptr<SummaryConfig> externalEclSummaryConfig_;
 
-    static bool externalDeckSet_;
     static std::unique_ptr<UDQState> externalUDQState_;
     static std::unique_ptr<Action::State> externalActionState_;
     static std::unique_ptr<WellTestState> externalWTestState_;
@@ -366,7 +358,7 @@ protected:
     std::unique_ptr<ErrorGuard> errorGuard_;
     std::shared_ptr<Python> python;
     // These variables may be owned by both Python and the simulator
-    std::shared_ptr<Deck> deck_;
+    static std::shared_ptr<Deck> deck_;
     std::shared_ptr<EclipseState> eclState_;
     std::shared_ptr<Schedule> eclSchedule_;
     std::shared_ptr<SummaryConfig> eclSummaryConfig_;

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -177,7 +177,7 @@ public:
         const Scalar totalCpuTime =
             simulator_.executionTimer().realTimeElapsed() +
             simulator_.setupTimer().realTimeElapsed() +
-            simulator_.vanguard().externalSetupTime();
+            simulator_.vanguard().setupTime();
 
         const auto localWellData            = simulator_.problem().wellModel().wellData();
         const auto localGroupAndNetworkData = simulator_.problem().wellModel()

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -35,7 +35,7 @@ void flowEbosBlackoilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -24,27 +24,6 @@
 
 namespace Opm {
 
-void flowEbosBlackoilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                             std::shared_ptr<EclipseState> eclState,
-                             std::shared_ptr<Schedule> schedule,
-                             std::unique_ptr<UDQState> udqState,
-                             std::unique_ptr<Action::State> actionState,
-                             std::unique_ptr<WellTestState> wtestState,
-                             std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalUDQState(std::move(udqState));
-    Vanguard::setExternalActionState(std::move(actionState));
-    Vanguard::setExternalWTestState(std::move(wtestState));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
-
 std::unique_ptr<FlowMainEbos<Properties::TTag::EclFlowProblem>>
 flowEbosBlackoilMainInit(int argc, char** argv, bool outputCout, bool outputFiles)
 {

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -42,7 +42,7 @@ void flowEbosBlackoilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setExternalUDQState(std::move(udqState));
     Vanguard::setExternalActionState(std::move(actionState));
     Vanguard::setExternalWTestState(std::move(wtestState));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 std::unique_ptr<FlowMainEbos<Properties::TTag::EclFlowProblem>>

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -38,7 +38,7 @@ void flowEbosBlackoilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalUDQState(std::move(udqState));
     Vanguard::setExternalActionState(std::move(actionState));
     Vanguard::setExternalWTestState(std::move(wtestState));

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -37,7 +37,7 @@ void flowEbosBlackoilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalUDQState(std::move(udqState));
     Vanguard::setExternalActionState(std::move(actionState));

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -36,7 +36,7 @@ void flowEbosBlackoilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalUDQState(std::move(udqState));

--- a/flow/flow_ebos_blackoil.hpp
+++ b/flow/flow_ebos_blackoil.hpp
@@ -21,25 +21,12 @@
 
 namespace Opm {
 
-class Deck;
-class EclipseState;
 template<class TypeTag> class FlowMainEbos;
-class Schedule;
-class SummaryConfig;
-class UDQState;
-class WellTestState;
+
 namespace Action {
 class State;
 }
 namespace Properties { namespace TTag { struct EclFlowProblem; } }
-
-void flowEbosBlackoilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                             std::shared_ptr<EclipseState> eclState,
-                             std::shared_ptr<Schedule> schedule,
-                             std::unique_ptr<UDQState> udqState,
-                             std::unique_ptr<Action::State> actionState,
-                             std::unique_ptr<WellTestState> wtestState,
-                             std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -46,7 +46,7 @@ void flowEbosBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -47,7 +47,7 @@ void flowEbosBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -48,7 +48,7 @@ void flowEbosBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -37,21 +37,6 @@ struct EnableBrine<TypeTag, TTag::EclFlowBrineProblem> {
 }}
 
 namespace Opm {
-void flowEbosBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                          std::shared_ptr<EclipseState> eclState,
-                          std::shared_ptr<Schedule> schedule,
-                          std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowBrineProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
-
 
 // ----------------- Main program -----------------
 int flowEbosBrineMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -49,7 +49,7 @@ void flowEbosBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -45,7 +45,7 @@ void flowEbosBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowBrineProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_brine.hpp
+++ b/flow/flow_ebos_brine.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_BRINE_HPP
 #define FLOW_EBOS_BRINE_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                          std::shared_ptr<EclipseState> eclState,
-                          std::shared_ptr<Schedule> schedule,
-                          std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosBrineMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_brine_precsalt_vapwat.cpp
+++ b/flow/flow_ebos_brine_precsalt_vapwat.cpp
@@ -57,7 +57,7 @@ void flowEbosBrinePrecsaltVapwatSetDeck(double setupTime, std::shared_ptr<Deck> 
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_brine_precsalt_vapwat.cpp
+++ b/flow/flow_ebos_brine_precsalt_vapwat.cpp
@@ -55,7 +55,7 @@ void flowEbosBrinePrecsaltVapwatSetDeck(double setupTime, std::shared_ptr<Deck> 
     using TypeTag = Properties::TTag::EclFlowBrinePrecsaltVapwatProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_brine_precsalt_vapwat.cpp
+++ b/flow/flow_ebos_brine_precsalt_vapwat.cpp
@@ -59,7 +59,7 @@ void flowEbosBrinePrecsaltVapwatSetDeck(double setupTime, std::shared_ptr<Deck> 
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 

--- a/flow/flow_ebos_brine_precsalt_vapwat.cpp
+++ b/flow/flow_ebos_brine_precsalt_vapwat.cpp
@@ -56,7 +56,7 @@ void flowEbosBrinePrecsaltVapwatSetDeck(double setupTime, std::shared_ptr<Deck> 
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_brine_precsalt_vapwat.cpp
+++ b/flow/flow_ebos_brine_precsalt_vapwat.cpp
@@ -47,21 +47,6 @@ struct EnableEvaporation<TypeTag, TTag::EclFlowBrinePrecsaltVapwatProblem> {
 }}
 
 namespace Opm {
-void flowEbosBrinePrecsaltVapwatSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                          std::shared_ptr<EclipseState> eclState,
-                          std::shared_ptr<Schedule> schedule,
-                          std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowBrinePrecsaltVapwatProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
-
 
 // ----------------- Main program -----------------
 int flowEbosBrinePrecsaltVapwatMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_brine_precsalt_vapwat.cpp
+++ b/flow/flow_ebos_brine_precsalt_vapwat.cpp
@@ -58,7 +58,7 @@ void flowEbosBrinePrecsaltVapwatSetDeck(double setupTime, std::shared_ptr<Deck> 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_brine_precsalt_vapwat.hpp
+++ b/flow/flow_ebos_brine_precsalt_vapwat.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_BRINE_PRECSALT_VAPWAT_HPP
 #define FLOW_EBOS_BRINE_PRECSALT_VAPWAT_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosBrinePrecsaltVapwatSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                          std::shared_ptr<EclipseState> eclState,
-                          std::shared_ptr<Schedule> schedule,
-                          std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosBrinePrecsaltVapwatMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_brine_saltprecipitation.cpp
+++ b/flow/flow_ebos_brine_saltprecipitation.cpp
@@ -52,7 +52,7 @@ void flowEbosBrineSaltPrecipitationSetDeck(double setupTime, std::shared_ptr<Dec
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_brine_saltprecipitation.cpp
+++ b/flow/flow_ebos_brine_saltprecipitation.cpp
@@ -42,21 +42,6 @@ struct EnableSaltPrecipitation<TypeTag, TTag::EclFlowBrineSaltPrecipitationProbl
 }}
 
 namespace Opm {
-void flowEbosBrineSaltPrecipitationSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                          std::shared_ptr<EclipseState> eclState,
-                          std::shared_ptr<Schedule> schedule,
-                          std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowBrineSaltPrecipitationProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
-
 
 // ----------------- Main program -----------------
 int flowEbosBrineSaltPrecipitationMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_brine_saltprecipitation.cpp
+++ b/flow/flow_ebos_brine_saltprecipitation.cpp
@@ -53,7 +53,7 @@ void flowEbosBrineSaltPrecipitationSetDeck(double setupTime, std::shared_ptr<Dec
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_brine_saltprecipitation.cpp
+++ b/flow/flow_ebos_brine_saltprecipitation.cpp
@@ -51,7 +51,7 @@ void flowEbosBrineSaltPrecipitationSetDeck(double setupTime, std::shared_ptr<Dec
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_brine_saltprecipitation.cpp
+++ b/flow/flow_ebos_brine_saltprecipitation.cpp
@@ -50,7 +50,7 @@ void flowEbosBrineSaltPrecipitationSetDeck(double setupTime, std::shared_ptr<Dec
     using TypeTag = Properties::TTag::EclFlowBrineSaltPrecipitationProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_brine_saltprecipitation.cpp
+++ b/flow/flow_ebos_brine_saltprecipitation.cpp
@@ -54,7 +54,7 @@ void flowEbosBrineSaltPrecipitationSetDeck(double setupTime, std::shared_ptr<Dec
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 

--- a/flow/flow_ebos_brine_saltprecipitation.hpp
+++ b/flow/flow_ebos_brine_saltprecipitation.hpp
@@ -21,16 +21,6 @@
 
 namespace Opm {
 
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosBrineSaltPrecipitationSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                          std::shared_ptr<EclipseState> eclState,
-                          std::shared_ptr<Schedule> schedule,
-                          std::shared_ptr<SummaryConfig> summaryConfig);
-
 //! \brief Main function used in flow binary.
 int flowEbosBrineSaltPrecipitationMain(int argc, char** argv, bool outputCout, bool outputFiles);
 

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -49,7 +49,7 @@ void flowEbosEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -46,7 +46,7 @@ void flowEbosEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -47,7 +47,7 @@ void flowEbosEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -48,7 +48,7 @@ void flowEbosEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -45,7 +45,7 @@ void flowEbosEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowEnergyProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -37,20 +37,6 @@ struct EnableEnergy<TypeTag, TTag::EclFlowEnergyProblem> {
 }}
 
 namespace Opm {
-void flowEbosEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                          std::shared_ptr<EclipseState> eclState,
-                          std::shared_ptr<Schedule> schedule,
-                          std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowEnergyProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
 
 // ----------------- Main program -----------------
 int flowEbosEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_energy.hpp
+++ b/flow/flow_ebos_energy.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_ENERGY_HPP
 #define FLOW_EBOS_ENERGY_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                           std::shared_ptr<EclipseState> eclState,
-                           std::shared_ptr<Schedule> schedule,
-                           std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_extbo.cpp
+++ b/flow/flow_ebos_extbo.cpp
@@ -37,20 +37,6 @@ struct EnableExtbo<TypeTag, TTag::EclFlowExtboProblem> {
 }}
 
 namespace Opm {
-void flowEbosExtboSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                            std::shared_ptr<EclipseState> eclState,
-                            std::shared_ptr<Schedule> schedule,
-                            std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowExtboProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
 
 // ----------------- Main program -----------------
 int flowEbosExtboMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_extbo.cpp
+++ b/flow/flow_ebos_extbo.cpp
@@ -47,7 +47,7 @@ void flowEbosExtboSetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_extbo.cpp
+++ b/flow/flow_ebos_extbo.cpp
@@ -48,7 +48,7 @@ void flowEbosExtboSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_extbo.cpp
+++ b/flow/flow_ebos_extbo.cpp
@@ -49,7 +49,7 @@ void flowEbosExtboSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_extbo.cpp
+++ b/flow/flow_ebos_extbo.cpp
@@ -45,7 +45,7 @@ void flowEbosExtboSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowExtboProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_extbo.cpp
+++ b/flow/flow_ebos_extbo.cpp
@@ -46,7 +46,7 @@ void flowEbosExtboSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_extbo.hpp
+++ b/flow/flow_ebos_extbo.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_EXTBO_HPP
 #define FLOW_EBOS_EXTBO_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosExtboSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                            std::shared_ptr<EclipseState> eclState,
-                            std::shared_ptr<Schedule> schedule,
-                            std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosExtboMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -49,7 +49,7 @@ void flowEbosFoamSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -45,7 +45,7 @@ void flowEbosFoamSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowFoamProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -46,7 +46,7 @@ void flowEbosFoamSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -37,21 +37,6 @@ struct EnableFoam<TypeTag, TTag::EclFlowFoamProblem> {
 }}
 
 namespace Opm {
-void flowEbosFoamSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                         std::shared_ptr<EclipseState> eclState,
-                         std::shared_ptr<Schedule> schedule,
-                         std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowFoamProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
-
 
 // ----------------- Main program -----------------
 int flowEbosFoamMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -48,7 +48,7 @@ void flowEbosFoamSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -47,7 +47,7 @@ void flowEbosFoamSetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_foam.hpp
+++ b/flow/flow_ebos_foam.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_FOAM_HPP
 #define FLOW_EBOS_FOAM_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosFoamSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                         std::shared_ptr<EclipseState> eclState,
-                         std::shared_ptr<Schedule> schedule,
-                         std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosFoamMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -58,21 +58,6 @@ public:
 }}
 
 namespace Opm {
-void flowEbosGasOilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                           std::shared_ptr<EclipseState> eclState,
-                           std::shared_ptr<Schedule> schedule,
-                           std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowGasOilProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
-
 
 // ----------------- Main program -----------------
 int flowEbosGasOilMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -68,7 +68,7 @@ void flowEbosGasOilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -70,7 +70,7 @@ void flowEbosGasOilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -66,7 +66,7 @@ void flowEbosGasOilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowGasOilProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -69,7 +69,7 @@ void flowEbosGasOilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -67,7 +67,7 @@ void flowEbosGasOilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_gasoil.hpp
+++ b/flow/flow_ebos_gasoil.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_GASOIL_HPP
 #define FLOW_EBOS_GASOIL_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosGasOilSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                           std::shared_ptr<EclipseState> eclState,
-                           std::shared_ptr<Schedule> schedule,
-                           std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosGasOilMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_gasoil_energy.cpp
+++ b/flow/flow_ebos_gasoil_energy.cpp
@@ -71,7 +71,7 @@ void flowEbosGasOilEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_gasoil_energy.cpp
+++ b/flow/flow_ebos_gasoil_energy.cpp
@@ -74,7 +74,7 @@ void flowEbosGasOilEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 

--- a/flow/flow_ebos_gasoil_energy.cpp
+++ b/flow/flow_ebos_gasoil_energy.cpp
@@ -72,7 +72,7 @@ void flowEbosGasOilEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_gasoil_energy.cpp
+++ b/flow/flow_ebos_gasoil_energy.cpp
@@ -62,21 +62,6 @@ struct EnableEnergy<TypeTag, TTag::EclFlowGasOilEnergyProblem> {
 }}
 
 namespace Opm {
-void flowEbosGasOilEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                           std::shared_ptr<EclipseState> eclState,
-						   std::shared_ptr<Schedule> schedule,
-                           std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowGasOilEnergyProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
-
 
 // ----------------- Main program -----------------
 int flowEbosGasOilEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_gasoil_energy.cpp
+++ b/flow/flow_ebos_gasoil_energy.cpp
@@ -73,7 +73,7 @@ void flowEbosGasOilEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_gasoil_energy.cpp
+++ b/flow/flow_ebos_gasoil_energy.cpp
@@ -70,7 +70,7 @@ void flowEbosGasOilEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowGasOilEnergyProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_gasoil_energy.hpp
+++ b/flow/flow_ebos_gasoil_energy.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_GASOIL_ENERGY_HPP
 #define FLOW_EBOS_GASOIL_ENERGY_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosGasOilEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                           std::shared_ptr<EclipseState> eclState,
-                           std::shared_ptr<Schedule> schedule,
-                           std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosGasOilEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_gaswater.cpp
+++ b/flow/flow_ebos_gaswater.cpp
@@ -71,7 +71,7 @@ void flowEbosGasWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_gaswater.cpp
+++ b/flow/flow_ebos_gaswater.cpp
@@ -69,7 +69,7 @@ void flowEbosGasWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowGasWaterProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_gaswater.cpp
+++ b/flow/flow_ebos_gaswater.cpp
@@ -70,7 +70,7 @@ void flowEbosGasWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_gaswater.cpp
+++ b/flow/flow_ebos_gaswater.cpp
@@ -73,7 +73,7 @@ void flowEbosGasWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 

--- a/flow/flow_ebos_gaswater.cpp
+++ b/flow/flow_ebos_gaswater.cpp
@@ -72,7 +72,7 @@ void flowEbosGasWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_gaswater.cpp
+++ b/flow/flow_ebos_gaswater.cpp
@@ -61,20 +61,6 @@ public:
 }}
 
 namespace Opm {
-void flowEbosGasWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                           std::shared_ptr<EclipseState> eclState,
-                           std::shared_ptr<Schedule> schedule,
-                           std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowGasWaterProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
 
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_gaswater.hpp
+++ b/flow/flow_ebos_gaswater.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_GASWATER_HPP
 #define FLOW_EBOS_GASWATER_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosGasWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                           std::shared_ptr<EclipseState> eclState,
-                           std::shared_ptr<Schedule> schedule,
-                           std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosGasWaterMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_gaswater_brine.cpp
+++ b/flow/flow_ebos_gaswater_brine.cpp
@@ -72,7 +72,7 @@ void flowEbosGasWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_gaswater_brine.cpp
+++ b/flow/flow_ebos_gaswater_brine.cpp
@@ -73,7 +73,7 @@ void flowEbosGasWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_gaswater_brine.cpp
+++ b/flow/flow_ebos_gaswater_brine.cpp
@@ -69,7 +69,7 @@ void flowEbosGasWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowGasWaterBrineProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_gaswater_brine.cpp
+++ b/flow/flow_ebos_gaswater_brine.cpp
@@ -70,7 +70,7 @@ void flowEbosGasWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_gaswater_brine.cpp
+++ b/flow/flow_ebos_gaswater_brine.cpp
@@ -71,7 +71,7 @@ void flowEbosGasWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_gaswater_brine.cpp
+++ b/flow/flow_ebos_gaswater_brine.cpp
@@ -61,20 +61,6 @@ public:
 }}
 
 namespace Opm {
-void flowEbosGasWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                                  std::shared_ptr<EclipseState> eclState,
-                                  std::shared_ptr<Schedule> schedule,
-                                  std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowGasWaterBrineProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
 
 // ----------------- Main program -----------------
 int flowEbosGasWaterBrineMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_gaswater_brine.hpp
+++ b/flow/flow_ebos_gaswater_brine.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_GASWATER_BRINE_HPP
 #define FLOW_EBOS_GASWATER_BRINE_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosGasWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                                  std::shared_ptr<EclipseState> eclState,
-                                  std::shared_ptr<Schedule> schedule,
-                                  std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosGasWaterBrineMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
@@ -72,20 +72,6 @@ public:
 }}
 
 namespace Opm {
-void flowEbosGasWaterSaltprecVapwatSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                                  std::shared_ptr<EclipseState> eclState,
-                                  std::shared_ptr<Schedule> schedule,
-                                  std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowGasWaterSaltprecVapwatProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
 
 // ----------------- Main program -----------------
 int flowEbosGasWaterSaltprecVapwatMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
@@ -80,7 +80,7 @@ void flowEbosGasWaterSaltprecVapwatSetDeck(double setupTime, std::shared_ptr<Dec
     using TypeTag = Properties::TTag::EclFlowGasWaterSaltprecVapwatProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
@@ -83,7 +83,7 @@ void flowEbosGasWaterSaltprecVapwatSetDeck(double setupTime, std::shared_ptr<Dec
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
@@ -82,7 +82,7 @@ void flowEbosGasWaterSaltprecVapwatSetDeck(double setupTime, std::shared_ptr<Dec
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
@@ -81,7 +81,7 @@ void flowEbosGasWaterSaltprecVapwatSetDeck(double setupTime, std::shared_ptr<Dec
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
@@ -84,7 +84,7 @@ void flowEbosGasWaterSaltprecVapwatSetDeck(double setupTime, std::shared_ptr<Dec
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_gaswater_saltprec_vapwat.hpp
+++ b/flow/flow_ebos_gaswater_saltprec_vapwat.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_GASWATERSALTPRECVAPWAT_BRINE_HPP
 #define FLOW_EBOS_GASWATERSALTPRECVAPWAT_BRINE_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosGasWaterSaltprecVapwatSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                                  std::shared_ptr<EclipseState> eclState,
-                                  std::shared_ptr<Schedule> schedule,
-                                  std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosGasWaterSaltprecVapwatMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_micp.cpp
+++ b/flow/flow_ebos_micp.cpp
@@ -72,7 +72,7 @@ void flowEbosMICPSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_micp.cpp
+++ b/flow/flow_ebos_micp.cpp
@@ -70,7 +70,7 @@ void flowEbosMICPSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_micp.cpp
+++ b/flow/flow_ebos_micp.cpp
@@ -71,7 +71,7 @@ void flowEbosMICPSetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_micp.cpp
+++ b/flow/flow_ebos_micp.cpp
@@ -73,7 +73,7 @@ void flowEbosMICPSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_micp.cpp
+++ b/flow/flow_ebos_micp.cpp
@@ -69,7 +69,7 @@ void flowEbosMICPSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowMICPProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_micp.cpp
+++ b/flow/flow_ebos_micp.cpp
@@ -61,20 +61,6 @@ public:
 }}
 
 namespace Opm {
-void flowEbosMICPSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                                    std::shared_ptr<EclipseState> eclState,
-                                    std::shared_ptr<Schedule> schedule,
-                                    std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowMICPProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
 
 // ----------------- Main program -----------------
 int flowEbosMICPMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_micp.hpp
+++ b/flow/flow_ebos_micp.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_MICP_HPP
 #define FLOW_EBOS_MICP_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosMICPSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                                    std::shared_ptr<EclipseState> eclState,
-                                    std::shared_ptr<Schedule> schedule,
-                                    std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosMICPMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -66,7 +66,7 @@ void flowEbosOilWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowOilWaterProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -70,7 +70,7 @@ void flowEbosOilWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -68,7 +68,7 @@ void flowEbosOilWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -67,7 +67,7 @@ void flowEbosOilWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -58,20 +58,6 @@ public:
 }}
 
 namespace Opm {
-void flowEbosOilWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                             std::shared_ptr<EclipseState> eclState,
-                             std::shared_ptr<Schedule> schedule,
-                             std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowOilWaterProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
 
 // ----------------- Main program -----------------
 int flowEbosOilWaterMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -69,7 +69,7 @@ void flowEbosOilWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_oilwater.hpp
+++ b/flow/flow_ebos_oilwater.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_OILWATER_HPP
 #define FLOW_EBOS_OILWATER_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosOilWaterSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                             std::shared_ptr<EclipseState> eclState,
-                             std::shared_ptr<Schedule> schedule,
-                             std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main functon used in main flow binary.
 int flowEbosOilWaterMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_oilwater_brine.cpp
+++ b/flow/flow_ebos_oilwater_brine.cpp
@@ -69,7 +69,7 @@ void flowEbosOilWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowOilWaterBrineProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_oilwater_brine.cpp
+++ b/flow/flow_ebos_oilwater_brine.cpp
@@ -61,20 +61,6 @@ public:
 }}
 
 namespace Opm {
-void flowEbosOilWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                                  std::shared_ptr<EclipseState> eclState,
-                                  std::shared_ptr<Schedule> schedule,
-                                  std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowOilWaterBrineProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
 
 // ----------------- Main program -----------------
 int flowEbosOilWaterBrineMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_oilwater_brine.cpp
+++ b/flow/flow_ebos_oilwater_brine.cpp
@@ -72,7 +72,7 @@ void flowEbosOilWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_oilwater_brine.cpp
+++ b/flow/flow_ebos_oilwater_brine.cpp
@@ -71,7 +71,7 @@ void flowEbosOilWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_oilwater_brine.cpp
+++ b/flow/flow_ebos_oilwater_brine.cpp
@@ -73,7 +73,7 @@ void flowEbosOilWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_oilwater_brine.cpp
+++ b/flow/flow_ebos_oilwater_brine.cpp
@@ -70,7 +70,7 @@ void flowEbosOilWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_oilwater_brine.hpp
+++ b/flow/flow_ebos_oilwater_brine.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_OILWATER_BRINE_HPP
 #define FLOW_EBOS_OILWATER_BRINE_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosOilWaterBrineSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                                  std::shared_ptr<EclipseState> eclState,
-                                  std::shared_ptr<Schedule> schedule,
-                                  std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosOilWaterBrineMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -71,7 +71,7 @@ void flowEbosOilWaterPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -61,20 +61,6 @@ public:
 }}
 
 namespace Opm {
-void flowEbosOilWaterPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                                    std::shared_ptr<EclipseState> eclState,
-                                    std::shared_ptr<Schedule> schedule,
-                                    std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowOilWaterPolymerProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
 
 // ----------------- Main program -----------------
 int flowEbosOilWaterPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -73,7 +73,7 @@ void flowEbosOilWaterPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -72,7 +72,7 @@ void flowEbosOilWaterPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -70,7 +70,7 @@ void flowEbosOilWaterPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -69,7 +69,7 @@ void flowEbosOilWaterPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck
     using TypeTag = Properties::TTag::EclFlowOilWaterPolymerProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_oilwater_polymer.hpp
+++ b/flow/flow_ebos_oilwater_polymer.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_OILWATER_POLYMER_HPP
 #define FLOW_EBOS_OILWATER_POLYMER_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosOilWaterPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                                    std::shared_ptr<EclipseState> eclState,
-                                    std::shared_ptr<Schedule> schedule,
-                                    std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main functon used in main flow binary.
 int flowEbosOilWaterPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_onephase.cpp
+++ b/flow/flow_ebos_onephase.cpp
@@ -67,7 +67,7 @@ void flowEbosWaterOnlySetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_onephase.cpp
+++ b/flow/flow_ebos_onephase.cpp
@@ -57,21 +57,6 @@ public:
 
 } // namespace Opm::Properties
 
-void flowEbosWaterOnlySetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                              std::shared_ptr<EclipseState> eclState,
-                              std::shared_ptr<Schedule> schedule,
-                              std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowProblemWaterOnly;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
-
 // ----------------- Main program -----------------
 int flowEbosWaterOnlyMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {

--- a/flow/flow_ebos_onephase.cpp
+++ b/flow/flow_ebos_onephase.cpp
@@ -66,7 +66,7 @@ void flowEbosWaterOnlySetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_onephase.cpp
+++ b/flow/flow_ebos_onephase.cpp
@@ -68,7 +68,7 @@ void flowEbosWaterOnlySetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_onephase.cpp
+++ b/flow/flow_ebos_onephase.cpp
@@ -69,7 +69,7 @@ void flowEbosWaterOnlySetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_onephase.cpp
+++ b/flow/flow_ebos_onephase.cpp
@@ -65,7 +65,7 @@ void flowEbosWaterOnlySetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowProblemWaterOnly;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_onephase.hpp
+++ b/flow/flow_ebos_onephase.hpp
@@ -22,26 +22,12 @@
 #ifndef FLOW_ONEPHASE_HPP
 #define FLOW_ONEPHASE_HPP
 
-#include <memory>
-
 namespace Opm {
 
-class Deck;
-class EclipseState;
-template<class TypeTag> class FlowMainEbos;
-class Schedule;
-class SummaryConfig;
-class UDQState;
-class WellTestState;
-namespace Action {
-class State;
-}
-
-void flowEbosWaterOnlySetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                              std::shared_ptr<EclipseState> eclState,
-                              std::shared_ptr<Schedule> schedule,
-                              std::shared_ptr<SummaryConfig> summaryConfig);
+//! \brief Main functon used in main flow binary.
 int flowEbosWaterOnlyMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_onephase binary.
 int flowEbosWaterOnlyMainStandalone(int argc, char** argv);
 }
 

--- a/flow/flow_ebos_onephase_energy.cpp
+++ b/flow/flow_ebos_onephase_energy.cpp
@@ -76,7 +76,7 @@ void flowEbosWaterOnlyEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_onephase_energy.cpp
+++ b/flow/flow_ebos_onephase_energy.cpp
@@ -75,7 +75,7 @@ void flowEbosWaterOnlyEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_onephase_energy.cpp
+++ b/flow/flow_ebos_onephase_energy.cpp
@@ -72,7 +72,7 @@ void flowEbosWaterOnlyEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck
     using TypeTag = Properties::TTag::EclFlowProblemWaterOnlyEnergy;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_onephase_energy.cpp
+++ b/flow/flow_ebos_onephase_energy.cpp
@@ -73,7 +73,7 @@ void flowEbosWaterOnlyEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_onephase_energy.cpp
+++ b/flow/flow_ebos_onephase_energy.cpp
@@ -64,21 +64,6 @@ public:
 
 } // namespace Opm::Properties
 
-void flowEbosWaterOnlyEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                                    std::shared_ptr<EclipseState> eclState,
-                                    std::shared_ptr<Schedule> schedule,
-                                    std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowProblemWaterOnlyEnergy;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
-
 // ----------------- Main program -----------------
 int flowEbosWaterOnlyEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles)
 {

--- a/flow/flow_ebos_onephase_energy.cpp
+++ b/flow/flow_ebos_onephase_energy.cpp
@@ -74,7 +74,7 @@ void flowEbosWaterOnlyEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_onephase_energy.hpp
+++ b/flow/flow_ebos_onephase_energy.hpp
@@ -22,27 +22,14 @@
 #ifndef FLOW_ONEPHASE_ENERGY_HPP
 #define FLOW_ONEPHASE_ENERGY_HPP
 
-#include <memory>
-
 namespace Opm {
 
-class Deck;
-class EclipseState;
-template<class TypeTag> class FlowMainEbos;
-class Schedule;
-class SummaryConfig;
-class UDQState;
-class WellTestState;
-namespace Action {
-class State;
-}
-
-void flowEbosWaterOnlyEnergySetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                                    std::shared_ptr<EclipseState> eclState,
-                                    std::shared_ptr<Schedule> schedule,
-                                    std::shared_ptr<SummaryConfig> summaryConfig);
+//! \brief Main functon used in main flow binary.
 int flowEbosWaterOnlyEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_onephase_energy binary.
 int flowEbosWaterOnlyEnergyMainStandalone(int argc, char** argv);
+
 }
 
 #endif

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -48,7 +48,7 @@ void flowEbosPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -45,7 +45,7 @@ void flowEbosPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowPolymerProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -37,20 +37,6 @@ struct EnablePolymer<TypeTag, TTag::EclFlowPolymerProblem> {
 }}
 
 namespace Opm {
-void flowEbosPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                            std::shared_ptr<EclipseState> eclState,
-                            std::shared_ptr<Schedule> schedule,
-                            std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowPolymerProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
 
 // ----------------- Main program -----------------
 int flowEbosPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -46,7 +46,7 @@ void flowEbosPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -47,7 +47,7 @@ void flowEbosPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -49,7 +49,7 @@ void flowEbosPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 // ----------------- Main program -----------------

--- a/flow/flow_ebos_polymer.hpp
+++ b/flow/flow_ebos_polymer.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_POLYMER_HPP
 #define FLOW_EBOS_POLYMER_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosPolymerSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                            std::shared_ptr<EclipseState> eclState,
-                            std::shared_ptr<Schedule> schedule,
-                            std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles);

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -45,7 +45,7 @@ void flowEbosSolventSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using TypeTag = Properties::TTag::EclFlowSolventProblem;
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalSetupTime(setupTime);
+    Vanguard::setSetupTime(setupTime);
     Vanguard::setExternalDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -49,7 +49,7 @@ void flowEbosSolventSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
     Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
+    Vanguard::setSummaryConfig(std::move(summaryConfig));
 }
 
 

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -48,7 +48,7 @@ void flowEbosSolventSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
     Vanguard::setEclState(std::move(eclState));
-    Vanguard::setExternalSchedule(std::move(schedule));
+    Vanguard::setSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }
 

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -37,21 +37,6 @@ struct EnableSolvent<TypeTag, TTag::EclFlowSolventProblem> {
 }}
 
 namespace Opm {
-void flowEbosSolventSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                            std::shared_ptr<EclipseState> eclState,
-                            std::shared_ptr<Schedule> schedule,
-                            std::shared_ptr<SummaryConfig> summaryConfig)
-{
-    using TypeTag = Properties::TTag::EclFlowSolventProblem;
-    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
-
-    Vanguard::setSetupTime(setupTime);
-    Vanguard::setDeck(std::move(deck));
-    Vanguard::setEclState(std::move(eclState));
-    Vanguard::setSchedule(std::move(schedule));
-    Vanguard::setSummaryConfig(std::move(summaryConfig));
-}
-
 
 // ----------------- Main program -----------------
 int flowEbosSolventMain(int argc, char** argv, bool outputCout, bool outputFiles)

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -47,7 +47,7 @@ void flowEbosSolventSetDeck(double setupTime, std::shared_ptr<Deck> deck,
 
     Vanguard::setSetupTime(setupTime);
     Vanguard::setDeck(std::move(deck));
-    Vanguard::setExternalEclState(std::move(eclState));
+    Vanguard::setEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));
 }

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -46,7 +46,7 @@ void flowEbosSolventSetDeck(double setupTime, std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setSetupTime(setupTime);
-    Vanguard::setExternalDeck(std::move(deck));
+    Vanguard::setDeck(std::move(deck));
     Vanguard::setExternalEclState(std::move(eclState));
     Vanguard::setExternalSchedule(std::move(schedule));
     Vanguard::setExternalSummaryConfig(std::move(summaryConfig));

--- a/flow/flow_ebos_solvent.hpp
+++ b/flow/flow_ebos_solvent.hpp
@@ -17,19 +17,7 @@
 #ifndef FLOW_EBOS_SOLVENT_HPP
 #define FLOW_EBOS_SOLVENT_HPP
 
-#include <memory>
-
 namespace Opm {
-
-class Deck;
-class EclipseState;
-class Schedule;
-class SummaryConfig;
-
-void flowEbosSolventSetDeck(double setupTime, std::shared_ptr<Deck> deck,
-                            std::shared_ptr<EclipseState> eclState,
-                            std::shared_ptr<Schedule> schedule,
-                            std::shared_ptr<SummaryConfig> summaryConfig);
 
 //! \brief Main function used in flow binary.
 int flowEbosSolventMain(int argc, char** argv, bool outoutCout, bool outputFiles);

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -106,7 +106,7 @@ void flowEbosSetDeck(std::shared_ptr<Deck> deck,
 
     Vanguard::setDeck(deck);
     Vanguard::setEclState(eclState);
-    Vanguard::setExternalSchedule(schedule);
+    Vanguard::setSchedule(schedule);
     Vanguard::setExternalSummaryConfig(summaryConfig);
 }
 

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -104,7 +104,7 @@ void flowEbosSetDeck(std::shared_ptr<Deck> deck,
 {
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
-    Vanguard::setExternalDeck(deck);
+    Vanguard::setDeck(deck);
     Vanguard::setExternalEclState(eclState);
     Vanguard::setExternalSchedule(schedule);
     Vanguard::setExternalSummaryConfig(summaryConfig);

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -107,7 +107,7 @@ void flowEbosSetDeck(std::shared_ptr<Deck> deck,
     Vanguard::setDeck(deck);
     Vanguard::setEclState(eclState);
     Vanguard::setSchedule(schedule);
-    Vanguard::setExternalSummaryConfig(summaryConfig);
+    Vanguard::setSummaryConfig(summaryConfig);
 }
 
 // ----------------- Main program -----------------

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -105,7 +105,7 @@ void flowEbosSetDeck(std::shared_ptr<Deck> deck,
     using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
 
     Vanguard::setDeck(deck);
-    Vanguard::setExternalEclState(eclState);
+    Vanguard::setEclState(eclState);
     Vanguard::setExternalSchedule(schedule);
     Vanguard::setExternalSummaryConfig(summaryConfig);
 }

--- a/tests/test_ecl_output.cc
+++ b/tests/test_ecl_output.cc
@@ -26,22 +26,24 @@
 
 #include <ebos/equil/equilibrationhelpers.hh>
 #include <ebos/eclproblem.hh>
-#include <opm/models/utils/start.hh>
+#include <ebos/collecttoiorank.hh>
+#include <ebos/ecloutputblackoilmodule.hh>
+#include <ebos/eclwriter.hh>
 
 #include <opm/grid/UnstructuredGrid.h>
 #include <opm/grid/GridManager.hpp>
 
+#include <opm/input/eclipse/Schedule/Action/State.hpp>
 #include <opm/input/eclipse/Units/Units.hpp>
 
 #include <opm/io/eclipse/ESmry.hpp>
 
+#include <opm/models/utils/start.hh>
+
 #include <opm/output/eclipse/Summary.hpp>
-#include <ebos/collecttoiorank.hh>
-#include <ebos/ecloutputblackoilmodule.hh>
-#include <ebos/eclwriter.hh>
-#include <opm/input/eclipse/Schedule/Action/State.hpp>
-#include <opm/simulators/wells/BlackoilWellModel.hpp>
+
 #include <opm/simulators/flow/BlackoilModelParametersEbos.hpp>
+#include <opm/simulators/wells/BlackoilWellModel.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -133,7 +135,9 @@ initSimulator(const char *filename)
 
     Opm::setupParameters_<TypeTag>(/*argc=*/sizeof(argv)/sizeof(argv[0]), argv, /*registerParams=*/false);
 
-    return std::unique_ptr<Simulator>(new Simulator);
+    Opm::EclGenericVanguard::readDeck(filename);
+
+    return std::make_unique<Simulator>();
 }
 
 struct EclOutputFixture {

--- a/tests/test_equil.cc
+++ b/tests/test_equil.cc
@@ -26,15 +26,17 @@
 
 #include <ebos/equil/equilibrationhelpers.hh>
 #include <ebos/eclproblem.hh>
-#include <opm/models/utils/start.hh>
-
-#include <opm/simulators/wells/BlackoilWellModel.hpp>
-#include <opm/simulators/flow/BlackoilModelParametersEbos.hpp>
+#include <ebos/eclgenericvanguard.hh>
 
 #include <opm/grid/UnstructuredGrid.h>
 #include <opm/grid/GridManager.hpp>
 
 #include <opm/input/eclipse/Units/Units.hpp>
+
+#include <opm/models/utils/start.hh>
+
+#include <opm/simulators/flow/BlackoilModelParametersEbos.hpp>
+#include <opm/simulators/wells/BlackoilWellModel.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -103,7 +105,9 @@ initSimulator(const char *filename)
 
     Opm::setupParameters_<TypeTag>(/*argc=*/sizeof(argv)/sizeof(argv[0]), argv, /*registerParams=*/false);
 
-    return std::unique_ptr<Simulator>(new Simulator);
+    Opm::EclGenericVanguard::readDeck(filename);
+
+    return std::make_unique<Simulator>();
 }
 
 template <class GridView>

--- a/tests/test_glift1.cpp
+++ b/tests/test_glift1.cpp
@@ -90,7 +90,9 @@ initSimulator(const char *filename)
 
     Opm::setupParameters_<TypeTag>(/*argc=*/sizeof(argv)/sizeof(argv[0]), argv, /*registerParams=*/true);
 
-    return std::unique_ptr<Simulator>(new Simulator);
+    Opm::EclGenericVanguard::readDeck(filename);
+
+    return std::make_unique<Simulator>();
 }
 
 


### PR DESCRIPTION
This was used by the ebos_xx simulators, but is currently unused. Simplify by only supporting external configuration. Furthermore simplify the configuration process and unify across simulators.