### PR TITLE
Changed the relative change used in adaptive time stepping

### DIFF
--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -527,10 +527,8 @@ namespace Opm {
         // compute the "relative" change of the solution between time steps
         Scalar relativeChange() const
         {
-            Scalar resultDeltaPressure = 0.0;
-            Scalar resultDenomPressure = 0.0;
-            Scalar resultDeltaSaturation = 0.0;
-            Scalar resultDenomSaturation = 0.0;
+            std::array<Scalar,4> r{};
+            auto& [resultDeltaPressure, resultDenomPressure, resultDeltaSaturation, resultDenomSaturation] = r;
 
             const auto& elemMapper = simulator_.model().elementMapper();
             const auto& gridView = simulator_.gridView();
@@ -600,10 +598,7 @@ namespace Opm {
                 }
             }
 
-            resultDeltaPressure = gridView.comm().sum(resultDeltaPressure);
-            resultDenomPressure = gridView.comm().sum(resultDenomPressure);
-            resultDeltaSaturation = gridView.comm().sum(resultDeltaSaturation);
-            resultDeltaSaturation = gridView.comm().sum(resultDeltaSaturation);
+            gridView.comm.sum(r.data(), 4);
 
             if (resultDenomPressure > 0.0 && resultDenomSaturation > 0.0)
                 return std::max(resultDeltaPressure/resultDenomPressure, resultDeltaSaturation/resultDenomSaturation);

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -594,8 +594,8 @@ namespace Opm {
                         Scalar tmpSat = saturationsNew[phaseIdx] - saturationsOld[phaseIdx];
                         resultDeltaSaturation += tmpSat*tmpSat;
                         resultDenomSaturation += saturationsNew[phaseIdx]*saturationsNew[phaseIdx];
-                        assert(std::isfinite(resultDelta));
-                        assert(std::isfinite(resultDenom));
+                        assert(std::isfinite(resultDeltaSaturation));
+                        assert(std::isfinite(resultDenomSaturation));
                     }
                 }
             }

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -598,7 +598,7 @@ namespace Opm {
                 }
             }
 
-            gridView.comm.sum(r.data(), 4);
+            gridView.comm().sum(r.data(), r.size());
 
             if (resultDenomPressure > 0.0 && resultDenomSaturation > 0.0)
                 return std::max(resultDeltaPressure/resultDenomPressure, resultDeltaSaturation/resultDenomSaturation);

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -605,7 +605,7 @@ namespace Opm {
             resultDeltaSaturation = gridView.comm().sum(resultDeltaSaturation);
             resultDeltaSaturation = gridView.comm().sum(resultDeltaSaturation);
 
-            if (resultDenomPressure > 0.0 || resultDenomSaturation > 0.0)
+            if (resultDenomPressure > 0.0 && resultDenomSaturation > 0.0)
                 return std::max(resultDeltaPressure/resultDenomPressure, resultDeltaSaturation/resultDenomSaturation);
             return 0.0;
         }


### PR DESCRIPTION
The current implementation of the relative change used in the adaptive time stepping (mainly in the PID controller) added pressure and saturation in a way which practically meant that saturation was ignored (since the saturation values are so much lower than the pressure values), and hence that the relative change ended up only considering changes in pressure and not in saturation.

The new implementation separates the pressure and saturation into two different relative change values, and then returns the maximum of these two.