### PR TITLE
fixed: avoid segfault in cleanup if simulator has not been set up

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -415,7 +415,7 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
             // force closing of all log files.
             OpmLog::removeAllBackends();
 
-            if (mpi_rank_ != 0 || mpi_size_ < 2 || !this->output_files_) {
+            if (mpi_rank_ != 0 || mpi_size_ < 2 || !this->output_files_ || !ebosSimulator_) {
                 return;
             }
 


### PR DESCRIPTION
If an exception is thrown during simulator setup, the ebosSimulator_ object might not be instanced. We then deref a nullptr calling the eclState() member further down.