### PR TITLE
CartesianCoordinateLevel added for ALUGrid

### DIFF
--- a/ebos/alucartesianindexmapper.hh
+++ b/ebos/alucartesianindexmapper.hh
@@ -241,6 +241,15 @@ public:
             throw std::invalid_argument("cartesianCoordinate not implemented for dimension " + std::to_string(dimension));
     }
 
+    /** \brief Only for unifying calls with CartesianIndexMapper<CpGrid> where levels are relevant */
+    void cartesianCoordinateLevel(const int compressedElementIndex, std::array<int, dimension>& coords, int level) const
+    {
+        if (level) {
+            throw std::invalid_argument("Invalid level.\n");
+        }
+        cartesianCoordinate(compressedElementIndex, coords);
+    }
+
     template <class GridView>
     std::unique_ptr<GlobalIndexDataHandle<GridView> > dataHandle(const GridView& gridView)
     {

--- a/opm/core/props/satfunc/RelpermDiagnostics.cpp
+++ b/opm/core/props/satfunc/RelpermDiagnostics.cpp
@@ -850,7 +850,7 @@ namespace Opm {
             std::string cellIdx;
             {
                 std::array<int, 3> ijk;
-                cartesianIndexMapper.cartesianCoordinate(c, ijk);
+                cartesianIndexMapper.cartesianCoordinateLevel(c, ijk, 0);
                 cellIdx = "(" + std::to_string(ijk[0]) + ", " +
                     std::to_string(ijk[1]) + ", " +
                     std::to_string(ijk[2]) + ")";


### PR DESCRIPTION
For a cell on the leaf grid view, cartesianIndexMapper.cartesianCoordinate( cell idx, ...) computes the ijk index of the parent cell or the equivalent cell on level zero, for CpGrid with LGRs. For every level, included level 0, a new method to compute the ijk index, given the index cell on a certain level and its level, is included. See OPM/opm-grid#696. 

Such a method has been added also for ALUGrid and is needed in RelpermDiagnostics.cpp, to create the string of a cell index, from level zero.  To unify calls between the different grid types (CpGrid, Polyhedral, ALU).