### PR TITLE
Refactor Construction of Analytic Aquifer Objects

### DIFF
--- a/opm/simulators/aquifers/BlackoilAquiferModel.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel.hpp
@@ -48,6 +48,7 @@
 
 #include <vector>
 #include <type_traits>
+#include <string_view>
 
 namespace Opm
 {
@@ -125,8 +126,20 @@ protected:
     // TODO: possibly better to use unorder_map here for aquifers
     std::vector<std::unique_ptr<AquiferInterface<TypeTag>>> aquifers;
 
-    // This initialization function is used to connect the parser objects with the ones needed by AquiferCarterTracy
+    // This initialization function is used to connect the parser objects
+    // with the ones needed by AquiferCarterTracy
     void init();
+
+private:
+    void createDynamicAquifers(const int episode_index);
+
+    void initializeStaticAquifers();
+
+    template <typename AquiferType, typename AquiferData>
+    std::unique_ptr<AquiferType>
+    createAnalyticAquiferPointer(const AquiferData& aqData,
+                                 const int          aquiferID,
+                                 std::string_view   aqType) const;
 };
 
 

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -491,7 +491,7 @@ BOOST_AUTO_TEST_CASE(AquiferConstantFlux)
     Opm::Serializer ser(packer);
     ser.pack(data_out);
     const size_t pos1 = ser.position();
-    decltype(data_out) data_in({}, {}, sim);
+    decltype(data_out) data_in({}, sim, {});
     ser.unpack(data_in);
     const size_t pos2 = ser.position();
     BOOST_CHECK_MESSAGE(pos1 == pos2, "Packed size differ from unpack size for AquiferConstantFlux");


### PR DESCRIPTION
In particular, split the 'static' aquifer object initialisation of member function `init()` into a new helper function
```
initializeStaticAquifers()
```
This is in preparation of adding a similar function to handle dynamic aquifer object initialisation from a restart file.  To that end, also add a new member function
```
createDynamicAquifers(episode_index)
```
containing the current implementation of `beginEpisode()`.  Creating the dynamic objects from a restart file then amounts to calling this function with a different 'episode_index'.  As another aid to maintainability, add a new templated member function
```
createAnalyticAquiferPointer()
```
which forms `unique_ptr<AquiferInterface>` objects for every known type of analytic aquifer.  This, in turn, requires reordering the parameters of the `AquiferConstantFlux` constructor to match those of the existing Fetkovich and Carter-Tracy types.

Finally, split the calculation of the constant flux aquifer's total flux rate out to a new helper function
```
AquiferConstantFlux::totalFluxRate()
```