### PR TITLE
solve linear system more accuratly (factor 1/10) when newton iter > 8

### DIFF
--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -385,9 +385,9 @@ namespace Opm
             std::function<Vector()> weightsCalculator = getWeightsCalculator();
             const int newton_iteration = this->simulator_.model().newtonMethod().numIterations();
 
-            // solve linear system more accuratly when newton iterations > 8
-            if (newton_iteration == 8 || newton_iteration == 0 || shouldCreateSolver()) {
-                if (newton_iteration == 8) {
+            // solve linear system more accuratly from the 6th newton iteration
+            if (newton_iteration == 6 || newton_iteration == 0 || shouldCreateSolver()) {
+                if (newton_iteration == 6) {
                     prm_.put("tol", this->parameters_.linear_solver_reduction_/10);
                 } else if (newton_iteration == 0) {
                     prm_.put("tol", this->parameters_.linear_solver_reduction_);

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -383,8 +383,16 @@ namespace Opm
         {
 
             std::function<Vector()> weightsCalculator = getWeightsCalculator();
+            const int newton_iteration = this->simulator_.model().newtonMethod().numIterations();
 
-            if (shouldCreateSolver()) {
+            // solve linear system more accuratly when newton iterations > 8
+            if (newton_iteration == 8 || newton_iteration == 0 || shouldCreateSolver()) {
+                if (newton_iteration == 8) {
+                    prm_.put("tol", this->parameters_.linear_solver_reduction_/10);
+                } else if (newton_iteration == 0) {
+                    prm_.put("tol", this->parameters_.linear_solver_reduction_);
+                }
+
                 if (isParallel()) {
 #if HAVE_MPI
                     if (useWellConn_) {


### PR DESCRIPTION
Motivation avoid stagnation when forcing small time-steps by `TUNING` or `--solver-max-time-step-in-days=XXX`.

The 8 and 1/10 in the PR is hard-coded and based on intuition and inspired a bit on "CHOOSING THE FORCING TERMS IN AN INEXACT NEWTON METHOD*" EISENSTAT et al 2016. and seems to work fine on the models I have tested. May need to be adjusted further and should potentially be input parameters rather than hard-coded numbers.