### PR TITLE
Make the TPFA linearizer default for 1/2/3 phase blackoil.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,8 +422,10 @@ add_dependencies(moduleVersion opmsimulators)
 set(FLOW_MODELS blackoil brine energy extbo foam gasoil gaswater
                 oilwater oilwater_brine gaswater_brine oilwater_polymer
                 oilwater_polymer_injectivity micp polymer solvent
-                gasoil_energy brine_saltprecipitation gaswater_saltprec_vapwat brine_precsalt_vapwat)
-set(FLOW_VARIANT_MODELS brine_energy onephase onephase_energy blackoil_tpfa)
+                gasoil_energy brine_saltprecipitation
+                gaswater_saltprec_vapwat brine_precsalt_vapwat
+                blackoil_tpfa gasoildiffuse)
+set(FLOW_VARIANT_MODELS brine_energy onephase onephase_energy)
 
 set(FLOW_TGTS)
 foreach(OBJ ${COMMON_MODELS} ${FLOW_MODELS} ${FLOW_VARIANT_MODELS})

--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -73,6 +73,7 @@ class EclEquilInitializer
     enum { dimWorld = GridView::dimensionworld };
     enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    enum { enableDissolution = Indices::compositionSwitchIdx >= 0 };
     enum { enableBrine = getPropValue<TypeTag, Properties::EnableBrine>() };
     enum { enableEvaporation = getPropValue<TypeTag, Properties::EnableEvaporation>() };
     enum { enableSaltPrecipitation = getPropValue<TypeTag, Properties::EnableSaltPrecipitation>() };
@@ -84,7 +85,7 @@ public:
                                                 FluidSystem,
                                                 enableTemperature,
                                                 enableEnergy,
-                                                Indices::gasEnabled,
+                                                enableDissolution,
                                                 enableEvaporation,
                                                 enableBrine,
                                                 enableSaltPrecipitation,

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -25,6 +25,9 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -32,6 +35,15 @@ struct EclFlowGasOilProblem {
     using InheritsFrom = std::tuple<EclFlowProblem>;
 };
 }
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::EclFlowGasOilProblem> { using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::EclFlowGasOilProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+template<class TypeTag>
+struct EnableDiffusion<TypeTag, TTag::EclFlowGasOilProblem> { static constexpr bool value = false; };
 
 //! The indices required by the model
 template<class TypeTag>

--- a/flow/flow_ebos_gasoildiffuse.cpp
+++ b/flow/flow_ebos_gasoildiffuse.cpp
@@ -1,0 +1,85 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#include <flow/flow_ebos_gasoil.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoiltwophaseindices.hh>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
+#include <opm/simulators/flow/Main.hpp>
+
+namespace Opm {
+namespace Properties {
+namespace TTag {
+struct EclFlowGasOilDiffuseProblem {
+    using InheritsFrom = std::tuple<EclFlowProblem>;
+};
+}
+
+
+template<class TypeTag>
+struct EnableDiffusion<TypeTag, TTag::EclFlowGasOilDiffuseProblem> { static constexpr bool value = true; };
+
+//! The indices required by the model
+template<class TypeTag>
+struct Indices<TypeTag, TTag::EclFlowGasOilDiffuseProblem>
+{
+private:
+    // it is unfortunately not possible to simply use 'TypeTag' here because this leads
+    // to cyclic definitions of some properties. if this happens the compiler error
+    // messages unfortunately are *really* confusing and not really helpful.
+    using BaseTypeTag = TTag::EclFlowProblem;
+    using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
+
+public:
+  typedef BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
+                                  getPropValue<TypeTag, Properties::EnableExtbo>(),
+                                  getPropValue<TypeTag, Properties::EnablePolymer>(),
+                                  getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                  getPropValue<TypeTag, Properties::EnableFoam>(),
+                                  getPropValue<TypeTag, Properties::EnableBrine>(),
+                                  /*PVOffset=*/0,
+                                  /*disabledCompIdx=*/FluidSystem::waterCompIdx,
+                                  getPropValue<TypeTag, Properties::EnableMICP>()> type;
+};
+}}
+
+namespace Opm {
+
+// ----------------- Main program -----------------
+int flowEbosGasOilDiffuseMain(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    resetLocale();
+
+    FlowMainEbos<Properties::TTag::EclFlowGasOilDiffuseProblem>
+        mainfunc {argc, argv, outputCout, outputFiles} ;
+    return mainfunc.execute();
+}
+
+int flowEbosGasOilDiffuseMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Properties::TTag::EclFlowGasOilDiffuseProblem;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
+}
+
+}

--- a/flow/flow_ebos_gasoildiffuse.hpp
+++ b/flow/flow_ebos_gasoildiffuse.hpp
@@ -1,0 +1,30 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef FLOW_EBOS_GASOILDIFFUSE_HPP
+#define FLOW_EBOS_GASOILDIFFUSE_HPP
+
+namespace Opm {
+
+//! \brief Main function used in flow binary.
+int flowEbosGasOilDiffuseMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_gasoil binary.
+int flowEbosGasOilDiffuseMainStandalone(int argc, char** argv);
+
+}
+
+#endif // FLOW_EBOS_GASOILDIFFUSE_HPP

--- a/flow/flow_ebos_gaswater.cpp
+++ b/flow/flow_ebos_gaswater.cpp
@@ -28,6 +28,9 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -35,6 +38,15 @@ struct EclFlowGasWaterProblem {
     using InheritsFrom = std::tuple<EclFlowProblem>;
 };
 }
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::EclFlowGasWaterProblem> { using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::EclFlowGasWaterProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+template<class TypeTag>
+struct EnableDiffusion<TypeTag, TTag::EclFlowGasWaterProblem> { static constexpr bool value = false; };
 
 //! The indices required by the model
 template<class TypeTag>

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -25,6 +25,9 @@
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
 
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -32,6 +35,18 @@ struct EclFlowOilWaterProblem {
     using InheritsFrom = std::tuple<EclFlowProblem>;
 };
 }
+
+
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::EclFlowOilWaterProblem> { using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::EclFlowOilWaterProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+template<class TypeTag>
+struct EnableDiffusion<TypeTag, TTag::EclFlowOilWaterProblem> { static constexpr bool value = false; };
+
 
 //! The indices required by the model
 template<class TypeTag>

--- a/flow/flow_ebos_onephase.cpp
+++ b/flow/flow_ebos_onephase.cpp
@@ -22,6 +22,8 @@
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/models/blackoil/blackoilonephaseindices.hh>
 
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
 
 namespace Opm {
 namespace Properties {
@@ -31,6 +33,16 @@ struct EclFlowProblemWaterOnly {
     using InheritsFrom = std::tuple<EclFlowProblem>;
 };
 }
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::EclFlowProblemWaterOnly> { using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::EclFlowProblemWaterOnly> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+template<class TypeTag>
+struct EnableDiffusion<TypeTag, TTag::EclFlowProblemWaterOnly> { static constexpr bool value = false; };
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::EclFlowProblemWaterOnly>

--- a/flow/flow_gasoildiffuse.cpp
+++ b/flow/flow_gasoildiffuse.cpp
@@ -1,0 +1,24 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+#include <flow/flow_ebos_gasoildiffuse.hpp>
+
+
+int main(int argc, char** argv)
+{
+    return Opm::flowEbosGasOilDiffuseMainStandalone(argc, argv);
+}

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -23,6 +23,7 @@
 #define OPM_MAIN_HEADER_INCLUDED
 
 #include <flow/flow_ebos_blackoil.hpp>
+#include <flow/flow_ebos_blackoil_tpfa.hpp>
 
 #include <flow/flow_ebos_gasoil.hpp>
 #include <flow/flow_ebos_gasoil_energy.hpp>
@@ -117,9 +118,6 @@ int flowEbosMain(int argc, char** argv, bool outputCout, bool outputFiles)
 //   usage scenarios, we refactored the original run() in flow.cpp into this class.
 class Main
 {
-private:
-    using FlowMainEbosType = FlowMainEbos<Properties::TTag::EclFlowProblem>;
-
 public:
     Main(int argc, char** argv) : argc_(argc), argv_(argv)  { initMPI();  }
 
@@ -236,6 +234,7 @@ public:
         return exitCode;
     }
 
+    using FlowMainEbosType = FlowMainEbos<Properties::TTag::EclFlowProblem>;
     // To be called from the Python interface code. Only do the
     // initialization and then return a pointer to the FlowEbosMain
     // object that can later be accessed directly from the Python interface
@@ -737,7 +736,7 @@ private:
 
     int runBlackOil()
     {
-        return flowEbosBlackoilMain(argc_, argv_, outputCout_, outputFiles_);
+        return flowEbosBlackoilTpfaMain(argc_, argv_, outputCout_, outputFiles_);
     }
 
     int argc_{0};


### PR DESCRIPTION
All other use cases still use the traditional linearizer.