### PR TITLE
Improve error message when time step is cut too often/much.

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -446,6 +446,7 @@ std::set<std::string> consistentlyFailingWells(const std::vector<StepReport>& sr
                 std::string causeOfFailure;
                 try {
                     substepReport = solver.step(substepTimer);
+
                     if (solverVerbose_) {
                         // report number of linear iterations
                         OpmLog::debug("Overall linear iterations used: " + std::to_string(substepReport.total_linear_iterations));
@@ -580,7 +581,8 @@ std::set<std::string> consistentlyFailingWells(const std::vector<StepReport>& sr
                         if (solverVerbose_) {
                             OpmLog::error(msg);
                         }
-                        OPM_THROW_NOLOG(NumericalProblem, msg);
+                        // Use throw directly to prevent file and line
+                        throw LinearTimeSteppingBreakdown{msg};
                     }
 
                     // The new, chopped timestep.
@@ -596,7 +598,8 @@ std::set<std::string> consistentlyFailingWells(const std::vector<StepReport>& sr
                         if (solverVerbose_) {
                             OpmLog::error(msg);
                         }
-                        OPM_THROW_NOLOG(NumericalProblem, msg);
+                        // Use throw directly to prevent file and line
+                        throw LinearTimeSteppingBreakdown{msg};
                     }
 
                     // Define utility function for chopping timestep.


### PR DESCRIPTION
Changes
```
Program threw an exception: [/home/mblatt/src/dune/opm/opm-simulators/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp:586] Solver failed to converge after cutting timestep 11 times.
```
to
```
Simulation aborted: Solver failed to converge after cutting timestep 11 times.
```

Which seems more user friendly.

Needs OPM/opm-common#3599