### PR TITLE
added: StandardWellEquations and StandardWellAssemble

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -97,6 +97,8 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/wells/PerfData.cpp
   opm/simulators/wells/SegmentState.cpp
   opm/simulators/wells/SingleWellState.cpp
+  opm/simulators/wells/StandardWellAssemble.cpp
+  opm/simulators/wells/StandardWellEquations.cpp
   opm/simulators/wells/StandardWellEval.cpp
   opm/simulators/wells/StandardWellGeneric.cpp
   opm/simulators/wells/TargetCalculator.cpp
@@ -382,6 +384,10 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/SingleWellState.hpp
   opm/simulators/wells/StandardWell.hpp
   opm/simulators/wells/StandardWell_impl.hpp
+  opm/simulators/wells/StandardWellAssemble.hpp
+  opm/simulators/wells/StandardWellEquations.hpp
+  opm/simulators/wells/StandardWellEval.hpp
+  opm/simulators/wells/StandardWellGeneric.hpp
   opm/simulators/wells/TargetCalculator.hpp
   opm/simulators/wells/VFPHelpers.hpp
   opm/simulators/wells/VFPInjProperties.hpp

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -19,6 +19,7 @@
 */
 
 
+#include <opm/simulators/linalg/SmallDenseMatrixUtils.hpp>
 #include <opm/simulators/wells/MSWellHelpers.hpp>
 #include <opm/simulators/wells/WellBhpThpCalculator.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -39,7 +39,6 @@
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
 #include <opm/models/blackoil/blackoilmicpmodules.hh>
 
-#include <opm/material/densead/DynamicEvaluation.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
 
@@ -122,7 +121,6 @@ namespace Opm
         using Eval = typename StdWellEval::Eval;
         using EvalWell = typename StdWellEval::EvalWell;
         using BVectorWell = typename StdWellEval::BVectorWell;
-        using DiagMatrixBlockWellType = typename StdWellEval::DiagMatrixBlockWellType;
 
         StandardWell(const Well& well,
                      const ParallelWellInfo& pw_info,

--- a/opm/simulators/wells/StandardWellAssemble.cpp
+++ b/opm/simulators/wells/StandardWellAssemble.cpp
@@ -1,0 +1,414 @@
+/*
+  Copyright 2017 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2017 Statoil ASA.
+  Copyright 2016 - 2017 IRIS AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+#include <opm/simulators/wells/StandardWellAssemble.hpp>
+
+#include <opm/core/props/BlackoilPhases.hpp>
+
+#include <opm/material/densead/Evaluation.hpp>
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
+
+#include <opm/models/blackoil/blackoilindices.hh>
+#include <opm/models/blackoil/blackoilonephaseindices.hh>
+#include <opm/models/blackoil/blackoiltwophaseindices.hh>
+
+#include <opm/simulators/linalg/matrixblock.hh>
+
+#include <opm/simulators/wells/WellAssemble.hpp>
+#include <opm/simulators/wells/WellBhpThpCalculator.hpp>
+#include <opm/simulators/wells/WellInterfaceFluidSystem.hpp>
+
+namespace Opm {
+
+template<class FluidSystem, class Indices, class Scalar>
+template<class EvalWell>
+void
+StandardWellAssemble<FluidSystem,Indices,Scalar>::
+assembleControlEq(const WellState& well_state,
+                  const GroupState& group_state,
+                  const Schedule& schedule,
+                  const SummaryState& summaryState,
+                  const int numWellEq,
+                  const EvalWell& wqTotal,
+                  const EvalWell& bhp,
+                  const std::function<EvalWell(int)>& getQs,
+                  const double rho,
+                  StandardWellEquations<Indices,Scalar>& A,
+                  DeferredLogger& deferred_logger) const
+{
+    static constexpr int Water = BlackoilPhases::Aqua;
+    static constexpr int Oil = BlackoilPhases::Liquid;
+    static constexpr int Gas = BlackoilPhases::Vapour;
+    EvalWell control_eq(numWellEq + Indices::numEq, 0.0);
+
+    const auto& well = well_.wellEcl();
+
+    auto getRates = [&]() {
+        std::vector<EvalWell> rates(3, EvalWell(numWellEq + Indices::numEq, 0.0));
+        if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
+            rates[Water] = getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx));
+        }
+        if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
+            rates[Oil] = getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::oilCompIdx));
+        }
+        if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+            rates[Gas] = getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx));
+        }
+        return rates;
+    };
+
+    if (well_.wellIsStopped()) {
+        control_eq = wqTotal;
+    } else if (well_.isInjector()) {
+        // Find injection rate.
+        const EvalWell injection_rate = wqTotal;
+        // Setup function for evaluation of BHP from THP (used only if needed).
+        std::function<EvalWell()> bhp_from_thp = [&]() {
+            const auto rates = getRates();
+            return WellBhpThpCalculator(well_).calculateBhpFromThp(well_state,
+                                                                   rates,
+                                                                   well,
+                                                                   summaryState,
+                                                                   rho,
+                                                                   deferred_logger);
+        };
+
+        // Call generic implementation.
+        const auto& inj_controls = well.injectionControls(summaryState);
+        WellAssemble(well_).
+             assembleControlEqInj(well_state,
+                                  group_state,
+                                  schedule,
+                                  summaryState,
+                                  inj_controls,
+                                  bhp,
+                                  injection_rate,
+                                  bhp_from_thp,
+                                  control_eq,
+                                  deferred_logger);
+    } else {
+        // Find rates.
+        const auto rates = getRates();
+        // Setup function for evaluation of BHP from THP (used only if needed).
+        std::function<EvalWell()> bhp_from_thp = [&]() {
+             return WellBhpThpCalculator(well_).calculateBhpFromThp(well_state,
+                                                                    rates,
+                                                                    well,
+                                                                    summaryState,
+                                                                    rho,
+                                                                    deferred_logger);
+        };
+        // Call generic implementation.
+        const auto& prod_controls = well.productionControls(summaryState);
+        WellAssemble(well_).
+            assembleControlEqProd(well_state,
+                                  group_state,
+                                  schedule,
+                                  summaryState,
+                                  prod_controls,
+                                  bhp,
+                                  rates,
+                                  bhp_from_thp,
+                                  control_eq,
+                                  deferred_logger);
+    }
+
+    // using control_eq to update the matrix and residuals
+    // TODO: we should use a different index system for the well equations
+    A.resWell_[0][A.Bhp] = control_eq.value();
+    for (int pv_idx = 0; pv_idx < numWellEq; ++pv_idx) {
+        A.duneD_[0][0][A.Bhp][pv_idx] = control_eq.derivative(pv_idx + Indices::numEq);
+    }
+}
+
+template<class FluidSystem, class Indices, class Scalar>
+template<class EvalWell>
+void StandardWellAssemble<FluidSystem,Indices,Scalar>::
+assembleInjectivityEq(const EvalWell& eq_pskin,
+                      const EvalWell& eq_wat_vel,
+                      const int pskin_index,
+                      const int wat_vel_index,
+                      const int cell_idx,
+                      const int numWellEq,
+                      StandardWellEquations<Indices,Scalar>& eqns) const
+{
+    eqns.resWell_[0][pskin_index] = eq_pskin.value();
+    eqns.resWell_[0][wat_vel_index] = eq_wat_vel.value();
+    for (int pvIdx = 0; pvIdx < numWellEq; ++pvIdx) {
+        eqns.duneD_[0][0][wat_vel_index][pvIdx] = eq_wat_vel.derivative(pvIdx+Indices::numEq);
+        eqns.duneD_[0][0][pskin_index][pvIdx] = eq_pskin.derivative(pvIdx+Indices::numEq);
+    }
+
+    // the water velocity is impacted by the reservoir primary varaibles. It needs to enter matrix B
+    for (int pvIdx = 0; pvIdx < Indices::numEq; ++pvIdx) {
+        eqns.duneB_[0][cell_idx][wat_vel_index][pvIdx] = eq_wat_vel.derivative(pvIdx);
+    }
+}
+
+template<class FluidSystem, class Indices, class Scalar>
+template<class EvalWell>
+void StandardWellAssemble<FluidSystem,Indices,Scalar>::
+assemblePerforationEq(const EvalWell& cq_s_effective,
+                      const int componentIdx,
+                      const int cell_idx,
+                      const int numWellEq,
+                      StandardWellEquations<Indices,Scalar>& eqns) const
+{
+    // subtract sum of phase fluxes in the well equations.
+    eqns.resWell_[0][componentIdx] += cq_s_effective.value();
+
+    // assemble the jacobians
+    for (int pvIdx = 0; pvIdx < numWellEq; ++pvIdx) {
+        // also need to consider the efficiency factor when manipulating the jacobians.
+        eqns.duneC_[0][cell_idx][pvIdx][componentIdx] -= cq_s_effective.derivative(pvIdx+Indices::numEq); // intput in transformed matrix
+        eqns.duneD_[0][0][componentIdx][pvIdx] += cq_s_effective.derivative(pvIdx+Indices::numEq);
+    }
+
+    for (int pvIdx = 0; pvIdx < Indices::numEq; ++pvIdx) {
+        eqns.duneB_[0][cell_idx][componentIdx][pvIdx] += cq_s_effective.derivative(pvIdx);
+    }
+}
+
+template<class FluidSystem, class Indices, class Scalar>
+template<class EvalWell>
+void StandardWellAssemble<FluidSystem,Indices,Scalar>::
+assembleZFracEq(const EvalWell& cq_s_zfrac_effective,
+                const int cell_idx,
+                const int numWellEq,
+                StandardWellEquations<Indices,Scalar>& eqns) const
+{
+    for (int pvIdx = 0; pvIdx < numWellEq; ++pvIdx) {
+        eqns.duneC_[0][cell_idx][pvIdx][Indices::contiZfracEqIdx] -= cq_s_zfrac_effective.derivative(pvIdx+Indices::numEq);
+    }
+}
+
+template<class FluidSystem, class Indices, class Scalar>
+template<class EvalWell>
+void StandardWellAssemble<FluidSystem,Indices,Scalar>::
+assembleSourceEq(const EvalWell& resWell_loc,
+                 const int componentIdx,
+                 const int numWellEq,
+                 StandardWellEquations<Indices,Scalar>& eqns) const
+{
+    for (int pvIdx = 0; pvIdx < numWellEq; ++pvIdx) {
+        eqns.duneD_[0][0][componentIdx][pvIdx] += resWell_loc.derivative(pvIdx+Indices::numEq);
+    }
+    eqns.resWell_[0][componentIdx] += resWell_loc.value();
+}
+
+template<class FluidSystem, class Indices, class Scalar>
+template<class PressureMatrix, class BVector>
+void StandardWellAssemble<FluidSystem,Indices,Scalar>::
+addWellPressureEqs(const BVector& weights,
+                   const int pressureVarIndex,
+                   const bool use_well_weights,
+                   const WellState& well_state,
+                   const int numWellEq,
+                   const StandardWellEquations<Indices,Scalar>& eqns,
+                   PressureMatrix& jacobian) const
+
+{
+    // This adds pressure quation for cpr
+    // For use_well_weights=true
+    //    weights lamda = inv(D)'v  v = 0 v(bhpInd) = 1
+    //    the well equations are summed i lambda' B(:,pressureVarINd) -> B  lambda'*D(:,bhpInd) -> D
+    // For use_well_weights = false
+    //    weights lambda = \sum_i w /n where ths sum is over weights of all perforation cells
+    //    in the case of pressure controlled trivial equations are used and bhp  C=B=0
+    //    then the flow part of the well equations are summed lambda'*B(1:n,pressureVarInd) -> B lambda'*D(1:n,bhpInd) -> D
+    // For bouth
+    //    C -> w'C(:,bhpInd) where w is weights of the perforation cell
+
+    // Add the well contributions in cpr
+    // use_well_weights is a quasiimpes formulation which is not implemented in multisegment
+    int bhp_var_index = StandardWellEquations<Indices,Scalar>::Bhp;
+    int nperf = 0;
+    auto cell_weights = weights[0];// not need for not(use_well_weights)
+    cell_weights = 0.0;
+    assert(eqns.duneC_.M() == weights.size());
+    const int welldof_ind = eqns.duneC_.M() + well_.indexOfWell();
+    // do not assume anything about pressure controlled with use_well_weights (work fine with the assumtion also)
+    if (!well_.isPressureControlled(well_state) || use_well_weights) {
+        // make coupling for reservoir to well
+        for (auto colC = eqns.duneC_[0].begin(),
+                  endC = eqns.duneC_[0].end(); colC != endC; ++colC) {
+            const auto row_ind = colC.index();
+            const auto& bw = weights[row_ind];
+            double matel = 0;
+            assert((*colC).M() == bw.size());
+            for (size_t i = 0; i < bw.size(); ++i) {
+                matel += (*colC)[bhp_var_index][i] * bw[i];
+            }
+
+            jacobian[row_ind][welldof_ind] = matel;
+            cell_weights += bw;
+            nperf += 1;
+        }
+    }
+    cell_weights /= nperf;
+
+    using BVectorWell = typename StandardWellEquations<Indices,Scalar>::BVectorWell;
+
+    BVectorWell  bweights(1);
+    size_t blockSz = numWellEq;
+    bweights[0].resize(blockSz);
+    bweights[0] = 0.0;
+    double diagElem = 0;
+    {
+        if (use_well_weights) {
+            // calculate weighs and set diagonal element
+            //NB! use this options without treating pressure controlled separated
+            //NB! calculate quasiimpes well weights NB do not work well with trueimpes reservoir weights
+            double abs_max = 0;
+            BVectorWell rhs(1);
+            rhs[0].resize(blockSz);
+            rhs[0][bhp_var_index] = 1.0;
+            auto inv_diag_block = eqns.invDuneD_[0][0];
+            auto inv_diag_block_transpose = Opm::wellhelpers::transposeDenseDynMatrix(inv_diag_block);
+            for (size_t i = 0; i < blockSz; ++i) {
+                bweights[0][i] = 0;
+                for (size_t j = 0; j < blockSz; ++j) {
+                    bweights[0][i] += inv_diag_block_transpose[i][j]*rhs[0][j];
+                }
+                abs_max = std::max(abs_max, std::fabs(bweights[0][i]));
+            }
+            assert( abs_max > 0.0 );
+            for (size_t i = 0; i < blockSz; ++i) {
+                bweights[0][i] /= abs_max;
+            }
+            diagElem = 1.0/abs_max;
+        } else {
+            // set diagonal element
+            if (well_.isPressureControlled(well_state)) {
+                bweights[0][blockSz-1] = 1.0;
+                diagElem = 1.0;// better scaling could have used the calculation below if weights were calculated
+            } else {
+                for (size_t i = 0; i < cell_weights.size(); ++i) {
+                    bweights[0][i] = cell_weights[i];
+                }
+                bweights[0][blockSz-1] = 0.0;
+                diagElem = 0.0;
+                const auto& locmat = eqns.duneD_[0][0];
+                for (size_t i = 0; i < cell_weights.size(); ++i) {
+                    diagElem += locmat[i][bhp_var_index]*cell_weights[i];
+                }
+            }
+        }
+    }
+    //
+    jacobian[welldof_ind][welldof_ind] = diagElem;
+    // set the matrix elements for well reservoir coupling
+    if (!well_.isPressureControlled(well_state) || use_well_weights) {
+        for (auto colB = eqns.duneB_[0].begin(),
+                  endB = eqns.duneB_[0].end(); colB != endB; ++colB) {
+            const auto col_index = colB.index();
+            const auto& bw = bweights[0];
+            double matel = 0;
+            for (size_t i = 0; i < bw.size(); ++i) {
+                 matel += (*colB)[i][pressureVarIndex] * bw[i];
+            }
+            jacobian[welldof_ind][col_index] = matel;
+        }
+    }
+}
+
+#define INSTANCE(Dim,Block,...) \
+template class StandardWellAssemble<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,__VA_ARGS__,double>; \
+template void \
+StandardWellAssemble<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,__VA_ARGS__,double>:: \
+assembleControlEq(const WellState&, \
+                  const GroupState&, \
+                  const Schedule&, \
+                  const SummaryState&, \
+                  const int, \
+                  const DenseAd::Evaluation<double,-1,Dim>&, \
+                  const DenseAd::Evaluation<double,-1,Dim>&, \
+                  const std::function<DenseAd::Evaluation<double,-1,Dim>(int)>&, \
+                  const double, \
+                  StandardWellEquations<__VA_ARGS__,double>&, \
+                  DeferredLogger&) const; \
+template void \
+StandardWellAssemble<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,__VA_ARGS__,double>:: \
+assembleInjectivityEq(const DenseAd::Evaluation<double,-1,Dim>&, \
+                      const DenseAd::Evaluation<double,-1,Dim>&, \
+                      const int, \
+                      const int, \
+                      const int, \
+                      const int, \
+                      StandardWellEquations<__VA_ARGS__,double>&) const; \
+template void \
+StandardWellAssemble<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,__VA_ARGS__,double>:: \
+assemblePerforationEq(const DenseAd::Evaluation<double,-1,Dim>&, \
+                      const int, \
+                      const int, \
+                      const int, \
+                      StandardWellEquations<__VA_ARGS__,double>&) const; \
+template void \
+StandardWellAssemble<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,__VA_ARGS__,double>:: \
+assembleZFracEq(const DenseAd::Evaluation<double,-1,Dim>&, \
+                const int, \
+                const int, \
+                StandardWellEquations<__VA_ARGS__,double>&) const; \
+template void \
+StandardWellAssemble<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,__VA_ARGS__,double>:: \
+assembleSourceEq(const DenseAd::Evaluation<double,-1,Dim>&, \
+                      const int, \
+                      const int, \
+                      StandardWellEquations<__VA_ARGS__,double>&) const; \
+template void \
+StandardWellAssemble<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,__VA_ARGS__,double>:: \
+addWellPressureEqs(const Dune::BlockVector<Dune::FieldVector<double,Block>>&, \
+                   const int, \
+                   const bool, \
+                   const WellState&, \
+                   const int, \
+                   const StandardWellEquations<__VA_ARGS__,double>&, \
+                   Dune::BCRSMatrix<MatrixBlock<double,1,1>>& jacobian) const;
+
+// One phase
+INSTANCE(4u, 1, BlackOilOnePhaseIndices<0u,0u,0u,0u,false,false,0u,1u,0u>)
+INSTANCE(5u, 2, BlackOilOnePhaseIndices<0u,0u,0u,1u,false,false,0u,1u,0u>)
+INSTANCE(9u, 6, BlackOilOnePhaseIndices<0u,0u,0u,0u,false,false,0u,1u,5u>)
+
+// Two phase
+INSTANCE(6u, 2, BlackOilTwoPhaseIndices<0u,0u,0u,0u,false,false,0u,0u,0u>)
+INSTANCE(6u, 2, BlackOilTwoPhaseIndices<0u,0u,0u,0u,false,false,0u,1u,0u>)
+INSTANCE(6u, 2, BlackOilTwoPhaseIndices<0u,0u,0u,0u,false,false,0u,2u,0u>)
+INSTANCE(7u, 3, BlackOilTwoPhaseIndices<0u,0u,1u,0u,false,false,0u,2u,0u>)
+INSTANCE(7u, 1, BlackOilTwoPhaseIndices<0u,0u,1u,0u,false,true,0u,2u,0u>)
+INSTANCE(7u, 3, BlackOilTwoPhaseIndices<0u,0u,0u,1u,false,false,0u,1u,0u>)
+INSTANCE(7u, 3, BlackOilTwoPhaseIndices<0u,0u,0u,0u,false,true,0u,0u,0u>)
+INSTANCE(7u, 3, BlackOilTwoPhaseIndices<0u,0u,0u,0u,false,true,0u,2u,0u>)
+INSTANCE(8u, 4, BlackOilTwoPhaseIndices<0u,0u,2u,0u,false,false,0u,2u,0u>)
+
+// Blackoil
+INSTANCE(8u, 3, BlackOilIndices<0u,0u,0u,0u,false,false,0u,0u>)
+INSTANCE(9u, 4, BlackOilIndices<0u,0u,0u,0u,true,false,0u,0u>)
+INSTANCE(9u, 4, BlackOilIndices<0u,0u,0u,0u,false,true,0u,0u>)
+INSTANCE(9u, 4, BlackOilIndices<0u,1u,0u,0u,false,false,0u,0u>)
+INSTANCE(9u, 4, BlackOilIndices<0u,0u,1u,0u,false,false,0u,0u>)
+INSTANCE(9u, 4, BlackOilIndices<0u,0u,0u,1u,false,false,0u,0u>)
+INSTANCE(10u, 4, BlackOilIndices<1u,0u,0u,0u,false,false,0u,0u>)
+INSTANCE(10u, 5, BlackOilIndices<0u,0u,0u,1u,false,true,0u,0u>)
+INSTANCE(10u, 1, BlackOilIndices<0u,0u,0u,1u,false,false,1u,0u>)
+
+}

--- a/opm/simulators/wells/StandardWellAssemble.hpp
+++ b/opm/simulators/wells/StandardWellAssemble.hpp
@@ -1,0 +1,114 @@
+/*
+  Copyright 2017 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2017 Statoil ASA.
+  Copyright 2016 - 2017 IRIS AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef OPM_STANDARDWELL_ASSEMBLE_HEADER_INCLUDED
+#define OPM_STANDARDWELL_ASSEMBLE_HEADER_INCLUDED
+
+#include <dune/common/dynmatrix.hh>
+#include <dune/common/dynvector.hh>
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/bvector.hh>
+
+#include <opm/material/densead/DynamicEvaluation.hpp>
+
+#include <opm/simulators/wells/StandardWellEquations.hpp>
+#include <opm/simulators/wells/WellHelpers.hpp>
+
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace Opm
+{
+
+class DeferredLogger;
+class GroupState;
+class Schedule;
+class SummaryState;
+class WellContributions;
+template<class T> class WellInterfaceFluidSystem;
+class WellState;
+
+template<class FluidSystem, class Indices, class Scalar>
+class StandardWellAssemble {
+public:
+    StandardWellAssemble(const WellInterfaceFluidSystem<FluidSystem>& well)
+        : well_(well)
+    {}
+
+    template<class EvalWell>
+    void assembleControlEq(const WellState& well_state,
+                           const GroupState& group_state,
+                           const Schedule& schedule,
+                           const SummaryState& summaryState,
+                           const int numWellEq,
+                           const EvalWell& wqTotal,
+                           const EvalWell& bhp,
+                           const std::function<EvalWell(int)>& getQs,
+                           const double rho,
+                           StandardWellEquations<Indices,Scalar>& A,
+                           DeferredLogger& deferred_logger) const;
+
+    template<class EvalWell>
+    void assembleInjectivityEq(const EvalWell& eq_pskin,
+                               const EvalWell& eq_wat_vel,
+                               const int pskin_index,
+                               const int wat_vel_index,
+                               const int cell_idx,
+                               const int numWellEq,
+                               StandardWellEquations<Indices,Scalar>& eqns) const;
+
+    template<class EvalWell>
+    void assemblePerforationEq(const EvalWell& cq_s_effective,
+                               const int componentIdx,
+                               const int cell_idx,
+                               const int numWellEq,
+                               StandardWellEquations<Indices,Scalar>& eqns) const;
+
+    template<class EvalWell>
+    void assembleZFracEq(const EvalWell& cq_s_zfrac_effective,
+                         const int cell_idx,
+                         const int numWellEq,
+                         StandardWellEquations<Indices,Scalar>& eqns) const;
+
+    template<class EvalWell>
+    void assembleSourceEq(const EvalWell& resWell_loc,
+                          const int componentIdx,
+                          const int numWellEq,
+                          StandardWellEquations<Indices,Scalar>& eqns) const;
+
+    template<class PressureMatrix, class BVector>
+    void addWellPressureEqs(const BVector& x,
+                            const int pressureVarIndex,
+                            const bool use_well_weights,
+                            const WellState& well_state,
+                            const int numWellEq,
+                            const StandardWellEquations<Indices,Scalar>& eqns,
+                            PressureMatrix& mat) const;
+
+private:
+    const WellInterfaceFluidSystem<FluidSystem>& well_;
+};
+
+}
+
+#endif // OPM_STANDARDWELL_ASSEMBLE_HEADER_INCLUDED

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -1,0 +1,308 @@
+/*
+  Copyright 2017 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2017 Statoil ASA.
+  Copyright 2016 - 2017 IRIS AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+#include <opm/simulators/wells/StandardWellEquations.hpp>
+
+#include <opm/common/Exceptions.hpp>
+
+#include <opm/models/blackoil/blackoilindices.hh>
+#include <opm/models/blackoil/blackoilonephaseindices.hh>
+#include <opm/models/blackoil/blackoiltwophaseindices.hh>
+
+#include <opm/simulators/linalg/istlsparsematrixadapter.hh>
+#include <opm/simulators/linalg/matrixblock.hh>
+#include <opm/simulators/linalg/SmallDenseMatrixUtils.hpp>
+#include <opm/simulators/linalg/bda/WellContributions.hpp>
+
+#include <opm/simulators/wells/WellHelpers.hpp>
+
+namespace Opm {
+
+template<class Indices, class Scalar>
+StandardWellEquations<Indices,Scalar>::
+StandardWellEquations(const ParallelWellInfo& parallel_well_info)
+    : parallelB_(duneB_, parallel_well_info)
+{
+    duneB_.setBuildMode(OffDiagMatWell::row_wise);
+    duneC_.setBuildMode(OffDiagMatWell::row_wise);
+    invDuneD_.setBuildMode(DiagMatWell::row_wise);
+}
+
+template<class Indices, class Scalar>
+void StandardWellEquations<Indices,Scalar>::
+init(const int num_cells,
+         const int numWellEq,
+         const int numPerfs,
+         const std::vector<int> cells)
+{
+    // setup sparsity pattern for the matrices
+    //[A C^T    [x    =  [ res
+    // B D] x_well]      res_well]
+    // set the size of the matrices
+    duneD_.setSize(1, 1, 1);
+    duneB_.setSize(1, num_cells, numPerfs);
+    duneC_.setSize(1, num_cells, numPerfs);
+
+    for (auto row = duneD_.createbegin(),
+              end = duneD_.createend(); row != end; ++row) {
+        // Add nonzeros for diagonal
+        row.insert(row.index());
+    }
+    // the block size is run-time determined now
+    duneD_[0][0].resize(numWellEq, numWellEq);
+
+    for (auto row = duneB_.createbegin(),
+              end = duneB_.createend(); row != end; ++row) {
+        for (int perf = 0 ; perf < numPerfs; ++perf) {
+            const int cell_idx = cells[perf];
+            row.insert(cell_idx);
+        }
+    }
+
+    for (int perf = 0 ; perf < numPerfs; ++perf) {
+        const int cell_idx = cells[perf];
+         // the block size is run-time determined now
+         duneB_[0][cell_idx].resize(numWellEq, Indices::numEq);
+    }
+
+    // make the C^T matrix
+    for (auto row = duneC_.createbegin(),
+              end = duneC_.createend(); row != end; ++row) {
+        for (int perf = 0; perf < numPerfs; ++perf) {
+            const int cell_idx = cells[perf];
+            row.insert(cell_idx);
+        }
+    }
+
+    for (int perf = 0; perf < numPerfs; ++perf) {
+        const int cell_idx = cells[perf];
+        duneC_[0][cell_idx].resize(numWellEq, Indices::numEq);
+    }
+
+    resWell_.resize(1);
+    // the block size of resWell_ is also run-time determined now
+    resWell_[0].resize(numWellEq);
+
+    // resize temporary class variables
+    Bx_.resize(duneB_.N());
+    for (unsigned i = 0; i < duneB_.N(); ++i) {
+        Bx_[i].resize(numWellEq);
+    }
+
+    invDrw_.resize(duneD_.N());
+    for (unsigned i = 0; i < duneD_.N(); ++i) {
+        invDrw_[i].resize(numWellEq);
+    }
+}
+
+template<class Indices, class Scalar>
+void StandardWellEquations<Indices,Scalar>::clear()
+{
+    duneB_ = 0.0;
+    duneC_ = 0.0;
+    duneD_ = 0.0;
+    resWell_ = 0.0;
+}
+
+template<class Indices, class Scalar>
+void StandardWellEquations<Indices,Scalar>::apply(const BVector& x, BVector& Ax) const
+{
+    // Bx_ = duneB_ * x
+    parallelB_.mv(x, Bx_);
+
+    // invDBx = invDuneD_ * Bx_
+    // TODO: with this, we modified the content of the invDrw_.
+    // Is it necessary to do this to save some memory?
+    auto& invDBx = invDrw_;
+    invDuneD_.mv(Bx_, invDBx);
+
+    // Ax = Ax - duneC_^T * invDBx
+    duneC_.mmtv(invDBx, Ax);
+}
+
+template<class Indices, class Scalar>
+void StandardWellEquations<Indices,Scalar>::apply(BVector& r) const
+{
+    assert(invDrw_.size() == invDuneD_.N());
+
+    // invDrw_ = invDuneD_ * resWell_
+    invDuneD_.mv(resWell_, invDrw_);
+    // r = r - duneC_^T * invDrw_
+    duneC_.mmtv(invDrw_, r);
+}
+
+template<class Indices, class Scalar>
+void StandardWellEquations<Indices,Scalar>::
+recoverSolutionWell(const BVector& x, BVectorWell& xw) const
+{
+    assert(Bx_.size() == duneB_.N());
+    assert(invDrw_.size() == invDuneD_.N());
+    BVectorWell resWell = resWell_;
+    // resWell = resWell - B * x
+    parallelB_.mmv(x, resWell);
+    // xw = D^-1 * resWell
+    invDuneD_.mv(resWell, xw);
+}
+
+template<class Indices, class Scalar>
+void StandardWellEquations<Indices,Scalar>::
+solve(BVectorWell& dx_well) const
+{
+    invDuneD_.mv(resWell_, dx_well);
+}
+
+template<class Indices, class Scalar>
+void StandardWellEquations<Indices,Scalar>::invert()
+{
+    try {
+        invDuneD_ = duneD_; // Not strictly need if not cpr with well contributions is used
+        detail::invertMatrix(invDuneD_[0][0]);
+    } catch (NumericalProblem&) {
+        // for singular matrices, use identity as the inverse
+        invDuneD_[0][0] = 0.0;
+        for (size_t i = 0; i < invDuneD_[0][0].rows(); ++i) {
+            invDuneD_[0][0][i][i] = 1.0;
+        }
+    }
+}
+
+template<class Indices, class Scalar>
+void StandardWellEquations<Indices,Scalar>::
+addWellContribution(WellContributions& wellContribs) const
+{
+    std::vector<int> colIndices;
+    std::vector<double> nnzValues;
+    colIndices.reserve(duneB_.nonzeroes());
+    nnzValues.reserve(duneB_.nonzeroes() * numStaticWellEq * Indices::numEq);
+
+    // duneC
+    for (auto colC = duneC_[0].begin(),
+              endC = duneC_[0].end(); colC != endC; ++colC )
+    {
+        colIndices.emplace_back(colC.index());
+        for (int i = 0; i < numStaticWellEq; ++i) {
+            for (int j = 0; j < Indices::numEq; ++j) {
+                nnzValues.emplace_back((*colC)[i][j]);
+            }
+        }
+    }
+    wellContribs.addMatrix(WellContributions::MatrixType::C, colIndices.data(),
+                           nnzValues.data(), duneC_.nonzeroes());
+
+    // invDuneD
+    colIndices.clear();
+    nnzValues.clear();
+    colIndices.emplace_back(0);
+    for (int i = 0; i < numStaticWellEq; ++i)
+    {
+        for (int j = 0; j < numStaticWellEq; ++j) {
+            nnzValues.emplace_back(invDuneD_[0][0][i][j]);
+        }
+    }
+    wellContribs.addMatrix(WellContributions::MatrixType::D, colIndices.data(),
+                           nnzValues.data(), 1);
+
+    // duneB
+    colIndices.clear();
+    nnzValues.clear();
+    for (auto colB = duneB_[0].begin(),
+              endB = duneB_[0].end(); colB != endB; ++colB)
+    {
+        colIndices.emplace_back(colB.index());
+        for (int i = 0; i < numStaticWellEq; ++i) {
+            for (int j = 0; j < Indices::numEq; ++j) {
+                nnzValues.emplace_back((*colB)[i][j]);
+            }
+        }
+    }
+    wellContribs.addMatrix(WellContributions::MatrixType::B, colIndices.data(),
+                           nnzValues.data(), duneB_.nonzeroes());
+}
+
+template<class Indices, class Scalar>
+template<class SparseMatrixAdapter>
+void StandardWellEquations<Indices,Scalar>::
+addWellContributions(SparseMatrixAdapter& jacobian) const
+{
+    // We need to change matrx A as follows
+    // A -= C^T D^-1 B
+    // D is diagonal
+    // B and C have 1 row, nc colums and nonzero
+    // at (0,j) only if this well has a perforation at cell j.
+    typename SparseMatrixAdapter::MatrixBlock tmpMat;
+    Dune::DynamicMatrix<Scalar> tmp;
+    for (auto colC = duneC_[0].begin(),
+              endC = duneC_[0].end(); colC != endC; ++colC)
+    {
+        const auto row_index = colC.index();
+
+        for (auto colB = duneB_[0].begin(),
+                  endB = duneB_[0].end(); colB != endB; ++colB)
+        {
+            detail::multMatrix(invDuneD_[0][0],  (*colB), tmp);
+            detail::negativeMultMatrixTransposed((*colC), tmp, tmpMat);
+            jacobian.addToBlock(row_index, colB.index(), tmpMat);
+        }
+    }
+}
+
+template<class Indices, class Scalar>
+void StandardWellEquations<Indices,Scalar>::sumDistributed(Parallel::Communication comm)
+{
+    // accumulate resWell_ and duneD_ in parallel to get effects of all perforations (might be distributed)
+    wellhelpers::sumDistributedWellEntries(duneD_[0][0], resWell_[0], comm);
+}
+
+#define INSTANCE(Block,...) \
+template class StandardWellEquations<__VA_ARGS__,double>; \
+template void \
+StandardWellEquations<__VA_ARGS__,double>:: \
+addWellContributions(Linear::IstlSparseMatrixAdapter<MatrixBlock<double,Block,Block>>&) const;
+
+// One phase
+INSTANCE(1, BlackOilOnePhaseIndices<0u,0u,0u,0u,false,false,0u,1u,0u>)
+INSTANCE(2, BlackOilOnePhaseIndices<0u,0u,0u,1u,false,false,0u,1u,0u>)
+INSTANCE(6, BlackOilOnePhaseIndices<0u,0u,0u,0u,false,false,0u,1u,5u>)
+
+// Two phase
+INSTANCE(2, BlackOilTwoPhaseIndices<0u,0u,0u,0u,false,false,0u,0u,0u>)
+INSTANCE(2, BlackOilTwoPhaseIndices<0u,0u,0u,0u,false,false,0u,1u,0u>)
+INSTANCE(2, BlackOilTwoPhaseIndices<0u,0u,0u,0u,false,false,0u,2u,0u>)
+INSTANCE(3, BlackOilTwoPhaseIndices<0u,0u,1u,0u,false,false,0u,2u,0u>)
+INSTANCE(1, BlackOilTwoPhaseIndices<0u,0u,1u,0u,false,true,0u,2u,0u>)
+INSTANCE(3, BlackOilTwoPhaseIndices<0u,0u,0u,1u,false,false,0u,1u,0u>)
+INSTANCE(3, BlackOilTwoPhaseIndices<0u,0u,0u,0u,false,true,0u,0u,0u>)
+INSTANCE(3, BlackOilTwoPhaseIndices<0u,0u,0u,0u,false,true,0u,2u,0u>)
+INSTANCE(4, BlackOilTwoPhaseIndices<0u,0u,2u,0u,false,false,0u,2u,0u>)
+
+// Blackoil
+INSTANCE(3, BlackOilIndices<0u,0u,0u,0u,false,false,0u,0u>)
+INSTANCE(4, BlackOilIndices<0u,0u,0u,0u,true,false,0u,0u>)
+INSTANCE(4, BlackOilIndices<0u,0u,0u,0u,false,true,0u,0u>)
+INSTANCE(4, BlackOilIndices<0u,1u,0u,0u,false,false,0u,0u>)
+INSTANCE(4, BlackOilIndices<0u,0u,1u,0u,false,false,0u,0u>)
+INSTANCE(4, BlackOilIndices<0u,0u,0u,1u,false,false,0u,0u>)
+INSTANCE(4, BlackOilIndices<1u,0u,0u,0u,false,false,0u,0u>)
+INSTANCE(5, BlackOilIndices<0u,0u,0u,1u,false,true,0u,0u>)
+INSTANCE(1, BlackOilIndices<0u,0u,0u,1u,false,false,1u,0u>)
+
+}

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -1,0 +1,155 @@
+/*
+  Copyright 2017 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2017 Statoil ASA.
+  Copyright 2016 - 2017 IRIS AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef OPM_STANDARDWELL_EQUATIONS_HEADER_INCLUDED
+#define OPM_STANDARDWELL_EQUATIONS_HEADER_INCLUDED
+
+#include <opm/simulators/utils/ParallelCommunication.hpp>
+#include <opm/simulators/wells/WellHelpers.hpp>
+
+#include <dune/common/dynmatrix.hh>
+#include <dune/common/dynvector.hh>
+#include <dune/istl/bcrsmatrix.hh>
+#include <dune/istl/bvector.hh>
+
+namespace Opm
+{
+
+class BlackOilDefaultIndexTraits;
+template<class Scalar, class Indices> class BlackOilFluidSystem;
+template<class FluidSystem, class Indices, class Scalar> class StandardWellAssemble;
+class WellContributions;
+
+//! \brief Matrices and vectors for the well.
+template<class Indices, class Scalar>
+class StandardWellEquations {
+public:
+    // number of the conservation equations
+    static constexpr int numWellConservationEq = Indices::numPhases + Indices::numSolvents;
+    // number of the well control equations
+    static constexpr int numWellControlEq = 1;
+    // number of the well equations that will always be used
+    // based on the solution strategy, there might be other well equations be introduced
+    static constexpr int numStaticWellEq = numWellConservationEq + numWellControlEq;
+    // the index for Bhp in primary variables and also the index of well control equation
+    // they both will be the last one in their respective system.
+    // TODO: we should have indices for the well equations and well primary variables separately
+    static constexpr int Bhp = numStaticWellEq - numWellControlEq;
+
+    // sparsity pattern for the matrices
+    //[A C^T    [x       =  [ res
+    // B  D ]   x_well]      res_well]
+
+    // the vector type for the res_well and x_well
+    using VectorBlockWellType = Dune::DynamicVector<Scalar>;
+    using BVectorWell = Dune::BlockVector<VectorBlockWellType>;
+
+    // the matrix type for the diagonal matrix D
+    using DiagMatrixBlockWellType = Dune::DynamicMatrix<Scalar>;
+    using DiagMatWell = Dune::BCRSMatrix<DiagMatrixBlockWellType>;
+
+    // the matrix type for the non-diagonal matrix B and C^T
+    using OffDiagMatrixBlockWellType = Dune::DynamicMatrix<Scalar>;
+    using OffDiagMatWell = Dune::BCRSMatrix<OffDiagMatrixBlockWellType>;
+
+    // block vector type
+    using BVector = Dune::BlockVector<Dune::FieldVector<Scalar,Indices::numEq>>;
+
+    //! \brief Constructor initializes matrix assembly mode and the parallel helper.
+    StandardWellEquations(const ParallelWellInfo& parallel_well_info);
+
+    //! \brief Setup sparsity pattern for the matrices.
+    //! \param num_cells Total number of cells
+    //! \param numWellEq Number of well equations
+    //! \param numPerfs Number of perforations
+    //! \param cells Cell indices for perforations
+    void init(const int num_cells,
+              const int numWellEq,
+              const int numPerfs,
+              const std::vector<int> cells);
+
+    //! \brief Set all coefficients to 0.
+    void clear();
+
+    //! \brief Apply linear operator to vector.
+    void apply(const BVector& x, BVector& Ax) const;
+
+    //! \brief Apply linear operator to vector.
+    void apply(BVector& r) const;
+
+    //! \brief Apply inverted D matrix to vector.
+    void solve(BVectorWell& dx_well) const;
+
+    //! \brief Invert D matrix.
+    void invert();
+
+    // xw = inv(D)*(rw - C*x)
+    void recoverSolutionWell(const BVector& x, BVectorWell& xw) const;
+
+    //! \brief Add the contribution (C, D^-1, B matrices) of this Well to the WellContributions object
+    void addWellContribution(WellContributions& wellContribs) const;
+
+    //! \brief Add the contribution (C, D^-1, B matrices) of this Well to the SparseMatrixAdapter
+    template<class SparseMatrixAdapter>
+    void addWellContributions(SparseMatrixAdapter& jacobian) const;
+
+    //! \brief Get the number of blocks of the C and B matrices, used to allocate memory in a WellContributions object
+    unsigned int getNumBlocks() const
+    {
+        return duneB_.nonzeroes();
+    }
+
+    //! \brief Returns a const reference to the residual.
+    const BVectorWell& getResidual() const
+    {
+        return resWell_;
+    }
+
+    //! \brief Sum with off-process contribution.
+    void sumDistributed(Parallel::Communication comm);
+
+protected:
+    friend class StandardWellAssemble<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,
+                                      Indices, Scalar>;
+    // residuals of the well equations
+    BVectorWell resWell_;
+
+    // two off-diagonal matrices
+    OffDiagMatWell duneB_;
+    OffDiagMatWell duneC_;
+
+    // diagonal matrix for the well
+    DiagMatWell duneD_;
+    DiagMatWell invDuneD_;
+
+private:
+    // several vector used in the matrix calculation
+    mutable BVectorWell Bx_;
+    mutable BVectorWell invDrw_;
+
+    // Wrapper for the parallel application of B for distributed wells
+    wellhelpers::ParallelStandardWellB<Scalar> parallelB_;
+};
+
+}
+
+#endif // OPM_STANDARDWELL_EQUATIONS_HEADER_INCLUDED

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -746,7 +746,7 @@ updatePrimaryVariablesNewton(const BVectorWell& dwells,
     processFractions();
 
     // updating the total rates Q_t
-    const double relaxation_factor_rate = this->relaxationFactorRate(old_primary_variables, dwells);
+    const double relaxation_factor_rate = this->relaxationFactorRate(old_primary_variables, dwells[0][WQTotal]);
     primary_variables_[WQTotal] = old_primary_variables[WQTotal] - dwells[0][WQTotal] * relaxation_factor_rate;
 
     // updating the bottom hole pressure

--- a/opm/simulators/wells/StandardWellGeneric.cpp
+++ b/opm/simulators/wells/StandardWellGeneric.cpp
@@ -64,14 +64,13 @@ template<class Scalar>
 double
 StandardWellGeneric<Scalar>::
 relaxationFactorRate(const std::vector<double>& primary_variables,
-                     const BVectorWell& dwells)
+                     const double newton_update)
 {
     double relaxation_factor = 1.0;
     static constexpr int WQTotal = 0;
 
     // For injector, we only check the total rates to avoid sign change of rates
     const double original_total_rate = primary_variables[WQTotal];
-    const double newton_update = dwells[0][WQTotal];
     const double possible_update_total_rate = primary_variables[WQTotal] - newton_update;
 
     // 0.8 here is a experimental value, which remains to be optimized

--- a/opm/simulators/wells/StandardWellGeneric.cpp
+++ b/opm/simulators/wells/StandardWellGeneric.cpp
@@ -52,11 +52,7 @@ StandardWellGeneric(const WellInterfaceGeneric& baseif)
     : baseif_(baseif)
     , perf_densities_(baseif_.numPerfs())
     , perf_pressure_diffs_(baseif_.numPerfs())
-    , parallelB_(duneB_, baseif_.parallelWellInfo())
 {
-    duneB_.setBuildMode(OffDiagMatWell::row_wise);
-    duneC_.setBuildMode(OffDiagMatWell::row_wise);
-    invDuneD_.setBuildMode(DiagMatWell::row_wise);
 }
 
 
@@ -147,14 +143,6 @@ computeConnectionPressureDelta()
     const auto beg = perf_pressure_diffs_.begin();
     const auto end = perf_pressure_diffs_.end();
     baseif_.parallelWellInfo().partialSumPerfValues(beg, end);
-}
-
-template<class Scalar>
-unsigned int
-StandardWellGeneric<Scalar>::
-getNumBlocks() const
-{
-    return duneB_.nonzeroes();
 }
 
 template class StandardWellGeneric<double>;

--- a/opm/simulators/wells/StandardWellGeneric.hpp
+++ b/opm/simulators/wells/StandardWellGeneric.hpp
@@ -74,7 +74,7 @@ protected:
 
     // calculate a relaxation factor to avoid overshoot of total rates
     static double relaxationFactorRate(const std::vector<double>& primary_variables,
-                                       const BVectorWell& dwells);
+                                       const double newton_update);
 
     // relaxation factor considering only one fraction value
     static double relaxationFactorFraction(const double old_value,

--- a/opm/simulators/wells/StandardWellGeneric.hpp
+++ b/opm/simulators/wells/StandardWellGeneric.hpp
@@ -23,11 +23,6 @@
 #ifndef OPM_STANDARDWELL_GENERIC_HEADER_INCLUDED
 #define OPM_STANDARDWELL_GENERIC_HEADER_INCLUDED
 
-#include <dune/common/dynmatrix.hh>
-#include <dune/common/dynvector.hh>
-#include <dune/istl/bcrsmatrix.hh>
-#include <dune/istl/bvector.hh>
-
 #include <opm/simulators/wells/WellHelpers.hpp>
 
 #include <optional>
@@ -49,27 +44,6 @@ template<class Scalar>
 class StandardWellGeneric
 {
 protected:
-    // sparsity pattern for the matrices
-    //[A C^T    [x       =  [ res
-    // B  D ]   x_well]      res_well]
-
-    // the vector type for the res_well and x_well
-    using VectorBlockWellType = Dune::DynamicVector<Scalar>;
-    using BVectorWell = Dune::BlockVector<VectorBlockWellType>;
-
-    // the matrix type for the diagonal matrix D
-    using DiagMatrixBlockWellType = Dune::DynamicMatrix<Scalar>;
-    using DiagMatWell = Dune::BCRSMatrix<DiagMatrixBlockWellType>;
-
-    // the matrix type for the non-diagonal matrix B and C^T
-    using OffDiagMatrixBlockWellType = Dune::DynamicMatrix<Scalar>;
-    using OffDiagMatWell = Dune::BCRSMatrix<OffDiagMatrixBlockWellType>;
-
-public:
-    /// get the number of blocks of the C and B matrices, used to allocate memory in a WellContributions object
-    unsigned int getNumBlocks() const;
-
-protected:
     StandardWellGeneric(const WellInterfaceGeneric& baseif);
 
     // calculate a relaxation factor to avoid overshoot of total rates
@@ -85,27 +59,10 @@ protected:
     // Base interface reference
     const WellInterfaceGeneric& baseif_;
 
-    // residuals of the well equations
-    BVectorWell resWell_;
-
     // densities of the fluid in each perforation
     std::vector<double> perf_densities_;
     // pressure drop between different perforations
     std::vector<double> perf_pressure_diffs_;
-
-    // two off-diagonal matrices
-    OffDiagMatWell duneB_;
-    OffDiagMatWell duneC_;
-    // diagonal matrix for the well
-    DiagMatWell invDuneD_;
-    DiagMatWell duneD_;
-
-    // Wrapper for the parallel application of B for distributed wells
-    wellhelpers::ParallelStandardWellB<Scalar> parallelB_;
-
-    // several vector used in the matrix calculation
-    mutable BVectorWell Bx_;
-    mutable BVectorWell invDrw_;
 
     double getRho() const
     {

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -19,9 +19,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <opm/common/utility/numeric/RootFinders.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
-#include <opm/simulators/linalg/SmallDenseMatrixUtils.hpp>
+#include <opm/simulators/wells/StandardWellAssemble.hpp>
 #include <opm/simulators/wells/VFPHelpers.hpp>
 #include <opm/simulators/wells/WellBhpThpCalculator.hpp>
 #include <opm/simulators/wells/WellConvergence.hpp>
@@ -432,10 +431,7 @@ namespace Opm
         if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return;
 
         // clear all entries
-        this->duneB_ = 0.0;
-        this->duneC_ = 0.0;
-        this->duneD_ = 0.0;
-        this->resWell_ = 0.0;
+        this->linSys_.clear();
 
         assembleWellEqWithoutIterationImpl(ebosSimulator, dt, well_state, group_state, deferred_logger);
     }
@@ -487,19 +483,12 @@ namespace Opm
 
                 connectionRates[perf][componentIdx] = Base::restrictEval(cq_s_effective);
 
-                // subtract sum of phase fluxes in the well equations.
-                this->resWell_[0][componentIdx] += cq_s_effective.value();
-
-                // assemble the jacobians
-                for (int pvIdx = 0; pvIdx < this->numWellEq_; ++pvIdx) {
-                    // also need to consider the efficiency factor when manipulating the jacobians.
-                    this->duneC_[0][cell_idx][pvIdx][componentIdx] -= cq_s_effective.derivative(pvIdx+Indices::numEq); // intput in transformed matrix
-                    this->duneD_[0][0][componentIdx][pvIdx] += cq_s_effective.derivative(pvIdx+Indices::numEq);
-                }
-
-                for (int pvIdx = 0; pvIdx < Indices::numEq; ++pvIdx) {
-                    this->duneB_[0][cell_idx][componentIdx][pvIdx] += cq_s_effective.derivative(pvIdx);
-                }
+                StandardWellAssemble<FluidSystem,Indices,Scalar>(*this).
+                    assemblePerforationEq(cq_s_effective,
+                                          componentIdx,
+                                          cell_idx,
+                                          this->numWellEq_,
+                                          this->linSys_);
 
                 // Store the perforation phase flux for later usage.
                 if (has_solvent && componentIdx == Indices::contiSolventEqIdx) {
@@ -511,9 +500,9 @@ namespace Opm
             }
 
             if constexpr (has_zFraction) {
-                for (int pvIdx = 0; pvIdx < this->numWellEq_; ++pvIdx) {
-                    this->duneC_[0][cell_idx][pvIdx][Indices::contiZfracEqIdx] -= cq_s_zfrac_effective.derivative(pvIdx+Indices::numEq);
-                }
+                StandardWellAssemble<FluidSystem,Indices,Scalar>(*this).
+                    assembleZFracEq(cq_s_zfrac_effective, cell_idx,
+                                    this->numWellEq_, this->linSys_);
             }
         }
         // Update the connection
@@ -529,8 +518,8 @@ namespace Opm
         }
 
         // accumulate resWell_ and duneD_ in parallel to get effects of all perforations (might be distributed)
-        wellhelpers::sumDistributedWellEntries(this->duneD_[0][0], this->resWell_[0],
-                                               this->parallel_well_info_.communication());
+        this->linSys_.sumDistributed(this->parallel_well_info_.communication());
+
         // add vol * dF/dt + Q to the well equations;
         for (int componentIdx = 0; componentIdx < numWellConservationEq; ++componentIdx) {
             // TODO: following the development in MSW, we need to convert the volume of the wellbore to be surface volume
@@ -541,27 +530,27 @@ namespace Opm
                 resWell_loc += (this->wellSurfaceVolumeFraction(componentIdx) - this->F0_[componentIdx]) * volume / dt;
             }
             resWell_loc -= this->getQs(componentIdx) * this->well_efficiency_factor_;
-            for (int pvIdx = 0; pvIdx < this->numWellEq_; ++pvIdx) {
-                this->duneD_[0][0][componentIdx][pvIdx] += resWell_loc.derivative(pvIdx+Indices::numEq);
-            }
-            this->resWell_[0][componentIdx] += resWell_loc.value();
+            StandardWellAssemble<FluidSystem,Indices,Scalar>(*this).
+                assembleSourceEq(resWell_loc, componentIdx, this->numWellEq_, this->linSys_);
         }
 
         const auto& summaryState = ebosSimulator.vanguard().summaryState();
         const Schedule& schedule = ebosSimulator.vanguard().schedule();
-        this->assembleControlEq(well_state, group_state, schedule, summaryState, deferred_logger);
-
+        std::function<EvalWell(int)> gQ = [this](int a) { return this->getQs(a); };
+        StandardWellAssemble<FluidSystem,Indices,Scalar>(*this).
+            assembleControlEq(well_state, group_state,
+                              schedule, summaryState,
+                              this->numWellEq_,
+                              this->getWQTotal(),
+                              this->getBhp(),
+                              gQ,
+                              this->getRho(),
+                              this->linSys_,
+                              deferred_logger);
 
         // do the local inversion of D.
         try {
-            this->invDuneD_ = this->duneD_; // Not strictly need if not cpr with well contributions is used
-            detail::invertMatrix(this->invDuneD_[0][0]);
-        } catch (NumericalProblem&) {
-            // for singular matrices, use identity as the inverse
-            this->invDuneD_[0][0] = 0.0;
-            for (size_t i = 0; i < this->invDuneD_[0][0].rows(); ++i) {
-                this->invDuneD_[0][0][i][i] = 1.0;
-            }
+            this->linSys_.invert();
         } catch( ... ) {
             OPM_DEFLOG_THROW(NumericalIssue,"Error when inverting local well equations for well " + name(), deferred_logger);
         }
@@ -1689,7 +1678,7 @@ namespace Opm
         // which is why we do not put the assembleWellEq here.
         BVectorWell dx_well(1);
         dx_well[0].resize(this->numWellEq_);
-        this->invDuneD_.mv(this->resWell_, dx_well);
+        this->linSys_.solve(dx_well);
 
         updateWellState(dx_well, well_state, deferred_logger);
     }
@@ -1725,20 +1714,8 @@ namespace Opm
             // Contributions are already in the matrix itself
             return;
         }
-        assert( this->Bx_.size() == this->duneB_.N() );
-        assert( this->invDrw_.size() == this->invDuneD_.N() );
 
-        // Bx_ = duneB_ * x
-        this->parallelB_.mv(x, this->Bx_);
-
-        // invDBx = invDuneD_ * Bx_
-        // TODO: with this, we modified the content of the invDrw_.
-        // Is it necessary to do this to save some memory?
-        BVectorWell& invDBx = this->invDrw_;
-        this->invDuneD_.mv(this->Bx_, invDBx);
-
-        // Ax = Ax - duneC_^T * invDBx
-        this->duneC_.mmtv(invDBx,Ax);
+        this->linSys_.apply(x, Ax);
     }
 
 
@@ -1751,12 +1728,7 @@ namespace Opm
     {
         if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return;
 
-        assert( this->invDrw_.size() == this->invDuneD_.N() );
-
-        // invDrw_ = invDuneD_ * resWell_
-        this->invDuneD_.mv(this->resWell_, this->invDrw_);
-        // r = r - duneC_^T * invDrw_
-        this->duneC_.mmtv(this->invDrw_, r);
+        this->linSys_.apply(r);
     }
 
     template<typename TypeTag>
@@ -1766,11 +1738,7 @@ namespace Opm
     {
         if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return;
 
-        BVectorWell resWell = this->resWell_;
-        // resWell = resWell - B * x
-        this->parallelB_.mmv(x, resWell);
-        // xw = D^-1 * resWell
-        this->invDuneD_.mv(resWell, xw);
+        this->linSys_.recoverSolutionWell(x, xw);
     }
 
 
@@ -1789,7 +1757,7 @@ namespace Opm
         BVectorWell xw(1);
         xw[0].resize(this->numWellEq_);
 
-        recoverSolutionWell(x, xw);
+        this->linSys_.recoverSolutionWell(x, xw);
         updateWellState(xw, well_state, deferred_logger);
     }
 
@@ -2171,24 +2139,7 @@ namespace Opm
     void
     StandardWell<TypeTag>::addWellContributions(SparseMatrixAdapter& jacobian) const
     {
-        // We need to change matrx A as follows
-        // A -= C^T D^-1 B
-        // D is diagonal
-        // B and C have 1 row, nc colums and nonzero
-        // at (0,j) only if this well has a perforation at cell j.
-        typename SparseMatrixAdapter::MatrixBlock tmpMat;
-        Dune::DynamicMatrix<Scalar> tmp;
-        for ( auto colC = this->duneC_[0].begin(), endC = this->duneC_[0].end(); colC != endC; ++colC )
-        {
-            const auto row_index = colC.index();
-
-            for ( auto colB = this->duneB_[0].begin(), endB = this->duneB_[0].end(); colB != endB; ++colB )
-            {
-                detail::multMatrix(this->invDuneD_[0][0],  (*colB), tmp);
-                detail::negativeMultMatrixTransposed((*colC), tmp, tmpMat);
-                jacobian.addToBlock( row_index, colB.index(), tmpMat );
-            }
-        }
+        this->linSys_.addWellContributions(jacobian);
     }
 
     
@@ -2200,105 +2151,11 @@ namespace Opm
                                                     const bool use_well_weights,
                                                     const WellState& well_state) const
     {
-        // This adds pressure quation for cpr
-        // For use_well_weights=true
-        //    weights lamda = inv(D)'v  v = 0 v(bhpInd) = 1
-        //    the well equations are summed i lambda' B(:,pressureVarINd) -> B  lambda'*D(:,bhpInd) -> D
-        // For use_well_weights = false
-        //    weights lambda = \sum_i w /n where ths sum is over weights of all perforation cells
-        //    in the case of pressure controlled trivial equations are used and bhp  C=B=0
-        //    then the flow part of the well equations are summed lambda'*B(1:n,pressureVarInd) -> B lambda'*D(1:n,bhpInd) -> D
-        // For bouth
-        //    C -> w'C(:,bhpInd) where w is weights of the perforation cell
-        
-        // Add the well contributions in cpr
-        // use_well_weights is a quasiimpes formulation which is not implemented in multisegment
-        int bhp_var_index = Bhp;
-        int nperf = 0;
-        auto cell_weights = weights[0];// not need for not(use_well_weights)
-        cell_weights = 0.0;
-        assert(this->duneC_.M() == weights.size());
-        const int welldof_ind = this->duneC_.M() + this->index_of_well_;
-        // do not assume anything about pressure controlled with use_well_weights (work fine with the assumtion also)
-        if( not( this->isPressureControlled(well_state) ) || use_well_weights ){
-            // make coupling for reservoir to well            
-            for (auto colC = this->duneC_[0].begin(), endC = this->duneC_[0].end(); colC != endC; ++colC) {
-                const auto row_ind = colC.index();
-                const auto& bw = weights[row_ind];
-                double matel = 0;        
-                assert((*colC).M() == bw.size());
-                for (size_t i = 0; i < bw.size(); ++i) {
-                    matel += (*colC)[bhp_var_index][i] * bw[i];
-                }
-                
-                jacobian[row_ind][welldof_ind] = matel;
-                cell_weights += bw;
-                nperf += 1;
-            }
-        }
-        cell_weights /= nperf;
-        
-        BVectorWell  bweights(1);
-        size_t blockSz = this->numWellEq_;
-        bweights[0].resize(blockSz);
-        bweights[0] = 0.0;
-        double diagElem = 0;
-        {            
-            if ( use_well_weights ){
-                // calculate weighs and set diagonal element
-                //NB! use this options without treating pressure controlled separated
-                //NB! calculate quasiimpes well weights NB do not work well with trueimpes reservoir weights
-                double abs_max = 0;
-                BVectorWell rhs(1);           
-                rhs[0].resize(blockSz);
-                rhs[0][bhp_var_index] = 1.0;
-                DiagMatrixBlockWellType inv_diag_block = this->invDuneD_[0][0];
-                DiagMatrixBlockWellType inv_diag_block_transpose = Opm::wellhelpers::transposeDenseDynMatrix(inv_diag_block);
-                for (size_t i = 0; i < blockSz; ++i) {
-                    bweights[0][i] = 0;
-                    for (size_t j = 0; j < blockSz; ++j) {
-                        bweights[0][i] += inv_diag_block_transpose[i][j]*rhs[0][j];
-                    }
-                    abs_max = std::max(abs_max, std::fabs(bweights[0][i]));
-                }
-                assert( abs_max > 0.0 );
-                for (size_t i = 0; i < blockSz; ++i) {
-                    bweights[0][i] /= abs_max;
-                }
-                diagElem = 1.0/abs_max;
-            }else{
-                // set diagonal element
-                if( this->isPressureControlled(well_state) ){
-                    bweights[0][blockSz-1] = 1.0;
-                    diagElem = 1.0;// better scaling could have used the calculation below if weights were calculated
-                }else{
-                    for (size_t i = 0; i < cell_weights.size(); ++i) {
-                        bweights[0][i] = cell_weights[i];
-                    }
-                    bweights[0][blockSz-1] = 0.0;
-                    diagElem = 0.0;
-                    const auto& locmat = this->duneD_[0][0]; 
-                    for (size_t i = 0; i < cell_weights.size(); ++i) {
-                        diagElem += locmat[i][bhp_var_index]*cell_weights[i];
-                    }
-                    
-                }                 
-            }
-        }
-        //
-        jacobian[welldof_ind][welldof_ind] = diagElem;
-        // set the matrix elements for well reservoir coupling
-        if( not( this->isPressureControlled(well_state) ) || use_well_weights ){
-            for (auto colB = this->duneB_[0].begin(), endB = this->duneB_[0].end(); colB != endB; ++colB) {
-                const auto col_index = colB.index();
-                const auto& bw = bweights[0];
-                double matel = 0;
-                for (size_t i = 0; i < bw.size(); ++i) {
-                     matel += (*colB)[i][pressureVarIndex] * bw[i];
-                }
-                jacobian[welldof_ind][col_index] = matel;
-            }
-        }
+        StandardWellAssemble<FluidSystem,Indices,Scalar>(*this).
+            addWellPressureEqs(weights, pressureVarIndex,
+                               use_well_weights, well_state,
+                               this->numWellEq_, this->linSys_,
+                               jacobian);
     }
 
     
@@ -2466,7 +2323,6 @@ namespace Opm
 
         // equation for the water velocity
         const EvalWell eq_wat_vel = this->primary_variables_evaluation_[wat_vel_index] - water_velocity;
-        this->resWell_[0][wat_vel_index] = eq_wat_vel.value();
 
         const auto& ws = well_state.well(this->index_of_well_);
         const auto& perf_data = ws.perf_data;
@@ -2481,16 +2337,14 @@ namespace Opm
         const EvalWell eq_pskin = this->primary_variables_evaluation_[pskin_index]
                                   - pskin(throughput, this->primary_variables_evaluation_[wat_vel_index], poly_conc, deferred_logger);
 
-        this->resWell_[0][pskin_index] = eq_pskin.value();
-        for (int pvIdx = 0; pvIdx < this->numWellEq_; ++pvIdx) {
-            this->duneD_[0][0][wat_vel_index][pvIdx] = eq_wat_vel.derivative(pvIdx+Indices::numEq);
-            this->duneD_[0][0][pskin_index][pvIdx] = eq_pskin.derivative(pvIdx+Indices::numEq);
-        }
-
-        // the water velocity is impacted by the reservoir primary varaibles. It needs to enter matrix B
-        for (int pvIdx = 0; pvIdx < Indices::numEq; ++pvIdx) {
-            this->duneB_[0][cell_idx][wat_vel_index][pvIdx] = eq_wat_vel.derivative(pvIdx);
-        }
+        StandardWellAssemble<FluidSystem,Indices,Scalar>(*this).
+            assembleInjectivityEq(eq_pskin,
+                                  eq_wat_vel,
+                                  pskin_index,
+                                  wat_vel_index,
+                                  cell_idx,
+                                  this->numWellEq_,
+                                  this->linSys_);
     }
 
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -225,8 +225,6 @@ public:
     // Add well contributions to matrix
     virtual void addWellContributions(SparseMatrixAdapter&) const = 0;
 
-    virtual bool isPressureControlled(const WellState& well_state) const;
-    
     virtual void addWellPressureEquations(PressureMatrix& mat,
                                           const BVector& x,
                                           const int pressureVarIndex,

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -416,4 +416,18 @@ void WellInterfaceGeneric::reportWellSwitching(const SingleWellState& ws, Deferr
     }
 }
 
+bool WellInterfaceGeneric::isPressureControlled(const WellState& well_state) const
+{
+    const auto& ws = well_state.well(this->index_of_well_);
+    if (this->isInjector()) {
+        const Well::InjectorCMode& current = ws.injection_cmode;
+        return current == Well::InjectorCMode::THP ||
+               current == Well::InjectorCMode::BHP;
+    } else {
+        const Well::ProducerCMode& current = ws.production_cmode;
+        return current == Well::ProducerCMode::THP ||
+               current == Well::ProducerCMode::BHP;
+    }
+}
+
 } // namespace Opm

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -193,6 +193,8 @@ public:
                              WellTestState& wellTestState,
                              DeferredLogger& deferred_logger) const;
 
+    bool isPressureControlled(const WellState& well_state) const;
+
 protected:
     bool getAllowCrossFlow() const;
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -572,34 +572,6 @@ namespace Opm
     }
 
     template<typename TypeTag>
-    bool
-    WellInterface<TypeTag>::isPressureControlled(const WellState& well_state) const
-    {
-         bool thp_controlled_well = false;
-        bool bhp_controlled_well = false;
-        const auto& ws = well_state.well(this->index_of_well_);
-        if (this->isInjector()) {
-            const Well::InjectorCMode& current = ws.injection_cmode;
-            if (current == Well::InjectorCMode::THP) {
-                thp_controlled_well = true;
-            }
-            if (current == Well::InjectorCMode::BHP) {
-                bhp_controlled_well = true;
-            }
-        } else {
-            const Well::ProducerCMode& current = ws.production_cmode;
-            if (current == Well::ProducerCMode::THP) {
-                thp_controlled_well = true;
-            }
-            if (current == Well::ProducerCMode::BHP) {
-                bhp_controlled_well = true;
-            }
-        }
-        bool ispressureControlled =  (bhp_controlled_well || thp_controlled_well);
-        return ispressureControlled;
-    }
-
-    template<typename TypeTag>
     void
     WellInterface<TypeTag>::addCellRates(RateVector& rates, int cellIdx) const
     {


### PR DESCRIPTION
the former is a container class for the equation system, as well as methods for applying to vectors.
the latter handles the assembly of the equation system.

in particular the equation system is now private to these two classes (the assembler can access equations members
through a friend declaration).

Sits on top of https://github.com/OPM/opm-simulators/pull/4236 and https://github.com/OPM/opm-simulators/pull/4237