### PR TITLE
Permit DATUMR and DATUMRX Keywords in Input File

### DIFF
--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -109,8 +109,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"COORDSYS", {false, std::string{"Multiple grid systems not supported, COORDSYS is ignored."}}},
         {"COPYBOX", {true, std::nullopt}},
         {"CRITPERM", {true, std::nullopt}},
-        {"DATUMR", {true, std::nullopt}},
-        {"DATUMRX", {true, std::nullopt}},
         {"DCQDEFN", {true, std::nullopt}},
         {"DEBUG", {false, std::nullopt}},
         {"DELAYACT", {true, std::nullopt}},


### PR DESCRIPTION
Following PRs

  * OPM/opm-common#3958
  * OPM/opm-simulators#5240

these keywords are nominally supported, at least for the block level summary keywords (`BPPx`).