### PR TITLE
Enable aquifers with H2STORE

### DIFF
--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -715,7 +715,7 @@ private:
 
     void applyNumericalAquifers_(const GridView& gridView,
                                  const NumericalAquifers& aquifer,
-                                 const bool co2store);
+                                 const bool co2store_or_h2store);
 
     template<class RMap>
     void setRegionPvtIdx(const EclipseState& eclState, const RMap& reg);

--- a/ebos/equil/initstateequil_impl.hh
+++ b/ebos/equil/initstateequil_impl.hh
@@ -1669,6 +1669,8 @@ applyNumericalAquifers_(const GridView& gridView,
     ElementMapper elemMapper(gridView, Dune::mcmgElementLayout());
     auto elemIt = gridView.template begin</*codim=*/0>();
     const auto& elemEndIt = gridView.template end</*codim=*/0>();
+    const auto oilPos = FluidSystem::oilPhaseIdx;
+    const auto gasPos = FluidSystem::gasPhaseIdx;
     for (; elemIt != elemEndIt; ++elemIt) {
         const Element& element = *elemIt;
         const unsigned int elemIdx = elemMapper.index(element);
@@ -1676,16 +1678,12 @@ applyNumericalAquifers_(const GridView& gridView,
         const auto search = num_aqu_cells.find(cartIx);
         if (search != num_aqu_cells.end()) {
             // numerical aquifer cells are filled with water initially
-            if (FluidSystem::phaseIsActive(watPos)) {
-                this->sat_[watPos][elemIdx] = 1.;
-            }
+            this->sat_[watPos][elemIdx] = 1.;
 
-            const auto oilPos = FluidSystem::oilPhaseIdx;
             if (!co2store_or_h2store && FluidSystem::phaseIsActive(oilPos)) {
                 this->sat_[oilPos][elemIdx] = 0.;
             }
 
-            const auto gasPos = FluidSystem::gasPhaseIdx;
             if (FluidSystem::phaseIsActive(gasPos)) {
                 this->sat_[gasPos][elemIdx] = 0.;
             }

--- a/opm/simulators/aquifers/AquiferAnalytical.hpp
+++ b/opm/simulators/aquifers/AquiferAnalytical.hpp
@@ -246,7 +246,7 @@ protected:
 
     int compIdx_() const
     {
-        if (this->co2store_())
+        if (this->co2store_or_h2store_())
             return FluidSystem::oilCompIdx;
 
         return FluidSystem::waterCompIdx;

--- a/opm/simulators/aquifers/AquiferCarterTracy.hpp
+++ b/opm/simulators/aquifers/AquiferCarterTracy.hpp
@@ -104,7 +104,7 @@ public:
         aquCT->dimensionless_pressure = this->dimensionless_pressure_;
         aquCT->influxConstant = this->aquct_data_.influxConstant();
 
-        if (!this->co2store_()) {
+        if (!this->co2store_or_h2store_()) {
             aquCT->timeConstant = this->aquct_data_.timeConstant();
             aquCT->waterDensity = this->aquct_data_.waterDensity();
             aquCT->waterViscosity = this->aquct_data_.waterViscosity();
@@ -217,7 +217,7 @@ protected:
 
     void calculateAquiferConstants() override
     {
-        this->Tc_ = this->co2store_()
+        this->Tc_ = this->co2store_or_h2store_()
             ? this->timeConstantCO2Store()
             : this->aquct_data_.timeConstant();
 
@@ -245,7 +245,7 @@ protected:
             this->Ta0_ = this->aquct_data_.initial_temperature.value();
         }
 
-        this->rhow_ = this->co2store_()
+        this->rhow_ = this->co2store_or_h2store_()
             ? this->waterDensityCO2Store()
             : this->aquct_data_.waterDensity();
     }

--- a/opm/simulators/aquifers/AquiferConstantFlux.hpp
+++ b/opm/simulators/aquifers/AquiferConstantFlux.hpp
@@ -214,7 +214,7 @@ private:
     // TODO: this is a function from AquiferAnalytical
     int compIdx_() const
     {
-        if (this->co2store_())
+        if (this->co2store_or_h2store_())
             return FluidSystem::oilCompIdx;
 
         return FluidSystem::waterCompIdx;

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -80,7 +80,8 @@ public:
 protected:
     bool co2store_or_h2store_() const
     {
-        return ebos_simulator_.vanguard().eclState().runspec().co2Storage() || ebos_simulator_.vanguard().eclState().runspec().h2Storage();
+        const auto& rspec = ebos_simulator_.vanguard().eclState().runspec();
+        return rspec.co2Storage() || rspec.h2Storage();
     }
 
     int phaseIdx_() const

--- a/opm/simulators/aquifers/AquiferInterface.hpp
+++ b/opm/simulators/aquifers/AquiferInterface.hpp
@@ -78,15 +78,15 @@ public:
     int aquiferID() const { return this->aquiferID_; }
 
 protected:
-    bool co2store_() const
+    bool co2store_or_h2store_() const
     {
-        return ebos_simulator_.vanguard().eclState().runspec().co2Storage();
+        return ebos_simulator_.vanguard().eclState().runspec().co2Storage() || ebos_simulator_.vanguard().eclState().runspec().h2Storage();
     }
 
     int phaseIdx_() const
     {
         // If OIL is used to model brine the aquifer should do the same
-        if (co2store_() && FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx))
+        if (co2store_or_h2store_() && FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx))
             return FluidSystem::oilPhaseIdx;
 
         return FluidSystem::waterPhaseIdx;


### PR DESCRIPTION
Enable aquifer keywords when H2STORE is active with OIL phase (as brine). Pretty much an extension of what is already available for CO2STORE.