### PR TITLE
Fix fast amg wrapper and generalize RebuildOnUpdatePreconditioner

### DIFF
--- a/opm/simulators/linalg/PreconditionerFactory_impl.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory_impl.hpp
@@ -173,13 +173,13 @@ struct StandardPreconditioners {
         F::addCreator("ILUn", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
             return createParILU(op, prm, comm, prm.get<int>("ilulevel", 0));
         });
-        // F::addCreator("DuneILU", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
-        //     const int n = prm.get<int>("ilulevel", 0);
-        //     const double w = prm.get<double>("relaxation", 1.0);
-        //     const bool resort = prm.get<bool>("resort", false);
-        //     return wrapBlockPreconditioner<RebuildOnUpdatePreconditioner<Dune::SeqILU<M, V, V>, const M&>>(
-        //         comm, op.getmat(), n, w, resort);
-        // });
+        F::addCreator("DuneILU", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
+            const int n = prm.get<int>("ilulevel", 0);
+            const double w = prm.get<double>("relaxation", 1.0);
+            const bool resort = prm.get<bool>("resort", false);
+            return wrapBlockPreconditioner<RebuildOnUpdatePreconditioner<Dune::SeqILU<M, V, V>, const M&, const int, const double, const bool>>(
+                comm, op.getmat(), n, w, resort);
+        });
         F::addCreator("DILU", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
             DUNE_UNUSED_PARAMETER(prm);
             return wrapBlockPreconditioner<MultithreadDILU<M, V, V>>(comm, op.getmat());

--- a/opm/simulators/linalg/PreconditionerFactory_impl.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory_impl.hpp
@@ -523,7 +523,7 @@ struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation> {
                 Dune::Amg::Parameters parms;
                 parms.setNoPreSmoothSteps(1);
                 parms.setNoPostSmoothSteps(1);
-                return getDummyUpdateWrapper<Dune::Amg::FastAMG<O, V>>(op, crit, parms);
+                return getRebuildOnUpdateWrapper<Dune::Amg::FastAMG<O, V>, O, decltype(crit), decltype(parms)>(op, crit, parms);
             });
         }
         if constexpr (std::is_same_v<O, WellModelMatrixAdapter<M, V, V, false>>) {

--- a/opm/simulators/linalg/PreconditionerFactory_impl.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory_impl.hpp
@@ -177,7 +177,7 @@ struct StandardPreconditioners {
             const int n = prm.get<int>("ilulevel", 0);
             const double w = prm.get<double>("relaxation", 1.0);
             const bool resort = prm.get<bool>("resort", false);
-            return wrapBlockPreconditioner<RebuildOnUpdatePreconditioner<Dune::SeqILU<M, V, V>, const M&, const int, const double, const bool>>(
+            return wrapBlockPreconditioner<RebuildOnUpdatePreconditioner<Dune::SeqILU<M, V, V>>>(
                 comm, op.getmat(), n, w, resort);
         });
         F::addCreator("DILU", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
@@ -425,7 +425,7 @@ struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation> {
             const double w = prm.get<double>("relaxation", 1.0);
             const int n = prm.get<int>("ilulevel", 0);
             const bool resort = prm.get<bool>("resort", false);
-            return getRebuildOnUpdateWrapper<Dune::SeqILU<M, V, V>, const M&, const int, const double, const bool>(op.getmat(), n, w, resort);
+            return getRebuildOnUpdateWrapper<Dune::SeqILU<M, V, V>>(op.getmat(), n, w, resort);
         });
         F::addCreator("ParOverILU0", [](const O& op, const P& prm, const std::function<V()>&, std::size_t) {
             const double w = prm.get<double>("relaxation", 1.0);
@@ -523,7 +523,7 @@ struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation> {
                 Dune::Amg::Parameters parms;
                 parms.setNoPreSmoothSteps(1);
                 parms.setNoPostSmoothSteps(1);
-                return getRebuildOnUpdateWrapper<Dune::Amg::FastAMG<O, V>, O, decltype(crit), decltype(parms)>(op, crit, parms);
+                return getRebuildOnUpdateWrapper<Dune::Amg::FastAMG<O, V>>(op, crit, parms);
             });
         }
         if constexpr (std::is_same_v<O, WellModelMatrixAdapter<M, V, V, false>>) {

--- a/opm/simulators/linalg/PreconditionerFactory_impl.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory_impl.hpp
@@ -173,13 +173,13 @@ struct StandardPreconditioners {
         F::addCreator("ILUn", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
             return createParILU(op, prm, comm, prm.get<int>("ilulevel", 0));
         });
-        F::addCreator("DuneILU", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
-            const int n = prm.get<int>("ilulevel", 0);
-            const double w = prm.get<double>("relaxation", 1.0);
-            const bool resort = prm.get<bool>("resort", false);
-            return wrapBlockPreconditioner<RebuildOnUpdatePreconditioner<Dune::SeqILU<M, V, V>, const M&>>(
-                comm, op.getmat(), n, w, resort);
-        });
+        // F::addCreator("DuneILU", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
+        //     const int n = prm.get<int>("ilulevel", 0);
+        //     const double w = prm.get<double>("relaxation", 1.0);
+        //     const bool resort = prm.get<bool>("resort", false);
+        //     return wrapBlockPreconditioner<RebuildOnUpdatePreconditioner<Dune::SeqILU<M, V, V>, const M&>>(
+        //         comm, op.getmat(), n, w, resort);
+        // });
         F::addCreator("DILU", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
             DUNE_UNUSED_PARAMETER(prm);
             return wrapBlockPreconditioner<MultithreadDILU<M, V, V>>(comm, op.getmat());
@@ -425,7 +425,7 @@ struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation> {
             const double w = prm.get<double>("relaxation", 1.0);
             const int n = prm.get<int>("ilulevel", 0);
             const bool resort = prm.get<bool>("resort", false);
-            return getRebuildOnUpdateWrapper<Dune::SeqILU<M, V, V>, const M&>(op.getmat(), n, w, resort);
+            return getRebuildOnUpdateWrapper<Dune::SeqILU<M, V, V>, const M&, const int, const double, const bool>(op.getmat(), n, w, resort);
         });
         F::addCreator("ParOverILU0", [](const O& op, const P& prm, const std::function<V()>&, std::size_t) {
             const double w = prm.get<double>("relaxation", 1.0);

--- a/opm/simulators/linalg/PreconditionerWithUpdate.hpp
+++ b/opm/simulators/linalg/PreconditionerWithUpdate.hpp
@@ -87,9 +87,10 @@ getDummyUpdateWrapper(Args&&... args)
 /// @brief Interface class ensuring make function is overriden
 /// @tparam OriginalPreconditioner - An arbitrary Preconditioner type
 template <class OriginalPreconditioner>
-struct GeneralPreconditionerMaker
-{
-    virtual std::unique_ptr<Preconditioner<typename OriginalPreconditioner::domain_type, typename OriginalPreconditioner::range_type>> make() = 0;
+struct GeneralPreconditionerMaker {
+    virtual std::unique_ptr<
+        Preconditioner<typename OriginalPreconditioner::domain_type, typename OriginalPreconditioner::range_type>>
+    make() = 0;
 };
 
 /// @brief Struct implementing a make function which creates a preconditioner
@@ -97,15 +98,18 @@ struct GeneralPreconditionerMaker
 /// @tparam OriginalPreconditioner - An arbitrary preconditioner type
 /// @tparam ...Args - All arguments needed to construct the preconditioner of choice
 template <class OriginalPreconditioner, class... Args>
-struct PreconditionerMaker : public GeneralPreconditionerMaker<OriginalPreconditioner>
-{
+struct PreconditionerMaker : public GeneralPreconditionerMaker<OriginalPreconditioner> {
     PreconditionerMaker(Args&&... args)
         : args_(args...)
     {
     }
-    std::unique_ptr<Preconditioner<typename OriginalPreconditioner::domain_type, typename OriginalPreconditioner::range_type>> make() override
+    std::unique_ptr<
+        Preconditioner<typename OriginalPreconditioner::domain_type, typename OriginalPreconditioner::range_type>>
+    make() override
     {
-        return std::unique_ptr<Preconditioner<typename OriginalPreconditioner::domain_type, typename OriginalPreconditioner::range_type>>{new auto(std::make_from_tuple<OriginalPreconditioner>(args_))};
+        return std::unique_ptr<
+            Preconditioner<typename OriginalPreconditioner::domain_type, typename OriginalPreconditioner::range_type>> {
+            new auto(std::make_from_tuple<OriginalPreconditioner>(args_))};
     }
     std::tuple<Args...> args_;
 };
@@ -119,8 +123,8 @@ class RebuildOnUpdatePreconditioner : public PreconditionerWithUpdate<typename O
 {
 public:
     RebuildOnUpdatePreconditioner(Args... args)
-        : preconditioner_params_(args...),
-        preconditioner_maker_(std::make_unique<ConcreteMakerType>(std::forward<Args>(args)...))
+        : preconditioner_params_(args...)
+        , preconditioner_maker_(std::make_unique<ConcreteMakerType>(std::forward<Args>(args)...))
     {
         update();
     }
@@ -160,7 +164,9 @@ private:
 
     std::tuple<Args...> preconditioner_params_;
     std::unique_ptr<AbstractMakerType> preconditioner_maker_;
-    std::unique_ptr<Preconditioner<typename OriginalPreconditioner::domain_type,typename OriginalPreconditioner::range_type>> orig_precond_;
+    std::unique_ptr<
+        Preconditioner<typename OriginalPreconditioner::domain_type, typename OriginalPreconditioner::range_type>>
+        orig_precond_;
 };
 
 /// @brief Wrapper function creating and return a shared pointer to a preconditioner which is reconstructed on update
@@ -172,7 +178,8 @@ template <class OriginalPreconditioner, class... Args>
 std::shared_ptr<RebuildOnUpdatePreconditioner<OriginalPreconditioner, Args...>>
 getRebuildOnUpdateWrapper(Args... args)
 {
-    return std::make_shared<RebuildOnUpdatePreconditioner<OriginalPreconditioner, Args...>>(std::forward<Args>(args)...);
+    return std::make_shared<RebuildOnUpdatePreconditioner<OriginalPreconditioner, Args...>>(
+        std::forward<Args>(args)...);
 }
 
 } // namespace Dune


### PR DESCRIPTION
Atgeirr suggested that the famg preconditioner should have an update that reconstructs the preconditioner, this is fixed in this PR.
While doing this the RebuildOnUpdatePreconditioner wrapper class was made more general using parameter packs to keep the factory as clean as possible.