### PR TITLE
Ignore Coordsys and print a warning

### DIFF
--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -106,7 +106,7 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"CPIFACTL", {true, std::nullopt}},
         {"CONNECTION", {true, std::nullopt}},
         {"CONNECTION_PROBE", {true, std::nullopt}},
-        {"COORDSYS", {true, std::nullopt}},
+        {"COORDSYS", {false, std::string{"Multiple grid systems not supported, COORDSYS is ignored."}}},
         {"COPYBOX", {true, std::nullopt}},
         {"CRITPERM", {true, std::nullopt}},
         {"DATUMR", {true, std::nullopt}},


### PR DESCRIPTION
COORDSYS is often used for single reservoir systems. Lets ignore it. Note that if NUMRES > 1 the simulator will stop. 