### PR TITLE
dont mark inoperable wells uncoverged

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1775,7 +1775,7 @@ namespace Opm {
                 local_report += well->getWellConvergence(
                         summary_state, this->wellState(), B_avg, local_deferredLogger,
                         iterationIdx > param_.strict_outer_iter_wells_);
-            } else {
+            } else if (!well->isSolvable()) {
                 ConvergenceReport report;
                 using CR = ConvergenceReport;
                 report.setWellFailed({CR::WellFailure::Type::Unsolvable, CR::Severity::Normal, -1, well->name()});

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -476,6 +476,11 @@ bool WellInterfaceGeneric::isOperableAndSolvable() const
     return operability_status_.isOperableAndSolvable();
 }
 
+bool WellInterfaceGeneric::isSolvable() const
+{
+    return operability_status_.isSolvable();
+}
+
 bool WellInterfaceGeneric::useVfpExplicit() const
 {
     const auto& wvfpexp = well_ecl_.getWVFPEXP();

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -87,6 +87,8 @@ public:
 
     // whether the well is operable
     bool isOperableAndSolvable() const;
+    bool isSolvable() const;
+
     bool useVfpExplicit () const;
     bool thpLimitViolatedButNotSwitched() const;
 
@@ -251,6 +253,10 @@ protected:
             } else {
                 return ( (isOperableUnderBHPLimit() || isOperableUnderTHPLimit()) );
             }
+        }
+
+        bool isSolvable() const {
+            return solvable;
         }
 
         bool isOperableUnderBHPLimit() const {


### PR DESCRIPTION
Should only affect cases where --enable-well-operability-check-iter=true (default is false).