### PR TITLE
make sure computeWellRatesWithBhpIterations honor bhp limit (can change) for StandardWell

### DIFF
--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -374,6 +374,8 @@ namespace Opm
 
         void assembleWellEqWithoutIterationImpl(const Simulator& ebosSimulator,
                                                 const double dt,
+                                                const Well::InjectionControls& inj_controls,
+                                                const Well::ProductionControls& prod_controls,
                                                 WellState& well_state,
                                                 const GroupState& group_state,
                                                 DeferredLogger& deferred_logger);

--- a/opm/simulators/wells/StandardWellAssemble.cpp
+++ b/opm/simulators/wells/StandardWellAssemble.cpp
@@ -87,6 +87,8 @@ assembleControlEq(const WellState& well_state,
                   const GroupState& group_state,
                   const Schedule& schedule,
                   const SummaryState& summaryState,
+                  const Well::InjectionControls& inj_controls,
+                  const Well::ProductionControls& prod_controls,
                   const PrimaryVariables& primary_variables,
                   const double rho,
                   StandardWellEquations<Scalar,Indices::numEq>& eqns1,
@@ -129,8 +131,6 @@ assembleControlEq(const WellState& well_state,
                                                                    deferred_logger);
         };
 
-             // Call generic implementation.
-        const auto& inj_controls = well.injectionControls(summaryState);
         WellAssemble(well_).
             assembleControlEqInj(well_state,
                                  group_state,
@@ -154,8 +154,6 @@ assembleControlEq(const WellState& well_state,
                                                                    rho,
                                                                    deferred_logger);
         };
-           // Call generic implementation.
-        const auto& prod_controls = well.productionControls(summaryState);
         WellAssemble(well_).
             assembleControlEqProd(well_state,
                                   group_state,

--- a/opm/simulators/wells/StandardWellAssemble.hpp
+++ b/opm/simulators/wells/StandardWellAssemble.hpp
@@ -23,6 +23,8 @@
 #ifndef OPM_STANDARDWELL_ASSEMBLE_HEADER_INCLUDED
 #define OPM_STANDARDWELL_ASSEMBLE_HEADER_INCLUDED
 
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
+
 namespace Opm
 {
 
@@ -53,6 +55,8 @@ public:
                            const GroupState& group_state,
                            const Schedule& schedule,
                            const SummaryState& summaryState,
+                           const Well::InjectionControls& inj_controls,
+                           const Well::ProductionControls& prod_controls,
                            const PrimaryVariables& primary_variables,
                            const double rho,
                            StandardWellEquations<Scalar,Indices::numEq>& eqns,


### PR DESCRIPTION
During the refactoring of other well part, this confusing code showed up again. 

We tried to do something in the opposite way in another old PR https://github.com/OPM/opm-simulators/pull/4183,  while this PR should be the more correct direction to go. 

Referring to the discussion in the PR https://github.com/OPM/opm-simulators/pull/4183, especially the following comment. 
https://github.com/OPM/opm-simulators/pull/4183#issuecomment-1303071931


