### PR TITLE
Honor MULTZ- when determining TRANSZ over pinched cells (pinch all)

### DIFF
--- a/ebos/ecltransmissibility.cc
+++ b/ebos/ecltransmissibility.cc
@@ -621,22 +621,24 @@ applyAllZMultipliers_(Scalar& trans,
         assert(insideFaceIdx==5); // as insideCartElemIdx < outsideCartElemIdx holds for the Z column
         assert(outsideCartElemIdx > insideCartElemIdx);
         auto lastCartElemIdx = outsideCartElemIdx - cartDims[0]*cartDims[1];
-        // Last multiplier
-        Scalar mult = transMult.getMultiplier(lastCartElemIdx , FaceDir::ZPlus);
+        // Last multiplier using (Z+)*(Z-)
+        Scalar mult = transMult.getMultiplier(lastCartElemIdx , FaceDir::ZPlus) *
+            transMult.getMultiplier(outsideCartElemIdx , FaceDir::ZMinus);
 
         if ( !pinchTop )
         {
-            // pick the smallest multiplier for Z+ while looking down the pillar until reaching the other end of the connection
-            // While Z- is not all used here.
-            for(auto cartElemIdx = insideCartElemIdx; cartElemIdx < lastCartElemIdx;
-                cartElemIdx += cartDims[0]*cartDims[1])
+            // pick the smallest multiplier using (Z+)*(Z-) while looking down
+            // the pillar until reaching the other end of the connection
+            for(auto cartElemIdx = insideCartElemIdx; cartElemIdx < lastCartElemIdx;)
             {
-                mult = std::min(mult, transMult.getMultiplier(cartElemIdx, FaceDir::ZPlus));
+                auto multiplier = transMult.getMultiplier(cartElemIdx, FaceDir::ZPlus);
+                cartElemIdx += cartDims[0]*cartDims[1];
+                multiplier *= transMult.getMultiplier(cartElemIdx, FaceDir::ZMinus);
+                mult = std::min(mult, multiplier);
             }
         }
 
         trans *= mult;
-        applyMultipliers_(trans, outsideFaceIdx, outsideCartElemIdx, transMult);
     }
     else
     {


### PR DESCRIPTION
Previously, a barrier between cells in Z-direction was only honored if it was done using MULTZ. We disregarded MULTZ- completely when calculating the TRANZ over pinched cells.

Now we also take into account MULTZ-.
Please note that this PR will always does this and not only with this in the deck:
```
GRIDOPTS
'YES'		0 / 
```
Not 100% sure whether this is what we want.

This is to fix an issue with tests in OPM/opm-tests#872.

Needs OPM/opm-common#3272 to work as expected.