### PR TITLE
removing extra bracket to restore compilation

### DIFF
--- a/opm/simulators/linalg/FlexibleSolver_impl.hpp
+++ b/opm/simulators/linalg/FlexibleSolver_impl.hpp
@@ -178,7 +178,7 @@ namespace Dune
                                                                                           tol,// desired residual reduction factor
                                                                                           restart, 
                                                                                           maxiter, // maximum number of iterations
-                                                                                          verbosity));
+                                                                                          verbosity);
 #if HAVE_SUITESPARSE_UMFPACK
         } else if (solver_type == "umfpack") {
             bool dummy = false;


### PR DESCRIPTION
the compilation mistake was introduced in https://github.com/OPM/opm-simulators/pull/4564