### PR TITLE
avoid including MultisegmentWellContribution in WellContributions.hpp

### DIFF
--- a/opm/simulators/linalg/bda/WellContributions.cpp
+++ b/opm/simulators/linalg/bda/WellContributions.cpp
@@ -18,11 +18,12 @@
 */
 
 #include <config.h> // CMake
+#include <opm/simulators/linalg/bda/WellContributions.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/ErrorMacros.hpp>
 
-#include <opm/simulators/linalg/bda/WellContributions.hpp>
+#include <opm/simulators/linalg/bda/MultisegmentWellContribution.hpp>
 
 #ifdef HAVE_OPENCL
 #include <opm/simulators/linalg/bda/opencl/openclWellContributions.hpp>
@@ -36,8 +37,9 @@
 #include <opm/simulators/linalg/bda/rocsparseWellContributions.hpp>
 #endif
 
-namespace Opm
-{
+namespace Opm {
+
+WellContributions::~WellContributions() = default;
 
 std::unique_ptr<WellContributions>
 WellContributions::create(const std::string& accelerator_mode, bool useWellConn)

--- a/opm/simulators/linalg/bda/WellContributions.hpp
+++ b/opm/simulators/linalg/bda/WellContributions.hpp
@@ -23,14 +23,14 @@
 #include <memory>
 #include <vector>
 
-#include <opm/simulators/linalg/bda/MultisegmentWellContribution.hpp>
 #if HAVE_SUITESPARSE_UMFPACK
 #include<umfpack.h>
 #endif
 #include <dune/common/version.hh>
 
-namespace Opm
-{
+namespace Opm {
+
+class MultisegmentWellContribution;
 
 /// This class serves to eliminate the need to include the WellContributions into the matrix (with --matrix-add-well-contributions=true) for the cusparseSolver or openclSolver.
 /// If the --matrix-add-well-contributions commandline parameter is true, this class should still be used, but be empty.
@@ -89,7 +89,7 @@ public:
     void alloc();
 
     /// Empty destructor.
-    virtual ~WellContributions() = default;
+    virtual ~WellContributions();
 
     /// Indicate how large the blocks of the StandardWell (C and B) are
     /// \param[in] dim         number of columns

--- a/opm/simulators/linalg/bda/cuda/cuWellContributions.cu
+++ b/opm/simulators/linalg/bda/cuda/cuWellContributions.cu
@@ -19,14 +19,15 @@
 
 
 #include <config.h> // CMake
+#include <opm/simulators/linalg/bda/cuda/cuWellContributions.hpp>
 
-#include "opm/simulators/linalg/bda/cuda/cuWellContributions.hpp"
-
-#include "opm/simulators/linalg/bda/cuda/cuda_header.hpp"
-#include <cuda_runtime.h>
-
-#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
+
+#include <opm/simulators/linalg/bda/MultisegmentWellContribution.hpp>
+#include <opm/simulators/linalg/bda/cuda/cuda_header.hpp>
+
+#include <cuda_runtime.h>
 
 namespace Opm
 {

--- a/opm/simulators/linalg/bda/opencl/openclWellContributions.cpp
+++ b/opm/simulators/linalg/bda/opencl/openclWellContributions.cpp
@@ -18,12 +18,12 @@
 */
 
 #include <config.h> // CMake
-
 #include <opm/simulators/linalg/bda/opencl/openclWellContributions.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/ErrorMacros.hpp>
 
+#include <opm/simulators/linalg/bda/MultisegmentWellContribution.hpp>
 
 namespace Opm
 {

--- a/opm/simulators/linalg/bda/rocsparseWellContributions.cpp
+++ b/opm/simulators/linalg/bda/rocsparseWellContributions.cpp
@@ -39,9 +39,9 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/ErrorMacros.hpp>
 
+#include <opm/simulators/linalg/bda/MultisegmentWellContribution.hpp>
 
 #include <hip/hip_runtime.h>
-
 
 #define HIP_CHECK(stat)                               \
     {                                                 \


### PR DESCRIPTION
Instead of rebuilding 'the world' touching MultisegmentWellContribution.hpp now rebuilds just a handful of sources.