### PR TITLE
Avoid use of sstream in deferred logger header / macros

### DIFF
--- a/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
+++ b/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
@@ -29,7 +29,6 @@
 #include <opm/simulators/utils/ParallelCommunication.hpp>
 
 #include <string>
-#include <sstream>
 #include <exception>
 #include <stdexcept>
 
@@ -42,13 +41,14 @@
 // exception class derived from either std::logic_error or
 // std::runtime_error.
 //
-// Usage: OPM_DEFLOG_THROW(ExceptionClass, "Error message " << value, DeferredLogger);
-#define OPM_DEFLOG_THROW(Exception, message, deferred_logger)                             \
-    do {                                                                \
-        std::ostringstream oss__;                                       \
-        oss__ << "[" << __FILE__ << ":" << __LINE__ << "] " << message; \
-        deferred_logger.error(oss__.str());                               \
-        throw Exception(oss__.str());                                   \
+// Usage: OPM_DEFLOG_THROW(ExceptionClass, "Error message", DeferredLogger);
+#define OPM_DEFLOG_THROW(Exception, message, deferred_logger)   \
+    do {                                                        \
+        std::string oss__ = std::string{"["} + __FILE__ + ":" + \
+                            std::to_string(__LINE__) + "] " +   \
+                            message;                            \
+        deferred_logger.error(oss__);                           \
+        throw Exception(oss__);                                 \
     } while (false)
 
 namespace {

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -834,7 +834,9 @@ namespace Opm {
         }
         // It should be able to find in wells_ecl.
         if (index_well_ecl == nw_wells_ecl) {
-            OPM_DEFLOG_THROW(std::logic_error, "Could not find well " << well_name << " in wells_ecl ", deferred_logger);
+            OPM_DEFLOG_THROW(std::logic_error,
+                             fmt::format("Could not find well {} in wells_ecl ", well_name),
+                             deferred_logger);
         }
 
         return this->createWellPointer(index_well_ecl, report_step);
@@ -877,8 +879,9 @@ namespace Opm {
                 calculateExplicitQuantities(local_deferredLogger);
                 prepareTimeStep(local_deferredLogger);
             }
-            OPM_END_PARALLEL_TRY_CATCH_LOG(local_deferredLogger, "assemble() failed (It=0): ",
-                                               terminal_output_, grid().comm());
+            OPM_END_PARALLEL_TRY_CATCH_LOG(local_deferredLogger,
+                                           "assemble() failed (It=0): ",
+                                           terminal_output_, grid().comm());
         }
 
         const bool well_group_control_changed = assembleImpl(iterationIdx, dt, 0, local_deferredLogger);

--- a/opm/simulators/wells/GasLiftCommon.cpp
+++ b/opm/simulators/wells/GasLiftCommon.cpp
@@ -20,6 +20,8 @@
 #include <config.h>
 #include <opm/simulators/wells/GasLiftCommon.hpp>
 
+#include <fmt/format.h>
+
 namespace Opm {
 
 GasLiftCommon::

--- a/opm/simulators/wells/GasLiftCommon.hpp
+++ b/opm/simulators/wells/GasLiftCommon.hpp
@@ -25,7 +25,6 @@
 #include <opm/simulators/wells/GroupState.hpp>
 
 #include <string>
-#include <fmt/format.h>
 
 namespace Opm
 {

--- a/opm/simulators/wells/GasLiftSingleWell.hpp
+++ b/opm/simulators/wells/GasLiftSingleWell.hpp
@@ -30,7 +30,6 @@
 #include <optional>
 #include <vector>
 #include <utility>
-#include <fmt/format.h>
 
 namespace Opm
 {

--- a/opm/simulators/wells/GasLiftSingleWell_impl.hpp
+++ b/opm/simulators/wells/GasLiftSingleWell_impl.hpp
@@ -17,6 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <fmt/format.h>
+
 namespace Opm {
 
 template<typename TypeTag>

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -22,8 +22,6 @@
 
 #include <opm/simulators/wells/MultisegmentWellEval.hpp>
 
-#include <dune/istl/umfpack.hh>
-
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 
 #include <opm/models/blackoil/blackoilindices.hh>
@@ -32,7 +30,6 @@
 
 #include <opm/simulators/timestepping/ConvergenceReport.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
-#include <opm/simulators/wells/MSWellHelpers.hpp>
 #include <opm/simulators/wells/MultisegmentWellAssemble.hpp>
 #include <opm/simulators/wells/WellAssemble.hpp>
 #include <opm/simulators/wells/WellConvergence.hpp>

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -36,6 +36,8 @@
 #include <opm/simulators/wells/WellInterfaceIndices.hpp>
 #include <opm/simulators/wells/WellState.hpp>
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -275,8 +277,11 @@ assembleICDPressureEq(const int seg,
             icd_pressure_drop = segments_.pressureDropValve(seg);
             break;
         default: {
-            OPM_DEFLOG_THROW(std::runtime_error, "Segment " + std::to_string(this->segmentSet()[seg].segmentNumber())
-                             + " for well " + baseif_.name() + " is not of ICD type", deferred_logger);
+            OPM_DEFLOG_THROW(std::runtime_error,
+                             fmt::format("Segment {} for well {} is not of ICD type",
+                                         this->segmentSet()[seg].segmentNumber(),
+                                         baseif_.name()),
+                             deferred_logger);
         }
     }
     pressure_equation = pressure_equation - icd_pressure_drop;
@@ -336,8 +341,8 @@ getFiniteWellResiduals(const std::vector<Scalar>& B_avg,
                 }
             }
             if (std::isnan(residual) || std::isinf(residual)) {
-                deferred_logger.debug("nan or inf value for residal get for well " + baseif_.name()
-                                      + " segment " + std::to_string(seg) + " eq_idx " + std::to_string(eq_idx));
+                deferred_logger.debug(fmt::format("nan or inf value for residual for well {} segment {} eq_idx {}",
+                                                  baseif_.name(), seg, eq_idx));
                 return {false, residuals};
             }
 
@@ -351,7 +356,7 @@ getFiniteWellResiduals(const std::vector<Scalar>& B_avg,
     {
         const double control_residual = std::abs(linSys_.residual()[0][numWellEq - 1]);
         if (std::isnan(control_residual) || std::isinf(control_residual)) {
-           deferred_logger.debug("nan or inf value for control residal get for well " + baseif_.name());
+           deferred_logger.debug(fmt::format("nan or inf value for control residual for well {}", baseif_.name()));
            return {false, residuals};
         }
         residuals[numWellEq] = control_residual;
@@ -390,7 +395,9 @@ getControlTolerance(const WellState& well_state,
             control_tolerance = tolerance_wells;
             break;
         default:
-            OPM_DEFLOG_THROW(std::runtime_error, "Unknown well control control types for well " << baseif_.name(), deferred_logger);
+            OPM_DEFLOG_THROW(std::runtime_error,
+                             fmt::format("Unknown well control control types for well {}", baseif_.name()),
+                             deferred_logger);
         }
     }
 
@@ -416,7 +423,9 @@ getControlTolerance(const WellState& well_state,
             control_tolerance = tolerance_wells; // smaller tolerance for rate control
             break;
         default:
-            OPM_DEFLOG_THROW(std::runtime_error, "Unknown well control control types for well " << baseif_.name(), deferred_logger);
+            OPM_DEFLOG_THROW(std::runtime_error,
+                             fmt::format("Unknown well control control types for well {}", baseif_.name()),
+                             deferred_logger);
         }
     }
 

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -23,6 +23,8 @@
 
 #include <opm/common/ErrorMacros.hpp>
 
+#include <opm/material/densead/EvaluationFormat.hpp>
+
 #include <opm/material/fluidsystems/BlackOilDefaultIndexTraits.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 
@@ -35,7 +37,6 @@
 #include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 
 #include <fmt/format.h>
-#include <sstream>
 
 namespace Opm
 {
@@ -238,14 +239,14 @@ computeFluidProperties(const EvalWell& temperature,
 
             const EvalWell d = 1.0 - rs * rv;
             if (d <= 0.0) {
-                std::ostringstream sstr;
-                sstr << "Problematic d value " << d << " obtained for well " << well_.name()
-                     << " during segment density calculations with rs " << rs
-                     << ", rv " << rv << " and pressure " << seg_pressure
-                     << " obtaining d " << d
-                     << " Continue as if no dissolution (rs = 0) and vaporization (rv = 0) "
-                     << " for this connection.";
-                deferred_logger.debug(sstr.str());
+                const std::string str =
+                    fmt::format("Problematic d value {} obtained for well {} "
+                                "during segment density calculations with rs {}, "
+                                "rv {} and pressure {}. "
+                                "Continue as if no dissolution (rs = 0) and "
+                                "vaporization (rv = 0) for this connection.",
+                                d, well_.name(), rv, seg_pressure);
+                deferred_logger.debug(str);
             } else {
                 if (rs > 0.0) {
                     mix[gasCompIdx] = (mix_s[gasCompIdx] - mix_s[oilCompIdx] * rs) / d;
@@ -448,14 +449,14 @@ getSurfaceVolume(const EvalWell& temperature,
 
         const EvalWell d = 1.0 - rs * rv;
         if (d <= 0.0 || d > 1.0) {
-            std::ostringstream sstr;
-            sstr << "Problematic d value " << d << " obtained for well " << well_.name()
-                 << " during conversion to surface volume with rs " << rs
-                 << ", rv " << rv << " and pressure " << seg_pressure
-                 << " obtaining d " << d
-                 << " Continue as if no dissolution (rs = 0) and vaporization (rv = 0) "
-                 << " for this connection.";
-            OpmLog::debug(sstr.str());
+            const std::string str =
+                fmt::format("Problematic d value {} obtained for well {} "
+                            "during conversion to surface volume with rs {}, "
+                            "rv {} and pressure {}. "
+                            "Continue as if no dissolution (rs = 0) and "
+                            "vaporization (rv = 0) for this connection.",
+                            d, well_.name(), rs, rv, seg_pressure);
+            OpmLog::debug(str);
         } else {
             if (rs > 0.0) {
                 mix[gasCompIdx] = (mix_s[gasCompIdx] - mix_s[oilCompIdx] * rs) / d;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -23,6 +23,8 @@
 
 #include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
 
+#include <opm/material/densead/EvaluationFormat.hpp>
+
 #include <opm/simulators/wells/MultisegmentWellAssemble.hpp>
 #include <opm/simulators/wells/WellBhpThpCalculator.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
@@ -841,9 +843,11 @@ namespace Opm
                 const Value d = 1.0 - rv * rs;
 
                 if (getValue(d) == 0.0) {
-                    OPM_DEFLOG_THROW(NumericalProblem, "Zero d value obtained for well " << this->name()
-                                                       << " during flux calculation"
-                                                       << " with rs " << rs << " and rv " << rv, deferred_logger);
+                    OPM_DEFLOG_THROW(NumericalProblem,
+                                     fmt::format("Zero d value obtained for well {} "
+                                                 "during flux calculation with rs {} and rv {}",
+                                                 this->name(), rs, rv),
+                                     deferred_logger);
                 }
 
                 const Value tmp_oil = (cmix_s[oilCompIdx] - rv * cmix_s[gasCompIdx]) / d;
@@ -2012,10 +2016,9 @@ namespace Opm
         }
         else {
             OPM_DEFLOG_THROW(NotImplemented,
-                             "Unsupported Injector Type ("
-                             << static_cast<int>(preferred_phase)
-                             << ") for well " << this->name()
-                             << " during connection I.I. calculation",
+                             fmt::format("Unsupported Injector Type ({}) "
+                                         "for well {} during connection I.I. calculation",
+                                         static_cast<int>(preferred_phase), this->name()),
                              deferred_logger);
         }
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -49,7 +49,6 @@
 
 #include <memory>
 #include <optional>
-#include <fmt/format.h>
 
 namespace Opm
 {

--- a/opm/simulators/wells/StandardWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.cpp
@@ -696,7 +696,9 @@ checkFinite(DeferredLogger& deferred_logger) const
 {
     for (const Scalar v : value_) {
         if (!isfinite(v))
-            OPM_DEFLOG_THROW(NumericalProblem, "Infinite primary variable after update from wellState well: " << well_.name(),  deferred_logger);
+            OPM_DEFLOG_THROW(NumericalProblem,
+                             "Infinite primary variable after update from wellState, well: " + well_.name(),
+                             deferred_logger);
     }
 }
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -27,6 +27,8 @@
 #include <opm/simulators/wells/WellBhpThpCalculator.hpp>
 #include <opm/simulators/wells/WellConvergence.hpp>
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <functional>
 #include <numeric>

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2050,7 +2050,9 @@ namespace Opm
         if constexpr (Base::has_polymermw) {
             const int water_table_id = this->well_ecl_.getPolymerProperties().m_skprwattable;
             if (water_table_id <= 0) {
-                OPM_DEFLOG_THROW(std::runtime_error, "Unused SKPRWAT table id used for well " << name(), deferred_logger);
+                OPM_DEFLOG_THROW(std::runtime_error,
+                                 fmt::format("Unused SKPRWAT table id used for well {}", name()),
+                                 deferred_logger);
             }
             const auto& water_table_func = PolymerModule::getSkprwatTable(water_table_id);
             const EvalWell throughput_eval(this->primary_variables_.numWellEq() + Indices::numEq, throughput);
@@ -2059,8 +2061,10 @@ namespace Opm
             pskin_water = water_table_func.eval(throughput_eval, water_velocity);
             return pskin_water;
         } else {
-            OPM_DEFLOG_THROW(std::runtime_error, "Polymermw is not activated, "
-                                          "while injecting skin pressure is requested for well " << name(), deferred_logger);
+            OPM_DEFLOG_THROW(std::runtime_error,
+                             fmt::format("Polymermw is not activated, while injecting "
+                                         "skin pressure is requested for well {}", name()),
+                             deferred_logger);
         }
     }
 
@@ -2084,7 +2088,9 @@ namespace Opm
             }
             const int polymer_table_id = this->well_ecl_.getPolymerProperties().m_skprpolytable;
             if (polymer_table_id <= 0) {
-                OPM_DEFLOG_THROW(std::runtime_error, "Unavailable SKPRPOLY table id used for well " << name(), deferred_logger);
+                OPM_DEFLOG_THROW(std::runtime_error,
+                                 fmt::format("Unavailable SKPRPOLY table id used for well {}", name()),
+                                 deferred_logger);
             }
             const auto& skprpolytable = PolymerModule::getSkprpolyTable(polymer_table_id);
             const double reference_concentration = skprpolytable.refConcentration;
@@ -2100,8 +2106,10 @@ namespace Opm
             const EvalWell pskin = pskin_water + (pskin_poly - pskin_water) / reference_concentration * poly_inj_conc;
             return sign * pskin;
         } else {
-            OPM_DEFLOG_THROW(std::runtime_error, "Polymermw is not activated, "
-                                          "while injecting skin pressure is requested for well " << name(), deferred_logger);
+            OPM_DEFLOG_THROW(std::runtime_error,
+                             fmt::format("Polymermw is not activated, while injecting "
+                                         "skin pressure is requested for well {}", name()),
+                             deferred_logger);
         }
     }
 
@@ -2127,8 +2135,10 @@ namespace Opm
             molecular_weight = table_func.eval(throughput_eval, abs(water_velocity));
             return molecular_weight;
         } else {
-            OPM_DEFLOG_THROW(std::runtime_error, "Polymermw is not activated, "
-                                          "while injecting polymer molecular weight is requested for well " << name(), deferred_logger);
+            OPM_DEFLOG_THROW(std::runtime_error,
+                             fmt::format("Polymermw is not activated, while injecting "
+                                         "polymer molecular weight is requested for well {}", name()),
+                             deferred_logger);
         }
     }
 
@@ -2551,10 +2561,9 @@ namespace Opm
         }
         else {
             OPM_DEFLOG_THROW(NotImplemented,
-                             "Unsupported Injector Type ("
-                             << static_cast<int>(preferred_phase)
-                             << ") for well " << this->name()
-                             << " during connection I.I. calculation",
+                             fmt::format("Unsupported Injector Type ({}) "
+                                         "for well {} during connection I.I. calculation",
+                                         static_cast<int>(preferred_phase), this->name()),
                              deferred_logger);
         }
 

--- a/opm/simulators/wells/WellAssemble.cpp
+++ b/opm/simulators/wells/WellAssemble.cpp
@@ -95,7 +95,9 @@ assembleControlEqProd(const WellState& well_state,
         break;
     }
     case Well::ProducerCMode::CRAT: {
-        OPM_DEFLOG_THROW(std::runtime_error, "CRAT control not supported " << well_.name(), deferred_logger);
+        OPM_DEFLOG_THROW(std::runtime_error,
+                         "CRAT control not supported, well " + well_.name(),
+                         deferred_logger);
     }
     case Well::ProducerCMode::RESV: {
         auto total_rate = rates[0]; // To get the correct type only.
@@ -166,10 +168,14 @@ assembleControlEqProd(const WellState& well_state,
         break;
     }
     case Well::ProducerCMode::CMODE_UNDEFINED: {
-        OPM_DEFLOG_THROW(std::runtime_error, "Well control must be specified for well " + well_.name(), deferred_logger);
+        OPM_DEFLOG_THROW(std::runtime_error,
+                         "Well control must be specified for well " + well_.name(),
+                         deferred_logger);
     }
     case Well::ProducerCMode::NONE: {
-        OPM_DEFLOG_THROW(std::runtime_error, "Well control must be specified for well " + well_.name(), deferred_logger);
+        OPM_DEFLOG_THROW(std::runtime_error,
+                         "Well control must be specified for well " + well_.name(),
+                         deferred_logger);
     }
     }
 }

--- a/opm/simulators/wells/WellConvergence.cpp
+++ b/opm/simulators/wells/WellConvergence.cpp
@@ -72,7 +72,9 @@ checkConvergenceControlEq(const WellState& well_state,
             control_tolerance = tolerances.grup;
             break;
         default:
-            OPM_DEFLOG_THROW(std::runtime_error, "Unknown well control control types for well " << well_.name(), deferred_logger);
+            OPM_DEFLOG_THROW(std::runtime_error,
+                             "Unknown well control control types for well " + well_.name(),
+                             deferred_logger);
         }
     }
     else if (well_.isProducer() )
@@ -101,7 +103,9 @@ checkConvergenceControlEq(const WellState& well_state,
             control_tolerance = tolerances.grup;
             break;
         default:
-            OPM_DEFLOG_THROW(std::runtime_error, "Unknown well control control types for well " << well_.name(), deferred_logger);
+            OPM_DEFLOG_THROW(std::runtime_error,
+                             "Unknown well control control types for well " + well_.name(),
+                             deferred_logger);
         }
     }
 

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -32,6 +32,9 @@
 #include <opm/simulators/wells/WellHelpers.hpp>
 #include <opm/simulators/wells/WellState.hpp>
 #include <opm/simulators/wells/WellTest.hpp>
+
+#include <fmt/format.h>
+
 #include <cassert>
 #include <cmath>
 #include <cstddef>
@@ -65,7 +68,7 @@ WellInterfaceGeneric::WellInterfaceGeneric(const Well& well,
         return perf1.ecl_index < perf2.ecl_index;
     }));
     if (time_step < 0) {
-        OPM_THROW(std::invalid_argument, "Negtive time step is used to construct WellInterface");
+        OPM_THROW(std::invalid_argument, "Negative time step is used to construct WellInterface");
     }
 
     ref_depth_ = well.getRefDepth();
@@ -355,8 +358,11 @@ bool WellInterfaceGeneric::isVFPActive(DeferredLogger& deferred_logger) const
             if (vfp_properties_->getProd()->hasTable(table_id)) {
                 return true;
             } else {
-                OPM_DEFLOG_THROW(std::runtime_error, "VFPPROD table " << std::to_string(table_id) << " is specified,"
-                              << " for well " << name() << ", while we could not access it during simulation", deferred_logger);
+                OPM_DEFLOG_THROW(std::runtime_error,
+                                 fmt::format("VFPPROD table {} is specified "
+                                             "for well {}, while we could not access it during simulation",
+                                             table_id, name()),
+                                 deferred_logger);
             }
         }
 
@@ -368,8 +374,11 @@ bool WellInterfaceGeneric::isVFPActive(DeferredLogger& deferred_logger) const
             if (vfp_properties_->getInj()->hasTable(table_id)) {
                 return true;
             } else {
-                OPM_DEFLOG_THROW(std::runtime_error, "VFPINJ table " << std::to_string(table_id) << " is specified,"
-                              << " for well " << name() << ", while we could not access it during simulation", deferred_logger);
+                OPM_DEFLOG_THROW(std::runtime_error,
+                                 fmt::format("VFPINJ table {} is specified "
+                                             "for well {}, while we could not access it during simulation",
+                                             table_id, name()),
+                                 deferred_logger);
             }
         }
     }
@@ -410,9 +419,8 @@ void WellInterfaceGeneric::reportWellSwitching(const SingleWellState& ws, Deferr
     }
     // only report the final switching
     if (from != to) {
-        std::string msg = "    Well " + name()
-        + " control mode changed from " + from + " to " + to;
-        deferred_logger.info(msg);
+        deferred_logger.info(fmt::format("    Well {} control mode changed from {} to {}",
+                                         name(), from, to));
     }
 }
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -29,6 +29,8 @@
 
 #include <dune/common/version.hh>
 
+#include <fmt/format.h>
+
 namespace Opm
 {
 
@@ -941,7 +943,9 @@ namespace Opm
             }
             case Well::ProducerCMode::CRAT:
             {
-                OPM_DEFLOG_THROW(std::runtime_error, "CRAT control not supported " << this->name(), deferred_logger);
+                OPM_DEFLOG_THROW(std::runtime_error,
+                                 fmt::format("CRAT control not supported, well {}", this->name()),
+                                 deferred_logger);
             }
             case Well::ProducerCMode::RESV:
             {


### PR DESCRIPTION
Instead use {fmt} at callsites where available or simple string::operator+(..).

Waiting for #4292 