### PR TITLE
Changed: Do not use dune-fem in default simulators even if it is available

### DIFF
--- a/ebos/collecttoiorank.cc
+++ b/ebos/collecttoiorank.cc
@@ -35,6 +35,10 @@
 
 namespace Opm {
 
+template class CollectDataToIORank<Dune::CpGrid,
+                                   Dune::CpGrid,
+                                   Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>;
+
 #if HAVE_DUNE_FEM
 template class CollectDataToIORank<Dune::CpGrid,
                                    Dune::CpGrid,
@@ -46,10 +50,6 @@ template class CollectDataToIORank<Dune::CpGrid,
                                            Dune::CpGrid,
                                            Dune::PartitionIteratorType(4),
                                            false> > >;
-#else // ! HAVE_DUNE_FEM
-template class CollectDataToIORank<Dune::CpGrid,
-                                   Dune::CpGrid,
-                                   Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>;
-#endif
+#endif // HAVE_DUNE_FEM
 
 } // end namespace Opm

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -493,44 +493,44 @@ computeCellThickness(const typename GridView::template Codim<0>::Entity& element
     zz2 /=4;
     return zz2-zz1;
 }
+template class EclGenericCpGridVanguard<
+    Dune::MultipleCodimMultipleGeomTypeMapper<
+        Dune::GridView<
+            Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
+    Dune::GridView<
+        Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
+    double>;
 
 #if HAVE_DUNE_FEM
-    template class EclGenericCpGridVanguard<
-        Dune::MultipleCodimMultipleGeomTypeMapper<
-            Dune::GridView<
-                Dune::Fem::GridPart2GridViewTraits<
-                    Dune::Fem::AdaptiveLeafGridPart<
-                        Dune::CpGrid,
-                        Dune::PartitionIteratorType(4),
-                        false>>>>,
+template class EclGenericCpGridVanguard<
+    Dune::MultipleCodimMultipleGeomTypeMapper<
         Dune::GridView<
             Dune::Fem::GridPart2GridViewTraits<
                 Dune::Fem::AdaptiveLeafGridPart<
                     Dune::CpGrid,
                     Dune::PartitionIteratorType(4),
-                    false>>>,
-        double>;
+                    false>>>>,
+    Dune::GridView<
+        Dune::Fem::GridPart2GridViewTraits<
+            Dune::Fem::AdaptiveLeafGridPart<
+                Dune::CpGrid,
+                Dune::PartitionIteratorType(4),
+                false>>>,
+    double>;
 
-    template class EclGenericCpGridVanguard<
-        Dune::MultipleCodimMultipleGeomTypeMapper<
-            Dune::Fem::GridPart2GridViewImpl<
-                Dune::Fem::AdaptiveLeafGridPart<
-                    Dune::CpGrid,
-                    Dune::PartitionIteratorType(4),
-                    false>>>,
+template class EclGenericCpGridVanguard<
+    Dune::MultipleCodimMultipleGeomTypeMapper<
         Dune::Fem::GridPart2GridViewImpl<
             Dune::Fem::AdaptiveLeafGridPart<
                 Dune::CpGrid,
                 Dune::PartitionIteratorType(4),
-                false> >,
-        double>;
-#else
-    template class EclGenericCpGridVanguard<
-        Dune::MultipleCodimMultipleGeomTypeMapper<
-            Dune::GridView<
-                Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
-        Dune::GridView<
-            Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
-        double>;
-#endif
+                false>>>,
+    Dune::Fem::GridPart2GridViewImpl<
+        Dune::Fem::AdaptiveLeafGridPart<
+            Dune::CpGrid,
+            Dune::PartitionIteratorType(4),
+            false> >,
+    double>;
+#endif // HAVE_DUNE_FEM
+
 } // namespace Opm

--- a/ebos/eclgenericproblem.cc
+++ b/ebos/eclgenericproblem.cc
@@ -40,6 +40,10 @@
 
 namespace Opm {
 
+template class EclGenericProblem<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
+                                 BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,
+                                 double>;
+
 #if HAVE_DUNE_FEM
 template class EclGenericProblem<Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,
                                  BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,
@@ -51,10 +55,6 @@ template class EclGenericProblem<Dune::Fem::GridPart2GridViewImpl<
                                         false> >,
                                  BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,
                                  double>;
-#else
-template class EclGenericProblem<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
-                                 BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,
-                                 double>;
-#endif
+#endif // HAVE_DUNE_FEM
 
 } // end namespace Opm

--- a/ebos/eclgenericthresholdpressure.cc
+++ b/ebos/eclgenericthresholdpressure.cc
@@ -36,6 +36,11 @@
 
 namespace Opm {
 
+template class EclGenericThresholdPressure<Dune::CpGrid,
+                                           Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
+                                           Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
+                                           double>;
+
 #if HAVE_DUNE_FEM
 template class EclGenericThresholdPressure<Dune::CpGrid,
                                            Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,
@@ -54,12 +59,6 @@ template class EclGenericThresholdPressure<Dune::CpGrid,
                                                         Dune::PartitionIteratorType(4),
                                                         false>>>,
                                             double>;
-#else
-template class EclGenericThresholdPressure<Dune::CpGrid,
-                                           Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
-                                           Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
-                                           double>;
-#endif
-
+#endif // HAVE_DUNE_FEM
 
 } // namespace Opm

--- a/ebos/eclgenerictracermodel.cc
+++ b/ebos/eclgenerictracermodel.cc
@@ -31,6 +31,12 @@
 
 namespace Opm {
 
+template class EclGenericTracerModel<Dune::CpGrid,
+                                     Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
+                                     Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
+                                     Opm::EcfvStencil<double,Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,false,false>,
+                                     double>;
+
 #if HAVE_DUNE_FEM
 template class EclGenericTracerModel<Dune::CpGrid,
                                      Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,
@@ -46,12 +52,6 @@ template class EclGenericTracerModel<Dune::CpGrid,
                                                                   Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false> >,
                                                       false, false>,
                                      double>;
-#else
-template class EclGenericTracerModel<Dune::CpGrid,
-                                     Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
-                                     Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
-                                     Opm::EcfvStencil<double,Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,false,false>,
-                                     double>;
-#endif //HAVE_DUNE_FEM
+#endif // HAVE_DUNE_FEM
 
 } // namespace Opm

--- a/ebos/eclgenericwriter.cc
+++ b/ebos/eclgenericwriter.cc
@@ -38,6 +38,12 @@
 
 namespace Opm {
 
+template class EclGenericWriter<Dune::CpGrid,
+                                Dune::CpGrid,
+                                Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
+                                Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
+                                double>;
+
 #if HAVE_DUNE_FEM
 template class EclGenericWriter<Dune::CpGrid,
                                 Dune::CpGrid,
@@ -57,12 +63,6 @@ template class EclGenericWriter<Dune::CpGrid,
                                             Dune::PartitionIteratorType(4),
                                             false>>>,
                                 double>;
-#else // !HAVE_DUNE_FEM
-template class EclGenericWriter<Dune::CpGrid,
-                                Dune::CpGrid,
-                                Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
-                                Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
-                                double>;
-#endif // HAVE_DUNE_FEM
+#endif // HAVE_DUNE_FEM*/
 
 } // namespace Opm

--- a/ebos/eclproblem_properties.hh
+++ b/ebos/eclproblem_properties.hh
@@ -170,6 +170,23 @@ struct LocalLinearizerSplice<TypeTag, TTag::EclBaseProblem> {
     using type = TTag::AutoDiffLocalLinearizer;
 };
 
+template<class TypeTag>
+struct BaseDiscretizationType<TypeTag, TTag::EclBaseProblem> {
+    using type = FvBaseDiscretizationNoAdapt<TypeTag>;
+};
+
+template<class TypeTag>
+struct DiscreteFunction<TypeTag, TTag::EclBaseProblem> {
+    using BaseDiscretization = FvBaseDiscretization<TypeTag>;
+    using type = typename BaseDiscretization::BlockVectorWrapper;
+};
+
+template<class TypeTag>
+struct GridView<TypeTag, TTag::EclBaseProblem>
+{
+    using type = typename GetPropType<TypeTag, Properties::Grid>::LeafGridView;
+};
+
 // Set the material law for fluid fluxes
 template<class TypeTag>
 struct MaterialLaw<TypeTag, TTag::EclBaseProblem>

--- a/ebos/ecltransmissibility.cc
+++ b/ebos/ecltransmissibility.cc
@@ -35,6 +35,12 @@
 
 namespace Opm {
 
+template class EclTransmissibility<Dune::CpGrid,
+                                   Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
+                                   Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
+                                   Dune::CartesianIndexMapper<Dune::CpGrid>,
+                                   double>;
+
 #ifdef HAVE_DUNE_FEM
 template class EclTransmissibility<Dune::CpGrid,
                                    Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,
@@ -55,12 +61,6 @@ template class EclTransmissibility<Dune::CpGrid,
                                                false> > >,
                                    Dune::CartesianIndexMapper<Dune::CpGrid>,
                                    double>;
-#else // !DUNE_FEM
-template class EclTransmissibility<Dune::CpGrid,
-                                   Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
-                                   Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
-                                   Dune::CartesianIndexMapper<Dune::CpGrid>,
-                                   double>;
-#endif //HAVE_DUNE_FEM
+#endif // HAVE_DUNE_FEM
 
 } // namespace Opm

--- a/ebos/equil/initstateequil.cc
+++ b/ebos/equil/initstateequil.cc
@@ -37,37 +37,42 @@ namespace Opm {
 namespace EQUIL {
 namespace DeckDependent {
 
-#if HAVE_DUNE_FEM
-using GridView = Dune::Fem::GridPart2GridViewImpl<
-                                     Dune::Fem::AdaptiveLeafGridPart<
-                                         Dune::CpGrid,
-                                         Dune::PartitionIteratorType(4),
-                                         false>>;
-#else
-using GridView = Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>;
-#endif
-
-using Mapper = Dune::MultipleCodimMultipleGeomTypeMapper<GridView>;
-template class InitialStateComputer<BlackOilFluidSystem<double>,
-                                    Dune::CpGrid,
-                                    GridView,
-                                    Mapper,
-                                    Dune::CartesianIndexMapper<Dune::CpGrid>>;
-
 using MatLaw = EclMaterialLawManager<ThreePhaseMaterialTraits<double,0,1,2>>;
-template InitialStateComputer<BlackOilFluidSystem<double>,
-                              Dune::CpGrid,
-                              GridView,
-                              Mapper,
-                              Dune::CartesianIndexMapper<Dune::CpGrid>>::
-    InitialStateComputer(MatLaw&,
-                         const EclipseState&,
-                         const Dune::CpGrid&,
-                         const GridView&,
-                         const Dune::CartesianIndexMapper<Dune::CpGrid>&,
-                         const double,
-                         const int,
-                         const bool);
+
+#define INSTANCE_COMP(GridView, Mapper) \
+    template class InitialStateComputer<BlackOilFluidSystem<double>, \
+                                        Dune::CpGrid, \
+                                        GridView, \
+                                        Mapper, \
+                                        Dune::CartesianIndexMapper<Dune::CpGrid>>; \
+    template InitialStateComputer<BlackOilFluidSystem<double>, \
+                                  Dune::CpGrid, \
+                                  GridView, \
+                                  Mapper, \
+                                  Dune::CartesianIndexMapper<Dune::CpGrid>>::\
+        InitialStateComputer(MatLaw&, \
+                             const EclipseState&, \
+                             const Dune::CpGrid&, \
+                             const GridView&, \
+                             const Dune::CartesianIndexMapper<Dune::CpGrid>&, \
+                             const double, \
+                             const int, \
+                             const bool);
+
+using GridView = Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>;
+using Mapper = Dune::MultipleCodimMultipleGeomTypeMapper<GridView>;
+INSTANCE_COMP(GridView, Mapper)
+
+#if HAVE_DUNE_FEM
+using GridViewFem = Dune::Fem::GridPart2GridViewImpl<
+                                        Dune::Fem::AdaptiveLeafGridPart<
+                                            Dune::CpGrid,
+                                            Dune::PartitionIteratorType(4),
+                                            false>>;
+using MapperFem = Dune::MultipleCodimMultipleGeomTypeMapper<GridViewFem>;
+INSTANCE_COMP(GridViewFem, MapperFem)
+#endif // HAVE_DUNE_FEM
+
 } // namespace DeckDependent
 
 namespace Details {


### PR DESCRIPTION
It is now typetag configurable. Should be enabled where used.

Downstream of https://github.com/OPM/opm-models/pull/821