### PR TITLE
[pure testing] disabling althernative well rate init by default

### DIFF
--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -325,7 +325,7 @@ struct ShutUnsolvableWells<TypeTag, TTag::FlowModelParameters> {
 };
 template<class TypeTag>
 struct AlternativeWellRateInit<TypeTag, TTag::FlowModelParameters> {
-    static constexpr bool value = true;
+    static constexpr bool value = false;
 };
 template<class TypeTag>
 struct StrictOuterIterWells<TypeTag, TTag::FlowModelParameters> {


### PR DESCRIPTION
pure testing. Helping the investigation of https://github.com/OPM/opm-simulators/pull/4817 . 