### PR TITLE
not setting THP to be zero based whether having THP constraint from the Deck input in the WellState

### DIFF
--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -397,17 +397,11 @@ void WellState::init(const std::vector<double>& cellPressures,
 
                 // Productivity index.
                 new_well.productivity_index = prev_well.productivity_index;
-            }
 
-            // If in the new step, there is no THP related
-            // target/limit anymore, its thp value should be set to
-            // zero.
-            const bool has_thp = well.isInjector()
-                ? well.injectionControls (summary_state).hasControl(Well::InjectorCMode::THP)
-                : well.productionControls(summary_state).hasControl(Well::ProducerCMode::THP);
-
-            if (!has_thp) {
-                new_well.thp = 0;
+                // if there is no valid VFP table associated, we set the THP value to be 0.
+                if (well.vfp_table_number() == 0) {
+                    new_well.thp = 0.;
+                }
             }
         }
     }


### PR DESCRIPTION
instead, we set the thp to be zero based on whether having a valid VFP table. The following is comments/arguments for the change (not well organized.) Basically the current code only works for limited cases due to coincidence (THP and VFP are provided/absent at the same time), while might impact other scenarios.  The code in this PR although not 100% necessary, while it should not do any harm.  

1. in the current form, the WellState is not aware of possible THP constraint from the network, so even it is trying to set the THP to be zero based on the absence of THP constraint, it is not doing with the full information. setting the thp to be zero based on part information in the WellState turns out to be problematic for some network setup. 

2. when provided a VFP table, even there is no THP constraint specified, we need the thp value for output purpose. Setting the THP value to be zero might not do any harm for this situation, but it does not do any good either.
 
3. The current code in the master might impact the simulation when network involved.  Using whether having a valid VFP table is a better/safer criterion. It should not do any bad to any simulations. For example, when network setup is involved, a valid VFP table has to be provided.  

