### PR TITLE
use stricter tolerances for WINJMULT_MSW/WINJDAM_MSW parallel tests

### DIFF
--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -177,17 +177,17 @@ add_test_compare_parallel_simulation(CASENAME winjmult_msw
                                      FILENAME WINJMULT_MSW
                                      SIMULATOR flow
                                      ABS_TOL ${abs_tol}
-                                     REL_TOL 0.12
+                                     REL_TOL ${rel_tol}
                                      DIR winjmult
-                                     TEST_ARGS --enable-tuning=true)
+                                     TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
 
 add_test_compare_parallel_simulation(CASENAME winjdam_msw
                                      FILENAME WINJDAM_MSW
                                      SIMULATOR flow
                                      ABS_TOL ${abs_tol}
-                                     REL_TOL 0.1
+                                     REL_TOL ${rel_tol}
                                      DIR winjdam
-                                     TEST_ARGS --enable-tuning=true)
+                                     TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
 
 add_test_compare_parallel_simulation(CASENAME 3_a_mpi_multflt_mod2
                                      FILENAME 3_A_MPI_MULTFLT_SCHED_MODEL2


### PR DESCRIPTION
so we can use standard rel_tol tolerances and not the very relaxed values currently in use