### PR TITLE
fixed: segfault due to taking a reference to temporary

### DIFF
--- a/tests/test_parallel_wbp_calculation.cpp
+++ b/tests/test_parallel_wbp_calculation.cpp
@@ -565,9 +565,9 @@ BOOST_AUTO_TEST_CASE(Create)
 
     BOOST_REQUIRE_EQUAL(comm.size(), 2);
 
+    const Opm::GridDims dims{5, 5, 10};
     auto wbpCalcService = Opm::ParallelWBPCalculation {
-        Opm::GridDims { 5, 5, 10 },
-        comm
+        dims, comm
     };
 
     setCallbacks(comm.rank(), wbpCalcService);


### PR DESCRIPTION
The WBP calculation service holds on to a reference to the given parameter so we have to use a local and not a temporary.