### PR TITLE
Support at Least NTFIP Distinict Regions for Inter-Region Flow

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -31,12 +31,17 @@
 #include <opm/output/data/Solution.hpp>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Regdims.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
+
 #include <opm/input/eclipse/Schedule/RFTConfig.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
+
 #include <opm/input/eclipse/Units/Units.hpp>
 
 #include <opm/simulators/utils/PressureAverage.hpp>
@@ -136,6 +141,12 @@ std::string EclString(const Opm::Inplace::Phase phase)
 
         return regions;
     }
+
+    std::size_t declaredMaxRegionID(const Opm::Runspec& rspec)
+    {
+        return std::max(rspec.tabdims().getNumFIPRegions(),
+                        rspec.regdims().getNTFIP());
+    }
 }
 
 namespace Opm {
@@ -160,7 +171,9 @@ EclGenericOutputBlackoilModule(const EclipseState& eclState,
     , schedule_(schedule)
     , summaryConfig_(summaryConfig)
     , summaryState_(summaryState)
-    , interRegionFlows_(numCells(eclState), defineInterRegionFlowArrays(eclState, summaryConfig))
+    , interRegionFlows_(numCells(eclState),
+                        defineInterRegionFlowArrays(eclState, summaryConfig),
+                        declaredMaxRegionID(eclState.runspec()))
     , logOutput_(eclState, schedule, summaryState)
     , enableEnergy_(enableEnergy)
     , enableTemperature_(enableTemperature)

--- a/opm/simulators/flow/EclInterRegFlows.cpp
+++ b/opm/simulators/flow/EclInterRegFlows.cpp
@@ -105,7 +105,10 @@ assignGlobalMaxRegionID(const std::size_t regID)
         return false;
     }
 
-    this->maxGlobalRegionID_ = regID;
+    if (regID > this->maxGlobalRegionID_) {
+        this->maxGlobalRegionID_ = regID;
+    }
+
     return true;
 }
 
@@ -128,7 +131,8 @@ Opm::EclInterRegFlowMap::createMapFromNames(std::vector<std::string> names)
 
 Opm::EclInterRegFlowMap::
 EclInterRegFlowMap(const std::size_t                numCells,
-                   const std::vector<SingleRegion>& regions)
+                   const std::vector<SingleRegion>& regions,
+                   const std::size_t                declaredMaxRegID)
 {
     this->regionMaps_.reserve(regions.size());
     this->names_.reserve(regions.size());
@@ -138,6 +142,12 @@ EclInterRegFlowMap(const std::size_t                numCells,
     for (const auto& region : regions) {
         this->regionMaps_.emplace_back(region.definition);
         this->names_.push_back(region.name);
+    }
+
+    if (declaredMaxRegID > std::size_t{0}) {
+        for (auto& regionMap : this->regionMaps_) {
+            regionMap.assignGlobalMaxRegionID(declaredMaxRegID);
+        }
     }
 }
 

--- a/opm/simulators/flow/EclInterRegFlows.hpp
+++ b/opm/simulators/flow/EclInterRegFlows.hpp
@@ -210,8 +210,13 @@ namespace Opm {
         ///    overlap cells if applicable.
         ///
         /// \param[in] regions All applicable region definition arrays.
+        ///
+        /// \param[in] declaredMaxRegID Declared maximum region ID in the
+        ///    run-typically from the TABDIMS and/or REGDIMS keywords.  Used
+        ///    for sizing internal data structures if greater than zero.
         explicit EclInterRegFlowMap(const std::size_t                numCells,
-                                    const std::vector<SingleRegion>& regions);
+                                    const std::vector<SingleRegion>& regions,
+                                    const std::size_t                declaredMaxRegID = 0);
 
         EclInterRegFlowMap(const EclInterRegFlowMap& rhs) = default;
         EclInterRegFlowMap(EclInterRegFlowMap&& rhs) noexcept = default;


### PR DESCRIPTION
This commit ensures that we have backing support for region IDs up to and including NTFIP (TABDIMS(5), REGDIMS(1)).  The existing setup would fail (segmentation violation) in the case of a summary vector of the form

    ROFT
      36 31 /
    /

when the maximum FIPNUM value was 30.  We nevertheless support maximum FIPNUM values exceeding NTFIP.

We add a new optional parameter to the EclInterRegionFlowMap constructor.  The parameter allows client code to specifiy a "minimum maximum" region ID that all ranks must support.  This value will be enforced during parallel aggregation.