### PR TITLE
not updating connection pressure for StandardWell early in computeWellRatesWithBhpIterations. 

### DIFF
--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1438,7 +1438,9 @@ namespace Opm
             well_state_copy.wellRates(this->index_of_well_)[phase]
                     = sign * ws.well_potentials[phase];
         }
-        well_copy.calculateExplicitQuantities(ebosSimulator, well_state_copy, deferred_logger);
+        well_copy.updatePrimaryVariables(summary_state, well_state_copy, deferred_logger);
+        well_copy.initPrimaryVariablesEvaluation();
+        well_copy.computeAccumWell();
 
         const double dt = ebosSimulator.timeStepSize();
         const bool converged = well_copy.iterateWellEqWithControl(ebosSimulator, dt, inj_controls, prod_controls, well_state_copy, group_state, deferred_logger);


### PR DESCRIPTION
In `computeWellRatesWithBhpIterations()`, the perforation rates are not updated with updated well rates, and explicit quantities are not sensible to update based on the inconsistent well rates and perforation rates.

Better to keep the original explicit quantities for better consistency.

Furthermore, it can be dangerous to update the explicit quantities based on the irrelevant perforation rates, since the ratios can be very undesirable due to cross flow.  

Connection pressure will be updated later before calculating the rates.