### PR TITLE
Output pore volume in RPTRST

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -430,6 +430,7 @@ assignToSolution(data::Solution& sol)
         DataEntry{"PPCW",     UnitSystem::measure::pressure,                              ppcw_},
         DataEntry{"PRESROCC", UnitSystem::measure::pressure,                              minimumOilPressure_},
         DataEntry{"PRESSURE", UnitSystem::measure::pressure,                              fluidPressure_},
+        DataEntry{"RPORV",    UnitSystem::measure::volume,                                rPorV_},
         DataEntry{"RS",       UnitSystem::measure::gas_oil_ratio,                         rs_},
         DataEntry{"RSSAT",    UnitSystem::measure::gas_oil_ratio,                         gasDissolutionFactor_},
         DataEntry{"RV",       UnitSystem::measure::oil_gas_ratio,                         rv_},
@@ -1078,6 +1079,10 @@ doAllocBuffers(const unsigned bufferSize,
     if (FluidSystem::phaseIsActive(gasPhaseIdx) && rstKeywords["BG"] > 0) {
         rstKeywords["BG"] = 0;
         invB_[gasPhaseIdx].resize(bufferSize, 0.0);
+    }
+    if (rstKeywords["RPORV"] > 0) {
+        rstKeywords["RPORV"] = 0;
+        rPorV_.resize(bufferSize, 0.0);
     }
 
     enableFlows_ = false;

--- a/ebos/eclgenericoutputblackoilmodule.hh
+++ b/ebos/eclgenericoutputblackoilmodule.hh
@@ -396,6 +396,7 @@ protected:
     ScalarBuffer pressureTimesPoreVolume_;
     ScalarBuffer pressureTimesHydrocarbonVolume_;
     ScalarBuffer dynamicPoreVolume_;
+    ScalarBuffer rPorV_;
     ScalarBuffer fluidPressure_;
     ScalarBuffer temperature_;
     ScalarBuffer rs_;

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -461,6 +461,11 @@ public:
                 this->extboZ_[globalDofIdx] = intQuants.zFraction().value();
             }
 
+            if (!this->rPorV_.empty()) {
+                const auto totVolume = elemCtx.simulator().model().dofTotalVolume(globalDofIdx);
+                this->rPorV_[globalDofIdx] = totVolume * intQuants.porosity().value();
+            }
+
             if (!this->mFracCo2_.empty()) {
                 const Scalar stdVolOil = getValue(fs.saturation(oilPhaseIdx)) * getValue(fs.invB(oilPhaseIdx))
                     + getValue(fs.saturation(gasPhaseIdx)) * getValue(fs.invB(gasPhaseIdx)) * getValue(fs.Rv());


### PR DESCRIPTION
Output pore volume at reservoir condition using the RPORV mnemonic in RPTRST.