### PR TITLE
Add disgasw to gas water saltprec vapwat simulator

### DIFF
--- a/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
@@ -47,6 +47,11 @@ struct EnableEvaporation<TypeTag, TTag::EclFlowGasWaterSaltprecVapwatProblem> {
     static constexpr bool value = true;
 };
 
+template<class TypeTag>
+struct EnableDisgasInWater<TypeTag, TTag::EclFlowGasWaterSaltprecVapwatProblem> {
+    static constexpr bool value = true;
+};
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::EclFlowGasWaterSaltprecVapwatProblem>


### PR DESCRIPTION
Any reasons for not allowing dissolved gas in water here? Or should I rather add a separate simulator for this?