### PR TITLE
making sure zero rate controlled production wells have zero rate in the simulation results

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1324,7 +1324,8 @@ namespace Opm {
         OPM_BEGIN_PARALLEL_TRY_CATCH();
         {
             for (auto& well : well_container_) {
-                well->recoverWellSolutionAndUpdateWellState(x, this->wellState(), local_deferredLogger);
+                const auto& summary_state = ebosSimulator_.vanguard().summaryState();
+                well->recoverWellSolutionAndUpdateWellState(summary_state, x, this->wellState(), local_deferredLogger);
             }
 
         }
@@ -1659,7 +1660,8 @@ namespace Opm {
             auto& events = this->wellState().well(well->indexOfWell()).events;
             if (events.hasEvent(WellState::event_mask)) {
                 well->updateWellStateWithTarget(ebosSimulator_, this->groupState(), this->wellState(), deferred_logger);
-                well->updatePrimaryVariables(this->wellState(), deferred_logger);
+                const auto& summary_state = ebosSimulator_.vanguard().summaryState();
+                well->updatePrimaryVariables(summary_state, this->wellState(), deferred_logger);
                 well->initPrimaryVariablesEvaluation();
                 // There is no new well control change input within a report step,
                 // so next time step, the well does not consider to have effective events anymore.
@@ -1733,7 +1735,8 @@ namespace Opm {
     updatePrimaryVariables(DeferredLogger& deferred_logger)
     {
         for (const auto& well : well_container_) {
-            well->updatePrimaryVariables(this->wellState(), deferred_logger);
+            const auto& summary_state = ebosSimulator_.vanguard().summaryState();
+            well->updatePrimaryVariables(summary_state, this->wellState(), deferred_logger);
         }
     }
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -108,7 +108,8 @@ namespace Opm
 
         /// using the solution x to recover the solution xw for wells and applying
         /// xw to update Well State
-        void recoverWellSolutionAndUpdateWellState(const BVector& x,
+        void recoverWellSolutionAndUpdateWellState(const SummaryState& summary_state,
+                                                   const BVector& x,
                                                    WellState& well_state,
                                                    DeferredLogger& deferred_logger) override;
 
@@ -118,9 +119,13 @@ namespace Opm
                                            std::vector<double>& well_potentials,
                                            DeferredLogger& deferred_logger) override;
 
-        void updatePrimaryVariables(const WellState& well_state, DeferredLogger& deferred_logger) override;
+        void updatePrimaryVariables(const SummaryState& summary_state,
+                                    const WellState& well_state,
+                                    DeferredLogger& deferred_logger) override;
 
-        virtual void solveEqAndUpdateWellState(WellState& well_state, DeferredLogger& deferred_logger) override; // const?
+        virtual void solveEqAndUpdateWellState(const Simulator& ebos_simulator,
+                                               WellState& well_state,
+                                               DeferredLogger& deferred_logger) override; // const?
 
         virtual void calculateExplicitQuantities(const Simulator& ebosSimulator,
                                                  const WellState& well_state,
@@ -171,7 +176,8 @@ namespace Opm
         mutable int debug_cost_counter_ = 0;
 
         // updating the well_state based on well solution dwells
-        void updateWellState(const BVectorWell& dwells,
+        void updateWellState(const SummaryState& summary_state,
+                             const BVectorWell& dwells,
                              WellState& well_state,
                              DeferredLogger& deferred_logger,
                              const double relaxation_factor = 1.0);

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -123,10 +123,6 @@ namespace Opm
                                     const WellState& well_state,
                                     DeferredLogger& deferred_logger) override;
 
-        virtual void solveEqAndUpdateWellState(const Simulator& ebos_simulator,
-                                               WellState& well_state,
-                                               DeferredLogger& deferred_logger) override; // const?
-
         virtual void calculateExplicitQuantities(const Simulator& ebosSimulator,
                                                  const WellState& well_state,
                                                  DeferredLogger& deferred_logger) override; // should be const?

--- a/opm/simulators/wells/MultisegmentWellAssemble.cpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.cpp
@@ -34,6 +34,7 @@
 #include <opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp>
 #include <opm/simulators/wells/WellAssemble.hpp>
 #include <opm/simulators/wells/WellBhpThpCalculator.hpp>
+#include <opm/simulators/wells/WellHelpers.hpp>
 #include <opm/simulators/wells/WellInterfaceIndices.hpp>
 #include <opm/simulators/wells/WellState.hpp>
 
@@ -163,7 +164,7 @@ assembleControlEq(const WellState& well_state,
                                                  bhp_from_thp,
                                                  control_eq,
                                                  deferred_logger);
-    } else if (rateControlWithZeroTarget(well_state.well(well_.indexOfWell()).production_cmode, prod_controls)) {
+    } else if (wellhelpers::rateControlWithZeroTarget(well_state.well(well_.indexOfWell()).production_cmode, prod_controls)) {
         // Production mode, zero target. Treat as STOP.
         control_eq = primary_variables.getWQTotal();
     } else {

--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
@@ -64,7 +64,7 @@ init()
 
 template<class FluidSystem, class Indices, class Scalar>
 void MultisegmentWellPrimaryVariables<FluidSystem,Indices,Scalar>::
-update(const WellState& well_state)
+update(const WellState& well_state, const bool zero_rate_target)
 {
     static constexpr int Water = BlackoilPhases::Aqua;
     static constexpr int Gas = BlackoilPhases::Vapour;
@@ -104,6 +104,9 @@ update(const WellState& well_state)
             }
         }
         value_[seg][WQTotal] = total_seg_rate;
+        if (zero_rate_target && seg == 0) {
+            value_[seg][WQTotal] = 0;
+        }
         if (std::abs(total_seg_rate) > 0.) {
             if (has_wfrac_variable) {
                 const int water_pos = pu.phase_pos[Water];
@@ -152,6 +155,7 @@ void MultisegmentWellPrimaryVariables<FluidSystem,Indices,Scalar>::
 updateNewton(const BVectorWell& dwells,
              const double relaxation_factor,
              const double dFLimit,
+             const bool zero_rate_target,
              const double max_pressure_change)
 {
     const std::vector<std::array<double, numWellEq>> old_primary_variables = value_;
@@ -192,6 +196,10 @@ updateNewton(const BVectorWell& dwells,
                 }
             }
         }
+    }
+
+    if (zero_rate_target) {
+        value_[0][WQTotal] = 0.;
     }
 }
 

--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
@@ -88,12 +88,13 @@ public:
     void init();
 
     //! \brief Copy values from well state.
-    void update(const WellState& well_state);
+    void update(const WellState& well_state, const bool zero_rate_target);
 
     //! \brief Update values from newton update vector.
     void updateNewton(const BVectorWell& dwells,
                       const double relaxation_factor,
                       const double DFLimit,
+                      const bool zero_rate_target,
                       const double max_pressure_change);
 
     //! \brief Copy values to well state.

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -148,9 +148,12 @@ namespace Opm
     template <typename TypeTag>
     void
     MultisegmentWell<TypeTag>::
-    updatePrimaryVariables(const WellState& well_state, DeferredLogger& /* deferred_logger */)
+    updatePrimaryVariables(const SummaryState& summary_state,
+                           const WellState& well_state,
+                           DeferredLogger& /* deferred_logger */)
     {
-        this->primary_variables_.update(well_state);
+        const bool zero_rate_target = this->wellUnderZeroProductionRateControl(summary_state, well_state);
+        this->primary_variables_.update(well_state, zero_rate_target);
     }
 
 
@@ -240,7 +243,8 @@ namespace Opm
     template <typename TypeTag>
     void
     MultisegmentWell<TypeTag>::
-    recoverWellSolutionAndUpdateWellState(const BVector& x,
+    recoverWellSolutionAndUpdateWellState(const SummaryState& summary_state,
+                                          const BVector& x,
                                           WellState& well_state,
                                           DeferredLogger& deferred_logger)
     {
@@ -250,7 +254,7 @@ namespace Opm
 
         BVectorWell xw(1);
         this->linSys_.recoverSolutionWell(x, xw);
-        updateWellState(xw, well_state, deferred_logger);
+        updateWellState(summary_state, xw, well_state, deferred_logger);
     }
 
 
@@ -528,7 +532,9 @@ namespace Opm
     template <typename TypeTag>
     void
     MultisegmentWell<TypeTag>::
-    solveEqAndUpdateWellState(WellState& well_state, DeferredLogger& deferred_logger)
+    solveEqAndUpdateWellState(const Simulator& ebos_simulator,
+                              WellState& well_state,
+                              DeferredLogger& deferred_logger)
     {
         if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return;
 
@@ -536,7 +542,8 @@ namespace Opm
         // which is why we do not put the assembleWellEq here.
         const BVectorWell dx_well = this->linSys_.solve();
 
-        updateWellState(dx_well, well_state, deferred_logger);
+        const auto& summary_state = ebos_simulator.vanguard().summaryState();
+        updateWellState(summary_state, dx_well, well_state, deferred_logger);
     }
 
 
@@ -619,7 +626,8 @@ namespace Opm
     template <typename TypeTag>
     void
     MultisegmentWell<TypeTag>::
-    updateWellState(const BVectorWell& dwells,
+    updateWellState(const SummaryState& summary_state,
+                    const BVectorWell& dwells,
                     WellState& well_state,
                     DeferredLogger& deferred_logger,
                     const double relaxation_factor)
@@ -628,9 +636,11 @@ namespace Opm
 
         const double dFLimit = this->param_.dwell_fraction_max_;
         const double max_pressure_change = this->param_.max_pressure_change_ms_wells_;
+        const bool zero_rate_target = this->wellUnderZeroProductionRateControl(summary_state, well_state);
         this->primary_variables_.updateNewton(dwells,
                                               relaxation_factor,
                                               dFLimit,
+                                              zero_rate_target,
                                               max_pressure_change);
 
         this->primary_variables_.copyToWellState(*this, getRefDensity(),
@@ -649,7 +659,8 @@ namespace Opm
                                 const WellState& well_state,
                                 DeferredLogger& deferred_logger)
     {
-        updatePrimaryVariables(well_state, deferred_logger);
+        const auto& summary_state = ebosSimulator.vanguard().summaryState();
+        updatePrimaryVariables(summary_state, well_state, deferred_logger);
         initPrimaryVariablesEvaluation();
         computePerfCellPressDiffs(ebosSimulator);
         computeInitialSegmentFluids(ebosSimulator);
@@ -1492,7 +1503,8 @@ namespace Opm
                 this->regularize_ = true;
                 deferred_logger.debug(sstr.str());
             }
-            updateWellState(dx_well, well_state, deferred_logger, relaxation_factor);
+            const auto& summary_state = ebosSimulator.vanguard().summaryState();
+            updateWellState(summary_state, dx_well, well_state, deferred_logger, relaxation_factor);
             initPrimaryVariablesEvaluation();
         }
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -532,27 +532,6 @@ namespace Opm
     template <typename TypeTag>
     void
     MultisegmentWell<TypeTag>::
-    solveEqAndUpdateWellState(const Simulator& ebos_simulator,
-                              WellState& well_state,
-                              DeferredLogger& deferred_logger)
-    {
-        if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return;
-
-        // We assemble the well equations, then we check the convergence,
-        // which is why we do not put the assembleWellEq here.
-        const BVectorWell dx_well = this->linSys_.solve();
-
-        const auto& summary_state = ebos_simulator.vanguard().summaryState();
-        updateWellState(summary_state, dx_well, well_state, deferred_logger);
-    }
-
-
-
-
-
-    template <typename TypeTag>
-    void
-    MultisegmentWell<TypeTag>::
     computePerfCellPressDiffs(const Simulator& ebosSimulator)
     {
         for (int perf = 0; perf < this->number_of_perforations_; ++perf) {

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -156,7 +156,8 @@ namespace Opm
 
         /// using the solution x to recover the solution xw for wells and applying
         /// xw to update Well State
-        void recoverWellSolutionAndUpdateWellState(const BVector& x,
+        void recoverWellSolutionAndUpdateWellState(const SummaryState& summary_state,
+                                                   const BVector& x,
                                                    WellState& well_state,
                                                    DeferredLogger& deferred_logger) override;
 
@@ -166,9 +167,13 @@ namespace Opm
                                            std::vector<double>& well_potentials,
                                            DeferredLogger& deferred_logger) /* const */ override;
 
-        void updatePrimaryVariables(const WellState& well_state, DeferredLogger& deferred_logger) override;
+        void updatePrimaryVariables(const SummaryState& summary_state,
+                                    const WellState& well_state,
+                                    DeferredLogger& deferred_logger) override;
 
-        virtual void solveEqAndUpdateWellState(WellState& well_state, DeferredLogger& deferred_logger) override;
+        void solveEqAndUpdateWellState(const SummaryState& summary_state,
+                                       WellState& well_state,
+                                       DeferredLogger& deferred_logger);
 
         virtual void calculateExplicitQuantities(const Simulator& ebosSimulator,
                                                  const WellState& well_state,
@@ -252,7 +257,8 @@ namespace Opm
         bool regularize_;
 
         // updating the well_state based on well solution dwells
-        void updateWellState(const BVectorWell& dwells,
+        void updateWellState(const SummaryState& summary_state,
+                             const BVectorWell& dwells,
                              WellState& well_state,
                              DeferredLogger& deferred_logger);
 
@@ -359,7 +365,7 @@ namespace Opm
                                             DeferredLogger& deferred_logger) const;
 
         void updatePrimaryVariablesNewton(const BVectorWell& dwells,
-                                          const WellState& well_state,
+                                          const bool zero_rate_target,
                                           DeferredLogger& deferred_logger);
 
         void updateWellStateFromPrimaryVariables(WellState& well_state, DeferredLogger& deferred_logger) const;

--- a/opm/simulators/wells/StandardWellAssemble.cpp
+++ b/opm/simulators/wells/StandardWellAssemble.cpp
@@ -143,7 +143,7 @@ assembleControlEq(const WellState& well_state,
                                  bhp_from_thp,
                                  control_eq,
                                  deferred_logger);
-    } else if (rateControlWithZeroTarget(well_state.well(well_.indexOfWell()).production_cmode, prod_controls)) {
+    } else if (wellhelpers::rateControlWithZeroTarget(well_state.well(well_.indexOfWell()).production_cmode, prod_controls)) {
         // Production mode, zero target. Treat as STOP.
         control_eq = primary_variables.eval(PrimaryVariables::WQTotal);
     } else {

--- a/opm/simulators/wells/StandardWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.cpp
@@ -81,7 +81,7 @@ Scalar relaxationFactorRate(const Scalar old_value,
     const Scalar original_total_rate = old_value;
     const Scalar possible_update_total_rate = old_value - newton_update;
 
-    // 0.8 here is a experimental value, which remains to be optimized
+    // 0.8 here is an experimental value, which remains to be optimized
     // if the original rate is zero or possible_update_total_rate is zero, relaxation_factor will
     // always be 1.0, more thoughts might be needed.
     if (original_total_rate * possible_update_total_rate < 0.) { // sign changed
@@ -121,7 +121,9 @@ resize(const int numWellEq)
 
 template<class FluidSystem, class Indices, class Scalar>
 void StandardWellPrimaryVariables<FluidSystem,Indices,Scalar>::
-update(const WellState& well_state, DeferredLogger& deferred_logger)
+update(const WellState& well_state,
+       const bool zero_rate_target,
+       DeferredLogger& deferred_logger)
 {
     static constexpr int Water = BlackoilPhases::Aqua;
     static constexpr int Oil = BlackoilPhases::Liquid;
@@ -158,6 +160,9 @@ update(const WellState& well_state, DeferredLogger& deferred_logger)
         }
     } else {
             value_[WQTotal] = total_well_rate;
+            if (zero_rate_target) {
+                value_[WQTotal] = 0.;
+            }
     }
 
     if (std::abs(total_well_rate) > 0.) {
@@ -240,6 +245,7 @@ updatePolyMW(const WellState& well_state)
 template<class FluidSystem, class Indices, class Scalar>
 void StandardWellPrimaryVariables<FluidSystem,Indices,Scalar>::
 updateNewton(const BVectorWell& dwells,
+             const bool zero_rate_target,
              [[maybe_unused]] const double dFLimit,
              const double dBHPLimit)
 {
@@ -275,6 +281,10 @@ updateNewton(const BVectorWell& dwells,
 
     // updating the total rates Q_t
     value_[WQTotal] = value_[WQTotal] - dwells[0][WQTotal] * relaxation_factor_rate;
+    if (zero_rate_target) {
+        value_[WQTotal] = 0.;
+    }
+    // TODO: here, we make sure it is zero for zero rated wells
 
     // updating the bottom hole pressure
     const int sign1 = dwells[0][Bhp] > 0 ? 1: -1;

--- a/opm/simulators/wells/StandardWellPrimaryVariables.hpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.hpp
@@ -101,13 +101,16 @@ public:
     int numWellEq() const { return numWellEq_; }
 
     //! \brief Copy values from well state.
-    void update(const WellState& well_state, DeferredLogger& deferred_logger);
+    void update(const WellState& well_state,
+                const bool zero_rate_target,
+                DeferredLogger& deferred_logger);
 
     //! \brief Copy polymer molecular weigt values from well state.
     void updatePolyMW(const WellState& well_state);
 
     //! \brief Update values from newton update vector.
     void updateNewton(const BVectorWell& dwells,
+                      const bool zero_rate_target,
                       const double dFLimit,
                       const double dBHPLimit);
 

--- a/opm/simulators/wells/WellAssemble.cpp
+++ b/opm/simulators/wells/WellAssemble.cpp
@@ -43,32 +43,6 @@
 namespace Opm
 {
 
-bool rateControlWithZeroTarget(const Well::ProducerCMode mode,
-                               const Well::ProductionControls& controls)
-{
-    switch (mode) {
-    case Well::ProducerCMode::ORAT:
-        return controls.oil_rate == 0.0;
-    case Well::ProducerCMode::WRAT:
-        return controls.water_rate == 0.0;
-    case Well::ProducerCMode::GRAT:
-        return controls.gas_rate == 0.0;
-    case Well::ProducerCMode::LRAT:
-        return controls.liquid_rate == 0.0;
-    case Well::ProducerCMode::CRAT:
-        // Unsupported, will cause exception elsewhere, treat as nonzero target here.
-        return false;
-    case Well::ProducerCMode::RESV:
-        if (controls.prediction_mode) {
-            return controls.resv_rate == 0.0;
-        } else {
-            return controls.water_rate == 0.0 && controls.oil_rate == 0.0 && controls.gas_rate == 0.0;
-        }
-    default:
-        return false;
-    }
-}
-
 template<class FluidSystem>
 WellAssemble<FluidSystem>::
 WellAssemble(const WellInterfaceFluidSystem<FluidSystem>& well)

--- a/opm/simulators/wells/WellAssemble.hpp
+++ b/opm/simulators/wells/WellAssemble.hpp
@@ -44,10 +44,6 @@ class WellState;
 class WellInjectionControls;
 class WellProductionControls;
 
-/// Helper to avoid singular control equations.
-bool rateControlWithZeroTarget(const WellProducerCMode mode,
-                               const WellProductionControls& controls);
-
 template<class FluidSystem>
 class WellAssemble {
     static constexpr int Water = BlackoilPhases::Aqua;

--- a/opm/simulators/wells/WellHelpers.cpp
+++ b/opm/simulators/wells/WellHelpers.cpp
@@ -25,6 +25,9 @@
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 
+#include <opm/input/eclipse/Schedule/Well/WellProductionControls.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
+
 #include <opm/simulators/wells/ParallelWellInfo.hpp>
 
 #include <fmt/format.h>
@@ -167,6 +170,33 @@ DenseMatrix transposeDenseDynMatrix(const DenseMatrix& M)
     }
     return tmp;
 }
+
+bool rateControlWithZeroTarget(const WellProducerCMode& mode,
+                               const WellProductionControls& controls)
+{
+    switch (mode) {
+        case WellProducerCMode::ORAT:
+            return controls.oil_rate == 0.0;
+        case WellProducerCMode::WRAT:
+            return controls.water_rate == 0.0;
+        case WellProducerCMode::GRAT:
+            return controls.gas_rate == 0.0;
+        case WellProducerCMode::LRAT:
+            return controls.liquid_rate == 0.0;
+        case WellProducerCMode::CRAT:
+            // Unsupported, will cause exception elsewhere, treat as nonzero target here.
+            return false;
+        case WellProducerCMode::RESV:
+            if (controls.prediction_mode) {
+                return controls.resv_rate == 0.0;
+            } else {
+                return controls.water_rate == 0.0 && controls.oil_rate == 0.0 && controls.gas_rate == 0.0;
+            }
+        default:
+            return false;
+    }
+}
+
 
 template class ParallelStandardWellB<double>;
 

--- a/opm/simulators/wells/WellHelpers.hpp
+++ b/opm/simulators/wells/WellHelpers.hpp
@@ -31,6 +31,8 @@
 namespace Opm {
 
 class ParallelWellInfo;
+enum class WellProducerCMode;
+class WellProductionControls;
 
 namespace wellhelpers {
 
@@ -82,6 +84,10 @@ void sumDistributedWellEntries(Dune::DynamicMatrix<Scalar>& mat,
 // used for calculating quasiimpes well weights
 template <class DenseMatrix>
 DenseMatrix transposeDenseDynMatrix(const DenseMatrix& M);
+
+/// Helper to check whether the well is under zero production rate control
+bool rateControlWithZeroTarget(const WellProducerCMode& mode,
+                               const WellProductionControls& controls);
 
 } // namespace wellhelpers
 } // namespace Opm

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -156,10 +156,6 @@ public:
 
     virtual ConvergenceReport getWellConvergence(const WellState& well_state, const std::vector<double>& B_avg, DeferredLogger& deferred_logger, const bool relax_tolerance) const = 0;
 
-    virtual void solveEqAndUpdateWellState(const Simulator& ebos_simulator,
-                                           WellState& well_state,
-                                           DeferredLogger& deferred_logger) = 0;
-
     void assembleWellEq(const Simulator& ebosSimulator,
                         const double dt,
                         WellState& well_state,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -156,7 +156,9 @@ public:
 
     virtual ConvergenceReport getWellConvergence(const WellState& well_state, const std::vector<double>& B_avg, DeferredLogger& deferred_logger, const bool relax_tolerance) const = 0;
 
-    virtual void solveEqAndUpdateWellState(WellState& well_state, DeferredLogger& deferred_logger) = 0;
+    virtual void solveEqAndUpdateWellState(const Simulator& ebos_simulator,
+                                           WellState& well_state,
+                                           DeferredLogger& deferred_logger) = 0;
 
     void assembleWellEq(const Simulator& ebosSimulator,
                         const double dt,
@@ -180,7 +182,8 @@ public:
 
     /// using the solution x to recover the solution xw for wells and applying
     /// xw to update Well State
-    virtual void recoverWellSolutionAndUpdateWellState(const BVector& x,
+    virtual void recoverWellSolutionAndUpdateWellState(const SummaryState& summary_state,
+                                                       const BVector& x,
                                                        WellState& well_state,
                                                        DeferredLogger& deferred_logger) = 0;
 
@@ -212,7 +215,9 @@ public:
                            const GroupState& group_state,
                            DeferredLogger& deferred_logger) /* const */;
 
-    virtual void updatePrimaryVariables(const WellState& well_state, DeferredLogger& deferred_logger) = 0;
+    virtual void updatePrimaryVariables(const SummaryState& summary_state,
+                                        const WellState& well_state,
+                                        DeferredLogger& deferred_logger) = 0;
 
     virtual void calculateExplicitQuantities(const Simulator& ebosSimulator,
                                              const WellState& well_state,
@@ -359,7 +364,8 @@ protected:
 
     Eval getPerfCellPressure(const FluidState& fs) const;
 
-
+    bool wellUnderZeroProductionRateControl(const SummaryState& summary_state,
+                                            const WellState& well_state) const;
 };
 
 }


### PR DESCRIPTION
We want to make sure the simulated well rates will be `0` for zero rate constrained wells or STOPped wells . With master branch, we might obtain small well rates values for those wells, which might make problem for the output of ratios. 

```
-- Days   dd/mm/yyyy         WMCTL:B-1H        WOPR:B-1H        WWPR:B-1H        WWCT:B-1H 

2822.00   29/07/2005                  0      4.46914e-30      2.74773e-30         0.380737 
```

Although numerically correct, while it might cause a spurious well ratios (WGOR or WWCT) plots.

In this PR, what we do is that we make sure the primary variable related to total rate will be initialized to be `0`. It turns out to be sufficient. 
