### PR TITLE
EclActionHandler: move from ebos/ to opm/simulators/flow

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -24,7 +24,6 @@
 # find opm -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND MAIN_SOURCE_FILES
   ebos/collecttoiorank.cc
-  ebos/eclactionhandler.cc
   ebos/eclgenericcpgridvanguard.cc
   ebos/eclgenericoutputblackoilmodule.cc
   ebos/eclgenericproblem.cc
@@ -45,6 +44,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/flow/Banners.cpp
   opm/simulators/flow/countGlobalCells.cpp
   opm/simulators/flow/ConvergenceOutputConfiguration.cpp
+  opm/simulators/flow/EclActionHandler.cpp
   opm/simulators/flow/ExtraConvergenceOutputThread.cpp
   opm/simulators/flow/FlowMainEbos.cpp
   opm/simulators/flow/KeywordValidation.cpp
@@ -380,7 +380,6 @@ list (APPEND PUBLIC_HEADER_FILES
   ebos/collecttoiorank.hh
   ebos/collecttoiorank_impl.hh
   ebos/ebos.hh
-  ebos/eclactionhandler.hh
   ebos/eclalugridvanguard.hh
   ebos/eclbaseaquifermodel.hh
   ebos/eclbasevanguard.hh
@@ -422,6 +421,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/flow/BlackoilModelParametersEbos.hpp
   opm/simulators/flow/Banners.hpp
   opm/simulators/flow/ConvergenceOutputConfiguration.hpp
+  opm/simulators/flow/EclActionHandler.hpp
   opm/simulators/flow/ExtraConvergenceOutputThread.hpp
   opm/simulators/flow/FlowMainEbos.hpp
   opm/simulators/flow/Main.hpp

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -32,7 +32,6 @@
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
 
-#include <ebos/eclactionhandler.hh>
 #include <ebos/eclbaseaquifermodel.hh>
 #include <ebos/eclcpgridvanguard.hh>
 #include <ebos/ecldummygradientcalculator.hh>
@@ -78,6 +77,7 @@
 
 #include <opm/output/eclipse/EclipseIO.hpp>
 
+#include <opm/simulators/flow/EclActionHandler.hpp>
 #include <opm/simulators/timestepping/SimulatorReport.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/simulators/utils/ParallelSerialization.hpp>

--- a/opm/simulators/flow/EclActionHandler.cpp
+++ b/opm/simulators/flow/EclActionHandler.cpp
@@ -207,7 +207,7 @@ void EclActionHandler::applySimulatorUpdate(const int report_step,
 std::unordered_map<std::string, double>
 EclActionHandler::fetchWellPI(const int reportStep,
                               const Action::ActionX& action,
-                              const std::vector<std::string>& matching_wells)
+                              const std::vector<std::string>& matching_wells) const
 {
 
   auto wellpi_wells = action.wellpi_wells(WellMatcher(schedule_[reportStep].well_order(),

--- a/opm/simulators/flow/EclActionHandler.cpp
+++ b/opm/simulators/flow/EclActionHandler.cpp
@@ -22,8 +22,7 @@
 */
 
 #include <config.h>
-
-#include <ebos/eclactionhandler.hh>
+#include <opm/simulators/flow/EclActionHandler.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/TimeService.hpp>

--- a/opm/simulators/flow/EclActionHandler.hpp
+++ b/opm/simulators/flow/EclActionHandler.hpp
@@ -82,7 +82,7 @@ public:
     std::unordered_map<std::string, double>
     fetchWellPI(int reportStep,
                 const Action::ActionX& action,
-                const std::vector<std::string>& matching_wells);
+                const std::vector<std::string>& matching_wells) const;
 
     EclipseState& ecl_state_;
     Schedule& schedule_;

--- a/opm/simulators/flow/EclActionHandler.hpp
+++ b/opm/simulators/flow/EclActionHandler.hpp
@@ -21,8 +21,8 @@
   copyright holders.
 */
 
-#ifndef ECL_ACTION_HANDLER_HH
-#define ECL_ACTION_HANDLER_HH
+#ifndef ECL_ACTION_HANDLER_HPP
+#define ECL_ACTION_HANDLER_HPP
 
 #include <opm/simulators/utils/ParallelCommunication.hpp>
 
@@ -69,10 +69,10 @@ public:
 
 private:
   /*
-    This function is run after applyAction has been completed in the Schedule
-    implementation. The sim_update argument should have members & flags for
-    the simulator properties which need to be updated. This functionality is
-    probably not complete.
+     This function is run after applyAction has been completed in the Schedule
+     implementation. The sim_update argument should have members & flags for
+     the simulator properties which need to be updated. This functionality is
+     probably not complete.
   */
   void applySimulatorUpdate(int report_step,
                             const SimulatorUpdate& sim_update,
@@ -94,4 +94,4 @@ private:
 
 } // namespace Opm
 
-#endif
+#endif // ECL_ACTION_HANDLER_HPP

--- a/opm/simulators/flow/EclActionHandler.hpp
+++ b/opm/simulators/flow/EclActionHandler.hpp
@@ -49,47 +49,47 @@ class UDQState;
 class EclActionHandler
 {
 public:
-  //! \brief Function handle to update transmissiblities.
-  using TransFunc = std::function<void(bool)>;
+    //! \brief Function handle to update transmissiblities.
+    using TransFunc = std::function<void(bool)>;
 
-  EclActionHandler(EclipseState& ecl_state,
-                   Schedule& schedule,
-                   Action::State& actionState,
-                   SummaryState& summaryState,
-                   BlackoilWellModelGeneric& wellModel,
-                   Parallel::Communication comm);
+    EclActionHandler(EclipseState& ecl_state,
+                     Schedule& schedule,
+                     Action::State& actionState,
+                     SummaryState& summaryState,
+                     BlackoilWellModelGeneric& wellModel,
+                     Parallel::Communication comm);
 
-  void applyActions(int reportStep,
-                    double sim_time,
-                    const TransFunc& updateTrans);
+    void applyActions(int reportStep,
+                      double sim_time,
+                      const TransFunc& updateTrans);
 
-  //! \brief Evaluates UDQ assign statements.
-  void evalUDQAssignments(const unsigned episodeIdx,
-                          UDQState& udq_state);
+    //! \brief Evaluates UDQ assign statements.
+    void evalUDQAssignments(const unsigned episodeIdx,
+                            UDQState& udq_state);
 
-private:
-  /*
-     This function is run after applyAction has been completed in the Schedule
-     implementation. The sim_update argument should have members & flags for
-     the simulator properties which need to be updated. This functionality is
-     probably not complete.
-  */
-  void applySimulatorUpdate(int report_step,
-                            const SimulatorUpdate& sim_update,
-                            bool& commit_wellstate,
-                            const TransFunc& updateTrans);
+  private:
+    /*
+       This function is run after applyAction has been completed in the Schedule
+       implementation. The sim_update argument should have members & flags for
+       the simulator properties which need to be updated. This functionality is
+       probably not complete.
+    */
+    void applySimulatorUpdate(int report_step,
+                              const SimulatorUpdate& sim_update,
+                              bool& commit_wellstate,
+                              const TransFunc& updateTrans);
 
-  std::unordered_map<std::string, double>
-  fetchWellPI(int reportStep,
-              const Action::ActionX& action,
-              const std::vector<std::string>& matching_wells);
+    std::unordered_map<std::string, double>
+    fetchWellPI(int reportStep,
+                const Action::ActionX& action,
+                const std::vector<std::string>& matching_wells);
 
-  EclipseState& ecl_state_;
-  Schedule& schedule_;
-  Action::State& actionState_;
-  SummaryState& summaryState_;
-  BlackoilWellModelGeneric& wellModel_;
-  Parallel::Communication comm_;
+    EclipseState& ecl_state_;
+    Schedule& schedule_;
+    Action::State& actionState_;
+    SummaryState& summaryState_;
+    BlackoilWellModelGeneric& wellModel_;
+    Parallel::Communication comm_;
 };
 
 } // namespace Opm


### PR DESCRIPTION
Since there is no opm-models usage, we should move this out of the ebos/ folder.