### PR TITLE
Communicate exceptions during WellModel::updateAndCommunicate

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2144,10 +2144,16 @@ namespace Opm {
                          DeferredLogger& deferred_logger)
     {
         updateAndCommunicateGroupData(reportStepIdx, iterationIdx);
+
+        // updateWellStateWithTarget might throw for multisegment wells hence we
+        // have a parallel try catch here to thrown on all processes.
+        OPM_BEGIN_PARALLEL_TRY_CATCH()
         // if a well or group change control it affects all wells that are under the same group
         for (const auto& well : well_container_) {
             well->updateWellStateWithTarget(ebosSimulator_, this->groupState(), this->wellState(), deferred_logger);
         }
+        OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel::updateAndCommunicate failed: ",
+                                   ebosSimulator_.gridView().comm())
         updateAndCommunicateGroupData(reportStepIdx, iterationIdx);
     }
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -501,9 +501,19 @@ namespace Opm
 
         // We assemble the well equations, then we check the convergence,
         // which is why we do not put the assembleWellEq here.
-        const BVectorWell dx_well = this->linSys_.solve();
+        try{
+            const BVectorWell dx_well = this->linSys_.solve();
 
-        updateWellState(summary_state, dx_well, well_state, deferred_logger);
+            updateWellState(summary_state, dx_well, well_state, deferred_logger);
+        }
+        catch(const NumericalProblem& exp) {
+            // Add information about the well and log to deferred logger
+            // (Logging done inside of solve() method will only be seen if
+            // this is the process with rank zero)
+            deferred_logger.problem("In MultisegmentWell::solveEqAndUpdateWellState for well "
+                                    + this->name() +": "+exp.what());
+            throw;
+        }
     }
 
 
@@ -1306,7 +1316,18 @@ namespace Opm
 
             assembleWellEqWithoutIteration(ebosSimulator, dt, inj_controls, prod_controls, well_state, group_state, deferred_logger);
 
-            const BVectorWell dx_well = this->linSys_.solve();
+            BVectorWell dx_well;
+            try{
+                dx_well = this->linSys_.solve();
+            }
+            catch(const NumericalProblem& exp) {
+                // Add information about the well and log to deferred logger
+                // (Logging done inside of solve() method will only be seen if
+                // this is the process with rank zero)
+                deferred_logger.problem("In MultisegmentWell::iterateWellEqWithControl for well "
+                                        + this->name() +": "+exp.what());
+                throw;
+            }
 
             if (it > this->param_.strict_inner_iter_wells_) {
                 relax_convergence = true;


### PR DESCRIPTION
For multi segment well the underlying call to
MultisegmentWell::updateWellStateWithTarget (at least if updateWellStateWithTHPTargetProd is called for a producer under thp control) might throw as there might be a singular matrix during the solve needed in MultisegmentWell::iterateWellEqWithControl.

Previously, if that happened then the MPI process where it happened would stop the nonlinear iteration as failed and try with a chopped time step. The others might go one with the current time step and we would see MPI errors about truncated messages.

Now we communicate any exception happening during this part of WellModel::updateAndCommunicate and all processes will stop the nonlinear iteration as failed and chop the time step.