### PR TITLE
Improve IDE experience

### DIFF
--- a/opm/simulators/aquifers/BlackoilAquiferModel.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel.hpp
@@ -20,7 +20,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef OPM_BLACKOILAQUIFERMODEL_HEADER_INCLUDED
 #define OPM_BLACKOILAQUIFERMODEL_HEADER_INCLUDED
 
@@ -146,6 +145,8 @@ private:
 
 } // namespace Opm
 
+#ifndef OPM_BLACKOILAQUIFERMODEL_IMPL_HEADER_INCLUDED
 #include "BlackoilAquiferModel_impl.hpp"
+#endif
 
 #endif

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -18,6 +18,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// Improve IDE experience
+#ifndef OPM_BLACKOILAQUIFERMODEL_HEADER_INCLUDED
+#include <config.h>
+#define OPM_BLACKOILAQUIFERMODEL_IMPL_HEADER_INCLUDED
+#include <opm/simulators/aquifers/BlackoilAquiferModel.hpp>
+#endif
+
 #include <opm/simulators/aquifers/AquiferConstantFlux.hpp>
 
 #include <opm/common/ErrorMacros.hpp>

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -27,15 +27,11 @@
 #include <ebos/eclproblem.hh>
 #include <opm/common/OpmLog/OpmLog.hpp>
 
-#include <cassert>
 #include <cstddef>
 #include <map>
 #include <memory>
 #include <optional>
-#include <set>
 #include <string>
-#include <tuple>
-#include <unordered_map>
 #include <vector>
 
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
@@ -558,5 +554,8 @@ namespace Opm {
 
 } // namespace Opm
 
+#ifndef OPM_BLACKOILWELLMODEL_IMPL_HEADER_INCLUDED
 #include "BlackoilWellModel_impl.hpp"
+#endif
+
 #endif

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -20,6 +20,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// Improve IDE experience
+#ifndef OPM_BLACKOILWELLMODEL_HEADER_INCLUDED
+#define OPM_BLACKOILWELLMODEL_IMPL_HEADER_INCLUDED
+#include <config.h>
+#include <opm/simulators/wells/BlackoilWellModel.hpp>
+#endif
+
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/core/props/phaseUsageFromDeck.hpp>
 #include <opm/grid/utility/cartesianToCompressed.hpp>
@@ -41,6 +48,7 @@
 #endif
 
 #include <algorithm>
+#include <cassert>
 #include <iomanip>
 #include <utility>
 

--- a/opm/simulators/wells/GasLiftSingleWell.hpp
+++ b/opm/simulators/wells/GasLiftSingleWell.hpp
@@ -69,6 +69,8 @@ namespace Opm
 
 } // namespace Opm
 
+#ifndef OPM_GASLIFT_SINGLE_WELL_IMPL_HEADER_INCLUDED
 #include "GasLiftSingleWell_impl.hpp"
+#endif
 
 #endif // OPM_GASLIFT_SINGLE_WELL_HEADER_INCLUDED

--- a/opm/simulators/wells/GasLiftSingleWell_impl.hpp
+++ b/opm/simulators/wells/GasLiftSingleWell_impl.hpp
@@ -17,6 +17,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// Improve IDE experience
+#ifndef OPM_GASLIFT_SINGLE_WELL_HEADER_INCLUDED
+#define OPM_GASLIFT_SINGLE_WELL_IMPL_HEADER_INCLUDED
+#include <config.h>
+#include <opm/simulators/wells/GasLiftSingleWell.hpp>
+#endif
+
 #include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
 #include <fmt/format.h>
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -323,6 +323,8 @@ namespace Opm
 
 }
 
+#ifndef OPM_MULTISEGMENTWELL_IMPL_HEADER_INCLUDED
 #include "MultisegmentWell_impl.hpp"
+#endif
 
 #endif // OPM_MULTISEGMENTWELL_HEADER_INCLUDED

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -18,6 +18,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// Improve IDE experience
+#ifndef OPM_MULTISEGMENTWELL_HEADER_INCLUDED
+#define OPM_MULTISEGMENTWELL_IMPL_HEADER_INCLUDED
+#include <config.h>
+#include <opm/simulators/wells/MultisegmentWell.hpp>
+#endif
+
 #include <opm/common/Exceptions.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -514,6 +514,8 @@ namespace Opm
 
 }
 
+#ifndef OPM_STANDARDWELL_IMPL_HEADER_INCLUDED
 #include "StandardWell_impl.hpp"
+#endif
 
 #endif // OPM_STANDARDWELL_HEADER_INCLUDED

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -19,6 +19,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// Improve IDE experience
+#ifndef OPM_STANDARDWELL_HEADER_INCLUDED
+#define OPM_STANDARDWELL_IMPL_HEADER_INCLUDED
+#include <config.h>
+#include <opm/simulators/wells/StandardWell.hpp>
+#endif
+
 #include <opm/common/Exceptions.hpp>
 
 #include <opm/input/eclipse/Units/Units.hpp>

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -490,6 +490,8 @@ protected:
 
 } // namespace Opm
 
+#ifndef OPM_WELLINTERFACE_IMPL_HEADER_INCLUDED
 #include "WellInterface_impl.hpp"
+#endif
 
 #endif // OPM_WELLINTERFACE_HEADER_INCLUDED

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -19,6 +19,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// Improve IDE experience
+#ifndef OPM_WELLINTERFACE_HEADER_INCLUDED
+#include <config.h>
+#define OPM_WELLINTERFACE_IMPL_HEADER_INCLUDED
+#include <opm/simulators/wells/WellInterface.hpp>
+#endif
+
 #include <opm/common/Exceptions.hpp>
 
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>


### PR DESCRIPTION
The _impl.hpp pattern is not very friendly to code analyzers such as clangd used in IDEs.
This adds logic so clangd see the _impl.hpp as a proper translation unit (include config.h and include the main .hpp file).

I've been carrying these locally for a long time. Let's see if this is acceptable for the main repo.