### PR TITLE
Use serial ZOLTAN load balancer by default.

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -169,7 +169,7 @@ struct OwnerCellsFirst<TypeTag, TTag::EclBaseVanguard> {
 };
 template<class TypeTag>
 struct SerialPartitioning<TypeTag, TTag::EclBaseVanguard> {
-    static constexpr bool value = false;
+    static constexpr bool value = true;
 };
 
 template<class TypeTag>


### PR DESCRIPTION
We have experienced rather poor partitioning when using the parallel version of ZOLTAN. We are not sure what the cause for this is and wheher we can fix this by using different defaults or different underlying partioners.

For the time being we simply change the default. This will cause some time increase when loadbalancing the grid but the rest of the simulator might actually be faster and compensate for this.