### PR TITLE
Move include of config.h to cpp-file

### DIFF
--- a/ebos/eclinterregflows.cc
+++ b/ebos/eclinterregflows.cc
@@ -19,6 +19,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <ebos/eclinterregflows.hh>
 
 #include <algorithm>

--- a/opm/core/props/BlackoilPhases.cpp
+++ b/opm/core/props/BlackoilPhases.cpp
@@ -16,6 +16,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <algorithm>
 #include <vector>
 

--- a/opm/core/props/phaseUsageFromDeck.cpp
+++ b/opm/core/props/phaseUsageFromDeck.cpp
@@ -18,6 +18,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <opm/core/props/phaseUsageFromDeck.hpp>
 
 #include <opm/common/ErrorMacros.hpp>

--- a/opm/core/props/satfunc/RelpermDiagnostics.cpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <opm/core/props/satfunc/RelpermDiagnostics.hpp>
 #include <opm/core/props/phaseUsageFromDeck.hpp>
 

--- a/opm/core/props/satfunc/RelpermDiagnostics.hpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.hpp
@@ -23,10 +23,6 @@
 #include <vector>
 #include <utility>
 
-#if HAVE_CONFIG_H
-#include "config.h"
-#endif // HAVE_CONFIG_H
-
 #include <opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp>
 
 namespace Opm {

--- a/opm/simulators/flow/KeywordValidation.cpp
+++ b/opm/simulators/flow/KeywordValidation.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <map>
 #include <string>
 #include <type_traits>

--- a/opm/simulators/flow/ValidationFunctions.cpp
+++ b/opm/simulators/flow/ValidationFunctions.cpp
@@ -17,6 +17,9 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/simulators/flow/KeywordValidation.hpp>

--- a/opm/simulators/linalg/bda/FPGAUtils.cpp
+++ b/opm/simulators/linalg/bda/FPGAUtils.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <sys/time.h>
 #include <fstream>
 

--- a/opm/simulators/linalg/bda/Reorder.cpp
+++ b/opm/simulators/linalg/bda/Reorder.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <opm/simulators/linalg/bda/Reorder.hpp>
 
 #include <opm/simulators/linalg/bda/BlockedMatrix.hpp>

--- a/opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
+++ b/opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <cassert>
 #include <iostream>
 #include <vector>

--- a/opm/simulators/utils/ParallelFileMerger.cpp
+++ b/opm/simulators/utils/ParallelFileMerger.cpp
@@ -18,6 +18,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <opm/simulators/utils/ParallelFileMerger.hpp>
 #include <iostream>
 

--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <opm/simulators/utils/PartiallySupportedFlowKeywords.hpp>
 
 using namespace Opm::KeywordValidation;

--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <opm/simulators/utils/UnsupportedFlowKeywords.hpp>
 
 namespace Opm::FlowKeywordValidation

--- a/opm/simulators/utils/moduleVersion.cpp
+++ b/opm/simulators/utils/moduleVersion.cpp
@@ -17,6 +17,11 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
+
 #include <opm/simulators/utils/moduleVersion.hpp>
 #include "project-timestamp.h"
 #include "project-version.h"

--- a/opm/simulators/wells/ALQState.cpp
+++ b/opm/simulators/wells/ALQState.cpp
@@ -16,6 +16,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <cstddef>
 #include <stdexcept>
 

--- a/opm/simulators/wells/GlobalWellInfo.cpp
+++ b/opm/simulators/wells/GlobalWellInfo.cpp
@@ -16,6 +16,11 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <stdexcept>
 
 #include <opm/simulators/wells/GlobalWellInfo.hpp>

--- a/opm/simulators/wells/GroupState.cpp
+++ b/opm/simulators/wells/GroupState.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <iterator>
 
 #include <opm/json/JsonObject.hpp>

--- a/opm/simulators/wells/PerfData.cpp
+++ b/opm/simulators/wells/PerfData.cpp
@@ -18,6 +18,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <opm/simulators/wells/PerfData.hpp>
 
 namespace Opm

--- a/opm/simulators/wells/SegmentState.cpp
+++ b/opm/simulators/wells/SegmentState.cpp
@@ -16,6 +16,10 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <algorithm>
 #include <stdexcept>
 

--- a/opm/simulators/wells/WGState.cpp
+++ b/opm/simulators/wells/WGState.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <opm/core/props/BlackoilPhases.hpp>
 #include <opm/simulators/wells/WGState.hpp>
 

--- a/opm/simulators/wells/WellProdIndexCalculator.cpp
+++ b/opm/simulators/wells/WellProdIndexCalculator.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <opm/simulators/wells/WellProdIndexCalculator.hpp>
 
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>

--- a/tests/test_ALQState.cpp
+++ b/tests/test_ALQState.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <stdexcept>
 #include <opm/simulators/wells/ALQState.hpp>
 

--- a/tests/test_GroupState.cpp
+++ b/tests/test_GroupState.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <stdexcept>
 
 #include <opm/simulators/wells/GroupState.hpp>

--- a/tests/test_keyword_validator.cpp
+++ b/tests/test_keyword_validator.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <string>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>

--- a/tests/test_thresholdpressure.cpp
+++ b/tests/test_thresholdpressure.cpp
@@ -1,3 +1,7 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif // HAVE_CONFIG_H
+
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>


### PR DESCRIPTION
One should never include config.h in a header. To the very least it results in redefined macros.

Let's hope we don't rely on this elsewhere (have not tried compilation :grimacing: )