### PR TITLE
OpenMP: allow oversubscribing to prevent only 1 thread on some hardware

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -387,7 +387,10 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
                 if (requested_threads > 0)
                     threads = requested_threads;
 
-                omp_set_num_threads(std::min(threads, omp_get_num_procs()));
+                // We are not limiting this to the number of processes
+                // reported by OpenMP as on some hardware (and some OpenMPI
+                // versions) this will be 1 when run with mpirun
+                omp_set_num_threads(threads);
             }
 #endif
 

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -670,15 +670,17 @@ private:
         // This function is called before the parallel OpenMP stuff gets initialized.
         // That initialization happends after the deck is read and we want this message.
         // Hence we duplicate the code of setupParallelism to get the number of threads.
-        if (std::getenv("OMP_NUM_THREADS"))
+        if (std::getenv("OMP_NUM_THREADS")) {
             threads =  omp_get_max_threads();
-        else
-            threads = std::min(2, omp_get_max_threads());
+        }
+        else {
+            threads = 2;
 
-        const int input_threads = EWOMS_GET_PARAM(TypeTag, int, ThreadsPerProcess);
+            const int input_threads = EWOMS_GET_PARAM(TypeTag, int, ThreadsPerProcess);
 
-        if (input_threads > 0)
-            threads = std::min(input_threads, omp_get_max_threads());
+            if (input_threads > 0)
+                threads = input_threads;
+        }
 #endif
 
         return threads;


### PR DESCRIPTION
Note that this needs OPM/opm-models#811

There is a strange interaction when using MPI and OpenMP on some hardware/MPI implementations. I a serial run omp_get_num_procs() would return the number of processors but when started under mpirun it would always return 1.
    
 With this we now allow users to use any amount of threads as we want to be able to use 2 threads on such machines.

Together with the companion PR we also make sure that the number of threads used by the linearizer is consistent with here (Prefer OMP_NUM_THREADS over command-line ThreadsPerProcess and use 2 if nothing is specified).