### PR TITLE
changed: use return value

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1202,9 +1202,7 @@ namespace Opm {
             auto& well = well_container_[i];
             std::shared_ptr<StandardWell<TypeTag> > derived = std::dynamic_pointer_cast<StandardWell<TypeTag> >(well);
             if (derived) {
-                unsigned int numBlocks;
-                derived->getNumBlocks(numBlocks);
-                wellContribs.addNumBlocks(numBlocks);
+                wellContribs.addNumBlocks(derived->getNumBlocks());
             }
         }
 

--- a/opm/simulators/wells/StandardWellGeneric.cpp
+++ b/opm/simulators/wells/StandardWellGeneric.cpp
@@ -392,11 +392,11 @@ computeBhpAtThpLimitInj(const std::function<std::vector<double>(const double)>& 
 }
 
 template<class Scalar>
-void
+unsigned int
 StandardWellGeneric<Scalar>::
-getNumBlocks(unsigned int& numBlocks) const
+getNumBlocks() const
 {
-    numBlocks = duneB_.nonzeroes();
+    return duneB_.nonzeroes();
 }
 
 template class StandardWellGeneric<double>;

--- a/opm/simulators/wells/StandardWellGeneric.hpp
+++ b/opm/simulators/wells/StandardWellGeneric.hpp
@@ -66,7 +66,7 @@ protected:
 
 public:
     /// get the number of blocks of the C and B matrices, used to allocate memory in a WellContributions object
-    void getNumBlocks(unsigned int& _nnzs) const;
+    unsigned int getNumBlocks() const;
 
 protected:
     StandardWellGeneric(const WellInterfaceGeneric& baseif);


### PR DESCRIPTION
no reason to pass a reference here, just use return