### PR TITLE
Output Well Flow Sheets for All Wells

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -235,27 +235,21 @@ template<class FluidSystem, class Scalar>
 void EclGenericOutputBlackoilModule<FluidSystem,Scalar>::
 outputCumLog(std::size_t reportStepNum)
 {
-    logOutput_.cumulative(reportStepNum,
-                          [this](const std::string& name)
-                          { return this->isDefunctParallelWell(name); });
+    this->logOutput_.cumulative(reportStepNum);
 }
 
 template<class FluidSystem,class Scalar>
 void EclGenericOutputBlackoilModule<FluidSystem,Scalar>::
 outputProdLog(std::size_t reportStepNum)
 {
-    logOutput_.production(reportStepNum,
-                          [this](const std::string& name)
-                          { return this->isDefunctParallelWell(name); });
+    this->logOutput_.production(reportStepNum);
 }
 
 template<class FluidSystem,class Scalar>
 void EclGenericOutputBlackoilModule<FluidSystem,Scalar>::
 outputInjLog(std::size_t reportStepNum)
 {
-    logOutput_.injection(reportStepNum,
-                         [this](const std::string& name)
-                         { return this->isDefunctParallelWell(name); });
+    this->logOutput_.injection(reportStepNum);
 }
 
 

--- a/opm/simulators/flow/LogOutputHelper.cpp
+++ b/opm/simulators/flow/LogOutputHelper.cpp
@@ -95,8 +95,7 @@ LogOutputHelper<Scalar>::LogOutputHelper(const EclipseState& eclState,
 
 template<class Scalar>
 void LogOutputHelper<Scalar>::
-cumulative(const std::size_t reportStepNum,
-           std::function<bool(const std::string&)> isDefunct) const
+cumulative(const std::size_t reportStepNum) const
 {
     this->beginCumulativeReport_();
 
@@ -138,11 +137,6 @@ cumulative(const std::size_t reportStepNum,
     }
 
     for (const auto& wname : schedule_.wellNames(reportStepNum)) {
-        // don't bother with wells not on this process
-        if (isDefunct(wname)) {
-            continue;
-        }
-
         const auto& well = schedule_.getWell(wname, reportStepNum);
         tmp_names[0] = wname; // WellCumDataType::WellName
         auto wName = static_cast<std::string>(wname);
@@ -381,8 +375,7 @@ timeStamp(const std::string& lbl, double elapsed, int rstep, boost::posix_time::
 
 template<class Scalar>
 void LogOutputHelper<Scalar>::
-injection(const std::size_t reportStepNum,
-          std::function<bool(const std::string&)> isDefunct) const
+injection(const std::size_t reportStepNum) const
 {
     this->beginInjectionReport_();
 
@@ -415,11 +408,6 @@ injection(const std::size_t reportStepNum,
     }
 
     for (const auto& wname : schedule_.wellNames(reportStepNum)) {
-        // don't bother with wells not on this process
-        if (isDefunct(wname)) {
-            continue;
-        }
-
         const auto& well = schedule_.getWell(wname, reportStepNum);
 
         // Ignore Producer wells
@@ -507,8 +495,7 @@ injection(const std::size_t reportStepNum,
 
 template<class Scalar>
 void LogOutputHelper<Scalar>::
-production(const std::size_t reportStepNum,
-           std::function<bool(const std::string&)> isDefunct) const
+production(const std::size_t reportStepNum) const
 {
     this->beginProductionReport_();
 
@@ -550,12 +537,6 @@ production(const std::size_t reportStepNum,
     }
 
     for (const auto& wname : schedule_.wellNames(reportStepNum)) {
-
-        // don't bother with wells not on this process
-        if (isDefunct(wname)) {
-            continue;
-        }
-
         const auto& well = schedule_.getWell(wname, reportStepNum);
 
         // Ignore injector wells

--- a/opm/simulators/flow/LogOutputHelper.hpp
+++ b/opm/simulators/flow/LogOutputHelper.hpp
@@ -25,7 +25,6 @@
 #include <opm/output/eclipse/Inplace.hpp>
 
 #include <cstddef>
-#include <functional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -47,8 +46,7 @@ public:
                     const SummaryState& st);
 
     //! \brief Write cumulative production and injection reports to output.
-    void cumulative(const std::size_t reportStepNum,
-                    std::function<bool(const std::string&)> isDefunct) const;
+    void cumulative(const std::size_t reportStepNum) const;
 
     //! \brief Write error report to output.
     void error(const std::vector<int>& failedCellsPbub,
@@ -63,12 +61,10 @@ public:
     void fipResv(const Inplace& inplace, const std::string& name) const;
 
     //! \brief Write injection report to output.
-    void injection(const std::size_t reportStepNum,
-                   std::function<bool(const std::string&)> isDefunct) const;
+    void injection(const std::size_t reportStepNum) const;
 
     //! \brief Write production report to output.
-    void production(const std::size_t reportStepNum,
-                    std::function<bool(const std::string&)> isDefunct) const;
+    void production(const std::size_t reportStepNum) const;
 
     void timeStamp(const std::string& lbl, double elapsed, int rstep, boost::posix_time::ptime currentDate) const;
 

--- a/tests/test_LogOutputHelper.cpp
+++ b/tests/test_LogOutputHelper.cpp
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(Cumulative)
     }
 
     Opm::LogOutputHelper<double> helper(eclState, schedule, st);
-    helper.cumulative(0, [](const std::string&) { return false; });
+    helper.cumulative(0);
     std::string data = trimStream(str);
     BOOST_CHECK_EQUAL(data, reference);
 }
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(Injection)
     }
 
     Opm::LogOutputHelper<double> helper(eclState, schedule, st);
-    helper.injection(0, [](const std::string&) { return false; });
+    helper.injection(0);
     std::string data = trimStream(str);
     BOOST_CHECK_EQUAL(data, reference);
 }
@@ -451,7 +451,7 @@ BOOST_AUTO_TEST_CASE(Production)
     }
 
     Opm::LogOutputHelper<double> helper(eclState, schedule, st);
-    helper.production(0, [](const std::string&) { return false; });
+    helper.production(0);
     std::string data = trimStream(str);
     BOOST_CHECK_EQUAL(data, reference);
 }


### PR DESCRIPTION
There is no need to restrict PRT file flow reports to those wells which are active on the current rank since the `SummaryState` object holds information for all wells active at the current report step.

---

As an example of the impact of this change, here's the difference between abridged cumulative flow reports from the last report step of [`NORNE_ATW2013`](https://github.com/OPM/opm-tests/blob/4d1ef6e376f16f8a792056e13873e529f799c2ec/norne/NORNE_ATW2013.DATA) when run as
```sh
OMP_NUM_THREADS=1 mpirun -np 6  ${flow} --ecl-deck-file-name=${cse}
```
with different output directories (`np/6/dev` for this PR and `np/6/master` for the current master sources).  Flow values omitted here to avoid cluttering the display.

```diff
--- np/6/master/cumulative.rpt.last	2024-01-04 14:00:32.737251300 +0100
+++ np/6/dev/cumulative.rpt.last	2024-01-04 13:59:18.869309148 +0100
@@ -11,15 +11,40 @@
 :   FIELD:           :        :    :
 [...]
 :D2-DUMMY:           :        :    :
+:    C-4H:   11,   35:     INJ:WRAT:
+:    B-2H:   15,   31:    PROD:RESV:
+:    D-1H:   22,   22:    PROD:ORAT:
+:    D-2H:   14,   28:    PROD:RESV:
+:    B-4H:   10,   32:    PROD:ORAT:
+:    D-4H:   19,   38:    PROD:ORAT:
+:    C-1H:   26,   44:     INJ:GRAT:
 :    E-3H:   12,   72:    PROD:ORAT:
+:    C-2H:   23,   15:     INJ:WRAT:
+:    B-1H:   14,   34:    PROD:ORAT:
+:    C-3H:    9,   13:     INJ:GRAT:
+:    F-1H:   12,   85:     INJ:WRAT:
 :    B-3H:    9,   37:    PROD:RESV:
 :    E-1H:   18,   68:    PROD:RESV:
 :    F-2H:   18,   83:     INJ:WRAT:
 :    E-2H:   13,   67:    PROD:ORAT:
+:    E-4H:   36,   96:    PROD:ORAT:
+:   E-4AH:   38,   98:    PROD:ORAT:
+:    D-3H:   19,   54:    PROD:ORAT:
+:   D-3AH:   19,   54:    PROD:ORAT:
 :    F-3H:    6,   57:     INJ:WRAT:
+:   E-3AH:    7,   64:    PROD:ORAT:
 :   B-4AH:    9,   46:    PROD:ORAT:
+:    F-4H:   36,   68:     INJ:WRAT:
 :   B-4BH:    9,   46:    PROD:ORAT:
+:   D-4AH:   16,   66:    PROD:ORAT:
+:   D-1CH:   25,   37:    PROD:RESV:
+:   C-4AH:   29,   51:     INJ:GRAT:
+:   B-4DH:   10,   29:    PROD:RESV:
 :   E-3BH:   15,   74:    PROD:ORAT:
 :   E-3CH:   15,   74:    PROD:RESV:
 :   E-2AH:   13,   67:    PROD:RESV:
+:   D-3BH:   19,   54:    PROD:RESV:
+:   B-1AH:   10,   24:    PROD:ORAT:
+:   B-1BH:   10,   24:    PROD:RESV:
+:    K-3H:   11,   28:    PROD:RESV:
 :--------:-----------:--------:----:
```