### PR TITLE
not calculating emulsionViscosity for small liquid_fraction

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -888,7 +888,7 @@ pressureDropSpiralICD(const int seg) const
     const EvalWell liquid_fraction = water_fraction + oil_fraction;
 
     // viscosity contribution from the liquid
-    const EvalWell liquid_viscosity_fraction = liquid_fraction < 1.e-30 ? 0 :
+    const EvalWell liquid_viscosity_fraction = liquid_fraction < 1.e-30 ? oil_fraction * oil_viscosity + water_fraction * water_viscosity :
             liquid_fraction * mswellhelpers::emulsionViscosity(water_fraction, water_viscosity, oil_fraction, oil_viscosity, sicd);
 
     const EvalWell mixture_viscosity = liquid_viscosity_fraction + gas_fraction * gas_viscosity;

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -884,9 +884,14 @@ pressureDropSpiralICD(const int seg) const
         density.clearDerivatives();
     }
 
-    const EvalWell liquid_emulsion_viscosity = mswellhelpers::emulsionViscosity(water_fraction, water_viscosity,
-                                                                                oil_fraction, oil_viscosity, sicd);
-    const EvalWell mixture_viscosity = (water_fraction + oil_fraction) * liquid_emulsion_viscosity + gas_fraction * gas_viscosity;
+
+    const EvalWell liquid_fraction = water_fraction + oil_fraction;
+
+    // viscosity contribution from the liquid
+    const EvalWell liquid_viscosity_fraction = liquid_fraction < 1.e-30 ? 0 :
+            liquid_fraction * mswellhelpers::emulsionViscosity(water_fraction, water_viscosity, oil_fraction, oil_viscosity, sicd);
+
+    const EvalWell mixture_viscosity = liquid_viscosity_fraction + gas_fraction * gas_viscosity;
 
     const EvalWell reservoir_rate = segment_mass_rates_[seg] / density;
 


### PR DESCRIPTION
it might introduce inf/nan in the Jacobian matrix.

At the beginning, was thinking to return zero emulsionViscosity for small liquid_fraction, but zero viscosity is something weird. In the PR, basically, we make `liquid_fraction * emulsionViscosity` to be zero.  Maybe less strange. 

Please suggest. 