### PR TITLE
Chase Constructor API Change for Opm::Connection Class

### DIFF
--- a/opm/simulators/wells/WellFilterCake.cpp
+++ b/opm/simulators/wells/WellFilterCake.cpp
@@ -96,8 +96,6 @@ updateInjFCMult(const WellInterfaceGeneric& well,
             const double poro = filter_cake.poro;
             const double perm = filter_cake.perm;
             const double rw = connection.getFilterCakeRadius();
-            const auto cr0 = connection.r0();
-            const auto crw = connection.rw();
             const double K = connection.Kh() / connection.connectionLength();
             const double factor = filter_cake.sf_multiplier;
             // the thickness of the filtration cake
@@ -130,10 +128,7 @@ updateInjFCMult(const WellInterfaceGeneric& well,
             }
             filtrate_data.skin_factor[perf] = skin_factor;
 
-            // the original skin factor for the connection
-            const auto cskinfactor = connection.skinFactor();
-            // compute a multiplier for the well connection transmissibility
-            const auto denom = std::log(cr0 / std::min(crw, cr0)) + cskinfactor;
+            const auto denom = connection.ctfProperties().peaceman_denom;
             const auto denom2 = denom + skin_factor;
             inj_fc_multiplier_[perf] = denom / denom2;
         } else {

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -177,17 +177,17 @@ add_test_compare_parallel_simulation(CASENAME winjmult_msw
                                      FILENAME WINJMULT_MSW
                                      SIMULATOR flow
                                      ABS_TOL ${abs_tol}
-                                     REL_TOL 0.12
+                                     REL_TOL ${rel_tol}
                                      DIR winjmult
-                                     TEST_ARGS --enable-tuning=true)
+                                     TEST_ARGS --ecl-enable-drift-compensation=false --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
 
 add_test_compare_parallel_simulation(CASENAME winjdam_msw
                                      FILENAME WINJDAM_MSW
                                      SIMULATOR flow
                                      ABS_TOL ${abs_tol}
-                                     REL_TOL 0.1
+                                     REL_TOL ${rel_tol}
                                      DIR winjdam
-                                     TEST_ARGS --enable-tuning=true)
+                                     TEST_ARGS --ecl-enable-drift-compensation=false --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
 
 add_test_compare_parallel_simulation(CASENAME 3_a_mpi_multflt_mod2
                                      FILENAME 3_A_MPI_MULTFLT_SCHED_MODEL2

--- a/tests/test_parallel_wbp_calculation.cpp
+++ b/tests/test_parallel_wbp_calculation.cpp
@@ -411,18 +411,28 @@ namespace {
         };
 
         for (auto k = topConn; k < kMax; ++k) {
+            const auto depth = 2000 + (2*k + 1) / static_cast<double>(2);
+
+            auto ctf_props = Opm::Connection::CTFProperties{};
+
+            // 0.03, 0.0, 0.01, 0.02, 0.03, ...
+            ctf_props.CF = ((k + 3 - topConn) % 4) / 100.0;
+
+            ctf_props.Kh = 1.0;
+            ctf_props.Ke = 1.0;
+            ctf_props.rw = 1.0;
+            ctf_props.r0 = 0.5;
+            ctf_props.re = 0.5;
+            ctf_props.connection_length = 1.0;
+
             conns.emplace_back(i, j, k, globIndex({i, j, k}, dims), k - topConn,
-                               2000 + (2*k + 1) / static_cast<double>(2),
 
                                // Open, Shut, Open, Open, Shut, ...
                                state[(k - topConn) % state.size()],
 
-                               // 0.03, 0.0, 0.01, 0.02, 0.03, ...
-                               ((k + 3 - topConn) % 4) / 100.0,
-
-                               1.0, 1.0, 0.5, 0.5, 1.0, 0.0, 0, 0.0, 0.0,
                                Opm::Connection::Direction::Z,
-                               Opm::Connection::CTFKind::DeckValue, k - topConn, false);
+                               Opm::Connection::CTFKind::DeckValue,
+                               0, depth, ctf_props, k - topConn, false);
         }
 
         return std::make_shared<Opm::WellConnections>


### PR DESCRIPTION
Downstream follow-up to OPM/opm-common#3763.  This must be merged in concert with the upstream PR.