### PR TITLE
setting the bhp to be bhp_limit when bhp value is not initialized with rate target control when updateWellStateWithTarget()

### DIFF
--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -874,6 +874,10 @@ namespace Opm
             // within the wellbore from the previous result, and hopefully it is a good
             // initial guess for the zero rate target.
             ws.surface_rates[phasePos] = std::max(1.e-7, ws.surface_rates[phasePos]);
+
+            if (ws.bhp == 0.) {
+                ws.bhp = controls.bhp_limit;
+            }
         }
         //Producer
         else
@@ -1096,6 +1100,10 @@ namespace Opm
 
                 break;
             } // end of switch
+
+            if (ws.bhp == 0.) {
+                ws.bhp = controls.bhp_limit;
+            }
         }
     }
 


### PR DESCRIPTION
It is part of the efforts to get https://github.com/OPM/opm-simulators/pull/4772 in to fix a reported issue.  While with https://github.com/OPM/opm-simulators/pull/4772, this bug got exposed. 

For a well gets SHUT due to economic or physical causes, wellstate.shut() will make most of the quantities 0. If the well under rate type control, updateWellStateTarget will not set any bhp values. It causes the Newton update stagnate under certain circumstances (for example, the circumstances introduced by https://github.com/OPM/opm-simulators/pull/4772) . In any case, beginning the bhp from an uninitialized value 0 is not optimal. 

The initial attempt to to always set the bhp to be bhp_limit (https://github.com/OPM/opm-simulators/pull/4839), while it will introduce bigger impact and I will not be able to afford the efforts to check the failures. At the end, a tailored version is introduced in this PR to limit the impact of the change. 