### PR TITLE
EclProblem: cleanup time stepping related members

### DIFF
--- a/ebos/eclgenericproblem.hh
+++ b/ebos/eclgenericproblem.hh
@@ -367,10 +367,6 @@ protected:
     bool enableTuning_;
     Scalar initialTimeStepSize_;
     Scalar maxTimeStepAfterWellEvent_;
-    Scalar maxTimeStepSize_;
-    Scalar restartShrinkFactor_;
-    unsigned maxFails_;
-    Scalar minTimeStepSize_;
     
     // equilibration parameters
     int numPressurePointsEquil_;

--- a/ebos/eclgenericproblem.hh
+++ b/ebos/eclgenericproblem.hh
@@ -263,19 +263,6 @@ public:
      */
     Scalar porosity(unsigned globalSpaceIdx, unsigned timeIdx) const;
 
-    /*!
-     * \brief Returns the minimum allowable size of a time step.
-     */
-    Scalar minTimeStepSize() const
-    { return minTimeStepSize_; }
-
-    /*!
-     * \brief Returns the maximum number of subsequent failures for the time integration
-     *        before giving up.
-     */
-    unsigned maxTimeIntegrationFailures() const
-    { return maxFails_; }
-
     bool vapparsActive(int episodeIdx) const;
 
     int numPressurePointsEquil() const

--- a/ebos/eclgenericproblem_impl.hh
+++ b/ebos/eclgenericproblem_impl.hh
@@ -471,9 +471,6 @@ beginEpisode_(bool enableExperiments,
         const auto& tuning = sched_state.tuning();
         initialTimeStepSize_ = sched_state.max_next_tstep();
         maxTimeStepAfterWellEvent_ = tuning.TMAXWC;
-        maxTimeStepSize_ = tuning.TSMAXZ;
-        restartShrinkFactor_ = 1./tuning.TSFCNV;
-        minTimeStepSize_ = tuning.TSMINZ;
         return true;
     }
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -190,8 +190,6 @@ public:
     using EclGenericProblem<GridView,FluidSystem,Scalar>::helpPreamble;
     using EclGenericProblem<GridView,FluidSystem,Scalar>::shouldWriteOutput;
     using EclGenericProblem<GridView,FluidSystem,Scalar>::shouldWriteRestartFile;
-    using EclGenericProblem<GridView,FluidSystem,Scalar>::maxTimeIntegrationFailures;
-    using EclGenericProblem<GridView,FluidSystem,Scalar>::minTimeStepSize;
     using EclGenericProblem<GridView,FluidSystem,Scalar>::rockCompressibility;
     using EclGenericProblem<GridView,FluidSystem,Scalar>::rockReferencePressure;
     using EclGenericProblem<GridView,FluidSystem,Scalar>::porosity;

--- a/ebos/eclproblem_properties.hh
+++ b/ebos/eclproblem_properties.hh
@@ -124,14 +124,6 @@ struct EclEnableAquifers {
 
 // time stepping parameters
 template<class TypeTag, class MyTypeTag>
-struct EclMaxTimeStepSizeAfterWellEvent {
-    using type = UndefinedProperty;
-};
-template<class TypeTag, class MyTypeTag>
-struct EclRestartShrinkFactor {
-    using type = UndefinedProperty;
-};
-template<class TypeTag, class MyTypeTag>
 struct EclEnableTuning {
     using type = UndefinedProperty;
 };
@@ -533,16 +525,6 @@ struct EnableExperiments<TypeTag, TTag::EclBaseProblem> {
 };
 
 // set defaults for the time stepping parameters
-template<class TypeTag>
-struct EclMaxTimeStepSizeAfterWellEvent<TypeTag, TTag::EclBaseProblem> {
-    using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 3600*24*365.25;
-};
-template<class TypeTag>
-struct EclRestartShrinkFactor<TypeTag, TTag::EclBaseProblem> {
-    using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 3;
-};
 template<class TypeTag>
 struct EclEnableTuning<TypeTag, TTag::EclBaseProblem> {
     static constexpr bool value = false;

--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -164,8 +164,6 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
             EWOMS_HIDE_PARAM(TypeTag, MinTimeStepSize);
             EWOMS_HIDE_PARAM(TypeTag, PredeterminedTimeStepsFile);
 
-            EWOMS_HIDE_PARAM(TypeTag, EclMaxTimeStepSizeAfterWellEvent);
-            EWOMS_HIDE_PARAM(TypeTag, EclRestartShrinkFactor);
             EWOMS_HIDE_PARAM(TypeTag, EclEnableTuning);
 
             // flow also does not use the eWoms Newton method

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -57,6 +57,14 @@
 
 #include <algorithm>
 
+namespace Opm::Properties {
+    namespace TTag {
+    struct TestRestartTypeTag {
+            using InheritsFrom = std::tuple<EbosTypeTag, FlowTimeSteppingParameters>;
+        };
+    }
+}
+
 template<class T>
 std::tuple<T,int,int> PackUnpack(T& in)
 {
@@ -427,11 +435,12 @@ namespace {
 
 struct AquiferFixture {
     AquiferFixture() {
-        using TT = Opm::Properties::TTag::EbosTypeTag;
+        using TT = Opm::Properties::TTag::TestRestartTypeTag;
         const char* argv[] = {
             "test_RestartSerialization",
             "--ecl-deck-file-name=GLIFT1.DATA"
         };
+        Opm::AdaptiveTimeSteppingEbos<TT>::registerParameters();
         Opm::setupParameters_<TT>(2, argv, /*registerParams=*/true);
         Opm::EclGenericVanguard::setCommunication(std::make_unique<Opm::Parallel::Communication>());
     }
@@ -444,7 +453,7 @@ BOOST_GLOBAL_FIXTURE(AquiferFixture);
 #define TEST_FOR_AQUIFER(TYPE) \
 BOOST_AUTO_TEST_CASE(TYPE) \
 { \
-    using TT = Opm::Properties::TTag::EbosTypeTag; \
+    using TT = Opm::Properties::TTag::TestRestartTypeTag; \
     Opm::EclGenericVanguard::readDeck("GLIFT1.DATA"); \
     using Simulator = Opm::GetPropType<TT, Opm::Properties::Simulator>; \
     Simulator sim; \
@@ -465,7 +474,7 @@ TEST_FOR_AQUIFER(AquiferFetkovich)
 
 BOOST_AUTO_TEST_CASE(AquiferNumerical)
 {
-    using TT = Opm::Properties::TTag::EbosTypeTag;
+    using TT = Opm::Properties::TTag::TestRestartTypeTag;
     Opm::EclGenericVanguard::readDeck("GLIFT1.DATA");
     using Simulator = Opm::GetPropType<TT, Opm::Properties::Simulator>;
     Simulator sim;
@@ -483,7 +492,7 @@ BOOST_AUTO_TEST_CASE(AquiferNumerical)
 
 BOOST_AUTO_TEST_CASE(AquiferConstantFlux)
 {
-    using TT = Opm::Properties::TTag::EbosTypeTag;
+    using TT = Opm::Properties::TTag::TestRestartTypeTag;
     Opm::EclGenericVanguard::readDeck("GLIFT1.DATA");
     using Simulator = Opm::GetPropType<TT, Opm::Properties::Simulator>;
     Simulator sim;

--- a/tests/test_equil.cc
+++ b/tests/test_equil.cc
@@ -82,7 +82,7 @@ namespace TTag {
 
 
 struct TestEquilTypeTag {
-    using InheritsFrom = std::tuple<FlowModelParameters, EclBaseProblem, BlackOilModel>;
+    using InheritsFrom = std::tuple<FlowTimeSteppingParameters, FlowModelParameters, EclBaseProblem, BlackOilModel>;
 };
 struct TestEquilVapwatTypeTag {
     using InheritsFrom = std::tuple<FlowModelParameters, EclBaseProblem, BlackOilModel>;
@@ -239,6 +239,7 @@ struct EquilFixture {
 #endif
         Opm::EclGenericVanguard::setCommunication(std::make_unique<Opm::Parallel::Communication>());
         Opm::BlackoilModelParametersEbos<TypeTag>::registerParameters();
+        Opm::AdaptiveTimeSteppingEbos<TypeTag>::registerParameters();
         Opm::Parameters::registerParam<TypeTag, bool>("EnableTerminalOutput",
                                                       "EnableTerminalOutput",
                                                       Opm::getPropValue<TypeTag, Opm::Properties::EnableTerminalOutput>(),

--- a/tests/test_glift1.cpp
+++ b/tests/test_glift1.cpp
@@ -67,7 +67,7 @@
 namespace Opm::Properties {
     namespace TTag {
         struct TestGliftTypeTag {
-            using InheritsFrom = std::tuple<EbosTypeTag>;
+            using InheritsFrom = std::tuple<EbosTypeTag, FlowTimeSteppingParameters>;
         };
     }
 }
@@ -86,6 +86,7 @@ initSimulator(const char *filename)
         filename_arg.c_str()
     };
 
+    Opm::AdaptiveTimeSteppingEbos<TypeTag>::registerParameters();
     Opm::setupParameters_<TypeTag>(/*argc=*/sizeof(argv)/sizeof(argv[0]), argv, /*registerParams=*/true);
 
     Opm::EclGenericVanguard::readDeck(filename);


### PR DESCRIPTION
Remove some unused methods and members. Avoid duplicate (and hidden) command line parameters.

I don't quite know the history here. It's either leftovers or duplicates that were required for the old ebos simulators. In any case I believe this can now be cleaned up without any fallout.