### PR TITLE
Only do CPU decomposition if needed, when using GPU

### DIFF
--- a/opm/simulators/linalg/ISTLSolverEbos.cpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.cpp
@@ -266,6 +266,13 @@ apply(Vector& rhs,
 }
 
 template<class Matrix, class Vector>
+bool BdaSolverInfo<Matrix,Vector>::
+gpuActive()
+{
+    return bridge_->getUseGpu();
+}
+
+template<class Matrix, class Vector>
 template<class Grid>
 void BdaSolverInfo<Matrix,Vector>::
 blockJacobiAdjacency(const Grid& grid,


### PR DESCRIPTION
The current structure looks like this
```
ISTLSolverEbos::prepare():
  prepareFlexibleSolver()

ISTLSolverEbos::solve():
  if(!bdaSolver->apply()){
    flexibleSolver_.solver_->apply()
  }
```
Both `prepare()` and `solve()` are called every linear solve.
The problem is that `bdaSolver->apply()` also performs the ILU0 decomposition (on GPU). This means the CPU ILU0 decomposition via Dune, in `prepareFlexibleSolver()` is wasted.
This PR moves the `prepareFlexibleSolver()` call to the fallback, the part that is called when the GPU fails, but only when `COMPILE_BDA_BRIDGE` is true.
If the Bridge is not compiled or not activated via `--accelerator-mode`, the decomposition is still done in `prepare()`, and the solve in `solve()`.

The drawback is that this messes up the reported timing at the end of Flow.
Currently it reports `Linear solve time` and `Linear setup`, where the former includes the latter.
With this change, using the GPU will cause the setup time to go to 0, and the solve time to decrease with the same amount.
In the future, the `bdaSolver->apply()` should be split into `prepare()` and `solve()` as well, to fix this, but this requires all GPU solvers to have a split interface first.

For NORNE, this saves about 19s in total when using the GPU, otherwise it is unaffected.
```
NORNE, mi210:
old, 2023-3-16, 5c1d9644:
none, 1 MPI   : 476 (69+215+ 88+83), 1894, 1523, 22266 | 0
rocsparse,   0: 410 (75+133+ 93+85), 1963, 1591, 21975 | 1
rocsparse, 150: 352 (71+ 91+ 88+82), 1879, 1516, 25310 | 2
opencl,   0:    655 (72+375+102+84), 1946, 1575, 24675 | 0
opencl, 150:    392 (70+122+ 97+82), 1917, 1551, 28024 | 0
new:
none, 1 MPI   : 473 (69+215+ 87+82), 1894, 1523, 22266 | 0
rocsparse,   0: 394 (74+113+ 97+86), 1919, 1550, 21640 | 1
rocsparse, 150: 352 (70+ 77+ 92+83), 1879, 1514, 25492 | 2
opencl,   0:    640 (74+359+102+84), 1946, 1575, 24675 | 0
opencl, 150:    372 (70+103+ 98+81), 1917, 1551, 28024 | 0
```