### PR TITLE
Improved and refactored Damaris subsystem.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -365,6 +365,8 @@ list (APPEND TEST_DATA_FILES
 list (APPEND PUBLIC_HEADER_FILES
   ebos/alucartesianindexmapper.hh
   ebos/collecttoiorank.hh
+  ebos/damarisgenericwriter.hh
+  ebos/damariswriter.hh
   ebos/ebos.hh
   ebos/eclactionhandler.hh
   ebos/eclalugridvanguard.hh

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -32,6 +32,7 @@ list (APPEND MAIN_SOURCE_FILES
   ebos/eclgenerictracermodel.cc
   ebos/eclgenericvanguard.cc
   ebos/eclgenericwriter.cc
+  ebos/damarisgenericwriter.cc
   ebos/eclinterregflows.cc
   ebos/eclsolutioncontainers.cc
   ebos/ecltransmissibility.cc
@@ -486,6 +487,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/utils/ParallelFileMerger.hpp
   opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
   opm/simulators/utils/DeferredLogger.hpp
+  opm/simulators/utils/GridDataOutput.hpp
   opm/simulators/utils/gatherDeferredLogger.hpp
   opm/simulators/utils/moduleVersion.hpp
   opm/simulators/utils/ParallelEclipseState.hpp

--- a/ebos/damarisgenericwriter.cc
+++ b/ebos/damarisgenericwriter.cc
@@ -1,0 +1,283 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+
+#ifdef HAVE_DAMARIS
+
+#include <ebos/damarisgenericwriter.hh>
+
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/cpgrid/GridHelpers.hpp>
+#include <opm/grid/polyhedralgrid.hh>
+#include <opm/grid/utility/cartesianToCompressed.hpp>
+#if HAVE_DUNE_ALUGRID
+#include "eclalugridvanguard.hh"
+#include <dune/alugrid/grid.hh>
+#include <dune/alugrid/3d/gridview.hh>
+#endif // HAVE_DUNE_ALUGRID
+
+// #include <opm/output/eclipse/EclipseIO.hpp>
+#include <opm/output/eclipse/RestartValue.hpp>
+#include <opm/output/eclipse/Summary.hpp>
+
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/input/eclipse/Schedule/Action/State.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
+#include <opm/input/eclipse/Schedule/Well/PAvgCalculatorCollection.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <dune/grid/common/mcmgmapper.hh>
+
+#if HAVE_MPI
+#include <ebos/eclmpiserializer.hh>
+#endif
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/gridpart/adaptiveleafgridpart.hh>
+#include <dune/fem/gridpart/common/gridpart2gridview.hh>
+#include <ebos/femcpgridcompat.hh>
+#endif // HAVE_DUNE_FEM
+
+#if HAVE_MPI
+#include <mpi.h>
+#endif
+
+#include <array>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+
+namespace Opm {
+
+template<class Grid, class EquilGrid, class GridView, class ElementMapper, class Scalar>
+DamarisGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>::
+DamarisGenericWriter(const Schedule& schedule,
+                 const EclipseState& eclState,
+                 const SummaryConfig& summaryConfig,
+                 const Grid& grid,
+                 const EquilGrid* equilGrid,
+                 const GridView& gridView,
+                 const Dune::CartesianIndexMapper<Grid>& cartMapper,
+                 const Dune::CartesianIndexMapper<EquilGrid>* equilCartMapper,
+                 bool enableAsyncOutput,
+                 bool enableEsmry )
+    : collectToIORank_(grid,
+                       equilGrid,
+                       gridView,
+                       cartMapper,
+                       equilCartMapper,
+                       summaryConfig.fip_regions_interreg_flow())
+    , grid_(grid)
+    , gridView_(gridView)
+    , schedule_(schedule)
+    , eclState_(eclState)
+    , summaryConfig_(summaryConfig)
+    , cartMapper_(cartMapper)
+    , equilCartMapper_(equilCartMapper)
+    , equilGrid_(equilGrid)
+{
+ 
+}
+
+
+template<class Grid, class EquilGrid, class GridView, class ElementMapper, class Scalar>
+void DamarisGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>::
+writeInit(const std::function<unsigned int(unsigned int)>& map)
+{
+
+}
+
+
+template<class Grid, class EquilGrid, class GridView, class ElementMapper, class Scalar>
+void DamarisGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>::
+doWriteOutput(const int                     reportStepNum,
+              const bool                    isSubStep,
+              data::Solution&&              localCellData,
+              data::Wells&&                 localWellData,
+              data::GroupAndNetworkValues&& localGroupAndNetworkData,
+              data::Aquifers&&              localAquiferData,
+              WellTestState&&               localWTestState,
+              const Action::State& actionState,
+              const UDQState& udqState,
+              const SummaryState& summaryState,
+              const std::vector<Scalar>& thresholdPressure,
+              Scalar curTime,
+              Scalar nextStepSize,
+              bool doublePrecision,
+              bool isFlowsn,
+              std::array<std::pair<std::string, std::pair<std::vector<int>, std::vector<double>>>, 3>&& flowsn,
+              bool isFloresn,
+              std::array<std::pair<std::string, std::pair<std::vector<int>, std::vector<double>>>, 3>&& floresn)
+{
+    const auto isParallel = this->collectToIORank_.isParallel();
+    const bool needsReordering = this->collectToIORank_.doesNeedReordering();
+
+    RestartValue restartValue {
+        (isParallel || needsReordering) ? this->collectToIORank_.globalCellData()
+                   : std::move(localCellData),
+
+        isParallel ? this->collectToIORank_.globalWellData()
+                   : std::move(localWellData),
+
+        isParallel ? this->collectToIORank_.globalGroupAndNetworkData()
+                   : std::move(localGroupAndNetworkData),
+
+        isParallel ? this->collectToIORank_.globalAquiferData()
+                   : std::move(localAquiferData)
+    };
+
+    if (eclState_.getSimulationConfig().useThresholdPressure()) {
+        restartValue.addExtra("THRESHPR", UnitSystem::measure::pressure,
+                              thresholdPressure);
+    }
+
+    // Add suggested next timestep to extra data.
+    if (! isSubStep) {
+        restartValue.addExtra("OPMEXTRA", std::vector<double>(1, nextStepSize));
+    }
+
+    // Add nnc flows and flores.
+    if (isFlowsn) {
+        const auto flowsn_global = isParallel ? this->collectToIORank_.globalFlowsn() : std::move(flowsn);
+        for (const auto& flows : flowsn_global) { 
+            if (flows.first.empty())
+                continue;
+            if (flows.first == "FLOGASN+") {
+                restartValue.addExtra(flows.first, UnitSystem::measure::gas_surface_rate, flows.second.second);
+            }
+            else {
+                restartValue.addExtra(flows.first, UnitSystem::measure::liquid_surface_rate, flows.second.second);
+            }
+        }
+    }
+    if (isFloresn) {
+        const auto floresn_global = isParallel ? this->collectToIORank_.globalFloresn() : std::move(floresn);
+        for (const auto& flores : floresn_global) {
+            if (flores.first.empty())
+                continue;
+            restartValue.addExtra(flores.first, UnitSystem::measure::rate, flores.second.second);
+        }
+    }
+
+    /*
+    // We do not use tasklet to write the data when offloading to Damaris
+    */
+}
+
+
+
+
+template<class Grid, class EquilGrid, class GridView, class ElementMapper, class Scalar>
+const typename DamarisGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>::TransmissibilityType&
+DamarisGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>::
+globalTrans() const
+{
+    assert (globalTrans_);
+    return *globalTrans_;
+}
+
+#if HAVE_DUNE_FEM
+template class DamarisGenericWriter<Dune::CpGrid,
+                                Dune::CpGrid,
+                                Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>, Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>>,
+                                double>;
+template class DamarisGenericWriter<Dune::CpGrid,
+                                Dune::CpGrid,
+                                Dune::Fem::GridPart2GridViewImpl<
+                                    Dune::Fem::AdaptiveLeafGridPart<
+                                        Dune::CpGrid,
+                                        Dune::PartitionIteratorType(4),
+                                        false>>,
+                                Dune::MultipleCodimMultipleGeomTypeMapper<
+                                    Dune::Fem::GridPart2GridViewImpl<
+                                        Dune::Fem::AdaptiveLeafGridPart<
+                                            Dune::CpGrid,
+                                            Dune::PartitionIteratorType(4),
+                                            false>>>,
+                                double>;
+
+
+#ifdef HAVE_DUNE_ALUGRID
+#if HAVE_MPI
+    using ALUGrid3CN = Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming, Dune::ALUGridMPIComm>;
+#else
+    using ALUGrid3CN = Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming, Dune::ALUGridNoComm>;
+#endif //HAVE_MPI
+                                                               
+template class DamarisGenericWriter<ALUGrid3CN,
+                                Dune::CpGrid,
+                                Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<ALUGrid3CN, Dune::PartitionIteratorType(4), false>>>, Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<ALUGrid3CN, Dune::PartitionIteratorType(4), false>>>>,
+                                double>;
+                                
+template class DamarisGenericWriter<ALUGrid3CN,
+                                Dune::CpGrid,
+                                Dune::Fem::GridPart2GridViewImpl<
+                                    Dune::Fem::AdaptiveLeafGridPart<
+                                        ALUGrid3CN,
+                                        Dune::PartitionIteratorType(4),
+                                        false>>,
+                                Dune::MultipleCodimMultipleGeomTypeMapper<
+                                    Dune::Fem::GridPart2GridViewImpl<
+                                        Dune::Fem::AdaptiveLeafGridPart<
+                                            ALUGrid3CN,
+                                            Dune::PartitionIteratorType(4),
+                                            false>>>,
+                                double>;                                
+#endif // HAVE_DUNE_ALUGRID
+
+#else // !HAVE_DUNE_FEM
+template class DamarisGenericWriter<Dune::CpGrid,
+                                Dune::CpGrid,
+                                Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
+                                Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
+                                double>;
+#if HAVE_DUNE_ALUGRID
+#if HAVE_MPI
+    using ALUGrid3CN = Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming, Dune::ALUGridMPIComm>;
+#else
+    using ALUGrid3CN = Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming, Dune::ALUGridNoComm>;
+#endif //HAVE_MPI
+template class DamarisGenericWriter<ALUGrid3CN,
+                                Dune::CpGrid,
+                                Dune::GridView<Dune::ALU3dLeafGridViewTraits<const ALUGrid3CN,Dune::PartitionIteratorType(4)>>,  Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::ALU3dLeafGridViewTraits<const ALUGrid3CN, Dune::PartitionIteratorType(4)>>>,
+                                double>;
+
+#endif // HAVE_DUNE_ALUGRID
+#endif // !HAVE_DUNE_FEM
+
+template class DamarisGenericWriter<Dune::PolyhedralGrid<3,3,double>,
+                                Dune::PolyhedralGrid<3,3,double>,
+                                Dune::GridView<Dune::PolyhedralGridViewTraits<3, 3, double, Dune::PartitionIteratorType(4)>>,                              Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::PolyhedralGridViewTraits<3,3,double,Dune::PartitionIteratorType(4)>>>,
+                                double>;
+                                                                  
+} // namespace Opm
+
+#endif  // #ifdef HAVE_DAMARIS

--- a/ebos/damarisgenericwriter.cc
+++ b/ebos/damarisgenericwriter.cc
@@ -225,7 +225,7 @@ template class DamarisGenericWriter<Dune::CpGrid,
                                 double>;
 
 
-#ifdef HAVE_DUNE_ALUGRID
+#if HAVE_DUNE_ALUGRID
 #if HAVE_MPI
     using ALUGrid3CN = Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming, Dune::ALUGridMPIComm>;
 #else

--- a/ebos/damarisgenericwriter.hh
+++ b/ebos/damarisgenericwriter.hh
@@ -141,7 +141,6 @@ protected:
     const Dune::CartesianIndexMapper<Grid>& cartMapper_;
     const Dune::CartesianIndexMapper<EquilGrid>* equilCartMapper_;
     const EquilGrid* equilGrid_;
-    std::vector<std::size_t> wbp_index_list_;
     SimulatorReportSingle sub_step_report_;
     SimulatorReport simulation_report_;
     // mutable std::vector<NNCdata> outputNnc_;

--- a/ebos/damarisgenericwriter.hh
+++ b/ebos/damarisgenericwriter.hh
@@ -1,0 +1,157 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \copydoc Opm::EclWriter
+ */
+#ifndef EWOMS_DAMARIS_GENERIC_WRITER_HH
+#define EWOMS_DAMARIS_GENERIC_WRITER_HH
+
+#ifdef HAVE_DAMARIS
+
+#include "collecttoiorank.hh"
+#include <ebos/ecltransmissibility.hh>
+#include <opm/models/parallel/tasklets.hh>
+#include <opm/simulators/timestepping/SimulatorReport.hpp>
+
+#include <cstddef>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Opm {
+
+// class EclipseIO;
+class EclipseState;
+class EclInterRegFlowMap;
+class Inplace;
+struct NNCdata;
+class Schedule;
+class SummaryConfig;
+class SummaryState;
+class UDQState;
+
+} // namespace Opm
+
+namespace Opm { namespace Action {
+class State;
+}} // namespace Opm::Action
+
+namespace Opm {
+
+template <class Grid, class EquilGrid, class GridView, class ElementMapper, class Scalar>
+class DamarisGenericWriter
+{
+    using CartesianIndexMapper = Dune::CartesianIndexMapper<Grid>;
+    using EquilCartesianIndexMapper = Dune::CartesianIndexMapper<EquilGrid>;
+    using CollectDataToIORankType = CollectDataToIORank<Grid,EquilGrid,GridView>;
+    using TransmissibilityType = EclTransmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>;
+
+public:
+    // The Simulator object should preferably have been const - the
+    // only reason that is not the case is due to the SummaryState
+    // object owned deep down by the vanguard.
+    DamarisGenericWriter(const Schedule& schedule,
+                     const EclipseState& eclState,
+                     const SummaryConfig& summaryConfig,
+                     const Grid& grid,
+                     const EquilGrid* equilGrid,
+                     const GridView& gridView,
+                     const Dune::CartesianIndexMapper<Grid>& cartMapper,
+                     const Dune::CartesianIndexMapper<EquilGrid>* equilCartMapper,
+                     bool enableAsyncOutput,
+                     bool enableEsmry);
+
+    // const EclipseIO& eclIO() const;
+
+    void writeInit(const std::function<unsigned int(unsigned int)>& map);
+
+    void setTransmissibilities(const TransmissibilityType* globalTrans)
+    {
+        globalTrans_ = globalTrans;
+    }
+
+    void setSubStepReport(const SimulatorReportSingle& report)
+    {
+        sub_step_report_ = report;
+    }
+    void setSimulationReport(const SimulatorReport& report)
+    {
+        simulation_report_ = report;
+    }
+
+
+
+protected:
+    const TransmissibilityType& globalTrans() const;
+    unsigned int gridEquilIdxToGridIdx(unsigned int elemIndex) const;
+
+    void doWriteOutput(const int                     reportStepNum,
+                       const bool                    isSubStep,
+                       data::Solution&&              localCellData,
+                       data::Wells&&                 localWellData,
+                       data::GroupAndNetworkValues&& localGroupAndNetworkData,
+                       data::Aquifers&&              localAquiferData,
+                       WellTestState&&               localWTestState,
+                       const Action::State& actionState,
+                       const UDQState& udqState,
+                       const SummaryState& summaryState,
+                       const std::vector<Scalar>& thresholdPressure,
+                       Scalar curTime,
+                       Scalar nextStepSize,
+                       bool doublePrecision,
+                       bool isFlowsn,
+                       std::array<std::pair<std::string, std::pair<std::vector<int>, std::vector<double>>>, 3>&& flowsn,
+                       bool isFloresn,
+                       std::array<std::pair<std::string, std::pair<std::vector<int>, std::vector<double>>>, 3>&& floresn);
+
+
+    CollectDataToIORankType collectToIORank_;
+    const Grid& grid_;
+    const GridView& gridView_;
+    const Schedule& schedule_;
+    const EclipseState& eclState_;
+    const SummaryConfig& summaryConfig_;
+    //std::unique_ptr<EclipseIO> eclIO_;
+    //std::unique_ptr<TaskletRunner> taskletRunner_;
+    Scalar restartTimeStepSize_;
+    const TransmissibilityType* globalTrans_ = nullptr;
+    const Dune::CartesianIndexMapper<Grid>& cartMapper_;
+    const Dune::CartesianIndexMapper<EquilGrid>* equilCartMapper_;
+    const EquilGrid* equilGrid_;
+    std::vector<std::size_t> wbp_index_list_;
+    SimulatorReportSingle sub_step_report_;
+    SimulatorReport simulation_report_;
+    // mutable std::vector<NNCdata> outputNnc_;
+
+private:
+    data::Solution computeTrans_(const std::unordered_map<int,int>& cartesianToActive, const std::function<unsigned int(unsigned int)>& map) const;
+    // std::vector<NNCdata> exportNncStructure_(const std::unordered_map<int,int>& cartesianToActive, const std::function<unsigned int(unsigned int)>& map) const;
+};
+
+} // namespace Opm
+
+#endif  // #ifdef HAVE_DAMARIS
+#endif

--- a/ebos/damarisgenericwriter.hh
+++ b/ebos/damarisgenericwriter.hh
@@ -28,7 +28,7 @@
 #ifndef EWOMS_DAMARIS_GENERIC_WRITER_HH
 #define EWOMS_DAMARIS_GENERIC_WRITER_HH
 
-#ifdef HAVE_DAMARIS
+#if HAVE_DAMARIS
 
 #include "collecttoiorank.hh"
 #include <ebos/ecltransmissibility.hh>

--- a/ebos/damariswriter.hh
+++ b/ebos/damariswriter.hh
@@ -151,8 +151,7 @@ public:
         // Get the size of the unique vector elements (excludes the shared 'ghost' elements)
         numElements_ = std::distance(interior_elements.begin(), interior_elements.end());
 
-        this->damarisOutputModule_ = std::make_unique<EclOutputBlackOilModule<TypeTag>>(simulator, this->wbp_index_list_, this->collectToIORank_);
-        this->wbp_index_list_.clear();
+        this->damarisOutputModule_ = std::make_unique<EclOutputBlackOilModule<TypeTag>>(simulator, this->collectToIORank_);
     }
 
     ~DamarisWriter()

--- a/ebos/damariswriter.hh
+++ b/ebos/damariswriter.hh
@@ -1,0 +1,631 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \copydoc Opm::DamarisWriter
+ */
+#ifndef EWOMS_DAMARIS_WRITER_HH
+#define EWOMS_DAMARIS_WRITER_HH
+
+#ifdef HAVE_DAMARIS
+#include <ebos/collecttoiorank.hh>
+#include <ebos/damarisgenericwriter.hh>
+#include <ebos/ecloutputblackoilmodule.hh>
+
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+#include <opm/simulators/utils/ParallelRestart.hpp>
+
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <opm/output/eclipse/RestartValue.hpp>
+
+#include <dune/grid/common/partitionset.hh>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+
+#include <opm/simulators/utils/DamarisOutputModule.hpp>
+#include <opm/simulators/utils/GridDataOutput.hpp>
+#include <damaris/util/DamarisGeometryData.hpp>
+
+
+namespace Opm::Properties {
+
+// #ifdef HAVE_DAMARIS
+template<class TypeTag, class MyTypeTag>
+struct EnableDamarisOutput {
+    using type = UndefinedProperty;
+};
+template<class TypeTag, class MyTypeTag>
+struct EnableDamarisOutputCollective {
+    using type = UndefinedProperty;
+};
+// #endif
+
+} // namespace Opm::Properties
+
+namespace Opm {
+
+// namespace Action { class State; }
+// class EclipseIO;
+// class UDQState;
+
+/*!
+ * \ingroup EclBlackOilSimulator
+ *
+ * \brief Collects necessary output values and pass it to opm-output.
+ *
+ * Caveats:
+ * - The only DUNE grid which is currently supported is Dune::CpGrid
+ *   from the OPM module "opm-grid". Using another grid won't
+ *   fail at compile time but you will provoke a fatal exception
+ * - This class requires to use the black oil model with the element
+ *   centered finite volume discretization.
+ */
+ 
+ 
+template <class TypeTag>
+class DamarisWriter : public DamarisGenericWriter<GetPropType<TypeTag, Properties::Grid>,
+                                          GetPropType<TypeTag, Properties::EquilGrid>,
+                                          GetPropType<TypeTag, Properties::GridView>,
+                                          GetPropType<TypeTag, Properties::ElementMapper>,
+                                          GetPropType<TypeTag, Properties::Scalar>>
+{
+    using Simulator = GetPropType<TypeTag, Properties::Simulator>;
+    using Vanguard = GetPropType<TypeTag, Properties::Vanguard>;
+    using GridView = GetPropType<TypeTag, Properties::GridView>;
+    using Grid = GetPropType<TypeTag, Properties::Grid>;
+    using EquilGrid = GetPropType<TypeTag, Properties::EquilGrid>;
+    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
+    using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
+    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+    using Element = typename GridView::template Codim<0>::Entity;
+    using ElementMapper = GetPropType<TypeTag, Properties::ElementMapper>;
+    using ElementIterator = typename GridView::template Codim<0>::Iterator;
+    using BaseType = DamarisGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>;
+    
+    typedef Dune::MultipleCodimMultipleGeomTypeMapper< GridView > VertexMapper;
+
+    enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
+    enum { enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>() };
+
+public:
+    static void registerParameters()
+    {
+        // EclOutputBlackOilModule<TypeTag>::registerParameters();
+
+
+        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableDamarisOutputCollective,
+                             "Write output via Damaris using parallel HDF5 to get single file per timestep instead of one per Damaris core.");
+
+
+    }
+
+    // The Simulator object should preferably have been const - the
+    // only reason that is not the case is due to the SummaryState
+    // object owned deep down by the vanguard.
+    DamarisWriter(Simulator& simulator)
+        : BaseType(simulator.vanguard().schedule(),
+                   simulator.vanguard().eclState(),
+                   simulator.vanguard().summaryConfig(),
+                   simulator.vanguard().grid(),
+                   simulator.vanguard().grid().comm().rank() == 0 ? &simulator.vanguard().equilGrid() : nullptr,
+                   simulator.vanguard().gridView(),
+                   simulator.vanguard().cartesianIndexMapper(),
+                   simulator.vanguard().grid().comm().rank() == 0 ? &simulator.vanguard().equilCartesianIndexMapper() : nullptr,
+                   EWOMS_GET_PARAM(TypeTag, bool, EnableAsyncEclOutput), EWOMS_GET_PARAM(TypeTag, bool, EnableEsmry))
+        , simulator_(simulator)
+    {
+        //    this->damarisUpdate_ = enableDamarisOutput_();
+        this->damarisUpdate_ = true ;
+        
+        rank_ = simulator_.vanguard().grid().comm().rank() ;
+        const auto& gridView = simulator_.gridView();
+        const auto& interior_elements = elements(gridView, Dune::Partitions::interior);
+        // Get the size of the unique vector elements (excludes the shared 'ghost' elements)
+        numElements_ = std::distance(interior_elements.begin(), interior_elements.end());
+
+        this->damarisOutputModule_ = std::make_unique<EclOutputBlackOilModule<TypeTag>>(simulator, this->wbp_index_list_, this->collectToIORank_);
+        this->wbp_index_list_.clear();
+    }
+
+    ~DamarisWriter()
+    { }
+
+    const EquilGrid& globalGrid() const
+    {
+        return simulator_.vanguard().equilGrid();
+    }
+
+    /*!
+     * \brief collect and pass data and pass it to eclIO writer
+     */
+    void evalSummaryState(bool isSubStep)
+    {
+        OPM_TIMEBLOCK(evalSummaryState);
+        const int reportStepNum = simulator_.episodeIndex() + 1;
+        /*
+          The summary data is not evaluated for timestep 0, that is
+          implemented with a:
+
+             if (time_step == 0)
+                 return;
+
+          check somewhere in the summary code. When the summary code was
+          split in separate methods Summary::eval() and
+          Summary::add_timestep() it was necessary to pull this test out
+          here to ensure that the well and group related keywords in the
+          restart file, like XWEL and XGRP were "correct" also in the
+          initial report step.
+
+          "Correct" in this context means unchanged behavior, might very
+          well be more correct to actually remove this if test.
+        */
+        if (reportStepNum == 0)
+            return;
+
+        const Scalar curTime = simulator_.time() + simulator_.timeStepSize();
+        const Scalar totalCpuTime =
+            simulator_.executionTimer().realTimeElapsed() +
+            simulator_.setupTimer().realTimeElapsed() +
+            simulator_.vanguard().setupTime();
+
+        const auto localWellData            = simulator_.problem().wellModel().wellData();
+        const auto localGroupAndNetworkData = simulator_.problem().wellModel()
+            .groupAndNetworkData(reportStepNum);
+
+        const auto localAquiferData = simulator_.problem().aquiferModel().aquiferData();
+        const auto localWellTestState = simulator_.problem().wellModel().wellTestState();
+        this->prepareLocalCellData(isSubStep, reportStepNum);
+
+        if (this->damarisOutputModule_->needInterfaceFluxes(isSubStep)) {
+            this->captureLocalFluxData();
+        }
+         /*
+            For ECL ouput this section used: 
+            this->collectToIORank_.collect({},
+            ... some loging of iteration numbers etc.
+            this->evalSummary(...)
+        */
+    }
+
+    void writeOutput(data::Solution& localCellData , bool isSubStep)
+    {
+        OPM_TIMEBLOCK(writeOutput);
+        const int reportStepNum = simulator_.episodeIndex() + 1;
+        std::cout << "INFO: damarisWriter_->writeOutput() prepareLocalCellData being called " << std::endl ;
+        
+        if (!isSubStep)
+            this->damarisOutputModule_->invalidateLocalData() ;  // <jcb> added this as localCellData was not being written
+        this->prepareLocalCellData(isSubStep, reportStepNum);
+        this->damarisOutputModule_->outputErrorLog(simulator_.gridView().comm());
+
+        // output using eclWriter if enabled
+       
+        //    The damarisWriter is not outputing well or aquifer data (yet)
+            auto localWellData = simulator_.problem().wellModel().wellData(); // data::Well
+            auto localAquiferData = simulator_.problem().aquiferModel().aquiferData();
+            auto localWellTestState = simulator_.problem().wellModel().wellTestState();
+            auto flowsn = this->damarisOutputModule_->getFlowsn();
+            const bool isFlowsn = this->damarisOutputModule_->hasFlowsn();
+            auto floresn = this->damarisOutputModule_->getFloresn();
+            const bool isFloresn = this->damarisOutputModule_->hasFloresn();
+        
+        
+        // auto localWellData = simulator_.problem().wellModel().wellData(); // data::Well
+        // data::Solution localCellData = {};
+        if (! isSubStep) {
+            
+            if (localCellData.size() == 0) {
+                this->damarisOutputModule_->assignToSolution(localCellData);
+            }
+
+            // add cell data to perforations for Rft output
+            this->damarisOutputModule_->addRftDataToWells(localWellData, reportStepNum);
+        } // end of ! isSubstep
+
+        this->writeDamarisGridOutput(isSubStep) ;
+        // int rank =simulator_.vanguard().grid().comm().rank() ;
+        
+        // if (rank == 0) {
+        
+        for ( auto damVar : localCellData ) {
+           // std::map<std::string, data::CellData>
+          const std::string name = damVar.first ;
+          data::CellData  dataCol = damVar.second ;
+          std::cout << "Name of Damaris Varaiable       : (" << rank_ << ")  "  << name << "  Size : "  << dataCol.data.size() <<  std::endl ;  // dataCol.data().size()
+          
+          /*if (name == "PRESSURE") {
+              if (dataCol.data.data() != nullptr) {
+                  damaris_write(name.c_str(), (void*) dataCol.data.data() ) ;
+              }
+                    //damaris_write("PRESSURE", (void*)this->damarisOutputModule_->getPRESSURE_ptr());
+          }*/
+        }
+        
+        this->writeDamarisCellDataOutput(localCellData, isSubStep) ;
+        
+        auto mybloc = damarisOutputModule_->getBlockData() ;
+        for ( auto damVar : mybloc ) {
+           // std::map<std::string, data::CellData>
+          const std::string name = std::get<0>(damVar.first) ;
+          const int part = std::get<1>(damVar.first) ;
+          double  dataCol = damVar.second ;
+          std::cout << "Name of Damaris Block Varaiable : (" << rank_ << ")  "  << name  << "  part : " << part << "  Value : "  << dataCol <<  std::endl ;  // dataCol.data().size()
+        }
+        
+        if (! isSubStep)
+        {
+            //damaris_end_iteration();
+        }
+        /*
+            For ECL ouput this section used: 
+            this->collectToIORank_.collect()
+            this->doWriteOutput(...)
+        */
+    }
+    
+
+
+    void endRestart()
+    {}
+
+    const EclOutputBlackOilModule<TypeTag>& eclOutputModule() const
+    { return *damarisOutputModule_; }
+
+    EclOutputBlackOilModule<TypeTag>& mutableEclOutputModule() const
+    { return *damarisOutputModule_; }
+
+    Scalar restartTimeStepSize() const
+    { return restartTimeStepSize_; }
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(*damarisOutputModule_);
+    }
+
+private:
+
+    int damaris_err_ ;
+    int rank_  ;//  = simulator_.vanguard().grid().comm().rank() ;
+    int numElements_ ;
+    
+    static bool enableDamarisOutput_()
+    { 
+        return EWOMS_GET_PARAM(TypeTag, bool, EnableDamarisOutput); 
+    }
+
+
+     void writeDamarisCellDataOutput(data::Solution& localCellData, bool isSubStep)
+    {
+        static int firstcall = 0 ;
+        if (!isSubStep) {
+            // Output the PRESSURE field
+            if (this->damarisOutputModule_->getPRESSURE_ptr() != nullptr) {
+                damaris_write("PRESSURE", (void*)this->damarisOutputModule_->getPRESSURE_ptr());
+               // damaris_end_iteration();
+               
+               // Only call this once, and only when the Damaris data is valid
+               if (firstcall == 0) {
+                   SetGlobalIndexForDamaris() ;
+                    firstcall = 1 ;
+               }
+               
+               damaris_err_ =  damaris_end_iteration();
+               if (damaris_err_ != DAMARIS_OK) {
+                    std::cerr << "ERROR rank =" << rank_ << " : damariswriter::writeDamarisCellDataOutput() : damaris_end_iteration()" 
+                    << ", Damaris error = " <<  damaris_error_string(damaris_err_) << std::endl ;
+               }
+            }
+        }
+    }
+    
+     void SetGlobalIndexForDamaris () 
+    {
+        // GLOBAL_CELL_INDEX is used to reorder variable data when writing to disk 
+        // This is enabled using select-file="GLOBAL_CELL_INDEX" in the <variable> XML tag
+        if ( this->collectToIORank_.isParallel() ){
+            const std::vector<int>& local_to_global =  this->collectToIORank_.localIdxToGlobalIdxMapping(); 
+            damaris_err_ = damaris_write("GLOBAL_CELL_INDEX", local_to_global.data());
+        } else {
+            std::vector<int> local_to_global_filled ;
+            local_to_global_filled.resize(this->numElements_) ;
+            for (int i = 0 ; i < this->numElements_ ; i++)
+            {
+                local_to_global_filled[i] = i ;
+            }
+            damaris_err_ = damaris_write("GLOBAL_CELL_INDEX", local_to_global_filled.data());
+        }
+        
+        if (damaris_err_ != DAMARIS_OK) {
+            std::cerr << "ERROR rank =" << rank_ << " : eclwrite::writeOutput() : damaris_write(\"GLOBAL_CELL_INDEX\", local_to_global.data())" 
+                  << ", Damaris error = " <<  damaris_error_string(damaris_err_) << std::endl ;
+        }
+    }
+    
+    
+    void writeDamarisGridOutput(bool isSubStep)
+    {
+        // const int rank = simulator_.vanguard().grid().comm().rank() ;
+        
+        // N.B. damarisUpdate_ should be set to true if at any time the model geometry changes
+        if (this->damarisUpdate_) {
+            const auto& gridView = simulator_.gridView();
+            const auto& interior_elements = elements(gridView, Dune::Partitions::interior);
+            // Get the size of the unique vector elements (excludes the shared 'ghost' elements)
+            const int numElements = std::distance(interior_elements.begin(), interior_elements.end());
+            // Sets the damaris parameter values which then defines sizes of the arrays per-rank and globally.
+            // Also sets the offsets to where a ranks array data sits within the global array. 
+            // This is usefull for HDF5 output and for defining distributed arrays in Dask.
+            Opm::DamarisOutput::setupDamarisWritingPars(simulator_.vanguard().grid().comm(), numElements);
+            
+            Opm::GridDataOutput::SimMeshDataAccessor geomData(gridView, Dune::Partitions::interior) ; // N.B. we cannot reuse the same object using a different partition.
+            try {
+               
+                damaris::model::vertex_data_structure vertex_structure = damaris::model::VERTEX_SEPARATE_X_Y_Z ;  // define this as we know it works with Ascent
+                damaris::model::DamarisGeometryData damarisMeshVars(vertex_structure, geomData.getNVertices(), 
+                                                            geomData.getNCells(), geomData.getNCorners(), rank_) ;
+               
+                const bool hasPolyCells = geomData.polyhedralCellPresent() ;
+                if ( hasPolyCells ) {
+                    std::cout << "The DUNE geometry grid has polyhedral elements - currently not supported by Damaris " << std::endl ;
+                } 
+                damarisMeshVars.set_hasPolyhedralCells(hasPolyCells) ;
+               
+                /* This is our template XML model for x,y,z coordinates
+                  <parameter name="n_coords_local"     type="int" value="1" />
+                  <parameter name="n_coords_global"    type="int" value="1" comment="only needed if we need to write to HDF5 in Collective mode/>
+                  <layout    name="n_coords_layout"    type="double" dimensions="n_coords_local"   comment="For the individual x, y and z coordinates of the mesh vertices, these values are referenced in the topologies/topo/subelements/connectivity_pg data"  />
+                  <group name="coordset/coords/values"> 
+                      <variable name="x"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="PythonConduitTest" time-varying="false" />
+                      <variable name="y"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="PythonConduitTest" time-varying="false" />
+                      <variable name="z"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="PythonConduitTest" time-varying="false" />
+                  </group>
+                */
+                int xyz_coord_dims = 1 ;
+                std::vector<std::string> param_names = {"n_coords_local"} ;  // a vector of strings as a variables layout may be defined by multiple parameters 
+                std::string variable_x = "coordset/coords/values/x" ;  // This string must match the group/variable name of the Damaris XML file 
+                std::string variable_y = "coordset/coords/values/y" ;  // This string must match the group/variable name of the Damaris XML file 
+                std::string variable_z = "coordset/coords/values/z" ;  // This string must match the group/variable name of the Damaris XML file 
+                
+                damarisMeshVars.set_damaris_var_name_vertex_x(xyz_coord_dims,  param_names, variable_x) ;
+                damarisMeshVars.set_damaris_var_name_vertex_y(xyz_coord_dims,  param_names, variable_y) ;
+                damarisMeshVars.set_damaris_var_name_vertex_z(xyz_coord_dims,  param_names, variable_z) ;
+                
+                // Used to store Damaris parameters, which are then used to resize the 
+                // shared memory region used to save the mesh data
+                // there should be as many values for paramaters as names used in param_names.
+                // Each name corresponds to the value at the same position in the vector.
+                std::vector<int> param_vertices ;  
+                std::vector<int> param_connectivity ;
+                std::vector<int> param_offsets ;
+                
+                
+                param_vertices.push_back(geomData.getNVertices() ) ; 
+                // For the vertex data x, y and z arrays, SetAll_VERTEX_SEPARATE_X_Y_Z_shmem()  will set the arrays 
+                // size (using the paramater value) and then allocate the shared memory region. This is where we 
+                // will write the vertex data to, so that Damaris has access to it.
+                damarisMeshVars.SetAll_VERTEX_SEPARATE_X_Y_Z_shmem(param_vertices) ;  
+                
+                // Now we can return the memory that Damaris has allocated in shmem 
+                damaris::model::DamarisVar<double>* var_x =  dynamic_cast<damaris::model::DamarisVar<double>* >(damarisMeshVars.get_x()) ;
+                damaris::model::DamarisVar<double>* var_y =  dynamic_cast<damaris::model::DamarisVar<double>* >(damarisMeshVars.get_y()) ;
+                damaris::model::DamarisVar<double>* var_z =  dynamic_cast<damaris::model::DamarisVar<double>* >(damarisMeshVars.get_z()) ;
+                
+                if ( geomData.writeGridPoints(var_x->data_ptr(),var_y->data_ptr(),var_z->data_ptr()) < 0)
+                     DUNE_THROW(Dune::IOError, geomData.getError()  );
+                
+               
+                // We do not need these as the ~DamarisGeometryData destructor will call them  
+                // damarisMeshVars.CommitAll_VERTEX_SEPARATE_X_Y_Z_shmem() ;
+                // damarisMeshVars.ClearAll_VERTEX_SEPARATE_X_Y_Z_shmem() ;
+                
+                /* This is our template XML model for connectivity 
+                  <parameter name="n_connectivity_ph"        type="int"  value="1" />
+                  <layout    name="n_connections_layout_ph"  type="int"  dimensions="n_connectivity_ph"   comment="Layout for connectivities "  />
+                  <parameter name="n_offsets_types_ph"       type="int"  value="1" />
+                  <layout    name="n_offsets_layout_ph"      type="int"  dimensions="n_offsets_types_ph"  comment="Layout for the offsets_ph"  />
+                  <layout    name="n_types_layout_ph"        type="char" dimensions="n_offsets_types_ph"  comment="Layout for the types_ph "  />
+                  <group name="topologies/topo/elements">
+                      <variable name="connectivity" layout="n_connections_layout_ph"  type="scalar"  visualizable="false"  unit=""   script="PythonConduitTest" time-varying="false" />
+                      <variable name="offsets"      layout="n_offsets_layout_ph"    type="scalar"  visualizable="false"  unit=""   script="PythonConduitTest" time-varying="false" />
+                      <variable name="types"        layout="n_types_layout_ph"    type="scalar"  visualizable="false"  unit=""   script="PythonConduitTest" time-varying="false" />
+                  </group>
+                */
+               
+                param_names[0] = "n_connectivity_ph" ; 
+                std::string varname = std::string("topologies/topo/elements/connectivity") ;  // This string must match the group/variable name of the Damaris XML file 
+                damarisMeshVars.set_damaris_var_name_connectivity(xyz_coord_dims, param_names , varname ) ;
+                param_names[0] = "n_offsets_types_ph" ; 
+                varname = std::string("topologies/topo/elements/offsets") ;                   // This string must match the group/variable name of the Damaris XML file 
+                damarisMeshVars.set_damaris_var_name_offsets(xyz_coord_dims, param_names, varname ) ;
+                param_names[0] = "n_offsets_types_ph" ; 
+                varname = std::string("topologies/topo/elements/types") ;                     // This string must match the group/variable name of the Damaris XML file 
+                damarisMeshVars.set_damaris_var_name_types(xyz_coord_dims, param_names, varname ) ;
+                
+                // Here we retrieve the DamarisVar objects. We need to *match the type* of the data as set in the Damaris XML file
+                damaris::model::DamarisVar<int>* var_connectivity =  dynamic_cast<damaris::model::DamarisVar<int>* >(damarisMeshVars.get_connectivity()) ;
+                damaris::model::DamarisVar<int>* var_offsets      =  dynamic_cast<damaris::model::DamarisVar<int>* >(damarisMeshVars.get_offsets()) ;
+                damaris::model::DamarisVar<char>* var_types       =  dynamic_cast<damaris::model::DamarisVar<char>* >(damarisMeshVars.get_types()) ;
+                
+                // Set the Damaris shared memory for each variable needed to store mesh data
+                param_connectivity.push_back( geomData.getNCorners() ) ;
+                var_connectivity->SetDamarisParameter(param_connectivity) ;
+                var_connectivity->SetPointersToDamarisShmem() ;
+               
+                param_offsets.push_back(geomData.getNCells() ) ;
+                var_offsets->SetDamarisParameter(param_offsets) ;
+                var_offsets->SetPointersToDamarisShmem() ;
+                var_types->SetDamarisParameter(param_offsets) ;
+                var_types->SetPointersToDamarisShmem() ;
+                
+                // Copy the mesh data from the Durne grid
+                long i = 0 ;
+                Opm::GridDataOutput::ConnectivityVertexOrder vtkorder = Opm::GridDataOutput::VTK ;
+                
+                i = geomData.writeConnectivity(var_connectivity->data_ptr(), vtkorder) ;
+                if ( i  != geomData.getNCorners())
+                     DUNE_THROW(Dune::IOError, geomData.getError() );
+                
+                i = geomData.writeOffsetsCells(var_offsets->data_ptr()) ;
+                if ( i != geomData.getNCells()+1)
+                     DUNE_THROW(Dune::IOError,geomData.getError() );
+                
+                i = geomData.writeCellTypes(var_types->data_ptr()) ;
+                if ( i != geomData.getNCells())
+                     DUNE_THROW(Dune::IOError,geomData.getError() );
+                //  Commit and clear damaris functions are called when the object goes out of scope (in the destructor)
+            }
+            catch (std::exception& e) 
+            {
+                std :: cout << e.what() << std::endl;
+            }
+
+
+            //this-SetGlobalIndexForDamaris() ;
+              
+          
+            // Currently by default we assume static grid (unchanging through the simulation)
+            // Set damarisUpdate_ to true if we want to update the geometry to sent to Damaris 
+            this->damarisUpdate_ = false; 
+        }// end of if (this->damarisUpdate_)
+    }
+
+   
+
+    void prepareLocalCellData(const bool isSubStep,
+                              const int  reportStepNum)
+    {
+        OPM_TIMEBLOCK(prepareLocalCellData);
+        if (damarisOutputModule_->localDataValid()) {
+            return;
+        }
+        std::cout << "INFO: damarisWriter_->prepareLocalCellData()  got past localDataValid() " << std::endl ;
+
+        const auto& gridView = simulator_.vanguard().gridView();
+        const int numElements = gridView.size(/*codim=*/0);
+        const bool log = this->collectToIORank_.isIORank();
+
+        damarisOutputModule_->allocBuffers(numElements, reportStepNum,
+                                      isSubStep, log, /*isRestart*/ false);
+
+        ElementContext elemCtx(simulator_);
+        OPM_BEGIN_PARALLEL_TRY_CATCH();
+        {
+        OPM_TIMEBLOCK(prepareCellBasedData);
+        for (const auto& elem : elements(gridView)) {
+            elemCtx.updatePrimaryStencil(elem);
+            elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
+
+            damarisOutputModule_->processElement(elemCtx);
+        }
+        }
+        if(!simulator_.model().linearizer().getFlowsInfo().empty()){
+            OPM_TIMEBLOCK(prepareFlowsData);
+            for (const auto& elem : elements(gridView)) {
+                elemCtx.updatePrimaryStencil(elem);
+                elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
+                damarisOutputModule_->processElementFlows(elemCtx);
+            }
+        }
+        {
+        OPM_TIMEBLOCK(prepareBlockData);
+        for (const auto& elem : elements(gridView)) {
+            elemCtx.updatePrimaryStencil(elem);
+            elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
+            damarisOutputModule_->processElementBlockData(elemCtx);
+        }
+        }
+        {
+        OPM_TIMEBLOCK(prepareFluidInPlace);
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+        for (int dofIdx=0; dofIdx < numElements; ++dofIdx){
+                const auto& intQuants = *(simulator_.model().cachedIntensiveQuantities(dofIdx, /*timeIdx=*/0));
+                const auto totVolume = simulator_.model().dofTotalVolume(dofIdx);
+                damarisOutputModule_->updateFluidInPlace(dofIdx, intQuants, totVolume);
+        }
+        }
+        damarisOutputModule_->validateLocalData();
+        OPM_END_PARALLEL_TRY_CATCH("DamarisWriter::prepareLocalCellData() failed: ", simulator_.vanguard().grid().comm());
+    }
+
+
+    void captureLocalFluxData()
+    {
+        OPM_TIMEBLOCK(captureLocalData);
+        const auto& gridView = this->simulator_.vanguard().gridView();
+        const auto timeIdx = 0u;
+
+        auto elemCtx = ElementContext { this->simulator_ };
+
+        const auto elemMapper = ElementMapper { gridView, Dune::mcmgElementLayout() };
+        const auto activeIndex = [&elemMapper](const Element& e)
+        {
+            return elemMapper.index(e);
+        };
+
+        const auto cartesianIndex = [this](const int elemIndex)
+        {
+            return this->cartMapper_.cartesianIndex(elemIndex);
+        };
+
+        this->damarisOutputModule_->initializeFluxData();
+
+        OPM_BEGIN_PARALLEL_TRY_CATCH();
+
+        for (const auto& elem : elements(gridView, Dune::Partitions::interiorBorder)) {
+            elemCtx.updateStencil(elem);
+            elemCtx.updateIntensiveQuantities(timeIdx);
+            elemCtx.updateExtensiveQuantities(timeIdx);
+
+            this->damarisOutputModule_->processFluxes(elemCtx, activeIndex, cartesianIndex);
+        }
+
+        OPM_END_PARALLEL_TRY_CATCH("DamarisWriter::captureLocalFluxData() failed: ",
+                                   this->simulator_.vanguard().grid().comm())
+
+        this->damarisOutputModule_->finalizeFluxData();
+    }
+    
+
+    Simulator& simulator_;
+    std::unique_ptr<EclOutputBlackOilModule<TypeTag>> damarisOutputModule_;
+    Scalar restartTimeStepSize_;
+
+
+    bool damarisUpdate_ = false;  ///< Whenever this is true writeOutput() will set up Damaris mesh information and offsets of model fields
+
+};
+} // namespace Opm
+#endif  // HAVE_DAMARIS
+
+#endif

--- a/ebos/damariswriter.hh
+++ b/ebos/damariswriter.hh
@@ -509,9 +509,9 @@ private:
                               const int  reportStepNum)
     {
         OPM_TIMEBLOCK(prepareLocalCellData);
-        if (damarisOutputModule_->localDataValid()) {
-            return;
-        }
+        // if (damarisOutputModule_->localDataValid()) {
+        //     return;
+        // }
         // std::cout << "INFO: damarisWriter_->prepareLocalCellData()  got past localDataValid() " << std::endl ;
 
         const auto& gridView = simulator_.vanguard().gridView();

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1189,6 +1189,9 @@ public:
         }
         bool isSubStep = !EWOMS_GET_PARAM(TypeTag, bool, EnableWriteAllSolutions) && !this->simulator().episodeWillBeOver();
         eclWriter_->evalSummaryState(isSubStep);
+#if HAVE_DAMARIS
+        damarisWriter_->evalSummaryState(isSubStep);
+#endif // HAVE_DAMARIS
 
         int episodeIdx = this->episodeIndex();
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -437,7 +437,7 @@ struct EnableEclOutput<TypeTag,TTag::EclBaseProblem> {
     static constexpr bool value = true;
 };
 
-#ifdef HAVE_DAMARIS
+#if HAVE_DAMARIS
 
 //! Disable the Damaris output by default
 template<class TypeTag>
@@ -451,7 +451,7 @@ struct EnableDamarisOutputCollective<TypeTag, TTag::EclBaseProblem> {
     static constexpr bool value = true;
 };
 
-#endif
+#endif // HAVE_DAMARIS
 
 // If available, write the ECL output in a non-blocking manner
 template<class TypeTag>
@@ -696,7 +696,7 @@ class EclProblem : public GetPropType<TypeTag, Properties::BaseProblem>
     using DimMatrix = Dune::FieldMatrix<Scalar, dimWorld, dimWorld>;
 
     using EclWriterType = EclWriter<TypeTag>;
-#ifdef HAVE_DAMARIS
+#if HAVE_DAMARIS
     using DamarisWriterType = DamarisWriter<TypeTag>;
 #endif
 
@@ -721,7 +721,7 @@ public:
     {
         ParentType::registerParameters();
         EclWriterType::registerParameters();
-#ifdef HAVE_DAMARIS
+#if HAVE_DAMARIS
         DamarisWriterType::registerParameters();
 #endif
         VtkEclTracerModule<TypeTag>::registerParameters();
@@ -732,7 +732,7 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableEclOutput,
                              "Write binary output which is compatible with the commercial "
                              "Eclipse simulator");
-#ifdef HAVE_DAMARIS
+#if HAVE_DAMARIS
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableDamarisOutput,
                              "Write a specific variable using Damaris in a separate core");
 #endif
@@ -818,7 +818,7 @@ public:
 
         // create the ECL writer
         eclWriter_ = std::make_unique<EclWriterType>(simulator);
-#ifdef HAVE_DAMARIS
+#if HAVE_DAMARIS
         // create Damaris writer
         damarisWriter_ = std::make_unique<DamarisWriterType>(simulator);     
         enableDamarisOutput_ = EWOMS_GET_PARAM(TypeTag, bool, EnableDamarisOutput) ;
@@ -826,7 +826,7 @@ public:
         enableDriftCompensation_ = EWOMS_GET_PARAM(TypeTag, bool, EclEnableDriftCompensation);
 
         enableEclOutput_ = EWOMS_GET_PARAM(TypeTag, bool, EnableEclOutput);
-        
+
         if constexpr (enableExperiments)
             enableAquifers_ = EWOMS_GET_PARAM(TypeTag, bool, EclEnableAquifers);
         else
@@ -1259,7 +1259,7 @@ public:
         bool isSubStep = !EWOMS_GET_PARAM(TypeTag, bool, EnableWriteAllSolutions) && !this->simulator().episodeWillBeOver();
         
         data::Solution localCellData = {};
-#ifdef HAVE_DAMARIS
+#if HAVE_DAMARIS
         // N.B. the Damaris output has to be done before the ECL output as the ECL one 
         // does all kinds of std::move() relocation of data
         if (enableDamarisOutput_) {
@@ -1276,7 +1276,7 @@ public:
         // this will write all pending output to disk
         // to avoid corruption of output files
         eclWriter_.reset();
-#ifdef HAVE_DAMARIS
+#if HAVE_DAMARIS
         damarisWriter_.reset();  // This is a usinque_ptr method
 #endif 
     }
@@ -3106,7 +3106,7 @@ private:
     bool enableEclOutput_;
     std::unique_ptr<EclWriterType> eclWriter_;
     
-#ifdef HAVE_DAMARIS
+#if HAVE_DAMARIS
     bool enableDamarisOutput_ = false ;
     std::unique_ptr<DamarisWriterType> damarisWriter_;
 #endif 

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -112,7 +112,7 @@ class EclWriter : public EclGenericWriter<GetPropType<TypeTag, Properties::Grid>
     using ElementIterator = typename GridView::template Codim<0>::Iterator;
     using BaseType = EclGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>;
     
-    typedef Dune::MultipleCodimMultipleGeomTypeMapper< GridView > VertexMapper;
+    using VertexMapper = Dune::MultipleCodimMultipleGeomTypeMapper< GridView >;
 
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
@@ -129,7 +129,7 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableEsmry,
                              "Write ESMRY file for fast loading of summary data.");
                              
-#ifdef HAVE_DAMARIS
+#if HAVE_DAMARIS
    //     EWOMS_REGISTER_PARAM(TypeTag, bool, EnableDamarisOutputCollective,
     //                         "Write output via Damaris using parallel HDF5 to get single file per timestep instead of one per Damaris core.");
 #endif                             

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -328,7 +328,7 @@ private:
         // Reset to false as we cannot use Damaris if there is only one rank.
         if ((enableDamarisOutput_ == true) && (EclGenericVanguard::comm().size() == 1)) {
             std::string msg ;
-            msg = "\nUse of Damaris (command line argument --enable-damaris-output=true) has been dissabled for run with only one rank.\n" ;
+            msg = "\nUse of Damaris (command line argument --enable-damaris-output=true) has been disabled for run with only one rank.\n" ;
             OpmLog::info(msg);
             enableDamarisOutput_ = false ;
         }

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -3,7 +3,7 @@
   Copyright 2014 Dr. Blatt - HPC-Simulation-Software & Services
   Copyright 2015 IRIS AS
   Copyright 2014 STATOIL ASA.
-
+  Copyright 2023 Inria
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -142,8 +142,8 @@ public:
     int runDynamic()
     {
         int exitCode = EXIT_SUCCESS;
-        if (isSimulationRank_) {
-            if (initialize_<Properties::TTag::FlowEarlyBird>(exitCode)) {
+        if (initialize_<Properties::TTag::FlowEarlyBird>(exitCode)) {
+            if (isSimulationRank_) {
                 return this->dispatchDynamic_();
             }
         }
@@ -155,8 +155,8 @@ public:
     int runStatic()
     {
         int exitCode = EXIT_SUCCESS;
-        if (isSimulationRank_) {
-            if (initialize_<TypeTag>(exitCode)) {
+        if (initialize_<TypeTag>(exitCode)) {
+            if (isSimulationRank_) {
                 return this->dispatchStatic_<TypeTag>();
             }
         }
@@ -325,79 +325,87 @@ private:
 
 #if HAVE_DAMARIS
         enableDamarisOutput_ = EWOMS_GET_PARAM(PreTypeTag, bool, EnableDamarisOutput);
+        // Reset to false as we cannot use Damaris if there is only one rank.
+        if ((enableDamarisOutput_ == true) && (EclGenericVanguard::comm().size() == 1)) {
+            std::string msg ;
+            msg = "\nUse of Damaris (command line argument --enable-damaris-output=true) has been dissabled for run with only one rank.\n" ;
+            OpmLog::info(msg);
+            enableDamarisOutput_ = false ;
+        }
+        
         if (enableDamarisOutput_) {
             this->setupDamaris(outputDir,
                                EWOMS_GET_PARAM(PreTypeTag, bool, EnableDamarisOutputCollective));
         }
 #endif // HAVE_DAMARIS
+        if (isSimulationRank_) {
+            int mpiRank = EclGenericVanguard::comm().rank();
+            outputCout_ = false;
+            if (mpiRank == 0)
+                outputCout_ = EWOMS_GET_PARAM(PreTypeTag, bool, EnableTerminalOutput);
 
-        int mpiRank = EclGenericVanguard::comm().rank();
-        outputCout_ = false;
-        if (mpiRank == 0)
-            outputCout_ = EWOMS_GET_PARAM(PreTypeTag, bool, EnableTerminalOutput);
 
-
-        if (deckFilename.empty()) {
-            if (mpiRank == 0) {
-                std::cerr << "No input case given. Try '--help' for a usage description.\n";
+            if (deckFilename.empty()) {
+                if (mpiRank == 0) {
+                    std::cerr << "No input case given. Try '--help' for a usage description.\n";
+                }
+                exitCode = EXIT_FAILURE;
+                return false;
             }
-            exitCode = EXIT_FAILURE;
-            return false;
-        }
 
-        using PreVanguard = GetPropType<PreTypeTag, Properties::Vanguard>;
-        try {
-            deckFilename = PreVanguard::canonicalDeckPath(deckFilename);
-        }
-        catch (const std::exception& e) {
-            if ( mpiRank == 0 ) {
-                std::cerr << "Exception received: " << e.what() << ". Try '--help' for a usage description.\n";
+            using PreVanguard = GetPropType<PreTypeTag, Properties::Vanguard>;
+            try {
+                deckFilename = PreVanguard::canonicalDeckPath(deckFilename);
             }
-#if HAVE_MPI
-            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
-#endif
-            exitCode = EXIT_FAILURE;
-            return false;
-        }
+            catch (const std::exception& e) {
+                if ( mpiRank == 0 ) {
+                    std::cerr << "Exception received: " << e.what() << ". Try '--help' for a usage description.\n";
+                }
+    #if HAVE_MPI
+                MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    #endif
+                exitCode = EXIT_FAILURE;
+                return false;
+            }
 
-        std::string cmdline_params;
-        if (outputCout_) {
-            printFlowBanner(EclGenericVanguard::comm().size(),
-                            getNumThreads<PreTypeTag>(),
-                            Opm::moduleVersionName());
-            std::ostringstream str;
-            Parameters::printValues<PreTypeTag>(str);
-            cmdline_params = str.str();
-        }
-
-        // Create Deck and EclipseState.
-        try {
-            this->readDeck(deckFilename,
-                           outputDir,
-                           EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
-                           !EWOMS_GET_PARAM(PreTypeTag, bool, SchedRestart),
-                           EWOMS_GET_PARAM(PreTypeTag, bool,  EnableLoggingFalloutWarning),
-                           EWOMS_GET_PARAM(PreTypeTag, std::string, ParsingStrictness),
-                           mpiRank,
-                           EWOMS_GET_PARAM(PreTypeTag, int, EclOutputInterval),
-                           cmdline_params,
-                           Opm::moduleVersion(),
-                           Opm::compileTimestamp());
-            setupTime_ = externalSetupTimer.elapsed();
-        }
-        catch (const std::invalid_argument& e)
-        {
+            std::string cmdline_params;
             if (outputCout_) {
-                std::cerr << "Failed to create valid EclipseState object." << std::endl;
-                std::cerr << "Exception caught: " << e.what() << std::endl;
+                printFlowBanner(EclGenericVanguard::comm().size(),
+                                getNumThreads<PreTypeTag>(),
+                                Opm::moduleVersionName());
+                std::ostringstream str;
+                Parameters::printValues<PreTypeTag>(str);
+                cmdline_params = str.str();
             }
-#if HAVE_MPI
-            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
-#endif
-            exitCode = EXIT_FAILURE;
-            return false;
-        }
 
+            // Create Deck and EclipseState.
+            try {
+                this->readDeck(deckFilename,
+                               outputDir,
+                               EWOMS_GET_PARAM(PreTypeTag, std::string, OutputMode),
+                               !EWOMS_GET_PARAM(PreTypeTag, bool, SchedRestart),
+                               EWOMS_GET_PARAM(PreTypeTag, bool,  EnableLoggingFalloutWarning),
+                               EWOMS_GET_PARAM(PreTypeTag, std::string, ParsingStrictness),
+                               mpiRank,
+                               EWOMS_GET_PARAM(PreTypeTag, int, EclOutputInterval),
+                               cmdline_params,
+                               Opm::moduleVersion(),
+                               Opm::compileTimestamp());
+                setupTime_ = externalSetupTimer.elapsed();
+            }
+            catch (const std::invalid_argument& e)
+            {
+                if (outputCout_) {
+                    std::cerr << "Failed to create valid EclipseState object." << std::endl;
+                    std::cerr << "Exception caught: " << e.what() << std::endl;
+                }
+    #if HAVE_MPI
+                MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    #endif
+                exitCode = EXIT_FAILURE;
+                return false;
+            }
+        }
         exitCode = EXIT_SUCCESS;
         return true;
     }

--- a/opm/simulators/utils/DamarisOutputModule.cpp
+++ b/opm/simulators/utils/DamarisOutputModule.cpp
@@ -1,6 +1,6 @@
 /*
   Copyright 2022 SINTEF Digital, Mathematics and Cybernetics.
-
+  Copyright 2023 Inria
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -32,7 +32,7 @@
 namespace Opm::DamarisOutput
 {
 
-std::string initDamarisXmlFile(); // Defined in initDamarisXMLFile.cpp, to avoid messing up this file.
+std::string initDamarisTemplateXmlFile(); // Defined in initDamarisXMLFile.cpp, to avoid messing up this file.
 
 
 void
@@ -42,7 +42,7 @@ initializeDamaris(MPI_Comm comm, int mpiRank, std::string outputDir, bool enable
         outputDir = ".";
     }
     // Prepare the XML file
-    std::string damaris_config_xml = initDamarisXmlFile();
+    std::string damaris_config_xml = initDamarisTemplateXmlFile();
     damaris::model::ModifyModel myMod = damaris::model::ModifyModel(damaris_config_xml);
     // The map will make it precise the output directory and FileMode (either FilePerCore or Collective storage)
     // The map file find all occurences of the string in position 1 and repalce it/them with string in position 2
@@ -74,6 +74,8 @@ initializeDamaris(MPI_Comm comm, int mpiRank, std::string outputDir, bool enable
         }
     }
 }
+
+
 
 void
 setupDamarisWritingPars(Parallel::Communication comm, const int n_elements_local_grid)

--- a/opm/simulators/utils/DamarisOutputModule.hpp
+++ b/opm/simulators/utils/DamarisOutputModule.hpp
@@ -1,6 +1,6 @@
 /*
   Copyright 2022 SINTEF Digital, Mathematics and Cybernetics.
-
+  Copyright 2023 Inria
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -32,10 +32,19 @@
 namespace Opm::DamarisOutput
 {
  // Initialize an XML file
- std::string initDamarisXmlFile();
- // Initialize Damaris by filling in th XML file and stroring it in the chosed directory
+ std::string initDamarisTemplateXmlFile();
+ 
+ // Initialize Damaris by filling in th XML file and storing it in the chosen directory
  void initializeDamaris(MPI_Comm comm, int mpiRank, std::string OutputDir, bool enableDamarisOutputCollective);
- // Setup Damaris Parameters for writing e.g., grid size and communicator to output "PRESSURE" field
+ 
+/** 
+* Set up Damaris Parameters for writing e.g., grid size and communicator to output "PRESSURE" field
+* This function is used to set the size of the local arrays and to compute the offsets into a
+* global view of the variable for use by HDF5 collective writing mode and for defining distributed 
+* arrays in Dask. 
+* N.B. As we are to use the HDF5 select-file attribute, the offsets are only used to write the 
+*      'select-file' data i.e. GLOBAL_CELL_INDEX
+*/
  void setupDamarisWritingPars(Parallel::Communication comm, const int n_elements_local_grid);
 
 } // namespace Opm::DamarisOutput

--- a/opm/simulators/utils/GridDataOutput.hpp
+++ b/opm/simulators/utils/GridDataOutput.hpp
@@ -1,0 +1,495 @@
+// -*- tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi: set et ts=4 sw=2 sts=2:
+/*
+  Copyright 2023 Inria, Bretagne–Atlantique Research Center
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_SIM_MESH_DATA2_HPP
+#define OPM_SIM_MESH_DATA2_HPP
+
+#include <sstream>
+#include <dune/grid/common/rangegenerators.hh>
+#include <dune/grid/io/file/vtk/common.hh>
+
+/** @file
+    @brief Allows model geometry data to be passed to external code - via a copy direct to input pointers. 
+    
+    This data extractor provides the full set of vertices (corresponding to Dune::Partition::all) and then 
+    allows a user to specify Dune sub-partitions to get the references into the vertex array and element 
+    (aka cell) types for the sub-partition. This allows the full set of verticies to be reused for 
+    visualisation of the various sub-partitions, at the expense of copying all the vertices. Typically
+    a user is interested in the interiorBoarder elements which make use of the bulk (~80%) of the vertices.
+    This saves having to renumber the indexes to the vertices for the sub-partitions.
+    
+    N.B. The class checks for polyhedral cells within the requested partiton and breaks with an exception if found.
+    
+
+    Example:
+        // From the opm-simulators repository
+        #include <opm/simulators/utils/GridDataOutput.hpp>
+        
+        // N.B. does not seem to be able to be allocated with new operator.
+        Opm::GridDataOutput::SimMeshDataAccessor geomData(gridView,  Dune::Partition::interior ) ;
+        
+        geomData.printGridDetails() ;
+        
+        int nvert = geomData.getNVertices() ;
+        double * x_vert = new double[nvert] ;
+        double * y_vert = new double[nvert] ;
+        double * z_vert = new double[nvert] ;
+        geomData.writeGridPoints(x_vert,y_vert,z_vert) ;
+        
+        ... do something with vertex data ....
+        
+        free [] x_vert;
+        free [] y_vert;
+        free [] z_vert;
+        
+        
+    TODO: Extend to support Grid field data output.
+*/
+
+namespace Opm::GridDataOutput
+{
+
+
+  /**
+   * @brief Writer for obtaining mesh data from a Dune grid
+   *  
+   */
+  // template< class GridView, unsigned int partitions >
+  enum ConnectivityVertexOrder { DUNE = 0 , VTK = 1 } ;
+  
+  template< class GridView, unsigned int partitions >
+  class SimMeshDataAccessor {
+
+
+  public:
+    /**
+     * @brief Construct a SimMeshDataAccessor working on a specific GridView and specialize to a Dune::PartitionSet<>.
+     *
+     * @param gridView The gridView 
+     * @param PartitionSet<> the set of cells from which to extract geometric data
+     *
+     *  The PartitionSet of the data can be specified from one of:
+     *   Dune::Partitions::all
+     *   Dune::Partitions::interior
+     *   Dune::Partitions::border
+     *   Dune::Partitions::overlap
+     *   Dune::Partitions::front
+     *   Dune::Partitions::ghost
+     *   Dune::Partitions::interiorBorder
+     *   Dune::Partitions::interiorBorderOverlap
+     *   Dune::Partitions::interiorBorderOverlapFront
+     *   Dune::Partitions::all
+     *
+     * N.B. To visualise 'field' data on the extracted grid mesh then the field variable
+     *       should contain at least as many vlaues as the mesh has cells  (ncells_) or vertices (nvertices_)
+     *       depending on if data is cell centred or vertex centred, respectively.
+     *
+     *  This class does not work with grids containing polyhedral cells (well, it has not been tested
+     *  with this kind of grid data). The user should call polyhedralCellPresent() to test if polyhedral 
+     *  cells are present and decide what they want to do before copying data using the data accessor methods.
+     */
+    explicit SimMeshDataAccessor ( const GridView &gridView,  
+                            Dune::PartitionSet<partitions>  dunePartition)
+        : gridView_( gridView ),
+          dunePartition_(dunePartition)
+    { 
+        dimw_ = GridView::dimension ; // this is an enum
+        
+        partition_value_ = dunePartition.value ;
+        
+        countEntities() ;
+    }
+
+
+    //! destructor
+    ~SimMeshDataAccessor ()
+    {
+
+    }
+
+     /**
+       Checks for cells that have polyhedral type within the current partition of cells
+       
+       returns true if a polyhedral sell is found. If this is the case then this partition 
+       is not going to be available for visualisation as this class does not yet handle 
+       polyhedral cells.
+    */
+    bool polyhedralCellPresent() 
+    {
+        for (const auto& cit :  elements(gridView_, dunePartition_))
+        {       
+            auto  corner_geom = cit.geometry() ;
+            if( Dune::VTK::geometryType( corner_geom.type() ) == Dune::VTK::polyhedron )
+            {
+                return true ;
+            }
+       } 
+       return false;
+    }
+
+
+    /** 
+        Count the vertices, cells and corners.
+        
+        We count all the vertices ( the Dune::Partitions::all partition ) as then we do not need to renumber
+        the vertices as all the subsets use references to the full set.
+    */ 
+    void countEntities(  )
+    {
+        // We include all the vertices for this ranks partition
+        const auto& vert_partition_it = vertices(gridView_, Dune::Partitions::all);
+        nvertices_ = std::distance(vert_partition_it.begin(), vert_partition_it.end());
+        
+        const auto& cell_partition_it = elements(gridView_, dunePartition_);
+        ncells_ = std::distance(cell_partition_it.begin(), cell_partition_it.end());
+        
+        ncorners_ = 0 ;
+        for (const auto& cit : cell_partition_it)
+        {
+            auto  corner_geom = cit.geometry() ;
+            ncorners_ += corner_geom.corners() ;
+        }
+    }
+
+
+     /**
+       Write the positions of vertices - directly to the pointers given in paramaters 
+       
+       returns the number of vertices written, or -1 if an error was detected
+    */
+    template <typename T> 
+    long  writeGridPoints( T*  x_inout,  T*  y_inout, T* z_inout )
+    {
+        long i = 0 ;
+        
+        if (dimw_ == 3) {
+            for (const auto& vit :   vertices(gridView_, Dune::Partitions::all) )
+            {      
+                // if (i < nvertices_) // As this class is templated on the Dune::PartitionSet<partitions>, this cannot change
+                auto xyz_local = vit.geometry().corner(0);  // verticies only have one corner
+                x_inout[i] = static_cast<T>(xyz_local[0]) ;
+                y_inout[i] = static_cast<T>(xyz_local[1]) ;
+                z_inout[i] = static_cast<T>(xyz_local[2]) ; 
+                i++ ;
+            }
+        } else if (dimw_ == 2)  {
+            for (const auto& vit :   vertices(gridView_, Dune::Partitions::all) )
+            {      
+                // if (i < nvertices_) // As this class is templated on the Dune::PartitionSet<partitions>, this cannot change
+                auto xyz_local = vit.geometry().corner(0);  // verticies only have one corner
+                x_inout[i] = static_cast<T>(xyz_local[0]) ;
+                y_inout[i] = static_cast<T>(xyz_local[1]) ;
+                z_inout[i] = static_cast<T>(0.0);
+                i++ ;
+            }
+        }
+        
+        return i ;
+    }
+    
+    
+    /**
+     Write positions of vertices as array of structures : x,y,z,x,y,z,x,y,z,...
+     
+     returns the number of vertices written, or -1 if an error was detected
+    */
+    template <typename T> 
+    long writeGridPoints_AOS( T*  xyz_inout )
+    {
+        long i = 0 ;
+        // long toomany = 3 * nvertices_ ;
+        
+        if (dimw_ == 3) {
+            for (const auto& vit :   vertices(gridView_, Dune::Partitions::all))
+            {   
+                 // if (i < toomany) // As this class is templated on the Dune::PartitionSet<partitions>, this cannot change
+                auto xyz_local = vit.geometry().corner(0);
+                xyz_inout[i++] = static_cast<T>(xyz_local[0]) ;
+                xyz_inout[i++] = static_cast<T>(xyz_local[1]) ;
+                xyz_inout[i++] = static_cast<T>(xyz_local[2]) ;
+                
+            }
+        } else if (dimw_ == 2)  {
+            for (const auto& vit :   vertices(gridView_, Dune::Partitions::all))
+            {   
+                 // if (i < toomany) // As this class is templated on the Dune::PartitionSet<partitions>, this cannot change
+                auto xyz_local = vit.geometry().corner(0);
+                xyz_inout[i++] = static_cast<T>(xyz_local[0]) ;
+                xyz_inout[i++] = static_cast<T>(xyz_local[1]) ;
+                xyz_inout[i++] = static_cast<T>(0.0) ;  
+            }
+        }
+        
+        return ( (i) / 3 );
+    }
+    
+    
+    /**
+     Write positions of vertices as structure of arrays  : x,x,x,...,y,y,y,...,z,z,z,...
+     
+     returns the number of vertices written, or -1 if an error was detected
+    */
+    template <typename T> 
+    long writeGridPoints_SOA( T*  xyz_inout )
+    {
+        long i = 0 ;
+        
+        // Get offsets into structure
+        T * xyz_inout_y = xyz_inout + nvertices_ ;
+        T * xyz_inout_z = xyz_inout + (2*nvertices_) ;
+        
+        if (dimw_ == 3) {
+            for (const auto& vit :   vertices(gridView_, Dune::Partitions::all))
+            {     
+                //if (i < nvertices_)  // As this class is templated on the Dune::PartitionSet<partitions>, this cannot change
+                auto xyz_local = vit.geometry().corner(0);
+                xyz_inout[i] = static_cast<T>(xyz_local[0]) ;
+                xyz_inout_y[i]= static_cast<T>(xyz_local[1]) ;
+                xyz_inout_z[i] = static_cast<T>(xyz_local[2]) ;
+                i++ ;
+            }
+        } else if (dimw_ == 2)  {
+            for (const auto& vit :   vertices(gridView_, Dune::Partitions::all))
+            {     
+                //if (i < nvertices_)  // As this class is templated on the Dune::PartitionSet<partitions>, this cannot change
+                auto xyz_local = vit.geometry().corner(0);
+                xyz_inout[i] = static_cast<T>(xyz_local[0]) ;
+                xyz_inout_y[i]= static_cast<T>(xyz_local[1]) ;
+                xyz_inout_z[i] = static_cast<T>(0.0);  
+                i++ ;
+            }
+            
+        }
+        return (i) ;
+    }
+    
+    
+    
+    /**
+    * Write the connectivity array - directly to the pointer given in paramater 1
+      Reorders the indecies into VTK order.
+      
+      returns the number of corner indecies written, or -1 if an error was detected
+    */
+    template <typename I>
+    long writeConnectivity(I * connectivity_inout, ConnectivityVertexOrder whichOrder)
+    {
+        long i = 0 ;
+        // connectivity
+        if ( whichOrder == DUNE )  {
+        // DUNE order
+            for (const auto& cit :  elements(gridView_, dunePartition_))
+            {  
+              // const int cell_corners = cit.subEntities( 3 );  // get the full list of verticies of the cell
+              auto cell_corners = cit.geometry().corners() ;
+              for( auto vx = 0; vx < cell_corners; ++ vx )  
+              {
+                  // if (i < ncorners_) // As this class is templated on the Dune::PartitionSet<partitions>, this cannot change
+                  const int vxIdx = gridView_.indexSet().subIndex( cit, vx, 3 );
+                  connectivity_inout[i + vx] = vxIdx ;
+              }
+              i += cell_corners ; 
+            }
+        } else {
+            // VTK order
+            for (const auto& cit :  elements(gridView_, dunePartition_))
+            {  
+              // const int cell_corners = cit.subEntities( 3 );  // get the full list of verticies of the cell
+              auto cell_corners = cit.geometry().corners() ;
+              for( auto vx = 0; vx < cell_corners; ++ vx )  
+              {
+                  // if (i < ncorners_) { // As this class is templated on the Dune::PartitionSet<partitions>, this cannot change
+                  const int vxIdx = gridView_.indexSet().subIndex( cit, vx, 3 );
+                  int vtkOrder ; 
+                  vtkOrder = Dune::VTK::renumber(cit.type(), vx) ;
+                  connectivity_inout[i + vtkOrder] = vxIdx ;
+              }
+              
+              i += cell_corners ; 
+            }
+        }
+        
+        
+        return (i) ;
+    }
+    
+    /**
+    * Write the offsets values  - directly to the pointer given in paramater 1
+      Returns the number of offset values written, or -1 if an error was detected
+    */
+    template <typename I>
+    long writeOffsetsCells( I* offsets_inout  )
+    {
+        // offsets
+        I offset = 0;
+        long i = 1 ;
+        offsets_inout[0] = 0 ;
+        for (const auto& cit :  elements(gridView_, dunePartition_))
+        {  
+            // const int cell_corners = cit.subEntities( 3 );  // get the full list of verticies of the cell
+            auto cell_corners = cit.geometry().corners() ;
+            // if (i <= ncells_) { // As this class is templated on the Dune::PartitionSet<partitions>, this cannot change
+            offsets_inout[i] = offsets_inout[i-1] +  cell_corners ;
+            i++ ;
+        }
+
+        return (i) ;
+    }
+    
+    /**
+    * Write the Cell types array - directly to the pointer given in paramater 1
+    */
+    template <typename I>
+    long writeCellTypes( I* types_inout)
+    {
+        int i = 0 ;
+        // types
+        for (const auto& cit :  elements(gridView_, dunePartition_))
+        {
+          // if (i < ncells_) { // As this class is templated on the Dune::PartitionSet<partitions>, this cannot change
+              I vtktype = static_cast<I>(Dune::VTK::geometryType(cit.type()));
+              types_inout[i++] = vtktype ;
+        }
+        
+        return (i) ;
+      
+    }
+    
+    
+   std::string getPartitionTypeString (  )
+   {
+      //std::stringstream ss ;
+      //ss << dunePartition_ << std::endl ;
+      //return ss.str() ;
+       if (this->dunePartition_ ==  Dune::Partitions::all)
+           return (std::string("Dune::Partitions::all")) ;
+       if (this->dunePartition_ ==  Dune::Partitions::interior)
+           return (std::string("Dune::Partitions::interior")) ;
+       if (this->dunePartition_ ==  Dune::Partitions::interiorBorder)
+           return (std::string("Dune::Partitions::interiorBorder")) ;
+       if (this->dunePartition_ ==  Dune::Partitions::interiorBorderOverlap)
+           return (std::string("Dune::Partitions::interiorBorderOverlap")) ;
+       if (this->dunePartition_ ==  Dune::Partitions::front)
+           return (std::string("Dune::Partitions::front")) ;
+       if (this->dunePartition_ ==  Dune::Partitions::interiorBorderOverlapFront)
+           return (std::string("Dune::Partitions::InteriorBorderOverlapFront")) ;
+       if (this->dunePartition_ ==  Dune::Partitions::border)
+           return (std::string("Dune::Partitions::border")) ;
+       if (this->dunePartition_ ==  Dune::Partitions::ghost)
+           return (std::string("Dune::Partitions::ghost")) ;
+       
+       return (std::string("Unknown Dune::PartitionSet<>")) ;
+   }
+   
+   
+   Dune::PartitionSet<partitions> getPartition ( void )
+   {
+       return ( this->dunePartition_ ) ;
+   }
+    
+    
+  void   printGridDetails()
+  {
+      std::cout << "Dune Partition = " << partition_value_ << ", " << getPartitionTypeString()  << std::endl ;
+      printNCells() ;
+      printNVertices() ;
+      printNCorners() ;
+  }
+    
+  void printNCells()
+  {
+      std::cout << "ncells = " << ncells_ << std::endl ;
+  }
+  
+  void printNVertices()
+  {
+      std::cout << "nvertices = " << nvertices_ << std::endl ;
+  }
+  
+  void printNCorners()
+  {
+      std::cout << "ncorners = " << ncorners_ << std::endl ;
+  }
+  
+  int getNCells()
+  {
+      return(ncells_) ;
+  }
+  
+  int getNVertices()
+  {
+      return(nvertices_) ;
+  }
+  
+  int getNCorners()
+  {
+      return(ncorners_) ;
+  }
+  
+  std::string getError()
+  {
+      return error_strm_.str() ;
+  }
+  
+  void clearError()
+  {
+       error_strm_.str("") ;
+  }
+  
+  bool hasError()
+  {
+      if ( error_strm_.str().length() > 0 ) 
+          return true ;
+      else 
+          return false ;
+  }
+  
+
+  protected:
+
+    GridView gridView_;  // the grid
+    
+    Dune::PartitionSet<partitions>  dunePartition_ ;
+    unsigned int partition_value_ ;
+
+    /**
+    Current partition grid information
+    */
+    int ncells_;
+    /**
+    Current partition grid information
+    */
+    int nvertices_;
+    /**
+    Current partition grid information
+    */
+    int ncorners_; 
+    
+    int dimw_ ;  // dimensions of the input grid
+    
+  private:
+    std::stringstream error_strm_ ;
+
+  };
+  
+}
+
+#endif 

--- a/opm/simulators/utils/GridDataOutput.hpp
+++ b/opm/simulators/utils/GridDataOutput.hpp
@@ -128,21 +128,23 @@ namespace Opm::GridDataOutput
      /**
        Checks for cells that have polyhedral type within the current partition of cells
        
-       returns true if a polyhedral sell is found. If this is the case then this partition 
+       returns true if a polyhedral cell is found. If this is the case then this partition 
        is not going to be available for visualisation as this class does not yet handle 
        polyhedral cells.
     */
     bool polyhedralCellPresent() 
     {
-        for (const auto& cit :  elements(gridView_, dunePartition_))
-        {       
-            auto  corner_geom = cit.geometry() ;
-            if( Dune::VTK::geometryType( corner_geom.type() ) == Dune::VTK::polyhedron )
-            {
-                return true ;
+        if constexpr (std::is_same_v<typename GridView::Grid, Dune::CpGrid>) {
+            return false;
+        } else {
+            for (const auto& cit : elements(gridView_, dunePartition_)) {
+                auto corner_geom = cit.geometry();
+                if (Dune::VTK::geometryType(corner_geom.type()) == Dune::VTK::polyhedron) {
+                    return true;
+                }
             }
-       } 
-       return false;
+        }
+        return false;
     }
 
 

--- a/opm/simulators/utils/initDamarisXmlFile.cpp
+++ b/opm/simulators/utils/initDamarisXmlFile.cpp
@@ -54,7 +54,7 @@ std::string initDamarisTemplateXmlFile()
     <layout   name="zonal_layout_usmesh_integer"             type="int" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
     <variable name="GLOBAL_CELL_INDEX"    layout="zonal_layout_usmesh_integer"     type="scalar"  visualizable="false"  time-varying="false"  centering="zonal" />
     <layout   name="zonal_layout_usmesh"             type="double" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
-    <variable name="PRESSURE"    layout="zonal_layout_usmesh"     type="scalar"  visualizable="false"     unit="Bar"   centering="zonal" select-file="GLOBAL_CELL_INDEX" store="_MYSTORE_OR_EMPTY_REGEX_"  script="PythonScript" />
+    <variable name="PRESSURE"    layout="zonal_layout_usmesh"     type="scalar"  visualizable="false"     unit="Bar"   centering="zonal" select-file="GLOBAL_CELL_INDEX" store="_MYSTORE_OR_EMPTY_REGEX_" />
     _MORE_VARIABLES_REGEX_
     
     

--- a/opm/simulators/utils/initDamarisXmlFile.cpp
+++ b/opm/simulators/utils/initDamarisXmlFile.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 KerData Research Team, Inria Rennes, Bretagne–Atlantique Research Center
+  Copyright 2022 2023 Inria, Bretagne–Atlantique Research Center
   Copyright 2022 SINTEF Digital, Mathematics and Cybernetics.
 
   This file is part of the Open Porous Media project (OPM).
@@ -29,8 +29,12 @@ namespace Opm::DamarisOutput
 
     The entries in the map below will be filled by corresponding Damaris
     Keywords.
+    
+    N.B. Ensure all text items that are to be replaced are quoted with double quotes
+    e.g. unit="_REPLACE_UNIT_"   
+    *not* unit=_REPLACE_UNIT_ unless the quotes are included
 */
-std::string initDamarisXmlFile()
+std::string initDamarisTemplateXmlFile()
 {
     std::string init_damaris = R"V0G0N(<?xml version="1.0"?>
 <simulation name="opm-flow" language="c" xmlns="http://damaris.gforge.inria.fr/damaris/model">
@@ -50,8 +54,47 @@ std::string initDamarisXmlFile()
     <layout   name="zonal_layout_usmesh_integer"             type="int" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
     <variable name="GLOBAL_CELL_INDEX"    layout="zonal_layout_usmesh_integer"     type="scalar"  visualizable="false"  time-varying="false"  centering="zonal" />
     <layout   name="zonal_layout_usmesh"             type="double" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
-    <variable name="PRESSURE"    layout="zonal_layout_usmesh"     type="scalar"  visualizable="false"     unit="Pa"   centering="zonal"  store="_MYSTORE_OR_EMPTY_REGEX_" />
+    <variable name="PRESSURE"    layout="zonal_layout_usmesh"     type="scalar"  visualizable="false"     unit="Bar"   centering="zonal" select-file="GLOBAL_CELL_INDEX" store="_MYSTORE_OR_EMPTY_REGEX_"  script="PythonScript" />
     _MORE_VARIABLES_REGEX_
+    
+    
+    <parameter name="n_coords_local"     type="int" value="1" />
+    <layout    name="n_coords_layout"    type="double" dimensions="n_coords_local"   comment="For the individual x, y and z coordinates of the mesh vertices, these values are referenced in the topologies/topo/subelements/connectivity_pg data"  />
+    <group name="coordset/coords/values"> 
+        <variable name="x"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="PythonScript" time-varying="false" />
+        <variable name="y"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="PythonScript" time-varying="false" />
+        <variable name="z"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="PythonScript" time-varying="false" />
+    </group>
+    
+    
+    <parameter name="n_connectivity_ph"        type="int"  value="1" />
+    <layout    name="n_connections_layout_ph"  type="int"  dimensions="n_connectivity_ph"   comment="Layout for connectivities "  />
+    <parameter name="n_offsets_types_ph"       type="int"  value="1" />
+    <layout    name="n_offsets_layout_ph"      type="int"  dimensions="n_offsets_types_ph + 1"  comment="Layout for the offsets_ph"  />
+    <layout    name="n_types_layout_ph"        type="char" dimensions="n_offsets_types_ph"  comment="Layout for the types_ph "  />
+    <group name="topologies/topo/elements">
+        <variable name="connectivity" layout="n_connections_layout_ph"  type="scalar"  visualizable="false"    script="PythonScript" time-varying="false" />
+        <variable name="offsets"      layout="n_offsets_layout_ph"    type="scalar"  visualizable="false"     script="PythonScript" time-varying="false" />
+        <variable name="types"        layout="n_types_layout_ph"    type="scalar"  visualizable="false"    script="PythonScript" time-varying="false" />
+    </group>
+    
+    
+    <mesh name="unstructured_mesh" type="unstructured" topology="3" time-varying="false" 
+               comment="This Mesh definition is for connection with Paraview.
+                        This definition only references the actual variables that define an unstructured mesh available above.
+                        Current issues: 
+                          1. x,y,z vertex coordinates are separate - need to test if 3 individual arrays works;
+                          2. GID is not defined for ASCENT data above; 
+                          3. Paraview is expecting sizes and not offsets" >
+          <coord                name="coordset/coords/values/x"  unit="m"    />
+          <coord                name="coordset/coords/values/y"  unit="m"    />
+          <coord                name="coordset/coords/values/z"  unit="m"    />
+          <vertex_global_id     name=""                          offset="-1" />
+          <section_types        name="topologies/topo/elements/types"        />
+          <section_sizes        name="topologies/topo/elements/offsets"      />
+          <section_connectivity name="topologies/topo/elements/connectivity" />
+    </mesh>
+    
 </data>
 
 <storage>
@@ -62,10 +105,18 @@ std::string initDamarisXmlFile()
     </store>
 </storage>
 
+<scripts>
+    <pyscript name="PythonScript" file="opm_python_script.py" language="python" frequency="1" scheduler-file="" nthreads="0" keep-workers="no" />
+</scripts>
+
+<paraview update-frequency="1" >
+        <script>paraview_script.py</script>
+</paraview>
+
 <actions>
 </actions>
 
-<log FileName="_PATH_REGEX_/damaris_log/exa_dbg" RotationSize="5" LogFormat="[%TimeStamp%]: %Message%"  Flush="True"  LogLevel="debug" />
+<log FileName="_PATH_REGEX_/damaris_log/opm-flow" RotationSize="5" LogFormat="[%TimeStamp%]: %Message%"  Flush="True"  LogLevel="info" />
 
 </simulation>)V0G0N";
 


### PR DESCRIPTION
Contains the following changes:
 - sorting through what causes the i/o write to fill the eclgenericblackoilmodule buffers
 - Demo of reused eclwriter code to cycle through avaiable fields (data::CellData). The results of printing are output per rank. Different datasets output very different fields.
 - refactor of eclwriter::writeOutput() to remove Damaris specific code ; Added eclwriter::writeDamarisOutput() that does Damaris specific processing when --enable-damaris-output=true and now works independently from --enable-ecl-output=true|false ; Check added to see if running a single core but with --enable-damaris-output=true and then switching off damaris processing as it needs > 1 rank to work; Write message after simulator ranks have finished to say that we are waiting for Damaris server processes to finish; added code to write correct local_to_global_filled for the Damaris GLOBAL_CELL_INDEX variable when there is only a single simulator rank - fix courtesy of Atgeirr R
 - addition to inbuilt XML template to use HDF5 select option to reorder data on disk by default (for Collective mode writing)
 - added check for returned number of values written when writing mesh; changed inbuilt xml file function name to be more descriptive; rebased Main.hpp on curent opm master
 - fixed merge conflict in Main.hpp; Added off by one to fix issue with mesh offset array if passing offsets to Paraview
 - added new header file to PUBLIC_HEADER_FILES list for cmake
 - added copyright header; bu fix for end of simulation stall; bug fix for single sim single Damaris config; added mesh capable internal XML file
 - changed loop structures and fixed bug when only 1 client due to no local_to_global index data
 - updated mesh data access using simplified Dune iterator interface. Does not deal with polygonal shape in mesh
 - tidy up of code - should use dask_pub_sub version of Damaris
 - version of eclwriter using damaris util classes for passing mesh data to Damaris
 - code going through debug of mesh access classes for Damaris
 - refactored vtkwriter code to give access to the Grid mesh data. To be used to pass the mesh data to Damaris