### PR TITLE
Overlap creation of jacobian matrix with GPU data transfers

### DIFF
--- a/opm/simulators/linalg/ISTLSolverBda.cpp
+++ b/opm/simulators/linalg/ISTLSolverBda.cpp
@@ -43,6 +43,10 @@
 
 #include <opm/grid/polyhedralgrid.hh>
 
+#include <thread>
+
+std::shared_ptr<std::thread> copyThread;
+
 namespace Opm {
 namespace detail {
 
@@ -108,7 +112,8 @@ apply(Vector& rhs,
 #endif
 
         if (numJacobiBlocks_ > 1) {
-            this->copyMatToBlockJac(matrix, *blockJacobiForGPUILU0_);
+            copyThread = std::make_shared<std::thread>([&](){this->copyMatToBlockJac(matrix, *blockJacobiForGPUILU0_);});
+            
             // Const_cast needed since the CUDA stuff overwrites values for better matrix condition..
             bridge_->solve_system(&matrix, blockJacobiForGPUILU0_.get(),
                                   numJacobiBlocks_, rhs, *wellContribs, result);

--- a/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.cu
+++ b/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.cu
@@ -40,6 +40,7 @@
 
 #if HAVE_OPENMP
 #include <thread>
+#include <omp.h>
 extern std::shared_ptr<std::thread> copyThread;
 #endif // HAVE_OPENMP
 
@@ -328,7 +329,8 @@ void cusparseSolverBackend<block_size>::copy_system_to_gpu(std::shared_ptr<Block
     cudaMemcpyAsync(d_bVals, matrix->nnzValues, nnz * sizeof(double), cudaMemcpyHostToDevice, stream);
     if (useJacMatrix) {
 #if HAVE_OPENMP
-        copyThread->join();
+	if(omp_get_max_threads() > 1)
+	   copyThread->join();
 #endif
         cudaMemcpyAsync(d_mVals, jacMatrix->nnzValues, nnzbs_prec * block_size * block_size * sizeof(double), cudaMemcpyHostToDevice, stream);
     } else {
@@ -372,7 +374,8 @@ void cusparseSolverBackend<block_size>::update_system_on_gpu(std::shared_ptr<Blo
     cudaMemcpyAsync(d_bVals, matrix->nnzValues, nnz * sizeof(double), cudaMemcpyHostToDevice, stream);
     if (useJacMatrix) {
 #if HAVE_OPENMP
-        copyThread->join();
+	if(omp_get_max_threads() > 1)
+	   copyThread->join();
 #endif
         cudaMemcpyAsync(d_mVals, jacMatrix->nnzValues, nnzbs_prec * block_size * block_size * sizeof(double), cudaMemcpyHostToDevice, stream);
     } else {

--- a/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/cuda/cusparseSolverBackend.hpp
@@ -71,6 +71,8 @@ private:
     bool useJacMatrix = false;
     int nnzbs_prec;             // number of nonzero blocks in the matrix for preconditioner
                                 // could be jacMatrix or matrix
+                                
+    double c_copy = 0.0; // cummulative timer measuring the total time it takes to transfer the data to the GPU
 
     /// Solve linear system using ilu0-bicgstab
     /// \param[in] wellContribs   contains all WellContributions, to apply them separately, instead of adding them to matrix A

--- a/opm/simulators/linalg/bda/rocsparseSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/rocsparseSolverBackend.cpp
@@ -41,6 +41,8 @@
 
 #include <opm/simulators/linalg/bda/BdaResult.hpp>
 
+#include <thread>
+
 #include <hip/hip_runtime_api.h>
 #include <hip/hip_version.h>
 
@@ -86,6 +88,8 @@
     } while(0)
 
 #include <cstddef>
+
+extern std::shared_ptr<std::thread> copyThread;
 
 namespace Opm
 {
@@ -431,21 +435,26 @@ void rocsparseSolverBackend<block_size>::copy_system_to_gpu(double *b) {
     HIP_CHECK(hipMemcpyAsync(d_Arows, mat->rowPointers, sizeof(rocsparse_int) * (Nb + 1), hipMemcpyHostToDevice, stream));
     HIP_CHECK(hipMemcpyAsync(d_Acols, mat->colIndices, sizeof(rocsparse_int) * nnzb, hipMemcpyHostToDevice, stream));
     HIP_CHECK(hipMemcpyAsync(d_Avals, mat->nnzValues, sizeof(double) * nnz, hipMemcpyHostToDevice, stream));
+    HIP_CHECK(hipMemsetAsync(d_x, 0, sizeof(double) * N, stream));
+    HIP_CHECK(hipMemcpyAsync(d_b, b, sizeof(double) * N, hipMemcpyHostToDevice, stream));
+    
     if (useJacMatrix) {
+        copyThread->join();
         HIP_CHECK(hipMemcpyAsync(d_Mrows, jacMat->rowPointers, sizeof(rocsparse_int) * (Nb + 1), hipMemcpyHostToDevice, stream));
         HIP_CHECK(hipMemcpyAsync(d_Mcols, jacMat->colIndices, sizeof(rocsparse_int) * nnzbs_prec, hipMemcpyHostToDevice, stream));
         HIP_CHECK(hipMemcpyAsync(d_Mvals, jacMat->nnzValues, sizeof(double) * nnzbs_prec * block_size * block_size, hipMemcpyHostToDevice, stream));
     } else {
         HIP_CHECK(hipMemcpyAsync(d_Mvals, d_Avals, sizeof(double) * nnz, hipMemcpyDeviceToDevice, stream));
     }
-    HIP_CHECK(hipMemsetAsync(d_x, 0, sizeof(double) * N, stream));
-    HIP_CHECK(hipMemcpyAsync(d_b, b, sizeof(double) * N, hipMemcpyHostToDevice, stream));
 
     if (verbosity >= 3) {
         HIP_CHECK(hipStreamSynchronize(stream));
+        
+        c_copy += t.stop();
         std::ostringstream out;
-        out << "rocsparseSolver::copy_system_to_gpu(): " << t.stop() << " s";
-        OpmLog::info(out.str());
+        out << "-----rocsparseSolver::copy_system_to_gpu(): " << t.elapsed() << " s\n";
+        out << "---rocsparseSolver::cum copy: " << c_copy << " s";
+	OpmLog::info(out.str());
     }
 } // end copy_system_to_gpu()
 
@@ -455,18 +464,23 @@ void rocsparseSolverBackend<block_size>::update_system_on_gpu(double *b) {
     Timer t;
 
     HIP_CHECK(hipMemcpyAsync(d_Avals, mat->nnzValues, sizeof(double) * nnz, hipMemcpyHostToDevice, stream));
+    HIP_CHECK(hipMemsetAsync(d_x, 0, sizeof(double) * N, stream));
+    HIP_CHECK(hipMemcpyAsync(d_b, b, sizeof(double) * N, hipMemcpyHostToDevice, stream));
+    
     if (useJacMatrix) {
+        copyThread->join();
         HIP_CHECK(hipMemcpyAsync(d_Mvals, jacMat->nnzValues, sizeof(double) * nnzbs_prec * block_size * block_size, hipMemcpyHostToDevice, stream));
     } else {
         HIP_CHECK(hipMemcpyAsync(d_Mvals, d_Avals, sizeof(double) * nnz, hipMemcpyDeviceToDevice, stream));
     }
-    HIP_CHECK(hipMemsetAsync(d_x, 0, sizeof(double) * N, stream));
-    HIP_CHECK(hipMemcpyAsync(d_b, b, sizeof(double) * N, hipMemcpyHostToDevice, stream));
-
+    
     if (verbosity >= 3) {
         HIP_CHECK(hipStreamSynchronize(stream));
+
+        c_copy += t.stop();
         std::ostringstream out;
-        out << "rocsparseSolver::update_system_on_gpu(): " << t.stop() << " s";
+        out << "-----rocsparseSolver::update_system_on_gpu(): " << t.elapsed() << " s\n";
+        out << "---rocsparseSolver::cum copy: " << c_copy << " s";
         OpmLog::info(out.str());
     }
 } // end update_system_on_gpu()

--- a/opm/simulators/linalg/bda/rocsparseSolverBackend.hpp
+++ b/opm/simulators/linalg/bda/rocsparseSolverBackend.hpp
@@ -55,6 +55,8 @@ class rocsparseSolverBackend : public BdaSolver<block_size>
 
 private:
 
+    double c_copy = 0.0; // cummulative timer measuring the total time it takes to transfer the data to the GPU
+
     bool useJacMatrix = false;
 
     bool analysis_done = false;


### PR DESCRIPTION
This PR optimizes the memory operations time by overlapping the creation (which includes a host memory copy) of the jacobian matrix used in the blockJacobi ILU with copying the matrix data to the GPU. For NORNE this gives a 17% reduction in the total transfer/copy time, while for the bigmodel this reduction is around 50% on a system with a AMD EPYC 7763 64-Core Processor + AMD MI210 GPU / NVIDIA A100 GPU.