### PR TITLE
Refactor property updating in EclProblem

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2087,12 +2087,8 @@ private:
     {
         ElementContext elemCtx(this->simulator());
         const auto& vanguard = this->simulator().vanguard();
-        auto elemIt = vanguard.gridView().template begin</*codim=*/0>();
-        const auto& elemEndIt = vanguard.gridView().template end</*codim=*/0>();
         OPM_BEGIN_PARALLEL_TRY_CATCH();
-        for (; elemIt != elemEndIt; ++elemIt) {
-            const Element& elem = *elemIt;
-
+        for (const auto& elem : elements(vanguard.gridView())) {
             elemCtx.updatePrimaryStencil(elem);
             elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2234,26 +2234,14 @@ private:
             return false;
 
         this->maxWaterSaturation_[/*timeIdx=*/1] = this->maxWaterSaturation_[/*timeIdx=*/0];
-        ElementContext elemCtx(this->simulator());
-        const auto& vanguard = this->simulator().vanguard();
-        auto elemIt = vanguard.gridView().template begin</*codim=*/0>();
-        const auto& elemEndIt = vanguard.gridView().template end</*codim=*/0>();
-        OPM_BEGIN_PARALLEL_TRY_CATCH();
-        for (; elemIt != elemEndIt; ++elemIt) {
-            const Element& elem = *elemIt;
-
-            elemCtx.updatePrimaryStencil(elem);
-            elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
-
-            unsigned compressedDofIdx = elemCtx.globalSpaceIndex(/*spaceIdx=*/0, /*timeIdx=*/0);
-            const auto& iq = elemCtx.intensiveQuantities(/*spaceIdx=*/0, /*timeIdx=*/0);
-            const auto& fs = iq.fluidState();
-
-            Scalar Sw = decay<Scalar>(fs.saturation(waterPhaseIdx));
-            this->maxWaterSaturation_[compressedDofIdx] = std::max(this->maxWaterSaturation_[compressedDofIdx], Sw);
-        }
-        OPM_END_PARALLEL_TRY_CATCH("EclProblem::updateMayWaterSaturation() failed: ", vanguard.grid().comm());
-
+        this->updateProperty_("EclProblem::updateMaxWaterSaturation_() failed:",
+                              [this](unsigned compressedDofIdx, const IntensiveQuantities& iq)
+                              {
+                                  const auto& fs = iq.fluidState();
+                                  const Scalar Sw = decay<Scalar>(fs.saturation(waterPhaseIdx));
+                                  auto& mow = this->maxWaterSaturation_;
+                                  mow[compressedDofIdx] = std::max(mow[compressedDofIdx], Sw);
+                               });
         return true;
     }
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2251,26 +2251,14 @@ private:
         if (this->minOilPressure_.empty())
             return false;
 
-        OPM_BEGIN_PARALLEL_TRY_CATCH();
-        ElementContext elemCtx(this->simulator());
-        const auto& vanguard = this->simulator().vanguard();
-        auto elemIt = vanguard.gridView().template begin</*codim=*/0>();
-        const auto& elemEndIt = vanguard.gridView().template end</*codim=*/0>();
-        for (; elemIt != elemEndIt; ++elemIt) {
-            const Element& elem = *elemIt;
-
-            elemCtx.updatePrimaryStencil(elem);
-            elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
-
-            unsigned compressedDofIdx = elemCtx.globalSpaceIndex(/*spaceIdx=*/0, /*timeIdx=*/0);
-            const auto& iq = elemCtx.intensiveQuantities(/*spaceIdx=*/0, /*timeIdx=*/0);
-            const auto& fs = iq.fluidState();
-
-            this->minOilPressure_[compressedDofIdx] =
-                std::min(this->minOilPressure_[compressedDofIdx],
-                         getValue(fs.pressure(oilPhaseIdx)));
-        }
-        OPM_END_PARALLEL_TRY_CATCH("EclProblem::updateMinPressure_() failed: ", this->simulator().vanguard().grid().comm());
+        this->updateProperty_("EclProblem::updateMinPressure_() failed:",
+                              [this](unsigned compressedDofIdx, const IntensiveQuantities& iq)
+                              {
+                                const auto& fs = iq.fluidState();
+                                const Scalar mo = getValue(fs.pressure(oilPhaseIdx));
+                                auto& mos = this->minOilPressure_;
+                                mos[compressedDofIdx] = std::min(mos[compressedDofIdx], mo);
+                              });
         return true;
     }
 


### PR DESCRIPTION
introduce a common function for looping over grid cells and updating something based on compressedDofIdx and the intensive quantities. do this by passing a std::function (ie lambdas).

update various functions having this structure to use the new common function. this to reduce code duplication. while at it const some more variables and reduce some long statements.