### PR TITLE
Refactor element centroids lookup

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -513,7 +513,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/utils/moduleVersion.hpp
   opm/simulators/utils/ParallelEclipseState.hpp
   opm/simulators/utils/ParallelRestart.hpp
-  opm/simulators/utils/PropsCentroidsDataHandle.hpp
+  opm/simulators/utils/PropsDataHandle.hpp
   opm/simulators/utils/SerializationPackers.hpp
   opm/simulators/utils/VectorVectorDataHandle.hpp
   opm/simulators/utils/PressureAverage.hpp

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -31,7 +31,7 @@
 
 #include <opm/grid/common/GridEnums.hpp>
 #include <opm/grid/common/CartesianIndexMapper.hpp>
-
+#include <opm/grid/LookUpCellCentroid.hh>
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 
@@ -42,6 +42,8 @@
 
 #include <opm/simulators/flow/BlackoilModelParametersEbos.hpp>
 
+
+
 #include <array>
 #include <cstddef>
 #include <optional>
@@ -51,6 +53,7 @@
 namespace Opm {
 template <class TypeTag>
 class EclBaseVanguard;
+template<typename Grid, typename GridView> struct LookUpCellCentroid;
 }
 
 namespace Opm::Properties {
@@ -475,21 +478,17 @@ protected:
     std::function<std::array<double,dimensionworld>(int)>
     cellCentroids_(const CartMapper& cartMapper) const
     {
-        return [this, cartMapper](int elemIdx) {
-                   const auto& centroids = this->centroids_;
-                   auto rank = this->gridView().comm().rank();
-                   std::array<double,dimensionworld> centroid;
-                   if (rank == 0) {
-                       unsigned cartesianCellIdx = cartMapper.cartesianIndex(elemIdx);
-                       centroid = this->eclState().getInputGrid().getCellCenter(cartesianCellIdx);
-                   } else
-                   {
-                       std::copy(centroids.begin() + elemIdx * dimensionworld,
-                                 centroids.begin() + (elemIdx + 1) * dimensionworld,
-                                 centroid.begin());
-                   }
-                   return centroid;
-               };
+        auto rank = this->gridView().comm().rank();
+        if (rank == 0)
+        {
+            LookUpCellCentroid<Grid,GridView> lookUpCellCentroid(this->gridView(), cartMapper, &(this ->eclState().getInputGrid()));
+            return lookUpCellCentroid;
+        }
+        else
+        {
+            LookUpCellCentroid<Grid,GridView> lookUpCellCentroid(this->gridView(), cartMapper, nullptr);
+            return lookUpCellCentroid;
+        }
     }
 
     void callImplementationInit()
@@ -506,7 +505,7 @@ protected:
     {
         std::size_t num_cells = asImp_().grid().leafGridView().size(0);
         is_interior_.resize(num_cells);
-        
+
         ElementMapper elemMapper(this->gridView(), Dune::mcmgElementLayout());
         for (const auto& element : elements(this->gridView()))
         {
@@ -578,7 +577,7 @@ private:
 
         return zz/Scalar(corners);
     }
-    
+
     Scalar computeCellThickness(const typename GridView::template Codim<0>::Entity& element) const
     {
         typedef typename Element::Geometry Geometry;
@@ -609,11 +608,6 @@ private:
     { return *static_cast<const Implementation*>(this); }
 
 protected:
-    /*! \brief The cell centroids after loadbalance was called.
-     * Empty otherwise. Used by EclTransmissibilty.
-     */
-    std::vector<double> centroids_;
-
     /*! \brief Mapping between cartesian and compressed cells.
      *  It is initialized the first time it is called
      */

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -143,8 +143,8 @@ public:
         this->doLoadBalance_(this->edgeWeightsMethod(), this->ownersFirst(),
                              this->serialPartitioning(), this->enableDistributedWells(),
                              this->zoltanImbalanceTol(), this->gridView(),
-                             this->schedule(), this->centroids_,
-                             this->eclState(), this->parallelWells_, this->numJacobiBlocks());
+                             this->schedule(), this->eclState(),
+                             this->parallelWells_, this->numJacobiBlocks());
 #endif
 
         this->updateGridView_();
@@ -160,7 +160,7 @@ public:
     unsigned int gridEquilIdxToGridIdx(unsigned int elemIndex) const {
          return elemIndex;
      }
- 
+
     unsigned int gridIdxToEquilGridIdx(unsigned int elemIndex) const {
         return elemIndex;
     }

--- a/ebos/eclgenericcpgridvanguard.hh
+++ b/ebos/eclgenericcpgridvanguard.hh
@@ -131,7 +131,6 @@ protected:
                         const double                            zoltanImbalanceTol,
                         const GridView&                         gridView,
                         const Schedule&                         schedule,
-                        std::vector<double>&                    centroids,
                         EclipseState&                           eclState,
                         EclGenericVanguard::ParallelWellStruct& parallelWells,
                         const int                               numJacobiBlocks);
@@ -149,7 +148,6 @@ private:
                         const bool                              loadBalancerSet,
                         const std::vector<double>&              faceTrans,
                         const std::vector<Well>&                wells,
-                        std::vector<double>&                    centroids,
                         EclipseState&                           eclState,
                         EclGenericVanguard::ParallelWellStruct& parallelWells);
 
@@ -161,7 +159,6 @@ private:
                         const bool                              loadBalancerSet,
                         const std::vector<double>&              faceTrans,
                         const std::vector<Well>&                wells,
-                        std::vector<double>&                    centroids,
                         ParallelEclipseState*                   eclState,
                         EclGenericVanguard::ParallelWellStruct& parallelWells);
 

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -44,7 +44,7 @@ public:
     friend class ParallelEclipseState; //!< Friend so props can be setup.
     //! \brief Friend to set up props
     template<class Grid>
-    friend class PropsCentroidsDataHandle;
+    friend class PropsDataHandle;
 
     //! \brief Constructor.
     //! \param manager The field property manager to wrap.
@@ -144,7 +144,7 @@ protected:
 class ParallelEclipseState : public EclipseState {
     //! \brief Friend to set up props
     template<class Grid>
-    friend class PropsCentroidsDataHandle;
+    friend class PropsDataHandle;
 public:
     //! \brief Default constructor.
     ParallelEclipseState(Parallel::Communication comm);


### PR DESCRIPTION
The new structure LookUpCellCentroid is added, replacing code for search centroids of elements. Associated with OPM/opm-grid#672 (merged).
Currently, this new structure is used only when the rank is different from zero (CpGrid). Refactoring the code for the case zero rank (other grids), breaks many tests and it's (temporary ) postponed. 

EclBaseVanguard::centroids_ is removed. 

ProsCentroidsDataHandle.hpp now is called PropsDataHandle.hpp (centroids is removed too). 
