### PR TITLE
Ensure initial well solve is performed in corner case

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -494,8 +494,11 @@ namespace Opm {
                 const bool event = report_step_starts_ && events.hasEvent(well->name(), effective_events_mask);
                 const bool dyn_status_change = this->wellState().well(well->name()).status
                         != this->prevWellState().well(well->name()).status;
-
-                if (event || dyn_status_change) {
+                bool prev_zero_rates = true;
+                for (const double& rate : this->prevWellState().well(well->name()).surface_rates){
+                    prev_zero_rates &= (rate == 0.0);
+                } 
+                if (event || dyn_status_change || prev_zero_rates){
                     try {
                         well->updateWellStateWithTarget(ebosSimulator_, this->groupState(), this->wellState(), local_deferredLogger);
                         well->calculateExplicitQuantities(ebosSimulator_, this->wellState(), local_deferredLogger);


### PR DESCRIPTION
In the case when a well was under zero-rate constraint in the previous step, an initial well solve will currently not be performed. It will however trigger _alternative-well-rate-init_ and this initialization can be very problematic if used as initial guess for balancing of networks. This suggest a rather hacky fix, happy to formulate it differently if there is a good suggestion.    