### PR TITLE
Add Serialization Support for std::bitset<3>

### DIFF
--- a/opm/simulators/utils/MPIPacker.cpp
+++ b/opm/simulators/utils/MPIPacker.cpp
@@ -127,6 +127,7 @@ unpack(time_point& data,
     data = TimeService::from_time_t(res);
 }
 
+template struct Packing<false,std::bitset<3>>;
 template struct Packing<false,std::bitset<4>>;
 template struct Packing<false,std::bitset<10>>;
 


### PR DESCRIPTION
Needed in upcoming work for communicating dynamic phase quantities per segment in a multisegmented well.