### PR TITLE
fixed: wrong order of OpmInit and use of the USE_MPI option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,12 +91,12 @@ endif()
 
 find_package(opm-common REQUIRED)
 
+include(OpmInit)
+OpmSetPolicies()
+
 if(USE_MPI)
   set(HDF5_PREFER_PARALLEL TRUE)
 endif()
-
-include(OpmInit)
-OpmSetPolicies()
 
 # not the same location as most of the other projects? this hook overrides
 macro (dir_hook)


### PR DESCRIPTION
Whadya know. I tested sibling builds and now I understand why people got in trouble with the hdf5 library selection.

Did not see this locally because I use the super-build. Did not see this on jenkins because it explicitly sets USE_MPI in its toolchain file.