### PR TITLE
Avoid cache

### DIFF
--- a/ebos/FIBlackOilModel.hpp
+++ b/ebos/FIBlackOilModel.hpp
@@ -1,0 +1,57 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \copydoc Opm::FIBlackOilModel
+ */
+#ifndef FI_BLACK_OIL_MODEL_HPP
+#define FI_BLACK_OIL_MODEL_HPP
+
+namespace Opm{
+    template<typename TypeTag>
+    class FIBlackOilModel: public BlackOilModel<TypeTag>{
+        using Parent = BlackOilModel<TypeTag>;
+        using Simulator = GetPropType<TypeTag, Properties::Simulator>;
+        using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
+    public:
+        FIBlackOilModel(Simulator& simulator): BlackOilModel<TypeTag>(simulator){
+        }
+        
+        // standard flow
+        const IntensiveQuantities& intensiveQuantities(unsigned globalIdx, unsigned timeIdx) const{
+            const auto& primaryVars = this->solution(timeIdx);
+            const auto& problem = this->simulator_.problem();
+            const auto intquant = this->cachedIntensiveQuantities(globalIdx, timeIdx);
+            if (!this->enableIntensiveQuantityCache_){
+                OPM_THROW(std::logic_error, "Run without intentive quantites not enabled: Use --enable-intensive-quantity=true");
+            }
+            if(!intquant){
+                OPM_THROW(std::logic_error, "Intensive quantites need to be updated in code");
+            }    
+            return *intquant;    
+        }
+
+    };
+}
+#endif

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -50,6 +50,7 @@
 #include "ecltracermodel.hh"
 #include "vtkecltracermodule.hh"
 #include "eclgenericproblem.hh"
+#include "FIBlackOilModel.hpp"
 
 #include <opm/core/props/satfunc/RelpermDiagnostics.hpp>
 
@@ -204,6 +205,11 @@ struct Problem<TypeTag, TTag::EclBaseProblem> {
     using type = EclProblem<TypeTag>;
 };
 
+template<class TypeTag>
+struct Model<TypeTag, TTag::EclBaseProblem> {
+    using type = FIBlackOilModel<TypeTag>;
+};
+    
 // Select the element centered finite volume method as spatial discretization
 template<class TypeTag>
 struct SpatialDiscretizationSplice<TypeTag, TTag::EclBaseProblem> {

--- a/opm/simulators/aquifers/AquiferAnalytical.hpp
+++ b/opm/simulators/aquifers/AquiferAnalytical.hpp
@@ -150,7 +150,7 @@ public:
         if (idx < 0)
             return;
 
-        const auto* intQuantsPtr = model.cachedIntensiveQuantities(cellIdx, timeIdx);
+        const auto* intQuantsPtr = &model.intensiveQuantities(cellIdx, timeIdx);
         if (intQuantsPtr == nullptr) {
             throw std::logic_error("Invalid intensive quantities cache detected in AquiferAnalytical::addToSource()");
         }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1907,7 +1907,7 @@ namespace Opm {
 
             for (int perf = 0; perf < num_perf_this_well; ++perf) {
                 const int cell_idx = well_perf_data_[wellID][perf].cell_index;
-                const auto& intQuants = *(ebosSimulator_.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
+                const auto& intQuants = ebosSimulator_.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
                 const auto& fs = intQuants.fluidState();
 
                 // we on only have one temperature pr cell any phaseIdx will do

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -380,7 +380,7 @@ namespace Opm
         for (int seg = 0; seg < nseg; ++seg) {
             for (const int perf : this->segments_.perforations()[seg]) {
                 const int cell_idx = this->well_cells_[perf];
-                const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+                const auto& intQuants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
                 // flux for each perforation
                 std::vector<Scalar> mob(this->num_components_, 0.);
                 getMobilityScalar(ebosSimulator, perf, mob);
@@ -554,7 +554,7 @@ namespace Opm
             std::vector<double> density(this->number_of_phases_, 0.0);
 
             const int cell_idx = this->well_cells_[perf];
-            const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+            const auto& intQuants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
             const auto& fs = intQuants.fluidState();
 
             double sum_kr = 0.;
@@ -671,7 +671,7 @@ namespace Opm
         {
             const auto cell_idx = this->well_cells_[perf];
             return ebosSimulator.model()
-               .cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0)->fluidState();
+               .intensiveQuantities(cell_idx, /*timeIdx=*/ 0).fluidState();
         };
 
         const int np = this->number_of_phases_;
@@ -1045,7 +1045,7 @@ namespace Opm
         {
             // using the first perforated cell
             const int cell_idx = this->well_cells_[0];
-            const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
+            const auto& intQuants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
             const auto& fs = intQuants.fluidState();
             temperature.setValue(fs.temperature(FluidSystem::oilPhaseIdx).value());
             saltConcentration = this->extendEval(fs.saltConcentration());
@@ -1073,7 +1073,7 @@ namespace Opm
         // TODO: most of this function, if not the whole function, can be moved to the base class
         const int cell_idx = this->well_cells_[perf];
         assert (int(mob.size()) == this->num_components_);
-        const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
+        const auto& intQuants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
         const auto& materialLawManager = ebosSimulator.problem().materialLawManager();
 
         // either use mobility of the perforation cell or calcualte its own
@@ -1125,7 +1125,7 @@ namespace Opm
         // TODO: most of this function, if not the whole function, can be moved to the base class
         const int cell_idx = this->well_cells_[perf];
         assert (int(mob.size()) == this->num_components_);
-        const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
+        const auto& intQuants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
         const auto& materialLawManager = ebosSimulator.problem().materialLawManager();
 
         // either use mobility of the perforation cell or calcualte its own
@@ -1266,7 +1266,7 @@ namespace Opm
                 getMobilityScalar(ebos_simulator, perf, mob);
 
                 const int cell_idx = this->well_cells_[perf];
-                const auto& int_quantities = *(ebos_simulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+                const auto& int_quantities = ebos_simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
                 const auto& fs = int_quantities.fluidState();
                 // pressure difference between the segment and the perforation
                 const double perf_seg_press_diff = this->segments_.getPressureDiffSegPerf(seg, perf);
@@ -1621,7 +1621,7 @@ namespace Opm
             auto& perf_press_state = perf_data.pressure;
             for (const int perf : this->segments_.perforations()[seg]) {
                 const int cell_idx = this->well_cells_[perf];
-                const auto& int_quants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+                const auto& int_quants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
                 std::vector<EvalWell> mob(this->num_components_, 0.0);
                 getMobilityEval(ebosSimulator, perf, mob);
                 const double trans_mult = ebosSimulator.problem().template rockCompTransMultiplier<double>(int_quants, cell_idx);
@@ -1704,7 +1704,7 @@ namespace Opm
             for (const int perf : this->segments_.perforations()[seg]) {
 
                 const int cell_idx = this->well_cells_[perf];
-                const auto& intQuants = *(ebos_simulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+                const auto& intQuants = ebos_simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
                 const auto& fs = intQuants.fluidState();
 
                 // pressure difference between the segment and the perforation
@@ -1758,7 +1758,7 @@ namespace Opm
             // using the pvt region of first perforated cell
             // TODO: it should be a member of the WellInterface, initialized properly
             const int cell_idx = this->well_cells_[0];
-            const auto& intQuants = *(ebos_simulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
+            const auto& intQuants = ebos_simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
             const auto& fs = intQuants.fluidState();
             temperature.setValue(fs.temperature(FluidSystem::oilPhaseIdx).value());
             saltConcentration = this->extendEval(fs.saltConcentration());
@@ -1905,7 +1905,7 @@ namespace Opm
         for (int seg = 0; seg < nseg; ++seg) {
             for (const int perf : this->segments_.perforations()[seg]) {
                 const int cell_idx = this->well_cells_[perf];
-                const auto& int_quants = *(ebos_simulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+                const auto& int_quants = ebos_simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
                 const auto& fs = int_quants.fluidState();
                 double pressure_cell = this->getPerfCellPressure(fs).value();
                 max_pressure = std::max(max_pressure, pressure_cell);
@@ -1933,7 +1933,7 @@ namespace Opm
             const Scalar seg_pressure = getValue(this->primary_variables_.getSegmentPressure(seg));
             for (const int perf : this->segments_.perforations()[seg]) {
                 const int cell_idx = this->well_cells_[perf];
-                const auto& int_quants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+                const auto& int_quants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
                 std::vector<Scalar> mob(this->num_components_, 0.0);
                 getMobilityScalar(ebosSimulator, perf, mob);
                 const double trans_mult = ebosSimulator.problem().template rockCompTransMultiplier<double>(int_quants, cell_idx);

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -638,7 +638,7 @@ namespace Opm
         const bool allow_cf = this->getAllowCrossFlow() || openCrossFlowAvoidSingularity(ebosSimulator);
         const EvalWell& bhp = this->primary_variables_.eval(Bhp);
         const int cell_idx = this->well_cells_[perf];
-        const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+        const auto& intQuants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
         std::vector<EvalWell> mob(this->num_components_, {this->primary_variables_.numWellEq() + Indices::numEq, 0.});
         getMobilityEval(ebosSimulator, perf, mob, deferred_logger);
 
@@ -856,7 +856,7 @@ namespace Opm
     {
         const int cell_idx = this->well_cells_[perf];
         assert (int(mob.size()) == this->num_components_);
-        const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
+        const auto& intQuants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
         const auto& materialLawManager = ebosSimulator.problem().materialLawManager();
 
         // either use mobility of the perforation cell or calcualte its own
@@ -925,7 +925,7 @@ namespace Opm
     {
         const int cell_idx = this->well_cells_[perf];
         assert (int(mob.size()) == this->num_components_);
-        const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
+        const auto& intQuants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
         const auto& materialLawManager = ebosSimulator.problem().materialLawManager();
 
         // either use mobility of the perforation cell or calcualte its own
@@ -1065,7 +1065,7 @@ namespace Opm
             getMobilityScalar(ebos_simulator, perf, mob, deferred_logger);
 
             const int cell_idx = this->well_cells_[perf];
-            const auto& int_quantities = *(ebos_simulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+            const auto& int_quantities = ebos_simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
             const auto& fs = int_quantities.fluidState();
             // the pressure of the reservoir grid block the well connection is in
             double p_r = this->getPerfCellPressure(fs).value();
@@ -1260,7 +1260,7 @@ namespace Opm
 
         for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
             const int cell_idx = this->well_cells_[perf];
-            const auto& intQuants = *(ebos_simulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
+            const auto& intQuants = ebos_simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
             const auto& fs = intQuants.fluidState();
 
             const double pressure = this->getPerfCellPressure(fs).value();
@@ -1355,27 +1355,27 @@ namespace Opm
         std::function<Scalar(int,int)> getTemperature =
         [&ebosSimulator](int cell_idx, int phase_idx)
         {
-            return ebosSimulator.model().cachedIntensiveQuantities(cell_idx, 0)->fluidState().temperature(phase_idx).value();
+            return ebosSimulator.model().intensiveQuantities(cell_idx, 0).fluidState().temperature(phase_idx).value();
         };
         std::function<Scalar(int)> getSaltConcentration =
         [&ebosSimulator](int cell_idx)
         {
-            return ebosSimulator.model().cachedIntensiveQuantities(cell_idx, 0)->fluidState().saltConcentration().value();
+            return ebosSimulator.model().intensiveQuantities(cell_idx, 0).fluidState().saltConcentration().value();
         };
         std::function<int(int)> getPvtRegionIdx =
         [&ebosSimulator](int cell_idx)
         {
-            return ebosSimulator.model().cachedIntensiveQuantities(cell_idx, 0)->fluidState().pvtRegionIndex();
+            return ebosSimulator.model().intensiveQuantities(cell_idx, 0).fluidState().pvtRegionIndex();
         };
         std::function<Scalar(int)> getInvFac =
         [&ebosSimulator](int cell_idx)
         {
-            return ebosSimulator.model().cachedIntensiveQuantities(cell_idx, 0)->solventInverseFormationVolumeFactor().value();
+            return ebosSimulator.model().intensiveQuantities(cell_idx, 0).solventInverseFormationVolumeFactor().value();
         };
         std::function<Scalar(int)> getSolventDensity =
         [&ebosSimulator](int cell_idx)
         {
-            return ebosSimulator.model().cachedIntensiveQuantities(cell_idx, 0)->solventRefDensity();
+            return ebosSimulator.model().intensiveQuantities(cell_idx, 0).solventRefDensity();
         };
 
         this->connections_.computePropertiesForPressures(well_state,
@@ -1438,7 +1438,7 @@ namespace Opm
         {
             const auto cell_idx = this->well_cells_[perf];
             return ebosSimulator.model()
-               .cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0)->fluidState();
+               .intensiveQuantities(cell_idx, /*timeIdx=*/ 0).fluidState();
         };
 
         const int np = this->number_of_phases_;
@@ -1518,22 +1518,22 @@ namespace Opm
         std::function<Scalar(int,int)> invB =
         [&ebosSimulator](int cell_idx, int phase_idx)
         {
-            return ebosSimulator.model().cachedIntensiveQuantities(cell_idx, 0)->fluidState().invB(phase_idx).value();
+            return ebosSimulator.model().intensiveQuantities(cell_idx, 0).fluidState().invB(phase_idx).value();
         };
         std::function<Scalar(int,int)> mobility =
         [&ebosSimulator](int cell_idx, int phase_idx)
         {
-            return ebosSimulator.model().cachedIntensiveQuantities(cell_idx, 0)->mobility(phase_idx).value();
+            return ebosSimulator.model().intensiveQuantities(cell_idx, 0).mobility(phase_idx).value();
         };
         std::function<Scalar(int)> invFac =
         [&ebosSimulator](int cell_idx)
         {
-            return ebosSimulator.model().cachedIntensiveQuantities(cell_idx, 0)->solventInverseFormationVolumeFactor().value();
+            return ebosSimulator.model().intensiveQuantities(cell_idx, 0).solventInverseFormationVolumeFactor().value();
         };
         std::function<Scalar(int)> solventMobility =
         [&ebosSimulator](int cell_idx)
         {
-            return ebosSimulator.model().cachedIntensiveQuantities(cell_idx, 0)->solventMobility().value();
+            return ebosSimulator.model().intensiveQuantities(cell_idx, 0).solventMobility().value();
         };
 
         this->connections_.computeProperties(well_state,
@@ -1680,7 +1680,7 @@ namespace Opm
 
         for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
             const int cell_idx = this->well_cells_[perf];
-            const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+            const auto& intQuants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
             // flux for each perforation
             std::vector<Scalar> mob(this->num_components_, 0.);
             getMobilityScalar(ebosSimulator, perf, mob, deferred_logger);
@@ -2007,7 +2007,7 @@ namespace Opm
                                    DeferredLogger& deferred_logger) const
     {
         const int cell_idx = this->well_cells_[perf];
-        const auto& int_quant = *(ebos_simulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+        const auto& int_quant = ebos_simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
         const EvalWell polymer_concentration = this->extendEval(int_quant.polymerConcentration());
 
         // TODO: not sure should based on the well type or injecting/producing peforations
@@ -2230,7 +2230,7 @@ namespace Opm
                           std::vector<EvalWell>& cq_s) const
     {
         const int cell_idx = this->well_cells_[perf];
-        const auto& int_quants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+        const auto& int_quants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
         const auto& fs = int_quants.fluidState();
         const EvalWell b_w = this->extendEval(fs.invB(FluidSystem::waterPhaseIdx));
         const double area = M_PI * this->bore_diameters_[perf] * this->perf_length_[perf];
@@ -2255,7 +2255,7 @@ namespace Opm
                                DeferredLogger& deferred_logger)
     {
         const int cell_idx = this->well_cells_[perf];
-        const auto& int_quants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+        const auto& int_quants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
         const auto& fs = int_quants.fluidState();
         const EvalWell b_w = this->extendEval(fs.invB(FluidSystem::waterPhaseIdx));
         const EvalWell water_flux_r = water_flux_s / b_w;
@@ -2393,7 +2393,7 @@ namespace Opm
         double max_pressure = 0.0;
         for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
             const int cell_idx = this->well_cells_[perf];
-            const auto& int_quants = *(ebos_simulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+            const auto& int_quants = ebos_simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
             const auto& fs = int_quants.fluidState();
             double pressure_cell = this->getPerfCellPressure(fs).value();
             max_pressure = std::max(max_pressure, pressure_cell);
@@ -2537,7 +2537,7 @@ namespace Opm
         const bool allow_cf = this->getAllowCrossFlow() || openCrossFlowAvoidSingularity(ebosSimulator);
         for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
             const int cell_idx = this->well_cells_[perf];
-            const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/ 0));
+            const auto& intQuants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
             std::vector<Scalar> mob(this->num_components_, 0.);
             getMobilityScalar(ebosSimulator, perf, mob, deferred_logger);
             std::vector<Scalar> cq_s(this->num_components_, 0.);

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1052,7 +1052,7 @@ namespace Opm
         }
         for (int perf = 0; perf < nperf; ++perf) {
             const int cell_idx = this->well_cells_[perf];
-            const auto& intQuants = *(ebosSimulator.model().cachedIntensiveQuantities(cell_idx, /*timeIdx=*/0));
+            const auto& intQuants = ebosSimulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
             const auto& fs = intQuants.fluidState();
             const double well_tw_fraction = this->well_index_[perf] / total_tw;
             double total_mobility = 0.0;


### PR DESCRIPTION
Added explicit call to intensive quantities to make it possible to run the code with calculation the property on the fly.
It also add better checking and error messages, if wrong options or logical errors in the code. 