### PR TITLE
fixed: don't link python module to flow_libblackoil

### DIFF
--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -9,16 +9,13 @@
 #  https://pybind11.readthedocs.io/en/stable/compiling.html
 #
 pybind11_add_module(simulators ${PYBIND11_SYSTEM}
+  $<TARGET_OBJECTS:moduleVersion>
+  Pybind11Exporter.cpp
   PyBlackOilSimulator.cpp
-  Pybind11Exporter.cpp)
+  )
 
 set(PYTHON_OPM_SIMULATORS_PACKAGE_PATH ${PROJECT_BINARY_DIR}/python/opm/simulators)
 set_target_properties( simulators PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PYTHON_OPM_SIMULATORS_PACKAGE_PATH} )
-
-target_sources(simulators
-  PRIVATE
-  $<TARGET_OBJECTS:moduleVersion>
-  $<TARGET_OBJECTS:flow_libblackoil>)
 
 target_link_libraries( simulators PRIVATE opmsimulators )
 

--- a/python/simulators/PyBlackOilSimulator.cpp
+++ b/python/simulators/PyBlackOilSimulator.cpp
@@ -27,12 +27,25 @@
 //#include <opm/simulators/flow/python/PyFluidState.hpp>
 #include <opm/simulators/flow/python/PyMaterialState.hpp>
 #include <opm/simulators/flow/python/PyBlackOilSimulator.hpp>
-#include <flow/flow_ebos_blackoil.hpp>
 // NOTE: EXIT_SUCCESS, EXIT_FAILURE is defined in cstdlib
 #include <cstdlib>
-#include <iostream>
 #include <stdexcept>
 #include <string>
+
+namespace Opm {
+
+std::unique_ptr<FlowMain<Properties::TTag::FlowProblemTPFA>>
+flowEbosBlackoilTpfaMainInit(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    resetLocale();
+
+    return std::make_unique<FlowMain<Properties::TTag::FlowProblemTPFA>>(
+        argc, argv, outputCout, outputFiles);
+}
+
+}
 
 namespace py = pybind11;
 


### PR DESCRIPTION
this leads to ODR violations which causes all sorts of havoc. this was done to reuse a trivial method, duplicate it in the python source instead.

This is the final fallout of the troubles observed in https://github.com/OPM/opm-simulators/pull/4950
After a long time we were finally able to track the crash down to building using ninja rather than make.
Using object libraries the order of the objects differ in the linker command; with ninja the object libraries are always placed first while with make they are not. This makes a difference as the linker choose the duplicated symbols based on which source come first, and by pure luck the order with make had the linker choose the 'correct' copy of the symbol, while the order with ninja had it choose the wrong symbol.