### PR TITLE
Treat rate control with zero target same as stopped well.

### DIFF
--- a/opm/simulators/wells/MultisegmentWellAssemble.cpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.cpp
@@ -35,6 +35,7 @@
 #include <opm/simulators/wells/WellAssemble.hpp>
 #include <opm/simulators/wells/WellBhpThpCalculator.hpp>
 #include <opm/simulators/wells/WellInterfaceIndices.hpp>
+#include <opm/simulators/wells/WellState.hpp>
 
 namespace Opm {
 
@@ -162,6 +163,9 @@ assembleControlEq(const WellState& well_state,
                                                  bhp_from_thp,
                                                  control_eq,
                                                  deferred_logger);
+    } else if (rateControlWithZeroTarget(well_state.well(well_.indexOfWell()).production_cmode, prod_controls)) {
+        // Production mode, zero target. Treat as STOP.
+        control_eq = primary_variables.getWQTotal();
     } else {
         // Find rates.
         const auto rates = getRates();

--- a/opm/simulators/wells/StandardWellAssemble.cpp
+++ b/opm/simulators/wells/StandardWellAssemble.cpp
@@ -36,6 +36,7 @@
 #include <opm/simulators/wells/WellAssemble.hpp>
 #include <opm/simulators/wells/WellBhpThpCalculator.hpp>
 #include <opm/simulators/wells/WellInterfaceFluidSystem.hpp>
+#include <opm/simulators/wells/WellState.hpp>
 
 namespace Opm {
 
@@ -142,6 +143,9 @@ assembleControlEq(const WellState& well_state,
                                  bhp_from_thp,
                                  control_eq,
                                  deferred_logger);
+    } else if (rateControlWithZeroTarget(well_state.well(well_.indexOfWell()).production_cmode, prod_controls)) {
+        // Production mode, zero target. Treat as STOP.
+        control_eq = primary_variables.eval(PrimaryVariables::WQTotal);
     } else {
              // Find rates.
         const auto rates = getRates();

--- a/opm/simulators/wells/WellAssemble.cpp
+++ b/opm/simulators/wells/WellAssemble.cpp
@@ -43,6 +43,32 @@
 namespace Opm
 {
 
+bool rateControlWithZeroTarget(const Well::ProducerCMode mode,
+                               const Well::ProductionControls& controls)
+{
+    switch (mode) {
+    case Well::ProducerCMode::ORAT:
+        return controls.oil_rate == 0.0;
+    case Well::ProducerCMode::WRAT:
+        return controls.water_rate == 0.0;
+    case Well::ProducerCMode::GRAT:
+        return controls.gas_rate == 0.0;
+    case Well::ProducerCMode::LRAT:
+        return controls.liquid_rate == 0.0;
+    case Well::ProducerCMode::CRAT:
+        // Unsupported, will cause exception elsewhere, treat as nonzero target here.
+        return false;
+    case Well::ProducerCMode::RESV:
+        if (controls.prediction_mode) {
+            return controls.resv_rate == 0.0;
+        } else {
+            return controls.water_rate == 0.0 && controls.oil_rate == 0.0 && controls.gas_rate == 0.0;
+        }
+    default:
+        return false;
+    }
+}
+
 template<class FluidSystem>
 WellAssemble<FluidSystem>::
 WellAssemble(const WellInterfaceFluidSystem<FluidSystem>& well)

--- a/opm/simulators/wells/WellAssemble.hpp
+++ b/opm/simulators/wells/WellAssemble.hpp
@@ -27,6 +27,7 @@
 #include <opm/core/props/BlackoilPhases.hpp>
 
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
 
 #include <functional>
 
@@ -42,6 +43,10 @@ template<class FluidSystem> class WellInterfaceFluidSystem;
 class WellState;
 class WellInjectionControls;
 class WellProductionControls;
+
+/// Helper to avoid singular control equations.
+bool rateControlWithZeroTarget(const WellProducerCMode mode,
+                               const WellProductionControls& controls);
 
 template<class FluidSystem>
 class WellAssemble {
@@ -79,6 +84,8 @@ public:
 private:
     const WellInterfaceFluidSystem<FluidSystem>& well_;
 };
+
+
 
 }
 


### PR DESCRIPTION
This is a bit broader than OPM/opm-common#3430, in that it targets not just WCONHIST-induced situations. It works, but gives slightly different results than the other PR on the Norne case. Why is not clear to me.