### PR TITLE
-fixed use of intensivequantites

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -2,7 +2,7 @@
 // vi: set et ts=4 sw=4 sts=4:
 /*
   Copyright 2023 INRIA
-  
+
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -756,10 +756,10 @@ public:
         }
 
         bool isSubStep = !EWOMS_GET_PARAM(TypeTag, bool, EnableWriteAllSolutions) && !this->simulator().episodeWillBeOver();
-        
+
         data::Solution localCellData = {};
 #if HAVE_DAMARIS
-        // N.B. the Damaris output has to be done before the ECL output as the ECL one 
+        // N.B. the Damaris output has to be done before the ECL output as the ECL one
         // does all kinds of std::move() relocation of data
         if (enableDamarisOutput_) {
             damarisWriter_->writeOutput(localCellData, isSubStep) ;
@@ -1423,10 +1423,10 @@ public:
         this->simulator().vanguard().cartesianCoordinate(globalDofIdx, ijk);
 
         if (source.hasSource(ijk)) {
-            const int pvtRegionIdx = this->pvtRegionIndex(globalDofIdx);  
+            const int pvtRegionIdx = this->pvtRegionIndex(globalDofIdx);
             static std::array<SourceComponent, 3> sc_map = {SourceComponent::WATER, SourceComponent::OIL, SourceComponent::GAS};
-            static std::array<int, 3> phidx_map = {FluidSystem::waterPhaseIdx, FluidSystem::oilPhaseIdx, FluidSystem::gasPhaseIdx}; 
-            static std::array<int, 3> cidx_map = {waterCompIdx, oilCompIdx, gasCompIdx}; 
+            static std::array<int, 3> phidx_map = {FluidSystem::waterPhaseIdx, FluidSystem::oilPhaseIdx, FluidSystem::gasPhaseIdx};
+            static std::array<int, 3> cidx_map = {waterCompIdx, oilCompIdx, gasCompIdx};
 
             for (unsigned i = 0; i < phidx_map.size(); ++i) {
                 const auto phaseIdx = phidx_map[i];
@@ -1434,7 +1434,7 @@ public:
                 const auto compIdx = cidx_map[i];
                 if (!FluidSystem::phaseIsActive(phaseIdx)) {
                     continue;
-                } 
+                }
                 Scalar mass_rate = source.rate({ijk, sourceComp}) / this->model().dofTotalVolume(globalDofIdx);
                 if constexpr (getPropValue<TypeTag, Properties::BlackoilConserveSurfaceVolume>()) {
                     mass_rate /= FluidSystem::referenceDensity(phaseIdx, pvtRegionIdx);
@@ -1609,7 +1609,7 @@ public:
                         //single (water) phase
                         fluidState.setPressure(phaseIdx, pressure);
                 }
-                
+
                 double temperature = initialFluidStates_[globalDofIdx].temperature(0); // we only have one temperature
                 const auto temperature_input = bc.temperature;
                 if(temperature_input)
@@ -1738,7 +1738,7 @@ public:
         OPM_TIMEBLOCK_LOCAL(permFactTransMultiplier);
         if (!enableSaltPrecipitation)
             return 1.0;
-        
+
         const auto& fs = intQuants.fluidState();
         unsigned tableIdx = fs.pvtRegionIndex();
         LhsEval porosityFactor = decay<LhsEval>(1. - fs.saltSaturation());
@@ -1754,12 +1754,12 @@ public:
     LhsEval wellTransMultiplier(const IntensiveQuantities& intQuants, unsigned elementIdx) const
     {
         OPM_TIMEBLOCK_LOCAL(wellTransMultiplier);
-        
+
         bool implicit = !EWOMS_GET_PARAM(TypeTag, bool, ExplicitRockCompaction);
         double trans_mult = implicit ? this->simulator().problem().template computeRockCompTransMultiplier_<double>(intQuants, elementIdx)
                                      : this->simulator().problem().getRockCompTransMultVal(elementIdx);
         trans_mult *= this->simulator().problem().template permFactTransMultiplier<double>(intQuants);
-    
+
         return trans_mult;
     }
 
@@ -1876,7 +1876,7 @@ protected:
 #pragma omp parallel for
 #endif
         for (unsigned dofIdx = 0; dofIdx < numGridDof; ++dofIdx) {
-                const auto& iq = *model.cachedIntensiveQuantities(dofIdx, /*timeIdx=*/ 0);
+                const auto& iq = model.intensiveQuantities(dofIdx, /*timeIdx=*/ 0);
                 func(dofIdx, iq);
         }
         OPM_END_PARALLEL_TRY_CATCH(failureMsg, vanguard.grid().comm());
@@ -2735,7 +2735,7 @@ private:
         std::size_t numGridDof = this->model().numGridDof();
         this->rockCompTransMultVal_.resize(numGridDof, 1.0);
         for (std::size_t elementIdx = 0; elementIdx < numGridDof; ++elementIdx) {
-            const auto& iq = *model.cachedIntensiveQuantities(elementIdx, /*timeIdx=*/ 0);
+            const auto& iq = model.intensiveQuantities(elementIdx, /*timeIdx=*/ 0);
             Scalar trans_mult = computeRockCompTransMultiplier_<Scalar>(iq, elementIdx);
             this->rockCompTransMultVal_[elementIdx] = trans_mult;
         }
@@ -2798,11 +2798,11 @@ private:
 
     bool enableEclOutput_;
     std::unique_ptr<EclWriterType> eclWriter_;
-    
+
 #if HAVE_DAMARIS
     bool enableDamarisOutput_ = false ;
     std::unique_ptr<DamarisWriterType> damarisWriter_;
-#endif 
+#endif
 
     PffGridVector<GridView, Stencil, PffDofData_, DofMapper> pffDofData_;
     TracerModel tracerModel_;

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -114,7 +114,7 @@ class EclWriter : public EclGenericWriter<GetPropType<TypeTag, Properties::Grid>
     using ElementMapper = GetPropType<TypeTag, Properties::ElementMapper>;
     using ElementIterator = typename GridView::template Codim<0>::Iterator;
     using BaseType = EclGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>;
-    
+
     typedef Dune::MultipleCodimMultipleGeomTypeMapper< GridView > VertexMapper;
 
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
@@ -133,7 +133,7 @@ public:
 
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableEsmry,
                              "Write ESMRY file for fast loading of summary data.");
-                                                        
+
     }
 
     // The Simulator object should preferably have been const - the
@@ -158,7 +158,7 @@ public:
     {
         this->eclOutputModule_ = std::make_unique<EclOutputBlackOilModule<TypeTag>>
             (simulator, this->collectToIORank_);
-            
+
         rank_ = simulator_.vanguard().grid().comm().rank() ;
     }
 
@@ -177,7 +177,7 @@ public:
     {
         OPM_TIMEBLOCK(evalSummaryState);
         const int reportStepNum = simulator_.episodeIndex() + 1;
-        
+
         /*
           The summary data is not evaluated for timestep 0, that is
           implemented with a:
@@ -195,7 +195,7 @@ public:
           "Correct" in this context means unchanged behavior, might very
           well be more correct to actually remove this if test.
         */
-        
+
         if (reportStepNum == 0)
             return;
 
@@ -248,22 +248,22 @@ public:
             OPM_END_PARALLEL_TRY_CATCH("Collect to I/O rank: ",
                                        this->simulator_.vanguard().grid().comm());
         }
-        
+
 
         std::map<std::string, double> miscSummaryData;
         std::map<std::string, std::vector<double>> regionData;
         Inplace inplace;
-        
+
         {
             OPM_TIMEBLOCK(outputFipLogAndFipresvLog);
 
             inplace = eclOutputModule_->calc_inplace(miscSummaryData, regionData, simulator_.gridView().comm());
-            
+
             if (this->collectToIORank_.isIORank()){
                 inplace_ = inplace;
             }
         }
-        
+
         // Add TCPU
         if (totalCpuTime != 0.0) {
             miscSummaryData["TCPU"] = totalCpuTime;
@@ -338,7 +338,7 @@ public:
 #pragma omp parallel for
 #endif
         for (int dofIdx = 0; dofIdx < num_interior; ++dofIdx) {
-            const auto& intQuants = *simulator_.model().cachedIntensiveQuantities(dofIdx, /*timeIdx=*/0);
+            const auto& intQuants = simulator_.model().intensiveQuantities(dofIdx, /*timeIdx=*/0);
             const auto totVolume = simulator_.model().dofTotalVolume(dofIdx);
 
             this->eclOutputModule_->updateFluidInPlace(dofIdx, intQuants, totVolume);
@@ -349,15 +349,15 @@ public:
         Inplace inplace;
         {
             OPM_TIMEBLOCK(outputFipLogAndFipresvLog);
-            
+
             boost::posix_time::ptime start_time = boost::posix_time::from_time_t(simulator_.vanguard().schedule().getStartTime());
 
             inplace = eclOutputModule_->calc_inplace(miscSummaryData, regionData, simulator_.gridView().comm());
 
             if (this->collectToIORank_.isIORank()){
                 inplace_ = inplace;
-                
-                eclOutputModule_->outputFipAndResvLog(inplace_, 0, 0.0, start_time, 
+
+                eclOutputModule_->outputFipAndResvLog(inplace_, 0, 0.0, start_time,
                                                      false, simulator_.gridView().comm());
             }
         }
@@ -387,24 +387,24 @@ public:
 
         // data::Solution localCellData = {};
         if (! isSubStep) {
-            
+
             auto rstep = timer.reportStepNum();
-            
+
             if ((rstep > 0) && (this->collectToIORank_.isIORank())){
 
                 eclOutputModule_->outputFipAndResvLog(inplace_, rstep, timer.simulationTimeElapsed(),
-                                                     timer.currentDateTime(), false, simulator_.gridView().comm()); 
+                                                     timer.currentDateTime(), false, simulator_.gridView().comm());
 
 
-                eclOutputModule_->outputTimeStamp("WELLS", timer.simulationTimeElapsed(), rstep, timer.currentDateTime()); 
-                                                             
+                eclOutputModule_->outputTimeStamp("WELLS", timer.simulationTimeElapsed(), rstep, timer.currentDateTime());
+
                 eclOutputModule_->outputProdLog(reportStepNum);
                 eclOutputModule_->outputInjLog(reportStepNum);
                 eclOutputModule_->outputCumLog(reportStepNum);
 
                 OpmLog::note("");   // Blank line after all reports.
             }
-            
+
             if (localCellData.empty()) {
                 this->eclOutputModule_->assignToSolution(localCellData);
             }
@@ -646,7 +646,7 @@ private:
 #pragma omp parallel for
 #endif
             for (int dofIdx = 0; dofIdx < num_interior; ++dofIdx) {
-                const auto& intQuants = *simulator_.model().cachedIntensiveQuantities(dofIdx, /*timeIdx=*/0);
+                const auto& intQuants = simulator_.model().intensiveQuantities(dofIdx, /*timeIdx=*/0);
                 const auto totVolume = simulator_.model().dofTotalVolume(dofIdx);
 
                 this->eclOutputModule_->updateFluidInPlace(dofIdx, intQuants, totVolume);

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -85,11 +85,11 @@ namespace Opm {
             {
                 using Item = PAvgDynamicSourceData::SourceDataSpan<double>::Item;
 
-                const auto* intQuants = this->ebosSimulator_.model()
-                    .cachedIntensiveQuantities(localCell, /*timeIndex = */0);
-                const auto& fs = intQuants->fluidState();
+                const auto& intQuants = this->ebosSimulator_.model()
+                    .intensiveQuantities(localCell, /*timeIndex = */0);
+                const auto& fs = intQuants.fluidState();
 
-                sourceTerms.set(Item::PoreVol, intQuants->porosity().value() *
+                sourceTerms.set(Item::PoreVol, intQuants.porosity().value() *
                                 this->ebosSimulator_.model().dofTotalVolume(localCell));
 
                 constexpr auto io = FluidSystem::oilPhaseIdx;


### PR DESCRIPTION
Remove use of changedIntensiveQuantites in case one would like to reduce memory on the cost of more expensive assembly and update. 