### PR TITLE
Initialize rates/previous rates before well-test

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -544,6 +544,14 @@ namespace Opm {
             well->setVFPProperties(vfp_properties_.get());
             well->setGuideRate(&guideRate_);
 
+            // initialize rates/previous rates to prevent zero fractions in vfp-interpolation
+            if (well->isProducer()) {
+                well->updateWellStateRates(ebosSimulator_, this->wellState(), deferred_logger);
+            }
+            if (well->isVFPActive(deferred_logger)) {
+                well->setPrevSurfaceRates(this->wellState(), this->prevWellState());
+            }
+
             well->wellTesting(ebosSimulator_, simulationTime, this->wellState(), this->groupState(), wellTestState(), deferred_logger);
         }
     }


### PR DESCRIPTION
Also for well-testing it's important to have a non-zero initial guess for rates, and that there are non-zero _explicit_ water/gas fractions available for vfp-interpolation (e.g., non-zero _previous rates_). Otherwise the well is likely to converge to the zero rate/zero fractions case and deemed inoperable.   