### PR TITLE
Update Well Topology if Triggered From ACTIONX

### DIFF
--- a/opm/simulators/flow/EclActionHandler.cpp
+++ b/opm/simulators/flow/EclActionHandler.cpp
@@ -188,21 +188,24 @@ void EclActionHandler::applySimulatorUpdate(const int report_step,
                                             const SimulatorUpdate& sim_update,
                                             bool& commit_wellstate,
                                             const TransFunc& updateTrans)
-  {
-      OPM_TIMEBLOCK(applySimulatorUpdate);
-      this->wellModel_.updateEclWells(report_step, sim_update.affected_wells, summaryState_);
-      if (!sim_update.affected_wells.empty())
-          commit_wellstate = true;
+{
+    OPM_TIMEBLOCK(applySimulatorUpdate);
 
-      if (sim_update.tran_update) {
-          const auto& keywords = schedule_[report_step].geo_keywords();
-          ecl_state_.apply_schedule_keywords( keywords );
-          eclBroadcast(comm_, ecl_state_.getTransMult() );
+    this->wellModel_.updateEclWells(report_step, sim_update, this->summaryState_);
 
-          // re-compute transmissibility
-          updateTrans(true);
-      }
-  }
+    if (!sim_update.affected_wells.empty()) {
+        commit_wellstate = true;
+    }
+
+    if (sim_update.tran_update) {
+        const auto& keywords = schedule_[report_step].geo_keywords();
+        ecl_state_.apply_schedule_keywords( keywords );
+        eclBroadcast(comm_, ecl_state_.getTransMult() );
+
+        // re-compute transmissibility
+        updateTrans(true);
+    }
+}
 
 std::unordered_map<std::string, double>
 EclActionHandler::fetchWellPI(const int reportStep,

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -54,14 +54,15 @@
 namespace Opm {
     class DeferredLogger;
     class EclipseState;
+    class GasLiftGroupInfo;
     class GasLiftSingleWellGeneric;
     class GasLiftWellState;
-    class GasLiftGroupInfo;
     class Group;
     class GuideRateConfig;
     class ParallelWellInfo;
     class RestartValue;
     class Schedule;
+    struct SimulatorUpdate;
     class SummaryConfig;
     class VFPProperties;
     class WellInterfaceGeneric;
@@ -152,7 +153,7 @@ public:
     double wellPI(const std::string& well_name) const;
 
     void updateEclWells(const int timeStepIdx,
-                        const std::unordered_set<std::string>& wells,
+                        const SimulatorUpdate& sim_update,
                         const SummaryState& st);
 
     void initFromRestartFile(const RestartValue& restartValues,
@@ -578,6 +579,8 @@ protected:
     bool glift_debug = false;
 
     double last_glift_opt_time_ = -1.0;
+
+    bool wellStructureChangedDynamically_{false};
 
     std::map<std::string, std::string> switched_prod_groups_;
     std::map<std::pair<std::string, Opm::Phase>, std::string> switched_inj_groups_;

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -171,7 +171,7 @@ add_test_compare_parallel_simulation(CASENAME actionx_m1
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      DIR udq_actionx
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
+                                     TEST_ARGS --solver-max-time-step-in-days=0.2 --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
 
 add_test_compare_parallel_simulation(CASENAME winjmult_msw
                                      FILENAME WINJMULT_MSW

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -430,7 +430,7 @@ add_test_compareECLFiles(CASENAME actionx_m1
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          DIR udq_actionx
-                         TEST_ARGS --solver-max-time-step-in-days=1)
+                         TEST_ARGS --solver-max-time-step-in-days=0.2)
 
 add_test_compareECLFiles(CASENAME pinch_multz_all
                          FILENAME PINCH_MULTZ_ALL


### PR DESCRIPTION
This commit adds a new flag data member,
```C++
bool wellStructureChangedDynamically_
```
to the generic black-oil well model.  This flag captures the
```C++
well_structure_changed
```
value from the `SimulatorUpdate` structure in the `updateEclWells()` member function.  Then, in `BlackoilWellModel::beginTimeStep()`, we key a well structure update off this flag when set.  This, in turn, enables creating or opening wells as a result of an `ACTIONX` block updating the structure in the middle of a report step.