### PR TITLE
removing the usage of GTotal in the well code

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -71,7 +71,7 @@ namespace Opm
         using typename MSWEval::OffDiagMatrixBlockWellType;
         using MSWEval::GFrac;
         using MSWEval::WFrac;
-        using MSWEval::GTotal;
+        using MSWEval::WQTotal;
         using MSWEval::SPres;
         using MSWEval::numWellEq;
         using typename Base::PressureMatrix;

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -68,7 +68,7 @@ protected:
     // Table showing the primary variable indices, depending on what phases are present:
     //
     //         WOG     OG     WG     WO    W/O/G (single phase)
-    // GTotal    0      0      0      0                       0
+    // WQTotal   0      0      0      0                       0
     // WFrac     1  -1000      1      1                   -1000
     // GFrac     2      1  -1000  -1000                   -1000
     // Spres     3      2      2      2                       1
@@ -83,7 +83,7 @@ protected:
     static constexpr bool has_wfrac_variable = has_water && Indices::numPhases > 1;
     static constexpr bool has_gfrac_variable = has_gas && has_oil;
 
-    static constexpr int GTotal = 0;
+    static constexpr int WQTotal = 0;
     static constexpr int WFrac = has_wfrac_variable ? 1 : -1000;
     static constexpr int GFrac = has_gfrac_variable ? has_wfrac_variable + 1 : -1000;
     static constexpr int SPres = has_wfrac_variable + has_gfrac_variable + 1;
@@ -190,7 +190,7 @@ protected:
     EvalWell getFrictionPressureLoss(const int seg) const;
     EvalWell getHydroPressureLoss(const int seg) const;
     EvalWell getQs(const int comp_idx) const;
-    EvalWell getSegmentGTotal(const int seg) const;
+    EvalWell getSegmentWQTotal(const int seg) const;
     EvalWell getSegmentPressure(const int seg) const;
     EvalWell getSegmentRate(const int seg, const int comp_idx) const;
     EvalWell getSegmentRateUpwinding(const int seg,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1655,10 +1655,10 @@ namespace Opm
                     const EvalWell segment_rate = this->getSegmentRateUpwinding(seg, comp_idx) * this->well_efficiency_factor_;
 
                     const int seg_upwind = this->upwinding_segments_[seg];
-                    // segment_rate contains the derivatives with respect to GTotal in seg,
+                    // segment_rate contains the derivatives with respect to WQTotal in seg,
                     // and WFrac and GFrac in seg_upwind
                     this->resWell_[seg][comp_idx] -= segment_rate.value();
-                    this->duneD_[seg][seg][comp_idx][GTotal] -= segment_rate.derivative(GTotal + Indices::numEq);
+                    this->duneD_[seg][seg][comp_idx][WQTotal] -= segment_rate.derivative(WQTotal + Indices::numEq);
                     if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
                         this->duneD_[seg][seg_upwind][comp_idx][WFrac] -= segment_rate.derivative(WFrac + Indices::numEq);
                     }
@@ -1676,10 +1676,10 @@ namespace Opm
                         const EvalWell inlet_rate = this->getSegmentRateUpwinding(inlet, comp_idx) * this->well_efficiency_factor_;
 
                         const int inlet_upwind = this->upwinding_segments_[inlet];
-                        // inlet_rate contains the derivatives with respect to GTotal in inlet,
+                        // inlet_rate contains the derivatives with respect to WQTotal in inlet,
                         // and WFrac and GFrac in inlet_upwind
                         this->resWell_[seg][comp_idx] += inlet_rate.value();
-                        this->duneD_[seg][inlet][comp_idx][GTotal] += inlet_rate.derivative(GTotal + Indices::numEq);
+                        this->duneD_[seg][inlet][comp_idx][WQTotal] += inlet_rate.derivative(WQTotal + Indices::numEq);
                         if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
                             this->duneD_[seg][inlet_upwind][comp_idx][WFrac] += inlet_rate.derivative(WFrac + Indices::numEq);
                         }

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -71,7 +71,7 @@ protected:
     // Table showing the primary variable indices, depending on what phases are present:
     //
     //         WOG     OG     WG     WO    W/O/G (single phase)
-    // GTotal    0      0      0      0                       0
+    // WQTotal   0      0      0      0                       0
     // WFrac     1  -1000     -1000   1                   -1000
     // GFrac     2      1      1  -1000                   -1000
     // Spres     3      2      2      2                       1


### PR DESCRIPTION
It was a mistake from the very beginning and partly replaced by WQTotal. 

This PR aiming at removing the usage of GTotal at all and replacing it with WQTotal.  WQTotal is a more proper name. 