### PR TITLE
Fix: verbose timing for openclSolver

### DIFF
--- a/opm/simulators/linalg/bda/opencl/BILU0.cpp
+++ b/opm/simulators/linalg/bda/opencl/BILU0.cpp
@@ -267,7 +267,6 @@ bool BILU0<block_size>::create_preconditioner(BlockedMatrix *mat, BlockedMatrix 
 
     Timer t_decomposition;
     std::ostringstream out;
-    cl::Event event;
     for (int color = 0; color < numColors; ++color) {
         const unsigned int firstRow = rowsPerColorPrefix[color];
         const unsigned int lastRow = rowsPerColorPrefix[color+1];
@@ -278,6 +277,7 @@ bool BILU0<block_size>::create_preconditioner(BlockedMatrix *mat, BlockedMatrix 
     }
 
     if (verbosity >= 3) {
+        queue->finish();
         out << "BILU0 decomposition: " << t_decomposition.stop() << " s";
         OpmLog::info(out.str());
     }


### PR DESCRIPTION
When `verbosity>=3`, the openclSolver will time certain components, like the preconditioner application, spmv, and well application, and print them.
To get accurate timings, the solver must wait for the opencl kernels to finish, which it did not before.
This uses `queue->finish()`, this works because `openclSolver` only ever uses one queue. If multiple queues were to be used, for example when overlapping copying and computation, or having two kernels simultaneously, changes have to be made.

I wanted to put `if(verbosity>=3)queue->finish();` into an inlined function before.
But I've also merged some of the timers, so that they only work when their results are actually used. The `Dune::Timer` is lightweight, but the `if(verbosity>=3)` should be even more lightweight.