### PR TITLE
Chase Upstream API Update

### DIFF
--- a/ebos/eclactionhandler.cc
+++ b/ebos/eclactionhandler.cc
@@ -256,7 +256,7 @@ void EclActionHandler::evalUDQAssignments(const unsigned episodeIdx,
 {
     const auto& udq = schedule_[episodeIdx].udq();
     const auto& well_matcher = schedule_.wellMatcher(episodeIdx);
-    udq.eval_assign(episodeIdx, well_matcher, summaryState_, udq_state);
+    udq.eval_assign(episodeIdx, schedule_, well_matcher, summaryState_, udq_state);
 }
 
 } // namespace Opm

--- a/ebos/eclgenericwriter.cc
+++ b/ebos/eclgenericwriter.cc
@@ -578,6 +578,7 @@ evalSummary(const int                                            reportStepNum,
 
         this->schedule_.getUDQConfig(udq_step)
             .eval(udq_step,
+                  this->schedule_,
                   this->schedule_.wellMatcher(udq_step),
                   summaryState,
                   udqState);


### PR DESCRIPTION
The `eval_assign()` and `eval()` member functions of `UDQConfig` now take a `const Schedule&` parameter.