### PR TITLE
Support LGRs when creating/resetting transmissibilities

### DIFF
--- a/ebos/ecltransmissibility_impl.hh
+++ b/ebos/ecltransmissibility_impl.hh
@@ -788,7 +788,7 @@ updateFromEclState_(bool global)
     for (auto it = trans.begin(); it != trans.end(); ++it, ++key, ++perform)
     {
         if(*perform){
-            if(grid_.maxLevel()>1) {
+            if(grid_.maxLevel()>0) {
                 OPM_THROW(std::invalid_argument, "Calculations on TRANX/TRANY/TRANZ arrays are not support with LGRS, yet.");
             }
             fp->apply_tran(*key, *it);

--- a/ebos/ecltransmissibility_impl.hh
+++ b/ebos/ecltransmissibility_impl.hh
@@ -732,6 +732,8 @@ applyAllZMultipliers_(Scalar& trans,
 {
     if (insideFaceIdx > 3) { // top or or bottom
         assert(insideFaceIdx==5); // as insideCartElemIdx < outsideCartElemIdx holds for the Z column
+        /** Warning: insideCartElemIdx == outsideCartElemIdx when cells on the leaf have the same parent cell on level zero,
+            for CpGrid with LGRs. What do to in this case? Assert fails. */
         assert(outsideCartElemIdx > insideCartElemIdx);
         auto lastCartElemIdx = outsideCartElemIdx - cartDims[0]*cartDims[1];
         // Last multiplier using (Z+)*(Z-)
@@ -786,7 +788,10 @@ updateFromEclState_(bool global)
     for (auto it = trans.begin(); it != trans.end(); ++it, ++key, ++perform)
     {
         if(*perform)
-            fp->apply_tran(*key, *it);
+            if(grid_.maxLevel()>1) {
+                OPM_THROW(std::invalid_argument, "Calculations on TRANX/TRANY/TRANZ arrays are not support with LGRS, yet.");
+            }
+        fp->apply_tran(*key, *it);
     }
 
     resetTransmissibilityFromArrays_(is_tran, trans);
@@ -830,21 +835,29 @@ createTransmissibilityArrays_(const std::array<bool,3>& is_tran)
 
             auto isID = isId(c1, c2);
 
-            if (gc2 - gc1 == 1 && cartDims[0] > 1) {
+            // For CpGrid with LGRs, when leaf grid view cells with indices c1 and c2
+            // have the same parent cell on level zero, then gc2 - gc1 == 0. In that case,
+            // 'intersection.indexInSIde()' needed to be checked to determine the direction, i.e.
+            // add in the if/else-if  'gc2 == gc1 && intersection.indexInInside() == ... '
+            if ((gc2 - gc1 == 1 || (gc2 == gc1 && (intersection.indexInInside() == 0 || intersection.indexInInside() == 1)))
+                && cartDims[0] > 1) {
                 if (is_tran[0])
                     // set simulator internal transmissibilities to values from inputTranx
                      trans[0][c1] = trans_[isID];
             }
-            else if (gc2 - gc1 == cartDims[0] && cartDims[1] > 1) {
+            else if ((gc2 - gc1 == cartDims[0] || (gc2 == gc1 && (intersection.indexInInside() == 2 || intersection.indexInInside() == 3)))
+                     && cartDims[1] > 1) {
                 if (is_tran[1])
                     // set simulator internal transmissibilities to values from inputTrany
                      trans[1][c1] = trans_[isID];
             }
-            else if (gc2 - gc1 == cartDims[0]*cartDims[1]) {
+            else if (gc2 - gc1 == cartDims[0]*cartDims[1] ||
+                     (gc2 == gc1 && (intersection.indexInInside() == 4 || intersection.indexInInside() == 5))) {
                 if (is_tran[2])
                     // set simulator internal transmissibilities to values from inputTranz
-                     trans[2][c1] = trans_[isID];
+                    trans[2][c1] = trans_[isID];
             }
+
             //else.. We don't support modification of NNC at the moment.
         }
     }
@@ -873,6 +886,9 @@ resetTransmissibilityFromArrays_(const std::array<bool,3>& is_tran,
             // order of the local indices, the transmissibilities are still
             // stored at the cell with the lower global cartesian index as
             // the fieldprops are communicated by the grid.
+            /** c1 < c2 <=> gc1 < gc2 is no longer true when the grid is a
+                CpGrid with LGRs. When cells c1 and c2 have the same parent
+                cell on level zero, then gc1 == gc2. */ 
             unsigned c1 = elemMapper.index(intersection.inside());
             unsigned c2 = elemMapper.index(intersection.outside());
             int gc1 = cartMapper_.cartesianIndex(c1);
@@ -882,21 +898,29 @@ resetTransmissibilityFromArrays_(const std::array<bool,3>& is_tran,
 
             auto isID = isId(c1, c2);
 
-            if (gc2 - gc1 == 1 && cartDims[0] > 1) {
+            // For CpGrid with LGRs, when leaf grid view cells with indices c1 and c2
+            // have the same parent cell on level zero, then gc2 - gc1 == 0. In that case,
+            // 'intersection.indexInSIde()' needed to be checked to determine the direction, i.e.
+            // add in the if/else-if  'gc2 == gc1 && intersection.indexInInside() == ... '
+            if ((gc2 - gc1 == 1  || (gc2 == gc1 && (intersection.indexInInside() == 0 || intersection.indexInInside() == 1)))
+                 && cartDims[0] > 1) {
                 if (is_tran[0])
                     // set simulator internal transmissibilities to values from inputTranx
                     trans_[isID] = trans[0][c1];
             }
-            else if (gc2 - gc1 == cartDims[0] && cartDims[1] > 1) {
+            else if ((gc2 - gc1 == cartDims[0] || (gc2 == gc1 && (intersection.indexInInside() == 2|| intersection.indexInInside() == 3)))
+                     && cartDims[1] > 1) {
                 if (is_tran[1])
                     // set simulator internal transmissibilities to values from inputTrany
                     trans_[isID] = trans[1][c1];
             }
-            else if (gc2 - gc1 == cartDims[0]*cartDims[1]) {
+            else if (gc2 - gc1 == cartDims[0]*cartDims[1] ||
+                     (gc2 == gc1 && (intersection.indexInInside() == 4 || intersection.indexInInside() == 5))) {
                 if (is_tran[2])
                     // set simulator internal transmissibilities to values from inputTranz
                     trans_[isID] = trans[2][c1];
             }
+
             //else.. We don't support modification of NNC at the moment.
         }
     }

--- a/ebos/ecltransmissibility_impl.hh
+++ b/ebos/ecltransmissibility_impl.hh
@@ -787,11 +787,12 @@ updateFromEclState_(bool global)
 
     for (auto it = trans.begin(); it != trans.end(); ++it, ++key, ++perform)
     {
-        if(*perform)
+        if(*perform){
             if(grid_.maxLevel()>1) {
                 OPM_THROW(std::invalid_argument, "Calculations on TRANX/TRANY/TRANZ arrays are not support with LGRS, yet.");
             }
-        fp->apply_tran(*key, *it);
+            fp->apply_tran(*key, *it);
+        }
     }
 
     resetTransmissibilityFromArrays_(is_tran, trans);


### PR DESCRIPTION
When the grid is a CpGrid with LGRs, and two cells on the leaf have the same parent cell on level zero, their Cartesian indices of the leaf grid cells coincide since they inherit the one of their parent cell from level zero.

This PR modifies createTransmissibilyt_() and resetTransmissibility_() to take this into account.