### PR TITLE
changed: rename FlowMain.cpp to FlowUtils.cpp

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -43,7 +43,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/flow/Banners.cpp
   opm/simulators/flow/ConvergenceOutputConfiguration.cpp
   opm/simulators/flow/ExtraConvergenceOutputThread.cpp
-  opm/simulators/flow/FlowMain.cpp
+  opm/simulators/flow/FlowUtils.cpp
   opm/simulators/flow/GenericOutputBlackoilModule.cpp
   opm/simulators/flow/InterRegFlows.cpp
   opm/simulators/flow/KeywordValidation.cpp
@@ -452,6 +452,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/flow/DummyGradientCalculator.hpp
   opm/simulators/flow/ExtraConvergenceOutputThread.hpp
   opm/simulators/flow/FlowMain.hpp
+  opm/simulators/flow/FlowUtils.hpp
   opm/simulators/flow/FlowsData.hpp
   opm/simulators/flow/GenericOutputBlackoilModule.hpp
   opm/simulators/flow/InterRegFlows.hpp

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -22,14 +22,15 @@
 #ifndef OPM_FLOW_MAIN_HEADER_INCLUDED
 #define OPM_FLOW_MAIN_HEADER_INCLUDED
 
-#include <opm/simulators/flow/Banners.hpp>
-#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
-
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 
 #include <opm/models/utils/start.hh>
+
+#include <opm/simulators/flow/Banners.hpp>
+#include <opm/simulators/flow/FlowUtils.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/misc/mpimanager.hh>
@@ -39,7 +40,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <string_view>
 
 namespace Opm::Properties {
 
@@ -74,21 +74,6 @@ struct OutputInterval<TypeTag, TTag::FlowProblem> {
 } // namespace Opm::Properties
 
 namespace Opm {
-namespace detail {
-
-void checkAllMPIProcesses();
-
-void mergeParallelLogFiles(std::string_view output_dir,
-                           std::string_view deck_filename,
-                           bool enableLoggingFalloutWarning);
-
-void handleExtraConvergenceOutput(SimulatorReport& report,
-                                  std::string_view option,
-                                  std::string_view optionName,
-                                  std::string_view output_dir,
-                                  std::string_view base_name);
-
-}
 
     class Deck;
 

--- a/opm/simulators/flow/FlowUtils.cpp
+++ b/opm/simulators/flow/FlowUtils.cpp
@@ -21,21 +21,29 @@
 */
 
 #include <config.h>
-#include <opm/simulators/flow/FlowMain.hpp>
+#include <opm/simulators/flow/FlowUtils.hpp>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/String.hpp>
 
 #include <opm/simulators/flow/ConvergenceOutputConfiguration.hpp>
-
+#include <opm/simulators/timestepping/SimulatorReport.hpp>
 #include <opm/simulators/utils/ParallelFileMerger.hpp>
+
+#if HAVE_MPI
+#include <ebos/eclgenericvanguard.hh>
+#endif
+
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <unistd.h>
+#include <vector>
 
-namespace Opm {
-namespace detail {
+namespace Opm::detail {
 
 void mergeParallelLogFiles(std::string_view output_dir,
                            std::string_view deckFilename,
@@ -156,5 +164,4 @@ void checkAllMPIProcesses()
 #endif
 }
 
-} // namespace detail
-} // namespace Opm
+} // namespace Opm::detail

--- a/opm/simulators/flow/FlowUtils.hpp
+++ b/opm/simulators/flow/FlowUtils.hpp
@@ -1,0 +1,45 @@
+/*
+  Copyright 2013, 2014, 2015 SINTEF ICT, Applied Mathematics.
+  Copyright 2014 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015 IRIS AS
+  Copyright 2014 STATOIL ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_FLOW_UTILS_HEADER_INCLUDED
+#define OPM_FLOW_UTILS_HEADER_INCLUDED
+
+#include <string_view>
+
+namespace Opm { struct SimulatorReport; }
+
+namespace Opm::detail {
+
+void checkAllMPIProcesses();
+
+void mergeParallelLogFiles(std::string_view output_dir,
+                           std::string_view deck_filename,
+                           bool enableLoggingFalloutWarning);
+
+void handleExtraConvergenceOutput(SimulatorReport& report,
+                                  std::string_view option,
+                                  std::string_view optionName,
+                                  std::string_view output_dir,
+                                  std::string_view base_name);
+
+} // namespace Opm::detail
+
+#endif // OPM_FLOW_UTILS_HEADER_INCLUDED


### PR DESCRIPTION
and add a dedicated header.

this way we don't need to pull in FlowMain.hpp for the prototypes, avoiding pulling in the entire simulator machinery just to build some simple utility functions.