### PR TITLE
AdaptiveTimeSteppingEbos: some cleanups

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -782,7 +782,7 @@ namespace Opm {
             return failing_wells;
         }
 
-        typedef std::unique_ptr<TimeStepControlInterface> TimeStepControlType;
+        using TimeStepControlType = std::unique_ptr<TimeStepControlInterface>;
 
         TimeStepControlType timeStepControl_; //!< time step control object
         double restartFactor_;               //!< factor to multiply time step with when solver fails to converge

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -432,7 +432,7 @@ namespace Opm {
                 }
 
                 SimulatorReportSingle substepReport;
-                std::string causeOfFailure = "";
+                std::string causeOfFailure;
                 try {
                     substepReport = solver.step(substepTimer);
                     if (solverVerbose_) {

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -3,8 +3,12 @@
 #ifndef OPM_ADAPTIVE_TIME_STEPPING_EBOS_HPP
 #define OPM_ADAPTIVE_TIME_STEPPING_EBOS_HPP
 
-#include <iostream>
-#include <utility>
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 8)
+#include <dune/istl/istlexception.hh>
+#else
+#include <dune/istl/ilu.hh>
+#endif
 
 #include <opm/common/Exceptions.hpp>
 #include <opm/common/ErrorMacros.hpp>
@@ -17,11 +21,27 @@
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
 #include <opm/input/eclipse/Units/Units.hpp>
 
+#include <opm/models/utils/basicproperties.hh>
+#include <opm/models/utils/parametersystem.hh>
+#include <opm/models/utils/propertysystem.hh>
+
 #include <opm/simulators/timestepping/SimulatorReport.hpp>
 #include <opm/simulators/timestepping/SimulatorTimer.hpp>
 #include <opm/simulators/timestepping/AdaptiveSimulatorTimer.hpp>
 #include <opm/simulators/timestepping/TimeStepControlInterface.hpp>
 #include <opm/simulators/timestepping/TimeStepControl.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <memory>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace Opm::Properties {
 


### PR DESCRIPTION
- include required headers
- using instead of typedef
- no reason to initialize string with ""