### PR TITLE
mpiserializer: handle all vectors

### DIFF
--- a/ebos/eclmpiserializer.hh
+++ b/ebos/eclmpiserializer.hh
@@ -145,6 +145,32 @@ public:
         }
     }
 
+    //! \brief Handler for bool vectors.
+    //! \param data The vector to (de-)serialize
+    void vector(std::vector<bool>& data)
+    {
+        if (m_op == Operation::PACKSIZE) {
+            m_packSize += Mpi::packSize(data.size(), m_comm);
+            m_packSize += data.size()*Mpi::packSize(bool(), m_comm);
+        } else if (m_op == Operation::PACK) {
+            (*this)(data.size());
+            for (const auto entry : data) { // Not a reference: vector<bool> range
+                bool b = entry;
+                (*this)(b);
+            }
+        } else if (m_op == Operation::UNPACK) {
+            size_t size;
+            (*this)(size);
+            data.clear();
+            data.reserve(size);
+            for (size_t i = 0; i < size; ++i) {
+                bool entry;
+                (*this)(entry);
+                data.push_back(entry);
+            }
+        }
+    }
+
     template <class Array>
     void array(Array& data)
     {

--- a/ebos/eclmpiserializer.hh
+++ b/ebos/eclmpiserializer.hh
@@ -64,7 +64,7 @@ decltype(auto) make_variant(std::size_t index)
 }
 
 template<class T>
-using remove_cvr_t = std::remove_const_t<std::remove_reference_t<T>>;
+using remove_cvr_t = std::remove_cv_t<std::remove_reference_t<T>>;
 
 } // namespace detail
 

--- a/opm/simulators/utils/MPIPacker.hpp
+++ b/opm/simulators/utils/MPIPacker.hpp
@@ -29,7 +29,6 @@
 #include <string>
 #include <tuple>
 #include <typeinfo>
-#include <vector>
 
 namespace Opm
 {
@@ -77,12 +76,6 @@ std::size_t packSize(const T& data, Opm::Parallel::MPIComm comm)
 
 template<class T1, class T2>
 std::size_t packSize(const std::pair<T1,T2>& data, Opm::Parallel::MPIComm comm);
-
-template<class T, class A>
-std::size_t packSize(const std::vector<T,A>& data, Opm::Parallel::MPIComm comm);
-
-template<class A>
-std::size_t packSize(const std::vector<bool,A>& data, Opm::Parallel::MPIComm comm);
 
 template<class... Ts>
 std::size_t packSize(const std::tuple<Ts...>& data, Opm::Parallel::MPIComm comm);
@@ -137,14 +130,6 @@ void pack(const T& data, std::vector<char>& buffer, int& position,
 
 template<class T1, class T2>
 void pack(const std::pair<T1,T2>& data, std::vector<char>& buffer, int& position,
-          Opm::Parallel::MPIComm comm);
-
-template<class T, class A>
-void pack(const std::vector<T,A>& data, std::vector<char>& buffer, int& position,
-          Opm::Parallel::MPIComm comm);
-
-template<class A>
-void pack(const std::vector<bool,A>& data, std::vector<char>& buffer, int& position,
           Opm::Parallel::MPIComm comm);
 
 template<class... Ts>
@@ -205,14 +190,6 @@ void unpack(T& data, std::vector<char>& buffer, int& position,
 template<class T1, class T2>
 void unpack(std::pair<T1,T2>& data, std::vector<char>& buffer, int& position,
             Opm::Parallel::MPIComm comm);
-
-template<class T, class A>
-void unpack(std::vector<T,A>& data, std::vector<char>& buffer, int& position,
-            Opm::Parallel::MPIComm comm);
-
-template<class A>
-void unpack(std::vector<bool,A>& data, std::vector<char>& buffer, int& position,
-          Opm::Parallel::MPIComm comm);
 
 template<class... Ts>
 void unpack(std::tuple<Ts...>& data, std::vector<char>& buffer,

--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -42,7 +42,6 @@
 
 namespace Opm {
 
-
 void eclStateBroadcast(Parallel::Communication comm, EclipseState& eclState, Schedule& schedule,
                        SummaryConfig& summaryConfig,
                        UDQState& udqState,
@@ -50,12 +49,7 @@ void eclStateBroadcast(Parallel::Communication comm, EclipseState& eclState, Sch
                        WellTestState&  wtestState)
 {
     Opm::EclMpiSerializer ser(comm);
-    ser.broadcast(eclState);
-    ser.broadcast(schedule);
-    ser.broadcast(summaryConfig);
-    ser.broadcast(udqState);
-    ser.broadcast(actionState);
-    ser.broadcast(wtestState);
+    ser.broadcast(0, eclState, schedule, summaryConfig, udqState, actionState, wtestState);
 }
 
 template <class T>
@@ -64,7 +58,6 @@ void eclBroadcast(Parallel::Communication comm, T& data)
     Opm::EclMpiSerializer ser(comm);
     ser.broadcast(data);
 }
-
 
 template void eclBroadcast<TransMult>(Parallel::Communication, TransMult&);
 template void eclBroadcast<Schedule>(Parallel::Communication, Schedule&);

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -27,6 +27,7 @@
 
 #include <opm/simulators/wells/VFPProperties.hpp>
 #include <opm/simulators/utils/MPIPacker.hpp>
+#include <ebos/eclmpiserializer.hh>
 
 #include <algorithm>
 #include <utility>
@@ -1058,8 +1059,9 @@ namespace Opm {
                 //   data if they are going to check the group rates in stage1
                 //   Another similar idea is to only communicate the rates to
                 //   process j = i + 1
-                Mpi::broadcast(comm, i, group_indexes, group_oil_rates,
-                               group_gas_rates, group_water_rates, group_alq_rates);
+                EclMpiSerializer ser(comm);
+                ser.broadcast(i, group_indexes, group_oil_rates,
+                              group_gas_rates, group_water_rates, group_alq_rates);
                 if (comm.rank() != i) {
                     for (int j=0; j<num_rates_to_sync; j++) {
                         group_info.updateRate(group_indexes[j],

--- a/tests/test_broadcast.cpp
+++ b/tests/test_broadcast.cpp
@@ -26,6 +26,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/simulators/utils/MPIPacker.hpp>
+#include <ebos/eclmpiserializer.hh>
 #include <dune/common/parallel/mpihelper.hh>
 
 #include <numeric>
@@ -70,7 +71,8 @@ BOOST_AUTO_TEST_CASE(BroadCast)
     double d1 = cc.rank() == 0 ? 7.0 : 0.0;
     size_t i1 = cc.rank() == 0 ? 8 : 0;
 
-    Opm::Mpi::broadcast(cc, 0, d, i, d1, i1);
+    Opm::EclMpiSerializer ser(cc);
+    ser.broadcast(0, d, i, d1, i1);
 
     for (size_t c = 0; c < 3; ++c) {
         BOOST_CHECK_EQUAL(d[c], 1.0+c);


### PR DESCRIPTION
Handle all vectors in eclmpiserializer and remove support in MPIPacker.

This contains some more changes, in particular we need to move the variadic broadcast support into the serializer since that previously relied on the vector support in the MPIPacker.