### PR TITLE
Fixing the perfRates initialization with all zero motiblity

### DIFF
--- a/opm/simulators/wells/StandardWellConnections.cpp
+++ b/opm/simulators/wells/StandardWellConnections.cpp
@@ -35,6 +35,7 @@
 #include <opm/simulators/wells/WellInterfaceIndices.hpp>
 #include <opm/simulators/wells/WellState.hpp>
 
+#include <limits>
 #include <numeric>
 #include <sstream>
 
@@ -475,21 +476,32 @@ computeProperties(const WellState& well_state,
             const int cell_idx = well_.cells()[perf];
             const double well_tw_fraction = well_.wellIndex()[perf] / total_tw;
             double total_mobility = 0.0;
+            double total_invB = 0.;
             for (int p = 0; p < np; ++p) {
                 int ebosPhaseIdx = well_.flowPhaseToEbosPhaseIdx(p);
                 total_mobility += invB(cell_idx, ebosPhaseIdx) * mobility(cell_idx, ebosPhaseIdx);
+                total_invB += invB(cell_idx, ebosPhaseIdx);
             }
             if constexpr (Indices::enableSolvent) {
                 total_mobility += solventInverseFormationVolumeFactor(cell_idx) * solventMobility(cell_idx);
+                total_invB += solventInverseFormationVolumeFactor(cell_idx);
             }
+            const bool non_zero_total_mobility = total_mobility > std::numeric_limits<double>::min();
+            assert(total_invB > std::numeric_limits<double>::min());
+            // for the perforation having zero mobility for all the phases, we use a small value to generate a small
+            // perforation rates for those perforations, at the same time, we can use the rates to recover the mixing
+            // ratios for those perforations.
+            constexpr double small_value = 1.e-10;
             for (int p = 0; p < np; ++p) {
-                int ebosPhaseIdx = well_.flowPhaseToEbosPhaseIdx(p);
-                perfRates[perf * well_.numComponents() + p] = well_tw_fraction *
-                        invB(cell_idx, ebosPhaseIdx) * mobility(cell_idx, ebosPhaseIdx) / total_mobility;
+                const int ebosPhaseIdx = well_.flowPhaseToEbosPhaseIdx(p);
+                const double factor = non_zero_total_mobility ?
+                    invB(cell_idx, ebosPhaseIdx) * mobility(cell_idx, ebosPhaseIdx) / total_mobility : invB(cell_idx, ebosPhaseIdx) * small_value / total_invB;
+                perfRates[perf * well_.numComponents() + p] = well_tw_fraction * factor;
             }
             if constexpr (Indices::enableSolvent) {
-                perfRates[perf * well_.numComponents() + Indices::contiSolventEqIdx] = well_tw_fraction *
-                        solventInverseFormationVolumeFactor(cell_idx) * solventMobility(cell_idx) / total_mobility;
+                const double factor = non_zero_total_mobility ?
+                      solventInverseFormationVolumeFactor(cell_idx) * solventMobility(cell_idx) / total_mobility : solventInverseFormationVolumeFactor(cell_idx) * small_value / total_invB;
+                perfRates[perf * well_.numComponents() + Indices::contiSolventEqIdx] = well_tw_fraction * factor;
             }
         }
     }


### PR DESCRIPTION
For this part of code in the master branch, it was assumed that the total_mobility will not be zero. 

But for one case that we are looking at, there are some cells with oil-water (zero gas saturation), we have the relative permeability (also mobility) for all the three phases are zero. 

This PR assuming the mobility for all the phases are equal for the situation above. 

Since the original perfRates initialization is far from accurate,  mostly hoping to have a not too bad perfRates ratios for the wellbore density calculation. 

The PR only aims to recover the running for the special situation of that specific case without attempting to improve the original initialization design.  

I mark it as draft before confirmed by the reporter. 

It contains the PR https://github.com/OPM/opm-simulators/pull/4681 , which is a pure bug fix.  PR https://github.com/OPM/opm-simulators/pull/4681 should go in first or closed if this PR goes in directly. 