### PR TITLE
Adding hydrostatic and acceleration pressure losses to icd segments

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -253,26 +253,7 @@ assembleDefaultPressureEq(const int seg,
         assemblePressureEq(seg, seg_upwind, outlet_segment_index,
                            pressure_equation, outlet_pressure, linSys_);
 
-    if (this->accelerationalPressureLossConsidered()) {
-        handleAccelerationPressureLoss(seg, well_state);
-    }
-
-    // Since density derivatives are organized differently than what is required for assemblePressureEq, 
-    // this part needs to be assembled separately. Optionally use average density variant.  
-    const auto hydro_pressure_drop_seg = segments_.getHydroPressureLoss(seg, seg);
-    if (!use_average_density){
-        MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
-            assembleHydroPressureLoss(seg, seg, hydro_pressure_drop_seg, linSys_);
-            segments.pressure_drop_hydrostatic[seg] = hydro_pressure_drop_seg.value();
-    } else {
-        const int seg_outlet = this->segmentNumberToIndex(this->segmentSet()[seg].outletSegment());
-        const auto hydro_pressure_drop_outlet = segments_.getHydroPressureLoss(seg, seg_outlet);
-        MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
-            assembleHydroPressureLoss(seg, seg, 0.5*hydro_pressure_drop_seg, linSys_);
-        MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
-            assembleHydroPressureLoss(seg, seg_outlet, 0.5*hydro_pressure_drop_outlet, linSys_);
-        segments.pressure_drop_hydrostatic[seg] = 0.5*hydro_pressure_drop_seg.value() + 0.5*hydro_pressure_drop_outlet.value();
-    }
+    assembleAccelerationAndHydroPressureLosses(seg, well_state, use_average_density);
 }
 
 template<typename FluidSystem, typename Indices, typename Scalar>
@@ -281,6 +262,7 @@ MultisegmentWellEval<FluidSystem,Indices,Scalar>::
 assembleICDPressureEq(const int seg,
                       const UnitSystem& unit_system,
                       WellState& well_state,
+                      const bool use_average_density,
                       DeferredLogger& deferred_logger)
 {
     // TODO: upwinding needs to be taken care of
@@ -338,6 +320,39 @@ assembleICDPressureEq(const int seg,
                            linSys_,
                            FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx),
                            FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx));
+
+    assembleAccelerationAndHydroPressureLosses(seg, well_state, use_average_density);
+}
+
+template<typename FluidSystem, typename Indices, typename Scalar>
+void
+MultisegmentWellEval<FluidSystem,Indices,Scalar>::
+assembleAccelerationAndHydroPressureLosses(const int seg,
+                                           WellState& well_state,
+                                           const bool use_average_density)
+{
+    auto& ws = well_state.well(baseif_.indexOfWell());
+    auto& segments = ws.segments;
+    if (this->accelerationalPressureLossConsidered()) {
+        handleAccelerationPressureLoss(seg, well_state);
+    }
+
+    // Since density derivatives are organized differently than what is required for assemblePressureEq,
+    // this part needs to be assembled separately. Optionally use average density variant.
+    const auto hydro_pressure_drop_seg = segments_.getHydroPressureLoss(seg, seg);
+    if (!use_average_density){
+        MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
+            assembleHydroPressureLoss(seg, seg, hydro_pressure_drop_seg, linSys_);
+            segments.pressure_drop_hydrostatic[seg] = hydro_pressure_drop_seg.value();
+    } else {
+        const int seg_outlet = this->segmentNumberToIndex(this->segmentSet()[seg].outletSegment());
+        const auto hydro_pressure_drop_outlet = segments_.getHydroPressureLoss(seg, seg_outlet);
+        MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
+            assembleHydroPressureLoss(seg, seg, 0.5*hydro_pressure_drop_seg, linSys_);
+        MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
+            assembleHydroPressureLoss(seg, seg_outlet, 0.5*hydro_pressure_drop_outlet, linSys_);
+        segments.pressure_drop_hydrostatic[seg] = 0.5*hydro_pressure_drop_seg.value() + 0.5*hydro_pressure_drop_outlet.value();
+    }
 }
 
 template<typename FluidSystem, typename Indices, typename Scalar>
@@ -353,7 +368,7 @@ assemblePressureEq(const int seg,
         case Segment::SegmentType::SICD :
         case Segment::SegmentType::AICD :
         case Segment::SegmentType::VALVE : {
-            assembleICDPressureEq(seg, unit_system, well_state,deferred_logger);
+            assembleICDPressureEq(seg, unit_system, well_state, use_average_density, deferred_logger);
             break;
         }
         default :

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -331,8 +331,6 @@ assembleAccelerationAndHydroPressureLosses(const int seg,
                                            WellState& well_state,
                                            const bool use_average_density)
 {
-    auto& ws = well_state.well(baseif_.indexOfWell());
-    auto& segments = ws.segments;
     if (this->accelerationalPressureLossConsidered()) {
         handleAccelerationPressureLoss(seg, well_state);
     }
@@ -340,6 +338,8 @@ assembleAccelerationAndHydroPressureLosses(const int seg,
     // Since density derivatives are organized differently than what is required for assemblePressureEq,
     // this part needs to be assembled separately. Optionally use average density variant.
     const auto hydro_pressure_drop_seg = segments_.getHydroPressureLoss(seg, seg);
+    auto& ws = well_state.well(baseif_.indexOfWell());
+    auto& segments = ws.segments;    
     if (!use_average_density){
         MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
             assembleHydroPressureLoss(seg, seg, hydro_pressure_drop_seg, linSys_);

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -343,7 +343,7 @@ assembleAccelerationAndHydroPressureLosses(const int seg,
     if (!use_average_density){
         MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
             assembleHydroPressureLoss(seg, seg, hydro_pressure_drop_seg, linSys_);
-            segments.pressure_drop_hydrostatic[seg] = hydro_pressure_drop_seg.value();
+        segments.pressure_drop_hydrostatic[seg] = hydro_pressure_drop_seg.value();
     } else {
         const int seg_outlet = this->segmentNumberToIndex(this->segmentSet()[seg].outletSegment());
         const auto hydro_pressure_drop_outlet = segments_.getHydroPressureLoss(seg, seg_outlet);

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -83,7 +83,12 @@ protected:
     void assembleICDPressureEq(const int seg,
                                const UnitSystem& unit_system,
                                WellState& well_state,
+                               const bool use_average_density,
                                DeferredLogger& deferred_logger);
+
+    void assembleAccelerationAndHydroPressureLosses(const int seg,
+                                                    WellState& well_state,
+                                                    const bool use_average_density);
 
 
     void assemblePressureEq(const int seg,


### PR DESCRIPTION
Valves may be placed in long segments with significant depth differences (e.g., at branch inlets), where the hydrostatic contribution in particular may be significant. 