### PR TITLE
increasing RelaxedPressureTolMsw default to be 2.e4

### DIFF
--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -393,7 +393,7 @@ struct RelaxedWellFlowTol<TypeTag, TTag::FlowModelParameters> {
 template<class TypeTag>
 struct RelaxedPressureTolMsw<TypeTag, TTag::FlowModelParameters> {
     using type = GetPropType<TypeTag, Scalar>;
-    static constexpr type value = 1.0e4;
+    static constexpr type value = 2.0e4;
 };
 template<class TypeTag>
 struct MaximumNumberOfWellSwitches<TypeTag, TTag::FlowModelParameters> {


### PR DESCRIPTION
there is one testing case gets stuck with pressure residual 1.557e4 for one of the segments of a well. 

This PR is for testing purpose to check the impact of the new default pressure tolerance. 