### PR TITLE
HDF5File: enable gzip compression

### DIFF
--- a/opm/simulators/utils/HDF5File.hpp
+++ b/opm/simulators/utils/HDF5File.hpp
@@ -98,6 +98,18 @@ private:
                        const std::string& group,
                        const std::string& dset) const;
 
+    //! \brief Return a dataset creation properly list with compression settings.
+    //! \param size Size of dataset
+    hid_t getCompression(hsize_t size) const;
+
+    //! \brief Helper function to write a dataset.
+    //! \param rank Process rank that should write
+    //! \param dataset_id Handle for dataset to write
+    //! \param dxpl Dataset transfer property list
+    //! \param size Size of dataset
+    //! \param data Data to write
+    void writeDset(int rank, hid_t dataset_id,
+                   hid_t dxpl, hsize_t size, const void* data) const;
     hid_t m_file = H5I_INVALID_HID; //!< File handle
     Parallel::Communication comm_;
 };


### PR DESCRIPTION
I am keeping this in draft state, but I want to open so we can discuss a little.

Enabling gzip compression (level 9 - the highest compression effort) brings a serialized Norne state down from 43MB to 6.5MB, so there is certainly merit to this.

However, obviously compression eats cpu time, and doing this on the simulator thread will stall the simulator for seconds.
So I have 3 questions;

1) Should we enable this (i think yes).
2) Should we make it configurable (I think maybe not).
3) Should I put effort into moving the compression and storage onto a work thread, akin to the convergence output stuff?