### PR TITLE
fixed: if we write the size as a size_t we better read it as a size_t

### DIFF
--- a/ebos/collecttoiorank_impl.hh
+++ b/ebos/collecttoiorank_impl.hh
@@ -825,7 +825,7 @@ public:
             std::string name;
             buffer.read(name);
             globalFlows_[i].name = name;
-            unsigned int size = 0;
+            std::size_t size = 0;
             buffer.read(size);
             for (unsigned int j = 0; j < size; ++j) {
                 int nncIdx;


### PR DESCRIPTION
fixes regression after 7dcc411397baa585dca1fb6b804d074d9c3203d3