### PR TITLE
[fix,MPI] Handle exception during assembleWellEqWithoutIteration correctly

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1518,7 +1518,7 @@ namespace Opm {
     {
         // We make sure that all processes throw in case there is an exception
         // on one of them (WetGasPvt::saturationPressure might throw if not converged)
-        OPM_BEGIN_PARALLEL_TRY_CATCH()
+        OPM_BEGIN_PARALLEL_TRY_CATCH();
 
         for (auto& well: well_container_) {
             well->assembleWellEqWithoutIteration(ebosSimulator_, dt, this->wellState(), this->groupState(),


### PR DESCRIPTION
For this particular model WetGasPVT::saturationPressure did throw because convergence in the newton solver is not reached in 20 iterations. Unfortunately, the exception was only seen on one MPI rank and the others continued.

With this commit we communicate the problem and throw on all MPI processes. Time step will be cut as a result.