### PR TITLE
Use MPI_FOUND not MPI_Found.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -111,7 +111,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/wells/WGState.cpp
   )
 
-if (DAMARIS_FOUND AND MPI_Found)
+if (DAMARIS_FOUND AND MPI_FOUND)
   list (APPEND MAIN_SOURCE_FILES opm/simulators/utils/DamarisOutputModule.cpp) 
   list (APPEND MAIN_SOURCE_FILES opm/simulators/utils/DamarisKeywords.cpp)
   list (APPEND MAIN_SOURCE_FILES opm/simulators/utils/initDamarisXmlFile.cpp)


### PR DESCRIPTION
According to https://cmake.org/cmake/help/latest/module/FindMPI.html the capitalized version is what we should use.

(Same as in opm-common.)