### PR TITLE
Fix guard and warning

### DIFF
--- a/ebos/eclgenericproblem_impl.hh
+++ b/ebos/eclgenericproblem_impl.hh
@@ -21,7 +21,7 @@
   copyright holders.
 */
 #ifndef EWOMS_GENERIC_ECL_PROBLEM_IMPL_HH
-#define EWOMS_GENERIC_ECL_PROBLEM_IPML_HH
+#define EWOMS_GENERIC_ECL_PROBLEM_IMPL_HH
 
 #include <ebos/eclgenericproblem.hh>
 

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -484,7 +484,7 @@ getResidualMeasureValue(const WellState& well_state,
     assert(int(residuals.size()) == numWellEq + 1);
 
     const double rate_tolerance = tolerance_wells;
-    int count = 0;
+    [[maybe_unused]] int count = 0;
     double sum = 0;
     for (int eq_idx = 0; eq_idx < numWellEq - 1; ++eq_idx) {
         if (residuals[eq_idx] > rate_tolerance) {


### PR DESCRIPTION
Two minor fixes addressing compile warnings. The header guard fix solves a real potential problem.