### PR TITLE
Write pc for watergas systems

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -430,6 +430,7 @@ assignToSolution(data::Solution& sol)
         DataEntry{"OIL_DEN",  UnitSystem::measure::density,                               density_[oilPhaseIdx]},
         DataEntry{"OIL_VISC", UnitSystem::measure::viscosity,                             viscosity_[oilPhaseIdx]},
         DataEntry{"PBUB",     UnitSystem::measure::pressure,                              bubblePointPressure_},
+        DataEntry{"PCGW",     UnitSystem::measure::pressure,                              pcgw_},
         DataEntry{"PCOG",     UnitSystem::measure::pressure,                              pcog_},
         DataEntry{"PCOW",     UnitSystem::measure::pressure,                              pcow_},
         DataEntry{"PDEW",     UnitSystem::measure::pressure,                              dewPointPressure_},
@@ -1224,6 +1225,10 @@ doAllocBuffers(const unsigned bufferSize,
         relativePermeability_[gasPhaseIdx].resize(bufferSize, 0.0);
     }
 
+    if (FluidSystem::phaseIsActive(gasPhaseIdx) && FluidSystem::phaseIsActive(waterPhaseIdx) && rstKeywords["PCGW"] > 0) {
+        rstKeywords["PCGW"] = 0;
+        pcgw_.resize(bufferSize, 0.0);
+    }
     if (FluidSystem::phaseIsActive(oilPhaseIdx) && FluidSystem::phaseIsActive(waterPhaseIdx) && rstKeywords["PCOW"] > 0) {
         rstKeywords["PCOW"] = 0;
         pcow_.resize(bufferSize, 0.0);

--- a/ebos/eclgenericoutputblackoilmodule.hh
+++ b/ebos/eclgenericoutputblackoilmodule.hh
@@ -448,6 +448,7 @@ protected:
     ScalarBuffer cUrea_;
     ScalarBuffer cBiofilm_;
     ScalarBuffer cCalcite_;
+    ScalarBuffer pcgw_;
     ScalarBuffer pcow_;
     ScalarBuffer pcog_;
 

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -362,6 +362,10 @@ public:
                 this->rv_[globalDofIdx] = getValue(fs.Rv());
                 Valgrind::CheckDefined(this->rv_[globalDofIdx]);
             }
+            if (!this->pcgw_.empty()) {
+                this->pcgw_[globalDofIdx] = getValue(fs.pressure(gasPhaseIdx)) - getValue(fs.pressure(waterPhaseIdx));
+                Valgrind::CheckDefined(this->pcgw_[globalDofIdx]);
+            }
             if (!this->pcow_.empty()) {
                 this->pcow_[globalDofIdx] = getValue(fs.pressure(oilPhaseIdx)) - getValue(fs.pressure(waterPhaseIdx));
                 Valgrind::CheckDefined(this->pcow_[globalDofIdx]);


### PR DESCRIPTION
This PR allows to write in the restart file the capillary pressure for gas water systems using `PCOG`.