### PR TITLE
Include all derivatives for acceleration term in MS wells

### DIFF
--- a/opm/simulators/wells/MultisegmentWellAssemble.hpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.hpp
@@ -80,19 +80,20 @@ public:
                            Equations& eqns,
                            DeferredLogger& deferred_logger) const;
 
+    //! \brief Assemble piece of the acceleration term
+    void assembleAccelerationTerm(const int seg_target,
+                                  const int seg,
+                                  const int seg_upwing,
+                                  const EvalWell& accelerationTerm,
+                                  Equations& eqns1) const;
 
-    //! \brief Assemble pressure loss term.
-    void assemblePressureLoss(const int seg,
-                              const int seg_upwind,
-                              const EvalWell& accelerationPressureLoss,
-                              Equations& eqns) const;
-
-
+    //! \brief Assemble hydraulic pressure term
     void assembleHydroPressureLoss(const int seg,
                                    const int seg_density,
                                    const EvalWell& hydro_pressure_drop_seg,
                                    Equations& eqns1) const;
 
+    //! \brief Assemble additional derivatives due to reverse flow
     void assemblePressureEqExtraDerivatives(const int seg,
                                             const int seg_upwind,
                                             const EvalWell& extra_derivatives,

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -128,8 +128,8 @@ protected:
                                    const double tolerance_pressure_ms_wells,
                                    DeferredLogger& deferred_logger) const;
 
-    void handleAccelerationPressureLoss(const int seg,
-                                        WellState& well_state);
+    void assembleAccelerationPressureLoss(const int seg,
+                                          WellState& well_state);
 
     EvalWell pressureDropAutoICD(const int seg,
                                  const UnitSystem& unit_system) const;

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -88,12 +88,20 @@ public:
     EvalWell pressureDropValve(const int seg, 
                                const SummaryState& st,
                                const bool extra_reverse_flow_derivatives = false) const;
-    // pressure loss due to acceleration
-    EvalWell accelerationPressureLoss(const int seg) const;
+
+    // pressure loss contribution due to acceleration
+    EvalWell accelerationPressureLossContribution(const int seg,
+                                                  const double area, 
+                                                  const bool extra_reverse_flow_derivatives = false) const;
 
     const std::vector<std::vector<int>>& inlets() const
     {
         return inlets_;
+    }
+
+    const std::vector<int>& inlets(const int seg) const
+    {
+        return inlets_[seg];
     }
 
     const std::vector<std::vector<int>>& perforations() const


### PR DESCRIPTION
In master, the assembling of the acceleration pressure drop term skips certain derivatives for reverse flow (I also believe one of the derivatives is misplaced). This PR rewrites this and includes all derivatives analogously to what has been done for other terms.

For most cases, I would expect this to have minor effect, however, have seen cases where it improves convergence.  