### PR TITLE
Add CO2STORE_GW and CO2STORE_GASWAT to regression tests

### DIFF
--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -509,6 +509,20 @@ add_test_compareECLFiles(CASENAME co2store
                          REL_TOL ${rel_tol}
                          DIR co2store)
 
+add_test_compareECLFiles(CASENAME co2store_gw
+                         FILENAME CO2STORE_GW
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR co2store)
+
+add_test_compareECLFiles(CASENAME co2store_gaswat
+                         FILENAME CO2STORE_GASWAT
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR co2store)
+
 add_test_compareECLFiles(CASENAME ppcwmax
                          FILENAME PPCWMAX-01
                          SIMULATOR flow


### PR DESCRIPTION
This supersede an earlier PR that includes the CO2STORE_GASWAT test 
https://github.com/OPM/opm-simulators/pull/4525
that was never merged. The code change seems to have been merged in other PRs.
 
The two tests are similar but test different input setup. 
Especially the CO2STORE_GW test salinity which recently was broken and should be fixed by 

https://github.com/OPM/opm-common/pull/3574

My plan is to frist merge these tests. Then rerun with https://github.com/OPM/opm-common/pull/3574. The test should then fail and we can update the reference with bugfix. 