### PR TITLE
add missing include after upstream header removal

### DIFF
--- a/tests/test_norne_pvt.cpp
+++ b/tests/test_norne_pvt.cpp
@@ -41,6 +41,7 @@
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 
 #include <opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp>


### PR DESCRIPTION
Required by upstream https://github.com/OPM/opm-common/pull/3266 but can be processed before.