### PR TITLE
Promote Segment Data in WRFTPLT to Supported Status

### DIFF
--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -294,12 +294,6 @@ partiallySupported()
             },
          },
          {
-            "WRFTPLT",
-            {
-               {4,{false, allow_values<std::string> {"NO"}, "WRFTPLT(MULTISEG): output is currently not supported – will continue"}}, // OUTPUT_SEGMENT
-            },
-         },
-         {
             "WTEST",
             {
                {3,{false, allow_values<std::string> {"E", "P", "EP", "PE", ""}, "WTEST(TEST): only the E (economic) option is currently supported – will continue"}}, // REASON


### PR DESCRIPTION
While there are a few arrays we admittedly don't create, the level of support is now sufficiently complete that declaring values other than `'NO'` as "supported" is warranted.