### PR TITLE
-- added need functions for element context for thermal

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1570,6 +1570,27 @@ public:
         return initialFluidStates_[globalDofIdx].temperature(/*phaseIdx=*/0);
     }
 
+
+    Scalar temperature(unsigned globalDofIdx, unsigned timeIdx) const
+    {
+        // use the initial temperature of the DOF if temperature is not a primary
+        // variable
+         return initialFluidStates_[globalDofIdx].temperature(/*phaseIdx=*/0);
+    }
+
+    const SolidEnergyLawParams&
+    solidEnergyLawParams(unsigned globalSpaceIdx,
+                         unsigned /*timeIdx*/) const
+    {
+        return this->thermalLawManager_->solidEnergyLawParams(globalSpaceIdx);
+    }
+    const ThermalConductionLawParams &
+    thermalConductionLawParams(unsigned globalSpaceIdx,
+                               unsigned /*timeIdx*/)const
+    {
+        return this->thermalLawManager_->thermalConductionLawParams(globalSpaceIdx);
+    }
+
     /*!
      * \copydoc FvBaseProblem::boundary
      *


### PR DESCRIPTION
Functions need to make intensive quantities independent of element cache. Use is in opm-flowexperimental, for now but will be moved to simulators when full tpfa linearizing of energy is done.