### PR TITLE
[fix] Do parallel sums with int instead of bool.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1924,7 +1924,7 @@ namespace Opm {
             }
         }
 
-        changed_well_to_group = comm.sum(changed_well_to_group);
+        changed_well_to_group = comm.sum(static_cast<int>(changed_well_to_group));
         if (changed_well_to_group) {
             updateAndCommunicate(episodeIdx, iterationIdx, deferred_logger);
             changed_well_group = true;
@@ -1939,7 +1939,7 @@ namespace Opm {
                 changed_well_individual = changed_well || changed_well_individual;
             }
         }
-        changed_well_individual = comm.sum(changed_well_individual);
+        changed_well_individual = comm.sum(static_cast<int>(changed_well_individual));
         if (changed_well_individual) {
             updateAndCommunicate(episodeIdx, iterationIdx, deferred_logger);
             changed_well_group = true;


### PR DESCRIPTION
Using bool here is at least frowned upon. To be honest, I have no idea what happens underneath here if we pass a bool. In contrast to other pod types we do not associate it with a builtin type of MPI (not even sure what to use). Hence we probably create a custom type for sending and receiving. That should work. But I have no idea what will be used for summation. Hence this might have very unpredictable results.

BTW: I am debugging a case that previously crashed and now suddenly works. This seems to be the only relevant change I made in the meantime.