### PR TITLE
removing the well controls in assembleWellEqWithoutIteration

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -275,16 +275,12 @@ namespace Opm
 
         virtual bool iterateWellEqWithControl(const Simulator& ebosSimulator,
                                               const double dt,
-                                              const Well::InjectionControls& inj_controls,
-                                              const Well::ProductionControls& prod_controls,
                                               WellState& well_state,
                                               const GroupState& group_state,
                                               DeferredLogger& deferred_logger) override;
 
         virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
                                                     const double dt,
-                                                    const Well::InjectionControls& inj_controls,
-                                                    const Well::ProductionControls& prod_controls,
                                                     WellState& well_state,
                                                     const GroupState& group_state,
                                                     DeferredLogger& deferred_logger) override;

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -1249,8 +1249,6 @@ assembleControlEq(const WellState& well_state,
                   const GroupState& group_state,
                   const Schedule& schedule,
                   const SummaryState& summaryState,
-                  const Well::InjectionControls& inj_controls,
-                  const Well::ProductionControls& prod_controls,
                   const double rho,
                   DeferredLogger& deferred_logger)
 {
@@ -1280,6 +1278,7 @@ assembleControlEq(const WellState& well_state,
         control_eq = getWQTotal();
     } else if (baseif_.isInjector() ) {
         // Find scaling factor to get injection rate,
+        const auto& inj_controls = well.injectionControls(summaryState);
         const InjectorType injectorType = inj_controls.injector_type;
         double scaling = 1.0;
         const auto& pu = baseif_.phaseUsage();
@@ -1327,6 +1326,7 @@ assembleControlEq(const WellState& well_state,
             return baseif_.calculateBhpFromThp(well_state, rates, well, summaryState, rho, deferred_logger);
         };
         // Call generic implementation.
+        const auto& prod_controls = well.productionControls(summaryState);
         baseif_.assembleControlEqProd(well_state,
                                       group_state,
                                       schedule,

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -123,8 +123,6 @@ protected:
                            const GroupState& group_state,
                            const Schedule& schedule,
                            const SummaryState& summaryState,
-                           const Well::InjectionControls& inj_controls,
-                           const Well::ProductionControls& prod_controls,
                            const double rho,
                            DeferredLogger& deferred_logger);
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -192,8 +192,6 @@ namespace Opm
         // iterate well equations with the specified control until converged
         bool iterateWellEqWithControl(const Simulator& ebosSimulator,
                                       const double dt,
-                                      const Well::InjectionControls& inj_controls,
-                                      const Well::ProductionControls& prod_controls,
                                       WellState& well_state,
                                       const GroupState& group_state,
                                       DeferredLogger& deferred_logger) override;
@@ -367,8 +365,6 @@ namespace Opm
 
         virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
                                                     const double dt,
-                                                    const Well::InjectionControls& inj_controls,
-                                                    const Well::ProductionControls& prod_controls,
                                                     WellState& well_state,
                                                     const GroupState& group_state,
                                                     DeferredLogger& deferred_logger) override;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -419,8 +419,6 @@ namespace Opm
     StandardWell<TypeTag>::
     assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
                                    const double dt,
-                                   const Well::InjectionControls& /*inj_controls*/,
-                                   const Well::ProductionControls& /*prod_controls*/,
                                    WellState& well_state,
                                    const GroupState& group_state,
                                    DeferredLogger& deferred_logger)
@@ -2662,8 +2660,6 @@ namespace Opm
     StandardWell<TypeTag>::
     iterateWellEqWithControl(const Simulator& ebosSimulator,
                              const double dt,
-                             const Well::InjectionControls& inj_controls,
-                             const Well::ProductionControls& prod_controls,
                              WellState& well_state,
                              const GroupState& group_state,
                              DeferredLogger& deferred_logger)
@@ -2674,7 +2670,7 @@ namespace Opm
         bool relax_convergence = false;
         this->regularize_ = false;
         do {
-            assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
+            assembleWellEqWithoutIteration(ebosSimulator, dt, well_state, group_state, deferred_logger);
 
             if (it > this->param_.strict_inner_iter_wells_) {
                 relax_convergence = true;

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -329,8 +329,6 @@ protected:
 
     virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
                                                 const double dt,
-                                                const Well::InjectionControls& inj_controls,
-                                                const Well::ProductionControls& prod_controls,
                                                 WellState& well_state,
                                                 const GroupState& group_state,
                                                 DeferredLogger& deferred_logger) = 0;
@@ -338,8 +336,6 @@ protected:
     // iterate well equations with the specified control until converged
     virtual bool iterateWellEqWithControl(const Simulator& ebosSimulator,
                                           const double dt,
-                                          const Well::InjectionControls& inj_controls,
-                                          const Well::ProductionControls& prod_controls,
                                           WellState& well_state,
                                           const GroupState& group_state,
                                           DeferredLogger& deferred_logger) = 0;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -402,11 +402,9 @@ namespace Opm
                          DeferredLogger& deferred_logger)
     {
         const auto& summary_state = ebosSimulator.vanguard().summaryState();
-        const auto inj_controls = this->well_ecl_.isInjector() ? this->well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
-        const auto prod_controls = this->well_ecl_.isProducer() ? this->well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
         bool converged = false;
         try {
-            converged = this->iterateWellEqWithControl(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
+            converged = this->iterateWellEqWithControl(ebosSimulator, dt, well_state, group_state, deferred_logger);
         } catch (NumericalIssue& e ) {
             const std::string msg = "Inner well iterations failed for well " + this->name() + " Treat the well as unconverged. ";
             deferred_logger.warning("INNER_ITERATION_FAILED", msg);
@@ -564,10 +562,7 @@ namespace Opm
             this->changed_to_open_this_step_ = true;
         }
 
-        const auto& summary_state = ebosSimulator.vanguard().summaryState();
-        const auto inj_controls = this->well_ecl_.isInjector() ? this->well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
-        const auto prod_controls = this->well_ecl_.isProducer() ? this->well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
-        assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
+        assembleWellEqWithoutIteration(ebosSimulator, dt, well_state, group_state, deferred_logger);
     }
 
     template<typename TypeTag>


### PR DESCRIPTION
Not totally correct regarding the correctness yet due to the following code, 

```c++
        const auto& summary_state = ebosSimulator.vanguard().summaryState();
        const auto inj_controls = this->well_ecl_.isInjector() ? this->well_ecl_.injectionControls(summary_state) : Well::InjectionControls(0);
        const auto prod_controls = this->well_ecl_.isProducer() ? this->well_ecl_.productionControls(summary_state) : Well::ProductionControls(0);
```

But it is confusing to see the different usages between the `StandardWell` and `MultisegmentWell`. 