### PR TITLE
Damaris - Moving Damaris functionality to it's own class

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -145,7 +145,7 @@ list (APPEND MAIN_SOURCE_FILES
   )
 
 
-if (DAMARIS_FOUND AND MPI_FOUND)
+if (Damaris_FOUND AND MPI_FOUND)
   list (APPEND MAIN_SOURCE_FILES opm/simulators/utils/DamarisOutputModule.cpp)
   list (APPEND MAIN_SOURCE_FILES opm/simulators/utils/DamarisKeywords.cpp)
   list (APPEND MAIN_SOURCE_FILES opm/simulators/utils/initDamarisXmlFile.cpp)
@@ -589,6 +589,10 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/WellTest.hpp
   opm/simulators/wells/WGState.hpp
   )
+
+if (Damaris_FOUND AND MPI_FOUND)
+  list (APPEND PUBLIC_HEADER_FILES ebos/damariswriter.hh)
+endif()
 
 if(HDF5_FOUND)
   list(APPEND PUBLIC_HEADER_FILES

--- a/ebos/damariswriter.hh
+++ b/ebos/damariswriter.hh
@@ -1,0 +1,377 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2022 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2023 Inria, Bretagne–Atlantique Research Center
+  
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \copydoc Opm::DamarisWriter
+ */
+#ifndef EWOMS_DAMARIS_WRITER_HH
+#define EWOMS_DAMARIS_WRITER_HH
+
+#include <dune/grid/common/partitionset.hh>
+
+#include <ebos/collecttoiorank.hh>
+#include <ebos/eclbasevanguard.hh>
+#include <ebos/eclgenericwriter.hh>
+#include <ebos/ecloutputblackoilmodule.hh>
+
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <opm/output/eclipse/RestartValue.hpp>
+
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+#include <opm/simulators/utils/ParallelRestart.hpp>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+#include <fmt/format.h>
+
+#include <Damaris.h>
+
+namespace Opm::Properties {
+
+template<class TypeTag, class MyTypeTag>
+struct EnableDamarisOutput {
+    using type = UndefinedProperty;
+};
+template<class TypeTag, class MyTypeTag>
+struct EnableDamarisOutputCollective {
+    using type = UndefinedProperty;
+};
+} // namespace Opm::Properties
+
+namespace Opm {
+
+/*!
+ * \ingroup EclBlackOilSimulator
+ *
+ * \brief Collects necessary output values and pass them to Damaris server processes.
+ *
+ * Currently only passing through PRESSURE, GLOBAL_CELL_INDEX and MPI_RANK information.
+ * This clss will be enhanced to pass through the 3D mesh information to Damaris to enable
+ * in situ visualization via Paraview or Ascent. And developed so that variables specified 
+ * through the Eclipse input deck will be available to Damaris.
+ */
+ 
+ 
+template <class TypeTag>
+class DamarisWriter : public EclGenericWriter<GetPropType<TypeTag, Properties::Grid>,
+                                          GetPropType<TypeTag, Properties::EquilGrid>,
+                                          GetPropType<TypeTag, Properties::GridView>,
+                                          GetPropType<TypeTag, Properties::ElementMapper>,
+                                          GetPropType<TypeTag, Properties::Scalar>>
+{
+    using Simulator = GetPropType<TypeTag, Properties::Simulator>;
+    using GridView = GetPropType<TypeTag, Properties::GridView>;
+    using Grid = GetPropType<TypeTag, Properties::Grid>;
+    using EquilGrid = GetPropType<TypeTag, Properties::EquilGrid>;
+    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
+    using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
+    using Element = typename GridView::template Codim<0>::Entity;
+    using ElementMapper = GetPropType<TypeTag, Properties::ElementMapper>;
+    
+    using BaseType = EclGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>;
+    
+public:
+    static void registerParameters()
+    {
+        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableDamarisOutputCollective,
+                             "Write output via Damaris using parallel HDF5 to get single file per timestep instead of one per Damaris core.");
+    }
+
+    // The Simulator object should preferably have been const - the
+    // only reason that is not the case is due to the SummaryState
+    // object owned deep down by the vanguard.
+    DamarisWriter(Simulator& simulator)
+        : BaseType(simulator.vanguard().schedule(),
+                   simulator.vanguard().eclState(),
+                   simulator.vanguard().summaryConfig(),
+                   simulator.vanguard().grid(),
+                   simulator.vanguard().grid().comm().rank() == 0 ? &simulator.vanguard().equilGrid() : nullptr,
+                   simulator.vanguard().gridView(),
+                   simulator.vanguard().cartesianIndexMapper(),
+                   simulator.vanguard().grid().comm().rank() == 0 ? &simulator.vanguard().equilCartesianIndexMapper() : nullptr,
+                   false, false)
+        , simulator_(simulator)
+    {
+        this->damarisUpdate_ = true ;
+
+        rank_ = simulator_.vanguard().grid().comm().rank() ;
+        nranks_ = simulator_.vanguard().grid().comm().size();
+        
+        const auto& gridView = simulator_.gridView();
+        const auto& interior_elements = elements(gridView, Dune::Partitions::interior);
+        // Get the size of the unique vector elements (excludes the shared 'ghost' elements)
+        numElements_ = std::distance(interior_elements.begin(), interior_elements.end());
+
+        this->elements_rank_offsets_.resize(nranks_) ;
+        this->damarisOutputModule_ = std::make_unique<EclOutputBlackOilModule<TypeTag>>(simulator, this->collectToIORank_);
+    }
+
+    ~DamarisWriter()
+    { }
+
+    /*!
+     * \brief Writes localCellData through to Damaris servers. Sets up the unstructured mesh which is passed to Damaris.
+     */
+    void writeOutput(data::Solution& localCellData , bool isSubStep)
+    {
+        OPM_TIMEBLOCK(writeOutput);
+        const int reportStepNum = simulator_.episodeIndex() + 1;
+
+        // added this as localCellData was not being written
+        if (!isSubStep)
+            this->damarisOutputModule_->invalidateLocalData() ;  
+        this->prepareLocalCellData(isSubStep, reportStepNum);
+        this->damarisOutputModule_->outputErrorLog(simulator_.gridView().comm());
+
+        // The damarisWriter is not outputing well or aquifer data (yet)
+        auto localWellData = simulator_.problem().wellModel().wellData(); // data::Well
+
+        if (! isSubStep) 
+        {
+            if (localCellData.size() == 0) {
+                this->damarisOutputModule_->assignToSolution(localCellData);
+            }
+
+            // add cell data to perforations for Rft output
+            this->damarisOutputModule_->addRftDataToWells(localWellData, reportStepNum);
+            
+            // On first call and if the mesh and variable size change then set damarisUpdate_ to true
+            if (damarisUpdate_ == true) {
+                // Sets the damaris parameter values "n_elements_local" and "n_elements_total" 
+                // which define sizes of the Damaris variables, per-rank and globally (over all ranks).
+                // Also sets the offsets to where a ranks array data sits within the global array. 
+                // This is usefull for HDF5 output and for defining distributed arrays in Dask.
+                this->setupDamarisWritingPars(simulator_.vanguard().grid().comm(), numElements_, elements_rank_offsets_);
+                
+                // sets data for non-time-varying variables MPI_RANK and GLOBAL_CELL_INDEX
+                this->setGlobalIndexForDamaris() ; 
+                
+                // Currently by default we assume static grid (unchanging through the simulation)
+                // Set damarisUpdate_ to true if we want to update the geometry to sent to Damaris 
+                this->damarisUpdate_ = false; 
+            }
+
+            if (this->damarisOutputModule_->getPRESSURE_ptr() != nullptr) 
+            {
+                int64_t temp_int64_t[1];
+                temp_int64_t[0] = static_cast<int64_t>(this->elements_rank_offsets_[rank_]);
+                dam_err_ = damaris_set_position("PRESSURE", temp_int64_t);
+                if (dam_err_ != DAMARIS_OK && rank_ == 0) {
+                    OpmLog::error(fmt::format("ERORR: damariswriter::writeOutput()       : ( rank:{}) damaris_set_position(PRESSURE, ...), Damaris Error: {}  ",  rank_, damaris_error_string(dam_err_) ));
+                }
+
+                dam_err_ = damaris_write("PRESSURE", (void*)this->damarisOutputModule_->getPRESSURE_ptr());
+                if (dam_err_ != DAMARIS_OK) {
+                   OpmLog::error(fmt::format("ERORR: damariswriter::writeOutput()       : ( rank:{}) damaris_write(PRESSURE, ...), Damaris Error: {}  ",  rank_, damaris_error_string(dam_err_) ));
+                }
+
+                dam_err_ =  damaris_end_iteration();
+                if (dam_err_ != DAMARIS_OK) {
+                    OpmLog::error(fmt::format("ERORR: damariswriter::writeOutput()       : ( rank:{}) damaris_end_iteration(), Damaris Error: {}  ",  rank_, damaris_error_string(dam_err_) ));
+                }
+            }
+         } // end of ! isSubstep
+    }
+
+private:
+    int dam_err_ ;
+    int rank_  ;       
+    int nranks_ ;
+    int numElements_ ;  ///<  size of the unique vector elements
+    
+    Simulator& simulator_;
+    std::unique_ptr<EclOutputBlackOilModule<TypeTag>> damarisOutputModule_;
+    std::vector<unsigned long long> elements_rank_offsets_ ;
+    bool damarisUpdate_ = false;  ///< Whenever this is true writeOutput() will set up Damaris mesh information and offsets of model fields
+
+    static bool enableDamarisOutput_()
+    { 
+        return EWOMS_GET_PARAM(TypeTag, bool, EnableDamarisOutput); 
+    }
+
+    void setGlobalIndexForDamaris () 
+    {
+        // GLOBAL_CELL_INDEX is used to reorder variable data when writing to disk 
+        // This is enabled using select-file="GLOBAL_CELL_INDEX" in the <variable> XML tag
+        if ( this->collectToIORank_.isParallel() ){
+            const std::vector<int>& local_to_global =  this->collectToIORank_.localIdxToGlobalIdxMapping(); 
+            dam_err_ = damaris_write("GLOBAL_CELL_INDEX", local_to_global.data());
+        } else {
+            std::vector<int> local_to_global_filled ;
+            local_to_global_filled.resize(this->numElements_) ;
+            for (int i = 0 ; i < this->numElements_ ; i++)
+            {
+                local_to_global_filled[i] = i ;
+            }
+            dam_err_ = damaris_write("GLOBAL_CELL_INDEX", local_to_global_filled.data());
+        }
+
+        if (dam_err_ != DAMARIS_OK) {
+            OpmLog::error(fmt::format("ERORR: damariswriter::writeOutput()       :"
+                                     "( rank:{}) damaris_write(GLOBAL_CELL_INDEX, ...), Damaris Error: {}  ",  
+                                     rank_, damaris_error_string(dam_err_) ));
+        }
+
+        std::vector<int> mpiRank(this->numElements_, rank_ ) ;
+        dam_err_ = damaris_write("MPI_RANK", mpiRank.data() ) ;
+        if (dam_err_ != DAMARIS_OK) {
+           OpmLog::error(fmt::format("ERORR: damariswriter::writeOutput()       :"
+                                     " ( rank:{}) damaris_write(MPI_RANK, ...), Damaris Error: {}  ",
+                                     rank_, damaris_error_string(dam_err_) ));
+        }
+    }
+
+    void setupDamarisWritingPars(Parallel::Communication comm, const int n_elements_local_grid, std::vector<unsigned long long>& elements_rank_offsets)
+    {
+        // one for each rank -- to be gathered from each client rank
+        std::vector<unsigned long long> elements_rank_sizes(nranks_); 
+        // n_elements_local_grid should be the full model size
+        const unsigned long long n_elements_local = n_elements_local_grid;
+
+        // This gets the n_elements_local from all ranks and copies them to a std::vector of all the values on all ranks
+        // (elements_rank_sizes[]).
+        comm.allgather(&n_elements_local, 1, elements_rank_sizes.data());
+        elements_rank_offsets[0] = 0ULL;
+        // This scan makes the offsets to the start of each ranks grid section if each local grid data was concatenated (in
+        // rank order)
+        for (int t1 = 1; t1 < nranks_; t1++) {
+            elements_rank_offsets[t1] = elements_rank_offsets[t1 - 1] + elements_rank_sizes[t1 - 1];
+        }
+
+        // find the global/total size
+        unsigned long long n_elements_global_max = elements_rank_offsets[nranks_ - 1];
+        n_elements_global_max += elements_rank_sizes[nranks_ - 1]; // add the last ranks size to the already accumulated offset values
+
+        if (rank_ == 0) {
+            OpmLog::debug(fmt::format("In setupDamarisWritingPars(): n_elements_global_max = {}", n_elements_global_max));
+        }
+
+        // Set the paramater so that the Damaris servers can allocate the correct amount of memory for the variabe
+        // Damaris parameters only support int data types. This will limit models to be under size of 2^32-1 elements
+        // ToDo: Do we need to check that local ranks are 0 based ?
+        int temp_int = static_cast<int>(elements_rank_sizes[rank_]);
+        dam_err_ = damaris_parameter_set("n_elements_local", &temp_int, sizeof(int));
+        if (dam_err_ != DAMARIS_OK && rank_ == 0) {
+            OpmLog::error("Damaris library produced an error result for "
+                          "damaris_parameter_set(\"n_elements_local\", &temp_int, sizeof(int));");
+        }
+        // Damaris parameters only support int data types. This will limit models to be under size of 2^32-1 elements
+        // ToDo: Do we need to check that n_elements_global_max will fit in a C int type (INT_MAX)
+        temp_int = static_cast<int>(n_elements_global_max);
+        dam_err_ = damaris_parameter_set("n_elements_total", &temp_int, sizeof(int));
+        if (dam_err_ != DAMARIS_OK && rank_ == 0) {
+            OpmLog::error("Damaris library produced an error result for "
+                          "damaris_parameter_set(\"n_elements_total\", &temp_int, sizeof(int));");
+        }
+
+        // Use damaris_set_position to set the offset in the global size of the array.
+        // This is used so that output functionality (e.g. HDF5Store) knows global offsets of the data of the ranks
+        int64_t temp_int64_t[1];
+        temp_int64_t[0] = static_cast<int64_t>(elements_rank_offsets[rank_]);
+        dam_err_ = damaris_set_position("PRESSURE", temp_int64_t);
+        if (dam_err_ != DAMARIS_OK && rank_ == 0) {
+            OpmLog::error("Damaris library produced an error result for "
+                          "damaris_set_position(\"PRESSURE\", temp_int64_t);");
+        }
+        dam_err_ = damaris_set_position("GLOBAL_CELL_INDEX", temp_int64_t);
+        if (dam_err_ != DAMARIS_OK && rank_ == 0) {
+            OpmLog::error("Damaris library produced an error result for "
+                          "damaris_set_position(\"GLOBAL_CELL_INDEX\", temp_int64_t);");
+        }
+        dam_err_ = damaris_set_position("MPI_RANK", temp_int64_t);
+        if (dam_err_ != DAMARIS_OK && rank_ == 0) {
+            OpmLog::error("Damaris library produced an error result for "
+                          "damaris_set_position(\"MPI_RANK\", temp_int64_t);");
+        }
+    }
+
+    void prepareLocalCellData(const bool isSubStep,
+                              const int  reportStepNum)
+    {
+        OPM_TIMEBLOCK(prepareLocalCellData);
+        if (damarisOutputModule_->localDataValid()) {
+            return;
+        }
+
+        const auto& gridView = simulator_.vanguard().gridView();
+        const int numElements = gridView.size(/*codim=*/0);
+        const bool log = this->collectToIORank_.isIORank();
+
+        damarisOutputModule_->allocBuffers(numElements, reportStepNum,
+                                      isSubStep, log, /*isRestart*/ false);
+
+        ElementContext elemCtx(simulator_);
+        OPM_BEGIN_PARALLEL_TRY_CATCH();
+        {
+        OPM_TIMEBLOCK(prepareCellBasedData);
+        for (const auto& elem : elements(gridView)) {
+            elemCtx.updatePrimaryStencil(elem);
+            elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
+
+            damarisOutputModule_->processElement(elemCtx);
+        }
+        }
+        if(!simulator_.model().linearizer().getFlowsInfo().empty()){
+            OPM_TIMEBLOCK(prepareFlowsData);
+            for (const auto& elem : elements(gridView)) {
+                elemCtx.updatePrimaryStencil(elem);
+                elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
+                damarisOutputModule_->processElementFlows(elemCtx);
+            }
+        }
+        {
+        OPM_TIMEBLOCK(prepareBlockData);
+        for (const auto& elem : elements(gridView)) {
+            elemCtx.updatePrimaryStencil(elem);
+            elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
+            damarisOutputModule_->processElementBlockData(elemCtx);
+        }
+        }
+        {
+        OPM_TIMEBLOCK(prepareFluidInPlace);
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+        for (int dofIdx=0; dofIdx < numElements; ++dofIdx){
+                const auto& intQuants = *(simulator_.model().cachedIntensiveQuantities(dofIdx, /*timeIdx=*/0));
+                const auto totVolume = simulator_.model().dofTotalVolume(dofIdx);
+                damarisOutputModule_->updateFluidInPlace(dofIdx, intQuants, totVolume);
+        }
+        }
+        damarisOutputModule_->validateLocalData();
+        OPM_END_PARALLEL_TRY_CATCH("DamarisWriter::prepareLocalCellData() failed: ", simulator_.vanguard().grid().comm());
+    }
+};
+
+} // namespace Opm
+
+#endif

--- a/ebos/eclproblem_properties.hh
+++ b/ebos/eclproblem_properties.hh
@@ -35,6 +35,9 @@
 #include <ebos/eclnewtonmethod.hh>
 #include <ebos/ecloutputblackoilmodule.hh>
 #include <ebos/eclwriter.hh>
+#if HAVE_DAMARIS
+#include <ebos/damariswriter.hh>
+#endif
 #include <ebos/FIBlackOilModel.hpp>
 #include <ebos/vtkecltracermodule.hh>
 

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -42,13 +42,14 @@
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/simulators/utils/ParallelRestart.hpp>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+
 #include <limits>
 #include <stdexcept>
 #include <string>
 
-#if HAVE_DAMARIS
-#include <opm/simulators/utils/DamarisOutputModule.hpp>
-#endif
+
+// #include <opm/simulators/utils/GridDataOutput.hpp>
 
 
 namespace Opm::Properties {
@@ -65,16 +66,6 @@ template<class TypeTag, class MyTypeTag>
 struct EclOutputDoublePrecision {
     using type = UndefinedProperty;
 };
-#ifdef HAVE_DAMARIS
-template<class TypeTag, class MyTypeTag>
-struct EnableDamarisOutput {
-    using type = UndefinedProperty;
-};
-template<class TypeTag, class MyTypeTag>
-struct EnableDamarisOutputCollective {
-    using type = UndefinedProperty;
-};
-#endif
 template<class TypeTag, class MyTypeTag>
 struct EnableEsmry {
     using type = UndefinedProperty;
@@ -121,6 +112,8 @@ class EclWriter : public EclGenericWriter<GetPropType<TypeTag, Properties::Grid>
     using ElementMapper = GetPropType<TypeTag, Properties::ElementMapper>;
     using ElementIterator = typename GridView::template Codim<0>::Iterator;
     using BaseType = EclGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>;
+    
+    typedef Dune::MultipleCodimMultipleGeomTypeMapper< GridView > VertexMapper;
 
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     enum { enableMech = getPropValue<TypeTag, Properties::EnableMech>() };
@@ -134,12 +127,10 @@ public:
 
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableAsyncEclOutput,
                              "Write the ECL-formated results in a non-blocking way (i.e., using a separate thread).");
-#ifdef HAVE_DAMARIS
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableDamarisOutputCollective,
-                             "Write output via Damaris using parallel HDF5 to get single file per timestep instead of one per Damaris core.");
-#endif
+
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableEsmry,
                              "Write ESMRY file for fast loading of summary data.");
+                                                        
     }
 
     // The Simulator object should preferably have been const - the
@@ -162,12 +153,10 @@ public:
                    EWOMS_GET_PARAM(TypeTag, bool, EnableEsmry))
         , simulator_(simulator)
     {
-#ifdef HAVE_DAMARIS
-        this->damarisUpdate_ = enableDamarisOutput_();
-#endif
-
         this->eclOutputModule_ = std::make_unique<EclOutputBlackOilModule<TypeTag>>
             (simulator, this->collectToIORank_);
+            
+        rank_ = simulator_.vanguard().grid().comm().rank() ;
     }
 
     ~EclWriter()
@@ -328,7 +317,7 @@ public:
         }
     }
 
-    void writeOutput(bool isSubStep)
+    void writeOutput(data::Solution&& localCellData, bool isSubStep)
     {
         OPM_TIMEBLOCK(writeOutput);
 
@@ -336,30 +325,7 @@ public:
         this->prepareLocalCellData(isSubStep, reportStepNum);
         this->eclOutputModule_->outputErrorLog(simulator_.gridView().comm());
 
-#ifdef HAVE_DAMARIS
-        if (EWOMS_GET_PARAM(TypeTag, bool, EnableDamarisOutput)) {
-            // N.B. damarisUpdate_ should be set to true if at any time the model geometry changes
-            if (this->damarisUpdate_) {
-                const auto& gridView = simulator_.gridView();
-                const auto& interior_elements = elements(gridView, Dune::Partitions::interior);
-                const int numElements = std::distance(interior_elements.begin(), interior_elements.end());
-                Opm::DamarisOutput::setupDamarisWritingPars(simulator_.vanguard().grid().comm(), numElements);
-                const std::vector<int>& local_to_global = this->collectToIORank_.localIdxToGlobalIdxMapping();
-                damaris_write("GLOBAL_CELL_INDEX", local_to_global.data());
-                // By default we assume static grid
-                this->damarisUpdate_ = false;
-            }
-
-            if (!isSubStep) {
-                // Output the PRESSURE field
-                if (this->eclOutputModule_->getPRESSURE_ptr() != nullptr) {
-                    damaris_write("PRESSURE", (void*)this->eclOutputModule_->getPRESSURE_ptr());
-                    damaris_end_iteration();
-                }
-            }
-        }
-#endif
-
+        // output using eclWriter if enabled
         auto localWellData = simulator_.problem().wellModel().wellData();
         auto localGroupAndNetworkData = simulator_.problem().wellModel()
             .groupAndNetworkData(reportStepNum);
@@ -373,9 +339,12 @@ public:
         const bool isFloresn = this->eclOutputModule_->hasFloresn();
         auto floresn = this->eclOutputModule_->getFloresn();
 
-        data::Solution localCellData = {};
+        // data::Solution localCellData = {};
         if (! isSubStep) {
-            this->eclOutputModule_->assignToSolution(localCellData);
+            
+            if (localCellData.empty()) {
+                this->eclOutputModule_->assignToSolution(localCellData);
+            }
 
             // Add cell data to perforations for RFT output
             this->eclOutputModule_->addRftDataToWells(localWellData, reportStepNum);
@@ -524,11 +493,6 @@ private:
     static bool enableEclOutput_()
     { return EWOMS_GET_PARAM(TypeTag, bool, EnableEclOutput); }
 
-#ifdef HAVE_DAMARIS
-    static bool enableDamarisOutput_()
-    { return EWOMS_GET_PARAM(TypeTag, bool, EnableDamarisOutput); }
-#endif
-
     const EclipseState& eclState() const
     { return simulator_.vanguard().eclState(); }
 
@@ -665,12 +629,9 @@ private:
     }
 
     Simulator& simulator_;
-    std::unique_ptr<EclOutputBlackOilModule<TypeTag>> eclOutputModule_;
+    std::unique_ptr<EclOutputBlackOilModule<TypeTag> > eclOutputModule_;
     Scalar restartTimeStepSize_;
-
-#ifdef HAVE_DAMARIS
-    bool damarisUpdate_ = false;  ///< Whenever this is true writeOutput() will set up Damaris offsets of model fields
-#endif
+    int rank_ ;
 };
 
 } // namespace Opm

--- a/opm/simulators/utils/DamarisKeywords.cpp
+++ b/opm/simulators/utils/DamarisKeywords.cpp
@@ -44,6 +44,10 @@ DamarisKeywords(std::string OutputDir, bool enableDamarisOutputCollective)
             {"_MORE_VARIABLES_REGEX_", ""},
             {"_PATH_REGEX_", OutputDir},
             {"_MYSTORE_OR_EMPTY_REGEX_", "MyStore"},
+            {"_PYTHON_OR_EMPTY_REGEX_", ""},  
+            {"_PYTHON_XML_NAME_", "#"},
+            {"_PARAVIEWPY_OR_EMPTY_REGEX_", ""},  
+            {"_MESHNAME_OR_HASH_", "#"},
         };
         return damaris_keywords;
     } else {
@@ -55,6 +59,10 @@ DamarisKeywords(std::string OutputDir, bool enableDamarisOutputCollective)
             {"_MORE_VARIABLES_REGEX_", ""},
             {"_PATH_REGEX_", OutputDir},
             {"_MYSTORE_OR_EMPTY_REGEX_", "MyStore"},
+            {"_PYTHON_OR_EMPTY_REGEX_", ""},
+            {"_PYTHON_XML_NAME_", "#"},
+            {"_PARAVIEWPY_OR_EMPTY_REGEX_", ""},
+            {"_MESHNAME_OR_HASH_", "#"},
         };
         return damaris_keywords;
     }

--- a/opm/simulators/utils/DamarisOutputModule.cpp
+++ b/opm/simulators/utils/DamarisOutputModule.cpp
@@ -1,5 +1,6 @@
 /*
   Copyright 2022 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2023 INRIA
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -75,72 +76,4 @@ initializeDamaris(MPI_Comm comm, int mpiRank, std::string outputDir, bool enable
     }
 }
 
-void
-setupDamarisWritingPars(Parallel::Communication comm, const int n_elements_local_grid)
-{
-    int damaris_err = DAMARIS_OK;
-
-    const int nranks = comm.size();
-    const int rank = comm.rank();
-
-    std::vector<unsigned long long> elements_rank_sizes(nranks); // one for each rank -- to be gathered from each client rank
-    std::vector<unsigned long long> elements_rank_offsets(nranks); // one for each rank, first one 0 -- to be computed - Probably could use MPI_Scan()!
-
-    // n_elements_local_grid should be the full model size
-    const unsigned long long n_elements_local = n_elements_local_grid;
-
-    // Left in for debugging, but commented out to avoid spamming the terminal from non-output ranks.
-    // std::cout << "INFO (" << rank << "): n_elements_local_grid   = " << n_elements_local_grid << std::endl;
-
-    // This gets the n_elements_local from all ranks and copies them to a std::vector of all the values on all ranks
-    // (elements_rank_sizes[]).
-    comm.allgather(&n_elements_local, 1, elements_rank_sizes.data());
-    elements_rank_offsets[0] = 0ULL;
-    // This scan makes the offsets to the start of each ranks grid section if each local grid data was concatenated (in
-    // rank order)
-    for (int t1 = 1; t1 < nranks; t1++) {
-        elements_rank_offsets[t1] = elements_rank_offsets[t1 - 1] + elements_rank_sizes[t1 - 1];
-    }
-
-    // find the global/total size
-    unsigned long long n_elements_global_max = elements_rank_offsets[nranks - 1];
-    n_elements_global_max += elements_rank_sizes[nranks - 1]; // add the last ranks size to the already accumulated offset values
-
-    if (rank == 0) {
-        OpmLog::debug(fmt::format("In setupDamarisWritingPars(): n_elements_global_max = {}", n_elements_global_max));
-    }
-
-    // Set the paramater so that the Damaris servers can allocate the correct amount of memory for the variabe
-    // Damaris parameters only support int data types. This will limit models to be under size of 2^32-1 elements
-    // ToDo: Do we need to check that local ranks are 0 based ?
-    int temp_int = static_cast<int>(elements_rank_sizes[rank]);
-    damaris_err = damaris_parameter_set("n_elements_local", &temp_int, sizeof(int));
-    if (damaris_err != DAMARIS_OK && rank == 0) {
-        OpmLog::error("Damaris library produced an error result for "
-                      "damaris_parameter_set(\"n_elements_local\", &temp_int, sizeof(int));");
-    }
-    // Damaris parameters only support int data types. This will limit models to be under size of 2^32-1 elements
-    // ToDo: Do we need to check that n_elements_global_max will fit in a C int type (INT_MAX)
-    temp_int = static_cast<int>(n_elements_global_max);
-    damaris_err = damaris_parameter_set("n_elements_total", &temp_int, sizeof(int));
-    if (damaris_err != DAMARIS_OK && rank == 0) {
-        OpmLog::error("Damaris library produced an error result for "
-                      "damaris_parameter_set(\"n_elements_total\", &temp_int, sizeof(int));");
-    }
-
-    // Use damaris_set_position to set the offset in the global size of the array.
-    // This is used so that output functionality (e.g. HDF5Store) knows global offsets of the data of the ranks
-    int64_t temp_int64_t[1];
-    temp_int64_t[0] = static_cast<int64_t>(elements_rank_offsets[rank]);
-    damaris_err = damaris_set_position("PRESSURE", temp_int64_t);
-    if (damaris_err != DAMARIS_OK && rank == 0) {
-        OpmLog::error("Damaris library produced an error result for "
-                      "damaris_set_position(\"PRESSURE\", temp_int64_t);");
-    }
-    damaris_err = damaris_set_position("GLOBAL_CELL_INDEX", temp_int64_t);
-    if (damaris_err != DAMARIS_OK && rank == 0) {
-        OpmLog::error("Damaris library produced an error result for "
-                      "damaris_set_position(\"GLOBAL_CELL_INDEX\", temp_int64_t);");
-    }
-}
 } // namespace Opm::DamarisOutput

--- a/opm/simulators/utils/DamarisOutputModule.hpp
+++ b/opm/simulators/utils/DamarisOutputModule.hpp
@@ -1,6 +1,7 @@
 /*
   Copyright 2022 SINTEF Digital, Mathematics and Cybernetics.
-
+  Copyright 2023 INRIA
+  
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -35,7 +36,5 @@ namespace Opm::DamarisOutput
  std::string initDamarisXmlFile();
  // Initialize Damaris by filling in th XML file and stroring it in the chosed directory
  void initializeDamaris(MPI_Comm comm, int mpiRank, std::string OutputDir, bool enableDamarisOutputCollective);
- // Setup Damaris Parameters for writing e.g., grid size and communicator to output "PRESSURE" field
- void setupDamarisWritingPars(Parallel::Communication comm, const int n_elements_local_grid);
 
 } // namespace Opm::DamarisOutput

--- a/opm/simulators/utils/initDamarisXmlFile.cpp
+++ b/opm/simulators/utils/initDamarisXmlFile.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 KerData Research Team, Inria Rennes, Bretagne–Atlantique Research Center
+  Copyright 2022 2023 Inria, Bretagne–Atlantique Research Center
   Copyright 2022 SINTEF Digital, Mathematics and Cybernetics.
 
   This file is part of the Open Porous Media project (OPM).
@@ -29,6 +29,10 @@ namespace Opm::DamarisOutput
 
     The entries in the map below will be filled by corresponding Damaris
     Keywords.
+    
+    N.B. Ensure all text items that are to be replaced are quoted with double quotes
+    e.g. unit="_REPLACE_UNIT_"   
+    *not* unit=_REPLACE_UNIT_
 */
 std::string initDamarisXmlFile()
 {
@@ -47,11 +51,103 @@ std::string initDamarisXmlFile()
     <parameter name="n_elements_local"     type="int" value="1" />
     <parameter name="n"     type="int" value="1" />
 
-    <layout   name="zonal_layout_usmesh_integer"             type="int" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
-    <variable name="GLOBAL_CELL_INDEX"    layout="zonal_layout_usmesh_integer"     type="scalar"  visualizable="false"  time-varying="false"  centering="zonal" />
-    <layout   name="zonal_layout_usmesh"             type="double" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
-    <variable name="PRESSURE"    layout="zonal_layout_usmesh"     type="scalar"  visualizable="false" select-file="GLOBAL_CELL_INDEX"     unit="bar"   centering="zonal"  store="_MYSTORE_OR_EMPTY_REGEX_" />
+    <layout   name="zonal_layout_usmesh_integer"  type="int"   dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
+    <variable name="GLOBAL_CELL_INDEX"            layout="zonal_layout_usmesh_integer"     type="scalar"  visualizable="false"  time-varying="false" store="_MYSTORE_OR_EMPTY_REGEX_" centering="zonal" />
+    <layout   name="zonal_layout_usmesh"          type="double" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
+    <variable name="PRESSURE"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="unstructured_mesh"  unit="Bar"  centering="zonal"  time-varying="true"  
+                                                                        select-file="GLOBAL_CELL_INDEX" store="_MYSTORE_OR_EMPTY_REGEX_"   script="_PYTHON_XML_NAME_" />
     _MORE_VARIABLES_REGEX_
+    
+    <variable name="MPI_RANK"  layout="zonal_layout_usmesh_integer"   type="scalar"  visualizable="true" mesh="unstructured_mesh" unit="rank"  centering="zonal"  select-file="GLOBAL_CELL_INDEX"  store="#" time-varying="false"  script="#" comment="The cells MPI rank"/>
+    
+    <variable name="KRNSW_GO"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="unstructured_mesh"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="_PYTHON_XML_NAME_" />
+    <variable name="KRNSW_OW"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="_PYTHON_XML_NAME_" />
+    <variable name="PCSWM_GO"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="_PYTHON_XML_NAME_" />
+    <variable name="PCSWM_OW"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="_PYTHON_XML_NAME_" />
+    <variable name="PPCW"      layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit="Bar"  centering="zonal"  time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="_PYTHON_XML_NAME_" />    
+    <variable name="RS"        layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit="Bar"  centering="zonal"  time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="_PYTHON_XML_NAME_" comment="Dissolved Gas units Gas Oil Ratio" />
+    <variable name="RV"        layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit="Bar"  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX" store="#"  script="_PYTHON_XML_NAME_" />
+    <variable name="SOMAX"     layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit=""     centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX" store="#"  script="#" />
+    <variable name="1OVERBG"   layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
+    <variable name="1OVERBO"   layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
+    <variable name="1OVERBW"   layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
+    <variable name="GASKR"     layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
+    <variable name="GAS_DEN"   layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
+    <variable name="GAS_VISC"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
+    <variable name="OILKR"     layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
+    <variable name="OIL_DEN"   layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
+    <variable name="OIL_VISC"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
+    <variable name="WATKR"     layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
+    <variable name="WAT_DEN"   layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
+    <variable name="WAT_VISC"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
+
+    
+    
+    <variable name="2FBF"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"   time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="4FBF"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="DFBF"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="GCDI"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="GCDM"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="GIP"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"   time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />      
+    <variable name="GIPG"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="GIPL"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"   time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="GIPR"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="HTOF"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="OIP"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"   time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />      
+    <variable name="OIPG"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="OIPL"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="OIPR"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="RPV"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"   time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />      
+    <variable name="S36F"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="SEAF"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="SGAS"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="SIP"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />      
+    <variable name="SWAT"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="TFBF"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="WCD"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />      
+    <variable name="WIP"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"   time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />      
+    <variable name="WIPG"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="WIPL"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    <variable name="WIPR"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
+    
+    
+    <parameter name="n_coords_local"     type="int" value="1" />
+    <layout    name="n_coords_layout"    type="double" dimensions="n_coords_local"   comment="For the individual x, y and z coordinates of the mesh vertices, these values are referenced in the topologies/topo/subelements/connectivity_pg data"  />
+    <group name="coordset/coords/values"> 
+        <variable name="x"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="_PYTHON_XML_NAME_" time-varying="false" />
+        <variable name="y"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="_PYTHON_XML_NAME_" time-varying="false" />
+        <variable name="z"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="_PYTHON_XML_NAME_" time-varying="false" />
+    </group>
+    
+    
+    <parameter name="n_connectivity_ph"        type="int"  value="1" />
+    <layout    name="n_connections_layout_ph"  type="int"  dimensions="n_connectivity_ph"   comment="Layout for connectivities "  />
+    <parameter name="n_offsets_types_ph"       type="int"  value="1" />
+    <layout    name="n_offsets_layout_ph"      type="int"  dimensions="n_offsets_types_ph+1"  comment="Layout for the offsets_ph"  />
+    <layout    name="n_types_layout_ph"        type="char" dimensions="n_offsets_types_ph"  comment="Layout for the types_ph "  />
+    <group name="topologies/topo/elements">
+        <variable name="connectivity"  layout="n_connections_layout_ph"  type="scalar"  visualizable="false"  script="_PYTHON_XML_NAME_" time-varying="false" />
+        <variable name="offsets"       layout="n_offsets_layout_ph"      type="scalar"  visualizable="false"  script="_PYTHON_XML_NAME_" time-varying="false" />
+        <variable name="types"         layout="n_types_layout_ph"        type="scalar"  visualizable="false"  script="_PYTHON_XML_NAME_" time-varying="false" />
+    </group>
+    
+    
+    <mesh name="unstructured_mesh" type="unstructured" topology="3" time-varying="false" 
+             comment="This Mesh definition is for connection with Paraview.
+                      This definition references the variables that define an unstructured mesh specified above." >
+        <coord                name="coordset/coords/values/x"  unit="m"    />
+        <coord                name="coordset/coords/values/y"  unit="m"    />
+        <coord                name="coordset/coords/values/z"  unit="m"    />
+        <vertex_global_id     name="#"                         offset="0"  />
+        <element_offsets      name="topologies/topo/elements/offsets"      />
+        <section_types        name="topologies/topo/elements/types"        />
+        <section_sizes        name="#"                                     />
+        <section_connectivity name="topologies/topo/elements/connectivity" />
+        <polyhedral_cell_faces_connectivity  name="#"                      /> 
+        <polyhedral_cell_faces_offsets       name="#"                      />
+        <polyhedral_n_faces_per_cell         name="#"                      />
+    </mesh>
+    
 </data>
 
 <storage>
@@ -62,10 +158,18 @@ std::string initDamarisXmlFile()
     </store>
 </storage>
 
+<scripts>
+    <pyscript name="PythonScript" file="_PYTHON_OR_EMPTY_REGEX_" language="python" frequency="1" scheduler-file="" nthreads="0" keep-workers="no" />
+</scripts>
+
+<!-- paraview update-frequency="1" write-vtk="0" write-vtk-binary="false">
+        <script>_PARAVIEWPY_OR_EMPTY_REGEX_</script>
+</paraview -->
+
 <actions>
 </actions>
 
-<log FileName="_PATH_REGEX_/damaris_log/exa_dbg" RotationSize="5" LogFormat="[%TimeStamp%]: %Message%"  Flush="True"  LogLevel="debug" />
+<log FileName="_PATH_REGEX_/damaris_log/opm-flow" RotationSize="5" LogFormat="[%TimeStamp%]: %Message%"  Flush="true"  LogLevel="info" />
 
 </simulation>)V0G0N";
 


### PR DESCRIPTION
Step one for moving Damaris calls out of EclWriter class and into its own DamarisWriter class; 
  
EclProblem now calls the writeOutput methods of DamarisWriter  and EclWriter and passes in the data::Solution object that is shared between them; 
  
Currently has an issue in the first iteration (iteration 0 in Damaris) there is no PRESSURE data - perhaps DamarisWriter does not initialize data::Solution correctly?
  
Moved setupDamarisWritingPars into the DamarisWriter class from DaamrisOutputModule (which now only has initialization code)
  