### PR TITLE
Construct the matrices in the AMG hierarchy with deterministic indices.

### DIFF
--- a/opm/simulators/linalg/PreconditionerFactory_impl.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory_impl.hpp
@@ -95,6 +95,17 @@ struct AMGSmootherArgsHelper<Opm::ParallelOverlappingILU0<M,V,V,C>>
 };
 
 
+template <typename C>
+auto setUseFixedOrder(C criterion, bool booleanValue) -> decltype(criterion.setUseFixedOrder(booleanValue))
+{
+    return criterion.setUseFixedOrder(booleanValue); // Set flag to ensure that the matrices in the AMG hierarchy are constructed with deterministic indices.
+}
+template <typename C>
+void setUseFixedOrder(C, ...)
+{
+    // do nothing, since the function setUseFixedOrder does not exist yet
+}
+
 template <class Operator, class Comm, class Matrix, class Vector>
 typename AMGHelper<Operator, Comm, Matrix, Vector>::Criterion
 AMGHelper<Operator,Comm,Matrix,Vector>::criterion(const PropertyTree& prm)
@@ -117,6 +128,7 @@ AMGHelper<Operator,Comm,Matrix,Vector>::criterion(const PropertyTree& prm)
     criterion.setMaxConnectivity(prm.get<int>("maxconnectivity", 15));
     criterion.setMaxAggregateSize(prm.get<int>("maxaggsize", 6));
     criterion.setMinAggregateSize(prm.get<int>("minaggsize", 4));
+    setUseFixedOrder(criterion, true); // If possible, set flag to ensure that the matrices in the AMG hierarchy are constructed with deterministic indices.
     return criterion;
 }
 

--- a/opm/simulators/linalg/PreconditionerFactory_impl.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory_impl.hpp
@@ -95,6 +95,7 @@ struct AMGSmootherArgsHelper<Opm::ParallelOverlappingILU0<M,V,V,C>>
 };
 
 
+// trailing return type with decltype used for detecting existence of setUseFixedOrder member function by overloading the setUseFixedOrder function
 template <typename C>
 auto setUseFixedOrder(C criterion, bool booleanValue) -> decltype(criterion.setUseFixedOrder(booleanValue))
 {

--- a/opm/simulators/linalg/twolevelmethodcpr.hh
+++ b/opm/simulators/linalg/twolevelmethodcpr.hh
@@ -187,9 +187,8 @@ public:
     std::vector<bool> excluded(fineOperator.getmat().N(), false);
     VisitedMap vm(excluded.begin(), Dune::IdentityMap());
     ParallelInformation pinfo;
-    std::size_t aggregates = renumberer.coarsen(pinfo, pg, vm,
-                                                *aggregatesMap_, pinfo,
-                                                noAggregates);
+
+    std::size_t aggregates = coarsen(renumberer, pinfo, pg, vm,*aggregatesMap_, noAggregates, true);
     std::vector<bool>& visited=excluded;
 
     typedef std::vector<bool>::iterator Iterator;
@@ -228,6 +227,30 @@ public:
   }
 
 private:
+  template <typename RN, typename PI, typename PG, typename VM, typename AM>
+  auto coarsen(RN& renumberer,
+               PI& pinfo,
+               PG& pg,
+               VM& vm,
+               AM& aggregatesMap,
+               int noAggregates,
+               bool useFixedOrder) ->
+               decltype(renumberer.coarsen(pinfo, pg, vm, aggregatesMap, pinfo, noAggregates, useFixedOrder))
+  {
+    return renumberer.coarsen(pinfo, pg, vm, aggregatesMap, pinfo, noAggregates, useFixedOrder);
+  }
+
+  template <typename RN, typename PI, typename PG, typename VM, typename AM>
+  auto coarsen(RN& renumberer,
+               PI& pinfo,
+               PG& pg,
+               VM& vm,
+               AM& aggregatesMap,
+               int noAggregates, ...)
+  {
+    return renumberer.coarsen(pinfo, pg, vm, aggregatesMap, pinfo, noAggregates);
+  }
+
   typename O::matrix_type::field_type prolongDamp_;
   std::shared_ptr<AggregatesMap> aggregatesMap_;
   Criterion criterion_;

--- a/opm/simulators/linalg/twolevelmethodcpr.hh
+++ b/opm/simulators/linalg/twolevelmethodcpr.hh
@@ -227,6 +227,7 @@ public:
   }
 
 private:
+  // trailing return type with decltype used for detecting the signature of coarsen member function by overloading this coarsen function
   template <typename RN, typename PI, typename PG, typename VM, typename AM>
   auto coarsen(RN& renumberer,
                PI& pinfo,


### PR DESCRIPTION
@blattms: With the tests in opm-simulators, I've checked that the flag gets propagated correctly to the respective method 'sync' in the indicessyncer dune-common (see https://gitlab.dune-project.org/core/dune-common/-/merge_requests/1335 and https://gitlab.dune-project.org/core/dune-istl/-/merge_requests/553).
We can merge this now and as soon as the changes in dune-common and dune-istl are available on earlier dune version, I can adapt the DUNE_VERSION_GTE query here.