### PR TITLE
Nldd refinements

### DIFF
--- a/opm/simulators/flow/BlackoilModelEbosNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelEbosNldd.hpp
@@ -30,6 +30,7 @@
 
 #include <opm/simulators/aquifers/AquiferGridUtils.hpp>
 
+#include <opm/simulators/flow/countGlobalCells.hpp>
 #include <opm/simulators/flow/partitionCells.hpp>
 #include <opm/simulators/flow/priVarsPacking.hpp>
 #include <opm/simulators/flow/SubDomain.hpp>
@@ -894,8 +895,15 @@ private:
             ? this->model_.ebosSimulator().vanguard().schedule().getWellsatEnd()
             : std::vector<Well>{};
 
+        // If defaulted parameter for number of domains, choose a reasonable default.
+        constexpr int default_cells_per_domain = 1000;
+        const int num_cells = Opm::detail::countGlobalCells(grid);
+        const int num_domains = param.num_local_domains_ > 0
+            ? param.num_local_domains_
+            : num_cells / default_cells_per_domain;
+
         return ::Opm::partitionCells(param.local_domain_partition_method_,
-                                     param.num_local_domains_,
+                                     num_domains,
                                      grid.leafGridView(), wells, zoltan_ctrl);
     }
 

--- a/opm/simulators/flow/BlackoilModelEbosNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelEbosNldd.hpp
@@ -331,7 +331,7 @@ private:
     solveDomain(const Domain& domain,
                 const SimulatorTimerInterface& timer,
                 [[maybe_unused]] const int global_iteration,
-                const bool initial_assembly_required = false)
+                const bool initial_assembly_required)
     {
         auto& ebosSimulator = model_.ebosSimulator();
 
@@ -764,7 +764,7 @@ private:
     {
         auto initial_local_well_primary_vars = model_.wellModel().getPrimaryVarsDomain(domain);
         auto initial_local_solution = Details::extractVector(solution, domain.cells);
-        auto res = solveDomain(domain, timer, iteration);
+        auto res = solveDomain(domain, timer, iteration, false);
         local_report = res.first;
         if (local_report.converged) {
             auto local_solution = Details::extractVector(solution, domain.cells);
@@ -788,7 +788,7 @@ private:
     {
         auto initial_local_well_primary_vars = model_.wellModel().getPrimaryVarsDomain(domain);
         auto initial_local_solution = Details::extractVector(solution, domain.cells);
-        auto res = solveDomain(domain, timer, iteration);
+        auto res = solveDomain(domain, timer, iteration, true);
         local_report = res.first;
         if (!local_report.converged) {
             // We look at the detailed convergence report to evaluate

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -439,7 +439,7 @@ struct LocalDomainsPartitioningMethod<TypeTag, TTag::FlowModelParameters> {
 };
 template<class TypeTag>
 struct LocalDomainsOrderingMeasure<TypeTag, TTag::FlowModelParameters> {
-    static constexpr auto value = "pressure";
+    static constexpr auto value = "maxpressure";
 };
 // if openMP is available, determine the number threads per process automatically.
 #if _OPENMP
@@ -579,7 +579,7 @@ namespace Opm
         int num_local_domains_{0};
         double local_domain_partition_imbalance_{1.03};
         std::string local_domain_partition_method_;
-        DomainOrderingMeasure local_domain_ordering_{DomainOrderingMeasure::AveragePressure};
+        DomainOrderingMeasure local_domain_ordering_{DomainOrderingMeasure::MaxPressure};
 
         bool write_partitions_{false};
 
@@ -642,7 +642,9 @@ namespace Opm
             std::string measure = EWOMS_GET_PARAM(TypeTag, std::string, LocalDomainsOrderingMeasure);
             if (measure == "residual") {
                 local_domain_ordering_ = DomainOrderingMeasure::Residual;
-            } else if (measure == "pressure") {
+            } else if (measure == "maxpressure") {
+                local_domain_ordering_ = DomainOrderingMeasure::MaxPressure;
+            } else if (measure == "averagepressure") {
                 local_domain_ordering_ = DomainOrderingMeasure::AveragePressure;
             } else {
                 throw std::runtime_error("Invalid domain ordering '" + measure + "' specified.");
@@ -701,7 +703,7 @@ namespace Opm
             EWOMS_REGISTER_PARAM(TypeTag, std::string, LocalDomainsPartitioningMethod, "Subdomain partitioning method. "
                                  "Allowed values are 'zoltan', 'simple', and the name of a partition file ending with '.partition'.");
             EWOMS_REGISTER_PARAM(TypeTag, std::string, LocalDomainsOrderingMeasure, "Subdomain ordering measure. "
-                                 "Allowed values are 'pressure' and  'residual'.");
+                                 "Allowed values are 'maxpressure', 'averagepressure' and  'residual'.");
 
             EWOMS_REGISTER_PARAM(TypeTag, bool, DebugEmitCellPartition, "Whether or not to emit cell partitions as a debugging aid.");
 

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -620,7 +620,7 @@ namespace Opm
             use_average_density_ms_wells_ = EWOMS_GET_PARAM(TypeTag, bool, UseAverageDensityMsWells);
             local_well_solver_control_switching_ = EWOMS_GET_PARAM(TypeTag, bool, LocalWellSolveControlSwitching);
             nonlinear_solver_ = EWOMS_GET_PARAM(TypeTag, std::string, NonlinearSolver);
-            std::string approach = EWOMS_GET_PARAM(TypeTag, std::string, LocalSolveApproach);
+            const auto approach = EWOMS_GET_PARAM(TypeTag, std::string, LocalSolveApproach);
             if (approach == "jacobi") {
                 local_solve_approach_ = DomainSolveApproach::Jacobi;
             } else if (approach == "gauss-seidel") {
@@ -639,17 +639,7 @@ namespace Opm
             deck_file_name_ = EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName);
             network_max_strict_iterations_ = EWOMS_GET_PARAM(TypeTag, int, NetworkMaxStrictIterations);
             network_max_iterations_ = EWOMS_GET_PARAM(TypeTag, int, NetworkMaxIterations);
-            std::string measure = EWOMS_GET_PARAM(TypeTag, std::string, LocalDomainsOrderingMeasure);
-            if (measure == "residual") {
-                local_domain_ordering_ = DomainOrderingMeasure::Residual;
-            } else if (measure == "maxpressure") {
-                local_domain_ordering_ = DomainOrderingMeasure::MaxPressure;
-            } else if (measure == "averagepressure") {
-                local_domain_ordering_ = DomainOrderingMeasure::AveragePressure;
-            } else {
-                throw std::runtime_error("Invalid domain ordering '" + measure + "' specified.");
-            }
-
+            local_domain_ordering_ = domainOrderingMeasureFromString(EWOMS_GET_PARAM(TypeTag, std::string, LocalDomainsOrderingMeasure));
             write_partitions_ = EWOMS_GET_PARAM(TypeTag, bool, DebugEmitCellPartition);
         }
 

--- a/opm/simulators/flow/BlackoilModelParametersEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelParametersEbos.hpp
@@ -402,7 +402,7 @@ struct NonlinearSolver<TypeTag, TTag::FlowModelParameters> {
 };
 template<class TypeTag>
 struct LocalSolveApproach<TypeTag, TTag::FlowModelParameters> {
-    static constexpr auto value = "jacobi";
+    static constexpr auto value = "gauss-seidel";
 };
 template<class TypeTag>
 struct MaxLocalSolveIterations<TypeTag, TTag::FlowModelParameters> {
@@ -416,7 +416,7 @@ struct LocalToleranceScalingMb<TypeTag, TTag::FlowModelParameters> {
 template<class TypeTag>
 struct LocalToleranceScalingCnv<TypeTag, TTag::FlowModelParameters> {
     using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 0.01;
+    static constexpr type value = 0.1;
 };
 template<class TypeTag>
 struct NlddNumInitialNewtonIter<TypeTag, TTag::FlowModelParameters> {

--- a/opm/simulators/flow/SubDomain.hpp
+++ b/opm/simulators/flow/SubDomain.hpp
@@ -22,6 +22,8 @@
 
 #include <opm/grid/common/SubGridPart.hpp>
 
+#include <fmt/format.h>
+
 #include <utility>
 #include <vector>
 
@@ -39,6 +41,19 @@ namespace Opm
         MaxPressure,
         Residual
     };
+
+    inline DomainOrderingMeasure domainOrderingMeasureFromString(const std::string_view measure)
+    {
+        if (measure == "residual") {
+            return DomainOrderingMeasure::Residual;
+        } else if (measure == "maxpressure") {
+            return DomainOrderingMeasure::MaxPressure;
+        } else if (measure == "averagepressure") {
+            return DomainOrderingMeasure::AveragePressure;
+        } else {
+            throw std::runtime_error(fmt::format("Invalid domain ordering '{}' specified", measure));
+        }
+    }
 
     /// Representing a part of a grid, in a way suitable for performing
     /// local solves.

--- a/opm/simulators/flow/SubDomain.hpp
+++ b/opm/simulators/flow/SubDomain.hpp
@@ -36,6 +36,7 @@ namespace Opm
     //! \brief Measure to use for domain ordering.
     enum class DomainOrderingMeasure {
         AveragePressure,
+        MaxPressure,
         Residual
     };
 


### PR DESCRIPTION
This fixes a bug for the `gauss-seidel` NLDD approach that would actually do a `jacobi` initialization for the very first iteration of a local domain solve.

We add the `maxpressure` option for Gauss-Seidel NLDD domain ordering, and make it the new default ordering, and make `gauss-seidel` the default approach.

Finally, we make the default number of domains equal to one domain per 1000 cells, instead of just a single domain, and tweak the default cnv tolerance scaling for local solves.

These changes are intended to lower the bar to testing the `--nonlinear-solver=nldd` option. You still need to use `--matrix-add-well-contributions=true` to run with NLDD, otherwise defaults should be sufficient for reasonable behaviour.