### PR TITLE
Warn about fault names with more than 8 characters

### DIFF
--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -34,6 +34,7 @@
 #include <opm/output/data/GuideRateValue.hpp>
 #include <opm/output/data/Solution.hpp>
 #include <opm/output/data/Wells.hpp>
+#include <opm/input/eclipse/EclipseState/Util/OrderedMap.hpp>
 #include <opm/output/eclipse/EclipseIO.hpp>
 #include <opm/output/eclipse/RestartValue.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
@@ -1090,6 +1091,8 @@ INSTANTIATE_PACK(std::map<std::string,double>)
 INSTANTIATE_PACK(std::map<int,int>)
 INSTANTIATE_PACK(std::map<int,data::AquiferData>)
 INSTANTIATE_PACK(std::unordered_map<std::string,size_t>)
+INSTANTIATE_PACK(std::unordered_map<std::string,size_t,Opm::OrderedMapDetail::TruncatedStringHash<std::string::npos>, Opm::OrderedMapDetail::TruncatedStringEquals<std::string::npos>>)
+INSTANTIATE_PACK(std::unordered_map<std::string,size_t,Opm::OrderedMapDetail::TruncatedStringHash<8>, Opm::OrderedMapDetail::TruncatedStringEquals<8>>)
 INSTANTIATE_PACK(std::unordered_map<std::string,std::string>)
 INSTANTIATE_PACK(std::unordered_set<std::string>)
 INSTANTIATE_PACK(std::set<std::string>)

--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -83,6 +83,14 @@ partiallySupported()
             },
          },
          {
+             "FAULTS",
+             {
+                 {1, {false, [](const std::string& val){ return val.size()<=8;},
+                      "FAULTS(FLTNAME): Only names of faults up to 8 characters are supported. Will ignore excess characters."
+                     }
+                 },},
+         },
+         {
             "GCONINJE",
             {
                {10,{true, allow_values<std::string> {"RATE", "NETV", "RESV", "VOID"}, "GCONINJE(GUIPHASE): only RATE/NETV/RESV/VOID are supported - will STOP"}}, // GUIDE_RATE_DEF
@@ -122,6 +130,15 @@ partiallySupported()
             {
                {3,{false, allow_values<std::string> {"NONE"}, "MISCIBLE(MISOPT): only option NONE is supported – value ignored"}}, // TWOPOINT
             },
+         },
+         {
+             "MULTFLT",
+             {
+                 {1, {false, [](const std::string& val){ return val.size()<=8;},
+                      "MLTFLT(FLTNAME): Only names of faults up to 8 characters are supported. Will ignore excess characters."
+                     }
+                 },
+             },
          },
          {
             "MULTIREG",
@@ -197,6 +214,15 @@ partiallySupported()
                {20,{false, allow_values<std::string> {}, "TABDIMS(NOTUSED): should be defaulted (1*) - ignored as not used"}}, // ITEM20_NOT_USED
                {25,{false, allow_values<std::string> {}, "TABDIMS(RESVED): should be defaulted (1*) - ignored as not used"}}, // RESERVED
             },
+         },
+         {
+             "THPRESFT",
+             {
+                 {1, {false, [](const std::string& val){ return val.size()<=8;},
+                      "THPRESFT(FLTNAME): Only names of faults up to 8 characters are supported. Will ignore excess characters."
+                     }
+                 },
+             },
          },
          {
             "TRACER",


### PR DESCRIPTION
This issues warning a la
```
  FAULTS: invalid value 'BlaBlubbLong_depth_copy' in record 1647 for item 1
  In file: /path/to/file.grdecl, line 4
  FAULTS(FAULTNAME): Only names of faults up to 8 characters are supported. Will ignore excess characters
```

This is of course abusing the partially supported keyword code a bit.
An alternative might be to a Deck type 'STRING8' in addition to `STRING` and `RAWSTRING` to do the same. Just not sure whether it is possible to issue a warning like here. (Would open up to handle well names the same...)

Needs OPM/opm-common#3062