### PR TITLE
make sure getTHPConstratint() consistent between the WellInterfaceGeneric and WellBhpThpCalculator

### DIFF
--- a/opm/simulators/wells/WellBhpThpCalculator.cpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.cpp
@@ -66,18 +66,7 @@ WellBhpThpCalculator::wellHasTHPConstraints(const SummaryState& summaryState) co
 
 double WellBhpThpCalculator::getTHPConstraint(const SummaryState& summaryState) const
 {
-    const auto& well_ecl = well_.wellEcl();
-    if (well_ecl.isInjector()) {
-        const auto& controls = well_ecl.injectionControls(summaryState);
-        return controls.thp_limit;
-    }
-
-    if (well_ecl.isProducer( )) {
-        const auto& controls = well_ecl.productionControls(summaryState);
-        return controls.thp_limit;
-    }
-
-    return 0.0;
+    return well_.getTHPConstraint(summaryState);
 }
 
 double WellBhpThpCalculator::mostStrictBhpFromBhpLimits(const SummaryState& summaryState) const

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -211,7 +211,17 @@ double WellInterfaceGeneric::getTHPConstraint(const SummaryState& summaryState) 
         return *dynamic_thp_limit_;
     }
 
-    return WellBhpThpCalculator(*this).getTHPConstraint(summaryState);
+    if (well_ecl_.isInjector()) {
+        const auto& controls = well_ecl_.injectionControls(summaryState);
+        return controls.thp_limit;
+    }
+
+    if (well_ecl_.isProducer( )) {
+        const auto& controls = well_ecl_.productionControls(summaryState);
+        return controls.thp_limit;
+    }
+
+    return 0.0;
 }
 
 bool WellInterfaceGeneric::underPredictionMode() const


### PR DESCRIPTION
potentially a fallout introduced from the PR https://github.com/OPM/opm-simulators/pull/4188 , thanks @akva2 for spotting the potential problem. 

There is still some testing needs to clear out for now. So mark the PR as draft for now. 
