### PR TITLE
added: data::CellData mpiserializer test

### DIFF
--- a/tests/test_ParallelRestart.cpp
+++ b/tests/test_ParallelRestart.cpp
@@ -497,7 +497,7 @@ BOOST_AUTO_TEST_CASE(dataNodeData)
     DO_CHECKS(data::NodeData)
 }
 
-BOOST_AUTO_TEST_CASE(CellData)
+BOOST_AUTO_TEST_CASE(CellData_)
 {
     Opm::data::CellData val1;
     val1.dim = Opm::UnitSystem::measure::length;
@@ -571,6 +571,7 @@ TEST_FOR_TYPE(BCConfig)
 TEST_FOR_TYPE(BrineDensityTable)
 TEST_FOR_TYPE(ColumnSchema)
 TEST_FOR_TYPE(Connection)
+TEST_FOR_TYPE_NAMED(data::CellData, CellData)
 TEST_FOR_TYPE(Deck)
 TEST_FOR_TYPE(DeckItem)
 TEST_FOR_TYPE(DeckKeyword)


### PR DESCRIPTION
Sits on top of https://github.com/OPM/opm-simulators/pull/4056
Downstream of https://github.com/OPM/opm-common/pull/3119

Temporarily we now have two tests for serializing CellData, one using the direct Mpi::pack/unpack/packsize and one using the eclmpiserializer.