### PR TITLE
Partitioning tracers

### DIFF
--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -523,8 +523,8 @@ public:
             auto restartValues = loadParallelRestart(this->eclIO_.get(), actionState, summaryState, solutionKeys, extraKeys,
                                                      gridView.grid().comm());
             for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
-                unsigned globalIdx = this->collectToIORank_.localIdxToGlobalIdx(elemIdx);
-                eclOutputModule_->setRestart(restartValues.solution, elemIdx, globalIdx);
+                unsigned globalIdx = this->collectOnIORank_.localIdxToGlobalIdx(elemIdx);
+                outputModule_->setRestart(restartValues.solution, elemIdx, globalIdx);
             }
 
             auto& tracer_model = simulator_.problem().tracerModel();
@@ -534,7 +534,7 @@ public:
                 const auto& sol_tracer_name = tracer_model.sname(tracer_index);
                 const auto& sol_tracer_solution = restartValues.solution.template data<double>(sol_tracer_name);
                 for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
-                    unsigned globalIdx = this->collectToIORank_.localIdxToGlobalIdx(elemIdx);
+                    unsigned globalIdx = this->collectOnIORank_.localIdxToGlobalIdx(elemIdx);
                     tracer_model.setFreeTracerConcentration(tracer_index, globalIdx, free_tracer_solution[globalIdx]);
                     tracer_model.setSolTracerConcentration(tracer_index, globalIdx, sol_tracer_solution[globalIdx]);
                 }

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -721,6 +721,9 @@ assignToSolution(data::Solution& sol)
         for (auto tracerIdx = 0*tracers.size();
              tracerIdx < tracers.size(); ++tracerIdx)
         {
+            if (solTracerConcentrations_[tracerIdx].empty())
+                continue;
+
             sol.insert(tracers[tracerIdx].sname(),
                        UnitSystem::measure::identity,
                        std::move(solTracerConcentrations_[tracerIdx]),
@@ -854,6 +857,7 @@ doAllocBuffers(const unsigned bufferSize,
                const bool     vapparsActive,
                const bool     enableHysteresis,
                const unsigned numTracers,
+               const std::vector<bool>& enableSolTracers,
                const unsigned numOutputNnc)
 {
     // Output RESTART_OPM_EXTENDED only when explicitly requested by user.
@@ -1328,7 +1332,8 @@ doAllocBuffers(const unsigned bufferSize,
         solTracerConcentrations_.resize(numTracers);
         for (unsigned tracerIdx = 0; tracerIdx < numTracers; ++tracerIdx)
         {
-            solTracerConcentrations_[tracerIdx].resize(bufferSize, 0.0);
+            if (enableSolTracers[tracerIdx])
+                solTracerConcentrations_[tracerIdx].resize(bufferSize, 0.0);
         }
     }
 

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -700,21 +700,37 @@ assignToSolution(data::Solution& sol)
     }
 
     // Tracers
-    if (! this->tracerConcentrations_.empty()) {
+    if (! this->freeTracerConcentrations_.empty()) {
         const auto& tracers = this->eclState_.tracer();
         for (auto tracerIdx = 0*tracers.size();
              tracerIdx < tracers.size(); ++tracerIdx)
         {
             sol.insert(tracers[tracerIdx].fname(),
                        UnitSystem::measure::identity,
-                       std::move(tracerConcentrations_[tracerIdx]),
+                       std::move(freeTracerConcentrations_[tracerIdx]),
                        data::TargetType::RESTART_TRACER_SOLUTION);
         }
 
-        // Put tracerConcentrations container into a valid state.  Otherwise
+        // Put freeTracerConcentrations container into a valid state.  Otherwise
         // we'll move from vectors that have already been moved from if we
         // get here and it's not a restart step.
-        this->tracerConcentrations_.clear();
+        this->freeTracerConcentrations_.clear();
+    }
+    if (! this->solTracerConcentrations_.empty()) {
+        const auto& tracers = this->eclState_.tracer();
+        for (auto tracerIdx = 0*tracers.size();
+             tracerIdx < tracers.size(); ++tracerIdx)
+        {
+            sol.insert(tracers[tracerIdx].sname(),
+                       UnitSystem::measure::identity,
+                       std::move(solTracerConcentrations_[tracerIdx]),
+                       data::TargetType::RESTART_TRACER_SOLUTION);
+        }
+
+        // Put solTracerConcentrations container into a valid state.  Otherwise
+        // we'll move from vectors that have already been moved from if we
+        // get here and it's not a restart step.
+        this->solTracerConcentrations_.clear();
     }
 }
 
@@ -1304,10 +1320,15 @@ doAllocBuffers(const unsigned bufferSize,
 
     // tracers
     if (numTracers > 0) {
-        tracerConcentrations_.resize(numTracers);
+        freeTracerConcentrations_.resize(numTracers);
         for (unsigned tracerIdx = 0; tracerIdx < numTracers; ++tracerIdx)
         {
-            tracerConcentrations_[tracerIdx].resize(bufferSize, 0.0);
+            freeTracerConcentrations_[tracerIdx].resize(bufferSize, 0.0);
+        }
+        solTracerConcentrations_.resize(numTracers);
+        for (unsigned tracerIdx = 0; tracerIdx < numTracers; ++tracerIdx)
+        {
+            solTracerConcentrations_[tracerIdx].resize(bufferSize, 0.0);
         }
     }
 

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -340,6 +340,7 @@ protected:
                         const bool vapparsActive,
                         const bool enableHysteresis,
                         unsigned numTracers,
+                        const std::vector<bool>& enableSolTracers,
                         unsigned numOutputNnc);
 
     void makeRegionSum(Inplace& inplace,

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -504,7 +504,8 @@ protected:
     std::array<ScalarBuffer, numPhases> viscosity_;
     std::array<ScalarBuffer, numPhases> relativePermeability_;
 
-    std::vector<ScalarBuffer> tracerConcentrations_;
+    std::vector<ScalarBuffer> freeTracerConcentrations_;
+    std::vector<ScalarBuffer> solTracerConcentrations_;
 
     std::array<ScalarBuffer, numPhases> residual_;
 

--- a/opm/simulators/flow/GenericTracerModel.cpp
+++ b/opm/simulators/flow/GenericTracerModel.cpp
@@ -24,6 +24,8 @@
 
 #include <opm/simulators/flow/GenericTracerModel_impl.hpp>
 
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
+
 #if HAVE_DUNE_FEM
 #include <dune/common/version.hh>
 #include <dune/fem/gridpart/adaptiveleafgridpart.hh>
@@ -39,6 +41,7 @@ template class GenericTracerModel<Dune::CpGrid,
                                   Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,
                                   Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>>,
                                   Opm::EcfvStencil<double,Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>,false,false>,
+                                  BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,
                                   double>;
 
 #if HAVE_DUNE_FEM
@@ -50,12 +53,14 @@ template class GenericTracerModel<Dune::CpGrid,
                                   GV,
                                   Dune::MultipleCodimMultipleGeomTypeMapper<GV>,
                                   EcfvStencil<double, GV, false, false>,
+                                  BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,
                                   double>;
 #else
 template class GenericTracerModel<Dune::CpGrid,
                                   Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,
                                   Dune::MultipleCodimMultipleGeomTypeMapper<Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>>,
                                   EcfvStencil<double,Dune::GridView<Dune::Fem::GridPart2GridViewTraits<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false>>>,false,false>,
+                                  BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,
                                   double>;
 template class GenericTracerModel<Dune::CpGrid,
                                   Dune::Fem::GridPart2GridViewImpl<Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, (Dune::PartitionIteratorType)4, false> >,
@@ -65,6 +70,7 @@ template class GenericTracerModel<Dune::CpGrid,
                                   EcfvStencil<double, Dune::Fem::GridPart2GridViewImpl<
                                                                Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid, Dune::PartitionIteratorType(4), false> >,
                                                    false, false>,
+                                  BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>,
                                   double>;
 #endif
 #endif // HAVE_DUNE_FEM

--- a/opm/simulators/flow/GenericTracerModel.hpp
+++ b/opm/simulators/flow/GenericTracerModel.hpp
@@ -85,9 +85,9 @@ public:
     */
     const std::map<std::pair<std::string, std::string>, Scalar>&
     getWellTracerRates() const {return wellTracerRate_;}
-    const std::map<std::pair<std::string, std::string>, double>&
+    const std::map<std::pair<std::string, std::string>, Scalar>&
     getWellFreeTracerRates() const {return wellFreeTracerRate_;}
-    const std::map<std::pair<std::string, std::string>, double>&
+    const std::map<std::pair<std::string, std::string>, Scalar>&
     getWellSolTracerRates() const {return wellSolTracerRate_;}
 
     template<class Serializer>
@@ -136,8 +136,8 @@ protected:
 
     // <wellName, tracerIdx> -> wellRate
     std::map<std::pair<std::string, std::string>, Scalar> wellTracerRate_;
-    std::map<std::pair<std::string, std::string>, double> wellFreeTracerRate_;
-    std::map<std::pair<std::string, std::string>, double> wellSolTracerRate_;
+    std::map<std::pair<std::string, std::string>, Scalar> wellFreeTracerRate_;
+    std::map<std::pair<std::string, std::string>, Scalar> wellSolTracerRate_;
     /// \brief Function returning the cell centers
     std::function<std::array<double,dimWorld>(int)> centroids_;
 };

--- a/opm/simulators/flow/GenericTracerModel.hpp
+++ b/opm/simulators/flow/GenericTracerModel.hpp
@@ -68,6 +68,8 @@ public:
     const std::string& name(int tracerIdx) const;
     std::string fname(int tracerIdx) const;
     std::string sname(int tracerIdx) const;
+    std::string wellfname(int tracerIdx) const;
+    std::string wellsname(int tracerIdx) const;
 
 
     /*!
@@ -83,12 +85,18 @@ public:
     */
     const std::map<std::pair<std::string, std::string>, Scalar>&
     getWellTracerRates() const {return wellTracerRate_;}
+    const std::map<std::pair<std::string, std::string>, double>&
+    getWellFreeTracerRates() const {return wellFreeTracerRate_;}
+    const std::map<std::pair<std::string, std::string>, double>&
+    getWellSolTracerRates() const {return wellSolTracerRate_;}
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
         serializer(tracerConcentration_);
         serializer(wellTracerRate_);
+        serializer(wellFreeTracerRate_);
+        serializer(wellSolTracerRate_);
     }
 
 protected:
@@ -128,6 +136,8 @@ protected:
 
     // <wellName, tracerIdx> -> wellRate
     std::map<std::pair<std::string, std::string>, Scalar> wellTracerRate_;
+    std::map<std::pair<std::string, std::string>, double> wellFreeTracerRate_;
+    std::map<std::pair<std::string, std::string>, double> wellSolTracerRate_;
     /// \brief Function returning the cell centers
     std::function<std::array<double,dimWorld>(int)> centroids_;
 };

--- a/opm/simulators/flow/GenericTracerModel.hpp
+++ b/opm/simulators/flow/GenericTracerModel.hpp
@@ -89,6 +89,8 @@ public:
     getWellFreeTracerRates() const {return wellFreeTracerRate_;}
     const std::map<std::pair<std::string, std::string>, Scalar>&
     getWellSolTracerRates() const {return wellSolTracerRate_;}
+    const std::map<std::tuple<std::string, std::string, std::size_t>, Scalar>&
+    getMswTracerRates() const {return mSwTracerRate_;}
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)
@@ -134,10 +136,14 @@ protected:
     std::vector<TracerVectorSingle> freeTracerConcentration_;
     std::vector<TracerVectorSingle> solTracerConcentration_;
 
-    // <wellName, tracerIdx> -> wellRate
+    // <wellName, tracerName> -> wellRate
     std::map<std::pair<std::string, std::string>, Scalar> wellTracerRate_;
     std::map<std::pair<std::string, std::string>, Scalar> wellFreeTracerRate_;
     std::map<std::pair<std::string, std::string>, Scalar> wellSolTracerRate_;
+
+    // <wellName, tracerName, segNum> -> wellRate
+    std::map<std::tuple<std::string, std::string, std::size_t>, Scalar> mSwTracerRate_;
+
     /// \brief Function returning the cell centers
     std::function<std::array<double,dimWorld>(int)> centroids_;
 };

--- a/opm/simulators/flow/GenericTracerModel.hpp
+++ b/opm/simulators/flow/GenericTracerModel.hpp
@@ -52,8 +52,9 @@ class Well;
 template<class Grid, class GridView, class DofMapper, class Stencil, class Scalar>
 class GenericTracerModel {
 public:
-    using TracerMatrix = Dune::BCRSMatrix<Opm::MatrixBlock<Scalar, 1, 1>>;
-    using TracerVector = Dune::BlockVector<Dune::FieldVector<Scalar,1>>;
+    using TracerVectorSingle = Dune::BlockVector<Dune::FieldVector<Scalar, 1>>;
+    using TracerMatrix = Dune::BCRSMatrix<Opm::MatrixBlock<Scalar, 2, 2>>;
+    using TracerVector = Dune::BlockVector<Dune::FieldVector<Scalar, 2>>;
     using CartesianIndexMapper = Dune::CartesianIndexMapper<Grid>;
     static constexpr int dimWorld = Grid::dimensionworld;
     /*!
@@ -66,13 +67,16 @@ public:
      */
     const std::string& name(int tracerIdx) const;
     std::string fname(int tracerIdx) const;
+    std::string sname(int tracerIdx) const;
 
 
     /*!
      * \brief Return the tracer concentration for tracer index and global DofIdx
      */
-    Scalar tracerConcentration(int tracerIdx, int globalDofIdx) const;
-    void setTracerConcentration(int tracerIdx, int globalDofIdx, Scalar value);
+    Scalar freeTracerConcentration(int tracerIdx, int globalDofIdx) const;
+    Scalar solTracerConcentration(int tracerIdx, int globalDofIdx) const;
+    void setFreeTracerConcentration(int tracerIdx, int globalDofIdx, Scalar value);
+    void setSolTracerConcentration(int tracerIdx, int globalDofIdx, Scalar value);
 
     /*!
     * \brief Return well tracer rates
@@ -117,9 +121,10 @@ protected:
     const DofMapper& dofMapper_;
 
     std::vector<int> tracerPhaseIdx_;
-    std::vector<Dune::BlockVector<Dune::FieldVector<Scalar, 1>>> tracerConcentration_;
+    std::vector<TracerVector> tracerConcentration_;
     std::unique_ptr<TracerMatrix> tracerMatrix_;
-    std::vector<Dune::BlockVector<Dune::FieldVector<Scalar, 1>>> storageOfTimeIndex1_;
+    std::vector<TracerVectorSingle> freeTracerConcentration_;
+    std::vector<TracerVectorSingle> solTracerConcentration_;
 
     // <wellName, tracerIdx> -> wellRate
     std::map<std::pair<std::string, std::string>, Scalar> wellTracerRate_;

--- a/opm/simulators/flow/GenericTracerModel.hpp
+++ b/opm/simulators/flow/GenericTracerModel.hpp
@@ -36,6 +36,8 @@
 
 #include <opm/simulators/linalg/matrixblock.hh>
 
+#include <opm/input/eclipse/EclipseState/Phase.hpp>
+
 #include <array>
 #include <cstddef>
 #include <functional>
@@ -49,7 +51,7 @@ namespace Opm {
 class EclipseState;
 class Well;
 
-template<class Grid, class GridView, class DofMapper, class Stencil, class Scalar>
+template<class Grid, class GridView, class DofMapper, class Stencil, class FluidSystem, class Scalar>
 class GenericTracerModel {
 public:
     using TracerVectorSingle = Dune::BlockVector<Dune::FieldVector<Scalar, 1>>;
@@ -71,6 +73,8 @@ public:
     std::string wellfname(int tracerIdx) const;
     std::string wellsname(int tracerIdx) const;
 
+    Phase phase(int tracerIdx) const;
+    const std::vector<bool>& enableSolTracers() const;
 
     /*!
      * \brief Return the tracer concentration for tracer index and global DofIdx
@@ -79,6 +83,7 @@ public:
     Scalar solTracerConcentration(int tracerIdx, int globalDofIdx) const;
     void setFreeTracerConcentration(int tracerIdx, int globalDofIdx, Scalar value);
     void setSolTracerConcentration(int tracerIdx, int globalDofIdx, Scalar value);
+    void setEnableSolTracers(int tracerIdx, bool enableSolTracer);
 
     /*!
     * \brief Return well tracer rates
@@ -96,9 +101,12 @@ public:
     void serializeOp(Serializer& serializer)
     {
         serializer(tracerConcentration_);
+        serializer(freeTracerConcentration_);
+        serializer(solTracerConcentration_);
         serializer(wellTracerRate_);
         serializer(wellFreeTracerRate_);
         serializer(wellSolTracerRate_);
+        serializer(mSwTracerRate_);
     }
 
 protected:
@@ -131,6 +139,7 @@ protected:
     const DofMapper& dofMapper_;
 
     std::vector<int> tracerPhaseIdx_;
+    std::vector<bool> enableSolTracers_;
     std::vector<TracerVector> tracerConcentration_;
     std::unique_ptr<TracerMatrix> tracerMatrix_;
     std::vector<TracerVectorSingle> freeTracerConcentration_;

--- a/opm/simulators/flow/GenericTracerModel_impl.hpp
+++ b/opm/simulators/flow/GenericTracerModel_impl.hpp
@@ -168,6 +168,20 @@ sname(int tracerIdx) const
 }
 
 template<class Grid,class GridView, class DofMapper, class Stencil, class Scalar>
+std::string GenericTracerModel<Grid,GridView,DofMapper,Stencil,Scalar>::
+wellfname(int tracerIdx) const
+{
+    return this->eclState_.tracer()[tracerIdx].wellfname();
+}
+
+template<class Grid,class GridView, class DofMapper, class Stencil, class Scalar>
+std::string GenericTracerModel<Grid,GridView,DofMapper,Stencil,Scalar>::
+wellsname(int tracerIdx) const
+{
+    return this->eclState_.tracer()[tracerIdx].wellsname();
+}
+
+template<class Grid,class GridView, class DofMapper, class Stencil, class Scalar>
 Scalar GenericTracerModel<Grid,GridView,DofMapper,Stencil,Scalar>::
 currentConcentration_(const Well& eclWell, const std::string& name) const
 {
@@ -376,7 +390,7 @@ template<class Grid,class GridView, class DofMapper, class Stencil, class Scalar
 bool GenericTracerModel<Grid,GridView,DofMapper,Stencil,Scalar>::
 linearSolveBatchwise_(const TracerMatrix& M, std::vector<TracerVector>& x, std::vector<TracerVector>& b)
 {
-    Scalar tolerance = 1e-2;
+    Scalar tolerance = 1e-6;
     int maxIter = 100;
 
     int verbosity = 0;

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -240,6 +240,7 @@ public:
                              problem.vapparsActive(std::max(simulator_.episodeIndex(), 0)),
                              problem.materialLawManager()->enableHysteresis(),
                              problem.tracerModel().numTracers(),
+                             problem.tracerModel().enableSolTracers(),
                              problem.eclWriter()->getOutputNnc().size());
     }
 

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -661,14 +661,23 @@ public:
 
             // tracers
             const auto& tracerModel = simulator_.problem().tracerModel();
-            if (! this->tracerConcentrations_.empty()) {
+            if (! this->freeTracerConcentrations_.empty()) {
                 for (int tracerIdx = 0; tracerIdx < tracerModel.numTracers(); ++tracerIdx) {
-                    if (this->tracerConcentrations_[tracerIdx].empty()) {
+                    if (this->freeTracerConcentrations_[tracerIdx].empty()) {
                         continue;
                     }
-
-                    this->tracerConcentrations_[tracerIdx][globalDofIdx] =
-                        tracerModel.tracerConcentration(tracerIdx, globalDofIdx);
+                    this->freeTracerConcentrations_[tracerIdx][globalDofIdx] =
+                        tracerModel.freeTracerConcentration(tracerIdx, globalDofIdx);
+                }
+            }
+            if (! this->solTracerConcentrations_.empty()) {
+                for (int tracerIdx = 0; tracerIdx < tracerModel.numTracers(); ++tracerIdx) {
+                    if (this->solTracerConcentrations_[tracerIdx].empty()) {
+                        continue;
+                    }
+                    this->solTracerConcentrations_[tracerIdx][globalDofIdx] =
+                        tracerModel.solTracerConcentration(tracerIdx, globalDofIdx);
+                    
                 }
             }
 

--- a/opm/simulators/flow/TracerModel.hpp
+++ b/opm/simulators/flow/TracerModel.hpp
@@ -489,7 +489,6 @@ protected:
             }
 
             Scalar rate_f = rate - rate_s;
-
             if (rate_f > 0) {
                 for (int tIdx = 0; tIdx < tr.numTracer(); ++tIdx) {
                     // Injection of free tracer only
@@ -498,6 +497,10 @@ protected:
                     // Store _injector_ tracer rate for reporting
                     this->wellTracerRate_.at(std::make_pair(eclWell.name(),this->name(tr.idx_[tIdx]))) += rate_f*wtracer[tIdx];
                     this->wellFreeTracerRate_.at(std::make_pair(eclWell.name(),this->wellfname(tr.idx_[tIdx]))) += rate_f*wtracer[tIdx];
+                    if (eclWell.isMultiSegment()) {
+                        this->mSwTracerRate_[std::make_tuple(eclWell.name(), this->name(tr.idx_[tIdx]), eclWell.getConnections().get(i).segment())] = 
+                            rate_f*wtracer[tIdx];
+                    }
                 }
                 dfVol_[tr.phaseIdx_][I] -= rate_f * dt;
             }
@@ -511,6 +514,10 @@ protected:
                         rate_f * tr.concentration_[tIdx][I][0];
                     this->wellFreeTracerRate_.at(std::make_pair(eclWell.name(),this->wellfname(tr.idx_[tIdx]))) +=
                         rate_f * tr.concentration_[tIdx][I][0];
+                    if (eclWell.isMultiSegment()) {
+                        this->mSwTracerRate_[std::make_tuple(eclWell.name(), this->name(tr.idx_[tIdx]), eclWell.getConnections().get(i).segment())] = 
+                            rate_f * tr.concentration_[tIdx][I][0];
+                    }
                 }
                 dfVol_[tr.phaseIdx_][I] -= rate_f * dt;
                 
@@ -525,6 +532,10 @@ protected:
                         rate_s * tr.concentration_[tIdx][I][1];
                     this->wellSolTracerRate_.at(std::make_pair(eclWell.name(),this->wellsname(tr.idx_[tIdx]))) +=
                         rate_s * tr.concentration_[tIdx][I][1];
+                    if (eclWell.isMultiSegment()) {
+                        this->mSwTracerRate_[std::make_tuple(eclWell.name(), this->name(tr.idx_[tIdx]), eclWell.getConnections().get(i).segment())] = 
+                            rate_s * tr.concentration_[tIdx][I][1];
+                    }
                 }
                 dsVol_[tr.phaseIdx_][I] -= rate_s * dt;
 

--- a/opm/simulators/flow/TracerModel.hpp
+++ b/opm/simulators/flow/TracerModel.hpp
@@ -466,7 +466,7 @@ protected:
             this->wellSolTracerRate_[std::make_pair(eclWell.name(), this->wellsname(tr.idx_[tIdx]))] = 0.0;
         }
 
-        std::vector<double> wtracer(tr.numTracer());
+        std::vector<Scalar> wtracer(tr.numTracer());
         for (int tIdx = 0; tIdx < tr.numTracer(); ++tIdx) {
             wtracer[tIdx] = this->currentConcentration_(eclWell, this->name(tr.idx_[tIdx]));
         }

--- a/opm/simulators/flow/VtkTracerModule.hpp
+++ b/opm/simulators/flow/VtkTracerModule.hpp
@@ -107,10 +107,12 @@ namespace Opm {
         {
             if (eclTracerConcentrationOutput_()){
                 const auto& tracerModel = this->simulator_.problem().tracerModel();
-                eclTracerConcentration_.resize(tracerModel.numTracers());
-                for (std::size_t tracerIdx = 0; tracerIdx < eclTracerConcentration_.size(); ++tracerIdx) {
+                eclFreeTracerConcentration_.resize(tracerModel.numTracers());
+                eclSolTracerConcentration_.resize(tracerModel.numTracers());
+                for (std::size_t tracerIdx = 0; tracerIdx < eclFreeTracerConcentration_.size(); ++tracerIdx) {
 
-                    this->resizeScalarBuffer_(eclTracerConcentration_[tracerIdx]);
+                    this->resizeScalarBuffer_(eclFreeTracerConcentration_[tracerIdx]);
+                    this->resizeScalarBuffer_(eclSolTracerConcentration_[tracerIdx]);
                 }
             }
 
@@ -131,8 +133,9 @@ namespace Opm {
                 unsigned globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
 
                 if (eclTracerConcentrationOutput_()){
-                    for (std::size_t tracerIdx  = 0; tracerIdx < eclTracerConcentration_.size(); ++tracerIdx) {
-                        eclTracerConcentration_[tracerIdx][globalDofIdx] = tracerModel.tracerConcentration(tracerIdx, globalDofIdx);
+                    for (std::size_t tracerIdx  = 0; tracerIdx < eclFreeTracerConcentration_.size(); ++tracerIdx) {
+                        eclFreeTracerConcentration_[tracerIdx][globalDofIdx] = tracerModel.freeTracerConcentration(tracerIdx, globalDofIdx);
+                        eclSolTracerConcentration_[tracerIdx][globalDofIdx] = tracerModel.solTracerConcentration(tracerIdx, globalDofIdx);
                     }
                 }
             }
@@ -149,9 +152,11 @@ namespace Opm {
 
             if (eclTracerConcentrationOutput_()){
                 const auto& tracerModel = this->simulator_.problem().tracerModel();
-                for (std::size_t tracerIdx = 0; tracerIdx < eclTracerConcentration_.size(); ++tracerIdx) {
-                    const std::string tmp = "tracerConcentration_" + tracerModel.name(tracerIdx);
-                    this->commitScalarBuffer_(baseWriter,tmp.c_str(), eclTracerConcentration_[tracerIdx]);
+                for (std::size_t tracerIdx = 0; tracerIdx < eclFreeTracerConcentration_.size(); ++tracerIdx) {
+                    const std::string tmp = "freeTracerConcentration_" + tracerModel.name(tracerIdx);
+                    this->commitScalarBuffer_(baseWriter,tmp.c_str(), eclFreeTracerConcentration_[tracerIdx]);
+                    const std::string tmp2 = "solTracerConcentration_" + tracerModel.name(tracerIdx);
+                    this->commitScalarBuffer_(baseWriter,tmp2.c_str(), eclSolTracerConcentration_[tracerIdx]);
                 }
             }
 
@@ -167,7 +172,8 @@ namespace Opm {
         }
 
 
-        std::vector<ScalarBuffer> eclTracerConcentration_;
+        std::vector<ScalarBuffer> eclFreeTracerConcentration_;
+        std::vector<ScalarBuffer> eclSolTracerConcentration_;
     };
 } // namespace Opm
 

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -271,10 +271,13 @@ template<class Scalar> class WellContributions;
                         .tracerModel().getWellFreeTracerRates();
                     const auto& solTracerRates = simulator_.problem()
                         .tracerModel().getWellSolTracerRates();
+                    const auto& mswTracerRates = simulator_.problem()
+                        .tracerModel().getMswTracerRates();
 
                     this->assignWellTracerRates(wsrpt, tracerRates);
                     this->assignWellTracerRates(wsrpt, freeTracerRates);
                     this->assignWellTracerRates(wsrpt, solTracerRates);
+                    this->assignMswTracerRates(wsrpt, mswTracerRates);
                 }
 
                 BlackoilWellModelGuideRates(*this)

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -267,8 +267,14 @@ template<class Scalar> class WellContributions;
                 {
                     const auto& tracerRates = this->simulator_.problem()
                         .tracerModel().getWellTracerRates();
+                    const auto& freeTracerRates = simulator_.problem()
+                        .tracerModel().getWellFreeTracerRates();
+                    const auto& solTracerRates = simulator_.problem()
+                        .tracerModel().getWellSolTracerRates();
 
                     this->assignWellTracerRates(wsrpt, tracerRates);
+                    this->assignWellTracerRates(wsrpt, freeTracerRates);
+                    this->assignWellTracerRates(wsrpt, solTracerRates);
                 }
 
                 BlackoilWellModelGuideRates(*this)

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1699,6 +1699,33 @@ assignWellTracerRates(data::Wells& wsrpt,
 }
 
 template<class Scalar>
+void BlackoilWellModelGeneric<Scalar>::
+assignMswTracerRates(data::Wells& wsrpt,
+                     const MswTracerRates& mswTracerRates) const
+{
+    if (mswTracerRates.empty())
+        return;
+    
+    for (const auto& mswTR : mswTracerRates) {
+        std::string wellName = std::get<0>(mswTR.first);
+        auto xwPos = wsrpt.find(wellName);
+        if (xwPos == wsrpt.end()) { // No well results.
+            continue;
+        }
+        std::string tracerName = std::get<1>(mswTR.first);
+        std::size_t segNumber = std::get<2>(mswTR.first);
+        Scalar rate = mswTR.second;
+
+        auto& wData = xwPos->second;
+        auto segPos = wData.segments.find(segNumber);
+        if (segPos != wData.segments.end()) {
+            auto& segment = segPos->second;
+            segment.rates.set(data::Rates::opt::tracer, rate, tracerName);
+        }
+    }
+}
+
+template<class Scalar>
 std::vector<std::vector<int>> BlackoilWellModelGeneric<Scalar>::
 getMaxWellConnections() const
 {

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -437,6 +437,9 @@ protected:
     using WellTracerRates = std::map<std::pair<std::string, std::string>, Scalar>;
     void assignWellTracerRates(data::Wells& wsrpt,
                                const WellTracerRates& wellTracerRates) const;
+    using MswTracerRates = std::map<std::tuple<std::string, std::string, std::size_t>, Scalar>;
+    void assignMswTracerRates(data::Wells& wsrpt,
+                              const MswTracerRates& mswTracerRates) const;
 
     Schedule& schedule_;
     const SummaryState& summaryState_;

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -381,10 +381,10 @@ BOOST_AUTO_TEST_CASE(BlackoilWellModelGeneric)
     BOOST_CHECK_MESSAGE(data_out == data_in, "Deserialized BlackoilWellModelGeneric differ");
 }
 
-template<class Grid, class GridView, class DofMapper, class Stencil, class Scalar>
-class GenericTracerModelTest : public Opm::GenericTracerModel<Grid,GridView,DofMapper,Stencil,Scalar>
+template<class Grid, class GridView, class DofMapper, class Stencil, class FluidSystem, class Scalar>
+class GenericTracerModelTest : public Opm::GenericTracerModel<Grid,GridView,DofMapper,Stencil,FluidSystem,Scalar>
 {
-    using Base = Opm::GenericTracerModel<Grid,GridView,DofMapper,Stencil,Scalar>;
+    using Base = Opm::GenericTracerModel<Grid,GridView,DofMapper,Stencil,FluidSystem,Scalar>;
 public:
     GenericTracerModelTest(const GridView& gridView,
                               const Opm::EclipseState& eclState,
@@ -438,6 +438,7 @@ BOOST_AUTO_TEST_CASE(FlowGenericTracerModel)
                                            GridView,
                                            Dune::MultipleCodimMultipleGeomTypeMapper<GridView>,
                                            Opm::EcfvStencil<double, GridView, false, false>,
+                                           Opm::BlackOilFluidSystem<double, Opm::BlackOilDefaultIndexTraits>,
                                            double>
         ::serializationTestObject(gridView, eclState, mapper, dofMapper, centroids);
     Opm::Serialization::MemPacker packer;
@@ -474,6 +475,7 @@ BOOST_AUTO_TEST_CASE(FlowGenericTracerModelFem)
                                            GridView,
                                            Dune::MultipleCodimMultipleGeomTypeMapper<GridView>,
                                            Opm::EcfvStencil<double, GridView, false, false>,
+                                           Opm::BlackOilFluidSystem<double, Opm::BlackOilDefaultIndexTraits>,
                                            double>
         ::serializationTestObject(gridView, eclState, mapper, dofMapper, centroids);
     Opm::Serialization::MemPacker packer;

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -402,7 +402,7 @@ public:
                             const std::function<std::array<double,Grid::dimensionworld>(int)> centroids)
     {
         GenericTracerModelTest result(gridView, eclState, cartMapper, dofMapper, centroids);
-        result.tracerConcentration_ = {{1.0}, {2.0}, {3.0}};
+        result.tracerConcentration_ = {{{1.0, 2.0}}, {{3.0, 4.0}}, {{5.0, 6.0}}};
         result.wellTracerRate_.insert({{"foo", "bar"}, 4.0});
 
         return result;


### PR DESCRIPTION
Extended the tracer model to include partitioning of tracers into free and solution states whenever dissolved gas/vaporized oil exist. Essentially the tracer linear system has been extended with equations for free and solution tracers with simple mass transfer coupling between them. Both free and solution tracers are now outputted in restart files.

The PR is in draft mode to discuss and further improve/develop the tracer model. Per now it seems the results for the solution tracer part generally does not match reference results (e.g. in the [gas tracer test](https://github.com/OPM/opm-tests/tree/master/tracer)); only matches for simple test cases (e.g., one cell partitioning tracers). However, results for the free tracer part does generally match reference results and are also improved over current master implementation.

Note: Due to the current implementation of the TRACERS keyword, only option 2 (=number of water tracers) is used in the simulations. So this option must be set regardless of which type of tracer that is used. Correcting this seemed a bit over my head at the moment, but when/if this draft becomes a real PR, the keyword behavior must be fixed.

Depends on: https://github.com/OPM/opm-common/pull/4001