### PR TITLE
Bugfix sign of gpmaint prod

### DIFF
--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -712,11 +712,13 @@ namespace WellGroupHelpers
         double current_rate = 0.0;
         const auto& pu = well_state.phaseUsage();
         bool injection = true;
+        double sign = 1.0;
         switch (gpm->flow_target()) {
             case GPMaint::FlowTarget::RESV_PROD:
             {
                 current_rate = -group_state.injection_vrep_rate(group.name());
                 injection = false;
+                sign = -1.0;
                 break;
             }
             case GPMaint::FlowTarget::RESV_OINJ:
@@ -768,7 +770,7 @@ namespace WellGroupHelpers
         // (i.e. error > 0) and higher for producers.
         bool activate = (injection && error > 0) || (!injection && error < 0);
         double rate = activate? gpm->rate(gpmaint_state, current_rate, error, dt) : 0.0;
-        group_state.update_gpmaint_target(group.name(), rate);
+        group_state.update_gpmaint_target(group.name(), std::max(0.0, sign * rate));
     }
 
 

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -499,6 +499,13 @@ add_test_compareECLFiles(CASENAME waghyst2
                          REL_TOL ${rel_tol}
                          DIR waghystr)
 
+add_test_compareECLFiles(CASENAME gpmaint11
+                         FILENAME GPMAINT-11
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR gpmaint)
+
 set(_pinch_cases
   T1A_GAP T1A_NOGAP T1A_NOPINCH
   T1A1_NOGAP


### PR DESCRIPTION
A sign was removed in #4664.

I notice that we don't have any `GPMAINT` cases under regression testing. I will put this as draft until we have double checked that this does not create an issue for the other gpmaint cases in https://github.com/OPM/opm-tests/tree/master/gpmaint

And we should out them under regression testing asap.