### PR TITLE
ParallelRestart: use variadic broadcast

### DIFF
--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -52,8 +52,7 @@ RestartValue loadParallelRestart(const EclipseIO* eclIO,
     }
 
     EclMpiSerializer ser(comm);
-    ser.broadcast(restartValues);
-    ser.broadcast(summaryState);
+    ser.broadcast(0, restartValues, summaryState);
     return restartValues;
 #else
     (void) comm;


### PR DESCRIPTION
micro optimization, there is no reason to do this in two operations