### PR TITLE
RestartSerialization: add missing PerfData

### DIFF
--- a/opm/simulators/wells/PerfData.cpp
+++ b/opm/simulators/wells/PerfData.cpp
@@ -24,9 +24,7 @@
 
 #include <opm/simulators/wells/PerfData.hpp>
 
-namespace Opm
-{
-
+namespace Opm {
 
 PerfData::PerfData(std::size_t num_perf, double pressure_first_connection_, bool injector_, std::size_t num_phases)
     : injector(injector_)
@@ -49,6 +47,29 @@ PerfData::PerfData(std::size_t num_perf, double pressure_first_connection_, bool
         this->skin_pressure.resize(num_perf);
         this->water_velocity.resize(num_perf);
     }
+}
+
+PerfData PerfData::serializationTestObject()
+{
+    PerfData result;
+    result.pressure_first_connection = 1.0;
+    result.pressure = {2.0, 3.0, 4.0};
+    result.rates = {5.0, 6.0};
+    result.phase_rates = {7.0};
+    result.solvent_rates = {8.0, 9.0};
+    result.polymer_rates = {10.0, 11.0, 12.0};
+    result.brine_rates = {13.0};
+    result.prod_index = {14.0, 15.0};
+    result.micp_rates = {16.0};
+    result.cell_index = {17, 18, 19, 20};
+    result.connection_transmissibility_factor = {21.0};
+    result.satnum_id = {22, 23};
+    result.ecl_index = {24};
+    result.water_throughput = {25.0, 26.0};
+    result.skin_pressure = {27.0, 28.0};
+    result.water_velocity = {29.0, 30.0};
+
+    return result;
 }
 
 std::size_t PerfData::size() const {
@@ -79,6 +100,26 @@ bool PerfData::try_assign(const PerfData& other) {
     this->prod_index = other.prod_index;
     this->micp_rates = other.micp_rates;
     return true;
+}
+
+bool PerfData::operator==(const PerfData& rhs) const
+{
+    return this->pressure_first_connection == rhs.pressure_first_connection &&
+           this->pressure == rhs.pressure &&
+           this->rates == rhs.rates &&
+           this->phase_rates == rhs.phase_rates &&
+           this->solvent_rates == rhs.solvent_rates &&
+           this->polymer_rates == rhs.polymer_rates &&
+           this->brine_rates == rhs.brine_rates &&
+           this->prod_index == rhs.prod_index &&
+           this->micp_rates == rhs.micp_rates &&
+           this->cell_index == rhs.cell_index &&
+           this->connection_transmissibility_factor == rhs.connection_transmissibility_factor &&
+           this->satnum_id == rhs.satnum_id &&
+           this->ecl_index == rhs.ecl_index &&
+           this->water_throughput == rhs.water_throughput &&
+           this->skin_pressure == rhs.skin_pressure &&
+           this->water_velocity == rhs.water_velocity;
 }
 
 }

--- a/opm/simulators/wells/PerfData.hpp
+++ b/opm/simulators/wells/PerfData.hpp
@@ -21,10 +21,10 @@
 #ifndef OPM_PERFDATA_HEADER_INCLUDED
 #define OPM_PERFDATA_HEADER_INCLUDED
 
+#include <cstddef>
 #include <vector>
 
-namespace Opm
-{
+namespace Opm {
 
 class PerfData
 {
@@ -32,13 +32,39 @@ private:
     bool injector;
 
 public:
+    PerfData() = default;
     PerfData(std::size_t num_perf, double pressure_first_connection_, bool injector_, std::size_t num_phases);
+
+    static PerfData serializationTestObject();
+
     std::size_t size() const;
     bool empty() const;
     bool try_assign(const PerfData& other);
 
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(pressure_first_connection);
+        serializer(pressure);
+        serializer(rates);
+        serializer(phase_rates);
+        serializer(solvent_rates);
+        serializer(polymer_rates);
+        serializer(brine_rates);
+        serializer(prod_index);
+        serializer(micp_rates);
+        serializer(cell_index);
+        serializer(connection_transmissibility_factor);
+        serializer(satnum_id);
+        serializer(ecl_index);
+        serializer(water_throughput);
+        serializer(skin_pressure);
+        serializer(water_velocity);
+    }
 
-    double pressure_first_connection;
+    bool operator==(const PerfData&) const;
+
+    double pressure_first_connection{};
     std::vector<double> pressure;
     std::vector<double> rates;
     std::vector<double> phase_rates;
@@ -52,7 +78,6 @@ public:
     std::vector<double> connection_transmissibility_factor;
     std::vector<int> satnum_id;
     std::vector<std::size_t> ecl_index;
-
 
     // The water_throughput, skin_pressure and water_velocity variables are only
     // used for injectors to check the injectivity.

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -58,6 +58,7 @@ SingleWellState::SingleWellState(const std::string& name_,
 SingleWellState SingleWellState::serializationTestObject(const ParallelWellInfo& pinfo)
 {
     SingleWellState result("testing", pinfo, true, 1.0, {}, PhaseUsage{}, 2.0);
+    result.perf_data = PerfData::serializationTestObject();
 
     return result;
 }

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -71,6 +71,7 @@ public:
         serializer(events);
         serializer(injection_cmode);
         serializer(production_cmode);
+        serializer(perf_data);
     }
 
     bool operator==(const SingleWellState&) const;

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -40,6 +40,7 @@
 #include <opm/simulators/wells/ALQState.hpp>
 #include <opm/simulators/wells/BlackoilWellModelGeneric.hpp>
 #include <opm/simulators/wells/GroupState.hpp>
+#include <opm/simulators/wells/PerfData.hpp>
 #include <opm/simulators/wells/SegmentState.hpp>
 #include <opm/simulators/wells/SingleWellState.hpp>
 
@@ -83,6 +84,7 @@ BOOST_AUTO_TEST_CASE(NAME) \
 TEST_FOR_TYPE(ALQState)
 TEST_FOR_TYPE(GroupState)
 TEST_FOR_TYPE(HardcodedTimeStepControl)
+TEST_FOR_TYPE(PerfData)
 TEST_FOR_TYPE(PIDAndIterationCountTimeStepControl)
 TEST_FOR_TYPE(PIDTimeStepControl)
 TEST_FOR_TYPE(SegmentState)


### PR DESCRIPTION
Turns out that while perfdata is recreated for the current well state, it is not so for the previous ones. Thus we have to serialize this in order to have it available for the previous well state upon restart.