### PR TITLE
Remove check for active wells for drift compensation

### DIFF
--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -1543,9 +1543,7 @@ public:
 
         // if requested, compensate systematic mass loss for cells which were "well
         // behaved" in the last time step
-        // Note that we don't allow for drift compensation if there are no active wells.
-        const bool compensateDrift = wellModel_.wellsActive();
-        if (enableDriftCompensation_ && compensateDrift) {
+        if (enableDriftCompensation_) {
             const auto& simulator = this->simulator();
             const auto& model = this->model();
 


### PR DESCRIPTION
Well is active condition for drift compensation was added some time ago due to convergence issues for a case without any dynamics. For CO2 injection simulation the drift compensation is still beneficial even when wells are no longer active. An alternative to this PR is to add a parameter like onlyEnableDriftCompensationWhenWellsAreActive, but I would rather just disable driftCompensation for these cases completely. 