### PR TITLE
Equilibration with PPCWMAX

### DIFF
--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -544,7 +544,7 @@ private:
     /// \param[in] pcow O/W capillary pressure value (Po - Pw).
     ///
     /// \return Water saturation value.
-    std::tuple<double, bool> applySwatInit(const double pcow);
+    std::pair<double, bool> applySwatInit(const double pcow);
 
     /// Derive water saturation from SWATINIT data.
     ///
@@ -558,7 +558,7 @@ private:
     ///
     /// \return Water saturation value.  Input value, possibly mollified by
     ///    current set of material laws.
-    std::tuple<double, bool> applySwatInit(const double pc, const double sw);
+    std::pair<double, bool> applySwatInit(const double pc, const double sw);
 
     /// Invoke material law container's capillary pressure calculator on
     /// current fluid state.

--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -544,7 +544,7 @@ private:
     /// \param[in] pcow O/W capillary pressure value (Po - Pw).
     ///
     /// \return Water saturation value.
-    double applySwatInit(const double pcow);
+    std::tuple<double, bool> applySwatInit(const double pcow);
 
     /// Derive water saturation from SWATINIT data.
     ///
@@ -558,7 +558,7 @@ private:
     ///
     /// \return Water saturation value.  Input value, possibly mollified by
     ///    current set of material laws.
-    double applySwatInit(const double pc, const double sw);
+    std::tuple<double, bool> applySwatInit(const double pc, const double sw);
 
     /// Invoke material law container's capillary pressure calculator on
     /// current fluid state.

--- a/ebos/equil/initstateequil_impl.hh
+++ b/ebos/equil/initstateequil_impl.hh
@@ -699,10 +699,11 @@ void PhaseSaturations<MaterialLawManager, FluidSystem, Region, CellID>::deriveWa
         }
         else {
             auto [swout, newSwatInit] = this->applySwatInit(pcow);
-            if (newSwatInit == true)
+            if (newSwatInit)
                 sw = this->invertCapPress(pcow, this->waterPos(), isIncr);
-            else
+            else {
                 sw = swout;
+            }
         }
     }
 }
@@ -730,8 +731,9 @@ fixUnphysicalTransition()
             const auto isIncr = false; // dPcow/dSw <= 0 for all Sw.
             sw = this->invertCapPress(pcgw, this->waterPos(), isIncr);
         }
-        else
+        else {
             sw = swout;
+        }
     }
 
     sw = satFromSumOfPcs<FluidSystem>
@@ -859,21 +861,19 @@ accountForScaledSaturations()
 }
 
 template <class MaterialLawManager, class FluidSystem, class Region, typename CellID>
-std::tuple<double, bool>
+std::pair<double, bool>
 PhaseSaturations<MaterialLawManager, FluidSystem, Region, CellID>::
 applySwatInit(const double pcow)
 {
-    auto [swout, newSwatInit] = this->applySwatInit(pcow, this->swatInit_[this->evalPt_.position->cell]);
-    return {swout, newSwatInit};
+    return this->applySwatInit(pcow, this->swatInit_[this->evalPt_.position->cell]);
 }
 
 template <class MaterialLawManager, class FluidSystem, class Region, typename CellID>
-std::tuple<double, bool>
+std::pair<double, bool>
 PhaseSaturations<MaterialLawManager, FluidSystem, Region, CellID>::
 applySwatInit(const double pcow, const double sw)
 {
-    auto [swout, newSwatInit] =this->matLawMgr_.applySwatinit(this->evalPt_.position->cell, pcow, sw);
-    return {swout, newSwatInit};
+    return this->matLawMgr_.applySwatinit(this->evalPt_.position->cell, pcow, sw);
 }
 
 template <class MaterialLawManager, class FluidSystem, class Region, typename CellID>

--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -490,7 +490,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"PLYATEMP", {true, std::nullopt}},
         {"PLYCAMAX", {true, std::nullopt}},
         {"PLYDHFLF", {true, std::nullopt}},
-        {"PPCWMAX", {true, std::nullopt}},
         {"PRORDER", {true, std::nullopt}},
         {"PRVD", {true, std::nullopt}},
         {"PVTGWO", {true, std::nullopt}},

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -495,6 +495,13 @@ add_test_compareECLFiles(CASENAME co2store
                          REL_TOL ${rel_tol}
                          DIR co2store)
 
+add_test_compareECLFiles(CASENAME ppcwmax
+                         FILENAME PPCWMAX-01
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR ppcwmax)
+
 add_test_compareECLFiles(CASENAME co2store_diffusive
                          FILENAME CO2STORE_DIFFUSIVE
                          SIMULATOR flow


### PR DESCRIPTION
This implements changes accommodating PPCWMAX when applying SWATINIT in equilibration, in particular the re-calculation of initial water saturation.

Depends on https://github.com/OPM/opm-common/pull/3570 