### PR TITLE
Catch exceptions from well testing 

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -586,7 +586,7 @@ namespace Opm {
 
             try {
                 well->wellTesting(ebosSimulator_, simulationTime, this->wellState(), this->groupState(), wellTestState(), deferred_logger);
-            } catch (std::runtime_error& e) {
+            } catch (std::exception& e) {
                 const std::string msg = fmt::format("Exception during testing of well: {}. The well will not open.\n Exception message: {}", wellEcl.name(), e.what());
                 deferred_logger.warning("WELL_TESTING_FAILED", msg);
             }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -584,7 +584,12 @@ namespace Opm {
                 well->setPrevSurfaceRates(this->wellState(), this->prevWellState());
             }
 
-            well->wellTesting(ebosSimulator_, simulationTime, this->wellState(), this->groupState(), wellTestState(), deferred_logger);
+            try {
+                well->wellTesting(ebosSimulator_, simulationTime, this->wellState(), this->groupState(), wellTestState(), deferred_logger);
+            } catch (std::runtime_error& e) {
+                const std::string msg = fmt::format("Exception during testing of well: {}. The well will not open.\n Exception message: {}", wellEcl.name(), e.what());
+                deferred_logger.warning("WELL_TESTING_FAILED", msg);
+            }
         }
     }
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -586,7 +586,7 @@ namespace Opm {
 
             try {
                 well->wellTesting(ebosSimulator_, simulationTime, this->wellState(), this->groupState(), wellTestState(), deferred_logger);
-            } catch (std::exception& e) {
+            } catch (const std::exception& e) {
                 const std::string msg = fmt::format("Exception during testing of well: {}. The well will not open.\n Exception message: {}", wellEcl.name(), e.what());
                 deferred_logger.warning("WELL_TESTING_FAILED", msg);
             }


### PR DESCRIPTION
Numerical problems during well testing (often: inf/nan in MSW matrices) will currently be caught at a higher level, causing time step chops in serial mode and possibly MPI communication errors in parallel. 

With this change wells that experience such problems during testing will simply not open, and MPI errors (mainly experienced during testing of https://github.com/OPM/opm-simulators/pull/4986) are no longer present. 