### PR TITLE
Set last test time of wells closed with WECON to be the actual closing time.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -255,6 +255,7 @@ namespace Opm {
         OPM_BEGIN_PARALLEL_TRY_CATCH();
         {
             // test wells
+            wellTestState().update_close_on_next_step_wells(simulationTime);
             wellTesting(reportStepIdx, simulationTime, local_deferredLogger);
 
             // create the well container

--- a/opm/simulators/wells/WellTest.cpp
+++ b/opm/simulators/wells/WellTest.cpp
@@ -348,7 +348,7 @@ void WellTest::updateWellTestStateEconomic(const SingleWellState& ws,
             deferred_logger.warning("NOT_SUPPORTING_FOLLOWONWELL", "opening following on well after well closed is not supported yet");
         }
 
-        well_test_state.close_well(well_.name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
+        well_test_state.close_well_on_next_step(well_.name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
         if (write_message_to_opmlog) {
             if (well_.wellEcl().getAutomaticShutIn()) {
                 const std::string msg = std::string("well ") + well_.name() + std::string(" will be shut due to rate economic limit");
@@ -416,7 +416,7 @@ void WellTest::updateWellTestStateEconomic(const SingleWellState& ws,
             }
         case WellEconProductionLimits::EconWorkover::WELL:
             {
-            well_test_state.close_well(well_.name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
+            well_test_state.close_well_on_next_step(well_.name(), WellTestConfig::Reason::ECONOMIC, simulation_time);
             if (write_message_to_opmlog) {
                 if (well_.wellEcl().getAutomaticShutIn()) {
                     // tell the control that the well is closed


### PR DESCRIPTION
Requires https://github.com/OPM/opm-common/pull/3515