### PR TITLE
Add and use OPM_DEFLOG_PROBLEM macro.

### DIFF
--- a/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
+++ b/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
@@ -32,7 +32,7 @@
 #include <exception>
 #include <stdexcept>
 
-// Macro to throw an exception.
+// Macro to log an error and throw an exception.
 // Inspired by ErrorMacros.hpp in opm-common.
 // NOTE: For this macro to work, the
 // exception class must exhibit a constructor with the signature
@@ -50,6 +50,23 @@
         deferred_logger.error(oss_);                           \
         throw Exception(oss_);                                 \
     } while (false)
+
+// Macro to log a problem and throw an exception.
+// Idenitical to OPM_DEFLOG_THROW() except for using
+// the "problem" category instead of "error" for the
+// log message. The Exception argument will typically
+// be NumericalProblem.
+//
+// Usage: OPM_DEFLOG_PROBLEM(ExceptionClass, "Error message", DeferredLogger);
+#define OPM_DEFLOG_PROBLEM(Exception, message, deferred_logger)  \
+    do {                                                         \
+        std::string oss_ = std::string{"["} + __FILE__ + ":" +   \
+                           std::to_string(__LINE__) + "] " +     \
+                           message;                              \
+        deferred_logger.problem(oss_);                           \
+        throw Exception(oss_);                                   \
+    } while (false)
+
 
 namespace {
 

--- a/opm/simulators/wells/MSWellHelpers.cpp
+++ b/opm/simulators/wells/MSWellHelpers.cpp
@@ -206,7 +206,7 @@ invDX(const MatrixType& D, VectorType x, DeferredLogger& deferred_logger)
     linsolver.apply(y, x, res);
 
     if ( !res.converged ) {
-        OPM_DEFLOG_THROW(NumericalProblem, "the invDX did not converge ", deferred_logger);
+        OPM_DEFLOG_PROBLEM(NumericalProblem, "the invDX did not converge ", deferred_logger);
     }
 
     return y;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -848,11 +848,11 @@ namespace Opm
                 const Value d = 1.0 - rv * rs;
 
                 if (getValue(d) == 0.0) {
-                    OPM_DEFLOG_THROW(NumericalProblem,
-                                     fmt::format("Zero d value obtained for well {} "
-                                                 "during flux calculation with rs {} and rv {}",
-                                                 this->name(), rs, rv),
-                                     deferred_logger);
+                    OPM_DEFLOG_PROBLEM(NumericalProblem,
+                                       fmt::format("Zero d value obtained for well {} "
+                                                   "during flux calculation with rs {} and rv {}",
+                                                   this->name(), rs, rv),
+                                       deferred_logger);
                 }
 
                 const Value tmp_oil = (cmix_s[oilCompIdx] - rv * cmix_s[gasCompIdx]) / d;

--- a/opm/simulators/wells/StandardWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.cpp
@@ -68,7 +68,7 @@ Scalar relaxationFactorFraction(const Scalar old_value,
     constexpr double epislon = std::numeric_limits<Scalar>::epsilon();
     if (old_value < -epislon ||  old_value > 1.0 + epislon) {
         const std::string msg = fmt::format(" illegal fraction value {} {} is found for well {}", value_name, old_value, well_name);
-        OPM_DEFLOG_THROW(Opm::NumericalProblem, msg, deferred_logger);
+        OPM_DEFLOG_PROBLEM(Opm::NumericalProblem, msg, deferred_logger);
     }
     const Scalar& safe_old_value = std::clamp(old_value, 0.0, 1.0);
 
@@ -707,7 +707,7 @@ relaxationFactorFractionsProducer(const BVectorWell& dwells, DeferredLogger& def
         }
         if (relaxation_factor < 0.0 || relaxation_factor > 1.0) {
             const std::string msg = fmt::format(" illegal relaxation factor {} is obtained for well {}", relaxation_factor, this->well_.name());
-            OPM_DEFLOG_THROW(NumericalProblem, msg, deferred_logger);
+            OPM_DEFLOG_PROBLEM(NumericalProblem, msg, deferred_logger);
         }
     }
     return relaxation_factor;
@@ -719,9 +719,9 @@ checkFinite(DeferredLogger& deferred_logger) const
 {
     for (const Scalar v : value_) {
         if (!isfinite(v))
-            OPM_DEFLOG_THROW(NumericalProblem,
-                             "Infinite primary variable after update from wellState, well: " + well_.name(),
-                             deferred_logger);
+            OPM_DEFLOG_PROBLEM(NumericalProblem,
+                               "Infinite primary variable after update from wellState, well: " + well_.name(),
+                               deferred_logger);
     }
 }
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -467,7 +467,7 @@ namespace Opm
         try {
             this->linSys_.invert();
         } catch( ... ) {
-            OPM_DEFLOG_THROW(NumericalProblem, "Error when inverting local well equations for well " + name(), deferred_logger);
+            OPM_DEFLOG_PROBLEM(NumericalProblem, "Error when inverting local well equations for well " + name(), deferred_logger);
         }
     }
 


### PR DESCRIPTION
This should replace OPM_DEFLOG_THROW in places where the problem category is more appropriate than the error category.

In this commit, uses of OPM_DEFLOG_THROW have been replaced whenever the exception class used was NumericalProblem.

This also addresses the same problem as #4957 but at the problem sites, instead of afterwards when the DeferredLogger's messages are logged.

Closes #4957 as it is an alternative solution that is even broader.