### PR TITLE
Extract Well and Group Initialization

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -367,8 +367,7 @@ namespace Opm {
 
             std::vector<bool> is_cell_perforated_{};
 
-            void initializeWellState(const int           timeStepIdx,
-                                     const SummaryState& summaryState);
+            void initializeWellState(const int timeStepIdx);
 
             // create the well container
             void createWellContainer(const int time_step) override;
@@ -445,9 +444,24 @@ namespace Opm {
                                               const double dt,
                                               DeferredLogger& local_deferredLogger);
 
+            /// Update rank's notion of intersecting wells and their
+            /// associate solution variables.
+            ///
+            /// \param[in] reportStepIdx Report step.
+            ///
+            /// \param[in] enableWellPIScaling Whether or not to enable WELPI
+            ///   scaling.  Typically enabled (i.e., true) only at the start
+            ///   of a report step.
+            void initializeLocalWellStructure(const int  reportStepIdx,
+                                              const bool enableWellPIScaling);
+
+            /// Initialize group control modes/constraints and group solution state.
+            ///
+            /// \param[in] reportStepIdx Report step.
+            void initializeGroupStructure(const int reportStepIdx);
 
             // called at the end of a time step
-            void timeStepSucceeded(const double& simulationTime, const double dt);
+            void timeStepSucceeded(const double simulationTime, const double dt);
 
             // called at the end of a report step
             void endReportStep();

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -262,7 +262,7 @@ namespace Opm {
             }
 
             const Group& fieldGroup = schedule().getGroup("FIELD", timeStepIdx);
-            WellGroupHelpers::setCmodeGroup(fieldGroup, schedule(), summaryState, timeStepIdx, this->wellState(), this->groupState());
+            WellGroupHelpers::setCmodeGroup(fieldGroup, schedule(), summaryState, timeStepIdx, this->groupState());
 
             // Compute reservoir volumes for RESV controls.
             rateConverter_ = std::make_unique<RateConverterType>(phase_usage_,

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -134,12 +134,12 @@ namespace WellGroupHelpers
                        const Schedule& schedule,
                        const SummaryState& summaryState,
                        const int reportStepIdx,
-                       WellState& wellState,
                        GroupState& group_state)
     {
 
         for (const std::string& groupName : group.groups()) {
-            setCmodeGroup(schedule.getGroup(groupName, reportStepIdx), schedule, summaryState, reportStepIdx, wellState, group_state);
+            setCmodeGroup(schedule.getGroup(groupName, reportStepIdx),
+                          schedule, summaryState, reportStepIdx, group_state);
         }
 
         // use NONE as default control

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -53,7 +53,6 @@ namespace WellGroupHelpers
                        const Schedule& schedule,
                        const SummaryState& summaryState,
                        const int reportStepIdx,
-                       WellState& wellState,
                        GroupState& group_state);
 
     void accumulateGroupEfficiencyFactor(const Group& group,


### PR DESCRIPTION
In preparation of adding support for opening/creating wells or groups in the middle of a report step.  This is needed if an `ACTIONX` block runs something like `WELOPEN` or `WELSPECS`/`COMPDAT`.