### PR TITLE
added: build system option to enable Tracy profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(USE_CHOW_PATEL_ILU_GPU_PARALLEL "Try to use more parallelism on the GPU d
 option(BUILD_FLOW_ALU_GRID "Build flow blackoil with alu grid" OFF)
 option(USE_DAMARIS_LIB "Use the Damaris library for asynchronous I/O?" OFF)
 option(USE_BDA_BRIDGE "Enable the BDA bridge (GPU/AMGCL solvers)" ON)
+option(USE_TRACY_PROFILER "Enable tracy profiling" OFF)
 
 # The following was copied from CMakeLists.txt in opm-common.
 # TODO: factor out the common parts in opm-common and opm-simulator as a cmake module
@@ -257,6 +258,12 @@ macro (config_hook)
   if(NOT fmt_FOUND)
     add_definitions(-DFMT_HEADER_ONLY)
     list(APPEND EXTRA_INCLUDES SYSTEM ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
+  endif()
+  if(USE_TRACY_PROFILER AND Tracy_FOUND)
+    set(USE_TRACY 1)
+    list(APPEND opm-simulators_LIBRARIES Tracy::TracyClient)
+  else()
+    set(USE_TRACY)
   endif()
   include_directories(${EXTRA_INCLUDES})
 

--- a/opm-simulators-prereqs.cmake
+++ b/opm-simulators-prereqs.cmake
@@ -22,6 +22,7 @@ set (opm-simulators_CONFIG_VAR
   HAVE_SUITESPARSE_UMFPACK
   HAVE_DAMARIS
   HAVE_HDF5
+  USE_TRACY
   )
 
 # dependencies
@@ -54,6 +55,7 @@ set (opm-simulators_DEPS
   "opm-models REQUIRED"
   "Damaris 1.7"
   "HDF5"
+  "Tracy"
   )
 
 find_package_deps(opm-simulators)


### PR DESCRIPTION
To make it easy to enable tracy profiling. Downstream of https://github.com/OPM/opm-common/pull/3631