### PR TITLE
Fix WCONPROD GRAT control mode with solvent

### DIFF
--- a/opm/simulators/wells/StandardWellAssemble.cpp
+++ b/opm/simulators/wells/StandardWellAssemble.cpp
@@ -113,6 +113,9 @@ assembleControlEq(const WellState& well_state,
         if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
             rates[Gas] = primary_variables.getQs(Indices::canonicalToActiveComponentIndex(FluidSystem::gasCompIdx));
         }
+        if constexpr (Indices::enableSolvent) {
+            rates[Gas] += primary_variables.getQs(Indices::contiSolventEqIdx);
+        }
         return rates;
     };
 


### PR DESCRIPTION
Solvent production rate is now added to gas production rate such that their total rate is limited by GRAT control mode in WCONPROD.

From a (poorly constructed) example:
With current master, WNPR gets very large, and only the gas rate shown by (WGPR - WNPR) plot is limited by GRAT = 100 000 SM3/DAY
![wgpr_wnpr_master](https://github.com/OPM/opm-simulators/assets/9841912/e8cfeab4-396b-4438-a900-6f50a6aa556f)

With PR, the total gas rate (WGPR) is limited by GRAT = 100 000 SM3/DAY 
![wgpr_wnpr_fix](https://github.com/OPM/opm-simulators/assets/9841912/502c8769-2094-45a4-91f0-03527bfac76f)
