### PR TITLE
avoid dead stores

### DIFF
--- a/tests/cuistl/test_cujac.cpp
+++ b/tests/cuistl/test_cujac.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(CUJACApplyBlocksize2, T, NumericTypes)
            | |0 0|  | 0 -1| |     | |4| |       | |-2.0| |
    */
     const int N = 2;
-    const int blocksize = 2;
+    constexpr int blocksize = 2;
     const int nonZeroes = 3;
     using M = Dune::FieldMatrix<T, blocksize, blocksize>;
     using SpMatrix = Dune::BCRSMatrix<M>;
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(CUJACApplyBlocksize1, T, NumericTypes)
            | 0  0  0 -1|       |1|       |  -2|
    */
     const int N = 4;
-    const int blocksize = 1;
+    constexpr int blocksize = 1;
     const int nonZeroes = 8;
     using M = Dune::FieldMatrix<T, blocksize, blocksize>;
     using SpMatrix = Dune::BCRSMatrix<M>;

--- a/tests/test_dilu.cpp
+++ b/tests/test_dilu.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(SeqDILUDiagIsCorrect2x2NoZeros, T, NumericTypes)
     */
 
     const int N = 2;
-    const int bz = 2;
+    constexpr int bz = 2;
     const int nonZeroes = 4;
     using Matrix = Dune::BCRSMatrix<Dune::FieldMatrix<double, bz, bz>>;
     using Vector = Dune::BlockVector<Dune::FieldVector<double, bz>>;
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(SeqDILUDiagIsCorrect2x2, T, NumericTypes)
     */
 
     const int N = 2;
-    const int bz = 2;
+    constexpr int bz = 2;
     const int nonZeroes = 3;
     using Matrix = Dune::BCRSMatrix<Dune::FieldMatrix<double, bz, bz>>;
     using Vector = Dune::BlockVector<Dune::FieldVector<double, bz>>;


### PR DESCRIPTION
These are only used as template parameters. Make them compile time variables.