### PR TITLE
CpGrid with Lgrs (partially) supported for simulation

### DIFF
--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -438,7 +438,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::addLgrsUpdateLeafV
         const auto lgrCarfin = lgrCollection.getLgr(lgr);
         cells_per_dim_vec.push_back({lgrCarfin.NX(), lgrCarfin.NY(), lgrCarfin.NZ()});
         startIJK_vec.push_back({lgrCarfin.I1(), lgrCarfin.J1(), lgrCarfin.K1()});
-        endIJK_vec.push_back({lgrCarfin.I2(), lgrCarfin.J2(), lgrCarfin.K2()});
+        endIJK_vec.push_back({lgrCarfin.I2()+1, lgrCarfin.J2()+1, lgrCarfin.K2()+1});
         lgrName_vec.emplace_back(lgrCarfin.NAME());
 
     }

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -354,6 +354,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Ecl
 
     cartesianIndexMapper_ = std::make_unique<CartesianIndexMapper>(*grid_);
 
+        OpmLog::info("\nCreating grid with LGRs");
 #if HAVE_MPI
     {
         const bool has_numerical_aquifer = eclState.aquifer().hasNumericalAquifer();

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -364,6 +364,7 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Ecl
     // If there are lgrs, create the grid with them, and update the leaf grid view.
     if (lgrsSize)
     {
+        OpmLog::info("\nAdding LGRs to the grid and updating its leaf grid view");
         this->addLgrsUpdateLeafView(lgrs, lgrsSize);
     }
 

--- a/ebos/eclgenericcpgridvanguard.cc
+++ b/ebos/eclgenericcpgridvanguard.cc
@@ -436,11 +436,11 @@ void EclGenericCpGridVanguard<ElementMapper,GridView,Scalar>::addLgrsUpdateLeafV
     for (int lgr = 0; lgr < lgrsSize; ++lgr)
     {
         const auto lgrCarfin = lgrCollection.getLgr(lgr);
-        cells_per_dim_vec.push_back({lgrCarfin.NX(), lgrCarfin.NY(), lgrCarfin.NZ()});
+        cells_per_dim_vec.push_back({lgrCarfin.NX()/(lgrCarfin.I2() +1 - lgrCarfin.I1()),
+                lgrCarfin.NY()/(lgrCarfin.J2() +1 - lgrCarfin.J1()), lgrCarfin.NZ()/(lgrCarfin.K2() +1 - lgrCarfin.K1())});
         startIJK_vec.push_back({lgrCarfin.I1(), lgrCarfin.J1(), lgrCarfin.K1()});
         endIJK_vec.push_back({lgrCarfin.I2()+1, lgrCarfin.J2()+1, lgrCarfin.K2()+1});
         lgrName_vec.emplace_back(lgrCarfin.NAME());
-
     }
     this->grid_->addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgrName_vec);
 };

--- a/ebos/eclgenericcpgridvanguard.hh
+++ b/ebos/eclgenericcpgridvanguard.hh
@@ -28,6 +28,7 @@
 #define EWOMS_ECL_CP_GRID_GENERIC_VANGUARD_HH
 
 #include <ebos/eclgenericvanguard.hh>
+#include <opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp>
 
 #include <opm/grid/CpGrid.hpp>
 
@@ -170,6 +171,7 @@ protected:
     void allocCartMapper();
 
     void doCreateGrids_(EclipseState& eclState);
+    void createCpGridWithLgrs(const LgrCollection& lgrCollection, const int lgrsSize);
 
     virtual void allocTrans() = 0;
     virtual double getTransmissibility(unsigned I, unsigned J) const = 0;

--- a/ebos/eclgenericcpgridvanguard.hh
+++ b/ebos/eclgenericcpgridvanguard.hh
@@ -28,7 +28,6 @@
 #define EWOMS_ECL_CP_GRID_GENERIC_VANGUARD_HH
 
 #include <ebos/eclgenericvanguard.hh>
-#include <opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp>
 
 #include <opm/grid/CpGrid.hpp>
 
@@ -42,6 +41,7 @@ namespace Opm {
     class Schedule;
     class Well;
     class ParallelEclipseState;
+    class LgrCollection;
 }
 
 namespace Opm {
@@ -171,7 +171,7 @@ protected:
     void allocCartMapper();
 
     void doCreateGrids_(EclipseState& eclState);
-    void createCpGridWithLgrs(const LgrCollection& lgrCollection, const int lgrsSize);
+    void addLgrsUpdateLeafView(const LgrCollection& lgrCollection, const int lgrsSize);
 
     virtual void allocTrans() = 0;
     virtual double getTransmissibility(unsigned I, unsigned J) const = 0;

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2098,7 +2098,7 @@ protected:
         this->referencePorosity_[/*timeIdx=*/0].resize(numDof);
 
         const auto& fp = eclState.fieldProps();
-        const std::vector<double> porvData = fp.porv(false);
+        const std::vector<double> porvData = this -> fieldPropDoubleOnLeafAssigner_()(fp, "PORV");
         for (std::size_t dofIdx = 0; dofIdx < numDof; ++dofIdx) {
             Scalar poreVolume = porvData[dofIdx];
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -688,7 +688,10 @@ public:
         }
         }
         bool isSubStep = !EWOMS_GET_PARAM(TypeTag, bool, EnableWriteAllSolutions) && !this->simulator().episodeWillBeOver();
-        eclWriter_->evalSummaryState(isSubStep);
+        // For CpGrid with LGRs, ecl/vtk output is not supported yet.
+        if (enableEclOutput_) {
+            eclWriter_->evalSummaryState(isSubStep);
+        }
 
         int episodeIdx = this->episodeIndex();
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2101,7 +2101,7 @@ protected:
         this->referencePorosity_[/*timeIdx=*/0].resize(numDof);
 
         const auto& fp = eclState.fieldProps();
-        const std::vector<double> porvData = this -> fieldPropDoubleOnLeafAssigner_()(fp, "PORV");
+        const std::vector<double> porvData = this -> fieldPropDoubleOnLeafAssigner_()(fp, "PORV", numDof);
         for (std::size_t dofIdx = 0; dofIdx < numDof; ++dofIdx) {
             Scalar poreVolume = porvData[dofIdx];
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2101,7 +2101,7 @@ protected:
         this->referencePorosity_[/*timeIdx=*/0].resize(numDof);
 
         const auto& fp = eclState.fieldProps();
-        const std::vector<double> porvData = this -> fieldPropDoubleOnLeafAssigner_()(fp, "PORV", numDof);
+        const std::vector<double> porvData = this -> fieldPropDoubleOnLeafAssigner_()(fp, "PORV");
         for (std::size_t dofIdx = 0; dofIdx < numDof; ++dofIdx) {
             Scalar poreVolume = porvData[dofIdx];
 

--- a/ebos/ecltransmissibility_impl.hh
+++ b/ebos/ecltransmissibility_impl.hh
@@ -804,7 +804,7 @@ updateFromEclState_(bool global)
             if(grid_.maxLevel()>0) {
                 OPM_THROW(std::invalid_argument, "Calculations on TRANX/TRANY/TRANZ arrays are not support with LGRS, yet.");
             }
-            fp->apply_tran(*key, *it);
+        fp->apply_tran(*key, *it);
         }
     }
 


### PR DESCRIPTION
Creating a CpGrid with multiple LGRs (local grid refinement) and updating the leaf grid view is now supported for simulations, under certain assumptions on the set of cells to be refined.  The LGRs have to be disjoint, contain all active cells, and form a cuboid-shaped block. 

Further tasks: Output files. 

Remark: The current output files present some differences (at final time step, on the LGRs) that need to be further analyzed and, potentially modified. I believe it would help to merge this PR before the PRs that move files from ebos to a new place, e.g. OPM/opm-simulators#5194.
