### PR TITLE
[bugfix,mswells] Throw for connections not attached to segments correctly.

### DIFF
--- a/opm/simulators/wells/MultisegmentWellGeneric.cpp
+++ b/opm/simulators/wells/MultisegmentWellGeneric.cpp
@@ -37,6 +37,8 @@
 #include <cmath>
 #include <stdexcept>
 
+#include <fmt/format.h>
+
 namespace Opm
 {
 
@@ -65,6 +67,13 @@ MultisegmentWellGeneric(WellInterfaceGeneric& baseif)
         const Connection& connection = completion_set.get(perf);
         if (connection.state() == Connection::State::OPEN) {
             const int segment_index = segmentNumberToIndex(connection.segment());
+            if ( segment_index == -1) {
+                OPM_THROW(std::logic_error,
+                          fmt::format("COMPSEGS: Well {} has connection in cell {}, {}, {} "
+                                      "without associated segment.", baseif_.wellEcl().name(),
+                                      connection.getI() + 1, connection.getJ() + 1,
+                                      connection.getK() + 1));
+            }
             segment_perforations_[segment_index].push_back(i_perf_wells);
             baseif.perfDepth()[i_perf_wells] = connection.depth();
             const double segment_depth = segmentSet()[segment_index].depth();

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -627,6 +627,14 @@ void WellState::initWellStateMSWell(const std::vector<Well>& wells_ecl,
                 const Connection& connection = completion_set.get(perf);
                 if (connection.state() == Connection::State::OPEN) {
                     const int segment_index = segment_set.segmentNumberToIndex(connection.segment());
+                    if ( segment_index == -1) {
+                        OPM_THROW(std::logic_error,
+                                  fmt::format("COMPSEGS: Well {} has connection in cell {}, {}, {} "
+                                              "without associated segment.", well_ecl.name(),
+                                              connection.getI() + 1 , connection.getJ() + 1,
+                                              connection.getK() + 1 ));
+                    }
+
                     segment_perforations[segment_index].push_back(n_activeperf);
                     n_activeperf++;
                 }


### PR DESCRIPTION
[bugfix] Throw for connections not attached to segments .

If there are connections of a multisegment well that are not connected to any segment, we throw with a meaningful error message instead of a silent segmentation fault. In that case an invalid segment index of zero will be returned. The corresponding storage index returned by segmentToNumberIndex becomes -1. This previously lead to segmentation faults when using it to index a container.

~There might be connections of a multisegment well that are not connected to any segment. In that case an invalid segment index of zero will be returned. The corresponding storage index returned by segmentToNumberIndex becomes -1. This will lead to segmentation faults when using it to index a container.~

~With this patch we check whether a connection is part of a segment and only add it to the list of perforations of a segment if it is.~

This is still untested but hopefully resolves an issue we are facing with a model. I will undraft once I have tested it.