### PR TITLE
fixed: do not include EclMpiSerializer without mpi

### DIFF
--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -29,7 +29,9 @@
 #include <memory>
 
 #include <dune/common/parallel/mpitraits.hh>
+#if HAVE_MPI
 #include <ebos/eclmpiserializer.hh>
+#endif
 #include <opm/output/data/Aquifer.hpp>
 #include <opm/output/data/Cells.hpp>
 #include <opm/output/data/Groups.hpp>


### PR DESCRIPTION
This keeps popping up and I keep forgetting it.

While the code in the primitive serializer has dummy implementations without MPI, an annoying issue in dune keeps biting us.
CollectiveCommunication&lt;<MPI_Comm&gt;> has a casting operator to MPI_Comm.
However, CollectiveCommunication&lt;Dune::No_Comm&gt; has no casting operator to Dune::No_Comm.

We rely on the casting operator so we can use the collectivecommunication as a MPI_comm where appropriate. And then it all breaks in serial..