### PR TITLE
Main.hpp: remove unnecessary ArrayDimChecker.hpp include

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -54,7 +54,6 @@
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/input/eclipse/Schedule/ArrayDimChecker.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>


### PR DESCRIPTION
Reduce hotness of ArrayDimChecker.hpp by 88% (29 files, 4 files instead of 33)