### PR TITLE
Add missing reverse flow derivatives for valve/icd/aicd

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -234,10 +234,10 @@ assembleDefaultPressureEq(const int seg,
     auto& segments = ws.segments;
 
     if (this->frictionalPressureLossConsidered()) {
-        const auto friction_pressure_drop = segments_.getFrictionPressureLoss(seg, false);
+        const auto friction_pressure_drop = segments_.getFrictionPressureLoss(seg);
         if (reverseFlow){
             // call function once again to obtain/assemble remaining derivatives
-            extra_derivatives = -segments_.getFrictionPressureLoss(seg, true);
+            extra_derivatives = -segments_.getFrictionPressureLoss(seg, /*extra_reverse_flow_derivatives*/ true);
             MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
                 assemblePressureEqExtraDerivatives(seg, seg_upwind, extra_derivatives, linSys_);
         }
@@ -292,21 +292,21 @@ assembleICDPressureEq(const int seg,
     EvalWell extra_derivatives;
     switch(this->segmentSet()[seg].segmentType()) {
         case Segment::SegmentType::SICD :
-            icd_pressure_drop = segments_.pressureDropSpiralICD(seg, /*extra derivatives*/false);
+            icd_pressure_drop = segments_.pressureDropSpiralICD(seg);
             if (reverseFlow){
-                extra_derivatives = -segments_.pressureDropSpiralICD(seg, /*extra derivatives*/true);
+                extra_derivatives = -segments_.pressureDropSpiralICD(seg, /*extra_reverse_flow_derivatives*/ true);
             }
             break;
         case Segment::SegmentType::AICD :
-            icd_pressure_drop = segments_.pressureDropAutoICD(seg, unit_system, /*extra derivatives*/false);
+            icd_pressure_drop = segments_.pressureDropAutoICD(seg, unit_system);
             if (reverseFlow){
-                extra_derivatives = -segments_.pressureDropAutoICD(seg, unit_system, /*extra derivatives*/true);
+                extra_derivatives = -segments_.pressureDropAutoICD(seg, unit_system, /*extra_reverse_flow_derivatives*/ true);
             }
             break;
         case Segment::SegmentType::VALVE :
-            icd_pressure_drop = segments_.pressureDropValve(seg, /*extra derivatives*/false);
+            icd_pressure_drop = segments_.pressureDropValve(seg);
             if (reverseFlow){
-                extra_derivatives = -segments_.pressureDropValve(seg, /*extra derivatives*/true);
+                extra_derivatives = -segments_.pressureDropValve(seg, /*extra_reverse_flow_derivatives*/ true);
             }
             break;
         default: {

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -283,19 +283,31 @@ assembleICDPressureEq(const int seg,
     // the pressure equation is something like
     // p_seg - deltaP - p_outlet = 0.
     // the major part is how to calculate the deltaP
+    const int seg_upwind = segments_.upwinding_segment(seg);
+    const bool reverseFlow = seg != seg_upwind; // special treatment for reverse flow
 
     EvalWell pressure_equation = primary_variables_.getSegmentPressure(seg);
 
     EvalWell icd_pressure_drop;
+    EvalWell extra_derivatives;
     switch(this->segmentSet()[seg].segmentType()) {
         case Segment::SegmentType::SICD :
-            icd_pressure_drop = segments_.pressureDropSpiralICD(seg);
+            icd_pressure_drop = segments_.pressureDropSpiralICD(seg, /*extra derivatives*/false);
+            if (reverseFlow){
+                extra_derivatives = -segments_.pressureDropSpiralICD(seg, /*extra derivatives*/true);
+            }
             break;
         case Segment::SegmentType::AICD :
-            icd_pressure_drop = segments_.pressureDropAutoICD(seg, unit_system);
+            icd_pressure_drop = segments_.pressureDropAutoICD(seg, unit_system, /*extra derivatives*/false);
+            if (reverseFlow){
+                extra_derivatives = -segments_.pressureDropAutoICD(seg, unit_system, /*extra derivatives*/true);
+            }
             break;
         case Segment::SegmentType::VALVE :
-            icd_pressure_drop = segments_.pressureDropValve(seg);
+            icd_pressure_drop = segments_.pressureDropValve(seg, /*extra derivatives*/false);
+            if (reverseFlow){
+                extra_derivatives = -segments_.pressureDropValve(seg, /*extra derivatives*/true);
+            }
             break;
         default: {
             OPM_DEFLOG_THROW(std::runtime_error,
@@ -305,6 +317,12 @@ assembleICDPressureEq(const int seg,
                              deferred_logger);
         }
     }
+    if (reverseFlow){
+        MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
+            assemblePressureEqExtraDerivatives(seg, seg_upwind, extra_derivatives, linSys_);
+
+    }
+
     pressure_equation = pressure_equation - icd_pressure_drop;
     auto& ws = well_state.well(baseif_.indexOfWell());
     ws.segments.pressure_drop_friction[seg] = icd_pressure_drop.value();
@@ -313,7 +331,6 @@ assembleICDPressureEq(const int seg,
     const int outlet_segment_index = this->segmentNumberToIndex(this->segmentSet()[seg].outletSegment());
     const EvalWell outlet_pressure = primary_variables_.getSegmentPressure(outlet_segment_index);
 
-    const int seg_upwind = segments_.upwinding_segment(seg);
     MultisegmentWellAssemble<FluidSystem,Indices,Scalar>(baseif_).
         assemblePressureEq(seg, seg_upwind, outlet_segment_index,
                            pressure_equation, outlet_pressure,

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -498,7 +498,8 @@ getSurfaceVolume(const EvalWell& temperature,
 template<class FluidSystem, class Indices, class Scalar>
 typename MultisegmentWellSegments<FluidSystem,Indices,Scalar>::EvalWell
 MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
-getFrictionPressureLoss(const int seg, const bool return_extra_derivatives) const
+getFrictionPressureLoss(const int seg, 
+                        const bool extra_reverse_flow_derivatives /*false*/) const
 {
     EvalWell mass_rate = mass_rates_[seg];
     const int seg_upwind = upwinding_segments_[seg];
@@ -511,7 +512,7 @@ getFrictionPressureLoss(const int seg, const bool return_extra_derivatives) cons
     // at segment node while fraction derivatives are given at upwind node.
 
     if (seg != seg_upwind) {
-        if (!return_extra_derivatives){
+        if (!extra_reverse_flow_derivatives){
             constexpr int WQTotal = Indices::numEq + PrimaryVariables::WQTotal;
             constexpr int SPres = Indices::numEq + PrimaryVariables::SPres;
             density.setDerivative(WQTotal, 0.0);
@@ -550,7 +551,7 @@ template<class FluidSystem, class Indices, class Scalar>
 typename MultisegmentWellSegments<FluidSystem,Indices,Scalar>::EvalWell
 MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
 pressureDropSpiralICD(const int seg,
-                      const bool return_extra_derivatives) const
+                      const bool extra_reverse_flow_derivatives /*false*/) const
 {
     const auto& segment_set = well_.wellEcl().getSegments();
     const SICD& sicd = segment_set[seg].spiralICD();
@@ -593,14 +594,14 @@ pressureDropSpiralICD(const int seg,
     if (seg != seg_upwind) {
         constexpr int nvar = FluidSystem::numPhases + 1;
         std::vector<bool> zero_mask(nvar, false);
-        if (!return_extra_derivatives){
+        if (!extra_reverse_flow_derivatives){
             zero_mask[PrimaryVariables::WQTotal] = true;
             zero_mask[PrimaryVariables::SPres] = true;
         } else {
-            if (PrimaryVariables::has_water){
+            if constexpr (PrimaryVariables::has_water){
                 zero_mask[PrimaryVariables::WFrac] = true;
             }
-            if (PrimaryVariables::has_gas){
+            if constexpr (PrimaryVariables::has_gas){
                 zero_mask[PrimaryVariables::GFrac] = true;
             }
             // mass_rate has no extra derivatives (they are organized as in equations)
@@ -654,7 +655,7 @@ typename MultisegmentWellSegments<FluidSystem,Indices,Scalar>::EvalWell
 MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
 pressureDropAutoICD(const int seg,
                     const UnitSystem& unit_system, 
-                    const bool return_extra_derivatives) const
+                    const bool extra_reverse_flow_derivatives /*false*/) const
 {
     const auto& segment_set = well_.wellEcl().getSegments();
     const AutoICD& aicd = segment_set[seg].autoICD();
@@ -704,7 +705,7 @@ pressureDropAutoICD(const int seg,
     if (seg != seg_upwind) {
         constexpr int nvar = FluidSystem::numPhases + 1;
         std::vector<bool> zero_mask(nvar, false);
-        if (!return_extra_derivatives){
+        if (!extra_reverse_flow_derivatives){
             zero_mask[PrimaryVariables::WQTotal] = true;
             zero_mask[PrimaryVariables::SPres] = true;
         } else {
@@ -762,7 +763,7 @@ template<class FluidSystem, class Indices, class Scalar>
 typename MultisegmentWellSegments<FluidSystem,Indices,Scalar>::EvalWell
 MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
 pressureDropValve(const int seg,
-                  const bool return_extra_derivatives) const
+                  const bool extra_reverse_flow_derivatives /*false*/) const
 {
     const auto& segment_set = well_.wellEcl().getSegments();
     const Valve& valve = segment_set[seg].valve();
@@ -777,7 +778,7 @@ pressureDropValve(const int seg,
     // For reference: the pressure equation assumes pressure/flow derivatives are given 
     // at segment node while fraction derivatives are given at upwind node. 
     if (seg != seg_upwind) {
-        if (!return_extra_derivatives){
+        if (!extra_reverse_flow_derivatives){
             constexpr int WQTotal = Indices::numEq + PrimaryVariables::WQTotal;
             constexpr int SPres = Indices::numEq + PrimaryVariables::SPres;
             density.setDerivative(WQTotal, 0.0);

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -74,15 +74,18 @@ public:
     EvalWell getFrictionPressureLoss(const int seg, const bool return_upwind_derivatives) const;
 
     // pressure drop for Spiral ICD segment (WSEGSICD)
-    EvalWell pressureDropSpiralICD(const int seg) const;
+    EvalWell pressureDropSpiralICD(const int seg,
+                                   const bool return_extra_derivatives) const;
 
     // pressure drop for Autonomous ICD segment (WSEGAICD)
     EvalWell pressureDropAutoICD(const int seg,
-                                 const UnitSystem& unit_system) const;
+                                 const UnitSystem& unit_system,
+                                 const bool return_extra_derivatives) const;
 
     // pressure drop for sub-critical valve (WSEGVALV)
-    EvalWell pressureDropValve(const int seg) const;
-
+    EvalWell pressureDropValve(const int seg, 
+                               const bool return_extra_derivatives) const;
+                               
     // pressure loss due to acceleration
     EvalWell accelerationPressureLoss(const int seg) const;
 

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -71,20 +71,21 @@ public:
                               const int pvt_region_index,
                               const int seg_idx) const;
 
-    EvalWell getFrictionPressureLoss(const int seg, const bool return_upwind_derivatives) const;
+    EvalWell getFrictionPressureLoss(const int seg, 
+                                     const bool extra_reverse_flow_derivatives = false) const;
 
     // pressure drop for Spiral ICD segment (WSEGSICD)
     EvalWell pressureDropSpiralICD(const int seg,
-                                   const bool return_extra_derivatives) const;
+                                   const bool extra_reverse_flow_derivatives = false) const;
 
     // pressure drop for Autonomous ICD segment (WSEGAICD)
     EvalWell pressureDropAutoICD(const int seg,
                                  const UnitSystem& unit_system,
-                                 const bool return_extra_derivatives) const;
+                                 const bool extra_reverse_flow_derivatives = false) const;
 
     // pressure drop for sub-critical valve (WSEGVALV)
     EvalWell pressureDropValve(const int seg, 
-                               const bool return_extra_derivatives) const;
+                               const bool extra_reverse_flow_derivatives = false) const;
                                
     // pressure loss due to acceleration
     EvalWell accelerationPressureLoss(const int seg) const;


### PR DESCRIPTION
In the case when the flow direction through valves/icd's is reversed, some derivatives are currently omitted (there is no _room_ for them in the current implementation). This PR fixes this by performing a second call to the respective functions and by doing a seperate assembly of the _extra_ derivatives. This is the same approach that was taken for acceleration pressure loss in #4640 (which helped in preventing singular well systems). 

The changes here have been tested on larger models and although results are not very conclusive, some positive effects have been observed. I think it's not unlikely though, that we will run into cases where these derivatives really matter (convergence and/or singularities), so unless they turn out to make things worse I think they should be incuded.  