### PR TITLE
Don't Provide Deck Accessors in FlowMainEbos

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -431,12 +431,6 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
             }
         }
 
-        const Deck& deck() const
-        { return ebosSimulator_->vanguard().deck(); }
-
-        Deck& deck()
-        { return ebosSimulator_->vanguard().deck(); }
-
         const EclipseState& eclState() const
         { return ebosSimulator_->vanguard().eclState(); }
 


### PR DESCRIPTION
Following commits f4f8c033d and c7016854d (PR #4286), the "vanguard" no longer maintains an internal `Deck` data member.  Don't pretend that it does by providing member functions to access that data member.  If someone tries to actually call these member functions then they will get an unfriendly diagnostic message and a build failure.