### PR TITLE
Add extra output to INFOITER file detailing unconverged wells.

### DIFF
--- a/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
+++ b/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
@@ -112,6 +112,49 @@ namespace {
         return maxChar;
     }
 
+
+    std::string to_string(const Opm::ConvergenceReport::Severity s)
+    {
+        using S = Opm::ConvergenceReport::Severity;
+        switch (s) {
+        case S::None:
+            return "None";
+        case S::Normal:
+            return "Normal";
+        case S::TooLarge:
+            return "TooLarge";
+        case S::NotANumber:
+            return "NotANumber";
+        }
+        throw std::logic_error("Unknown ConvergenceReport::Severity");
+    }
+
+
+    std::string to_string(const Opm::ConvergenceReport::WellFailure::Type t)
+    {
+        using T = Opm::ConvergenceReport::WellFailure::Type;
+        switch (t) {
+        case T::Invalid:
+            return "Invalid";
+        case T::MassBalance:
+            return "MassBalance";
+        case T::Pressure:
+            return "Pressure";
+        case T::ControlBHP:
+            return "ControlBHP";
+        case T::ControlTHP:
+            return "ControlTHP";
+        case T::ControlRate:
+            return "ControlRate";
+        case T::Unsolvable:
+            return "Unsolvable";
+        case T::WrongFlowDirection:
+            return "WrongFlowDirection";
+        }
+        throw std::logic_error("Unknown ConvergenceReport::WellFailure::Type");
+    }
+
+
     void writeConvergenceRequest(std::ostream&                                           os,
                                  const Opm::ConvergenceOutputThread::ConvertToTimeUnits& convertTime,
                                  std::string::size_type                                  colSize,
@@ -134,7 +177,19 @@ namespace {
             }
 
             os << std::right << std::setw(colSize + 1)
-               << (report.wellFailed() ? "FAIL" : "CONV") << '\n';
+               << (report.wellFailed() ? "FAIL" : "CONV");
+            if (report.wellFailed()) {
+                for (const auto& wf : report.wellFailures()) {
+                    os << " { "
+                       << wf.wellName() << ' ' << to_string(wf.type());
+                    if (wf.type() == Opm::ConvergenceReport::WellFailure::Type::MassBalance) {
+                        os << " Severity=" << to_string(wf.severity())
+                           << " Phase=" << wf.phase();
+                    }
+                    os << " }";
+                }
+            }
+            os << '\n';
 
             ++iter;
         }


### PR DESCRIPTION
This will add extra information about well convergence failures to the INFOITER file (if that file is requested, it remains off by default).

Instead of
```
        113           0  1.8260e+03          18  1.8038e-04  9.0530e+01  3.3362e-04  8.3487e+02  1.8634e-04  4.9056e+02        FAIL
```
you will get (scroll right to see the difference)
```
        113           0  1.8260e+03          18  1.8038e-04  9.0530e+01  3.3362e-04  8.3487e+02  1.8634e-04  4.9056e+02        FAIL { A5 MassBalance NormalSeverity Phase 1 } { OP5 Unsolvable }
```
In the above, A5 and OP5 are well names, the next item is the type of failure, and for mass balance errors (only) we add the severity of the error (Normal, TooLarge, NotANumber) and the phase index affected. For iterations with no well failures (CONV not FAIL in the well convergence column), no data is added.

I think this can be valuable for debugging, also potentially for power users.