### PR TITLE
[cleanup] Fix that phaseUsage might be used uninitialzed in test.

### DIFF
--- a/opm/core/props/BlackoilPhases.hpp
+++ b/opm/core/props/BlackoilPhases.hpp
@@ -52,14 +52,14 @@ namespace Opm
         std::array<int, MaxNumPhases + NumCryptoPhases> phase_pos;
 
         int num_phases;
-        bool has_solvent;
-        bool has_polymer;
-        bool has_energy;
+        bool has_solvent{};
+        bool has_polymer{};
+        bool has_energy{};
         // polymer molecular weight
-        bool has_polymermw;
-        bool has_foam;
-        bool has_brine;
-        bool has_zFraction;
+        bool has_polymermw{};
+        bool has_foam{};
+        bool has_brine{};
+        bool has_zFraction{};
 
     };
 


### PR DESCRIPTION
We need to make sure that all pods are initialzed when using the default constructor. Fixes
```
RateConverter.hpp:83:50: warning: ‘phaseUsage’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   83 |                 , attr_      (rmap_, Attributes())
      |                                                  ^
```