### PR TITLE
fix to broken built with clang

### DIFF
--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -268,7 +268,7 @@ void BlackoilAquiferModel<TypeTag>::createDynamicAquifers(const int episode_inde
         auto aquPos =
             std::find_if(std::begin(this->aquifers),
                          std::end(this->aquifers),
-                [id](const auto& aquPtr)
+                [id = id](const auto& aquPtr)
             {
                 return aquPtr->aquiferID() == id;
             });


### PR DESCRIPTION
This commit fixes the current broken built with clang 
```
/Users/dmar/Github/opm/opm-simulators/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp:273:47: error: reference to local binding 'id' declared in enclosing function 'Opm::BlackoilAquiferModel<Opm::Properties::TTag::EclFlowProblemWaterOnlyEnergy>::createDynamicAquifers'
                return aquPtr->aquiferID() == id;
```