### PR TITLE
Add timing block

### DIFF
--- a/ebos/eclgenerictracermodel.hh
+++ b/ebos/eclgenerictracermodel.hh
@@ -29,7 +29,7 @@
 #define EWOMS_ECL_GENERIC_TRACER_MODEL_HH
 
 #include <opm/grid/common/CartesianIndexMapper.hpp>
-
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/models/blackoil/blackoilmodel.hh>
 
 #include <opm/simulators/linalg/matrixblock.hh>

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -216,6 +216,7 @@ public:
      */
     void processElement(const ElementContext& elemCtx)
     {
+        OPM_TIMEBLOCK_LOCAL(processElement);
         if (!std::is_same<Discretization, EcfvDiscretization<TypeTag>>::value)
             return;
 
@@ -857,6 +858,7 @@ public:
     template <class ActiveIndex, class CartesianIndex>
     void processFluxes(const ElementContext& elemCtx, ActiveIndex&& activeIndex, CartesianIndex&& cartesianIndex)
     {
+        OPM_TIMEBLOCK_LOCAL(processFluxes);
         const auto identifyCell = [&activeIndex, &cartesianIndex](const Element& elem) -> EclInterRegFlowMap::Cell {
             const auto cellIndex = activeIndex(elem);
 
@@ -983,7 +985,7 @@ private:
 
     void updateFluidInPlace_(const ElementContext& elemCtx, unsigned dofIdx)
     {
-
+        OPM_TIMEBLOCK_LOCAL(updateFluidInPlace);
         const auto& intQuants = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0);
         const auto& fs = intQuants.fluidState();
         unsigned globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1198,14 +1198,15 @@ public:
      */
     void writeOutput(bool verbose = true)
     {
-        OPM_TIMEBLOCK(writeOutput);
+        OPM_TIMEBLOCK(problemWriteOutput);
         // use the generic code to prepare the output fields and to
         // write the desired VTK files.
         ParentType::writeOutput(verbose);
 
         bool isSubStep = !EWOMS_GET_PARAM(TypeTag, bool, EnableWriteAllSolutions) && !this->simulator().episodeWillBeOver();
-        if (enableEclOutput_)
+        if (enableEclOutput_){
             eclWriter_->writeOutput(isSubStep);
+        }
     }
 
     void finalizeOutput() {

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -305,6 +305,7 @@ public:
 
     void writeOutput(bool isSubStep)
     {
+        OPM_TIMEBLOCK(writeOutput);
         const int reportStepNum = simulator_.episodeIndex() + 1;
         this->prepareLocalCellData(isSubStep, reportStepNum);
         this->eclOutputModule_->outputErrorLog(simulator_.gridView().comm());
@@ -500,6 +501,7 @@ private:
     void prepareLocalCellData(const bool isSubStep,
                               const int  reportStepNum)
     {
+        OPM_TIMEBLOCK(prepareLocalCellData);
         const auto& gridView = simulator_.vanguard().gridView();
         const int numElements = gridView.size(/*codim=*/0);
         const bool log = this->collectToIORank_.isIORank();
@@ -520,6 +522,7 @@ private:
 
     void captureLocalFluxData()
     {
+        OPM_TIMEBLOCK(captureLocalData);
         const auto& gridView = this->simulator_.vanguard().gridView();
         const auto timeIdx = 0u;
 

--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -237,6 +237,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
               converged_(false),
               matrix_()
         {
+            OPM_TIMEBLOCK(istlSolverEbos);
             const bool on_io_rank = (simulator.gridView().comm().rank() == 0);
 #if HAVE_MPI
             comm_.reset( new CommunicationType( simulator_.vanguard().grid().comm() ) );
@@ -311,6 +312,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
 
         void prepare(const SparseMatrixAdapter& M, Vector& b)
         {
+            OPM_TIMEBLOCK(istlSolverEbosPrepare);        
             static bool firstcall = true;
 #if HAVE_MPI
             if (firstcall) {
@@ -370,6 +372,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
 
         bool solve(Vector& x)
         {
+            OPM_TIMEBLOCK(istlSolverEbosSolve);        
             calls_ += 1;
             // Write linear system if asked for.
             const int verbosity = prm_.get<int>("verbosity", 0);
@@ -396,6 +399,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                                   x, result))
 #endif
             {
+                OPM_TIMEBLOCK(flexibleSolverApply);
                 assert(flexibleSolver_.solver_);
                 flexibleSolver_.solver_->apply(x, *rhs_, result);
             }
@@ -448,7 +452,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
 
         void prepareFlexibleSolver()
         {
-
+            OPM_TIMEBLOCK(prepareFlexibleSolver);        
             if (shouldCreateSolver()) {
                 std::function<Vector()> trueFunc =
                     [this]
@@ -460,7 +464,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                     auto wellOp = std::make_unique<WellModelOperator>(simulator_.problem().wellModel());
                     flexibleSolver_.wellOperator_ = std::move(wellOp);
                 }
-
+                OPM_TIMEBLOCK(flexibleSolverCreate);
                 flexibleSolver_.create(getMatrix(),
                                        isParallel(),
                                        prm_,
@@ -470,6 +474,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             }
             else
             {
+                OPM_TIMEBLOCK(flexibleSolverUpdate);        
                 flexibleSolver_.pre_->update();
             }
         }
@@ -527,6 +532,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         // conservation equations, ignoring all other terms.
         Vector getTrueImpesWeights(int pressureVarIndex) const
         {
+            OPM_TIMEBLOCK(getTrueImpesWeights);
             Vector weights(rhs_->size());
             ElementContext elemCtx(simulator_);
             Amg::getTrueImpesWeights(pressureVarIndex, weights,


### PR DESCRIPTION
Add timing blocks which can be used with tracy to get timings. Examples are in the attatchment.
It is same type of pullrequests in opm-common opm-models

 
![image](https://user-images.githubusercontent.com/1936524/218998854-047188a8-1e10-449e-8230-88ee508a0877.png)
![image](https://user-images.githubusercontent.com/1936524/218999361-b17cd312-cf74-4d36-818c-3606faadc6ca.png)
![image](https://user-images.githubusercontent.com/1936524/218999531-d13cc96a-86b9-4401-b0ed-1fe1e2b9fe76.png)
![image](https://user-images.githubusercontent.com/1936524/218999732-aa0cb596-7744-428e-ad25-8da36ac4542d.png)
