### PR TITLE
fixed: remove default constructor declaration

### DIFF
--- a/opm/simulators/wells/VFPProperties.hpp
+++ b/opm/simulators/wells/VFPProperties.hpp
@@ -38,9 +38,6 @@ class VFPProdTable;
  */
 class VFPProperties {
 public:
-    VFPProperties() = default;
-
-
     /**
      * Constructor
      * Takes *no* ownership of data.


### PR DESCRIPTION
a class with a reference member cannot be default initialized, so constructor is implicitly deleted. quells a clang warning