### PR TITLE
Fix minimum newton iteration

### DIFF
--- a/opm/simulators/flow/BlackoilModelEbos.hpp
+++ b/opm/simulators/flow/BlackoilModelEbos.hpp
@@ -337,7 +337,7 @@ namespace Opm {
             // the step is not considered converged until at least minIter iterations is done
             {
                 auto convrep = getConvergence(timer, iteration, residual_norms);
-                report.converged = convrep.converged() && iteration > minIter;
+                report.converged = convrep.converged() && iteration >= minIter;
                 ConvergenceReport::Severity severity = convrep.severityOfWorstFailure();
                 convergence_reports_.back().report.push_back(std::move(convrep));
 

--- a/opm/simulators/flow/NonlinearSolverEbos.hpp
+++ b/opm/simulators/flow/NonlinearSolverEbos.hpp
@@ -69,7 +69,7 @@ struct NewtonMaxIterations<TypeTag, TTag::FlowNonLinearSolver> {
 };
 template<class TypeTag>
 struct NewtonMinIterations<TypeTag, TTag::FlowNonLinearSolver> {
-    static constexpr int value = 1;
+    static constexpr int value = 2;
 };
 template<class TypeTag>
 struct NewtonRelaxationType<TypeTag, TTag::FlowNonLinearSolver> {


### PR DESCRIPTION
This bug has been around for some time. In practice master will always use 2 newton iterations even though default is to use 1. A lot of the tests will fail so this need some testing before it can be merged. A faster merge would be to change the default to 2, then all test will pass, but I think default should be 1.  