### PR TITLE
Refactor centroids lookup with separated functions

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -514,7 +514,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/utils/moduleVersion.hpp
   opm/simulators/utils/ParallelEclipseState.hpp
   opm/simulators/utils/ParallelRestart.hpp
-  opm/simulators/utils/PropsCentroidsDataHandle.hpp
+  opm/simulators/utils/PropsDataHandle.hpp
   opm/simulators/utils/SerializationPackers.hpp
   opm/simulators/utils/VectorVectorDataHandle.hpp
   opm/simulators/utils/PressureAverage.hpp

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -31,7 +31,7 @@
 
 #include <opm/grid/common/GridEnums.hpp>
 #include <opm/grid/common/CartesianIndexMapper.hpp>
-
+#include <opm/grid/LookUpCellCentroid.hh>
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 
@@ -42,6 +42,8 @@
 
 #include <opm/simulators/flow/BlackoilModelParametersEbos.hpp>
 
+
+
 #include <array>
 #include <cstddef>
 #include <optional>
@@ -51,6 +53,7 @@
 namespace Opm {
 template <class TypeTag>
 class EclBaseVanguard;
+template<typename Grid, typename GridView> struct LookUpCellCentroid;
 }
 
 namespace Opm::Properties {
@@ -476,20 +479,19 @@ protected:
     cellCentroids_(const CartMapper& cartMapper) const
     {
         return [this, cartMapper](int elemIdx) {
-                   const auto& centroids = this->centroids_;
-                   auto rank = this->gridView().comm().rank();
-                   std::array<double,dimensionworld> centroid;
-                   if (rank == 0) {
-                       unsigned cartesianCellIdx = cartMapper.cartesianIndex(elemIdx);
-                       centroid = this->eclState().getInputGrid().getCellCenter(cartesianCellIdx);
-                   } else
-                   {
-                       std::copy(centroids.begin() + elemIdx * dimensionworld,
-                                 centroids.begin() + (elemIdx + 1) * dimensionworld,
-                                 centroid.begin());
-                   }
-                   return centroid;
-               };
+            std::array<double,dimensionworld> centroid;
+            if (this->gridView().comm().rank() == 0)
+            {
+                LookUpCellCentroid<Grid,GridView> lookUpCellCentroid(this->gridView(), cartMapper, &(this->eclState().getInputGrid()));
+                centroid = lookUpCellCentroid.getCentroidFromEclGrid(elemIdx);
+            }
+            else
+            {
+                LookUpCellCentroid<Grid,GridView> lookUpCellCentroid(this->gridView(), cartMapper, nullptr);
+                centroid = lookUpCellCentroid.getCentroidFromCpGrid(elemIdx);
+            }
+            return centroid;
+        };
     }
 
     void callImplementationInit()
@@ -506,7 +508,7 @@ protected:
     {
         std::size_t num_cells = asImp_().grid().leafGridView().size(0);
         is_interior_.resize(num_cells);
-        
+
         ElementMapper elemMapper(this->gridView(), Dune::mcmgElementLayout());
         for (const auto& element : elements(this->gridView()))
         {
@@ -578,7 +580,7 @@ private:
 
         return zz/Scalar(corners);
     }
-    
+
     Scalar computeCellThickness(const typename GridView::template Codim<0>::Entity& element) const
     {
         typedef typename Element::Geometry Geometry;
@@ -609,11 +611,6 @@ private:
     { return *static_cast<const Implementation*>(this); }
 
 protected:
-    /*! \brief The cell centroids after loadbalance was called.
-     * Empty otherwise. Used by EclTransmissibilty.
-     */
-    std::vector<double> centroids_;
-
     /*! \brief Mapping between cartesian and compressed cells.
      *  It is initialized the first time it is called
      */

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -208,8 +208,8 @@ public:
         this->doLoadBalance_(this->edgeWeightsMethod(), this->ownersFirst(),
                              this->serialPartitioning(), this->enableDistributedWells(),
                              this->zoltanImbalanceTol(), this->gridView(),
-                             this->schedule(), this->centroids_,
-                             this->eclState(), this->parallelWells_, this->numJacobiBlocks());
+                             this->schedule(), this->eclState(),
+                             this->parallelWells_, this->numJacobiBlocks());
 #endif
 
         this->updateGridView_();

--- a/ebos/eclgenericcpgridvanguard.hh
+++ b/ebos/eclgenericcpgridvanguard.hh
@@ -131,7 +131,6 @@ protected:
                         const double                            zoltanImbalanceTol,
                         const GridView&                         gridView,
                         const Schedule&                         schedule,
-                        std::vector<double>&                    centroids,
                         EclipseState&                           eclState,
                         EclGenericVanguard::ParallelWellStruct& parallelWells,
                         const int                               numJacobiBlocks);
@@ -149,7 +148,6 @@ private:
                         const bool                              loadBalancerSet,
                         const std::vector<double>&              faceTrans,
                         const std::vector<Well>&                wells,
-                        std::vector<double>&                    centroids,
                         EclipseState&                           eclState,
                         EclGenericVanguard::ParallelWellStruct& parallelWells);
 
@@ -161,7 +159,6 @@ private:
                         const bool                              loadBalancerSet,
                         const std::vector<double>&              faceTrans,
                         const std::vector<Well>&                wells,
-                        std::vector<double>&                    centroids,
                         ParallelEclipseState*                   eclState,
                         EclGenericVanguard::ParallelWellStruct& parallelWells);
 

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -44,7 +44,7 @@ public:
     friend class ParallelEclipseState; //!< Friend so props can be setup.
     //! \brief Friend to set up props
     template<class Grid>
-    friend class PropsCentroidsDataHandle;
+    friend class PropsDataHandle;
 
     //! \brief Constructor.
     //! \param manager The field property manager to wrap.
@@ -144,7 +144,7 @@ protected:
 class ParallelEclipseState : public EclipseState {
     //! \brief Friend to set up props
     template<class Grid>
-    friend class PropsCentroidsDataHandle;
+    friend class PropsDataHandle;
 public:
     //! \brief Default constructor.
     ParallelEclipseState(Parallel::Communication comm);


### PR DESCRIPTION
The new structure LookUpCellCentroid is added, replacing code for search centroids of elements. Associated with OPM/opm-grid#676.

EclBaseVanguard::centroids_ is removed.

ProsCentroidsDataHandle.hpp now is called PropsDataHandle.hpp (centroids is removed too).