### PR TITLE
added: set vappars in fluidsystem/pvt at start of report step

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1038,6 +1038,15 @@ public:
         // Evaluate UDQ assign statements to make sure the settings are
         // available as UDA controls for the current report step.
         actionHandler_.evalUDQAssignments(episodeIdx, simulator.vanguard().udqState());
+
+        if (episodeIdx >= 0) {
+            const auto& oilVap = schedule[episodeIdx].oilvap();
+            if (oilVap.getType() == OilVaporizationProperties::OilVaporization::VAPPARS) {
+                FluidSystem::setVapPars(oilVap.vap1(), oilVap.vap2());
+            } else {
+                FluidSystem::setVapPars(0.0, 0.0);
+            }
+        }
     }
 
     /*!


### PR DESCRIPTION
to properly handle vappars updates in SCHEDULE

Downstream of https://github.com/OPM/opm-common/pull/3553