### PR TITLE
Treat exceptions during computation of well potentials as warnings.

### DIFF
--- a/opm/simulators/utils/DeferredLogger.cpp
+++ b/opm/simulators/utils/DeferredLogger.cpp
@@ -82,10 +82,18 @@ namespace Opm
         messages_.push_back({Log::MessageType::Note, "", message});
     }
 
-    void DeferredLogger::logMessages()
+    void DeferredLogger::logMessages(bool convert_error_to_warning)
     {
-        for (const auto& m : messages_) {
-            OpmLog::addTaggedMessage(m.flag, m.tag, m.text);
+        if(convert_error_to_warning) {
+            for (const auto& m : messages_) {
+                OpmLog::addTaggedMessage((m.flag==Log::MessageType::Error)?
+                                         Log::MessageType::Warning : m.flag, m.tag, m.text);
+            }
+        }
+        else {
+            for (const auto& m : messages_) {
+                OpmLog::addTaggedMessage(m.flag, m.tag, m.text);
+            }
         }
         messages_.clear();
     }

--- a/opm/simulators/utils/DeferredLogger.hpp
+++ b/opm/simulators/utils/DeferredLogger.hpp
@@ -82,7 +82,7 @@ enum ExcEnum {
 
         /// Log all messages to the OpmLog backends,
         /// and clear the message container.
-        void logMessages();
+        void logMessages(bool convert_eror_to_warning=false);
 
         /// Clear the message container without logging them.
         void clearMessages();

--- a/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
+++ b/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
@@ -95,12 +95,13 @@ inline void logAndCheckForExceptionsAndThrow(Opm::DeferredLogger& deferred_logge
                                              Opm::ExceptionType::ExcEnum exc_type,
                                              const std::string& message,
                                              const bool terminal_output,
-                                             Opm::Parallel::Communication comm)
+                                             Opm::Parallel::Communication comm,
+                                             const bool convert_error_to_warning = false)
 {
     Opm::DeferredLogger global_deferredLogger = gatherDeferredLogger(deferred_logger, comm);
 
     if (terminal_output) {
-        global_deferredLogger.logMessages(/* convert_error_to_warning= */ true);
+        global_deferredLogger.logMessages(convert_error_to_warning);
     }
     // Now that all messages have been logged, they are automatically
     // cleared from the global logger, but we must also clear them

--- a/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
+++ b/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
@@ -100,7 +100,7 @@ inline void logAndCheckForExceptionsAndThrow(Opm::DeferredLogger& deferred_logge
     Opm::DeferredLogger global_deferredLogger = gatherDeferredLogger(deferred_logger, comm);
 
     if (terminal_output) {
-        global_deferredLogger.logMessages();
+        global_deferredLogger.logMessages(/* convert_error_to_warning= */ true);
     }
     // Now that all messages have been logged, they are automatically
     // cleared from the global logger, but we must also clear them

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1309,7 +1309,7 @@ updateWellPotentials(const int reportStepIdx,
     }
     logAndCheckForExceptionsAndThrow(deferred_logger, exc_type,
                                      "computeWellPotentials() failed: " + exc_msg,
-                                     terminal_output_, comm_);
+                                     terminal_output_, comm_, /* convert_error_to_warning= */ true);
 
 }
 


### PR DESCRIPTION
Numerical problems during the calculation were reported as errors and counted as such in the PRT file. Yet, the simulation would carry on (maybe with a smaller timestep), anyway. At least some users are parsing the PRT file to extract the number errors to get an indication whether a run succeeded. For this having
```
Error:
[opm-simulators/opm/simulators/wells/StandardWellPrimaryVariables.cpp:722] Infinite primary variable after update from wellState, well: BLA
...
Error summary:
Warnings 1416
Info 980
Errors 1
Bugs 0
Debug 0
Problems 0
```
on an otherwise successful run seemed unreasonable.

Therefore we now make sure that those exceptions are treated as warnings when they are logged (Errors 0). We do this by adding a boolean flag to DeferredLogger::logMessage to indicate that we want this kind of convertion. Default is false.