### PR TITLE
fixed: remove opm-material from data update script

### DIFF
--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -276,7 +276,7 @@ else
 fi
 if [ -n "$CONVERT_ECL" ]
 then
-  for dep in opm-common opm-grid opm-material opm-models
+  for dep in opm-common opm-grid opm-models
   do
     pushd $WORKSPACE/deps/$dep > /dev/null
     name=`printf "%-14s" $dep`


### PR DESCRIPTION
Missed this when merging material into common.