### PR TITLE
GroupEconomicLimitsChecker: cleanup includes

### DIFF
--- a/opm/simulators/wells/GroupEconomicLimitsChecker.cpp
+++ b/opm/simulators/wells/GroupEconomicLimitsChecker.cpp
@@ -18,15 +18,24 @@
 */
 
 #include <config.h>
-#include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
 #include <opm/simulators/wells/GroupEconomicLimitsChecker.hpp>
-#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+
+#include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
+
+#include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
+
+#include <opm/simulators/wells/BlackoilWellModelGeneric.hpp>
+#include <opm/simulators/wells/WellGroupHelpers.hpp>
+
 #include <fmt/format.h>
 
 #include <ctime>
 #include <chrono>
-#include <iostream>
+#include <sstream>
 #include <iomanip>
 
 namespace Opm {

--- a/opm/simulators/wells/GroupEconomicLimitsChecker.cpp
+++ b/opm/simulators/wells/GroupEconomicLimitsChecker.cpp
@@ -334,7 +334,7 @@ addPrintMessage(const std::string &msg, const double value, const double limit, 
 
 bool
 GroupEconomicLimitsChecker::
-closeWellsRecursive(Group group, int level)
+closeWellsRecursive(const Group& group, int level)
 {
     bool wells_closed = false;
 

--- a/opm/simulators/wells/GroupEconomicLimitsChecker.hpp
+++ b/opm/simulators/wells/GroupEconomicLimitsChecker.hpp
@@ -24,6 +24,7 @@
 #include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <array>
 #include <map>
 #include <string>
 
@@ -78,7 +79,7 @@ class WellTestState;
         const Schedule &schedule_;
         GroupEconProductionLimits::GEconGroupProp gecon_props_;
         bool debug_ = true;
-        double production_rates_[NUM_PHASES];
+        std::array<double,NUM_PHASES> production_rates_;
         std::map<int, BlackoilPhases::PhaseIndex> phase_idx_map_ = {
             {0, BlackoilPhases::Liquid},
             {1, BlackoilPhases::Vapour},

--- a/opm/simulators/wells/GroupEconomicLimitsChecker.hpp
+++ b/opm/simulators/wells/GroupEconomicLimitsChecker.hpp
@@ -20,21 +20,22 @@
 #ifndef OPM_GROUP_ECONOMIC_LIMITS_CHECKER_HEADER_INCLUDED
 #define OPM_GROUP_ECONOMIC_LIMITS_CHECKER_HEADER_INCLUDED
 
-#include <opm/simulators/wells/BlackoilWellModelGeneric.hpp>
-#include <opm/simulators/utils/DeferredLogger.hpp>
-#include <opm/simulators/wells/WellGroupHelpers.hpp>
-#include <opm/simulators/wells/WellState.hpp>
 #include <opm/core/props/BlackoilPhases.hpp>
-#include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
-#include <ctime>
+#include <map>
+#include <string>
 
 namespace Opm
 {
+
+class BlackoilWellModelGeneric;
+class DeferredLogger;
+class Group;
+class WellState;
+class WellTestState;
+
     class GroupEconomicLimitsChecker
     {
     public:

--- a/opm/simulators/wells/GroupEconomicLimitsChecker.hpp
+++ b/opm/simulators/wells/GroupEconomicLimitsChecker.hpp
@@ -64,7 +64,7 @@ class WellTestState;
     private:
         void displayDebugMessage(const std::string &msg) const;
         void addPrintMessage(const std::string &msg, const double value, const double limit, const UnitSystem::measure measure);
-        bool closeWellsRecursive(Group group, int level=0);
+        bool closeWellsRecursive(const Group& group, int level = 0);
         void throwNotImplementedError(const std::string &error) const;
         const BlackoilWellModelGeneric &well_model_;
         const Group &group_;


### PR DESCRIPTION
Pass a parameters as a const ref instead of value and use std::array.