### PR TITLE
changed: make PreconditionerType an enum class

### DIFF
--- a/opm/simulators/linalg/bda/opencl/CPR.cpp
+++ b/opm/simulators/linalg/bda/opencl/CPR.cpp
@@ -44,7 +44,7 @@ using Opm::OpmLog;
 using Dune::Timer;
 
 template <unsigned int block_size>
-CPR<block_size>::CPR(int verbosity_, bool opencl_ilu_parallel_) :
+CPR<block_size>::CPR(bool opencl_ilu_parallel_, int verbosity_) :
     Preconditioner<block_size>(verbosity_), opencl_ilu_parallel(opencl_ilu_parallel_)
 {
     bilu0 = std::make_unique<BILU0<block_size> >(opencl_ilu_parallel, verbosity_);

--- a/opm/simulators/linalg/bda/opencl/CPR.hpp
+++ b/opm/simulators/linalg/bda/opencl/CPR.hpp
@@ -115,8 +115,7 @@ private:
     void create_preconditioner_amg(BlockedMatrix *mat);
 
 public:
-
-    CPR(int verbosity, bool opencl_ilu_parallel);
+    CPR(bool opencl_ilu_parallel, int verbosity);
 
     bool analyze_matrix(BlockedMatrix *mat) override;
     bool analyze_matrix(BlockedMatrix *mat, BlockedMatrix *jacMat) override;

--- a/opm/simulators/linalg/bda/opencl/Preconditioner.cpp
+++ b/opm/simulators/linalg/bda/opencl/Preconditioner.cpp
@@ -44,13 +44,13 @@ void Preconditioner<block_size>::setOpencl(std::shared_ptr<cl::Context>& context
 
 template <unsigned int block_size>
 std::unique_ptr<Preconditioner<block_size>>
-Preconditioner<block_size>::create(Type type, int verbosity, bool opencl_ilu_parallel)
+Preconditioner<block_size>::create(Type type, bool opencl_ilu_parallel, int verbosity)
 {
     switch (type ) {
     case Type::BILU0:
         return std::make_unique<BILU0<block_size> >(opencl_ilu_parallel, verbosity);
     case Type::CPR:
-        return std::make_unique<CPR<block_size> >(verbosity, opencl_ilu_parallel);
+        return std::make_unique<CPR<block_size> >(opencl_ilu_parallel, verbosity);
     case Type::BISAI:
         return std::make_unique<BISAI<block_size> >(opencl_ilu_parallel, verbosity);
     }
@@ -70,7 +70,7 @@ bool Preconditioner<block_size>::create_preconditioner(BlockedMatrix *mat, [[may
 }
 
 #define INSTANTIATE_BDA_FUNCTIONS(n)  \
-template std::unique_ptr<Preconditioner<n> > Preconditioner<n>::create(Type, int, bool);         \
+template std::unique_ptr<Preconditioner<n> > Preconditioner<n>::create(Type, bool, int);         \
 template void Preconditioner<n>::setOpencl(std::shared_ptr<cl::Context>&, std::shared_ptr<cl::CommandQueue>&); \
 template bool Preconditioner<n>::analyze_matrix(BlockedMatrix *, BlockedMatrix *);                             \
 template bool Preconditioner<n>::create_preconditioner(BlockedMatrix *, BlockedMatrix *);

--- a/opm/simulators/linalg/bda/opencl/Preconditioner.cpp
+++ b/opm/simulators/linalg/bda/opencl/Preconditioner.cpp
@@ -40,13 +40,15 @@ void Preconditioner<block_size>::setOpencl(std::shared_ptr<cl::Context>& context
 }
 
 template <unsigned int block_size>
-std::unique_ptr<Preconditioner<block_size> > Preconditioner<block_size>::create(PreconditionerType type, int verbosity, bool opencl_ilu_parallel) {
-    if (type == PreconditionerType::BILU0) {
-        return std::make_unique<Opm::Accelerator::BILU0<block_size> >(opencl_ilu_parallel, verbosity);
-    } else if (type == PreconditionerType::CPR) {
-        return std::make_unique<Opm::Accelerator::CPR<block_size> >(verbosity, opencl_ilu_parallel);
-    } else if (type == PreconditionerType::BISAI) {
-        return std::make_unique<Opm::Accelerator::BISAI<block_size> >(opencl_ilu_parallel, verbosity);
+std::unique_ptr<Preconditioner<block_size>>
+Preconditioner<block_size>::create(Type type, int verbosity, bool opencl_ilu_parallel)
+{
+    if (type == Type::BILU0) {
+        return std::make_unique<BILU0<block_size> >(opencl_ilu_parallel, verbosity);
+    } else if (type == Type::CPR) {
+        return std::make_unique<CPR<block_size> >(verbosity, opencl_ilu_parallel);
+    } else if (type == Type::BISAI) {
+        return std::make_unique<BISAI<block_size> >(opencl_ilu_parallel, verbosity);
     } else {
         OPM_THROW(std::logic_error, "Invalid PreconditionerType");
     }
@@ -63,7 +65,7 @@ bool Preconditioner<block_size>::create_preconditioner(BlockedMatrix *mat, [[may
 }
 
 #define INSTANTIATE_BDA_FUNCTIONS(n)  \
-template std::unique_ptr<Preconditioner<n> > Preconditioner<n>::create(PreconditionerType, int, bool);         \
+template std::unique_ptr<Preconditioner<n> > Preconditioner<n>::create(Type, int, bool);         \
 template void Preconditioner<n>::setOpencl(std::shared_ptr<cl::Context>&, std::shared_ptr<cl::CommandQueue>&); \
 template bool Preconditioner<n>::analyze_matrix(BlockedMatrix *, BlockedMatrix *);                             \
 template bool Preconditioner<n>::create_preconditioner(BlockedMatrix *, BlockedMatrix *);

--- a/opm/simulators/linalg/bda/opencl/Preconditioner.cpp
+++ b/opm/simulators/linalg/bda/opencl/Preconditioner.cpp
@@ -18,14 +18,17 @@
 */
 
 #include <config.h>
-#include <memory>
+#include <opm/simulators/linalg/bda/opencl/Preconditioner.hpp>
+
 #include <opm/common/TimingMacros.hpp>
 #include <opm/common/ErrorMacros.hpp>
 
 #include <opm/simulators/linalg/bda/opencl/BILU0.hpp>
 #include <opm/simulators/linalg/bda/opencl/BISAI.hpp>
 #include <opm/simulators/linalg/bda/opencl/CPR.hpp>
-#include <opm/simulators/linalg/bda/opencl/Preconditioner.hpp>
+
+#include <memory>
+#include <string>
 
 namespace Opm
 {
@@ -43,15 +46,17 @@ template <unsigned int block_size>
 std::unique_ptr<Preconditioner<block_size>>
 Preconditioner<block_size>::create(Type type, int verbosity, bool opencl_ilu_parallel)
 {
-    if (type == Type::BILU0) {
+    switch (type ) {
+    case Type::BILU0:
         return std::make_unique<BILU0<block_size> >(opencl_ilu_parallel, verbosity);
-    } else if (type == Type::CPR) {
+    case Type::CPR:
         return std::make_unique<CPR<block_size> >(verbosity, opencl_ilu_parallel);
-    } else if (type == Type::BISAI) {
+    case Type::BISAI:
         return std::make_unique<BISAI<block_size> >(opencl_ilu_parallel, verbosity);
-    } else {
-        OPM_THROW(std::logic_error, "Invalid PreconditionerType");
     }
+
+    OPM_THROW(std::logic_error,
+              "Invalid preconditioner type " + std::to_string(static_cast<int>(type)));
 }
 
 template <unsigned int block_size>

--- a/opm/simulators/linalg/bda/opencl/Preconditioner.hpp
+++ b/opm/simulators/linalg/bda/opencl/Preconditioner.hpp
@@ -22,11 +22,12 @@
 
 #include <opm/simulators/linalg/bda/opencl/opencl.hpp>
 
+#include <memory>
+
 namespace Opm
 {
 namespace Accelerator
 {
-
 
 class BlockedMatrix;
 
@@ -51,13 +52,13 @@ protected:
     {};
 
 public:
-    enum PreconditionerType {
+    enum class Type {
         BILU0,
         CPR,
         BISAI
     };
 
-    static std::unique_ptr<Preconditioner> create(PreconditionerType type, int verbosity, bool opencl_ilu_parallel);
+    static std::unique_ptr<Preconditioner> create(Type type, int verbosity, bool opencl_ilu_parallel);
 
     virtual ~Preconditioner() = default;
 

--- a/opm/simulators/linalg/bda/opencl/Preconditioner.hpp
+++ b/opm/simulators/linalg/bda/opencl/Preconditioner.hpp
@@ -58,7 +58,9 @@ public:
         BISAI
     };
 
-    static std::unique_ptr<Preconditioner> create(Type type, int verbosity, bool opencl_ilu_parallel);
+    static std::unique_ptr<Preconditioner> create(Type type,
+                                                  bool opencl_ilu_parallel,
+                                                  int verbosity);
 
     virtual ~Preconditioner() = default;
 

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
@@ -65,7 +65,7 @@ openclSolverBackend<block_size>::openclSolverBackend(int verbosity_, int maxit_,
         OPM_THROW(std::logic_error, "Error unknown value for argument --linear-solver, " + linsolver);
     }
 
-    using PreconditionerType = typename Preconditioner<block_size>::PreconditionerType;
+    using PreconditionerType = typename Preconditioner<block_size>::Type;
     if (use_cpr) {
         prec = Preconditioner<block_size>::create(PreconditionerType::CPR, verbosity, opencl_ilu_parallel);
     } else if (use_isai) {

--- a/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
+++ b/opm/simulators/linalg/bda/opencl/openclSolverBackend.cpp
@@ -67,11 +67,11 @@ openclSolverBackend<block_size>::openclSolverBackend(int verbosity_, int maxit_,
 
     using PreconditionerType = typename Preconditioner<block_size>::Type;
     if (use_cpr) {
-        prec = Preconditioner<block_size>::create(PreconditionerType::CPR, verbosity, opencl_ilu_parallel);
+        prec = Preconditioner<block_size>::create(PreconditionerType::CPR, opencl_ilu_parallel, verbosity);
     } else if (use_isai) {
-        prec = Preconditioner<block_size>::create(PreconditionerType::BISAI, verbosity, opencl_ilu_parallel);
+        prec = Preconditioner<block_size>::create(PreconditionerType::BISAI, opencl_ilu_parallel, verbosity);
     } else {
-        prec = Preconditioner<block_size>::create(PreconditionerType::BILU0, verbosity, opencl_ilu_parallel);
+        prec = Preconditioner<block_size>::create(PreconditionerType::BILU0, opencl_ilu_parallel, verbosity);
     }
 
     std::ostringstream out;


### PR DESCRIPTION
this to avoid symbol clashes with the implementations. while at it rename it to Type as Preconditioner::PreconditionerType is redundant.

I ran into this while working in this area and found it a bit annoying so let's improve.