### PR TITLE
Communicate Dynamic Transmissibility Multiplier to Output Layer

### DIFF
--- a/opm/simulators/wells/PerfData.cpp
+++ b/opm/simulators/wells/PerfData.cpp
@@ -27,7 +27,10 @@
 
 namespace Opm {
 
-PerfData::PerfData(std::size_t num_perf, double pressure_first_connection_, bool injector_, std::size_t num_phases)
+PerfData::PerfData(const std::size_t num_perf,
+                   const double pressure_first_connection_,
+                   const bool injector_,
+                   const std::size_t num_phases)
     : injector(injector_)
     , pressure_first_connection(pressure_first_connection_)
     , pressure(num_perf)
@@ -42,6 +45,7 @@ PerfData::PerfData(std::size_t num_perf, double pressure_first_connection_, bool
     , cell_index(num_perf)
     , connection_transmissibility_factor(num_perf)
     , connection_d_factor(num_perf)
+    , connection_compaction_tmult(num_perf)
     , satnum_id(num_perf)
     , ecl_index(num_perf)
 {
@@ -69,6 +73,7 @@ PerfData PerfData::serializationTestObject()
     result.cell_index = {17, 18, 19, 20};
     result.connection_transmissibility_factor = {21.0};
     result.connection_d_factor = {21.5};
+    result.connection_compaction_tmult.assign(1, 21.75);
     result.satnum_id = {22, 23};
     result.ecl_index = {24};
     result.water_throughput = {25.0, 26.0};
@@ -79,20 +84,25 @@ PerfData PerfData::serializationTestObject()
     return result;
 }
 
-std::size_t PerfData::size() const {
+std::size_t PerfData::size() const
+{
     return this->pressure.size();
 }
 
-bool PerfData::empty() const {
+bool PerfData::empty() const
+{
     return this->pressure.empty();
 }
 
-bool PerfData::try_assign(const PerfData& other) {
-    if (this->size() != other.size())
+bool PerfData::try_assign(const PerfData& other)
+{
+    if (this->size() != other.size()) {
         return false;
+    }
 
-    if (this->injector != other.injector)
+    if (this->injector != other.injector) {
         return false;
+    }
 
     this->pressure_first_connection = other.pressure_first_connection;
     this->pressure = other.pressure;
@@ -102,36 +112,39 @@ bool PerfData::try_assign(const PerfData& other) {
     this->solvent_rates = other.solvent_rates;
     this->polymer_rates = other.polymer_rates;
     this->brine_rates = other.brine_rates;
+    this->prod_index = other.prod_index;
+    this->micp_rates = other.micp_rates;
     this->water_throughput = other.water_throughput;
     this->skin_pressure = other.skin_pressure;
     this->water_velocity = other.water_velocity;
-    this->prod_index = other.prod_index;
-    this->micp_rates = other.micp_rates;
     this->filtrate_data = other.filtrate_data;
+
     return true;
 }
 
 bool PerfData::operator==(const PerfData& rhs) const
 {
-    return this->pressure_first_connection == rhs.pressure_first_connection &&
-           this->pressure == rhs.pressure &&
-           this->rates == rhs.rates &&
-           this->phase_rates == rhs.phase_rates &&
-           this->phase_mixing_rates == rhs.phase_mixing_rates &&
-           this->solvent_rates == rhs.solvent_rates &&
-           this->polymer_rates == rhs.polymer_rates &&
-           this->brine_rates == rhs.brine_rates &&
-           this->prod_index == rhs.prod_index &&
-           this->micp_rates == rhs.micp_rates &&
-           this->cell_index == rhs.cell_index &&
-           this->connection_transmissibility_factor == rhs.connection_transmissibility_factor &&
-           this->connection_d_factor == rhs.connection_d_factor &&
-           this->satnum_id == rhs.satnum_id &&
-           this->ecl_index == rhs.ecl_index &&
-           this->water_throughput == rhs.water_throughput &&
-           this->skin_pressure == rhs.skin_pressure &&
-           this->water_velocity == rhs.water_velocity &&
-           this->filtrate_data == rhs.filtrate_data;
+    return (this->pressure_first_connection == rhs.pressure_first_connection)
+        && (this->pressure == rhs.pressure)
+        && (this->rates == rhs.rates)
+        && (this->phase_rates == rhs.phase_rates)
+        && (this->phase_mixing_rates == rhs.phase_mixing_rates)
+        && (this->solvent_rates == rhs.solvent_rates)
+        && (this->polymer_rates == rhs.polymer_rates)
+        && (this->brine_rates == rhs.brine_rates)
+        && (this->prod_index == rhs.prod_index)
+        && (this->micp_rates == rhs.micp_rates)
+        && (this->cell_index == rhs.cell_index)
+        && (this->connection_transmissibility_factor == rhs.connection_transmissibility_factor)
+        && (this->connection_d_factor == rhs.connection_d_factor)
+        && (this->connection_compaction_tmult == rhs.connection_compaction_tmult)
+        && (this->satnum_id == rhs.satnum_id)
+        && (this->ecl_index == rhs.ecl_index)
+        && (this->water_throughput == rhs.water_throughput)
+        && (this->skin_pressure == rhs.skin_pressure)
+        && (this->water_velocity == rhs.water_velocity)
+        && (this->filtrate_data == rhs.filtrate_data)
+        ;
 }
 
-}
+} // namespace Opm

--- a/opm/simulators/wells/PerfData.hpp
+++ b/opm/simulators/wells/PerfData.hpp
@@ -1,7 +1,6 @@
 /*
   Copyright 2021 Equinor ASA.
 
-
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -36,7 +35,10 @@ private:
 
 public:
     PerfData() = default;
-    PerfData(std::size_t num_perf, double pressure_first_connection_, bool injector_, std::size_t num_phases);
+    PerfData(std::size_t num_perf,
+             double pressure_first_connection_,
+             bool injector_,
+             std::size_t num_phases);
 
     static PerfData serializationTestObject();
 
@@ -60,6 +62,7 @@ public:
         serializer(cell_index);
         serializer(connection_transmissibility_factor);
         serializer(connection_d_factor);
+        serializer(connection_compaction_tmult);
         serializer(satnum_id);
         serializer(ecl_index);
         serializer(water_throughput);
@@ -70,31 +73,38 @@ public:
 
     bool operator==(const PerfData&) const;
 
+    // Note to maintainers: If you make changes to this list of data
+    // members, then please update the constructor, operator==(),
+    // serializationTestObject(), and serializeOp() accordingly.  Moreover,
+    // if you're adding a new member representing a dynamically calculated
+    // result, e.g., a flow rate, then please update try_assign() as well.
+
     double pressure_first_connection{};
-    std::vector<double> pressure;
-    std::vector<double> rates;
-    std::vector<double> phase_rates;
-    std::vector<std::array<double,4>> phase_mixing_rates;
-    std::vector<double> solvent_rates;
-    std::vector<double> polymer_rates;
-    std::vector<double> brine_rates;
-    std::vector<double> prod_index;
-    std::vector<double> micp_rates;
-    std::vector<std::size_t> cell_index;
-    std::vector<double> connection_transmissibility_factor;
-    std::vector<double> connection_d_factor;
-    std::vector<int> satnum_id;
-    std::vector<std::size_t> ecl_index;
+    std::vector<double> pressure{};
+    std::vector<double> rates{};
+    std::vector<double> phase_rates{};
+    std::vector<std::array<double,4>> phase_mixing_rates{};
+    std::vector<double> solvent_rates{};
+    std::vector<double> polymer_rates{};
+    std::vector<double> brine_rates{};
+    std::vector<double> prod_index{};
+    std::vector<double> micp_rates{};
+    std::vector<std::size_t> cell_index{};
+    std::vector<double> connection_transmissibility_factor{};
+    std::vector<double> connection_d_factor{};
+    std::vector<double> connection_compaction_tmult{};
+    std::vector<int> satnum_id{};
+    std::vector<std::size_t> ecl_index{};
 
-    // The water_throughput, skin_pressure and water_velocity variables are only
-    // used for injectors to check the injectivity.
-    std::vector<double> water_throughput;
-    std::vector<double> skin_pressure;
-    std::vector<double> water_velocity;
+    // The water_throughput, skin_pressure and water_velocity variables are
+    // only used for injectors to check the injectivity.
+    std::vector<double> water_throughput{};
+    std::vector<double> skin_pressure{};
+    std::vector<double> water_velocity{};
 
-    ConnFiltrateData filtrate_data;
+    ConnFiltrateData filtrate_data{};
 };
 
 } // namespace Opm
 
-#endif // OPM_PERFORATIONDATA_HEADER_INCLUDED
+#endif // OPM_PERFDATA_HEADER_INCLUDED

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1642,7 +1642,8 @@ namespace Opm
             return conns[connIx[perf]].CF();
         };
 
-        auto& ctf = ws.perf_data.connection_transmissibility_factor;
+        auto& tmult = ws.perf_data.connection_compaction_tmult;
+        auto& ctf   = ws.perf_data.connection_transmissibility_factor;
 
         for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
             const int cell_idx = this->well_cells_[perf];
@@ -1650,10 +1651,10 @@ namespace Opm
             const auto& intQuants = simulator.model()
                 .intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
 
-            const auto tmult = simulator.problem()
+            tmult[perf] = simulator.problem()
                 .template wellTransMultiplier<double>(intQuants, cell_idx);
 
-            ctf[perf] = connCF(perf) * tmult;
+            ctf[perf] = connCF(perf) * tmult[perf];
         }
     }
 

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -594,6 +594,7 @@ void WellState::reportConnections(std::vector<data::Connection>& connections,
         connection.reservoir_rate = perf_rates[i];
         connection.trans_factor = perf_data.connection_transmissibility_factor[i];
         connection.d_factor = perf_data.connection_d_factor[i];
+        connection.compact_mult = perf_data.connection_compaction_tmult[i];
         connection.rates.set(rt::dissolved_gas, perf_mixing_rates[i][ws.dissolved_gas]);
         connection.rates.set(rt::vaporized_oil, perf_mixing_rates[i][ws.vaporized_oil]);
         if (!ws.producer) {


### PR DESCRIPTION
This PR captures the rock compaction transmissibility multiplier in the `PerfData` during the non-linear iterations and communicates the converged value back to the output layer through the new data member to the `data::Connection` structure,
```C++
double data::Connection::compact_mult
```
added in upstream PR OPM/opm-common#3766.