### PR TITLE
fixed: wrong root rank in variadic broadcast

### DIFF
--- a/ebos/eclmpiserializer.hh
+++ b/ebos/eclmpiserializer.hh
@@ -436,20 +436,20 @@ public:
                 m_op = Operation::PACK;
                 variadic_call(args...);
                 m_packSize = m_position;
-                m_comm.broadcast(&m_packSize, 1, 0);
-                m_comm.broadcast(m_buffer.data(), m_position, 0);
+                m_comm.broadcast(&m_packSize, 1, root);
+                m_comm.broadcast(m_buffer.data(), m_position, root);
             } catch (...) {
                 m_packSize = std::numeric_limits<size_t>::max();
-                m_comm.broadcast(&m_packSize, 1, 0);
+                m_comm.broadcast(&m_packSize, 1, root);
                 throw;
             }
         } else {
-            m_comm.broadcast(&m_packSize, 1, 0);
+            m_comm.broadcast(&m_packSize, 1, root);
             if (m_packSize == std::numeric_limits<size_t>::max()) {
                 throw std::runtime_error("Error detected in parallel serialization");
             }
             m_buffer.resize(m_packSize);
-            m_comm.broadcast(m_buffer.data(), m_packSize, 0);
+            m_comm.broadcast(m_buffer.data(), m_packSize, root);
             m_position = 0;
             m_op = Operation::UNPACK;
             variadic_call(std::forward<Args>(args)...);

--- a/tests/test_broadcast.cpp
+++ b/tests/test_broadcast.cpp
@@ -61,18 +61,18 @@ BOOST_AUTO_TEST_CASE(BroadCast)
     auto cc = Dune::MPIHelper::getCollectiveCommunication();
 
     std::vector<double> d(3);
-    if (cc.rank() == 0)
+    if (cc.rank() == 1)
         std::iota(d.begin(), d.end(), 1.0);
 
     std::vector<int> i(3);
-    if (cc.rank() == 0)
+    if (cc.rank() == 1)
         std::iota(i.begin(), i.end(), 4);
 
-    double d1 = cc.rank() == 0 ? 7.0 : 0.0;
-    size_t i1 = cc.rank() == 0 ? 8 : 0;
+    double d1 = cc.rank() == 1 ? 7.0 : 0.0;
+    size_t i1 = cc.rank() == 1 ? 8 : 0;
 
     Opm::EclMpiSerializer ser(cc);
-    ser.broadcast(0, d, i, d1, i1);
+    ser.broadcast(1, d, i, d1, i1);
 
     for (size_t c = 0; c < 3; ++c) {
         BOOST_CHECK_EQUAL(d[c], 1.0+c);


### PR DESCRIPTION
change the test to broadcast from rank 1 instead of 0 so this bug does not resurface.

i screwed up juggling all my branches and accidentially squashed the fix for this is the wrong branch. sorry for that.