### PR TITLE
Solvent well fix

### DIFF
--- a/opm/simulators/wells/StandardWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.cpp
@@ -255,8 +255,10 @@ updateNewton(const BVectorWell& dwells,
 
     // for injectors, very typical one of the fractions will be one, and it is easy to get zero value
     // fractions. not sure what is the best way to handle it yet, so we just use 1.0 here
+    // The relaxationFactorFractionProducer code does not take into account solvent
+    // so we use 1.0 for cases with solvent.
     [[maybe_unused]] const double relaxation_factor_fractions =
-        well_.isProducer() ? this->relaxationFactorFractionsProducer(dwells) : 1.0;
+        (well_.isProducer() && !Indices::enableSolvent) ? this->relaxationFactorFractionsProducer(dwells) : 1.0;
 
     // update the second and third well variable (The flux fractions)
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1372,6 +1372,14 @@ namespace Opm
             for(int p = 0; p < np; ++p) {
                 well_flux[this->ebosCompIdxToFlowCompIdx(p)] += cq_s[p];
             }
+
+            // the solvent contribution is added to the gas potentials
+            if constexpr (has_solvent) {
+                const auto& pu = this->phaseUsage();
+                assert(pu.phase_used[Gas]);
+                const int gas_pos = pu.phase_pos[Gas];
+                well_flux[gas_pos] += cq_s[Indices::contiSolventEqIdx];
+            }
         }
         this->parallel_well_info_.communication().sum(well_flux.data(), well_flux.size());
     }


### PR DESCRIPTION
These fixes are necessary to run the co2eor norne model described in [OPM/opm-publications/ghgt14](https://github.com/OPM/opm-publications/tree/1aef1411ac4ad953cece5684a380b46fddfb9357/ghgt14).