### PR TITLE
Option for doing well control/status switching during local well solve

### DIFF
--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -174,6 +174,10 @@ template<class TypeTag, class MyTypeTag>
 struct UseAverageDensityMsWells {
     using type = UndefinedProperty;
 };
+template<class TypeTag, class MyTypeTag>
+struct LocalWellSolveControlSwitching {
+    using type = UndefinedProperty;
+};
 // Network solver parameters
 template<class TypeTag, class MyTypeTag>
 struct NetworkMaxStrictIterations {
@@ -366,6 +370,11 @@ template<class TypeTag>
 struct UseAverageDensityMsWells<TypeTag, TTag::FlowModelParameters> {
     static constexpr bool value = false;
 };
+template<class TypeTag>
+struct LocalWellSolveControlSwitching<TypeTag, TTag::FlowModelParameters> {
+    static constexpr bool value = true;
+};
+
 // Network solver parameters
 template<class TypeTag>
 struct NetworkMaxStrictIterations<TypeTag, TTag::FlowModelParameters> {
@@ -530,6 +539,9 @@ namespace Opm
         /// Whether to approximate segment densities by averaging over segment and its outlet 
         bool use_average_density_ms_wells_;
 
+        /// Whether to allow control switching during local well solutions 
+        bool local_well_solver_control_switching_;
+
         /// Maximum number of iterations in the network solver before relaxing tolerance
         int network_max_strict_iterations_;
         
@@ -586,6 +598,7 @@ namespace Opm
             check_well_operability_iter_ = EWOMS_GET_PARAM(TypeTag, bool, EnableWellOperabilityCheckIter);
             max_number_of_well_switches_ = EWOMS_GET_PARAM(TypeTag, int, MaximumNumberOfWellSwitches);
             use_average_density_ms_wells_ = EWOMS_GET_PARAM(TypeTag, bool, UseAverageDensityMsWells);
+            local_well_solver_control_switching_ = EWOMS_GET_PARAM(TypeTag, bool, LocalWellSolveControlSwitching);
             nonlinear_solver_ = EWOMS_GET_PARAM(TypeTag, std::string, NonlinearSolver);
             std::string approach = EWOMS_GET_PARAM(TypeTag, std::string, LocalSolveApproach);
             if (approach == "jacobi") {
@@ -651,6 +664,7 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, bool, EnableWellOperabilityCheckIter, "Enable the well operability checking during iterations");
             EWOMS_REGISTER_PARAM(TypeTag, int, MaximumNumberOfWellSwitches, "Maximum number of times a well can switch to the same control");
             EWOMS_REGISTER_PARAM(TypeTag, bool, UseAverageDensityMsWells, "Approximate segment densitities by averaging over segment and its outlet");
+            EWOMS_REGISTER_PARAM(TypeTag, bool, LocalWellSolveControlSwitching, "Allow control switching during local well solutions");
             EWOMS_REGISTER_PARAM(TypeTag, int, NetworkMaxStrictIterations, "Maximum iterations in network solver before relaxing tolerance");
             EWOMS_REGISTER_PARAM(TypeTag, int, NetworkMaxIterations, "Maximum number of iterations in the network solver before giving up");
             EWOMS_REGISTER_PARAM(TypeTag, std::string, NonlinearSolver, "Choose nonlinear solver. Valid choices are newton or nldd.");

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -372,7 +372,7 @@ struct UseAverageDensityMsWells<TypeTag, TTag::FlowModelParameters> {
 };
 template<class TypeTag>
 struct LocalWellSolveControlSwitching<TypeTag, TTag::FlowModelParameters> {
-    static constexpr bool value = true;
+    static constexpr bool value = false;
 };
 
 // Network solver parameters

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2258,6 +2258,9 @@ namespace Opm {
                     deferred_logger.warning("WELL_INITIAL_SOLVE_FAILED", msg);
                 }
             }
+            // If we're using local well solves that include control switches, they also update
+            // operability, so reset before main iterations begin
+            well->resetWellOperability();
         }
         updatePrimaryVariables(deferred_logger);
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -256,6 +256,14 @@ namespace Opm
                                               const GroupState& group_state,
                                               DeferredLogger& deferred_logger) override;
 
+        virtual bool iterateWellEqWithSwitching(const Simulator& ebosSimulator,
+                             const double dt,
+                             const Well::InjectionControls& inj_controls,
+                             const Well::ProductionControls& prod_controls,
+                             WellState& well_state,
+                             const GroupState& group_state,
+                             DeferredLogger& deferred_logger) override;
+
         virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
                                                     const double dt,
                                                     const Well::InjectionControls& inj_controls,

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -257,12 +257,12 @@ namespace Opm
                                               DeferredLogger& deferred_logger) override;
 
         virtual bool iterateWellEqWithSwitching(const Simulator& ebosSimulator,
-                             const double dt,
-                             const Well::InjectionControls& inj_controls,
-                             const Well::ProductionControls& prod_controls,
-                             WellState& well_state,
-                             const GroupState& group_state,
-                             DeferredLogger& deferred_logger) override;
+                                                const double dt,
+                                                const Well::InjectionControls& inj_controls,
+                                                const Well::ProductionControls& prod_controls,
+                                                WellState& well_state,
+                                                const GroupState& group_state,
+                                                DeferredLogger& deferred_logger) override;
 
         virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
                                                     const double dt,

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -523,9 +523,6 @@ getResidualMeasureValue(const WellState& well_state,
         ++count;
     }
 
-    // if (count == 0), it should be converged.
-    assert(count != 0);
-
     return sum;
 }
 

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -523,6 +523,9 @@ getResidualMeasureValue(const WellState& well_state,
         ++count;
     }
 
+    // if (count == 0), it should be converged.
+    assert(count != 0);
+
     return sum;
 }
 

--- a/opm/simulators/wells/MultisegmentWellGeneric.cpp
+++ b/opm/simulators/wells/MultisegmentWellGeneric.cpp
@@ -140,11 +140,9 @@ segmentNumberToIndex(const int segment_number) const
 template<typename Scalar>
 void
 MultisegmentWellGeneric<Scalar>::
-detectOscillations(const std::vector<double>& measure_history,
-                   const int it,
-                   bool& oscillate,
-                   bool& stagnate) const
+detectOscillations(const std::vector<double>& measure_history, bool& oscillate, bool& stagnate) const
 {
+    const auto it = measure_history.size() - 1;
     if ( it < 2 ) {
         oscillate = false;
         stagnate = false;

--- a/opm/simulators/wells/MultisegmentWellGeneric.hpp
+++ b/opm/simulators/wells/MultisegmentWellGeneric.hpp
@@ -65,7 +65,6 @@ protected:
 
     /// Detect oscillation or stagnation based on the residual measure history
     void detectOscillations(const std::vector<double>& measure_history,
-                            const int it,
                             bool& oscillate,
                             bool& stagnate) const;
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -207,12 +207,12 @@ namespace Opm
 
         // iterate well equations including control switching
         bool iterateWellEqWithSwitching(const Simulator& ebosSimulator,
-                               const double dt,
-                               const Well::InjectionControls& inj_controls,
-                               const Well::ProductionControls& prod_controls,
-                               WellState& well_state,
-                               const GroupState& group_state,
-                               DeferredLogger& deferred_logger) override;                              
+                                        const double dt,
+                                        const Well::InjectionControls& inj_controls,
+                                        const Well::ProductionControls& prod_controls,
+                                        WellState& well_state,
+                                        const GroupState& group_state,
+                                        DeferredLogger& deferred_logger) override;
 
         /// \brief Wether the Jacobian will also have well contributions in it.
         virtual bool jacobianContainsWellContributions() const override

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -205,6 +205,15 @@ namespace Opm
                                       const GroupState& group_state,
                                       DeferredLogger& deferred_logger) override;
 
+        // iterate well equations including control switching
+        bool iterateWellEqWithSwitching(const Simulator& ebosSimulator,
+                               const double dt,
+                               const Well::InjectionControls& inj_controls,
+                               const Well::ProductionControls& prod_controls,
+                               WellState& well_state,
+                               const GroupState& group_state,
+                               DeferredLogger& deferred_logger) override;                              
+
         /// \brief Wether the Jacobian will also have well contributions in it.
         virtual bool jacobianContainsWellContributions() const override
         {

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2175,7 +2175,7 @@ namespace Opm
         const auto& summary_state = ebosSimulator.vanguard().summaryState();
 
         // Max status switch frequency should be 2 to avoid getting stuck in cycle 
-        const int min_its_after_switch = 2;
+        constexpr int min_its_after_switch = 2;
         int its_since_last_switch = min_its_after_switch;
         int switch_count= 0;
         const auto well_status = this->wellStatus_;
@@ -2236,12 +2236,13 @@ namespace Opm
                 }
                 // We reset the well status to it's original state. Status is updated 
                 // on the outside based on operability status
-                this->wellStatus_ = well_status; 
+                // TODO: this looks strange, let us check
+                this->wellStatus_ = well_status;
             }
         } else {
-            std::ostringstream sstr;
-            sstr << "     Well " << this->name() << " did not converge in " << it << " inner iterations (" << switch_count << " control/status switches).";
-            deferred_logger.debug(sstr.str());
+            const std::string message = fmt::format("   Well {} did not converged in {} inner iterations ("
+                                                    "{} control/status switches).", this->name(), it, switch_count);
+            deferred_logger.debug(message);
             // add operability here as well ?
         }
         return converged;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2234,9 +2234,13 @@ namespace Opm
                 } else {
                     this->operability_status_.operable_under_only_bhp_limit = !is_stopped;
                 }
-                // We reset the well status to it's original state. Status is updated 
+                // We reset the well status to its original state. Status is updated
                 // on the outside based on operability status
-                // TODO: this looks strange, let us check
+                // \Note for future reference: For the well to update its status to stop/shut,
+                // the flag changed_to_stopped_this_step_ in prepareWellBeforeAssembling needs to be set to true.
+                // For this to happen, isOperableAndSolvable() must change from true to false,
+                // and (until the most recent commit) the well needs to be open for this to trigger.
+                // Hence, the resetting of status.
                 this->wellStatus_ = well_status;
             }
         } else {

--- a/opm/simulators/wells/WellConstraints.cpp
+++ b/opm/simulators/wells/WellConstraints.cpp
@@ -39,13 +39,16 @@ checkIndividualConstraints(SingleWellState& ws,
                            const SummaryState& summaryState,
                            const RateConvFunc& calcReservoirVoidageRates,
                            bool& thp_limit_violated_but_not_switched,
-                           DeferredLogger& deferred_logger) const
+                           DeferredLogger& deferred_logger,
+                           const std::optional<Well::InjectionControls>& inj_controls,
+                           const std::optional<Well::ProductionControls>& prod_controls) const
 {
     if (well_.isProducer()) {
         auto new_cmode = this->activeProductionConstraint(ws, summaryState,
                                                           calcReservoirVoidageRates,
                                                           thp_limit_violated_but_not_switched,
-                                                          deferred_logger);
+                                                          deferred_logger, 
+                                                          prod_controls);
         if (new_cmode != ws.production_cmode) {
             ws.production_cmode = new_cmode;
             return true;
@@ -55,7 +58,8 @@ checkIndividualConstraints(SingleWellState& ws,
     if (well_.isInjector()) {
         auto new_cmode = this->activeInjectionConstraint(ws, summaryState,
                                                         thp_limit_violated_but_not_switched,
-                                                        deferred_logger);
+                                                        deferred_logger, 
+                                                        inj_controls);
         if (new_cmode != ws.injection_cmode) {
             ws.injection_cmode = new_cmode;
             return true;
@@ -69,11 +73,12 @@ Well::InjectorCMode WellConstraints::
 activeInjectionConstraint(const SingleWellState& ws,
                           const SummaryState& summaryState,
                           bool& thp_limit_violated_but_not_switched,
-                          DeferredLogger& deferred_logger) const
+                          DeferredLogger& deferred_logger,
+                          const std::optional<Well::InjectionControls>& inj_controls) const
 {
     const PhaseUsage& pu = well_.phaseUsage();
 
-    const auto controls = well_.wellEcl().injectionControls(summaryState);
+    const auto controls =  inj_controls.has_value() ? inj_controls.value() : well_.wellEcl().injectionControls(summaryState);
     const auto currentControl = ws.injection_cmode;
 
     if (controls.hasControl(Well::InjectorCMode::BHP) && currentControl != Well::InjectorCMode::BHP)
@@ -166,10 +171,11 @@ activeProductionConstraint(const SingleWellState& ws,
                            const SummaryState& summaryState,
                            const RateConvFunc& calcReservoirVoidageRates,
                            bool& thp_limit_violated_but_not_switched,
-                           DeferredLogger& deferred_logger) const
+                           DeferredLogger& deferred_logger,
+                           const std::optional<Well::ProductionControls>& prod_controls) const
 {
     const PhaseUsage& pu = well_.phaseUsage();
-    const auto controls = well_.wellEcl().productionControls(summaryState);
+    const auto controls = prod_controls.has_value() ? prod_controls.value() : well_.wellEcl().productionControls(summaryState);
     const auto currentControl = ws.production_cmode;
 
     if (controls.hasControl(Well::ProducerCMode::BHP) && currentControl != Well::ProducerCMode::BHP) {

--- a/opm/simulators/wells/WellConstraints.hpp
+++ b/opm/simulators/wells/WellConstraints.hpp
@@ -24,9 +24,12 @@
 #ifndef OPM_WELL_CONSTRAINTS_HEADER_INCLUDED
 #define OPM_WELL_CONSTRAINTS_HEADER_INCLUDED
 
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
+
 #include <functional>
 #include <utility>
 #include <vector>
+#include <optional>
 
 namespace Opm
 {
@@ -55,21 +58,25 @@ public:
                                const SummaryState& summaryState,
                                const RateConvFunc& calcReservoirVoidageRates,
                                bool& thp_limit_violated_but_not_switched,
-                               DeferredLogger& deferred_logger) const;
+                               DeferredLogger& deferred_logger,
+                               const std::optional<Well::InjectionControls>& inj_controls = std::nullopt,
+                               const std::optional<Well::ProductionControls>& prod_controls = std::nullopt) const;
 
 private:
     WellInjectorCMode
     activeInjectionConstraint(const SingleWellState& ws,
                               const SummaryState& summaryState,
                               bool& thp_limit_violated_but_not_switched,
-                              DeferredLogger& deferred_logger) const;
+                              DeferredLogger& deferred_logger,
+                              const std::optional<Well::InjectionControls>& inj_controls = std::nullopt) const;
 
     WellProducerCMode
     activeProductionConstraint(const SingleWellState& ws,
                                const SummaryState& summaryState,
                                const RateConvFunc& calcReservoirVoidageRates,
                                bool& thp_limit_violated_but_not_switched,
-                               DeferredLogger& deferred_logger) const;
+                               DeferredLogger& deferred_logger,
+                               const std::optional<Well::ProductionControls>& prod_controls = std::nullopt) const;
 
     const WellInterfaceGeneric& well_; //!< Reference to well interface
 };

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -242,12 +242,12 @@ public:
                            DeferredLogger& deferred_logger) /* const */;
 
     bool updateWellControlAndStatusLocalIteration(const Simulator& ebos_simulator,
-                      WellState& well_state,
-                      const GroupState& group_state,
-                      const Well::InjectionControls& inj_controls,
-                      const Well::ProductionControls& prod_controls,
-                      const double& WQTotal, 
-                      DeferredLogger& deferred_logger); /* const */                                               
+                                                  WellState& well_state,
+                                                  const GroupState& group_state,
+                                                  const Well::InjectionControls& inj_controls,
+                                                  const Well::ProductionControls& prod_controls,
+                                                  const double WQTotal,
+                                                  DeferredLogger& deferred_logger);
 
     virtual void updatePrimaryVariables(const SummaryState& summary_state,
                                         const WellState& well_state,
@@ -402,12 +402,12 @@ protected:
                                           DeferredLogger& deferred_logger) = 0;
 
     virtual bool iterateWellEqWithSwitching(const Simulator& ebosSimulator,
-                                          const double dt,
-                                          const WellInjectionControls& inj_controls,
-                                          const WellProductionControls& prod_controls,
-                                          WellState& well_state,
-                                          const GroupState& group_state,
-                                          DeferredLogger& deferred_logger) = 0;                                          
+                                            const double dt,
+                                            const WellInjectionControls& inj_controls,
+                                            const WellProductionControls& prod_controls,
+                                            WellState& well_state,
+                                            const GroupState& group_state,
+                                            DeferredLogger& deferred_logger) = 0;
 
     bool iterateWellEquations(const Simulator& ebosSimulator,
                               const double dt,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -241,6 +241,14 @@ public:
                            const GroupState& group_state,
                            DeferredLogger& deferred_logger) /* const */;
 
+    bool updateWellControlAndStatusLocalIteration(const Simulator& ebos_simulator,
+                      WellState& well_state,
+                      const GroupState& group_state,
+                      const Well::InjectionControls& inj_controls,
+                      const Well::ProductionControls& prod_controls,
+                      const double& WQTotal, 
+                      DeferredLogger& deferred_logger); /* const */                                               
+
     virtual void updatePrimaryVariables(const SummaryState& summary_state,
                                         const WellState& well_state,
                                         DeferredLogger& deferred_logger) = 0;
@@ -302,6 +310,9 @@ public:
                                const WellState& well_state,
                                DeferredLogger& deferred_logger);
 
+    bool updateWellOperabilityFromWellEq(const Simulator& ebos_simulator,
+                                         const WellState& well_state,
+                                         DeferredLogger& deferred_logger);
 
     // update perforation water throughput based on solved water rate
     virtual void updateWaterThroughput(const double dt, WellState& well_state) const = 0;
@@ -389,6 +400,14 @@ protected:
                                           WellState& well_state,
                                           const GroupState& group_state,
                                           DeferredLogger& deferred_logger) = 0;
+
+    virtual bool iterateWellEqWithSwitching(const Simulator& ebosSimulator,
+                                          const double dt,
+                                          const WellInjectionControls& inj_controls,
+                                          const WellProductionControls& prod_controls,
+                                          WellState& well_state,
+                                          const GroupState& group_state,
+                                          DeferredLogger& deferred_logger) = 0;                                          
 
     bool iterateWellEquations(const Simulator& ebosSimulator,
                               const double dt,

--- a/opm/simulators/wells/WellInterfaceFluidSystem.cpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.cpp
@@ -105,7 +105,9 @@ bool
 WellInterfaceFluidSystem<FluidSystem>::
 checkIndividualConstraints(SingleWellState& ws,
                            const SummaryState& summaryState,
-                           DeferredLogger& deferred_logger) const
+                           DeferredLogger& deferred_logger,
+                           const std::optional<Well::InjectionControls>& inj_controls,
+                           const std::optional<Well::ProductionControls>& prod_controls) const
 {
     auto rRates = [this](const int fipreg,
                          const int pvtRegion,
@@ -119,7 +121,7 @@ checkIndividualConstraints(SingleWellState& ws,
     return WellConstraints(*this).
             checkIndividualConstraints(ws, summaryState, rRates,
                                        this->operability_status_.thp_limit_violated_but_not_switched,
-                                       deferred_logger);
+                                       deferred_logger, inj_controls, prod_controls);
 }
 
 template <typename FluidSystem>

--- a/opm/simulators/wells/WellInterfaceFluidSystem.hpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.hpp
@@ -79,7 +79,9 @@ protected:
 
     bool checkIndividualConstraints(SingleWellState& ws,
                                     const SummaryState& summaryState,
-                                    DeferredLogger& deferred_logger) const;
+                                    DeferredLogger& deferred_logger,
+                                    const std::optional<Well::InjectionControls>& inj_controls = std::nullopt,
+                                    const std::optional<Well::ProductionControls>& prod_controls = std::nullopt) const;
 
     bool checkGroupConstraints(WellState& well_state,
                                const GroupState& group_state,

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -344,22 +344,23 @@ void WellInterfaceGeneric::setVFPProperties(const VFPProperties* vfp_properties_
     vfp_properties_ = vfp_properties_arg;
 }
 
-void WellInterfaceGeneric::setPrevSurfaceRates(WellState& well_state, 
+void WellInterfaceGeneric::setPrevSurfaceRates(WellState& well_state,
                                                const WellState& prev_well_state) const
     {
         auto& ws = well_state.well(this->index_of_well_);
         auto& ws_prev = prev_well_state.well(this->index_of_well_);
         // The logic here is a bit fragile:
-        // We need non-zero prev_surface_rates for the purpose of providing explicit fractions 
+        // We need non-zero prev_surface_rates for the purpose of providing explicit fractions
         // (if needed) for vfp interpolation.
         // We assume that current surface rates either are initialized from previous step
-        // or (if newly opened) from updateWellStateRates. This is fine unless well was 
-        // stopped in previous step in which case it's rates will be zero. In this case, 
+        // or (if newly opened) from updateWellStateRates. This is fine unless well was
+        // stopped in previous step in which case it's rates will be zero. In this case,
         // we select the previous rates of the previous well state (and hope for the best).
-        bool zero_rates = true;
-        for (const double& rate : ws.surface_rates){
-            zero_rates &= (rate == 0.0);
-        } 
+        const bool zero_rates = std::all_of(ws.surface_rates.begin(), ws.surface_rates.end(),
+                [](double rate) {
+                    return rate == 0.; // TODO: should we use a threshhold for comparison?
+                } );
+
         if (zero_rates) {
             ws.prev_surface_rates = ws_prev.prev_surface_rates;
         } else {

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -209,6 +209,9 @@ public:
     bool stopppedOrZeroRateTarget(const SummaryState& summary_state,
                                   const WellState& well_state) const;
 
+    bool wellUnderZeroRateTarget(const SummaryState& summary_state,
+                                 const WellState& well_state) const;                                  
+
     double wellEfficiencyFactor() const
     { return well_efficiency_factor_; }
 
@@ -217,6 +220,8 @@ public:
     {
         inj_fc_multiplier_ = inj_fc_multiplier;
     }
+
+    void resetWellOperability();  
 
 protected:
     bool getAllowCrossFlow() const;
@@ -231,9 +236,6 @@ protected:
     int polymerTable_() const;
     int polymerInjTable_() const;
     int polymerWaterTable_() const;
-
-    bool wellUnderZeroRateTarget(const SummaryState& summary_state,
-                                 const WellState& well_state) const;
 
     std::pair<bool,bool>
     computeWellPotentials(std::vector<double>& well_potentials,

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -209,9 +209,6 @@ public:
     bool stopppedOrZeroRateTarget(const SummaryState& summary_state,
                                   const WellState& well_state) const;
 
-    bool wellUnderZeroRateTarget(const SummaryState& summary_state,
-                                 const WellState& well_state) const;                                  
-
     double wellEfficiencyFactor() const
     { return well_efficiency_factor_; }
 
@@ -221,7 +218,7 @@ public:
         inj_fc_multiplier_ = inj_fc_multiplier;
     }
 
-    void resetWellOperability();  
+    void resetWellOperability();
 
 protected:
     bool getAllowCrossFlow() const;
@@ -236,6 +233,9 @@ protected:
     int polymerTable_() const;
     int polymerInjTable_() const;
     int polymerWaterTable_() const;
+
+    bool wellUnderZeroRateTarget(const SummaryState& summary_state,
+                                 const WellState& well_state) const;
 
     std::pair<bool,bool>
     computeWellPotentials(std::vector<double>& well_potentials,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -626,10 +626,22 @@ namespace Opm
         const bool well_operable = this->operability_status_.isOperableAndSolvable();
 
         if (!well_operable && old_well_operable) {
-            if (!this->wellIsStopped()) {
+            if (this->param_.local_well_solver_control_switching_) {
                 deferred_logger.info(" well " + this->name() + " gets STOPPED during iteration ");
                 this->stopWell();
                 changed_to_stopped_this_step_ = true;
+            } else {
+                // \Note: keep the old manner for now for testing checking.
+                // Will be investgiated and fixed in a later PR
+                if (this->well_ecl_.getAutomaticShutIn()) {
+                    deferred_logger.info(" well " + this->name() + " gets SHUT during iteration ");
+                } else {
+                    if (!this->wellIsStopped()) {
+                        deferred_logger.info(" well " + this->name() + " gets STOPPED during iteration ");
+                        this->stopWell();
+                        changed_to_stopped_this_step_ = true;
+                    }
+                }
             }
         } else if (well_operable && !old_well_operable) {
             deferred_logger.info(" well " + this->name() + " gets REVIVED during iteration ");


### PR DESCRIPTION
This PR is a lightly cleaned up version of PR https://github.com/OPM/opm-simulators/pull/4808 . 

In this PR, a new function `iterateWellEqWithSwitching()` is added so that when we do the local solve for well equations, control/status will be updated during the iteration process, such that the converged well gets correct control/status regarding to the current reservoir state. Various change in the other parts of the code were made to make the function work as intended.

A running option local-well-solve-control-switching is added to trigger the use of the new function `iterateWellEqWithSwitching()`. In this PR, it is defaulted to be `false` at the moment, so it should not affect the running of cases when running without the running option on. 

It is developed by @steink with discussion with others.