### PR TITLE
Mark SGWFLET as Unsupported

### DIFF
--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -551,6 +551,7 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"RSSPEC", {true, std::nullopt}},
         {"SAMG", {true, std::nullopt}},
         {"SAVE", {false, std::nullopt}},
+        {"SGWFLET", {false, std::nullopt}},
         {"SKIP", {true, std::nullopt}},
         {"SKIP100", {true, std::nullopt}},
         {"SKIP300", {true, std::nullopt}},


### PR DESCRIPTION
Although the SGOFLET and SWOFLET keywords are supposed (I'm in the process of testing these), the SGWFLET is not as there is no JSON definition. I have also corrected the manual as well.

This ready for review, as it a very minor change.