### PR TITLE
Enabling disGas and watVap at compile time for gasWaterBrine systems

### DIFF
--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -78,7 +78,7 @@ class EclEquilInitializer
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     enum { enableDissolution = Indices::compositionSwitchIdx >= 0 };
     enum { enableBrine = getPropValue<TypeTag, Properties::EnableBrine>() };
-    enum { enableEvaporation = getPropValue<TypeTag, Properties::EnableEvaporation>() };
+    enum { enableVapwat = getPropValue<TypeTag, Properties::EnableVapwat>() };
     enum { enableSaltPrecipitation = getPropValue<TypeTag, Properties::EnableSaltPrecipitation>() };
     enum { has_disgas_in_water = getPropValue<TypeTag, Properties::EnableDisgasInWater>() };
 
@@ -91,7 +91,7 @@ public:
                                                 enableTemperature,
                                                 enableEnergy,
                                                 enableDissolution,
-                                                enableEvaporation,
+                                                enableVapwat,
                                                 enableBrine,
                                                 enableSaltPrecipitation,
                                                 has_disgas_in_water,

--- a/flow/flow_ebos_brine_precsalt_vapwat.cpp
+++ b/flow/flow_ebos_brine_precsalt_vapwat.cpp
@@ -41,7 +41,7 @@ struct EnableSaltPrecipitation<TypeTag, TTag::EclFlowBrinePrecsaltVapwatProblem>
 };
 
 template<class TypeTag>
-struct EnableEvaporation<TypeTag, TTag::EclFlowBrinePrecsaltVapwatProblem> {
+struct EnableVapwat<TypeTag, TTag::EclFlowBrinePrecsaltVapwatProblem> {
     static constexpr bool value = true;
 };
 }}

--- a/flow/flow_ebos_gaswater_brine.cpp
+++ b/flow/flow_ebos_gaswater_brine.cpp
@@ -36,6 +36,14 @@ template<class TypeTag>
 struct EnableBrine<TypeTag, TTag::EclFlowGasWaterBrineProblem> {
     static constexpr bool value = true;
 };
+template<class TypeTag>
+struct EnableDisgasInWater<TypeTag, TTag::EclFlowGasWaterBrineProblem> {
+    static constexpr bool value = true;
+};
+template<class TypeTag>
+struct EnableVapwat<TypeTag, TTag::EclFlowGasWaterBrineProblem> {
+    static constexpr bool value = true;
+};
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::EclFlowGasWaterBrineProblem>

--- a/flow/flow_ebos_gaswater_dissolution.cpp
+++ b/flow/flow_ebos_gaswater_dissolution.cpp
@@ -54,7 +54,7 @@ struct EnableDisgasInWater<TypeTag, TTag::EclFlowGasWaterDissolutionProblem> {
 };
 
 template<class TypeTag>
-struct EnableEvaporation<TypeTag, TTag::EclFlowGasWaterDissolutionProblem> {
+struct EnableVapwat<TypeTag, TTag::EclFlowGasWaterDissolutionProblem> {
     static constexpr bool value = true;
 };
 

--- a/flow/flow_ebos_gaswater_dissolution_diffuse.cpp
+++ b/flow/flow_ebos_gaswater_dissolution_diffuse.cpp
@@ -54,7 +54,7 @@ struct EnableDisgasInWater<TypeTag, TTag::EclFlowGasWaterDissolutionDiffuseProbl
 };
 
 template<class TypeTag>
-struct EnableEvaporation<TypeTag, TTag::EclFlowGasWaterDissolutionDiffuseProblem> {
+struct EnableVapwat<TypeTag, TTag::EclFlowGasWaterDissolutionDiffuseProblem> {
     static constexpr bool value = true;
 };
 

--- a/flow/flow_ebos_gaswater_energy.cpp
+++ b/flow/flow_ebos_gaswater_energy.cpp
@@ -59,7 +59,7 @@ struct EnableDisgasInWater<TypeTag, TTag::EclFlowGasWaterEnergyProblem> {
 };
 
 template<class TypeTag>
-struct EnableEvaporation<TypeTag, TTag::EclFlowGasWaterEnergyProblem> {
+struct EnableVapwat<TypeTag, TTag::EclFlowGasWaterEnergyProblem> {
     static constexpr bool value = true;
 };
 

--- a/flow/flow_ebos_gaswater_saltprec_energy.cpp
+++ b/flow/flow_ebos_gaswater_saltprec_energy.cpp
@@ -43,7 +43,7 @@ struct EnableSaltPrecipitation<TypeTag, TTag::EclFlowGasWaterSaltprecEnergyProbl
 };
 
 template<class TypeTag>
-struct EnableEvaporation<TypeTag, TTag::EclFlowGasWaterSaltprecEnergyProblem> {
+struct EnableVapwat<TypeTag, TTag::EclFlowGasWaterSaltprecEnergyProblem> {
     static constexpr bool value = true;
 };
 

--- a/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_ebos_gaswater_saltprec_vapwat.cpp
@@ -43,7 +43,7 @@ struct EnableSaltPrecipitation<TypeTag, TTag::EclFlowGasWaterSaltprecVapwatProbl
 };
 
 template<class TypeTag>
-struct EnableEvaporation<TypeTag, TTag::EclFlowGasWaterSaltprecVapwatProblem> {
+struct EnableVapwat<TypeTag, TTag::EclFlowGasWaterSaltprecVapwatProblem> {
     static constexpr bool value = true;
 };
 

--- a/opm/simulators/aquifers/AquiferAnalytical.hpp
+++ b/opm/simulators/aquifers/AquiferAnalytical.hpp
@@ -65,7 +65,7 @@ public:
     enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     enum { enableBrine = getPropValue<TypeTag, Properties::EnableBrine>() };
-    enum { enableEvaporation = getPropValue<TypeTag, Properties::EnableEvaporation>() };
+    enum { enableVapwat = getPropValue<TypeTag, Properties::EnableVapwat>() };
     enum { has_disgas_in_water = getPropValue<TypeTag, Properties::EnableDisgasInWater>() };
 
     enum { enableSaltPrecipitation = getPropValue<TypeTag, Properties::EnableSaltPrecipitation>() };
@@ -80,7 +80,7 @@ public:
                                           enableTemperature,
                                           enableEnergy,
                                           BlackoilIndices::gasEnabled,
-                                          enableEvaporation,
+                                          enableVapwat,
                                           enableBrine,
                                           enableSaltPrecipitation,
                                           has_disgas_in_water,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -117,7 +117,7 @@ public:
     static constexpr bool has_polymermw = getPropValue<TypeTag, Properties::EnablePolymerMW>();
     static constexpr bool has_foam = getPropValue<TypeTag, Properties::EnableFoam>();
     static constexpr bool has_brine = getPropValue<TypeTag, Properties::EnableBrine>();
-    static constexpr bool has_watVapor = getPropValue<TypeTag, Properties::EnableEvaporation>();
+    static constexpr bool has_watVapor = getPropValue<TypeTag, Properties::EnableVapwat>();
     static constexpr bool has_disgas_in_water = getPropValue<TypeTag, Properties::EnableDisgasInWater>();
     static constexpr bool has_saltPrecip = getPropValue<TypeTag, Properties::EnableSaltPrecipitation>();
     static constexpr bool has_micp = getPropValue<TypeTag, Properties::EnableMICP>();

--- a/tests/test_equil.cc
+++ b/tests/test_equil.cc
@@ -94,7 +94,7 @@ struct EclWellModel<TypeTag, TTag::TestEquilTypeTag> {
     using type = BlackoilWellModel<TypeTag>;
 };
 template<class TypeTag>
-struct EnableEvaporation<TypeTag, TTag::TestEquilTypeTag> {
+struct EnableVapwat<TypeTag, TTag::TestEquilTypeTag> {
     static constexpr bool value = true;
 };
 template<class TypeTag>
@@ -102,7 +102,7 @@ struct EclWellModel<TypeTag, TTag::TestEquilVapwatTypeTag> {
     using type = BlackoilWellModel<TypeTag>;
 };
 template<class TypeTag>
-struct EnableEvaporation<TypeTag, TTag::TestEquilVapwatTypeTag> {
+struct EnableVapwat<TypeTag, TTag::TestEquilVapwatTypeTag> {
     static constexpr bool value = true;
 };
 } // namespace Opm::Properties


### PR DESCRIPTION
This allows to run decks with 
```
WATER
GAS
BRINE
CO2STORE
VAPWAT
DISGASW
```