### PR TITLE
Split 3D Vectors into Base and Extended Categories

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -1005,7 +1005,7 @@ doAllocBuffers(unsigned bufferSize,
                unsigned numTracers,
                unsigned numOutputNnc)
 {
-    // Only output RESTART_AUXILIARY asked for by the user.
+    // Output RESTART_OPM_EXTENDED only when explicitly requested by user.
     std::map<std::string, int> rstKeywords = schedule_.rst_keywords(reportStepNum);
     for (auto& [keyword, should_write] : rstKeywords) {
         if (this->isOutputCreationDirective_(keyword)) {
@@ -1288,6 +1288,22 @@ doAllocBuffers(unsigned bufferSize,
             this->density_[phaseIdx].resize(bufferSize, 0.0);
         }
     }
+
+    if (auto& deng = rstKeywords["DENG"]; (deng > 0) && FluidSystem::phaseIsActive(gasPhaseIdx)) {
+        deng = 0;
+        this->density_[gasPhaseIdx].resize(bufferSize, 0.0);
+    }
+
+    if (auto& deno = rstKeywords["DENO"]; (deno > 0) && FluidSystem::phaseIsActive(oilPhaseIdx)) {
+        deno = 0;
+        this->density_[oilPhaseIdx].resize(bufferSize, 0.0);
+    }
+
+    if (auto& denw = rstKeywords["DENW"]; (denw > 0) && FluidSystem::phaseIsActive(waterPhaseIdx)) {
+        denw = 0;
+        this->density_[waterPhaseIdx].resize(bufferSize, 0.0);
+    }
+
     const bool hasVWAT = (rstKeywords["VISC"] > 0) || (rstKeywords["VWAT"] > 0);
     const bool hasVOIL = (rstKeywords["VISC"] > 0) || (rstKeywords["VOIL"] > 0);
     const bool hasVGAS = (rstKeywords["VISC"] > 0) || (rstKeywords["VGAS"] > 0);

--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -811,15 +811,15 @@ assignToSolution(data::Solution& sol)
     for (const auto& entry : data)
         doInsert(entry);
 
-    if (!temperature_.empty()) {
-        if (enableEnergy_)
-            sol.insert("TEMP", UnitSystem::measure::temperature, std::move(temperature_), data::TargetType::RESTART_SOLUTION);
-        else {
-            // Flow allows for initializing of non-constant initial temperature.
-            // For output of this temperature for visualization and restart set --enable-opm-restart=true
-            assert(enableTemperature_);
-            sol.insert("TEMP", UnitSystem::measure::temperature, std::move(temperature_), data::TargetType::RESTART_AUXILIARY);
-        }
+    if ((this->enableEnergy_ || this->enableTemperature_) &&
+        ! this->temperature_.empty())
+    {
+        const auto tag = this->enableEnergy_
+            ? data::TargetType::RESTART_SOLUTION
+            : data::TargetType::RESTART_OPM_EXTENDED;
+
+        sol.insert("TEMP", UnitSystem::measure::temperature,
+                   std::move(this->temperature_), tag);
     }
 
     if (FluidSystem::phaseIsActive(waterPhaseIdx) &&


### PR DESCRIPTION
The `base` arrays are compatible in both name and interpretation to those emitted in the `SOLUTION` section from other simulators whereas the `extended` arrays are specific to Flow.  Tag extended arrays as `OPM_EXTENDED` instead of `AUXILIARY` as the latter is deprecated and will be removed at some point in the future.

While here, also re-tag the `TEMP` array as `OPM_EXTENDED` when not required for thermal simulations and add support for the per-phase fluid density `RPTRST` request keys (`DENx`, with `x` being `O`, `G`, or `W`) in addition to the collective key `DEN` that we already support.