### PR TITLE
limiting the lower limit of 1 - rs*rv

### DIFF
--- a/opm/simulators/wells/StandardWellConnections.cpp
+++ b/opm/simulators/wells/StandardWellConnections.cpp
@@ -212,7 +212,8 @@ computeDensities(const std::vector<Scalar>& perfComponentRates,
                 rv = std::min(mix[oilpos] / mix[gaspos], props.rvmax_perf[perf]);
             }
             const Scalar d = 1.0 - rs*rv;
-            if (d <= 0.0) {
+            constexpr Scalar epsilon = 1.e-5;
+            if (d <= epsilon) {
                 std::ostringstream sstr;
                 sstr << "Problematic d value " << d << " obtained for well " << well_.name()
                      << " during computeConnectionDensities with rs " << rs


### PR DESCRIPTION
to do an urgent fix while refactoring the issue on a broader view, while needs much more investigation, discussion and testing.

It is likely we need more restrictive rs and rv than the following code can provide. 
```c++
            if (!props.rsmax_perf.empty() && mix[oilpos] > 1e-12) {
                rs = std::min(mix[gaspos] / mix[oilpos], props.rsmax_perf[perf]);
            }
            if (!props.rvmax_perf.empty() && mix[gaspos] > 1e-12) {
                rv = std::min(mix[oilpos] / mix[gaspos], props.rvmax_perf[perf]);
            }
```

And we should limit the rsmax or rvmax, and using mix to derive rs and rv can be non-physical.  It is possible `1. - rs*rv`  should not be so much smaller than 1., at least not in orders. 

This PR should not impact much results, except some extremely sensitive cases, but it should not make any running worse. 

