### PR TITLE
Fixed indexing error in PID controller

### DIFF
--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -206,7 +206,7 @@ namespace Opm
             const double kD = 0.01 ;
             const double newDt = (dt * std::pow( errors_[ 1 ] / errors_[ 2 ], kP ) *
                                  std::pow( tol_         / errors_[ 2 ], kI ) *
-                                 std::pow( errors_[0]*errors_[0]/errors_[ 1 ]/errors_[ 2 ], kD ));
+                                 std::pow( errors_[1]*errors_[1]/errors_[ 0 ]/errors_[ 2 ], kD ));
             if( verbose_ )
                 OpmLog::info(fmt::format("Computed step size (pow): {} days", unit::convert::to( newDt, unit::day )));
             return newDt;


### PR DESCRIPTION
The PID controller formula (see articles referred to in the comments in the OPM code, e.g. "D. Kuzmin and S. Turek, Numerical simulation of turbulent bubbly flows (2004)") as implemented in the current version of OPM contains an indexing error.

Comparing the implementation and PID controller formula, errors_[0] correspond to e_{n-2}, errors_[1] to e_{n-1}, and errors_[2] to e_n.