### PR TITLE
Fix to write vtks on report steps

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -737,7 +737,9 @@ public:
         OPM_TIMEBLOCK(problemWriteOutput);
         // use the generic code to prepare the output fields and to
         // write the desired VTK files.
-        ParentType::writeOutput(verbose);
+        if (EWOMS_GET_PARAM(TypeTag, bool, EnableWriteAllSolutions) || this->simulator().episodeWillBeOver()){
+            ParentType::writeOutput(verbose);
+        }
 
         bool isSubStep = !EWOMS_GET_PARAM(TypeTag, bool, EnableWriteAllSolutions) && !this->simulator().episodeWillBeOver();
         


### PR DESCRIPTION
If `--enable-vtk-output=true` and `--enable-write-all-solutions=false` (it is false as default), then the VTK files are written for all solutions. This commit fixes that, i.e., the VTK files are written for the report steps (unless we set `--enable-write-all-solutions=true`). 