### PR TITLE
fixed: also add dependency with ninja generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,7 +556,7 @@ foreach(OBJ ${COMMON_MODELS} ${FLOW_MODELS} ${FLOW_VARIANT_MODELS})
   if(TARGET fmt::fmt)
     target_link_libraries(flow_lib${OBJ} fmt::fmt)
   endif()
-  if(TARGET opmcommon AND CMAKE_GENERATOR MATCHES "Makefiles")
+  if(TARGET opmcommon)
       add_dependencies(flow_lib${OBJ} opmcommon)
   endif()
   opm_add_test(flow_${OBJ}


### PR DESCRIPTION
I swear last time I looked at this ninja managed to resolve the dependency on its own, but maybe I was just hallucinating or something. In any case, let us get it right now.

The simulator objects depends on the generated headers in opm-common. When doing a super build we have to explicitly declare this dependency or simulator objects might start building too early with many build threads. While optimally we'd declare the dependency on the generated headers, these are not grouped under a single target so we'd have to have a long list of headers. Instead we simply use the opmcommon library as the proxy.