### PR TITLE
we should not request alq_value for injectors

### DIFF
--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
@@ -393,6 +393,8 @@ copyToWellState(const MultisegmentWellGeneric<Scalar>& mswell,
                        [maxVel](const auto hf) { return (hf > 0.0) ? maxVel : 0.0; });
     }
 
+    // Note: for the ALQ value, in the StandardWell, WellInterfaceGeneric::getALQ(well_state) is used.
+    // We might want to unify the way regarding AQL value.
     WellBhpThpCalculator(well_)
         .updateThp(rho, stop_or_zero_rate_target, [this]() { return well_.wellEcl().alq_value(); },
                    {FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx),

--- a/opm/simulators/wells/WellBhpThpCalculator.hpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.hpp
@@ -57,7 +57,7 @@ public:
     double calculateThpFromBhp(const std::vector<double>& rates,
                                const double bhp,
                                const double rho,
-                               const double alq,
+                               const std::optional<double>& alq,
                                DeferredLogger& deferred_logger) const;
 
     //! \brief Compute BHP from THP limit for a producer.


### PR DESCRIPTION
through the function { return well_.wellEcl().alq_value(); }.

It will throw a runtime_error which is not properly caught.