### PR TITLE
GCONPROD Item 7, only RATE is supported

### DIFF
--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -98,6 +98,7 @@ partiallySupported()
             "GCONPROD",
             {
                {2,{true, allow_values<std::string> {"NONE", "FLD", "ORAT", "WRAT", "GRAT", "LRAT", "RESV"}, "GCONPROD(TARGET): valid option should be NONE/FLD/ORAT/WRAT/GRAT/LRAT or RESV"}}, // CONTROL_MODE
+               {7,{true, allow_values<std::string> {"RATE"}, "GCONPROD(ACTION): Only RATE is supported"}}, 
                {11,{true, allow_values<std::string> {"NONE"}, "GCONPROD(ACTWAT): water violation procedure not implemented, item should be defaulted"}}, // WATER_EXCEED_PROCEDURE
                {12,{true, allow_values<std::string> {"NONE"}, "GCONPROD(ACTGAS): gas violation procedure not implemented, item should be defaulted"}}, // GAS_EXCEED_PROCEDURE
                {13,{true, allow_values<std::string> {"NONE"}, "GCONPROD(ACTLIQ): liquid violation procedure not implemented, item should be defaulted"}}, // LIQUID_EXCEED_PROCEDURE


### PR DESCRIPTION
Only Rate is supported in Item 7 and the simulator should not continue if other options are given. 

Notice that the default value (NONE) is not yet supported. 

A PR has been submitted to opm-tests to update 3 date decks the data

see PR  OPM/opm-tests#945

Notice that this PR should not be merged before OPM/opm-tests#945 is merged.