### PR TITLE
Remove Leftover Debug Printout

### DIFF
--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -278,7 +278,6 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                 os << "Property tree for linear solvers:\n";
                 for (std::size_t i = 0; i<prm_.size(); i++) {
                     prm_[i].write_json(os, true);
-                    std::cerr<< "debug: ["<<i<<"] : " << os.str() <<std::endl;
                 }
                 OpmLog::note(os.str());
             }


### PR DESCRIPTION
This information already goes to the .DBG file so there's no need to echo it to the main console as well.

Backport of #4941