### PR TITLE
Direct All Non-Triggered Action Messages to Debug File

### DIFF
--- a/ebos/eclactionhandler.cc
+++ b/ebos/eclactionhandler.cc
@@ -101,7 +101,7 @@ namespace {
                         (numInactive != 1) ? "s" : "",
                         timeString);
 
-        Opm::OpmLog::info("ACTION_NOT_TRIGGERED", message);
+        Opm::OpmLog::debug("ACTION_NOT_TRIGGERED", message);
     }
 } // Anonymous namespace
 


### PR DESCRIPTION
End users typically do not care that a particular action did NOT trigger at a particular time and these messages will typically reduce the utility of the `CASE.PRT` file.  On important field cases we've seen more than 100,000 such messages in a single run which is quite overwhelming.

Since we're now directing the messages to the `.DBG` file instead we're not taking away any diagnostic ability, merely altering the location of the information.