### PR TITLE
[bugfix] Do not unconditionally dereference std::optional.

### DIFF
--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -682,7 +682,11 @@ namespace WellGroupHelpers
         if (!gpm)
             return;
 
-        const auto [name, number] = *gpm->region();
+        const auto& region = gpm->region();
+        if (!region)
+            return;
+
+        const auto [name, number] = *region;
         const double error = gpm->pressure_target() - regional_values.pressure(number);
         double current_rate = 0.0;
         const auto& pu = well_state.phaseUsage();


### PR DESCRIPTION
In WellGroupHelpers we unconditional referenced the region member of GPMaint. Unfortunately, that is a std:optional and doing this can create quite some havoc.

Now we stop processing if it is unset. Not sure whether this is what we want, though.

Drive-by fix. Unfortunately, not the issue that I am after.