### PR TITLE
Bug fix: remove dependencies for rocm & cuda on opencl to run block Jacobi ILU

### DIFF
--- a/opm/simulators/flow/FlowBaseVanguard.hpp
+++ b/opm/simulators/flow/FlowBaseVanguard.hpp
@@ -89,12 +89,12 @@ struct EdgeWeightsMethod {
     using type = UndefinedProperty;
 };
 
-#if HAVE_OPENCL || HAVE_ROCSPARSE
+#if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
 template<class TypeTag, class MyTypeTag>
 struct NumJacobiBlocks {
     using type = UndefinedProperty;
 };
-#endif  // HAVE_OPENCL || HAVE_ROCSPARSE
+#endif
 
 template<class TypeTag, class MyTypeTag>
 struct OwnerCellsFirst {
@@ -156,12 +156,12 @@ struct EdgeWeightsMethod<TypeTag, TTag::FlowBaseVanguard> {
     static constexpr int value = 1;
 };
 
-#if HAVE_OPENCL || HAVE_ROCSPARSE
+#if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
 template<class TypeTag>
 struct NumJacobiBlocks<TypeTag, TTag::FlowBaseVanguard> {
     static constexpr int value = 0;
 };
-#endif // HAVE_OPENCL || HAVE_ROCSPARSE
+#endif
 
 template<class TypeTag>
 struct OwnerCellsFirst<TypeTag, TTag::FlowBaseVanguard> {
@@ -256,7 +256,7 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, int, EdgeWeightsMethod,
                              "Choose edge-weighing strategy: 0=uniform, 1=trans, 2=log(trans).");
 
-#if HAVE_OPENCL || HAVE_ROCSPARSE
+#if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
         EWOMS_REGISTER_PARAM(TypeTag, int, NumJacobiBlocks,
                              "Number of blocks to be created for the Block-Jacobi preconditioner.");
 #endif
@@ -302,7 +302,7 @@ public:
         fileName_ = EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName);
         edgeWeightsMethod_   = Dune::EdgeWeightMethod(EWOMS_GET_PARAM(TypeTag, int, EdgeWeightsMethod));
 
-#if HAVE_OPENCL || HAVE_ROCSPARSE
+#if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
         numJacobiBlocks_ = EWOMS_GET_PARAM(TypeTag, int, NumJacobiBlocks);
 #endif
 

--- a/opm/simulators/flow/FlowGenericVanguard.hpp
+++ b/opm/simulators/flow/FlowGenericVanguard.hpp
@@ -199,7 +199,7 @@ public:
      */
     int numJacobiBlocks() const
     {
-#if HAVE_OPENCL || HAVE_ROCSPARSE
+#if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
         return numJacobiBlocks_;
 #else
         return 0;
@@ -285,9 +285,9 @@ protected:
     std::string fileName_;
     Dune::EdgeWeightMethod edgeWeightsMethod_;
 
-#if HAVE_OPENCL || HAVE_ROCSPARSE
+#if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
     int numJacobiBlocks_{0};
-#endif  // HAVE_OPENCL || HAVE_ROCSPARSE
+#endif
 
     bool ownersFirst_;
 #if HAVE_MPI

--- a/opm/simulators/flow/GenericCpGridVanguard.cpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.cpp
@@ -206,14 +206,14 @@ doLoadBalance_(const Dune::EdgeWeightMethod             edgeWeightsMethod,
         // first cell of a well (e.g. for pressure).  Hence this is now
         // skipped.  Rank 0 had everything even before.
 
-#if HAVE_OPENCL
+#if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
         if (partitionJacobiBlocks) {
             this->cell_part_ = this->grid_->
                 zoltanPartitionWithoutScatter(&wells, faceTrans.data(),
                                               numJacobiBlocks,
                                               zoltanImbalanceTol);
         }
-#endif // HAVE_OPENCL
+#endif
     }
 }
 

--- a/opm/simulators/linalg/ISTLSolverBda.hpp
+++ b/opm/simulators/linalg/ISTLSolverBda.hpp
@@ -195,7 +195,7 @@ public:
             ParentType::prepare(M,b);
         }
 
-#if HAVE_OPENCL
+#if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
         // update matrix entries for solvers.
         if (firstcall && bdaBridge_) {
             // model will not change the matrix object. Hence simply store a pointer


### PR DESCRIPTION
This PR fixes a bug introduced when we removed the rocm dependency on opencl (#4883), which disabled the possibility to run the rocsparse and cusparse backends with the optimized version of block Jacobi ILU. 