### PR TITLE
Minor adjustment avoids exception when used with FIELD group.

### DIFF
--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -194,7 +194,7 @@ namespace WellGroupHelpers
                                          double& factor)
     {
         factor *= group.getGroupEfficiencyFactor();
-        if (group.parent() != "FIELD")
+        if (group.parent() != "FIELD" && !group.parent().empty())
             accumulateGroupEfficiencyFactor(
                 schedule.getGroup(group.parent(), reportStepIdx), schedule, reportStepIdx, factor);
     }


### PR DESCRIPTION
This is necessary to allow wells directly parented to FIELD. This is not currently allowed, but will be relaxed by an upstream PR.