### PR TITLE
Apply Full SWATINIT-Like PCOW Rescaling at Restart

### DIFF
--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -1090,9 +1090,8 @@ public:
         }
 
         if (simulator_.vanguard().eclState().fieldProps().has_double("SWATINIT")) {
-            const auto& oilWaterScaledEpsInfoDrainage
-                = simulator.problem().materialLawManager()->oilWaterScaledEpsInfoDrainage(elemIdx);
-            const_cast<EclEpsScalingPointsInfo<Scalar>&>(oilWaterScaledEpsInfoDrainage).maxPcow = this->ppcw_[elemIdx];
+            simulator.problem().materialLawManager()
+                ->applyRestartSwatInit(elemIdx, this->ppcw_[elemIdx]);
         }
     }
 


### PR DESCRIPTION
We switch to using the `applyRestartSwatInit()` member function (PR OPM/opm-common#3731) instead of directly mutating a data member of the `EpsInfo` structure. This way we defer the rescaling to a context with a more complete view of the changes needed to convey the information to all components involved.