### PR TITLE
Lookup NTG on Leaf Grid View

### DIFF
--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -32,6 +32,8 @@
 #include <dune/common/fmatrix.hh>
 
 #include <opm/grid/common/CartesianIndexMapper.hpp>
+#include <opm/grid/LookUpData.hh>
+
 
 #include <array>
 #include <functional>
@@ -47,6 +49,7 @@ class KeywordLocation;
 class EclipseState;
 struct NNCdata;
 class TransMult;
+
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
 class EclTransmissibility {
@@ -268,6 +271,9 @@ protected:
     bool enableDiffusivity_;
     std::unordered_map<std::uint64_t, Scalar> thermalHalfTrans_; //NB this is based on direction map size is ca 2*trans_ (diffusivity_)
     std::unordered_map<std::uint64_t, Scalar> diffusivity_;
+
+    const LookUpData<Grid,GridView> lookUpData_;
+    const LookUpCartesianData<Grid,GridView> lookUpCartesianData_;
 };
 
 } // namespace Opm

--- a/ebos/ecltransmissibility_impl.hh
+++ b/ebos/ecltransmissibility_impl.hh
@@ -156,10 +156,10 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
     const auto& comm = gridView_.comm();
     ElementMapper elemMapper(gridView_, Dune::mcmgElementLayout());
 
-    // get the ntg values, the ntg values are modified for the cells merged with minpv
-    const std::vector<double>& ntg = eclState_.fieldProps().get_double("NTG");
-    const bool updateDiffusivity = eclState_.getSimulationConfig().isDiffusive() && enableDiffusivity_;
     unsigned numElements = elemMapper.size();
+    // get the ntg values, the ntg values are modified for the cells merged with minpv
+    const std::vector<double>& ntg = this->lookUpData_.assignFieldPropsDoubleOnLeaf(eclState_.fieldProps(), "NTG", numElements);
+    const bool updateDiffusivity = eclState_.getSimulationConfig().isDiffusive() && enableDiffusivity_;
 
     if (map)
         extractPermeability_(map);
@@ -473,9 +473,6 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
                                                         outsideElemIdx,
                                                         axisCentroids),
                                         porosity_[outsideElemIdx]);
-
-                auto coarseElemIdx = this->lookUpData_.template getFieldPropIdx<Grid>(elemIdx);
-                auto coarseOutsideElemIdx = this-> lookUpData_.template getFieldPropIdx<Grid>(outsideElemIdx);
 
                 applyNtg_(halfDiffusivity1, insideFaceIdx, coarseElemIdx, ntg);
                 applyNtg_(halfDiffusivity2, outsideFaceIdx, coarseOutsideElemIdx, ntg);

--- a/ebos/ecltransmissibility_impl.hh
+++ b/ebos/ecltransmissibility_impl.hh
@@ -352,11 +352,8 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
                                               axisCentroids),
                               permeability_[outsideElemIdx]);
 
-            auto coarseElemIdx = lookUpData_.template getFieldPropIdx<Grid>(elemIdx);;
-            auto coarseOutsideElemIdx = lookUpData_.template getFieldPropIdx<Grid>(outsideElemIdx);
-            
-            applyNtg_(halfTrans1, insideFaceIdx, coarseElemIdx, ntg);
-            applyNtg_(halfTrans2, outsideFaceIdx, coarseOutsideElemIdx, ntg);
+            applyNtg_(halfTrans1, insideFaceIdx, elemIdx, ntg);
+            applyNtg_(halfTrans2, outsideFaceIdx, outsideElemIdx, ntg);
 
             // convert half transmissibilities to full face
             // transmissibilities using the harmonic mean
@@ -474,8 +471,8 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
                                                         axisCentroids),
                                         porosity_[outsideElemIdx]);
 
-                applyNtg_(halfDiffusivity1, insideFaceIdx, coarseElemIdx, ntg);
-                applyNtg_(halfDiffusivity2, outsideFaceIdx, coarseOutsideElemIdx, ntg);
+                applyNtg_(halfDiffusivity1, insideFaceIdx, elemIdx, ntg);
+                applyNtg_(halfDiffusivity2, outsideFaceIdx, outsideElemIdx, ntg);
 
                 //TODO Add support for multipliers
                 Scalar diffusivity;
@@ -500,7 +497,7 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
     // Loop over all elements (global grid) and store Cartesian index
     for (const auto& elem : elements(grid_.leafGridView())) {
         int elemIdx = elemMapper.index(elem);
-        int cartElemIdx =  this->lookUpCartesianData_.template getFieldPropCartesianIdx<Grid>(elemIdx);
+        int cartElemIdx =  cartMapper_.cartesianIndex(elemIdx);
         globalToLocal[cartElemIdx] = elemIdx;
     }
 
@@ -1043,7 +1040,7 @@ applyNncMultreg_(const std::unordered_map<std::size_t,int>& cartesianToCompresse
     const auto& inputNNC = this->eclState_.getInputNNC();
     const auto& transMult = this->eclState_.getTransMult();
 
-    auto compressedIdx = [&cartesianToCompressed, this](const std::size_t globIdx)
+    auto compressedIdx = [&cartesianToCompressed](const std::size_t globIdx)
     {
         auto ixPos = cartesianToCompressed.find(globIdx);
         return (ixPos == cartesianToCompressed.end()) ? -1 : ixPos->second;


### PR DESCRIPTION
To support LGRs, the lookup of NTG has been updated, namely, for a leaf grid view cell, the ntg value is looked up via its parent cell (if existent), or its equivalent cell in level 0.  

Needs OPM/opm-grid#689 .
