### PR TITLE
Include name of missing OPM restart file in error.

### DIFF
--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -241,7 +241,7 @@ public:
                 path.replace_filename(ioconfig.getBaseName() + ".OPMRST");
                 loadFile_ = path;
                 if (!std::filesystem::exists(loadFile_)) {
-                    OPM_THROW(std::runtime_error, "Error locating serialized restart file");
+                    OPM_THROW(std::runtime_error, "Error locating serialized restart file " + loadFile_);
                 }
             }
         }


### PR DESCRIPTION
Otherwise it is hard to tell for the (newbie?) user what went wrong.