### PR TITLE
Restore Non-MPI Builds

### DIFF
--- a/opm/simulators/linalg/ParallelIstlInformation.cpp
+++ b/opm/simulators/linalg/ParallelIstlInformation.cpp
@@ -350,6 +350,6 @@ INSTANCE(int)
 INSTANCE(float)
 INSTANCE(std::size_t)
 
-#endif
+} // namespace Opm
 
-}
+#endif // HAVE_MPI && HAVE_DUNE_ISTL


### PR DESCRIPTION
Commit 371b2592f (PR #4010) misordered the closing brace of a namespace and the conditional declarations dependent upon MPI availability.  This commit restores the expected order and fixes non-MPI builds.