### PR TITLE
avoiding wrong sign for QTotal primary variable for top segment

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -463,6 +463,13 @@ updatePrimaryVariables(const WellState& well_state) const
             total_seg_rate += baseif_.scalingFactor(p) * segment_rates[baseif_.numPhases() * seg + p];
         }
 
+        if (seg == 0) {
+            if (baseif_.isInjector()) {
+                total_seg_rate = std::max(total_seg_rate, 0.);
+            } else {
+                total_seg_rate = std::min(total_seg_rate, 0.);
+            }
+        }
         primary_variables_[seg][GTotal] = total_seg_rate;
         if (std::abs(total_seg_rate) > 0.) {
             if (has_wfrac_variable) {


### PR DESCRIPTION
for multisegment wells.

The scenario is that an injector is with zero rate control, and we get something like `-2.e-233` value for the primary variable and triggered assertion failure
```
MultisegmentWellEval.cpp:1783: void Opm::MultisegmentWellEval<FluidSystem, Indices, Scalar>::updateUpwindingSegments() [with FluidSystem = Opm::BlackOilFluidSystem<double, Opm::BlackOilDefaultIndexTraits>; Indices = Opm::BlackOilIndices<0, 0, 0, 0, false, false, 0, 0>; Scalar = double]: 
Assertion `! (baseif_.isInjector() && primary_variables_evaluation_[seg][GTotal] < 0.)' failed.
```