### PR TITLE
Disable ecl-output when LGRs

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1358,7 +1358,10 @@ public:
             aquiferModel_.initialSolutionApplied();
 
         if (this->simulator().episodeIndex() == 0) {
-            eclWriter_->writeInitialFIPReport();
+            // For CpGrid with LGRs, vtk output is not supported yet.
+            if (enableEclOutput_) {
+                eclWriter_->writeInitialFIPReport();
+            }
         }
     }
 


### PR DESCRIPTION
Disable Eclipse output when the grid is a CpGrid with LGRs since it's not supported yet.