### PR TITLE
Improve computeWellPotentials() exception output

### DIFF
--- a/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
+++ b/opm/simulators/utils/DeferredLoggingErrorHelpers.hpp
@@ -114,6 +114,10 @@ inline void logAndCheckForExceptionsAndThrow(Opm::DeferredLogger& deferred_logge
                                              const bool terminal_output,
                                              Opm::Parallel::Communication comm)
 {
+    // add exception message to logger in order to display message from all ranks
+    if (exc_type != Opm::ExceptionType::NONE && comm.size() > 1) {
+        deferred_logger.error("[Exception on rank " + std::to_string(comm.rank()) + "]: " + message);
+    }
     Opm::DeferredLogger global_deferredLogger = gatherDeferredLogger(deferred_logger, comm);
 
     if (terminal_output) {

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2185,12 +2185,18 @@ namespace Opm {
     {
         const int np = numPhases();
         std::vector<double> potentials;
-        const auto& well= well_container_[widx];
+        const auto& well = well_container_[widx];
+        std::string cur_exc_msg;
+        auto cur_exc_type = ExceptionType::NONE;
         try {
             well->computeWellPotentials(ebosSimulator_, well_state_copy, potentials, deferred_logger);
         }
         // catch all possible exception and store type and message.
-        OPM_PARALLEL_CATCH_CLAUSE(exc_type, exc_msg);
+        OPM_PARALLEL_CATCH_CLAUSE(cur_exc_type, cur_exc_msg);
+        if (cur_exc_type != ExceptionType::NONE) {
+            exc_msg += fmt::format("\nFor well {}: {}", well->name(), cur_exc_msg);
+        }
+        exc_type = std::max(exc_type, cur_exc_type);
         // Store it in the well state
         // potentials is resized and set to zero in the beginning of well->ComputeWellPotentials
         // and updated only if sucessfull. i.e. the potentials are zero for exceptions


### PR DESCRIPTION
In a model I'm looking into the simulator quits with the rather uninformative message:
```
Simulation aborted as program threw an unexpected exception: computeWellPotentials() failed:
```

The problem is that the exception does not happen on the root process, and thus the exception message
only contains the prefix. Instead of adding new code to sync the exception message between processes,
I opted to use the existing functionality for the deferred logger and add the exception message as errors in there.

Furthermore since we are queuing up exceptions here, we should also concatenate the messages from all exceptions.
The output is now a lot more informative,

```
Error: [Exception on rank 2]: computeWellPotentials() failed: 
For well WELL1: [/home/akva/kode/opm/opm-simulators/opm/simulators/wells/VFPHelpers.cpp:692] Nonexistent VFP table 0 referenced.
For well WELL2: [/home/akva/kode/opm/opm-simulators/opm/simulators/wells/VFPHelpers.cpp:692] Nonexistent VFP table 0 referenced.
Simulation aborted as program threw an unexpected exception: computeWellPotentials() failed:
```
Note that you still get the same "empty" exception in the end but all information is now conveyed to the user.