### PR TITLE
add tpfa as lineariser for gasoil_energy (with diffusion) and gas oil diffusion

### DIFF
--- a/flow/flow_ebos_gasoil_energy.cpp
+++ b/flow/flow_ebos_gasoil_energy.cpp
@@ -68,7 +68,7 @@ template<class TypeTag>
 struct LocalResidual<TypeTag, TTag::EclFlowGasOilEnergyProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::EclFlowGasOilEnergyProblem> { static constexpr bool value = false; };
+struct EnableDiffusion<TypeTag, TTag::EclFlowGasOilEnergyProblem> { static constexpr bool value = true; };
 
 }}
 

--- a/flow/flow_ebos_gasoildiffuse.cpp
+++ b/flow/flow_ebos_gasoildiffuse.cpp
@@ -24,6 +24,8 @@
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp>
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
 
 namespace Opm {
 namespace Properties {
@@ -32,6 +34,12 @@ struct EclFlowGasOilDiffuseProblem {
     using InheritsFrom = std::tuple<EclFlowProblem>;
 };
 }
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::EclFlowGasOilDiffuseProblem> { using type = TpfaLinearizer<TypeTag>; };
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::EclFlowGasOilDiffuseProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 
 template<class TypeTag>


### PR DESCRIPTION
-- set tpfa lineariser for gasoil cases with energy and diffusion
-- for now all energy cases also have enabled diffusion

This PR replaces https://github.com/OPM/opm-simulators/pull/4816 for convenience. 

And the PR depends on https://github.com/OPM/opm-models/pull/825