### PR TITLE
pass well state to output also for shut wells

### DIFF
--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -347,10 +347,6 @@ WellState::report(const int* globalCellIdxMap,
     data::Wells res;
     for( std::size_t well_index = 0; well_index < this->size(); well_index++) {
         const auto& ws = this->well(well_index);
-        if ((ws.status == Well::Status::SHUT) && !wasDynamicallyClosed(well_index))
-        {
-            continue;
-        }
 
         const auto& reservoir_rates = ws.reservoir_rates;
         const auto& well_potentials = ws.well_potentials;
@@ -657,6 +653,8 @@ void WellState::stopWell(int well_index)
 {
     auto& ws = this->well(well_index);
     ws.stop();
+    if(ws.producer)
+        setALQ(this->name(well_index), 0.0);
 }
 
 void WellState::openWell(int well_index)
@@ -669,6 +667,8 @@ void WellState::shutWell(int well_index)
 {
     auto& ws = this->well(well_index);
     ws.shut();
+    if(ws.producer)
+        setALQ(this->name(well_index), 0.0);
 }
 
 void WellState::updateStatus(int well_index, Well::Status status)


### PR DESCRIPTION
I think this is a better approach since it would not hide non-zero values in the wellState. 