### PR TITLE
we only use drift compensation when wells are active

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -1396,7 +1396,7 @@ if(MPI_FOUND)
                                        SIMULATOR flow
                                        ABS_TOL ${abs_tol_parallel}
                                        REL_TOL ${rel_tol_parallel}
-                                       TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
+                                       TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --ecl-enable-drift-compensation=false)
 
   add_test_compare_parallel_simulation(CASENAME spe1_gaswater
                                        FILENAME SPE1CASE2_GASWATER
@@ -1411,7 +1411,7 @@ if(MPI_FOUND)
                                        SIMULATOR flow
                                        ABS_TOL ${abs_tol_parallel}
                                        REL_TOL ${rel_tol_parallel}
-                                       TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
+                                       TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --ecl-enable-drift-compensation=false)
 
   # A test for distributed standard wells. We load distribute only along the z-axis
   add_test_compare_parallel_simulation(CASENAME spe9
@@ -1419,7 +1419,7 @@ if(MPI_FOUND)
                                        SIMULATOR flow_distribute_z
                                        ABS_TOL ${abs_tol_parallel}
                                        REL_TOL ${rel_tol_parallel}
-                                       TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
+                                       TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --ecl-enable-drift-compensation=false)
 
   add_test_compare_parallel_simulation(CASENAME spe9group
                                        FILENAME SPE9_CP_GROUP
@@ -1540,7 +1540,7 @@ if(MPI_FOUND)
                                        ABS_TOL ${abs_tol_parallel}
                                        REL_TOL ${rel_tol_parallel}
 				       DIR model2
-                                       TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
+                                       TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --ecl-enable-drift-compensation=false)
 
   add_test_compare_parallel_simulation(CASENAME rxft
                                        FILENAME TEST_RXFT
@@ -1548,7 +1548,7 @@ if(MPI_FOUND)
                                        ABS_TOL ${abs_tol_parallel}
                                        REL_TOL 1.0e-3
                                        DIR rxft_smry
-                                       TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
+                                       TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --ecl-enable-drift-compensation=false)
 endif()
 
 if(OPM_TESTS_ROOT)

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1883,12 +1883,8 @@ public:
 
         // if requested, compensate systematic mass loss for cells which were "well
         // behaved" in the last time step
-        // Note that we don't allow for drift compensation if there is
-        // no source terms i.e. no wells and no aquifers.
-        const auto& schedule = this->simulator().vanguard().schedule();
-        int episodeIdx = this->simulator().episodeIndex();
-        const auto& aquifer = this->simulator().vanguard().eclState().aquifer();
-        bool compensateDrift =  schedule.numWells(episodeIdx) > 0 && aquifer.active();
+        // Note that we don't allow for drift compensation if there are no active wells.
+        const bool compensateDrift = wellModel_.wellsActive();
         if (enableDriftCompensation_ && compensateDrift) {
             const auto& simulator = this->simulator();
             const auto& model = this->model();


### PR DESCRIPTION
The targeting situation is that for one case, the wells are not running for some report steps with only aquifers. Drift compensation really impacts the convergence for that running. 

The alternative can be to make `aquifer.active()` based on how much flux the aquifer is doing. 

This PR sits on top of https://github.com/OPM/opm-simulators/pull/4101 . 