### PR TITLE
Implicit IPR for stability/operablity checks and solution of thp-wells

### DIFF
--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -182,6 +182,10 @@ template<class TypeTag, class MyTypeTag>
 struct LocalWellSolveControlSwitching {
     using type = UndefinedProperty;
 };
+template<class TypeTag, class MyTypeTag>
+struct UseImplicitIpr {
+    using type = UndefinedProperty;
+};
 // Network solver parameters
 template<class TypeTag, class MyTypeTag>
 struct NetworkMaxStrictIterations {
@@ -386,6 +390,10 @@ template<class TypeTag>
 struct LocalWellSolveControlSwitching<TypeTag, TTag::FlowModelParameters> {
     static constexpr bool value = false;
 };
+template<class TypeTag>
+struct UseImplicitIpr<TypeTag, TTag::FlowModelParameters> {
+    static constexpr bool value = false;
+};
 
 // Network solver parameters
 template<class TypeTag>
@@ -559,6 +567,9 @@ namespace Opm
         /// Whether to allow control switching during local well solutions 
         bool local_well_solver_control_switching_;
 
+        /// Whether to use implicit IPR for thp stability checks and solution search
+        bool use_implicit_ipr_;
+
         /// Maximum number of iterations in the network solver before relaxing tolerance
         int network_max_strict_iterations_;
         
@@ -619,6 +630,7 @@ namespace Opm
             max_number_of_well_switches_ = EWOMS_GET_PARAM(TypeTag, int, MaximumNumberOfWellSwitches);
             use_average_density_ms_wells_ = EWOMS_GET_PARAM(TypeTag, bool, UseAverageDensityMsWells);
             local_well_solver_control_switching_ = EWOMS_GET_PARAM(TypeTag, bool, LocalWellSolveControlSwitching);
+            use_implicit_ipr_ = EWOMS_GET_PARAM(TypeTag, bool, UseImplicitIpr);
             nonlinear_solver_ = EWOMS_GET_PARAM(TypeTag, std::string, NonlinearSolver);
             const auto approach = EWOMS_GET_PARAM(TypeTag, std::string, LocalSolveApproach);
             if (approach == "jacobi") {
@@ -680,6 +692,7 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, int, MaximumNumberOfWellSwitches, "Maximum number of times a well can switch to the same control");
             EWOMS_REGISTER_PARAM(TypeTag, bool, UseAverageDensityMsWells, "Approximate segment densitities by averaging over segment and its outlet");
             EWOMS_REGISTER_PARAM(TypeTag, bool, LocalWellSolveControlSwitching, "Allow control switching during local well solutions");
+            EWOMS_REGISTER_PARAM(TypeTag, bool, UseImplicitIpr, "Compute implict IPR for stability checks and stable solution search");            
             EWOMS_REGISTER_PARAM(TypeTag, int, NetworkMaxStrictIterations, "Maximum iterations in network solver before relaxing tolerance");
             EWOMS_REGISTER_PARAM(TypeTag, int, NetworkMaxIterations, "Maximum number of iterations in the network solver before giving up");
             EWOMS_REGISTER_PARAM(TypeTag, std::string, NonlinearSolver, "Choose nonlinear solver. Valid choices are newton or nldd.");

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -132,6 +132,8 @@ namespace Opm
                                                  const WellState& well_state,
                                                  DeferredLogger& deferred_logger) override; // should be const?
 
+        void updateIPRImplicit(const Simulator& ebos_simulator, WellState& well_state, DeferredLogger& deferred_logger);                                                 
+
         virtual void updateProductivityIndex(const Simulator& ebosSimulator,
                                              const WellProdIndexCalculator& wellPICalc,
                                              WellState& well_state,
@@ -246,6 +248,10 @@ namespace Opm
                                  const Simulator& ebos_simulator,
                                  DeferredLogger& deferred_logger) const;
 
+        bool computeWellPotentialsImplicit(const Simulator& ebos_simulator,
+                                           std::vector<double>& well_potentials,
+                                           DeferredLogger& deferred_logger) const;                                      
+
         virtual double getRefDensity() const override;
 
         virtual bool iterateWellEqWithControl(const Simulator& ebosSimulator,
@@ -262,7 +268,8 @@ namespace Opm
                                                 const Well::ProductionControls& prod_controls,
                                                 WellState& well_state,
                                                 const GroupState& group_state,
-                                                DeferredLogger& deferred_logger) override;
+                                                DeferredLogger& deferred_logger, 
+                                                const bool allow_switch = true) override;
 
         virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
                                                     const double dt,

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -269,7 +269,8 @@ namespace Opm
                                                 WellState& well_state,
                                                 const GroupState& group_state,
                                                 DeferredLogger& deferred_logger, 
-                                                const bool allow_switch = true) override;
+                                                const bool fixed_control = false, 
+                                                const bool fixed_status = false) override;
 
         virtual void assembleWellEqWithoutIteration(const Simulator& ebosSimulator,
                                                     const double dt,

--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -182,6 +182,13 @@ MultisegmentWellEquations<Scalar,numWellEq,numEq>::solve() const
 }
 
 template<class Scalar, int numWellEq, int numEq>
+typename MultisegmentWellEquations<Scalar,numWellEq,numEq>::BVectorWell
+MultisegmentWellEquations<Scalar,numWellEq,numEq>::solve(const BVectorWell& rhs) const
+{
+    return mswellhelpers::applyUMFPack(*duneDSolver_, rhs);
+}
+
+template<class Scalar, int numWellEq, int numEq>
 void MultisegmentWellEquations<Scalar,numWellEq,numEq>::
 recoverSolutionWell(const BVector& x, BVectorWell& xw) const
 {

--- a/opm/simulators/wells/MultisegmentWellEquations.hpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.hpp
@@ -96,6 +96,7 @@ public:
     //! \brief Apply inverted D matrix to residual and return result.
     BVectorWell solve() const;
 
+    //! \brief Apply inverted D matrix to rhs and return result.
     BVectorWell solve(const BVectorWell& rhs) const;
 
     //! \brief Recover well solution.

--- a/opm/simulators/wells/MultisegmentWellEquations.hpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.hpp
@@ -96,6 +96,8 @@ public:
     //! \brief Apply inverted D matrix to residual and return result.
     BVectorWell solve() const;
 
+    BVectorWell solve(const BVectorWell& rhs) const;
+
     //! \brief Recover well solution.
     //! \details xw = inv(D)*(rw - C*x)
     void recoverSolutionWell(const BVector& x, BVectorWell& xw) const;

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -161,8 +161,8 @@ getWellConvergence(const WellState& well_state,
                                    tolerance_wells,
                                    tolerance_wells,
                                    max_residual_allowed},
-                                  well_is_stopped,  
                                   std::abs(linSys_.residual()[0][SPres]),
+                                  well_is_stopped,  
                                   report,
                                   deferred_logger);
 

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -542,9 +542,6 @@ getResidualMeasureValue(const WellState& well_state,
         ++count;
     }
 
-    // if (count == 0), it should be converged.
-    //assert(count != 0);
-
     return sum;
 }
 

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -86,7 +86,8 @@ getWellConvergence(const WellState& well_state,
                    const double relaxed_inner_tolerance_flow_ms_well,
                    const double tolerance_pressure_ms_wells,
                    const double relaxed_inner_tolerance_pressure_ms_well,
-                   const bool relax_tolerance) const
+                   const bool relax_tolerance, 
+                   const bool well_is_stopped) const
 {
     assert(int(B_avg.size()) == baseif_.numComponents());
 
@@ -160,13 +161,14 @@ getWellConvergence(const WellState& well_state,
                                    tolerance_wells,
                                    tolerance_wells,
                                    max_residual_allowed},
+                                  well_is_stopped,  
                                   std::abs(linSys_.residual()[0][SPres]),
                                   report,
                                   deferred_logger);
 
     // for stopped well, we do not enforce the following checking to avoid dealing with sign of near-zero values
     // for BHP or THP controlled wells, we need to make sure the flow direction is correct
-    if (!baseif_.wellIsStopped() && baseif_.isPressureControlled(well_state)) {
+    if (!well_is_stopped && baseif_.isPressureControlled(well_state)) {
         // checking the flow direction
         const double sign = baseif_.isProducer() ? -1. : 1.;
         const auto weight_total_flux = this->primary_variables_.getWQTotal() * sign;
@@ -541,7 +543,7 @@ getResidualMeasureValue(const WellState& well_state,
     }
 
     // if (count == 0), it should be converged.
-    assert(count != 0);
+    //assert(count != 0);
 
     return sum;
 }

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -106,7 +106,8 @@ protected:
                                          const double relaxed_inner_tolerance_flow_ms_well,
                                          const double tolerance_pressure_ms_wells,
                                          const double relaxed_inner_tolerance_pressure_ms_well,
-                                         const bool relax_tolerance) const;
+                                         const bool relax_tolerance, 
+                                         const bool well_is_stopped) const;
 
     std::pair<bool, std::vector<Scalar> >
     getFiniteWellResiduals(const std::vector<Scalar>& B_avg,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1522,7 +1522,8 @@ namespace Opm
                              WellState& well_state,
                              const GroupState& group_state,
                              DeferredLogger& deferred_logger, 
-                             const bool allow_switch /*true*/)
+                             const bool fixed_control /*false*/, 
+                             const bool fixed_status /*false*/)
     {
         //if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return true;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1326,16 +1326,16 @@ namespace Opm
             updateIPR(ebos_simulator, deferred_logger);
             for (int comp_idx = 0; comp_idx < this->num_components_; ++comp_idx){
                 const int idx = this->ebosCompIdxToFlowCompIdx(comp_idx);
-                ws.ipr_a[idx] = this->ipr_a_[comp_idx];
-                ws.ipr_b[idx] = this->ipr_b_[comp_idx];
+                ws.implicit_ipr_a[idx] = this->ipr_a_[comp_idx];
+                ws.implicit_ipr_b[idx] = this->ipr_b_[comp_idx];
             }
             return;
             */
         }
         const auto& group_state  = ebos_simulator.problem().wellModel().groupState();
 
-        std::fill(ws.ipr_a.begin(), ws.ipr_a.end(), 0.);
-        std::fill(ws.ipr_b.begin(), ws.ipr_b.end(), 0.);
+        std::fill(ws.implicit_ipr_a.begin(), ws.implicit_ipr_a.end(), 0.);
+        std::fill(ws.implicit_ipr_b.begin(), ws.implicit_ipr_b.end(), 0.);
         //WellState well_state_copy = well_state;    
         auto inj_controls = Well::InjectionControls(0);
         auto prod_controls = Well::ProductionControls(0);
@@ -1358,9 +1358,9 @@ namespace Opm
             const EvalWell comp_rate = this->primary_variables_.getQs(comp_idx);
             const int idx = this->ebosCompIdxToFlowCompIdx(comp_idx);
             for (size_t pvIdx = 0; pvIdx < num_eq; ++pvIdx) {
-                ws.ipr_b[idx] -= x_well[0][pvIdx]*comp_rate.derivative(pvIdx+Indices::numEq);
+                ws.implicit_ipr_b[idx] -= x_well[0][pvIdx]*comp_rate.derivative(pvIdx+Indices::numEq);
             }
-            ws.ipr_a[idx] = ws.ipr_b[idx]*ws.bhp - comp_rate.value();
+            ws.implicit_ipr_a[idx] = ws.implicit_ipr_b[idx]*ws.bhp - comp_rate.value();
         }
         // reset cmode
         ws.production_cmode = cmode;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1327,7 +1327,7 @@ namespace Opm
             const auto msg = fmt::format("updateIPRImplicit: Well {} has zero rate, IPRs might be problematic", this->name());
             deferred_logger.debug(msg);
             /*
-            // could revert to standard approach here    
+            // could revert to standard approach here:    
             updateIPR(ebos_simulator, deferred_logger);
             for (int comp_idx = 0; comp_idx < this->num_components_; ++comp_idx){
                 const int idx = this->ebosCompIdxToFlowCompIdx(comp_idx);
@@ -1589,8 +1589,6 @@ namespace Opm
                              const bool fixed_control /*false*/, 
                              const bool fixed_status /*false*/)
     {
-        //if (!this->isOperableAndSolvable() && !this->wellIsStopped()) return true;
-
         const int max_iter_number = this->param_.max_inner_iter_ms_wells_;
 
         {
@@ -1741,9 +1739,6 @@ namespace Opm
                 } else {
                     this->operability_status_.operable_under_only_bhp_limit = !is_stopped;
                 }
-                // We reset the well status to it's original state. Status is updated 
-                // on the outside based on operability status
-                // this->wellStatus_ = well_status;
             }
             std::string message = fmt::format("   Well {} converged in {} inner iterations ("
                                                     "{} control/status switches).", this->name(), it, switch_count);

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -549,8 +549,12 @@ namespace Opm
         well_copy.calculateExplicitQuantities(ebos_simulator, well_state_copy, deferred_logger);
         const double dt = ebos_simulator.timeStepSize();
         // solve equations
-        const bool converged = well_copy.iterateWellEqWithSwitching(ebos_simulator, dt, inj_controls, prod_controls, well_state_copy, group_state,
-                                                                    deferred_logger);
+        bool converged = false;
+        if (this->well_ecl_.isProducer() && this->wellHasTHPConstraints(summary_state)) {
+            converged = well_copy.solveWellWithTHPConstraint(ebos_simulator, dt, inj_controls, prod_controls, well_state_copy, group_state, deferred_logger);
+        } else {
+            converged = well_copy.iterateWellEqWithSwitching(ebos_simulator, dt, inj_controls, prod_controls, well_state_copy, group_state, deferred_logger);
+        }
 
         // fetch potentials (sign is updated on the outside).
         well_potentials.clear();

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -42,6 +42,8 @@ SingleWellState::SingleWellState(const std::string& name_,
     , temperature(temp)
     , well_potentials(pu_.num_phases)
     , productivity_index(pu_.num_phases)
+    , ipr_a(pu_.num_phases)
+    , ipr_b(pu_.num_phases)
     , surface_rates(pu_.num_phases)
     , reservoir_rates(pu_.num_phases)
     , prev_surface_rates(pu_.num_phases)
@@ -89,6 +91,8 @@ void SingleWellState::shut() {
     std::fill(this->prev_surface_rates.begin(), this->prev_surface_rates.end(), 0);
     std::fill(this->reservoir_rates.begin(), this->reservoir_rates.end(), 0);
     std::fill(this->productivity_index.begin(), this->productivity_index.end(), 0);
+    std::fill(this->ipr_a.begin(), this->ipr_a.end(), 0);
+    std::fill(this->ipr_b.begin(), this->ipr_b.end(), 0);
 
     auto& connpi = this->perf_data.prod_index;
     connpi.assign(connpi.size(), 0);
@@ -305,6 +309,8 @@ bool SingleWellState::operator==(const SingleWellState& rhs) const
            this->phase_mixing_rates == rhs.phase_mixing_rates &&
            this->well_potentials == rhs.well_potentials &&
            this->productivity_index == rhs.productivity_index &&
+           this->ipr_a == rhs.ipr_a &&
+           this->ipr_b == rhs.ipr_b &&
            this->surface_rates == rhs.surface_rates &&
            this->reservoir_rates == rhs.reservoir_rates &&
            this->prev_surface_rates == rhs.prev_surface_rates &&

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -42,8 +42,8 @@ SingleWellState::SingleWellState(const std::string& name_,
     , temperature(temp)
     , well_potentials(pu_.num_phases)
     , productivity_index(pu_.num_phases)
-    , ipr_a(pu_.num_phases)
-    , ipr_b(pu_.num_phases)
+    , implicit_ipr_a(pu_.num_phases)
+    , implicit_ipr_b(pu_.num_phases)
     , surface_rates(pu_.num_phases)
     , reservoir_rates(pu_.num_phases)
     , prev_surface_rates(pu_.num_phases)
@@ -91,8 +91,8 @@ void SingleWellState::shut() {
     std::fill(this->prev_surface_rates.begin(), this->prev_surface_rates.end(), 0);
     std::fill(this->reservoir_rates.begin(), this->reservoir_rates.end(), 0);
     std::fill(this->productivity_index.begin(), this->productivity_index.end(), 0);
-    std::fill(this->ipr_a.begin(), this->ipr_a.end(), 0);
-    std::fill(this->ipr_b.begin(), this->ipr_b.end(), 0);
+    std::fill(this->implicit_ipr_a.begin(), this->implicit_ipr_a.end(), 0);
+    std::fill(this->implicit_ipr_b.begin(), this->implicit_ipr_b.end(), 0);
 
     auto& connpi = this->perf_data.prod_index;
     connpi.assign(connpi.size(), 0);
@@ -309,8 +309,8 @@ bool SingleWellState::operator==(const SingleWellState& rhs) const
            this->phase_mixing_rates == rhs.phase_mixing_rates &&
            this->well_potentials == rhs.well_potentials &&
            this->productivity_index == rhs.productivity_index &&
-           this->ipr_a == rhs.ipr_a &&
-           this->ipr_b == rhs.ipr_b &&
+           this->implicit_ipr_a == rhs.implicit_ipr_a &&
+           this->implicit_ipr_b == rhs.implicit_ipr_b &&
            this->surface_rates == rhs.surface_rates &&
            this->reservoir_rates == rhs.reservoir_rates &&
            this->prev_surface_rates == rhs.prev_surface_rates &&

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -61,6 +61,8 @@ public:
         serializer(phase_mixing_rates);
         serializer(well_potentials);
         serializer(productivity_index);
+        serializer(ipr_a);
+        serializer(ipr_b);        
         serializer(surface_rates);
         serializer(reservoir_rates);
         serializer(prev_surface_rates);
@@ -98,6 +100,8 @@ public:
 
     std::vector<double> well_potentials;
     std::vector<double> productivity_index;
+    std::vector<double> ipr_a;
+    std::vector<double> ipr_b;    
     std::vector<double> surface_rates;
     std::vector<double> reservoir_rates;
     std::vector<double> prev_surface_rates;

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -61,8 +61,8 @@ public:
         serializer(phase_mixing_rates);
         serializer(well_potentials);
         serializer(productivity_index);
-        serializer(ipr_a);
-        serializer(ipr_b);        
+        serializer(implicit_ipr_a);
+        serializer(implicit_ipr_b);        
         serializer(surface_rates);
         serializer(reservoir_rates);
         serializer(prev_surface_rates);
@@ -100,8 +100,8 @@ public:
 
     std::vector<double> well_potentials;
     std::vector<double> productivity_index;
-    std::vector<double> ipr_a;
-    std::vector<double> ipr_b;    
+    std::vector<double> implicit_ipr_a;
+    std::vector<double> implicit_ipr_b;    
     std::vector<double> surface_rates;
     std::vector<double> reservoir_rates;
     std::vector<double> prev_surface_rates;

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -212,7 +212,8 @@ namespace Opm
                                         const Well::ProductionControls& prod_controls,
                                         WellState& well_state,
                                         const GroupState& group_state,
-                                        DeferredLogger& deferred_logger) override;
+                                        DeferredLogger& deferred_logger, 
+                                        const bool allow_switch = true) override;
 
         /// \brief Wether the Jacobian will also have well contributions in it.
         virtual bool jacobianContainsWellContributions() const override
@@ -239,6 +240,8 @@ namespace Opm
             const SummaryState& summary_state,
             const double alq_value,
             DeferredLogger& deferred_logger) const override;
+
+        void updateIPRImplicit(const Simulator& ebosSimulator, WellState& well_state, DeferredLogger& deferred_logger);                
 
         virtual void computeWellRatesWithBhp(
             const Simulator& ebosSimulator,
@@ -320,6 +323,10 @@ namespace Opm
             const Simulator& ebosSimulator,
             DeferredLogger& deferred_logger,
             const WellState &well_state) const;
+
+        bool computeWellPotentialsImplicit(const Simulator& ebos_simulator,
+                                           std::vector<double>& well_potentials,
+                                           DeferredLogger& deferred_logger) const;               
 
         virtual double getRefDensity() const override;
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -213,7 +213,8 @@ namespace Opm
                                         WellState& well_state,
                                         const GroupState& group_state,
                                         DeferredLogger& deferred_logger, 
-                                        const bool allow_switch = true) override;
+                                        const bool fixed_control = false,
+                                        const bool fixed_status = false) override;
 
         /// \brief Wether the Jacobian will also have well contributions in it.
         virtual bool jacobianContainsWellContributions() const override

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -242,7 +242,7 @@ namespace Opm
             const double alq_value,
             DeferredLogger& deferred_logger) const override;
 
-        void updateIPRImplicit(const Simulator& ebosSimulator, WellState& well_state, DeferredLogger& deferred_logger);                
+        void updateIPRImplicit(const Simulator& ebosSimulator, WellState& well_state, DeferredLogger& deferred_logger) override;
 
         virtual void computeWellRatesWithBhp(
             const Simulator& ebosSimulator,

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -177,6 +177,11 @@ void StandardWellEquations<Scalar,numEq>::solve(BVectorWell& dx_well) const
     invDuneD_.mv(resWell_, dx_well);
 }
 
+template<class Scalar, int numEq>
+void StandardWellEquations<Scalar,numEq>::solve(BVectorWell& rhs_well, BVectorWell& x_well) const
+{
+    invDuneD_.mv(rhs_well, x_well);
+}
 
 template<class Scalar, int numEq>
 void StandardWellEquations<Scalar,numEq>::

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -178,7 +178,7 @@ void StandardWellEquations<Scalar,numEq>::solve(BVectorWell& dx_well) const
 }
 
 template<class Scalar, int numEq>
-void StandardWellEquations<Scalar,numEq>::solve(BVectorWell& rhs_well, BVectorWell& x_well) const
+void StandardWellEquations<Scalar,numEq>::solve(const BVectorWell& rhs_well, BVectorWell& x_well) const
 {
     invDuneD_.mv(rhs_well, x_well);
 }

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -90,7 +90,7 @@ public:
     void solve(BVectorWell& dx_well) const;
 
     //! \brief Apply inverted D matrix to rhs and store in vector.
-    void solve(BVectorWell& rhs_well, BVectorWell& x_well) const;
+    void solve(const BVectorWell& rhs_well, BVectorWell& x_well) const;
     
     //! \brief Invert D matrix.
     void invert();

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -89,6 +89,9 @@ public:
     //! \brief Apply inverted D matrix to residual and store in vector.
     void solve(BVectorWell& dx_well) const;
 
+    //! \brief Apply inverted D matrix to rhs and store in vector.
+    void solve(BVectorWell& rhs_well, BVectorWell& x_well) const;
+    
     //! \brief Invert D matrix.
     void invert();
 

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -106,6 +106,7 @@ getWellConvergence(const WellState& well_state,
                    const double tol_wells,
                    const double relaxed_tolerance_flow,
                    const bool relax_tolerance,
+                   const bool well_is_stopped, 
                    std::vector<double>& res,
                    DeferredLogger& deferred_logger) const
 {
@@ -150,12 +151,13 @@ getWellConvergence(const WellState& well_state,
         checkConvergenceControlEq(well_state,
                                   {1.e3, 1.e4, 1.e-4, 1.e-6, maxResidualAllowed},
                                   std::abs(this->linSys_.residual()[0][Bhp]),
+                                  well_is_stopped, 
                                   report,
                                   deferred_logger);
 
     // for stopped well, we do not enforce the following checking to avoid dealing with sign of near-zero values
     // for BHP or THP controlled wells, we need to make sure the flow direction is correct
-    if (!baseif_.wellIsStopped() && baseif_.isPressureControlled(well_state)) {
+    if (!well_is_stopped && baseif_.isPressureControlled(well_state)) {
         // checking the flow direction
         const double sign = baseif_.isProducer() ? -1. : 1.;
         const auto weight_total_flux = this->primary_variables_.value(PrimaryVariables::WQTotal) * sign;

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -85,6 +85,7 @@ protected:
                                          const double tol_wells,
                                          const double relaxed_tolerance_flow,
                                          const bool relax_tolerance,
+                                         const bool well_is_stopped, 
                                          std::vector<double>& res,
                                          DeferredLogger& deferred_logger) const;
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1181,6 +1181,7 @@ namespace Opm
                                                                          tol_wells,
                                                                          this->param_.relaxed_tolerance_flow_well_,
                                                                          relax_tolerance,
+                                                                         this->wellIsStopped(),
                                                                          res,
                                                                          deferred_logger);
 
@@ -2335,16 +2336,19 @@ namespace Opm
         const auto well_status_orig = this->wellStatus_;
         auto well_status_cur = well_status_orig;
         int status_switch_count = 0;
+        // only allow switcing if well is not under zero-rate target and is open from schedule
         bool allow_switching = !this->wellUnderZeroRateTarget(summary_state, well_state) && (this->well_ecl_.getStatus() == WellStatus::OPEN);
-        allow_switching = allow_switching && (!fixed_control && !fixed_status);
+        allow_switching = allow_switching && (!fixed_control || !fixed_status);
         bool changed = false;
         bool final_check = false; 
-
+        /*
         if (allow_switching) {
+            // ??????????????????????????????????????????
             this->operability_status_.can_obtain_bhp_with_thp_limit = true;
             this->operability_status_.obey_thp_limit_under_bhp_limit = true;
             this->operability_status_.operable_under_only_bhp_limit = true;
         }
+        */
         do {
             its_since_last_switch++;
             if (allow_switching && its_since_last_switch >= min_its_after_switch){

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -832,6 +832,89 @@ namespace Opm
         this->parallel_well_info_.communication().sum(this->ipr_b_.data(), this->ipr_b_.size());
     }
 
+    template<typename TypeTag>
+    void
+    StandardWell<TypeTag>::
+    updateIPRImplicit(const Simulator& ebosSimulator,
+                      WellState& well_state, 
+                      DeferredLogger& deferred_logger)
+    {   
+        // Compute IPR based on *converged* well-equation:
+        // For a component rate r the derivative dr/dbhp is obtained by 
+        // dr/dbhp = - (partial r/partial x) * inv(partial Eq/partial x) * (partial Eq/partial control_value)
+        // where Eq(x)=0 is the well equation setup with bhp control and primary varables x 
+        //StandardWell<TypeTag> well_copy(*this);
+
+        // We shouldn't have zero rates at this stage, but check
+        bool zero_rates;
+        auto rates = well_state.well(this->index_of_well_).surface_rates;
+        zero_rates = true;
+        for (std::size_t p = 0; p < rates.size(); ++p) {
+            zero_rates &= rates[p] == 0.0;
+        }
+        auto& ws = well_state.well(this->index_of_well_);
+        if (zero_rates) {
+            const auto msg = fmt::format("updateIPRImplicit: Well {} has zero rate, reverting to explicit IPR-calulations", this->name());
+            deferred_logger.debug(msg);
+            updateIPR(ebosSimulator, deferred_logger);
+            for (int comp_idx = 0; comp_idx < this->num_components_; ++comp_idx){
+                const int idx = this->ebosCompIdxToFlowCompIdx(comp_idx);
+                ws.ipr_a[idx] = this->ipr_a_[comp_idx];
+                ws.ipr_b[idx] = this->ipr_b_[comp_idx];
+            }
+        } else {
+            const auto& group_state  = ebosSimulator.problem().wellModel().groupState();
+
+            // XXX maybe don't update this
+            std::fill(ws.ipr_a.begin(), ws.ipr_a.end(), 0.);
+            std::fill(ws.ipr_b.begin(), ws.ipr_b.end(), 0.);
+            //WellState well_state_copy = well_state;    
+            auto inj_controls = Well::InjectionControls(0);
+            auto prod_controls = Well::ProductionControls(0);
+            prod_controls.addControl(Well::ProducerCMode::BHP);
+            prod_controls.bhp_limit = well_state.well(this->index_of_well_).bhp;
+
+            //  Set current control to bhp, and bhp value in state, modify bhp limit in control object.
+            const auto cmode = ws.production_cmode;
+            ws.production_cmode = Well::ProducerCMode::BHP;
+            const double dt = ebosSimulator.timeStepSize();
+            assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
+
+            const double nEq = this->primary_variables_.numWellEq();
+            BVectorWell rhs(1);
+            rhs[0].resize(nEq);
+            // rhs = 0 except -1 for control eq
+            for (size_t i=0; i < nEq; ++i){
+                rhs[0][i] = 0.0;            
+            }
+            rhs[0][Bhp] = -1.0;
+
+            BVectorWell x_well(1);
+            x_well[0].resize(nEq);
+            this->linSys_.solve(rhs, x_well);
+
+            for (int comp_idx = 0; comp_idx < this->num_components_; ++comp_idx){
+                EvalWell comp_rate = this->primary_variables_.getQs(comp_idx);
+                const int idx = this->ebosCompIdxToFlowCompIdx(comp_idx);
+                for (size_t pvIdx = 0; pvIdx < nEq; ++pvIdx) {
+                    ws.ipr_b[idx] -= x_well[0][pvIdx]*comp_rate.derivative(pvIdx+Indices::numEq);
+                }
+                ws.ipr_a[idx] = ws.ipr_b[idx]*ws.bhp - comp_rate.value();
+                
+                //for (size_t pvIdx = 0; pvIdx < nEq; ++pvIdx) {
+                //    this->ipr_b_[comp_idx] -= x_well[0][pvIdx]*comp_rate.derivative(pvIdx+Indices::numEq);
+                //}
+                // XXX maybe don't update this 
+                //this->ipr_a_[comp_idx] = this->ipr_b_[comp_idx]*ws.bhp - comp_rate.value();
+                // For ipr in well_state use same ordering as potentials etc.
+                //const int idx = this->ebosCompIdxToFlowCompIdx(comp_idx);
+                //ws.ipr_a[idx] = this->ipr_a_[comp_idx];
+                //ws.ipr_b[idx] = this->ipr_b_[comp_idx];
+            }
+            // reset cmode
+            ws.production_cmode = cmode;
+        }
+    }
 
     template<typename TypeTag>
     void
@@ -1492,6 +1575,63 @@ namespace Opm
         return potentials;
     }
 
+    template<typename TypeTag>
+    bool
+    StandardWell<TypeTag>::
+    computeWellPotentialsImplicit(const Simulator& ebos_simulator,
+                                  std::vector<double>& well_potentials,
+                                  DeferredLogger& deferred_logger) const
+    {
+        // Create a copy of the well.
+        // TODO: check if we can avoid taking multiple copies. Call from updateWellPotentials 
+        // is allready a copy, but not from other calls.
+        StandardWell<TypeTag> well_copy(*this);
+
+        // store a copy of the well state, we don't want to update the real well state
+        WellState well_state_copy = ebos_simulator.problem().wellModel().wellState();
+        const auto& group_state = ebos_simulator.problem().wellModel().groupState();
+        auto& ws = well_state_copy.well(this->index_of_well_);
+
+        // get current controls
+        const auto& summary_state = ebos_simulator.vanguard().summaryState();
+        auto inj_controls = well_copy.well_ecl_.isInjector()
+            ? well_copy.well_ecl_.injectionControls(summary_state)
+            : Well::InjectionControls(0);
+        auto prod_controls = well_copy.well_ecl_.isProducer()
+            ? well_copy.well_ecl_.productionControls(summary_state) :
+            Well::ProductionControls(0);
+
+        // prepare/modify well state and control
+        well_copy.prepareForPotentialCalculations(summary_state, well_state_copy, inj_controls, prod_controls);
+        
+        // initialize rates from previous potentials
+        const int np = this->number_of_phases_;
+        bool trivial = true;
+        for (int phase = 0; phase < np; ++phase){
+            trivial = trivial && (ws.well_potentials[phase] == 0.0) ;
+        }
+        if (!trivial) {
+            const double sign = well_copy.well_ecl_.isInjector() ? 1.0 : -1.0;
+            for (int phase = 0; phase < np; ++phase) {
+                ws.surface_rates[phase] = sign * ws.well_potentials[phase];
+            }
+        }
+
+        well_copy.calculateExplicitQuantities(ebos_simulator, well_state_copy, deferred_logger);
+        const double dt = ebos_simulator.timeStepSize();
+        // iterate to get a solution at the given bhp.
+        const bool converged = well_copy.iterateWellEqWithSwitching(ebos_simulator, dt, inj_controls, prod_controls, well_state_copy, group_state,
+                                           deferred_logger);
+
+        // fetch potentials (sign is updated on the outside).
+        well_potentials.clear();
+        well_potentials.resize(np, 0.0);
+        for (int compIdx = 0; compIdx < this->num_components_; ++compIdx) {
+            const EvalWell rate = well_copy.primary_variables_.getQs(compIdx);
+            well_potentials[this->ebosCompIdxToFlowCompIdx(compIdx)] = rate.value();
+        }
+        return converged;
+    }
 
 
     template<typename TypeTag>
@@ -1554,29 +1694,35 @@ namespace Opm
             return;
         }
 
-        // does the well have a THP related constraint?
-        const auto& summaryState = ebosSimulator.vanguard().summaryState();
-        if (!Base::wellHasTHPConstraints(summaryState) || bhp_controlled_well) {
-            // get the bhp value based on the bhp constraints
-            double bhp = WellBhpThpCalculator(*this).mostStrictBhpFromBhpLimits(summaryState);
+        bool converged_implicit = false;
+        if (this->param_.local_well_solver_control_switching_) {
+            converged_implicit = computeWellPotentialsImplicit(ebosSimulator, well_potentials, deferred_logger);
+        }
+        if (!converged_implicit) {        
+            // does the well have a THP related constraint?
+            const auto& summaryState = ebosSimulator.vanguard().summaryState();
+            if (!Base::wellHasTHPConstraints(summaryState) || bhp_controlled_well) {
+                // get the bhp value based on the bhp constraints
+                double bhp = WellBhpThpCalculator(*this).mostStrictBhpFromBhpLimits(summaryState);
 
-            // In some very special cases the bhp pressure target are
-            // temporary violated. This may lead to too small or negative potentials
-            // that could lead to premature shutting of wells.
-            // As a remedy the bhp that gives the largest potential is used.
-            // For converged cases, ws.bhp <=bhp for injectors and ws.bhp >= bhp,
-            // and the potentials will be computed using the limit as expected.
-            const auto& ws = well_state.well(this->index_of_well_);
-            if (this->isInjector())
-                bhp = std::max(ws.bhp, bhp);
-            else
-                bhp = std::min(ws.bhp, bhp);
+                // In some very special cases the bhp pressure target are
+                // temporary violated. This may lead to too small or negative potentials
+                // that could lead to premature shutting of wells.
+                // As a remedy the bhp that gives the largest potential is used.
+                // For converged cases, ws.bhp <=bhp for injectors and ws.bhp >= bhp,
+                // and the potentials will be computed using the limit as expected.
+                const auto& ws = well_state.well(this->index_of_well_);
+                if (this->isInjector())
+                    bhp = std::max(ws.bhp, bhp);
+                else
+                    bhp = std::min(ws.bhp, bhp);
 
-            assert(std::abs(bhp) != std::numeric_limits<double>::max());
-            computeWellRatesWithBhpIterations(ebosSimulator, bhp, well_potentials, deferred_logger);
-        } else {
-            // the well has a THP related constraint
-            well_potentials = computeWellPotentialWithTHP(ebosSimulator, deferred_logger, well_state);
+                assert(std::abs(bhp) != std::numeric_limits<double>::max());
+                computeWellRatesWithBhpIterations(ebosSimulator, bhp, well_potentials, deferred_logger);
+            } else {
+                // the well has a THP related constraint
+                well_potentials = computeWellPotentialWithTHP(ebosSimulator, deferred_logger, well_state);
+            }
         }
 
         this->checkNegativeWellPotentials(well_potentials,
@@ -2174,32 +2320,40 @@ namespace Opm
                                const Well::ProductionControls& prod_controls,
                                WellState& well_state,
                                const GroupState& group_state,
-                               DeferredLogger& deferred_logger)
+                               DeferredLogger& deferred_logger, 
+                               const bool allow_switch /*true*/)
     {
         const int max_iter = this->param_.max_inner_iter_wells_;
-
+        
         int it = 0;
         bool converged;
         bool relax_convergence = false;
         this->regularize_ = false;
         const auto& summary_state = ebosSimulator.vanguard().summaryState();
 
-        // Max status switch frequency should be 2 to avoid getting stuck in cycle
-        constexpr int min_its_after_switch = 2;
+        // Max status switch frequency should be 2 to avoid getting stuck in cycle 
+        constexpr int min_its_after_switch = 4;
         int its_since_last_switch = min_its_after_switch;
         int switch_count= 0;
-        const auto well_status = this->wellStatus_;
+        // if we fail to solve eqs, we reset status/control before leaving
+        const auto well_status_orig = this->wellStatus_;
+        auto well_status_cur = well_status_orig;
+        int status_switch_count = 0;
         const bool allow_switching = !this->wellUnderZeroRateTarget(summary_state, well_state) && (this->well_ecl_.getStatus() == WellStatus::OPEN);
         bool changed = false;
-        bool final_check = false;
+        bool final_check = false; 
         do {
             its_since_last_switch++;
             if (allow_switching && its_since_last_switch >= min_its_after_switch){
                 const double wqTotal = this->primary_variables_.eval(WQTotal).value();
-                changed = this->updateWellControlAndStatusLocalIteration(ebosSimulator, well_state, group_state, inj_controls, prod_controls, wqTotal, deferred_logger);
+                changed = this->updateWellControlAndStatusLocalIteration(ebosSimulator, well_state, group_state, inj_controls, prod_controls, wqTotal, deferred_logger, allow_switch); 
                 if (changed){
                     its_since_last_switch = 0;
                     switch_count++;
+                    if (well_status_cur != this->wellStatus_) {
+                        well_status_cur = this->wellStatus_;
+                        status_switch_count++;
+                    }
                 }
                 if (!changed && final_check) {
                     break;
@@ -2207,7 +2361,7 @@ namespace Opm
                     final_check = false;
                 }
             }
-
+  
             assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
 
             if (it > this->param_.strict_inner_iter_wells_) {
@@ -2226,14 +2380,20 @@ namespace Opm
                     its_since_last_switch = min_its_after_switch;
                 } else {
                     break;
-                }
+                }   
             }
 
             ++it;
             solveEqAndUpdateWellState(summary_state, well_state, deferred_logger);
             initPrimaryVariablesEvaluation();
-        } while (it < max_iter);
 
+            if (status_switch_count > 10) {
+                // constantly changing status, give up (do operability check on the outside)
+                converged = false;
+                break;
+            }
+        } while (it < max_iter);
+        
         if (converged) {
             if (allow_switching){
                 // update operability if status change
@@ -2251,11 +2411,12 @@ namespace Opm
                 // For this to happen, isOperableAndSolvable() must change from true to false,
                 // and (until the most recent commit) the well needs to be open for this to trigger.
                 // Hence, the resetting of status.
-                this->wellStatus_ = well_status;
+                //this->wellStatus_ = well_status;
             }
         } else {
+            this->wellStatus_ = well_status_orig;
             const std::string message = fmt::format("   Well {} did not converged in {} inner iterations ("
-                                                    "{} control/status switches).", this->name(), it, switch_count);
+                                                    "{} switches, {} status changes).", this->name(), it, switch_count, status_switch_count);
             deferred_logger.debug(message);
             // add operability here as well ?
         }

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -856,7 +856,7 @@ namespace Opm
             const auto msg = fmt::format("updateIPRImplicit: Well {} has zero rate, IPRs might be probelmatic", this->name());
             deferred_logger.debug(msg);
             /*
-            // could revert to standard approach here    
+            // could revert to standard approach here:    
             updateIPR(ebos_simulator, deferred_logger);
             for (int comp_idx = 0; comp_idx < this->num_components_; ++comp_idx){
                 const int idx = this->ebosCompIdxToFlowCompIdx(comp_idx);
@@ -2341,14 +2341,7 @@ namespace Opm
         allow_switching = allow_switching && (!fixed_control || !fixed_status);
         bool changed = false;
         bool final_check = false; 
-        /*
-        if (allow_switching) {
-            // ??????????????????????????????????????????
-            this->operability_status_.can_obtain_bhp_with_thp_limit = true;
-            this->operability_status_.obey_thp_limit_under_bhp_limit = true;
-            this->operability_status_.operable_under_only_bhp_limit = true;
-        }
-        */
+
         do {
             its_since_last_switch++;
             if (allow_switching && its_since_last_switch >= min_its_after_switch){
@@ -2411,14 +2404,6 @@ namespace Opm
                 } else {
                     this->operability_status_.operable_under_only_bhp_limit = !is_stopped;
                 }
-                // We reset the well status to its original state. Status is updated
-                // on the outside based on operability status
-                // \Note for future reference: For the well to update its status to stop/shut,
-                // the flag changed_to_stopped_this_step_ in prepareWellBeforeAssembling needs to be set to true.
-                // For this to happen, isOperableAndSolvable() must change from true to false,
-                // and (until the most recent commit) the well needs to be open for this to trigger.
-                // Hence, the resetting of status.
-                //this->wellStatus_ = well_status;
             }
         } else {
             this->wellStatus_ = well_status_orig;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1611,8 +1611,12 @@ namespace Opm
         well_copy.calculateExplicitQuantities(ebos_simulator, well_state_copy, deferred_logger);
         const double dt = ebos_simulator.timeStepSize();
         // iterate to get a solution at the given bhp.
-        const bool converged = well_copy.iterateWellEqWithSwitching(ebos_simulator, dt, inj_controls, prod_controls, well_state_copy, group_state,
-                                           deferred_logger);
+        bool converged = false;
+        if (this->well_ecl_.isProducer() && this->wellHasTHPConstraints(summary_state)) {
+            converged = well_copy.solveWellWithTHPConstraint(ebos_simulator, dt, inj_controls, prod_controls, well_state_copy, group_state, deferred_logger);
+        } else {
+            converged = well_copy.iterateWellEqWithSwitching(ebos_simulator, dt, inj_controls, prod_controls, well_state_copy, group_state, deferred_logger);
+        }
 
         // fetch potentials (sign is updated on the outside).
         well_potentials.clear();

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2392,11 +2392,6 @@ namespace Opm
             solveEqAndUpdateWellState(summary_state, well_state, deferred_logger);
             initPrimaryVariablesEvaluation();
 
-            if (status_switch_count > 10) {
-                // constantly changing status, give up (do operability check on the outside)
-                converged = false;
-                break;
-            }
         } while (it < max_iter);
         
         if (converged) {

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2332,8 +2332,9 @@ namespace Opm
         constexpr int min_its_after_switch = 4;
         int its_since_last_switch = min_its_after_switch;
         int switch_count= 0;
-        // if we fail to solve eqs, we reset status/control before leaving
+        // if we fail to solve eqs, we reset status/operability before leaving
         const auto well_status_orig = this->wellStatus_;
+        const auto operability_orig = this->operability_status_;
         auto well_status_cur = well_status_orig;
         int status_switch_count = 0;
         // only allow switcing if well is not under zero-rate target and is open from schedule
@@ -2341,7 +2342,9 @@ namespace Opm
         allow_switching = allow_switching && (!fixed_control || !fixed_status);
         bool changed = false;
         bool final_check = false; 
-
+        // well needs to be set operable or else solving/updating of re-opened wells is skipped
+        this->operability_status_.resetOperability();
+        this->operability_status_.solvable = true;
         do {
             its_since_last_switch++;
             if (allow_switching && its_since_last_switch >= min_its_after_switch){
@@ -2407,6 +2410,7 @@ namespace Opm
             }
         } else {
             this->wellStatus_ = well_status_orig;
+            this->operability_status_ = operability_orig;
             const std::string message = fmt::format("   Well {} did not converged in {} inner iterations ("
                                                     "{} switches, {} status changes).", this->name(), it, switch_count, status_switch_count);
             deferred_logger.debug(message);

--- a/opm/simulators/wells/VFPHelpers.cpp
+++ b/opm/simulators/wells/VFPHelpers.cpp
@@ -506,6 +506,9 @@ getMinimumBHPCoordinate(const VFPProdTable& table,
                         const double gfr,
                         const double alq)
 {   
+    // Given fixed thp, wfr, gfr and alq, this function finds the minimum bhp and returns
+    // the corresponding pair (-flo_at_bhp_min, bhp_min). No assumption is taken on the 
+    // shape of the function bhp(flo), so all points in the flo-axis is checked. 
     double flo_at_bhp_min = 0.0; // start by checking flo=0
     auto flo_i = detail::findInterpData(flo_at_bhp_min, table.getFloAxis());
     auto thp_i = detail::findInterpData( thp, table.getTHPAxis());
@@ -515,9 +518,9 @@ getMinimumBHPCoordinate(const VFPProdTable& table,
 
     detail::VFPEvaluation bhp_i = detail::interpolate(table, flo_i, thp_i, wfr_i, gfr_i, alq_i);
     double bhp_min = bhp_i.value;
-    std::vector<double> flos = table.getFloAxis();
+    const std::vector<double>& flos = table.getFloAxis();
     for (size_t i = 0; i < flos.size(); ++i) {
-        flo_i = detail::findInterpData(flos[i], table.getFloAxis());
+        flo_i = detail::findInterpData(flos[i], flos);
         bhp_i = detail::interpolate(table, flo_i, thp_i, wfr_i, gfr_i, alq_i);
         if (bhp_i.value < bhp_min){
             bhp_min = bhp_i.value;
@@ -538,6 +541,12 @@ intersectWithIPR(const VFPProdTable& table,
                  const double ipr_b, 
                  const std::function<double(const double)>& adjust_bhp)
 {   
+    // Given fixed thp, wfr, gfr and alq, this function finds a stable (-flo, bhp)-intersection 
+    // between the ipr-line and bhp(flo) if such an intersection exists. For multiple stable 
+    // intersections, the one corresonding the largest flo i returned.
+    // The adjust_bhp-function is used to adjust the vfp-table bhp-values to actual bhp-values due
+    // vfp/well ref-depth differences and/or WVFPDP-related pressure adjustments. 
+
     // NOTE: ipr-line is q=b*bhp - a!
     // ipr is given for negative flo, so
     // flo = -b*bhp + a, i.e., bhp = -(flo-a)/b  

--- a/opm/simulators/wells/VFPHelpers.cpp
+++ b/opm/simulators/wells/VFPHelpers.cpp
@@ -535,7 +535,8 @@ intersectWithIPR(const VFPProdTable& table,
                  const double gfr,
                  const double alq, 
                  const double ipr_a,
-                 const double ipr_b)
+                 const double ipr_b, 
+                 const std::function<double(const double)>& adjust_bhp)
 {   
     // NOTE: ipr-line is q=b*bhp - a!
     // ipr is given for negative flo, so
@@ -547,9 +548,9 @@ intersectWithIPR(const VFPProdTable& table,
 
     if (ipr_b == 0.0) {
         // this shouldn't happen, but deal with it to be safe
-        auto flo_i = detail::findInterpData(-ipr_a, table.getFloAxis());
+        auto flo_i = detail::findInterpData(ipr_a, table.getFloAxis());
         detail::VFPEvaluation bhp_i = detail::interpolate(table, flo_i, thp_i, wfr_i, gfr_i, alq_i);
-        return std::make_pair(ipr_b, bhp_i.value);
+        return std::make_pair(-ipr_a, adjust_bhp(bhp_i.value));
     }
     // find largest flo (flo_x) for which y = bhp(flo) + (flo-a)/b = 0 and dy/dflo > 0
     double flo_x = -1.0;
@@ -558,18 +559,18 @@ intersectWithIPR(const VFPProdTable& table,
     flo0 = 0.0; // start by checking flo=0
     auto flo_i = detail::findInterpData(flo0, table.getFloAxis());
     detail::VFPEvaluation bhp_i = detail::interpolate(table, flo_i, thp_i, wfr_i, gfr_i, alq_i);
-    y0 = bhp_i.value - ipr_a/ipr_b; // +0.0/ipr_b
+    y0 = adjust_bhp(bhp_i.value) - ipr_a/ipr_b; // +0.0/ipr_b
 
     std::vector<double> flos = table.getFloAxis();
     for (size_t i = 0; i < flos.size(); ++i) {
         flo1 = flos[i];
         flo_i = detail::findInterpData(flo1, table.getFloAxis());
         bhp_i = detail::interpolate(table, flo_i, thp_i, wfr_i, gfr_i, alq_i);
-        y1 = bhp_i.value + (flo1 - ipr_a)/ipr_b;
+        y1 = adjust_bhp(bhp_i.value) + (flo1 - ipr_a)/ipr_b;
         if (y0 < 0 && y1 >= 0){
             // crossing with positive slope
             double w = -y0/(y1-y0);
-            w = std::clamp(w, 0.0, 1.0); // just to be safe (if y0~y1)
+            w = std::clamp(w, 0.0, 1.0); // just to be safe (if y0~y1~0)
             flo_x = flo0 + w*(flo1 - flo0);
         }
         flo0 = flo1;

--- a/opm/simulators/wells/VFPHelpers.cpp
+++ b/opm/simulators/wells/VFPHelpers.cpp
@@ -543,7 +543,7 @@ intersectWithIPR(const VFPProdTable& table,
 {   
     // Given fixed thp, wfr, gfr and alq, this function finds a stable (-flo, bhp)-intersection 
     // between the ipr-line and bhp(flo) if such an intersection exists. For multiple stable 
-    // intersections, the one corresonding the largest flo i returned.
+    // intersections, the one corresponding the largest flo is returned.
     // The adjust_bhp-function is used to adjust the vfp-table bhp-values to actual bhp-values due
     // vfp/well ref-depth differences and/or WVFPDP-related pressure adjustments. 
 

--- a/opm/simulators/wells/VFPHelpers.hpp
+++ b/opm/simulators/wells/VFPHelpers.hpp
@@ -25,6 +25,7 @@
 #include <functional>
 #include <map>
 #include <vector>
+#include <optional>
 
 /**
  * This file contains a set of helper functions used by VFPProd / VFPInj.
@@ -181,6 +182,28 @@ double findTHP(const std::vector<double>& bhp_array,
                const std::vector<double>& thp_array,
                double bhp);
 
+/**
+* Get (flo, bhp) at minimum bhp for given thp,wfr,gfr,alq
+*/
+std::pair<double, double> 
+getMinimumBHPCoordinate(const VFPProdTable& table,
+                        const double thp,
+                        const double wfr,
+                        const double gfr,
+                        const double alq);
+
+/**
+* Get (flo, bhp) at largest occuring stable vfp/ipr-intersection
+* if it exists
+*/  
+std::optional<std::pair<double, double>> 
+intersectWithIPR(const VFPProdTable& table,
+                 const double thp,
+                 const double wfr,
+                 const double gfr,
+                 const double alq, 
+                 const double ipr_a,
+                 const double ipr_b);                        
 
 } // namespace detail
 

--- a/opm/simulators/wells/VFPHelpers.hpp
+++ b/opm/simulators/wells/VFPHelpers.hpp
@@ -203,7 +203,8 @@ intersectWithIPR(const VFPProdTable& table,
                  const double gfr,
                  const double alq, 
                  const double ipr_a,
-                 const double ipr_b);                        
+                 const double ipr_b,
+                 const std::function<double(const double)>& adjust_bhp);                        
 
 } // namespace detail
 

--- a/opm/simulators/wells/VFPProdProperties.cpp
+++ b/opm/simulators/wells/VFPProdProperties.cpp
@@ -90,8 +90,7 @@ double VFPProdProperties::bhp(int table_id,
                               const double& alq,
                               const double& explicit_wfr,
                               const double& explicit_gfr,
-                              const bool    use_expvfp, 
-                              const double ipr_slope) const {
+                              const bool    use_expvfp) const {
     const VFPProdTable& table = detail::getTable(m_tables, table_id);
 
     detail::VFPEvaluation retval = detail::bhp(table, aqua, liquid, vapour, thp_arg, alq, explicit_wfr,explicit_gfr, use_expvfp);
@@ -168,8 +167,7 @@ EvalWell VFPProdProperties::bhp(const int table_id,
                                 const double& alq,
                                 const double& explicit_wfr,
                                 const double& explicit_gfr,
-                                const bool use_expvfp,
-                                const double ipr_slope /*=0*/) const
+                                const bool use_expvfp) const
 {
     //Get the table
     const VFPProdTable& table = detail::getTable(m_tables, table_id);
@@ -202,7 +200,7 @@ EvalWell VFPProdProperties::bhp(const int table_id,
 #define INSTANCE(...) \
     template __VA_ARGS__ VFPProdProperties::bhp<__VA_ARGS__>(const int, \
                                                              const __VA_ARGS__&, const __VA_ARGS__&, const __VA_ARGS__&, \
-                                                             const double&, const double&, const double&, const double&, const bool, const double) const;
+                                                             const double&, const double&, const double&, const double&, const bool) const;
 
 INSTANCE(DenseAd::Evaluation<double, -1, 4u>)
 INSTANCE(DenseAd::Evaluation<double, -1, 5u>)

--- a/opm/simulators/wells/VFPProdProperties.cpp
+++ b/opm/simulators/wells/VFPProdProperties.cpp
@@ -137,6 +137,22 @@ bhpwithflo(const std::vector<double>& flos,
     return bhps;
 }
 
+double
+VFPProdProperties::
+minimumBHP(const int table_id,
+           const double thp,
+           const double wfr,
+           const double gfr,
+           const double alq) const
+{
+    // Get the table
+    const VFPProdTable& table = detail::getTable(m_tables, table_id);
+    const auto retval = detail::getMinimumBHPCoordinate(table, thp, wfr, gfr, alq);
+    // returned pair is (flo, bhp)
+    return retval.second;
+}
+
+
 
 void VFPProdProperties::addTable(const VFPProdTable& new_table) {
     this->m_tables.emplace( new_table.getTableNum(), new_table );
@@ -176,7 +192,8 @@ EvalWell VFPProdProperties::bhp(const int table_id,
 
     detail::VFPEvaluation bhp_val = detail::interpolate(table, flo_i, thp_i, wfr_i, gfr_i, alq_i);
 
-    bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (std::max(0.0, bhp_val.dflo) * flo);
+   //bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (std::max(0.0, bhp_val.dflo) * flo);
+   bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (bhp_val.dflo* flo);
 
     bhp.setValue(bhp_val.value);
     return bhp;

--- a/opm/simulators/wells/VFPProdProperties.cpp
+++ b/opm/simulators/wells/VFPProdProperties.cpp
@@ -90,7 +90,8 @@ double VFPProdProperties::bhp(int table_id,
                               const double& alq,
                               const double& explicit_wfr,
                               const double& explicit_gfr,
-                              const bool    use_expvfp) const {
+                              const bool    use_expvfp, 
+                              const double ipr_slope) const {
     const VFPProdTable& table = detail::getTable(m_tables, table_id);
 
     detail::VFPEvaluation retval = detail::bhp(table, aqua, liquid, vapour, thp_arg, alq, explicit_wfr,explicit_gfr, use_expvfp);
@@ -167,7 +168,8 @@ EvalWell VFPProdProperties::bhp(const int table_id,
                                 const double& alq,
                                 const double& explicit_wfr,
                                 const double& explicit_gfr,
-                                const bool use_expvfp) const
+                                const bool use_expvfp,
+                                const double ipr_slope /*=0*/) const
 {
     //Get the table
     const VFPProdTable& table = detail::getTable(m_tables, table_id);
@@ -192,8 +194,12 @@ EvalWell VFPProdProperties::bhp(const int table_id,
 
     detail::VFPEvaluation bhp_val = detail::interpolate(table, flo_i, thp_i, wfr_i, gfr_i, alq_i);
 
-   //bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (std::max(0.0, bhp_val.dflo) * flo);
-   bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (bhp_val.dflo* flo);
+   
+   //if (bhp_val.dflo < ipr_slope) {
+   //     bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (std::max(0.0, bhp_val.dflo) * flo);
+   //} else {
+    bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (bhp_val.dflo* flo);
+   //}
 
     bhp.setValue(bhp_val.value);
     return bhp;
@@ -202,7 +208,7 @@ EvalWell VFPProdProperties::bhp(const int table_id,
 #define INSTANCE(...) \
     template __VA_ARGS__ VFPProdProperties::bhp<__VA_ARGS__>(const int, \
                                                              const __VA_ARGS__&, const __VA_ARGS__&, const __VA_ARGS__&, \
-                                                             const double&, const double&, const double&, const double&, const bool) const;
+                                                             const double&, const double&, const double&, const double&, const bool, const double) const;
 
 INSTANCE(DenseAd::Evaluation<double, -1, 4u>)
 INSTANCE(DenseAd::Evaluation<double, -1, 5u>)

--- a/opm/simulators/wells/VFPProdProperties.cpp
+++ b/opm/simulators/wells/VFPProdProperties.cpp
@@ -194,13 +194,7 @@ EvalWell VFPProdProperties::bhp(const int table_id,
 
     detail::VFPEvaluation bhp_val = detail::interpolate(table, flo_i, thp_i, wfr_i, gfr_i, alq_i);
 
-   
-   //if (bhp_val.dflo < ipr_slope) {
-   //     bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (std::max(0.0, bhp_val.dflo) * flo);
-   //} else {
-    bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (bhp_val.dflo* flo);
-   //}
-
+    bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (std::max(0.0, bhp_val.dflo) * flo);
     bhp.setValue(bhp_val.value);
     return bhp;
 }

--- a/opm/simulators/wells/VFPProdProperties.hpp
+++ b/opm/simulators/wells/VFPProdProperties.hpp
@@ -129,7 +129,11 @@ public:
         return m_tables.empty();
     }
 
-
+    /**
+     * Returns minimum bhp for given thp, wfr, gfr and alq 
+     */
+    double minimumBHP(const int table_id, const double thp, 
+                      const double wfr, const double gfr, const double alq) const;
 protected:
     // calculate a group bhp values with a group of flo rate values
     std::vector<double> bhpwithflo(const std::vector<double>& flos,

--- a/opm/simulators/wells/VFPProdProperties.hpp
+++ b/opm/simulators/wells/VFPProdProperties.hpp
@@ -68,8 +68,7 @@ public:
                  const double& alq,
                  const double& explicit_wfr,
                  const double& explicit_gfr,
-                 const bool    use_expvfp, 
-                 const double ipr_slope = 0.0) const;
+                 const bool    use_expvfp) const;
 
     /**
      * Linear interpolation of bhp as a function of the input parameters
@@ -91,8 +90,7 @@ public:
             const double& alq,
             const double& explicit_wfr,
             const double& explicit_gfr,
-            const bool    use_expvfp, 
-            const double ipr_slope = 0.0) const;
+            const bool    use_expvfp) const;
 
     /**
      * Linear interpolation of thp as a function of the input parameters

--- a/opm/simulators/wells/VFPProdProperties.hpp
+++ b/opm/simulators/wells/VFPProdProperties.hpp
@@ -68,7 +68,8 @@ public:
                  const double& alq,
                  const double& explicit_wfr,
                  const double& explicit_gfr,
-                 const bool    use_expvfp) const;
+                 const bool    use_expvfp, 
+                 const double ipr_slope = 0.0) const;
 
     /**
      * Linear interpolation of bhp as a function of the input parameters
@@ -90,7 +91,8 @@ public:
             const double& alq,
             const double& explicit_wfr,
             const double& explicit_gfr,
-            const bool    use_expvfp) const;
+            const bool    use_expvfp, 
+            const double ipr_slope = 0.0) const;
 
     /**
      * Linear interpolation of thp as a function of the input parameters

--- a/opm/simulators/wells/VFPProperties.hpp
+++ b/opm/simulators/wells/VFPProperties.hpp
@@ -92,23 +92,6 @@ public:
         return detail::getGFR(table, aqua, liquid, vapour);
     }
 
-    std::pair<double, double> 
-    getFloIPR(const int table_id, const std::size_t well_index) const {
-        std::pair<double,double>retval(0.0, 0.0);
-        const VFPProdTable& table = this->m_prod.getTable(table_id);
-        const auto& pu = well_state_.phaseUsage();
-        const auto& ipr_a= well_state_.well(well_index).implicit_ipr_a;
-        const auto& aqua_a = pu.phase_used[BlackoilPhases::Aqua]? ipr_a[pu.phase_pos[BlackoilPhases::Aqua]]:0.0;
-        const auto& liquid_a = pu.phase_used[BlackoilPhases::Liquid]? ipr_a[pu.phase_pos[BlackoilPhases::Liquid]]:0.0;
-        const auto& vapour_a = pu.phase_used[BlackoilPhases::Vapour]? ipr_a[pu.phase_pos[BlackoilPhases::Vapour]]:0.0;
-        const auto& ipr_b= well_state_.well(well_index).implicit_ipr_b;
-        const auto& aqua_b = pu.phase_used[BlackoilPhases::Aqua]? ipr_b[pu.phase_pos[BlackoilPhases::Aqua]]:0.0;
-        const auto& liquid_b = pu.phase_used[BlackoilPhases::Liquid]? ipr_b[pu.phase_pos[BlackoilPhases::Liquid]]:0.0;
-        const auto& vapour_b = pu.phase_used[BlackoilPhases::Vapour]? ipr_b[pu.phase_pos[BlackoilPhases::Vapour]]:0.0;
-        return std::make_pair(detail::getFlo(table, aqua_a, liquid_a, vapour_a), 
-                                detail::getFlo(table, aqua_b, liquid_b, vapour_b));
-    }
-
 private:
     VFPInjProperties m_inj;
     VFPProdProperties m_prod;

--- a/opm/simulators/wells/VFPProperties.hpp
+++ b/opm/simulators/wells/VFPProperties.hpp
@@ -97,11 +97,11 @@ public:
         std::pair<double,double>retval(0.0, 0.0);
         const VFPProdTable& table = this->m_prod.getTable(table_id);
         const auto& pu = well_state_.phaseUsage();
-        const auto& ipr_a= well_state_.well(well_index).ipr_a;
+        const auto& ipr_a= well_state_.well(well_index).implicit_ipr_a;
         const auto& aqua_a = pu.phase_used[BlackoilPhases::Aqua]? ipr_a[pu.phase_pos[BlackoilPhases::Aqua]]:0.0;
         const auto& liquid_a = pu.phase_used[BlackoilPhases::Liquid]? ipr_a[pu.phase_pos[BlackoilPhases::Liquid]]:0.0;
         const auto& vapour_a = pu.phase_used[BlackoilPhases::Vapour]? ipr_a[pu.phase_pos[BlackoilPhases::Vapour]]:0.0;
-        const auto& ipr_b= well_state_.well(well_index).ipr_b;
+        const auto& ipr_b= well_state_.well(well_index).implicit_ipr_b;
         const auto& aqua_b = pu.phase_used[BlackoilPhases::Aqua]? ipr_b[pu.phase_pos[BlackoilPhases::Aqua]]:0.0;
         const auto& liquid_b = pu.phase_used[BlackoilPhases::Liquid]? ipr_b[pu.phase_pos[BlackoilPhases::Liquid]]:0.0;
         const auto& vapour_b = pu.phase_used[BlackoilPhases::Vapour]? ipr_b[pu.phase_pos[BlackoilPhases::Vapour]]:0.0;

--- a/opm/simulators/wells/VFPProperties.hpp
+++ b/opm/simulators/wells/VFPProperties.hpp
@@ -92,6 +92,23 @@ public:
         return detail::getGFR(table, aqua, liquid, vapour);
     }
 
+    std::pair<double, double> 
+    getFloIPR(const int table_id, const std::size_t well_index) const {
+        std::pair<double,double>retval(0.0, 0.0);
+        const VFPProdTable& table = this->m_prod.getTable(table_id);
+        const auto& pu = well_state_.phaseUsage();
+        const auto& ipr_a= well_state_.well(well_index).ipr_a;
+        const auto& aqua_a = pu.phase_used[BlackoilPhases::Aqua]? ipr_a[pu.phase_pos[BlackoilPhases::Aqua]]:0.0;
+        const auto& liquid_a = pu.phase_used[BlackoilPhases::Liquid]? ipr_a[pu.phase_pos[BlackoilPhases::Liquid]]:0.0;
+        const auto& vapour_a = pu.phase_used[BlackoilPhases::Vapour]? ipr_a[pu.phase_pos[BlackoilPhases::Vapour]]:0.0;
+        const auto& ipr_b= well_state_.well(well_index).ipr_b;
+        const auto& aqua_b = pu.phase_used[BlackoilPhases::Aqua]? ipr_b[pu.phase_pos[BlackoilPhases::Aqua]]:0.0;
+        const auto& liquid_b = pu.phase_used[BlackoilPhases::Liquid]? ipr_b[pu.phase_pos[BlackoilPhases::Liquid]]:0.0;
+        const auto& vapour_b = pu.phase_used[BlackoilPhases::Vapour]? ipr_b[pu.phase_pos[BlackoilPhases::Vapour]]:0.0;
+        return std::make_pair(detail::getFlo(table, aqua_a, liquid_a, vapour_a), 
+                                detail::getFlo(table, aqua_b, liquid_b, vapour_b));
+    }
+
 private:
     VFPInjProperties m_inj;
     VFPProdProperties m_prod;

--- a/opm/simulators/wells/WellBhpThpCalculator.cpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.cpp
@@ -962,7 +962,7 @@ getFloIPR(const WellState& well_state,
     const double& liquid_b = pu.phase_used[BlackoilPhases::Liquid]? ipr_b[pu.phase_pos[BlackoilPhases::Liquid]] : 0.0;
     const double& vapour_b = pu.phase_used[BlackoilPhases::Vapour]? ipr_b[pu.phase_pos[BlackoilPhases::Vapour]] : 0.0;
     // The getFlo helper is indended to pick one or add two of the phase rates (depending on FLO-type), 
-    // but we can equally use it to pick/add the corresonding ipr_a, ipr_b  
+    // but we can equally use it to pick/add the corresponding ipr_a, ipr_b  
     return std::make_pair(detail::getFlo(table, aqua_a, liquid_a, vapour_a), 
                           detail::getFlo(table, aqua_b, liquid_b, vapour_b));
 }

--- a/opm/simulators/wells/WellBhpThpCalculator.hpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.hpp
@@ -98,6 +98,25 @@ public:
                                const double rho,
                                DeferredLogger& deferred_logger) const;
 
+  double calculateMinimumBhpFromThp(const WellState& well_state,
+                                    const Well& well,
+                                    const SummaryState& summaryState,
+                                    const double rho) const;      
+
+  bool isStableSolution(const WellState& well_state,
+                        const Well& well,
+                        const std::vector<double>& rates,
+                        const SummaryState& summaryState,
+                        DeferredLogger& deferred_logger) const;   
+
+  std::optional<double>
+  estimateStableBhp (const WellState& well_state,
+                    const Well& well,
+                    const std::vector<double>& rates,
+                    const double rho,
+                    const SummaryState& summaryState,
+                    DeferredLogger& deferred_logger) const;                                                                             
+
 private:
     //! \brief Compute BHP from THP limit for an injector - implementation.
     template<class ErrorPolicy>

--- a/opm/simulators/wells/WellBhpThpCalculator.hpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.hpp
@@ -115,7 +115,12 @@ public:
                     const std::vector<double>& rates,
                     const double rho,
                     const SummaryState& summaryState,
-                    DeferredLogger& deferred_logger) const;                                                                             
+                    DeferredLogger& deferred_logger) const;    
+
+  std::pair<double, double>
+  getFloIPR(const WellState& well_state,
+            const Well& well, 
+            const SummaryState& summary_state) const;                                                                                              
 
 private:
     //! \brief Compute BHP from THP limit for an injector - implementation.

--- a/opm/simulators/wells/WellBhpThpCalculator.hpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.hpp
@@ -106,16 +106,14 @@ public:
   bool isStableSolution(const WellState& well_state,
                         const Well& well,
                         const std::vector<double>& rates,
-                        const SummaryState& summaryState,
-                        DeferredLogger& deferred_logger) const;   
+                        const SummaryState& summaryState) const;   
 
   std::optional<double>
   estimateStableBhp (const WellState& well_state,
                     const Well& well,
                     const std::vector<double>& rates,
                     const double rho,
-                    const SummaryState& summaryState,
-                    DeferredLogger& deferred_logger) const;    
+                    const SummaryState& summaryState) const;    
 
   std::pair<double, double>
   getFloIPR(const WellState& well_state,

--- a/opm/simulators/wells/WellConvergence.cpp
+++ b/opm/simulators/wells/WellConvergence.cpp
@@ -37,6 +37,7 @@ void WellConvergence::
 checkConvergenceControlEq(const WellState& well_state,
                           const Tolerances& tolerances,
                           const double well_control_residual,
+                          const bool well_is_stopped, 
                           ConvergenceReport& report,
                           DeferredLogger& deferred_logger) const
 {
@@ -46,7 +47,7 @@ checkConvergenceControlEq(const WellState& well_state,
 
     const int well_index = well_.indexOfWell();
     const auto& ws = well_state.well(well_index);
-    if (well_.wellIsStopped()) {
+    if (well_is_stopped) {
         ctrltype = CR::WellFailure::Type::ControlRate;
         control_tolerance = tolerances.rates; // use smaller tolerance for zero control?
     }

--- a/opm/simulators/wells/WellConvergence.hpp
+++ b/opm/simulators/wells/WellConvergence.hpp
@@ -52,6 +52,7 @@ public:
     void checkConvergenceControlEq(const WellState& well_state,
                                    const Tolerances& tolerances,
                                    const double well_control_residual,
+                                   const bool well_is_stopped, 
                                    ConvergenceReport& report,
                                    DeferredLogger& deferred_logger) const;
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -247,7 +247,8 @@ public:
                                                   const Well::InjectionControls& inj_controls,
                                                   const Well::ProductionControls& prod_controls,
                                                   const double WQTotal,
-                                                  DeferredLogger& deferred_logger);
+                                                  DeferredLogger& deferred_logger, 
+                                                  const bool allow_switch=true);
 
     virtual void updatePrimaryVariables(const SummaryState& summary_state,
                                         const WellState& well_state,
@@ -414,13 +415,39 @@ protected:
                                             const WellProductionControls& prod_controls,
                                             WellState& well_state,
                                             const GroupState& group_state,
-                                            DeferredLogger& deferred_logger) = 0;
+                                            DeferredLogger& deferred_logger, 
+                                            const bool allow_switch = true) = 0;
+
+    virtual void updateIPRImplicit(const Simulator& ebosSimulator,
+                                   WellState& well_state,
+                                   DeferredLogger& deferred_logger) = 0;                                            
 
     bool iterateWellEquations(const Simulator& ebosSimulator,
                               const double dt,
                               WellState& well_state,
                               const GroupState& group_state,
                               DeferredLogger& deferred_logger);
+
+    bool robustWellSolveWithTHP(const Simulator& ebos_simulator,
+                                const double dt,
+                                const Well::InjectionControls& inj_controls,
+                                const Well::ProductionControls& prod_controls,                                
+                                WellState& well_state,
+                                const GroupState& group_state,
+                                DeferredLogger& deferred_logger);
+
+    std::optional<double> estimateOperableBhp(const Simulator& ebos_simulator,
+                                              const double dt,
+                                              WellState& well_state,
+                                              const GroupState& group_state,
+                                              const SummaryState& summary_state,
+                                              DeferredLogger& deferred_logger);        
+
+    bool solveWellWithBhp(const Simulator& ebos_simulator,
+                          const double dt,
+                          const double bhp,
+                          WellState& well_state,
+                          DeferredLogger& deferred_logger);                                                                                       
 
     bool solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state, const GroupState& group_state,
                              DeferredLogger& deferred_logger);

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -441,7 +441,6 @@ protected:
     std::optional<double> estimateOperableBhp(const Simulator& ebos_simulator,
                                               const double dt,
                                               WellState& well_state,
-                                              const GroupState& group_state,
                                               const SummaryState& summary_state,
                                               DeferredLogger& deferred_logger);        
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -430,13 +430,13 @@ protected:
                               const GroupState& group_state,
                               DeferredLogger& deferred_logger);
 
-    bool robustWellSolveWithTHP(const Simulator& ebos_simulator,
-                                const double dt,
-                                const Well::InjectionControls& inj_controls,
-                                const Well::ProductionControls& prod_controls,                                
-                                WellState& well_state,
-                                const GroupState& group_state,
-                                DeferredLogger& deferred_logger);
+    bool solveWellWithTHPConstraint(const Simulator& ebos_simulator,
+                                    const double dt,
+                                    const Well::InjectionControls& inj_controls,
+                                    const Well::ProductionControls& prod_controls,                                
+                                    WellState& well_state,
+                                    const GroupState& group_state,
+                                    DeferredLogger& deferred_logger);
 
     std::optional<double> estimateOperableBhp(const Simulator& ebos_simulator,
                                               const double dt,

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -248,7 +248,8 @@ public:
                                                   const Well::ProductionControls& prod_controls,
                                                   const double WQTotal,
                                                   DeferredLogger& deferred_logger, 
-                                                  const bool allow_switch=true);
+                                                  const bool fixed_control = false, 
+                                                  const bool fixed_status = false);
 
     virtual void updatePrimaryVariables(const SummaryState& summary_state,
                                         const WellState& well_state,
@@ -416,7 +417,8 @@ protected:
                                             WellState& well_state,
                                             const GroupState& group_state,
                                             DeferredLogger& deferred_logger, 
-                                            const bool allow_switch = true) = 0;
+                                            const bool fixed_control = false, 
+                                            const bool fixed_status = false) = 0;
 
     virtual void updateIPRImplicit(const Simulator& ebosSimulator,
                                    WellState& well_state,
@@ -447,7 +449,12 @@ protected:
                           const double dt,
                           const double bhp,
                           WellState& well_state,
-                          DeferredLogger& deferred_logger);                                                                                       
+                          DeferredLogger& deferred_logger);         
+
+    bool solveWellWithZeroRate(const Simulator& ebos_simulator,
+                               const double dt,
+                               WellState& well_state,
+                               DeferredLogger& deferred_logger);                                                                                                       
 
     bool solveWellForTesting(const Simulator& ebosSimulator, WellState& well_state, const GroupState& group_state,
                              DeferredLogger& deferred_logger);

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -748,7 +748,7 @@ void WellInterfaceGeneric::
 prepareForPotentialCalculations(const SummaryState& summary_state,
                                 WellState& well_state, 
                                 Well::InjectionControls& inj_controls,
-                                Well::ProductionControls& prod_controls)
+                                Well::ProductionControls& prod_controls) const
 {
     const bool has_thp = this->wellHasTHPConstraints(summary_state);
     auto& ws = well_state.well(this->index_of_well_);

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -248,7 +248,7 @@ protected:
     void prepareForPotentialCalculations(const SummaryState& summary_state,
                                          WellState& well_state, 
                                          Well::InjectionControls& inj_controls,
-                                         Well::ProductionControls& prod_controls);                                  
+                                         Well::ProductionControls& prod_controls) const;
 
     // definition of the struct OperabilityStatus
     struct OperabilityStatus {

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -245,6 +245,11 @@ protected:
                                      const bool checkOperability,
                                      DeferredLogger& deferred_logger);
 
+    void prepareForPotentialCalculations(const SummaryState& summary_state,
+                                         WellState& well_state, 
+                                         Well::InjectionControls& inj_controls,
+                                         Well::ProductionControls& prod_controls);                                  
+
     // definition of the struct OperabilityStatus
     struct OperabilityStatus {
         bool isOperableAndSolvable() const {

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -517,12 +517,12 @@ namespace Opm
                 auto rates = well_state.well(this->index_of_well_).surface_rates;
                 this->adaptRatesForVFP(rates);
                 this->updateIPRImplicit(ebos_simulator, well_state, deferred_logger);
-                bool is_stable = WellBhpThpCalculator(*this).isStableSolution(well_state, this->well_ecl_, rates, summary_state, deferred_logger);
+                bool is_stable = WellBhpThpCalculator(*this).isStableSolution(well_state, this->well_ecl_, rates, summary_state);
                 if (!is_stable) {
                     // solution converged to an unstable point! 
                     this->operability_status_.use_vfpexplicit = true;
                     // msg = ...
-                    auto bhp_stable = WellBhpThpCalculator(*this).estimateStableBhp(well_state, this->well_ecl_, rates, this->getRefDensity(), summary_state, deferred_logger);
+                    auto bhp_stable = WellBhpThpCalculator(*this).estimateStableBhp(well_state, this->well_ecl_, rates, this->getRefDensity(), summary_state);
                     // if we find an intersection with a sufficiently lower bhp, re-solve equations
                     const double reltol = 1e-3;
                     const double cur_bhp = ws.bhp;
@@ -584,7 +584,7 @@ namespace Opm
         this->updateIPRImplicit(ebos_simulator, well_state, deferred_logger);
         auto rates = well_state.well(this->index_of_well_).surface_rates;
         this->adaptRatesForVFP(rates);
-        return WellBhpThpCalculator(*this).estimateStableBhp(well_state, this->well_ecl_, rates, this->getRefDensity(), summary_state, deferred_logger);
+        return WellBhpThpCalculator(*this).estimateStableBhp(well_state, this->well_ecl_, rates, this->getRefDensity(), summary_state);
     } 
 
     template<typename TypeTag>

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -456,7 +456,7 @@ namespace Opm
             if (!this->param_.local_well_solver_control_switching_){
                 converged = this->iterateWellEqWithControl(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
             } else {
-                if (this->param_.use_implicit_ipr_ && this->well_ecl_.isProducer() && this->wellHasTHPConstraints(summary_state)) {
+                if (this->param_.use_implicit_ipr_ && this->well_ecl_.isProducer() && this->wellHasTHPConstraints(summary_state) && (this->well_ecl_.getStatus() == WellStatus::OPEN)) {
                     converged = solveWellWithTHPConstraint(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
                 } else {
                     converged = this->iterateWellEqWithSwitching(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);


### PR DESCRIPTION
This draft PR contains functionality for computing implicit IPR (dq/dp derivative at current solution). Moreover several functions utilizing this for stability checking, estimating operability of stopped/unconverged wells and searching for solutions (vfp/IPR intersections) for use in problematic cases. In addition, direct computation of potentials is included.

For the new code to take effect, currently simulations must be run with _both_ options `--local-well-solve-control-switching=true` and `--use-implicit-ipr=true`.

**Note:** this code always aims at getting converged local well equations. If a well is not operable, it will converge to a stopped well. Currently, this may cause problems in the startup of networks (with zero rate initial guess) since branch vfp's don't support explicit lookup, and hence use zero fractions in this case. Support for explicit lookup in networks (which anyhow is a good idea) should be fixed prior to potentially merging this PR.  