### PR TITLE
removing the unused BlackoilWellModel::hasWell()

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -305,7 +305,6 @@ namespace Opm {
                                     const int iterationIdx);
 
             WellInterfacePtr getWell(const std::string& well_name) const;
-            bool hasWell(const std::string& well_name) const;
 
             using PressureMatrix = Dune::BCRSMatrix<Opm::MatrixBlock<double, 1, 1>>;
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1902,18 +1902,6 @@ namespace Opm {
         return *well;
     }
 
-    template<typename TypeTag>
-    bool
-    BlackoilWellModel<TypeTag>::
-    hasWell(const std::string& well_name) const
-    {
-        return std::any_of(well_container_.begin(), well_container_.end(),
-            [&well_name](const WellInterfacePtr& elem) -> bool
-        {
-            return elem->name() == well_name;
-        });
-    }
-
 
 
 


### PR DESCRIPTION
We have two `hasWell()` function in `BlackoilWellModel` and `BlackoilWellModelGeneric` , respectively, with different definition.  The one in `BlackoilWellModel` is hiding the one from `BlackoilWellModelGeneric`.  And the one in `BlackoilWellModel` is actually not used in the simulation code. 

We should remove one and I am removing the one not in use, while not knowing for sure which one should be kept from the function definition perspective. 

