### PR TITLE
[bugfix] Fix stopping network update in parallel at max steps.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1125,8 +1125,8 @@ namespace Opm {
 
             if (network_update_iteration >= max_iteration ) {
                 if (terminal_output_) {
-                    local_deferredLogger.info("maximum of " + std::to_string(max_iteration) + " iterations has been used, we stop the network update now, "
-                                              "the simulation will continue with unconvergeed network results");
+                    local_deferredLogger.info("maximum of " + std::to_string(max_iteration) + " iterations has been used, we stop the network update now. "
+                                              "The simulation will continue with unconverged network results");
                 }
                 break;
             }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1122,9 +1122,12 @@ namespace Opm {
             std::tie(do_network_update, well_group_control_changed) =
                     updateWellControlsAndNetworkIteration(mandatory_network_balance, relax_network_balance, dt,local_deferredLogger);
             ++network_update_iteration;
-            if (terminal_output_ && (network_update_iteration >= max_iteration) ) {
-                local_deferredLogger.info("maximum of " + std::to_string(max_iteration) + " iterations has been used, we stop the network update now, "
-                                                                                          "the simulation will continue with unconvergeed network results");
+
+            if (network_update_iteration >= max_iteration ) {
+                if (terminal_output_) {
+                    local_deferredLogger.info("maximum of " + std::to_string(max_iteration) + " iterations has been used, we stop the network update now, "
+                                              "the simulation will continue with unconvergeed network results");
+                }
                 break;
             }
         }


### PR DESCRIPTION
We did only break in the loop for rank 0 and not the other ones. Hence all other processes kept iterating beyond the maximum number of allowed iterations. This lead to hard to find crashes because of non-matching MPI communication.