### PR TITLE
added: StandardWellEquations

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -96,6 +96,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/wells/PerfData.cpp
   opm/simulators/wells/SegmentState.cpp
   opm/simulators/wells/SingleWellState.cpp
+  opm/simulators/wells/StandardWellEquations.cpp
   opm/simulators/wells/StandardWellEval.cpp
   opm/simulators/wells/StandardWellGeneric.cpp
   opm/simulators/wells/TargetCalculator.cpp
@@ -380,6 +381,8 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/SingleWellState.hpp
   opm/simulators/wells/StandardWell.hpp
   opm/simulators/wells/StandardWell_impl.hpp
+  opm/simulators/wells/StandardWellEquations.hpp
+  opm/simulators/wells/StandardWellEval.hpp
   opm/simulators/wells/TargetCalculator.hpp
   opm/simulators/wells/VFPHelpers.hpp
   opm/simulators/wells/VFPInjProperties.hpp

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -320,7 +320,7 @@ namespace Opm {
             Simulator& ebosSimulator_;
 
             // a vector of all the wells.
-            std::vector<WellInterfacePtr > well_container_{};
+            std::vector<WellInterfacePtr> well_container_{};
 
             std::vector<bool> is_cell_perforated_{};
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1203,7 +1203,7 @@ namespace Opm {
             auto& well = well_container_[i];
             std::shared_ptr<StandardWell<TypeTag> > derived = std::dynamic_pointer_cast<StandardWell<TypeTag> >(well);
             if (derived) {
-                wellContribs.addNumBlocks(derived->getNumBlocks());
+                wellContribs.addNumBlocks(derived->linSys().getNumBlocks());
             }
         }
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1213,9 +1213,9 @@ namespace Opm {
         for(unsigned int i = 0; i < well_container_.size(); i++){
             auto& well = well_container_[i];
             // maybe WellInterface could implement addWellContribution()
-            auto derived_std = std::dynamic_pointer_cast<StandardWell<TypeTag> >(well);
+            auto derived_std = std::dynamic_pointer_cast<StandardWell<TypeTag>>(well);
             if (derived_std) {
-                derived_std->addWellContribution(wellContribs);
+                derived_std->linSys().extract(derived_std->numStaticWellEq, wellContribs);
             } else {
                 auto derived_ms = std::dynamic_pointer_cast<MultisegmentWell<TypeTag> >(well);
                 if (derived_ms) {

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -19,6 +19,7 @@
 */
 
 
+#include <opm/simulators/linalg/SmallDenseMatrixUtils.hpp>
 #include <opm/simulators/wells/MSWellHelpers.hpp>
 #include <opm/simulators/wells/WellBhpThpCalculator.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -253,9 +253,6 @@ namespace Opm
     protected:
         bool regularize_;
 
-        // xw = inv(D)*(rw - C*x)
-        void recoverSolutionWell(const BVector& x, BVectorWell& xw) const;
-
         // updating the well_state based on well solution dwells
         void updateWellState(const BVectorWell& dwells,
                              WellState& well_state,

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -166,6 +166,18 @@ void StandardWellEquations<Scalar,numEq>::solve(BVectorWell& dx_well) const
     invDuneD_.mv(resWell_, dx_well);
 }
 
+
+template<class Scalar, int numEq>
+void StandardWellEquations<Scalar,numEq>::
+recoverSolutionWell(const BVector& x, BVectorWell& xw) const
+{
+    BVectorWell resWell = resWell_;
+    // resWell = resWell - B * x
+    parallelB_.mmv(x, resWell);
+    // xw = D^-1 * resWell
+    invDuneD_.mv(resWell, xw);
+}
+
 #define INSTANCE(N) \
 template class StandardWellEquations<double,N>;
 

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -262,6 +262,13 @@ extract(SparseMatrixAdapter& jacobian) const
     }
 }
 
+template<class Scalar, int numEq>
+unsigned int StandardWellEquations<Scalar,numEq>::
+getNumBlocks() const
+{
+    return duneB_.nonzeroes();
+}
+
 #define INSTANCE(N) \
 template class StandardWellEquations<double,N>; \
 template void StandardWellEquations<double,N>::extract(Linear::IstlSparseMatrixAdapter<MatrixBlock<double,N,N>>&) const;

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -111,6 +111,25 @@ void StandardWellEquations<Scalar,numEq>::clear()
     resWell_ = 0.0;
 }
 
+template<class Scalar, int numEq>
+void StandardWellEquations<Scalar,numEq>::apply(const BVector& x, BVector& Ax) const
+{
+    assert(Bx_.size() == duneB_.N());
+    assert(invDrw_.size() == invDuneD_.N());
+
+    // Bx_ = duneB_ * x
+    parallelB_.mv(x, Bx_);
+
+    // invDBx = invDuneD_ * Bx_
+    // TODO: with this, we modified the content of the invDrw_.
+    // Is it necessary to do this to save some memory?
+    auto& invDBx = invDrw_;
+    invDuneD_.mv(Bx_, invDBx);
+
+    // Ax = Ax - duneC_^T * invDBx
+    duneC_.mmtv(invDBx, Ax);
+}
+
 #define INSTANCE(N) \
 template class StandardWellEquations<double,N>;
 

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -35,6 +35,16 @@ StandardWellEquations(const ParallelWellInfo& parallel_well_info)
     invDuneD_.setBuildMode(DiagMatWell::row_wise);
 }
 
+
+template<class Scalar, int numEq>
+void StandardWellEquations<Scalar,numEq>::clear()
+{
+    duneB_ = 0.0;
+    duneC_ = 0.0;
+    duneD_ = 0.0;
+    resWell_ = 0.0;
+}
+
 #define INSTANCE(N) \
 template class StandardWellEquations<double,N>;
 

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -130,6 +130,17 @@ void StandardWellEquations<Scalar,numEq>::apply(const BVector& x, BVector& Ax) c
     duneC_.mmtv(invDBx, Ax);
 }
 
+template<class Scalar, int numEq>
+void StandardWellEquations<Scalar,numEq>::apply(BVector& r) const
+{
+    assert(invDrw_.size() == invDuneD_.N());
+
+    // invDrw_ = invDuneD_ * resWell_
+    invDuneD_.mv(resWell_, invDrw_);
+    // r = r - duneC_^T * invDrw_
+    duneC_.mmtv(invDrw_, r);
+}
+
 #define INSTANCE(N) \
 template class StandardWellEquations<double,N>;
 

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -160,6 +160,12 @@ void StandardWellEquations<Scalar,numEq>::invert()
     }
 }
 
+template<class Scalar, int numEq>
+void StandardWellEquations<Scalar,numEq>::solve(BVectorWell& dx_well) const
+{
+    invDuneD_.mv(resWell_, dx_well);
+}
+
 #define INSTANCE(N) \
 template class StandardWellEquations<double,N>;
 

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -385,6 +385,14 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
     }
 }
 
+template<class Scalar, int numEq>
+void StandardWellEquations<Scalar,numEq>::
+sumDistributed(Parallel::Communication comm)
+{
+  // accumulate resWell_ and duneD_ in parallel to get effects of all perforations (might be distributed)
+    wellhelpers::sumDistributedWellEntries(duneD_[0][0], resWell_[0], comm);
+}
+
 #define INSTANCE(N) \
 template class StandardWellEquations<double,N>; \
 template void StandardWellEquations<double,N>:: \

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -1,0 +1,48 @@
+/*
+  Copyright 2017 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2017 Statoil ASA.
+  Copyright 2016 - 2017 IRIS AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+#include <opm/simulators/wells/StandardWellEquations.hpp>
+
+namespace Opm
+{
+
+template<class Scalar, int numEq>
+StandardWellEquations<Scalar,numEq>::
+StandardWellEquations(const ParallelWellInfo& parallel_well_info)
+    : parallelB_(duneB_, parallel_well_info)
+{
+    duneB_.setBuildMode(OffDiagMatWell::row_wise);
+    duneC_.setBuildMode(OffDiagMatWell::row_wise),
+    invDuneD_.setBuildMode(DiagMatWell::row_wise);
+}
+
+#define INSTANCE(N) \
+template class StandardWellEquations<double,N>;
+
+INSTANCE(1)
+INSTANCE(2)
+INSTANCE(3)
+INSTANCE(4)
+INSTANCE(5)
+INSTANCE(6)
+
+}

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -85,6 +85,10 @@ public:
     //! \brief Invert D matrix.
     void invert();
 
+    //! \brief Recover well solution.
+    //! \details xw = inv(D)*(rw - C*x)
+    void recoverSolutionWell(const BVector& x, BVectorWell& xw) const;
+
     // two off-diagonal matrices
     OffDiagMatWell duneB_;
     OffDiagMatWell duneC_;

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -73,6 +73,9 @@ public:
     //! \brief Set all coefficients to 0.
     void clear();
 
+    //! \brief Apply linear operator to vector.
+    void apply(const BVector& x, BVector& Ax) const;
+
     // two off-diagonal matrices
     OffDiagMatWell duneB_;
     OffDiagMatWell duneC_;

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -60,6 +60,9 @@ public:
 
     StandardWellEquations(const ParallelWellInfo& parallel_well_info);
 
+    //! \brief Set all coefficients to 0.
+    void clear();
+
     // two off-diagonal matrices
     OffDiagMatWell duneB_;
     OffDiagMatWell duneC_;

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -79,6 +79,9 @@ public:
     //! \brief Apply linear operator to vector.
     void apply(BVector& r) const;
 
+    //! \brief Apply inverted D matrix to residual and store in vector.
+    void solve(BVectorWell& dx_well) const;
+
     //! \brief Invert D matrix.
     void invert();
 

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -23,6 +23,7 @@
 #ifndef OPM_STANDARDWELL_EQUATIONS_HEADER_INCLUDED
 #define OPM_STANDARDWELL_EQUATIONS_HEADER_INCLUDED
 
+#include <opm/simulators/utils/ParallelCommunication.hpp>
 #include <opm/simulators/wells/WellHelpers.hpp>
 
 #include <dune/common/dynmatrix.hh>
@@ -112,6 +113,9 @@ public:
 
     //! \brief Get the number of blocks of the C and B matrices.
     unsigned int getNumBlocks() const;
+
+    //! \brief Sum with off-process contribution.
+    void sumDistributed(Parallel::Communication comm);
 
     // two off-diagonal matrices
     OffDiagMatWell duneB_;

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -35,6 +35,8 @@ namespace Opm
 
 class ParallelWellInfo;
 class WellContributions;
+class WellInterfaceGeneric;
+class WellState;
 
 template<class Scalar, int numEq>
 class StandardWellEquations
@@ -97,6 +99,16 @@ public:
     //! \brief Add the matrices of this well to the sparse matrix adapter.
     template<class SparseMatrixAdapter>
     void extract(SparseMatrixAdapter& jacobian) const;
+
+    //! \brief Extract CPR pressure matrix.
+    template<class PressureMatrix>
+    void extractCPRPressureMatrix(PressureMatrix& jacobian,
+                                  const BVector& weights,
+                                  const int pressureVarIndex,
+                                  const bool use_well_weights,
+                                  const WellInterfaceGeneric& well,
+                                  const int bhp_var_index,
+                                  const WellState& well_state) const;
 
     //! \brief Get the number of blocks of the C and B matrices.
     unsigned int getNumBlocks() const;

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -34,6 +34,7 @@ namespace Opm
 {
 
 class ParallelWellInfo;
+class WellContributions;
 
 template<class Scalar, int numEq>
 class StandardWellEquations
@@ -88,6 +89,10 @@ public:
     //! \brief Recover well solution.
     //! \details xw = inv(D)*(rw - C*x)
     void recoverSolutionWell(const BVector& x, BVectorWell& xw) const;
+
+    //! \brief Add the matrices of this well to the WellContributions object.
+    void extract(const int numStaticWellEq,
+                 WellContributions& wellContribs) const;
 
     // two off-diagonal matrices
     OffDiagMatWell duneB_;

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -94,6 +94,10 @@ public:
     void extract(const int numStaticWellEq,
                  WellContributions& wellContribs) const;
 
+    //! \brief Add the matrices of this well to the sparse matrix adapter.
+    template<class SparseMatrixAdapter>
+    void extract(SparseMatrixAdapter& jacobian) const;
+
     // two off-diagonal matrices
     OffDiagMatWell duneB_;
     OffDiagMatWell duneC_;

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -76,6 +76,9 @@ public:
     //! \brief Apply linear operator to vector.
     void apply(const BVector& x, BVector& Ax) const;
 
+    //! \brief Apply linear operator to vector.
+    void apply(BVector& r) const;
+
     // two off-diagonal matrices
     OffDiagMatWell duneB_;
     OffDiagMatWell duneC_;

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -79,6 +79,9 @@ public:
     //! \brief Apply linear operator to vector.
     void apply(BVector& r) const;
 
+    //! \brief Invert D matrix.
+    void invert();
+
     // two off-diagonal matrices
     OffDiagMatWell duneB_;
     OffDiagMatWell duneC_;

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -98,6 +98,9 @@ public:
     template<class SparseMatrixAdapter>
     void extract(SparseMatrixAdapter& jacobian) const;
 
+    //! \brief Get the number of blocks of the C and B matrices.
+    unsigned int getNumBlocks() const;
+
     // two off-diagonal matrices
     OffDiagMatWell duneB_;
     OffDiagMatWell duneC_;

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -60,6 +60,16 @@ public:
 
     StandardWellEquations(const ParallelWellInfo& parallel_well_info);
 
+    //! \brief Setup sparsity pattern for the matrices.
+    //! \param num_cells Total number of cells
+    //! \param numWellEq Number of well equations
+    //! \param numPerfs Number of perforations
+    //! \param cells Cell indices for perforations
+    void init(const int num_cells,
+              const int numWellEq,
+              const int numPerfs,
+              const std::vector<int>& cells);
+
     //! \brief Set all coefficients to 0.
     void clear();
 

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -1044,13 +1044,6 @@ init(std::vector<double>& perf_depth,
                        baseif_.numPerfs(), baseif_.cells());
 }
 
-template<class FluidSystem, class Indices, class Scalar>
-unsigned int StandardWellEval<FluidSystem,Indices,Scalar>::
-getNumBlocks() const
-{
-    return linSys_.duneB_.nonzeroes();
-}
-
 #define INSTANCE(...) \
 template class StandardWellEval<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,__VA_ARGS__,double>;
 

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -1045,57 +1045,6 @@ init(std::vector<double>& perf_depth,
 }
 
 template<class FluidSystem, class Indices, class Scalar>
-void
-StandardWellEval<FluidSystem,Indices,Scalar>::
-addWellContribution(WellContributions& wellContribs) const
-{
-    std::vector<int> colIndices;
-    std::vector<double> nnzValues;
-    colIndices.reserve(this->linSys_.duneB_.nonzeroes());
-    nnzValues.reserve(this->linSys_.duneB_.nonzeroes()*numStaticWellEq * Indices::numEq);
-
-    // duneC
-    for (auto colC = this->linSys_.duneC_[0].begin(),
-              endC = this->linSys_.duneC_[0].end(); colC != endC; ++colC )
-    {
-        colIndices.emplace_back(colC.index());
-        for (int i = 0; i < numStaticWellEq; ++i) {
-            for (int j = 0; j < Indices::numEq; ++j) {
-                nnzValues.emplace_back((*colC)[i][j]);
-            }
-        }
-    }
-    wellContribs.addMatrix(WellContributions::MatrixType::C, colIndices.data(), nnzValues.data(), this->linSys_.duneC_.nonzeroes());
-
-    // invDuneD
-    colIndices.clear();
-    nnzValues.clear();
-    colIndices.emplace_back(0);
-    for (int i = 0; i < numStaticWellEq; ++i)
-    {
-        for (int j = 0; j < numStaticWellEq; ++j) {
-            nnzValues.emplace_back(this->linSys_.invDuneD_[0][0][i][j]);
-        }
-    }
-    wellContribs.addMatrix(WellContributions::MatrixType::D, colIndices.data(), nnzValues.data(), 1);
-
-    // duneB
-    colIndices.clear();
-    nnzValues.clear();
-    for (auto colB = this->linSys_.duneB_[0].begin(),
-              endB = this->linSys_.duneB_[0].end(); colB != endB; ++colB )
-    {
-        colIndices.emplace_back(colB.index());
-        for (int i = 0; i < numStaticWellEq; ++i) {
-            for (int j = 0; j < Indices::numEq; ++j) {
-                nnzValues.emplace_back((*colB)[i][j]);
-            }
-        }
-    }
-    wellContribs.addMatrix(WellContributions::MatrixType::B, colIndices.data(), nnzValues.data(), this->linSys_.duneB_.nonzeroes());
-}
-
-template<class FluidSystem, class Indices, class Scalar>
 unsigned int StandardWellEval<FluidSystem,Indices,Scalar>::
 getNumBlocks() const
 {

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -1040,63 +1040,8 @@ init(std::vector<double>& perf_depth,
     primary_variables_evaluation_.resize(numWellEq_, EvalWell{numWellEq_ + Indices::numEq, 0.0});
 
     // setup sparsity pattern for the matrices
-    //[A C^T    [x    =  [ res
-    // B D] x_well]      res_well]
-    // set the size of the matrices
-    this->linSys_.duneD_.setSize(1, 1, 1);
-    this->linSys_.duneB_.setSize(1, num_cells, baseif_.numPerfs());
-    this->linSys_.duneC_.setSize(1, num_cells, baseif_.numPerfs());
-
-    for (auto row = this->linSys_.duneD_.createbegin(),
-              end = this->linSys_.duneD_.createend(); row != end; ++row) {
-        // Add nonzeros for diagonal
-        row.insert(row.index());
-    }
-    // the block size is run-time determined now
-    this->linSys_.duneD_[0][0].resize(numWellEq_, numWellEq_);
-
-    for (auto row = this->linSys_.duneB_.createbegin(),
-              end = this->linSys_.duneB_.createend(); row != end; ++row) {
-        for (int perf = 0 ; perf < baseif_.numPerfs(); ++perf) {
-            const int cell_idx = baseif_.cells()[perf];
-            row.insert(cell_idx);
-        }
-    }
-
-    for (int perf = 0 ; perf < baseif_.numPerfs(); ++perf) {
-        const int cell_idx = baseif_.cells()[perf];
-         // the block size is run-time determined now
-         this->linSys_.duneB_[0][cell_idx].resize(numWellEq_, Indices::numEq);
-    }
-
-    // make the C^T matrix
-    for (auto row = this->linSys_.duneC_.createbegin(),
-              end = this->linSys_.duneC_.createend(); row != end; ++row) {
-        for (int perf = 0; perf < baseif_.numPerfs(); ++perf) {
-            const int cell_idx = baseif_.cells()[perf];
-            row.insert(cell_idx);
-        }
-    }
-
-    for (int perf = 0; perf < baseif_.numPerfs(); ++perf) {
-        const int cell_idx = baseif_.cells()[perf];
-        this->linSys_.duneC_[0][cell_idx].resize(numWellEq_, Indices::numEq);
-    }
-
-    this->linSys_.resWell_.resize(1);
-    // the block size of resWell_ is also run-time determined now
-    this->linSys_.resWell_[0].resize(numWellEq_);
-
-    // resize temporary class variables
-    this->linSys_.Bx_.resize(this->linSys_.duneB_.N());
-    for (unsigned i = 0; i < this->linSys_.duneB_.N(); ++i) {
-        this->linSys_.Bx_[i].resize(numWellEq_);
-    }
-
-    this->linSys_.invDrw_.resize(this->linSys_.duneD_.N());
-    for (unsigned i = 0; i < this->linSys_.duneD_.N(); ++i) {
-        this->linSys_.invDrw_[i].resize(numWellEq_);
-    }
+    this->linSys_.init(num_cells, this->numWellEq_,
+                       baseif_.numPerfs(), baseif_.cells());
 }
 
 template<class FluidSystem, class Indices, class Scalar>

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -53,7 +53,11 @@ protected:
     static constexpr int numWellControlEq = 1;
     // number of the well equations that will always be used
     // based on the solution strategy, there might be other well equations be introduced
+
+public:
     static constexpr int numStaticWellEq = numWellConservationEq + numWellControlEq;
+
+protected:
     // the index for Bhp in primary variables and also the index of well control equation
     // they both will be the last one in their respective system.
     // TODO: we should have indices for the well equations and well primary variables separately
@@ -96,9 +100,6 @@ public:
     using EvalWell = DenseAd::DynamicEvaluation<Scalar, numStaticWellEq + Indices::numEq + 1>;
     using Eval = DenseAd::Evaluation<Scalar, Indices::numEq>;
     using BVectorWell = typename StandardWellGeneric<Scalar>::BVectorWell;
-
-    /// add the contribution (C, D^-1, B matrices) of this Well to the WellContributions object
-    void addWellContribution(WellContributions& wellContribs) const;
 
     //! \brief Returns a const reference to equation system.
     const StandardWellEquations<Scalar,Indices::numEq>& linSys() const

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -23,6 +23,7 @@
 #ifndef OPM_STANDARDWELL_EVAL_HEADER_INCLUDED
 #define OPM_STANDARDWELL_EVAL_HEADER_INCLUDED
 
+#include <opm/simulators/wells/StandardWellEquations.hpp>
 #include <opm/simulators/wells/StandardWellGeneric.hpp>
 
 #include <opm/material/densead/DynamicEvaluation.hpp>
@@ -96,8 +97,12 @@ public:
     using Eval = DenseAd::Evaluation<Scalar, Indices::numEq>;
     using BVectorWell = typename StandardWellGeneric<Scalar>::BVectorWell;
 
-        /// add the contribution (C, D^-1, B matrices) of this Well to the WellContributions object
-        void addWellContribution(WellContributions& wellContribs) const;
+    /// add the contribution (C, D^-1, B matrices) of this Well to the WellContributions object
+    void addWellContribution(WellContributions& wellContribs) const;
+
+    //! \brief Returns a const reference to equation system.
+    const StandardWellEquations<Scalar,Indices::numEq>& linSys() const
+    { return linSys_; }
 
 protected:
     StandardWellEval(const WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif);
@@ -190,6 +195,8 @@ protected:
 
     // the saturations in the well bore under surface conditions at the beginning of the time step
     std::vector<double> F0_;
+
+    StandardWellEquations<Scalar,Indices::numEq> linSys_; //!< Linear equation system
 };
 
 }

--- a/opm/simulators/wells/StandardWellGeneric.cpp
+++ b/opm/simulators/wells/StandardWellGeneric.cpp
@@ -52,11 +52,7 @@ StandardWellGeneric(const WellInterfaceGeneric& baseif)
     : baseif_(baseif)
     , perf_densities_(baseif_.numPerfs())
     , perf_pressure_diffs_(baseif_.numPerfs())
-    , parallelB_(duneB_, baseif_.parallelWellInfo())
 {
-    duneB_.setBuildMode(OffDiagMatWell::row_wise);
-    duneC_.setBuildMode(OffDiagMatWell::row_wise);
-    invDuneD_.setBuildMode(DiagMatWell::row_wise);
 }
 
 
@@ -147,14 +143,6 @@ computeConnectionPressureDelta()
     const auto beg = perf_pressure_diffs_.begin();
     const auto end = perf_pressure_diffs_.end();
     baseif_.parallelWellInfo().partialSumPerfValues(beg, end);
-}
-
-template<class Scalar>
-unsigned int
-StandardWellGeneric<Scalar>::
-getNumBlocks() const
-{
-    return duneB_.nonzeroes();
 }
 
 template class StandardWellGeneric<double>;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -432,10 +432,7 @@ namespace Opm
         if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return;
 
         // clear all entries
-        this->linSys_.duneB_ = 0.0;
-        this->linSys_.duneC_ = 0.0;
-        this->linSys_.duneD_ = 0.0;
-        this->linSys_.resWell_ = 0.0;
+        this->linSys_.clear();
 
         assembleWellEqWithoutIterationImpl(ebosSimulator, dt, well_state, group_state, deferred_logger);
     }

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1736,12 +1736,7 @@ namespace Opm
     {
         if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return;
 
-        assert(this->linSys_.invDrw_.size() == this->linSys_.invDuneD_.N());
-
-        // invDrw_ = invDuneD_ * resWell_
-        this->linSys_.invDuneD_.mv(this->linSys_.resWell_, this->linSys_.invDrw_);
-        // r = r - duneC_^T * invDrw_
-        this->linSys_.duneC_.mmtv(this->linSys_.invDrw_, r);
+        this->linSys_.apply(r);
     }
 
     template<typename TypeTag>

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1722,20 +1722,8 @@ namespace Opm
             // Contributions are already in the matrix itself
             return;
         }
-        assert(this->linSys_.Bx_.size() == this->linSys_.duneB_.N());
-        assert(this->linSys_.invDrw_.size() == this->linSys_.invDuneD_.N());
 
-        // Bx_ = duneB_ * x
-        this->linSys_.parallelB_.mv(x, this->linSys_.Bx_);
-
-        // invDBx = invDuneD_ * Bx_
-        // TODO: with this, we modified the content of the invDrw_.
-        // Is it necessary to do this to save some memory?
-        BVectorWell& invDBx = this->linSys_.invDrw_;
-        this->linSys_.invDuneD_.mv(this->linSys_.Bx_, invDBx);
-
-        // Ax = Ax - duneC_^T * invDBx
-        this->linSys_.duneC_.mmtv(invDBx,Ax);
+        this->linSys_.apply(x, Ax);
     }
 
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1732,21 +1732,6 @@ namespace Opm
         this->linSys_.apply(r);
     }
 
-    template<typename TypeTag>
-    void
-    StandardWell<TypeTag>::
-    recoverSolutionWell(const BVector& x, BVectorWell& xw) const
-    {
-        if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return;
-
-        BVectorWell resWell = this->linSys_.resWell_;
-        // resWell = resWell - B * x
-        this->linSys_.parallelB_.mmv(x, resWell);
-        // xw = D^-1 * resWell
-        this->linSys_.invDuneD_.mv(resWell, xw);
-    }
-
-
 
 
 
@@ -1762,7 +1747,7 @@ namespace Opm
         BVectorWell xw(1);
         xw[0].resize(this->numWellEq_);
 
-        recoverSolutionWell(x, xw);
+        this->linSys_.recoverSolutionWell(x, xw);
         updateWellState(xw, well_state, deferred_logger);
     }
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -19,9 +19,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <opm/common/utility/numeric/RootFinders.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
-#include <opm/simulators/linalg/SmallDenseMatrixUtils.hpp>
 #include <opm/simulators/wells/VFPHelpers.hpp>
 #include <opm/simulators/wells/WellBhpThpCalculator.hpp>
 #include <opm/simulators/wells/WellConvergence.hpp>

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -526,8 +526,8 @@ namespace Opm
         }
 
         // accumulate resWell_ and duneD_ in parallel to get effects of all perforations (might be distributed)
-        wellhelpers::sumDistributedWellEntries(this->linSys_.duneD_[0][0], this->linSys_.resWell_[0],
-                                               this->parallel_well_info_.communication());
+        this->linSys_.sumDistributed(this->parallel_well_info_.communication());
+
         // add vol * dF/dt + Q to the well equations;
         for (int componentIdx = 0; componentIdx < numWellConservationEq; ++componentIdx) {
             // TODO: following the development in MSW, we need to convert the volume of the wellbore to be surface volume

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -551,14 +551,7 @@ namespace Opm
 
         // do the local inversion of D.
         try {
-            this->linSys_.invDuneD_ = this->linSys_.duneD_; // Not strictly need if not cpr with well contributions is used
-            detail::invertMatrix(this->linSys_.invDuneD_[0][0]);
-        } catch (NumericalProblem&) {
-            // for singular matrices, use identity as the inverse
-            this->linSys_.invDuneD_[0][0] = 0.0;
-            for (size_t i = 0; i < this->linSys_.invDuneD_[0][0].rows(); ++i) {
-                this->linSys_.invDuneD_[0][0][i][i] = 1.0;
-            }
+            this->linSys_.invert();
         } catch( ... ) {
             OPM_DEFLOG_THROW(NumericalIssue,"Error when inverting local well equations for well " + name(), deferred_logger);
         }

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1679,7 +1679,7 @@ namespace Opm
         // which is why we do not put the assembleWellEq here.
         BVectorWell dx_well(1);
         dx_well[0].resize(this->numWellEq_);
-        this->linSys_.invDuneD_.mv(this->linSys_.resWell_, dx_well);
+        this->linSys_.solve( dx_well);
 
         updateWellState(dx_well, well_state, deferred_logger);
     }

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2129,26 +2129,7 @@ namespace Opm
     void
     StandardWell<TypeTag>::addWellContributions(SparseMatrixAdapter& jacobian) const
     {
-        // We need to change matrx A as follows
-        // A -= C^T D^-1 B
-        // D is diagonal
-        // B and C have 1 row, nc colums and nonzero
-        // at (0,j) only if this well has a perforation at cell j.
-        typename SparseMatrixAdapter::MatrixBlock tmpMat;
-        Dune::DynamicMatrix<Scalar> tmp;
-        for (auto colC = this->linSys_.duneC_[0].begin(),
-                  endC = this->linSys_.duneC_[0].end(); colC != endC; ++colC)
-        {
-            const auto row_index = colC.index();
-
-            for (auto colB = this->linSys_.duneB_[0].begin(),
-                      endB = this->linSys_.duneB_[0].end(); colB != endB; ++colB)
-            {
-                detail::multMatrix(this->linSys_.invDuneD_[0][0],  (*colB), tmp);
-                detail::negativeMultMatrixTransposed((*colC), tmp, tmpMat);
-                jacobian.addToBlock( row_index, colB.index(), tmpMat );
-            }
-        }
+        this->linSys_.extract(jacobian);
     }
 
     

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -71,7 +71,6 @@ class WellInterface : public WellInterfaceIndices<GetPropType<TypeTag, Propertie
                                                   GetPropType<TypeTag, Properties::Scalar>>
 {
 public:
-
     using ModelParameters = BlackoilModelParametersEbos<TypeTag>;
 
     using Grid = GetPropType<TypeTag, Properties::Grid>;


### PR DESCRIPTION
This is a container class for the equation system, as well as methods for applying to vectors.

- better code organization
- less instances. instead of one instance per index instance there is now one instance per block size (1..6).

This is part of a process to refactor the equation system and assembly of this from in standard well, as drafted in https://github.com/OPM/opm-simulators/pull/4238. All data members are still public, but this will be remedied later.

Sits on top of https://github.com/OPM/opm-simulators/pull/4237