### PR TITLE
Fix compilation with amgcl/vexcl and without CUDA/OpenCL.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -253,10 +253,8 @@ namespace Opm {
             // subtract B*inv(D)*C * x from A*x
             void apply(const BVector& x, BVector& Ax) const;
 
-#if HAVE_CUDA || HAVE_OPENCL
             // accumulate the contributions of all Wells in the WellContributions object
             void getWellContributions(WellContributions& x) const;
-#endif
 
             // apply well model with scaling of alpha
             void applyScaleAdd(const Scalar alpha, const BVector& x, BVector& Ax) const;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -27,6 +27,8 @@
 
 #include <opm/simulators/wells/VFPProperties.hpp>
 #include <opm/simulators/utils/MPIPacker.hpp>
+#include <opm/simulators/linalg/bda/WellContributions.hpp>
+
 #if HAVE_MPI
 #include <ebos/eclmpiserializer.hh>
 #endif
@@ -1191,7 +1193,6 @@ namespace Opm {
         }
     }
 
-#if HAVE_CUDA || HAVE_OPENCL
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::
@@ -1229,7 +1230,6 @@ namespace Opm {
             }
         }
     }
-#endif
 
     // Ax = Ax - alpha * C D^-1 B x
     template<typename TypeTag>

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -1815,7 +1815,6 @@ updateUpwindingSegments()
     }
 }
 
-#if HAVE_CUDA || HAVE_OPENCL
 template<typename FluidSystem, typename Indices, typename Scalar>
 void
 MultisegmentWellEval<FluidSystem,Indices,Scalar>::
@@ -1883,7 +1882,6 @@ addWellContribution(WellContributions& wellContribs) const
                                                  Drows,
                                                  Cvals);
 }
-#endif
 
 #define INSTANCE(A,...) \
 template class MultisegmentWellEval<BlackOilFluidSystem<double,A>,__VA_ARGS__,double>;

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -54,10 +54,8 @@ template<typename FluidSystem, typename Indices, typename Scalar>
 class MultisegmentWellEval : public MultisegmentWellGeneric<Scalar>
 {
 public:
-#if HAVE_CUDA || HAVE_OPENCL
         /// add the contribution (C, D, B matrices) of this Well to the WellContributions object
         void addWellContribution(WellContributions& wellContribs) const;
-#endif
 
 protected:
     // TODO: for now, not considering the polymer, solvent and so on to simplify the development process.

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -34,13 +34,11 @@
 #include <opm/simulators/wells/ParallelWellInfo.hpp>
 #include <opm/simulators/wells/WellInterfaceIndices.hpp>
 #include <opm/simulators/wells/WellState.hpp>
+#include <opm/simulators/linalg/bda/WellContributions.hpp>
 
 #include <cassert>
 #include <cmath>
 
-#if HAVE_CUDA || HAVE_OPENCL
-#include <opm/simulators/linalg/bda/WellContributions.hpp>
-#endif
 
 
 namespace Opm
@@ -1109,7 +1107,6 @@ init(std::vector<double>& perf_depth,
     }
 }
 
-#if HAVE_CUDA || HAVE_OPENCL
 template<class FluidSystem, class Indices, class Scalar>
 void
 StandardWellEval<FluidSystem,Indices,Scalar>::
@@ -1158,7 +1155,6 @@ addWellContribution(WellContributions& wellContribs) const
     }
     wellContribs.addMatrix(WellContributions::MatrixType::B, colIndices.data(), nnzValues.data(), this->duneB_.nonzeroes());
 }
-#endif
 
 #define INSTANCE(A,...) \
 template class StandardWellEval<BlackOilFluidSystem<double,A>,__VA_ARGS__,double>;

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -96,10 +96,8 @@ public:
     using Eval = DenseAd::Evaluation<Scalar, Indices::numEq>;
     using BVectorWell = typename StandardWellGeneric<Scalar>::BVectorWell;
 
-#if HAVE_CUDA || HAVE_OPENCL
         /// add the contribution (C, D^-1, B matrices) of this Well to the WellContributions object
         void addWellContribution(WellContributions& wellContribs) const;
-#endif
 
 protected:
     StandardWellEval(const WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif);

--- a/opm/simulators/wells/StandardWellGeneric.cpp
+++ b/opm/simulators/wells/StandardWellGeneric.cpp
@@ -518,7 +518,6 @@ checkConvergencePolyMW(const std::vector<double>& res,
 }
 
 
-#if HAVE_CUDA || HAVE_OPENCL
 template<class Scalar>
 void
 StandardWellGeneric<Scalar>::
@@ -526,7 +525,6 @@ getNumBlocks(unsigned int& numBlocks) const
 {
     numBlocks = duneB_.nonzeroes();
 }
-#endif
 
 template class StandardWellGeneric<double>;
 

--- a/opm/simulators/wells/StandardWellGeneric.hpp
+++ b/opm/simulators/wells/StandardWellGeneric.hpp
@@ -65,10 +65,8 @@ protected:
     using OffDiagMatWell = Dune::BCRSMatrix<OffDiagMatrixBlockWellType>;
 
 public:
-#if HAVE_CUDA || HAVE_OPENCL
     /// get the number of blocks of the C and B matrices, used to allocate memory in a WellContributions object
     void getNumBlocks(unsigned int& _nnzs) const;
-#endif
 
 protected:
     StandardWellGeneric(int Bhp,


### PR DESCRIPTION
There is no reason to omit WellContributions if neither CUDA nor OpenCL is found as the implementations/functions only use C++- To the contrary, the defines used for deactivating were not consistent with usage elsewhere and resulted in compiler erorrs for exotic configuration