### PR TITLE
Remove Unused Return Value

### DIFF
--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -192,12 +192,9 @@ protected:
      *
      * \param cartesianToCompressed Vector containing the compressed index (or -1 for inactive
      *                              cells) as the element at the cartesian index.
-     * \return Two vector of NNCs (scaled by EDITNNC). The first one are the NNCs that have been applied
-     *         and the second the NNCs not resembled by faces of the grid. NNCs specified for
-     *         inactive cells are omitted in these vectors.
+     * \return Nothing.
      */
-    std::tuple<std::vector<NNCdata>, std::vector<NNCdata>>
-    applyNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianToCompressed);
+    void applyNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianToCompressed);
 
     /// \brief Multiplies the grid transmissibilities according to EDITNNC.
     void applyEditNncToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal);

--- a/ebos/ecltransmissibility_impl.hh
+++ b/ebos/ecltransmissibility_impl.hh
@@ -823,16 +823,12 @@ computeFaceProperties(const Intersection& intersection,
 }
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
-std::tuple<std::vector<NNCdata>, std::vector<NNCdata>>
+void
 EclTransmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
 applyNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianToCompressed)
 {
     // First scale NNCs with EDITNNC.
-    std::vector<NNCdata> unprocessedNnc;
-    std::vector<NNCdata> processedNnc;
     const auto& nnc_input = eclState_.getInputNNC().input();
-    if (nnc_input.empty())
-        return std::make_tuple(processedNnc, unprocessedNnc);
 
     for (const auto& nncEntry : nnc_input) {
         auto c1 = nncEntry.cell1;
@@ -859,20 +855,13 @@ applyNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianToCompr
         }
 
         auto candidate = trans_.find(isId(low, high));
-
-        if (candidate == trans_.end())
-            // This NNC is not resembled by the grid. Save it for later
-            // processing with local cell values
-            unprocessedNnc.push_back(nncEntry);
-        else {
+        if (candidate != trans_.end()) {
             // NNC is represented by the grid and might be a neighboring connection
             // In this case the transmissibilty is added to the value already
             // set or computed.
             candidate->second += nncEntry.trans;
-            processedNnc.push_back(nncEntry);
         }
     }
-    return std::make_tuple(processedNnc, unprocessedNnc);
 }
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>


### PR DESCRIPTION
The return value from `applyNncToGridTrans_()` was never used and the author confirms that this is intentional.  Remove the entire return value to signal this intention.

Resolves #4799.