### PR TITLE
Drop Ecl from two typetag entries/cl-parameters

### DIFF
--- a/ebos/ebos.hh
+++ b/ebos/ebos.hh
@@ -103,7 +103,7 @@ struct UseVolumetricResidual<TypeTag, TTag::EbosTypeTag> {
 
 // by default use flow's aquifer model for now
 template<class TypeTag>
-struct EclAquiferModel<TypeTag, TTag::EbosTypeTag> {
+struct AquiferModel<TypeTag, TTag::EbosTypeTag> {
     using type = BlackoilAquiferModel<TypeTag>;
 };
 

--- a/ebos/ebos.hh
+++ b/ebos/ebos.hh
@@ -66,7 +66,7 @@ struct EnableExperiments<TypeTag, TTag::EbosTypeTag> {
 
 // use flow's well model for now
 template<class TypeTag>
-struct EclWellModel<TypeTag, TTag::EbosTypeTag> {
+struct WellModel<TypeTag, TTag::EbosTypeTag> {
     using type = BlackoilWellModel<TypeTag>;
 };
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -173,7 +173,7 @@ class EclProblem : public GetPropType<TypeTag, Properties::BaseProblem>
     using Indices = GetPropType<TypeTag, Properties::Indices>;
     using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
     using WellModel = GetPropType<TypeTag, Properties::WellModel>;
-    using EclAquiferModel = GetPropType<TypeTag, Properties::EclAquiferModel>;
+    using AquiferModel = GetPropType<TypeTag, Properties::AquiferModel>;
 
     using SolventModule = BlackOilSolventModule<TypeTag>;
     using PolymerModule = BlackOilPolymerModule<TypeTag>;
@@ -1499,10 +1499,10 @@ public:
     WellModel& wellModel()
     { return wellModel_; }
 
-    const EclAquiferModel& aquiferModel() const
+    const AquiferModel& aquiferModel() const
     { return aquiferModel_; }
 
-    EclAquiferModel& mutableAquiferModel()
+    AquiferModel& mutableAquiferModel()
     { return aquiferModel_; }
 
     // temporary solution to facilitate output of initial state from flow
@@ -2772,7 +2772,7 @@ private:
     GlobalEqVector drift_;
 
     WellModel wellModel_;
-    EclAquiferModel aquiferModel_;
+    AquiferModel aquiferModel_;
 
     bool enableEclOutput_;
     std::unique_ptr<EclWriterType> eclWriter_;

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -172,7 +172,7 @@ class EclProblem : public GetPropType<TypeTag, Properties::BaseProblem>
     using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
     using Indices = GetPropType<TypeTag, Properties::Indices>;
     using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
-    using EclWellModel = GetPropType<TypeTag, Properties::EclWellModel>;
+    using WellModel = GetPropType<TypeTag, Properties::WellModel>;
     using EclAquiferModel = GetPropType<TypeTag, Properties::EclAquiferModel>;
 
     using SolventModule = BlackOilSolventModule<TypeTag>;
@@ -1493,10 +1493,10 @@ public:
      *
      * This can be used for inspecting wells outside of the problem.
      */
-    const EclWellModel& wellModel() const
+    const WellModel& wellModel() const
     { return wellModel_; }
 
-    EclWellModel& wellModel()
+    WellModel& wellModel()
     { return wellModel_; }
 
     const EclAquiferModel& aquiferModel() const
@@ -2771,7 +2771,7 @@ private:
     bool enableDriftCompensation_;
     GlobalEqVector drift_;
 
-    EclWellModel wellModel_;
+    WellModel wellModel_;
     EclAquiferModel aquiferModel_;
 
     bool enableEclOutput_;

--- a/ebos/eclproblem_properties.hh
+++ b/ebos/eclproblem_properties.hh
@@ -65,9 +65,9 @@ struct EclBaseProblem {
 };
 }
 
-// The class which deals with ECL wells
+// The class which deals with wells
 template<class TypeTag, class MyTypeTag>
-struct EclWellModel {
+struct WellModel {
     using type = UndefinedProperty;
 };
 

--- a/ebos/eclproblem_properties.hh
+++ b/ebos/eclproblem_properties.hh
@@ -115,7 +115,7 @@ struct EnableApiTracking {
 
 // The class which deals with ECL aquifers
 template<class TypeTag, class MyTypeTag>
-struct EclAquiferModel {
+struct AquiferModel {
     using type = UndefinedProperty;
 };
 
@@ -241,7 +241,7 @@ public:
 
 // by default use the dummy aquifer "model"
 template<class TypeTag>
-struct EclAquiferModel<TypeTag, TTag::EclBaseProblem> {
+struct AquiferModel<TypeTag, TTag::EclBaseProblem> {
     using type = EclBaseAquiferModel<TypeTag>;
 };
 

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -98,7 +98,7 @@ struct UseVolumetricResidual<TypeTag, TTag::FlowProblem> {
 };
 
 template<class TypeTag>
-struct EclAquiferModel<TypeTag, TTag::FlowProblem> {
+struct AquiferModel<TypeTag, TTag::FlowProblem> {
     using type = BlackoilAquiferModel<TypeTag>;
 };
 

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -142,7 +142,7 @@ struct EnableDispersion<TypeTag, TTag::FlowProblem> {
 };
 
 template<class TypeTag>
-struct EclWellModel<TypeTag, TTag::FlowProblem> {
+struct WellModel<TypeTag, TTag::FlowProblem> {
     using type = BlackoilWellModel<TypeTag>;
 };
 template<class TypeTag>

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -151,7 +151,7 @@ public:
     using MaterialLaw = GetPropType<TypeTag, Properties::MaterialLaw>;
     using SolutionVector = GetPropType<TypeTag, Properties::SolutionVector>;
     using MaterialLawParams = GetPropType<TypeTag, Properties::MaterialLawParams>;
-    using AquiferModel = GetPropType<TypeTag, Properties::EclAquiferModel>;
+    using AquiferModel = GetPropType<TypeTag, Properties::AquiferModel>;
 
     using TimeStepper = AdaptiveTimeStepping<TypeTag>;
     using PolymerModule = BlackOilPolymerModule<TypeTag>;

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -66,7 +66,7 @@ struct FlowIstlSolver {
 }
 
 template <class TypeTag, class MyTypeTag>
-struct EclWellModel;
+struct WellModel;
 
 //! Set the type of a global jacobian matrix for linear solvers that are based on
 //! dune-istl.
@@ -148,7 +148,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         using SparseMatrixAdapter = GetPropType<TypeTag, Properties::SparseMatrixAdapter>;
         using Vector = GetPropType<TypeTag, Properties::GlobalEqVector>;
         using Indices = GetPropType<TypeTag, Properties::Indices>;
-        using WellModel = GetPropType<TypeTag, Properties::EclWellModel>;
+        using WellModel = GetPropType<TypeTag, Properties::WellModel>;
         using Simulator = GetPropType<TypeTag, Properties::Simulator>;
         using Matrix = typename SparseMatrixAdapter::IstlMatrix;
         using ThreadManager = GetPropType<TypeTag, Properties::ThreadManager>;

--- a/opm/simulators/linalg/ISTLSolverBda.hpp
+++ b/opm/simulators/linalg/ISTLSolverBda.hpp
@@ -107,7 +107,7 @@ protected:
     using SparseMatrixAdapter = GetPropType<TypeTag, Properties::SparseMatrixAdapter>;
     using Vector = GetPropType<TypeTag, Properties::GlobalEqVector>;
     using Indices = GetPropType<TypeTag, Properties::Indices>;
-    using WellModel = GetPropType<TypeTag, Properties::EclWellModel>;
+    using WellModel = GetPropType<TypeTag, Properties::WellModel>;
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
     using Matrix = typename SparseMatrixAdapter::IstlMatrix;
     using ThreadManager = GetPropType<TypeTag, Properties::ThreadManager>;

--- a/tests/test_equil.cc
+++ b/tests/test_equil.cc
@@ -85,7 +85,7 @@ struct TestEquilVapwatTypeTag {
 }
 
 template<class TypeTag>
-struct EclWellModel<TypeTag, TTag::TestEquilTypeTag> {
+struct WellModel<TypeTag, TTag::TestEquilTypeTag> {
     using type = BlackoilWellModel<TypeTag>;
 };
 template<class TypeTag>
@@ -93,7 +93,7 @@ struct EnableVapwat<TypeTag, TTag::TestEquilTypeTag> {
     static constexpr bool value = true;
 };
 template<class TypeTag>
-struct EclWellModel<TypeTag, TTag::TestEquilVapwatTypeTag> {
+struct WellModel<TypeTag, TTag::TestEquilVapwatTypeTag> {
     using type = BlackoilWellModel<TypeTag>;
 };
 template<class TypeTag>


### PR DESCRIPTION
Some meat for the manual:

- `--ecl-well-model` is now `--well-model`
- `--ecl-aquifer-model` is now `--aquifer-model`