### PR TITLE
Fix shut-in logic for wells with shut-intructions

### DIFF
--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -626,23 +626,9 @@ namespace Opm
         const bool well_operable = this->operability_status_.isOperableAndSolvable();
 
         if (!well_operable && old_well_operable) {
-            if (this->param_.local_well_solver_control_switching_) {
-                deferred_logger.info(" well " + this->name() + " gets STOPPED during iteration ");
-                this->stopWell();
-                changed_to_stopped_this_step_ = true;
-            } else {
-                // \Note: keep the old manner for now for testing checking.
-                // Will be investgiated and fixed in a later PR
-                if (this->well_ecl_.getAutomaticShutIn()) {
-                    deferred_logger.info(" well " + this->name() + " gets SHUT during iteration ");
-                } else {
-                    if (!this->wellIsStopped()) {
-                        deferred_logger.info(" well " + this->name() + " gets STOPPED during iteration ");
-                        this->stopWell();
-                        changed_to_stopped_this_step_ = true;
-                    }
-                }
-            }
+            deferred_logger.info(" well " + this->name() + " gets STOPPED during iteration ");
+            this->stopWell();
+            changed_to_stopped_this_step_ = true;
         } else if (well_operable && !old_well_operable) {
             deferred_logger.info(" well " + this->name() + " gets REVIVED during iteration ");
             this->openWell();


### PR DESCRIPTION
This fix was originally part of a previous PR, but was removed to ease testing (it breaks a lot of tests), hence this separate PR.

Currently, a well with shut-in instruction "shut" that changes to non-operable during an iteration will give the message _well xxx gets SHUT during iteration_ , but no further actions are triggered. This is due to the flag _changed_to_stopped_this_step__ not being set.

The logic is a bit intricate, but for a well to get stopped/shut it needs to be found non-operable at the end of the time-step in
`timeStepSucceeded` -> `updateWellTestState` -> `checkWellOperability`
However, unless  _changed_to_stopped_this_step__ is true, it's operability is not updated, and the closing procedure in 
`updateWellTestState` -> `updateWellTestStatePhysical` -> `close_well`
is not triggered.

With this PR, a non-operable well will give the message _well xxx gets STOPPED during iteration_ (irrespective of it's shut-in instructions), and at the end of the time-step get closed according to it's shut/stop instruction (with accompanied message).