### PR TITLE
log problem if asked to continue with nonconverged nonlinear solver.

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeSteppingEbos.hpp
@@ -444,7 +444,7 @@ std::set<std::string> consistentlyFailingWells(const std::vector<StepReport>& sr
                             + std::to_string(minTimeStep_) + "\n which is the minimum threshold given"
                             +  "by option --solver-min-time-step= \n";
                     if (solverVerbose_) {
-                        OpmLog::error(msg);
+                        OpmLog::problem(msg);
                     }
                 }
 


### PR DESCRIPTION
The user has explicitly asked for this behavior using --solver-continue-on-convergence-failure=true in this rare case.

Completes #4977 