### PR TITLE
allow for TEMP

### DIFF
--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -619,7 +619,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"SURFWNUM", {true, std::nullopt}},
         {"SWF32D", {true, std::nullopt}},
         {"SWINGFAC", {true, std::nullopt}},
-        {"TEMP", {true, std::nullopt}},
         {"TEMPNODE", {true, std::nullopt}},
         {"TEMPTVD", {true, std::nullopt}},
         {"TIGHTEN", {true, std::nullopt}},


### PR DESCRIPTION
Keyword TEMP is supported in OPM, it does exactly the same as THERMAL. Considering both THERMAL and TEMP do not follow  what is in the commercial simulator, don't see why to break the run if the user calls for TEMP. 