### PR TITLE
Hook New WBPn Calculation Up to Well Model

### DIFF
--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -210,7 +210,7 @@ public:
             simulator_.vanguard().setupTime();
 
         const auto localWellData            = simulator_.problem().wellModel().wellData();
-        const auto localWBP                 = data::WellBlockAveragePressures{};
+        const auto localWBP                 = simulator_.problem().wellModel().wellBlockAveragePressures();
         const auto localGroupAndNetworkData = simulator_.problem().wellModel()
             .groupAndNetworkData(reportStepNum);
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -137,6 +137,9 @@ namespace Opm
                                              WellState& well_state,
                                              DeferredLogger& deferred_logger) const override;
 
+        double connectionDensity(const int globalConnIdx,
+                                 const int openConnIdx) const override;
+
         void addWellContributions(SparseMatrixAdapter& jacobian) const override;
 
         void addWellPressureEquations(PressureMatrix& mat,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -21,8 +21,12 @@
 #include <opm/common/Exceptions.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 
+#include <opm/input/eclipse/Schedule/MSW/Segment.hpp>
 #include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
+#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
+#include <opm/input/eclipse/Schedule/Well/Connection.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
+
 #include <opm/input/eclipse/Units/Units.hpp>
 
 #include <opm/material/densead/EvaluationFormat.hpp>
@@ -697,6 +701,28 @@ namespace Opm
 
         assert (static_cast<int>(subsetPerfID) == this->number_of_perforations_ &&
                 "Internal logic error in processing connections for PI/II");
+    }
+
+
+
+
+
+    template<typename TypeTag>
+    double
+    MultisegmentWell<TypeTag>::
+    connectionDensity(const int globalConnIdx,
+                      [[maybe_unused]] const int openConnIdx) const
+    {
+        // Simple approximation: Mixture density at reservoir connection is
+        // mixture density at connection's segment.
+
+        const auto segNum = this->wellEcl()
+            .getConnections()[globalConnIdx].segment();
+
+        const auto segIdx = this->wellEcl()
+            .getSegments().segmentNumberToIndex(segNum);
+
+        return this->segments_.density(segIdx).value();
     }
 
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -185,6 +185,9 @@ namespace Opm
                                              WellState& well_state,
                                              DeferredLogger& deferred_logger) const override;
 
+        virtual double connectionDensity(const int globalConnIdx,
+                                         const int openConnIdx) const override;
+
         virtual void addWellContributions(SparseMatrixAdapter& mat) const override;
 
         virtual void addWellPressureEquations(PressureMatrix& mat,

--- a/opm/simulators/wells/StandardWellConnections.hpp
+++ b/opm/simulators/wells/StandardWellConnections.hpp
@@ -73,7 +73,19 @@ public:
     //! \brief Returns density for first perforation.
     Scalar rho() const
     {
-        return this->perf_densities_.empty() ? 0.0 : perf_densities_[0];
+        return this->rho(0);
+    }
+
+    //! \brief Returns density for specific perforation/connection.
+    //!
+    //! \param[in] i Connection index
+    //!
+    //! \return Mixture density at connection \p i.
+    Scalar rho(const typename std::vector<Scalar>::size_type i) const
+    {
+        return (i < this->perf_densities_.size())
+            ? this->perf_densities_[i]
+            : 0.0;
     }
 
     //! \brief Returns pressure drop for a given perforation.

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1570,6 +1570,23 @@ namespace Opm
 
 
 
+
+
+    template<typename TypeTag>
+    double
+    StandardWell<TypeTag>::
+    connectionDensity([[maybe_unused]] const int globalConnIdx,
+                      const int openConnIdx) const
+    {
+        return (openConnIdx < 0)
+            ? 0.0
+            : this->connections_.rho(openConnIdx);
+    }
+
+
+
+
+
     template<typename TypeTag>
     void
     StandardWell<TypeTag>::

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -254,6 +254,9 @@ public:
                                          WellState& well_state,
                                          DeferredLogger& deferred_logger) const = 0;
 
+    virtual double connectionDensity(const int globalConnIdx,
+                                     const int openConnIdx) const = 0;
+
     /// \brief Wether the Jacobian will also have well contributions in it.
     virtual bool jacobianContainsWellContributions() const
     {


### PR DESCRIPTION
This PR activates the support for calculating WBPn summary result values per well in parallel.  To affect the calculation we add two new data members in BlackoilWellModelGeneric:

  - `conn_idx_map_`:  Maps well's connection index (`0..getConnections().size() - 1`) to connections on current rank.  Its `local()` connections are negative 1 (`-1`) if the connection is not on current rank, and a non-negative value otherwise.  The `global()` function maps well connections on current rank to global connection ID for each well.  Effectively the reverse of `local()`.  Finally, the `open()` function maps well connections on current rank to open/flowing connections on current rank. Negative 1 if connection is not flowing.

  - `wbpCalculationService`: Parallel collection of WBPn calculation objects that knows how to exchange source and result information between all ranks in a communicator.  Also handles distributed wells.

We furthermore need a way to compute connection-level fluid mixture density values.  For the standard well class we add a way to access the `StandardWellConnection`'s `perf_densities_` values.  However, since these are defined for open/flowing connections only, this means we're not able to fully meet the requirements of the
```
WELL/ALL
```
`WPAVE` depth correction procedure for standard wells.  The multi-segmented well type, on the other hand, uses the fluid mixture density in the associated well segment and is therefore well defined for `ALL` connections.  `OPEN` well connections are supported for both well types.