### PR TITLE
[fix] Prevent dangling refernces in Logger for test_LogOutputHelper

### DIFF
--- a/tests/test_LogOutputHelper.cpp
+++ b/tests/test_LogOutputHelper.cpp
@@ -170,6 +170,8 @@ BOOST_AUTO_TEST_CASE(Cumulative)
     helper.cumulative(0);
     std::string data = trimStream(str);
     BOOST_CHECK_EQUAL(data, reference);
+    // Cleanup backends with references to local variables
+    Opm::OpmLog::removeBackend("stream");
 }
 
 
@@ -200,6 +202,8 @@ Finding the dew point pressure failed for 3 cells [(5,1,1), (6,1,1), (7,1,1)]
     helper.error({1,20,30}, {4,5,6});
     std::string data = trimStream(str);
     BOOST_CHECK_EQUAL(data, reference);
+    // Cleanup backends with references to local variables
+    Opm::OpmLog::removeBackend("stream");
 }
 
 BOOST_AUTO_TEST_CASE(Fip)
@@ -287,6 +291,8 @@ BOOST_AUTO_TEST_CASE(Fip)
     helper.fip(current, initial, "FIPNUM");
 
     BOOST_CHECK_EQUAL(str.str(), reference);
+    // Cleanup backends with references to local variables
+    Opm::OpmLog::removeBackend("stream");
 }
 
 BOOST_AUTO_TEST_CASE(FipResv)
@@ -340,6 +346,8 @@ BOOST_AUTO_TEST_CASE(FipResv)
 
     helper.fipResv(current, "FIPNUM");
     BOOST_CHECK_EQUAL(str.str(), reference);
+    // Cleanup backends with references to local variables
+    Opm::OpmLog::removeBackend("stream");
 }
 
 
@@ -395,6 +403,8 @@ BOOST_AUTO_TEST_CASE(Injection)
     helper.injection(0);
     std::string data = trimStream(str);
     BOOST_CHECK_EQUAL(data, reference);
+    // Cleanup backends with references to local variables
+    Opm::OpmLog::removeBackend("stream");
 }
 
 
@@ -456,5 +466,7 @@ BOOST_AUTO_TEST_CASE(Production)
     helper.production(0);
     std::string data = trimStream(str);
     BOOST_CHECK_EQUAL(data, reference);
+    // Cleanup backends with references to local variables
+    Opm::OpmLog::removeBackend("stream");
 }
 


### PR DESCRIPTION
In the test methods of the test suite we construct a new logger that logs to a local stringstream. This logger will be stored in a static map and hence live longer that the test method and the stringstream.

Some methods use `Opm::Log::MessageType::Note`, others `Opm::Log::MessageType::Warning` for adding the logging backend . There is one map per `MessageType` and sometimes (e.g. previous method used Note and this one uses Warning) we will log to the old logger with dangling references.

This problem materialized in a segmentation fault on ppc64el architecture.