### PR TITLE
Optimize EclTracerModel::updateStorageCache

### DIFF
--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -51,8 +51,6 @@ namespace Opm {
  * \ingroup EclBlackOilSimulator
  *
  * \brief A class which handles tracers as specified in by ECL
- *
- * TODO: MPI parallelism.
  */
 template <class TypeTag>
 class EclTracerModel : public EclGenericTracerModel<GetPropType<TypeTag, Properties::Grid>,
@@ -94,9 +92,10 @@ public:
                    simulator.model().dofMapper(),
                    simulator.vanguard().cellCentroids())
         , simulator_(simulator)
-        , wat_(TracerBatch<TracerVector>(waterPhaseIdx))
-        , oil_(TracerBatch<TracerVector>(oilPhaseIdx))
-        , gas_(TracerBatch<TracerVector>(gasPhaseIdx))
+        , tbatch({waterPhaseIdx, oilPhaseIdx, gasPhaseIdx})
+        , wat_(tbatch[0])
+        , oil_(tbatch[1])
+        , gas_(tbatch[2])
     { }
 
 
@@ -478,11 +477,11 @@ protected:
     Simulator& simulator_;
 
     // This struct collects tracers of the same type (i.e, transported in same phase).
-    // The idea beeing that, under the assumption of linearity, tracers of same type can
+    // The idea being that, under the assumption of linearity, tracers of same type can
     // be solved in concert, having a common system matrix but separate right-hand-sides.
 
     // Since oil or gas tracers appears in dual compositions when VAPOIL respectively DISGAS
-    // is active, the template argument is intended to support future extension to these 
+    // is active, the template argument is intended to support future extension to these
     // scenarios by supplying an extended vector type.
 
     template <typename TV>
@@ -509,9 +508,10 @@ protected:
       }
     };
 
-    TracerBatch<TracerVector> wat_;
-    TracerBatch<TracerVector> oil_;
-    TracerBatch<TracerVector> gas_;
+    std::array<TracerBatch<TracerVector>,3> tbatch;
+    TracerBatch<TracerVector>& wat_;
+    TracerBatch<TracerVector>& oil_;
+    TracerBatch<TracerVector>& gas_;
 };
 
 } // namespace Opm

--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -397,7 +397,8 @@ protected:
         auto elemIt = simulator_.gridView().template begin</*codim=*/0>();
         auto elemEndIt = simulator_.gridView().template end</*codim=*/0>();
         for (; elemIt != elemEndIt; ++ elemIt) {
-            elemCtx.updateAll(*elemIt);
+            elemCtx.updatePrimaryStencil(*elemIt);
+            elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
             int globalDofIdx = elemCtx.globalSpaceIndex(0, /*timIdx=*/0);
             Scalar fVolume;
             computeVolume_(fVolume, tr.phaseIdx_, elemCtx, 0, /*timIdx=*/0);

--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -394,15 +394,13 @@ protected:
         tr.concentrationInitial_ = tr.concentration_;
 
         ElementContext elemCtx(simulator_);
-        auto elemIt = simulator_.gridView().template begin</*codim=*/0>();
-        auto elemEndIt = simulator_.gridView().template end</*codim=*/0>();
-        for (; elemIt != elemEndIt; ++ elemIt) {
-            elemCtx.updatePrimaryStencil(*elemIt);
+        for (const auto& elem : elements(simulator_.gridView())) {
+            elemCtx.updatePrimaryStencil(elem);
             elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
-            int globalDofIdx = elemCtx.globalSpaceIndex(0, /*timIdx=*/0);
+            int globalDofIdx = elemCtx.globalSpaceIndex(0, /*timeIdx=*/0);
             Scalar fVolume;
-            computeVolume_(fVolume, tr.phaseIdx_, elemCtx, 0, /*timIdx=*/0);
-            for (int tIdx =0; tIdx < tr.numTracer(); ++tIdx) {
+            computeVolume_(fVolume, tr.phaseIdx_, elemCtx, 0, /*timeIdx=*/0);
+            for (int tIdx = 0; tIdx < tr.numTracer(); ++tIdx) {
                 tr.storageOfTimeIndex1_[tIdx][globalDofIdx] = fVolume*tr.concentrationInitial_[tIdx][globalDofIdx];
             }
         }


### PR DESCRIPTION
As far as I can tell, there is no reason to update the whole element context here.

This yields a 10% reduction in the pre/post step for Norne on my machine.