### PR TITLE
HDF5Serializer: move out of ebos folder

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -629,6 +629,9 @@ if(HDF5_FOUND)
     opm/simulators/utils/HDF5Serializer.hpp
     opm/simulators/utils/HDF5File.hpp
   )
+  list(APPEND MAIN_SOURCE_FILES
+    opm/simulators/utils/HDF5Serializer.cpp
+  )
 endif()
 
 list (APPEND EXAMPLE_SOURCE_FILES

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -434,7 +434,6 @@ list (APPEND PUBLIC_HEADER_FILES
   ebos/ecltransmissibility_impl.hh
   ebos/eclwriter.hh
   ebos/femcpgridcompat.hh
-  ebos/hdf5serializer.hh
   ebos/vtkecltracermodule.hh
   opm/simulators/flow/countGlobalCells.hpp
   opm/simulators/flow/priVarsPacking.hpp
@@ -627,7 +626,7 @@ endif()
 
 if(HDF5_FOUND)
   list(APPEND PUBLIC_HEADER_FILES
-    ebos/hdf5serializer.hh
+    opm/simulators/utils/HDF5Serializer.hpp
     opm/simulators/utils/HDF5File.hpp
   )
 endif()

--- a/examples/opmrst_inspect.cpp
+++ b/examples/opmrst_inspect.cpp
@@ -19,7 +19,7 @@
 
 #include <config.h>
 
-#include <ebos/hdf5serializer.hh>
+#include <opm/simulators/utils/HDF5Serializer.hpp>
 
 #include <opm/simulators/timestepping/SimulatorTimer.hpp>
 #include <opm/simulators/utils/ParallelCommunication.hpp>

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoilEbos.hpp
@@ -54,7 +54,7 @@
 #include <vector>
 
 #if HAVE_HDF5
-#include <ebos/hdf5serializer.hh>
+#include <opm/simulators/utils/HDF5Serializer.hpp>
 #endif
 
 namespace Opm::Properties {

--- a/opm/simulators/flow/SimulatorSerializer.cpp
+++ b/opm/simulators/flow/SimulatorSerializer.cpp
@@ -32,7 +32,7 @@
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 
 #if HAVE_HDF5
-#include <ebos/hdf5serializer.hh>
+#include <opm/simulators/utils/HDF5Serializer.hpp>
 #endif
 
 #include <algorithm>

--- a/opm/simulators/utils/HDF5Serializer.cpp
+++ b/opm/simulators/utils/HDF5Serializer.cpp
@@ -1,0 +1,71 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#include <config.h>
+#include <opm/simulators/utils/HDF5Serializer.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+
+namespace Opm {
+
+void HDF5Serializer::writeHeader(const std::string& simulator_name,
+                                 const std::string& module_version,
+                                 const std::string& time_stamp,
+                                 const std::string& case_name,
+                                 const std::string& params,
+                                 int num_procs)
+{
+    try {
+        this->pack(simulator_name, module_version, time_stamp,
+                   case_name, params, num_procs);
+    } catch (...) {
+        m_packSize = std::numeric_limits<std::size_t>::max();
+        throw;
+    }
+    m_h5file.write("/", "simulator_info", m_buffer, HDF5File::DataSetMode::ROOT_ONLY);
+}
+
+int HDF5Serializer::lastReportStep() const
+{
+    const auto entries = m_h5file.list("/report_step");
+    int last = -1;
+    for (const auto& entry : entries) {
+        int num = std::atoi(entry.c_str());
+        last = std::max(last, num);
+    }
+
+    return last;
+}
+
+std::vector<int> HDF5Serializer::reportSteps() const
+{
+    const auto entries = m_h5file.list("/report_step");
+    std::vector<int> result(entries.size());
+    std::transform(entries.begin(), entries.end(), result.begin(),
+                   [](const std::string& input)
+                   {
+                      return std::atoi(input.c_str());
+                   });
+    std::sort(result.begin(), result.end());
+    return result;
+}
+
+}

--- a/opm/simulators/utils/HDF5Serializer.hpp
+++ b/opm/simulators/utils/HDF5Serializer.hpp
@@ -18,8 +18,8 @@
   module for the precise wording of the license and the list of
   copyright holders.
 */
-#ifndef ECL_HDF5_SERIALIZER_HH
-#define ECL_HDF5_SERIALIZER_HH
+#ifndef HDF5_SERIALIZER_HPP
+#define HDF5_SERIALIZER_HPP
 
 #include <opm/common/utility/Serializer.hpp>
 
@@ -29,7 +29,6 @@
 #include <opm/simulators/utils/SerializationPackers.hpp>
 
 #include <algorithm>
-#include <cctype>
 #include <cstdlib>
 
 namespace Opm {
@@ -134,4 +133,4 @@ private:
 
 }
 
-#endif
+#endif // HDF5_SERIALIZER_HPP

--- a/opm/simulators/utils/HDF5Serializer.hpp
+++ b/opm/simulators/utils/HDF5Serializer.hpp
@@ -24,12 +24,12 @@
 #include <opm/common/utility/Serializer.hpp>
 
 #include <opm/simulators/utils/HDF5File.hpp>
-#include <opm/simulators/utils/moduleVersion.hpp>
 #include <opm/simulators/utils/ParallelCommunication.hpp>
 #include <opm/simulators/utils/SerializationPackers.hpp>
 
-#include <algorithm>
-#include <cstdlib>
+#include <cstddef>
+#include <limits>
+#include <string>
 
 namespace Opm {
 
@@ -55,7 +55,7 @@ public:
         try {
             this->pack(data);
         } catch (...) {
-            m_packSize = std::numeric_limits<size_t>::max();
+            m_packSize = std::numeric_limits<std::size_t>::max();
             throw;
         }
 
@@ -74,17 +74,7 @@ public:
                      const std::string& time_stamp,
                      const std::string& case_name,
                      const std::string& params,
-                     int num_procs)
-    {
-        try {
-            this->pack(simulator_name, module_version, time_stamp,
-                       case_name, params, num_procs);
-        } catch (...) {
-            m_packSize = std::numeric_limits<size_t>::max();
-            throw;
-        }
-        m_h5file.write("/", "simulator_info", m_buffer, HDF5File::DataSetMode::ROOT_ONLY);
-    }
+                     int num_procs);
 
     //! \brief Read data and deserialize from restart file.
     //! \tparam T Type of class to read
@@ -100,31 +90,10 @@ public:
     }
 
     //! \brief Returns the last report step stored in file.
-    int lastReportStep() const
-    {
-        const auto entries = m_h5file.list("/report_step");
-        int last = -1;
-        for (const auto& entry : entries) {
-            int num = std::atoi(entry.c_str());
-            last = std::max(last, num);
-        }
-
-        return last;
-    }
+    int lastReportStep() const;
 
     //! \brief Returns a list of report steps stored in restart file.
-    std::vector<int> reportSteps() const
-    {
-        const auto entries = m_h5file.list("/report_step");
-        std::vector<int> result(entries.size());
-        std::transform(entries.begin(), entries.end(), result.begin(),
-                       [](const std::string& input)
-                       {
-                          return std::atoi(input.c_str());
-                       });
-        std::sort(result.begin(), result.end());
-        return result;
-    }
+    std::vector<int> reportSteps() const;
 
 private:
     const Serialization::MemPacker m_packer_priv{}; //!< Packer instance

--- a/tests/test_HDF5Serializer.cpp
+++ b/tests/test_HDF5Serializer.cpp
@@ -21,7 +21,7 @@
 
 #include <opm/common/utility/FileSystem.hpp>
 
-#include <ebos/hdf5serializer.hh>
+#include <opm/simulators/utils/HDF5Serializer.hpp>
 
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/simulators/utils/ParallelCommunication.hpp>
@@ -31,7 +31,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <filesystem>
-#include <stdexcept>
 
 using namespace Opm;
 

--- a/tests/test_HDF5Serializer_Parallel.cpp
+++ b/tests/test_HDF5Serializer_Parallel.cpp
@@ -19,7 +19,7 @@
 
 #include <config.h>
 
-#include <ebos/hdf5serializer.hh>
+#include <opm/simulators/utils/HDF5Serializer.hpp>
 
 #include <opm/common/utility/FileSystem.hpp>
 
@@ -32,7 +32,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <filesystem>
-#include <stdexcept>
 #include <string>
 
 using namespace Opm;


### PR DESCRIPTION
Does not interact with the typetag system. While at it put some methods in a tu.