### PR TITLE
Remove KRNUM from Unsupported Keyword List (Back-Port)

### DIFF
--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -324,7 +324,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"IONXSURF", {false, std::nullopt}},
         {"ISOLNUM", {false, std::nullopt}},
         {"JFUNCR", {false, std::nullopt}},
-        {"KRNUM", {false, std::nullopt}},
         {"KRNUMMF", {false, std::nullopt}},
         {"LANGMPL", {false, std::nullopt}},
         {"LANGMUIR", {false, std::nullopt}},


### PR DESCRIPTION
Remove KRNUM from Unsupported Keyword List, as it is now supported. This should be back-ported, to prevent a warning stating the keyword is not supported.