### PR TITLE
Parallel well domain and error logging for NLDD

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -76,6 +76,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/linalg/setupPropertyTree.cpp
   opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
   opm/simulators/timestepping/AdaptiveTimeSteppingEbos.cpp
+  opm/simulators/timestepping/ConvergenceReport.cpp
   opm/simulators/timestepping/TimeStepControl.cpp
   opm/simulators/timestepping/SimulatorTimer.cpp
   opm/simulators/timestepping/SimulatorTimerInterface.cpp

--- a/opm/simulators/flow/BlackoilModelEbosNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelEbosNldd.hpp
@@ -840,6 +840,13 @@ private:
                 if (mb_sum < acceptable_local_mb_sum && cnv_sum < acceptable_local_cnv_sum) {
                     local_report.converged = true;
                     logger.debug(fmt::format("Accepting solution in unconverged domain {} on rank {}.", domain.index, rank_));
+                } else {
+                    logger.debug("Unconverged local solution.");
+                }
+            } else {
+                logger.debug("Unconverged local solution with well convergence failures:");
+                for (const auto& wf : convrep.wellFailures()) {
+                    logger.debug(to_string(wf));
                 }
             }
         }

--- a/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
+++ b/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
@@ -45,22 +45,6 @@
 #include <vector>
 
 namespace {
-    std::string to_string(const Opm::ConvergenceReport::ReservoirFailure::Type t)
-    {
-        using Type = Opm::ConvergenceReport::ReservoirFailure::Type;
-
-        const auto type_strings = std::unordered_map<Type, std::string> {
-            { Type::Invalid    , "Invalid" },
-            { Type::MassBalance, "MB"      },
-            { Type::Cnv        , "CNV"     },
-        };
-
-        auto strPos = type_strings.find(t);
-        assert ((strPos != type_strings.end()) &&
-                "Unsupported convergence metric type");
-
-        return strPos->second;
-    }
 
     std::string
     formatMetricColumn(const Opm::ConvergenceOutputThread::ComponentToPhaseName& getPhaseName,
@@ -110,48 +94,6 @@ namespace {
         os << std::right << std::setw(maxChar + 1) << "WellStatus" << '\n';
 
         return maxChar;
-    }
-
-
-    std::string to_string(const Opm::ConvergenceReport::Severity s)
-    {
-        using S = Opm::ConvergenceReport::Severity;
-        switch (s) {
-        case S::None:
-            return "None";
-        case S::Normal:
-            return "Normal";
-        case S::TooLarge:
-            return "TooLarge";
-        case S::NotANumber:
-            return "NotANumber";
-        }
-        throw std::logic_error("Unknown ConvergenceReport::Severity");
-    }
-
-
-    std::string to_string(const Opm::ConvergenceReport::WellFailure::Type t)
-    {
-        using T = Opm::ConvergenceReport::WellFailure::Type;
-        switch (t) {
-        case T::Invalid:
-            return "Invalid";
-        case T::MassBalance:
-            return "MassBalance";
-        case T::Pressure:
-            return "Pressure";
-        case T::ControlBHP:
-            return "ControlBHP";
-        case T::ControlTHP:
-            return "ControlTHP";
-        case T::ControlRate:
-            return "ControlRate";
-        case T::Unsolvable:
-            return "Unsolvable";
-        case T::WrongFlowDirection:
-            return "WrongFlowDirection";
-        }
-        throw std::logic_error("Unknown ConvergenceReport::WellFailure::Type");
     }
 
 

--- a/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
+++ b/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
@@ -122,13 +122,7 @@ namespace {
                << (report.wellFailed() ? "FAIL" : "CONV");
             if (report.wellFailed()) {
                 for (const auto& wf : report.wellFailures()) {
-                    os << " { "
-                       << wf.wellName() << ' ' << to_string(wf.type());
-                    if (wf.type() == Opm::ConvergenceReport::WellFailure::Type::MassBalance) {
-                        os << " Severity=" << to_string(wf.severity())
-                           << " Phase=" << wf.phase();
-                    }
-                    os << " }";
+                    os << " " << to_string(wf);
                 }
             }
             os << '\n';

--- a/opm/simulators/timestepping/ConvergenceReport.cpp
+++ b/opm/simulators/timestepping/ConvergenceReport.cpp
@@ -1,0 +1,100 @@
+/*
+  Copyright 2024 SINTEF AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/simulators/timestepping/ConvergenceReport.hpp>
+
+#include <cassert>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+#include <fmt/format.h>
+
+
+namespace Opm
+{
+    std::string to_string(const ConvergenceReport::ReservoirFailure::Type t)
+    {
+        using Type = ConvergenceReport::ReservoirFailure::Type;
+
+        const auto type_strings = std::unordered_map<Type, std::string> {
+            { Type::Invalid    , "Invalid" },
+            { Type::MassBalance, "MB"      },
+            { Type::Cnv        , "CNV"     },
+        };
+
+        auto strPos = type_strings.find(t);
+        assert ((strPos != type_strings.end()) &&
+                "Unsupported convergence metric type");
+
+        return strPos->second;
+    }
+
+
+    std::string to_string(const ConvergenceReport::Severity s)
+    {
+        using S = ConvergenceReport::Severity;
+        switch (s) {
+        case S::None:
+            return "None";
+        case S::Normal:
+            return "Normal";
+        case S::TooLarge:
+            return "TooLarge";
+        case S::NotANumber:
+            return "NotANumber";
+        }
+        throw std::logic_error("Unknown ConvergenceReport::Severity");
+    }
+
+
+    std::string to_string(const ConvergenceReport::WellFailure::Type t)
+    {
+        using T = ConvergenceReport::WellFailure::Type;
+        switch (t) {
+        case T::Invalid:
+            return "Invalid";
+        case T::MassBalance:
+            return "MassBalance";
+        case T::Pressure:
+            return "Pressure";
+        case T::ControlBHP:
+            return "ControlBHP";
+        case T::ControlTHP:
+            return "ControlTHP";
+        case T::ControlRate:
+            return "ControlRate";
+        case T::Unsolvable:
+            return "Unsolvable";
+        case T::WrongFlowDirection:
+            return "WrongFlowDirection";
+        }
+        throw std::logic_error("Unknown ConvergenceReport::WellFailure::Type");
+    }
+
+
+    std::string to_string(const ConvergenceReport::WellFailure& wf)
+    {
+        std::string mberror = (wf.type() == ConvergenceReport::WellFailure::Type::MassBalance)
+            ? fmt::format(" Severity={} Phase={}", to_string(wf.severity()), wf.phase()) : "";
+        return fmt::format("{{ {} {}{} }}", wf.wellName(), to_string(wf.type()), mberror);
+    }
+
+
+} // namespace Opm

--- a/opm/simulators/timestepping/ConvergenceReport.hpp
+++ b/opm/simulators/timestepping/ConvergenceReport.hpp
@@ -229,6 +229,15 @@ namespace Opm
     };
 
 
+    std::string to_string(const ConvergenceReport::ReservoirFailure::Type t);
+
+    std::string to_string(const ConvergenceReport::Severity s);
+
+    std::string to_string(const ConvergenceReport::WellFailure::Type t);
+
+    std::string to_string(const ConvergenceReport::WellFailure& wf);
+
+
 } // namespace Opm
 
 #endif // OPM_CONVERGENCEREPORT_HEADER_INCLUDED


### PR DESCRIPTION
This improves diagnostics and error logging for NLDD.

Most code line changes are because the to_string() functions related to convergence failure output were moved to make them available for the NLDD diagnostics need.