### PR TITLE
Allow for Sparse Source-Location Subsets

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -350,13 +350,12 @@ initializeWellPerfData()
                         hasFirstConnection = true;
                     }
 
-                    auto pd = PerforationData{};
+                    auto& pd = well_perf_data_[well_index].emplace_back();
+
                     pd.cell_index = active_index;
                     pd.connection_transmissibility_factor = connection.CF();
                     pd.satnum_id = connection.satTableId();
                     pd.ecl_index = connection_index;
-
-                    well_perf_data_[well_index].push_back(pd);
 
                     parallelWellInfo.pushBackEclIndex(connection_index_above,
                                                       connection_index);

--- a/opm/simulators/wells/ParallelPAvgDynamicSourceData.cpp
+++ b/opm/simulators/wells/ParallelPAvgDynamicSourceData.cpp
@@ -148,7 +148,19 @@ void Opm::ParallelPAvgDynamicSourceData::defineCommunication()
 
     // 4) Build translation mapping from source term element indices to
     //    storage indices.
-    this->storageIndex_.resize(allIndices.size());
+    //
+    //    Note that if the source terms aren't all active--e.g., if a well
+    //    is connected in deactivated cells--then allIndices is not a
+    //    permutation of 0..allIndices.size()-1 and the maximum source
+    //    location may exceed size()-1.  Resize the storageIndex_ according
+    //    to the largest source location ID.
+    if (auto maxIxPos = std::max_element(allIndices.begin(), allIndices.end());
+        maxIxPos != allIndices.end())
+    {
+        // +1 for zero-based indices.
+        this->storageIndex_.resize(*maxIxPos + 1);
+    }
+
     auto storageIx = std::vector<double>::size_type{0};
     for (const auto& elemIndex : allIndices) {
         this->storageIndex_[elemIndex] = storageIx++;

--- a/opm/simulators/wells/PerforationData.hpp
+++ b/opm/simulators/wells/PerforationData.hpp
@@ -28,12 +28,12 @@ namespace Opm
 /// Static data associated with a well perforation.
 struct PerforationData
 {
-    int cell_index;
-    double connection_transmissibility_factor;
-    double connection_d_factor;
-    int satnum_id;
+    int cell_index{};
+    double connection_transmissibility_factor{};
+    double connection_d_factor{};
+    int satnum_id{};
     /// \brief The original index of the perforation in ECL Schedule
-    std::size_t ecl_index;
+    std::size_t ecl_index{};
 };
 
 struct PerforationRates


### PR DESCRIPTION
If a well is nominally connected in inactive cells, i.e., if its connections have not been filtered down to the active connections only, then `allIndices` may not be a permutation of
```
0 .. allIndices.size()-1
```
Handle this case by sizing `storageIndex_` according to the maximum index value instead of `allIndices.size()`.

While here, also switch to constructing `PerforationData` objects in place since this is (slightly) faster than "construct"+"copy".