### PR TITLE
Compute enthalpy for thermal boundary

### DIFF
--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -170,6 +170,10 @@ public:
                 const auto& rho = FluidSystem::density(fluidState, phaseIdx, regionIdx);
                 fluidState.setDensity(phaseIdx, rho);
 
+                if (enableEnergy) {
+                    const auto& h = FluidSystem::enthalpy(fluidState, phaseIdx, regionIdx);
+                    fluidState.setEnthalpy(phaseIdx, h);
+                }
             }
 
             // set the salt concentration

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1597,7 +1597,10 @@ public:
 
                     const auto& rho = FluidSystem::density(fluidState, phaseIdx, pvtRegionIdx);
                     fluidState.setDensity(phaseIdx, rho);
-
+                    if (enableEnergy) {
+                        const auto& h = FluidSystem::enthalpy(fluidState, phaseIdx, pvtRegionIdx);
+                        fluidState.setEnthalpy(phaseIdx, h);
+                    }
                 }
                 fluidState.checkDefined();
                 return fluidState;


### PR DESCRIPTION
The flux computation for the boundary assumes that the enthalpy is computed and set in the fluidstate. 