### PR TITLE
Add iterations to the network model

### DIFF
--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -382,6 +382,12 @@ partiallySupported()
             },
          },
          {
+            "NETBALAN",
+            {
+               {5,{false, allow_values<int> {10}, "NETBALAN(THPMXITE): option is not supported – will continue"}}, // MAX_ITER_THP
+            },
+         },
+         {
             "NETWORK",
             {
                {3,{false, allow_values<int> {20}, "NETWORK(NBCMAX): option is not used and should be defaulted– value ignored"}}, // NBCMAX
@@ -577,6 +583,16 @@ partiallySupported()
             "MULTFLT",
             {
                {3,{false, allow_values<double> {}, "MULTFLT(FLT-DIF): the diffusivity multiplier option is not supported – will continue"}}, // NOT_DEFINED
+            },
+         },
+         {
+            "NETBALAN",
+            {
+               {1,{true, [](const double value) { return value <= 0.0; }, "NETBALAN(NSTEP): only negative values or 0 supported – will stop"}}, // TIME_INTERVAL
+               {4,{false, allow_values<double> {0.01}, "NETBALAN(GRPCNV): not supported – will continue"}}, // THP_CONVERGENCE_LIMIT
+               {6,{false, allow_values<double> {1e20}, "NETBALAN(NTRGERR): not supported – will continue"}}, // TARGET_BALANCE_ERROR
+               {7,{false, allow_values<double> {1e20}, "NETBALAN(NMAXERR): not supported – will continue"}}, // MAX_BALANCE_ERROR
+               {8,{false, allow_values<double> {}, "NETBALAN(NTSMIN): not supported – will continue"}}, // MIN_TIME_STEP
             },
          },
          {

--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -398,7 +398,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"NARROW", {false, std::nullopt}},
         {"NCONSUMP", {false, std::nullopt}},
         {"NEFAC", {false, std::nullopt}},
-        {"NETBALAN", {false, std::nullopt}},
         {"NETCOMPA", {false, std::nullopt}},
         {"NEXT", {false, std::nullopt}},
         {"NEXTSTPL", {false, std::nullopt}},

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -282,7 +282,7 @@ namespace Opm {
             // at the beginning of each time step (Not report step)
             void prepareTimeStep(DeferredLogger& deferred_logger);
             void initPrimaryVariablesEvaluation() const;
-            void updateWellControls(DeferredLogger& deferred_logger, const bool checkGroupControls);
+            bool updateWellControls(DeferredLogger& deferred_logger, const bool checkGroupControls);
 
             void updateAndCommunicate(const int reportStepIdx,
                                       const int iterationIdx,
@@ -369,6 +369,10 @@ namespace Opm {
             // and in the well equations.
             void assemble(const int iterationIdx,
                           const double dt);
+            void assembleImpl(const int iterationIdx,
+                              const double dt,
+                              const int recursion_level,
+                              DeferredLogger& local_deferredLogger);
 
             // called at the end of a time step
             void timeStepSucceeded(const double& simulationTime, const double dt);

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -282,7 +282,8 @@ namespace Opm {
             // at the beginning of each time step (Not report step)
             void prepareTimeStep(DeferredLogger& deferred_logger);
             void initPrimaryVariablesEvaluation() const;
-            bool updateWellControls(DeferredLogger& deferred_logger, const bool checkGroupControls);
+            bool shouldBalanceNetwork(const int reportStepIndex, const int iterationIdx) const;
+            std::pair<bool, double> updateWellControls(DeferredLogger& deferred_logger, const bool checkGroupControls);
 
             void updateAndCommunicate(const int reportStepIdx,
                                       const int iterationIdx,
@@ -371,7 +372,7 @@ namespace Opm {
                           const double dt);
             void assembleImpl(const int iterationIdx,
                               const double dt,
-                              const int recursion_level,
+                              const std::size_t recursion_level,
                               DeferredLogger& local_deferredLogger);
 
             // called at the end of a time step

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -2092,14 +2092,14 @@ inferLocalShutWells()
     }
 }
 
-void
+bool
 BlackoilWellModelGeneric::
 updateNetworkPressures(const int reportStepIdx)
 {
     // Get the network and return if inactive.
     const auto& network = schedule()[reportStepIdx].network();
     if (!network.active()) {
-        return;
+        return false;
     }
     node_pressures_ = WellGroupHelpers::computeNetworkPressures(network,
                                                                 this->wellState(),
@@ -2109,6 +2109,7 @@ updateNetworkPressures(const int reportStepIdx)
                                                                 reportStepIdx);
 
     // Set the thp limits of wells
+    bool active_limit_change = false;
     for (auto& well : well_container_generic_) {
         // Producers only, since we so far only support the
         // "extended" network model (properties defined by
@@ -2118,10 +2119,18 @@ updateNetworkPressures(const int reportStepIdx)
             if (it != node_pressures_.end()) {
                 // The well belongs to a group with has a network pressure constraint,
                 // set the dynamic THP constraint of the well accordingly.
-                well->setDynamicThpLimit(it->second);
+                const double new_limit = it->second;
+                well->setDynamicThpLimit(new_limit);
+                const SingleWellState& ws = this->wellState()[well->indexOfWell()];
+                const bool thp_is_limit = ws.production_cmode == Well::ProducerCMode::THP;
+                const bool will_switch_to_thp = ws.thp < new_limit;
+                if (thp_is_limit || will_switch_to_thp) {
+                    active_limit_change = true;
+                }
             }
         }
     }
+    return active_limit_change;
 }
 
 void

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -250,7 +250,7 @@ protected:
 
     bool wasDynamicallyShutThisTimeStep(const int well_index) const;
 
-    bool updateNetworkPressures(const int reportStepIdx);
+    std::pair<bool, double> updateNetworkPressures(const int reportStepIdx);
 
     void updateWsolvent(const Group& group,
                         const int reportStepIdx,

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -250,7 +250,7 @@ protected:
 
     bool wasDynamicallyShutThisTimeStep(const int well_index) const;
 
-    void updateNetworkPressures(const int reportStepIdx);
+    bool updateNetworkPressures(const int reportStepIdx);
 
     void updateWsolvent(const Group& group,
                         const int reportStepIdx,

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1479,7 +1479,8 @@ namespace Opm {
         const auto& comm = ebosSimulator_.vanguard().grid().comm();
         updateAndCommunicateGroupData(episodeIdx, iterationIdx);
 
-        const bool network_changed = updateNetworkPressures(episodeIdx);
+        const bool local_network_changed = updateNetworkPressures(episodeIdx);
+        const bool network_changed = comm.sum(local_network_changed);
 
         std::set<std::string> switched_wells;
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -933,9 +933,11 @@ namespace Opm {
 
         // Maybe do a recursive call to iterate network and well controls.
         if (network_changed) {
-            const int max_local_network_iterations = 3;
-            const int last_newton_iteration_to_iterate_network = 2;
-            if (iterationIdx <= last_newton_iteration_to_iterate_network) {
+            // Only re-solve network for the first nupcol newton iterations.
+            const int nupcol = schedule()[reportStepIdx].nupcol();
+            if (iterationIdx <= nupcol) {
+                // Limit the number of iterations in the network re-solve.
+                const int max_local_network_iterations = 3;
                 if (recursion_level < max_local_network_iterations) {
                     assembleImpl(iterationIdx, dt, recursion_level + 1, local_deferredLogger);
                 }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -901,11 +901,11 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     assembleImpl(const int iterationIdx,
                  const double dt,
-                 const int recursion_level,
+                 const std::size_t recursion_level,
                  DeferredLogger& local_deferredLogger)
     {
 
-        const bool network_changed = updateWellControls(local_deferredLogger, /* check group controls */ true); 
+        const auto [network_changed, network_imbalance] = updateWellControls(local_deferredLogger, /* check group controls */ true);
 
         bool alq_updated = false;
         OPM_BEGIN_PARALLEL_TRY_CATCH();
@@ -933,12 +933,10 @@ namespace Opm {
 
         // Maybe do a recursive call to iterate network and well controls.
         if (network_changed) {
-            // Only re-solve network for the first nupcol newton iterations.
-            const int nupcol = schedule()[reportStepIdx].nupcol();
-            if (iterationIdx <= nupcol) {
-                // Limit the number of iterations in the network re-solve.
-                const int max_local_network_iterations = 3;
-                if (recursion_level < max_local_network_iterations) {
+            if (shouldBalanceNetwork(reportStepIdx, iterationIdx)) {
+                const auto& balance = schedule()[reportStepIdx].network_balance();
+                // Iterate if not converged, and number of iterations is not yet max (NETBALAN item 3).
+                if (recursion_level < balance.pressure_max_iter() && network_imbalance > balance.pressure_tolerance()) {
                     assembleImpl(iterationIdx, dt, recursion_level + 1, local_deferredLogger);
                 }
             }
@@ -1469,20 +1467,47 @@ namespace Opm {
     template<typename TypeTag>
     bool
     BlackoilWellModel<TypeTag>::
+    shouldBalanceNetwork(const int reportStepIdx, const int iterationIdx) const
+    {
+        const auto& balance = schedule()[reportStepIdx].network_balance();
+        if (balance.mode() == Network::Balance::CalcMode::TimeStepStart) {
+            return iterationIdx == 0;
+        } else if (balance.mode() == Network::Balance::CalcMode::NUPCOL) {
+            const int nupcol = schedule()[reportStepIdx].nupcol();
+            return iterationIdx < nupcol;
+        } else {
+            // We do not support any other rebalancing modes,
+            // i.e. TimeInterval based rebalancing is not available.
+            // This should be warned about elsewhere, so we choose to
+            // avoid spamming with a warning here.
+            return false;
+        }
+    }
+
+
+
+
+
+    template<typename TypeTag>
+    std::pair<bool, double>
+    BlackoilWellModel<TypeTag>::
     updateWellControls(DeferredLogger& deferred_logger, const bool checkGroupControls)
     {
         // Even if there are no wells active locally, we cannot
         // return as the DeferredLogger uses global communication.
         // For no well active globally we simply return.
-        if( !wellsActive() ) return false;
+        if( !wellsActive() ) return { false, 0.0 };
 
         const int episodeIdx = ebosSimulator_.episodeIndex();
         const int iterationIdx = ebosSimulator_.model().newtonMethod().numIterations();
         const auto& comm = ebosSimulator_.vanguard().grid().comm();
         updateAndCommunicateGroupData(episodeIdx, iterationIdx);
 
-        const bool local_network_changed = updateNetworkPressures(episodeIdx);
+        const auto [local_network_changed, local_network_imbalance]
+            = shouldBalanceNetwork(episodeIdx, iterationIdx) ?
+            updateNetworkPressures(episodeIdx) : std::make_pair(false, 0.0);
         const bool network_changed = comm.sum(local_network_changed);
+        const double network_imbalance = comm.max(local_network_imbalance);
 
         std::set<std::string> switched_wells;
 
@@ -1536,7 +1561,7 @@ namespace Opm {
         const Group& fieldGroup = schedule().getGroup("FIELD", episodeIdx);
         updateWsolvent(fieldGroup, episodeIdx,  this->nupcolWellState());
 
-        return network_changed;
+        return { network_changed, network_imbalance };
     }
 
 

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -347,6 +347,11 @@ void WellInterfaceGeneric::setDynamicThpLimit(const double thp_limit)
     dynamic_thp_limit_ = thp_limit;
 }
 
+std::optional<double> WellInterfaceGeneric::getDynamicThpLimit() const
+{
+    return dynamic_thp_limit_;
+}
+
 void WellInterfaceGeneric::updatePerforatedCell(std::vector<bool>& is_cell_perforated)
 {
 

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -101,6 +101,7 @@ public:
     void setRepRadiusPerfLength();
     void setWsolvent(const double wsolvent);
     void setDynamicThpLimit(const double thp_limit);
+    std::optional<double> getDynamicThpLimit() const;
     void updatePerforatedCell(std::vector<bool>& is_cell_perforated);
 
     /// Returns true if the well has one or more THP limits/constraints.


### PR DESCRIPTION
If the network solution changes we may iterate the solution process, recalculating the well and network solution if a network solution for a group changes and either:
 - the group has a well that is under thp control, or
 - the group has a well that is not under thp control, but would break the new thp limit.

Not much tested yet, therefore a draft PR.