### PR TITLE
Fix DIRICHLET option in BCPROP

### DIFF
--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -533,6 +533,13 @@ add_test_compareECLFiles(CASENAME co2store_gw
                          REL_TOL ${rel_tol}
                          DIR co2store)
 
+add_test_compareECLFiles(CASENAME co2store_gw_dirichlet
+                         FILENAME CO2STORE_GW_DIRICHLET
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR co2store)
+
 add_test_compareECLFiles(CASENAME co2store_gaswat
                          FILENAME CO2STORE_GASWAT
                          SIMULATOR flow


### PR DESCRIPTION
Fixed a bug with DIRICHLET option in BCPROP not working in gas-water runs. Additionally, fixed a bug where BCPROP had to be defined at every report step.

Test case for DIRICHLET and gas-water added in regression test commit is in the opm-tests PR: https://github.com/OPM/opm-tests/pull/1037