### PR TITLE
Convey More Dynamic State Values per Segment to Output Layer

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -35,6 +35,8 @@
 
 #include <array>
 #include <memory>
+#include <utility>
+#include <vector>
 
 namespace Dune {
 template<class Matrix> class UMFPack;

--- a/opm/simulators/wells/RateConverter.hpp
+++ b/opm/simulators/wells/RateConverter.hpp
@@ -422,18 +422,16 @@ namespace Opm {
              * \param[out] voidage_rates Reservoir volume flow rates for all
              *    active phases.
              */
-            template <class Rates>
-            void calcReservoirVoidageRates(const int    pvtRegionIdx,
-                                           const double p,
-                                           const double rs,
-                                           const double rv,
-                                           const double T,
-                                           const double saltConcentration,
-                                           const Rates& surface_rates,
-                                           Rates&       voidage_rates) const
+            template <typename SurfaceRates, typename VoidageRates>
+            void calcReservoirVoidageRates(const int           pvtRegionIdx,
+                                           const double        p,
+                                           const double        rs,
+                                           const double        rv,
+                                           const double        T,
+                                           const double        saltConcentration,
+                                           const SurfaceRates& surface_rates,
+                                           VoidageRates&       voidage_rates) const
             {
-                std::fill(voidage_rates.begin(), voidage_rates.end(), 0.0);
-
                 const auto& pu = this->phaseUsage_;
                 const auto  iw = RegionAttributeHelpers::PhasePos::water(pu);
                 const auto  io = RegionAttributeHelpers::PhasePos::oil  (pu);
@@ -441,6 +439,8 @@ namespace Opm {
 
                 const auto [Rs, Rv] = this->
                     dissolvedVaporisedRatio(io, ig, rs, rv, surface_rates);
+
+                std::fill_n(&voidage_rates[0], pu.num_phases, 0.0);
 
                 if (RegionAttributeHelpers::PhaseUsed::water(pu)) {
                     // q[w]_r = q[w]_s / bw

--- a/opm/simulators/wells/RateConverter.hpp
+++ b/opm/simulators/wells/RateConverter.hpp
@@ -482,6 +482,17 @@ namespace Opm {
                 }
             }
 
+            template <class Rates>
+            std::pair<double, double>
+            inferDissolvedVaporisedRatio(const double rsMax,
+                                         const double rvMax,
+                                         const Rates& surface_rates) const
+            {
+                const auto io = RegionAttributeHelpers::PhasePos::oil(this->phaseUsage_);
+                const auto ig = RegionAttributeHelpers::PhasePos::gas(this->phaseUsage_);
+                return this->dissolvedVaporisedRatio(io, ig, rsMax, rvMax, surface_rates);
+            }
+
             /**
              * Compute coefficients for surface-to-reservoir voidage
              * conversion for solvent.

--- a/opm/simulators/wells/SegmentState.hpp
+++ b/opm/simulators/wells/SegmentState.hpp
@@ -20,35 +20,53 @@
 #ifndef OPM_SEGMENTSTATE_HEADER_INCLUDED
 #define OPM_SEGMENTSTATE_HEADER_INCLUDED
 
+#include <cstddef>
 #include <vector>
 
 namespace Opm
 {
-
 class WellSegments;
-class WellConnections;
+} // namespace Opm
 
+namespace Opm
+{
 
 class SegmentState
 {
 public:
     SegmentState() = default;
     SegmentState(int num_phases, const WellSegments& segments);
+
     double pressure_drop(std::size_t index) const;
     bool empty() const;
     void scale_pressure(double bhp);
+
     const std::vector<int>& segment_number() const;
     std::size_t size() const;
 
     std::vector<double> rates;
+
+    /// Segment condition volume flow rates through segment (per phase)
+    std::vector<double> phase_resv_rates;
+
+    /// Segment condition flow velocity through segment (per phase)
+    std::vector<double> phase_velocity;
+
+    /// Segment condition holdup fractions through segment (per phase)
+    std::vector<double> phase_holdup;
+
+    /// Segment condition phase viscosities.
+    std::vector<double> phase_viscosity;
+
     std::vector<double> pressure;
     std::vector<double> pressure_drop_friction;
     std::vector<double> pressure_drop_hydrostatic;
     std::vector<double> pressure_drop_accel;
+
 private:
     std::vector<int>    m_segment_number;
 };
 
-}
+} // namepace Opm
 
-#endif
+#endif  // OPM_SEGMENTSTATE_HEADER_INCLUDED

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -18,15 +18,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <fmt/format.h>
 #include <config.h>
+
 #include <opm/simulators/wells/WellState.hpp>
 
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/simulators/wells/ParallelWellInfo.hpp>
 
 #include <opm/simulators/utils/ParallelCommunication.hpp>
+#include <opm/simulators/wells/ParallelWellInfo.hpp>
 #include <opm/grid/common/p2pcommunicator.hh>
 #include <opm/output/data/Wells.hpp>
 
@@ -35,6 +35,9 @@
 #include <numeric>
 #include <set>
 #include <stdexcept>
+#include <vector>
+
+#include <fmt/format.h>
 
 namespace {
 
@@ -425,14 +428,15 @@ data::Wells
 WellState::report(const int* globalCellIdxMap,
                   const std::function<bool(const int)>& wasDynamicallyClosed) const
 {
-    if (this->numWells() == 0)
+    if (this->numWells() == 0) {
         return {};
+    }
 
     using rt = data::Rates::opt;
     const auto& pu = this->phaseUsage();
 
     data::Wells res;
-    for( std::size_t well_index = 0; well_index < this->size(); well_index++) {
+    for (std::size_t well_index = 0; well_index < this->size(); ++well_index) {
         const auto& ws = this->well(well_index);
         if ((ws.status == Well::Status::SHUT) && !wasDynamicallyClosed(well_index))
         {
@@ -505,12 +509,10 @@ WellState::report(const int* globalCellIdxMap,
         }
 
         const auto& pwinfo = ws.parallel_info.get();
-        if (pwinfo.communication().size()==1)
-        {
+        if (pwinfo.communication().size() == 1) {
             reportConnections(well.connections, pu, well_index, globalCellIdxMap);
         }
-        else
-        {
+        else {
             std::vector<data::Connection> connections;
 
             reportConnections(connections, pu, well_index, globalCellIdxMap);
@@ -828,17 +830,21 @@ void WellState::updateGlobalIsGrup(const Comm& comm)
 }
 
 data::Segment
-WellState::reportSegmentResults(const int         well_id,
-                                const int         seg_ix,
-                                const int         seg_no) const
+WellState::reportSegmentResults(const int well_id,
+                                const int seg_ix,
+                                const int seg_no) const
 {
+    using PhaseQuant = data::SegmentPhaseQuantity::Item;
+
     const auto& segments = this->well(well_id).segments;
-    if (segments.empty())
+    if (segments.empty()) {
         return {};
+    }
 
     auto seg_res = data::Segment{};
     {
         using Value = data::SegmentPressures::Value;
+
         auto& segpress = seg_res.pressures;
         segpress[Value::Pressure] = segments.pressure[seg_ix];
         segpress[Value::PDrop] = segments.pressure_drop(seg_ix);
@@ -848,20 +854,40 @@ WellState::reportSegmentResults(const int         well_id,
     }
 
     const auto& pu = this->phaseUsage();
-    const auto rate = &segments.rates[seg_ix * pu.num_phases];
+    const auto* rate = &segments.rates[seg_ix * pu.num_phases];
+    const auto* resv = &segments.phase_resv_rates[seg_ix * pu.num_phases];
+    const auto* velocity = &segments.phase_velocity[seg_ix * pu.num_phases];
+    const auto* holdup = &segments.phase_holdup[seg_ix * pu.num_phases];
+    const auto* viscosity = &segments.phase_viscosity[seg_ix * pu.num_phases];
+
     if (pu.phase_used[Water]) {
-        seg_res.rates.set(data::Rates::opt::wat,
-                          rate[pu.phase_pos[Water]]);
+        const auto iw = pu.phase_pos[Water];
+
+        seg_res.rates.set(data::Rates::opt::wat, rate[iw]);
+        seg_res.rates.set(data::Rates::opt::reservoir_water, resv[iw]);
+        seg_res.velocity.set(PhaseQuant::Water, velocity[iw]);
+        seg_res.holdup.set(PhaseQuant::Water, holdup[iw]);
+        seg_res.viscosity.set(PhaseQuant::Water, viscosity[iw]);
     }
 
     if (pu.phase_used[Oil]) {
-        seg_res.rates.set(data::Rates::opt::oil,
-                          rate[pu.phase_pos[Oil]]);
+        const auto io = pu.phase_pos[Oil];
+
+        seg_res.rates.set(data::Rates::opt::oil, rate[io]);
+        seg_res.rates.set(data::Rates::opt::reservoir_oil, resv[io]);
+        seg_res.velocity.set(PhaseQuant::Oil, velocity[io]);
+        seg_res.holdup.set(PhaseQuant::Oil, holdup[io]);
+        seg_res.viscosity.set(PhaseQuant::Oil, viscosity[io]);
     }
 
     if (pu.phase_used[Gas]) {
-        seg_res.rates.set(data::Rates::opt::gas,
-                          rate[pu.phase_pos[Gas]]);
+        const auto ig = pu.phase_pos[Gas];
+
+        seg_res.rates.set(data::Rates::opt::gas, rate[ig]);
+        seg_res.rates.set(data::Rates::opt::reservoir_gas, resv[ig]);
+        seg_res.velocity.set(PhaseQuant::Gas, velocity[ig]);
+        seg_res.holdup.set(PhaseQuant::Gas, holdup[ig]);
+        seg_res.viscosity.set(PhaseQuant::Gas, viscosity[ig]);
     }
 
     seg_res.segNumber = seg_no;
@@ -913,5 +939,3 @@ WellState::parallelWellInfo(std::size_t well_index) const
 template void WellState::updateGlobalIsGrup<Parallel::Communication>(const Parallel::Communication& comm);
 template void WellState::communicateGroupRates<Parallel::Communication>(const Parallel::Communication& comm);
 } // namespace Opm
-
-

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -21,14 +21,16 @@
 #ifndef OPM_WELLSTATEFULLYIMPLICITBLACKOIL_HEADER_INCLUDED
 #define OPM_WELLSTATEFULLYIMPLICITBLACKOIL_HEADER_INCLUDED
 
-#include <opm/simulators/wells/ALQState.hpp>
-#include <opm/simulators/wells/SingleWellState.hpp>
-#include <opm/simulators/wells/GlobalWellInfo.hpp>
-#include <opm/simulators/wells/SegmentState.hpp>
-#include <opm/simulators/wells/WellContainer.hpp>
 #include <opm/core/props/BlackoilPhases.hpp>
-#include <opm/simulators/wells/PerforationData.hpp>
+
+#include <opm/simulators/wells/ALQState.hpp>
+#include <opm/simulators/wells/GlobalWellInfo.hpp>
 #include <opm/simulators/wells/PerfData.hpp>
+#include <opm/simulators/wells/PerforationData.hpp>
+#include <opm/simulators/wells/SegmentState.hpp>
+#include <opm/simulators/wells/SingleWellState.hpp>
+#include <opm/simulators/wells/WellContainer.hpp>
+
 #include <opm/output/data/Wells.hpp>
 
 #include <opm/input/eclipse/Schedule/Events.hpp>


### PR DESCRIPTION
In particular, report local condition segment flow velocities, segment holdup fractions, and segment phase viscosities.  To this end, expand the `SegmentState` to hold these additional quantities and update the values as part of [`updateWellStateFromPrimaryVariables()`](https://github.com/OPM/opm-simulators/blob/776180c08110d28790ff5cc783df2d19542ba3b9/opm/simulators/wells/MultisegmentWellEval.cpp#L1497).

We remark that the definition of the segment flow velocity is a little dubious and that we probably will have to revisit this definition (flow rate divided by cross-sectional area) at a later date.  Nevertheless, this PR is sufficiently ready to start testing segment-related RFT file output on more cases.