### PR TITLE
changed: pass the version info as parameters in Banners.cpp/Main.cpp

### DIFF
--- a/opm/simulators/flow/Banners.cpp
+++ b/opm/simulators/flow/Banners.cpp
@@ -26,7 +26,6 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <opm/simulators/timestepping/SimulatorReport.hpp>
-#include <opm/simulators/utils/moduleVersion.hpp>
 
 #include <fmt/format.h>
 
@@ -51,9 +50,10 @@ unsigned long long getTotalSystemMemory()
 
 namespace Opm {
 
-void printPRTHeader(const std::string& parameters)
+void printPRTHeader(const std::string& parameters,
+                    std::string_view moduleVersion,
+                    std::string_view compileTimestamp)
 {
-    const std::string version = moduleVersion();
     const double megabyte = 1024 * 1024;
     unsigned num_cpu = std::thread::hardware_concurrency();
     struct utsname arch;
@@ -73,13 +73,13 @@ void printPRTHeader(const std::string& parameters)
     ss << " #         #######    ######       #   #    \n\n";
     ss << "Flow is a simulator for fully implicit three-phase black-oil flow,";
     ss << " and is part of OPM.\nFor more information visit: https://opm-project.org \n\n";
-    ss << "Flow Version     =  " + version + "\n";
+    ss << "Flow Version     =  " << moduleVersion << "\n";
     if (uname(&arch) == 0) {
        ss << "Machine name     =  " << arch.nodename << " (Number of logical cores: " << num_cpu;
        ss << ", Memory size: " << std::fixed << std::setprecision (2) << mem_size << " MB) \n";
        ss << "Operating system =  " << arch.sysname << " " << arch.machine << " (Kernel: " << arch.release;
        ss << ", " << arch.version << " )\n";
-       ss << "Build time       =  " << compileTimestamp() << "\n";
+       ss << "Build time       =  " << compileTimestamp << "\n";
     }
     if (user) {
        ss << "User             =  " << user << std::endl;
@@ -91,11 +91,11 @@ void printPRTHeader(const std::string& parameters)
     OpmLog::note(ss.str());
 }
 
-void printFlowBanner(int nprocs, int nthreads)
+void printFlowBanner(int nprocs, int nthreads, std::string_view moduleVersionName)
 {
     const int lineLen = 70;
-    const std::string version = moduleVersionName();
-    const std::string banner = "This is flow "+version;
+    std::string banner = "This is flow ";
+    banner += moduleVersionName;
     const int bannerPreLen = (lineLen - 2 - banner.size())/2;
     const int bannerPostLen = bannerPreLen + (lineLen - 2 - banner.size())%2;
     std::cout << "**********************************************************************\n";

--- a/opm/simulators/flow/Banners.hpp
+++ b/opm/simulators/flow/Banners.hpp
@@ -23,16 +23,19 @@
 #define OPM_FLOW_BANNERS_HEADER_INCLUDED
 
 #include <string>
+#include <string_view>
 
 namespace Opm {
 
 class SimulatorReport;
 
 // Print an ASCII-art header to the PRT and DEBUG files.
-void printPRTHeader(const std::string& parameters);
+void printPRTHeader(const std::string& parameters,
+                    std::string_view moduleVersion,
+                    std::string_view compileTimestamp);
 
 // Print flow application banner.
-void printFlowBanner(int nprocs, int threads);
+void printFlowBanner(int nprocs, int threads, std::string_view moduleVersionName);
 
 // Print flow application trailer.
 void printFlowTrailer(int nprocs, int nthreads,

--- a/opm/simulators/flow/Main.cpp
+++ b/opm/simulators/flow/Main.cpp
@@ -141,7 +141,8 @@ void Main::initMPI()
 #endif // HAVE_MPI
 }
 
-void Main::handleVersionCmdLine_(int argc, char** argv)
+void Main::handleVersionCmdLine_(int argc, char** argv,
+                                 std::string_view moduleVersionName)
 {
     auto pos = std::find_if(argv, argv + argc,
         [](const char* arg)
@@ -150,7 +151,7 @@ void Main::handleVersionCmdLine_(int argc, char** argv)
     });
 
     if (pos != argv + argc) {
-        std::cout << "flow " << moduleVersionName() << std::endl;
+        std::cout << "flow " << moduleVersionName << std::endl;
         std::exit(EXIT_SUCCESS);
     }
 }
@@ -173,7 +174,9 @@ void Main::readDeck(const std::string& deckFilename,
                     const bool strictParsing,
                     const int mpiRank,
                     const int output_param,
-                    const std::string& parameters)
+                    const std::string& parameters,
+                    std::string_view moduleVersion,
+                    std::string_view compileTimestamp)
 {
     auto omode = setupLogging(mpiRank,
                               deckFilename,
@@ -182,7 +185,7 @@ void Main::readDeck(const std::string& deckFilename,
                               outputCout_, "STDOUT_LOGGER", allRanksDbgPrtLog);
 
     if (outputCout_) {
-        printPRTHeader(parameters);
+        printPRTHeader(parameters, moduleVersion, compileTimestamp);
         OpmLog::info("Reading deck file '" + deckFilename + "'");
     }
 

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -73,6 +73,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
@@ -278,7 +279,7 @@ private:
         Dune::Timer externalSetupTimer;
         externalSetupTimer.start();
 
-        handleVersionCmdLine_(argc_, argv_);
+        handleVersionCmdLine_(argc_, argv_, Opm::moduleVersionName());
 
         // we always want to use the default locale, and thus spare us the trouble
         // with incorrect locale settings.
@@ -357,7 +358,9 @@ private:
 
         std::string cmdline_params;
         if (outputCout_) {
-            printFlowBanner(EclGenericVanguard::comm().size(), getNumThreads<PreTypeTag>());
+            printFlowBanner(EclGenericVanguard::comm().size(),
+                            getNumThreads<PreTypeTag>(),
+                            Opm::moduleVersionName());
             std::ostringstream str;
             Parameters::printValues<PreTypeTag>(str);
             cmdline_params = str.str();
@@ -373,7 +376,9 @@ private:
                            EWOMS_GET_PARAM(PreTypeTag, bool, EclStrictParsing),
                            mpiRank,
                            EWOMS_GET_PARAM(PreTypeTag, int, EclOutputInterval),
-                           cmdline_params);
+                           cmdline_params,
+                           Opm::moduleVersion(),
+                           Opm::compileTimestamp());
             setupTime_ = externalSetupTimer.elapsed();
         }
         catch (const std::invalid_argument& e)
@@ -400,7 +405,8 @@ private:
     //
     // the call is intercepted by this function which will print "flow $version"
     // on stdout and exit(0).
-    void handleVersionCmdLine_(int argc, char** argv);
+    void handleVersionCmdLine_(int argc, char** argv,
+                               std::string_view moduleVersionName);
 
     // This function is a special case, if the program has been invoked
     // with the argument "--test-split-communicator=true" as the FIRST
@@ -617,7 +623,9 @@ private:
                   const bool strictParsing,
                   const int mpiRank,
                   const int output_param,
-                  const std::string& parameters);
+                  const std::string& parameters,
+                  std::string_view moduleVersion,
+                  std::string_view compileTimestamp);
 
     void setupVanguard();
 


### PR DESCRIPTION
we want to avoid these symbols in the library.

fixes shared linking.

this might seem a bit backwards, but thing is, if we put these in the library, every time you reconfigure, every binary is rebuilt because of the compile timestamp / module revision changing.