### PR TITLE
Fix stdwell apply on GPU

### DIFF
--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -1139,7 +1139,7 @@ addWellContribution(WellContributions& wellContribs) const
     for (int i = 0; i < numStaticWellEq; ++i)
     {
         for (int j = 0; j < numStaticWellEq; ++j) {
-            nnzValues.emplace_back(this->duneD_[0][0][i][j]);
+            nnzValues.emplace_back(this->invDuneD_[0][0][i][j]);
         }
     }
     wellContribs.addMatrix(WellContributions::MatrixType::D, colIndices.data(), nnzValues.data(), 1);


### PR DESCRIPTION
Fixes bug introduced in 06a8b0ee in #3937.
Keeping the wells separate would cause convergence issues on GPU (both cusparse and opencl).
@blattms 