### PR TITLE
If parsing strictness is set to 'low', proceed (with warning) if no matching wells found

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -527,6 +527,9 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
         const bool treatCriticalAsNonCritical = (parsingStrictness == "low");
         try {
             auto parseContext = setupParseContext(exitOnAllErrors);
+            if (treatCriticalAsNonCritical) { // Continue with invalid names if parsing strictness is set to low
+                parseContext->update(ParseContext::SCHEDULE_INVALID_NAME, InputErrorAction::WARN);
+            }
             readOnIORank(comm, deckFilename, parseContext.get(),
                          eclipseState, schedule, udqState, actionState, wtestState,
                          summaryConfig, std::move(python), initFromRestart,


### PR DESCRIPTION
… (in various schedule keywords). 

Depends on https://github.com/OPM/opm-common/pull/3698