### PR TITLE
Rename option FlowNewtonMaxIterations to NewtonMaxIterations.

### DIFF
--- a/opm/simulators/flow/NonlinearSolverEbos.hpp
+++ b/opm/simulators/flow/NonlinearSolverEbos.hpp
@@ -129,7 +129,7 @@ class WellState;
             static void registerParameters()
             {
                 EWOMS_REGISTER_PARAM(TypeTag, Scalar, NewtonMaxRelax, "The maximum relaxation factor of a Newton iteration used by flow");
-                EWOMS_REGISTER_PARAM(TypeTag, int, NewtonMaxIterations, "The maximum number of Newton iterations per time step used by flow");
+                EWOMS_REGISTER_PARAM(TypeTag, int, NewtonMaxIterations, "The maximum number of Newton iterations per time step");
                 EWOMS_REGISTER_PARAM(TypeTag, int, NewtonMinIterations, "The minimum number of Newton iterations per time step used by flow");
                 EWOMS_REGISTER_PARAM(TypeTag, std::string, NewtonRelaxationType, "The type of relaxation used by flow's Newton method");
             }

--- a/opm/simulators/flow/NonlinearSolverEbos.hpp
+++ b/opm/simulators/flow/NonlinearSolverEbos.hpp
@@ -128,10 +128,10 @@ class WellState;
 
             static void registerParameters()
             {
-                EWOMS_REGISTER_PARAM(TypeTag, Scalar, NewtonMaxRelax, "The maximum relaxation factor of a Newton iteration used by flow");
+                EWOMS_REGISTER_PARAM(TypeTag, Scalar, NewtonMaxRelax, "The maximum relaxation factor of a Newton iteration");
                 EWOMS_REGISTER_PARAM(TypeTag, int, NewtonMaxIterations, "The maximum number of Newton iterations per time step");
-                EWOMS_REGISTER_PARAM(TypeTag, int, NewtonMinIterations, "The minimum number of Newton iterations per time step used by flow");
-                EWOMS_REGISTER_PARAM(TypeTag, std::string, NewtonRelaxationType, "The type of relaxation used by flow's Newton method");
+                EWOMS_REGISTER_PARAM(TypeTag, int, NewtonMinIterations, "The minimum number of Newton iterations per time step");
+                EWOMS_REGISTER_PARAM(TypeTag, std::string, NewtonRelaxationType, "The type of relaxation used by Newton method");
             }
 
             void reset()

--- a/opm/simulators/flow/NonlinearSolverEbos.hpp
+++ b/opm/simulators/flow/NonlinearSolverEbos.hpp
@@ -28,6 +28,7 @@
 #include <opm/models/utils/parametersystem.hh>
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/basicproperties.hh>
+#include <opm/models/nonlinear/newtonmethodproperties.hh>
 #include <opm/common/Exceptions.hpp>
 
 #include <dune/common/fmatrix.hh>
@@ -44,10 +45,10 @@ template<class TypeTag, class MyTypeTag>
 struct NewtonMaxRelax {
     using type = UndefinedProperty;
 };
-template<class TypeTag, class MyTypeTag>
-struct FlowNewtonMaxIterations {
-    using type = UndefinedProperty;
-};
+
+// we are reusing NewtonMaxIterations from opm-models
+// See opm/models/nonlinear/newtonmethodproperties.hh
+
 template<class TypeTag, class MyTypeTag>
 struct NewtonMinIterations{
     using type = UndefinedProperty;
@@ -63,7 +64,7 @@ struct NewtonMaxRelax<TypeTag, TTag::FlowNonLinearSolver> {
     static constexpr type value = 0.5;
 };
 template<class TypeTag>
-struct FlowNewtonMaxIterations<TypeTag, TTag::FlowNonLinearSolver> {
+struct NewtonMaxIterations<TypeTag, TTag::FlowNonLinearSolver> {
     static constexpr int value = 20;
 };
 template<class TypeTag>
@@ -112,7 +113,7 @@ class WellState;
 
                 // overload with given parameters
                 relaxMax_ = EWOMS_GET_PARAM(TypeTag, Scalar, NewtonMaxRelax);
-                maxIter_ = EWOMS_GET_PARAM(TypeTag, int, FlowNewtonMaxIterations);
+                maxIter_ = EWOMS_GET_PARAM(TypeTag, int, NewtonMaxIterations);
                 minIter_ = EWOMS_GET_PARAM(TypeTag, int, NewtonMinIterations);
 
                 const auto& relaxationTypeString = EWOMS_GET_PARAM(TypeTag, std::string, NewtonRelaxationType);
@@ -128,7 +129,7 @@ class WellState;
             static void registerParameters()
             {
                 EWOMS_REGISTER_PARAM(TypeTag, Scalar, NewtonMaxRelax, "The maximum relaxation factor of a Newton iteration used by flow");
-                EWOMS_REGISTER_PARAM(TypeTag, int, FlowNewtonMaxIterations, "The maximum number of Newton iterations per time step used by flow");
+                EWOMS_REGISTER_PARAM(TypeTag, int, NewtonMaxIterations, "The maximum number of Newton iterations per time step used by flow");
                 EWOMS_REGISTER_PARAM(TypeTag, int, NewtonMinIterations, "The minimum number of Newton iterations per time step used by flow");
                 EWOMS_REGISTER_PARAM(TypeTag, std::string, NewtonRelaxationType, "The type of relaxation used by flow's Newton method");
             }

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -176,7 +176,7 @@ add_test_compareECLFiles(CASENAME spe3
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol}
-                         TEST_ARGS --tolerance-wells=1e-6 --flow-newton-max-iterations=20)
+                         TEST_ARGS --tolerance-wells=1e-6 --newton-max-iterations=20)
 
 add_test_compareECLFiles(CASENAME spe9
                          FILENAME SPE9_CP_SHORT
@@ -237,14 +237,14 @@ add_test_compareECLFiles(CASENAME spe5
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol}
-                         TEST_ARGS --flow-newton-max-iterations=20)
+                         TEST_ARGS --newton-max-iterations=20)
 
 add_test_compareECLFiles(CASENAME spe5_co2eor
                          FILENAME SPE5CASE1_DYN
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol}
-                         TEST_ARGS --flow-newton-max-iterations=20)
+                         TEST_ARGS --newton-max-iterations=20)
 
 add_test_compareECLFiles(CASENAME wecon_wtest
                          FILENAME 3D_WECON


### PR DESCRIPTION
Now it is consistent with other options (e.g. NewtonMinIterations.

Needs OPM/opm-models#741