### PR TITLE
Fix shut-in logic for wells with shut-instructions (revised)

### DIFF
--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -632,23 +632,9 @@ namespace Opm
         const bool well_operable = this->operability_status_.isOperableAndSolvable();
 
         if (!well_operable && old_well_operable) {
-            if (this->param_.local_well_solver_control_switching_) {
-                deferred_logger.info(" well " + this->name() + " gets STOPPED during iteration ");
-                this->stopWell();
-                changed_to_stopped_this_step_ = true;
-            } else {
-                // \Note: keep the old manner for now for testing checking.
-                // Will be investgiated and fixed in a later PR
-                if (this->well_ecl_.getAutomaticShutIn()) {
-                    deferred_logger.info(" well " + this->name() + " gets SHUT during iteration ");
-                } else {
-                    if (!this->wellIsStopped()) {
-                        deferred_logger.info(" well " + this->name() + " gets STOPPED during iteration ");
-                        this->stopWell();
-                        changed_to_stopped_this_step_ = true;
-                    }
-                }
-            }
+            deferred_logger.info(" well " + this->name() + " gets STOPPED during iteration ");
+            this->stopWell();
+            changed_to_stopped_this_step_ = true;
         } else if (well_operable && !old_well_operable) {
             deferred_logger.info(" well " + this->name() + " gets REVIVED during iteration ");
             this->openWell();

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -203,4 +203,4 @@ add_test_compare_parallel_simulation(CASENAME rxft
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL 1.0e-3
                                      DIR rxft_smry
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --ecl-enable-drift-compensation=false)
+                                     TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --ecl-enable-drift-compensation=false)

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -285,7 +285,7 @@ add_test_compareECLFiles(CASENAME polymer_oilwater
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
-                         TEST_ARGS --tolerance-mb=1.e-7)
+                         TEST_ARGS --solver-max-time-step-in-days=10 --tolerance-mb=1.e-7)
 
 add_test_compareECLFiles(CASENAME polymer_injectivity
                          FILENAME 2D_POLYMER_INJECTIVITY
@@ -439,7 +439,8 @@ add_test_compareECLFiles(CASENAME udq_actionx
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
-                         DIR udq_actionx)
+                         DIR udq_actionx
+                         TEST_ARGS --solver-max-time-step-in-days=5)
 
 add_test_compareECLFiles(CASENAME udq_wconprod
                          FILENAME UDQ_WCONPROD
@@ -1221,7 +1222,8 @@ add_test_compareECLFiles(CASENAME rxft_smry
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
-                         DIR rxft_smry )
+                         DIR rxft_smry
+                         TEST_ARGS --enable-tuning=true)
 
 add_test_compareECLFiles(CASENAME bo_diffusion
                          FILENAME BO_DIFFUSE_CASE1
@@ -1242,7 +1244,8 @@ add_test_compareECLFiles(CASENAME actionx_wpimult
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
-                         DIR actionx)
+                         DIR actionx
+                         TEST_ARGS --enable-tuning=true)
 
 add_test_compareECLFiles(CASENAME wvfpexp_02
                          FILENAME WVFPEXP-02


### PR DESCRIPTION
This is a rebased version of #4902 which additionally limits the timestep size of certain sensitive regression tests for improved determinism and stability.

Supersedes and closes #4902.