### PR TITLE
Defer SummaryConfig Initialisation

### DIFF
--- a/opm/simulators/flow/DamarisWriter.hpp
+++ b/opm/simulators/flow/DamarisWriter.hpp
@@ -36,6 +36,9 @@
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 
+#include <mpi.h>
+#include <opm/simulators/utils/MPISerializer.hpp>
+
 #include <opm/simulators/flow/countGlobalCells.hpp>
 #include <opm/simulators/flow/DamarisProperties.hpp>
 #include <opm/simulators/flow/EclGenericWriter.hpp>
@@ -149,25 +152,56 @@ public:
                    simulator.vanguard().eclState(),
                    simulator.vanguard().summaryConfig(),
                    simulator.vanguard().grid(),
-                   simulator.vanguard().grid().comm().rank() == 0 ? &simulator.vanguard().equilGrid() : nullptr,
+                   ((simulator.vanguard().grid().comm().rank() == 0)
+                    ? &simulator.vanguard().equilGrid()
+                    : nullptr),
                    simulator.vanguard().gridView(),
                    simulator.vanguard().cartesianIndexMapper(),
-                   simulator.vanguard().grid().comm().rank() == 0 ? &simulator.vanguard().equilCartesianIndexMapper() : nullptr,
+                   ((simulator.vanguard().grid().comm().rank() == 0)
+                    ? &simulator.vanguard().equilCartesianIndexMapper()
+                    : nullptr),
                    false, false)
         , simulator_(simulator)
     {
         this->damarisUpdate_ = true ;
 
-        rank_ = simulator_.vanguard().grid().comm().rank() ;
-        nranks_ = simulator_.vanguard().grid().comm().size();
-        
-        const auto& gridView = simulator_.gridView();
-        const auto& interior_elements = elements(gridView, Dune::Partitions::interior);
-        // Get the size of the unique vector elements (excludes the shared 'ghost' elements)
-        numElements_ = std::distance(interior_elements.begin(), interior_elements.end());
+        this->rank_ = this->simulator_.vanguard().grid().comm().rank() ;
+        this->nranks_ = this->simulator_.vanguard().grid().comm().size();
 
-        this->elements_rank_offsets_.resize(nranks_) ;
-        this->damarisOutputModule_ = std::make_unique<OutputBlackOilModule<TypeTag>>(simulator, this->collectOnIORank_);
+        this->elements_rank_offsets_.resize(this->nranks_);
+        
+        // Get the size of the unique vector elements (excludes the shared 'ghost' elements)
+        //
+        // Might possibly use
+        //
+        //     detail::countLocalInteriorCellsGridView(this->simulator_.gridView())
+        //
+        // from countGlobalCells.hpp instead of calling std::distance() directly.
+        {
+            const auto& gridView = this->simulator_.gridView();
+            const auto& interior_elements = elements(gridView, Dune::Partitions::interior);
+
+            this->numElements_ = std::distance(interior_elements.begin(), interior_elements.end());
+        }
+
+        if (this->nranks_ > 1) {
+            auto smryCfg = (this->rank_ == 0)
+                ? this->eclIO_->finalSummaryConfig()
+                : SummaryConfig{};
+
+            auto serialiser = Parallel::MpiSerializer {
+                this->simulator_.vanguard().grid().comm()
+            };
+
+            serialiser.broadcast(0, smryCfg);
+
+            this->damarisOutputModule_ = std::make_unique<OutputBlackOilModule<TypeTag>>
+                (simulator, smryCfg, this->collectOnIORank_);
+        }
+        else {
+            this->damarisOutputModule_ = std::make_unique<OutputBlackOilModule<TypeTag>>
+                (simulator, this->eclIO_->finalSummaryConfig(), this->collectOnIORank_);
+        }
     }
 
     /*!

--- a/opm/simulators/flow/DamarisWriter.hpp
+++ b/opm/simulators/flow/DamarisWriter.hpp
@@ -36,9 +36,6 @@
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 
-#include <mpi.h>
-#include <opm/simulators/utils/MPISerializer.hpp>
-
 #include <opm/simulators/flow/countGlobalCells.hpp>
 #include <opm/simulators/flow/DamarisProperties.hpp>
 #include <opm/simulators/flow/EclGenericWriter.hpp>
@@ -47,6 +44,7 @@
 #include <opm/simulators/utils/DamarisVar.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/simulators/utils/GridDataOutput.hpp>
+#include <opm/simulators/utils/ParallelSerialization.hpp>
 
 #include <fmt/format.h>
 
@@ -189,11 +187,7 @@ public:
                 ? this->eclIO_->finalSummaryConfig()
                 : SummaryConfig{};
 
-            auto serialiser = Parallel::MpiSerializer {
-                this->simulator_.vanguard().grid().comm()
-            };
-
-            serialiser.broadcast(0, smryCfg);
+            eclBroadcast(this->simulator_.vanguard().grid().comm(), smryCfg);
 
             this->damarisOutputModule_ = std::make_unique<OutputBlackOilModule<TypeTag>>
                 (simulator, smryCfg, this->collectOnIORank_);

--- a/opm/simulators/flow/EclGenericWriter.hpp
+++ b/opm/simulators/flow/EclGenericWriter.hpp
@@ -154,7 +154,6 @@ protected:
     const GridView& gridView_;
     const Schedule& schedule_;
     const EclipseState& eclState_;
-    const SummaryConfig& summaryConfig_;
     std::unique_ptr<EclipseIO> eclIO_;
     std::unique_ptr<TaskletRunner> taskletRunner_;
     Scalar restartTimeStepSize_;

--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -30,12 +30,14 @@
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
+
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/output/eclipse/EclipseIO.hpp>
@@ -207,7 +209,6 @@ EclGenericWriter(const Schedule& schedule,
     , gridView_       (gridView)
     , schedule_       (schedule)
     , eclState_       (eclState)
-    , summaryConfig_  (summaryConfig)
     , cartMapper_     (cartMapper)
     , equilCartMapper_(equilCartMapper)
     , equilGrid_      (equilGrid)
@@ -216,7 +217,7 @@ EclGenericWriter(const Schedule& schedule,
         this->eclIO_ = std::make_unique<EclipseIO>
             (this->eclState_,
              UgGridHelpers::createEclipseGrid(*equilGrid, eclState_.getInputGrid()),
-             this->schedule_, this->summaryConfig_, "", enableEsmry);
+             this->schedule_, summaryConfig, "", enableEsmry);
     }
 
     // create output thread if enabled and rank is I/O rank

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -36,11 +36,6 @@
 
 #include <opm/output/eclipse/RestartValue.hpp>
 
-#if HAVE_MPI
-#include <mpi.h>
-#include <opm/simulators/utils/MPISerializer.hpp>
-#endif
-
 #include <opm/simulators/flow/CollectDataOnIORank.hpp>
 #include <opm/simulators/flow/countGlobalCells.hpp>
 #include <opm/simulators/flow/EclGenericWriter.hpp>
@@ -49,6 +44,7 @@
 #include <opm/simulators/timestepping/SimulatorTimer.hpp>
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/simulators/utils/ParallelRestart.hpp>
+#include <opm/simulators/utils/ParallelSerialization.hpp>
 
 #include <limits>
 #include <stdexcept>
@@ -162,11 +158,7 @@ public:
                 ? this->eclIO_->finalSummaryConfig()
                 : SummaryConfig{};
 
-            auto serialiser = Parallel::MpiSerializer {
-                this->simulator_.vanguard().grid().comm()
-            };
-
-            serialiser.broadcast(0, smryCfg);
+            eclBroadcast(this->simulator_.vanguard().grid().comm(), smryCfg);
 
             this->outputModule_ = std::make_unique<OutputBlackOilModule<TypeTag>>
                 (simulator, smryCfg, this->collectOnIORank_);

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -184,8 +184,8 @@ GenericOutputBlackoilModule(const EclipseState& eclState,
                             bool enableMICP)
     : eclState_(eclState)
     , schedule_(schedule)
-    , summaryConfig_(summaryConfig)
     , summaryState_(summaryState)
+    , summaryConfig_(summaryConfig)
     , interRegionFlows_(numCells(eclState),
                         defineInterRegionFlowArrays(eclState, summaryConfig),
                         declaredMaxRegionID(eclState.runspec()))

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -24,6 +24,7 @@
 #define OPM_GENERIC_OUTPUT_BLACK_OIL_MODULE_HPP
 
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 #include <opm/output/data/Wells.hpp>
 #include <opm/output/eclipse/Inplace.hpp>
@@ -376,8 +377,9 @@ protected:
 
     const EclipseState& eclState_;
     const Schedule& schedule_;
-    const SummaryConfig& summaryConfig_;
     const SummaryState& summaryState_;
+
+    SummaryConfig summaryConfig_;
 
     InterRegFlowMap interRegionFlows_;
     LogOutputHelper<Scalar> logOutput_;

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -143,10 +143,11 @@ class OutputBlackOilModule : public GenericOutputBlackoilModule<GetPropType<Type
 public:
     template <class CollectDataToIORankType>
     OutputBlackOilModule(const Simulator& simulator,
+                         const SummaryConfig& smryCfg,
                          const CollectDataToIORankType& collectToIORank)
         : BaseType(simulator.vanguard().eclState(),
                    simulator.vanguard().schedule(),
-                   simulator.vanguard().summaryConfig(),
+                   smryCfg,
                    simulator.vanguard().summaryState(),
                    moduleVersionName(),
                    getPropValue<TypeTag, Properties::EnableEnergy>(),
@@ -185,9 +186,7 @@ public:
             OPM_THROW_NOLOG(std::runtime_error, msg);
         }
 
-        if (const auto& smryCfg = simulator.vanguard().summaryConfig();
-            smryCfg.match("[FB]PP[OGW]") || smryCfg.match("RPP[OGW]*"))
-        {
+        if (smryCfg.match("[FB]PP[OGW]") || smryCfg.match("RPP[OGW]*")) {
             auto rset = this->eclState_.fieldProps().fip_regions();
             rset.push_back("PVTNUM");
 

--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -82,11 +82,12 @@ void eclStateBroadcast(Parallel::Communication comm, EclipseState& eclState, Sch
 template <class T>
 void eclBroadcast(Parallel::Communication comm, T& data)
 {
-    Opm::Parallel::MpiSerializer ser(comm);
+    ::Opm::Parallel::MpiSerializer ser(comm);
     ser.broadcast(data);
 }
 
-template void eclBroadcast<TransMult>(Parallel::Communication, TransMult&);
-template void eclBroadcast<Schedule>(Parallel::Communication, Schedule&);
+template void eclBroadcast(Parallel::Communication, TransMult&);
+template void eclBroadcast(Parallel::Communication, Schedule&);
+template void eclBroadcast(Parallel::Communication, SummaryConfig&);
 
 }


### PR DESCRIPTION
In the current approach, the full list of summary vectors, especially those that are defined at the region level, is not known until we've processed all UDQ and/or ACTIONX definitions.  As a quick solution to this, switch to using the `SummaryConfig` object that's defined in the `EclipseIO` container instead of the object that gets constructed when reading the input files.

It is likely that we will have to rethink and refactor this construction process later.