### PR TITLE
Only print flow version in banner PRT file not all reports.

### DIFF
--- a/opm/simulators/flow/LogOutputHelper.cpp
+++ b/opm/simulators/flow/LogOutputHelper.cpp
@@ -89,9 +89,7 @@ LogOutputHelper<Scalar>::LogOutputHelper(const EclipseState& eclState,
     : eclState_(eclState)
     , schedule_(schedule)
     , summaryState_(summaryState)
-{ 
-    flowVersionName_ = moduleVersionName();
-}
+{}
 
 template<class Scalar>
 void LogOutputHelper<Scalar>::
@@ -366,7 +364,7 @@ timeStamp(const std::string& lbl, double elapsed, int rstep, boost::posix_time::
         << "  " << std::left << std::setw(9) << lbl << "AT" << std::right << std::setw(10) 
         << (double)unit::convert::to(elapsed, unit::day) << "  DAYS" << " *" << std::setw(30) << eclState_.getTitle() << "                                          *\n"
         << "  REPORT " << std::setw(4) << rstep << "    " << currentDate
-        << "  *                                             Flow  version " << std::setw(11) << flowVersionName_ << "  *\n"
+        << "  *                                                                        *\n"
         << "                              **************************************************************************\n";
 
     OpmLog::note(ss.str());

--- a/opm/simulators/flow/LogOutputHelper.hpp
+++ b/opm/simulators/flow/LogOutputHelper.hpp
@@ -167,7 +167,6 @@ private:
     const EclipseState& eclState_;
     const Schedule& schedule_;
     const SummaryState& summaryState_;
-    std::string flowVersionName_;
 };
 
 } // namespace Opm


### PR DESCRIPTION
With this patch it is only printed in the banner and not in all reports.

```
                              **************************************************************************
  WELLS    AT        31  DAYS *                 SPE1 - CASE 2                                          *
  REPORT    1    01 Feb 2015  *                                             Flow  version 2024.04-pre  *
                              **************************************************************************
```
becomes
```
                              **************************************************************************
  WELLS    AT        31  DAYS *                 SPE1 - CASE 2                                          *
  REPORT    1    01 Feb 2015  *                                                                        *
                              **************************************************************************
```

This also resolves linker issues with some tests when using shared libraries.

For discussion as the flow version was added to reports in #5068 .

Closes #5122 