### PR TITLE
Implement support for RPTSOL and RPTSCHED configuration of FIP output

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -1335,10 +1335,7 @@ accumulateRegionSums(const Parallel::Communication& comm)
     }
 
     // The first time the outputFipLog function is run we store the inplace values in
-    // the initialInplace_ member. This has at least two problems:
-    //
-    //   o We really want the *initial* value - now we get the value after
-    //     the first timestep.
+    // the initialInplace_ member. This has a problem:
     //
     //   o For restarted runs this is obviously wrong.
     //

--- a/ebos/eclgenericoutputblackoilmodule.hh
+++ b/ebos/eclgenericoutputblackoilmodule.hh
@@ -79,16 +79,16 @@ public:
     // write Fluid In Place to output log
     Inplace outputFipLog(std::map<std::string, double>& miscSummaryData,
                          std::map<std::string, std::vector<double>>& regionData,
+                         const std::size_t reportStepNum,
                          const bool substep,
                          const Parallel::Communication& comm);
 
     // write Reservoir Volumes to output log
     Inplace outputFipresvLog(std::map<std::string, double>& miscSummaryData,
                          std::map<std::string, std::vector<double>>& regionData,
+                         const std::size_t reportStepNum,
                          const bool substep,
                          const Parallel::Communication& comm);
-
-
 
     void outputErrorLog(const Parallel::Communication& comm) const;
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -754,8 +754,6 @@ public:
         if (enableEclOutput_){
             eclWriter_->writeOutput(std::move(localCellData), isSubStep);
         }
-        
-
     }
 
     void finalizeOutput() {
@@ -1346,6 +1344,10 @@ public:
 
         if (enableAquifers_)
             aquiferModel_.initialSolutionApplied();
+
+        if (this->simulator().episodeIndex() == 0) {
+            eclWriter_->writeInitialFIPReport();
+        }
     }
 
     /*!

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -248,9 +248,11 @@ public:
         std::map<std::string, std::vector<double>> regionData;
         Inplace inplace;
         {
-        OPM_TIMEBLOCK(outputFipLogAndFipresvLog);
-        inplace = eclOutputModule_->outputFipLog(miscSummaryData, regionData, isSubStep, simulator_.gridView().comm());
-        eclOutputModule_->outputFipresvLog(miscSummaryData, regionData, isSubStep, simulator_.gridView().comm());
+            OPM_TIMEBLOCK(outputFipLogAndFipresvLog);
+            inplace = eclOutputModule_->outputFipLog(miscSummaryData, regionData, reportStepNum,
+                                                     isSubStep, simulator_.gridView().comm());
+            eclOutputModule_->outputFipresvLog(miscSummaryData, regionData, reportStepNum,
+                                               isSubStep, simulator_.gridView().comm());
         }
         bool forceDisableProdOutput = false;
         bool forceDisableInjOutput = false;


### PR DESCRIPTION
This implements the configured FIP output from RPTSOL / RPTSCHED.

Sits on top of https://github.com/OPM/opm-simulators/pull/4978
Sits on top of https://github.com/OPM/opm-simulators/pull/4980

Downstream of https://github.com/OPM/opm-common/pull/3756