### PR TITLE
Fix wells active determination 

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -670,13 +670,6 @@ initFromRestartFile(const RestartValue& restartValues,
     initial_step_ = false;
 }
 
-void
-BlackoilWellModelGeneric::
-setWellsActive(const bool wells_active)
-{
-    wells_active_ = wells_active;
-}
-
 std::vector<Well>
 BlackoilWellModelGeneric::
 getLocalWells(const int timeStepIdx) const

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -388,13 +388,6 @@ wellsActive() const
 
 bool
 BlackoilWellModelGeneric::
-localWellsActive() const
-{
-    return numLocalWells() > 0;
-}
-
-bool
-BlackoilWellModelGeneric::
 anyMSWellOpenLocal() const
 {
     for (const auto& well : wells_ecl_) {
@@ -2140,10 +2133,6 @@ void
 BlackoilWellModelGeneric::
 calculateEfficiencyFactors(const int reportStepIdx)
 {
-    if ( !localWellsActive() ) {
-        return;
-    }
-
     for (auto& well : well_container_generic_) {
         const Well& wellEcl = well->wellEcl();
         double well_efficiency_factor = wellEcl.getEfficiencyFactor();

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -143,8 +143,6 @@ public:
                              const size_t numCells,
                              bool handle_ms_well);
 
-    void setWellsActive(const bool wells_active);
-
     /*
       Will assign the internal member last_valid_well_state_ to the
       current value of the this->active_well_state_. The state stored

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -90,8 +90,7 @@ public:
     /// return true if wells are available in the reservoir
     bool wellsActive() const;
     bool hasWell(const std::string& wname);
-    /// return true if wells are available on this process
-    bool localWellsActive() const;
+
     // whether there exists any multisegment well open on this process
     bool anyMSWellOpenLocal() const;
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -198,11 +198,6 @@ namespace Opm {
             this->initializeWellPerfData();
             this->initializeWellState(timeStepIdx, summaryState);
 
-            // Wells are active if they are active wells on at least
-            // one process.
-            wells_active_ = localWellsActive() ? 1 : 0;
-            wells_active_ = grid.comm().max(wells_active_);
-
             // handling MS well related
             if (param_.use_multisegment_well_&& anyMSWellOpenLocal()) { // if we use MultisegmentWell model
                 this->wellState().initWellStateMSWell(wells_ecl_, &this->prevWellState());
@@ -263,6 +258,11 @@ namespace Opm {
 
             // create the well container
             createWellContainer(reportStepIdx);
+
+            // Wells are active if they are active wells on at least one process.
+            const Grid& grid = ebosSimulator_.vanguard().grid();
+            wells_active_ = !this->well_container_.empty();
+            wells_active_ = grid.comm().max(wells_active_);
 
             // do the initialization for all the wells
             // TODO: to see whether we can postpone of the intialization of the well containers to

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1717,7 +1717,13 @@ namespace Opm {
     int
     BlackoilWellModel<TypeTag>::numComponents() const
     {
-        if (wellsActive()  && numPhases() < 3) {
+        // The numComponents here does not reflect the actual number of the components in the system.
+        // It more or less reflects the number of mass conservation equations for the well equations.
+        // For example, in the current formulation, we do not have the polymer conservation equation
+        // in the well equations. As a result, for an oil-water-polymer system, this function will return 2.
+        // In some way, it makes this function appear to be confusing from its name, and we need
+        // to revisit/revise this function again when extending the variants of system that flow can simulate.
+        if (numPhases() < 3) {
             return numPhases();
         }
         int numComp = FluidSystem::numComponents;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1104,10 +1104,6 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     apply( BVector& r) const
     {
-        if ( ! localWellsActive() ) {
-            return;
-        }
-
         for (auto& well : well_container_) {
             well->apply(r);
         }
@@ -1120,11 +1116,6 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     apply(const BVector& x, BVector& Ax) const
     {
-        // TODO: do we still need localWellsActive()?
-        if ( ! localWellsActive() ) {
-            return;
-        }
-
         for (auto& well : well_container_) {
             well->apply(x, Ax);
         }
@@ -1176,7 +1167,7 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     applyScaleAdd(const Scalar alpha, const BVector& x, BVector& Ax) const
     {
-        if ( ! localWellsActive() ) {
+        if (this->well_container_.empty()) {
             return;
         }
 
@@ -1304,10 +1295,8 @@ namespace Opm {
         DeferredLogger local_deferredLogger;
         OPM_BEGIN_PARALLEL_TRY_CATCH();
         {
-            if (localWellsActive()) {
-                for (auto& well : well_container_) {
-                    well->recoverWellSolutionAndUpdateWellState(x, this->wellState(), local_deferredLogger);
-                }
+            for (auto& well : well_container_) {
+                well->recoverWellSolutionAndUpdateWellState(x, this->wellState(), local_deferredLogger);
             }
 
         }


### PR DESCRIPTION
With the master branch, it uses the `wells_ecl` to determine whether wells are active, then SHUT wells might be counted. 

This is an effort to make this part cleaned up a little bit. 

`wellsActive()` or `localWellsActive()` are used many places, more testing and investigation will be required, so it is working in progress.