### PR TITLE
Check all ALQ values when testing a gaslift well for reopening

### DIFF
--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -263,6 +263,13 @@ public:
 
     void checkWellOperability(const Simulator& ebos_simulator, const WellState& well_state, DeferredLogger& deferred_logger);
 
+    bool gliftBeginTimeStepWellTestIterateWellEquations(
+        const Simulator& ebos_simulator,
+        const double dt,
+        WellState& well_state,
+        const GroupState &group_state,
+        DeferredLogger& deferred_logger);
+
     void gliftBeginTimeStepWellTestUpdateALQ(const Simulator& ebos_simulator,
                                              WellState& well_state,
                                              DeferredLogger& deferred_logger);

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -604,20 +604,24 @@ namespace Opm
         const auto& schedule = ebos_simulator.vanguard().schedule();
         auto report_step_idx = ebos_simulator.episodeIndex();
         const auto& glo = schedule.glo(report_step_idx);
-        assert(glo.has_well(well_name));
-        auto increment = glo.gaslift_increment();
-        auto alq = well_state.getALQ(well_name);
-        bool converged;
-        while (alq > 0) {
-            well_state.setALQ(well_name, alq);
-            if ((converged =
-                  iterateWellEquations(ebos_simulator, dt, well_state, group_state, deferred_logger)))
-            {
-                return converged;
+        if(glo.has_well(well_name)) {
+            auto increment = glo.gaslift_increment();
+            auto alq = well_state.getALQ(well_name);
+            bool converged;
+            while (alq > 0) {
+                well_state.setALQ(well_name, alq);
+                if ((converged =
+                      iterateWellEquations(ebos_simulator, dt, well_state, group_state, deferred_logger)))
+                {
+                    return converged;
+                }
+                alq -= increment;
             }
-            alq -= increment;
+            return false;
         }
-        return false;
+        else {
+            return iterateWellEquations(ebos_simulator, dt, well_state, group_state, deferred_logger);
+        }
     }
 
     template<typename TypeTag>


### PR DESCRIPTION
When testing a gaslift well under THP control, if the well does not converge with maximum alq try to reduce alq in increments to check if the well equations converge with a smaller alq.
