### PR TITLE
[bugfix] Deprecated getCollectiveComminication 

### DIFF
--- a/opm/simulators/linalg/ISTLSolverEbos.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbos.hpp
@@ -294,8 +294,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                 OPM_THROW(std::logic_error, "Solver number " + std::to_string(num) + " not available.");
             }
             activeSolverNum_ = num;
-            auto cc = Dune::MPIHelper::getCollectiveCommunication();
-            if (cc.rank() == 0) {
+            if (simulator_.gridView().comm().rank() == 0) {
                 OpmLog::debug("Active solver = " + std::to_string(activeSolverNum_)
                               + " (" + parameters_[activeSolverNum_].linsolver_ + ")");
             }


### PR DESCRIPTION
After DUNE version 2.7, the method getCollectiveCommunication() was changed to getCommunication(). The getCollectiveCommunication() issues the deprecation warning  and assumes all process take part in the communication. However, this might not be the case, namely, only a subset might be used. 

The fix consists in getting the communication object used be the grid as this uses only processes that are actually computing and not only outputting. 

