### PR TITLE
Fix network convergence issues

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1172,15 +1172,11 @@ updateNetworkPressures(const int reportStepIdx)
             // due to the fact our nodal pressure calculation is somewhat explicit
             // TODO: the following parameters are subject to adjustment for optimization purpose
             constexpr double upper_update_bound = 5.0 * unit::barsa;
-            constexpr double lower_update_bound = 0.05 * unit::barsa;
             // relative dampening factor based on update value
             constexpr double damping_factor = 0.1;
-            const double allowed_change = std::max(std::min(damping_factor * std::abs(change), upper_update_bound),
-                                                   lower_update_bound);
-            if (std::abs(change) > allowed_change) {
-                const double sign = change > 0 ? 1. : -1.;
-                node_pressures_[name] = pressure + sign * allowed_change;
-            }
+            const double damped_change = std::min(damping_factor * std::abs(change), upper_update_bound);                                                
+            const double sign = change > 0 ? 1. : -1.;
+            node_pressures_[name] = pressure + sign * damped_change;
         }
     } else {
         for (const auto& [name, pressure]: node_pressures_) {


### PR DESCRIPTION
During testing, two culprits for network convergence problems were identified:

1. The current lower bound on network pressure update may lead to convergence issues, so it's suggested simply to remove this.
2. The default (standard) well convergence tolerance is in some cases not sufficiently strict to get network convergence. This PR suggest a rather _ad-hoc_  solution by simply tightening the tolerance by a factor 10 for wells that are controlled under dynamic thp-limit.    