### PR TITLE
Apply Regional Multipliers to Initial Transmissibilities

### DIFF
--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -119,15 +119,27 @@ public:
      * either but at least it seems to be much better.
      */
     void finishInit(const std::function<unsigned int(unsigned int)>& map = {})
-    { update(true,map); }
+    {
+        this->update(true, map, /*applyNncMultRegT = */ true);
+    }
 
     /*!
      * \brief Compute all transmissibilities
      *
-     * \param global If true, update is called on all processes
-     * Also, this updates the "thermal half transmissibilities" if energy is enabled.
+     * \param[in] global Whether or not to call \c update() on all
+     *   processes.  Also, this updates the "thermal half
+     *   transmissibilities" if energy is enabled.
+     *
+     * \param[in] map Undocumented.
+     *
+     * \param[in] applyNncMultRegT Whether or not to apply regional
+     *   multipliers to explicit NNCs.  Explicit NNCs are those entered
+     *   directly in the input data, e.g., through the NNC/EDITNNC/EDITNNCR
+     *   keywords, or the result of generating connections to or within
+     *   numerical aquifers.  Default value: \c false, meaning do not apply
+     *   regional multipliers to explicit NNCs.
      */
-    void update(bool global, const std::function<unsigned int(unsigned int)>& map = {});
+    void update(bool global, const std::function<unsigned int(unsigned int)>& map = {}, bool applyNncMultRegT = false);
 
 protected:
     void updateFromEclState_(bool global);
@@ -201,6 +213,8 @@ protected:
 
     /// \brief Resets the grid transmissibilities according to EDITNNCR.
     void applyEditNncrToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal);
+
+    void applyNncMultreg_(const std::unordered_map<std::size_t,int>& globalToLocal);
 
     void applyEditNncToGridTransHelper_(const std::unordered_map<std::size_t,int>& globalToLocal,
                                         const std::string& keyword, const std::vector<NNCdata>& nncs,


### PR DESCRIPTION
This commit adds a new member function,
```C++
EclTransmissibility<>::applyNncMultreg_()
```
which applies regional transmissibility multipliers such as those entered in the `MULTREGT` keyword to the explicit input NNCs.  We make the application conditional on a new parameter, default value `false`, and pass `true` as the argument from `finishInit()`.

Along with `TransMult::getRegionMultiplierNNC()`, this implements all known connection behaviours for inter-region connections. Multipliers internal to a region in `MULTREGT` are not yet supported.