### PR TITLE
[bugfix] Fix well transmissibility weights for distributed wells.

### DIFF
--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1474,6 +1474,11 @@ namespace Opm
             for (int perf = 0; perf < nperf; ++perf) {
                 total_tw += this->well_index_[perf];
             }
+            const auto& comm = this->parallel_well_info_.communication();
+            if (comm.size() > 1)
+            {
+                total_tw = comm.sum(total_tw);
+            }
             for (int perf = 0; perf < nperf; ++perf) {
                 const int cell_idx = this->well_cells_[perf];
                 const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));


### PR DESCRIPTION
If we compute a sum over all perforations than we need to cater for the case of distributed wells. That is we need to also sum up  over all processes involved after performing the local sum.

One of these global sums was missing in computeWellConnectionDensitesPressures for producers when we compute the weights based on well transmissibilities.