### PR TITLE
[fix] Use only EnableTuning consistently (and not also EclEnableTuning)

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -238,7 +238,8 @@ public:
         if constexpr (enableExperiments)
             EWOMS_REGISTER_PARAM(TypeTag, bool, EclEnableAquifers,
                                  "Enable analytic and numeric aquifer models");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EclEnableTuning,
+
+        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableTuning,
                              "Honor some aspects of the TUNING keyword from the ECL deck.");
         EWOMS_REGISTER_PARAM(TypeTag, std::string, OutputMode,
                              "Specify which messages are going to be printed. Valid values are: none, log, all (default)");

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -328,7 +328,7 @@ public:
         else
             enableAquifers_ = true;
 
-        this->enableTuning_ = EWOMS_GET_PARAM(TypeTag, bool, EclEnableTuning);
+        this->enableTuning_ = EWOMS_GET_PARAM(TypeTag, bool, EnableTuning);
         this->initialTimeStepSize_ = EWOMS_GET_PARAM(TypeTag, Scalar, InitialTimeStepSize);
         this->maxTimeStepAfterWellEvent_ = EWOMS_GET_PARAM(TypeTag, double, TimeStepAfterEventInDays)*24*60*60;
 

--- a/ebos/eclproblem_properties.hh
+++ b/ebos/eclproblem_properties.hh
@@ -127,7 +127,7 @@ struct EclEnableAquifers {
 
 // time stepping parameters
 template<class TypeTag, class MyTypeTag>
-struct EclEnableTuning {
+struct EnableTuning {
     using type = UndefinedProperty;
 };
 template<class TypeTag, class MyTypeTag>
@@ -600,7 +600,7 @@ struct EnableExperiments<TypeTag, TTag::EclBaseProblem> {
 
 // set defaults for the time stepping parameters
 template<class TypeTag>
-struct EclEnableTuning<TypeTag, TTag::EclBaseProblem> {
+struct EnableTuning<TypeTag, TTag::EclBaseProblem> {
     static constexpr bool value = false;
 };
 

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -164,7 +164,6 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
             EWOMS_HIDE_PARAM(TypeTag, MinTimeStepSize);
             EWOMS_HIDE_PARAM(TypeTag, PredeterminedTimeStepsFile);
 
-            EWOMS_HIDE_PARAM(TypeTag, EclEnableTuning);
 
             // flow also does not use the eWoms Newton method
             EWOMS_HIDE_PARAM(TypeTag, NewtonMaxError);

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -63,10 +63,6 @@ template<class TypeTag, class MyTypeTag>
 struct EnableAdaptiveTimeStepping {
     using type = UndefinedProperty;
 };
-template<class TypeTag, class MyTypeTag>
-struct EnableTuning {
-    using type = UndefinedProperty;
-};
 
 template <class TypeTag, class MyTypeTag>
 struct OutputExtraConvergenceInfo
@@ -105,10 +101,6 @@ struct EnableTerminalOutput<TypeTag, TTag::EclFlowProblem> {
 template<class TypeTag>
 struct EnableAdaptiveTimeStepping<TypeTag, TTag::EclFlowProblem> {
     static constexpr bool value = true;
-};
-template<class TypeTag>
-struct EnableTuning<TypeTag, TTag::EclFlowProblem> {
-    static constexpr bool value = false;
 };
 
 template <class TypeTag>
@@ -231,8 +223,6 @@ public:
                              "Print high-level information about the simulation's progress to the terminal");
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableAdaptiveTimeStepping,
                              "Use adaptive time stepping between report steps");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableTuning,
-                             "Honor some aspects of the TUNING keyword.");
         EWOMS_REGISTER_PARAM(TypeTag, std::string, OutputExtraConvergenceInfo,
                              "Provide additional convergence output "
                              "files for diagnostic purposes. "


### PR DESCRIPTION
In some part queried the former and in most parts the latter. So user had to actually use both `--enable-tuning=true --ecl-enable-tuning`) to achieve what they wanted.