### PR TITLE
limiting the smallest injection rate to 1.e-7 for the injection phase.

### DIFF
--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -828,6 +828,13 @@ namespace Opm
             }
 
             }
+            // for wells with zero injection rate, if we assign exactly zero rate,
+            // we will have to assume some trivial composition in the wellbore.
+            // here, we use some small value (about 0.01 m^3/day ~= 1.e-7) to initialize
+            // the zero rate target, then we can use to retain the composition information
+            // within the wellbore from the previous result, and hopefully it is a good
+            // initial guess for the zero rate target.
+            ws.surface_rates[phasePos] = std::max(1.e-7, ws.surface_rates[phasePos]);
         }
         //Producer
         else


### PR DESCRIPTION
1.e-7 is something from 0.01/86400. 

It is trying to fix the running of a case with zero injection rate. 

Numerically, we do not need to set the rate to be exactly zero, which makes the initialization of the primary variables hard (primary variables contain well-bore composition information.)

For zero injection rate wells, the zero rate will be ensured through the well control equations. Initializing the rate to be something close to zero is good enough as an initial guess for the Newton iterations. 