### PR TITLE
Respect low parsing strictness in actions 

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -563,10 +563,9 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
                          summaryConfig, std::move(python), initFromRestart,
                          checkDeck, treatCriticalAsNonCritical, outputInterval, *errorGuard);
 
-            if (treatCriticalAsNonCritical) { // Update schedule so that re-parsing after actions use same strictness
-                assert(schedule);
-                schedule->treat_critical_as_non_critical(true);
-            }
+            // Update schedule so that re-parsing after actions use same strictness
+            assert(schedule);
+            schedule->treat_critical_as_non_critical(treatCriticalAsNonCritical);
         }
         catch (const OpmInputError& input_error) {
             failureMessage = input_error.what();

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -557,6 +557,7 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
             auto parseContext = setupParseContext(exitOnAllErrors);
             if (treatCriticalAsNonCritical) { // Continue with invalid names if parsing strictness is set to low
                 parseContext->update(ParseContext::SCHEDULE_INVALID_NAME, InputErrorAction::WARN);
+                schedule->treat_critical_as_non_critical(true);
             }
             readOnIORank(comm, deckFilename, parseContext.get(),
                          eclipseState, schedule, udqState, actionState, wtestState,

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -557,12 +557,16 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
             auto parseContext = setupParseContext(exitOnAllErrors);
             if (treatCriticalAsNonCritical) { // Continue with invalid names if parsing strictness is set to low
                 parseContext->update(ParseContext::SCHEDULE_INVALID_NAME, InputErrorAction::WARN);
-                schedule->treat_critical_as_non_critical(true);
             }
             readOnIORank(comm, deckFilename, parseContext.get(),
                          eclipseState, schedule, udqState, actionState, wtestState,
                          summaryConfig, std::move(python), initFromRestart,
                          checkDeck, treatCriticalAsNonCritical, outputInterval, *errorGuard);
+
+            if (treatCriticalAsNonCritical) { // Update schedule so that re-parsing after actions use same strictness
+                assert(schedule);
+                schedule->treat_critical_as_non_critical(true);
+            }
         }
         catch (const OpmInputError& input_error) {
             failureMessage = input_error.what();


### PR DESCRIPTION
(when reprocessing the schedule section after action application.)