### PR TITLE
not considering wells with wrong flow direction as converged

### DIFF
--- a/opm/simulators/timestepping/ConvergenceReport.hpp
+++ b/opm/simulators/timestepping/ConvergenceReport.hpp
@@ -81,7 +81,7 @@ namespace Opm
         class WellFailure
         {
         public:
-            enum struct Type { Invalid, MassBalance, Pressure, ControlBHP, ControlTHP, ControlRate, Unsolvable };
+            enum struct Type { Invalid, MassBalance, Pressure, ControlBHP, ControlTHP, ControlRate, Unsolvable, WrongFlowDirection };
             WellFailure(Type t, Severity s, int phase, const std::string& well_name)
                 : type_(t), severity_(s), phase_(phase), well_name_(well_name)
             {

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -164,6 +164,19 @@ getWellConvergence(const WellState& well_state,
                                   report,
                                   deferred_logger);
 
+    // for stopped well, we do not enforce the following checking to avoid dealing with sign of near-zero values
+    // for BHP or THP controlled wells, we need to make sure the flow direction is correct
+    if (!baseif_.wellIsStopped() && baseif_.isPressureControlled(well_state)) {
+        // checking the flow direction
+        const double sign = baseif_.isProducer() ? -1. : 1.;
+        const auto weight_total_flux = this->primary_variables_.getWQTotal() * sign;
+        constexpr int dummy_phase = -1;
+        if (weight_total_flux < 0.) {
+            report.setWellFailed(
+                    {CR::WellFailure::Type::WrongFlowDirection, CR::Severity::Normal, dummy_phase, baseif_.name()});
+        }
+    }
+
     return report;
 }
 

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -151,6 +151,19 @@ getWellConvergence(const WellState& well_state,
                                   report,
                                   deferred_logger);
 
+    // for stopped well, we do not enforce the following checking to avoid dealing with sign of near-zero values
+    // for BHP or THP controlled wells, we need to make sure the flow direction is correct
+    if (!baseif_.wellIsStopped() && baseif_.isPressureControlled(well_state)) {
+        // checking the flow direction
+        const double sign = baseif_.isProducer() ? -1. : 1.;
+        const auto weight_total_flux = this->primary_variables_.value(PrimaryVariables::WQTotal) * sign;
+        constexpr int dummy_phase = -1;
+        if (weight_total_flux < 0.) {
+            report.setWellFailed(
+                    {CR::WellFailure::Type::WrongFlowDirection, CR::Severity::Normal, dummy_phase, baseif_.name()});
+        }
+    }
+
     return report;
 }
 


### PR DESCRIPTION
under THP constraint, well can get converged with wrong flow direction (e.g. a producer is injecting), becasue we cut off the wrong flow direction as zero rate in the VFP evaluation