### PR TITLE
Fix PRT file output directory

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -439,8 +439,8 @@ Opm::setupLogging(const int          mpi_rank_,
             : std::filesystem::current_path().generic_string();
     }
 
-    logFileStream << output_dir << "/" << baseName;
-    debugFileStream << output_dir << "/" << baseName;
+    logFileStream << fpath.parent_path().string() << "/" << fpath.stem().string();
+    debugFileStream << fpath.parent_path().string() << "/" << fpath.stem().string();
 
     if (mpi_rank_ != 0) {
         // Added rank to log file for non-zero ranks.
@@ -449,6 +449,7 @@ Opm::setupLogging(const int          mpi_rank_,
         // If the following file appears then there is a bug.
         logFileStream << "." << mpi_rank_;
     }
+
     logFileStream << ".PRT";
     debugFileStream << ".DBG";
 


### PR DESCRIPTION
PRT and DBG file should go to same directory as the rest of the output files from the simulation. In current version of OPM Flow this goes wrong if flow is run from a directory which is not the same as the data file parent directory.

Example 

```
flowdaily_rh7 model/TEST3B_FLOW.DATA
```

PRT file and DBG file will show up in same directory as flow was started from 

```
bash-4.2$ ls
model  TEST3B_FLOW.DBG	TEST3B_FLOW.PRT
```
