### PR TITLE
Damaris internal XML file update to support HDF5 local to global write.

### DIFF
--- a/opm-simulators-prereqs.cmake
+++ b/opm-simulators-prereqs.cmake
@@ -53,7 +53,7 @@ set (opm-simulators_DEPS
   "opm-common REQUIRED"
   "opm-grid REQUIRED"
   "opm-models REQUIRED"
-  "Damaris 1.7"
+  "Damaris 1.9"
   "HDF5"
   "Tracy"
   )

--- a/opm/simulators/utils/initDamarisXmlFile.cpp
+++ b/opm/simulators/utils/initDamarisXmlFile.cpp
@@ -50,7 +50,7 @@ std::string initDamarisXmlFile()
     <layout   name="zonal_layout_usmesh_integer"             type="int" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
     <variable name="GLOBAL_CELL_INDEX"    layout="zonal_layout_usmesh_integer"     type="scalar"  visualizable="false"  time-varying="false"  centering="zonal" />
     <layout   name="zonal_layout_usmesh"             type="double" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
-    <variable name="PRESSURE"    layout="zonal_layout_usmesh"     type="scalar"  visualizable="false"     unit="Pa"   centering="zonal"  store="_MYSTORE_OR_EMPTY_REGEX_" />
+    <variable name="PRESSURE"    layout="zonal_layout_usmesh"     type="scalar"  visualizable="false" select-file="GLOBAL_CELL_INDEX"     unit="bar"   centering="zonal"  store="_MYSTORE_OR_EMPTY_REGEX_" />
     _MORE_VARIABLES_REGEX_
 </data>
 


### PR DESCRIPTION
Damaris was updated in version 1.8.0 to support the HDF5 H5Sselect_elements() capability to rewrite data in memory to another order on disk. This allows (MPI decomposed) local simulation data to be written back to its original global position on disk.

To support this there was a new element added to the Damaris XML <variable...> type, named "select-file", along with some other options (not required by OPM Flow). This keyword is added to the basic in-built Daamris XML file of OPM Flow.

See here for some details: 
[Damaris website: hdf5-backend](https://project.inria.fr/damaris/hdf5-backend/)
[Damaris github wiki: Damaris-HDF5-Select-Points-Support](https://gitlab.inria.fr/Damaris/damaris/-/wikis/Damaris-HDF5-Select-Points-Support)  


