### PR TITLE
removing unused ToleranceWellControl command line argument

### DIFF
--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -68,10 +68,6 @@ struct ToleranceWells {
     using type = UndefinedProperty;
 };
 template<class TypeTag, class MyTypeTag>
-struct ToleranceWellControl {
-    using type = UndefinedProperty;
-};
-template<class TypeTag, class MyTypeTag>
 struct MaxWelleqIter {
     using type = UndefinedProperty;
 };
@@ -204,11 +200,6 @@ template<class TypeTag>
 struct ToleranceWells<TypeTag, TTag::FlowModelParameters> {
     using type = GetPropType<TypeTag, Scalar>;
     static constexpr type value = 1e-4;
-};
-template<class TypeTag>
-struct ToleranceWellControl<TypeTag, TTag::FlowModelParameters> {
-    using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 1e-7;
 };
 template<class TypeTag>
 struct MaxWelleqIter<TypeTag, TTag::FlowModelParameters> {
@@ -346,9 +337,6 @@ namespace Opm
         double tolerance_cnv_relaxed_;
         /// Well convergence tolerance.
         double tolerance_wells_;
-        /// Tolerance for the well control equations
-        //  TODO: it might need to distinguish between rate control and pressure control later
-        double tolerance_well_control_;
         /// Tolerance for the pressure equations for multisegment wells
         double tolerance_pressure_ms_wells_;
         /// Relaxed tolerance for for the well flow residual
@@ -434,7 +422,6 @@ namespace Opm
             tolerance_cnv_ = EWOMS_GET_PARAM(TypeTag, Scalar, ToleranceCnv);
             tolerance_cnv_relaxed_ = EWOMS_GET_PARAM(TypeTag, Scalar, ToleranceCnvRelaxed);
             tolerance_wells_ = EWOMS_GET_PARAM(TypeTag, Scalar, ToleranceWells);
-            tolerance_well_control_ = EWOMS_GET_PARAM(TypeTag, Scalar, ToleranceWellControl);
             max_welleq_iter_ = EWOMS_GET_PARAM(TypeTag, int, MaxWelleqIter);
             use_multisegment_well_ = EWOMS_GET_PARAM(TypeTag, bool, UseMultisegmentWell);
             tolerance_pressure_ms_wells_ = EWOMS_GET_PARAM(TypeTag, Scalar, TolerancePressureMsWells);
@@ -471,7 +458,6 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, ToleranceCnv, "Local convergence tolerance (Maximum of local saturation errors)");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, ToleranceCnvRelaxed, "Relaxed local convergence tolerance that applies for iterations after the iterations with the strict tolerance");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, ToleranceWells, "Well convergence tolerance");
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, ToleranceWellControl, "Tolerance for the well control equations");
             EWOMS_REGISTER_PARAM(TypeTag, int, MaxWelleqIter, "Maximum number of iterations to determine solution the  well equations");
             EWOMS_REGISTER_PARAM(TypeTag, bool, UseMultisegmentWell, "Use the well model for multi-segment wells instead of the one for single-segment wells");
             EWOMS_REGISTER_PARAM(TypeTag, Scalar, TolerancePressureMsWells, "Tolerance for the pressure equations for multi-segment wells");


### PR DESCRIPTION
found it not used accidentally. We might want to have something similar while different in place. But before then, we can remove this one since it is not used.  