### PR TITLE
[Fix] Correct handling of NEXTSTEP in ACTIONX

### DIFF
--- a/opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
+++ b/opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
@@ -62,7 +62,7 @@ namespace Opm
         return ( report_step_ == 0 ) && ( current_step_ == 0 );
     }
 
-AdaptiveSimulatorTimer& AdaptiveSimulatorTimer::operator++ ()
+    AdaptiveSimulatorTimer& AdaptiveSimulatorTimer::operator++ ()
     {
         ++current_step_;
         current_time_ += dt_;
@@ -113,6 +113,12 @@ AdaptiveSimulatorTimer& AdaptiveSimulatorTimer::operator++ ()
     {
       assert(dt_ > 0);
         return dt_;
+    }
+
+    void AdaptiveSimulatorTimer::setCurrentStepLength(double dt)
+    {
+        assert(dt > 0);
+        dt_ = dt;
     }
 
     double AdaptiveSimulatorTimer::stepLengthTaken() const

--- a/opm/simulators/timestepping/AdaptiveSimulatorTimer.hpp
+++ b/opm/simulators/timestepping/AdaptiveSimulatorTimer.hpp
@@ -69,6 +69,9 @@ namespace Opm
         /// \brief \copydoc SimulationTimer::currentStepLength
         double currentStepLength () const;
 
+        // \brief Set next step length
+        void setCurrentStepLength(double dt);
+
         /// \brief \copydoc SimulationTimer::totalTime
         double totalTime() const;
 


### PR DESCRIPTION
Previously, the step size would only have used for the first time step of the next report step (at least of --enable-tuning=true was used).

Needs OPM/opm-common#3949
