### PR TITLE
Add Procedure for Calculating Basic FIP Region Statistics

### DIFF
--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -170,6 +170,8 @@ public:
         }
 
         this->rank_ = this->simulator_.vanguard().grid().comm().rank();
+
+        this->simulator_.vanguard().eclState().computeFipRegionStatistics();
     }
 
     ~EclWriter()

--- a/opm/simulators/utils/ParallelEclipseState.hpp
+++ b/opm/simulators/utils/ParallelEclipseState.hpp
@@ -179,6 +179,12 @@ public:
     //! \details Can only be called on root process.
     const FieldPropsManager& globalFieldProps() const override;
 
+    //! \brief Compute basic descriptive statistics about all FIP region sets
+    //!
+    //! MPI-aware version which knows how to compute statistics across all
+    //! ranks.
+    void computeFipRegionStatistics() override;
+
     //! \brief Returns a const ref to the eclipse grid.
     //! \details Can only be called on root process.
     const EclipseGrid& getInputGrid() const override;


### PR DESCRIPTION
This PR implements the parallel version of
```
EclipseState::computeFipRegionStatistics()
```
which computes a `FIPRegionStatistics` object for the current run's fluid-in-place regions.  The object construction uses an MPI-aware reduction process to compute the maximum region IDs across all MPI ranks.

While here, also unconditionally form the statistics object as part of the `EclWriter`'s constructor to ensure that all ranks participate in the process.  The initial approach of constructing the object on first use is not robust in parallel.  We may however wish to compute these statistics only when needed.  If so, that will be the subject of follow-up work.