### PR TITLE
eclgenerictracermodel.cc: add missing Well.hpp include

### DIFF
--- a/ebos/eclgenerictracermodel.cc
+++ b/ebos/eclgenerictracermodel.cc
@@ -34,6 +34,7 @@
 #include <opm/input/eclipse/EclipseState/Phase.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TracerVdTable.hpp>
 
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
 
 #include <dune/istl/operators.hh>

--- a/opm/simulators/wells/GasLiftGroupInfo.hpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.hpp
@@ -27,7 +27,6 @@
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hh>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/simulators/wells/GasLiftCommon.hpp>
@@ -45,6 +44,7 @@ namespace Opm
 {
 
 class GasLiftOpt;
+class Well;
 
 class GasLiftGroupInfo : public GasLiftCommon
 {


### PR DESCRIPTION
And forward in GasLiftGroupInfo.hpp (latter not yet of any value)

Required by https://github.com/OPM/opm-grid/pull/618