### PR TITLE
changed: store rates in an array in SingleWellState

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1560,10 +1560,7 @@ namespace Opm
         this->linSys_.clear();
 
         auto& ws = well_state.well(this->index_of_well_);
-        ws.dissolved_gas_rate = 0;
-        ws.dissolved_gas_rate_in_water = 0;
-        ws.vaporized_oil_rate = 0;
-        ws.vaporized_wat_rate = 0;
+        ws.phase_mixing_rates.fill(0.0);
 
         // for the black oil cases, there will be four equations,
         // the first three of them are the mass balance equations, the last one is the pressure equations.
@@ -1642,8 +1639,8 @@ namespace Opm
 
                 // updating the solution gas rate and solution oil rate
                 if (this->isProducer()) {
-                    ws.dissolved_gas_rate += perfRates.dis_gas;
-                    ws.vaporized_oil_rate += perfRates.vap_oil;
+                    ws.phase_mixing_rates[ws.dissolved_gas] += perfRates.dis_gas;
+                    ws.phase_mixing_rates[ws.vaporized_oil] += perfRates.vap_oil;
                 }
 
                 // store the perf pressure and rates

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -291,10 +291,7 @@ bool SingleWellState::operator==(const SingleWellState& rhs) const
            this->bhp == rhs.bhp &&
            this->thp == rhs.thp &&
            this->temperature == rhs.temperature &&
-           this->dissolved_gas_rate == rhs.dissolved_gas_rate &&
-           this->dissolved_gas_rate_in_water == rhs.dissolved_gas_rate_in_water &&
-           this->vaporized_oil_rate == rhs.vaporized_oil_rate &&
-           this->vaporized_wat_rate == rhs.vaporized_wat_rate &&
+           this->phase_mixing_rates == rhs.phase_mixing_rates &&
            this->well_potentials == rhs.well_potentials &&
            this->productivity_index == rhs.productivity_index &&
            this->surface_rates == rhs.surface_rates &&

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -58,10 +58,7 @@ public:
         serializer(bhp);
         serializer(thp);
         serializer(temperature);
-        serializer(dissolved_gas_rate);
-        serializer(dissolved_gas_rate_in_water);
-        serializer(vaporized_oil_rate);
-        serializer(vaporized_wat_rate);
+        serializer(phase_mixing_rates);
         serializer(well_potentials);
         serializer(productivity_index);
         serializer(surface_rates);
@@ -85,10 +82,15 @@ public:
     double bhp{0};
     double thp{0};
     double temperature{0};
-    double dissolved_gas_rate{0};
-    double dissolved_gas_rate_in_water{0};
-    double vaporized_oil_rate{0};
-    double vaporized_wat_rate{0};
+
+    std::array<double,4> phase_mixing_rates{};
+    enum RateIndices {
+      dissolved_gas = 0,
+      dissolved_gas_in_water = 1,
+      vaporized_oil = 2,
+      vaporized_water = 3
+    };
+
     std::vector<double> well_potentials;
     std::vector<double> productivity_index;
     std::vector<double> surface_rates;

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -540,9 +540,11 @@ WellState::report(const int* globalCellIdxMap,
             well.rates.set(rt::alq, 0.0);
         }
 
-        well.rates.set(rt::dissolved_gas, ws.dissolved_gas_rate + ws.dissolved_gas_rate_in_water);
-        well.rates.set(rt::vaporized_oil, ws.vaporized_oil_rate);
-        well.rates.set(rt::vaporized_water, ws.vaporized_wat_rate);
+        well.rates.set(rt::dissolved_gas,
+                       ws.phase_mixing_rates[ws.dissolved_gas] +
+                       ws.phase_mixing_rates[ws.dissolved_gas_in_water]);
+        well.rates.set(rt::vaporized_oil, ws.phase_mixing_rates[ws.vaporized_oil]);
+        well.rates.set(rt::vaporized_water, ws.phase_mixing_rates[ws.vaporized_water]);
 
         {
             auto& curr = well.current_control;


### PR DESCRIPTION
introduce an enum for indexing into the array. this again allows us to coalesce 4 parallel reductions into one.

another micro optimization.