### PR TITLE
remove derivative in thermal flux for injectors

### DIFF
--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -681,10 +681,13 @@ namespace Opm
                     fs.setDensity(phaseIdx, rho);
                     const auto& h = FluidSystem::enthalpy(fs, paramCache, phaseIdx);
                     fs.setEnthalpy(phaseIdx, h);
+                    cq_r_thermal *= this->extendEval(fs.enthalpy(phaseIdx)) * this->extendEval(fs.density(phaseIdx));
+                    connectionRates[perf][Indices::contiEnergyEqIdx] += getValue(cq_r_thermal);
+                } else {
+                    // compute the thermal flux
+                    cq_r_thermal *= this->extendEval(fs.enthalpy(phaseIdx)) * this->extendEval(fs.density(phaseIdx));
+                    connectionRates[perf][Indices::contiEnergyEqIdx] += Base::restrictEval(cq_r_thermal);
                 }
-                // compute the thermal flux
-                cq_r_thermal *= this->extendEval(fs.enthalpy(phaseIdx)) * this->extendEval(fs.density(phaseIdx));
-                connectionRates[perf][Indices::contiEnergyEqIdx] += Base::restrictEval(cq_r_thermal);
             }
         }
 


### PR DESCRIPTION
The well flux for injection perforations depends on the mobility in the cell. ie. we dont use the upstream value. this can lead to problems if the mobility depends strongly on temperature. The proposed change fixes the issue reported in #4244 

An alternative fix is to set the mobility of the injection perforation to Scalar but that will also affect non-isothermal cases. Initial testing indicates that this may have minor negative impact on convergence. Any comments?