### PR TITLE
Main.hpp: avoid ParseContext.hpp include

### DIFF
--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -30,7 +30,6 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/input/eclipse/Parser/InputErrorAction.hpp>
-#include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
 #include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
@@ -99,17 +98,10 @@ void EclGenericVanguard::readDeck(const std::string& filename)
     std::unique_ptr<Opm::WellTestState> wtestState;
     std::shared_ptr<Opm::SummaryConfig> summaryConfig;
 
-    auto parseContext =
-        std::make_unique<ParseContext>(std::vector<std::pair<std::string , InputErrorAction>>
-                                            {{ParseContext::PARSE_RANDOM_SLASH, InputErrorAction::IGNORE},
-                                             {ParseContext::PARSE_MISSING_DIMS_KEYWORD, InputErrorAction::WARN},
-                                             {ParseContext::SUMMARY_UNKNOWN_WELL, InputErrorAction::WARN},
-                                             {ParseContext::SUMMARY_UNKNOWN_GROUP, InputErrorAction::WARN}});
-
     Opm::readDeck(EclGenericVanguard::comm(),
                   filename, eclipseState, schedule, udqState,
                   actionState, wtestState,
-                  summaryConfig, nullptr, nullptr, std::move(parseContext),
+                  summaryConfig, nullptr, nullptr, false,
                   false, false, {});
 
     EclGenericVanguard::setParams(setupTimer.elapsed(),

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -50,7 +50,6 @@
 #include <flow/flow_ebos_micp.hpp>
 
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
-#include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -502,7 +502,6 @@ private:
                                       EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
                                       outputCout_, "STDOUT_LOGGER", allRanksDbgPrtLog);
             const bool strictParsing = EWOMS_GET_PARAM(PreTypeTag, bool, EclStrictParsing);
-            auto parseContext = setupParseContext(strictParsing);
 
             FlowMainEbos<PreTypeTag>::printPRTHeader(outputCout_);
 
@@ -517,7 +516,7 @@ private:
 
             readDeck(EclGenericVanguard::comm(), deckFilename, eclipseState_,
                      schedule_, udqState_, actionState_, wtestState_,
-                     summaryConfig_, nullptr, python, std::move(parseContext),
+                     summaryConfig_, nullptr, python, strictParsing,
                      init_from_restart_file, outputCout_, outputInterval);
 
             verifyValidCellGeometry(EclGenericVanguard::comm(), *this->eclipseState_);
@@ -718,7 +717,7 @@ private:
 
         return flowEbosWaterOnlyMain(argc_, argv_, outputCout_, outputFiles_);
     }
-    
+
     int runWaterOnlyEnergy(const Phases& phases)
     {
         if (!phases.active(Phase::WATER) || phases.size() != 2) {
@@ -742,7 +741,7 @@ private:
             return EXIT_FAILURE;
         }
 
-        if (phases.size() == 3) { 
+        if (phases.size() == 3) {
 
             if (phases.active(Phase::OIL)){ // oil water brine case
                 return flowEbosOilWaterBrineMain(argc_, argv_, outputCout_, outputFiles_);
@@ -752,7 +751,7 @@ private:
                     eclipseState_->getSimulationConfig().hasVAPWAT()) {
                     //case with water vaporization into gas phase and salt precipitation
                     return flowEbosGasWaterSaltprecVapwatMain(argc_, argv_, outputCout_, outputFiles_);
-                } 
+                }
                 else {
                     return flowEbosGasWaterBrineMain(argc_, argv_, outputCout_, outputFiles_);
                 }

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -489,7 +489,7 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
                    std::shared_ptr<SummaryConfig>& summaryConfig,
                    std::unique_ptr<ErrorGuard>     errorGuard,
                    std::shared_ptr<Python>         python,
-                   std::unique_ptr<ParseContext>   parseContext,
+                   const bool                      strictParsing,
                    const bool                      initFromRestart,
                    const bool                      checkDeck,
                    const std::optional<int>&       outputInterval)
@@ -503,6 +503,7 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
 
     if (comm.rank() == 0) { // Always true when !HAVE_MPI
         try {
+            auto parseContext = setupParseContext(strictParsing);
             readOnIORank(comm, deckFilename, parseContext.get(),
                          eclipseState, schedule, udqState, actionState, wtestState,
                          summaryConfig, std::move(python), initFromRestart,

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -86,7 +86,7 @@ void readDeck(Parallel::Communication         comm,
               std::shared_ptr<SummaryConfig>& summaryConfig,
               std::unique_ptr<ErrorGuard>     errorGuard,
               std::shared_ptr<Python>         python,
-              std::unique_ptr<ParseContext>   parseContext,
+              bool                            strictParsing,
               bool                            initFromRestart,
               bool                            checkDeck,
               const std::optional<int>&       outputInterval);


### PR DESCRIPTION
Reduce hotness of ParseContext.hpp by 33% (31 files, 62 files instead of 93)