### PR TITLE
EclGenericVanguard: rename setParams to defineSimulationModel

### DIFF
--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -69,13 +69,13 @@ EclGenericVanguard::EclGenericVanguard()
 
 EclGenericVanguard::~EclGenericVanguard() = default;
 
-void EclGenericVanguard::setParams(double setupTime,
-                                   std::shared_ptr<EclipseState> eclState,
-                                   std::shared_ptr<Schedule> schedule,
-                                   std::unique_ptr<UDQState> udqState,
-                                   std::unique_ptr<Action::State> actionState,
-                                   std::unique_ptr<WellTestState> wtestState,
-                                   std::shared_ptr<SummaryConfig> summaryConfig)
+void EclGenericVanguard::defineSimulationModel(double setupTime,
+                                               std::shared_ptr<EclipseState> eclState,
+                                               std::shared_ptr<Schedule> schedule,
+                                               std::unique_ptr<UDQState> udqState,
+                                               std::unique_ptr<Action::State> actionState,
+                                               std::unique_ptr<WellTestState> wtestState,
+                                               std::shared_ptr<SummaryConfig> summaryConfig)
 {
     EclGenericVanguard::setupTime_ = setupTime;
     EclGenericVanguard::eclState_ = std::move(eclState);
@@ -104,11 +104,11 @@ void EclGenericVanguard::readDeck(const std::string& filename)
                   summaryConfig, nullptr, false,
                   false, false, {});
 
-    EclGenericVanguard::setParams(setupTimer.elapsed(),
-                                  eclipseState, schedule,
-                                  std::move(udqState),
-                                  std::move(actionState),
-                                  std::move(wtestState), summaryConfig);
+    EclGenericVanguard::defineSimulationModel(setupTimer.elapsed(),
+                                              eclipseState, schedule,
+                                              std::move(udqState),
+                                              std::move(actionState),
+                                              std::move(wtestState), summaryConfig);
 }
 
 std::string EclGenericVanguard::canonicalDeckPath(const std::string& caseName)

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -101,13 +101,13 @@ public:
     /*!
      * \brief Set the simulation configuration objects.
      */
-    static void setParams(double setupTime,
-                          std::shared_ptr<EclipseState> eclState,
-                          std::shared_ptr<Schedule> schedule,
-                          std::unique_ptr<UDQState> udqState,
-                          std::unique_ptr<Action::State> actionState,
-                          std::unique_ptr<WellTestState> wtestState,
-                          std::shared_ptr<SummaryConfig> summaryConfig);
+    static void defineSimulationModel(double setupTime,
+                                      std::shared_ptr<EclipseState> eclState,
+                                      std::shared_ptr<Schedule> schedule,
+                                      std::unique_ptr<UDQState> udqState,
+                                      std::unique_ptr<Action::State> actionState,
+                                      std::unique_ptr<WellTestState> wtestState,
+                                      std::shared_ptr<SummaryConfig> summaryConfig);
 
     /*!
      * \brief Return a reference to the internalized ECL deck.

--- a/opm/simulators/flow/Main.cpp
+++ b/opm/simulators/flow/Main.cpp
@@ -211,13 +211,13 @@ void Main::readDeck(const std::string& deckFilename,
 
 void Main::setupVanguard()
 {
-    EclGenericVanguard::setParams(this->setupTime_,
-                                  this->eclipseState_,
-                                  this->schedule_,
-                                  std::move(this->udqState_),
-                                  std::move(this->actionState_),
-                                  std::move(this->wtestState_),
-                                  this->summaryConfig_);
+    EclGenericVanguard::defineSimulationModel(this->setupTime_,
+                                              this->eclipseState_,
+                                              this->schedule_,
+                                              std::move(this->udqState_),
+                                              std::move(this->actionState_),
+                                              std::move(this->wtestState_),
+                                              this->summaryConfig_);
 }
 
 #if HAVE_DAMARIS


### PR DESCRIPTION
setParams is a rather generic method name, be more specific