### PR TITLE
changed: pass the actual update value to relaxationFactorRate

### DIFF
--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -746,7 +746,7 @@ updatePrimaryVariablesNewton(const BVectorWell& dwells,
     processFractions();
 
     // updating the total rates Q_t
-    const double relaxation_factor_rate = this->relaxationFactorRate(old_primary_variables, dwells);
+    const double relaxation_factor_rate = this->relaxationFactorRate(old_primary_variables, dwells[0][WQTotal]);
     primary_variables_[WQTotal] = old_primary_variables[WQTotal] - dwells[0][WQTotal] * relaxation_factor_rate;
 
     // updating the bottom hole pressure

--- a/opm/simulators/wells/StandardWellGeneric.cpp
+++ b/opm/simulators/wells/StandardWellGeneric.cpp
@@ -64,14 +64,13 @@ template<class Scalar>
 double
 StandardWellGeneric<Scalar>::
 relaxationFactorRate(const std::vector<double>& primary_variables,
-                     const BVectorWell& dwells)
+                     const double newton_update)
 {
     double relaxation_factor = 1.0;
     static constexpr int WQTotal = 0;
 
     // For injector, we only check the total rates to avoid sign change of rates
     const double original_total_rate = primary_variables[WQTotal];
-    const double newton_update = dwells[0][WQTotal];
     const double possible_update_total_rate = primary_variables[WQTotal] - newton_update;
 
     // 0.8 here is a experimental value, which remains to be optimized

--- a/opm/simulators/wells/StandardWellGeneric.hpp
+++ b/opm/simulators/wells/StandardWellGeneric.hpp
@@ -74,7 +74,7 @@ protected:
 
     // calculate a relaxation factor to avoid overshoot of total rates
     static double relaxationFactorRate(const std::vector<double>& primary_variables,
-                                       const BVectorWell& dwells);
+                                       const double newton_update);
 
     // relaxation factor considering only one fraction value
     static double relaxationFactorFraction(const double old_value,


### PR DESCRIPTION
this to avoid ussage of BVectorWell in interface. in preparation for moving BVectorWell out of the well hierarchy.