### PR TITLE
Damaris: avoid signed/unsigned comparison warnings

### DIFF
--- a/opm/simulators/utils/DamarisVar.hpp
+++ b/opm/simulators/utils/DamarisVar.hpp
@@ -20,11 +20,15 @@
 #ifndef DAMARISVAR_HPP
 #define DAMARISVAR_HPP
 
+#include <opm/common/ErrorMacros.hpp>
+
 #include <cassert>
+#include <cstddef>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <typeinfo>
+#include <vector>
 
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS 1
 
@@ -190,13 +194,13 @@ namespace DamarisOutput
         T* data_ptr_; //!< This pointer will be mapped to the Damaris shared memory
                       //!< area for the variable in the SetPointersToDamarisShmem()
                       //!< method. The type T will match the Layout type
-        size_t current_size_; //!< The total number of elements that may be held by this
-                              //!< part of the variable - returned by the size() method.
-                              //!< N.B. the actual size of the data area is dependent on
-                              //!< how the <variable> XML is written, as paramaters can
-                              //!< be augmented by basic maths relationships. This value
-                              //!< may not even be initialised if ParameterIsSet() method
-                              //!< is being used (e.g. in version 2/ of the constructor below).
+        std::size_t current_size_; //!< The total number of elements that may be held by this
+                                   //!< part of the variable - returned by the size() method.
+                                   //!< N.B. the actual size of the data area is dependent on
+                                   //!< how the <variable> XML is written, as paramaters can
+                                   //!< be augmented by basic maths relationships. This value
+                                   //!< may not even be initialised if ParameterIsSet() method
+                                   //!< is being used (e.g. in version 2/ of the constructor below).
 
     public:
         /**
@@ -257,7 +261,7 @@ namespace DamarisOutput
         {
             dam_err_ = DAMARIS_OK;
 
-            assert(param_names_.size() == dims);
+            assert(param_names_.size() == static_cast<std::size_t>(dims));
             assert(dims > 0);
 
             has_error_ = false;
@@ -510,7 +514,7 @@ namespace DamarisOutput
          *  Returns the number of elements in the memory area.
          *  Used as a method for compatibility with std::vector
          */
-        size_t size()
+        std::size_t size()
         {
             if (parameters_set_ == true) {
                 return current_size_;
@@ -532,10 +536,10 @@ namespace DamarisOutput
          */
         void setDamarisParameter(const std::vector<int>& paramSizeVal)
         {
-            assert(paramSizeVal.size() == num_params_);
+            assert(paramSizeVal.size() == static_cast<std::size_t>(num_params_));
 
             bool resbool = true;
-            size_t total_size = 1;
+            std::size_t total_size = 1;
             for (int varnum = 0; varnum < num_params_; varnum++) {
                 param_sizes_[varnum] = paramSizeVal[varnum];
                 total_size *= param_sizes_[varnum];
@@ -582,7 +586,7 @@ namespace DamarisOutput
          */
         void setDamarisPosition(const std::vector<int64_t>& positionsVals)
         {
-            assert(positionsVals.size() == num_params_);
+            assert(positionsVals.size() == static_cast<std::size_t>(num_params_));
 
             for (int pos_dim = 0; pos_dim < num_params_; pos_dim++) {
                 positions_[pos_dim] = positionsVals[pos_dim];

--- a/opm/simulators/utils/GridDataOutput.hpp
+++ b/opm/simulators/utils/GridDataOutput.hpp
@@ -20,8 +20,12 @@
 #ifndef OPM_GRID_DATA_OUTPUT_HPP
 #define OPM_GRID_DATA_OUTPUT_HPP
 
+#include <opm/common/ErrorMacros.hpp>
+
 #include <dune/grid/common/rangegenerators.hh>
 #include <dune/grid/io/file/vtk/common.hh>
+
+#include <cstddef>
 #include <sstream>
 
 /** @file
@@ -239,13 +243,15 @@ public:
     template <typename VectType>
     long writeGridPoints(VectType& x_inout, VectType& y_inout, VectType& z_inout)
     {
-        size_t check_size_x = x_inout.size();
-        size_t check_size_y = y_inout.size();
-        size_t check_size_z = z_inout.size();
+        const std::size_t check_size_x = x_inout.size();
+        const std::size_t check_size_y = y_inout.size();
+        const std::size_t check_size_z = z_inout.size();
 
         using VT = decltype(x_inout.data()[0]);
 
-        if ((check_size_x < nvertices_) || (check_size_y < nvertices_) || (check_size_z < nvertices_)) {
+        if ((check_size_x < static_cast<std::size_t>(nvertices_)) ||
+            (check_size_y < static_cast<std::size_t>(nvertices_)) ||
+            (check_size_z < static_cast<std::size_t>(nvertices_))) {
             // assert(check_size >= nvertices_);
             OPM_THROW(std::runtime_error,
                       "Opm::GridDataOutput::writeGridPoints( VectType&  x_inout,  VectType&  "
@@ -332,11 +338,11 @@ public:
     template <typename VectType>
     long writeGridPoints_AOS(VectType& xyz_inout)
     {
-        size_t check_size = xyz_inout.size();
+        const std::size_t check_size = xyz_inout.size();
 
         using VT = decltype(xyz_inout.data()[0]);
 
-        if (check_size < nvertices_ * 3) {
+        if (check_size < static_cast<std::size_t>(nvertices_ * 3)) {
             assert(check_size >= nvertices_ * 3);
             OPM_THROW(std::runtime_error,
                       "Opm::GridDataOutput::writeGridPoints_AOS( VectType&  xyz_inout )  "
@@ -423,9 +429,9 @@ public:
     template <typename VectType>
     long writeGridPoints_SOA(VectType& xyz_inout)
     {
-        size_t check_size = xyz_inout.size();
+        const std::size_t check_size = xyz_inout.size();
 
-        if (check_size < nvertices_ * 3) {
+        if (check_size < static_cast<std::size_t>(nvertices_ * 3)) {
             // assert(check_size >= nvertices_ * 3);
             OPM_THROW(std::runtime_error,
                       "Opm::GridDataOutput::writeGridPoints_SOA( VectType&  xyz_inout )  "
@@ -526,9 +532,9 @@ public:
     template <typename VectType>
     long writeConnectivity(VectType& connectivity_inout, ConnectivityVertexOrder whichOrder)
     {
-        size_t check_size = connectivity_inout.size();
+        const std::size_t check_size = connectivity_inout.size();
 
-        if (check_size < ncorners_) {
+        if (check_size < static_cast<std::size_t>(ncorners_)) {
             // assert(check_size >= ncorners_);
             OPM_THROW(std::runtime_error,
                       "Opm::GridDataOutput::writeConnectivity( VectType&  "
@@ -609,8 +615,8 @@ public:
     template <typename VectType>
     long writeOffsetsCells(VectType& offsets_inout)
     {
-        size_t check_size = offsets_inout.size();
-        if (check_size < ncells_) {
+        const std::size_t check_size = offsets_inout.size();
+        if (check_size < static_cast<std::size_t>(ncells_)) {
             // assert(check_size >= ncells_);
             OPM_THROW(std::runtime_error,
                       "Opm::GridDataOutput::writeOffsetsCells( VectType& "
@@ -670,9 +676,9 @@ public:
     template <typename VectType>
     long writeCellTypes(VectType& types_inout)
     {
-        size_t check_size = types_inout.size();
+        const std::size_t check_size = types_inout.size();
 
-        if (check_size < ncells_) {
+        if (check_size < static_cast<std::size_t>(ncells_)) {
             OPM_THROW(std::runtime_error,
                       "Opm::GridDataOutput::writeCellTypes( VectType&  types_inout )  " + " Input objects check_size ("
                           + std::to_string(check_size) + ") is not sufficient to fit the ncells_ values ("


### PR DESCRIPTION
while at it use std::size_t