### PR TITLE
Remove redundant CPU decomposition when done also on GPU

### DIFF
--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -306,14 +306,8 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             return flexibleSolver_.size();
         }
 
-        void prepare(const SparseMatrixAdapter& M, Vector& b)
+        void initPrepare(const Matrix& M, Vector& b)
         {
-            prepare(M.istlMatrix(), b);
-        }
-
-        void prepare(const Matrix& M, Vector& b)
-        {
-            OPM_TIMEBLOCK(istlSolverEbosPrepare);
             const bool firstcall = (matrix_ == nullptr);
 #if HAVE_MPI
             if (firstcall && isParallel()) {
@@ -344,6 +338,19 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             if (isParallel() && prm_[activeSolverNum_].template get<std::string>("preconditioner.type") != "ParOverILU0") {
                 detail::makeOverlapRowsInvalid(getMatrix(), overlapRows_);
             }
+        }
+
+        void prepare(const SparseMatrixAdapter& M, Vector& b)
+        {
+            prepare(M.istlMatrix(), b);
+        }
+
+        void prepare(const Matrix& M, Vector& b)
+        {
+            OPM_TIMEBLOCK(istlSolverEbosPrepare);
+
+            initPrepare(M,b);
+
             prepareFlexibleSolver();
         }
 

--- a/opm/simulators/linalg/ISTLSolverEbosBda.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosBda.hpp
@@ -183,14 +183,13 @@ public:
         OPM_TIMEBLOCK(prepare);
         [[maybe_unused]] const bool firstcall = (this->matrix_ == nullptr);
 
-        // Avoid performing the decomposition on CPU when we also do it on GPU, but we do
-        // need to initialize the pointers.
-         if(bdaBridge_){
+        // Avoid performing the decomposition on CPU when we also do it on GPU,
+        // but we do need to initialize the pointers.
+        if (bdaBridge_) {
             ParentType::initPrepare(M,b);
-         }
-         else {
-             ParentType::prepare(M,b);
-         }
+        } else {
+            ParentType::prepare(M,b);
+        }
 
 #if HAVE_OPENCL
         // update matrix entries for solvers.

--- a/opm/simulators/linalg/ISTLSolverEbosBda.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosBda.hpp
@@ -182,7 +182,15 @@ public:
     {
         OPM_TIMEBLOCK(prepare);
         [[maybe_unused]] const bool firstcall = (this->matrix_ == nullptr);
-        ParentType::prepare(M,b);
+
+        // Avoid performing the decomposition on CPU when we also do it on GPU, but we do
+        // need to initialize the pointers.
+         if(bdaBridge_){
+            ParentType::initPrepare(M,b);
+         }
+         else {
+             ParentType::prepare(M,b);
+         }
 
 #if HAVE_OPENCL
         // update matrix entries for solvers.


### PR DESCRIPTION
Factor out the initialization code needed before doing a ILU decomposition to remove the redundant software decomposition when we also perform it on the GPU. This was previously done in #4558, but lost in the adaptation to ISTLSolverEbosBda. 