### PR TITLE
Publish Short Region Set Names Only

### DIFF
--- a/opm/simulators/utils/ParallelEclipseState.cpp
+++ b/opm/simulators/utils/ParallelEclipseState.cpp
@@ -228,10 +228,12 @@ bool ParallelFieldPropsManager::has_double(const std::string& keyword) const
 
 std::vector<std::string> ParallelFieldPropsManager::fip_regions() const
 {
+    constexpr auto maxchar = std::string::size_type{6};
+
     std::vector<std::string> result;
     for (const auto& key : m_intProps) {
         if (Fieldprops::keywords::isFipxxx(key.first)) {
-            result.push_back(key.first);
+            result.push_back(key.first.substr(0, maxchar));
         }
     }
     return result;


### PR DESCRIPTION
That way, in-place quantities will go through the short-to-canonical name translation in `FieldProps` regardless of their origin&ndash;e.g., `RPTSOL`/`RPTSCHED` or explicit `SUMMARY` section vectors.

This is the downstream counterpart to OPM/opm-common#3839.