### PR TITLE
Fix GPMAINT for groups without control

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -348,7 +348,7 @@ namespace Opm {
             bool alternative_well_rate_init_{};
 
             std::unique_ptr<RateConverterType> rateConverter_{};
-            std::unique_ptr<AverageRegionalPressureType> regionalAveragePressureCalculator_{};
+            std::map<std::string, std::unique_ptr<AverageRegionalPressureType>> regionalAveragePressureCalculator_{};
 
 
             SimulatorReportSingle last_report_{};

--- a/opm/simulators/wells/TargetCalculator.hpp
+++ b/opm/simulators/wells/TargetCalculator.hpp
@@ -59,7 +59,7 @@ namespace WellGroupHelpers
         template <typename RateType>
         RateType calcModeRateFromRates(const RateType* rates) const;
 
-        double groupTarget(const Group::ProductionControls ctrl) const;
+        double groupTarget(const std::optional<Group::ProductionControls>& ctrl, Opm::DeferredLogger& deferred_logger) const;
 
         GuideRateModel::Target guideTargetMode() const;
 
@@ -94,7 +94,7 @@ namespace WellGroupHelpers
             return rates[pos_];
         }
 
-        double groupTarget(const Group::InjectionControls& ctrl, Opm::DeferredLogger& deferred_logger) const;
+        double groupTarget(const std::optional<Group::InjectionControls>& ctrl, Opm::DeferredLogger& deferred_logger) const;
 
         GuideRateModel::Target guideTargetMode() const;
 

--- a/opm/simulators/wells/WellAssemble.cpp
+++ b/opm/simulators/wells/WellAssemble.cpp
@@ -164,7 +164,8 @@ assembleControlEqProd(const WellState& well_state,
                                                              bhp, active_rates,
                                                              rCoeff,
                                                              efficiencyFactor,
-                                                             control_eq);
+                                                             control_eq,
+                                                             deferred_logger);
         break;
     }
     case Well::ProducerCMode::CMODE_UNDEFINED: {

--- a/opm/simulators/wells/WellGroupControls.hpp
+++ b/opm/simulators/wells/WellGroupControls.hpp
@@ -84,7 +84,8 @@ public:
                                    const std::vector<EvalWell>& rates,
                                    const RateConvFunc& rateConverter,
                                    double efficiencyFactor,
-                                   EvalWell& control_eq) const;
+                                   EvalWell& control_eq,
+                                   DeferredLogger& deferred_logger) const;
 
     double getGroupProductionTargetRate(const Group& group,
                                         const WellState& well_state,
@@ -92,7 +93,8 @@ public:
                                         const Schedule& schedule,
                                         const SummaryState& summaryState,
                                         const RateConvFunc& rateConverter,
-                                        double efficiencyFactor) const;
+                                        double efficiencyFactor,
+                                        DeferredLogger& deferred_logger) const;
 
 private:
     const WellInterfaceGeneric& well_; //!< Reference to well interface

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -742,7 +742,6 @@ namespace WellGroupHelpers
             default:
                 throw std::invalid_argument("Invalid Flow target type in GPMAINT");
         }
-
         auto& gpmaint_state = group_state.gpmaint(group.name());
         double rate = gpm->rate(gpmaint_state, current_rate, error, dt);
         group_state.update_gpmaint_target(group.name(), std::max(0.0, sign * rate));
@@ -1266,7 +1265,12 @@ namespace WellGroupHelpers
             const std::vector<double>& groupSurfaceRates = group_state.production_rates(group_name);
             return tcalc.calcModeRateFromRates(groupSurfaceRates);
         };
-        const double orig_target = tcalc.groupTarget(group.productionControls(summaryState));
+
+        std::optional<Group::ProductionControls> ctrl;
+        if (!group.has_gpmaint_control(currentGroupControl))
+            ctrl = group.productionControls(summaryState);
+
+        const double orig_target = tcalc.groupTarget(ctrl, deferred_logger);
         // Assume we have a chain of groups as follows: BOTTOM -> MIDDLE -> TOP.
         // Then ...
         // TODO finish explanation.
@@ -1408,7 +1412,12 @@ namespace WellGroupHelpers
             return tcalc.calcModeRateFromRates(groupSurfaceRates);
         };
 
-        const double orig_target = tcalc.groupTarget(group.injectionControls(injectionPhase, summaryState), deferred_logger);
+        std::optional<Group::InjectionControls> ctrl;
+        if (!group.has_gpmaint_control(injectionPhase, currentGroupControl))
+            ctrl = group.injectionControls(injectionPhase, summaryState);
+
+
+        const double orig_target = tcalc.groupTarget(ctrl, deferred_logger);
         // Assume we have a chain of groups as follows: BOTTOM -> MIDDLE -> TOP.
         // Then ...
         // TODO finish explanation.

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -22,6 +22,8 @@
 #define OPM_WELLGROUPHELPERS_HEADER_INCLUDED
 
 #include <opm/input/eclipse/Schedule/Group/GuideRate.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+
 
 #include <map>
 #include <string>
@@ -38,6 +40,7 @@ struct PhaseUsage;
 class Schedule;
 class VFPProdProperties;
 class WellState;
+class FieldPropsManager;
 
 namespace Network { class ExtNetwork; }
 
@@ -308,6 +311,14 @@ namespace WellGroupHelpers
                                                       const SummaryState& summaryState,
                                                       const std::vector<double>& resv_coeff,
                                                       DeferredLogger& deferred_logger);
+
+    template <class AverageRegionalPressureType>
+    void setRegionAveragePressureCalculator(const Group& group,
+                                            const Schedule& schedule,
+                                            const int reportStepIdx,
+                                            const FieldPropsManager& fp,
+                                            const PhaseUsage& pu,
+                                            std::map<std::string, std::unique_ptr<AverageRegionalPressureType>>& regionalAveragePressureCalculator);
 
 
 } // namespace WellGroupHelpers

--- a/opm/simulators/wells/WellInterfaceFluidSystem.cpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.cpp
@@ -189,7 +189,8 @@ getGroupProductionTargetRate(const Group& group,
                           const GroupState& group_state,
                           const Schedule& schedule,
                           const SummaryState& summaryState,
-                          double efficiencyFactor) const
+                          double efficiencyFactor,
+                          DeferredLogger& deferred_logger) const
 {
     auto rCoeff = [this](const int id, const int region, std::vector<double>& coeff)
     {
@@ -199,7 +200,8 @@ getGroupProductionTargetRate(const Group& group,
     return WellGroupControls(*this).getGroupProductionTargetRate(group, well_state,
                                                                  group_state, schedule,
                                                                  summaryState,
-                                                                 rCoeff, efficiencyFactor);
+                                                                 rCoeff, efficiencyFactor,
+                                                                 deferred_logger);
 }
 
 template class WellInterfaceFluidSystem<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>>;

--- a/opm/simulators/wells/WellInterfaceFluidSystem.hpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.hpp
@@ -109,7 +109,8 @@ protected:
                                  const GroupState& group_state,
                                  const Schedule& schedule,
                                  const SummaryState& summaryState,
-                                 double efficiencyFactor) const;
+                                 double efficiencyFactor,
+                                 DeferredLogger& deferred_logger) const;
 
     // For the conversion between the surface volume rate and reservoir voidage rate
     const RateConverterType& rateConverter_;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1049,7 +1049,8 @@ namespace Opm
                                                           group_state,
                                                           schedule,
                                                           summaryState,
-                                                          efficiencyFactor);
+                                                          efficiencyFactor,
+                                                          deferred_logger);
 
                 // we don't want to scale with zero and get zero rates.
                 if (scale > 0) {


### PR DESCRIPTION
If GPMAINT is used the group does not need a valid control object. 

See issue reported in https://github.com/OPM/opm-tests/pull/881