### PR TITLE
fixed: parallel super builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,6 +493,9 @@ foreach(OBJ ${COMMON_MODELS} ${FLOW_MODELS} ${FLOW_VARIANT_MODELS})
   if(TARGET fmt::fmt)
     target_link_libraries(flow_lib${OBJ} fmt::fmt)
   endif()
+  if(TARGET opmcommon AND CMAKE_GENERATOR MATCHES "Makefiles")
+      add_dependencies(flow_lib${OBJ} opmcommon)
+  endif()
   opm_add_test(flow_${OBJ}
                ONLY_COMPILE
                SOURCES


### PR DESCRIPTION
commit e5e7ff7287 introduced a dependency on a generated header in a header file. this is problematic with super-builds as there is no explicit dependency for the simulator objects to these generated headers.

with the ninja-generator it is smart enough to figure out this across the subdirectories, but the make generator is not. hence we explicitly add a dependency on the opmcommon target in this case. ideally we would only depend on the generated header to allow compiling opmcommon and simulator objects in parallel. however there is as far as i know no way to depend on OUTPUT targets across subdirectories.