### PR TITLE
stricter tolerance for wells with zero rate target

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1365,7 +1365,10 @@ namespace Opm {
         const int iterationIdx = ebosSimulator_.model().newtonMethod().numIterations();
         for (const auto& well : well_container_) {
             if (well->isOperableAndSolvable() || well->wellIsStopped()) {
-                local_report += well->getWellConvergence(this->wellState(), B_avg, local_deferredLogger, iterationIdx > param_.strict_outer_iter_wells_ );
+                const auto& summary_state = ebosSimulator_.vanguard().summaryState();
+                local_report += well->getWellConvergence(
+                        summary_state, this->wellState(), B_avg, local_deferredLogger,
+                        iterationIdx > param_.strict_outer_iter_wells_);
             } else {
                 ConvergenceReport report;
                 using CR = ConvergenceReport;

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -96,10 +96,11 @@ namespace Opm
                                                DeferredLogger& deferred_logger) const override;
 
         /// check whether the well equations get converged for this well
-        virtual ConvergenceReport getWellConvergence(const WellState& well_state,
+        virtual ConvergenceReport getWellConvergence(const SummaryState& summary_state,
+                                                     const WellState& well_state,
                                                      const std::vector<double>& B_avg,
                                                      DeferredLogger& deferred_logger,
-                                                     const bool relax_tolerance = false) const override;
+                                                     const bool relax_tolerance) const override;
 
         /// Ax = Ax - C D^-1 B x
         virtual void apply(const BVector& x, BVector& Ax) const override;

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -144,10 +144,11 @@ namespace Opm
         void initPrimaryVariablesEvaluation() override;
 
         /// check whether the well equations get converged for this well
-        virtual ConvergenceReport getWellConvergence(const WellState& well_state,
+        virtual ConvergenceReport getWellConvergence(const SummaryState& summary_state,
+                                                     const WellState& well_state,
                                                      const std::vector<double>& B_avg,
                                                      DeferredLogger& deferred_logger,
-                                                     const bool relax_tolerance = false) const override;
+                                                     const bool relax_tolerance) const override;
 
         /// Ax = Ax - C D^-1 B x
         virtual void apply(const BVector& x, BVector& Ax) const override;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1403,7 +1403,8 @@ namespace Opm
     template<typename TypeTag>
     ConvergenceReport
     StandardWell<TypeTag>::
-    getWellConvergence(const WellState& well_state,
+    getWellConvergence(const SummaryState& summary_state,
+                       const WellState& well_state,
                        const std::vector<double>& B_avg,
                        DeferredLogger& deferred_logger,
                        const bool relax_tolerance) const
@@ -1412,15 +1413,21 @@ namespace Opm
         // For the polymer, energy and foam cases, there is one more mass balance equations of reservoir than wells
         assert((int(B_avg.size()) == this->num_components_) || has_polymer || has_energy || has_foam || has_brine || has_zFraction || has_micp);
 
+        // using sricter tolerance for stopped wells and wells under zero rate target control.
+        constexpr double stricter_factor = 1.e-4;
+        const double tol_wells = this->stopppedOrZeroRateTarget(summary_state, well_state) ?
+                                 this->param_.tolerance_wells_ * stricter_factor : this->param_.tolerance_wells_;
+
         std::vector<double> res;
         ConvergenceReport report = this->StdWellEval::getWellConvergence(well_state,
                                                                          B_avg,
                                                                          this->param_.max_residual_allowed_,
-                                                                         this->param_.tolerance_wells_,
+                                                                         tol_wells,
                                                                          this->param_.relaxed_tolerance_flow_well_,
                                                                          relax_tolerance,
                                                                          res,
                                                                          deferred_logger);
+
         checkConvergenceExtraEqs(res, report);
 
         return report;
@@ -2083,7 +2090,7 @@ namespace Opm
         this->linSys_.extract(jacobian);
     }
 
-    
+
     template <typename TypeTag>
     void
     StandardWell<TypeTag>::addWellPressureEquations(PressureMatrix& jacobian,
@@ -2101,7 +2108,7 @@ namespace Opm
                                                well_state);
     }
 
-    
+
 
     template<typename TypeTag>
     typename StandardWell<TypeTag>::EvalWell
@@ -2506,6 +2513,7 @@ namespace Opm
         bool converged;
         bool relax_convergence = false;
         this->regularize_ = false;
+        const auto& summary_state = ebosSimulator.vanguard().summaryState();
         do {
             assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
 
@@ -2514,7 +2522,7 @@ namespace Opm
                 this->regularize_ = true;
             }
 
-            auto report = getWellConvergence(well_state, Base::B_avg_, deferred_logger, relax_convergence);
+            auto report = getWellConvergence(summary_state, well_state, Base::B_avg_, deferred_logger, relax_convergence);
 
             converged = report.converged();
             if (converged) {
@@ -2522,7 +2530,6 @@ namespace Opm
             }
 
             ++it;
-            const auto& summary_state = ebosSimulator.vanguard().summaryState();
             solveEqAndUpdateWellState(summary_state, well_state, deferred_logger);
 
             // TODO: when this function is used for well testing purposes, will need to check the controls, so that we will obtain convergence

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -154,7 +154,11 @@ public:
 
     virtual void initPrimaryVariablesEvaluation() = 0;
 
-    virtual ConvergenceReport getWellConvergence(const WellState& well_state, const std::vector<double>& B_avg, DeferredLogger& deferred_logger, const bool relax_tolerance) const = 0;
+    virtual ConvergenceReport getWellConvergence(const SummaryState& summary_state,
+                                                 const WellState& well_state,
+                                                 const std::vector<double>& B_avg,
+                                                 DeferredLogger& deferred_logger,
+                                                 const bool relax_tolerance) const = 0;
 
     void assembleWellEq(const Simulator& ebosSimulator,
                         const double dt,


### PR DESCRIPTION
for StandardWell only at this moment.

It improves the results of a reported case with **zero RESV** control (black line referee result, green line master branch, red line this PR ). 

![image](https://user-images.githubusercontent.com/6847941/228859754-38c1cb75-dbd5-4e47-99eb-35066ed7083d.png)


And more importantly, with the defaulted relative slack tolerance, there is some error when coming to the connection rates and the well rates (**0** for this circumstance), potentially affecting the mass balance of the whole system (it means the flow out from the reservoir is not equal the flow into the reservoir through the wellbore with **0** well rates).  

Ideally stricter tolerance should be applied to all the wells (https://github.com/OPM/opm-simulators/pull/4556), but not sure how we should test and proceed with that direction, there might be some substantial investigation efforts involved.  This PR is implemented as a temporary approach to fix the immediate issue from the reported case. 
