### PR TITLE
fixed : make (MSW|Std) well copyable again

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -80,6 +80,8 @@ namespace Opm
                          const int index_of_well,
                          const std::vector<PerforationData>& perf_data);
 
+        MultisegmentWell(const MultisegmentWell& well);
+
         virtual void init(const PhaseUsage* phase_usage_arg,
                           const std::vector<double>& depth_arg,
                           const double gravity_arg,

--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -52,6 +52,18 @@ MultisegmentWellEquations(const MultisegmentWellGeneric<Scalar>& well)
 }
 
 template<class Scalar, int numWellEq, int numEq>
+MultisegmentWellEquations<Scalar,numWellEq,numEq>::
+MultisegmentWellEquations(const MultisegmentWellGeneric<Scalar>& well,
+                          const MultisegmentWellEquations& eqs)
+    : duneB_(eqs.duneB_)
+    , duneC_(eqs.duneC_)
+    , duneD_(eqs.duneD_)
+    , resWell_(eqs.resWell_)
+    , well_(well)
+{
+}
+
+template<class Scalar, int numWellEq, int numEq>
 void MultisegmentWellEquations<Scalar,numWellEq,numEq>::
 init(const int num_cells,
      const int numPerfs,

--- a/opm/simulators/wells/MultisegmentWellEquations.hpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.hpp
@@ -68,6 +68,9 @@ public:
     using OffDiagMatWell = Dune::BCRSMatrix<OffDiagMatrixBlockWellType>;
 
     MultisegmentWellEquations(const MultisegmentWellGeneric<Scalar>& well);
+    MultisegmentWellEquations(const MultisegmentWellGeneric<Scalar>& well,
+                              const MultisegmentWellEquations& eqs);
+    MultisegmentWellEquations(const MultisegmentWellEquations&) = delete;
 
     //! \brief Setup sparsity pattern for the matrices.
     //! \param num_cells Total number of cells

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -65,6 +65,19 @@ MultisegmentWellEval(WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif)
 }
 
 template<typename FluidSystem, typename Indices, typename Scalar>
+MultisegmentWellEval<FluidSystem,Indices,Scalar>::
+MultisegmentWellEval(WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif,
+                     const MultisegmentWellEval<FluidSystem,Indices,Scalar>& eval)
+    : MultisegmentWellGeneric<Scalar>(baseif)
+    , baseif_(baseif)
+    , linSys_(*this, eval.linSys_)
+    , primary_variables_(baseif, eval.primary_variables_)
+    , segments_(baseif, eval.segments_)
+    , cell_perforation_depth_diffs_(eval.cell_perforation_depth_diffs_)
+    , cell_perforation_pressure_diffs_(eval.cell_perforation_pressure_diffs_)
+{}
+
+template<typename FluidSystem, typename Indices, typename Scalar>
 void
 MultisegmentWellEval<FluidSystem,Indices,Scalar>::
 initMatrixAndVectors(const int num_cells)

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -72,6 +72,9 @@ public:
 
 protected:
     MultisegmentWellEval(WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif);
+    MultisegmentWellEval(const MultisegmentWellEval&) = delete;
+    MultisegmentWellEval(WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif,
+                         const MultisegmentWellEval& eval);
 
     void initMatrixAndVectors(const int num_cells);
 

--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
@@ -43,6 +43,15 @@
 namespace Opm {
 
 template<class FluidSystem, class Indices, class Scalar>
+MultisegmentWellPrimaryVariables<FluidSystem,Indices,Scalar>::
+MultisegmentWellPrimaryVariables(const WellInterfaceIndices<FluidSystem,Indices,Scalar>& well,
+                                 const MultisegmentWellPrimaryVariables& pv)
+    : value_(pv.value_)
+    , evaluation_(pv.evaluation_)
+    , well_(well)
+{}
+
+template<class FluidSystem, class Indices, class Scalar>
 void MultisegmentWellPrimaryVariables<FluidSystem,Indices,Scalar>::
 resize(const int numSegments)
 {

--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
@@ -83,6 +83,11 @@ public:
         : well_(well)
     {}
 
+    MultisegmentWellPrimaryVariables(const WellInterfaceIndices<FluidSystem,Indices,Scalar>& well,
+                                     const MultisegmentWellPrimaryVariables& pv);
+
+    MultisegmentWellPrimaryVariables(const MultisegmentWellPrimaryVariables&) = delete;
+
     //! \brief Resize values and evaluations.
     void resize(const int numSegments);
 

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -130,6 +130,24 @@ MultisegmentWellSegments(const int numSegments,
 }
 
 template<class FluidSystem, class Indices, class Scalar>
+MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
+MultisegmentWellSegments(WellInterfaceGeneric& well,
+                         const MultisegmentWellSegments& seg)
+    : perforations_(seg.perforations_)
+    , perforation_depth_diffs_(seg.perforation_depth_diffs_)
+    , inlets_(seg.inlets_)
+    , depth_diffs_(seg.depth_diffs_)
+    , densities_(seg.densities_)
+    , mass_rates_(seg.mass_rates_)
+    , viscosities_(seg.viscosities_)
+    , upwinding_segments_(seg.upwinding_segments_)
+    , phase_densities_(seg.phase_densities_)
+    , phase_fractions_(seg.phase_fractions_)
+    , phase_viscosities_(seg.phase_viscosities_)
+    , well_(well)
+{}
+
+template<class FluidSystem, class Indices, class Scalar>
 void MultisegmentWellSegments<FluidSystem,Indices,Scalar>::
 computeFluidProperties(const EvalWell& temperature,
                        const EvalWell& saltConcentration,

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -48,6 +48,9 @@ class MultisegmentWellSegments
 public:
     MultisegmentWellSegments(const int numSegments,
                              WellInterfaceGeneric& well);
+    MultisegmentWellSegments(WellInterfaceGeneric& well,
+                             const MultisegmentWellSegments& seg);
+    MultisegmentWellSegments(const MultisegmentWellSegments&) = delete;
 
     void computeFluidProperties(const EvalWell& temperature,
                                 const EvalWell& saltConcentration,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -102,6 +102,15 @@ namespace Opm
     }
 
 
+    template <typename TypeTag>
+    MultisegmentWell<TypeTag>::MultisegmentWell(const MultisegmentWell<TypeTag>& well)
+    : Base(well)
+    , MSWEval(static_cast<WellInterfaceIndices<FluidSystem,Indices,Scalar>&>(*this), well)
+    , regularize_(well.regularize_)
+    , segment_fluid_initial_(well.segment_fluid_initial_)
+    {}
+
+
 
 
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -133,6 +133,8 @@ namespace Opm
                      const int index_of_well,
                      const std::vector<PerforationData>& perf_data);
 
+        StandardWell(const StandardWell& well);
+
         virtual void init(const PhaseUsage* phase_usage_arg,
                           const std::vector<double>& depth_arg,
                           const double gravity_arg,

--- a/opm/simulators/wells/StandardWellConnections.hpp
+++ b/opm/simulators/wells/StandardWellConnections.hpp
@@ -42,6 +42,7 @@ class StandardWellConnections
 {
 public:
     StandardWellConnections(const WellInterfaceIndices<FluidSystem,Indices,Scalar>& well);
+    StandardWellConnections(const StandardWellConnections&) = delete;
 
     struct Properties
     {

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -50,6 +50,22 @@ StandardWellEquations(const ParallelWellInfo& parallel_well_info)
     invDuneD_.setBuildMode(DiagMatWell::row_wise);
 }
 
+
+template<class Scalar, int numEq>
+StandardWellEquations<Scalar,numEq>::
+StandardWellEquations(const ParallelWellInfo& parallel_well_info,
+                      const StandardWellEquations<Scalar,numEq>& eqs)
+    : duneB_(eqs.duneB_)
+    , duneC_(eqs.duneC_)
+    , invDuneD_(eqs.invDuneD_)
+    , duneD_(eqs.duneD_)
+    , parallelB_(duneB_, parallel_well_info)
+    , resWell_(eqs.resWell_)
+    , Bx_(eqs.Bx_)
+    , invDrw_(eqs.invDrw_)
+{
+}
+
 template<class Scalar, int numEq>
 void StandardWellEquations<Scalar,numEq>::
 init(const int num_cells,

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -66,6 +66,9 @@ public:
     using BVector = Dune::BlockVector<Dune::FieldVector<Scalar,numEq>>;
 
     StandardWellEquations(const ParallelWellInfo& parallel_well_info);
+    StandardWellEquations(const StandardWellEquations&) = delete;
+    StandardWellEquations(const ParallelWellInfo& parallel_well_info,
+                          const StandardWellEquations& eqs);
 
     //! \brief Setup sparsity pattern for the matrices.
     //! \param num_cells Total number of cells

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -56,6 +56,18 @@ StandardWellEval(const WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif)
 }
 
 template<class FluidSystem, class Indices, class Scalar>
+StandardWellEval<FluidSystem,Indices,Scalar>::
+StandardWellEval(const WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif,
+                 const StandardWellEval<FluidSystem,Indices,Scalar>& eval)
+    : baseif_(baseif)
+    , primary_variables_(baseif_, eval.primary_variables_)
+    , F0_(eval.F0_)
+    , linSys_(baseif_.parallelWellInfo(), eval.linSys_)
+    , connections_(baseif)
+{
+}
+
+template<class FluidSystem, class Indices, class Scalar>
 typename StandardWellEval<FluidSystem,Indices,Scalar>::EvalWell
 StandardWellEval<FluidSystem,Indices,Scalar>::
 extendEval(const Eval& in) const

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -71,6 +71,9 @@ public:
 
 protected:
     StandardWellEval(const WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif);
+    StandardWellEval(const WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif,
+                     const StandardWellEval& eval);
+    StandardWellEval(const StandardWellEval&) = delete;
 
     const WellInterfaceIndices<FluidSystem,Indices,Scalar>& baseif_;
 

--- a/opm/simulators/wells/StandardWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.cpp
@@ -96,6 +96,16 @@ Scalar relaxationFactorFraction(const Scalar old_value,
 namespace Opm {
 
 template<class FluidSystem, class Indices, class Scalar>
+StandardWellPrimaryVariables<FluidSystem,Indices,Scalar>::
+StandardWellPrimaryVariables(const WellInterfaceIndices<FluidSystem,Indices,Scalar>& well,
+                             const StandardWellPrimaryVariables& pv)
+    : value_(pv.value_)
+    , evaluation_(pv.evaluation_)
+    , well_(well)
+    , numWellEq_(pv.numWellEq_)
+{}
+
+template<class FluidSystem, class Indices, class Scalar>
 void StandardWellPrimaryVariables<FluidSystem,Indices,Scalar>::
 init()
 {

--- a/opm/simulators/wells/StandardWellPrimaryVariables.hpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.hpp
@@ -91,6 +91,11 @@ public:
         : well_(well)
     {}
 
+    StandardWellPrimaryVariables(const StandardWellPrimaryVariables&) = delete;
+
+    StandardWellPrimaryVariables(const WellInterfaceIndices<FluidSystem,Indices,Scalar>& well,
+                                 const StandardWellPrimaryVariables& pv);
+
     //! \brief Initialize evaluations from values.
     void init();
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -80,6 +80,12 @@ namespace Opm
     }
 
 
+    template<typename TypeTag>
+    StandardWell<TypeTag>::StandardWell(const StandardWell<TypeTag>& well)
+    : Base(well)
+    , StdWellEval(static_cast<const WellInterfaceIndices<FluidSystem,Indices,Scalar>&>(*this), well)
+    , regularize_(well.regularize_)
+    {}
 
 
 


### PR DESCRIPTION
the reference member in the base classes would point to the original instance, not the new instance