### PR TITLE
Rename --linsolver option to --linear-solver

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -418,7 +418,7 @@ add_test_compareECLFiles(CASENAME numerical_aquifer_3d_2aqu
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR aquifer-num
-                         TEST_ARGS --tolerance-cnv=0.00003 --time-step-control=pid --linsolver=cpr)
+                         TEST_ARGS --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr)
 
 add_test_compareECLFiles(CASENAME numerical_aquifer_3d_1aqu
                          FILENAME 3D_1AQU_3CELLS
@@ -426,7 +426,7 @@ add_test_compareECLFiles(CASENAME numerical_aquifer_3d_1aqu
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR aquifer-num
-                         TEST_ARGS --tolerance-cnv=0.00003 --time-step-control=pid --linsolver=cpr)
+                         TEST_ARGS --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr)
 
 add_test_compareECLFiles(CASENAME spe3
                          FILENAME SPE3CASE1
@@ -1364,7 +1364,7 @@ if(MPI_FOUND)
                                                  REL_TOL 5.0e-2
                                                  RESTART_STEP 3
                                                  DIR aquifer-num
-                                                 TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linsolver=cpr)
+                                                 TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr)
 
   add_test_compare_parallel_restarted_simulation(CASENAME numerical_aquifer_3d_1aqu
                                                  FILENAME 3D_1AQU_3CELLS
@@ -1373,7 +1373,7 @@ if(MPI_FOUND)
                                                  REL_TOL 5.0e-2
                                                  RESTART_STEP 3
                                                  DIR aquifer-num
-                                                 TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linsolver=cpr)
+                                                 TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr)
 
 # Single test to verify that we treat custom communicators correctly.
   opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-split-comm-test.sh "")
@@ -1516,7 +1516,7 @@ if(MPI_FOUND)
                                        ABS_TOL 0.17
                                        REL_TOL ${coarse_rel_tol_parallel}
                                        DIR aquifer-num
-                                       TEST_ARGS --tolerance-cnv=0.000003 --time-step-control=pid --linsolver=cpr)
+                                       TEST_ARGS --tolerance-cnv=0.000003 --time-step-control=pid --linear-solver=cpr)
 
   add_test_compare_parallel_simulation(CASENAME numerical_aquifer_3d_1aqu
                                        FILENAME 3D_1AQU_3CELLS
@@ -1524,7 +1524,7 @@ if(MPI_FOUND)
                                        ABS_TOL ${abs_tol_parallel}
                                        REL_TOL ${coarse_rel_tol_parallel}
                                        DIR aquifer-num
-                                       TEST_ARGS --tolerance-cnv=0.00003 --time-step-control=pid --linsolver=cpr)
+                                       TEST_ARGS --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr)
 
   add_test_compare_parallel_simulation(CASENAME actionx_m1
                                        FILENAME ACTIONX_M1

--- a/opm/simulators/linalg/FlowLinearSolverParameters.hpp
+++ b/opm/simulators/linalg/FlowLinearSolverParameters.hpp
@@ -114,7 +114,7 @@ struct CprReuseInterval {
     using type = UndefinedProperty;
 };
 template<class TypeTag, class MyTypeTag>
-struct Linsolver {
+struct LinearSolver {
     using type = UndefinedProperty;
 };
 template<class TypeTag, class MyTypeTag>
@@ -216,7 +216,7 @@ struct CprReuseInterval<TypeTag, TTag::FlowIstlSolverParams> {
     static constexpr int value = 10;
 };
 template<class TypeTag>
-struct Linsolver<TypeTag, TTag::FlowIstlSolverParams> {
+struct LinearSolver<TypeTag, TTag::FlowIstlSolverParams> {
     static constexpr auto value = "ilu0";
 };
 template<class TypeTag>
@@ -292,7 +292,7 @@ namespace Opm
             cpr_max_ell_iter_  =  EWOMS_GET_PARAM(TypeTag, int, CprMaxEllIter);
             cpr_reuse_setup_  =  EWOMS_GET_PARAM(TypeTag, int, CprReuseSetup);
             cpr_reuse_interval_  =  EWOMS_GET_PARAM(TypeTag, int, CprReuseInterval);
-            linsolver_ = EWOMS_GET_PARAM(TypeTag, std::string, Linsolver);
+            linsolver_ = EWOMS_GET_PARAM(TypeTag, std::string, LinearSolver);
             accelerator_mode_ = EWOMS_GET_PARAM(TypeTag, std::string, AcceleratorMode);
             bda_device_id_ = EWOMS_GET_PARAM(TypeTag, int, BdaDeviceId);
             opencl_platform_id_ = EWOMS_GET_PARAM(TypeTag, int, OpenclPlatformId);
@@ -319,7 +319,7 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, int, CprMaxEllIter, "MaxIterations of the elliptic pressure part of the cpr solver");
             EWOMS_REGISTER_PARAM(TypeTag, int, CprReuseSetup, "Reuse preconditioner setup. Valid options are 0: recreate the preconditioner for every linear solve, 1: recreate once every timestep, 2: recreate if last linear solve took more than 10 iterations, 3: never recreate, 4: recreated every CprReuseInterval");
             EWOMS_REGISTER_PARAM(TypeTag, int, CprReuseInterval, "Reuse preconditioner interval. Used when CprReuseSetup is set to 4, then the preconditioner will be fully recreated instead of reused every N linear solve, where N is this parameter.");
-            EWOMS_REGISTER_PARAM(TypeTag, std::string, Linsolver, "Configuration of solver. Valid options are: ilu0 (default), cpr (an alias for cpr_trueimpes), cpr_quasiimpes, cpr_trueimpes or amg. Alternatively, you can request a configuration to be read from a JSON file by giving the filename here, ending with '.json.'");
+            EWOMS_REGISTER_PARAM(TypeTag, std::string, LinearSolver, "Configuration of solver. Valid options are: ilu0 (default), cpr (an alias for cpr_trueimpes), cpr_quasiimpes, cpr_trueimpes or amg. Alternatively, you can request a configuration to be read from a JSON file by giving the filename here, ending with '.json.'");
             EWOMS_REGISTER_PARAM(TypeTag, std::string, AcceleratorMode, "Use GPU (cusparseSolver or openclSolver) or FPGA (fpgaSolver) as the linear solver, usage: '--accelerator-mode=[none|cusparse|opencl|fpga|amgcl]'");
             EWOMS_REGISTER_PARAM(TypeTag, int, BdaDeviceId, "Choose device ID for cusparseSolver or openclSolver, use 'nvidia-smi' or 'clinfo' to determine valid IDs");
             EWOMS_REGISTER_PARAM(TypeTag, int, OpenclPlatformId, "Choose platform ID for openclSolver, use 'clinfo' to determine valid platform IDs");

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -262,7 +262,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                 const std::string opencl_ilu_reorder = EWOMS_GET_PARAM(TypeTag, std::string, OpenclIluReorder);
                 const int linear_solver_verbosity = parameters_.linear_solver_verbosity_;
                 std::string fpga_bitstream = EWOMS_GET_PARAM(TypeTag, std::string, FpgaBitstream);
-                std::string linsolver = EWOMS_GET_PARAM(TypeTag, std::string, Linsolver);
+                std::string linsolver = EWOMS_GET_PARAM(TypeTag, std::string, LinearSolver);
                 bdaBridge = std::make_unique<detail::BdaSolverInfo<Matrix,Vector>>(accelerator_mode,
                                                                                    fpga_bitstream,
                                                                                    linear_solver_verbosity,

--- a/opm/simulators/linalg/bda/BdaBridge.hpp
+++ b/opm/simulators/linalg/bda/BdaBridge.hpp
@@ -61,7 +61,7 @@ public:
     /// \param[in] platformID                 the OpenCL platform ID to be used
     /// \param[in] deviceID                   the device ID to be used by the cusparse- and openclSolvers, too high values could cause runtime errors
     /// \param[in] opencl_ilu_reorder         select either level_scheduling or graph_coloring, see ILUReorder.hpp for explanation
-    /// \param[in] linsolver                  copy of cmdline argument --linsolver
+    /// \param[in] linsolver                  copy of cmdline argument --linear-solver
     BdaBridge(std::string accelerator_mode, std::string fpga_bitstream, int linear_solver_verbosity, int maxit, double tolerance,
         unsigned int platformID, unsigned int deviceID, std::string opencl_ilu_reorder, std::string linsolver);
 

--- a/opm/simulators/linalg/bda/opencl/BISAI.cpp
+++ b/opm/simulators/linalg/bda/opencl/BISAI.cpp
@@ -46,7 +46,7 @@ BISAI<block_size>::BISAI(ILUReorder opencl_ilu_reorder_, int verbosity_) :
     Preconditioner<block_size>(verbosity_)
 {
 #if CHOW_PATEL
-    OPM_THROW(std::logic_error, "Error --linsolver=isai cannot be used if ChowPatelIlu is used, probably defined by CMake\n");
+    OPM_THROW(std::logic_error, "Error --linear-solver=isai cannot be used if ChowPatelIlu is used, probably defined by CMake\n");
 #endif
     bilu0 = std::make_unique<BILU0<block_size> >(opencl_ilu_reorder_, verbosity_);
 }

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
@@ -61,9 +61,9 @@ openclSolverBackend<block_size>::openclSolverBackend(int verbosity_, int maxit_,
         use_cpr = false;
         use_isai = true;
     } else if (linsolver.compare("cpr_trueimpes") == 0) {
-        OPM_THROW(std::logic_error, "Error openclSolver does not support --linsolver=cpr_trueimpes");
+        OPM_THROW(std::logic_error, "Error openclSolver does not support --linerar-solver=cpr_trueimpes");
     } else {
-        OPM_THROW(std::logic_error, "Error unknown value for argument --linsolver, " + linsolver);
+        OPM_THROW(std::logic_error, "Error unknown value for argument --linear-solver, " + linsolver);
     }
 
     using PreconditionerType = typename Preconditioner<block_size>::PreconditionerType;

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.hpp
@@ -176,7 +176,7 @@ public:
     /// \param[in] platformID                 the OpenCL platform to be used
     /// \param[in] deviceID                   the device to be used
     /// \param[in] opencl_ilu_reorder         select either level_scheduling or graph_coloring, see Reorder.hpp for explanation
-    /// \param[in] linsolver                  indicating the preconditioner, equal to the --linsolver cmdline argument
+    /// \param[in] linsolver                  indicating the preconditioner, equal to the --linear-solver cmdline argument
     ///                                       only ilu0, cpr_quasiimpes and isai are supported
     openclSolverBackend(int linear_solver_verbosity, int maxit, double tolerance, unsigned int platformID, unsigned int deviceID,
         ILUReorder opencl_ilu_reorder, std::string linsolver);

--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -79,11 +79,11 @@ setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters 
         return setupCPR(conf, p);
     }
 
-    if ((conf == "cprw")) {      
+    if ((conf == "cprw")) {
         if (!LinearSolverMaxIterSet) {
             // Use our own default unless it was explicitly overridden by user.
             p.linear_solver_maxiter_ = 20;
-        }      
+        }
         return setupCPRW(conf, p);
     }
 
@@ -96,9 +96,12 @@ setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters 
         return setupILU(conf, p);
     }
 
-    // Same configuration as ILU0.
+    // At this point, the only separate ISAI implementation is with the OpenCL code, and
+    // it will check this argument to see if it should be using ISAI. The parameter tree
+    // will be ignored, so this is just a dummy configuration to avoid the throw below.
+    // If we are using CPU dune-istl solvers, this will just make "isai" an alias of "ilu".
     if (conf == "isai") {
-        return setupISAI(conf, p);
+        return setupILU(conf, p);
     }
 
     // No valid configuration option found.
@@ -234,22 +237,6 @@ setupAMG([[maybe_unused]] const std::string& conf, const FlowLinearSolverParamet
 
 PropertyTree
 setupILU([[maybe_unused]] const std::string& conf, const FlowLinearSolverParameters& p)
-{
-    using namespace std::string_literals;
-    PropertyTree prm;
-    prm.put("tol", p.linear_solver_reduction_);
-    prm.put("maxiter", p.linear_solver_maxiter_);
-    prm.put("verbosity", p.linear_solver_verbosity_);
-    prm.put("solver", "bicgstab"s);
-    prm.put("preconditioner.type", "ParOverILU0"s);
-    prm.put("preconditioner.relaxation", p.ilu_relaxation_);
-    prm.put("preconditioner.ilulevel", p.ilu_fillin_level_);
-    return prm;
-}
-
-
-PropertyTree
-setupISAI([[maybe_unused]] const std::string& conf, const FlowLinearSolverParameters& p)
 {
     using namespace std::string_literals;
     PropertyTree prm;

--- a/opm/simulators/linalg/setupPropertyTree.hpp
+++ b/opm/simulators/linalg/setupPropertyTree.hpp
@@ -33,11 +33,10 @@ PropertyTree setupPropertyTree(FlowLinearSolverParameters p,
                                bool LinearSolverMaxIterSet,
                                bool CprMaxEllIterSet);
 
-PropertyTree setupCPRW(const std::string& conf, const FlowLinearSolverParameters& p);    
+PropertyTree setupCPRW(const std::string& conf, const FlowLinearSolverParameters& p);
 PropertyTree setupCPR(const std::string& conf, const FlowLinearSolverParameters& p);
 PropertyTree setupAMG(const std::string& conf, const FlowLinearSolverParameters& p);
 PropertyTree setupILU(const std::string& conf, const FlowLinearSolverParameters& p);
-PropertyTree setupISAI(const std::string& conf, const FlowLinearSolverParameters& p);
 
 } // namespace Opm
 


### PR DESCRIPTION
Has been requested by many, so here it is. Also changes references to the option in comments. Not changing variable or member names.

The second commit removes the misleading dummy ISAI configuration option, but the ability to say `--linear-solver=isai` is kept for the benefit of the OpenCL code (we need to thing about how we want to make these things better integrated and simpler for the user).