### PR TITLE
eclgenericwriter.cc: add missing PAvgCalculatorCollection.hpp include

### DIFF
--- a/ebos/eclgenericwriter.cc
+++ b/ebos/eclgenericwriter.cc
@@ -45,6 +45,7 @@
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
+#include <opm/input/eclipse/Schedule/Well/PAvgCalculatorCollection.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 


### PR DESCRIPTION
Required by https://github.com/OPM/opm-common/pull/3374