### PR TITLE
Write global cell index to damaris

### DIFF
--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -110,7 +110,12 @@ public:
     { return toIORankComm_.size() > 1; }
 
     int localIdxToGlobalIdx(unsigned localIdx) const;
-   
+
+    const std::vector<int>& localIdxToGlobalIdxMapping() const
+    {
+        return localIdxToGlobalIdx_;
+    }
+
     bool doesNeedReordering() const
     { return needsReordering;}
 

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -309,8 +309,11 @@ public:
             // N.B. damarisUpdate_ should be set to true if at any time the model geometry changes
             if (this->damarisUpdate_) {
                 const auto& gridView = simulator_.gridView();
-                const int numElements = gridView.size(/*codim=*/0); // This it is the local ranks model size.
+                const auto& interior_elements = elements(gridView, Dune::Partitions::interior);
+                const int numElements = std::distance(interior_elements.begin(), interior_elements.end());
                 Opm::DamarisOutput::setupDamarisWritingPars(simulator_.vanguard().grid().comm(), numElements);
+                const std::vector<int>& local_to_global = this->collectToIORank_.localIdxToGlobalIdxMapping();
+                damaris_write("GLOBAL_CELL_INDEX", local_to_global.data());
                 // By default we assume static grid
                 this->damarisUpdate_ = false;
             }

--- a/opm/simulators/utils/DamarisOutputModule.cpp
+++ b/opm/simulators/utils/DamarisOutputModule.cpp
@@ -137,5 +137,10 @@ setupDamarisWritingPars(Parallel::Communication comm, const int n_elements_local
         OpmLog::error("Damaris library produced an error result for "
                       "damaris_set_position(\"PRESSURE\", temp_int64_t);");
     }
+    damaris_err = damaris_set_position("GLOBAL_CELL_INDEX", temp_int64_t);
+    if (damaris_err != DAMARIS_OK && rank == 0) {
+        OpmLog::error("Damaris library produced an error result for "
+                      "damaris_set_position(\"GLOBAL_CELL_INDEX\", temp_int64_t);");
+    }
 }
 } // namespace Opm::DamarisOutput

--- a/opm/simulators/utils/initDamarisXmlFile.cpp
+++ b/opm/simulators/utils/initDamarisXmlFile.cpp
@@ -47,6 +47,8 @@ std::string initDamarisXmlFile()
     <parameter name="n_elements_local"     type="int" value="1" />
     <parameter name="n"     type="int" value="1" />
 
+    <layout   name="zonal_layout_usmesh_integer"             type="int" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
+    <variable name="GLOBAL_CELL_INDEX"    layout="zonal_layout_usmesh_integer"     type="scalar"  visualizable="false"  time-varying="false"  centering="zonal" />
     <layout   name="zonal_layout_usmesh"             type="double" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
     <variable name="PRESSURE"    layout="zonal_layout_usmesh"     type="scalar"  visualizable="false"     unit="Pa"   centering="zonal"  store="_MYSTORE_OR_EMPTY_REGEX_" />
     _MORE_VARIABLES_REGEX_


### PR DESCRIPTION
This enables the damaris server to order data correctly in the HDF5 file. The necessary changes on the Damaris side are not yet merged there, but have been tested locally. In any case, the changes in this PR do not cause any trouble with the existing version of Damaris.