### PR TITLE
Get simulator time step size from Python BlackOilSimulator module

### DIFF
--- a/opm/simulators/flow/FlowMainEbos.hpp
+++ b/opm/simulators/flow/FlowMainEbos.hpp
@@ -321,6 +321,12 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
             return simtimer_.get();
         }
 
+        /// Get the size of the previous report step
+        double getPreviousReportStepSize()
+        {
+            return simtimer_->stepLengthTaken();
+        }
+
     private:
         // called by execute() or executeInitStep()
         int execute_(int (FlowMainEbos::* runOrInitFunc)(), bool cleanup)

--- a/opm/simulators/flow/python/PyBlackOilSimulator.hpp
+++ b/opm/simulators/flow/python/PyBlackOilSimulator.hpp
@@ -43,20 +43,23 @@ public:
         std::shared_ptr<Opm::EclipseState> state,
         std::shared_ptr<Opm::Schedule> schedule,
         std::shared_ptr<Opm::SummaryConfig> summary_config);
+    void advance(int report_step);
     bool checkSimulationFinished();
+    int currentStep();
     py::array_t<double> getCellVolumes();
+    double getDT();
     py::array_t<double> getPorosity();
     int run();
     void setPorosity(
          py::array_t<double, py::array::c_style | py::array::forcecast> array);
     int step();
-    void advance(int report_step);
-    int currentStep();
-    int stepInit();
     int stepCleanup();
-    const Opm::FlowMainEbos<TypeTag>& getFlowMainEbos() const;
+    int stepInit();
 
 private:
+    Opm::FlowMainEbos<TypeTag>& getFlowMainEbos() const;
+    PyMaterialState<TypeTag>& getMaterialState() const;
+
     const std::string deck_filename_;
     bool has_run_init_ = false;
     bool has_run_cleanup_ = false;

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -54,6 +54,11 @@ if(OPM_ENABLE_PYTHON_TESTS)
       COMMAND ${CMAKE_COMMAND}
       -E env PYTHONPATH=${PYTHON_PATH} ${PYTHON_EXECUTABLE}
       -m unittest test/test_schedule.py)
+  add_test(NAME python_throw
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python
+      COMMAND ${CMAKE_COMMAND}
+      -E env PYTHONPATH=${PYTHON_PATH} ${PYTHON_EXECUTABLE}
+      -m unittest test/test_throw.py)
 endif()
 
 find_file(PYTHON_INSTALL_PY install.py

--- a/python/test/pytest_common.py
+++ b/python/test/pytest_common.py
@@ -1,0 +1,12 @@
+import os
+from contextlib import contextmanager
+
+@contextmanager
+def pushd(path):
+    cwd = os.getcwd()
+    if not os.path.isdir(path):
+        os.makedirs(path)
+    os.chdir(path)
+    yield
+    os.chdir(cwd)
+

--- a/python/test/test_basic.py
+++ b/python/test/test_basic.py
@@ -3,16 +3,7 @@ import unittest
 from contextlib import contextmanager
 from pathlib import Path
 from opm.simulators import BlackOilSimulator
-
-@contextmanager
-def pushd(path):
-    cwd = os.getcwd()
-    if not os.path.isdir(path):
-        os.makedirs(path)
-    os.chdir(path)
-    yield
-    os.chdir(cwd)
-
+from .pytest_common import pushd
 
 class TestBasic(unittest.TestCase):
     @classmethod
@@ -63,6 +54,10 @@ class TestBasic(unittest.TestCase):
             sim = BlackOilSimulator("SPE1CASE1.DATA")
             sim.step_init()
             sim.step()
+            dt = sim.get_dt()
+            # NOTE: The timestep should be 1 month = 31 days
+            #  = 31 * 24 * 60 * 60 seconds = 2678400 seconds
+            self.assertAlmostEqual(dt, 2678400.0, places=7, msg='value of timestep')
             vol = sim.get_cell_volumes()
             self.assertEqual(len(vol), 300, 'length of volume vector')
             # NOTE: The volume should be 1000 ft x 1000 ft x 20 ft * 0.3 (porosity) 

--- a/python/test/test_schedule.py
+++ b/python/test/test_schedule.py
@@ -9,16 +9,7 @@ from opm.io.parser import Parser
 from opm.io.ecl_state import EclipseState
 from opm.io.schedule import Schedule
 from opm.io.summary import SummaryConfig
-
-@contextmanager
-def pushd(path):
-    cwd = os.getcwd()
-    if not os.path.isdir(path):
-        os.makedirs(path)
-    os.chdir(path)
-    yield
-    os.chdir(cwd)
-
+from .pytest_common import pushd
 
 class TestBasic(unittest.TestCase):
     @classmethod

--- a/python/test/test_throw.py
+++ b/python/test/test_throw.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+from pathlib import Path
+from opm.simulators import BlackOilSimulator
+from .pytest_common import pushd
+
+class TestBasic(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # NOTE: See comment in test_basic.py for the reason why we are
+        #   only using a single test_all() function instead of splitting
+        #   it up in multiple test functions
+        test_dir = Path(os.path.dirname(__file__))
+        cls.data_dir = test_dir.parent.joinpath("test_data/SPE1CASE1a")
+
+    def test_all(self):
+        with pushd(self.data_dir):
+            sim = BlackOilSimulator("SPE1CASE1.DATA")
+            # NOTE: The following call should throw an exception since the simulation
+            #   has not been initialized
+            with self.assertRaises(RuntimeError):
+                sim.get_dt()


### PR DESCRIPTION
Adds a `get_dt()` to the `opm.simulators.BlackOilSimulator` Python module. This will return the size of the previous simulator time step.