### PR TITLE
only output final change of well control

### DIFF
--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -435,19 +435,19 @@ void WellInterfaceGeneric::reportWellSwitching(const SingleWellState& ws, Deferr
     if (well_control_log_.empty())
         return;
 
-    std::string msg = "    Well " + name()
-        + " control mode changed from ";
-    for (const std::string& from : well_control_log_) {
-        msg += from + "->";
-    }
+    std::string from = well_control_log_[0];
     std::string to;
     if (isInjector()) {
         to = Well::InjectorCMode2String(ws.injection_cmode);
     } else {
         to = Well::ProducerCMode2String(ws.production_cmode);
     }
-    msg += to;
-    deferred_logger.info(msg);
+    // only report the final switching
+    if (from != to) {
+        std::string msg = "    Well " + name()
+        + " control mode changed from " + from + " to " + to;
+        deferred_logger.info(msg);
+    }
 }
 
 std::optional<double>


### PR DESCRIPTION
Note that the full switching history (i.e. pr iteration) is still reported to the debug file. 

The change was suggested by @OPMUSER  