### PR TITLE
not using spres_lower_limit limit non-top segments

### DIFF
--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
@@ -97,7 +97,8 @@ public:
                       const double relaxation_factor,
                       const double DFLimit,
                       const bool stop_or_zero_rate_target,
-                      const double max_pressure_change);
+                      const double max_pressure_change,
+                      DeferredLogger& deferred_logger);
 
     //! \brief Copy values to well state.
     void copyToWellState(const MultisegmentWellGeneric<Scalar>& mswell,

--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
@@ -26,6 +26,7 @@
 
 #include <opm/simulators/wells/MultisegmentWellEquations.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Units/Units.hpp>
 
 #include <array>
 #include <cstddef>
@@ -97,8 +98,7 @@ public:
                       const double relaxation_factor,
                       const double DFLimit,
                       const bool stop_or_zero_rate_target,
-                      const double max_pressure_change,
-                      DeferredLogger& deferred_logger);
+                      const double max_pressure_change);
 
     //! \brief Copy values to well state.
     void copyToWellState(const MultisegmentWellGeneric<Scalar>& mswell,
@@ -151,6 +151,9 @@ public:
     void setValue(const int idx, const std::array<Scalar, numWellEq>& val)
     { value_[idx] = val; }
 
+    //! output the segments with pressure close to lower pressure limit for debugging purpose
+    void outputLowLimitPressureSegments(DeferredLogger& deferred_logger) const;
+
 private:
     //! \brief Handle non-reasonable fractions due to numerical overshoot.
     void processFractions(const int seg);
@@ -168,6 +171,9 @@ private:
     std::vector<std::array<EvalWell, numWellEq>> evaluation_;
 
     const WellInterfaceIndices<FluidSystem,Indices,Scalar>& well_; //!< Reference to well interface
+
+    static constexpr double bhp_lower_limit = 1. * unit::barsa - 1. * unit::Pascal;
+    static constexpr double seg_pres_lower_limit = 0.;
 };
 
 }

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -689,7 +689,8 @@ namespace Opm
                                               relaxation_factor,
                                               dFLimit,
                                               stop_or_zero_rate_target,
-                                              max_pressure_change);
+                                              max_pressure_change,
+                                              deferred_logger);
 
         this->primary_variables_.copyToWellState(*this, getRefDensity(), stop_or_zero_rate_target,
                                                  well_state, summary_state, deferred_logger);

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -689,8 +689,7 @@ namespace Opm
                                               relaxation_factor,
                                               dFLimit,
                                               stop_or_zero_rate_target,
-                                              max_pressure_change,
-                                              deferred_logger);
+                                              max_pressure_change);
 
         this->primary_variables_.copyToWellState(*this, getRefDensity(), stop_or_zero_rate_target,
                                                  well_state, summary_state, deferred_logger);
@@ -1762,6 +1761,7 @@ namespace Opm
             const std::string message = fmt::format("   Well {} did not converge in {} inner iterations ("
                                                     "{} control/status switches).", this->name(), it, switch_count);
             deferred_logger.debug(message);
+            this->primary_variables_.outputLowLimitPressureSegments(deferred_logger);
         }
 
         return converged;


### PR DESCRIPTION
with multi-segments, the segment pressure can be lower than the bhp, so it is not desirable to use spres_lower_limit to limit the segment pressure. We only use spres_lower_limit to limit the bhp, which is still valid until we begin using bhp limit lower than 1 bar.