### PR TITLE
[bugfix] Use reasonable timestep if  NEXTSTEP in ACTIONX is used.

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -387,7 +387,8 @@ std::set<std::string> consistentlyFailingWells(const std::vector<StepReport>& sr
                 // get current delta t
                 auto oldValue = suggestedNextTimestep_;
                 if (tuningUpdater()) {
-                    substepTimer.setCurrentStepLength(suggestedNextTimestep_);
+                    // Use provideTimeStepEstimate to make we sure don't simulate longer than the report step is.
+                    substepTimer.provideTimeStepEstimate(suggestedNextTimestep_);
                     suggestedNextTimestep_ = oldValue;
                 }
                 const double dt = substepTimer.currentStepLength();


### PR DESCRIPTION
The step size might still need to be smaller than suggested to not simulate beyond the end of the current report step. To ensure this we now use AdaptiveTimeSimulationTimer::provideTimeStepEstimate which will limit it and also make sure that subsequent time steps will not get to small either.