### PR TITLE
Enable (limited) support  for UDT

### DIFF
--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -649,8 +649,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"TUNINGL", {false, std::nullopt}},
         {"TUNINGS", {false, std::nullopt}},
         {"TZONE", {true, std::nullopt}},
-        {"UDT", {true, std::nullopt}},
-        {"UDTDIMS", {true, std::nullopt}},
         {"UNCODHMD", {true, std::nullopt}},
         {"UNIFOUTS", {false, std::nullopt}},
         {"UNIFSAVE", {false, std::nullopt}},

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -498,6 +498,25 @@ foreach(pinch_case ${_pinch_cases})
     DIR pinch)
 endforeach()
 
+set(_udt_cases
+  1D-01B
+  1D-01
+  1D-02
+  1D-03
+)
+
+foreach(udt_case ${_udt_cases})
+  string(TOLOWER ${udt_case} udt_test)
+  add_test_compareECLFiles(CASENAME udt_${udt_test}
+    FILENAME UDT-${udt_case}
+    SIMULATOR flow
+    ABS_TOL ${abs_tol}
+    REL_TOL ${rel_tol}
+    TEST_ARGS --enable-tuning=true
+    DIR udt)
+endforeach()
+
+
 add_test_compareECLFiles(CASENAME udq_uadd
                          FILENAME UDQ_M1
                          SIMULATOR flow

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -63,10 +63,11 @@ do
   failed_test=`echo $failed_test | sed -e 's/.*://g' -e 's/\+/./g'`
   # Extract test properties
   dir=`dirname "$0"`
-  binary=$(awk -v search="set_tests_properties\\\($failed_test" -v prop="SIMULATOR" -f $dir/getprop.awk $BUILD_DIR/CTestTestfile.cmake)
-  dir_name=$(awk -v search="set_tests_properties\\\($failed_test" -v prop="DIRNAME" -f $dir/getprop.awk $BUILD_DIR/CTestTestfile.cmake)
-  file_name=$(awk -v search="set_tests_properties\\\($failed_test" -v prop="FILENAME" -f $dir/getprop.awk $BUILD_DIR/CTestTestfile.cmake)
-  test_name=$(awk -v search="set_tests_properties\\\($failed_test" -v prop="TESTNAME" -f $dir/getprop.awk $BUILD_DIR/CTestTestfile.cmake)
+  binary=$(awk -v search="set_tests_properties\\\($failed_test\$" -v prop="SIMULATOR" -f $dir/getprop.awk $BUILD_DIR/CTestTestfile.cmake)
+  dir_name=$(awk -v search="set_tests_properties\\\($failed_test\$" -v prop="DIRNAME" -f $dir/getprop.awk $BUILD_DIR/CTestTestfile.cmake)
+  file_name=$(awk -v search="set_tests_properties\\\($failed_test\$" -v prop="FILENAME" -f $dir/getprop.awk $BUILD_DIR/CTestTestfile.cmake)
+  test_name=$(awk -v search="set_tests_properties\\\($failed_test\$" -v prop="TESTNAME" -f $dir/getprop.awk $BUILD_DIR/CTestTestfile.cmake)
+  echo "$failed_test ${binary} ${dirname} ${file_name} ${test_name}"
   copyToReferenceDir \
           $BUILD_DIR/tests/results/$binary+$test_name \
           $OPM_TESTS_ROOT/$dir_name/opm-simulation-reference/$binary \


### PR DESCRIPTION
Remove keywords from unsupported list and add regression tests.

Only 1D UDTs are supported, however as this limitation is on the parser level I did not add it to partially supported since it will error out earlier.

Downstream of https://github.com/OPM/opm-common/pull/3728
Downstream of https://github.com/OPM/opm-tests/pull/1069