### PR TITLE
fix group switch logging

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelConstraints.cpp
+++ b/opm/simulators/wells/BlackoilWellModelConstraints.cpp
@@ -393,7 +393,7 @@ actionOnBrokenConstraints(const Group& group,
                                    group.name(),
                                    Group::InjectionCMode2String(oldControl),
                                    Group::InjectionCMode2String(newControl));
-            deferred_logger.info(msg);
+            deferred_logger.debug(msg);
         }
     }
 }
@@ -472,8 +472,8 @@ updateGroupIndividualControl(const Group& group,
                                                                             phase);
             if (changed_this.first != Group::InjectionCMode::NONE)
             {
-                switched_inj.insert({{group.name(), phase},
-                                     Group::InjectionCMode2String(changed_this.first)});
+                switched_inj.insert_or_assign({group.name(), phase},
+                                     Group::InjectionCMode2String(changed_this.first));
                 this->actionOnBrokenConstraints(group, changed_this.first, phase,
                                                 group_state, deferred_logger);
                 WellGroupHelpers::updateWellRatesFromGroupTargetScale(changed_this.second,
@@ -494,8 +494,8 @@ updateGroupIndividualControl(const Group& group,
         const auto controls = group.productionControls(wellModel_.summaryState());
         if (changed_this.first != Group::ProductionCMode::NONE)
         {
-            switched_prod.insert({group.name(),
-                                  Group::ProductionCMode2String(changed_this.first)});
+            switched_prod.insert_or_assign(group.name(),
+                                  Group::ProductionCMode2String(changed_this.first));
 
             this->actionOnBrokenConstraints(group,
                                             controls.exceed_action,

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -496,7 +496,7 @@ checkGroupHigherConstraints(const Group& group,
                 resv_coeff_inj,
                 deferred_logger);
                 if (is_changed) {
-                    switched_inj_groups_.insert({ {group.name(), phase}, Group::InjectionCMode2String(Group::InjectionCMode::FLD)});
+                    switched_inj_groups_.insert_or_assign({group.name(), phase}, Group::InjectionCMode2String(Group::InjectionCMode::FLD));
                     BlackoilWellModelConstraints(*this).
                         actionOnBrokenConstraints(group, Group::InjectionCMode::FLD,
                                                   phase, this->groupState(),
@@ -537,7 +537,7 @@ checkGroupHigherConstraints(const Group& group,
                 resv_coeff,
                 deferred_logger);
             if (is_changed) {
-                switched_prod_groups_.insert({group.name(), Group::ProductionCMode2String(Group::ProductionCMode::FLD)});
+                switched_prod_groups_.insert_or_assign(group.name(), Group::ProductionCMode2String(Group::ProductionCMode::FLD));
                 const auto exceed_action = group.productionControls(summaryState_).exceed_action;
                 BlackoilWellModelConstraints(*this).
                         actionOnBrokenConstraints(group, exceed_action,


### PR DESCRIPTION
We want to keep the last group control for the terminal output i.e. use insert_or_assign instead of just insert. 