### PR TITLE
Add Support for Reading MPI Partitioning From File

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -119,6 +119,12 @@ struct ZoltanParams {
     using type = UndefinedProperty;
 };
 
+template <class TypeTag, class MyTypeTag>
+struct ExternalPartition
+{
+    using type = UndefinedProperty;
+};
+
 template<class TypeTag, class MyTypeTag>
 struct AllowDistributedWells {
     using type = UndefinedProperty;
@@ -177,6 +183,12 @@ struct ZoltanImbalanceTol<TypeTag, TTag::EclBaseVanguard> {
 template<class TypeTag>
 struct ZoltanParams<TypeTag,TTag::EclBaseVanguard> {
     static constexpr auto value = "graph";
+};
+
+template <class TypeTag>
+struct ExternalPartition<TypeTag, TTag::EclBaseVanguard>
+{
+    static constexpr auto* value = "";
 };
 
 template<class TypeTag>
@@ -268,6 +280,12 @@ public:
                              "See https://sandialabs.github.io/Zoltan/ug_html/ug.html "
                              "for available Zoltan options.");
         EWOMS_HIDE_PARAM(TypeTag, ZoltanParams);
+        EWOMS_REGISTER_PARAM(TypeTag, std::string, ExternalPartition,
+                             "Name of file from which to load an externally generated "
+                             "partitioning of the model's active cells for MPI "
+                             "distribution purposes. If empty, the built-in partitioning "
+                             "method will be employed.");
+        EWOMS_HIDE_PARAM(TypeTag, ExternalPartition);
 #endif
         EWOMS_REGISTER_PARAM(TypeTag, bool, AllowDistributedWells,
                              "Allow the perforations of a well to be distributed to interior of multiple processes");
@@ -297,6 +315,7 @@ public:
         serialPartitioning_ = EWOMS_GET_PARAM(TypeTag, bool, SerialPartitioning);
         zoltanImbalanceTol_ = EWOMS_GET_PARAM(TypeTag, double, ZoltanImbalanceTol);
         zoltanParams_ = EWOMS_GET_PARAM(TypeTag, std::string, ZoltanParams);
+        externalPartitionFile_ = EWOMS_GET_PARAM(TypeTag, std::string, ExternalPartition);
 #endif
         enableDistributedWells_ = EWOMS_GET_PARAM(TypeTag, bool, AllowDistributedWells);
         ignoredKeywords_ = EWOMS_GET_PARAM(TypeTag, std::string, IgnoreKeywords);

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -52,6 +52,7 @@
 #include <ebos/femcpgridcompat.hh>
 #endif //HAVE_DUNE_FEM
 
+#include <algorithm>
 #include <cassert>
 #include <numeric>
 #include <optional>

--- a/ebos/eclgenericvanguard.hh
+++ b/ebos/eclgenericvanguard.hh
@@ -228,6 +228,11 @@ public:
      */
     double zoltanImbalanceTol() const
     { return zoltanImbalanceTol_; }
+
+    const std::string& externalPartitionFile() const
+    {
+        return this->externalPartitionFile_;
+    }
 #endif
 
     /*!
@@ -292,6 +297,7 @@ protected:
     bool serialPartitioning_;
     double zoltanImbalanceTol_;
     std::string zoltanParams_;
+    std::string externalPartitionFile_{};
 #endif
     bool enableDistributedWells_;
     std::string ignoredKeywords_;

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -97,7 +97,6 @@ struct LoadFile
     using type = UndefinedProperty;
 };
 
-
 template<class TypeTag>
 struct EnableTerminalOutput<TypeTag, TTag::EclFlowProblem> {
     static constexpr bool value = true;
@@ -134,7 +133,6 @@ struct LoadFile<TypeTag, TTag::EclFlowProblem>
 {
     static constexpr auto* value = "";
 };
-
 
 template <class TypeTag>
 struct LoadStep<TypeTag, TTag::EclFlowProblem>


### PR DESCRIPTION
This commit introduces new, experimental support for loading a partitioning of the cells from a text file.  The name of the file is passed into the simulator using the new, hidden, command line option
```
--external-partition=filename
```
and we perform some basic checking that the number of elements in the partition matches the number of cells in the `CpGrid` object.