### PR TITLE
[bugfix] Fixes deadlocks with agressively distributed wells

### DIFF
--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1607,7 +1607,6 @@ namespace Opm
             for (int perf = 0; perf < nperf; ++perf) {
                 total_tw += this->well_index_[perf];
             }
-            const auto& comm = this->parallel_well_info_.communication();
             if (comm.size() > 1)
             {
                 total_tw = comm.sum(total_tw);

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1596,6 +1596,12 @@ namespace Opm
         // approximate the perforation mixture using the mobility ratio
         // and weight the perforations using the well transmissibility.
         bool all_zero = std::all_of(perfRates.begin(), perfRates.end(), [](double val) { return val == 0.0; });
+        const auto& comm = this->parallel_well_info_.communication();
+        if (comm.size() > 1)
+        {
+            all_zero =  (comm.min(all_zero ? 1 : 0) == 1);
+        }
+
         if ( all_zero && this->isProducer() ) {
             double total_tw = 0;
             for (int perf = 0; perf < nperf; ++perf) {

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -63,9 +63,10 @@ void WellState::initSingleProducer(const Well& well,
     const double temp = 273.15 + 15.56;
 
     auto& ws = this->wells_.add(well.name(), SingleWellState{well.name(), well_info, true, pressure_first_connection, well_perf_data, pu, temp});
-    if ( ws.perf_data.empty())
-        return;
 
+    // the rest of the code needs to executed even if ws.perf_data is empty
+    // as this does not say anything for the whole well if it is distributed.
+    // Hence never ever return here!
     if (well.getStatus() == Well::Status::OPEN) {
         ws.status = Well::Status::OPEN;
     }
@@ -85,9 +86,10 @@ void WellState::initSingleInjector(const Well& well,
     const double temp = inj_controls.temperature;
 
     auto& ws = this->wells_.add(well.name(), SingleWellState{well.name(), well_info, false, pressure_first_connection, well_perf_data, pu, temp});
-    if ( ws.perf_data.empty())
-        return;
 
+    // the rest of the code needs to executed even if ws.perf_data is empty
+    // as this does not say anything for the whole well if it is distributed.
+    // Hence never ever return here!
     if (well.getStatus() == Well::Status::OPEN) {
         ws.status = Well::Status::OPEN;
     }


### PR DESCRIPTION
We should always keep in mind that the number local perforations is no sign/hint for the number of perforations the well would have in a sequential run. Hence returning in a function because `perf_data` is empty might lead to deadlocks and checking whether all perforations are empty needs communication. Both is fixed with this PR and now Norne runs with distributed wells even for @andrthu patch of opm-grid.

Such a small fix that needed lots of debugging time... Amazing.