### PR TITLE
Use compressedIndexForInterior() for mapping cartesian indices.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -316,9 +316,6 @@ namespace Opm {
 
             // a vector of all the wells.
             std::vector<WellInterfacePtr > well_container_{};
- 
-            // map from logically cartesian cell indices to compressed ones
-            std::vector<int> cartesian_to_compressed_;
 
             std::vector<bool> is_cell_perforated_{};
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -439,8 +439,6 @@ protected:
     std::vector<std::reference_wrapper<ParallelWellInfo>> local_parallel_well_info_;
 
     std::vector<WellProdIndexCalculator> prod_index_calc_;
-    
-    std::vector<int> cartesian_to_compressed_;
 
     std::vector<int> pvt_region_idx_;
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -128,8 +128,7 @@ namespace Opm {
             for ( size_t c=0; c < connectionSet.size(); c++ )
             {
                 const auto& connection = connectionSet.get(c);
-                int compressed_idx = cartesian_to_compressed_.at(connection.global_index());
-
+                int compressed_idx = compressedIndexForInterior(connection.global_index());
                 if ( compressed_idx >= 0 ) { // Ignore connections in inactive/remote cells.
                     wellCells.push_back(compressed_idx);
                 }


### PR DESCRIPTION
Closes #4012.