### PR TITLE
cleanup group switching output to terminal

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1219,7 +1219,7 @@ checkGroupHigherConstraints(const Group& group,
             auto currentControl = this->groupState().injection_control(group.name(), phase);
             if (currentControl != Group::InjectionCMode::FLD && group.injectionGroupControlAvailable(phase)) {
                 const Group& parentGroup = schedule().getGroup(group.parent(), reportStepIdx);
-                const std::pair<bool, double> changed_this = WellGroupHelpers::checkGroupConstraintsInj(
+                const auto [is_changed, scaling_factor] = WellGroupHelpers::checkGroupConstraintsInj(
                 group.name(),
                 group.parent(),
                 parentGroup,
@@ -1235,10 +1235,10 @@ checkGroupHigherConstraints(const Group& group,
                 summaryState_,
                 resv_coeff_inj,
                 deferred_logger);
-                if (changed_this.first) {
+                if (is_changed) {
                     switched_inj_groups_.insert({ {group.name(), phase}, Group::InjectionCMode2String(Group::InjectionCMode::FLD)});
                     actionOnBrokenConstraints(group, Group::InjectionCMode::FLD, phase, deferred_logger);
-                    WellGroupHelpers::updateWellRatesFromGroupTargetScale(changed_this.second, group, schedule(), reportStepIdx, /* isInjector */ true, this->groupState(), this->wellState());
+                    WellGroupHelpers::updateWellRatesFromGroupTargetScale(scaling_factor, group, schedule(), reportStepIdx, /* isInjector */ true, this->groupState(), this->wellState());
                     changed = true;
                 }
             }
@@ -1258,7 +1258,7 @@ checkGroupHigherConstraints(const Group& group,
         const Group::ProductionCMode& currentControl = this->groupState().production_control(group.name());
         if (currentControl != Group::ProductionCMode::FLD && group.productionGroupControlAvailable()) {
             const Group& parentGroup = schedule().getGroup(group.parent(), reportStepIdx);
-            const std::pair<bool, double> changed_this = WellGroupHelpers::checkGroupConstraintsProd(
+            const auto [is_changed, scaling_factor] = WellGroupHelpers::checkGroupConstraintsProd(
                 group.name(),
                 group.parent(),
                 parentGroup,
@@ -1273,11 +1273,11 @@ checkGroupHigherConstraints(const Group& group,
                 summaryState_,
                 resv_coeff,
                 deferred_logger);
-            if (changed_this.first) {
+            if (is_changed) {
                 switched_prod_groups_.insert({group.name(), Group::ProductionCMode2String(Group::ProductionCMode::FLD)});
                 const auto exceed_action = group.productionControls(summaryState_).exceed_action;
                 actionOnBrokenConstraints(group, exceed_action, Group::ProductionCMode::FLD, deferred_logger);
-                WellGroupHelpers::updateWellRatesFromGroupTargetScale(changed_this.second, group, schedule(), reportStepIdx, /* isInjector */ false, this->groupState(), this->wellState());
+                WellGroupHelpers::updateWellRatesFromGroupTargetScale(scaling_factor, group, schedule(), reportStepIdx, /* isInjector */ false, this->groupState(), this->wellState());
                 changed = true;
             }
         }

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -340,22 +340,18 @@ protected:
 
     bool checkGroupHigherConstraints(const Group& group,
                                      DeferredLogger& deferred_logger,
-                                     const int reportStepIdx,
-                                     std::set<std::string>& switched_groups);
+                                     const int reportStepIdx);
 
     bool updateGroupIndividualControl(const Group& group,
                                       DeferredLogger& deferred_logger,
-                                      const int reportStepIdx,
-                                      std::set<std::string>& switched_groups);
+                                      const int reportStepIdx);
 
     bool updateGroupIndividualControls(DeferredLogger& deferred_logger,
-                                       std::set<std::string>& switched_groups,
                                        const int reportStepIdx,
                                        const int iterationIdx);
 
     bool updateGroupHigherControls(DeferredLogger& deferred_logger,
-                                   const int reportStepIdx,
-                                   std::set<std::string>& switched_groups);
+                                   const int reportStepIdx);
 
     void actionOnBrokenConstraints(const Group& group,
                                    const Group::ExceedAction& exceed_action,
@@ -461,6 +457,10 @@ protected:
     bool glift_debug = false;
 
     double last_glift_opt_time_ = -1.0;
+
+    std::map<std::string, std::string> switched_prod_groups_;
+    std::map<std::pair<std::string, Opm::Phase>, std::string> switched_inj_groups_;
+
 
 private:
     WellInterfaceGeneric* getGenWell(const std::string& well_name);

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -468,26 +468,27 @@ namespace Opm {
         if (terminal_output_) {
 
             for (const auto& [name, to] : switched_prod_groups_) {
-                std::string msg = "    Production Group " + name
-                + " control mode changed from ";
                 const Group::ProductionCMode& oldControl = this->prevWGState().group_state.production_control(name);
                 std::string from = Group::ProductionCMode2String(oldControl);
-                msg += from;
-                msg += " to " + to;
                 if (to != from) {
+                    std::string msg = "    Production Group " + name
+                    + " control mode changed from ";
+                    msg += from;
+                    msg += " to " + to;
                     local_deferredLogger.info(msg);
                 }
             }
             for (const auto& [key, to] : switched_inj_groups_) {
                 const std::string& name = key.first;
                 const Opm::Phase& phase = key.second;
-                std::string msg = "    Injection Group " + name
-                + " control mode changed from ";
+
                 const Group::InjectionCMode& oldControl = this->prevWGState().group_state.injection_control(name, phase);
                 std::string from = Group::InjectionCMode2String(oldControl);
-                msg += from;
-                msg += " to " + to;
                 if (to != from) {
+                    std::string msg = "    Injection Group " + name
+                    + " control mode changed from ";
+                    msg += from;
+                    msg += " to " + to;
                     local_deferredLogger.info(msg);
                 }
             }


### PR DESCRIPTION
As requested by @OPMUSER  in https://github.com/OPM/opm-simulators/pull/3837#issuecomment-1141853225

I dropped the switching history RATE->FLE->RATE i.e. only the final change is dumped to the terminal. 
The old logging is moved to .DBG so if you are interested in detailed switching history you will find it there. 

I suggest doing the same for the wells as
ORAT->GRAT->ORAT type of output may not be that useful for the user IMO. 