### PR TITLE
only prediction wells can have THP constraint

### DIFF
--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -192,6 +192,11 @@ double WellInterfaceGeneric::rsRvInj() const
 
 bool WellInterfaceGeneric::wellHasTHPConstraints(const SummaryState& summaryState) const
 {
+    // only wells under prediction mode can have THP constraint
+    if (!this->wellEcl().predictionMode()) {
+        return false;
+    }
+
     if (dynamic_thp_limit_) {
         return true;
     }


### PR DESCRIPTION
This is reported and provided by @vkip . I think it can be one way of the solutions. 

An alternative way is to use the following code, 

```c++
    if (this->wellEcl().predictionMode() && dynamic_thp_limit_) {
        return true;
    }
```

It can make differences if we make mistakes from the parsing or other very special situations, but we have not seen it yet. The way in the PR should be the correct way. 