### PR TITLE
Add Support for Calculating Block Level Depth Corrected Pressures

### DIFF
--- a/ebos/eclgenericoutputblackoilmodule.cc
+++ b/ebos/eclgenericoutputblackoilmodule.cc
@@ -255,9 +255,30 @@ EclGenericOutputBlackoilModule<FluidSystem,Scalar>::
 
 template<class FluidSystem, class Scalar>
 void EclGenericOutputBlackoilModule<FluidSystem,Scalar>::
-outputTimeStamp(const std::string& lbl, double elapsed, int rstep, boost::posix_time::ptime currentDate)
+outputTimeStamp(const std::string& lbl,
+                const double elapsed,
+                const int rstep,
+                const boost::posix_time::ptime currentDate)
 {
     logOutput_.timeStamp(lbl, elapsed, rstep, currentDate);
+}
+
+template<class FluidSystem, class Scalar>
+void EclGenericOutputBlackoilModule<FluidSystem,Scalar>::
+prepareDensityAccumulation()
+{
+    if (this->regionAvgDensity_.has_value()) {
+        this->regionAvgDensity_->prepareAccumulation();
+    }
+}
+
+template<class FluidSystem, class Scalar>
+void EclGenericOutputBlackoilModule<FluidSystem,Scalar>::
+accumulateDensityParallel()
+{
+    if (this->regionAvgDensity_.has_value()) {
+        this->regionAvgDensity_->accumulateParallel();
+    }
 }
 
 template<class FluidSystem, class Scalar>
@@ -280,7 +301,6 @@ outputInjLog(std::size_t reportStepNum)
 {
     this->logOutput_.injection(reportStepNum);
 }
-
 
 template<class FluidSystem,class Scalar>
 Inplace EclGenericOutputBlackoilModule<FluidSystem,Scalar>::

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -600,12 +600,17 @@ private:
 
         {
             OPM_TIMEBLOCK(prepareCellBasedData);
+
+            this->eclOutputModule_->prepareDensityAccumulation();
+
             for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {
                 elemCtx.updatePrimaryStencil(elem);
                 elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
 
                 this->eclOutputModule_->processElement(elemCtx);
             }
+
+            this->eclOutputModule_->accumulateDensityParallel();
         }
 
         if constexpr (enableMech) {


### PR DESCRIPTION
This PR calculates the block-level depth-corrected phase pressures `BPPO`, `BPPG`, and `BPPW`.  We use the simulation configuration's `DatumDepth` feature to extract the reference depths for the `FIPNUM` region set per cell and accumulate average phase densities per PVT regions using the `RegionPhasePoreVolAverage` utility.  To that end, add a new `optional<>` data member of this type to the generic output module and initialise this if the input model requests such summary output.