### PR TITLE
Activate Regression Tests for Region Vectors in Field UDQs

### DIFF
--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -173,6 +173,14 @@ add_test_compare_parallel_simulation(CASENAME actionx_m1
                                      DIR udq_actionx
                                      TEST_ARGS --solver-max-time-step-in-days=0.2 --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-6)
 
+add_test_compare_parallel_simulation(CASENAME reg_smry_in_fld_udq
+                                     FILENAME UDQ_REG-01
+                                     SIMULATOR flow
+                                     ABS_TOL ${abs_tol_parallel}
+                                     REL_TOL ${coarse_rel_tol_parallel}
+                                     DIR udq_actionx
+                                     TEST_ARGS --enable-tuning=true)
+
 add_test_compare_parallel_simulation(CASENAME winjmult_msw
                                      FILENAME WINJMULT_MSW
                                      SIMULATOR flow

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -570,6 +570,14 @@ add_test_compareECLFiles(CASENAME udq_in_actionx
                          REL_TOL ${rel_tol}
                          DIR udq_actionx)
 
+add_test_compareECLFiles(CASENAME reg_smry_in_fld_udq
+                         FILENAME UDQ_REG-01
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR udq_actionx
+                         TEST_ARGS --enable-tuning=true)
+
 add_test_compareECLFiles(CASENAME cskin-01
                          FILENAME CSKIN-01
                          SIMULATOR flow


### PR DESCRIPTION
This PR adds sequential and parallel regression tests for the [`UDQ_REG-01`](https://github.com/OPM/opm-tests/blob/51a0015859d8724f17b95fa4ea6648ce8c0e55b1/udq_actionx/UDQ_REG-01.DATA) example model which uses region-level summary vectors in field-level UDQs.  Restarted tests are missing at this time.