### PR TITLE
[refactor] Remove numElems from LookUpData methods

### DIFF
--- a/ebos/eclgenericproblem_impl.hh
+++ b/ebos/eclgenericproblem_impl.hh
@@ -370,7 +370,6 @@ updateNum(const std::string& name, std::vector<T>& numbers, std::size_t num_regi
     if (!eclState_.fieldProps().has_int(name))
         return;
 
-    unsigned numElems = gridView_.size(/*codim=*/0);
     std::function<void(T, int)> valueCheck = [num_regions,name](T fieldPropValue, [[maybe_unused]] int fieldPropIdx) {
         if ( fieldPropValue > (int)num_regions) {
             throw std::runtime_error("Values larger than maximum number of regions "

--- a/ebos/eclgenericproblem_impl.hh
+++ b/ebos/eclgenericproblem_impl.hh
@@ -192,7 +192,7 @@ readRockParameters_(const std::vector<Scalar>& cellCenterDepths,
 
         rockTableIdx_ = this->lookUpData_.template assignFieldPropsIntOnLeaf<short unsigned int>(eclState_.fieldProps(),
                                                                                                  rock_config.rocknum_property(),
-                                                                                                 numElem, true /*needsTranslation*/,
+                                                                                                 true /*needsTranslation*/,
                                                                                                  valueCheck);
     }
 
@@ -381,7 +381,7 @@ updateNum(const std::string& name, std::vector<T>& numbers, std::size_t num_regi
         }
     };
 
-    numbers = this->lookUpData_.template assignFieldPropsIntOnLeaf<T>(eclState_.fieldProps(), name, numElems,
+    numbers = this->lookUpData_.template assignFieldPropsIntOnLeaf<T>(eclState_.fieldProps(), name,
                                                                       true /*needsTranslation*/, valueCheck);
 }
 

--- a/ebos/eclgenericthresholdpressure_impl.hh
+++ b/ebos/eclgenericthresholdpressure_impl.hh
@@ -133,7 +133,7 @@ finishInit()
 
     // internalize the data specified using the EQLNUM keyword
     elemEquilRegion_ = lookUpData_.template assignFieldPropsIntOnLeaf<short unsigned int>(eclState_.fieldProps(),
-                                                                                          "EQLNUM", numElements, true);
+                                                                                          "EQLNUM", true);
 
     /*
       If this is a restart run the ThresholdPressure object will be active,

--- a/ebos/eclgenericthresholdpressure_impl.hh
+++ b/ebos/eclgenericthresholdpressure_impl.hh
@@ -101,8 +101,6 @@ template<class Grid, class GridView, class ElementMapper, class Scalar>
 void EclGenericThresholdPressure<Grid,GridView,ElementMapper,Scalar>::
 finishInit()
 {
-    unsigned numElements = gridView_.size(/*codim=*/0);
-
     const auto& simConfig = eclState_.getSimulationConfig();
 
     enableThresholdPressure_ = simConfig.useThresholdPressure();

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2008,14 +2008,13 @@ protected:
     //
     // For CpGrid with local grid refinement, the field property of a cell on the leaf
     // is inherited from its parent or equivalent (when has no parent) cell on level zero.
-    std::function<std::vector<double>(const FieldPropsManager&, const std::string&, const unsigned int&)>
+    std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>
     fieldPropDoubleOnLeafAssigner_()
     {
         const auto& lookup = this->lookUpData_;
-        return [&lookup](const FieldPropsManager& fieldPropManager, const std::string& propString,
-                         const unsigned int& numElems)
+        return [&lookup](const FieldPropsManager& fieldPropManager, const std::string& propString)
         {
-            return lookup.assignFieldPropsDoubleOnLeaf(fieldPropManager, propString, numElems);
+            return lookup.assignFieldPropsDoubleOnLeaf(fieldPropManager, propString);
         };
     }
 
@@ -2024,15 +2023,13 @@ protected:
     // For CpGrid with local grid refinement, the field property of a cell on the leaf
     // is inherited from its parent or equivalent (when has no parent) cell on level zero.
     template<typename IntType>
-    std::function<std::vector<IntType>(const FieldPropsManager&, const std::string&, const unsigned int&, bool)>
+    std::function<std::vector<IntType>(const FieldPropsManager&, const std::string&, bool)>
     fieldPropIntTypeOnLeafAssigner_()
     {
         const auto& lookup = this->lookUpData_;
-        return [&lookup](const FieldPropsManager& fieldPropManager, const std::string& propString,
-                         const unsigned int& numElems, bool needsTranslation)
+        return [&lookup](const FieldPropsManager& fieldPropManager, const std::string& propString, bool needsTranslation)
         {
-            return lookup.template assignFieldPropsIntOnLeaf<IntType>(fieldPropManager, propString,
-                                                                      numElems, needsTranslation);
+            return lookup.template assignFieldPropsIntOnLeaf<IntType>(fieldPropManager, propString, needsTranslation);
         };
     }
 

--- a/ebos/ecltransmissibility_impl.hh
+++ b/ebos/ecltransmissibility_impl.hh
@@ -171,7 +171,7 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
 
     unsigned numElements = elemMapper.size();
     // get the ntg values, the ntg values are modified for the cells merged with minpv
-    const std::vector<double>& ntg = this->lookUpData_.assignFieldPropsDoubleOnLeaf(eclState_.fieldProps(), "NTG", numElements);
+    const std::vector<double>& ntg = this->lookUpData_.assignFieldPropsDoubleOnLeaf(eclState_.fieldProps(), "NTG");
     const bool updateDiffusivity = eclState_.getSimulationConfig().isDiffusive();
     const bool updateDispersivity = eclState_.getSimulationConfig().rock_config().dispersion();
 
@@ -596,17 +596,17 @@ extractPermeability_()
     // over several processes.)
     const auto& fp = eclState_.fieldProps();
     if (fp.has_double("PERMX")) {
-        const std::vector<double>& permxData = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp, "PERMX", numElem);
+        const std::vector<double>& permxData = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp, "PERMX");
 
         std::vector<double> permyData;
         if (fp.has_double("PERMY"))
-            permyData = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"PERMY", numElem);
+            permyData = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"PERMY");
         else
             permyData = permxData;
 
         std::vector<double> permzData;
         if (fp.has_double("PERMZ"))
-            permzData = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"PERMZ", numElem);
+            permzData = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"PERMZ");
         else
             permzData = permxData;
 
@@ -638,17 +638,17 @@ extractPermeability_(const std::function<unsigned int(unsigned int)>& map)
     // over several processes.)
     const auto& fp = eclState_.fieldProps();
     if (fp.has_double("PERMX")) {
-        const std::vector<double>& permxData = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"PERMX", numElem);
+        const std::vector<double>& permxData = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"PERMX");
 
         std::vector<double> permyData;
         if (fp.has_double("PERMY"))
-            permyData = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"PERMY", numElem);
+            permyData = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"PERMY");
         else
             permyData = permxData;
 
         std::vector<double> permzData;
         if (fp.has_double("PERMZ"))
-            permzData = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"PERMZ", numElem);
+            permzData = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"PERMZ");
         else
             permzData = permxData;
 
@@ -676,10 +676,9 @@ extractPorosity_()
     // provided by eclState are one-per-cell of "uncompressed" grid, whereas the
     // simulation grid might remove a few elements. (e.g. because it is distributed
     // over several processes.)
-    unsigned numElem = gridView_.size(/*codim=*/0);
     const auto& fp = eclState_.fieldProps();
     if (fp.has_double("PORO")) {
-        porosity_ = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"PORO", numElem);
+        porosity_ = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"PORO");
     }
     else
         throw std::logic_error("Can't read the porosityfrom the ecl state. "
@@ -694,9 +693,8 @@ extractDispersion_()
         throw std::runtime_error("Dispersion disabled at compile time, but the deck "
                                  "contains the DISPERC keyword.");
     }
-    unsigned numElem = gridView_.size(/*codim=*/0);
     const auto& fp = eclState_.fieldProps();
-    dispersion_ = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"DISPERC", numElem);
+    dispersion_ = this-> lookUpData_.assignFieldPropsDoubleOnLeaf(fp,"DISPERC");
 }
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>


### PR DESCRIPTION
Unnecessary function argument numElements removed. Associated with OPM/opm-common#3876 and OPM/opm-grid#704