### PR TITLE
Supporting centroids lookup for rank 0 and LGRs

### DIFF
--- a/ebos/eclalugridvanguard.hh
+++ b/ebos/eclalugridvanguard.hh
@@ -248,7 +248,7 @@ public:
     std::function<std::array<double,dimensionworld>(int)>
     cellCentroids() const
     {
-        return this->cellCentroids_(this->cartesianIndexMapper());
+        return this->cellCentroids_(this->cartesianIndexMapper(), false);
     }
 
     const TransmissibilityType& globalTransmissibility() const

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -476,11 +476,14 @@ protected:
      */
     template<class CartMapper>
     std::function<std::array<double,dimensionworld>(int)>
-    cellCentroids_(const CartMapper& cartMapper) const
+    cellCentroids_(const CartMapper& cartMapper, const bool& isCpGrid) const
     {
-        return [this, cartMapper](int elemIdx) {
+        return [this, cartMapper, isCpGrid](int elemIdx) {
             std::array<double,dimensionworld> centroid;
-            if (this->gridView().comm().rank() == 0)
+            const auto rank = this->gridView().comm().rank();
+            const auto maxLevel = this->gridView().grid().maxLevel();
+            bool useEclipse = !isCpGrid || (isCpGrid && (rank == 0) && (maxLevel == 0));
+            if (useEclipse)
             {
                 centroid =  this->eclState().getInputGrid().getCellCenter(cartMapper.cartesianIndex(elemIdx));
             }

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -239,7 +239,7 @@ public:
     std::function<std::array<double,dimensionworld>(int)>
     cellCentroids() const
     {
-        return this->cellCentroids_(this->cartesianIndexMapper());
+        return this->cellCentroids_(this->cartesianIndexMapper(), true);
     }
 
     const std::vector<int>& globalCell()

--- a/ebos/eclpolyhedralgridvanguard.hh
+++ b/ebos/eclpolyhedralgridvanguard.hh
@@ -222,7 +222,7 @@ public:
     std::function<std::array<double,EclBaseVanguard<TypeTag>::dimensionworld>(int)>
     cellCentroids() const
     {
-        return this->cellCentroids_(this->cartesianIndexMapper());
+        return this->cellCentroids_(this->cartesianIndexMapper(), false);
     }
 
     std::vector<int> cellPartition() const


### PR DESCRIPTION
This is a follow-up/completition of #4778 where we separate the case when centroids are searched for a grid with LGRs and rank zero.