### PR TITLE
start regression testing of WGRUPCON tests

### DIFF
--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -1097,3 +1097,17 @@ add_test_compareECLFiles(CASENAME model_metric_gridunit_metres
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR gridunit)
+
+add_test_compareECLFiles(CASENAME 01_wgrupcon
+                         FILENAME 01-WGRUPCON
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR wgrupcon)
+
+add_test_compareECLFiles(CASENAME 02_wgrupcon
+                         FILENAME 02-WGRUPCON
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR wgrupcon)

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -213,6 +213,8 @@ tests[model_field_gridunit_metres]="flow gridunit M_FIELD_GRID_METRES"
 tests[model_metric_gridunit_cm]="flow gridunit M_METRIC_GRID_CM"
 tests[model_metric_gridunit_feet]="flow gridunit M_METRIC_GRID_FEET"
 tests[model_metric_gridunit_metres]="flow gridunit M_METRIC_GRID_METRES"
+tests[01_wgrupcon]="flow wgrupcon 01-WGRUPCON"
+tests[02_wgrupcon]="flow wgrupcon 02-WGRUPCON"
 
 changed_tests=""
 


### PR DESCRIPTION
These two test has been supported since 
   
https://github.com/OPM/opm-simulators/pull/4575

Simulation results was checked before this was merged. To be on the safe side, simulation results has checked again today. 