### PR TITLE
Use internalized THPRESFT

### DIFF
--- a/ebos/eclgenericthresholdpressure.cc
+++ b/ebos/eclgenericthresholdpressure.cc
@@ -24,9 +24,6 @@
 #include <config.h>
 #include <ebos/eclgenericthresholdpressure.hh>
 
-#include <opm/material/densead/Evaluation.hpp>
-#include <opm/material/densead/Math.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/Eqldims.hpp>
@@ -60,13 +57,11 @@ EclGenericThresholdPressure<Grid,GridView,ElementMapper,Scalar>::
 EclGenericThresholdPressure(const CartesianIndexMapper& cartMapper,
                             const GridView& gridView,
                             const ElementMapper& elementMapper,
-                            const EclipseState& eclState,
-                            const Deck& deck)
+                            const EclipseState& eclState)
     : cartMapper_(cartMapper)
     , gridView_(gridView)
     , elementMapper_(elementMapper)
     , eclState_(eclState)
-    , deck_(deck)
 {
 }
 

--- a/ebos/eclgenericthresholdpressure.hh
+++ b/ebos/eclgenericthresholdpressure.hh
@@ -34,8 +34,6 @@
 
 namespace Opm {
 
-class Deck;
-class DeckKeyword;
 class EclipseState;
 
 template<class Grid, class GridView, class ElementMapper, class Scalar>
@@ -46,8 +44,7 @@ public:
     EclGenericThresholdPressure(const CartesianIndexMapper& cartMapper,
                                 const GridView& gridView,
                                 const ElementMapper& elementMapper,
-                                const EclipseState& eclState,
-                                const Deck& deck);
+                                const EclipseState& eclState);
 
     /*!
      * \brief Returns the theshold pressure [Pa] for the intersection between two elements.
@@ -91,7 +88,6 @@ protected:
     const GridView& gridView_;
     const ElementMapper& elementMapper_;
     const EclipseState& eclState_;
-    const Deck& deck_;
     std::vector<Scalar> thpresDefault_;
     std::vector<Scalar> thpres_;
     unsigned numEquilRegions_;

--- a/ebos/eclgenericthresholdpressure.hh
+++ b/ebos/eclgenericthresholdpressure.hh
@@ -47,8 +47,7 @@ public:
                                 const GridView& gridView,
                                 const ElementMapper& elementMapper,
                                 const EclipseState& eclState,
-                                const Deck& deck,
-                                bool enableExperiments);
+                                const Deck& deck);
 
     /*!
      * \brief Returns the theshold pressure [Pa] for the intersection between two elements.
@@ -103,7 +102,6 @@ protected:
     std::vector<int> cartElemFaultIdx_;
 
     bool enableThresholdPressure_;
-    bool enableExperiments_;
 };
 
 } // namespace Opm

--- a/ebos/eclgenericthresholdpressure.hh
+++ b/ebos/eclgenericthresholdpressure.hh
@@ -86,7 +86,7 @@ protected:
     // THPRES keyword.
     void applyExplicitThresholdPressures_();
 
-    void extractThpresft_(const DeckKeyword& thpresftKeyword);
+    void configureThpresft_();
 
     const CartesianIndexMapper& cartMapper_;
     const GridView& gridView_;

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -67,7 +67,6 @@ class EclThresholdPressure : public EclGenericThresholdPressure<GetPropType<Type
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
     using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
 
-    enum { enableExperiments = getPropValue<TypeTag, Properties::EnableExperiments>() };
     enum { numPhases = FluidSystem::numPhases };
 
 public:
@@ -76,8 +75,7 @@ public:
                    simulator.vanguard().gridView(),
                    simulator.model().elementMapper(),
                    simulator.vanguard().eclState(),
-                   simulator.vanguard().deck(),
-                   enableExperiments)
+                   simulator.vanguard().deck())
         , simulator_(simulator)
     {
     }

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -74,8 +74,7 @@ public:
         : BaseType(simulator.vanguard().cartesianIndexMapper(),
                    simulator.vanguard().gridView(),
                    simulator.model().elementMapper(),
-                   simulator.vanguard().eclState(),
-                   simulator.vanguard().deck())
+                   simulator.vanguard().eclState())
         , simulator_(simulator)
     {
     }


### PR DESCRIPTION
To avoid deck usage in the simulators.

Downstream of https://github.com/OPM/opm-common/pull/3225