### PR TITLE
fixed: grab list of FIP regions from FieldPropsManager

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -45,9 +45,6 @@
 #include <cassert>
 #include <cstddef>
 #include <functional>
-#include <initializer_list>
-#include <iomanip>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -180,8 +177,9 @@ EclGenericOutputBlackoilModule(const EclipseState& eclState,
     const auto& fp = eclState_.fieldProps();
 
     this->regions_["FIPNUM"] = fp.get_int("FIPNUM");
-    for (const auto& region : summaryConfig_.fip_regions())
+    for (const auto& region : fp.fip_regions()) {
         this->regions_[region] = fp.get_int(region);
+    }
 
     this->RPRNodes_  = summaryConfig_.keywords("RPR*");
     this->RPRPNodes_ = summaryConfig_.keywords("RPRP*");

--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -16,6 +16,7 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "opm/input/eclipse/EclipseState/Grid/FieldProps.hpp"
 #include <config.h>
 #include <opm/simulators/utils/ParallelEclipseState.hpp>
 
@@ -223,6 +224,17 @@ bool ParallelFieldPropsManager::has_double(const std::string& keyword) const
 {
     auto it = m_doubleProps.find(keyword);
     return it != m_doubleProps.end();
+}
+
+std::vector<std::string> ParallelFieldPropsManager::fip_regions() const
+{
+    std::vector<std::string> result;
+    for (const auto& key : m_intProps) {
+        if (Fieldprops::keywords::isFipxxx(key.first)) {
+            result.push_back(key.first);
+        }
+    }
+    return result;
 }
 
 

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -91,6 +91,9 @@ public:
     //! \param keyword Name of property
     bool has_double(const std::string& keyword) const override;
 
+    //! \brief Returns a list of registered FIP regions.
+    std::vector<std::string> fip_regions() const override;
+
     //! \brief Resets the underlying cartesian mapper
     //! \detail This has to be the cartesian mapper of the distributed grid.
     //! It will be used to autocreate properties not explicitly stored.


### PR DESCRIPTION
not from SummaryConfig. the latter only holds regions with summary keywords.

Downstream of https://github.com/OPM/opm-common/pull/3813