### PR TITLE
Allow for test definitions through json-files in opm-tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 project(opm-simulators C CXX)
 
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.19)
 
 
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -237,6 +237,51 @@ endfunction()
 
 ###########################################################################
 
+### Helper functions ###
+
+macro(parse_json_common_params)
+  string(JSON test_cases GET ${JSON_STRING} "test_cases")
+  string(JSON simulator GET ${JSON_STRING} "simulator")
+  string(JSON abs_tol GET ${JSON_STRING} "abs_tol")
+  string(JSON rel_tol GET ${JSON_STRING} "rel_tol")
+  string(JSON dir ERROR_VARIABLE err GET ${JSON_STRING} dir)
+  if (err)
+    # Common case - use directory hosting json file
+    get_filename_component(dir ${json_file} DIRECTORY)
+    get_filename_component(dir ${dir} NAME)
+  endif()
+endmacro()
+
+macro(parse_json_test_definition idx)
+  string(JSON casename GET ${test_cases} ${idx} casename)
+  string(JSON filename GET ${test_cases} ${idx} filename)
+  string(JSON loc_abs_tol ERROR_VARIABLE err GET ${test_cases} ${idx} abs_tol)
+  if (err)
+    set(loc_abs_tol ${abs_tol})
+  endif()
+  string(JSON loc_rel_tol ERROR_VARIABLE err GET ${test_cases} ${idx} rel_tol)
+  if (err)
+    set(loc_rel_tol ${rel_tol})
+  endif()
+  set(PARAMS CASENAME ${casename}
+             SIMULATOR ${simulator}
+             FILENAME ${filename}
+             ABS_TOL ${loc_abs_tol}
+             REL_TOL ${loc_rel_tol})
+  list(APPEND PARAMS DIR ${dir})
+  string(JSON restart_sched ERROR_VARIABLE err GET ${test_cases} ${idx} restart_sched)
+  if (NOT err)
+    list(APPEND PARAMS RESTART_SCHED ${restart_sched})
+  endif()
+  string(JSON restart_step ERROR_VARIABLE err GET ${test_cases} ${idx} restart_step)
+  if (NOT err)
+    list(APPEND PARAMS RESTART_STEP ${restart_step})
+  endif()
+  string(JSON test_args ERROR_VARIABLE err GET ${test_cases} ${idx} test_args)
+  if (NOT err)
+    list(APPEND PARAMS TEST_ARGS ${test_args})
+  endif()
+endmacro()
 
 if(NOT TARGET test-suite)
   add_custom_target(test-suite)

--- a/convert/parallelRestartTests.py
+++ b/convert/parallelRestartTests.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+
+import json
+import os
+import re
+import shutil
+
+try:
+    shutil.rmtree("definitions/parallel_restart")
+    os.makedirs('definitions/parallel_restart')
+except:
+    pass
+
+with open('../parallelRestartTests.cmake', 'r') as f:
+    s = f.read()
+
+for match in re.finditer('^add_test_compare_parallel_restarted_simulation\(([^\)]*)\)', s, re.MULTILINE):
+    params = match.group(1).split()
+    i = 0
+    mapping = dict()
+    mapping['test_cases'] = [dict()]
+    while i < len(params):
+        if params[i] == 'TEST_ARGS':
+            j = 1
+            val = ""
+            while i + j < len(params) and not params[i+j][0].isupper():
+                val = val + ' ' + params[i+j]
+                j = j + 1
+            mapping['test_cases'][0][params[i].lower()] = val.strip()
+            i = i + j
+        else:
+            if params[i] == 'ABS_TOL' and params[i+1] == '${abs_tol_restart}':
+                params[i+1] = 2e-1
+            if params[i] == 'REL_TOL' and params[i+1] == '${rel_tol_restart}':
+                params[i+1] = 4e-4
+            if params[i] == 'CASENAME' or params[i] == 'FILENAME' or params[i] == 'RESTART_STEP' or params[i] == 'RESTART_SCHEDULE':
+                mapping['test_cases'][0][params[i].lower()] = params[i+1]
+            else:
+                mapping[params[i].lower()] = params[i+1]
+            i = i + 2
+    with open('definitions/parallel_restart/{}.json'.format(mapping['test_cases'][0]['casename']),'w') as f:
+        f.write(json.dumps(mapping, indent=4))

--- a/convert/parallelTests.py
+++ b/convert/parallelTests.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python3
+
+import json
+import os
+import re
+
+import shutil
+
+try:
+    shutil.rmtree("definitions/parallel")
+    os.makedirs('definitions/parallel')
+except:
+    pass
+
+with open('../parallelTests.cmake', 'r') as f:
+    s = f.read()
+
+for match in re.finditer('^add_test_compare_parallel_simulation\(([^\)]*)\)', s, re.MULTILINE):
+    params = match.group(1).split()
+    i = 0
+    mapping = dict()
+    mapping['test_cases'] = [dict()]
+    while i < len(params):
+        if params[i] == 'TEST_ARGS':
+            j = 1
+            val = ""
+            while i + j < len(params) and not params[i+j][0].isupper():
+                val = val + ' ' + params[i+j]
+                j = j + 1
+            mapping['test_cases'][0][params[i].lower()] = val.strip()
+            i = i + j
+        else:
+            if params[i] == 'ABS_TOL' and params[i+1] == '${abs_tol}':
+                params[i+1] = 2e-2
+            if params[i] == 'REL_TOL' and params[i+1] == '${rel_tol}':
+                params[i+1] = 1e-5
+            if params[i] == 'REL_TOL' and params[i+1] == '${coarse_rel_tol}':
+                params[i+1] = 1e-2
+            if params[i] == 'ABS_TOL' and params[i+1] == '${abs_tol_parallel}':
+                params[i+1] = 0.02
+            if params[i] == 'REL_TOL' and params[i+1] == '${rel_tol_parallel}':
+                params[i+1] = 8e-5
+            if params[i] == 'REL_TOL' and params[i+1] == '${coarse_rel_tol_parallel}':
+                params[i+1] = 1e-2
+            if params[i] == 'CASENAME' or params[i] == 'FILENAME' or params[i] == 'RESTART_STEP' or params[i] == 'RESTART_SCHEDULE':
+                mapping['test_cases'][0][params[i].lower()] = params[i+1]
+            else:
+                mapping[params[i].lower()] = params[i+1]
+            i = i + 2
+    with open('definitions/parallel/{}.json'.format(mapping['test_cases'][0]['casename']),'w') as f:
+        f.write(json.dumps(mapping, indent=4))

--- a/convert/regressionTests.py
+++ b/convert/regressionTests.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+
+import json
+import os
+import shutil
+import re
+
+try:
+    shutil.rmtree("definitions/regression")
+    os.makedirs('definitions/regression')
+except:
+    pass
+
+with open('../regressionTests.cmake', 'r') as f:
+    s = f.read()
+
+for match in re.finditer('^add_test_compareECLFiles\(([^\)]*)\)', s, re.MULTILINE):
+    params = match.group(1).split()
+    i = 0
+    mapping = dict()
+    mapping['test_cases'] = [dict()]
+    while i < len(params):
+        if params[i] == 'TEST_ARGS':
+            j = 1
+            val = ""
+            while i + j < len(params) and not params[i+j][0].isupper():
+                val = val + ' ' + params[i+j]
+                j = j + 1
+            mapping['test_cases'][0][params[i].lower()] = val.strip()
+            i = i + j
+        else:
+            if params[i] == 'ABS_TOL' and params[i+1] == '${abs_tol}':
+                params[i+1] = 2e-2
+            if params[i] == 'REL_TOL' and params[i+1] == '${rel_tol}':
+                params[i+1] = 1e-5
+            if params[i] == 'REL_TOL' and params[i+1] == '${coarse_rel_tol}':
+                params[i+1] = 1e-2
+            if params[i] == 'CASENAME' or params[i] == 'FILENAME':
+                mapping['test_cases'][0][params[i].lower()] = params[i+1]
+            else:
+                mapping[params[i].lower()] = params[i+1]
+            i = i + 2
+    with open('definitions/regression/{}.json'.format(mapping['test_cases'][0]['casename']),'w') as f:
+        f.write(json.dumps(mapping, indent=4))

--- a/convert/restartTests.py
+++ b/convert/restartTests.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+
+import json
+import os
+import re
+import shutil
+
+try:
+    shutil.rmtree("definitions/restart")
+    os.makedirs('definitions/restart')
+except:
+    pass
+
+with open('../restartTests.cmake', 'r') as f:
+    s = f.read()
+
+for match in re.finditer('^add_test_compare_restarted_simulation\(([^\)]*)\)', s, re.MULTILINE):
+    params = match.group(1).split()
+    i = 0
+    mapping = dict()
+    mapping['test_cases'] = [dict()]
+    while i < len(params):
+        if params[i] == 'TEST_ARGS':
+            j = 1
+            val = ""
+            while i + j < len(params) and not params[i+j][0].isupper():
+                val = val + ' ' + params[i+j]
+                j = j + 1
+            mapping['test_cases'][0][params[i].lower()] = val.strip()
+            i = i + j
+        else:
+            if params[i] == 'ABS_TOL' and params[i+1] == '${abs_tol_restart}':
+                params[i+1] = 2e-1
+            if params[i] == 'ABS_TOL' and params[i+1] == '${abs_tol_restart_msw}':
+                params[i+1] = 2e2
+            if params[i] == 'REL_TOL' and params[i+1] == '${rel_tol_restart}':
+                params[i+1] = 4e-4
+            if params[i] == 'REL_TOL' and params[i+1] == '${rel_tol_restart_msw}':
+                params[i+1] = 1e-3
+            if params[i] == 'CASENAME' or params[i] == 'FILENAME' or params[i] == 'RESTART_STEP' or params[i] == 'RESTART_SCHEDULE':
+                mapping['test_cases'][0][params[i].lower()] = params[i+1]
+            else:
+                mapping[params[i].lower()] = params[i+1]
+            i = i + 2
+    with open('definitions/restart/{}.json'.format(mapping['test_cases'][0]['casename']),'w') as f:
+        f.write(json.dumps(mapping, indent=4))

--- a/parallelRestartTests.cmake
+++ b/parallelRestartTests.cmake
@@ -1,12 +1,17 @@
 # Parallel tests
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-parallel-restart-regressionTest.sh "")
-add_test_compare_parallel_restarted_simulation(CASENAME spe1
-                                               FILENAME SPE1CASE2_ACTNUM
-                                               SIMULATOR flow
-                                               ABS_TOL ${abs_tol_restart}
-                                               REL_TOL ${rel_tol_restart}
-                                               RESTART_STEP 6
-                                               TEST_ARGS --sched-restart=false)
+
+file(GLOB_RECURSE tests "${OPM_TESTS_ROOT}/parallelRestartTests.json")
+  foreach(json_file ${tests})
+  file(READ ${json_file} JSON_STRING)
+  parse_json_common_params()
+  string(JSON size LENGTH ${test_cases})
+  math(EXPR COUNT "${size}-1")
+  foreach(idx RANGE ${COUNT})
+    parse_json_test_definition(${idx})
+    add_test_compare_parallel_restarted_simulation(${PARAMS})
+  endforeach()
+endforeach()
 
 add_test_compare_parallel_restarted_simulation(CASENAME ctaquifer_2d_oilwater
                                                FILENAME 2D_OW_CTAQUIFER
@@ -16,7 +21,6 @@ add_test_compare_parallel_restarted_simulation(CASENAME ctaquifer_2d_oilwater
                                                RESTART_STEP 15
                                                DIR aquifer-oilwater
                                                TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
-
 add_test_compare_parallel_restarted_simulation(CASENAME fetkovich_2d
                                                FILENAME 2D_FETKOVICHAQUIFER
                                                SIMULATOR flow

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -5,6 +5,18 @@ set(abs_tol_parallel 0.02)
 set(rel_tol_parallel 8e-5)
 set(coarse_rel_tol_parallel 1e-2)
 
+file(GLOB_RECURSE tests "${OPM_TESTS_ROOT}/parallelTests.json")
+foreach(json_file ${tests})
+  file(READ ${json_file} JSON_STRING)
+  parse_json_common_params()
+  string(JSON size LENGTH ${test_cases})
+  math(EXPR COUNT "${size}-1")
+  foreach(idx RANGE ${COUNT})
+    parse_json_test_definition(${idx})
+    add_test_compare_parallel_simulation(${PARAMS})
+  endforeach()
+endforeach()
+
 add_test_compare_parallel_simulation(CASENAME spe1
                                      FILENAME SPE1CASE2
                                      SIMULATOR flow
@@ -155,12 +167,4 @@ add_test_compare_parallel_simulation(CASENAME 3_a_mpi_multflt_mod2
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${rel_tol_parallel}
       			       DIR model2
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --ecl-enable-drift-compensation=false)
-
-add_test_compare_parallel_simulation(CASENAME rxft
-                                     FILENAME TEST_RXFT
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL 1.0e-3
-                                     DIR rxft_smry
                                      TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --ecl-enable-drift-compensation=false)

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -6,6 +6,18 @@ set(abs_tol 2e-2)
 set(rel_tol 1e-5)
 set(coarse_rel_tol 1e-2)
 
+file(GLOB_RECURSE tests ${OPM_TESTS_ROOT}/regressionTests.json)
+foreach(json_file ${tests})
+  file(READ ${json_file} JSON_STRING)
+  parse_json_common_params()
+  string(JSON size LENGTH ${test_cases})
+  math(EXPR COUNT "${size}-1")
+  foreach(idx RANGE ${COUNT})
+    parse_json_test_definition(${idx})
+    add_test_compareECLFiles(${PARAMS})
+  endforeach()
+endforeach()
+
 add_test_compareECLFiles(CASENAME spe12
                          FILENAME SPE1CASE2
                          SIMULATOR flow
@@ -975,45 +987,3 @@ add_test_compareECLFiles(CASENAME spe1case2_krnum
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR spe1)
-
-add_test_compareECLFiles(CASENAME krnum_02x
-                         FILENAME KRNUM-02X
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR krnum)
-
-add_test_compareECLFiles(CASENAME krnum_02y
-                         FILENAME KRNUM-02Y
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR krnum)
-
-add_test_compareECLFiles(CASENAME krnum_02z
-                         FILENAME KRNUM-02Z
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR krnum)
-
-add_test_compareECLFiles(CASENAME krnum_03x
-                         FILENAME KRNUM-03X
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR krnum)
-
-add_test_compareECLFiles(CASENAME krnum_03y
-                         FILENAME KRNUM-03Y
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR krnum)
-
-add_test_compareECLFiles(CASENAME krnum_03z
-                         FILENAME KRNUM-03Z
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR krnum)

--- a/restartTests.cmake
+++ b/restartTests.cmake
@@ -4,6 +4,18 @@ opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-restart-regressionTest.sh ""
 set(abs_tol_restart 2e-1)
 set(rel_tol_restart 4e-4)
 
+file(GLOB_RECURSE tests "${OPM_TESTS_ROOT}/restartTests.json")
+foreach(json_file ${tests})
+  file(READ ${json_file} JSON_STRING)
+  parse_json_common_params()
+  string(JSON size LENGTH ${test_cases})
+  math(EXPR COUNT "${size}-1")
+  foreach(idx RANGE ${COUNT})
+    parse_json_test_definition(${idx})
+    add_test_compare_restarted_simulation(${PARAMS})
+  endforeach()
+endforeach()
+
 add_test_compare_restarted_simulation(CASENAME spe1
                                       FILENAME SPE1CASE2_ACTNUM
                                       SIMULATOR flow
@@ -55,22 +67,6 @@ add_test_compare_restarted_simulation(CASENAME numerical_aquifer_3d_2aqu
                                       RESTART_STEP 3
                                       DIR aquifer-num
                                       TEST_ARGS --sched-restart=true --enable-tuning=true)
-
-# The dynamic MSW data is not written to /read from the restart file
-# We therefore accept significant deviation in the results.
-# Note also that we use --sched-restart=true since some necessary
-# MSW info is still lacking in the restart file.
-set(abs_tol_restart_msw 2e2)
-set(rel_tol_restart_msw 1e-3)
-
-add_test_compare_restarted_simulation(CASENAME msw_3d_hfa
-                                      FILENAME 3D_MSW
-                                      SIMULATOR flow
-                                      ABS_TOL ${abs_tol_restart_msw}
-                                      REL_TOL ${rel_tol_restart_msw}
-                                      RESTART_STEP 10
-                                      TEST_ARGS --enable-adaptive-time-stepping=false --sched-restart=true)
-
 
 # Basic restart tests which only compare the summary output, this test driver should
 # only be used in situations where it is challenging to get agreement in the restart file.


### PR DESCRIPTION
This is an alternative to / evolution of https://github.com/OPM/opm-simulators/pull/4215

It would be more messy to keep it in the same PR so I just opened a second one.

Here the test json definitions are actually stored in opm-tests. It gives some flexibility (multiple/alternative test repos comes to mind), and in general keeps the definitions closer to the source.

If we go with this alternative we need to rethink how to do update_data since the currently not supported situation of having an update in opm-tests that you want to generate data for, would now be the case every time.