### PR TITLE
changed: stop forcing no adaptive time stepping in parallel restart test driver

### DIFF
--- a/parallelRestartTests.cmake
+++ b/parallelRestartTests.cmake
@@ -6,7 +6,7 @@ add_test_compare_parallel_restarted_simulation(CASENAME spe1
                                                ABS_TOL ${abs_tol_restart}
                                                REL_TOL ${rel_tol_restart}
                                                RESTART_STEP 6
-                                               TEST_ARGS --sched-restart=false)
+                                               TEST_ARGS --sched-restart=false --enable-adaptive-time-stepping=false)
 
 add_test_compare_parallel_restarted_simulation(CASENAME ctaquifer_2d_oilwater
                                                FILENAME 2D_OW_CTAQUIFER
@@ -15,7 +15,7 @@ add_test_compare_parallel_restarted_simulation(CASENAME ctaquifer_2d_oilwater
                                                REL_TOL ${rel_tol_restart}
                                                RESTART_STEP 15
                                                DIR aquifer-oilwater
-                                               TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
+                                               TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6 --enable-adaptive-time-stepping=false)
 
 add_test_compare_parallel_restarted_simulation(CASENAME fetkovich_2d
                                                FILENAME 2D_FETKOVICHAQUIFER
@@ -24,7 +24,7 @@ add_test_compare_parallel_restarted_simulation(CASENAME fetkovich_2d
                                                REL_TOL ${rel_tol_restart}
                                                RESTART_STEP 30
                                                DIR aquifer-fetkovich
-                                               TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
+                                               TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6 --enable-adaptive-time-stepping=false)
 
 add_test_compare_parallel_restarted_simulation(CASENAME numerical_aquifer_3d_2aqu
                                                FILENAME 3D_2AQU_NUM
@@ -33,7 +33,7 @@ add_test_compare_parallel_restarted_simulation(CASENAME numerical_aquifer_3d_2aq
                                                REL_TOL 5.0e-2
                                                RESTART_STEP 3
                                                DIR aquifer-num
-                                               TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr_trueimpes)
+                                               TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr_trueimpes --enable-adaptive-time-stepping=false)
 
 add_test_compare_parallel_restarted_simulation(CASENAME numerical_aquifer_3d_1aqu
                                                FILENAME 3D_1AQU_3CELLS
@@ -42,7 +42,7 @@ add_test_compare_parallel_restarted_simulation(CASENAME numerical_aquifer_3d_1aq
                                                REL_TOL 5.0e-2
                                                RESTART_STEP 3
                                                DIR aquifer-num
-                                               TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr_trueimpes)
+                                               TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr_trueimpes --enable-adaptive-time-stepping=false)
 
 # Serialized restart tests
 if(HDF5_FOUND)

--- a/tests/run-parallel-restart-regressionTest.sh
+++ b/tests/run-parallel-restart-regressionTest.sh
@@ -49,13 +49,13 @@ BASE_NAME=${FILENAME}_RESTART
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
-mpirun -np ${MPI_PROCS} ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --enable-adaptive-time-stepping=false --output-dir=${RESULT_PATH} ${TEST_ARGS}
+mpirun -np ${MPI_PROCS} ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH}/${FILENAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
 
 test $? -eq 0 || exit 1
 
 ${RST_DECK_COMMAND} ${INPUT_DATA_PATH}/${FILENAME}.DATA ${FILENAME}.UNRST:${RESTART_STEP} ${BASE_NAME}.DATA -m inline -s
 
-mpirun -np ${MPI_PROCS} ${BINPATH}/${EXE_NAME} ${BASE_NAME} --enable-adaptive-time-stepping=false --output-dir=${RESULT_PATH} ${TEST_ARGS}
+mpirun -np ${MPI_PROCS} ${BINPATH}/${EXE_NAME} ${BASE_NAME} --output-dir=${RESULT_PATH} ${TEST_ARGS}
 test $? -eq 0 || exit 1
 
 ecode=0


### PR DESCRIPTION
this should be controllable on a per-test level as other options.

keep current behavior for existing test by re-adding the option using TEST_ARGS.