### PR TITLE
MultisegmentWell: avoid mutable matrices/vectors

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -1670,7 +1670,7 @@ MultisegmentWellEval<FluidSystem,Indices,Scalar>::
 assemblePressureEq(const int seg,
                    const UnitSystem& unit_system,
                    WellState& well_state,
-                   DeferredLogger& deferred_logger) const
+                   DeferredLogger& deferred_logger)
 {
     switch(this->segmentSet()[seg].segmentType()) {
         case Segment::SegmentType::SICD :

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -1600,7 +1600,7 @@ MultisegmentWellEval<FluidSystem,Indices,Scalar>::
 assembleICDPressureEq(const int seg,
                       const UnitSystem& unit_system,
                       WellState& well_state,
-                      DeferredLogger& deferred_logger) const
+                      DeferredLogger& deferred_logger)
 {
     // TODO: upwinding needs to be taken care of
     // top segment can not be a spiral ICD device

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -1351,7 +1351,7 @@ template<typename FluidSystem, typename Indices, typename Scalar>
 void
 MultisegmentWellEval<FluidSystem,Indices,Scalar>::
 assembleDefaultPressureEq(const int seg,
-                          WellState& well_state) const
+                          WellState& well_state)
 {
     assert(seg != 0); // not top segment
 

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -1299,7 +1299,7 @@ template<typename FluidSystem, typename Indices, typename Scalar>
 void
 MultisegmentWellEval<FluidSystem,Indices,Scalar>::
 handleAccelerationPressureLoss(const int seg,
-                               WellState& well_state) const
+                               WellState& well_state)
 {
     const double area = this->segmentSet()[seg].crossArea();
     const EvalWell mass_rate = segment_mass_rates_[seg];

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -72,7 +72,7 @@ MultisegmentWellEval(WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif)
 template<typename FluidSystem, typename Indices, typename Scalar>
 void
 MultisegmentWellEval<FluidSystem,Indices,Scalar>::
-initMatrixAndVectors(const int num_cells) const
+initMatrixAndVectors(const int num_cells)
 {
     duneB_.setBuildMode(OffDiagMatWell::row_wise);
     duneC_.setBuildMode(OffDiagMatWell::row_wise);

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -131,7 +131,7 @@ protected:
                            DeferredLogger& deferred_logger);
 
     void assembleDefaultPressureEq(const int seg,
-                                   WellState& well_state) const;
+                                   WellState& well_state);
 
 
     // assemble pressure equation for ICD segments

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -247,10 +247,10 @@ protected:
 
     // TODO, the following should go to a class for computing purpose
     // two off-diagonal matrices
-    mutable OffDiagMatWell duneB_;
-    mutable OffDiagMatWell duneC_;
+    OffDiagMatWell duneB_;
+    OffDiagMatWell duneC_;
     // "diagonal" matrix for the well. It has offdiagonal entries for inlets and outlets.
-    mutable DiagMatWell duneD_;
+    DiagMatWell duneD_;
 
     /// \brief solver for diagonal matrix
     ///
@@ -258,7 +258,7 @@ protected:
     mutable std::shared_ptr<Dune::UMFPack<DiagMatWell> > duneDSolver_;
 
     // residuals of the well equations
-    mutable BVectorWell resWell_;
+    BVectorWell resWell_;
 
     // the values for the primary varibles
     // based on different solutioin strategies, the wells can have different primary variables

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -118,7 +118,7 @@ protected:
 
     MultisegmentWellEval(WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif);
 
-    void initMatrixAndVectors(const int num_cells) const;
+    void initMatrixAndVectors(const int num_cells);
     void initPrimaryVariablesEvaluation() const;
 
     void assembleControlEq(const WellState& well_state,

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -138,7 +138,7 @@ protected:
     void assembleICDPressureEq(const int seg,
                                const UnitSystem& unit_system,
                                WellState& well_state,
-                               DeferredLogger& deferred_logger) const;
+                               DeferredLogger& deferred_logger);
 
 
     void assemblePressureEq(const int seg,

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -144,7 +144,7 @@ protected:
     void assemblePressureEq(const int seg,
                             const UnitSystem& unit_system,
                             WellState& well_state,
-                            DeferredLogger& deferred_logger) const;
+                            DeferredLogger& deferred_logger);
 
     /// check whether the well equations get converged for this well
     ConvergenceReport getWellConvergence(const WellState& well_state,

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -211,7 +211,7 @@ protected:
                                    DeferredLogger& deferred_logger) const;
 
     void handleAccelerationPressureLoss(const int seg,
-                                        WellState& well_state) const;
+                                        WellState& well_state);
 
     // pressure drop for Autonomous ICD segment (WSEGAICD)
     EvalWell pressureDropAutoICD(const int seg,


### PR DESCRIPTION
No real reason for this, other than wrongly categorized member functions.