### PR TITLE
changed: put SupportsFaceTag in separate header

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -484,6 +484,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/aquifers/AquiferNumerical.hpp
   opm/simulators/aquifers/BlackoilAquiferModel.hpp
   opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+  opm/simulators/aquifers/SupportsFaceTag.hpp
   opm/simulators/linalg/bda/amgclSolverBackend.hpp
   opm/simulators/linalg/bda/BdaBridge.hpp
   opm/simulators/linalg/bda/BdaResult.hpp

--- a/flow/flow_blackoil_alugrid.cpp
+++ b/flow/flow_blackoil_alugrid.cpp
@@ -65,6 +65,12 @@ struct Vanguard<TypeTag, TTag::FlowProblemAlugrid> {
     using type = Opm::AluGridVanguard<TypeTag>;
 };
 }
+
+template<>
+class SupportsFaceTag<Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming>>
+    : public std::bool_constant<true>
+{};
+
 }
 
 int main(int argc, char** argv)

--- a/flow/flow_blackoil_polyhedralgrid.cpp
+++ b/flow/flow_blackoil_polyhedralgrid.cpp
@@ -67,6 +67,12 @@ namespace Properties {
         using type = Opm::EclPolyhedralGridVanguard<TypeTag>;
     };
 }
+
+template<>
+class SupportsFaceTag<Dune::PolyhedralGrid<3, 3>>
+    : public std::bool_constant<true>
+{};
+
 }
 
 int main(int argc, char** argv)

--- a/opm/simulators/aquifers/BlackoilAquiferModel.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel.hpp
@@ -20,7 +20,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef OPM_BLACKOILAQUIFERMODEL_HEADER_INCLUDED
 #define OPM_BLACKOILAQUIFERMODEL_HEADER_INCLUDED
 
@@ -33,14 +32,9 @@
 #include <opm/simulators/aquifers/AquiferCarterTracy.hpp>
 #include <opm/simulators/aquifers/AquiferFetkovich.hpp>
 #include <opm/simulators/aquifers/AquiferNumerical.hpp>
+#include <opm/simulators/aquifers/SupportsFaceTag.hpp>
 
 #include <opm/simulators/flow/BaseAquiferModel.hpp>
-
-#include <opm/grid/CpGrid.hpp>
-#include <opm/grid/polyhedralgrid.hh>
-#if HAVE_DUNE_ALUGRID
-#include <dune/alugrid/grid.hh>
-#endif
 
 #include <opm/material/densead/Math.hpp>
 
@@ -48,35 +42,9 @@
 #include <type_traits>
 #include <string_view>
 
-namespace Opm
-{
+namespace Opm {
 
-template<class Grid>
-class SupportsFaceTag
-    : public std::bool_constant<false>
-{};
-
-
-template<>
-class SupportsFaceTag<Dune::CpGrid>
-    : public std::bool_constant<true>
-{};
-
-
-template<>
-class SupportsFaceTag<Dune::PolyhedralGrid<3, 3>>
-    : public std::bool_constant<true>
-{};
-
-#if HAVE_DUNE_ALUGRID
-template<>
-class SupportsFaceTag<Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming>>
-    : public std::bool_constant<true>
-{};
-#endif
-
-
-/// Class for handling the blackoil well model.
+/// Class for handling the blackoil aquifer model.
 template <typename TypeTag>
 class BlackoilAquiferModel
 {
@@ -142,7 +110,6 @@ private:
 
     void computeConnectionAreaFraction() const;
 };
-
 
 } // namespace Opm
 

--- a/opm/simulators/aquifers/SupportsFaceTag.hpp
+++ b/opm/simulators/aquifers/SupportsFaceTag.hpp
@@ -1,0 +1,45 @@
+/*
+  File adapted from BlackoilWellModel.hpp
+
+  Copyright 2017 TNO - Heat Transfer & Fluid Dynamics, Modelling & Optimization of the Subsurface
+  Copyright 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef OPM_SUPPORTS_FACETAG_HEADER_INCLUDED
+#define OPM_SUPPORTS_FACETAG_HEADER_INCLUDED
+
+namespace Dune { class CpGrid; }
+
+namespace Opm {
+
+template<class Grid>
+class SupportsFaceTag
+    : public std::bool_constant<false>
+{};
+
+
+template<>
+class SupportsFaceTag<Dune::CpGrid>
+    : public std::bool_constant<true>
+{};
+
+
+} // namespace Opm
+
+#endif // OPM_SUPPORT_FACETAG_HEADER_INCLUDED


### PR DESCRIPTION
this way we don't have to pull in alugrid and polyhedralgrid in simulator objects that does not use them