### PR TITLE
Enable Loading Parallel NLDD Partition From File

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -79,6 +79,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/timestepping/SimulatorTimerInterface.cpp
   opm/simulators/timestepping/gatherConvergenceReport.cpp
   opm/simulators/utils/ComponentName.cpp
+  opm/simulators/utils/compressPartition.cpp
   opm/simulators/utils/DeferredLogger.cpp
   opm/simulators/utils/gatherDeferredLogger.cpp
   opm/simulators/utils/ParallelFileMerger.cpp
@@ -523,6 +524,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/timestepping/SimulatorTimerInterface.hpp
   opm/simulators/timestepping/gatherConvergenceReport.hpp
   opm/simulators/utils/ComponentName.hpp
+  opm/simulators/utils/compressPartition.hpp
   opm/simulators/utils/ParallelFileMerger.hpp
   opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
   opm/simulators/utils/DeferredLogger.hpp

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -45,6 +45,7 @@
 #include <memory>
 #include <stdexcept>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
 #include <fmt/format.h>
@@ -75,16 +76,43 @@ namespace Opm { namespace details {
             std::istream_iterator<int> {}
         };
 
-        if (partition.size() != static_cast<std::vector<int>::size_type>(grid.size(0))) {
-            throw std::invalid_argument {
-                fmt::format("Partition file '{}' with {} values does "
-                            "not match CpGrid instance with {} cells",
-                            this->partitionFile_.generic_string(),
-                            partition.size(), grid.size(0))
-            };
+        const auto nc =
+            static_cast<std::vector<int>::size_type>(grid.size(0));
+
+        if (partition.size() == nc) {
+            // Input is one process ID for each active cell
+            return partition;
         }
 
-        return partition;
+        if (partition.size() == 3 * nc) {
+            // Partition file is of the form
+            //
+            //   Process_ID   Cartesian_Idx   NLDD_Domain
+            //
+            // with one row for each active cell.  Select first column.
+            auto g2l = std::unordered_map<int, int>{};
+            auto locCell = 0;
+            for (const auto& globCell : grid.globalCell()) {
+                g2l.insert_or_assign(globCell, locCell++);
+            }
+
+            auto filtered_partition = std::vector<int>(nc);
+            for (auto c = 0*nc; c < nc; ++c) {
+                auto pos = g2l.find(partition[3*c + 1]);
+                if (pos != g2l.end()) {
+                    filtered_partition[pos->second] = partition[3*c + 0];
+                }
+            }
+
+            return filtered_partition;
+        }
+
+        throw std::invalid_argument {
+            fmt::format("Partition file '{}' with {} values does "
+                        "not match CpGrid instance with {} cells",
+                        this->partitionFile_.generic_string(),
+                        partition.size(), nc)
+        };
     }
 }} // namespace Opm::details
 

--- a/opm/simulators/flow/BlackoilModelEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelEbos.hpp
@@ -59,6 +59,8 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <ios>
 #include <limits>
@@ -1029,6 +1031,29 @@ namespace Opm {
         const std::vector<StepReport>& stepReports() const
         {
             return convergence_reports_;
+        }
+
+        void writePartitions(const std::filesystem::path& odir) const
+        {
+            if (this->nlddSolver_ != nullptr) {
+                this->nlddSolver_->writePartitions(odir);
+                return;
+            }
+
+            const auto& elementMapper = this->ebosSimulator().model().elementMapper();
+            const auto& cartMapper = this->ebosSimulator().vanguard().cartesianIndexMapper();
+
+            const auto& grid = this->ebosSimulator().vanguard().grid();
+            const auto& comm = grid.comm();
+            const auto nDigit = 1 + static_cast<int>(std::floor(std::log10(comm.size())));
+
+            std::ofstream pfile { odir / fmt::format("{1:0>{0}}", nDigit, comm.rank()) };
+
+            for (const auto& cell : elements(grid.leafGridView(), Dune::Partitions::interior)) {
+                pfile << comm.rank() << ' '
+                      << cartMapper.cartesianIndex(elementMapper.index(cell)) << ' '
+                      << comm.rank() << '\n';
+            }
         }
 
     protected:

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -117,6 +117,10 @@ template<class TypeTag, class MyTypeTag>
 struct EnableWellOperabilityCheckIter {
     using type = UndefinedProperty;
 };
+template<class TypeTag, class MyTypeTag>
+struct DebugEmitCellPartition {
+    using type = UndefinedProperty;
+};
 // parameters for multisegment wells
 template<class TypeTag, class MyTypeTag>
 struct TolerancePressureMsWells {
@@ -357,6 +361,10 @@ struct EnableWellOperabilityCheckIter<TypeTag, TTag::FlowModelParameters> {
     static constexpr bool value = false;
 };
 template<class TypeTag>
+struct DebugEmitCellPartition<TypeTag, TTag::FlowModelParameters> {
+    static constexpr bool value = false;
+};
+template<class TypeTag>
 struct RelaxedWellFlowTol<TypeTag, TTag::FlowModelParameters> {
     using type = GetPropType<TypeTag, Scalar>;
     static constexpr type value = 1e-3;
@@ -573,6 +581,8 @@ namespace Opm
         std::string local_domain_partition_method_;
         DomainOrderingMeasure local_domain_ordering_{DomainOrderingMeasure::AveragePressure};
 
+        bool write_partitions_{false};
+
         /// Construct from user parameters or defaults.
         BlackoilModelParametersEbos()
         {
@@ -637,6 +647,8 @@ namespace Opm
             } else {
                 throw std::runtime_error("Invalid domain ordering '" + measure + "' specified.");
             }
+
+            write_partitions_ = EWOMS_GET_PARAM(TypeTag, bool, DebugEmitCellPartition);
         }
 
         static void registerParameters()
@@ -690,6 +702,10 @@ namespace Opm
                                  "Allowed values are 'zoltan', 'simple', and the name of a partition file ending with '.partition'.");
             EWOMS_REGISTER_PARAM(TypeTag, std::string, LocalDomainsOrderingMeasure, "Subdomain ordering measure. "
                                  "Allowed values are 'pressure' and  'residual'.");
+
+            EWOMS_REGISTER_PARAM(TypeTag, bool, DebugEmitCellPartition, "Whether or not to emit cell partitions as a debugging aid.");
+
+            EWOMS_HIDE_PARAM(TypeTag, DebugEmitCellPartition);
         }
     };
 } // namespace Opm

--- a/opm/simulators/utils/compressPartition.cpp
+++ b/opm/simulators/utils/compressPartition.cpp
@@ -34,16 +34,9 @@ namespace {
         return { *mmPos.first, *mmPos.second };
     }
 
-} // Anonymous namespace
-
-std::pair<std::vector<int>, int>
-Opm::util::compressAndCountPartitionIDs(std::vector<int>&& parts0)
-{
-    auto parts = std::pair<std::vector<int>, int> { std::move(parts0), 0 };
-
-    auto& [partition, num_domains] = parts;
-
-    if (! partition.empty()) {
+    void compressAndCountPartitionIDs(std::vector<int>& partition,
+                                      int&              num_domains)
+    {
         const auto& [low, high] = valueRange(partition);
 
         auto seen = std::vector<bool>(high - low + 1, false);
@@ -64,6 +57,16 @@ Opm::util::compressAndCountPartitionIDs(std::vector<int>&& parts0)
             }
         }
     }
+} // Anonymous namespace
+
+std::pair<std::vector<int>, int>
+Opm::util::compressAndCountPartitionIDs(std::vector<int>&& parts0)
+{
+    auto parts = std::pair<std::vector<int>, int> { std::move(parts0), 0 };
+
+    if (! parts.first.empty()) {
+        ::compressAndCountPartitionIDs(parts.first, parts.second);
+    }
 
     return parts;
 }
@@ -71,4 +74,10 @@ Opm::util::compressAndCountPartitionIDs(std::vector<int>&& parts0)
 std::vector<int> Opm::util::compressPartitionIDs(std::vector<int>&& parts0)
 {
     return compressAndCountPartitionIDs(std::move(parts0)).first;
+}
+
+void Opm::util::compressPartitionIDs(std::vector<int>& parts0)
+{
+    [[maybe_unused]] auto num_domains = 0;
+    ::compressAndCountPartitionIDs(parts0, num_domains);
 }

--- a/opm/simulators/utils/compressPartition.cpp
+++ b/opm/simulators/utils/compressPartition.cpp
@@ -1,0 +1,74 @@
+/*
+  Copyright 2023 Equinor ASA
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/simulators/utils/compressPartition.hpp>
+
+#include <algorithm>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace {
+
+    template <typename T>
+    std::pair<T, T> valueRange(const std::vector<T>& x)
+    {
+        auto mmPos = std::minmax_element(x.begin(), x.end());
+
+        return { *mmPos.first, *mmPos.second };
+    }
+
+} // Anonymous namespace
+
+std::pair<std::vector<int>, int>
+Opm::util::compressAndCountPartitionIDs(std::vector<int>&& parts0)
+{
+    auto parts = std::pair<std::vector<int>, int> { std::move(parts0), 0 };
+
+    auto& [partition, num_domains] = parts;
+
+    if (! partition.empty()) {
+        const auto& [low, high] = valueRange(partition);
+
+        auto seen = std::vector<bool>(high - low + 1, false);
+        for (const auto& domain : partition) {
+            seen[domain - low] = domain >= 0;
+        }
+
+        auto compressed = std::vector<int>(seen.size(), -1);
+        for (auto i = 0*compressed.size(); i < compressed.size(); ++i) {
+            if (seen[i]) {
+                compressed[i] = num_domains++;
+            }
+        }
+
+        for (auto& domain : partition) {
+            if (domain >= 0) {
+                domain = compressed[domain - low];
+            }
+        }
+    }
+
+    return parts;
+}
+
+std::vector<int> Opm::util::compressPartitionIDs(std::vector<int>&& parts0)
+{
+    return compressAndCountPartitionIDs(std::move(parts0)).first;
+}

--- a/opm/simulators/utils/compressPartition.hpp
+++ b/opm/simulators/utils/compressPartition.hpp
@@ -28,6 +28,7 @@ namespace Opm { namespace util {
     compressAndCountPartitionIDs(std::vector<int>&& parts0);
 
     std::vector<int> compressPartitionIDs(std::vector<int>&& parts0);
+    void compressPartitionIDs(std::vector<int>& parts0);
 }} // namespace Opm::util
 
 #endif // OPM_UTIL_COMPRESS_PARTITION_HPP_INCLUDED

--- a/opm/simulators/utils/compressPartition.hpp
+++ b/opm/simulators/utils/compressPartition.hpp
@@ -1,0 +1,33 @@
+/*
+  Copyright 2023 Equinor ASA
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_UTIL_COMPRESS_PARTITION_HPP_INCLUDED
+#define OPM_UTIL_COMPRESS_PARTITION_HPP_INCLUDED
+
+#include <utility>
+#include <vector>
+
+namespace Opm { namespace util {
+    std::pair<std::vector<int>, int>
+    compressAndCountPartitionIDs(std::vector<int>&& parts0);
+
+    std::vector<int> compressPartitionIDs(std::vector<int>&& parts0);
+}} // namespace Opm::util
+
+#endif // OPM_UTIL_COMPRESS_PARTITION_HPP_INCLUDED


### PR DESCRIPTION
This PR adds support for loading a three-column NLDD partitioning scheme of the form
```
MPI_Rank  Cartesian_Index  NLDD_Domain_ID
```
from a text file.  In an MPI run it is assumed that the first column holds integers in the range `0..MPI_Size()-1`, and typically that each such integer is listed at least once.  In a sequential run, the MPI rank column is ignored.

This PR also adds support for outputting such text files in both sequential and MPI runs.  If the user activates the new, and hidden, debugging option
```
DebugEmitCellPartition (--debug-emit-cell-partition)
```
each rank will write one such three-column text file into the special-purpose subdirectory `partition/CaseName` of the run's output directory.  That file will be named according to the process' MPI rank, so the first column will be the same as the file name.

The option is primarily intended for debugging the NLDD partitioning scheme, so is mostly reserved for runs with low MPI sizes (e.g., less than 20).

While here, also make the `MPIPartitionFromFile` helper class of PR #4882 aware of this format so that we can use concatenated output files as an input to the MPI partitioning algorithm for repeatability.