### PR TITLE
Ensure intensive quantities are calculated at start of simulation.

### DIFF
--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -148,6 +148,8 @@ public:
     SimulatorReport run(SimulatorTimer& timer)
     {
         init(timer);
+        // Make cache up to date. No need for updating it in elementCtx.
+        ebosSimulator_.model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0);
         // Main simulation loop.
         while (!timer.done()) {
             bool continue_looping = runStep(timer);
@@ -218,8 +220,6 @@ public:
             ebosSimulator_.setEpisodeIndex(-1);
             ebosSimulator_.setEpisodeLength(0.0);
             ebosSimulator_.setTimeStepSize(0.0);
-            // Make cache up to date. No need for updating it in elementCtx.
-            ebosSimulator_.model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0);
             wellModel_().beginReportStep(timer.currentStepNum());
             ebosSimulator_.problem().writeOutput();
 


### PR DESCRIPTION
Moving it ensures it is also done for restart simulation runs. Without this, the well model will actually initialize the IQs, but only for owned cells, not overlap/ghost cells, which caused parallel failure.

This is not detected with the traditional linearizer, as the updating of ElementContexts will lead to evaluation of the missing cells, but with the TpfaLinearizer parallel restart fails without this.

Cherry-picked from https://github.com/OPM/opm-simulators/pull/4017