### PR TITLE
Fix Averaged Quantities for Non-HC Simulations

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -1191,6 +1191,13 @@ add_test_compareECLFiles(CASENAME bo_diffusion
                          REL_TOL ${rel_tol}
                          DIR diffusion )
 
+add_test_compareECLFiles(CASENAME fpr_nonhc
+                         FILENAME WATER2F
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR water-1ph)
+
 # Restart tests
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-restart-regressionTest.sh "")
 # Cruder tolerances for the restarted tests

--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -1544,7 +1544,7 @@ outputFipLogImpl(const Inplace& inplace) const
         Scalar fieldHydroCarbonPoreVolumeAveragedPressure = pressureAverage_(inplace.get(Inplace::Phase::PressureHydroCarbonPV),
                                                                              inplace.get(Inplace::Phase::HydroCarbonPV),
                                                                              inplace.get(Inplace::Phase::PressurePV),
-                                                                             inplace.get(Inplace::Phase::PoreVolume),
+                                                                             inplace.get(Inplace::Phase::DynamicPoreVolume),
                                                                              true);
 
         std::unordered_map<Inplace::Phase, Scalar> initial_values;
@@ -1586,7 +1586,7 @@ outputFipLogImpl(const Inplace& inplace) const
                 = pressureAverage_(inplace.get("FIPNUM", Inplace::Phase::PressureHydroCarbonPV, reg),
                                    inplace.get("FIPNUM", Inplace::Phase::HydroCarbonPV, reg),
                                    inplace.get("FIPNUM", Inplace::Phase::PressurePV, reg),
-                                   inplace.get("FIPNUM", Inplace::Phase::PoreVolume, reg),
+                                   inplace.get("FIPNUM", Inplace::Phase::DynamicPoreVolume, reg),
                                    true);
         pressureUnitConvert_(regHydroCarbonPoreVolumeAveragedPressure);
         outputRegionFluidInPlace_(std::move(initial_values),
@@ -1744,7 +1744,7 @@ updateSummaryRegionValues(const Inplace& inplace,
                 pressureAverage_(inplace.get(Inplace::Phase::PressureHydroCarbonPV),
                                  inplace.get(Inplace::Phase::HydroCarbonPV),
                                  inplace.get(Inplace::Phase::PressurePV),
-                                 inplace.get(Inplace::Phase::PoreVolume),
+                                 inplace.get(Inplace::Phase::DynamicPoreVolume),
                                  true);
         }
 
@@ -1753,7 +1753,7 @@ updateSummaryRegionValues(const Inplace& inplace,
                 pressureAverage_(inplace.get(Inplace::Phase::PressureHydroCarbonPV),
                                  inplace.get(Inplace::Phase::HydroCarbonPV),
                                  inplace.get(Inplace::Phase::PressurePV),
-                                 inplace.get(Inplace::Phase::PoreVolume),
+                                 inplace.get(Inplace::Phase::DynamicPoreVolume),
                                  false);
         }
 
@@ -1779,7 +1779,7 @@ updateSummaryRegionValues(const Inplace& inplace,
             pressureAverage_(get_vector(node, Inplace::Phase::PressureHydroCarbonPV),
                              get_vector(node, Inplace::Phase::HydroCarbonPV),
                              get_vector(node, Inplace::Phase::PressurePV),
-                             get_vector(node, Inplace::Phase::PoreVolume),
+                             get_vector(node, Inplace::Phase::DynamicPoreVolume),
                              true);
         }
 
@@ -1788,7 +1788,7 @@ updateSummaryRegionValues(const Inplace& inplace,
             pressureAverage_(get_vector(node, Inplace::Phase::PressureHydroCarbonPV),
                              get_vector(node, Inplace::Phase::HydroCarbonPV),
                              get_vector(node, Inplace::Phase::PressurePV),
-                             get_vector(node, Inplace::Phase::PoreVolume),
+                             get_vector(node, Inplace::Phase::DynamicPoreVolume),
                              false);
         }
     }

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -190,6 +190,7 @@ tests[max_watercut_4]="flow wtest/wecon_wct_max MAX_WATERCUT_4"
 tests[max_wgr_1]="flow wtest/wecon_wgr_max MAX_WGR_1"
 tests[rxft_smry]="flow rxft_smry TEST_RXFT"
 tests[bo_diffusion]="flow diffusion BO_DIFFUSE_CASE1"
+tests[fpr_nonhc]="flow water-1ph WATER2F"
 
 changed_tests=""
 


### PR DESCRIPTION
Commit 6d3da3d2e (PR #3397) introduced the notion of a "dynamic", pressure dependent pore-volume and switched the `PoreVolume` aggregates to reference condition evaluation for output to the `PORV` field in the .PRT file.  We did however fail to update all existing uses of `PoreVolume` which introduced an inconsistency.  In particular, for simulation models without hydrocarbons&mdash;e.g., a single-phase water run&mdash;the numerator of the volume weighted average would include
pressure effects through the rock compressibility but the denominator would not.

Thanks to Edmund Stephens for discovering the issue and providing an example model for analysing the underlying issue.

Resolves #3984 