### PR TITLE
correct reservoir rate constraint calculation

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelConstraints.cpp
+++ b/opm/simulators/wells/BlackoilWellModelConstraints.cpp
@@ -311,13 +311,13 @@ checkGroupProductionConstraints(const Group& group,
             double current_rate = 0.0;
             current_rate += WellGroupHelpers::sumWellResRates(group, wellModel_.schedule(),
                                                               well_state, reportStepIdx,
-                                                              pu.phase_pos[BlackoilPhases::Aqua], true);
+                                                              pu.phase_pos[BlackoilPhases::Aqua], false);
             current_rate += WellGroupHelpers::sumWellResRates(group, wellModel_.schedule(),
                                                               well_state, reportStepIdx,
-                                                              pu.phase_pos[BlackoilPhases::Liquid], true);
+                                                              pu.phase_pos[BlackoilPhases::Liquid], false);
             current_rate += WellGroupHelpers::sumWellResRates(group, wellModel_.schedule(),
                                                               well_state, reportStepIdx,
-                                                              pu.phase_pos[BlackoilPhases::Vapour], true);
+                                                              pu.phase_pos[BlackoilPhases::Vapour], false);
 
             // sum over all nodes
             current_rate = wellModel_.comm().sum(current_rate);


### PR DESCRIPTION
The `RESV` constraint was not honored specifying e.g.

 ```
GCONPROD 
-- if item 14 (RESV) is non-default this constraint should be honored (irrespective of item 7)
--   1     2      ORATE  WRATE GRATE LRATE    7	     8   ...      RESV           
  'PROD' 'LRAT'   1000. 1*     1.E6  2500.  'RATE' 'YES' 1* 1*  3* 800 
```

With the proposed change OPM-flow behaves the same as the commercial simulator, see figure below where also the RESV volume rate (orange line) is shown using the OPM master that clearly violates the constraint.
![image](https://github.com/OPM/opm-simulators/assets/56635911/0953fce8-29b6-4996-9631-8d7c3dd3896a)
