### PR TITLE
Add print dilu levelsets option

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -506,6 +506,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/linalg/bda/WellContributions.hpp
   opm/simulators/linalg/amgcpr.hh
   opm/simulators/linalg/DILU.hpp
+  opm/simulators/linalg/DILUUtil.hpp
   opm/simulators/linalg/twolevelmethodcpr.hh
   opm/simulators/linalg/ExtractParallelGridInformationToISTL.hpp
   opm/simulators/linalg/ExtraSmoothers.hpp

--- a/opm/simulators/linalg/DILUUtil.hpp
+++ b/opm/simulators/linalg/DILUUtil.hpp
@@ -25,30 +25,34 @@
 namespace Opm::DILUUtils{
 
 // TODO: make proper doxygen
-// This function is intended to be used by parallel DILU implementations to
-// explore how parallelizable different linear systems are. The results
-// are for now written to a file from where flow is run
+/// @brief This function writes to a file a sparse table and the sizes of each row
+/// The intended use is to be called from a DILU preconditioner to explore how
+/// parallelizable the upper and lower solves are. For now the function creats a file
+/// in the directory from which flow was called, only intended to be done when verbosity>0
+/// @tparam T Any type, it does not matter what objects are stored in the table
+/// @param sparse_table A pointer to a SparseTable, this function does not change the object
 template <class T>
-void writeSparseTableRowSizesToFile(const Opm::SparseTable<T> *sparseTable){
+void writeSparseTableRowSizesToFile(const Opm::SparseTable<T> *sparse_table){
 
         int rank = 0;
-        int size = sparseTable->size();
+        int size = sparse_table->size();
 #ifdef HAVE_MPI
         MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #endif
         std::string filename = "DILU_parallelism_distribution_on_rank_" + std::to_string(rank) + ".txt";
         std::ofstream file(filename);
 
-        file << "PRINTING NUMBER OF LEVEL SETS, THEN NUMBER OF LEVELS IN EACH SET" << std::endl;
+        // print brief exeplenation of how to interpret the data in the file
+        file << "First is the number of levels, then the size of each level set" << std::endl;
         file << size << std::endl;
 
         for (int i = 0; i < size; i++){
-            file << sparseTable->rowSize(i) << std::endl;
+            file << sparse_table->rowSize(i) << std::endl;
         }
 }
 
 template void writeSparseTableRowSizesToFile(const Opm::SparseTable<size_t>*);
 
-} // END NAMESPACE OPM
+} // namespace Opm::DILUUtils
 
 #endif

--- a/opm/simulators/linalg/DILUUtil.hpp
+++ b/opm/simulators/linalg/DILUUtil.hpp
@@ -29,7 +29,7 @@ namespace Opm::DILUUtils{
 // explore how parallelizable different linear systems are. The results
 // are for now written to a file from where flow is run
 template <class T>
-void writeSparseTableRowSizesToFile(Opm::SparseTable<T> *sparseTable){
+void writeSparseTableRowSizesToFile(const Opm::SparseTable<T> *sparseTable){
 
         int rank = 0;
         int size = sparseTable->size();
@@ -47,7 +47,7 @@ void writeSparseTableRowSizesToFile(Opm::SparseTable<T> *sparseTable){
         }
 }
 
-template void writeSparseTableRowSizesToFile(Opm::SparseTable<size_t>*);
+template void writeSparseTableRowSizesToFile(const Opm::SparseTable<size_t>*);
 
 } // END NAMESPACE OPM
 

--- a/opm/simulators/linalg/DILUUtil.hpp
+++ b/opm/simulators/linalg/DILUUtil.hpp
@@ -1,0 +1,54 @@
+
+/*
+  Copyright 2022-2023 SINTEF AS
+  This file is part of the Open Porous Media project (OPM).
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_DILUUTIL_HEADER_INCLUDED
+#define OPM_DILUUTIL_HEADER_INCLUDED
+
+#include <config.h>
+#include <fstream>
+#include <mpi.h>
+#include <opm/grid/utility/SparseTable.hpp>
+
+namespace Opm::DILUUtils{
+
+// TODO: make proper doxygen
+// This function is intended to be used by parallel DILU implementations to
+// explore how parallelizable different linear systems are. The results
+// are for now written to a file from where flow is run
+template <class T>
+void writeSparseTableRowSizesToFile(Opm::SparseTable<T> *sparseTable){
+
+        int rank = 0;
+        int size = sparseTable->size();
+#ifdef HAVE_MPI
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+#endif
+        std::string filename = "DILU_parallelism_distribution_on_rank_" + std::to_string(rank) + ".txt";
+        std::ofstream file(filename);
+
+        file << "PRINTING NUMBER OF LEVEL SETS, THEN NUMBER OF LEVELS IN EACH SET" << std::endl;
+        file << size << std::endl;
+
+        for (int i = 0; i < size; i++){
+            file << sparseTable->rowSize(i) << std::endl;
+        }
+}
+
+template void writeSparseTableRowSizesToFile(Opm::SparseTable<size_t>*);
+
+} // END NAMESPACE OPM
+
+#endif

--- a/opm/simulators/linalg/PreconditionerFactory_impl.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory_impl.hpp
@@ -177,8 +177,8 @@ struct StandardPreconditioners
           return createParILU(op, prm, comm, prm.get<int>("ilulevel", 0));
         });
         F::addCreator("DILU", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
-          DUNE_UNUSED_PARAMETER(prm);
-          return wrapBlockPreconditioner<MultithreadDILU<M, V, V>>(comm, op.getmat());
+          const int preconditioner_verbosity = prm.get<int>("verbosity", 0);
+          return wrapBlockPreconditioner<MultithreadDILU<M, V, V>>(comm, op.getmat(), preconditioner_verbosity);
         });
         F::addCreator("Jac", [](const O& op, const P& prm, const std::function<V()>&,
                      std::size_t, const C& comm) {

--- a/opm/simulators/linalg/PreconditionerFactory_impl.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory_impl.hpp
@@ -286,9 +286,10 @@ struct StandardPreconditioners
         });
 
         F::addCreator("CUDILU", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
+            const int preconditioner_verbosity = prm.get<int>("verbosity", 0);
             using field_type = typename V::field_type;
             using CuDILU = typename Opm::cuistl::CuDILU<M, Opm::cuistl::CuVector<field_type>, Opm::cuistl::CuVector<field_type>>;
-            auto cuDILU = std::make_shared<CuDILU>(op.getmat());
+            auto cuDILU = std::make_shared<CuDILU>(op.getmat(), preconditioner_verbosity);
 
             auto adapted = std::make_shared<Opm::cuistl::PreconditionerAdapter<V, V, CuDILU>>(cuDILU);
             auto wrapped = std::make_shared<Opm::cuistl::CuBlockPreconditioner<V, V, Comm>>(adapted, comm);
@@ -516,9 +517,10 @@ struct StandardPreconditioners<Operator,Dune::Amg::SequentialInformation>
         });
 
         F::addCreator("CUDILU", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t) {
+            const int preconditioner_verbosity = prm.get<int>("verbosity", 0);
             using field_type = typename V::field_type;
             using CUDILU = typename Opm::cuistl::CuDILU<M, Opm::cuistl::CuVector<field_type>, Opm::cuistl::CuVector<field_type>>;
-            return std::make_shared<Opm::cuistl::PreconditionerAdapter<V, V, CUDILU>>(std::make_shared<CUDILU>(op.getmat()));
+            return std::make_shared<Opm::cuistl::PreconditionerAdapter<V, V, CUDILU>>(std::make_shared<CUDILU>(op.getmat(), preconditioner_verbosity));
         });
 
         F::addCreator("CUDILUFloat", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t) {

--- a/opm/simulators/linalg/PreconditionerFactory_impl.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory_impl.hpp
@@ -374,8 +374,8 @@ struct StandardPreconditioners<Operator,Dune::Amg::SequentialInformation>
                 op.getmat(), n, w, Opm::MILU_VARIANT::ILU);
         });
         F::addCreator("DILU", [](const O& op, const P& prm, const std::function<V()>&, std::size_t) {
-            DUNE_UNUSED_PARAMETER(prm);
-            return std::make_shared<MultithreadDILU<M, V, V>>(op.getmat());
+            const int preconditioner_verbosity = prm.get<int>("verbosity", 0);
+            return std::make_shared<MultithreadDILU<M, V, V>>(op.getmat(), preconditioner_verbosity);
         });
         F::addCreator("Jac", [](const O& op, const P& prm, const std::function<V()>&, std::size_t) {
             const int n = prm.get<int>("repeats", 1);

--- a/opm/simulators/linalg/cuistl/CuDILU.hpp
+++ b/opm/simulators/linalg/cuistl/CuDILU.hpp
@@ -60,9 +60,16 @@ public:
     //!
     //!  Constructor gets all parameters to operate the prec.
     //! \param A The matrix to operate on.
-    //! \param w The relaxation factor.
     //!
     explicit CuDILU(const M& A);
+
+    //! \brief Constructor accounting for verbosity.
+    //!
+    //!  Constructor gets all parameters to operate the prec.
+    //! \param A The matrix to operate on.
+    //! \param verbosity The verbosity level.
+    //!
+    explicit CuDILU(const M& A, int verbosity);
 
     //! \brief Prepare the preconditioner.
     //! \note Does nothing at the time being.


### PR DESCRIPTION
This PR utilizes the verbosity field specified for a preconditioner to write the size of each DILU level set to a file. This functionality is useful for analyzing how parallelizable different linear systems are. 
It is implementing by updating the preconditionerFactory to call new constructors for CuDILU and cpu DILU that will call the printing function if needed and sensible. We know the structure will not change, therefore we use std::call_once.
Some minor adjustments in DILU.hpp coding style were also done.

Open questions: 
* Using global variables in DILU and CuDILU for call_once flags was done because I need a variable that outlives the preconditioner itself, but I am not sure if this is good practice. 
* Currently the created datafile exists in whatever directory flow was called from, a better way to do this is probably to place it together with other generated datafiles from the simulation. This might be good enough for now since the feature is not intended for regular simulator usage, but if not it must be rewritten somewhere with the simulator object in scope to fetch the file path, and also call some new get functions in the DILU classes that would expose the SparseTable containing the levelsets.