### PR TITLE
Add support for WVFPDP

### DIFF
--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -63,6 +63,7 @@
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
+#include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -25,8 +25,6 @@
 #include <ebos/eclgenericvanguard.hh>
 
 #include <opm/common/utility/MemPacker.hpp>
-
-#include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
 #include <opm/common/utility/Serializer.hpp>
 
 #include <opm/common/ErrorMacros.hpp>
@@ -65,6 +63,7 @@
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
+#include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>

--- a/ebos/eclgenericvanguard.cc
+++ b/ebos/eclgenericvanguard.cc
@@ -25,6 +25,8 @@
 #include <ebos/eclgenericvanguard.hh>
 
 #include <opm/common/utility/MemPacker.hpp>
+
+#include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
 #include <opm/common/utility/Serializer.hpp>
 
 #include <opm/common/ErrorMacros.hpp>
@@ -63,7 +65,6 @@
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
-#include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>

--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -57,6 +57,7 @@
 #include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WList.hpp>
 #include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
+#include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
 
 #include <ebos/eclmpiserializer.hh>

--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -754,7 +754,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"WTEMPQ", {true, std::nullopt}},
         {"WTHPMAX", {true, std::nullopt}},
         {"WTMULT", {true, std::nullopt}},
-        {"WVFPDP", {true, std::nullopt}},
         {"WWPAVE", {true, std::nullopt}},
         {"ZIPPY2", {false, std::nullopt}},
         {"ZIPP2OFF", {false, std::nullopt}},

--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
@@ -209,6 +209,7 @@ copyToWellState(const MultisegmentWellGeneric<Scalar>& mswell,
                 const double rho,
                 const bool stop_or_zero_rate_target,
                 WellState& well_state,
+                const SummaryState& summary_state,
                 DeferredLogger& deferred_logger) const
 {
     static constexpr int Gas = BlackoilPhases::Vapour;
@@ -400,7 +401,7 @@ copyToWellState(const MultisegmentWellGeneric<Scalar>& mswell,
                    {FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx),
                     FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx),
                     FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)},
-                   well_state, deferred_logger);
+                   well_state, summary_state, deferred_logger);
 }
 
 template<class FluidSystem, class Indices, class Scalar>

--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
@@ -25,6 +25,7 @@
 #include <opm/material/densead/Evaluation.hpp>
 
 #include <opm/simulators/wells/MultisegmentWellEquations.hpp>
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
 
 #include <array>
 #include <vector>
@@ -102,6 +103,7 @@ public:
                          const double rho,
                          const bool stop_or_zero_rate_target,
                          WellState& well_state,
+                         const SummaryState& summary_state,
                          DeferredLogger& deferred_logger) const;
 
     //! \brief Returns scaled volume fraction for a component in a segment.

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -645,7 +645,7 @@ namespace Opm
                                               max_pressure_change);
 
         this->primary_variables_.copyToWellState(*this, getRefDensity(), stop_or_zero_rate_target,
-                                                 well_state, deferred_logger);
+                                                 well_state, summary_state, deferred_logger);
         Base::calculateReservoirRates(well_state.well(this->index_of_well_));
     }
 
@@ -1135,12 +1135,13 @@ namespace Opm
                 std::vector<double> well_rates_bhp_limit;
                 computeWellRatesWithBhp(ebos_simulator, bhp_limit, well_rates_bhp_limit, deferred_logger);
 
+                const double thp_limit = this->getTHPConstraint(summaryState);
                 const double thp = WellBhpThpCalculator(*this).calculateThpFromBhp(well_rates_bhp_limit,
                                                                                    bhp_limit,
                                                                                    this->getRefDensity(),
                                                                                    this->wellEcl().alq_value(),
+                                                                                   thp_limit,
                                                                                    deferred_logger);
-                const double thp_limit = this->getTHPConstraint(summaryState);
                 if ( (this->isProducer() && thp < thp_limit) || (this->isInjector() && thp > thp_limit) ) {
                     this->operability_status_.obey_thp_limit_under_bhp_limit = false;
                 }

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -350,6 +350,7 @@ namespace Opm
 
         void updateWellStateFromPrimaryVariables(const bool stop_or_zero_rate_target,
                                                  WellState& well_state,
+                                                 const SummaryState& summary_state,
                                                  DeferredLogger& deferred_logger) const;
 
         virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -73,6 +73,7 @@ void
 StandardWellEval<FluidSystem,Indices,Scalar>::
 updateWellStateFromPrimaryVariables(const bool stop_or_zero_rate_target,
                                     WellState& well_state,
+                                    const SummaryState& summary_state,
                                     DeferredLogger& deferred_logger) const
 {
     this->primary_variables_.copyToWellState(well_state, deferred_logger);
@@ -84,7 +85,7 @@ updateWellStateFromPrimaryVariables(const bool stop_or_zero_rate_target,
                       {FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx),
                        FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx),
                        FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)},
-                      well_state, deferred_logger);
+                      well_state, summary_state, deferred_logger);
 }
 
 template<class FluidSystem, class Indices, class Scalar>

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -95,6 +95,7 @@ protected:
 
     void updateWellStateFromPrimaryVariables(const bool stop_or_zero_rate_target,
                                              WellState& well_state,
+                                             const SummaryState& summary_state,
                                              DeferredLogger& deferred_logger) const;
 
     PrimaryVariables primary_variables_; //!< Primary variables for well

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -917,7 +917,7 @@ namespace Opm
         const bool stop_or_zero_rate_target = this->stopppedOrZeroRateTarget(summary_state, well_state);
         updatePrimaryVariablesNewton(dwells, stop_or_zero_rate_target, deferred_logger);
 
-        updateWellStateFromPrimaryVariables(stop_or_zero_rate_target, well_state, deferred_logger);
+        updateWellStateFromPrimaryVariables(stop_or_zero_rate_target, well_state, summary_state, deferred_logger);
         Base::calculateReservoirRates(well_state.well(this->index_of_well_));
     }
 
@@ -953,9 +953,10 @@ namespace Opm
     StandardWell<TypeTag>::
     updateWellStateFromPrimaryVariables(const bool stop_or_zero_rate_target,
                                         WellState& well_state,
+                                        const SummaryState& summary_state,
                                         DeferredLogger& deferred_logger) const
     {
-        this->StdWellEval::updateWellStateFromPrimaryVariables(stop_or_zero_rate_target, well_state, deferred_logger);
+        this->StdWellEval::updateWellStateFromPrimaryVariables(stop_or_zero_rate_target, well_state, summary_state, deferred_logger);
 
         // other primary variables related to polymer injectivity study
         if constexpr (Base::has_polymermw) {
@@ -1096,12 +1097,13 @@ namespace Opm
                 computeWellRatesWithBhp(ebos_simulator, bhp_limit, well_rates_bhp_limit, deferred_logger);
 
                 this->adaptRatesForVFP(well_rates_bhp_limit);
+                const double thp_limit = this->getTHPConstraint(summaryState);
                 const double thp = WellBhpThpCalculator(*this).calculateThpFromBhp(well_rates_bhp_limit,
                                                                                    bhp_limit,
                                                                                    this->connections_.rho(),
                                                                                    this->getALQ(well_state),
+                                                                                   thp_limit,
                                                                                    deferred_logger);
-                const double thp_limit = this->getTHPConstraint(summaryState);
                 if ( (this->isProducer() && thp < thp_limit) || (this->isInjector() && thp > thp_limit) ) {
                     this->operability_status_.obey_thp_limit_under_bhp_limit = false;
                 }

--- a/opm/simulators/wells/WellBhpThpCalculator.cpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.cpp
@@ -166,7 +166,6 @@ findThpFromBhpIteratively(
     bool do_iterate = true;
     int it = 1;
     int max_iterations = 50;
-    bool debug = true;
     while(do_iterate) {
         if (it > max_iterations) {
             break;
@@ -323,7 +322,7 @@ void WellBhpThpCalculator::updateThp(const double rho,
     }
     const std::optional<double> alq = this->well_.isProducer() ? std::optional<double>(alq_value()) : std::nullopt;
     const double thp_limit = well_.getTHPConstraint(summary_state);
-    ws.thp = this->calculateThpFromBhp(rates, ws.bhp, rho, alq_value(), thp_limit, deferred_logger);
+    ws.thp = this->calculateThpFromBhp(rates, ws.bhp, rho, alq, thp_limit, deferred_logger);
 }
 
 template<class EvalWell>

--- a/opm/simulators/wells/WellBhpThpCalculator.cpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.cpp
@@ -340,7 +340,7 @@ calculateBhpFromThp(const WellState& well_state,
 
 double WellBhpThpCalculator::getVfpBhpAdjustment(const double bhp_tab, const double thp_limit) const
 {
-    return well_.wellEcl().getWVFPDP().getDP(bhp_tab, thp_limit);
+    return well_.wellEcl().getWVFPDP().getPressureLoss(bhp_tab, thp_limit);
 }
 
 template<class ErrorPolicy>

--- a/opm/simulators/wells/WellBhpThpCalculator.hpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.hpp
@@ -58,6 +58,7 @@ public:
                                const double bhp,
                                const double rho,
                                const std::optional<double>& alq,
+                               const double thp_limit,
                                DeferredLogger& deferred_logger) const;
 
     //! \brief Compute BHP from THP limit for a producer.
@@ -86,6 +87,7 @@ public:
                    const std::function<double()>& alq_value,
                    const std::array<unsigned,3>& active,
                    WellState& well_state,
+                   const SummaryState& summary_state,
                    DeferredLogger& deferred_logger) const;
 
   template<class EvalWell>

--- a/opm/simulators/wells/WellBhpThpCalculator.hpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.hpp
@@ -140,6 +140,12 @@ private:
                                   double& low, double& high,
                                   DeferredLogger& deferred_logger);
 
+    double findThpFromBhpIteratively(const std::function<double(const double, const double)>& thp_func,
+                                     const double bhp,
+                                     const double thp_limit,
+                                     const double dp,
+                                     DeferredLogger& deferred_logger) const;
+
     const WellInterfaceGeneric& well_; //!< Reference to well interface
 };
 

--- a/opm/simulators/wells/WellBhpThpCalculator.hpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.hpp
@@ -122,6 +122,9 @@ private:
                          const std::array<double, 2>& range,
                          DeferredLogger& deferred_logger) const;
 
+    //! \brief Get pressure adjustment to the bhp calculated from VFP table
+    double getVfpBhpAdjustment(const double bph_tab, const double thp_limit) const;
+
     //! \brief Find limits using bisection.
     bool bisectBracket(const std::function<double(const double)>& eq,
                        const std::array<double, 2>& range,

--- a/tests/test_ParallelSerialization.cpp
+++ b/tests/test_ParallelSerialization.cpp
@@ -108,6 +108,7 @@
 #include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WList.hpp>
 #include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
+#include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
 #include <opm/input/eclipse/Schedule/WriteRestartFileEvents.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.hpp>


### PR DESCRIPTION
This PR together with https://github.com/OPM/opm-common/pull/3504 implements support for keyword WVFPDP. The implementation show good agreement with an Eclipse reference solution for test case [WVFPDP-01.DATA](https://github.com/OPM/opm-tests/blob/master/vfp/WVFPDP-01.DATA) :

![image](https://user-images.githubusercontent.com/6708379/235903167-58fa9236-f81c-48c4-a996-d8f126bcdeca.png)


