### PR TITLE
Inplace: add missing enum entries in formatting function

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -70,6 +70,11 @@ std::string EclString(Opm::Inplace::Phase phase) {
     case Opm::Inplace::Phase::OilResVolume: return "OIPR";
     case Opm::Inplace::Phase::GasResVolume: return "GIPR";
     case Opm::Inplace::Phase::SALT: return "SIP";
+    case Opm::Inplace::Phase::CO2InWaterPhase: return "WCD";
+    case Opm::Inplace::Phase::CO2InGasPhaseInMob: return "GCDI";
+    case Opm::Inplace::Phase::CO2InGasPhaseMob: return "GCDM";
+    case Opm::Inplace::Phase::WaterInGasPhase: return "WIPG";
+    case Opm::Inplace::Phase::WaterInWaterPhase: return "WIPL";
     default: throw std::logic_error(fmt::format("Phase enum with integer value: {} not recognized", static_cast<int>(phase)));
     }
 }


### PR DESCRIPTION
This should restore build. I *think* I got the mapping right.