### PR TITLE
Increase supported equil regions from 255 to 65525

### DIFF
--- a/ebos/eclgenericthresholdpressure.cc
+++ b/ebos/eclgenericthresholdpressure.cc
@@ -99,8 +99,8 @@ thresholdPressure(int elem1Idx, int elem2Idx) const
     }
 
     // threshold pressure accross EQUIL regions
-    unsigned short equilRegion1Idx = elemEquilRegion_[elem1Idx];
-    unsigned short equilRegion2Idx = elemEquilRegion_[elem2Idx];
+    auto equilRegion1Idx = elemEquilRegion_[elem1Idx];
+    auto equilRegion2Idx = elemEquilRegion_[elem2Idx];
 
     if (equilRegion1Idx == equilRegion2Idx)
         return 0.0;
@@ -125,8 +125,8 @@ finishInit()
         std::numeric_limits<std::decay_t<decltype(elemEquilRegion_[0])>>::max();
 
     if (numEquilRegions_ > maxRegions) {
-        // make sure that the index of an equilibration region can be stored in a
-        // single byte
+        // make sure that the index of an equilibration region can be stored
+        // in the vector
         OPM_THROW(std::invalid_argument,
                   (fmt::format("The maximum number of supported "
                                "equilibration regions by OPM flow is {}!",
@@ -176,8 +176,8 @@ applyExplicitThresholdPressures_()
             unsigned insideElemIdx = elementMapper_.index(inside);
             unsigned outsideElemIdx = elementMapper_.index(outside);
 
-            unsigned equilRegionInside = elemEquilRegion_[insideElemIdx];
-            unsigned equilRegionOutside = elemEquilRegion_[outsideElemIdx];
+            auto equilRegionInside = elemEquilRegion_[insideElemIdx];
+            auto equilRegionOutside = elemEquilRegion_[outsideElemIdx];
             if (thpres.hasRegionBarrier(equilRegionInside + 1, equilRegionOutside + 1)) {
                 Scalar pth = 0.0;
                 if (thpres.hasThresholdPressure(equilRegionInside + 1, equilRegionOutside + 1)) {

--- a/ebos/eclgenericthresholdpressure.cc
+++ b/ebos/eclgenericthresholdpressure.cc
@@ -133,6 +133,14 @@ finishInit()
                                maxRegions)));
     }
 
+    if (numEquilRegions_ > 2048) {
+        // warn about performance
+        OpmLog::warning(fmt::format("Number of equil regions is {}. This larger "
+                                 "than 2048. Note, that this might "
+                                 "might have a negative impact on performance "
+                                 "and memory consumption", numEquilRegions_));
+    }
+
     // internalize the data specified using the EQLNUM keyword
     const auto& fp = eclState_.fieldProps();
     const auto& equilRegionData = fp.get_int("EQLNUM");

--- a/ebos/eclgenericthresholdpressure.cc
+++ b/ebos/eclgenericthresholdpressure.cc
@@ -129,16 +129,17 @@ finishInit()
         // in the vector
         OPM_THROW(std::invalid_argument,
                   (fmt::format("The maximum number of supported "
-                               "equilibration regions by OPM flow is {}!",
-                               maxRegions)));
+                               "equilibration regions by OPM flow is {}, but "
+                               "{} are used!",
+                               maxRegions, numEquilRegions_)));
     }
 
     if (numEquilRegions_ > 2048) {
         // warn about performance
-        OpmLog::warning(fmt::format("Number of equil regions is {}. This larger "
-                                 "than 2048. Note, that this might "
-                                 "might have a negative impact on performance "
-                                 "and memory consumption", numEquilRegions_));
+        OpmLog::warning(fmt::format("Number of equilibration regions is {}, which is "
+                                 "rather large. Note, that this might "
+                                 "have a negative impact on performance "
+                                 "and memory consumption.", numEquilRegions_));
     }
 
     // internalize the data specified using the EQLNUM keyword

--- a/ebos/eclgenericthresholdpressure.cc
+++ b/ebos/eclgenericthresholdpressure.cc
@@ -22,6 +22,7 @@
 */
 
 #include <config.h>
+#include <limits>
 #include <ebos/eclgenericthresholdpressure.hh>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
@@ -120,10 +121,16 @@ finishInit()
         return;
 
     numEquilRegions_ = eclState_.getTableManager().getEqldims().getNumEquilRegions();
-    if (numEquilRegions_ > 0xff) {
+    const decltype(numEquilRegions_) maxRegions =
+        std::numeric_limits<std::decay_t<decltype(elemEquilRegion_[0])>>::max();
+
+    if (numEquilRegions_ > maxRegions) {
         // make sure that the index of an equilibration region can be stored in a
         // single byte
-        throw std::runtime_error("The maximum number of supported equilibration regions is 255!");
+        OPM_THROW(std::invalid_argument,
+                  (fmt::format("The maximum number of supported "
+                               "equilibration regions by OPM flow is {}!",
+                               maxRegions)));
     }
 
     // internalize the data specified using the EQLNUM keyword

--- a/ebos/eclgenericthresholdpressure.hh
+++ b/ebos/eclgenericthresholdpressure.hh
@@ -97,7 +97,7 @@ protected:
     std::vector<Scalar> thpresDefault_;
     std::vector<Scalar> thpres_;
     unsigned numEquilRegions_{};
-    std::vector<unsigned char> elemEquilRegion_;
+    std::vector<unsigned short> elemEquilRegion_;
 
     // threshold pressure accross faults. EXPERIMENTAL!
     std::vector<Scalar> thpresftValues_;


### PR DESCRIPTION
Previously we stored the equil region idx as unsigned short which imposed this limit. Apparently there models that use more regions than allowed. Hence we now store the idx using unsigned short which allows 65535 regions.

Still there is a caveat in the code: The region interaction is stored as a dense matrix. This means that using the maximum allowed number of regions now would consume 32 GB of memory. In the future we actually store the interactions in a sparse matrix to get rid of this memory requirement. For now we just issue a warning if there are more than 2048 regions used.