### PR TITLE
Fix Sequential Build

### DIFF
--- a/examples/opmrst_inspect.cpp
+++ b/examples/opmrst_inspect.cpp
@@ -40,9 +40,9 @@ int main(int argc, char** argv)
     }
 
 #if HAVE_MPI
-    Opm::Parallel::Communication comm(MPI_COMM_SELF);
+    Opm::Parallel::Communication comm{MPI_COMM_SELF};
 #else
-    Opm::Parallel::Communication comm();
+    Opm::Parallel::Communication comm{};
 #endif
 
     Dune::MPIHelper::instance(argc, argv);

--- a/opm/simulators/utils/HDF5File.cpp
+++ b/opm/simulators/utils/HDF5File.cpp
@@ -26,6 +26,7 @@
 
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 
+#include <cassert>
 #include <filesystem>
 #include <stdexcept>
 
@@ -61,7 +62,7 @@ HDF5File::HDF5File(const std::string& fileName,
         acc_tpl = H5Pcreate(H5P_FILE_ACCESS);
         H5Pset_fapl_mpio(acc_tpl, comm_, info);
 #else
-        assert(0); // should be unreachable
+        assert(false); // should be unreachable
 #endif
     }
 

--- a/tests/test_HDF5File.cpp
+++ b/tests/test_HDF5File.cpp
@@ -30,17 +30,15 @@
 #include <filesystem>
 #include <stdexcept>
 
-using namespace Opm;
-
 BOOST_AUTO_TEST_CASE(ReadWrite)
 {
     auto path = std::filesystem::temp_directory_path() / Opm::unique_path("hdf5test%%%%%");
     std::filesystem::create_directory(path);
     auto rwpath = (path / "rw.hdf5").string();
 #if HAVE_MPI
-    Parallel::Communication comm(MPI_COMM_SELF);
+    Opm::Parallel::Communication comm{MPI_COMM_SELF};
 #else
-    Parallel::Communcation comm;
+    Opm::Parallel::Communication comm{};
 #endif
     const std::vector<char> test_data{1,2,3,4,5,6,8,9};
     {
@@ -61,9 +59,9 @@ BOOST_AUTO_TEST_CASE(ReadWrite)
 BOOST_AUTO_TEST_CASE(ThrowOpenNonexistent)
 {
 #if HAVE_MPI
-    Parallel::Communication comm(MPI_COMM_SELF);
+    Opm::Parallel::Communication comm{MPI_COMM_SELF};
 #else
-    Parallel::Communcation comm;
+    Opm::Parallel::Communication comm{};
 #endif
     BOOST_CHECK_THROW(Opm::HDF5File out_file("no_such_file.hdf5", Opm::HDF5File::OpenMode::READ, comm), std::runtime_error);
 }
@@ -74,9 +72,9 @@ BOOST_AUTO_TEST_CASE(ReadNonExistentDset)
     std::filesystem::create_directory(path);
     auto rwpath = (path / "existent_dset.hdf5").string();
 #if HAVE_MPI
-    Parallel::Communication comm(MPI_COMM_SELF);
+    Opm::Parallel::Communication comm{MPI_COMM_SELF};
 #else
-    Parallel::Communcation comm;
+    Opm::Parallel::Communication comm{};
 #endif
     const std::vector<char> test_data{1,2,3,4,5,6,8,9};
     {
@@ -101,9 +99,9 @@ BOOST_AUTO_TEST_CASE(WriteExistentDset)
     std::filesystem::create_directory(path);
     auto rwpath = (path / "existent_dset.hdf5").string();
 #if HAVE_MPI
-    Parallel::Communication comm(MPI_COMM_SELF);
+    Opm::Parallel::Communication comm{MPI_COMM_SELF};
 #else
-    Parallel::Communcation comm;
+    Opm::Parallel::Communication comm{};
 #endif
     const std::vector<char> test_data{1,2,3,4,5,6,8,9};
     {
@@ -121,9 +119,9 @@ BOOST_AUTO_TEST_CASE(List)
     std::filesystem::create_directory(path);
     auto rwpath = (path / "existent_dset.hdf5").string();
 #if HAVE_MPI
-    Parallel::Communication comm(MPI_COMM_SELF);
+    Opm::Parallel::Communication comm{MPI_COMM_SELF};
 #else
-    Parallel::Communcation comm;
+    Opm::Parallel::Communication comm{};
 #endif
     const std::vector<char> test_data{1,2,3,4,5,6,8,9};
     {

--- a/tests/test_HDF5Serializer.cpp
+++ b/tests/test_HDF5Serializer.cpp
@@ -24,6 +24,7 @@
 #include <ebos/hdf5serializer.hh>
 
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
+#include <opm/simulators/utils/ParallelCommunication.hpp>
 
 #define BOOST_TEST_MODULE HDF5FileTest
 #define BOOST_TEST_NO_MAIN
@@ -42,7 +43,7 @@ BOOST_AUTO_TEST_CASE(Header)
 #if HAVE_MPI
     Parallel::Communication comm(MPI_COMM_SELF);
 #else
-    Parallel::Communcation comm;
+    Parallel::Communication comm{};
 #endif
     std::array<std::string,5> output{"foo", "bar", "foobar", "bob", "bobbar"};
     {
@@ -72,7 +73,7 @@ BOOST_AUTO_TEST_CASE(WriteRead)
 #if HAVE_MPI
     Parallel::Communication comm(MPI_COMM_SELF);
 #else
-    Parallel::Communcation comm;
+    Parallel::Communication comm{};
 #endif
     auto output = Group::serializationTestObject();
     {


### PR DESCRIPTION
Include requisite headers and avoid "most vexing parse" problems.

Follow-up to #4466, but work in progress.