### PR TITLE
Support for mechanical dispersion

### DIFF
--- a/ebos/eclalugridvanguard.hh
+++ b/ebos/eclalugridvanguard.hh
@@ -189,7 +189,9 @@ public:
                                                                  getPropValue<TypeTag,
                                                                  Properties::EnableEnergy>(),
                                                                  getPropValue<TypeTag,
-                                                                 Properties::EnableDiffusion>());
+                                                                 Properties::EnableDiffusion>(),
+                                                                 getPropValue<TypeTag,
+                                                                 Properties::EnableDispersion>());
             // Re-ordering  for ALUGrid
             globalTrans_->update(false, [&](unsigned int i) { return gridEquilIdxToGridIdx(i);});
         }

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -281,7 +281,8 @@ protected:
                                                     this->grid(),
                                                     this->cellCentroids(),
                                                     getPropValue<TypeTag, Properties::EnableEnergy>(),
-                                                    getPropValue<TypeTag, Properties::EnableDiffusion>()));
+                                                    getPropValue<TypeTag, Properties::EnableDiffusion>(),
+                                                    getPropValue<TypeTag, Properties::EnableDispersion>()));
         globalTrans_->update(false);
     }
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -145,6 +145,7 @@ class EclProblem : public GetPropType<TypeTag, Properties::BaseProblem>
     enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     enum { enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>() };
+    enum { enableDispersion = getPropValue<TypeTag, Properties::EnableDispersion>() };
     enum { enableThermalFluxBoundaries = getPropValue<TypeTag, Properties::EnableThermalFluxBoundaries>() };
     enum { enableApiTracking = getPropValue<TypeTag, Properties::EnableApiTracking>() };
     enum { enableMICP = getPropValue<TypeTag, Properties::EnableMICP>() };
@@ -278,7 +279,8 @@ public:
                               simulator.vanguard().grid(),
                               simulator.vanguard().cellCentroids(),
                               enableEnergy,
-                              enableDiffusion)
+                              enableDiffusion,
+                              enableDispersion)
         , thresholdPressures_(simulator)
         , wellModel_(simulator)
         , aquiferModel_(simulator)
@@ -822,6 +824,13 @@ public:
      */
     Scalar diffusivity(const unsigned globalCellIn, const unsigned globalCellOut) const{
         return transmissibilities_.diffusivity(globalCellIn, globalCellOut);
+    }
+
+    /*!
+     * give the dispersivity for a face i.e. pair.
+     */
+    Scalar dispersivity(const unsigned globalCellIn, const unsigned globalCellOut) const{
+        return transmissibilities_.dispersivity(globalCellIn, globalCellOut);
     }
 
     /*!
@@ -2448,6 +2457,7 @@ private:
         ConditionalStorage<enableEnergy, Scalar> thermalHalfTransIn;
         ConditionalStorage<enableEnergy, Scalar> thermalHalfTransOut;
         ConditionalStorage<enableDiffusion, Scalar> diffusivity;
+        ConditionalStorage<enableDispersion, Scalar> dispersivity;
         Scalar transmissibility;
     };
 
@@ -2473,6 +2483,8 @@ private:
                 }
                 if constexpr (enableDiffusion)
                     *dofData.diffusivity = transmissibilities_.diffusivity(globalCenterElemIdx, globalElemIdx);
+                if (enableDispersion)
+                    dofData.dispersivity = transmissibilities_.dispersivity(globalCenterElemIdx, globalElemIdx);
             }
         };
 

--- a/ebos/eclproblem_properties.hh
+++ b/ebos/eclproblem_properties.hh
@@ -269,6 +269,12 @@ struct EnableDiffusion<TypeTag, TTag::EclBaseProblem> {
     static constexpr bool value = true;
 };
 
+// Enable dispersion
+template<class TypeTag>
+struct EnableDispersion<TypeTag, TTag::EclBaseProblem> {
+    static constexpr bool value = false;
+};
+
 // only write the solutions for the report steps to disk
 template<class TypeTag>
 struct EnableWriteAllSolutions<TypeTag, TTag::EclBaseProblem> {

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -66,7 +66,8 @@ public:
                         const Grid& grid,
                         std::function<std::array<double,dimWorld>(int)> centroids,
                         bool enableEnergy,
-                        bool enableDiffusivity);
+                        bool enableDiffusivity,
+                        bool enableDispersivity);
 
     /*!
      * \brief Return the permeability for an element.
@@ -106,6 +107,11 @@ public:
      * \brief Return the diffusivity for the intersection between two elements.
      */
     Scalar diffusivity(unsigned elemIdx1, unsigned elemIdx2) const;
+
+    /*!
+     * \brief Return the dispersivity for the intersection between two elements.
+     */
+    Scalar dispersivity(unsigned elemIdx1, unsigned elemIdx2) const;
 
     /*!
      * \brief Actually compute the transmissibility over a face as a pre-compute step.
@@ -230,6 +236,8 @@ protected:
 
     void extractPorosity_();
 
+    void extractDispersion_();
+
     void computeHalfTrans_(Scalar& halfTrans,
                            const DimVector& areaNormal,
                            int faceIdx, // in the reference element that contains the intersection
@@ -258,6 +266,7 @@ protected:
 
     std::vector<DimMatrix> permeability_;
     std::vector<Scalar> porosity_;
+    std::vector<Scalar> dispersion_;
     std::unordered_map<std::uint64_t, Scalar> trans_;
     const EclipseState& eclState_;
     const GridView& gridView_;
@@ -269,8 +278,10 @@ protected:
     std::map<std::pair<unsigned, unsigned>, Scalar> thermalHalfTransBoundary_;
     bool enableEnergy_;
     bool enableDiffusivity_;
+    bool enableDispersivity_;
     std::unordered_map<std::uint64_t, Scalar> thermalHalfTrans_; //NB this is based on direction map size is ca 2*trans_ (diffusivity_)
     std::unordered_map<std::uint64_t, Scalar> diffusivity_;
+    std::unordered_map<std::uint64_t, Scalar> dispersivity_;
 
     const LookUpData<Grid,GridView> lookUpData_;
     const LookUpCartesianData<Grid,GridView> lookUpCartesianData_;

--- a/flow/flow_ebos_gasoil_energy.cpp
+++ b/flow/flow_ebos_gasoil_energy.cpp
@@ -70,6 +70,9 @@ struct LocalResidual<TypeTag, TTag::EclFlowGasOilEnergyProblem> { using type = B
 template<class TypeTag>
 struct EnableDiffusion<TypeTag, TTag::EclFlowGasOilEnergyProblem> { static constexpr bool value = true; };
 
+template<class TypeTag>
+struct EnableDispersion<TypeTag, TTag::EclFlowGasOilEnergyProblem> { static constexpr bool value = true; };
+
 }}
 
 namespace Opm {

--- a/flow/flow_ebos_gasoildiffuse.cpp
+++ b/flow/flow_ebos_gasoildiffuse.cpp
@@ -41,9 +41,11 @@ struct Linearizer<TypeTag, TTag::EclFlowGasOilDiffuseProblem> { using type = Tpf
 template<class TypeTag>
 struct LocalResidual<TypeTag, TTag::EclFlowGasOilDiffuseProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
-
 template<class TypeTag>
 struct EnableDiffusion<TypeTag, TTag::EclFlowGasOilDiffuseProblem> { static constexpr bool value = true; };
+
+template<class TypeTag>
+struct EnableDispersion<TypeTag, TTag::EclFlowGasOilDiffuseProblem> { static constexpr bool value = true; };
 
 //! The indices required by the model
 template<class TypeTag>

--- a/flow/flow_ebos_gaswater_dissolution_diffuse.cpp
+++ b/flow/flow_ebos_gaswater_dissolution_diffuse.cpp
@@ -49,6 +49,9 @@ template<class TypeTag>
 struct EnableDiffusion<TypeTag, TTag::EclFlowGasWaterDissolutionDiffuseProblem> { static constexpr bool value = true; };
 
 template<class TypeTag>
+struct EnableDispersion<TypeTag, TTag::EclFlowGasWaterDissolutionDiffuseProblem> { static constexpr bool value = true; };
+
+template<class TypeTag>
 struct EnableDisgasInWater<TypeTag, TTag::EclFlowGasWaterDissolutionDiffuseProblem> {
     static constexpr bool value = true;
 };

--- a/flow/flow_ebos_gaswater_energy.cpp
+++ b/flow/flow_ebos_gaswater_energy.cpp
@@ -46,7 +46,10 @@ template<class TypeTag>
 struct LocalResidual<TypeTag, TTag::EclFlowGasWaterEnergyProblem> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
 template<class TypeTag>
-struct EnableDiffusion<TypeTag, TTag::EclFlowGasWaterEnergyProblem> { static constexpr bool value = false; };
+struct EnableDiffusion<TypeTag, TTag::EclFlowGasWaterEnergyProblem> { static constexpr bool value = true; };
+
+template<class TypeTag>
+struct EnableDispersion<TypeTag, TTag::EclFlowGasWaterEnergyProblem> { static constexpr bool value = true; };
 
 template<class TypeTag>
 struct EnableEnergy<TypeTag, TTag::EclFlowGasWaterEnergyProblem> {

--- a/opm/simulators/flow/BlackoilModelEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelEbos.hpp
@@ -133,6 +133,10 @@ template<class TypeTag>
 struct EnableMICP<TypeTag, TTag::EclFlowProblem> {
     static constexpr bool value = false;
 };
+template<class TypeTag>
+struct EnableDispersion<TypeTag, TTag::EclFlowProblem> {
+    static constexpr bool value = false;
+};
 
 template<class TypeTag>
 struct EclWellModel<TypeTag, TTag::EclFlowProblem> {


### PR DESCRIPTION
With https://github.com/OPM/opm-common/pull/3737 and https://github.com/OPM/opm-models/pull/847, this PR adds support for the linear disperison model described in the SPE CSP11 benchmark document (Eq. 2.3) (https://github.com/Simulation-Benchmarks/11thSPE-CSP/blob/main/description/spe_csp11_description.pdf). Two cases are added in https://github.com/OPM/opm-tests/pull/1072 , where the effect of adding dispersion is assessed for a finger and injection problem.
![Screenshot 2023-10-30 at 15 47 40](https://github.com/OPM/opm-simulators/assets/61784809/3b1091bc-78e1-4e6f-b01c-ca84b682a13a)
