### PR TITLE
for the cells having zero thickness we use the cell center depth to do the equilibration

### DIFF
--- a/ebos/equil/initstateequil.cc
+++ b/ebos/equil/initstateequil.cc
@@ -1864,8 +1864,18 @@ equilibrateHorizontal(const CellRange&  cells,
             totfrac += frac;
         }
 
-        saturations /= totfrac;
-        pressures   /= totfrac;
+        if (totfrac > 0.) {
+            saturations /= totfrac;
+            pressures /= totfrac;
+        } else {
+            // Fall back to centre point method for zero-thickness cells.
+            const auto pos = CellPos {
+                    cell, cellCenterDepth_[cell]
+            };
+
+            saturations = psat.deriveSaturations(pos, eqreg, ptable);
+            pressures   = psat.correctedPhasePressures();
+        }
 
         const auto temp = this->temperature_[cell];
         const auto cz   = cellCenterDepth_[cell];


### PR DESCRIPTION

In the targeting case, those cells happen to be numerical aquifer cells. 


The approach was along the direction suggested by @bska 