### PR TITLE
Bring WellContributions Declaration in Scope

### DIFF
--- a/opm/simulators/linalg/bda/BdaBridge.cpp
+++ b/opm/simulators/linalg/bda/BdaBridge.cpp
@@ -27,6 +27,7 @@
 
 #include <opm/simulators/linalg/bda/BdaBridge.hpp>
 #include <opm/simulators/linalg/bda/BdaResult.hpp>
+#include <opm/simulators/linalg/bda/WellContributions.hpp>
 
 #if HAVE_CUDA
 #include <opm/simulators/linalg/bda/cuda/cusparseSolverBackend.hpp>


### PR DESCRIPTION
This restores the build on machines which enable the BDA bridge, but which do not have OpenCL installed.