### PR TITLE
Use CMake's find_file to find install.py

### DIFF
--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -56,22 +56,20 @@ if(OPM_ENABLE_PYTHON_TESTS)
       -m unittest test/test_schedule.py)
 endif()
 
-set(_opm_common_python_script_dir "${opm-common_DIR}/python")
-if (NOT EXISTS "${_opm_common_python_script_dir}/install.py" )
-  # if the install.py script does not exist, assume that we are building against an installed opm-common
-  set(_opm_common_python_script_dir "${opm-common_PYTHON_COMMON_DIR}")
-endif()
+find_file(PYTHON_INSTALL_PY install.py
+  PATHS ${opm-common_DIR} ${opm-common_PYTHON_COMMON_DIR}
+  PATH_SUFFIXES python NO_DEFAULT_PATH REQUIRED)
 
 # NOTE: instead of using file( COPY ...) which copies the files at configure time (not at build time)
 #  we should add copying of the files at build time such that running "make" or "make all" will
 #  update the files if they have been modified. We use the install.py script in opm-common, see also
 #  CMakeLists.txt in opm-common
 add_custom_target(copy_python ALL
-    COMMAND ${PYTHON_EXECUTABLE} "${_opm_common_python_script_dir}/install.py"
+    COMMAND ${PYTHON_EXECUTABLE} "${PYTHON_INSTALL_PY}"
         ${PROJECT_SOURCE_DIR}/python/opm ${PROJECT_BINARY_DIR}/python 0
-    COMMAND ${PYTHON_EXECUTABLE} "${_opm_common_python_script_dir}/install.py"
+    COMMAND ${PYTHON_EXECUTABLE} "${PYTHON_INSTALL_PY}"
         ${PROJECT_SOURCE_DIR}/python/test ${PROJECT_BINARY_DIR}/python 0
-    COMMAND ${PYTHON_EXECUTABLE} "${_opm_common_python_script_dir}/install.py"
+    COMMAND ${PYTHON_EXECUTABLE} "${PYTHON_INSTALL_PY}"
         ${PROJECT_SOURCE_DIR}/python/test_data ${PROJECT_BINARY_DIR}/python 0
 )
 
@@ -85,7 +83,7 @@ if (OPM_INSTALL_PYTHON)
   install(
     CODE "execute_process(
       COMMAND ${PYTHON_EXECUTABLE}
-              ${_opm_common_python_script_dir}/install.py
+              ${PYTHON_INSTALL_PY}
               ${PROJECT_BINARY_DIR}/python/opm
               ${DEST_PREFIX}${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_PREFIX} 1)")
 endif()


### PR DESCRIPTION
This seems to be a more stable approach as it does not produce
```
/usr/bin/python3.9: can't open file
'/home/mblatt/src/dune/opm-2.9/opm-common//install.py': [Errno 2] No such file or directory
```
for rebuilds after failed attempts.

Closes #4138 