### PR TITLE
Adding --num-pressure-points-equil as a developer parameter 

### DIFF
--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -118,7 +118,8 @@ public:
                                  vanguard.grid(),
                                  vanguard.gridView(),
                                  vanguard.cartesianMapper(),
-                                 simulator.problem().gravity()[dimWorld - 1]);
+                                 simulator.problem().gravity()[dimWorld - 1],
+                                 simulator.problem().numPressurePointsEquil());
 
         // copy the result into the array of initial fluid states
         initialFluidStates_.resize(numElems);

--- a/ebos/eclgenericproblem.hh
+++ b/ebos/eclgenericproblem.hh
@@ -272,6 +272,9 @@ public:
     { return maxFails_; }
 
     bool vapparsActive(int episodeIdx) const;
+    
+    int numPressurePointsEquil() const 
+    { return numPressurePointsEquil_; }
 
     bool operator==(const EclGenericProblem& rhs) const;
 
@@ -404,6 +407,9 @@ protected:
     Scalar restartShrinkFactor_;
     unsigned maxFails_;
     Scalar minTimeStepSize_;
+    
+    // equilibration parameters
+    int numPressurePointsEquil_;
 
 private:
     template<class T>

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -198,6 +198,12 @@ template<class TypeTag, class MyTypeTag>
 struct OutputMode {
     using type = UndefinedProperty;
 };
+// Parameterize equilibration accuracy
+template<class TypeTag, class MyTypeTag>
+struct NumPressurePointsEquil {
+    using type = UndefinedProperty;
+};
+
 
 // Set the problem property
 template<class TypeTag>
@@ -583,6 +589,12 @@ template<class TypeTag>
 struct OutputMode<TypeTag, TTag::EclBaseProblem> {
     static constexpr auto value = "all";
 };
+// Parameterize equilibration accuracy
+template<class TypeTag>
+struct NumPressurePointsEquil<TypeTag, TTag::EclBaseProblem> {
+    static constexpr int value = 2000;
+};
+
 
 } // namespace Opm::Properties
 
@@ -727,6 +739,9 @@ public:
                              "Honor some aspects of the TUNING keyword from the ECL deck.");
         EWOMS_REGISTER_PARAM(TypeTag, std::string, OutputMode,
                              "Specify which messages are going to be printed. Valid values are: none, log, all (default)");
+        EWOMS_REGISTER_PARAM(TypeTag, int, NumPressurePointsEquil,
+                             "Number of pressure points (in each direction) in tables used for equilibration");
+        EWOMS_HIDE_PARAM(TypeTag, NumPressurePointsEquil); // Users will typically not need to modify this parameter..
 
     }
 
@@ -806,6 +821,7 @@ public:
         this->maxTimeStepAfterWellEvent_ = EWOMS_GET_PARAM(TypeTag, Scalar, EclMaxTimeStepSizeAfterWellEvent);
         this->restartShrinkFactor_ = EWOMS_GET_PARAM(TypeTag, Scalar, EclRestartShrinkFactor);
         this->maxFails_ = EWOMS_GET_PARAM(TypeTag, unsigned, MaxTimeStepDivisions);
+        this->numPressurePointsEquil_ = EWOMS_GET_PARAM(TypeTag, int, NumPressurePointsEquil);
 
         RelpermDiagnostics relpermDiagnostics;
         relpermDiagnostics.diagnosis(vanguard.eclState(), vanguard.cartesianIndexMapper());

--- a/ebos/equil/initstateequil.cc
+++ b/ebos/equil/initstateequil.cc
@@ -57,6 +57,7 @@ template InitialStateComputer<BlackOilFluidSystem<double>,
                          const GridView&,
                          const Dune::CartesianIndexMapper<Dune::CpGrid>&,
                          const double,
+                         const int,
                          const bool);
 #if HAVE_DUNE_ALUGRID
 #if HAVE_MPI
@@ -84,6 +85,7 @@ template InitialStateComputer<BlackOilFluidSystem<double>,
                          const ALUGridView&,
                          const Dune::CartesianIndexMapper<ALUGrid3CN>&,
                          const double,
+                         const int,
                          const bool);
 #endif //HAVE_DUNE_ALUGRID
 

--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -686,7 +686,7 @@ public:
                          const GridView& gridView,
                          const CartesianIndexMapper& cartMapper,
                          const double grav,
-                         const int num_pressure_points,
+                         const int num_pressure_points = 2000,
                          const bool applySwatInit = true);
 
     using Vec = std::vector<double>;

--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -686,6 +686,7 @@ public:
                          const GridView& gridView,
                          const CartesianIndexMapper& cartMapper,
                          const double grav,
+                         const int num_pressure_points,
                          const bool applySwatInit = true);
 
     using Vec = std::vector<double>;
@@ -763,6 +764,7 @@ private:
     Vec cellCenterDepth_;
     std::vector<std::pair<double,double>> cellZSpan_;
     std::vector<std::pair<double,double>> cellZMinMax_;
+    int num_pressure_points_;
 };
 
 } // namespace DeckDependent

--- a/ebos/equil/initstateequil_impl.hh
+++ b/ebos/equil/initstateequil_impl.hh
@@ -1299,6 +1299,7 @@ InitialStateComputer(MaterialLawManager& materialLawManager,
                      const GridView& gridView,
                      const CartesianIndexMapper& cartMapper,
                      const double grav,
+                     const int num_pressure_points,
                      const bool applySwatInit)
     : temperature_(grid.size(/*codim=*/0)),
       saltConcentration_(grid.size(/*codim=*/0)),
@@ -1310,7 +1311,8 @@ InitialStateComputer(MaterialLawManager& materialLawManager,
       rs_(grid.size(/*codim=*/0)),
       rv_(grid.size(/*codim=*/0)),
       rvw_(grid.size(/*codim=*/0)),
-      cartesianIndexMapper_(cartMapper)
+      cartesianIndexMapper_(cartMapper),
+      num_pressure_points_(num_pressure_points)
 {
     //Check for presence of kw SWATINIT
     if (applySwatInit) {
@@ -1750,8 +1752,8 @@ calcPressSatRsRv(const RMap& reg,
     using PhaseSat = Details::PhaseSaturations<
         MaterialLawManager, FluidSystem, EquilReg, typename RMap::CellId
     >;
-
-    auto ptable = Details::PressureTable<FluidSystem, EquilReg>{ grav };
+    
+    auto ptable = Details::PressureTable<FluidSystem, EquilReg>{ grav, this->num_pressure_points_ };
     auto psat   = PhaseSat { materialLawManager, this->swatInit_ };
     auto vspan  = std::array<double, 2>{};
 


### PR DESCRIPTION
Adding a developer parameter (invisible to end users) to change the number of pressure table points used in equilibration. 