### PR TITLE
Update of multisegment well pressure equations - testing

### DIFF
--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -164,6 +164,10 @@ template<class TypeTag, class MyTypeTag>
 struct MaximumNumberOfWellSwitches {
     using type = UndefinedProperty;
 };
+template<class TypeTag, class MyTypeTag>
+struct UseAverageDensityMsWells {
+    using type = UndefinedProperty;
+};
 
 template<class TypeTag>
 struct DbhpMaxRel<TypeTag, TTag::FlowModelParameters> {
@@ -308,6 +312,14 @@ template<class TypeTag>
 struct MaximumNumberOfWellSwitches<TypeTag, TTag::FlowModelParameters> {
     static constexpr int value = 3;
 };
+template<class TypeTag>
+struct UseAverageDensityMsWells<TypeTag, TTag::FlowModelParameters> {
+    static constexpr bool value = false;
+};
+
+
+
+
 
 // if openMP is available, determine the number threads per process automatically.
 #if _OPENMP
@@ -421,6 +433,9 @@ namespace Opm
         /// Maximum number of times a well can switch to the same controt
         int max_number_of_well_switches_;
 
+        /// Whether to approximate segment densities by averaging over segment and its outlet 
+        bool use_average_density_ms_wells_;
+
 
 
         /// Construct from user parameters or defaults.
@@ -457,6 +472,7 @@ namespace Opm
             check_well_operability_ = EWOMS_GET_PARAM(TypeTag, bool, EnableWellOperabilityCheck);
             check_well_operability_iter_ = EWOMS_GET_PARAM(TypeTag, bool, EnableWellOperabilityCheckIter);
             max_number_of_well_switches_ = EWOMS_GET_PARAM(TypeTag, int, MaximumNumberOfWellSwitches);
+            use_average_density_ms_wells_ = EWOMS_GET_PARAM(TypeTag, bool, UseAverageDensityMsWells);
             deck_file_name_ = EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName);
         }
 
@@ -495,6 +511,7 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, bool, EnableWellOperabilityCheck, "Enable the well operability checking");
             EWOMS_REGISTER_PARAM(TypeTag, bool, EnableWellOperabilityCheckIter, "Enable the well operability checking during iterations");
             EWOMS_REGISTER_PARAM(TypeTag, int, MaximumNumberOfWellSwitches, "Maximum number of times a well can switch to the same control");
+            EWOMS_REGISTER_PARAM(TypeTag, bool, UseAverageDensityMsWells, "Approximate segment densitities by averaging over segment and its outlet");
         }
     };
 } // namespace Opm

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -220,6 +220,9 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
             EWOMS_HIDE_PARAM(TypeTag, VtkWriteTortuosities);
             EWOMS_HIDE_PARAM(TypeTag, VtkWriteDiffusionCoefficients);
             EWOMS_HIDE_PARAM(TypeTag, VtkWriteEffectiveDiffusionCoefficients);
+            
+            // hide average density option 
+            EWOMS_HIDE_PARAM(TypeTag, UseAverageDensityMsWells);
 
             EWOMS_END_PARAM_REGISTRATION(TypeTag);
 

--- a/opm/simulators/wells/MultisegmentWellAssemble.cpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.cpp
@@ -226,7 +226,7 @@ assembleHydroPressureLoss(const int seg,
     MultisegmentWellEquationAccess<Scalar,numWellEq,Indices::numEq> eqns(eqns1);
     eqns.residual()[seg][SPres] -= hydro_pressure_drop.value();
     for (int pv_idx = 0; pv_idx < numWellEq; ++pv_idx) {
-        eqns.D()[seg][seg_upwind][SPres][pv_idx] -= hydro_pressure_drop.derivative(pv_idx + Indices::numEq);
+        eqns.D()[seg][seg][SPres][pv_idx] -= hydro_pressure_drop.derivative(pv_idx + Indices::numEq);
     }
 }
 

--- a/opm/simulators/wells/MultisegmentWellAssemble.cpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.cpp
@@ -219,14 +219,18 @@ assemblePressureLoss(const int seg,
 template<class FluidSystem, class Indices, class Scalar>
 void MultisegmentWellAssemble<FluidSystem,Indices,Scalar>::
 assembleHydroPressureLoss(const int seg, 
-                          const int seg_upwind, 
-                          const EvalWell& hydro_pressure_drop, 
+                          const int seg_outlet, 
+                          const EvalWell& hydro_pressure_drop_seg, 
+                          const EvalWell& hydro_pressure_drop_outlet, 
                           Equations& eqns1) const
 {
     MultisegmentWellEquationAccess<Scalar,numWellEq,Indices::numEq> eqns(eqns1);
-    eqns.residual()[seg][SPres] -= hydro_pressure_drop.value();
+    eqns.residual()[seg][SPres] -= (hydro_pressure_drop_seg.value() + hydro_pressure_drop_outlet.value());
     for (int pv_idx = 0; pv_idx < numWellEq; ++pv_idx) {
-        eqns.D()[seg][seg][SPres][pv_idx] -= hydro_pressure_drop.derivative(pv_idx + Indices::numEq);
+        eqns.D()[seg][seg][SPres][pv_idx] -= hydro_pressure_drop_seg.derivative(pv_idx + Indices::numEq);
+    }
+    for (int pv_idx = 0; pv_idx < numWellEq; ++pv_idx) {
+        eqns.D()[seg][seg_outlet][SPres][pv_idx] -= hydro_pressure_drop_outlet.derivative(pv_idx + Indices::numEq);
     }
 }
 

--- a/opm/simulators/wells/MultisegmentWellAssemble.cpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.cpp
@@ -219,19 +219,16 @@ assemblePressureLoss(const int seg,
 template<class FluidSystem, class Indices, class Scalar>
 void MultisegmentWellAssemble<FluidSystem,Indices,Scalar>::
 assembleHydroPressureLoss(const int seg, 
-                          const int seg_outlet, 
+                          const int seg_density, 
                           const EvalWell& hydro_pressure_drop_seg, 
-                          const EvalWell& hydro_pressure_drop_outlet, 
                           Equations& eqns1) const
 {
     MultisegmentWellEquationAccess<Scalar,numWellEq,Indices::numEq> eqns(eqns1);
-    eqns.residual()[seg][SPres] -= (hydro_pressure_drop_seg.value() + hydro_pressure_drop_outlet.value());
+    eqns.residual()[seg][SPres] -= hydro_pressure_drop_seg.value();
     for (int pv_idx = 0; pv_idx < numWellEq; ++pv_idx) {
-        eqns.D()[seg][seg][SPres][pv_idx] -= hydro_pressure_drop_seg.derivative(pv_idx + Indices::numEq);
+        eqns.D()[seg][seg_density][SPres][pv_idx] -= hydro_pressure_drop_seg.derivative(pv_idx + Indices::numEq);
     }
-    for (int pv_idx = 0; pv_idx < numWellEq; ++pv_idx) {
-        eqns.D()[seg][seg_outlet][SPres][pv_idx] -= hydro_pressure_drop_outlet.derivative(pv_idx + Indices::numEq);
-    }
+
 }
 
 template<class FluidSystem, class Indices, class Scalar>

--- a/opm/simulators/wells/MultisegmentWellAssemble.cpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.cpp
@@ -218,6 +218,35 @@ assemblePressureLoss(const int seg,
 
 template<class FluidSystem, class Indices, class Scalar>
 void MultisegmentWellAssemble<FluidSystem,Indices,Scalar>::
+assembleHydroPressureLoss(const int seg, 
+                          const int seg_upwind, 
+                          const EvalWell& hydro_pressure_drop, 
+                          Equations& eqns1) const
+{
+    MultisegmentWellEquationAccess<Scalar,numWellEq,Indices::numEq> eqns(eqns1);
+    eqns.residual()[seg][SPres] -= hydro_pressure_drop.value();
+    for (int pv_idx = 0; pv_idx < numWellEq; ++pv_idx) {
+        eqns.D()[seg][seg_upwind][SPres][pv_idx] -= hydro_pressure_drop.derivative(pv_idx + Indices::numEq);
+    }
+}
+
+template<class FluidSystem, class Indices, class Scalar>
+void MultisegmentWellAssemble<FluidSystem,Indices,Scalar>::
+assemblePressureEqExtraDerivatives(const int seg, 
+                                   const int seg_upwind, 
+                                   const EvalWell& extra_derivatives, 
+                                   Equations& eqns1) const
+{
+    MultisegmentWellEquationAccess<Scalar,numWellEq,Indices::numEq> eqns(eqns1);
+    // diregard residual
+    // Frac - derivatives are zero (they belong to upwind^2)
+    eqns.D()[seg][seg_upwind][SPres][SPres] += extra_derivatives.derivative(SPres + Indices::numEq);
+    eqns.D()[seg][seg_upwind][SPres][WQTotal] += extra_derivatives.derivative(WQTotal + Indices::numEq);
+}                                   
+
+
+template<class FluidSystem, class Indices, class Scalar>
+void MultisegmentWellAssemble<FluidSystem,Indices,Scalar>::
 assemblePressureEq(const int seg,
                    const int seg_upwind,
                    const int outlet_segment_index,

--- a/opm/simulators/wells/MultisegmentWellAssemble.cpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.cpp
@@ -261,7 +261,7 @@ assemblePressureEq(const int seg,
                    bool gfrac) const
 {
     MultisegmentWellEquationAccess<Scalar,numWellEq,Indices::numEq> eqns(eqns1);
-    eqns.residual()[seg][SPres] = pressure_equation.value();
+    eqns.residual()[seg][SPres] += pressure_equation.value();
     eqns.D()[seg][seg][SPres][SPres] += pressure_equation.derivative(SPres + Indices::numEq);
     eqns.D()[seg][seg][SPres][WQTotal] += pressure_equation.derivative(WQTotal + Indices::numEq);
     if (wfrac) {

--- a/opm/simulators/wells/MultisegmentWellAssemble.hpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.hpp
@@ -87,6 +87,17 @@ public:
                               const EvalWell& accelerationPressureLoss,
                               Equations& eqns) const;
 
+
+    void assembleHydroPressureLoss(const int seg, 
+                                   const int seg_upwind, 
+                                   const EvalWell& hydro_pressure_drop, 
+                                   Equations& eqs1) const;
+
+    void assemblePressureEqExtraDerivatives(const int seg, 
+                                            const int seg_upwind, 
+                                            const EvalWell& extra_derivatives, 
+                                            Equations& eqns1) const;
+
     //! \brief Assemble pressure terms.
     void assemblePressureEq(const int seg,
                             const int seg_upwind,

--- a/opm/simulators/wells/MultisegmentWellAssemble.hpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.hpp
@@ -89,9 +89,10 @@ public:
 
 
     void assembleHydroPressureLoss(const int seg, 
-                                   const int seg_upwind, 
-                                   const EvalWell& hydro_pressure_drop, 
-                                   Equations& eqs1) const;
+                                   const int seg_outlet, 
+                                   const EvalWell& hydro_pressure_drop_seg, 
+                                   const EvalWell& hydro_pressure_drop_outlet, 
+                                   Equations& eqns1) const;                                   
 
     void assemblePressureEqExtraDerivatives(const int seg, 
                                             const int seg_upwind, 

--- a/opm/simulators/wells/MultisegmentWellAssemble.hpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.hpp
@@ -89,9 +89,8 @@ public:
 
 
     void assembleHydroPressureLoss(const int seg, 
-                                   const int seg_outlet, 
+                                   const int seg_density, 
                                    const EvalWell& hydro_pressure_drop_seg, 
-                                   const EvalWell& hydro_pressure_drop_outlet, 
                                    Equations& eqns1) const;                                   
 
     void assemblePressureEqExtraDerivatives(const int seg, 

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -261,10 +261,13 @@ assembleDefaultPressureEq(const int seg,
     }
 
     // Do separately since different organization of derivatives 
-    const auto hydro_pressure_drop = segments_.getHydroPressureLoss(seg);
+    const int seg_outlet = this->segmentNumberToIndex(this->segmentSet()[seg].outletSegment());
+    const auto hydro_pressure_drop1 = segments_.getHalfHydroPressureLoss(seg, seg);
+    const auto hydro_pressure_drop2 = segments_.getHalfHydroPressureLoss(seg, seg_outlet);
     MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
-        assembleHydroPressureLoss(seg, seg_upwind, hydro_pressure_drop, linSys_);
-    segments.pressure_drop_hydrostatic[seg] = hydro_pressure_drop.value();
+        assembleHydroPressureLoss(seg, seg_outlet, hydro_pressure_drop1, hydro_pressure_drop2, linSys_);
+
+    segments.pressure_drop_hydrostatic[seg] = hydro_pressure_drop1.value() + hydro_pressure_drop2.value();
 }
 
 template<typename FluidSystem, typename Indices, typename Scalar>

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -218,7 +218,7 @@ assembleDefaultPressureEq(const int seg,
 {
     assert(seg != 0); // not top segment
     const int seg_upwind = segments_.upwinding_segment(seg);
-    const bool reverseFlow = seg != seg_upwind;
+    const bool reverseFlow = seg != seg_upwind; // special treatment for reverse flow
 
     // for top segment, the well control equation will be used.
     EvalWell pressure_equation = primary_variables_.getSegmentPressure(seg);
@@ -231,12 +231,24 @@ assembleDefaultPressureEq(const int seg,
 
     auto& ws = well_state.well(baseif_.indexOfWell());
     auto& segments = ws.segments;
-    //pressure_equation -= hydro_pressure_drop;
+
+    // We approximate the hydrostatic pressure loss over the segment by using the mean of the densities
+    // at the current segment node and its outlet node. Since density derivatives are organized 
+    // differently than what is required for assemblePressureEq, this part needs to be assembled separately.  
+    const int seg_outlet = this->segmentNumberToIndex(this->segmentSet()[seg].outletSegment());
+    const auto hydro_pressure_drop_seg = segments_.getHalfHydroPressureLoss(seg, seg);
+    const auto hydro_pressure_drop_outlet = segments_.getHalfHydroPressureLoss(seg, seg_outlet);
+    MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
+        assembleHydroPressureLoss(seg, seg_outlet, hydro_pressure_drop_seg, hydro_pressure_drop_outlet, linSys_);
+    segments.pressure_drop_hydrostatic[seg] = hydro_pressure_drop_seg.value() + hydro_pressure_drop_outlet.value();
 
     if (this->frictionalPressureLossConsidered()) {
         const auto friction_pressure_drop = segments_.getFrictionPressureLoss(seg, false);
         if (reverseFlow){
+            // call function once again to obtain/assemble remaining derivatives
             extra_derivatives = -segments_.getFrictionPressureLoss(seg, true);
+            MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
+                assemblePressureEqExtraDerivatives(seg, seg_upwind, extra_derivatives, linSys_);
         }
         pressure_equation -= friction_pressure_drop;
         segments.pressure_drop_friction[seg] = friction_pressure_drop.value();
@@ -246,28 +258,13 @@ assembleDefaultPressureEq(const int seg,
     const int outlet_segment_index = this->segmentNumberToIndex(this->segmentSet()[seg].outletSegment());
     const EvalWell outlet_pressure = primary_variables_.getSegmentPressure(outlet_segment_index);
 
-    //const int seg_upwind = segments_.upwinding_segment(seg);
     MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
         assemblePressureEq(seg, seg_upwind, outlet_segment_index,
                            pressure_equation, outlet_pressure, linSys_);
 
-    if (reverseFlow){
-        MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
-            assemblePressureEqExtraDerivatives(seg, seg_upwind, extra_derivatives, linSys_);
-    }
-
     if (this->accelerationalPressureLossConsidered()) {
         handleAccelerationPressureLoss(seg, well_state);
     }
-
-    // Do separately since different organization of derivatives 
-    const int seg_outlet = this->segmentNumberToIndex(this->segmentSet()[seg].outletSegment());
-    const auto hydro_pressure_drop1 = segments_.getHalfHydroPressureLoss(seg, seg);
-    const auto hydro_pressure_drop2 = segments_.getHalfHydroPressureLoss(seg, seg_outlet);
-    MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
-        assembleHydroPressureLoss(seg, seg_outlet, hydro_pressure_drop1, hydro_pressure_drop2, linSys_);
-
-    segments.pressure_drop_hydrostatic[seg] = hydro_pressure_drop1.value() + hydro_pressure_drop2.value();
 }
 
 template<typename FluidSystem, typename Indices, typename Scalar>

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -76,7 +76,8 @@ protected:
     void initMatrixAndVectors(const int num_cells);
 
     void assembleDefaultPressureEq(const int seg,
-                                   WellState& well_state);
+                                   WellState& well_state,
+                                   const bool use_average_density);
 
     // assemble pressure equation for ICD segments
     void assembleICDPressureEq(const int seg,
@@ -88,6 +89,7 @@ protected:
     void assemblePressureEq(const int seg,
                             const UnitSystem& unit_system,
                             WellState& well_state,
+                            const bool use_average_density,
                             DeferredLogger& deferred_logger);
 
     /// check whether the well equations get converged for this well

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -323,8 +323,8 @@ typename MultisegmentWellSegments<FluidSystem,Indices,Scalar>::EvalWell
 MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
 getHydroPressureLoss(const int seg) const
 {   
-    const int seg_upwind = upwinding_segments_[seg];
-    return densities_[seg_upwind] * well_.gravity() * depth_diffs_[seg];
+    //const int seg_upwind = upwinding_segments_[seg];
+    return densities_[seg] * well_.gravity() * depth_diffs_[seg];
 }
 
 

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -321,10 +321,10 @@ updateUpwindingSegments(const PrimaryVariables& primary_variables)
 template<class FluidSystem, class Indices, class Scalar>
 typename MultisegmentWellSegments<FluidSystem,Indices,Scalar>::EvalWell
 MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
-getHalfHydroPressureLoss(const int seg,
+getHydroPressureLoss(const int seg,
                          const int seg_density) const
 {   
-    return 0.5*densities_[seg_density] * well_.gravity() * depth_diffs_[seg];
+    return densities_[seg_density] * well_.gravity() * depth_diffs_[seg];
 }
 
 

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -322,9 +322,11 @@ template<class FluidSystem, class Indices, class Scalar>
 typename MultisegmentWellSegments<FluidSystem,Indices,Scalar>::EvalWell
 MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
 getHydroPressureLoss(const int seg) const
-{
-    return densities_[seg] * well_.gravity() * depth_diffs_[seg];
+{   
+    const int seg_upwind = upwinding_segments_[seg];
+    return densities_[seg_upwind] * well_.gravity() * depth_diffs_[seg];
 }
+
 
 template<class FluidSystem, class Indices, class Scalar>
 Scalar MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
@@ -484,19 +486,36 @@ getSurfaceVolume(const EvalWell& temperature,
 template<class FluidSystem, class Indices, class Scalar>
 typename MultisegmentWellSegments<FluidSystem,Indices,Scalar>::EvalWell
 MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
-getFrictionPressureLoss(const int seg) const
+getFrictionPressureLoss(const int seg, const bool return_upwind_derivatives) const
 {
-    const EvalWell mass_rate = mass_rates_[seg];
+    EvalWell mass_rate = mass_rates_[seg];
     const int seg_upwind = upwinding_segments_[seg];
     EvalWell density = densities_[seg_upwind];
     EvalWell visc = viscosities_[seg_upwind];
     // WARNING
     // We disregard the derivatives from the upwind density to make sure derivatives
     // wrt. to different segments dont get mixed.
+    
     if (seg != seg_upwind) {
-        density.clearDerivatives();
-        visc.clearDerivatives();
+        if (!return_upwind_derivatives){
+            const int WQTotal = Indices::numEq + PrimaryVariables::WQTotal;
+            const int SPres = Indices::numEq + PrimaryVariables::SPres;
+            density.setDerivative(WQTotal, 0.0);
+            density.setDerivative(SPres, 0.0);
+            visc.setDerivative(WQTotal, 0.0);
+            visc.setDerivative(SPres, 0.0);
+        } else {
+            const int WFrac = Indices::numEq + PrimaryVariables::WFrac;
+            const int GFrac = Indices::numEq + PrimaryVariables::GFrac;
+            // if has ...
+            density.setDerivative(WFrac, 0.0);
+            density.setDerivative(GFrac, 0.0);
+            visc.setDerivative(WFrac, 0.0);
+            visc.setDerivative(GFrac, 0.0);
+            mass_rate.clearDerivatives();
+        }
     }
+    
     const auto& segment_set = well_.wellEcl().getSegments();
     const int outlet_segment_index = segment_set.segmentNumberToIndex(segment_set[seg].outletSegment());
     const double length = segment_set[seg].totalLength() - segment_set[outlet_segment_index].totalLength();

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -322,10 +322,9 @@ template<class FluidSystem, class Indices, class Scalar>
 typename MultisegmentWellSegments<FluidSystem,Indices,Scalar>::EvalWell
 MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
 getHalfHydroPressureLoss(const int seg,
-                         const int seg_side) const
+                         const int seg_density) const
 {   
-    //const int seg_upwind = upwinding_segments_[seg];
-    return 0.5*densities_[seg_side] * well_.gravity() * depth_diffs_[seg];
+    return 0.5*densities_[seg_density] * well_.gravity() * depth_diffs_[seg];
 }
 
 
@@ -487,32 +486,37 @@ getSurfaceVolume(const EvalWell& temperature,
 template<class FluidSystem, class Indices, class Scalar>
 typename MultisegmentWellSegments<FluidSystem,Indices,Scalar>::EvalWell
 MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
-getFrictionPressureLoss(const int seg, const bool return_upwind_derivatives) const
+getFrictionPressureLoss(const int seg, const bool return_extra_derivatives) const
 {
     EvalWell mass_rate = mass_rates_[seg];
     const int seg_upwind = upwinding_segments_[seg];
     EvalWell density = densities_[seg_upwind];
     EvalWell visc = viscosities_[seg_upwind];
-    // WARNING
-    // We disregard the derivatives from the upwind density to make sure derivatives
-    // wrt. to different segments dont get mixed.
+    // In the reverse flow case, we don't have enough slots for all derivatives, e.g.,
+    // upwind pressure and flow. We amend this by a second function call optioin, where 
+    // only these remaining derivatives are considered.
+    // For reference: the pressure equation assumes pressure/flow derivatives are given 
+    // at segment node while fraction derivatives are given at upwind node.   
     
     if (seg != seg_upwind) {
-        if (!return_upwind_derivatives){
-            const int WQTotal = Indices::numEq + PrimaryVariables::WQTotal;
-            const int SPres = Indices::numEq + PrimaryVariables::SPres;
+        if (!return_extra_derivatives){
+            constexpr int WQTotal = Indices::numEq + PrimaryVariables::WQTotal;
+            constexpr int SPres = Indices::numEq + PrimaryVariables::SPres;
             density.setDerivative(WQTotal, 0.0);
             density.setDerivative(SPres, 0.0);
             visc.setDerivative(WQTotal, 0.0);
             visc.setDerivative(SPres, 0.0);
         } else {
-            const int WFrac = Indices::numEq + PrimaryVariables::WFrac;
-            const int GFrac = Indices::numEq + PrimaryVariables::GFrac;
-            // if has ...
-            density.setDerivative(WFrac, 0.0);
-            density.setDerivative(GFrac, 0.0);
-            visc.setDerivative(WFrac, 0.0);
-            visc.setDerivative(GFrac, 0.0);
+            if (PrimaryVariables::has_water){
+                constexpr int WFrac = Indices::numEq + PrimaryVariables::WFrac;
+                density.setDerivative(WFrac, 0.0);
+                visc.setDerivative(WFrac, 0.0);
+            }
+            if (PrimaryVariables::has_gas){
+                constexpr int GFrac = Indices::numEq + PrimaryVariables::GFrac;
+                density.setDerivative(GFrac, 0.0);
+                visc.setDerivative(GFrac, 0.0);
+            }
             mass_rate.clearDerivatives();
         }
     }

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -321,10 +321,11 @@ updateUpwindingSegments(const PrimaryVariables& primary_variables)
 template<class FluidSystem, class Indices, class Scalar>
 typename MultisegmentWellSegments<FluidSystem,Indices,Scalar>::EvalWell
 MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
-getHydroPressureLoss(const int seg) const
+getHalfHydroPressureLoss(const int seg,
+                         const int seg_side) const
 {   
     //const int seg_upwind = upwinding_segments_[seg];
-    return densities_[seg] * well_.gravity() * depth_diffs_[seg];
+    return 0.5*densities_[seg_side] * well_.gravity() * depth_diffs_[seg];
 }
 
 

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -51,7 +51,7 @@ public:
     //! \brief Update upwinding segments.
     void updateUpwindingSegments(const PrimaryVariables& primary_variables);
 
-    EvalWell getHalfHydroPressureLoss(const int seg,
+    EvalWell getHydroPressureLoss(const int seg,
                                       const int seg_side) const;
 
     //! Pressure difference between segment and perforation.

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -51,7 +51,8 @@ public:
     //! \brief Update upwinding segments.
     void updateUpwindingSegments(const PrimaryVariables& primary_variables);
 
-    EvalWell getHydroPressureLoss(const int seg) const;
+    EvalWell getHalfHydroPressureLoss(const int seg,
+                                      const int seg_side) const;
 
     //! Pressure difference between segment and perforation.
     Scalar getPressureDiffSegPerf(const int seg,

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -63,7 +63,7 @@ public:
                               const int pvt_region_index,
                               const int seg_idx) const;
 
-    EvalWell getFrictionPressureLoss(const int seg) const;
+    EvalWell getFrictionPressureLoss(const int seg, const bool return_upwind_derivatives) const;
 
     // pressure drop for Spiral ICD segment (WSEGSICD)
     EvalWell pressureDropSpiralICD(const int seg) const;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1589,7 +1589,7 @@ namespace Opm
                                         deferred_logger);
             } else {
                 const UnitSystem& unit_system = ebosSimulator.vanguard().eclState().getDeckUnitSystem();
-                this->assemblePressureEq(seg, unit_system, well_state, deferred_logger);
+                this->assemblePressureEq(seg, unit_system, well_state, this->param_.use_average_density_ms_wells_, deferred_logger);
             }
         }
 


### PR DESCRIPTION
* rewrite segment hydrostatic p-drop as average of neighboring nodes
* slightly hacky inclusion of "skipped" derivatives in the friction-term for reverse-flow cases. Could be done similarly also for valve-models, but currently not included for these. 