### PR TITLE
changed: introduce EclGenericVanguard::SetupParams

### DIFF
--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -66,6 +66,19 @@ class EclGenericVanguard {
 public:
     using ParallelWellStruct = std::vector<std::pair<std::string,bool>>;
 
+    struct SimulationModelParams {
+        double setupTime_;
+        std::unique_ptr<Parallel::Communication> comm_;
+        std::unique_ptr<UDQState> udqState_;
+        std::unique_ptr<Action::State> actionState_;
+        std::unique_ptr<WellTestState> wtestState_;
+        std::shared_ptr<EclipseState> eclState_;
+        std::shared_ptr<Schedule> eclSchedule_;
+        std::shared_ptr<SummaryConfig> eclSummaryConfig_;
+    };
+
+    static SimulationModelParams modelParams_;
+
     /*!
      * \brief Constructor.
      * \details Needs to be in compile unit.
@@ -89,7 +102,7 @@ public:
     /*!
      * \brief Returns the wall time required to set up the simulator before it was born.
      */
-    static double setupTime()
+    double setupTime()
     { return setupTime_; }
 
     /*!
@@ -101,13 +114,7 @@ public:
     /*!
      * \brief Set the simulation configuration objects.
      */
-    static void defineSimulationModel(double setupTime,
-                                      std::shared_ptr<EclipseState> eclState,
-                                      std::shared_ptr<Schedule> schedule,
-                                      std::unique_ptr<UDQState> udqState,
-                                      std::unique_ptr<Action::State> actionState,
-                                      std::unique_ptr<WellTestState> wtestState,
-                                      std::shared_ptr<SummaryConfig> summaryConfig);
+    void defineSimulationModel(SimulationModelParams&& params);
 
     /*!
      * \brief Return a reference to the internalized ECL deck.
@@ -258,7 +265,7 @@ protected:
 
     void init();
 
-    static double setupTime_;
+    double setupTime_;
 
     // These variables may be owned by both Python and the simulator
     static std::unique_ptr<Parallel::Communication> comm_;
@@ -285,22 +292,22 @@ protected:
     bool enableExperiments_;
 
     std::unique_ptr<SummaryState> summaryState_;
-    static std::unique_ptr<UDQState> udqState_;
-    static std::unique_ptr<Action::State> actionState_;
+    std::unique_ptr<UDQState> udqState_;
+    std::unique_ptr<Action::State> actionState_;
 
     // Observe that this instance is handled differently from the other state
     // variables, it will only be initialized for a restart run. While
     // initializing a restarted run this instance is transferred to the WGState
     // member in the well model.
-    static std::unique_ptr<WellTestState> wtestState_;
+    std::unique_ptr<WellTestState> wtestState_;
 
     // these attributes point  either to the internal  or to the external version of the
     // parser objects.
     std::shared_ptr<Python> python;
     // These variables may be owned by both Python and the simulator
-    static std::shared_ptr<EclipseState> eclState_;
-    static std::shared_ptr<Schedule> eclSchedule_;
-    static std::shared_ptr<SummaryConfig> eclSummaryConfig_;
+    std::shared_ptr<EclipseState> eclState_;
+    std::shared_ptr<Schedule> eclSchedule_;
+    std::shared_ptr<SummaryConfig> eclSummaryConfig_;
 
     /*! \brief Information about wells in parallel
      *

--- a/opm/simulators/flow/Main.cpp
+++ b/opm/simulators/flow/Main.cpp
@@ -211,13 +211,13 @@ void Main::readDeck(const std::string& deckFilename,
 
 void Main::setupVanguard()
 {
-    EclGenericVanguard::defineSimulationModel(this->setupTime_,
-                                              this->eclipseState_,
-                                              this->schedule_,
-                                              std::move(this->udqState_),
-                                              std::move(this->actionState_),
-                                              std::move(this->wtestState_),
-                                              this->summaryConfig_);
+    EclGenericVanguard::modelParams_.setupTime_ = this->setupTime_;
+    EclGenericVanguard::modelParams_.actionState_ = std::move(this->actionState_);
+    EclGenericVanguard::modelParams_.eclSchedule_ = this->schedule_;
+    EclGenericVanguard::modelParams_.eclState_ = this->eclipseState_;
+    EclGenericVanguard::modelParams_.eclSummaryConfig_ = this->summaryConfig_;
+    EclGenericVanguard::modelParams_.udqState_ = std::move(udqState_);
+    EclGenericVanguard::modelParams_.wtestState_ = std::move(wtestState_);
 }
 
 #if HAVE_DAMARIS


### PR DESCRIPTION
this is a struct that holds the information transferred from the simulator prior to vanguard instantation. this way we can avoid the static members for state, which causes issues for serialization (in particular, it makes it impossible to compare two instances like we do in tests).