### PR TITLE
Limit warnings to terminal during deck input.

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -465,7 +465,11 @@ Opm::setupLogging(const int          mpi_rank_,
     if (mpi_rank_ == 0) {
         std::shared_ptr<Opm::StreamLog> streamLog = std::make_shared<Opm::StreamLog>(std::cout, Opm::Log::StdoutMessageTypes);
         Opm::OpmLog::addBackend(stdout_log_id, streamLog);
-
+        // Set a tag limit of 10 (no category limit). Will later in
+        // the run be replaced by calling setupMessageLimiter(), after
+        // the deck is read and the (possibly user-set) category
+        // limits are known.
+        streamLog->setMessageLimiter(std::make_shared<Opm::MessageLimiter>(10));
         bool use_color_coding = OpmLog::stdoutIsTerminal();
         streamLog->setMessageFormatter(std::make_shared<Opm::SimpleMessageFormatter>(use_color_coding));
     }


### PR DESCRIPTION
With this, the tag limit of 10 is used from the very start of the run, and not only after the deck has been read.

This eliminates duplicate warnings (in excess of 10) during deck reading, they will still appear in the PRT and DBG files, however.