### PR TITLE
add missing WellSegments.hpp includes

### DIFF
--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -36,6 +36,7 @@
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
 #include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
+#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 #include <opm/input/eclipse/Schedule/Network/Balance.hpp>
 #include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
 #include <opm/input/eclipse/Schedule/RFTConfig.hpp>

--- a/opm/simulators/wells/BlackoilWellModelRestart.cpp
+++ b/opm/simulators/wells/BlackoilWellModelRestart.cpp
@@ -24,6 +24,7 @@
 #include <opm/simulators/wells/BlackoilWellModelRestart.hpp>
 
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
+#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 
 #include <opm/output/data/Groups.hpp>
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -165,11 +165,6 @@ namespace Opm
         // regularize msw equation
         bool regularize_;
 
-        // components of the pressure drop to be included
-        WellSegments::CompPressureDrop compPressureDrop() const;
-        // multi-phase flow model
-        WellSegments::MultiPhaseModel multiphaseModel() const;
-
         // the intial amount of fluids in each segment under surface condition
         std::vector<std::vector<double> > segment_fluid_initial_;
 

--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -26,6 +26,8 @@
 
 #include <opm/common/ErrorMacros.hpp>
 
+#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
+
 #include <opm/simulators/linalg/bda/WellContributions.hpp>
 #include <opm/simulators/linalg/istlsparsematrixadapter.hh>
 #include <opm/simulators/linalg/matrixblock.hh>

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -22,6 +22,8 @@
 
 #include <opm/simulators/wells/MultisegmentWellEval.hpp>
 
+#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
+
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 
 #include <opm/models/blackoil/blackoilindices.hh>

--- a/opm/simulators/wells/MultisegmentWellGeneric.cpp
+++ b/opm/simulators/wells/MultisegmentWellGeneric.cpp
@@ -182,6 +182,27 @@ accelerationalPressureLossConsidered() const
     return (segmentSet().compPressureDrop() == WellSegments::CompPressureDrop::HFA);
 }
 
+
+template<class Scalar>
+double
+MultisegmentWellGeneric<Scalar>::getSegmentDp(const int seg,
+                                              const double density,
+                                              const std::vector<double>& seg_dp) const
+{
+    const double segment_depth = this->segmentSet()[seg].depth();
+    const int outlet_segment_index = this->segmentNumberToIndex(this->segmentSet()[seg].outletSegment());
+    const double segment_depth_outlet = seg == 0 ? baseif_.refDepth() : this->segmentSet()[outlet_segment_index].depth();
+    double dp = wellhelpers::computeHydrostaticCorrection(segment_depth_outlet, segment_depth,
+                                                          density, baseif_.gravity());
+    // we add the hydrostatic correction from the outlet segment
+    // in order to get the correction all the way to the bhp ref depth.
+    if (seg > 0) {
+        dp += seg_dp[outlet_segment_index];
+    }
+
+    return dp;
+}
+
 template class MultisegmentWellGeneric<double>;
 
 } // namespace Opm

--- a/opm/simulators/wells/MultisegmentWellGeneric.cpp
+++ b/opm/simulators/wells/MultisegmentWellGeneric.cpp
@@ -24,6 +24,7 @@
 #include <opm/common/utility/numeric/RootFinders.hpp>
 
 #include <opm/input/eclipse/Schedule/VFPInjTable.hpp>
+#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/simulators/wells/VFPHelpers.hpp>

--- a/opm/simulators/wells/MultisegmentWellGeneric.hpp
+++ b/opm/simulators/wells/MultisegmentWellGeneric.hpp
@@ -72,6 +72,10 @@ protected:
     bool accelerationalPressureLossConsidered() const;
     bool frictionalPressureLossConsidered() const;
 
+    double getSegmentDp(const int seg,
+                        const double density,
+                        const std::vector<double>& seg_dp) const;
+
     const WellInterfaceGeneric& baseif_;
 };
 

--- a/opm/simulators/wells/MultisegmentWellGeneric.hpp
+++ b/opm/simulators/wells/MultisegmentWellGeneric.hpp
@@ -22,8 +22,6 @@
 #ifndef OPM_MULTISEGMENTWELL_GENERIC_HEADER_INCLUDED
 #define OPM_MULTISEGMENTWELL_GENERIC_HEADER_INCLUDED
 
-#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
-
 #include <functional>
 #include <optional>
 #include <vector>
@@ -35,6 +33,8 @@ namespace Opm
 class DeferredLogger;
 class SummaryState;
 class WellInterfaceGeneric;
+enum class WellSegmentCompPressureDrop;
+class WellSegments;
 class WellState;
 
 template <typename Scalar>
@@ -61,7 +61,7 @@ protected:
     void scaleSegmentPressuresWithBhp(WellState& well_state) const;
 
     // components of the pressure drop to be included
-    WellSegments::CompPressureDrop compPressureDrop() const;
+    WellSegmentCompPressureDrop compPressureDrop() const;
 
     /// Detect oscillation or stagnation based on the residual measure history
     void detectOscillations(const std::vector<double>& measure_history,

--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
@@ -22,6 +22,8 @@
 #include <config.h>
 #include <opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp>
 
+#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
+
 #include <opm/material/fluidsystems/BlackOilDefaultIndexTraits.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -23,6 +23,7 @@
 
 #include <opm/common/ErrorMacros.hpp>
 
+#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 
 #include <opm/material/densead/EvaluationFormat.hpp>

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1246,20 +1246,12 @@ namespace Opm
         std::fill(this->ipr_b_.begin(), this->ipr_b_.end(), 0.);
 
         const int nseg = this->numberOfSegments();
-        const double ref_depth = this->ref_depth_;
         std::vector<double> seg_dp(nseg, 0.0);
         for (int seg = 0; seg < nseg; ++seg) {
             // calculating the perforation rate for each perforation that belongs to this segment
-            const double segment_depth = this->segmentSet()[seg].depth();
-            const int outlet_segment_index = this->segmentNumberToIndex(this->segmentSet()[seg].outletSegment());
-            const double segment_depth_outlet = seg == 0? ref_depth : this->segmentSet()[outlet_segment_index].depth();
-            double dp = wellhelpers::computeHydrostaticCorrection(segment_depth_outlet, segment_depth,
-                                                                  this->segments_.density(seg).value(), this->gravity_);
-            // we add the hydrostatic correction from the outlet segment
-            // in order to get the correction all the way to the bhp ref depth.
-            if (seg > 0) {
-                dp += seg_dp[outlet_segment_index];
-            }
+            const double dp = this->getSegmentDp(seg,
+                                                 this->segments_.density(seg).value(),
+                                                 seg_dp);
             seg_dp[seg] = dp;
             for (const int perf : this->segments_.perforations()[seg]) {
                 std::vector<Scalar> mob(this->num_components_, 0.0);

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -23,6 +23,7 @@
 #include <opm/simulators/wells/WellState.hpp>
 
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 

--- a/tests/test_ParallelSerialization.cpp
+++ b/tests/test_ParallelSerialization.cpp
@@ -72,6 +72,7 @@
 #include <opm/input/eclipse/Schedule/MSW/AICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
+#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 #include <opm/input/eclipse/Schedule/Network/Balance.hpp>
 #include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
 #include <opm/input/eclipse/Schedule/Network/Node.hpp>

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -41,6 +41,7 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
+#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>


### PR DESCRIPTION
And avoid includes WellSegments.hpp in simulator objects.

Downstream of https://github.com/OPM/opm-common/pull/3344