### PR TITLE
[bugfix?] Do terminal output on rank zero in time stepper even for restart

### DIFF
--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -310,7 +310,7 @@ public:
             if (isRestart()) {
                 // For restarts the ebosSimulator may have gotten some information
                 // about the next timestep size from the OPMEXTRA field
-                adaptiveTimeStepping_->setSuggestedNextStep(ebosSimulator_.timeStepSize());
+                adaptiveTimeStepping_->setSuggestedNextStep(ebosSimulator_.timeStepSize(), terminalOutput_);
             }
         }
     }


### PR DESCRIPTION
Seeing this felt a bit strange. I assume the with restart there might have been some messages missing.

To me this PR results in more consistent behavior. I could very well be wrong, though.