### PR TITLE
Do a graceful exit instead of MPI_Abort for expected exceptions.

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -25,7 +25,10 @@
 
 int main(int argc, char** argv)
 {
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runDynamic();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runDynamic();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 

--- a/flow/flow_blackoil_alugrid.cpp
+++ b/flow/flow_blackoil_alugrid.cpp
@@ -35,6 +35,9 @@ struct EclEnableAquifers<TypeTag, TTag::EclFlowProblemAlugrid> {
 int main(int argc, char** argv)
 {
     using TypeTag = Opm::Properties::TTag::EclFlowProblemAlugrid;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }

--- a/flow/flow_distribute_z.cpp
+++ b/flow/flow_distribute_z.cpp
@@ -60,8 +60,11 @@ std::vector<int> loadBalanceInZOnly(const Dune::CpGrid& grid)
 
 int main(int argc, char** argv)
 {
-    auto mainObject = Opm::Main(argc, argv);
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
     Opm::EclCpGridVanguard<Opm::Properties::TTag::EclFlowProblem>::setExternalLoadBalancer(loadBalanceInZOnly);
-    return mainObject.runDynamic();
+    auto ret = mainObject->runDynamic();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 

--- a/flow/flow_ebos_blackoil.cpp
+++ b/flow/flow_ebos_blackoil.cpp
@@ -70,8 +70,11 @@ int flowEbosBlackoilTpfaMain(int argc, char** argv, bool outputCout, bool output
 int flowEbosBlackoilTpfaMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowProblemTPFA;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 } // namespace Opm

--- a/flow/flow_ebos_blackoil_legacyassembly.cpp
+++ b/flow/flow_ebos_blackoil_legacyassembly.cpp
@@ -45,8 +45,11 @@ int flowEbosBlackoilMain(int argc, char** argv, bool outputCout, bool outputFile
 int flowEbosBlackoilMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_blackoil_poly.cpp
+++ b/flow/flow_ebos_blackoil_poly.cpp
@@ -31,8 +31,11 @@ namespace Properties {
 int flowEbosBlackoilPolyMain(int argc, char** argv)
 {
     using TypeTag = Opm::Properties::TTag::EclFlowProblemPoly;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_brine.cpp
+++ b/flow/flow_ebos_brine.cpp
@@ -53,8 +53,11 @@ int flowEbosBrineMain(int argc, char** argv, bool outputCout, bool outputFiles)
 int flowEbosBrineMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowBrineProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_brine_energy.cpp
+++ b/flow/flow_ebos_brine_energy.cpp
@@ -37,8 +37,11 @@ struct EnableEnergy<TypeTag, TTag::EclFlowBrineProblem> {
 int flowEbosBrineEnergyMain(int argc, char** argv)
 {
     using TypeTag = Opm::Properties::TTag::EclFlowBrineProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_brine_precsalt_vapwat.cpp
+++ b/flow/flow_ebos_brine_precsalt_vapwat.cpp
@@ -63,8 +63,11 @@ int flowEbosBrinePrecsaltVapwatMain(int argc, char** argv, bool outputCout, bool
 int flowEbosBrinePrecsaltVapwatMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowBrinePrecsaltVapwatProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_brine_saltprecipitation.cpp
+++ b/flow/flow_ebos_brine_saltprecipitation.cpp
@@ -58,8 +58,11 @@ int flowEbosBrineSaltPrecipitationMain(int argc, char** argv, bool outputCout, b
 int flowEbosBrineSaltPrecipitationMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowBrineSaltPrecipitationProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_energy.cpp
+++ b/flow/flow_ebos_energy.cpp
@@ -53,8 +53,11 @@ int flowEbosEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles)
 int flowEbosEnergyMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowEnergyProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_extbo.cpp
+++ b/flow/flow_ebos_extbo.cpp
@@ -53,8 +53,11 @@ int flowEbosExtboMain(int argc, char** argv, bool outputCout, bool outputFiles)
 int flowEbosExtboMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowExtboProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_foam.cpp
+++ b/flow/flow_ebos_foam.cpp
@@ -53,8 +53,11 @@ int flowEbosFoamMain(int argc, char** argv, bool outputCout, bool outputFiles)
 int flowEbosFoamMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowFoamProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_gasoil.cpp
+++ b/flow/flow_ebos_gasoil.cpp
@@ -86,8 +86,11 @@ int flowEbosGasOilMain(int argc, char** argv, bool outputCout, bool outputFiles)
 int flowEbosGasOilMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowGasOilProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_gasoil_energy.cpp
+++ b/flow/flow_ebos_gasoil_energy.cpp
@@ -78,8 +78,11 @@ int flowEbosGasOilEnergyMain(int argc, char** argv, bool outputCout, bool output
 int flowEbosGasOilEnergyMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowGasOilEnergyProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_gasoildiffuse.cpp
+++ b/flow/flow_ebos_gasoildiffuse.cpp
@@ -78,8 +78,11 @@ int flowEbosGasOilDiffuseMain(int argc, char** argv, bool outputCout, bool outpu
 int flowEbosGasOilDiffuseMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowGasOilDiffuseProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_gaswater.cpp
+++ b/flow/flow_ebos_gaswater.cpp
@@ -90,8 +90,11 @@ int flowEbosGasWaterMain(int argc, char** argv, bool outputCout, bool outputFile
 int flowEbosGasWaterMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowGasWaterProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_gaswater_brine.cpp
+++ b/flow/flow_ebos_gaswater_brine.cpp
@@ -77,8 +77,11 @@ int flowEbosGasWaterBrineMain(int argc, char** argv, bool outputCout, bool outpu
 int flowEbosGasWaterBrineMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowGasWaterBrineProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_gaswater_dissolution.cpp
+++ b/flow/flow_ebos_gaswater_dissolution.cpp
@@ -100,8 +100,11 @@ int flowEbosGasWaterDissolutionMain(int argc, char** argv, bool outputCout, bool
 int flowEbosGasWaterDissolutionMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowGasWaterDissolutionProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_gaswater_dissolution_diffuse.cpp
+++ b/flow/flow_ebos_gaswater_dissolution_diffuse.cpp
@@ -100,8 +100,11 @@ int flowEbosGasWaterDissolutionDiffuseMain(int argc, char** argv, bool outputCou
 int flowEbosGasWaterDissolutionDiffuseMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowGasWaterDissolutionDiffuseProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_gaswater_energy.cpp
+++ b/flow/flow_ebos_gaswater_energy.cpp
@@ -105,8 +105,11 @@ int flowEbosGasWaterEnergyMain(int argc, char** argv, bool outputCout, bool outp
 int flowEbosGasWaterEnergyMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowGasWaterEnergyProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_gaswater_saltprec_energy.cpp
+++ b/flow/flow_ebos_gaswater_saltprec_energy.cpp
@@ -98,8 +98,11 @@ int flowEbosGasWaterSaltprecEnergyMain(int argc, char** argv, bool outputCout, b
 int flowEbosGasWaterSaltprecEnergyMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowGasWaterSaltprecEnergyProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
@@ -93,8 +93,11 @@ int flowEbosGasWaterSaltprecVapwatMain(int argc, char** argv, bool outputCout, b
 int flowEbosGasWaterSaltprecVapwatMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowGasWaterSaltprecVapwatProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_gaswater_solvent.cpp
+++ b/flow/flow_ebos_gaswater_solvent.cpp
@@ -83,8 +83,11 @@ int flowEbosGasWaterSolventMain(int argc, char** argv, bool outputCout, bool out
 int flowEbosGasWaterSolventMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowGasWaterSolventProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_micp.cpp
+++ b/flow/flow_ebos_micp.cpp
@@ -77,8 +77,11 @@ int flowEbosMICPMain(int argc, char** argv, bool outputCout, bool outputFiles)
 int flowEbosMICPMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowMICPProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_oilwater.cpp
+++ b/flow/flow_ebos_oilwater.cpp
@@ -89,8 +89,11 @@ int flowEbosOilWaterMain(int argc, char** argv, bool outputCout, bool outputFile
 int flowEbosOilWaterMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowOilWaterProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_oilwater_brine.cpp
+++ b/flow/flow_ebos_oilwater_brine.cpp
@@ -77,8 +77,11 @@ int flowEbosOilWaterBrineMain(int argc, char** argv, bool outputCout, bool outpu
 int flowEbosOilWaterBrineMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowOilWaterBrineProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_oilwater_polymer.cpp
+++ b/flow/flow_ebos_oilwater_polymer.cpp
@@ -77,8 +77,11 @@ int flowEbosOilWaterPolymerMain(int argc, char** argv, bool outputCout, bool out
 int flowEbosOilWaterPolymerMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowOilWaterPolymerProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_oilwater_polymer_injectivity.cpp
+++ b/flow/flow_ebos_oilwater_polymer_injectivity.cpp
@@ -90,8 +90,11 @@ int flowEbosOilWaterPolymerInjectivityMain(int argc, char** argv, bool outputCou
 int flowEbosOilWaterPolymerInjectivityMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowOilWaterPolymerInjectivityProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_onephase.cpp
+++ b/flow/flow_ebos_onephase.cpp
@@ -84,8 +84,11 @@ int flowEbosWaterOnlyMain(int argc, char** argv, bool outputCout, bool outputFil
 int flowEbosWaterOnlyMainStandalone(int argc, char** argv)
 {
     using TypeTag = Opm::Properties::TTag::EclFlowProblemWaterOnly;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_onephase_energy.cpp
+++ b/flow/flow_ebos_onephase_energy.cpp
@@ -79,8 +79,11 @@ int flowEbosWaterOnlyEnergyMain(int argc, char** argv, bool outputCout, bool out
 int flowEbosWaterOnlyEnergyMainStandalone(int argc, char** argv)
 {
     using TypeTag = Opm::Properties::TTag::EclFlowProblemWaterOnlyEnergy;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_polymer.cpp
+++ b/flow/flow_ebos_polymer.cpp
@@ -53,8 +53,11 @@ int flowEbosPolymerMain(int argc, char** argv, bool outputCout, bool outputFiles
 int flowEbosPolymerMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowPolymerProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_solvent.cpp
+++ b/flow/flow_ebos_solvent.cpp
@@ -53,8 +53,11 @@ int flowEbosSolventMain(int argc, char** argv, bool outputCout, bool outputFiles
 int flowEbosSolventMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowSolventProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/flow/flow_ebos_solvent_foam.cpp
+++ b/flow/flow_ebos_solvent_foam.cpp
@@ -58,8 +58,11 @@ int flowEbosSolventFoamMain(int argc, char** argv, bool outputCout, bool outputF
 int flowEbosSolventFoamMainStandalone(int argc, char** argv)
 {
     using TypeTag = Properties::TTag::EclFlowSolventFoamProblem;
-    auto mainObject = Opm::Main(argc, argv);
-    return mainObject.runStatic<TypeTag>();
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
 }
 
 }

--- a/opm/simulators/flow/FlowMainEbos.cpp
+++ b/opm/simulators/flow/FlowMainEbos.cpp
@@ -77,6 +77,84 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
       report.fullReports(os);
     }
 }
+void checkAllMPIProcesses()
+{
+#if HAVE_MPI
+    const auto& comm = EclGenericVanguard::comm();
+    if (comm.size() > 1)
+    {
+        // we try to prevent the abort here.
+        // For that we need a signal that each process is here.
+        // Each process sends  a message to rank 0.
+        const int tag = 357912;
+        if (comm.rank() == 0)
+        {
+            // wait for a message from all processes.
+            std::vector<MPI_Request> requests(comm.size() - 1, MPI_REQUEST_NULL);
+            std::vector<int> data(comm.size()-1);
+
+            for(decltype(comm.size()) i = 1; i < comm.size(); ++i)
+            {
+                if (auto error = MPI_Irecv(data.data() + i, 1, MPI_INT, i, tag, comm, requests.data() + i - 1);
+                    error != MPI_SUCCESS) {
+                    OpmLog::error(fmt::format("Error: Could not set up MPI receive (error code : {})", error));
+                    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+                }
+            }
+            std::size_t msgs = comm.size() - 1;
+            for(std::size_t tries = 0; msgs >0 && tries < 3; ++tries)
+            {
+                sleep(3);
+                int flag, idx;
+                for(auto left_msgs = msgs; left_msgs > 0; --left_msgs)
+                {
+                    if( auto error = MPI_Testany(comm.size()-1, requests.data(), &idx, &flag, MPI_STATUS_IGNORE);
+                        error != MPI_SUCCESS) {
+                        OpmLog::error(fmt::format("Error: Could not test for MPI message (error code : {})", error));
+                        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+                    }
+                    if (flag)
+                    {
+                        --msgs;
+                    }
+                }
+            }
+            if (msgs) {
+                // seems like some processes are stuck. Abort just to be save
+                MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+            }
+        }
+        else
+        {
+            int data= 3;
+            MPI_Request request = MPI_REQUEST_NULL;
+            if (auto error = MPI_Isend(&data, 1, MPI_INT, 0, tag, comm, &request);
+                error != MPI_SUCCESS) {
+                OpmLog::error(fmt::format("Error: Could send MPI message (error code : {})", error));
+                MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+            }
+            bool completed = false;
+            for(std::size_t tries = 0; !completed && tries < 3; tries++)
+            {
+                sleep(3);
+                int flag;
+                if( auto error = MPI_Test(&request, &flag, MPI_STATUS_IGNORE);
+                    error != MPI_SUCCESS) {
+                    OpmLog::error(fmt::format("Error: Could not test for MPI message (error code : {})", error));
+                    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+                }
+                if (flag)
+                {
+                    completed = true;
+                }
+            }
+            if (!completed) {
+                MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+            }
+        }
+    }
+#endif
+}
 
 } // namespace detail
 } // namespace Opm

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -320,6 +320,85 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
             return simtimer_.get();
         }
 
+        static void checkAllMPIProcesses()
+        {
+#if HAVE_MPI
+            const auto& comm = EclGenericVanguard::comm();
+            if (comm.size() > 1)
+            {
+                // we try to prevent the abort here.
+                // For that we need a signal that each process is here.
+                // Each process sends  a message to rank 0.
+                const int tag = 357912;
+                if (comm.rank() == 0)
+                {
+                    // wait for a message from all processes.
+                    std::vector<MPI_Request> requests(comm.size() - 1, MPI_REQUEST_NULL);
+                    std::vector<int> data(comm.size()-1);
+
+                    for(decltype(comm.size()) i = 1; i < comm.size(); ++i)
+                    {
+                        if (auto error = MPI_Irecv(data.data() + i, 1, MPI_INT, i, tag, comm, requests.data() + i - 1);
+                            error != MPI_SUCCESS) {
+                            OpmLog::error(fmt::format("Error: Could not set up MPI receive (error code : {})", error));
+                            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+                        }
+                    }
+                    std::size_t msgs = comm.size() - 1;
+                    for(std::size_t tries = 0; msgs >0 && tries < 3; ++tries)
+                    {
+                        sleep(3);
+                        int flag, idx;
+                        for(auto left_msgs = msgs; left_msgs > 0; --left_msgs)
+                        {
+                            if( auto error = MPI_Testany(comm.size()-1, requests.data(), &idx, &flag, MPI_STATUS_IGNORE);
+                                error != MPI_SUCCESS) {
+                                OpmLog::error(fmt::format("Error: Could not test for MPI message (error code : {})", error));
+                                MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+                            }
+                            if (flag)
+                            {
+                                --msgs;
+                            }
+                        }
+                    }
+                    if (msgs) {
+                        // seems like some processes are stuck. Abort just to be save
+                        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+                    }
+                }
+                else
+                {
+                    int data= 3;
+                    MPI_Request request = MPI_REQUEST_NULL;
+                    if (auto error = MPI_Isend(&data, 1, MPI_INT, 0, tag, comm, &request);
+                        error != MPI_SUCCESS) {
+                        OpmLog::error(fmt::format("Error: Could send MPI message (error code : {})", error));
+                        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+                    }
+                    bool completed = false;
+                    for(std::size_t tries = 0; !completed && tries < 3; tries++)
+                    {
+                        sleep(3);
+                        int flag;
+                        if( auto error = MPI_Test(&request, &flag, MPI_STATUS_IGNORE);
+                            error != MPI_SUCCESS) {
+                            OpmLog::error(fmt::format("Error: Could not test for MPI message (error code : {})", error));
+                            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+                        }
+                        if (flag)
+                        {
+                            completed = true;
+                        }
+                    }
+                    if (!completed) {
+                        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+                    }
+                }
+            }
+#endif
+        }
+
     private:
         // called by execute() or executeInitStep()
         int execute_(int (FlowMainEbos::* runOrInitFunc)(), bool cleanup)
@@ -338,10 +417,7 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
                         std::cout << message.str() << "\n";
                     }
                 }
-#if HAVE_MPI
-                if (this->mpi_size_ > 1)
-                    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
-#endif
+                this->checkAllMPIProcesses();
                 return EXIT_FAILURE;
             };
 
@@ -364,10 +440,14 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
                 return exitCode;
             }
             catch (const LinearTimeSteppingBreakdown& e) {
-                return logger(e, "Simulation aborted: ");
+                auto exitCode = logger(e, "Simulation aborted: ");
+                executeCleanup_();
+                return exitCode;
             }
             catch (const std::exception& e) {
-                return logger(e, "Simulation aborted as program threw an unexpected exception: ");
+                auto exitCode =  logger(e, "Simulation aborted as program threw an unexpected exception: ");
+                executeCleanup_();
+                return exitCode;
             }
         }
 


### PR DESCRIPTION
Instead of unconditionally issuing MPI_Abort if we encounter a fatal exception, we try to test whether all processes have experienced this exception and if this is the case just terminate nomally with a exit code that signals an error. We still use MPI_Abort if not all processes get an exception as this is the only way to make sure that the program aborts.

This approach also works around issues in some MPI implementations that might not correctly return the error.

Multiple messages like this are gone now:
```
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 1 in communicator MPI_COMM_WORLD
with errorcode 1.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
--------------------------------------------------------------------------
[smaug.dr-blatt.de:129359] 1 more process has sent help message help-mpi-api.txt / mpi-abort
[smaug.dr-blatt.de:129359] Set MCA parameter "orte_base_help_aggregate" to 0 to see all help / error messages
```

Bu we still see something like this:
```
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
mpirun detected that one or more processes exited with non-zero status, thus causing
the job to be terminated. The first process to do so was:

  Process name: [[35057,1],0]
  Exit code:1
--------------------------------------------------------------------------
```