### PR TITLE
Throw for LGRs combine with TRANX/Y/Z

### DIFF
--- a/ebos/ecltransmissibility_impl.hh
+++ b/ebos/ecltransmissibility_impl.hh
@@ -795,8 +795,12 @@ updateFromEclState_(bool global)
 
     for (auto it = trans.begin(); it != trans.end(); ++it, ++key, ++perform)
     {
-        if(*perform)
+        if(*perform) {
+            if(grid_.maxLevel()>0) {
+                OPM_THROW(std::invalid_argument, "Calculations on TRANX/TRANY/TRANZ arrays are not support with LGRS, yet.");
+            }
             fp->apply_tran(*key, *it);
+        }
     }
 
     resetTransmissibilityFromArrays_(is_tran, trans);


### PR DESCRIPTION
For now, LGRs do not support TRANX, TRANY, TRANZ, therefore a throw has been added.