### PR TITLE
AdaptiveTimeSteppingEbos: add serialization support

### DIFF
--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -108,7 +108,7 @@ namespace Opm
     ////////////////////////////////////////////////////////
 
     HardcodedTimeStepControl::
-    HardcodedTimeStepControl( const std::string& filename)
+    HardcodedTimeStepControl(const std::string& filename)
     {
         std::ifstream infile (filename);
         if (!infile.is_open()) {
@@ -125,11 +125,24 @@ namespace Opm
         }
     }
 
+    HardcodedTimeStepControl HardcodedTimeStepControl::serializationTestObject()
+    {
+        HardcodedTimeStepControl result;
+        result.subStepTime_ = {1.0, 2.0};
+
+        return result;
+    }
+
     double HardcodedTimeStepControl::
     computeTimeStepSize( const double /*dt */, const int /*iterations */, const RelativeChangeInterface& /* relativeChange */ , const double simulationTimeElapsed) const
     {
         auto nextTime = std::upper_bound(subStepTime_.begin(), subStepTime_.end(), simulationTimeElapsed);
         return (*nextTime - simulationTimeElapsed);
+    }
+
+    bool HardcodedTimeStepControl::operator==(const HardcodedTimeStepControl& ctrl) const
+    {
+        return this->subStepTime_ == ctrl.subStepTime_;
     }
 
 

--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -66,6 +66,12 @@ namespace Opm
         }
     }
 
+    SimpleIterationCountTimeStepControl
+    SimpleIterationCountTimeStepControl::serializationTestObject()
+    {
+        return {1, 1.0, 2.0, true};
+    }
+
     double SimpleIterationCountTimeStepControl::
     computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& /* relativeChange */, const double /*simulationTimeElapsed */) const
     {
@@ -84,6 +90,15 @@ namespace Opm
         }
 
         return dtEstimate;
+    }
+
+    bool SimpleIterationCountTimeStepControl::
+    operator==(const SimpleIterationCountTimeStepControl& ctrl) const
+    {
+         return this->target_iterations_ == ctrl.target_iterations_ &&
+                this->decayrate_ == ctrl.decayrate_ &&
+                this->growthrate_ == ctrl.growthrate_ &&
+                this->verbose_ == ctrl.verbose_;
     }
 
     ////////////////////////////////////////////////////////

--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -160,6 +160,15 @@ namespace Opm
         , verbose_( verbose )
     {}
 
+    PIDTimeStepControl
+    PIDTimeStepControl::serializationTestObject()
+    {
+        PIDTimeStepControl result(1.0, true);
+        result.errors_ = {2.0, 3.0};
+
+        return result;;
+    }
+
     double PIDTimeStepControl::
     computeTimeStepSize( const double dt, const int /* iterations */, const RelativeChangeInterface& relChange, const double /*simulationTimeElapsed */) const
     {
@@ -202,6 +211,13 @@ namespace Opm
                 OpmLog::info(fmt::format("Computed step size (pow): {} days", unit::convert::to( newDt, unit::day )));
             return newDt;
         }
+    }
+
+    bool PIDTimeStepControl::operator==(const PIDTimeStepControl& ctrl) const
+    {
+        return this->tol_ == ctrl.tol_ &&
+               this->errors_ == ctrl.errors_ &&
+               this->verbose_ == ctrl.verbose_;
     }
 
 

--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -242,6 +242,12 @@ namespace Opm
         , minTimeStepBasedOnIterations_(minTimeStepBasedOnIterations)
     {}
 
+    PIDAndIterationCountTimeStepControl
+    PIDAndIterationCountTimeStepControl::serializationTestObject()
+    {
+        return {1, 2.0, 3.0, 4.0, 5.0, true};
+    }
+
     double PIDAndIterationCountTimeStepControl::
     computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& relChange,  const double simulationTimeElapsed ) const
     {
@@ -262,6 +268,15 @@ namespace Opm
         }
 
         return std::min(dtEstimatePID, dtEstimateIter);
+    }
+
+    bool PIDAndIterationCountTimeStepControl::operator==(const PIDAndIterationCountTimeStepControl& ctrl) const
+    {
+        return static_cast<const PIDTimeStepControl&>(*this) == ctrl &&
+               this->target_iterations_ == ctrl.target_iterations_ &&
+               this->decayDampingFactor_ == ctrl.decayDampingFactor_ &&
+               this->growthDampingFactor_ == ctrl.growthDampingFactor_ &&
+               this->minTimeStepBasedOnIterations_ == ctrl.minTimeStepBasedOnIterations_;
     }
 
 } // end namespace Opm

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -21,12 +21,20 @@
 #ifndef OPM_TIMESTEPCONTROL_HEADER_INCLUDED
 #define OPM_TIMESTEPCONTROL_HEADER_INCLUDED
 
-#include <vector>
-
 #include <opm/simulators/timestepping/TimeStepControlInterface.hpp>
+
+#include <string>
+#include <vector>
 
 namespace Opm
 {
+    enum class TimeStepControlType {
+      SimpleIterationCount,
+      PID,
+      PIDAndIterationCount,
+      HardCodedTimeStep
+    };
+
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
     ///
     ///  A simple iteration count based adaptive time step control.
@@ -35,6 +43,7 @@ namespace Opm
     class SimpleIterationCountTimeStepControl : public TimeStepControlInterface
     {
     public:
+        static constexpr TimeStepControlType Type = TimeStepControlType::SimpleIterationCount;
         SimpleIterationCountTimeStepControl() = default;
 
         /// \brief constructor
@@ -87,6 +96,7 @@ namespace Opm
     class PIDTimeStepControl : public TimeStepControlInterface
     {
     public:
+        static constexpr TimeStepControlType Type = TimeStepControlType::PID;
         /// \brief constructor
         /// \param tol      tolerance for the relative changes of the numerical solution to be accepted
         ///                 in one time step (default is 1e-3)
@@ -126,6 +136,8 @@ namespace Opm
     {
         typedef PIDTimeStepControl BaseType;
     public:
+        static constexpr TimeStepControlType Type = TimeStepControlType::PIDAndIterationCount;
+
         /// \brief constructor
         /// \param target_iterations  number of desired iterations per time step
         /// \param tol        tolerance for the relative changes of the numerical solution to be accepted
@@ -174,6 +186,7 @@ namespace Opm
     class HardcodedTimeStepControl : public TimeStepControlInterface
     {
     public:
+        static constexpr TimeStepControlType Type = TimeStepControlType::HardCodedTimeStep;
         HardcodedTimeStepControl() = default;
 
         /// \brief constructor

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -138,8 +138,22 @@ namespace Opm
                                              const double minTimeStepBasedOnIterations = 0.,
                                              const bool verbose = false);
 
+        static PIDAndIterationCountTimeStepControl serializationTestObject();
+
         /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize
         double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& relativeChange, const double /*simulationTimeElapsed */ ) const;
+
+        template<class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(static_cast<PIDTimeStepControl&>(*this));
+            serializer(target_iterations_);
+            serializer(decayDampingFactor_);
+            serializer(growthDampingFactor_);
+            serializer(minTimeStepBasedOnIterations_);
+        }
+
+        bool operator==(const PIDAndIterationCountTimeStepControl&) const;
 
     protected:
         const int     target_iterations_;

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -148,12 +148,24 @@ namespace Opm
     class HardcodedTimeStepControl : public TimeStepControlInterface
     {
     public:
+        HardcodedTimeStepControl() = default;
+
         /// \brief constructor
         /// \param filename   filename contaning the timesteps
         explicit HardcodedTimeStepControl( const std::string& filename);
 
+        static HardcodedTimeStepControl serializationTestObject();
+
         /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize
         double computeTimeStepSize( const double dt, const int /* iterations */, const RelativeChangeInterface& /*relativeChange */, const double simulationTimeElapsed) const;
+
+        template<class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(subStepTime_);
+        }
+
+        bool operator==(const HardcodedTimeStepControl&) const;
 
     protected:
         // store the time (in days) of the substeps the simulator should use

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -35,6 +35,8 @@ namespace Opm
     class SimpleIterationCountTimeStepControl : public TimeStepControlInterface
     {
     public:
+        SimpleIterationCountTimeStepControl() = default;
+
         /// \brief constructor
         /// \param target_iterations  number of desired iterations (e.g. Newton iterations) per time step in one time step
         //  \param decayrate          decayrate of time step when target iterations are not met (should be <= 1)
@@ -45,14 +47,27 @@ namespace Opm
                                              const double growthrate,
                                              const bool verbose = false);
 
+        static SimpleIterationCountTimeStepControl serializationTestObject();
+
         /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize
         double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& /* relativeChange */, const double /*simulationTimeElapsed */ ) const;
 
+        template<class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(target_iterations_);
+            serializer(decayrate_);
+            serializer(growthrate_);
+            serializer(verbose_);
+        }
+
+        bool operator==(const SimpleIterationCountTimeStepControl&) const;
+
     protected:
-        const int     target_iterations_;
-        const double  decayrate_;
-        const double  growthrate_;
-        const bool    verbose_;
+        const int     target_iterations_ = 0;
+        const double  decayrate_ = 0.0;
+        const double  growthrate_ = 0.0;
+        const bool    verbose_ = false;
     };
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -94,14 +94,26 @@ namespace Opm
         PIDTimeStepControl( const double tol = 1e-3,
                             const bool verbose = false );
 
+        static PIDTimeStepControl serializationTestObject();
+
         /// \brief \copydoc TimeStepControlInterface::computeTimeStepSize
         double computeTimeStepSize( const double dt, const int /* iterations */, const RelativeChangeInterface& relativeChange, const double /*simulationTimeElapsed */ ) const;
 
-    protected:
-        const double tol_;
-        mutable std::vector< double > errors_;
+        template<class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(tol_);
+            serializer(errors_);
+            serializer(verbose_);
+        }
 
-        const bool verbose_;
+        bool operator==(const PIDTimeStepControl&) const;
+
+    protected:
+        const double tol_ = 1e-3;
+        mutable std::vector< double > errors_{};
+
+        const bool verbose_ = false;
     };
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -60,6 +60,7 @@ BOOST_AUTO_TEST_CASE(NAME) \
 #define TEST_FOR_TYPE(TYPE) \
     TEST_FOR_TYPE_NAMED(TYPE, TYPE)
 
+TEST_FOR_TYPE(HardcodedTimeStepControl)
 TEST_FOR_TYPE(SimpleIterationCountTimeStepControl)
 TEST_FOR_TYPE(SimulatorTimer)
 

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -61,6 +61,7 @@ BOOST_AUTO_TEST_CASE(NAME) \
     TEST_FOR_TYPE_NAMED(TYPE, TYPE)
 
 TEST_FOR_TYPE(HardcodedTimeStepControl)
+TEST_FOR_TYPE(PIDAndIterationCountTimeStepControl)
 TEST_FOR_TYPE(PIDTimeStepControl)
 TEST_FOR_TYPE(SimpleIterationCountTimeStepControl)
 TEST_FOR_TYPE(SimulatorTimer)

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -22,6 +22,7 @@
 #include <opm/common/utility/Serializer.hpp>
 
 #include <opm/simulators/timestepping/SimulatorTimer.hpp>
+#include <opm/simulators/timestepping/TimeStepControl.hpp>
 #include <opm/simulators/utils/SerializationPackers.hpp>
 
 #define BOOST_TEST_MODULE TestRestartSerialization
@@ -59,6 +60,7 @@ BOOST_AUTO_TEST_CASE(NAME) \
 #define TEST_FOR_TYPE(TYPE) \
     TEST_FOR_TYPE_NAMED(TYPE, TYPE)
 
+TEST_FOR_TYPE(SimpleIterationCountTimeStepControl)
 TEST_FOR_TYPE(SimulatorTimer)
 
 bool init_unit_test_func()

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -61,6 +61,7 @@ BOOST_AUTO_TEST_CASE(NAME) \
     TEST_FOR_TYPE_NAMED(TYPE, TYPE)
 
 TEST_FOR_TYPE(HardcodedTimeStepControl)
+TEST_FOR_TYPE(PIDTimeStepControl)
 TEST_FOR_TYPE(SimpleIterationCountTimeStepControl)
 TEST_FOR_TYPE(SimulatorTimer)
 

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -19,8 +19,11 @@
 
 #include <config.h>
 
+#include <ebos/ebos.hh>
+
 #include <opm/common/utility/Serializer.hpp>
 
+#include <opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp>
 #include <opm/simulators/timestepping/SimulatorTimer.hpp>
 #include <opm/simulators/timestepping/TimeStepControl.hpp>
 #include <opm/simulators/utils/SerializationPackers.hpp>
@@ -42,7 +45,7 @@ std::tuple<T,int,int> PackUnpack(T& in)
     ser.unpack(out);
     size_t pos2 = ser.position();
 
-    return std::make_tuple(out, pos1, pos2);
+    return std::make_tuple(std::move(out), pos1, pos2);
 }
 
 #define TEST_FOR_TYPE_NAMED_OBJ(TYPE, NAME, OBJ) \
@@ -65,6 +68,12 @@ TEST_FOR_TYPE(PIDAndIterationCountTimeStepControl)
 TEST_FOR_TYPE(PIDTimeStepControl)
 TEST_FOR_TYPE(SimpleIterationCountTimeStepControl)
 TEST_FOR_TYPE(SimulatorTimer)
+
+namespace Opm { using ATE = AdaptiveTimeSteppingEbos<Opm::Properties::TTag::EbosTypeTag>; }
+TEST_FOR_TYPE_NAMED_OBJ(ATE, AdaptiveTimeSteppingEbosHardcoded, serializationTestObjectHardcoded)
+TEST_FOR_TYPE_NAMED_OBJ(ATE, AdaptiveTimeSteppingEbosPID, serializationTestObjectPID)
+TEST_FOR_TYPE_NAMED_OBJ(ATE, AdaptiveTimeSteppingEbosPIDIt, serializationTestObjectPIDIt)
+TEST_FOR_TYPE_NAMED_OBJ(ATE, AdaptiveTimeSteppingEbosSimple, serializationTestObjectSimple)
 
 bool init_unit_test_func()
 {


### PR DESCRIPTION
Sits on top of https://github.com/OPM/opm-simulators/pull/4416

Required for "perfect" restart.