### PR TITLE
TUNING/NEXT[STEP]: Use max next time step only when specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,13 @@ opm_add_test(test_tuning_xxxMBE
                 ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
               ONLY_COMPILE)
 
+opm_add_test(test_tuning_tsinit_nextstep
+              SOURCES
+                tests/test_tuning_TSINIT_NEXTSTEP.cpp
+              LIBRARIES
+                ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} opmcommon
+              ONLY_COMPILE)
+
 if (HAVE_OPM_TESTS)
     include (${CMAKE_CURRENT_SOURCE_DIR}/compareECLFiles.cmake)
 endif()

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -312,6 +312,14 @@ add_test_runSimulator(CASENAME notuning_xxxmbe
 
 set_tests_properties(runSimulator/notuning_xxxmbe PROPERTIES WILL_FAIL TRUE)
 
+add_test_runSimulator(CASENAME tuning_tsinit_nextstep
+                      FILENAME 02_TUNING_TSINIT_NEXTSTEP
+                      SIMULATOR flow
+											DIR tuning
+                      TEST_ARGS --enable-tuning=true
+                      POST_COMMAND $<TARGET_FILE:test_tuning_tsinit_nextstep>)
+
+
 include (${CMAKE_CURRENT_SOURCE_DIR}/regressionTests.cmake)
 include (${CMAKE_CURRENT_SOURCE_DIR}/restartTests.cmake)
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -355,7 +355,7 @@ public:
             // if support for the TUNING keyword is enabled, we get the initial time
             // steping parameters from it instead of from command line parameters
             const auto& tuning = schedule[0].tuning();
-            this->initialTimeStepSize_ = tuning.TSINIT;
+            this->initialTimeStepSize_ = tuning.TSINIT.has_value() ? tuning.TSINIT.value() : -1.0;
             this->maxTimeStepAfterWellEvent_ = tuning.TMAXWC;
         }
 
@@ -542,7 +542,8 @@ public:
 
         // set the size of the initial time step of the episode
         Scalar dt = limitNextTimeStepSize_(simulator.episodeLength());
-        if (episodeIdx == 0 || tuningEvent)
+        // negative value of initialTimeStepSize_ indicates no active limit from TSINIT or NEXTSTEP
+        if ( (episodeIdx == 0 || tuningEvent) && this->initialTimeStepSize_ > 0)
             // allow the size of the initial time step to be set via an external parameter
             // if TUNING is enabled, also limit the time step size after a tuning event to TSINIT
             dt = std::min(dt, this->initialTimeStepSize_);

--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -339,7 +339,7 @@ std::set<std::string> consistentlyFailingWells(const std::vector<StepReport>& sr
             , solverRestartMax_(EWOMS_GET_PARAM(TypeTag, int, SolverMaxRestarts)) // 10
             , solverVerbose_(EWOMS_GET_PARAM(TypeTag, int, SolverVerbosity) > 0 && terminalOutput) // 2
             , timestepVerbose_(EWOMS_GET_PARAM(TypeTag, int, TimeStepVerbosity) > 0 && terminalOutput) // 2
-            , suggestedNextTimestep_(max_next_tstep) // 1.0
+            , suggestedNextTimestep_(max_next_tstep <= 0 ? EWOMS_GET_PARAM(TypeTag, double, InitialTimeStepInDays)*86400 : max_next_tstep) // 1.0
             , fullTimestepInitially_(EWOMS_GET_PARAM(TypeTag, bool, FullTimeStepInitially)) // false
             , timestepAfterEvent_(tuning.TMAXWC) // 1e30
             , useNewtonIteration_(false)
@@ -686,7 +686,10 @@ std::set<std::string> consistentlyFailingWells(const std::vector<StepReport>& sr
             growthFactor_ = tuning.TFDIFF;
             maxGrowth_ = tuning.TSFMAX;
             maxTimeStep_ = tuning.TSMAXZ;
-            suggestedNextTimestep_ = max_next_tstep;
+             // \Note Only update next suggested step if TSINIT was explicitly set in TUNING or NEXTSTEP is active. 
+            if (max_next_tstep > 0) {
+                suggestedNextTimestep_ = max_next_tstep;
+            }
             timestepAfterEvent_ = tuning.TMAXWC;
         }
 

--- a/tests/test_tuning_TSINIT_NEXTSTEP.cpp
+++ b/tests/test_tuning_TSINIT_NEXTSTEP.cpp
@@ -14,8 +14,9 @@ inline bool is_close(double a, double b, double tol = TOLERANCE) {
 }
 
 BOOST_AUTO_TEST_CASE(CheckTSINITAndNEXTSTEP)
-{    
-    //std::string case_name(boost::unit_test::framework::master_test_suite().argv[1]);        std::string case_name("02_TUNING_TSINIT_NEXTSTEP");
+{
+    std::string case_name("02_TUNING_TSINIT_NEXTSTEP");
+
     BOOST_TEST_MESSAGE("---------------------------------------------------------------------------");
     BOOST_TEST_MESSAGE("Checking TSINIT and NEXTSTEP, see file " + case_name + ".DATA");
     BOOST_TEST_MESSAGE("---------------------------------------------------------------------------");

--- a/tests/test_tuning_TSINIT_NEXTSTEP.cpp
+++ b/tests/test_tuning_TSINIT_NEXTSTEP.cpp
@@ -1,0 +1,52 @@
+#include <opm/io/eclipse/ESmry.hpp>
+
+#include <string>
+#include <cmath>
+#include <iostream>
+
+#define BOOST_TEST_MODULE TestTuningTSINIT
+#include <boost/test/unit_test.hpp>
+
+constexpr double TOLERANCE = 1.0e-10;
+
+inline bool is_close(double a, double b, double tol = TOLERANCE) {
+    return std::abs(a-b) <= tol;
+}
+
+BOOST_AUTO_TEST_CASE(CheckTSINITAndNEXTSTEP)
+{    
+		//std::string case_name(boost::unit_test::framework::master_test_suite().argv[1]);
+		std::string case_name("02_TUNING_TSINIT_NEXTSTEP");
+
+		BOOST_TEST_MESSAGE("---------------------------------------------------------------------------");
+		BOOST_TEST_MESSAGE("Checking TSINIT and NEXTSTEP, see file " + case_name + ".DATA");
+		BOOST_TEST_MESSAGE("---------------------------------------------------------------------------");
+
+
+		Opm::EclIO::ESmry smry(case_name, false);
+        smry.loadData({"TIME"});
+        const auto& time = smry.get("TIME");
+                
+        // First time step 1 day
+        BOOST_CHECK_CLOSE(time[0], 1.0, TOLERANCE);
+        
+        for (size_t i=0; i<time.size(); ++i) {
+            std::cout << "######################################" << std::endl;
+            std::cout << time[i] << std::endl;
+                    
+            // Max time step 3 days initially
+            if (time[i] < 14.0) BOOST_CHECK(time[i+1] <= (time[i]+3.0));
+            // No short next step 
+            if (is_close(time[i], 14.0)) BOOST_CHECK(time[i+1] > 15.1);
+            // Persistent NEXTSTEP=0.5
+            if (is_close(time[i], 31.0)) BOOST_CHECK_CLOSE(time[i+1], 31.5, TOLERANCE);
+            if (is_close(time[i], 45.0)) BOOST_CHECK_CLOSE(time[i+1], 45.5, TOLERANCE);
+            // Non-persistent NEXTSTEP=1.0
+            if (is_close(time[i], 60.0)) BOOST_CHECK_CLOSE(time[i+1], 61.0, TOLERANCE);
+            if (is_close(time[i], 74.0)) BOOST_CHECK(time[i+1] > 75.1);  
+            // TSINIT=0.5
+            if (is_close(time[i], 91.0)) BOOST_CHECK_CLOSE(time[i+1], 91.5, TOLERANCE);
+            if (is_close(time[i], 105.0)) BOOST_CHECK(time[i+1] > 105.6);
+        }  
+}
+

--- a/tests/test_tuning_TSINIT_NEXTSTEP.cpp
+++ b/tests/test_tuning_TSINIT_NEXTSTEP.cpp
@@ -15,38 +15,34 @@ inline bool is_close(double a, double b, double tol = TOLERANCE) {
 
 BOOST_AUTO_TEST_CASE(CheckTSINITAndNEXTSTEP)
 {    
-		//std::string case_name(boost::unit_test::framework::master_test_suite().argv[1]);
-		std::string case_name("02_TUNING_TSINIT_NEXTSTEP");
-
-		BOOST_TEST_MESSAGE("---------------------------------------------------------------------------");
-		BOOST_TEST_MESSAGE("Checking TSINIT and NEXTSTEP, see file " + case_name + ".DATA");
-		BOOST_TEST_MESSAGE("---------------------------------------------------------------------------");
-
-
-		Opm::EclIO::ESmry smry(case_name, false);
-        smry.loadData({"TIME"});
-        const auto& time = smry.get("TIME");
-                
-        // First time step 1 day
-        BOOST_CHECK_CLOSE(time[0], 1.0, TOLERANCE);
+    //std::string case_name(boost::unit_test::framework::master_test_suite().argv[1]);        std::string case_name("02_TUNING_TSINIT_NEXTSTEP");
+    BOOST_TEST_MESSAGE("---------------------------------------------------------------------------");
+    BOOST_TEST_MESSAGE("Checking TSINIT and NEXTSTEP, see file " + case_name + ".DATA");
+    BOOST_TEST_MESSAGE("---------------------------------------------------------------------------");
+    Opm::EclIO::ESmry smry(case_name, false);
+    smry.loadData({"TIME"});
+    const auto& time = smry.get("TIME");
         
-        for (size_t i=0; i<time.size(); ++i) {
-            std::cout << "######################################" << std::endl;
-            std::cout << time[i] << std::endl;
-                    
-            // Max time step 3 days initially
-            if (time[i] < 14.0) BOOST_CHECK(time[i+1] <= (time[i]+3.0));
-            // No short next step 
-            if (is_close(time[i], 14.0)) BOOST_CHECK(time[i+1] > 15.1);
-            // Persistent NEXTSTEP=0.5
-            if (is_close(time[i], 31.0)) BOOST_CHECK_CLOSE(time[i+1], 31.5, TOLERANCE);
-            if (is_close(time[i], 45.0)) BOOST_CHECK_CLOSE(time[i+1], 45.5, TOLERANCE);
-            // Non-persistent NEXTSTEP=1.0
-            if (is_close(time[i], 60.0)) BOOST_CHECK_CLOSE(time[i+1], 61.0, TOLERANCE);
-            if (is_close(time[i], 74.0)) BOOST_CHECK(time[i+1] > 75.1);  
-            // TSINIT=0.5
-            if (is_close(time[i], 91.0)) BOOST_CHECK_CLOSE(time[i+1], 91.5, TOLERANCE);
-            if (is_close(time[i], 105.0)) BOOST_CHECK(time[i+1] > 105.6);
-        }  
+    // First time step 1 day
+    BOOST_CHECK_CLOSE(time[0], 1.0, TOLERANCE);
+
+    for (size_t i=0; i<time.size(); ++i) {
+        std::cout << "######################################" << std::endl;
+        std::cout << time[i] << std::endl;
+                
+        // Max time step 3 days initially
+        if (time[i] < 14.0) BOOST_CHECK(time[i+1] <= (time[i]+3.0));
+        // No short next step 
+        if (is_close(time[i], 14.0)) BOOST_CHECK(time[i+1] > 15.1);
+        // Persistent NEXTSTEP=0.5
+        if (is_close(time[i], 31.0)) BOOST_CHECK_CLOSE(time[i+1], 31.5, TOLERANCE);
+        if (is_close(time[i], 45.0)) BOOST_CHECK_CLOSE(time[i+1], 45.5, TOLERANCE);
+        // Non-persistent NEXTSTEP=1.0
+        if (is_close(time[i], 60.0)) BOOST_CHECK_CLOSE(time[i+1], 61.0, TOLERANCE);
+        if (is_close(time[i], 74.0)) BOOST_CHECK(time[i+1] > 75.1);  
+        // TSINIT=0.5
+        if (is_close(time[i], 91.0)) BOOST_CHECK_CLOSE(time[i+1], 91.5, TOLERANCE);
+        if (is_close(time[i], 105.0)) BOOST_CHECK(time[i+1] > 105.6);
+    }  
 }
 


### PR DESCRIPTION
Use max time step from TUNING.TSINIT or NEXTSTEP only when specified.
Requires https://github.com/OPM/opm-common/pull/3528

