### PR TITLE
scale energy residual to have the same relative order as the mass balance residuals

### DIFF
--- a/opm/simulators/flow/BlackoilModelEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelEbos.hpp
@@ -748,7 +748,7 @@ namespace Opm {
                 }
 
                 if constexpr (has_energy_) {
-                    B_avg[ contiEnergyEqIdx ] += 1.0;
+                    B_avg[ contiEnergyEqIdx ] += 1.0 / (4.182e1); // converting J -> RM3 (entalpy / (cp * deltaK * rho) assuming change of 1e-5K of water
                     const auto R2 = ebosResid[cell_idx][contiEnergyEqIdx];
                     R_sum[ contiEnergyEqIdx ] += R2;
                     maxCoeff[ contiEnergyEqIdx ] = std::max( maxCoeff[ contiEnergyEqIdx ], std::abs( R2 ) / pvValue );


### PR DESCRIPTION
We are using the same tolerances for the MB and CNV for energy and the various mass balance equations. The motivation of this change is to make the energy tolerance more comparable with the ones for mass.  