### PR TITLE
moved fully implicit calls to opm-simulators

### DIFF
--- a/ebos/FIBlackOilModel.hpp
+++ b/ebos/FIBlackOilModel.hpp
@@ -35,28 +35,108 @@
 
 #include <stdexcept>
 
-namespace Opm{
-    template<typename TypeTag>
-    class FIBlackOilModel: public BlackOilModel<TypeTag>{
-        using Parent = BlackOilModel<TypeTag>;
-        using Simulator = GetPropType<TypeTag, Properties::Simulator>;
-        using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
-    public:
-        FIBlackOilModel(Simulator& simulator): BlackOilModel<TypeTag>(simulator){
-        }
-
-        // standard flow
-        const IntensiveQuantities& intensiveQuantities(unsigned globalIdx, unsigned timeIdx) const{
-            if (!this->enableIntensiveQuantityCache_){
-                OPM_THROW(std::logic_error, "Run without intensive quantites not enabled: Use --enable-intensive-quantity=true");
-            }
-            const auto* intquant = this->cachedIntensiveQuantities(globalIdx, timeIdx);
-            if(!intquant){
-                OPM_THROW(std::logic_error, "Intensive quantites need to be updated in code");
-            }
-            return *intquant;
-        }
-
+namespace Opm
+{
+template <typename TypeTag>
+class FIBlackOilModel : public BlackOilModel<TypeTag>
+{
+    using ParentType = BlackOilModel<TypeTag>;
+    using Simulator = GetPropType<TypeTag, Properties::Simulator>;
+    using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
+    using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
+    using ThreadManager = GetPropType<TypeTag, Properties::ThreadManager>;
+    using GridView = GetPropType<TypeTag, Properties::GridView>;
+    using Element = typename GridView::template Codim<0>::Entity;
+    using ElementIterator = typename GridView::template Codim<0>::Iterator;
+    enum {
+        numEq = getPropValue<TypeTag, Properties::NumEq>(),
+        historySize = getPropValue<TypeTag, Properties::TimeDiscHistorySize>(),
     };
+
+public:
+    FIBlackOilModel(Simulator& simulator)
+        : BlackOilModel<TypeTag>(simulator)
+    {
+    }
+    void invalidateAndUpdateIntensiveQuantities(unsigned timeIdx) const
+    {
+        this->invalidateIntensiveQuantitiesCache(timeIdx);
+
+        // loop over all elements...
+        ThreadedEntityIterator<GridView, /*codim=*/0> threadedElemIt(this->gridView_);
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        {
+            ElementContext elemCtx(this->simulator_);
+            ElementIterator elemIt = threadedElemIt.beginParallel();
+            for (; !threadedElemIt.isFinished(elemIt); elemIt = threadedElemIt.increment()) {
+                const Element& elem = *elemIt;
+                elemCtx.updatePrimaryStencil(elem);
+                elemCtx.updatePrimaryIntensiveQuantities(timeIdx);
+            }
+        }
+    }
+
+    template <class GridSubDomain>
+    void invalidateAndUpdateIntensiveQuantities(unsigned timeIdx, const GridSubDomain& gridSubDomain) const
+    {
+        // loop over all elements...
+        using GridViewType = decltype(gridSubDomain.view);
+        ThreadedEntityIterator<GridViewType, /*codim=*/0> threadedElemIt(gridSubDomain.view);
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        {
+
+            ElementContext elemCtx(this->simulator_);
+            auto elemIt = threadedElemIt.beginParallel();
+            for (; !threadedElemIt.isFinished(elemIt); elemIt = threadedElemIt.increment()) {
+                if (elemIt->partitionType() != Dune::InteriorEntity) {
+                    continue;
+                }
+                const Element& elem = *elemIt;
+                elemCtx.updatePrimaryStencil(elem);
+                // Mark cache for this element as invalid.
+                const std::size_t numPrimaryDof = elemCtx.numPrimaryDof(timeIdx);
+                for (unsigned dofIdx = 0; dofIdx < numPrimaryDof; ++dofIdx) {
+                    const unsigned globalIndex = elemCtx.globalSpaceIndex(dofIdx, timeIdx);
+                    this->setIntensiveQuantitiesCacheEntryValidity(globalIndex, timeIdx, false);
+                }
+                // Update for this element.
+                elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
+            }
+        }
+    }
+
+    /*!
+     * \brief Called by the update() method if it was
+     *        unsuccessful. This is primary a hook which the actual
+     *        model can overload.
+     */
+    void updateFailed()
+    {
+        // Reset the current solution to the one of the
+        // previous time step so that we can start the next
+        // update at a physically meaningful solution.
+        // this->solution(/*timeIdx=*/0) = this->solution(/*timeIdx=*/1);
+        ParentType::updateFailed();
+        invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0);
+    }
+
+    // standard flow
+    const IntensiveQuantities& intensiveQuantities(unsigned globalIdx, unsigned timeIdx) const
+    {
+        if (!this->enableIntensiveQuantityCache_) {
+            OPM_THROW(std::logic_error,
+                      "Run without intensive quantites not enabled: Use --enable-intensive-quantity=true");
+        }
+        const auto* intquant = this->cachedIntensiveQuantities(globalIdx, timeIdx);
+        if (!intquant) {
+            OPM_THROW(std::logic_error, "Intensive quantites need to be updated in code");
+        }
+        return *intquant;
+    }
+};
 } // namespace Opm
 #endif // FI_BLACK_OIL_MODEL_HPP

--- a/opm/simulators/flow/BlackoilModelEbosNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelEbosNldd.hpp
@@ -442,7 +442,7 @@ private:
                                                 // residual
 
         // if the solution is updated, the intensive quantities need to be recalculated
-        ebosSimulator.model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0, domain.view);
+        ebosSimulator.model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0, domain);
     }
 
     //! \brief Get reservoir quantities on this process needed for convergence calculations.
@@ -715,11 +715,11 @@ private:
             auto local_solution = Details::extractVector(solution, domain.cells);
             Details::setGlobal(local_solution, domain.cells, locally_solved);
             Details::setGlobal(initial_local_solution, domain.cells, solution);
-            model_.ebosSimulator().model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0, domain.view);
+            model_.ebosSimulator().model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0, domain);
         } else {
             model_.wellModel().setPrimaryVarsDomain(domain, initial_local_well_primary_vars);
             Details::setGlobal(initial_local_solution, domain.cells, solution);
-            model_.ebosSimulator().model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0, domain.view);
+            model_.ebosSimulator().model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0, domain);
         }
     }
 
@@ -766,7 +766,7 @@ private:
         } else {
             model_.wellModel().setPrimaryVarsDomain(domain, initial_local_well_primary_vars);
             Details::setGlobal(initial_local_solution, domain.cells, solution);
-            model_.ebosSimulator().model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0, domain.view);
+            model_.ebosSimulator().model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0, domain);
         }
     }
 


### PR DESCRIPTION
-- changed spesicic nldd calls to use subDomain instead of gridview (-- clang formated FIBlackoil)
-- moved fully implict related updates to FIblackoil

This pullrequest should be followed up with a delete of similar functions in fvbasediscretization.