### PR TITLE
compressedLevelZero used to read relative permeability

### DIFF
--- a/ebos/alucartesianindexmapper.hh
+++ b/ebos/alucartesianindexmapper.hh
@@ -197,6 +197,10 @@ public:
     int compressedSize() const
     { return cartesianIndex_.size(); }
 
+    /** \brief return number of cells in the active grid. Only for unifying calls with CpGrid and PolyhedralGrid specializations. */
+    int compressedLevelZeroSize() const
+    { return cartesianIndex_.size(); }
+
     /** \brief return index of the cells in the logical Cartesian grid */
     int cartesianIndex(const int compressedElementIndex) const
     {

--- a/opm/core/props/satfunc/RelpermDiagnostics.cpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.cpp
@@ -840,7 +840,7 @@ namespace Opm {
     {
         // All end points are subject to round-off errors, checks should account for it
         const float tolerance = 1e-6;
-        const int nc = cartesianIndexMapper.compressedSize();
+        const int nc = cartesianIndexMapper.compressedLevelZeroSize();
         const bool threepoint = eclState.runspec().endpointScaling().threepoint();
         scaledEpsInfo_.resize(nc);
         EclEpsGridProperties epsGridProperties(eclState, false);


### PR DESCRIPTION
When reading relative permeability defined by the input file, (currently) done for a grid without LGRs, the compressed index used has to be the one for level 0 grid. Therefore, a method compressedLevelZeroSize() has been added in the CartesianIndexMapper interface, for AluGrid. For CpGrid and Polyhedral, it's done in OPM/opm-grid694.