### PR TITLE
Do not set pressure diff to zero when not necessary.

### DIFF
--- a/ebos/eclfluxmodule.hh
+++ b/ebos/eclfluxmodule.hh
@@ -389,14 +389,16 @@ public:
         // of threshold pressure is a quite big hack that only makes sense for ECL
         // datasets. (and even there, its physical justification is quite
         // questionable IMO.)
-        if (std::abs(Toolbox::value(pressureDifference)) > thpres) {
-            if (pressureDifference < 0.0)
-                pressureDifference += thpres;
-            else
-                pressureDifference -= thpres;
-        }
-        else {
-            pressureDifference = 0.0;
+        if (thpres > 0.0) {
+            if (std::abs(Toolbox::value(pressureDifference)) > thpres) {
+                if (pressureDifference < 0.0)
+                    pressureDifference += thpres;
+                else
+                    pressureDifference -= thpres;
+            }
+            else {
+                pressureDifference = 0.0;
+            }
         }
     }
 


### PR DESCRIPTION
With zero threshold pressure and zero pressure difference, the existing code will set the pressure diff explicitly to zero. This will also set any derivatives to zero as well, which may disconnect the corresponding matrix rows.