### PR TITLE
Move connection rate helpers to StandardWellConnections

### DIFF
--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -443,10 +443,6 @@ namespace Opm
                                   const IntensiveQuantities& intQuants,
                                   DeferredLogger& deferred_logger) const;
 
-        Eval connectionRateFoam(const std::vector<EvalWell>& cq_s,
-                                const IntensiveQuantities& intQuants,
-                                DeferredLogger& deferred_logger) const;
-
         std::tuple<Eval,Eval,Eval>
         connectionRatesMICP(const std::vector<EvalWell>& cq_s,
                             const IntensiveQuantities& intQuants) const;

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -444,11 +444,6 @@ namespace Opm
                                   DeferredLogger& deferred_logger) const;
 
         std::tuple<Eval,EvalWell>
-        connectionRatePolymer(double& rate,
-                              const std::vector<EvalWell>& cq_s,
-                              const IntensiveQuantities& intQuants) const;
-
-        std::tuple<Eval,EvalWell>
         connectionRatezFraction(double& rate,
                                 const double dis_gas_rate,
                                 const std::vector<EvalWell>& cq_s,

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -443,10 +443,6 @@ namespace Opm
                                   const IntensiveQuantities& intQuants,
                                   DeferredLogger& deferred_logger) const;
 
-        std::tuple<Eval,Eval,Eval>
-        connectionRatesMICP(const std::vector<EvalWell>& cq_s,
-                            const IntensiveQuantities& intQuants) const;
-
         std::tuple<Eval,EvalWell>
         connectionRatePolymer(double& rate,
                               const std::vector<EvalWell>& cq_s,

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -438,11 +438,6 @@ namespace Opm
                                                       DeferredLogger& deferred_logger) const;
 
     private:
-        Eval connectionRateBrine(double& rate,
-                                 const double vap_wat_rate,
-                                 const std::vector<EvalWell>& cq_s,
-                                 const IntensiveQuantities& intQuants) const;
-
         Eval connectionRateEnergy(const double maxOilSaturation,
                                   const std::vector<EvalWell>& cq_s,
                                   const IntensiveQuantities& intQuants,

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -443,12 +443,6 @@ namespace Opm
                                   const IntensiveQuantities& intQuants,
                                   DeferredLogger& deferred_logger) const;
 
-        std::tuple<Eval,EvalWell>
-        connectionRatezFraction(double& rate,
-                                const double dis_gas_rate,
-                                const std::vector<EvalWell>& cq_s,
-                                const IntensiveQuantities& intQuants) const;
-
         template<class Value>
         void gasOilPerfRateInj(const std::vector<Value>& cq_s,
                                PerforationRates& perf_rates,

--- a/opm/simulators/wells/StandardWellConnections.cpp
+++ b/opm/simulators/wells/StandardWellConnections.cpp
@@ -578,6 +578,43 @@ connectionRateFoam(const std::vector<EvalWell>& cq_s,
     return well_.restrictEval(cq_s_foam);
 }
 
+template<class FluidSystem, class Indices, class Scalar>
+std::tuple<typename StandardWellConnections<FluidSystem,Indices,Scalar>::Eval,
+           typename StandardWellConnections<FluidSystem,Indices,Scalar>::Eval,
+           typename StandardWellConnections<FluidSystem,Indices,Scalar>::Eval>
+StandardWellConnections<FluidSystem,Indices,Scalar>::
+connectionRatesMICP(const std::vector<EvalWell>& cq_s,
+                    const std::variant<Scalar,EvalWell>& microbialConcentration,
+                    const std::variant<Scalar,EvalWell>& oxygenConcentration,
+                    const std::variant<Scalar,EvalWell>& ureaConcentration) const
+{
+    const unsigned waterCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx);
+    EvalWell cq_s_microbe = cq_s[waterCompIdx];
+    if (well_.isInjector()) {
+        cq_s_microbe *= std::get<Scalar>(microbialConcentration);
+    } else {
+        cq_s_microbe *= std::get<EvalWell>(microbialConcentration);
+    }
+
+    EvalWell cq_s_oxygen = cq_s[waterCompIdx];
+    if (well_.isInjector()) {
+        cq_s_oxygen *= std::get<Scalar>(oxygenConcentration);
+    } else {
+        cq_s_oxygen *= std::get<EvalWell>(oxygenConcentration);
+    }
+
+    EvalWell cq_s_urea = cq_s[waterCompIdx];
+    if (well_.isInjector()) {
+        cq_s_urea *= std::get<Scalar>(ureaConcentration);
+    } else {
+        cq_s_urea *= std::get<EvalWell>(ureaConcentration);
+    }
+
+    return {well_.restrictEval(cq_s_microbe),
+            well_.restrictEval(cq_s_oxygen),
+            well_.restrictEval(cq_s_urea)};
+}
+
 #define INSTANCE(...) \
 template class StandardWellConnections<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>, \
                                        __VA_ARGS__,double>;

--- a/opm/simulators/wells/StandardWellConnections.cpp
+++ b/opm/simulators/wells/StandardWellConnections.cpp
@@ -615,6 +615,30 @@ connectionRatesMICP(const std::vector<EvalWell>& cq_s,
             well_.restrictEval(cq_s_urea)};
 }
 
+template<class FluidSystem, class Indices, class Scalar>
+std::tuple<typename StandardWellConnections<FluidSystem,Indices,Scalar>::Eval,
+           typename StandardWellConnections<FluidSystem,Indices,Scalar>::EvalWell>
+StandardWellConnections<FluidSystem,Indices,Scalar>::
+connectionRatePolymer(double& rate,
+                    const std::vector<EvalWell>& cq_s,
+                    const std::variant<Scalar,EvalWell>& polymerConcentration) const
+{
+    // TODO: the application of well efficiency factor has not been tested with an example yet
+    const unsigned waterCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx);
+    EvalWell cq_s_poly = cq_s[waterCompIdx];
+    if (well_.isInjector()) {
+        cq_s_poly *= std::get<Scalar>(polymerConcentration);
+    } else {
+        cq_s_poly *= std::get<EvalWell>(polymerConcentration);
+    }
+    // Note. Efficiency factor is handled in the output layer
+    rate = cq_s_poly.value();
+
+    cq_s_poly *= well_.wellEfficiencyFactor();
+
+    return {well_.restrictEval(cq_s_poly), cq_s_poly};
+}
+
 #define INSTANCE(...) \
 template class StandardWellConnections<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>, \
                                        __VA_ARGS__,double>;

--- a/opm/simulators/wells/StandardWellConnections.hpp
+++ b/opm/simulators/wells/StandardWellConnections.hpp
@@ -93,6 +93,11 @@ public:
                             const Phase transportPhase,
                             DeferredLogger& deferred_logger) const;
 
+    std::tuple<Eval,EvalWell>
+    connectionRatePolymer(double& rate,
+                          const std::vector<EvalWell>& cq_s,
+                          const std::variant<Scalar,EvalWell>& polymerConcentration) const;
+
     std::tuple<Eval,Eval,Eval>
     connectionRatesMICP(const std::vector<EvalWell>& cq_s,
                         const std::variant<Scalar,EvalWell>& microbialConcentration,

--- a/opm/simulators/wells/StandardWellConnections.hpp
+++ b/opm/simulators/wells/StandardWellConnections.hpp
@@ -104,6 +104,12 @@ public:
                         const std::variant<Scalar,EvalWell>& oxygenConcentration,
                         const std::variant<Scalar,EvalWell>& ureaConcentration) const;
 
+    std::tuple<Eval,EvalWell>
+    connectionRatezFraction(double& rate,
+                            const double dis_gas_rate,
+                            const std::vector<EvalWell>& cq_s,
+                            const std::variant<Scalar, std::array<EvalWell,2>>& solventConcentration) const;
+
 private:
     void computePressureDelta();
 

--- a/opm/simulators/wells/StandardWellConnections.hpp
+++ b/opm/simulators/wells/StandardWellConnections.hpp
@@ -93,6 +93,12 @@ public:
                             const Phase transportPhase,
                             DeferredLogger& deferred_logger) const;
 
+    std::tuple<Eval,Eval,Eval>
+    connectionRatesMICP(const std::vector<EvalWell>& cq_s,
+                        const std::variant<Scalar,EvalWell>& microbialConcentration,
+                        const std::variant<Scalar,EvalWell>& oxygenConcentration,
+                        const std::variant<Scalar,EvalWell>& ureaConcentration) const;
+
 private:
     void computePressureDelta();
 

--- a/opm/simulators/wells/StandardWellConnections.hpp
+++ b/opm/simulators/wells/StandardWellConnections.hpp
@@ -33,6 +33,7 @@ namespace Opm
 {
 
 class DeferredLogger;
+enum class Phase;
 template<class FluidSystem, class Indices, class Scalar> class WellInterfaceIndices;
 class WellState;
 
@@ -86,6 +87,11 @@ public:
                              const double vap_wat_rate,
                              const std::vector<EvalWell>& cq_s,
                              const std::variant<Scalar,EvalWell>& saltConcentration) const;
+
+    Eval connectionRateFoam(const std::vector<EvalWell>& cq_s,
+                            const std::variant<Scalar,EvalWell>& foamConcentration,
+                            const Phase transportPhase,
+                            DeferredLogger& deferred_logger) const;
 
 private:
     void computePressureDelta();

--- a/opm/simulators/wells/StandardWellConnections.hpp
+++ b/opm/simulators/wells/StandardWellConnections.hpp
@@ -23,7 +23,10 @@
 #ifndef OPM_STANDARDWELL_CONNECTIONS_HEADER_INCLUDED
 #define OPM_STANDARDWELL_CONNECTIONS_HEADER_INCLUDED
 
+#include <opm/simulators/wells/StandardWellPrimaryVariables.hpp>
+
 #include <functional>
+#include <variant>
 #include <vector>
 
 namespace Opm
@@ -75,6 +78,14 @@ public:
     //! \brief Returns pressure drop for a given perforation.
     Scalar pressure_diff(const unsigned perf) const
     { return perf_pressure_diffs_[perf]; }
+
+    using Eval = typename WellInterfaceIndices<FluidSystem,Indices,Scalar>::Eval;
+    using EvalWell = typename StandardWellPrimaryVariables<FluidSystem,Indices,Scalar>::EvalWell;
+
+    Eval connectionRateBrine(double& rate,
+                             const double vap_wat_rate,
+                             const std::vector<EvalWell>& cq_s,
+                             const std::variant<Scalar,EvalWell>& saltConcentration) const;
 
 private:
     void computePressureDelta();

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -558,10 +558,18 @@ namespace Opm
         }
 
         if constexpr (has_zFraction) {
+            std::variant<Scalar,std::array<EvalWell,2>> solventConcentration;
+            if (this->isInjector()) {
+                solventConcentration = this->wsolvent();
+            } else {
+                solventConcentration = std::array{this->extendEval(intQuants.xVolume()),
+                                                  this->extendEval(intQuants.yVolume())};
+            }
             std::tie(connectionRates[perf][Indices::contiZfracEqIdx],
                      cq_s_zfrac_effective) =
-                connectionRatezFraction(perf_data.solvent_rates[perf],
-                                        perf_rates.dis_gas, cq_s, intQuants);
+                this->connections_.connectionRatezFraction(perf_data.solvent_rates[perf],
+                                                           perf_rates.dis_gas, cq_s,
+                                                           solventConcentration);
         }
 
         if constexpr (has_brine) {
@@ -2253,32 +2261,6 @@ namespace Opm
         }
 
         return result;
-    }
-
-
-    template <typename TypeTag>
-    std::tuple<typename StandardWell<TypeTag>::Eval,
-               typename StandardWell<TypeTag>::EvalWell>
-    StandardWell<TypeTag>::
-    connectionRatezFraction(double& rate,
-                            const double dis_gas_rate,
-                            const std::vector<EvalWell>& cq_s,
-                            const IntensiveQuantities& intQuants) const
-    {
-        // TODO: the application of well efficiency factor has not been tested with an example yet
-        const unsigned gasCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx);
-        EvalWell cq_s_zfrac_effective = cq_s[gasCompIdx];
-        if (this->isInjector()) {
-            cq_s_zfrac_effective *= this->wsolvent();
-        } else if (cq_s_zfrac_effective.value() != 0.0) {
-            const double dis_gas_frac = dis_gas_rate / cq_s_zfrac_effective.value();
-            cq_s_zfrac_effective *= this->extendEval(dis_gas_frac*intQuants.xVolume() + (1.0-dis_gas_frac)*intQuants.yVolume());
-        }
-
-        rate = cq_s_zfrac_effective.value();
-
-        cq_s_zfrac_effective *= this->well_efficiency_factor_;
-        return {Base::restrictEval(cq_s_zfrac_effective), cq_s_zfrac_effective};
     }
 
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -524,11 +524,19 @@ namespace Opm
         }
 
         if constexpr (has_polymer) {
+            std::variant<Scalar,EvalWell> polymerConcentration;
+            if (this->isInjector()) {
+                polymerConcentration = this->wpolymer();
+            } else {
+                polymerConcentration = this->extendEval(intQuants.polymerConcentration() *
+                                                        intQuants.polymerViscosityCorrection());
+            }
+
             [[maybe_unused]] EvalWell cq_s_poly;
             std::tie(connectionRates[perf][Indices::contiPolymerEqIdx],
                      cq_s_poly) =
-                connectionRatePolymer(perf_data.polymer_rates[perf],
-                                      cq_s, intQuants);
+                this->connections_.connectionRatePolymer(perf_data.polymer_rates[perf],
+                                                         cq_s, polymerConcentration);
 
             if constexpr (Base::has_polymermw) {
                 updateConnectionRatePolyMW(cq_s_poly, intQuants, well_state,
@@ -2245,31 +2253,6 @@ namespace Opm
         }
 
         return result;
-    }
-
-
-    template <typename TypeTag>
-    std::tuple<typename StandardWell<TypeTag>::Eval,
-               typename StandardWell<TypeTag>::EvalWell>
-    StandardWell<TypeTag>::
-    connectionRatePolymer(double& rate,
-                          const std::vector<EvalWell>& cq_s,
-                          const IntensiveQuantities& intQuants) const
-    {
-        // TODO: the application of well efficiency factor has not been tested with an example yet
-        const unsigned waterCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx);
-        EvalWell cq_s_poly = cq_s[waterCompIdx];
-        if (this->isInjector()) {
-            cq_s_poly *= this->wpolymer();
-        } else {
-            cq_s_poly *= this->extendEval(intQuants.polymerConcentration() * intQuants.polymerViscosityCorrection());
-        }
-        // Note. Efficiency factor is handled in the output layer
-        rate = cq_s_poly.value();
-
-        cq_s_poly *= this->well_efficiency_factor_;
-
-        return {Base::restrictEval(cq_s_poly), cq_s_poly};
     }
 
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -549,9 +549,17 @@ namespace Opm
         }
 
         if constexpr (has_brine) {
+            std::variant<Scalar,EvalWell> saltConcentration;
+            if (this->isInjector()) {
+                saltConcentration = this->wsalt();
+            } else {
+                saltConcentration = this->extendEval(intQuants.fluidState().saltConcentration());
+            }
+
             connectionRates[perf][Indices::contiBrineEqIdx] =
-                connectionRateBrine(perf_data.brine_rates[perf],
-                                    perf_rates.vap_wat, cq_s, intQuants);
+                this->connections_.connectionRateBrine(perf_data.brine_rates[perf],
+                                                       perf_rates.vap_wat, cq_s,
+                                                       saltConcentration);
         }
 
         if constexpr (has_micp) {
@@ -2133,32 +2141,6 @@ namespace Opm
             this->primary_variables_.setValue(ii, it[ii]);
         }
         return num_pri_vars;
-    }
-
-
-    template <typename TypeTag>
-    typename StandardWell<TypeTag>::Eval
-    StandardWell<TypeTag>::
-    connectionRateBrine(double& rate,
-                        const double vap_wat_rate,
-                        const std::vector<EvalWell>& cq_s,
-                        const IntensiveQuantities& intQuants) const
-    {
-        // TODO: the application of well efficiency factor has not been tested with an example yet
-        const unsigned waterCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx);
-        // Correction salt rate; evaporated water does not contain salt
-        EvalWell cq_s_sm = cq_s[waterCompIdx] - vap_wat_rate;
-        if (this->isInjector()) {
-            cq_s_sm *= this->wsalt();
-        } else {
-            cq_s_sm *= this->extendEval(intQuants.fluidState().saltConcentration());
-        }
-
-        // Note. Efficiency factor is handled in the output layer
-        rate = cq_s_sm.value();
-
-        cq_s_sm *= this->well_efficiency_factor_;
-        return Base::restrictEval(cq_s_sm);
     }
 
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -72,6 +72,9 @@ class WellInterface : public WellInterfaceIndices<GetPropType<TypeTag, Propertie
                                                   GetPropType<TypeTag, Properties::Indices>,
                                                   GetPropType<TypeTag, Properties::Scalar>>
 {
+    using Base = WellInterfaceIndices<GetPropType<TypeTag, Properties::FluidSystem>,
+                                      GetPropType<TypeTag, Properties::Indices>,
+                                      GetPropType<TypeTag, Properties::Scalar>>;
 public:
     using ModelParameters = BlackoilModelParametersEbos<TypeTag>;
 
@@ -94,8 +97,8 @@ public:
 
     using VectorBlockType = Dune::FieldVector<Scalar, Indices::numEq>;
     using MatrixBlockType = Dune::FieldMatrix<Scalar, Indices::numEq, Indices::numEq>;
+    using Eval = typename Base::Eval;
     using BVector = Dune::BlockVector<VectorBlockType>;
-    using Eval = DenseAd::Evaluation<Scalar, /*size=*/Indices::numEq>;
     using PressureMatrix = Dune::BCRSMatrix<Opm::MatrixBlock<double, 1, 1>>;
 
     using RateConverterType =
@@ -269,17 +272,6 @@ public:
     void addCellRates(RateVector& rates, int cellIdx) const;
 
     Scalar volumetricSurfaceRateForConnection(int cellIdx, int phaseIdx) const;
-
-    template <class EvalWell>
-    Eval restrictEval(const EvalWell& in) const
-    {
-        Eval out = 0.0;
-        out.setValue(in.value());
-        for (int eqIdx = 0; eqIdx < Indices::numEq; ++eqIdx) {
-            out.setDerivative(eqIdx, in.derivative(eqIdx));
-        }
-        return out;
-    }
 
     // TODO: theoretically, it should be a const function
     // Simulator is not const is because that assembleWellEq is non-const Simulator

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -197,6 +197,10 @@ public:
 
     bool stopppedOrZeroRateTarget(const SummaryState& summary_state,
                                   const WellState& well_state) const;
+
+    double wellEfficiencyFactor() const
+    { return well_efficiency_factor_; }
+
 protected:
     bool getAllowCrossFlow() const;
 

--- a/opm/simulators/wells/WellInterfaceIndices.hpp
+++ b/opm/simulators/wells/WellInterfaceIndices.hpp
@@ -23,6 +23,8 @@
 #ifndef OPM_WELLINTERFACE_INDICES_HEADER_INCLUDED
 #define OPM_WELLINTERFACE_INDICES_HEADER_INCLUDED
 
+#include <opm/material/densead/Evaluation.hpp>
+
 #include <opm/simulators/wells/WellInterfaceFluidSystem.hpp>
 
 namespace Opm
@@ -35,10 +37,22 @@ public:
     using WellInterfaceFluidSystem<FluidSystem>::Gas;
     using WellInterfaceFluidSystem<FluidSystem>::Oil;
     using WellInterfaceFluidSystem<FluidSystem>::Water;
+    using Eval = DenseAd::Evaluation<Scalar, /*size=*/Indices::numEq>;
 
     int flowPhaseToEbosCompIdx(const int phaseIdx) const;
     int ebosCompIdxToFlowCompIdx(const unsigned compIdx) const;
     double scalingFactor(const int phaseIdx) const;
+
+    template <class EvalWell>
+    Eval restrictEval(const EvalWell& in) const
+    {
+        Eval out = 0.0;
+        out.setValue(in.value());
+        for (int eqIdx = 0; eqIdx < Indices::numEq; ++eqIdx) {
+            out.setDerivative(eqIdx, in.derivative(eqIdx));
+        }
+        return out;
+    }
 
 protected:
     WellInterfaceIndices(const Well& well,


### PR DESCRIPTION
Thus we get to put more code in a compile unit instead of simulator objects.