### PR TITLE
SimulatorFullyImplicitBlackoilEbos: remove unused member

### DIFF
--- a/opm/simulators/flow/BlackoilModelEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelEbos.hpp
@@ -51,7 +51,6 @@
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/simulators/utils/ParallelCommunication.hpp>
 #include <opm/simulators/wells/BlackoilWellModel.hpp>
-#include <opm/simulators/wells/WellConnectionAuxiliaryModule.hpp>
 
 #include <dune/common/timer.hh>
 

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -713,7 +713,6 @@ protected:
 
     // Data.
     Simulator& ebosSimulator_;
-    std::unique_ptr<WellConnectionAuxiliaryModule<TypeTag>> wellAuxMod_;
 
     ModelParameters modelParam_;
     SolverParameters solverParam_;
@@ -738,7 +737,7 @@ protected:
     int saveStride_ = -1; //!< Stride to save serialized state at
     int saveStep_ = -1; //!< Specific step to save serialized state at
     int loadStep_ = -1; //!< Step to load serialized state from
-    std::string saveFile_; //!< File to load/save serialized state from/to.
+    std::string saveFile_; //!< File to load/save serialized state from/to
 };
 
 } // namespace Opm


### PR DESCRIPTION
In principle the whole WellConnectionAuxiliaryModule could be nuked, but I'm not entirely sure what the deal here is so I played it safe.