### PR TITLE
changed: refactor LogOutputHelper::fip

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -277,7 +277,8 @@ outputFipLog(std::map<std::string, double>& miscSummaryData,
                               regionData);
 
     if (!substep && !forceDisableFipOutput_) {
-        logOutput_.fip(inplace, this->initialInplace());
+        logOutput_.fip(inplace, this->initialInplace(), "");
+        logOutput_.fip(inplace, this->initialInplace(), "FIPNUM");
     }
 
     return inplace;

--- a/opm/simulators/flow/LogOutputHelper.hpp
+++ b/opm/simulators/flow/LogOutputHelper.hpp
@@ -54,7 +54,8 @@ public:
 
     //! \brief Write fluid-in-place reports to output.
     void fip(const Inplace& inplace,
-             const Inplace& initialInplace) const;
+             const Inplace& initialInplace,
+             const std::string& name) const;
 
     //! \brief Write fluid-in-place reservoir reports to output.
     void fipResv(const Inplace& inplace) const;
@@ -74,6 +75,7 @@ private:
     void outputRegionFluidInPlace_(std::unordered_map<Inplace::Phase, Scalar> oip,
                                    std::unordered_map<Inplace::Phase, Scalar> cip,
                                    const Scalar pav,
+                                   const std::string& name,
                                    const int reg) const;
 
     void outputResvFluidInPlace_(std::unordered_map<Inplace::Phase, Scalar> cipr,

--- a/tests/test_LogOutputHelper.cpp
+++ b/tests/test_LogOutputHelper.cpp
@@ -269,7 +269,8 @@ FIPNUM report region 1 pressure dependent pore volume = 50 RB
     current.add("FIPNUM", Opm::Inplace::Phase::PressurePV, 1, 6.0);
     current.add("FIPNUM", Opm::Inplace::Phase::DynamicPoreVolume, 1, 8.0);
 
-    helper.fip(current, initial);
+    helper.fip(current, initial, "");
+    helper.fip(current, initial, "FIPNUM");
     std::string data = trimStream(str);
     BOOST_CHECK_EQUAL(data, reference);
 }


### PR DESCRIPTION
only do one output per call. allow passing the name of the regions to process.

This will be necessary to support RTPSCHED/RPTSOL