### PR TITLE
Prevent negative oil fractions in well segments

### DIFF
--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
@@ -499,6 +499,12 @@ volumeFraction(const int seg,
     /* if (has_solvent) {
         oil_fraction -= evaluation_[seg][SFrac];
     } */
+
+    // oil_fraction may turn out negative due to round-off, in that case
+    // set to zero (but keep derivatives)
+    if (oil_fraction.value() < 0.0) {
+        oil_fraction.setValue(0.0); 
+    }
     return oil_fraction;
 }
 


### PR DESCRIPTION
In some special cases, `volumeFraction` can return slightly negative (~epsilon) oil faction due to round-off. This can lead to failure if segment represents e.g., an AICD-valve. Suggest to check for this and set value to zero if negative.