### PR TITLE
changes to make executable using original simulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,13 +441,13 @@ opm_add_test(flow_distribute_z
   $<TARGET_OBJECTS:moduleVersion>
   )
 
-opm_add_test(flow_blackoil_ebos
+opm_add_test(ebos
   ONLY_COMPILE
   ALWAYS_ENABLE
   DEPENDS opmsimulators
   LIBRARIES opmsimulators
   SOURCES
-  flow/flow_blackoil_ebos.cpp
+  flow/ebos.cpp
   $<TARGET_OBJECTS:moduleVersion>
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,7 +441,7 @@ opm_add_test(flow_distribute_z
   $<TARGET_OBJECTS:moduleVersion>
   )
 
-opm_add_test(flow_blackoil_ebos)
+opm_add_test(flow_blackoil_ebos
   ONLY_COMPILE
   ALWAYS_ENABLE
   DEPENDS opmsimulators

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,7 +446,7 @@ opm_add_test(flow_blackoil_ebos
   ALWAYS_ENABLE
   DEPENDS opmsimulators
   LIBRARIES opmsimulators
-  SOURCE
+  SOURCES
   flow/flow_blackoil_ebos.cpp
   $<TARGET_OBJECTS:moduleVersion>
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,17 @@ opm_add_test(flow_distribute_z
   $<TARGET_OBJECTS:moduleVersion>
   )
 
+opm_add_test(flow_blackoil_test
+  ONLY_COMPILE
+  ALWAYS_ENABLE
+  DEPENDS opmsimulators
+  LIBRARIES opmsimulators
+  SOURCES
+  flow/flow_blackoil_test.cpp
+  $<TARGET_OBJECTS:moduleVersion>
+  )
+
+
 if(dune-alugrid_FOUND)
   if (NOT BUILD_FLOW_ALU_GRID)
     set(FLOW_ALUGRID_ONLY_DEFAULT_ENABLE_IF "FALSE")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,13 +441,13 @@ opm_add_test(flow_distribute_z
   $<TARGET_OBJECTS:moduleVersion>
   )
 
-opm_add_test(flow_blackoil_test
+opm_add_test(flow_blackoil_ebos)
   ONLY_COMPILE
   ALWAYS_ENABLE
   DEPENDS opmsimulators
   LIBRARIES opmsimulators
-  SOURCES
-  flow/flow_blackoil_test.cpp
+  SOURCE
+  flow/flow_blackoil_ebos.cpp
   $<TARGET_OBJECTS:moduleVersion>
   )
 

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -232,6 +232,7 @@ void EclGenericVanguard::init()
     // it means that setParams is called
     if(!eclState_){
         this->readDeck(fileName_);
+        this->defineSimulationModel(std::move(this->modelParams_));
     }
 
     if (!this->summaryState_)

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -223,6 +223,17 @@ void EclGenericVanguard::init()
         std::transform(caseName_.begin(), caseName_.end(), caseName_.begin(), ::toupper);
     }
 
+    // set communicator if not set as in opm flow
+    if(!comm_){
+        EclGenericVanguard::setCommunication(std::make_unique<Parallel::Communication>());
+    }
+    
+    // set eclState if not already set as in opm flow
+    // it means that setParams is called
+    if(!eclState_){
+        this->readDeck(fileName_);
+    }
+
     if (!this->summaryState_)
         this->summaryState_ = std::make_unique<SummaryState>( TimeService::from_time_t(this->eclSchedule_->getStartTime() ));
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -914,7 +914,7 @@ public:
         // to the first "real" episode/report step
         // for restart the episode index and start is already set
         if (!initconfig.restartRequested()) {
-            simulator.startNextEpisode(schedule.seconds(0));
+            simulator.startNextEpisode(schedule.seconds(1));
             simulator.setEpisodeIndex(0);
         }
     }

--- a/flow/ebos.cpp
+++ b/flow/ebos.cpp
@@ -1,0 +1,47 @@
+/*
+  Copyright 2020, NORCE AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+#include <ebos/ebos.hh>
+#include <opm/simulators/flow/Main.hpp>
+
+namespace Opm {
+namespace Properties {
+namespace TTag {
+struct EclFlowProblemEbos {
+    using InheritsFrom = std::tuple<EbosTypeTag>;
+};
+}
+
+// // Set the problem class
+// template<class TypeTag>
+// struct Problem<TypeTag, TTag::EbosTypeTag> {
+//     using type = EbosProblem<TypeTag>;
+// };
+    
+// template<class TypeTag>
+// struct EclEnableAquifers<TypeTag, TTag::EclFlowProblemTest> {
+//     static constexpr bool value = false;
+// };
+}
+}
+int main(int argc, char** argv)
+{
+    using TypeTag = Opm::Properties::TTag::EclFlowProblemEbos;
+    return Opm::start<TypeTag>(argc, argv);
+}


### PR DESCRIPTION
- small changes to make the standard flow classes run with the pure simulator in opm-models.
-  this make an executable which is check can be used to check if the interface of the classes is consistent with opm-model design. 
-  This simulator is not checked as flow and probably have several issues
Known issues;
- match of
- some opening checks may be missing
- timestepping is not the same as in flow

Should the name be changed to not conflict with flow.