### PR TITLE
Adjust cpr-related defaults

### DIFF
--- a/opm/simulators/linalg/FlowLinearSolverParameters.hpp
+++ b/opm/simulators/linalg/FlowLinearSolverParameters.hpp
@@ -180,11 +180,11 @@ struct ScaleLinearSystem<TypeTag, TTag::FlowIstlSolverParams> {
 };
 template<class TypeTag>
 struct CprReuseSetup<TypeTag, TTag::FlowIstlSolverParams> {
-    static constexpr int value = 3;
+    static constexpr int value = 4;
 };
 template<class TypeTag>
 struct CprReuseInterval<TypeTag, TTag::FlowIstlSolverParams> {
-    static constexpr int value = 10;
+    static constexpr int value = 30;
 };
 template<class TypeTag>
 struct LinearSolver<TypeTag, TTag::FlowIstlSolverParams> {

--- a/opm/simulators/linalg/FlowLinearSolverParameters.hpp
+++ b/opm/simulators/linalg/FlowLinearSolverParameters.hpp
@@ -93,14 +93,6 @@ struct ScaleLinearSystem {
     using type = UndefinedProperty;
 };
 template<class TypeTag, class MyTypeTag>
-struct CprMaxEllIter {
-    using type = UndefinedProperty;
-};
-template<class TypeTag, class MyTypeTag>
-struct CprEllSolvetype {
-    using type = UndefinedProperty;
-};
-template<class TypeTag, class MyTypeTag>
 struct CprReuseSetup {
     using type = UndefinedProperty;
 };
@@ -187,14 +179,6 @@ struct ScaleLinearSystem<TypeTag, TTag::FlowIstlSolverParams> {
     static constexpr bool value = false;
 };
 template<class TypeTag>
-struct CprMaxEllIter<TypeTag, TTag::FlowIstlSolverParams> {
-    static constexpr int value = 20;
-};
-template<class TypeTag>
-struct CprEllSolvetype<TypeTag, TTag::FlowIstlSolverParams> {
-    static constexpr int value = 0;
-};
-template<class TypeTag>
 struct CprReuseSetup<TypeTag, TTag::FlowIstlSolverParams> {
     static constexpr int value = 3;
 };
@@ -249,7 +233,6 @@ namespace Opm
         std::string accelerator_mode_;
         int bda_device_id_;
         int opencl_platform_id_;
-        int cpr_max_ell_iter_;
         int cpr_reuse_setup_;
         int cpr_reuse_interval_;
         bool opencl_ilu_parallel_;
@@ -270,7 +253,6 @@ namespace Opm
             newton_use_gmres_ = EWOMS_GET_PARAM(TypeTag, bool, UseGmres);
             ignoreConvergenceFailure_ = EWOMS_GET_PARAM(TypeTag, bool, LinearSolverIgnoreConvergenceFailure);
             scale_linear_system_ = EWOMS_GET_PARAM(TypeTag, bool, ScaleLinearSystem);
-            cpr_max_ell_iter_  =  EWOMS_GET_PARAM(TypeTag, int, CprMaxEllIter);
             cpr_reuse_setup_  =  EWOMS_GET_PARAM(TypeTag, int, CprReuseSetup);
             cpr_reuse_interval_  =  EWOMS_GET_PARAM(TypeTag, int, CprReuseInterval);
             linsolver_ = EWOMS_GET_PARAM(TypeTag, std::string, LinearSolver);
@@ -295,7 +277,6 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, bool, UseGmres, "Use GMRES as the linear solver");
             EWOMS_REGISTER_PARAM(TypeTag, bool, LinearSolverIgnoreConvergenceFailure, "Continue with the simulation like nothing happened after the linear solver did not converge");
             EWOMS_REGISTER_PARAM(TypeTag, bool, ScaleLinearSystem, "Scale linear system according to equation scale and primary variable types");
-            EWOMS_REGISTER_PARAM(TypeTag, int, CprMaxEllIter, "MaxIterations of the elliptic pressure part of the cpr solver");
             EWOMS_REGISTER_PARAM(TypeTag, int, CprReuseSetup, "Reuse preconditioner setup. Valid options are 0: recreate the preconditioner for every linear solve, 1: recreate once every timestep, 2: recreate if last linear solve took more than 10 iterations, 3: never recreate, 4: recreated every CprReuseInterval");
             EWOMS_REGISTER_PARAM(TypeTag, int, CprReuseInterval, "Reuse preconditioner interval. Used when CprReuseSetup is set to 4, then the preconditioner will be fully recreated instead of reused every N linear solve, where N is this parameter.");
             EWOMS_REGISTER_PARAM(TypeTag, std::string, LinearSolver, "Configuration of solver. Valid options are: ilu0 (default), cpr (an alias for cpr_trueimpes), cpr_quasiimpes, cpr_trueimpes or amg. Alternatively, you can request a configuration to be read from a JSON file by giving the filename here, ending with '.json.'");

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -244,7 +244,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             parameters_.template init<TypeTag>();
             prm_ = setupPropertyTree(parameters_,
                                      EWOMS_PARAM_IS_SET(TypeTag, int, LinearSolverMaxIter),
-                                     EWOMS_PARAM_IS_SET(TypeTag, int, CprMaxEllIter));
+                                     EWOMS_PARAM_IS_SET(TypeTag, double, LinearSolverReduction));
 
 #if COMPILE_BDA_BRIDGE
             {

--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -38,8 +38,8 @@ namespace Opm
 /// from file the data in the JSON file will override any other options.
 PropertyTree
 setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters to potentially override.
-                  bool LinearSolverMaxIterSet,
-                  bool CprMaxEllIterSet)
+                  bool linearSolverMaxIterSet,
+                  bool linearSolverReductionSet)
 {
     std::string conf = p.linsolver_;
 
@@ -68,21 +68,25 @@ setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters 
             // Treat "cpr" as short cut for the true IMPES variant.
             conf = "cpr_trueimpes";
         }
-        if (!LinearSolverMaxIterSet) {
+        if (!linearSolverMaxIterSet) {
             // Use our own default unless it was explicitly overridden by user.
             p.linear_solver_maxiter_ = 20;
         }
-        if (!CprMaxEllIterSet) {
+        if (!linearSolverReductionSet) {
             // Use our own default unless it was explicitly overridden by user.
-            p.cpr_max_ell_iter_ = 1;
+            p.linear_solver_reduction_ = 0.005;
         }
         return setupCPR(conf, p);
     }
 
     if ((conf == "cprw")) {
-        if (!LinearSolverMaxIterSet) {
+        if (!linearSolverMaxIterSet) {
             // Use our own default unless it was explicitly overridden by user.
             p.linear_solver_maxiter_ = 20;
+        }
+        if (!linearSolverReductionSet) {
+            // Use our own default unless it was explicitly overridden by user.
+            p.linear_solver_reduction_ = 0.005;
         }
         return setupCPRW(conf, p);
     }
@@ -145,7 +149,7 @@ setupCPRW(const std::string& /*conf*/, const FlowLinearSolverParameters& p)
     prm.put("preconditioner.coarsesolver.preconditioner.type", "amg"s);
     prm.put("preconditioner.coarsesolver.preconditioner.alpha", 0.333333333333);
     prm.put("preconditioner.coarsesolver.preconditioner.relaxation", 1.0);
-    prm.put("preconditioner.coarsesolver.preconditioner.iterations", p.cpr_max_ell_iter_);
+    prm.put("preconditioner.coarsesolver.preconditioner.iterations", 1);
     prm.put("preconditioner.coarsesolver.preconditioner.coarsenTarget", 1200);
     prm.put("preconditioner.coarsesolver.preconditioner.pre_smooth", 1);
     prm.put("preconditioner.coarsesolver.preconditioner.post_smooth", 1);
@@ -191,11 +195,11 @@ setupCPR(const std::string& conf, const FlowLinearSolverParameters& p)
     prm.put("preconditioner.coarsesolver.preconditioner.type", "amg"s);
     prm.put("preconditioner.coarsesolver.preconditioner.alpha", 0.333333333333);
     prm.put("preconditioner.coarsesolver.preconditioner.relaxation", 1.0);
-    prm.put("preconditioner.coarsesolver.preconditioner.iterations", p.cpr_max_ell_iter_);
+    prm.put("preconditioner.coarsesolver.preconditioner.iterations", 1);
     prm.put("preconditioner.coarsesolver.preconditioner.coarsenTarget", 1200);
     prm.put("preconditioner.coarsesolver.preconditioner.pre_smooth", 1);
     prm.put("preconditioner.coarsesolver.preconditioner.post_smooth", 1);
-    prm.put("preconditioner.coarsesolver.preconditioner.beta", 1e-5);
+    prm.put("preconditioner.coarsesolver.preconditioner.beta", 0.0);
     prm.put("preconditioner.coarsesolver.preconditioner.smoother", "ILU0"s);
     prm.put("preconditioner.coarsesolver.preconditioner.verbosity", 0);
     prm.put("preconditioner.coarsesolver.preconditioner.maxlevel", 15);
@@ -204,7 +208,7 @@ setupCPR(const std::string& conf, const FlowLinearSolverParameters& p)
     // graph might be unsymmetric and hence not supported by the PTScotch/ParMetis
     // calls in DUNE. Accumulating to 1 skips PTScotch/ParMetis
     prm.put("preconditioner.coarsesolver.preconditioner.accumulate", 1);
-    prm.put("preconditioner.coarsesolver.preconditioner.prolongationdamping", 1.6);
+    prm.put("preconditioner.coarsesolver.preconditioner.prolongationdamping", 1.0);
     prm.put("preconditioner.coarsesolver.preconditioner.maxdistance", 2);
     prm.put("preconditioner.coarsesolver.preconditioner.maxconnectivity", 15);
     prm.put("preconditioner.coarsesolver.preconditioner.maxaggsize", 6);


### PR DESCRIPTION
Combining a number of minor adjustments for simpler and more consistent and robust use of the cpr options.
 - Remove two unused parameters. CprEllSolvetype is never used, and CprEllMaxIter
   is not used correctly as is (if used, it should change the maximum iterations of
   the coarse solver, not the repeats of the preconditioner) and is better left for
   JSON file customization.
 - Make the default AMG setup for "cpr" (including "cpr_trueimpes" and "cpr_quasiimpes")
   match the setup for "cprw". In particular, beta = 0.0 (not 1e-5) and
   prolongationdamping = 1.0 (not 1.6).
 - Just as we override the default maximum number of linear iterations for cpr and cprw
   (unless the user actually specified on the command line) to 20 instead of 100, we
   change the default reduction to be 0.005 instead of 0.01.
 - Change the default for CprReuseSetup to 4 (was 3). The old default never recreates the preconditioner from scratch, i.e. the hierarchy that is built for AMG is kept unchanged (the numbers in the matrices and therefore also smoothers etc. are updated every solve). The new default will recreate it every CprReuseInterval solves instead. The default for CprReuseInterval has been increased from 10 to 30 (but recall the interval was essentially infinite when CprReuseSetup was 3).