### PR TITLE
BlackOilAquiferModel: use implementations through interface

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -247,9 +247,10 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/timestepping/SimulatorReport.hpp
   opm/simulators/wells/SegmentState.hpp
   opm/simulators/wells/WellContainer.hpp
-  opm/simulators/aquifers/AquiferInterface.hpp
+  opm/simulators/aquifers/AquiferAnalytical.hpp
   opm/simulators/aquifers/AquiferCarterTracy.hpp
   opm/simulators/aquifers/AquiferFetkovich.hpp
+  opm/simulators/aquifers/AquiferInterface.hpp
   opm/simulators/aquifers/AquiferNumerical.hpp
   opm/simulators/aquifers/BlackoilAquiferModel.hpp
   opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp

--- a/opm/simulators/aquifers/AquiferAnalytical.hpp
+++ b/opm/simulators/aquifers/AquiferAnalytical.hpp
@@ -19,8 +19,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef OPM_AQUIFERINTERFACE_HEADER_INCLUDED
-#define OPM_AQUIFERINTERFACE_HEADER_INCLUDED
+#ifndef OPM_AQUIFERANALYTICAL_HEADER_INCLUDED
+#define OPM_AQUIFERANALYTICAL_HEADER_INCLUDED
 
 #include <opm/common/utility/numeric/linearInterpolation.hpp>
 #include <opm/input/eclipse/EclipseState/Aquifer/Aquancon.hpp>
@@ -45,7 +45,7 @@
 namespace Opm
 {
 template <typename TypeTag>
-class AquiferInterface
+class AquiferAnalytical
 {
 public:
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
@@ -78,7 +78,7 @@ public:
                                           BlackoilIndices::numPhases>;
 
     // Constructor
-    AquiferInterface(int aqID,
+    AquiferAnalytical(int aqID,
                      const std::vector<Aquancon::AquancCell>& connections,
                      const Simulator& ebosSimulator)
         : aquiferID_(aqID)
@@ -88,7 +88,7 @@ public:
     }
 
     // Destructor
-    virtual ~AquiferInterface()
+    virtual ~AquiferAnalytical()
     {
     }
 
@@ -132,7 +132,7 @@ public:
             pressure_previous_[idx] = getValue(iq.fluidState().pressure(phaseIdx_()));
         }
 
-        OPM_END_PARALLEL_TRY_CATCH("AquiferInterface::beginTimeStep() failed: ", ebos_simulator_.vanguard().grid().comm());
+        OPM_END_PARALLEL_TRY_CATCH("AquiferAnalytical::beginTimeStep() failed: ", ebos_simulator_.vanguard().grid().comm());
     }
 
     template <class Context>
@@ -157,7 +157,7 @@ public:
 
         const auto* intQuantsPtr = model.cachedIntensiveQuantities(cellIdx, timeIdx);
         if (intQuantsPtr == nullptr) {
-            throw std::logic_error("Invalid intensive quantities cache detected in AquiferInterface::addToSource()");
+            throw std::logic_error("Invalid intensive quantities cache detected in AquiferAnalytical::addToSource()");
         }
 
         // This is the pressure at td + dt
@@ -439,5 +439,7 @@ protected:
 
     // This function is used to initialize and calculate the alpha_i for each grid connection to the aquifer
 };
+
 } // namespace Opm
+
 #endif

--- a/opm/simulators/aquifers/AquiferCarterTracy.hpp
+++ b/opm/simulators/aquifers/AquiferCarterTracy.hpp
@@ -21,7 +21,7 @@
 #ifndef OPM_AQUIFERCT_HEADER_INCLUDED
 #define OPM_AQUIFERCT_HEADER_INCLUDED
 
-#include <opm/simulators/aquifers/AquiferInterface.hpp>
+#include <opm/simulators/aquifers/AquiferAnalytical.hpp>
 
 #include <opm/output/data/Aquifer.hpp>
 
@@ -34,10 +34,10 @@ namespace Opm
 {
 
 template <typename TypeTag>
-class AquiferCarterTracy : public AquiferInterface<TypeTag>
+class AquiferCarterTracy : public AquiferAnalytical<TypeTag>
 {
 public:
-    using Base = AquiferInterface<TypeTag>;
+    using Base = AquiferAnalytical<TypeTag>;
 
     using typename Base::BlackoilIndices;
     using typename Base::ElementContext;

--- a/opm/simulators/aquifers/AquiferCarterTracy.hpp
+++ b/opm/simulators/aquifers/AquiferCarterTracy.hpp
@@ -37,7 +37,7 @@ template <typename TypeTag>
 class AquiferCarterTracy : public AquiferInterface<TypeTag>
 {
 public:
-    typedef AquiferInterface<TypeTag> Base;
+    using Base = AquiferInterface<TypeTag>;
 
     using typename Base::BlackoilIndices;
     using typename Base::ElementContext;
@@ -236,6 +236,7 @@ protected:
         return this->aquct_data_.datum_depth;
     }
 }; // class AquiferCarterTracy
+
 } // namespace Opm
 
 #endif

--- a/opm/simulators/aquifers/AquiferFetkovich.hpp
+++ b/opm/simulators/aquifers/AquiferFetkovich.hpp
@@ -21,7 +21,7 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef OPM_AQUIFETP_HEADER_INCLUDED
 #define OPM_AQUIFETP_HEADER_INCLUDED
 
-#include <opm/simulators/aquifers/AquiferInterface.hpp>
+#include <opm/simulators/aquifers/AquiferAnalytical.hpp>
 
 #include <opm/output/data/Aquifer.hpp>
 
@@ -33,11 +33,11 @@ namespace Opm
 {
 
 template <typename TypeTag>
-class AquiferFetkovich : public AquiferInterface<TypeTag>
+class AquiferFetkovich : public AquiferAnalytical<TypeTag>
 {
 
 public:
-    using Base = AquiferInterface<TypeTag>;
+    using Base = AquiferAnalytical<TypeTag>;
 
     using typename Base::BlackoilIndices;
     using typename Base::ElementContext;

--- a/opm/simulators/aquifers/AquiferFetkovich.hpp
+++ b/opm/simulators/aquifers/AquiferFetkovich.hpp
@@ -37,7 +37,7 @@ class AquiferFetkovich : public AquiferInterface<TypeTag>
 {
 
 public:
-    typedef AquiferInterface<TypeTag> Base;
+    using Base = AquiferInterface<TypeTag>;
 
     using typename Base::BlackoilIndices;
     using typename Base::ElementContext;
@@ -171,5 +171,7 @@ protected:
         return this->aqufetp_data_.datum_depth;
     }
 }; // Class AquiferFetkovich
+
 } // namespace Opm
+
 #endif

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -1,0 +1,94 @@
+/*
+  Copyright 2017 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2017 Statoil ASA.
+  Copyright 2017 IRIS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_AQUIFERINTERFACE_HEADER_INCLUDED
+#define OPM_AQUIFERINTERFACE_HEADER_INCLUDED
+
+#include <opm/output/data/Aquifer.hpp>
+
+namespace Opm
+{
+
+template <typename TypeTag>
+class AquiferInterface
+{
+public:
+    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+    using RateVector = GetPropType<TypeTag, Properties::RateVector>;
+    using Simulator = GetPropType<TypeTag, Properties::Simulator>;
+
+    // Constructor
+    AquiferInterface(int aqID,
+                     const Simulator& ebosSimulator)
+        : aquiferID_(aqID)
+        , ebos_simulator_(ebosSimulator)
+    {
+    }
+
+    // Destructor
+    virtual ~AquiferInterface() = default;
+
+    virtual void initFromRestart(const data::Aquifers& aquiferSoln) = 0;
+
+    virtual void initialSolutionApplied() = 0;
+
+    virtual void beginTimeStep() = 0;
+    virtual void endTimeStep() = 0;
+
+    virtual data::AquiferData aquiferData() const = 0;
+
+    template <class Context>
+    void addToSource(RateVector& rates,
+                     const Context& context,
+                     const unsigned spaceIdx,
+                     const unsigned timeIdx)
+    {
+        const unsigned cellIdx = context.globalSpaceIndex(spaceIdx, timeIdx);
+        addToSource(rates, cellIdx, timeIdx);
+    }
+
+    virtual void addToSource(RateVector& rates,
+                             const unsigned cellIdx,
+                             const unsigned timeIdx) = 0;
+
+    int aquiferID() const { return this->aquiferID_; }
+
+protected:
+    bool co2store_() const
+    {
+        return ebos_simulator_.vanguard().eclState().runspec().co2Storage();
+    }
+
+    int phaseIdx_() const
+    {
+        if (co2store_())
+            return FluidSystem::oilPhaseIdx;
+
+        return FluidSystem::waterPhaseIdx;
+    }
+
+    const int aquiferID_{};
+    const Simulator& ebos_simulator_;
+};
+
+} // namespace Opm
+
+#endif

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -62,21 +62,20 @@ public:
     enum { enableEvaporation = getPropValue<TypeTag, Properties::EnableEvaporation>() };
     enum { enableSaltPrecipitation = getPropValue<TypeTag, Properties::EnableSaltPrecipitation>() };
 
-    static const int numEq = BlackoilIndices::numEq;
-    typedef double Scalar;
+    static constexpr int numEq = BlackoilIndices::numEq;
+    using Scalar = double;
 
-    typedef DenseAd::Evaluation<double, /*size=*/numEq> Eval;
+    using Eval = DenseAd::Evaluation<double, /*size=*/numEq>;
 
-    typedef BlackOilFluidState<Eval,
-                               FluidSystem,
-                               enableTemperature,
-                               enableEnergy,
-                               BlackoilIndices::gasEnabled,
-                               enableEvaporation,
-                               enableBrine,
-                               enableSaltPrecipitation,
-                               BlackoilIndices::numPhases>
-        FluidState;
+    using FluidState = BlackOilFluidState<Eval,
+                                          FluidSystem,
+                                          enableTemperature,
+                                          enableEnergy,
+                                          BlackoilIndices::gasEnabled,
+                                          enableEvaporation,
+                                          enableBrine,
+                                          enableSaltPrecipitation,
+                                          BlackoilIndices::numPhases>;
 
     // Constructor
     AquiferInterface(int aqID,

--- a/opm/simulators/aquifers/AquiferNumerical.hpp
+++ b/opm/simulators/aquifers/AquiferNumerical.hpp
@@ -50,7 +50,7 @@ public:
 
     enum { dimWorld = GridView::dimensionworld };
     enum { numPhases = FluidSystem::numPhases };
-    static const int numEq = BlackoilIndices::numEq;
+    static constexpr int numEq = BlackoilIndices::numEq;
 
     using Eval =  DenseAd::Evaluation<double, numEq>;
     using Toolbox = MathToolbox<Eval>;

--- a/opm/simulators/aquifers/AquiferNumerical.hpp
+++ b/opm/simulators/aquifers/AquiferNumerical.hpp
@@ -25,6 +25,7 @@
 
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp>
 
+#include <opm/simulators/aquifers/AquiferInterface.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 
 #include <algorithm>
@@ -37,16 +38,17 @@
 namespace Opm
 {
 template <typename TypeTag>
-class AquiferNumerical
+class AquiferNumerical : public AquiferInterface<TypeTag>
 {
 public:
-    using Simulator = GetPropType<TypeTag, Properties::Simulator>;
-    using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
-    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
     using BlackoilIndices = GetPropType<TypeTag, Properties::Indices>;
-
+    using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
+    using ExtensiveQuantities = GetPropType<TypeTag, Properties::ExtensiveQuantities>;
+    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
     using GridView = GetPropType<TypeTag, Properties::GridView>;
+    using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
     using MaterialLaw = GetPropType<TypeTag, Properties::MaterialLaw>;
+    using Simulator = GetPropType<TypeTag, Properties::Simulator>;
 
     enum { dimWorld = GridView::dimensionworld };
     enum { numPhases = FluidSystem::numPhases };
@@ -55,15 +57,14 @@ public:
     using Eval =  DenseAd::Evaluation<double, numEq>;
     using Toolbox = MathToolbox<Eval>;
 
-    using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
-    using ExtensiveQuantities = GetPropType<TypeTag, Properties::ExtensiveQuantities>;
+    using typename AquiferInterface<TypeTag>::RateVector;
+
     // Constructor
     AquiferNumerical(const SingleNumericalAquifer& aquifer,
                      const std::unordered_map<int, int>& cartesian_to_compressed,
                      const Simulator& ebos_simulator,
                      const int* global_cell)
-        : id_             (aquifer.id())
-        , ebos_simulator_ (ebos_simulator)
+        : AquiferInterface<TypeTag>(aquifer.id(), ebos_simulator)
         , flux_rate_      (0.0)
         , cumulative_flux_(0.0)
         , global_cell_    (global_cell)
@@ -88,7 +89,7 @@ public:
         }
     }
 
-    void initFromRestart(const data::Aquifers& aquiferSoln)
+    void initFromRestart(const data::Aquifers& aquiferSoln) override
     {
         auto xaqPos = aquiferSoln.find(this->aquiferID());
         if (xaqPos == aquiferSoln.end())
@@ -107,14 +108,17 @@ public:
         this->solution_set_from_restart_ = true;
     }
 
-    void endTimeStep()
+    void beginTimeStep() override {}
+    void addToSource(RateVector&, const unsigned, const unsigned) override {}
+
+    void endTimeStep() override
     {
         this->pressure_ = this->calculateAquiferPressure();
         this->flux_rate_ = this->calculateAquiferFluxRate();
         this->cumulative_flux_ += this->flux_rate_ * this->ebos_simulator_.timeStepSize();
     }
 
-    data::AquiferData aquiferData() const
+    data::AquiferData aquiferData() const override
     {
         data::AquiferData data;
         data.aquiferID = this->aquiferID();
@@ -128,7 +132,7 @@ public:
         return data;
     }
 
-    void initialSolutionApplied()
+    void initialSolutionApplied() override
     {
         if (this->solution_set_from_restart_) {
             return;
@@ -139,38 +143,7 @@ public:
         this->cumulative_flux_ = 0.;
     }
 
-    int aquiferID() const
-    {
-        return static_cast<int>(this->id_);
-    }
-
 private:
-    const std::size_t id_;
-    const Simulator& ebos_simulator_;
-    double flux_rate_; // aquifer influx rate
-    double cumulative_flux_; // cumulative aquifer influx
-    const int* global_cell_; // mapping to global index
-    std::vector<double> init_pressure_{};
-    double pressure_; // aquifer pressure
-    bool solution_set_from_restart_ {false};
-    bool connects_to_reservoir_ {false};
-
-    // TODO: maybe unordered_map can also do the work to save memory?
-    std::vector<int> cell_to_aquifer_cell_idx_;
-
-    inline bool co2store_() const
-    {
-        return ebos_simulator_.vanguard().eclState().runspec().co2Storage();
-    }
-
-    inline int phaseIdx_() const
-    {
-        if(co2store_())
-            return FluidSystem::oilPhaseIdx;
-
-        return FluidSystem::waterPhaseIdx;
-    }
-
     void checkConnectsToReservoir()
     {
         ElementContext elem_ctx(this->ebos_simulator_);
@@ -325,6 +298,19 @@ private:
 
         return aquifer_flux;
     }
+
+    double flux_rate_; // aquifer influx rate
+    double cumulative_flux_; // cumulative aquifer influx
+    const int* global_cell_; // mapping to global index
+    std::vector<double> init_pressure_{};
+    double pressure_; // aquifer pressure
+    bool solution_set_from_restart_ {false};
+    bool connects_to_reservoir_ {false};
+
+    // TODO: maybe unordered_map can also do the work to save memory?
+    std::vector<int> cell_to_aquifer_cell_idx_;
 };
+
 } // namespace Opm
+
 #endif

--- a/opm/simulators/aquifers/BlackoilAquiferModel.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel.hpp
@@ -113,28 +113,17 @@ protected:
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
     using Scalar = GetPropType<TypeTag, Properties::Scalar>;
 
-    typedef AquiferCarterTracy<TypeTag> AquiferCarterTracy_object;
-    typedef AquiferFetkovich<TypeTag> AquiferFetkovich_object;
-
     Simulator& simulator_;
 
-    // TODO: probably we can use one variable to store both types of aquifers, because
-    // they share the base class
-    mutable std::vector<AquiferCarterTracy_object> aquifers_CarterTracy;
-    mutable std::vector<AquiferFetkovich_object> aquifers_Fetkovich;
-    std::vector<AquiferNumerical<TypeTag>> aquifers_numerical;
+    std::vector<std::unique_ptr<AquiferInterface<TypeTag>>> aquifers;
 
     // This initialization function is used to connect the parser objects with the ones needed by AquiferCarterTracy
     void init();
-
-    bool aquiferActive() const;
-    bool aquiferCarterTracyActive() const;
-    bool aquiferFetkovichActive() const;
-    bool aquiferNumericalActive() const;
 };
 
 
 } // namespace Opm
 
 #include "BlackoilAquiferModel_impl.hpp"
+
 #endif


### PR DESCRIPTION
Refactor to have a common base for analytical and numerical aquifers, and then use them through this interface in the BlackOilAquiferModel.