### PR TITLE
Include fallback to explicit vfp lookup for tiny rates - testing

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -235,7 +235,7 @@ namespace Opm {
                 // update VFP properties
                 vfp_properties_ = std::make_unique<VFPProperties>(sched_state.vfpinj(),
                                                                   sched_state.vfpprod(),
-                                                                  this->prevWellState());
+                                                                  this->wellState());
                 this->initializeWellProdIndCalculators();
                 if (sched_state.events().hasEvent(ScheduleEvents::Events::WELL_PRODUCTIVITY_INDEX)) {
                     this->runWellPIScaling(timeStepIdx, local_deferredLogger);
@@ -337,6 +337,12 @@ namespace Opm {
                 if (well->isProducer()) {
                     well->updateWellStateRates(ebosSimulator_, this->wellState(), local_deferredLogger);
                 }
+            }
+        }
+
+        for (auto& well : well_container_) {
+            if (well->isVFPActive(local_deferredLogger)){
+                well->setExplicitSurfaceRates(this->wellState(), this->prevWellState());
             }
         }
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -342,7 +342,7 @@ namespace Opm {
 
         for (auto& well : well_container_) {
             if (well->isVFPActive(local_deferredLogger)){
-                well->setExplicitSurfaceRates(this->wellState(), this->prevWellState());
+                well->setPrevSurfaceRates(this->wellState(), this->prevWellState());
             }
         }
 

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -44,6 +44,7 @@ SingleWellState::SingleWellState(const std::string& name_,
     , productivity_index(pu_.num_phases)
     , surface_rates(pu_.num_phases)
     , reservoir_rates(pu_.num_phases)
+    , explicit_surface_rates(pu_.num_phases)
     , perf_data(perf_input.size(), pressure_first_connection, !is_producer, pu_.num_phases)
     , trivial_target(false)
 {
@@ -84,6 +85,7 @@ void SingleWellState::shut() {
     this->thp = 0;
     this->status = Well::Status::SHUT;
     std::fill(this->surface_rates.begin(), this->surface_rates.end(), 0);
+    std::fill(this->explicit_surface_rates.begin(), this->explicit_surface_rates.end(), 0);
     std::fill(this->reservoir_rates.begin(), this->reservoir_rates.end(), 0);
     std::fill(this->productivity_index.begin(), this->productivity_index.end(), 0);
 
@@ -296,6 +298,7 @@ bool SingleWellState::operator==(const SingleWellState& rhs) const
            this->productivity_index == rhs.productivity_index &&
            this->surface_rates == rhs.surface_rates &&
            this->reservoir_rates == rhs.reservoir_rates &&
+           this->explicit_surface_rates == rhs.explicit_surface_rates &&
            this->trivial_target == rhs.trivial_target &&
            this->segments == rhs.segments &&
            this->events == rhs.events &&

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -44,7 +44,7 @@ SingleWellState::SingleWellState(const std::string& name_,
     , productivity_index(pu_.num_phases)
     , surface_rates(pu_.num_phases)
     , reservoir_rates(pu_.num_phases)
-    , explicit_surface_rates(pu_.num_phases)
+    , prev_surface_rates(pu_.num_phases)
     , perf_data(perf_input.size(), pressure_first_connection, !is_producer, pu_.num_phases)
     , trivial_target(false)
 {
@@ -85,7 +85,7 @@ void SingleWellState::shut() {
     this->thp = 0;
     this->status = Well::Status::SHUT;
     std::fill(this->surface_rates.begin(), this->surface_rates.end(), 0);
-    std::fill(this->explicit_surface_rates.begin(), this->explicit_surface_rates.end(), 0);
+    std::fill(this->prev_surface_rates.begin(), this->prev_surface_rates.end(), 0);
     std::fill(this->reservoir_rates.begin(), this->reservoir_rates.end(), 0);
     std::fill(this->productivity_index.begin(), this->productivity_index.end(), 0);
 
@@ -298,7 +298,7 @@ bool SingleWellState::operator==(const SingleWellState& rhs) const
            this->productivity_index == rhs.productivity_index &&
            this->surface_rates == rhs.surface_rates &&
            this->reservoir_rates == rhs.reservoir_rates &&
-           this->explicit_surface_rates == rhs.explicit_surface_rates &&
+           this->prev_surface_rates == rhs.prev_surface_rates &&
            this->trivial_target == rhs.trivial_target &&
            this->segments == rhs.segments &&
            this->events == rhs.events &&

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -63,6 +63,7 @@ public:
         serializer(productivity_index);
         serializer(surface_rates);
         serializer(reservoir_rates);
+        serializer(explicit_surface_rates);
         serializer(trivial_target);
         serializer(segments);
         serializer(events);
@@ -95,6 +96,7 @@ public:
     std::vector<double> productivity_index;
     std::vector<double> surface_rates;
     std::vector<double> reservoir_rates;
+    std::vector<double> explicit_surface_rates;
     PerfData perf_data;
     bool trivial_target;
     SegmentState segments;

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -63,7 +63,7 @@ public:
         serializer(productivity_index);
         serializer(surface_rates);
         serializer(reservoir_rates);
-        serializer(explicit_surface_rates);
+        serializer(prev_surface_rates);
         serializer(trivial_target);
         serializer(segments);
         serializer(events);
@@ -96,7 +96,7 @@ public:
     std::vector<double> productivity_index;
     std::vector<double> surface_rates;
     std::vector<double> reservoir_rates;
-    std::vector<double> explicit_surface_rates;
+    std::vector<double> prev_surface_rates;
     PerfData perf_data;
     bool trivial_target;
     SegmentState segments;

--- a/opm/simulators/wells/VFPHelpers.cpp
+++ b/opm/simulators/wells/VFPHelpers.cpp
@@ -348,7 +348,7 @@ VFPEvaluation bhp(const VFPProdTable& table,
     double flo = detail::getFlo(table, aqua, liquid, vapour);
     double wfr = detail::getWFR(table, aqua, liquid, vapour);
     double gfr = detail::getGFR(table, aqua, liquid, vapour);
-    if (use_vfpexplicit) {
+    if (use_vfpexplicit || -flo < table.getFloAxis().front()) {
         wfr = explicit_wfr;
         gfr = explicit_gfr;
     }

--- a/opm/simulators/wells/VFPProdProperties.cpp
+++ b/opm/simulators/wells/VFPProdProperties.cpp
@@ -161,7 +161,7 @@ EvalWell VFPProdProperties::bhp(const int table_id,
     EvalWell flo = detail::getFlo(table, aqua, liquid, vapour);
     EvalWell wfr = detail::getWFR(table, aqua, liquid, vapour);
     EvalWell gfr = detail::getGFR(table, aqua, liquid, vapour);
-    if (use_expvfp) {
+    if (use_expvfp || -flo.value() < table.getFloAxis().front()) {
         wfr = explicit_wfr;
         gfr = explicit_gfr;
     }

--- a/opm/simulators/wells/VFPProperties.hpp
+++ b/opm/simulators/wells/VFPProperties.hpp
@@ -72,7 +72,7 @@ public:
     }
 
     double getExplicitWFR(const int table_id, const size_t well_index) const {
-        const auto& rates = well_state_.well(well_index).explicit_surface_rates;
+        const auto& rates = well_state_.well(well_index).prev_surface_rates;
         const auto& pu = well_state_.phaseUsage();
         const auto& aqua = pu.phase_used[BlackoilPhases::Aqua]? rates[pu.phase_pos[BlackoilPhases::Aqua]]:0.0;
         const auto& liquid = pu.phase_used[BlackoilPhases::Liquid]? rates[pu.phase_pos[BlackoilPhases::Liquid]]:0.0;
@@ -82,7 +82,7 @@ public:
     }
 
     double getExplicitGFR(const int table_id, const size_t well_index) const {
-        const auto& rates = well_state_.well(well_index).explicit_surface_rates;
+        const auto& rates = well_state_.well(well_index).prev_surface_rates;
         const auto& pu = well_state_.phaseUsage();
         const auto& aqua = pu.phase_used[BlackoilPhases::Aqua]? rates[pu.phase_pos[BlackoilPhases::Aqua]]:0.0;
         const auto& liquid = pu.phase_used[BlackoilPhases::Liquid]? rates[pu.phase_pos[BlackoilPhases::Liquid]]:0.0;

--- a/opm/simulators/wells/VFPProperties.hpp
+++ b/opm/simulators/wells/VFPProperties.hpp
@@ -72,7 +72,7 @@ public:
     }
 
     double getExplicitWFR(const int table_id, const size_t well_index) const {
-        const auto& rates = well_state_.well(well_index).surface_rates;
+        const auto& rates = well_state_.well(well_index).explicit_surface_rates;
         const auto& pu = well_state_.phaseUsage();
         const auto& aqua = pu.phase_used[BlackoilPhases::Aqua]? rates[pu.phase_pos[BlackoilPhases::Aqua]]:0.0;
         const auto& liquid = pu.phase_used[BlackoilPhases::Liquid]? rates[pu.phase_pos[BlackoilPhases::Liquid]]:0.0;
@@ -82,7 +82,7 @@ public:
     }
 
     double getExplicitGFR(const int table_id, const size_t well_index) const {
-        const auto& rates = well_state_.well(well_index).surface_rates;
+        const auto& rates = well_state_.well(well_index).explicit_surface_rates;
         const auto& pu = well_state_.phaseUsage();
         const auto& aqua = pu.phase_used[BlackoilPhases::Aqua]? rates[pu.phase_pos[BlackoilPhases::Aqua]]:0.0;
         const auto& liquid = pu.phase_used[BlackoilPhases::Liquid]? rates[pu.phase_pos[BlackoilPhases::Liquid]]:0.0;

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -315,8 +315,8 @@ public:
                               WellState& well_state,
                               DeferredLogger& deferred_logger) const;
 
-    void setExplicitSurfaceRates(WellState& well_state, 
-                                 const WellState& prev_well_state) const;                             
+    void setPrevSurfaceRates(WellState& well_state, 
+                             const WellState& prev_well_state) const;                             
 
     void solveWellEquation(const Simulator& ebosSimulator,
                            WellState& well_state,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -313,10 +313,7 @@ public:
     /// to the rates returned by computeCurrentWellRates().
     void updateWellStateRates(const Simulator& ebosSimulator,
                               WellState& well_state,
-                              DeferredLogger& deferred_logger) const;
-
-    void setPrevSurfaceRates(WellState& well_state, 
-                             const WellState& prev_well_state) const;                             
+                              DeferredLogger& deferred_logger) const;                      
 
     void solveWellEquation(const Simulator& ebosSimulator,
                            WellState& well_state,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -315,6 +315,9 @@ public:
                               WellState& well_state,
                               DeferredLogger& deferred_logger) const;
 
+    void setExplicitSurfaceRates(WellState& well_state, 
+                                 const WellState& prev_well_state) const;                             
+
     void solveWellEquation(const Simulator& ebosSimulator,
                            WellState& well_state,
                            const GroupState& group_state,

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -471,7 +471,7 @@ bool WellInterfaceGeneric::isOperableAndSolvable() const
 bool WellInterfaceGeneric::useVfpExplicit() const
 {
     const auto& wvfpexp = well_ecl_.getWVFPEXP();
-    return ((wvfpexp.explicit_lookup() && !changedToOpenThisStep())|| operability_status_.use_vfpexplicit);
+    return (wvfpexp.explicit_lookup() || operability_status_.use_vfpexplicit);
 }
 
 bool WellInterfaceGeneric::thpLimitViolatedButNotSwitched() const

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -347,6 +347,17 @@ void WellInterfaceGeneric::setVFPProperties(const VFPProperties* vfp_properties_
     vfp_properties_ = vfp_properties_arg;
 }
 
+void WellInterfaceGeneric::setPrevSurfaceRates(WellState& well_state, 
+                                               const WellState& prev_well_state) const
+    {
+        auto& ws = well_state.well(this->index_of_well_);
+        if (!this->changedToOpenThisStep()){
+            ws.prev_surface_rates = prev_well_state.well(this->index_of_well_).surface_rates;
+        } else {
+            ws.prev_surface_rates = ws.surface_rates;
+        }
+    }
+
 void WellInterfaceGeneric::setGuideRate(const GuideRate* guide_rate_arg)
 {
     guide_rate_ = guide_rate_arg;

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -94,6 +94,7 @@ public:
     void closeCompletions(const WellTestState& wellTestState);
 
     void setVFPProperties(const VFPProperties* vfp_properties_arg);
+    void setPrevSurfaceRates(WellState& well_state, const WellState& prev_well_state) const;
     void setGuideRate(const GuideRate* guide_rate_arg);
     void setWellEfficiencyFactor(const double efficiency_factor);
     void setRepRadiusPerfLength();

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1192,20 +1192,6 @@ namespace Opm
         }
     }
 
-    template <typename TypeTag>
-    void
-    WellInterface<TypeTag>::
-    setPrevSurfaceRates(WellState& well_state, 
-                            const WellState& prev_well_state) const
-    {
-        auto& ws = well_state.well(this->index_of_well_);
-        if (!this->changedToOpenThisStep()){
-            ws.prev_surface_rates = prev_well_state.well(this->index_of_well_).surface_rates;
-        } else {
-            ws.prev_surface_rates = ws.surface_rates;
-        }
-    }
-
     template<typename TypeTag>
     typename WellInterface<TypeTag>::Eval
     WellInterface<TypeTag>::getPerfCellPressure(const typename WellInterface<TypeTag>::FluidState& fs) const

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1192,6 +1192,25 @@ namespace Opm
         }
     }
 
+    template <typename TypeTag>
+    void
+    WellInterface<TypeTag>::
+    setExplicitSurfaceRates(WellState& well_state, 
+                            const WellState& prev_well_state) const
+    {
+        const int np = this->number_of_phases_;
+        auto& ws = well_state.well(this->index_of_well_);
+        if (!this->changedToOpenThisStep()){
+            for (int p = 0; p<np; ++p){
+                ws.explicit_surface_rates[p] = prev_well_state.well(this->index_of_well_).surface_rates[p];
+            }
+        } else {
+            for (int p = 0; p<np; ++p){
+                ws.explicit_surface_rates[p] = ws.surface_rates[p];
+            }
+        }
+    }
+
     template<typename TypeTag>
     typename WellInterface<TypeTag>::Eval
     WellInterface<TypeTag>::getPerfCellPressure(const typename WellInterface<TypeTag>::FluidState& fs) const

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1195,18 +1195,18 @@ namespace Opm
     template <typename TypeTag>
     void
     WellInterface<TypeTag>::
-    setExplicitSurfaceRates(WellState& well_state, 
+    setPrevSurfaceRates(WellState& well_state, 
                             const WellState& prev_well_state) const
     {
         const int np = this->number_of_phases_;
         auto& ws = well_state.well(this->index_of_well_);
         if (!this->changedToOpenThisStep()){
             for (int p = 0; p<np; ++p){
-                ws.explicit_surface_rates[p] = prev_well_state.well(this->index_of_well_).surface_rates[p];
+                ws.prev_surface_rates[p] = prev_well_state.well(this->index_of_well_).surface_rates[p];
             }
         } else {
             for (int p = 0; p<np; ++p){
-                ws.explicit_surface_rates[p] = ws.surface_rates[p];
+                ws.prev_surface_rates[p] = ws.surface_rates[p];
             }
         }
     }

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1198,16 +1198,11 @@ namespace Opm
     setPrevSurfaceRates(WellState& well_state, 
                             const WellState& prev_well_state) const
     {
-        const int np = this->number_of_phases_;
         auto& ws = well_state.well(this->index_of_well_);
         if (!this->changedToOpenThisStep()){
-            for (int p = 0; p<np; ++p){
-                ws.prev_surface_rates[p] = prev_well_state.well(this->index_of_well_).surface_rates[p];
-            }
+            ws.prev_surface_rates = prev_well_state.well(this->index_of_well_).surface_rates;
         } else {
-            for (int p = 0; p<np; ++p){
-                ws.prev_surface_rates[p] = ws.surface_rates[p];
-            }
+            ws.prev_surface_rates = ws.surface_rates;
         }
     }
 

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -1191,14 +1191,16 @@ add_test_compareECLFiles(CASENAME 01_wgrupcon
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
-                         DIR wgrupcon)
+                         DIR wgrupcon
+                         TEST_ARGS --enable-tuning=true)
 
 add_test_compareECLFiles(CASENAME 02_wgrupcon
                          FILENAME 02-WGRUPCON
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
-                         DIR wgrupcon)
+                         DIR wgrupcon
+                         TEST_ARGS --enable-tuning=true)
 add_test_compareECLFiles(CASENAME winjmult_stdw
                          FILENAME WINJMULT_STDW
                          SIMULATOR flow


### PR DESCRIPTION
When ~= zero rates are encountered during iterations (pre convergence), gas/water fractions become highly inaccuate which in turn may lead to solver getting stucked/well getting shut prematurely. A possible remedy suggested here is to switch to explicit lookup whenver rate drops below lowest value in table. To ensure that this approach also works for just opened wells, the logic around explicit lookup is also updated (since master implementation always employ implicit lookup for first step regardless).

The PR fixes issues for a few simple test-cases, but requires further testing   
