### PR TITLE
remove duplicate EclEnableTuning parameter

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -238,8 +238,6 @@ public:
         if constexpr (enableExperiments)
             EWOMS_REGISTER_PARAM(TypeTag, bool, EclEnableAquifers,
                                  "Enable analytic and numeric aquifer models");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EclEnableTuning,
-                             "Honor some aspects of the TUNING keyword from the ECL deck.");
         EWOMS_REGISTER_PARAM(TypeTag, std::string, OutputMode,
                              "Specify which messages are going to be printed. Valid values are: none, log, all (default)");
         EWOMS_REGISTER_PARAM(TypeTag, int, NumPressurePointsEquil,
@@ -327,7 +325,7 @@ public:
         else
             enableAquifers_ = true;
 
-        this->enableTuning_ = EWOMS_GET_PARAM(TypeTag, bool, EclEnableTuning);
+        this->enableTuning_ = EWOMS_GET_PARAM(TypeTag, bool, EnableTuning);
         this->initialTimeStepSize_ = EWOMS_GET_PARAM(TypeTag, Scalar, InitialTimeStepSize);
         this->maxTimeStepAfterWellEvent_ = EWOMS_GET_PARAM(TypeTag, double, TimeStepAfterEventInDays)*24*60*60;
 

--- a/ebos/eclproblem_properties.hh
+++ b/ebos/eclproblem_properties.hh
@@ -125,11 +125,6 @@ struct EclEnableAquifers {
     using type = UndefinedProperty;
 };
 
-// time stepping parameters
-template<class TypeTag, class MyTypeTag>
-struct EclEnableTuning {
-    using type = UndefinedProperty;
-};
 template<class TypeTag, class MyTypeTag>
 struct OutputMode {
     using type = UndefinedProperty;
@@ -595,12 +590,6 @@ struct EnableThermalFluxBoundaries<TypeTag, TTag::EclBaseProblem> {
 // i.e., experimental features must be explicitly enabled at compile time
 template<class TypeTag>
 struct EnableExperiments<TypeTag, TTag::EclBaseProblem> {
-    static constexpr bool value = false;
-};
-
-// set defaults for the time stepping parameters
-template<class TypeTag>
-struct EclEnableTuning<TypeTag, TTag::EclBaseProblem> {
     static constexpr bool value = false;
 };
 

--- a/ebos/ecltimesteppingparams.hh
+++ b/ebos/ecltimesteppingparams.hh
@@ -33,6 +33,11 @@ struct EclTimeSteppingParameters {};
 }
 
 template<class TypeTag, class MyTypeTag>
+struct EnableTuning {
+    using type = UndefinedProperty;
+};
+
+template<class TypeTag, class MyTypeTag>
 struct SolverGrowthFactor {
     using type = UndefinedProperty;
 };
@@ -60,6 +65,11 @@ struct SolverRestartFactor {
 template<class TypeTag, class MyTypeTag>
 struct TimeStepAfterEventInDays {
     using type = UndefinedProperty;
+};
+
+template<class TypeTag>
+struct EnableTuning<TypeTag, TTag::EclTimeSteppingParameters> {
+    static constexpr bool value = false;
 };
 
 template<class TypeTag>
@@ -105,6 +115,8 @@ namespace Opm {
 template<class TypeTag>
 void registerEclTimeSteppingParameters()
 {
+    EWOMS_REGISTER_PARAM(TypeTag, bool, EnableTuning,
+                         "Honor some aspects of the TUNING keyword.");
     EWOMS_REGISTER_PARAM(TypeTag, double, SolverGrowthFactor,
                          "The factor time steps are elongated after a successful substep");
     EWOMS_REGISTER_PARAM(TypeTag, double, SolverMaxGrowth,

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -164,8 +164,6 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
             EWOMS_HIDE_PARAM(TypeTag, MinTimeStepSize);
             EWOMS_HIDE_PARAM(TypeTag, PredeterminedTimeStepsFile);
 
-            EWOMS_HIDE_PARAM(TypeTag, EclEnableTuning);
-
             // flow also does not use the eWoms Newton method
             EWOMS_HIDE_PARAM(TypeTag, NewtonMaxError);
             EWOMS_HIDE_PARAM(TypeTag, NewtonTolerance);

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -63,10 +63,6 @@ template<class TypeTag, class MyTypeTag>
 struct EnableAdaptiveTimeStepping {
     using type = UndefinedProperty;
 };
-template<class TypeTag, class MyTypeTag>
-struct EnableTuning {
-    using type = UndefinedProperty;
-};
 
 template <class TypeTag, class MyTypeTag>
 struct OutputExtraConvergenceInfo
@@ -105,10 +101,6 @@ struct EnableTerminalOutput<TypeTag, TTag::EclFlowProblem> {
 template<class TypeTag>
 struct EnableAdaptiveTimeStepping<TypeTag, TTag::EclFlowProblem> {
     static constexpr bool value = true;
-};
-template<class TypeTag>
-struct EnableTuning<TypeTag, TTag::EclFlowProblem> {
-    static constexpr bool value = false;
 };
 
 template <class TypeTag>
@@ -231,8 +223,6 @@ public:
                              "Print high-level information about the simulation's progress to the terminal");
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableAdaptiveTimeStepping,
                              "Use adaptive time stepping between report steps");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableTuning,
-                             "Honor some aspects of the TUNING keyword.");
         EWOMS_REGISTER_PARAM(TypeTag, std::string, OutputExtraConvergenceInfo,
                              "Provide additional convergence output "
                              "files for diagnostic purposes. "


### PR DESCRIPTION
In some part we queried the former and in most parts the latter. So user had to actually use both `--enable-tuning=true --ecl-enable-tuning`) to achieve what they wanted.

Fabulous work from @akva2 
