### PR TITLE
SimulatorTimer: add serialization support

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -199,6 +199,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_parallelwellinfo.cpp
   tests/test_preconditionerfactory.cpp
   tests/test_relpermdiagnostics.cpp
+  tests/test_RestartSerialization.cpp
   tests/test_stoppedwells.cpp
   tests/test_timer.cpp
   tests/test_vfpproperties.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -82,6 +82,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/utils/gatherDeferredLogger.cpp
   opm/simulators/utils/ParallelFileMerger.cpp
   opm/simulators/utils/ParallelRestart.cpp
+  opm/simulators/utils/SerializationPackers.cpp
   opm/simulators/wells/ALQState.cpp
   opm/simulators/wells/BlackoilWellModelConstraints.cpp
   opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -372,6 +373,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/utils/ParallelEclipseState.hpp
   opm/simulators/utils/ParallelRestart.hpp
   opm/simulators/utils/PropsCentroidsDataHandle.hpp
+  opm/simulators/utils/SerializationPackers.hpp
   opm/simulators/utils/VectorVectorDataHandle.hpp
   opm/simulators/wells/ALQState.hpp
   opm/simulators/wells/BlackoilWellModel.hpp

--- a/opm/simulators/timestepping/SimulatorTimer.cpp
+++ b/opm/simulators/timestepping/SimulatorTimer.cpp
@@ -34,7 +34,7 @@ namespace Opm
     SimulatorTimer::SimulatorTimer()
         : current_step_(0),
           current_time_(0.0),
-          start_date_(std::make_shared<boost::gregorian::date>(2012,1,1))    // A really arbitrary default starting value?!
+          start_date_(2012,1,1)    // A really arbitrary default starting value?!
     {
     }
 
@@ -61,7 +61,7 @@ namespace Opm
         }
 
         setCurrentStepNum(report_step);
-        *start_date_ = boost::posix_time::from_time_t(schedule.getStartTime()).date();
+        start_date_ = boost::posix_time::from_time_t(schedule.getStartTime()).date();
     }
 
     /// Whether the current step is the first step.
@@ -111,7 +111,7 @@ namespace Opm
 
     boost::posix_time::ptime SimulatorTimer::startDateTime() const
     {
-        return boost::posix_time::ptime(*start_date_);
+        return boost::posix_time::ptime(start_date_);
     }
 
 

--- a/opm/simulators/timestepping/SimulatorTimer.cpp
+++ b/opm/simulators/timestepping/SimulatorTimer.cpp
@@ -20,11 +20,12 @@
 #include "config.h"
 #include <opm/simulators/timestepping/SimulatorTimer.hpp>
 #include <opm/common/utility/parameters/ParameterGroup.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Units/Units.hpp>
 #include <ostream>
 #include <numeric>
 
-#include <boost/date_time/gregorian_calendar.hpp>
+#include <boost/date_time/gregorian/gregorian_types.hpp>
 #include <boost/date_time/posix_time/conversion.hpp>
 
 namespace Opm
@@ -36,6 +37,18 @@ namespace Opm
           current_time_(0.0),
           start_date_(2012,1,1)    // A really arbitrary default starting value?!
     {
+    }
+
+    SimulatorTimer SimulatorTimer::serializationTestObject()
+    {
+        SimulatorTimer res;
+        res.timesteps_ = {1.0, 2.0, 3.0};
+        res.current_step_ = 4;
+        res.current_time_ = 5.0;
+        res.total_time_ = 6.0;
+        res.start_date_ = boost::gregorian::date(2023,1,31);
+
+        return res;
     }
 
     /// Initialize from parameters. Accepts the following:
@@ -162,6 +175,13 @@ namespace Opm
        return std::make_unique<SimulatorTimer>(*this);
     }
 
-
+    bool SimulatorTimer::operator==(const SimulatorTimer& rhs) const
+    {
+        return this->timesteps_ == rhs.timesteps_ &&
+               this->current_step_ == rhs.current_step_ &&
+               this->current_time_ == rhs.current_time_ &&
+               this->total_time_ == rhs.total_time_ &&
+               this->start_date_ == rhs.start_date_;
+    }
 
 } // namespace Opm

--- a/opm/simulators/timestepping/SimulatorTimer.hpp
+++ b/opm/simulators/timestepping/SimulatorTimer.hpp
@@ -20,7 +20,6 @@
 #ifndef OPM_SIMULATORTIMER_HEADER_INCLUDED
 #define OPM_SIMULATORTIMER_HEADER_INCLUDED
 
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/simulators/timestepping/SimulatorTimerInterface.hpp>
 
 #include <boost/date_time/gregorian/gregorian_types.hpp>
@@ -33,6 +32,7 @@ namespace Opm
 {
 
     class ParameterGroup;
+    class Schedule;
 
     class SimulatorTimer : public SimulatorTimerInterface
     {
@@ -43,6 +43,8 @@ namespace Opm
 
         /// Default constructor.
         SimulatorTimer();
+
+        static SimulatorTimer serializationTestObject();
 
         /// Initialize from parameters. Accepts the following:
         ///    num_psteps    (default 1)
@@ -116,6 +118,18 @@ namespace Opm
 
         /// return copy of object
         std::unique_ptr<SimulatorTimerInterface> clone() const override;
+
+        template<class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(timesteps_);
+            serializer(current_step_);
+            serializer(current_time_);
+            serializer(total_time_);
+            serializer(start_date_);
+        }
+
+        bool operator==(const SimulatorTimer& rhs) const;
 
     private:
         std::vector<double> timesteps_;

--- a/opm/simulators/timestepping/SimulatorTimer.hpp
+++ b/opm/simulators/timestepping/SimulatorTimer.hpp
@@ -23,10 +23,11 @@
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/simulators/timestepping/SimulatorTimerInterface.hpp>
 
-#include <iosfwd>
-#include <vector>
+#include <boost/date_time/gregorian/gregorian_types.hpp>
 
-namespace boost { namespace gregorian { class date; } }
+#include <iosfwd>
+#include <memory>
+#include <vector>
 
 namespace Opm
 {
@@ -114,14 +115,14 @@ namespace Opm
         bool lastStepFailed() const override { return false; }
 
         /// return copy of object
-        std::unique_ptr< SimulatorTimerInterface > clone() const override;
+        std::unique_ptr<SimulatorTimerInterface> clone() const override;
 
     private:
         std::vector<double> timesteps_;
         int current_step_;
         double current_time_;
         double total_time_;
-        std::shared_ptr<boost::gregorian::date> start_date_;
+        boost::gregorian::date start_date_;
     };
 
 

--- a/opm/simulators/utils/SerializationPackers.cpp
+++ b/opm/simulators/utils/SerializationPackers.cpp
@@ -1,0 +1,53 @@
+/*
+  Copyright 2019 Equinor AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+#include <opm/simulators/utils/SerializationPackers.hpp>
+
+#include <boost/date_time/gregorian/gregorian.hpp>
+
+namespace Opm {
+namespace Serialization {
+namespace detail {
+
+std::size_t Packing<false,boost::gregorian::date>::
+packSize(const boost::gregorian::date& data)
+{
+    return Packing<false,std::string>::packSize(boost::gregorian::to_simple_string(data));
+}
+
+void Packing<false,boost::gregorian::date>::
+pack(const boost::gregorian::date& data,
+     std::vector<char>& buffer, int& position)
+{
+    Packing<false,std::string>::pack(boost::gregorian::to_simple_string(data), buffer, position);
+}
+
+void Packing<false,boost::gregorian::date>::
+unpack(boost::gregorian::date& data,
+       std::vector<char>& buffer, int& position)
+{
+    std::string date;
+    Packing<false,std::string>::unpack(date, buffer, position);
+    data = boost::gregorian::from_simple_string(date);
+}
+
+} // end namespace detail
+} // end namespace Serialization
+} // end namespace Opm

--- a/opm/simulators/utils/SerializationPackers.hpp
+++ b/opm/simulators/utils/SerializationPackers.hpp
@@ -1,0 +1,49 @@
+/*
+  Copyright 2019 Equinor AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef SERIALIZATION_PACKERS_HPP
+#define SERIALIZATION_PACKERS_HPP
+
+#include <opm/common/utility/MemPacker.hpp>
+
+#include <boost/date_time/gregorian/gregorian_types.hpp>
+
+// Additional packers for serializers using the mempacker.
+
+namespace Opm {
+namespace Serialization {
+namespace detail {
+
+template<>
+struct Packing<false,boost::gregorian::date>
+{
+    static std::size_t packSize(const boost::gregorian::date& data);
+
+    static void pack(const boost::gregorian::date& data,
+                     std::vector<char>& buffer, int& position);
+
+    static void unpack(boost::gregorian::date& data,
+                       std::vector<char>& buffer, int& position);
+};
+
+}
+
+} // end namespace Serialization
+} // end namespace Opm
+
+#endif // SERIALIZATION_PACKERS_HPP

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -1,0 +1,72 @@
+/*
+  Copyright 2019 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#include <opm/common/utility/Serializer.hpp>
+
+#include <opm/simulators/timestepping/SimulatorTimer.hpp>
+#include <opm/simulators/utils/SerializationPackers.hpp>
+
+#define BOOST_TEST_MODULE TestRestartSerialization
+#define BOOST_TEST_NO_MAIN
+
+#include <boost/date_time/gregorian/gregorian.hpp>
+#include <boost/test/unit_test.hpp>
+
+template<class T>
+std::tuple<T,int,int> PackUnpack(T& in)
+{
+    Opm::Serialization::MemPacker packer;
+    Opm::Serializer ser(packer);
+    ser.pack(in);
+    size_t pos1 = ser.position();
+    T out{};
+    ser.unpack(out);
+    size_t pos2 = ser.position();
+
+    return std::make_tuple(out, pos1, pos2);
+}
+
+#define TEST_FOR_TYPE_NAMED_OBJ(TYPE, NAME, OBJ) \
+BOOST_AUTO_TEST_CASE(NAME) \
+{ \
+    auto val1 = Opm::TYPE::OBJ(); \
+    auto val2 = PackUnpack(val1); \
+    BOOST_CHECK_MESSAGE(std::get<1>(val2) == std::get<2>(val2), "Packed size differ from unpack size for " #TYPE); \
+    BOOST_CHECK_MESSAGE(val1 == std::get<0>(val2), "Deserialized " #TYPE " differ"); \
+}
+
+#define TEST_FOR_TYPE_NAMED(TYPE, NAME) \
+    TEST_FOR_TYPE_NAMED_OBJ(TYPE, NAME, serializationTestObject)
+
+#define TEST_FOR_TYPE(TYPE) \
+    TEST_FOR_TYPE_NAMED(TYPE, TYPE)
+
+TEST_FOR_TYPE(SimulatorTimer)
+
+bool init_unit_test_func()
+{
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    return boost::unit_test::unit_test_main(&init_unit_test_func, argc, argv);
+}

--- a/tests/test_timer.cpp
+++ b/tests/test_timer.cpp
@@ -33,6 +33,7 @@
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
 
 #include <string>
 #include <iostream>


### PR DESCRIPTION
Downstream of https://github.com/OPM/opm-common/pull/3383

The timer state needs to be serialized for "perfect" restarts.