### PR TITLE
including <optional> header to WellContainer

### DIFF
--- a/opm/simulators/wells/WellContainer.hpp
+++ b/opm/simulators/wells/WellContainer.hpp
@@ -21,6 +21,7 @@
 #define OPM_WELL_CONTAINER_HEADER_INCLUDED
 
 #include <initializer_list>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
to remove the following complaint from CLION compiler, not sure why it did not show up before. 


```c++
/home/kaib/OPM-devel4/opm/opm-simulators/opm/simulators/wells/WellContainer.hpp:144:10: error: ‘optional’ in namespace ‘std’ does not name a template type
  144 |     std::optional<int> well_index(const std::string& wname) const {
```