### PR TITLE
Function to lookup origin cell indices added in thermal field props.

### DIFF
--- a/ebos/eclgenericproblem.hh
+++ b/ebos/eclgenericproblem.hh
@@ -377,12 +377,6 @@ protected:
     using LookUpData = Opm::LookUpData<Grid,GridView>;
     const LookUpData lookUpData_;
 
-    auto getLookUpData(unsigned elemIdx) const
-    {
-        using GridType = std::remove_cv_t< typename std::remove_reference<decltype(gridView_.grid())>::type>;
-        return lookUpData_.template getFieldPropIdx<GridType>(elemIdx);
-    }
-
 private:
     template<class T>
     void updateNum(const std::string& name, std::vector<T>& numbers, std::size_t num_regions);


### PR DESCRIPTION
Two member functions have been added in EclProblem, to assign field properties of type double or int, unsigened int, ..., on the leaf grid view. 

For CpGrid with local grid refinement, the field property is inherited from the origin cell (parent or equivalent cell) in level zero. 

These new members: getFieldPropDoubleAssigner_ and getFieldPropIntTypeAssigner_, are used here to get thermal field properties on the leaf grid view, and in OPM/opm-simulator#5060, to get material field properties on the leaf grid view.