### PR TITLE
Fix linking errors when using shared libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,7 +350,6 @@ if (HAVE_OPM_TESTS)
 endif()
 
 target_sources(test_outputdir PRIVATE $<TARGET_OBJECTS:moduleVersion>)
-target_sources(test_LogOutputHelper PRIVATE $<TARGET_OBJECTS:moduleVersion>)
 target_sources(test_equil PRIVATE $<TARGET_OBJECTS:moduleVersion>)
 target_sources(test_RestartSerialization PRIVATE $<TARGET_OBJECTS:moduleVersion>)
 target_sources(test_glift1 PRIVATE $<TARGET_OBJECTS:moduleVersion>)

--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -172,6 +172,7 @@ EclGenericOutputBlackoilModule(const EclipseState& eclState,
                            const Schedule& schedule,
                            const SummaryConfig& summaryConfig,
                            const SummaryState& summaryState,
+                           const std::string& moduleVersion,
                            bool enableEnergy,
                            bool enableTemperature,
                            bool enableMech,
@@ -189,7 +190,7 @@ EclGenericOutputBlackoilModule(const EclipseState& eclState,
     , interRegionFlows_(numCells(eclState),
                         defineInterRegionFlowArrays(eclState, summaryConfig),
                         declaredMaxRegionID(eclState.runspec()))
-    , logOutput_(eclState, schedule, summaryState)
+    , logOutput_(eclState, schedule, summaryState, moduleVersion)
     , enableEnergy_(enableEnergy)
     , enableTemperature_(enableTemperature)
     , enableMech_(enableMech)

--- a/ebos/eclgenericoutputblackoilmodule.hh
+++ b/ebos/eclgenericoutputblackoilmodule.hh
@@ -303,6 +303,7 @@ protected:
                                    const Schedule& schedule,
                                    const SummaryConfig& summaryConfig,
                                    const SummaryState& summaryState,
+                                   const std::string& moduleVersionName,
                                    bool enableEnergy,
                                    bool enableTemperature,
                                    bool enableMech,

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -31,6 +31,8 @@
 
 #include <ebos/eclbasevanguard.hh>
 #include <ebos/eclgenericoutputblackoilmodule.hh>
+#include <opm/simulators/utils/moduleVersion.hpp>
+
 
 #include <opm/common/Exceptions.hpp>
 #include <opm/common/TimingMacros.hpp>
@@ -144,6 +146,7 @@ public:
                    simulator.vanguard().schedule(),
                    simulator.vanguard().summaryConfig(),
                    simulator.vanguard().summaryState(),
+                   moduleVersionName(),
                    getPropValue<TypeTag, Properties::EnableEnergy>(),
                    getPropValue<TypeTag, Properties::EnableTemperature>(),
                    getPropValue<TypeTag, Properties::EnableMech>(),

--- a/opm/simulators/flow/LogOutputHelper.cpp
+++ b/opm/simulators/flow/LogOutputHelper.cpp
@@ -85,13 +85,13 @@ namespace Opm {
 template<class Scalar>
 LogOutputHelper<Scalar>::LogOutputHelper(const EclipseState& eclState,
                                          const Schedule& schedule,
-                                         const SummaryState& summaryState)
+                                         const SummaryState& summaryState,
+                                         const std::string& moduleVersionName)
     : eclState_(eclState)
     , schedule_(schedule)
     , summaryState_(summaryState)
-{ 
-    flowVersionName_ = moduleVersionName();
-}
+    , flowVersionName_(moduleVersionName)
+{}
 
 template<class Scalar>
 void LogOutputHelper<Scalar>::

--- a/opm/simulators/flow/LogOutputHelper.hpp
+++ b/opm/simulators/flow/LogOutputHelper.hpp
@@ -43,7 +43,8 @@ class LogOutputHelper {
 public:
     LogOutputHelper(const EclipseState& eclState,
                     const Schedule& schedule,
-                    const SummaryState& st);
+                    const SummaryState& st,
+                    const std::string& moduleVersionName);
 
     //! \brief Write cumulative production and injection reports to output.
     void cumulative(const std::size_t reportStepNum) const;

--- a/tests/test_LogOutputHelper.cpp
+++ b/tests/test_LogOutputHelper.cpp
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(Cumulative)
         st.set(p.first, p.second * 1e3);
     }
 
-    Opm::LogOutputHelper<double> helper(eclState, schedule, st);
+    Opm::LogOutputHelper<double> helper(eclState, schedule, st, "dummy version");
     helper.cumulative(0);
     std::string data = trimStream(str);
     BOOST_CHECK_EQUAL(data, reference);
@@ -194,7 +194,7 @@ Finding the dew point pressure failed for 3 cells [(5,1,1), (6,1,1), (7,1,1)]
     Opm::EclipseState eclState(deck);
 
     Opm::SummaryState st;
-    Opm::LogOutputHelper<double> helper(eclState, schedule, st);
+    Opm::LogOutputHelper<double> helper(eclState, schedule, st, "dummy version");
 
     str.str(""); // clear out parser errors
     helper.error({1,20,30}, {4,5,6});
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(Fip)
     Opm::EclipseState eclState(deck);
     Opm::SummaryState st;
 
-    Opm::LogOutputHelper<double> helper(eclState, schedule, st);
+    Opm::LogOutputHelper<double> helper(eclState, schedule, st, "dummy version");
     Opm::Inplace initial, current;
     const auto& phases = current.phases();
     int offset = 17;
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_CASE(FipResv)
     Opm::EclipseState eclState(deck);
     Opm::SummaryState st;
 
-    Opm::LogOutputHelper<double> helper(eclState, schedule, st);
+    Opm::LogOutputHelper<double> helper(eclState, schedule, st, "dummy version");
     Opm::Inplace current;
     const auto& phases = current.phases();
     int offset = 17;
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(Injection)
         st.set(p.first, p.second);
     }
 
-    Opm::LogOutputHelper<double> helper(eclState, schedule, st);
+    Opm::LogOutputHelper<double> helper(eclState, schedule, st, "dummy version");
     helper.injection(0);
     std::string data = trimStream(str);
     BOOST_CHECK_EQUAL(data, reference);
@@ -452,7 +452,7 @@ BOOST_AUTO_TEST_CASE(Production)
         st.set(p.first, p.second);
     }
 
-    Opm::LogOutputHelper<double> helper(eclState, schedule, st);
+    Opm::LogOutputHelper<double> helper(eclState, schedule, st, "dummy version");
     helper.production(0);
     std::string data = trimStream(str);
     BOOST_CHECK_EQUAL(data, reference);


### PR DESCRIPTION
We accomplish that by passing the module version as a string to the constructors of LogOutputHelper and EclGenericOutputBlackoilModel instead of calling moduleVersionName() in LogOutputHelper. That way moduleVersionName is not needed by libopmsimulators anymore and compilation works again for people requesting shared libraries via CMake's BUILD_SHARED_LIBS variable.

Closes #5122 