### PR TITLE
removed RWGSALT from unsupported keywords list

### DIFF
--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -552,7 +552,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"RSCONST", {false, std::nullopt}},
         {"RSCONSTT", {false, std::nullopt}},
         {"RSSPEC", {false, std::nullopt}},
-        {"RWGSALT", {false, std::nullopt}},
         {"SAMG", {false, std::nullopt}},
         {"SAVE", {false, std::nullopt}},
         {"SKIP", {false, std::nullopt}},


### PR DESCRIPTION
This PR relates to 

- https://github.com/OPM/opm-common/pull/3187
- https://github.com/OPM/opm-material/pull/538
- https://github.com/OPM/opm-models/pull/744