### PR TITLE
Remove Deck member from simulators

### DIFF
--- a/ebos/eclgenericproblem.cc
+++ b/ebos/eclgenericproblem.cc
@@ -26,7 +26,6 @@
 
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/OverburdTable.hpp>

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -26,7 +26,6 @@
 
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/TimeService.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
@@ -55,7 +54,6 @@
 namespace Opm {
 
 double EclGenericVanguard::setupTime_ = 0.0;
-std::shared_ptr<Deck> EclGenericVanguard::deck_;
 std::shared_ptr<EclipseState> EclGenericVanguard::eclState_;
 std::shared_ptr<Schedule> EclGenericVanguard::eclSchedule_;
 std::shared_ptr<SummaryConfig> EclGenericVanguard::eclSummaryConfig_;
@@ -72,7 +70,6 @@ EclGenericVanguard::EclGenericVanguard()
 EclGenericVanguard::~EclGenericVanguard() = default;
 
 void EclGenericVanguard::setParams(double setupTime,
-                                   std::shared_ptr<Deck> deck,
                                    std::shared_ptr<EclipseState> eclState,
                                    std::shared_ptr<Schedule> schedule,
                                    std::unique_ptr<UDQState> udqState,
@@ -81,7 +78,6 @@ void EclGenericVanguard::setParams(double setupTime,
                                    std::shared_ptr<SummaryConfig> summaryConfig)
 {
     EclGenericVanguard::setupTime_ = setupTime;
-    EclGenericVanguard::deck_ = std::move(deck);
     EclGenericVanguard::eclState_ = std::move(eclState);
     EclGenericVanguard::eclSchedule_ = std::move(schedule);
     EclGenericVanguard::udqState_ = std::move(udqState);
@@ -117,7 +113,7 @@ void EclGenericVanguard::readDeck(const std::string& filename)
                   false, false, {});
 
     EclGenericVanguard::setParams(setupTimer.elapsed(),
-                                  deck, eclipseState, schedule,
+                                  eclipseState, schedule,
                                   std::move(udqState),
                                   std::move(actionState),
                                   std::move(wtestState), summaryConfig);

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -91,7 +91,6 @@ void EclGenericVanguard::readDeck(const std::string& filename)
     Dune::Timer setupTimer;
     setupTimer.start();
 
-    std::shared_ptr<Opm::Deck> deck;
     std::shared_ptr<Opm::EclipseState> eclipseState;
     std::shared_ptr<Opm::Schedule> schedule;
     std::unique_ptr<Opm::UDQState> udqState;
@@ -107,7 +106,7 @@ void EclGenericVanguard::readDeck(const std::string& filename)
                                              {ParseContext::SUMMARY_UNKNOWN_GROUP, InputError::WARN}});
 
     Opm::readDeck(EclGenericVanguard::comm(),
-                  filename, deck, eclipseState, schedule, udqState,
+                  filename, eclipseState, schedule, udqState,
                   actionState, wtestState,
                   summaryConfig, nullptr, nullptr, std::move(parseContext),
                   false, false, {});

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -103,22 +103,12 @@ public:
      * \brief Set the simulation configuration objects.
      */
     static void setParams(double setupTime,
-                          std::shared_ptr<Deck> deck,
                           std::shared_ptr<EclipseState> eclState,
                           std::shared_ptr<Schedule> schedule,
                           std::unique_ptr<UDQState> udqState,
                           std::unique_ptr<Action::State> actionState,
                           std::unique_ptr<WellTestState> wtestState,
                           std::shared_ptr<SummaryConfig> summaryConfig);
-
-    /*!
-     * \brief Return a reference to the parsed ECL deck.
-     */
-    const Deck& deck() const
-    { return *deck_; }
-
-    Deck& deck()
-    { return *deck_; }
 
     /*!
      * \brief Return a reference to the internalized ECL deck.
@@ -309,7 +299,6 @@ protected:
     // parser objects.
     std::shared_ptr<Python> python;
     // These variables may be owned by both Python and the simulator
-    static std::shared_ptr<Deck> deck_;
     static std::shared_ptr<EclipseState> eclState_;
     static std::shared_ptr<Schedule> eclSchedule_;
     static std::shared_ptr<SummaryConfig> eclSummaryConfig_;

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -268,7 +268,6 @@ public:
             // case. E.g. check that number of phases == 3
             EclGenericVanguard::setParams(
                 setupTime_,
-                deck_,
                 eclipseState_,
                 schedule_,
                 std::move(udqState_),
@@ -290,7 +289,6 @@ private:
         const auto& phases = rspec.phases();
 
         EclGenericVanguard::setParams(this->setupTime_,
-                                      this->deck_,
                                       this->eclipseState_,
                                       this->schedule_,
                                       std::move(this->udqState_),
@@ -374,7 +372,6 @@ private:
     int dispatchStatic_()
     {
         EclGenericVanguard::setParams(this->setupTime_,
-                                      this->deck_,
                                       this->eclipseState_,
                                       this->schedule_,
                                       std::move(this->udqState_),

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -47,12 +47,10 @@
 #include <flow/flow_ebos_oilwater_polymer_injectivity.hpp>
 #include <flow/flow_ebos_micp.hpp>
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/input/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/input/eclipse/Schedule/ArrayDimChecker.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
@@ -135,16 +133,15 @@ public:
 
     // This constructor can be called from Python when Python has
     // already parsed a deck
-    Main(std::shared_ptr<Deck> deck,
+    Main(const std::string& filename,
          std::shared_ptr<EclipseState> eclipseState,
          std::shared_ptr<Schedule> schedule,
          std::shared_ptr<SummaryConfig> summaryConfig)
-        : deck_{std::move(deck)}
-        , eclipseState_{std::move(eclipseState)}
+        : eclipseState_{std::move(eclipseState)}
         , schedule_{std::move(schedule)}
         , summaryConfig_{std::move(summaryConfig)}
     {
-        setArgvArgc_(deck_->getDataFile());
+        setArgvArgc_(filename);
         initMPI();
     }
 
@@ -523,7 +520,8 @@ private:
             if (output_param >= 0)
                 outputInterval = output_param;
 
-            readDeck(EclGenericVanguard::comm(), deckFilename, deck_, eclipseState_, schedule_, udqState_, actionState_, wtestState_,
+            readDeck(EclGenericVanguard::comm(), deckFilename, eclipseState_,
+                     schedule_, udqState_, actionState_, wtestState_,
                      summaryConfig_, nullptr, python, std::move(parseContext),
                      init_from_restart_file, outputCout_, outputInterval);
 
@@ -818,7 +816,6 @@ private:
     std::unique_ptr<WellTestState> wtestState_{};
 
     // These variables may be owned by both Python and the simulator
-    std::shared_ptr<Deck> deck_{};
     std::shared_ptr<EclipseState> eclipseState_{};
     std::shared_ptr<Schedule> schedule_{};
     std::shared_ptr<SummaryConfig> summaryConfig_{};

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -29,7 +29,6 @@
 #include <string>
 
 namespace Opm {
-    class Deck;
     class EclipseState;
     class ErrorGuard;
     class ParseContext;
@@ -77,7 +76,6 @@ setupLogging(int                mpi_rank_,
 /// are created and can be used outside later.
 void readDeck(Parallel::Communication         comm,
               const std::string&              deckFilename,
-              std::shared_ptr<Deck>&          deck,
               std::shared_ptr<EclipseState>&  eclipseState,
               std::shared_ptr<Schedule>&      schedule,
               std::unique_ptr<UDQState>&      udqState,

--- a/python/simulators/PyBlackOilSimulator.cpp
+++ b/python/simulators/PyBlackOilSimulator.cpp
@@ -147,7 +147,7 @@ int PyBlackOilSimulator::stepInit()
     }
     if (this->deck_) {
         main_ = std::make_unique<Opm::Main>(
-            this->deck_,
+            this->deck_->getDataFile(),
             this->eclipse_state_,
             this->schedule_,
             this->summary_config_


### PR DESCRIPTION
No reason holding on to the deck during simulations, just a waste of memory. Let's remedy that

Sits on top of
https://github.com/OPM/opm-simulators/pull/4284
https://github.com/OPM/opm-simulators/pull/4285

And is downstream of 
https://github.com/OPM/opm-common/pull/3225