### PR TITLE
Chase API Change for UDQ Evaluation

### DIFF
--- a/ebos/eclgenericwriter_impl.hh
+++ b/ebos/eclgenericwriter_impl.hh
@@ -652,6 +652,7 @@ evalSummary(const int                                            reportStepNum,
             .eval(udq_step,
                   this->schedule_,
                   this->schedule_.wellMatcher(udq_step),
+                  this->schedule_.segmentMatcherFactory(udq_step),
                   summaryState,
                   udqState);
     }

--- a/opm/simulators/flow/EclActionHandler.cpp
+++ b/opm/simulators/flow/EclActionHandler.cpp
@@ -254,8 +254,13 @@ void EclActionHandler::evalUDQAssignments(const unsigned episodeIdx,
                                           UDQState& udq_state)
 {
     const auto& udq = schedule_[episodeIdx].udq();
-    const auto& well_matcher = schedule_.wellMatcher(episodeIdx);
-    udq.eval_assign(episodeIdx, schedule_, well_matcher, summaryState_, udq_state);
+
+    udq.eval_assign(episodeIdx,
+                    this->schedule_,
+                    this->schedule_.wellMatcher(episodeIdx),
+                    this->schedule_.segmentMatcherFactory(episodeIdx),
+                    this->summaryState_,
+                    udq_state);
 }
 
 } // namespace Opm


### PR DESCRIPTION
In particular, pass a "segment matcher factory" into every function that forms UDQ context objects.