### PR TITLE
WellGroupHelpers: template Scalar type

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelConstraints.cpp
+++ b/opm/simulators/wells/BlackoilWellModelConstraints.cpp
@@ -74,7 +74,12 @@ checkGroupInjectionConstraints(const Group& group,
         if (currentControl != Group::InjectionCMode::RATE)
         {
             double current_rate = 0.0;
-            current_rate += WellGroupHelpers::sumWellSurfaceRates(group, wellModel_.schedule(), well_state, reportStepIdx, phasePos, /*isInjector*/true);
+            current_rate += WellGroupHelpers<double>::sumWellSurfaceRates(group,
+                                                                          wellModel_.schedule(),
+                                                                          well_state,
+                                                                          reportStepIdx,
+                                                                          phasePos,
+                                                                          /*isInjector*/true);
 
             // sum over all nodes
             current_rate = wellModel_.comm().sum(current_rate);
@@ -98,7 +103,12 @@ checkGroupInjectionConstraints(const Group& group,
         if (currentControl != Group::InjectionCMode::RESV)
         {
             double current_rate = 0.0;
-            current_rate += WellGroupHelpers::sumWellResRates(group, wellModel_.schedule(), well_state, reportStepIdx, phasePos, /*isInjector*/true);
+            current_rate += WellGroupHelpers<double>::sumWellResRates(group,
+                                                                      wellModel_.schedule(),
+                                                                      well_state,
+                                                                      reportStepIdx,
+                                                                      phasePos,
+                                                                      /*isInjector*/true);
             // sum over all nodes
             current_rate = wellModel_.comm().sum(current_rate);
 
@@ -123,17 +133,23 @@ checkGroupInjectionConstraints(const Group& group,
             double production_Rate = 0.0;
             const auto& controls = group.injectionControls(phase, wellModel_.summaryState());
             const Group& groupRein = wellModel_.schedule().getGroup(controls.reinj_group, reportStepIdx);
-            production_Rate += WellGroupHelpers::sumWellSurfaceRates(groupRein, wellModel_.schedule(),
-                                                                     well_state, reportStepIdx,
-                                                                     phasePos, /*isInjector*/false);
+            production_Rate += WellGroupHelpers<double>::sumWellSurfaceRates(groupRein,
+                                                                             wellModel_.schedule(),
+                                                                             well_state,
+                                                                             reportStepIdx,
+                                                                             phasePos,
+                                                                             /*isInjector*/false);
 
             // sum over all nodes
             production_Rate = wellModel_.comm().sum(production_Rate);
 
             double current_rate = 0.0;
-            current_rate += WellGroupHelpers::sumWellSurfaceRates(group, wellModel_.schedule(),
-                                                                  well_state, reportStepIdx,
-                                                                  phasePos, /*isInjector*/true);
+            current_rate += WellGroupHelpers<double>::sumWellSurfaceRates(group,
+                                                                          wellModel_.schedule(),
+                                                                          well_state,
+                                                                          reportStepIdx,
+                                                                          phasePos,
+                                                                          /*isInjector*/true);
 
             // sum over all nodes
             current_rate = wellModel_.comm().sum(current_rate);
@@ -153,29 +169,46 @@ checkGroupInjectionConstraints(const Group& group,
             double voidage_rate = 0.0;
             const auto& controls = group.injectionControls(phase, wellModel_.summaryState());
             const Group& groupVoidage = wellModel_.schedule().getGroup(controls.voidage_group, reportStepIdx);
-            voidage_rate += WellGroupHelpers::sumWellResRates(groupVoidage, wellModel_.schedule(),
-                                                              well_state, reportStepIdx,
-                                                              pu.phase_pos[BlackoilPhases::Aqua], false);
-            voidage_rate += WellGroupHelpers::sumWellResRates(groupVoidage, wellModel_.schedule(),
-                                                              well_state, reportStepIdx,
-                                                              pu.phase_pos[BlackoilPhases::Liquid], false);
-            voidage_rate += WellGroupHelpers::sumWellResRates(groupVoidage, wellModel_.schedule(),
-                                                              well_state, reportStepIdx,
-                                                              pu.phase_pos[BlackoilPhases::Vapour], false);
+            voidage_rate += WellGroupHelpers<double>::sumWellResRates(groupVoidage,
+                                                                      wellModel_.schedule(),
+                                                                      well_state,
+                                                                      reportStepIdx,
+                                                                      pu.phase_pos[BlackoilPhases::Aqua],
+                                                                      false);
+            voidage_rate += WellGroupHelpers<double>::sumWellResRates(groupVoidage,
+                                                                      wellModel_.schedule(),
+                                                                      well_state,
+                                                                      reportStepIdx,
+                                                                      pu.phase_pos[BlackoilPhases::Liquid],
+                                                                      false);
+            voidage_rate += WellGroupHelpers<double>::sumWellResRates(groupVoidage,
+                                                                      wellModel_.schedule(),
+                                                                      well_state, reportStepIdx,
+                                                                      pu.phase_pos[BlackoilPhases::Vapour],
+                                                                      false);
 
             // sum over all nodes
             voidage_rate = wellModel_.comm().sum(voidage_rate);
 
             double total_rate = 0.0;
-            total_rate += WellGroupHelpers::sumWellResRates(group, wellModel_.schedule(),
-                                                            well_state, reportStepIdx,
-                                                            pu.phase_pos[BlackoilPhases::Aqua], true);
-            total_rate += WellGroupHelpers::sumWellResRates(group, wellModel_.schedule(),
-                                                            well_state, reportStepIdx,
-                                                            pu.phase_pos[BlackoilPhases::Liquid], true);
-            total_rate += WellGroupHelpers::sumWellResRates(group, wellModel_.schedule(),
-                                                            well_state, reportStepIdx,
-                                                            pu.phase_pos[BlackoilPhases::Vapour], true);
+            total_rate += WellGroupHelpers<double>::sumWellResRates(group,
+                                                                    wellModel_.schedule(),
+                                                                    well_state,
+                                                                    reportStepIdx,
+                                                                    pu.phase_pos[BlackoilPhases::Aqua],
+                                                                    true);
+            total_rate += WellGroupHelpers<double>::sumWellResRates(group,
+                                                                    wellModel_.schedule(),
+                                                                    well_state,
+                                                                    reportStepIdx,
+                                                                    pu.phase_pos[BlackoilPhases::Liquid],
+                                                                    true);
+            total_rate += WellGroupHelpers<double>::sumWellResRates(group,
+                                                                    wellModel_.schedule(),
+                                                                    well_state,
+                                                                    reportStepIdx,
+                                                                    pu.phase_pos[BlackoilPhases::Vapour],
+                                                                    true);
 
             // sum over all nodes
             total_rate = wellModel_.comm().sum(total_rate);
@@ -208,9 +241,12 @@ checkGroupProductionConstraints(const Group& group,
         if (currentControl != Group::ProductionCMode::ORAT)
         {
             double current_rate = 0.0;
-            current_rate += WellGroupHelpers::sumWellSurfaceRates(group, wellModel_.schedule(),
-                                                                  well_state, reportStepIdx,
-                                                                  pu.phase_pos[BlackoilPhases::Liquid], false);
+            current_rate += WellGroupHelpers<double>::sumWellSurfaceRates(group,
+                                                                          wellModel_.schedule(),
+                                                                          well_state,
+                                                                          reportStepIdx,
+                                                                          pu.phase_pos[BlackoilPhases::Liquid],
+                                                                          false);
 
             // sum over all nodes
             current_rate = wellModel_.comm().sum(current_rate);
@@ -228,11 +264,13 @@ checkGroupProductionConstraints(const Group& group,
     {
         if (currentControl != Group::ProductionCMode::WRAT)
         {
-
             double current_rate = 0.0;
-            current_rate += WellGroupHelpers::sumWellSurfaceRates(group, wellModel_.schedule(),
-                                                                  well_state, reportStepIdx,
-                                                                  pu.phase_pos[BlackoilPhases::Aqua], false);
+            current_rate += WellGroupHelpers<double>::sumWellSurfaceRates(group,
+                                                                          wellModel_.schedule(),
+                                                                          well_state,
+                                                                          reportStepIdx,
+                                                                          pu.phase_pos[BlackoilPhases::Aqua],
+                                                                          false);
 
             // sum over all nodes
             current_rate = wellModel_.comm().sum(current_rate);
@@ -250,9 +288,12 @@ checkGroupProductionConstraints(const Group& group,
         if (currentControl != Group::ProductionCMode::GRAT)
         {
             double current_rate = 0.0;
-            current_rate += WellGroupHelpers::sumWellSurfaceRates(group, wellModel_.schedule(),
-                                                                  well_state, reportStepIdx,
-                                                                  pu.phase_pos[BlackoilPhases::Vapour], false);
+            current_rate += WellGroupHelpers<double>::sumWellSurfaceRates(group,
+                                                                          wellModel_.schedule(),
+                                                                          well_state,
+                                                                          reportStepIdx,
+                                                                          pu.phase_pos[BlackoilPhases::Vapour],
+                                                                          false);
 
             // sum over all nodes
             current_rate = wellModel_.comm().sum(current_rate);
@@ -269,21 +310,30 @@ checkGroupProductionConstraints(const Group& group,
         if (currentControl != Group::ProductionCMode::LRAT)
         {
             double current_rate = 0.0;
-            current_rate += WellGroupHelpers::sumWellSurfaceRates(group, wellModel_.schedule(),
-                                                                  well_state, reportStepIdx,
-                                                                  pu.phase_pos[BlackoilPhases::Liquid], false);
-            current_rate += WellGroupHelpers::sumWellSurfaceRates(group, wellModel_.schedule(),
-                                                                  well_state, reportStepIdx,
-                                                                  pu.phase_pos[BlackoilPhases::Aqua], false);
+            current_rate += WellGroupHelpers<double>::sumWellSurfaceRates(group,
+                                                                          wellModel_.schedule(),
+                                                                          well_state,
+                                                                          reportStepIdx,
+                                                                          pu.phase_pos[BlackoilPhases::Liquid],
+                                                                          false);
+            current_rate += WellGroupHelpers<double>::sumWellSurfaceRates(group,
+                                                                          wellModel_.schedule(),
+                                                                          well_state,
+                                                                          reportStepIdx,
+                                                                          pu.phase_pos[BlackoilPhases::Aqua],
+                                                                          false);
 
             // sum over all nodes
             current_rate = wellModel_.comm().sum(current_rate);
 
             bool skip = false;
             if (controls.liquid_target == controls.oil_target) {
-                double current_water_rate = WellGroupHelpers::sumWellSurfaceRates(group, wellModel_.schedule(),
-                                                                                  well_state, reportStepIdx,
-                                                                                  pu.phase_pos[BlackoilPhases::Aqua], false);
+                double current_water_rate = WellGroupHelpers<double>::sumWellSurfaceRates(group,
+                                                                                          wellModel_.schedule(),
+                                                                                          well_state,
+                                                                                          reportStepIdx,
+                                                                                          pu.phase_pos[BlackoilPhases::Aqua],
+                                                                                          false);
                 current_water_rate = wellModel_.comm().sum(current_water_rate);
                 if (std::abs(current_water_rate) < 1e-12) {
                     skip = true;
@@ -309,15 +359,24 @@ checkGroupProductionConstraints(const Group& group,
         if (currentControl != Group::ProductionCMode::RESV)
         {
             double current_rate = 0.0;
-            current_rate += WellGroupHelpers::sumWellResRates(group, wellModel_.schedule(),
-                                                              well_state, reportStepIdx,
-                                                              pu.phase_pos[BlackoilPhases::Aqua], false);
-            current_rate += WellGroupHelpers::sumWellResRates(group, wellModel_.schedule(),
-                                                              well_state, reportStepIdx,
-                                                              pu.phase_pos[BlackoilPhases::Liquid], false);
-            current_rate += WellGroupHelpers::sumWellResRates(group, wellModel_.schedule(),
-                                                              well_state, reportStepIdx,
-                                                              pu.phase_pos[BlackoilPhases::Vapour], false);
+            current_rate += WellGroupHelpers<double>::sumWellResRates(group,
+                                                                      wellModel_.schedule(),
+                                                                      well_state,
+                                                                      reportStepIdx,
+                                                                      pu.phase_pos[BlackoilPhases::Aqua],
+                                                                      false);
+            current_rate += WellGroupHelpers<double>::sumWellResRates(group,
+                                                                      wellModel_.schedule(),
+                                                                      well_state,
+                                                                      reportStepIdx,
+                                                                      pu.phase_pos[BlackoilPhases::Liquid],
+                                                                      false);
+            current_rate += WellGroupHelpers<double>::sumWellResRates(group,
+                                                                      wellModel_.schedule(),
+                                                                      well_state,
+                                                                      reportStepIdx,
+                                                                      pu.phase_pos[BlackoilPhases::Vapour],
+                                                                      false);
 
             // sum over all nodes
             current_rate = wellModel_.comm().sum(current_rate);
@@ -457,11 +516,10 @@ actionOnBrokenConstraints(const Group& group,
         break;
     }
     case Group::ExceedAction::WELL: {
-
         std::tie(worst_offending_well, std::ignore) =
-            WellGroupHelpers::worstOffendingWell(group, wellModel_.schedule(), reportStepIdx,
-                                                 newControl, wellModel_.phaseUsage(),
-                                                 wellModel_.comm(), well_state, deferred_logger);
+            WellGroupHelpers<double>::worstOffendingWell(group, wellModel_.schedule(), reportStepIdx,
+                                                         newControl, wellModel_.phaseUsage(),
+                                                         wellModel_.comm(), well_state, deferred_logger);
         break;
     }
     case Group::ExceedAction::PLUG: {
@@ -520,13 +578,13 @@ updateGroupIndividualControl(const Group& group,
                                      Group::InjectionCMode2String(changed_this.first));
                 this->actionOnBrokenConstraints(group, changed_this.first, phase,
                                                 group_state, deferred_logger);
-                WellGroupHelpers::updateWellRatesFromGroupTargetScale(changed_this.second,
-                                                                      group,
-                                                                      wellModel_.schedule(),
-                                                                      reportStepIdx,
-                                                                      /* isInjector */ false,
-                                                                      wellModel_.groupState(),
-                                                                      well_state);
+                WellGroupHelpers<double>::updateWellRatesFromGroupTargetScale(changed_this.second,
+                                                                              group,
+                                                                              wellModel_.schedule(),
+                                                                              reportStepIdx,
+                                                                              /* isInjector */ false,
+                                                                              wellModel_.groupState(),
+                                                                              well_state);
                 changed = true;
             }
         }
@@ -549,13 +607,13 @@ updateGroupIndividualControl(const Group& group,
             if(changed) {
                 switched_prod.insert_or_assign(group.name(),
                                     Group::ProductionCMode2String(changed_this.first));
-                WellGroupHelpers::updateWellRatesFromGroupTargetScale(changed_this.second,
-                                                                    group,
-                                                                    wellModel_.schedule(),
-                                                                    reportStepIdx,
-                                                                    /* isInjector */ false,
-                                                                    wellModel_.groupState(),
-                                                                    well_state);
+                WellGroupHelpers<double>::updateWellRatesFromGroupTargetScale(changed_this.second,
+                                                                              group,
+                                                                              wellModel_.schedule(),
+                                                                              reportStepIdx,
+                                                                              /* isInjector */ false,
+                                                                              wellModel_.groupState(),
+                                                                              well_state);
             } else if (worst_offending_well) {
                 closed_offending_wells.insert_or_assign(group.name(), 
                             std::make_pair(Group::ProductionCMode2String(changed_this.first), *worst_offending_well));

--- a/opm/simulators/wells/BlackoilWellModelGuideRates.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGuideRates.cpp
@@ -328,7 +328,7 @@ getGuideRateValues(const Well& well) const
         return grval;
     }
 
-    const auto qs = WellGroupHelpers::
+    const auto qs = WellGroupHelpers<double>::
         getWellRateVector(wellModel_.wellState(), wellModel_.phaseUsage(), wname);
 
     this->getGuideRateValues(qs, well.isInjector(), wname, grval);
@@ -355,7 +355,7 @@ getGuideRateValues(const Group& group) const
         return grval;
     }
 
-    const auto qs = WellGroupHelpers::
+    const auto qs = WellGroupHelpers<double>::
         getProductionGroupRateVector(wellModel_.groupState(), wellModel_.phaseUsage(), gname);
 
     const auto is_inj = false; // This procedure only applies to G*PGR.
@@ -433,7 +433,7 @@ assignWellGuideRates(data::Wells& wsrpt,
         const auto get_gr = parent
             || RetrieveWellGuideRate{wellModel_.guideRate(), wname};
 
-        const auto qs = WellGroupHelpers::
+        const auto qs = WellGroupHelpers<double>::
             getWellRateVector(wellModel_.wellState(), wellModel_.phaseUsage(), wname);
 
         auto getGR = [this, &wname, &qs](const GuideRateModel::Target t)

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -343,16 +343,16 @@ namespace Opm {
             const auto& fieldGroup =
                 this->schedule().getGroup("FIELD", reportStepIdx);
 
-            WellGroupHelpers::setCmodeGroup(fieldGroup,
-                                            this->schedule(),
-                                            this->summaryState(),
-                                            reportStepIdx,
-                                            this->groupState());
+            WellGroupHelpers<Scalar>::setCmodeGroup(fieldGroup,
+                                                    this->schedule(),
+                                                    this->summaryState(),
+                                                    reportStepIdx,
+                                                    this->groupState());
 
             // Define per region average pressure calculators for use by
             // pressure maintenance groups (GPMAINT keyword).
             if (this->schedule()[reportStepIdx].has_gpmaint()) {
-                WellGroupHelpers::setRegionAveragePressureCalculator
+                WellGroupHelpers<Scalar>::setRegionAveragePressureCalculator
                     (fieldGroup,
                      this->schedule(),
                      reportStepIdx,
@@ -505,10 +505,20 @@ namespace Opm {
 
         //update guide rates
         const auto& comm = simulator_.vanguard().grid().comm();
-        std::vector<double> pot(numPhases(), 0.0);
-        const Group& fieldGroup = schedule().getGroup("FIELD", reportStepIdx);
-        WellGroupHelpers::updateGuideRates(fieldGroup, schedule(), summaryState, this->phase_usage_, reportStepIdx, simulationTime,
-                                           this->wellState(), this->groupState(), comm, &this->guideRate_, pot, local_deferredLogger);
+        std::vector<double> pot(this->numPhases(), 0.0);
+        const Group& fieldGroup = this->schedule().getGroup("FIELD", reportStepIdx);
+        WellGroupHelpers<double>::updateGuideRates(fieldGroup,
+                                                   this->schedule(),
+                                                   summaryState,
+                                                   this->phase_usage_,
+                                                   reportStepIdx,
+                                                   simulationTime,
+                                                   this->wellState(),
+                                                   this->groupState(),
+                                                   comm,
+                                                   &this->guideRate_,
+                                                   pot,
+                                                   local_deferredLogger);
         std::string exc_msg;
         auto exc_type = ExceptionType::NONE;
         // update gpmaint targets
@@ -517,8 +527,13 @@ namespace Opm {
                 calculator.second->template defineState<ElementContext>(simulator_);
             }
             const double dt = simulator_.timeStepSize();
-            WellGroupHelpers::updateGpMaintTargetForGroups(fieldGroup,
-                                                           schedule_, regionalAveragePressureCalculator_, reportStepIdx, dt, this->wellState(), this->groupState());
+            WellGroupHelpers<double>::updateGpMaintTargetForGroups(fieldGroup,
+                                                                   this->schedule_,
+                                                                   regionalAveragePressureCalculator_,
+                                                                   reportStepIdx,
+                                                                   dt,
+                                                                   this->wellState(),
+                                                                   this->groupState());
         }
         try {
             // Compute initial well solution for new wells and injectors that change injection type i.e. WAG.
@@ -574,8 +589,11 @@ namespace Opm {
             well->init(&phase_usage_, depth_, gravity_, local_num_cells_, B_avg_, true);
 
             double well_efficiency_factor = wellEcl.getEfficiencyFactor();
-            WellGroupHelpers::accumulateGroupEfficiencyFactor(schedule().getGroup(wellEcl.groupName(), timeStepIdx),
-                                                              schedule(), timeStepIdx, well_efficiency_factor);
+            WellGroupHelpers<double>::accumulateGroupEfficiencyFactor(this->schedule().getGroup(wellEcl.groupName(),
+                                                                                                timeStepIdx),
+                                                                      this->schedule(),
+                                                                      timeStepIdx,
+                                                                      well_efficiency_factor);
 
             well->setWellEfficiencyFactor(well_efficiency_factor);
             well->setVFPProperties(vfp_properties_.get());
@@ -1191,12 +1209,21 @@ namespace Opm {
             const double simulationTime = simulator_.time();
             const auto& comm = simulator_.vanguard().grid().comm();
             const auto& summaryState = simulator_.vanguard().summaryState();
-            std::vector<double> pot(numPhases(), 0.0);
-            const Group& fieldGroup = schedule().getGroup("FIELD", reportStepIdx);
-            WellGroupHelpers::updateGuideRates(fieldGroup, schedule(), summaryState, this->phase_usage_, reportStepIdx, simulationTime,
-                                               this->wellState(), this->groupState(), comm, &this->guideRate_, pot, local_deferredLogger);
+            std::vector<double> pot(this->numPhases(), 0.0);
+            const Group& fieldGroup = this->schedule().getGroup("FIELD", reportStepIdx);
+            WellGroupHelpers<double>::updateGuideRates(fieldGroup,
+                                                       this->schedule(),
+                                                       summaryState,
+                                                       this->phase_usage_,
+                                                       reportStepIdx,
+                                                       simulationTime,
+                                                       this->wellState(),
+                                                       this->groupState(),
+                                                       comm,
+                                                       &this->guideRate_,
+                                                       pot,
+                                                       local_deferredLogger);
         }
-
 
         return {more_network_update, well_group_control_changed};
     }

--- a/opm/simulators/wells/FractionCalculator.cpp
+++ b/opm/simulators/wells/FractionCalculator.cpp
@@ -144,8 +144,8 @@ guideRate(const std::string& name,
           const std::string& always_included_child)
 {
     if (schedule_.hasWell(name, report_step_)) {
-        return WellGroupHelpers::getGuideRate(name, schedule_, well_state_, group_state_,
-                                              report_step_, guide_rate_, target_, pu_);
+        return WellGroupHelpers<Scalar>::getGuideRate(name, schedule_, well_state_, group_state_,
+                                                      report_step_, guide_rate_, target_, pu_);
     } else {
         if (groupControlledWells(name, always_included_child) > 0) {
             if (is_producer_ && guide_rate_->has(name)) {
@@ -171,14 +171,14 @@ int FractionCalculator<Scalar>::
 groupControlledWells(const std::string& group_name,
                      const std::string& always_included_child)
 {
-    return WellGroupHelpers::groupControlledWells(schedule_,
-                                                  well_state_,
-                                                  this->group_state_,
-                                                  report_step_,
-                                                  group_name,
-                                                  always_included_child,
-                                                  is_producer_,
-                                                  injection_phase_);
+    return WellGroupHelpers<Scalar>::groupControlledWells(schedule_,
+                                                          well_state_,
+                                                          this->group_state_,
+                                                          report_step_,
+                                                          group_name,
+                                                          always_included_child,
+                                                          is_producer_,
+                                                          injection_phase_);
 }
 
 template<class Scalar>
@@ -186,9 +186,9 @@ GuideRate::RateVector FractionCalculator<Scalar>::
 getGroupRateVector(const std::string& group_name)
 {
     assert(is_producer_);
-    return WellGroupHelpers::getProductionGroupRateVector(this->group_state_,
-                                                          this->pu_,
-                                                          group_name);
+    return WellGroupHelpers<Scalar>::getProductionGroupRateVector(this->group_state_,
+                                                                  this->pu_,
+                                                                  group_name);
 }
 
 template class FractionCalculator<double>;

--- a/opm/simulators/wells/FractionCalculator.cpp
+++ b/opm/simulators/wells/FractionCalculator.cpp
@@ -30,7 +30,7 @@
 
 #include <cassert>
 
-namespace Opm::WellGroupHelpers {
+namespace Opm::WGHelpers {
 
 FractionCalculator::FractionCalculator(const Schedule& schedule,
                                        const WellState<double>& well_state,

--- a/opm/simulators/wells/FractionCalculator.hpp
+++ b/opm/simulators/wells/FractionCalculator.hpp
@@ -32,7 +32,7 @@ class Schedule;
 template<class Scalar> class WellState;
 }
 
-namespace Opm::WellGroupHelpers {
+namespace Opm::WGHelpers {
 
 class FractionCalculator
 {
@@ -72,6 +72,6 @@ private:
     Phase injection_phase_;
 };
 
-} // namespace Opm::WellGroupHelpers
+} // namespace Opm::WGHelpers
 
 #endif // OPM_FRACTION_CALCULATOR_HEADER_INCLUDED

--- a/opm/simulators/wells/FractionCalculator.hpp
+++ b/opm/simulators/wells/FractionCalculator.hpp
@@ -34,36 +34,37 @@ template<class Scalar> class WellState;
 
 namespace Opm::WGHelpers {
 
+template<class Scalar>
 class FractionCalculator
 {
 public:
     FractionCalculator(const Schedule& schedule,
-                       const WellState<double>& well_state,
-                       const GroupState<double>& group_state,
+                       const WellState<Scalar>& well_state,
+                       const GroupState<Scalar>& group_state,
                        const int report_step,
                        const GuideRate* guide_rate,
                        const GuideRateModel::Target target,
                        const PhaseUsage& pu,
                        const bool is_producer,
                        const Phase injection_phase);
-    double fraction(const std::string& name,
+    Scalar fraction(const std::string& name,
                     const std::string& control_group_name,
                     const bool always_include_this);
-    double localFraction(const std::string& name,
+    Scalar localFraction(const std::string& name,
                          const std::string& always_included_child);
 
 private:
     std::string parent(const std::string& name);
-    double guideRateSum(const Group& group,
+    Scalar guideRateSum(const Group& group,
                         const std::string& always_included_child);
-    double guideRate(const std::string& name,
+    Scalar guideRate(const std::string& name,
                      const std::string& always_included_child);
     int groupControlledWells(const std::string& group_name,
                              const std::string& always_included_child);
     GuideRate::RateVector getGroupRateVector(const std::string& group_name);
     const Schedule& schedule_;
-    const WellState<double>& well_state_;
-    const GroupState<double>& group_state_;
+    const WellState<Scalar>& well_state_;
+    const GroupState<Scalar>& group_state_;
     int report_step_;
     const GuideRate* guide_rate_;
     GuideRateModel::Target target_;

--- a/opm/simulators/wells/GroupEconomicLimitsChecker.cpp
+++ b/opm/simulators/wells/GroupEconomicLimitsChecker.cpp
@@ -77,9 +77,12 @@ GroupEconomicLimitsChecker(const BlackoilWellModelGeneric& well_model,
         auto phase_idx = this->phase_idx_map_[i];
         this->phase_idx_reverse_map_[phase_idx] = static_cast<int>(i);
         auto phase_pos = this->well_model_.phaseUsage().phase_pos[phase_idx];
-        Scalar production_rate = WellGroupHelpers::sumWellSurfaceRates(
-            this->group_, this->schedule_, this->well_state_,
-            this->report_step_idx_, phase_pos, /*isInjector*/false);
+        Scalar production_rate = WellGroupHelpers<Scalar>::sumWellSurfaceRates(this->group_,
+                                                                               this->schedule_,
+                                                                               this->well_state_,
+                                                                               this->report_step_idx_,
+                                                                               phase_pos,
+                                                                               /*isInjector*/false);
         this->production_rates_[i] = this->well_model_.comm().sum(production_rate);
     }
 }

--- a/opm/simulators/wells/TargetCalculator.cpp
+++ b/opm/simulators/wells/TargetCalculator.cpp
@@ -26,16 +26,10 @@
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/simulators/wells/GroupState.hpp>
 
-#include <algorithm>
 #include <cassert>
 #include <stdexcept>
-#include <type_traits>
 
-namespace Opm
-{
-
-namespace WellGroupHelpers
-{
+namespace Opm::WGHelpers {
 
 TargetCalculator::TargetCalculator(const Group::ProductionCMode cmode,
                                    const PhaseUsage& pu,
@@ -279,6 +273,4 @@ INSTANCE_TARGET_CALCULATOR(DenseAd::Evaluation<double,-1,9>)
 INSTANCE_TARGET_CALCULATOR(DenseAd::Evaluation<double,-1,10>)
 INSTANCE_TARGET_CALCULATOR(DenseAd::Evaluation<double,-1,11>)
 
-} // namespace WellGroupHelpers
-
-} // namespace Opm
+} // namespace Opm::WGHelpers

--- a/opm/simulators/wells/TargetCalculator.cpp
+++ b/opm/simulators/wells/TargetCalculator.cpp
@@ -154,15 +154,17 @@ TargetCalculator<Scalar>::guideTargetMode() const
     }
 }
 
-InjectionTargetCalculator::InjectionTargetCalculator(const Group::InjectionCMode& cmode,
-                                                     const PhaseUsage& pu,
-                                                     const std::vector<double>& resv_coeff,
-                                                     const std::string& group_name,
-                                                     const double sales_target,
-                                                     const GroupState<double>& group_state,
-                                                     const Phase& injection_phase,
-                                                     const bool use_gpmaint,
-                                                     DeferredLogger& deferred_logger)
+template<class Scalar>
+InjectionTargetCalculator<Scalar>::
+InjectionTargetCalculator(const Group::InjectionCMode& cmode,
+                          const PhaseUsage& pu,
+                          const std::vector<Scalar>& resv_coeff,
+                          const std::string& group_name,
+                          const Scalar sales_target,
+                          const GroupState<Scalar>& group_state,
+                          const Phase& injection_phase,
+                          const bool use_gpmaint,
+                          DeferredLogger& deferred_logger)
     : cmode_(cmode)
     , pu_(pu)
     , resv_coeff_(resv_coeff)
@@ -199,8 +201,10 @@ InjectionTargetCalculator::InjectionTargetCalculator(const Group::InjectionCMode
     }
 }
 
-
-double InjectionTargetCalculator::groupTarget(const std::optional<Group::InjectionControls>& ctrl, Opm::DeferredLogger& deferred_logger) const
+template<class Scalar>
+Scalar InjectionTargetCalculator<Scalar>::
+groupTarget(const std::optional<Group::InjectionControls>& ctrl,
+            DeferredLogger& deferred_logger) const
 {
     if (!ctrl && !use_gpmaint_) {
         OPM_DEFLOG_THROW(std::logic_error,
@@ -210,32 +214,32 @@ double InjectionTargetCalculator::groupTarget(const std::optional<Group::Injecti
     }
     switch (cmode_) {
     case Group::InjectionCMode::RATE:
-        if(use_gpmaint_ && this->group_state_.has_gpmaint_target(this->group_name_))
+        if (use_gpmaint_ && this->group_state_.has_gpmaint_target(this->group_name_))
             return this->group_state_.gpmaint_target(this->group_name_);
 
         return ctrl->surface_max_rate;
     case Group::InjectionCMode::RESV:
-        if(use_gpmaint_ && this->group_state_.has_gpmaint_target(this->group_name_))
+        if (use_gpmaint_ && this->group_state_.has_gpmaint_target(this->group_name_))
             return this->group_state_.gpmaint_target(this->group_name_) / resv_coeff_[pos_];
 
         return ctrl->resv_max_rate / resv_coeff_[pos_];
     case Group::InjectionCMode::REIN: {
-        double production_rate = this->group_state_.injection_rein_rates(ctrl->reinj_group)[pos_];
+        Scalar production_rate = this->group_state_.injection_rein_rates(ctrl->reinj_group)[pos_];
         return ctrl->target_reinj_fraction * production_rate;
     }
     case Group::InjectionCMode::VREP: {
-        const std::vector<double>& group_injection_reductions = this->group_state_.injection_reduction_rates(this->group_name_);
-        double voidage_rate = group_state_.injection_vrep_rate(ctrl->voidage_group) * ctrl->target_void_fraction;
-        double inj_reduction = 0.0;
+        const std::vector<Scalar>& group_injection_reductions = this->group_state_.injection_reduction_rates(this->group_name_);
+        Scalar voidage_rate = group_state_.injection_vrep_rate(ctrl->voidage_group) * ctrl->target_void_fraction;
+        Scalar inj_reduction = 0.0;
         if (ctrl->phase != Phase::WATER)
             inj_reduction += group_injection_reductions[pu_.phase_pos[BlackoilPhases::Aqua]]
-                    * resv_coeff_[pu_.phase_pos[BlackoilPhases::Aqua]];
+                           * resv_coeff_[pu_.phase_pos[BlackoilPhases::Aqua]];
         if (ctrl->phase != Phase::OIL)
             inj_reduction += group_injection_reductions[pu_.phase_pos[BlackoilPhases::Liquid]]
-                    * resv_coeff_[pu_.phase_pos[BlackoilPhases::Liquid]];
+                           * resv_coeff_[pu_.phase_pos[BlackoilPhases::Liquid]];
         if (ctrl->phase != Phase::GAS)
             inj_reduction += group_injection_reductions[pu_.phase_pos[BlackoilPhases::Vapour]]
-                    * resv_coeff_[pu_.phase_pos[BlackoilPhases::Vapour]];
+                           * resv_coeff_[pu_.phase_pos[BlackoilPhases::Vapour]];
         voidage_rate -= inj_reduction;
         return voidage_rate / resv_coeff_[pos_];
     }
@@ -243,7 +247,7 @@ double InjectionTargetCalculator::groupTarget(const std::optional<Group::Injecti
         assert(pos_ == pu_.phase_pos[BlackoilPhases::Vapour]);
         // Gas injection rate = Total gas production rate + gas import rate - gas consumption rate - sales rate;
         // Gas import and consumption is already included in the REIN rates
-        double inj_rate = group_state_.injection_rein_rates(this->group_name_)[pos_];
+        Scalar inj_rate = group_state_.injection_rein_rates(this->group_name_)[pos_];
         inj_rate -= sales_target_;
         return inj_rate;
     }
@@ -255,7 +259,9 @@ double InjectionTargetCalculator::groupTarget(const std::optional<Group::Injecti
     }
 }
 
-GuideRateModel::Target InjectionTargetCalculator::guideTargetMode() const
+template<class Scalar>
+GuideRateModel::Target
+InjectionTargetCalculator<Scalar>::guideTargetMode() const
 {
     return target_;
 }
@@ -264,6 +270,7 @@ GuideRateModel::Target InjectionTargetCalculator::guideTargetMode() const
 template __VA_ARGS__ TargetCalculator<double>::calcModeRateFromRates<__VA_ARGS__>(const __VA_ARGS__* rates) const;
 
 template class TargetCalculator<double>;
+template class InjectionTargetCalculator<double>;
 
 INSTANCE_TARGET_CALCULATOR(double)
 INSTANCE_TARGET_CALCULATOR(DenseAd::Evaluation<double,3,0>)

--- a/opm/simulators/wells/TargetCalculator.hpp
+++ b/opm/simulators/wells/TargetCalculator.hpp
@@ -38,15 +38,16 @@ namespace WGHelpers {
 
 /// Based on a group control mode, extract or calculate rates, and
 /// provide other conveniences.
+template<class Scalar>
 class TargetCalculator
 {
 public:
     TargetCalculator(const Group::ProductionCMode cmode,
                      const PhaseUsage& pu,
-                     const std::vector<double>& resv_coeff,
-                     const double group_grat_target_from_sales,
+                     const std::vector<Scalar>& resv_coeff,
+                     const Scalar group_grat_target_from_sales,
                      const std::string& group_name,
-                     const GroupState<double>& group_state,
+                     const GroupState<Scalar>& group_state,
                      const bool use_gpmaint);
 
     template <typename RateType>
@@ -58,17 +59,18 @@ public:
     template <typename RateType>
     RateType calcModeRateFromRates(const RateType* rates) const;
 
-    double groupTarget(const std::optional<Group::ProductionControls>& ctrl, Opm::DeferredLogger& deferred_logger) const;
+    Scalar groupTarget(const std::optional<Group::ProductionControls>& ctrl,
+                       DeferredLogger& deferred_logger) const;
 
     GuideRateModel::Target guideTargetMode() const;
 
 private:
     Group::ProductionCMode cmode_;
     const PhaseUsage& pu_;
-    const std::vector<double>& resv_coeff_;
-    const double group_grat_target_from_sales_;
+    const std::vector<Scalar>& resv_coeff_;
+    const Scalar group_grat_target_from_sales_;
     const std::string& group_name_;
-    const GroupState<double>& group_state_;
+    const GroupState<Scalar>& group_state_;
     bool use_gpmaint_;
 };
 

--- a/opm/simulators/wells/TargetCalculator.hpp
+++ b/opm/simulators/wells/TargetCalculator.hpp
@@ -34,7 +34,7 @@ class DeferredLogger;
 template<class Scalar> class GroupState;
 struct PhaseUsage;
 
-namespace WellGroupHelpers {
+namespace WGHelpers {
 
 /// Based on a group control mode, extract or calculate rates, and
 /// provide other conveniences.
@@ -109,7 +109,7 @@ private:
     GuideRateModel::Target target_;
 };
 
-} // namespace WellGroupHelpers
+} // namespace WGHelpers
 
 } // namespace Opm
 

--- a/opm/simulators/wells/TargetCalculator.hpp
+++ b/opm/simulators/wells/TargetCalculator.hpp
@@ -76,15 +76,16 @@ private:
 
 /// Based on a group control mode, extract or calculate rates, and
 /// provide other conveniences.
+template<class Scalar>
 class InjectionTargetCalculator
 {
 public:
     InjectionTargetCalculator(const Group::InjectionCMode& cmode,
                               const PhaseUsage& pu,
-                              const std::vector<double>& resv_coeff,
+                              const std::vector<Scalar>& resv_coeff,
                               const std::string& group_name,
-                              const double sales_target,
-                              const GroupState<double>& group_state,
+                              const Scalar sales_target,
+                              const GroupState<Scalar>& group_state,
                               const Phase& injection_phase,
                               const bool use_gpmaint,
                               DeferredLogger& deferred_logger);
@@ -95,17 +96,18 @@ public:
         return rates[pos_];
     }
 
-    double groupTarget(const std::optional<Group::InjectionControls>& ctrl, Opm::DeferredLogger& deferred_logger) const;
+    Scalar groupTarget(const std::optional<Group::InjectionControls>& ctrl,
+                       DeferredLogger& deferred_logger) const;
 
     GuideRateModel::Target guideTargetMode() const;
 
 private:
     Group::InjectionCMode cmode_;
     const PhaseUsage& pu_;
-    const std::vector<double>& resv_coeff_;
+    const std::vector<Scalar>& resv_coeff_;
     const std::string& group_name_;
-    double sales_target_;
-    const GroupState<double>& group_state_;
+    Scalar sales_target_;
+    const GroupState<Scalar>& group_state_;
     bool use_gpmaint_;
     int pos_;
     GuideRateModel::Target target_;

--- a/opm/simulators/wells/WellGroupConstraints.cpp
+++ b/opm/simulators/wells/WellGroupConstraints.cpp
@@ -74,21 +74,21 @@ checkGroupConstraintsInj(const Group& group,
 
     const auto& ws = well_state.well(well_.indexOfWell());
     // Call check for the well's injection phase.
-    return WellGroupHelpers::checkGroupConstraintsInj(well_.name(),
-                                                      well_.wellEcl().groupName(),
-                                                      group,
-                                                      well_state,
-                                                      group_state,
-                                                      well_.currentStep(),
-                                                      well_.guideRate(),
-                                                      ws.surface_rates.data(),
-                                                      injectionPhase,
-                                                      well_.phaseUsage(),
-                                                      efficiencyFactor,
-                                                      schedule,
-                                                      summaryState,
-                                                      resv_coeff,
-                                                      deferred_logger);
+    return WellGroupHelpers<double>::checkGroupConstraintsInj(well_.name(),
+                                                              well_.wellEcl().groupName(),
+                                                              group,
+                                                              well_state,
+                                                              group_state,
+                                                              well_.currentStep(),
+                                                              well_.guideRate(),
+                                                              ws.surface_rates.data(),
+                                                              injectionPhase,
+                                                              well_.phaseUsage(),
+                                                              efficiencyFactor,
+                                                              schedule,
+                                                              summaryState,
+                                                              resv_coeff,
+                                                              deferred_logger);
 }
 
 std::pair<bool, double>
@@ -107,20 +107,20 @@ checkGroupConstraintsProd(const Group& group,
     rateConverter(0, well_.pvtRegionIdx(), group.name(), resv_coeff); // FIPNUM region 0 here, should use FIPNUM from WELSPECS.
 
     const auto& ws = well_state.well(well_.indexOfWell());
-    return WellGroupHelpers::checkGroupConstraintsProd(well_.name(),
-                                                       well_.wellEcl().groupName(),
-                                                       group,
-                                                       well_state,
-                                                       group_state,
-                                                       well_.currentStep(),
-                                                       well_.guideRate(),
-                                                       ws.surface_rates.data(),
-                                                       well_.phaseUsage(),
-                                                       efficiencyFactor,
-                                                       schedule,
-                                                       summaryState,
-                                                       resv_coeff,
-                                                       deferred_logger);
+    return WellGroupHelpers<double>::checkGroupConstraintsProd(well_.name(),
+                                                               well_.wellEcl().groupName(),
+                                                               group,
+                                                               well_state,
+                                                               group_state,
+                                                               well_.currentStep(),
+                                                               well_.guideRate(),
+                                                               ws.surface_rates.data(),
+                                                               well_.phaseUsage(),
+                                                               efficiencyFactor,
+                                                               schedule,
+                                                               summaryState,
+                                                               resv_coeff,
+                                                               deferred_logger);
 }
 
 bool WellGroupConstraints::

--- a/opm/simulators/wells/WellGroupControls.cpp
+++ b/opm/simulators/wells/WellGroupControls.cpp
@@ -136,17 +136,27 @@ getGroupInjectionControl(const Group& group,
         const auto& gconsale = schedule[well_.currentStep()].gconsale().get(group.name(), summaryState);
         sales_target = gconsale.sales_target;
     }
-    WellGroupHelpers::InjectionTargetCalculator tcalc(currentGroupControl, pu,
-                                                      resv_coeff, group.name(),
-                                                      sales_target, group_state,
-                                                      injectionPhase,
-                                                      group.has_gpmaint_control(injectionPhase, currentGroupControl),
-                                                      deferred_logger);
-    WellGroupHelpers::FractionCalculator fcalc(schedule, well_state,
-                                               group_state, well_.currentStep(),
-                                               well_.guideRate(),
-                                               tcalc.guideTargetMode(),
-                                               pu, false, injectionPhase);
+
+    WGHelpers::InjectionTargetCalculator tcalc(currentGroupControl,
+                                               pu,
+                                               resv_coeff,
+                                               group.name(),
+                                               sales_target,
+                                               group_state,
+                                               injectionPhase,
+                                               group.has_gpmaint_control(injectionPhase,
+                                                                         currentGroupControl),
+                                               deferred_logger);
+
+    WGHelpers::FractionCalculator fcalc(schedule,
+                                        well_state,
+                                        group_state,
+                                        well_.currentStep(),
+                                        well_.guideRate(),
+                                        tcalc.guideTargetMode(),
+                                        pu,
+                                        false,
+                                        injectionPhase);
 
     auto localFraction = [&](const std::string& child) {
         return fcalc.localFraction(child, child);
@@ -260,14 +270,26 @@ getGroupInjectionTargetRate(const Group& group,
         const auto& gconsale = schedule[well_.currentStep()].gconsale().get(group.name(), summaryState);
         sales_target = gconsale.sales_target;
     }
-    WellGroupHelpers::InjectionTargetCalculator tcalc(currentGroupControl, pu, resv_coeff,
-                                                      group.name(), sales_target, group_state,
-                                                      injectionPhase,
-                                                      group.has_gpmaint_control(injectionPhase, currentGroupControl),
-                                                      deferred_logger);
-    WellGroupHelpers::FractionCalculator fcalc(schedule, well_state, group_state,
-                                               well_.currentStep(), well_.guideRate(),
-                                               tcalc.guideTargetMode(), pu, false, injectionPhase);
+    WGHelpers::InjectionTargetCalculator tcalc(currentGroupControl,
+                                               pu,
+                                               resv_coeff,
+                                               group.name(),
+                                               sales_target,
+                                               group_state,
+                                               injectionPhase,
+                                               group.has_gpmaint_control(injectionPhase,
+                                                                         currentGroupControl),
+                                               deferred_logger);
+
+    WGHelpers::FractionCalculator fcalc(schedule,
+                                        well_state,
+                                        group_state,
+                                        well_.currentStep(),
+                                        well_.guideRate(),
+                                        tcalc.guideTargetMode(),
+                                        pu,
+                                        false,
+                                        injectionPhase);
 
     auto localFraction = [&](const std::string& child) {
         return fcalc.localFraction(child, child); //Note child needs to be passed to always include since the global isGrup map is not updated yet.
@@ -363,15 +385,23 @@ void WellGroupControls::getGroupProductionControl(const Group& group,
     if (group_state.has_grat_sales_target(group.name()))
         gratTargetFromSales = group_state.grat_sales_target(group.name());
 
-    WellGroupHelpers::TargetCalculator tcalc(currentGroupControl, pu, resv_coeff,
-                                             gratTargetFromSales, group.name(),
-                                             group_state,
-                                             group.has_gpmaint_control(currentGroupControl));
-    WellGroupHelpers::FractionCalculator fcalc(schedule, well_state, group_state,
-                                               well_.currentStep(),
-                                               well_.guideRate(),
-                                               tcalc.guideTargetMode(),
-                                               pu, true, Phase::OIL);
+    WGHelpers::TargetCalculator tcalc(currentGroupControl,
+                                      pu,
+                                      resv_coeff,
+                                      gratTargetFromSales,
+                                      group.name(),
+                                      group_state,
+                                      group.has_gpmaint_control(currentGroupControl));
+
+    WGHelpers::FractionCalculator fcalc(schedule,
+                                        well_state,
+                                        group_state,
+                                        well_.currentStep(),
+                                        well_.guideRate(),
+                                        tcalc.guideTargetMode(),
+                                        pu,
+                                        true,
+                                        Phase::OIL);
 
     auto localFraction = [&](const std::string& child) {
         return fcalc.localFraction(child, child);
@@ -452,12 +482,23 @@ getGroupProductionTargetRate(const Group& group,
     if (group_state.has_grat_sales_target(group.name()))
         gratTargetFromSales = group_state.grat_sales_target(group.name());
 
-    WellGroupHelpers::TargetCalculator tcalc(currentGroupControl, pu, resv_coeff, gratTargetFromSales, group.name(), group_state, group.has_gpmaint_control(currentGroupControl));
-    WellGroupHelpers::FractionCalculator fcalc(schedule, well_state, group_state,
-                                               well_.currentStep(),
-                                               well_.guideRate(),
-                                               tcalc.guideTargetMode(),
-                                               pu, true, Phase::OIL);
+    WGHelpers::TargetCalculator tcalc(currentGroupControl,
+                                      pu,
+                                      resv_coeff,
+                                      gratTargetFromSales,
+                                      group.name(),
+                                      group_state,
+                                      group.has_gpmaint_control(currentGroupControl));
+
+    WGHelpers::FractionCalculator fcalc(schedule,
+                                        well_state,
+                                        group_state,
+                                        well_.currentStep(),
+                                        well_.guideRate(),
+                                        tcalc.guideTargetMode(),
+                                        pu,
+                                        true,
+                                        Phase::OIL);
 
     auto localFraction = [&](const std::string& child) {
         return fcalc.localFraction(child, child); //Note child needs to be passed to always include since the global isGrup map is not updated yet.
@@ -545,4 +586,5 @@ INSTANCE(DenseAd::Evaluation<double,-1,8u>)
 INSTANCE(DenseAd::Evaluation<double,-1,9u>)
 INSTANCE(DenseAd::Evaluation<double,-1,10u>)
 INSTANCE(DenseAd::Evaluation<double,-1,11u>)
+
 } // namespace Opm

--- a/opm/simulators/wells/WellGroupControls.cpp
+++ b/opm/simulators/wells/WellGroupControls.cpp
@@ -173,8 +173,8 @@ getGroupInjectionControl(const Group& group,
 
     const double orig_target = tcalc.groupTarget(ctrl,
                                                 deferred_logger);
-    const auto chain = WellGroupHelpers::groupChainTopBot(well_.name(), group.name(),
-                                                          schedule, well_.currentStep());
+    const auto chain = WellGroupHelpers<double>::groupChainTopBot(well_.name(), group.name(),
+                                                                  schedule, well_.currentStep());
     // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
     const std::size_t num_ancestors = chain.size() - 1;
     double target = orig_target;
@@ -306,7 +306,10 @@ getGroupInjectionTargetRate(const Group& group,
 
     const double orig_target = tcalc.groupTarget(ctrl, deferred_logger);
 
-    const auto chain = WellGroupHelpers::groupChainTopBot(well_.name(), group.name(), schedule, well_.currentStep());
+    const auto chain = WellGroupHelpers<double>::groupChainTopBot(well_.name(),
+                                                                  group.name(),
+                                                                  schedule,
+                                                                  well_.currentStep());
     // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
     const std::size_t num_ancestors = chain.size() - 1;
     double target = orig_target;
@@ -417,8 +420,8 @@ void WellGroupControls::getGroupProductionControl(const Group& group,
         ctrl = group.productionControls(summaryState);
 
     const double orig_target = tcalc.groupTarget(ctrl, deferred_logger);
-    const auto chain = WellGroupHelpers::groupChainTopBot(well_.name(), group.name(),
-                                                          schedule, well_.currentStep());
+    const auto chain = WellGroupHelpers<double>::groupChainTopBot(well_.name(), group.name(),
+                                                                  schedule, well_.currentStep());
     // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
     const std::size_t num_ancestors = chain.size() - 1;
     double target = orig_target;
@@ -514,8 +517,8 @@ getGroupProductionTargetRate(const Group& group,
         ctrl = group.productionControls(summaryState);
 
     const double orig_target = tcalc.groupTarget(ctrl, deferred_logger);
-    const auto chain = WellGroupHelpers::groupChainTopBot(well_.name(), group.name(),
-                                                          schedule, well_.currentStep());
+    const auto chain = WellGroupHelpers<double>::groupChainTopBot(well_.name(), group.name(),
+                                                                  schedule, well_.currentStep());
     // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
     const std::size_t num_ancestors = chain.size() - 1;
     double target = orig_target;

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -1165,8 +1165,23 @@ std::pair<bool, double> checkGroupConstraintsProd(const std::string& name,
     if (group_state.has_grat_sales_target(group.name()))
         gratTargetFromSales = group_state.grat_sales_target(group.name());
 
-    TargetCalculator tcalc(currentGroupControl, pu, resv_coeff, gratTargetFromSales, group.name(), group_state, group.has_gpmaint_control(currentGroupControl));
-    FractionCalculator fcalc(schedule, wellState, group_state, reportStepIdx, guideRate, tcalc.guideTargetMode(), pu, true, Phase::OIL);
+    WGHelpers::TargetCalculator tcalc(currentGroupControl,
+                                      pu,
+                                      resv_coeff,
+                                      gratTargetFromSales,
+                                      group.name(),
+                                      group_state,
+                                      group.has_gpmaint_control(currentGroupControl));
+
+    WGHelpers::FractionCalculator fcalc(schedule,
+                                        wellState,
+                                        group_state,
+                                        reportStepIdx,
+                                        guideRate,
+                                        tcalc.guideTargetMode(),
+                                        pu,
+                                        true,
+                                        Phase::OIL);
 
     auto localFraction = [&](const std::string& child) { return fcalc.localFraction(child, name); };
 
@@ -1311,8 +1326,26 @@ std::pair<bool, double> checkGroupConstraintsInj(const std::string& name,
         const auto& gconsale = schedule[reportStepIdx].gconsale().get(group.name(), summaryState);
         sales_target = gconsale.sales_target;
     }
-    InjectionTargetCalculator tcalc(currentGroupControl, pu, resv_coeff, group.name(), sales_target, group_state, injectionPhase, group.has_gpmaint_control(injectionPhase, currentGroupControl), deferred_logger);
-    FractionCalculator fcalc(schedule, wellState, group_state, reportStepIdx, guideRate, tcalc.guideTargetMode(), pu, false, injectionPhase);
+    WGHelpers::InjectionTargetCalculator tcalc(currentGroupControl,
+                                               pu,
+                                               resv_coeff,
+                                               group.name(),
+                                               sales_target,
+                                               group_state,
+                                               injectionPhase,
+                                               group.has_gpmaint_control(injectionPhase,
+                                                                         currentGroupControl),
+                                               deferred_logger);
+
+    WGHelpers::FractionCalculator fcalc(schedule,
+                                        wellState,
+                                        group_state,
+                                        reportStepIdx,
+                                        guideRate,
+                                        tcalc.guideTargetMode(),
+                                        pu,
+                                        false,
+                                        injectionPhase);
 
     auto localFraction = [&](const std::string& child) { return fcalc.localFraction(child, name); };
 

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -124,13 +124,14 @@ namespace {
     }
 } // namespace Anonymous
 
-namespace Opm::WellGroupHelpers {
+namespace Opm {
 
-void setCmodeGroup(const Group& group,
-                   const Schedule& schedule,
-                   const SummaryState& summaryState,
-                   const int reportStepIdx,
-                   GroupState<double>& group_state)
+void WellGroupHelpers::
+setCmodeGroup(const Group& group,
+              const Schedule& schedule,
+              const SummaryState& summaryState,
+              const int reportStepIdx,
+              GroupState<double>& group_state)
 {
 
     for (const std::string& groupName : group.groups()) {
@@ -184,10 +185,11 @@ void setCmodeGroup(const Group& group,
     }
 }
 
-void accumulateGroupEfficiencyFactor(const Group& group,
-                                     const Schedule& schedule,
-                                     const int reportStepIdx,
-                                     double& factor)
+void WellGroupHelpers::
+accumulateGroupEfficiencyFactor(const Group& group,
+                                const Schedule& schedule,
+                                const int reportStepIdx,
+                                double& factor)
 {
     factor *= group.getGroupEfficiencyFactor();
     if (group.parent() != "FIELD" && !group.parent().empty())
@@ -195,32 +197,34 @@ void accumulateGroupEfficiencyFactor(const Group& group,
             schedule.getGroup(group.parent(), reportStepIdx), schedule, reportStepIdx, factor);
 }
 
-
-double sumWellSurfaceRates(const Group& group,
-                           const Schedule& schedule,
-                           const WellState<double>& wellState,
-                           const int reportStepIdx,
-                           const int phasePos,
-                           const bool injector)
+double WellGroupHelpers::
+sumWellSurfaceRates(const Group& group,
+                    const Schedule& schedule,
+                    const WellState<double>& wellState,
+                    const int reportStepIdx,
+                    const int phasePos,
+                    const bool injector)
 {
     return sumWellPhaseRates(false, group, schedule, wellState, reportStepIdx, phasePos, injector);
 }
 
-double sumWellResRates(const Group& group,
-                       const Schedule& schedule,
-                       const WellState<double>& wellState,
-                       const int reportStepIdx,
-                       const int phasePos,
-                       const bool injector)
+double WellGroupHelpers::
+sumWellResRates(const Group& group,
+                const Schedule& schedule,
+                const WellState<double>& wellState,
+                const int reportStepIdx,
+                const int phasePos,
+                const bool injector)
 {
     return sumWellPhaseRates(true, group, schedule, wellState, reportStepIdx, phasePos, injector);
 }
 
-double sumSolventRates(const Group& group,
-                       const Schedule& schedule,
-                       const WellState<double>& wellState,
-                       const int reportStepIdx,
-                       const bool injector)
+double WellGroupHelpers::
+sumSolventRates(const Group& group,
+                const Schedule& schedule,
+                const WellState<double>& wellState,
+                const int reportStepIdx,
+                const bool injector)
 {
 
     double rate = 0.0;
@@ -258,15 +262,16 @@ double sumSolventRates(const Group& group,
     return rate;
 }
 
-void updateGuideRatesForInjectionGroups(const Group& group,
-                                        const Schedule& schedule,
-                                        const SummaryState& summaryState,
-                                        const Opm::PhaseUsage& pu,
-                                        const int reportStepIdx,
-                                        const WellState<double>& wellState,
-                                        const GroupState<double>& group_state,
-                                        GuideRate* guideRate,
-                                        Opm::DeferredLogger& deferred_logger)
+void WellGroupHelpers::
+updateGuideRatesForInjectionGroups(const Group& group,
+                                   const Schedule& schedule,
+                                   const SummaryState& summaryState,
+                                   const PhaseUsage& pu,
+                                   const int reportStepIdx,
+                                   const WellState<double>& wellState,
+                                   const GroupState<double>& group_state,
+                                   GuideRate* guideRate,
+                                   DeferredLogger& deferred_logger)
 {
     for (const std::string& groupName : group.groups()) {
         const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
@@ -318,15 +323,16 @@ void updateGuideRatesForInjectionGroups(const Group& group,
     }
 }
 
-void updateGroupTargetReduction(const Group& group,
-                                const Schedule& schedule,
-                                const int reportStepIdx,
-                                const bool isInjector,
-                                const PhaseUsage& pu,
-                                const GuideRate& guide_rate,
-                                const WellState<double>& wellState,
-                                GroupState<double>& group_state,
-                                std::vector<double>& groupTargetReduction)
+void WellGroupHelpers::
+updateGroupTargetReduction(const Group& group,
+                           const Schedule& schedule,
+                           const int reportStepIdx,
+                           const bool isInjector,
+                           const PhaseUsage& pu,
+                           const GuideRate& guide_rate,
+                           const WellState<double>& wellState,
+                           GroupState<double>& group_state,
+                           std::vector<double>& groupTargetReduction)
 {
     const int np = wellState.numPhases();
     for (const std::string& subGroupName : group.groups()) {
@@ -456,13 +462,15 @@ void updateGroupTargetReduction(const Group& group,
         group_state.update_production_reduction_rates(group.name(), groupTargetReduction);
 }
 
-void updateWellRatesFromGroupTargetScale(const double scale,
-                                         const Group& group,
-                                         const Schedule& schedule,
-                                         const int reportStepIdx,
-                                         bool isInjector,
-                                         const GroupState<double>& group_state,
-                                         WellState<double>& wellState) {
+void WellGroupHelpers::
+updateWellRatesFromGroupTargetScale(const double scale,
+                                    const Group& group,
+                                    const Schedule& schedule,
+                                    const int reportStepIdx,
+                                    bool isInjector,
+                                    const GroupState<double>& group_state,
+                                    WellState<double>& wellState)
+{
     for (const std::string& groupName : group.groups()) {
         bool individual_control = false;
         if (isInjector) {
@@ -524,12 +532,12 @@ void updateWellRatesFromGroupTargetScale(const double scale,
 
 }
 
-
-void updateVREPForGroups(const Group& group,
-                         const Schedule& schedule,
-                         const int reportStepIdx,
-                         const WellState<double>& wellState,
-                         GroupState<double>& group_state)
+void WellGroupHelpers::
+updateVREPForGroups(const Group& group,
+                    const Schedule& schedule,
+                    const int reportStepIdx,
+                    const WellState<double>& wellState,
+                    GroupState<double>& group_state)
 {
     for (const std::string& groupName : group.groups()) {
         const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
@@ -549,11 +557,12 @@ void updateVREPForGroups(const Group& group,
     group_state.update_injection_vrep_rate(group.name(), resv);
 }
 
-void updateReservoirRatesInjectionGroups(const Group& group,
-                                         const Schedule& schedule,
-                                         const int reportStepIdx,
-                                         const WellState<double>& wellState,
-                                         GroupState<double>& group_state)
+void WellGroupHelpers::
+updateReservoirRatesInjectionGroups(const Group& group,
+                                    const Schedule& schedule,
+                                    const int reportStepIdx,
+                                    const WellState<double>& wellState,
+                                    GroupState<double>& group_state)
 {
     for (const std::string& groupName : group.groups()) {
         const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
@@ -573,11 +582,12 @@ void updateReservoirRatesInjectionGroups(const Group& group,
     group_state.update_injection_reservoir_rates(group.name(), resv);
 }
 
-void updateSurfaceRatesInjectionGroups(const Group& group,
-                                       const Schedule& schedule,
-                                       const int reportStepIdx,
-                                       const WellState<double>& wellState,
-                                       GroupState<double>& group_state)
+void WellGroupHelpers::
+updateSurfaceRatesInjectionGroups(const Group& group,
+                                  const Schedule& schedule,
+                                  const int reportStepIdx,
+                                  const WellState<double>& wellState,
+                                  GroupState<double>& group_state)
 {
     for (const std::string& groupName : group.groups()) {
         const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
@@ -597,11 +607,12 @@ void updateSurfaceRatesInjectionGroups(const Group& group,
     group_state.update_injection_surface_rates(group.name(), rates);
 }
 
-void updateWellRates(const Group& group,
-                     const Schedule& schedule,
-                     const int reportStepIdx,
-                     const WellState<double>& wellStateNupcol,
-                     WellState<double>& wellState)
+void WellGroupHelpers::
+updateWellRates(const Group& group,
+                const Schedule& schedule,
+                const int reportStepIdx,
+                const WellState<double>& wellStateNupcol,
+                WellState<double>& wellState)
 {
     for (const std::string& groupName : group.groups()) {
         const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
@@ -627,11 +638,12 @@ void updateWellRates(const Group& group,
     }
 }
 
-void updateGroupProductionRates(const Group& group,
-                                const Schedule& schedule,
-                                const int reportStepIdx,
-                                const WellState<double>& wellState,
-                                GroupState<double>& group_state)
+void WellGroupHelpers::
+updateGroupProductionRates(const Group& group,
+                           const Schedule& schedule,
+                           const int reportStepIdx,
+                           const WellState<double>& wellState,
+                           GroupState<double>& group_state)
 {
     for (const std::string& groupName : group.groups()) {
         const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
@@ -645,15 +657,15 @@ void updateGroupProductionRates(const Group& group,
     group_state.update_production_rates(group.name(), rates);
 }
 
-
-void updateREINForGroups(const Group& group,
-                         const Schedule& schedule,
-                         const int reportStepIdx,
-                         const PhaseUsage& pu,
-                         const SummaryState& st,
-                         const WellState<double>& wellState,
-                         GroupState<double>& group_state,
-                         bool sum_rank)
+void WellGroupHelpers::
+updateREINForGroups(const Group& group,
+                    const Schedule& schedule,
+                    const int reportStepIdx,
+                    const PhaseUsage& pu,
+                    const SummaryState& st,
+                    const WellState<double>& wellState,
+                    GroupState<double>& group_state,
+                    bool sum_rank)
 {
     const int np = wellState.numPhases();
     for (const std::string& groupName : group.groups()) {
@@ -682,13 +694,14 @@ void updateREINForGroups(const Group& group,
 
 
 template <class RegionalValues>
-void updateGpMaintTargetForGroups(const Group& group,
-                                  const Schedule& schedule,
-                                  const RegionalValues& regional_values,
-                                  const int reportStepIdx,
-                                  const double dt,
-                                  const WellState<double>& well_state,
-                                  GroupState<double>& group_state)
+void WellGroupHelpers::
+updateGpMaintTargetForGroups(const Group& group,
+                             const Schedule& schedule,
+                             const RegionalValues& regional_values,
+                             const int reportStepIdx,
+                             const double dt,
+                             const WellState<double>& well_state,
+                             GroupState<double>& group_state)
 {
     for (const std::string& groupName : group.groups()) {
         const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
@@ -772,6 +785,7 @@ void updateGpMaintTargetForGroups(const Group& group,
 
 
 std::map<std::string, double>
+WellGroupHelpers::
 computeNetworkPressures(const Opm::Network::ExtNetwork& network,
                         const WellState<double>& well_state,
                         const GroupState<double>& group_state,
@@ -911,6 +925,7 @@ computeNetworkPressures(const Opm::Network::ExtNetwork& network,
 
 
 GuideRate::RateVector
+WellGroupHelpers::
 getWellRateVector(const WellState<double>& well_state,
                   const PhaseUsage& pu,
                   const std::string& name)
@@ -919,6 +934,7 @@ getWellRateVector(const WellState<double>& well_state,
 }
 
 GuideRate::RateVector
+WellGroupHelpers::
 getProductionGroupRateVector(const GroupState<double>& group_state,
                              const PhaseUsage& pu,
                              const std::string& group_name)
@@ -926,14 +942,15 @@ getProductionGroupRateVector(const GroupState<double>& group_state,
     return getGuideRateVector(group_state.production_rates(group_name), pu);
 }
 
-double getGuideRate(const std::string& name,
-                    const Schedule& schedule,
-                    const WellState<double>& wellState,
-                    const GroupState<double>& group_state,
-                    const int reportStepIdx,
-                    const GuideRate* guideRate,
-                    const GuideRateModel::Target target,
-                    const PhaseUsage& pu)
+double WellGroupHelpers::
+getGuideRate(const std::string& name,
+             const Schedule& schedule,
+             const WellState<double>& wellState,
+             const GroupState<double>& group_state,
+             const int reportStepIdx,
+             const GuideRate* guideRate,
+             const GuideRateModel::Target target,
+             const PhaseUsage& pu)
 {
     if (schedule.hasWell(name, reportStepIdx)) {
         if (guideRate->has(name) || guideRate->hasPotentials(name)) {
@@ -979,16 +996,16 @@ double getGuideRate(const std::string& name,
     return totalGuideRate;
 }
 
-
-double getGuideRateInj(const std::string& name,
-                       const Schedule& schedule,
-                       const WellState<double>& wellState,
-                       const GroupState<double>& group_state,
-                       const int reportStepIdx,
-                       const GuideRate* guideRate,
-                       const GuideRateModel::Target target,
-                       const Phase& injectionPhase,
-                       const PhaseUsage& pu)
+double WellGroupHelpers::
+getGuideRateInj(const std::string& name,
+                const Schedule& schedule,
+                const WellState<double>& wellState,
+                const GroupState<double>& group_state,
+                const int reportStepIdx,
+                const GuideRate* guideRate,
+                const GuideRateModel::Target target,
+                const Phase& injectionPhase,
+                const PhaseUsage& pu)
 {
     if (schedule.hasWell(name, reportStepIdx)) {
         return getGuideRate(name, schedule, wellState, group_state,
@@ -1030,16 +1047,15 @@ double getGuideRateInj(const std::string& name,
     return totalGuideRate;
 }
 
-
-
-int groupControlledWells(const Schedule& schedule,
-                         const WellState<double>& well_state,
-                         const GroupState<double>& group_state,
-                         const int report_step,
-                         const std::string& group_name,
-                         const std::string& always_included_child,
-                         const bool is_production_group,
-                         const Phase injection_phase)
+int WellGroupHelpers::
+groupControlledWells(const Schedule& schedule,
+                     const WellState<double>& well_state,
+                     const GroupState<double>& group_state,
+                     const int report_step,
+                     const std::string& group_name,
+                     const std::string& always_included_child,
+                     const bool is_production_group,
+                     const Phase injection_phase)
 {
     const Group& group = schedule.getGroup(group_name, report_step);
     int num_wells = 0;
@@ -1074,7 +1090,11 @@ int groupControlledWells(const Schedule& schedule,
 }
 
 std::vector<std::string>
-groupChainTopBot(const std::string& bottom, const std::string& top, const Schedule& schedule, const int report_step)
+WellGroupHelpers::
+groupChainTopBot(const std::string& bottom,
+                 const std::string& top,
+                 const Schedule& schedule,
+                 const int report_step)
 {
     // Get initial parent, 'bottom' can be a well or a group.
     std::string parent;
@@ -1099,23 +1119,22 @@ groupChainTopBot(const std::string& bottom, const std::string& top, const Schedu
     return chain;
 }
 
-
-
-
-std::pair<bool, double> checkGroupConstraintsProd(const std::string& name,
-                                                  const std::string& parent,
-                                                  const Group& group,
-                                                  const WellState<double>& wellState,
-                                                  const GroupState<double>& group_state,
-                                                  const int reportStepIdx,
-                                                  const GuideRate* guideRate,
-                                                  const double* rates,
-                                                  const PhaseUsage& pu,
-                                                  const double efficiencyFactor,
-                                                  const Schedule& schedule,
-                                                  const SummaryState& summaryState,
-                                                  const std::vector<double>& resv_coeff,
-                                                  DeferredLogger& deferred_logger)
+std::pair<bool, double>
+WellGroupHelpers::
+checkGroupConstraintsProd(const std::string& name,
+                          const std::string& parent,
+                          const Group& group,
+                          const WellState<double>& wellState,
+                          const GroupState<double>& group_state,
+                          const int reportStepIdx,
+                          const GuideRate* guideRate,
+                          const double* rates,
+                          const PhaseUsage& pu,
+                          const double efficiencyFactor,
+                          const Schedule& schedule,
+                          const SummaryState& summaryState,
+                          const std::vector<double>& resv_coeff,
+                          DeferredLogger& deferred_logger)
 {
     // When called for a well ('name' is a well name), 'parent'
     // will be the name of 'group'. But if we recurse, 'name' and
@@ -1263,21 +1282,23 @@ std::pair<bool, double> checkGroupConstraintsProd(const std::string& name,
     return std::make_pair(current_rate > target_rate, scale);
 }
 
-std::pair<bool, double> checkGroupConstraintsInj(const std::string& name,
-                                                 const std::string& parent,
-                                                 const Group& group,
-                                                 const WellState<double>& wellState,
-                                                 const GroupState<double>& group_state,
-                                                 const int reportStepIdx,
-                                                 const GuideRate* guideRate,
-                                                 const double* rates,
-                                                 Phase injectionPhase,
-                                                 const PhaseUsage& pu,
-                                                 const double efficiencyFactor,
-                                                 const Schedule& schedule,
-                                                 const SummaryState& summaryState,
-                                                 const std::vector<double>& resv_coeff,
-                                                 DeferredLogger& deferred_logger)
+std::pair<bool, double>
+WellGroupHelpers::
+checkGroupConstraintsInj(const std::string& name,
+                         const std::string& parent,
+                         const Group& group,
+                         const WellState<double>& wellState,
+                         const GroupState<double>& group_state,
+                         const int reportStepIdx,
+                         const GuideRate* guideRate,
+                         const double* rates,
+                         Phase injectionPhase,
+                         const PhaseUsage& pu,
+                         const double efficiencyFactor,
+                         const Schedule& schedule,
+                         const SummaryState& summaryState,
+                         const std::vector<double>& resv_coeff,
+                         DeferredLogger& deferred_logger)
 {
     // When called for a well ('name' is a well name), 'parent'
     // will be the name of 'group'. But if we recurse, 'name' and
@@ -1432,6 +1453,7 @@ std::pair<bool, double> checkGroupConstraintsInj(const std::string& name,
 }
 
 std::pair<std::optional<std::string>, double>
+WellGroupHelpers::
 worstOffendingWell(const Group& group,
                    const Schedule& schedule,
                    const int reportStepIdx,
@@ -1530,12 +1552,13 @@ worstOffendingWell(const Group& group,
 }
 
 template <class AverageRegionalPressureType>
-void setRegionAveragePressureCalculator(const Group& group,
-                                        const Schedule& schedule,
-                                        const int reportStepIdx,
-                                        const FieldPropsManager& fp,
-                                        const PhaseUsage& pu,
-                                        std::map<std::string, std::unique_ptr<AverageRegionalPressureType>>& regionalAveragePressureCalculator)
+void WellGroupHelpers::
+setRegionAveragePressureCalculator(const Group& group,
+                                   const Schedule& schedule,
+                                   const int reportStepIdx,
+                                   const FieldPropsManager& fp,
+                                   const PhaseUsage& pu,
+                                   std::map<std::string, std::unique_ptr<AverageRegionalPressureType>>& regionalAveragePressureCalculator)
 {
     for (const std::string& groupName : group.groups()) {
         setRegionAveragePressureCalculator( schedule.getGroup(groupName, reportStepIdx), schedule,
@@ -1556,18 +1579,19 @@ void setRegionAveragePressureCalculator(const Group& group,
     }
 }
 
-void updateGuideRates(const Group& group,
-                      const Schedule& schedule,
-                      const SummaryState& summary_state,
-                      const PhaseUsage& pu,
-                      const int report_step,
-                      const double sim_time,
-                      WellState<double>& well_state,
-                      const GroupState<double>& group_state,
-                      const Parallel::Communication& comm,
-                      GuideRate* guide_rate,
-                      std::vector<double>& pot,
-                      Opm::DeferredLogger& deferred_logger)
+void WellGroupHelpers::
+updateGuideRates(const Group& group,
+                 const Schedule& schedule,
+                 const SummaryState& summary_state,
+                 const PhaseUsage& pu,
+                 const int report_step,
+                 const double sim_time,
+                 WellState<double>& well_state,
+                 const GroupState<double>& group_state,
+                 const Parallel::Communication& comm,
+                 GuideRate* guide_rate,
+                 std::vector<double>& pot,
+                 DeferredLogger& deferred_logger)
 {
     guide_rate->updateGuideRateExpiration(sim_time, report_step);
     updateGuideRateForProductionGroups(group, schedule, pu, report_step, sim_time, well_state, group_state, comm, guide_rate, pot);
@@ -1575,16 +1599,17 @@ void updateGuideRates(const Group& group,
     updateGuideRatesForWells(schedule, pu, report_step, sim_time, well_state, comm, guide_rate);
 }
 
-void updateGuideRateForProductionGroups(const Group& group,
-                                        const Schedule& schedule,
-                                        const PhaseUsage& pu,
-                                        const int reportStepIdx,
-                                        const double& simTime,
-                                        WellState<double>& wellState,
-                                        const GroupState<double>& group_state,
-                                        const Parallel::Communication& comm,
-                                        GuideRate* guideRate,
-                                        std::vector<double>& pot)
+void WellGroupHelpers::
+updateGuideRateForProductionGroups(const Group& group,
+                                   const Schedule& schedule,
+                                   const PhaseUsage& pu,
+                                   const int reportStepIdx,
+                                   const double& simTime,
+                                   WellState<double>& wellState,
+                                   const GroupState<double>& group_state,
+                                   const Parallel::Communication& comm,
+                                   GuideRate* guideRate,
+                                   std::vector<double>& pot)
 {
     const int np = pu.num_phases;
     for (const std::string& groupName : group.groups()) {
@@ -1653,13 +1678,14 @@ void updateGuideRateForProductionGroups(const Group& group,
     guideRate->compute(group.name(), reportStepIdx, simTime, oilPot, gasPot, waterPot);
 }
 
-void updateGuideRatesForWells(const Schedule& schedule,
-                              const PhaseUsage& pu,
-                              const int reportStepIdx,
-                              const double& simTime,
-                              const WellState<double>& wellState,
-                              const Parallel::Communication& comm,
-                              GuideRate* guideRate)
+void WellGroupHelpers::
+updateGuideRatesForWells(const Schedule& schedule,
+                         const PhaseUsage& pu,
+                         const int reportStepIdx,
+                         const double& simTime,
+                         const WellState<double>& wellState,
+                         const Parallel::Communication& comm,
+                         GuideRate* guideRate)
 {
     for (const auto& well : schedule.getWells(reportStepIdx)) {
         std::array<double,3> potentials{};
@@ -1706,4 +1732,5 @@ template void WellGroupHelpers::
                                              const FieldPropsManager&,
                                              const PhaseUsage&,
                                              AvgPMap&);
+
 } // namespace Opm::WellGroupHelpers

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -124,1559 +124,1553 @@ namespace {
     }
 } // namespace Anonymous
 
-namespace Opm
+namespace Opm::WellGroupHelpers {
+
+void setCmodeGroup(const Group& group,
+                   const Schedule& schedule,
+                   const SummaryState& summaryState,
+                   const int reportStepIdx,
+                   GroupState<double>& group_state)
 {
 
+    for (const std::string& groupName : group.groups()) {
+        setCmodeGroup(schedule.getGroup(groupName, reportStepIdx),
+                      schedule, summaryState, reportStepIdx, group_state);
+    }
 
-namespace WellGroupHelpers
+    // use NONE as default control
+    const Phase all[] = {Phase::WATER, Phase::OIL, Phase::GAS};
+    for (Phase phase : all) {
+        if (!group_state.has_injection_control(group.name(), phase)) {
+            group_state.injection_control(group.name(), phase, Group::InjectionCMode::NONE);
+        }
+    }
+    if (!group_state.has_production_control(group.name())) {
+        group_state.production_control(group.name(), Group::ProductionCMode::NONE);
+    }
+
+    const auto& events = schedule[reportStepIdx].wellgroup_events();
+    if (group.isInjectionGroup()
+        && events.hasEvent(group.name(), ScheduleEvents::GROUP_INJECTION_UPDATE)) {
+
+        for (Phase phase : all) {
+            if (!group.hasInjectionControl(phase))
+                continue;
+
+            const auto& controls = group.injectionControls(phase, summaryState);
+            group_state.injection_control(group.name(), phase, controls.cmode);
+        }
+    }
+
+    if (group.isProductionGroup()
+        && events.hasEvent(group.name(), ScheduleEvents::GROUP_PRODUCTION_UPDATE)) {
+        const auto controls = group.productionControls(summaryState);
+        group_state.production_control(group.name(), controls.cmode);
+    }
+
+    if (group.has_gpmaint_control(Group::ProductionCMode::RESV)) {
+        group_state.production_control(group.name(), Group::ProductionCMode::RESV);
+    }
+    for (Phase phase : all) {
+        if (group.has_gpmaint_control(phase, Group::InjectionCMode::RATE)) {
+            group_state.injection_control(group.name(), phase, Group::InjectionCMode::RATE);
+        } else if (group.has_gpmaint_control(phase, Group::InjectionCMode::RESV)) {
+            group_state.injection_control(group.name(), phase, Group::InjectionCMode::RESV);
+        }
+    }
+
+    if (schedule[reportStepIdx].gconsale().has(group.name())) {
+        group_state.injection_control(group.name(), Phase::GAS, Group::InjectionCMode::SALE);
+    }
+}
+
+void accumulateGroupEfficiencyFactor(const Group& group,
+                                     const Schedule& schedule,
+                                     const int reportStepIdx,
+                                     double& factor)
 {
+    factor *= group.getGroupEfficiencyFactor();
+    if (group.parent() != "FIELD" && !group.parent().empty())
+        accumulateGroupEfficiencyFactor(
+            schedule.getGroup(group.parent(), reportStepIdx), schedule, reportStepIdx, factor);
+}
 
 
-    void setCmodeGroup(const Group& group,
-                       const Schedule& schedule,
-                       const SummaryState& summaryState,
-                       const int reportStepIdx,
-                       GroupState<double>& group_state)
-    {
-
-        for (const std::string& groupName : group.groups()) {
-            setCmodeGroup(schedule.getGroup(groupName, reportStepIdx),
-                          schedule, summaryState, reportStepIdx, group_state);
-        }
-
-        // use NONE as default control
-        const Phase all[] = {Phase::WATER, Phase::OIL, Phase::GAS};
-        for (Phase phase : all) {
-            if (!group_state.has_injection_control(group.name(), phase)) {
-                group_state.injection_control(group.name(), phase, Group::InjectionCMode::NONE);
-            }
-        }
-        if (!group_state.has_production_control(group.name())) {
-            group_state.production_control(group.name(), Group::ProductionCMode::NONE);
-        }
-
-        const auto& events = schedule[reportStepIdx].wellgroup_events();
-        if (group.isInjectionGroup()
-            && events.hasEvent(group.name(), ScheduleEvents::GROUP_INJECTION_UPDATE)) {
-
-            for (Phase phase : all) {
-                if (!group.hasInjectionControl(phase))
-                    continue;
-
-                const auto& controls = group.injectionControls(phase, summaryState);
-                group_state.injection_control(group.name(), phase, controls.cmode);
-            }
-        }
-
-        if (group.isProductionGroup()
-            && events.hasEvent(group.name(), ScheduleEvents::GROUP_PRODUCTION_UPDATE)) {
-            const auto controls = group.productionControls(summaryState);
-            group_state.production_control(group.name(), controls.cmode);
-        }
-
-        if (group.has_gpmaint_control(Group::ProductionCMode::RESV)) {
-            group_state.production_control(group.name(), Group::ProductionCMode::RESV);
-        }
-        for (Phase phase : all) {
-            if (group.has_gpmaint_control(phase, Group::InjectionCMode::RATE)) {
-                group_state.injection_control(group.name(), phase, Group::InjectionCMode::RATE);
-            } else if (group.has_gpmaint_control(phase, Group::InjectionCMode::RESV)) {
-                group_state.injection_control(group.name(), phase, Group::InjectionCMode::RESV);
-            }
-        }
-
-        if (schedule[reportStepIdx].gconsale().has(group.name())) {
-            group_state.injection_control(group.name(), Phase::GAS, Group::InjectionCMode::SALE);
-        }
-    }
-
-    void accumulateGroupEfficiencyFactor(const Group& group,
-                                         const Schedule& schedule,
-                                         const int reportStepIdx,
-                                         double& factor)
-    {
-        factor *= group.getGroupEfficiencyFactor();
-        if (group.parent() != "FIELD" && !group.parent().empty())
-            accumulateGroupEfficiencyFactor(
-                schedule.getGroup(group.parent(), reportStepIdx), schedule, reportStepIdx, factor);
-    }
-
-
-    double sumWellSurfaceRates(const Group& group,
-                               const Schedule& schedule,
-                               const WellState<double>& wellState,
-                               const int reportStepIdx,
-                               const int phasePos,
-                               const bool injector)
-    {
-        return sumWellPhaseRates(false, group, schedule, wellState, reportStepIdx, phasePos, injector);
-    }
-
-    double sumWellResRates(const Group& group,
+double sumWellSurfaceRates(const Group& group,
                            const Schedule& schedule,
                            const WellState<double>& wellState,
                            const int reportStepIdx,
                            const int phasePos,
                            const bool injector)
-    {
-        return sumWellPhaseRates(true, group, schedule, wellState, reportStepIdx, phasePos, injector);
+{
+    return sumWellPhaseRates(false, group, schedule, wellState, reportStepIdx, phasePos, injector);
+}
+
+double sumWellResRates(const Group& group,
+                       const Schedule& schedule,
+                       const WellState<double>& wellState,
+                       const int reportStepIdx,
+                       const int phasePos,
+                       const bool injector)
+{
+    return sumWellPhaseRates(true, group, schedule, wellState, reportStepIdx, phasePos, injector);
+}
+
+double sumSolventRates(const Group& group,
+                       const Schedule& schedule,
+                       const WellState<double>& wellState,
+                       const int reportStepIdx,
+                       const bool injector)
+{
+
+    double rate = 0.0;
+    for (const std::string& groupName : group.groups()) {
+        const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+        const auto& gefac = groupTmp.getGroupEfficiencyFactor();
+        rate += gefac * sumSolventRates(groupTmp, schedule, wellState, reportStepIdx, injector);
     }
 
-    double sumSolventRates(const Group& group,
-                           const Schedule& schedule,
-                           const WellState<double>& wellState,
-                           const int reportStepIdx,
-                           const bool injector)
-    {
+    for (const std::string& wellName : group.wells()) {
+        const auto& well_index = wellState.index(wellName);
+        if (!well_index.has_value())
+            continue;
 
-        double rate = 0.0;
-        for (const std::string& groupName : group.groups()) {
-            const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            const auto& gefac = groupTmp.getGroupEfficiencyFactor();
-            rate += gefac * sumSolventRates(groupTmp, schedule, wellState, reportStepIdx, injector);
+        if (! wellState.wellIsOwned(well_index.value(), wellName) ) // Only sum once
+        {
+            continue;
         }
 
-        for (const std::string& wellName : group.wells()) {
-            const auto& well_index = wellState.index(wellName);
-            if (!well_index.has_value())
-                continue;
+        const auto& wellEcl = schedule.getWell(wellName, reportStepIdx);
+        // only count producers or injectors
+        if ((wellEcl.isProducer() && injector) || (wellEcl.isInjector() && !injector))
+            continue;
 
-            if (! wellState.wellIsOwned(well_index.value(), wellName) ) // Only sum once
-            {
-                continue;
-            }
+        if (wellEcl.getStatus() == Well::Status::SHUT)
+            continue;
 
-            const auto& wellEcl = schedule.getWell(wellName, reportStepIdx);
-            // only count producers or injectors
-            if ((wellEcl.isProducer() && injector) || (wellEcl.isInjector() && !injector))
-                continue;
-
-            if (wellEcl.getStatus() == Well::Status::SHUT)
-                continue;
-
-            const auto& ws = wellState.well(well_index.value());
-            double factor = wellEcl.getEfficiencyFactor();
-            if (injector)
-                rate += factor * ws.sum_solvent_rates();
-            else
-                rate -= factor * ws.sum_solvent_rates();
-        }
-        return rate;
-    }
-
-    void updateGuideRatesForInjectionGroups(const Group& group,
-                                            const Schedule& schedule,
-                                            const SummaryState& summaryState,
-                                            const Opm::PhaseUsage& pu,
-                                            const int reportStepIdx,
-                                            const WellState<double>& wellState,
-                                            const GroupState<double>& group_state,
-                                            GuideRate* guideRate,
-                                            Opm::DeferredLogger& deferred_logger)
-    {
-        for (const std::string& groupName : group.groups()) {
-            const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            updateGuideRatesForInjectionGroups(groupTmp, schedule, summaryState, pu, reportStepIdx, wellState, group_state, guideRate, deferred_logger);
-        }
-        const Phase all[] = {Phase::WATER, Phase::OIL, Phase::GAS};
-        for (Phase phase : all) {
-
-            if(!group.hasInjectionControl(phase))
-                continue;
-
-            double guideRateValue = 0.0;
-            const auto& controls = group.injectionControls(phase, summaryState);
-            switch (controls.guide_rate_def){
-            case Group::GuideRateInjTarget::RATE:
-                break;
-            case Group::GuideRateInjTarget::VOID:
-            {
-                guideRateValue = group_state.injection_vrep_rate(group.name());
-                break;
-            }
-            case Group::GuideRateInjTarget::NETV:
-            {
-                guideRateValue = group_state.injection_vrep_rate(group.name());
-                const std::vector<double>& injRES = group_state.injection_reservoir_rates(group.name());
-                if (phase != Phase::OIL && pu.phase_used[BlackoilPhases::Liquid])
-                    guideRateValue -= injRES[pu.phase_pos[BlackoilPhases::Liquid]];
-                if (phase != Phase::GAS && pu.phase_used[BlackoilPhases::Vapour])
-                    guideRateValue -= injRES[pu.phase_pos[BlackoilPhases::Vapour]];
-                if (phase != Phase::WATER && pu.phase_used[BlackoilPhases::Aqua])
-                    guideRateValue -= injRES[pu.phase_pos[BlackoilPhases::Aqua]];
-                break;
-            }
-            case Group::GuideRateInjTarget::RESV:
-                OPM_DEFLOG_THROW(std::runtime_error, "GUIDE PHASE RESV not implemented. Group " + group.name(), deferred_logger);
-            case Group::GuideRateInjTarget::POTN:
-                break;
-            case Group::GuideRateInjTarget::NO_GUIDE_RATE:
-                break;
-            default:
-                OPM_DEFLOG_THROW(std::logic_error,
-                                 "Invalid GuideRateInjTarget in updateGuideRatesForInjectionGroups",
-                                 deferred_logger);
-            }
-
-            const UnitSystem& unit_system = schedule.getUnits();
-            guideRateValue = unit_system.from_si(UnitSystem::measure::rate, guideRateValue);
-            guideRate->compute(group.name(), phase, reportStepIdx, guideRateValue);
-        }
-    }
-
-    void updateGroupTargetReduction(const Group& group,
-                                    const Schedule& schedule,
-                                    const int reportStepIdx,
-                                    const bool isInjector,
-                                    const PhaseUsage& pu,
-                                    const GuideRate& guide_rate,
-                                    const WellState<double>& wellState,
-                                    GroupState<double>& group_state,
-                                    std::vector<double>& groupTargetReduction)
-    {
-        const int np = wellState.numPhases();
-        for (const std::string& subGroupName : group.groups()) {
-            std::vector<double> subGroupTargetReduction(np, 0.0);
-            const Group& subGroup = schedule.getGroup(subGroupName, reportStepIdx);
-            updateGroupTargetReduction(subGroup,
-                                       schedule,
-                                       reportStepIdx,
-                                       isInjector,
-                                       pu,
-                                       guide_rate,
-                                       wellState,
-                                       group_state,
-                                       subGroupTargetReduction);
-
-            const double subGroupEfficiency = subGroup.getGroupEfficiencyFactor();
-
-            // accumulate group contribution from sub group
-            if (isInjector) {
-                const Phase all[] = {Phase::WATER, Phase::OIL, Phase::GAS};
-                for (Phase phase : all) {
-
-                    int phase_pos = -1;
-                    switch (phase) {
-                    case Phase::GAS:
-                        if (pu.phase_used[BlackoilPhases::Vapour]) {
-                            phase_pos = pu.phase_pos[BlackoilPhases::Vapour];
-                        }
-                        break;
-                    case Phase::OIL:
-                        if (pu.phase_used[BlackoilPhases::Liquid]) {
-                            phase_pos = pu.phase_pos[BlackoilPhases::Liquid];
-                        }
-                        break;
-                    case Phase::WATER:
-                        if (pu.phase_used[BlackoilPhases::Aqua]) {
-                            phase_pos = pu.phase_pos[BlackoilPhases::Aqua];
-                        }
-                        break;
-                    default:
-                        // just to avoid warning
-                        throw std::invalid_argument("unhandled phase enum");
-                    }
-
-                    // the phase is not present
-                    if (phase_pos == -1)
-                        continue;
-
-                    const Group::InjectionCMode& currentGroupControl
-                            = group_state.injection_control(subGroup.name(), phase);
-                    const bool individual_control = (currentGroupControl != Group::InjectionCMode::FLD
-                            && currentGroupControl != Group::InjectionCMode::NONE);
-                    const int num_group_controlled_wells
-                            = groupControlledWells(schedule, wellState, group_state, reportStepIdx, subGroupName, "", !isInjector, phase);
-                    if (individual_control || num_group_controlled_wells == 0) {
-                        groupTargetReduction[phase_pos]
-                            += subGroupEfficiency * sumWellSurfaceRates(subGroup, schedule, wellState, reportStepIdx, phase_pos, isInjector);
-                    } else {
-                        // Accumulate from this subgroup only if no group guide rate is set for it.
-                        if (!guide_rate.has(subGroupName, phase)) {
-                            groupTargetReduction[phase_pos] += subGroupEfficiency * subGroupTargetReduction[phase_pos];
-                        }
-                    }
-                }
-            } else {
-                const Group::ProductionCMode& currentGroupControl = group_state.production_control(subGroupName);
-                const bool individual_control = (currentGroupControl != Group::ProductionCMode::FLD
-                                                 && currentGroupControl != Group::ProductionCMode::NONE);
-                const int num_group_controlled_wells
-                    = groupControlledWells(schedule, wellState, group_state, reportStepIdx, subGroupName, "", !isInjector, /*injectionPhaseNotUsed*/Phase::OIL);
-                if (individual_control || num_group_controlled_wells == 0) {
-                    for (int phase = 0; phase < np; phase++) {
-                        groupTargetReduction[phase]
-                            += subGroupEfficiency * sumWellSurfaceRates(subGroup, schedule, wellState, reportStepIdx, phase, isInjector);
-                    }
-                } else {
-                    // The subgroup may participate in group control.
-                    if (!guide_rate.has(subGroupName)) {
-                        // Accumulate from this subgroup only if no group guide rate is set for it.
-                        for (int phase = 0; phase < np; phase++) {
-                            groupTargetReduction[phase] += subGroupEfficiency * subGroupTargetReduction[phase];
-                        }
-                    }
-                }
-            }
-        }
-
-        for (const std::string& wellName : group.wells()) {
-            const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
-
-            if (wellTmp.isProducer() && isInjector)
-                continue;
-
-            if (wellTmp.isInjector() && !isInjector)
-                continue;
-
-            if (wellTmp.getStatus() == Well::Status::SHUT)
-                continue;
-
-            const auto& well_index = wellState.index(wellName);
-            if (!well_index.has_value())
-                continue;
-
-            if (! wellState.wellIsOwned(well_index.value(), wellName) ) // Only sum once
-            {
-                continue;
-            }
-
-            const double efficiency = wellTmp.getEfficiencyFactor();
-            // add contributino from wells not under group control
-            const auto& ws = wellState.well(well_index.value());
-            if (isInjector) {
-                if (ws.injection_cmode != Well::InjectorCMode::GRUP)
-                    for (int phase = 0; phase < np; phase++) {
-                        groupTargetReduction[phase] += ws.surface_rates[phase] * efficiency;
-                    }
-            } else {
-                if (ws.production_cmode != Well::ProducerCMode::GRUP)
-                    for (int phase = 0; phase < np; phase++) {
-                        groupTargetReduction[phase] -= ws.surface_rates[phase] * efficiency;
-                    }
-            }
-        }
-        if (isInjector)
-            group_state.update_injection_reduction_rates(group.name(), groupTargetReduction);
+        const auto& ws = wellState.well(well_index.value());
+        double factor = wellEcl.getEfficiencyFactor();
+        if (injector)
+            rate += factor * ws.sum_solvent_rates();
         else
-            group_state.update_production_reduction_rates(group.name(), groupTargetReduction);
+            rate -= factor * ws.sum_solvent_rates();
     }
+    return rate;
+}
 
-    void updateWellRatesFromGroupTargetScale(const double scale,
-                                             const Group& group,
-                                             const Schedule& schedule,
-                                             const int reportStepIdx,
-                                             bool isInjector,
-                                             const GroupState<double>& group_state,
-                                             WellState<double>& wellState) {
-        for (const std::string& groupName : group.groups()) {
-            bool individual_control = false;
-            if (isInjector) {
-                const Phase all[] = {Phase::WATER, Phase::OIL, Phase::GAS};
-                for (Phase phase : all) {
-                    const Group::InjectionCMode& currentGroupControl
-                            = group_state.injection_control(groupName, phase);
-                    individual_control = individual_control || (currentGroupControl != Group::InjectionCMode::FLD
-                                                     && currentGroupControl != Group::InjectionCMode::NONE);
+void updateGuideRatesForInjectionGroups(const Group& group,
+                                        const Schedule& schedule,
+                                        const SummaryState& summaryState,
+                                        const Opm::PhaseUsage& pu,
+                                        const int reportStepIdx,
+                                        const WellState<double>& wellState,
+                                        const GroupState<double>& group_state,
+                                        GuideRate* guideRate,
+                                        Opm::DeferredLogger& deferred_logger)
+{
+    for (const std::string& groupName : group.groups()) {
+        const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+        updateGuideRatesForInjectionGroups(groupTmp, schedule, summaryState, pu, reportStepIdx, wellState, group_state, guideRate, deferred_logger);
+    }
+    const Phase all[] = {Phase::WATER, Phase::OIL, Phase::GAS};
+    for (Phase phase : all) {
+
+        if(!group.hasInjectionControl(phase))
+            continue;
+
+        double guideRateValue = 0.0;
+        const auto& controls = group.injectionControls(phase, summaryState);
+        switch (controls.guide_rate_def){
+        case Group::GuideRateInjTarget::RATE:
+            break;
+        case Group::GuideRateInjTarget::VOID:
+        {
+            guideRateValue = group_state.injection_vrep_rate(group.name());
+            break;
+        }
+        case Group::GuideRateInjTarget::NETV:
+        {
+            guideRateValue = group_state.injection_vrep_rate(group.name());
+            const std::vector<double>& injRES = group_state.injection_reservoir_rates(group.name());
+            if (phase != Phase::OIL && pu.phase_used[BlackoilPhases::Liquid])
+                guideRateValue -= injRES[pu.phase_pos[BlackoilPhases::Liquid]];
+            if (phase != Phase::GAS && pu.phase_used[BlackoilPhases::Vapour])
+                guideRateValue -= injRES[pu.phase_pos[BlackoilPhases::Vapour]];
+            if (phase != Phase::WATER && pu.phase_used[BlackoilPhases::Aqua])
+                guideRateValue -= injRES[pu.phase_pos[BlackoilPhases::Aqua]];
+            break;
+        }
+        case Group::GuideRateInjTarget::RESV:
+            OPM_DEFLOG_THROW(std::runtime_error, "GUIDE PHASE RESV not implemented. Group " + group.name(), deferred_logger);
+        case Group::GuideRateInjTarget::POTN:
+            break;
+        case Group::GuideRateInjTarget::NO_GUIDE_RATE:
+            break;
+        default:
+            OPM_DEFLOG_THROW(std::logic_error,
+                             "Invalid GuideRateInjTarget in updateGuideRatesForInjectionGroups",
+                             deferred_logger);
+        }
+
+        const UnitSystem& unit_system = schedule.getUnits();
+        guideRateValue = unit_system.from_si(UnitSystem::measure::rate, guideRateValue);
+        guideRate->compute(group.name(), phase, reportStepIdx, guideRateValue);
+    }
+}
+
+void updateGroupTargetReduction(const Group& group,
+                                const Schedule& schedule,
+                                const int reportStepIdx,
+                                const bool isInjector,
+                                const PhaseUsage& pu,
+                                const GuideRate& guide_rate,
+                                const WellState<double>& wellState,
+                                GroupState<double>& group_state,
+                                std::vector<double>& groupTargetReduction)
+{
+    const int np = wellState.numPhases();
+    for (const std::string& subGroupName : group.groups()) {
+        std::vector<double> subGroupTargetReduction(np, 0.0);
+        const Group& subGroup = schedule.getGroup(subGroupName, reportStepIdx);
+        updateGroupTargetReduction(subGroup,
+                                   schedule,
+                                   reportStepIdx,
+                                   isInjector,
+                                   pu,
+                                   guide_rate,
+                                   wellState,
+                                   group_state,
+                                   subGroupTargetReduction);
+
+        const double subGroupEfficiency = subGroup.getGroupEfficiencyFactor();
+
+        // accumulate group contribution from sub group
+        if (isInjector) {
+            const Phase all[] = {Phase::WATER, Phase::OIL, Phase::GAS};
+            for (Phase phase : all) {
+
+                int phase_pos = -1;
+                switch (phase) {
+                case Phase::GAS:
+                    if (pu.phase_used[BlackoilPhases::Vapour]) {
+                        phase_pos = pu.phase_pos[BlackoilPhases::Vapour];
+                    }
+                    break;
+                case Phase::OIL:
+                    if (pu.phase_used[BlackoilPhases::Liquid]) {
+                        phase_pos = pu.phase_pos[BlackoilPhases::Liquid];
+                    }
+                    break;
+                case Phase::WATER:
+                    if (pu.phase_used[BlackoilPhases::Aqua]) {
+                        phase_pos = pu.phase_pos[BlackoilPhases::Aqua];
+                    }
+                    break;
+                default:
+                    // just to avoid warning
+                    throw std::invalid_argument("unhandled phase enum");
+                }
+
+                // the phase is not present
+                if (phase_pos == -1)
+                    continue;
+
+                const Group::InjectionCMode& currentGroupControl
+                        = group_state.injection_control(subGroup.name(), phase);
+                const bool individual_control = (currentGroupControl != Group::InjectionCMode::FLD
+                        && currentGroupControl != Group::InjectionCMode::NONE);
+                const int num_group_controlled_wells
+                        = groupControlledWells(schedule, wellState, group_state, reportStepIdx, subGroupName, "", !isInjector, phase);
+                if (individual_control || num_group_controlled_wells == 0) {
+                    groupTargetReduction[phase_pos]
+                        += subGroupEfficiency * sumWellSurfaceRates(subGroup, schedule, wellState, reportStepIdx, phase_pos, isInjector);
+                } else {
+                    // Accumulate from this subgroup only if no group guide rate is set for it.
+                    if (!guide_rate.has(subGroupName, phase)) {
+                        groupTargetReduction[phase_pos] += subGroupEfficiency * subGroupTargetReduction[phase_pos];
+                    }
+                }
+            }
+        } else {
+            const Group::ProductionCMode& currentGroupControl = group_state.production_control(subGroupName);
+            const bool individual_control = (currentGroupControl != Group::ProductionCMode::FLD
+                                             && currentGroupControl != Group::ProductionCMode::NONE);
+            const int num_group_controlled_wells
+                = groupControlledWells(schedule, wellState, group_state, reportStepIdx, subGroupName, "", !isInjector, /*injectionPhaseNotUsed*/Phase::OIL);
+            if (individual_control || num_group_controlled_wells == 0) {
+                for (int phase = 0; phase < np; phase++) {
+                    groupTargetReduction[phase]
+                        += subGroupEfficiency * sumWellSurfaceRates(subGroup, schedule, wellState, reportStepIdx, phase, isInjector);
                 }
             } else {
-                const Group::ProductionCMode& currentGroupControl = group_state.production_control(groupName);
-                individual_control = (currentGroupControl != Group::ProductionCMode::FLD
-                                                 && currentGroupControl != Group::ProductionCMode::NONE);
-            }
-            if (!individual_control) {
-                const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-                updateWellRatesFromGroupTargetScale(scale, groupTmp, schedule, reportStepIdx, isInjector, group_state, wellState);
-            }
-        }
-
-        const int np = wellState.numPhases();
-        for (const std::string& wellName : group.wells()) {
-            const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
-
-            if (wellTmp.isProducer() && isInjector)
-                continue;
-
-            if (wellTmp.isInjector() && !isInjector)
-                continue;
-
-            if (wellTmp.getStatus() == Well::Status::SHUT)
-                continue;
-
-            const auto& well_index = wellState.index(wellName);
-            if (!well_index.has_value())
-                continue;
-
-            if (! wellState.wellIsOwned(well_index.value(), wellName) ) // Only sum once
-            {
-                continue;
-            }
-
-            // scale rates
-            auto& ws = wellState.well(well_index.value());
-            if (isInjector) {
-                if (ws.injection_cmode == Well::InjectorCMode::GRUP)
+                // The subgroup may participate in group control.
+                if (!guide_rate.has(subGroupName)) {
+                    // Accumulate from this subgroup only if no group guide rate is set for it.
                     for (int phase = 0; phase < np; phase++) {
-                        ws.surface_rates[phase] *= scale;
+                        groupTargetReduction[phase] += subGroupEfficiency * subGroupTargetReduction[phase];
                     }
-            } else {
-                if (ws.production_cmode == Well::ProducerCMode::GRUP)
-                    for (int phase = 0; phase < np; phase++) {
-                        ws.surface_rates[phase] *= scale;
-                    }
+                }
             }
         }
-
-
     }
 
+    for (const std::string& wellName : group.wells()) {
+        const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
 
-    void updateVREPForGroups(const Group& group,
-                             const Schedule& schedule,
-                             const int reportStepIdx,
-                             const WellState<double>& wellState,
-                             GroupState<double>& group_state)
-    {
-        for (const std::string& groupName : group.groups()) {
+        if (wellTmp.isProducer() && isInjector)
+            continue;
+
+        if (wellTmp.isInjector() && !isInjector)
+            continue;
+
+        if (wellTmp.getStatus() == Well::Status::SHUT)
+            continue;
+
+        const auto& well_index = wellState.index(wellName);
+        if (!well_index.has_value())
+            continue;
+
+        if (! wellState.wellIsOwned(well_index.value(), wellName) ) // Only sum once
+        {
+            continue;
+        }
+
+        const double efficiency = wellTmp.getEfficiencyFactor();
+        // add contributino from wells not under group control
+        const auto& ws = wellState.well(well_index.value());
+        if (isInjector) {
+            if (ws.injection_cmode != Well::InjectorCMode::GRUP)
+                for (int phase = 0; phase < np; phase++) {
+                    groupTargetReduction[phase] += ws.surface_rates[phase] * efficiency;
+                }
+        } else {
+            if (ws.production_cmode != Well::ProducerCMode::GRUP)
+                for (int phase = 0; phase < np; phase++) {
+                    groupTargetReduction[phase] -= ws.surface_rates[phase] * efficiency;
+                }
+        }
+    }
+    if (isInjector)
+        group_state.update_injection_reduction_rates(group.name(), groupTargetReduction);
+    else
+        group_state.update_production_reduction_rates(group.name(), groupTargetReduction);
+}
+
+void updateWellRatesFromGroupTargetScale(const double scale,
+                                         const Group& group,
+                                         const Schedule& schedule,
+                                         const int reportStepIdx,
+                                         bool isInjector,
+                                         const GroupState<double>& group_state,
+                                         WellState<double>& wellState) {
+    for (const std::string& groupName : group.groups()) {
+        bool individual_control = false;
+        if (isInjector) {
+            const Phase all[] = {Phase::WATER, Phase::OIL, Phase::GAS};
+            for (Phase phase : all) {
+                const Group::InjectionCMode& currentGroupControl
+                        = group_state.injection_control(groupName, phase);
+                individual_control = individual_control || (currentGroupControl != Group::InjectionCMode::FLD
+                                                 && currentGroupControl != Group::InjectionCMode::NONE);
+            }
+        } else {
+            const Group::ProductionCMode& currentGroupControl = group_state.production_control(groupName);
+            individual_control = (currentGroupControl != Group::ProductionCMode::FLD
+                                             && currentGroupControl != Group::ProductionCMode::NONE);
+        }
+        if (!individual_control) {
             const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            updateVREPForGroups(groupTmp, schedule, reportStepIdx, wellState, group_state);
+            updateWellRatesFromGroupTargetScale(scale, groupTmp, schedule, reportStepIdx, isInjector, group_state, wellState);
         }
-        const int np = wellState.numPhases();
-        double resv = 0.0;
-        for (int phase = 0; phase < np; ++phase) {
-            resv += sumWellPhaseRates(true,
-                                      group,
-                                      schedule,
-                                      wellState,
-                                      reportStepIdx,
-                                      phase,
-                                      /*isInjector*/ false);
-        }
-        group_state.update_injection_vrep_rate(group.name(), resv);
     }
 
-    void updateReservoirRatesInjectionGroups(const Group& group,
-                                             const Schedule& schedule,
-                                             const int reportStepIdx,
-                                             const WellState<double>& wellState,
-                                             GroupState<double>& group_state)
-    {
-        for (const std::string& groupName : group.groups()) {
-            const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            updateReservoirRatesInjectionGroups(groupTmp, schedule, reportStepIdx, wellState, group_state);
+    const int np = wellState.numPhases();
+    for (const std::string& wellName : group.wells()) {
+        const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
+
+        if (wellTmp.isProducer() && isInjector)
+            continue;
+
+        if (wellTmp.isInjector() && !isInjector)
+            continue;
+
+        if (wellTmp.getStatus() == Well::Status::SHUT)
+            continue;
+
+        const auto& well_index = wellState.index(wellName);
+        if (!well_index.has_value())
+            continue;
+
+        if (! wellState.wellIsOwned(well_index.value(), wellName) ) // Only sum once
+        {
+            continue;
         }
-        const int np = wellState.numPhases();
-        std::vector<double> resv(np, 0.0);
-        for (int phase = 0; phase < np; ++phase) {
-            resv[phase] = sumWellPhaseRates(true,
-                                            group,
-                                            schedule,
-                                            wellState,
-                                            reportStepIdx,
-                                            phase,
-                                            /*isInjector*/ true);
+
+        // scale rates
+        auto& ws = wellState.well(well_index.value());
+        if (isInjector) {
+            if (ws.injection_cmode == Well::InjectorCMode::GRUP)
+                for (int phase = 0; phase < np; phase++) {
+                    ws.surface_rates[phase] *= scale;
+                }
+        } else {
+            if (ws.production_cmode == Well::ProducerCMode::GRUP)
+                for (int phase = 0; phase < np; phase++) {
+                    ws.surface_rates[phase] *= scale;
+                }
         }
-        group_state.update_injection_reservoir_rates(group.name(), resv);
     }
 
-    void updateSurfaceRatesInjectionGroups(const Group& group,
-                                           const Schedule& schedule,
-                                           const int reportStepIdx,
-                                           const WellState<double>& wellState,
-                                           GroupState<double>& group_state)
-    {
-        for (const std::string& groupName : group.groups()) {
-            const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            updateSurfaceRatesInjectionGroups(groupTmp, schedule, reportStepIdx, wellState, group_state);
-        }
-        const int np = wellState.numPhases();
-        std::vector<double> rates(np, 0.0);
-        for (int phase = 0; phase < np; ++phase) {
-            rates[phase] = sumWellPhaseRates(false,
-                                            group,
-                                            schedule,
-                                            wellState,
-                                            reportStepIdx,
-                                            phase,
-                                            /*isInjector*/ true);
-        }
-        group_state.update_injection_surface_rates(group.name(), rates);
-    }
 
-    void updateWellRates(const Group& group,
+}
+
+
+void updateVREPForGroups(const Group& group,
                          const Schedule& schedule,
                          const int reportStepIdx,
-                         const WellState<double>& wellStateNupcol,
-                         WellState<double>& wellState)
-    {
-        for (const std::string& groupName : group.groups()) {
-            const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            updateWellRates(groupTmp, schedule, reportStepIdx, wellStateNupcol, wellState);
-        }
-        const int np = wellState.numPhases();
-        for (const std::string& wellName : group.wells()) {
-            std::vector<double> rates(np, 0.0);
-            const auto& well_index = wellState.index(wellName);
-            if (well_index.has_value()) { // the well is found on this node
-                const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
-                int sign = 1;
-                // production wellRates are negative. The users of currentWellRates uses the convention in
-                // opm-common that production and injection rates are positive.
-                if (!wellTmp.isInjector())
-                    sign = -1;
-                const auto& ws = wellStateNupcol.well(well_index.value());
-                for (int phase = 0; phase < np; ++phase) {
-                    rates[phase] = sign * ws.surface_rates[phase];
-                }
-            }
-            wellState.setCurrentWellRates(wellName, rates);
-        }
+                         const WellState<double>& wellState,
+                         GroupState<double>& group_state)
+{
+    for (const std::string& groupName : group.groups()) {
+        const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+        updateVREPForGroups(groupTmp, schedule, reportStepIdx, wellState, group_state);
     }
+    const int np = wellState.numPhases();
+    double resv = 0.0;
+    for (int phase = 0; phase < np; ++phase) {
+        resv += sumWellPhaseRates(true,
+                                  group,
+                                  schedule,
+                                  wellState,
+                                  reportStepIdx,
+                                  phase,
+                                  /*isInjector*/ false);
+    }
+    group_state.update_injection_vrep_rate(group.name(), resv);
+}
 
-    void updateGroupProductionRates(const Group& group,
-                                    const Schedule& schedule,
-                                    const int reportStepIdx,
-                                    const WellState<double>& wellState,
-                                    GroupState<double>& group_state)
-    {
-        for (const std::string& groupName : group.groups()) {
-            const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            updateGroupProductionRates(groupTmp, schedule, reportStepIdx, wellState, group_state);
-        }
-        const int np = wellState.numPhases();
+void updateReservoirRatesInjectionGroups(const Group& group,
+                                         const Schedule& schedule,
+                                         const int reportStepIdx,
+                                         const WellState<double>& wellState,
+                                         GroupState<double>& group_state)
+{
+    for (const std::string& groupName : group.groups()) {
+        const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+        updateReservoirRatesInjectionGroups(groupTmp, schedule, reportStepIdx, wellState, group_state);
+    }
+    const int np = wellState.numPhases();
+    std::vector<double> resv(np, 0.0);
+    for (int phase = 0; phase < np; ++phase) {
+        resv[phase] = sumWellPhaseRates(true,
+                                        group,
+                                        schedule,
+                                        wellState,
+                                        reportStepIdx,
+                                        phase,
+                                        /*isInjector*/ true);
+    }
+    group_state.update_injection_reservoir_rates(group.name(), resv);
+}
+
+void updateSurfaceRatesInjectionGroups(const Group& group,
+                                       const Schedule& schedule,
+                                       const int reportStepIdx,
+                                       const WellState<double>& wellState,
+                                       GroupState<double>& group_state)
+{
+    for (const std::string& groupName : group.groups()) {
+        const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+        updateSurfaceRatesInjectionGroups(groupTmp, schedule, reportStepIdx, wellState, group_state);
+    }
+    const int np = wellState.numPhases();
+    std::vector<double> rates(np, 0.0);
+    for (int phase = 0; phase < np; ++phase) {
+        rates[phase] = sumWellPhaseRates(false,
+                                        group,
+                                        schedule,
+                                        wellState,
+                                        reportStepIdx,
+                                        phase,
+                                        /*isInjector*/ true);
+    }
+    group_state.update_injection_surface_rates(group.name(), rates);
+}
+
+void updateWellRates(const Group& group,
+                     const Schedule& schedule,
+                     const int reportStepIdx,
+                     const WellState<double>& wellStateNupcol,
+                     WellState<double>& wellState)
+{
+    for (const std::string& groupName : group.groups()) {
+        const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+        updateWellRates(groupTmp, schedule, reportStepIdx, wellStateNupcol, wellState);
+    }
+    const int np = wellState.numPhases();
+    for (const std::string& wellName : group.wells()) {
         std::vector<double> rates(np, 0.0);
-        for (int phase = 0; phase < np; ++phase) {
-            rates[phase] = sumWellPhaseRates(false, group, schedule, wellState, reportStepIdx, phase, /*isInjector*/ false);
-        }
-        group_state.update_production_rates(group.name(), rates);
-    }
-
-
-    void updateREINForGroups(const Group& group,
-                             const Schedule& schedule,
-                             const int reportStepIdx,
-                             const PhaseUsage& pu,
-                             const SummaryState& st,
-                             const WellState<double>& wellState,
-                             GroupState<double>& group_state,
-                             bool sum_rank)
-    {
-        const int np = wellState.numPhases();
-        for (const std::string& groupName : group.groups()) {
-            const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            updateREINForGroups(groupTmp, schedule, reportStepIdx, pu, st, wellState, group_state, sum_rank);
-        }
-
-        std::vector<double> rein(np, 0.0);
-        for (int phase = 0; phase < np; ++phase) {
-            rein[phase] = sumWellPhaseRates(false, group, schedule, wellState, reportStepIdx, phase, /*isInjector*/ false);
-        }
-
-        // add import rate and subtract consumption rate for group for gas
-        if (sum_rank) {
-            if (schedule[reportStepIdx].gconsump().has(group.name())) {
-                const auto& gconsump = schedule[reportStepIdx].gconsump().get(group.name(), st);
-                if (pu.phase_used[BlackoilPhases::Vapour]) {
-                    rein[pu.phase_pos[BlackoilPhases::Vapour]] += gconsump.import_rate;
-                    rein[pu.phase_pos[BlackoilPhases::Vapour]] -= gconsump.consumption_rate;
-                }
-            }
-        }
-
-        group_state.update_injection_rein_rates(group.name(), rein);
-    }
-
-
-    template <class RegionalValues>
-    void updateGpMaintTargetForGroups(const Group& group,
-                                      const Schedule& schedule,
-                                      const RegionalValues& regional_values,
-                                      const int reportStepIdx,
-                                      const double dt,
-                                      const WellState<double>& well_state,
-                                      GroupState<double>& group_state)
-    {
-        for (const std::string& groupName : group.groups()) {
-            const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
-            updateGpMaintTargetForGroups(groupTmp, schedule, regional_values, reportStepIdx, dt, well_state, group_state);
-        }
-        const auto& gpm = group.gpmaint();
-        if (!gpm)
-            return;
-
-        const auto& region = gpm->region();
-        if (!region)
-            return;
-
-        const auto [name, number] = *region;
-        const double error = gpm->pressure_target() - regional_values.at(name)->pressure(number);
-        double current_rate = 0.0;
-        const auto& pu = well_state.phaseUsage();
-        bool injection = true;
-        double sign = 1.0;
-        switch (gpm->flow_target()) {
-            case GPMaint::FlowTarget::RESV_PROD:
-            {
-                current_rate = -group_state.injection_vrep_rate(group.name());
-                injection = false;
-                sign = -1.0;
-                break;
-            }
-            case GPMaint::FlowTarget::RESV_OINJ:
-            {
-                if (pu.phase_used[BlackoilPhases::Liquid])
-                    current_rate = group_state.injection_reservoir_rates(group.name())[pu.phase_pos[BlackoilPhases::Liquid]];
-
-                break;
-            }
-            case GPMaint::FlowTarget::RESV_WINJ:
-            {
-                if (pu.phase_used[BlackoilPhases::Aqua])
-                    current_rate = group_state.injection_reservoir_rates(group.name())[pu.phase_pos[BlackoilPhases::Aqua]];
-
-                break;
-            }
-            case GPMaint::FlowTarget::RESV_GINJ:
-            {
-                if (pu.phase_used[BlackoilPhases::Vapour])
-                    current_rate = group_state.injection_reservoir_rates(group.name())[pu.phase_pos[BlackoilPhases::Vapour]];
-                break;
-            }
-            case GPMaint::FlowTarget::SURF_OINJ:
-            {
-                if (pu.phase_used[BlackoilPhases::Liquid])
-                    current_rate = group_state.injection_surface_rates(group.name())[pu.phase_pos[BlackoilPhases::Liquid]];
-
-                break;
-            }
-            case GPMaint::FlowTarget::SURF_WINJ:
-            {
-                if (pu.phase_used[BlackoilPhases::Aqua])
-                    current_rate = group_state.injection_surface_rates(group.name())[pu.phase_pos[BlackoilPhases::Aqua]];
-
-                break;
-            }
-            case GPMaint::FlowTarget::SURF_GINJ:
-            {
-                if (pu.phase_used[BlackoilPhases::Vapour])
-                    current_rate = group_state.injection_surface_rates(group.name())[pu.phase_pos[BlackoilPhases::Vapour]];
-
-                break;
-            }
-            default:
-                throw std::invalid_argument("Invalid Flow target type in GPMAINT");
-        }
-        auto& gpmaint_state = group_state.gpmaint(group.name());
-        // we only activate gpmaint if pressure is lower than the target regional pressure for injectors
-        // (i.e. error > 0) and higher for producers.
-        bool activate = (injection && error > 0) || (!injection && error < 0);
-        double rate = activate? gpm->rate(gpmaint_state, current_rate, error, dt) : 0.0;
-        group_state.update_gpmaint_target(group.name(), std::max(0.0, sign * rate));
-    }
-
-
-
-
-    std::map<std::string, double>
-    computeNetworkPressures(const Opm::Network::ExtNetwork& network,
-                            const WellState<double>& well_state,
-                            const GroupState<double>& group_state,
-                            const VFPProdProperties& vfp_prod_props,
-                            const Schedule& schedule,
-                            const int report_time_step)
-    {
-        // TODO: Only dealing with production networks for now.
-
-        if (!network.active()) {
-            return {};
-        }
-
-        std::map<std::string, double> node_pressures;
-        auto roots = network.roots();
-        for (const auto& root : roots) {
-            // Fixed pressure nodes of the network are the roots of trees.
-            // Leaf nodes must correspond to groups in the group structure.
-            // Let us first find all leaf nodes of the network. We also
-            // create a vector of all nodes, ordered so that a child is
-            // always after its parent.
-            std::stack<std::string> children;
-            std::set<std::string> leaf_nodes;
-            std::vector<std::string> root_to_child_nodes;
-            //children.push(network.root().name());
-            children.push(root.get().name());
-            while (!children.empty()) {
-                const auto node = children.top();
-                children.pop();
-                root_to_child_nodes.push_back(node);
-                auto branches = network.downtree_branches(node);
-                if (branches.empty()) {
-                    leaf_nodes.insert(node);
-                }
-                for (const auto& branch : branches) {
-                    children.push(branch.downtree_node());
-                }
-            }
-            assert(children.empty());
-
-            // Starting with the leaf nodes of the network, get the flow rates
-            // from the corresponding groups.
-            std::map<std::string, std::vector<double>> node_inflows;
-            for (const auto& node : leaf_nodes) {
-                node_inflows[node] = group_state.production_rates(node);
-                // Add the ALQ amounts to the gas rates if requested.
-                if (network.node(node).add_gas_lift_gas()) {
-                    const auto& group = schedule.getGroup(node, report_time_step);
-                    for (const std::string& wellname : group.wells()) {
-                        const Well& well = schedule.getWell(wellname, report_time_step);
-                        if (well.isInjector()) continue;
-                        // Here we use the efficiency unconditionally, but if WEFAC item 3
-                        // for the well is false (it defaults to true) then we should NOT use
-                        // the efficiency factor. Fixing this requires not only changing the
-                        // code here, but also:
-                        //    - Adding a member to the well for this flag, and setting it in Schedule::handleWEFAC().
-                        //    - Making the wells' maximum flows (i.e. not time-averaged by using a efficiency factor)
-                        //      available and using those (for wells with WEFAC(3) true only) when accumulating group
-                        //      rates, but ONLY for network calculations.
-                        const double efficiency = well.getEfficiencyFactor();
-                        node_inflows[node][BlackoilPhases::Vapour] += well_state.getALQ(wellname) * efficiency;
-                    }
-                }
-            }
-
-            // Accumulate in the network, towards the roots. Note that a
-            // root (i.e. fixed pressure node) can still be contributing
-            // flow towards other nodes in the network, i.e.  a node is
-            // the root of a subtree.
-            auto child_to_root_nodes = root_to_child_nodes;
-            std::reverse(child_to_root_nodes.begin(), child_to_root_nodes.end());
-            for (const auto& node : child_to_root_nodes) {
-                const auto upbranch = network.uptree_branch(node);
-                if (upbranch) {
-                    // Add downbranch rates to upbranch.
-                    std::vector<double>& up = node_inflows[(*upbranch).uptree_node()];
-                    const std::vector<double>& down = node_inflows[node];
-                    if (up.empty()) {
-                        up = down;
-                    } else {
-                        assert (up.size() == down.size());
-                        for (std::size_t ii = 0; ii < up.size(); ++ii) {
-                            up[ii] += down[ii];
-                        }
-                    }
-                }
-            }
-
-            // Going the other way (from roots to leafs), calculate the pressure
-            // at each node using VFP tables and rates.
-            //std::map<std::string, double> node_pressures;
-            for (const auto& node : root_to_child_nodes) {
-                auto press = network.node(node).terminal_pressure();
-                if (press) {
-                    node_pressures[node] = *press;
-                } else {
-                    const auto upbranch = network.uptree_branch(node);
-                    assert(upbranch);
-                    const double up_press = node_pressures[(*upbranch).uptree_node()];
-                    const auto vfp_table = (*upbranch).vfp_table();
-                    if (vfp_table) {
-                        // The rates are here positive, but the VFP code expects the
-                        // convention that production rates are negative, so we must
-                        // take a copy and flip signs.
-                        auto rates = node_inflows[node];
-                        for (auto& r : rates) { r *= -1.0; }
-                        assert(rates.size() == 3);
-                        const double alq = 0.0; // TODO: Do not ignore ALQ
-                        node_pressures[node] = vfp_prod_props.bhp(*vfp_table,
-                                                                rates[BlackoilPhases::Aqua],
-                                                                rates[BlackoilPhases::Liquid],
-                                                                rates[BlackoilPhases::Vapour],
-                                                                up_press,
-                                                                alq,
-                                                                0.0, //explicit_wfr
-                                                                0.0, //explicit_gfr
-                                                                false); //use_expvfp we dont support explicit lookup
-    #define EXTRA_DEBUG_NETWORK 0
-    #if EXTRA_DEBUG_NETWORK
-                        std::ostringstream oss;
-                        oss << "parent: " << (*upbranch).uptree_node() << "  child: " << node
-                            << "  rates = [ " << rates[0]*86400 << ", " << rates[1]*86400 << ", " << rates[2]*86400 << " ]"
-                            << "  p(parent) = " << up_press/1e5 << "  p(child) = " << node_pressures[node]/1e5 << std::endl;
-                        OpmLog::debug(oss.str());
-    #endif
-                    } else {
-                        // Table number specified as 9999 in the deck, no pressure loss.
-                        node_pressures[node] = up_press;
-                    }
-                }
-            }
-        }
-        return node_pressures;
-    }
-
-
-
-
-    GuideRate::RateVector
-    getWellRateVector(const WellState<double>& well_state,
-                      const PhaseUsage& pu,
-                      const std::string& name)
-    {
-        return getGuideRateVector(well_state.currentWellRates(name), pu);
-    }
-
-    GuideRate::RateVector
-    getProductionGroupRateVector(const GroupState<double>& group_state,
-                                 const PhaseUsage& pu,
-                                 const std::string& group_name)
-    {
-        return getGuideRateVector(group_state.production_rates(group_name), pu);
-    }
-
-    double getGuideRate(const std::string& name,
-                        const Schedule& schedule,
-                        const WellState<double>& wellState,
-                        const GroupState<double>& group_state,
-                        const int reportStepIdx,
-                        const GuideRate* guideRate,
-                        const GuideRateModel::Target target,
-                        const PhaseUsage& pu)
-    {
-        if (schedule.hasWell(name, reportStepIdx)) {
-            if (guideRate->has(name) || guideRate->hasPotentials(name)) {
-                return guideRate->get(name, target, getWellRateVector(wellState, pu, name));
-            } else {
-                return 0.0;
-            }
-        }
-
-        if (guideRate->has(name)) {
-            return guideRate->get(name, target, getProductionGroupRateVector(group_state, pu, name));
-        }
-
-        double totalGuideRate = 0.0;
-        const Group& group = schedule.getGroup(name, reportStepIdx);
-
-        for (const std::string& groupName : group.groups()) {
-            const Group::ProductionCMode& currentGroupControl = group_state.production_control(groupName);
-            if (currentGroupControl == Group::ProductionCMode::FLD
-                || currentGroupControl == Group::ProductionCMode::NONE) {
-                // accumulate from sub wells/groups
-                totalGuideRate += getGuideRate(groupName, schedule, wellState, group_state, reportStepIdx, guideRate, target, pu);
-            }
-        }
-
-        for (const std::string& wellName : group.wells()) {
+        const auto& well_index = wellState.index(wellName);
+        if (well_index.has_value()) { // the well is found on this node
             const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
-
-            if (wellTmp.isInjector())
-                continue;
-
-            if (wellTmp.getStatus() == Well::Status::SHUT)
-                continue;
-
-            // Only count wells under group control or the ru
-            if (!wellState.isProductionGrup(wellName))
-                continue;
-
-            totalGuideRate += getGuideRate(wellName, schedule, wellState, group_state,
-                                           reportStepIdx, guideRate, target, pu);
-
-        }
-        return totalGuideRate;
-    }
-
-
-    double getGuideRateInj(const std::string& name,
-                           const Schedule& schedule,
-                           const WellState<double>& wellState,
-                           const GroupState<double>& group_state,
-                           const int reportStepIdx,
-                           const GuideRate* guideRate,
-                           const GuideRateModel::Target target,
-                           const Phase& injectionPhase,
-                           const PhaseUsage& pu)
-    {
-        if (schedule.hasWell(name, reportStepIdx)) {
-            return getGuideRate(name, schedule, wellState, group_state,
-                                reportStepIdx, guideRate, target, pu);
-        }
-
-        if (guideRate->has(name, injectionPhase)) {
-            return guideRate->get(name, injectionPhase);
-        }
-
-        double totalGuideRate = 0.0;
-        const Group& group = schedule.getGroup(name, reportStepIdx);
-
-        for (const std::string& groupName : group.groups()) {
-            const Group::InjectionCMode& currentGroupControl
-                = group_state.injection_control(groupName, injectionPhase);
-            if (currentGroupControl == Group::InjectionCMode::FLD
-                || currentGroupControl == Group::InjectionCMode::NONE) {
-                // accumulate from sub wells/groups
-                totalGuideRate += getGuideRateInj(groupName, schedule, wellState, group_state, reportStepIdx, guideRate, target, injectionPhase, pu);
-            }
-        }
-
-        for (const std::string& wellName : group.wells()) {
-            const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
-
+            int sign = 1;
+            // production wellRates are negative. The users of currentWellRates uses the convention in
+            // opm-common that production and injection rates are positive.
             if (!wellTmp.isInjector())
-                continue;
-
-            if (wellTmp.getStatus() == Well::Status::SHUT)
-                continue;
-
-            // Only count wells under group control or the ru
-            if (!wellState.isInjectionGrup(wellName))
-                continue;
-
-            totalGuideRate += guideRate->get(wellName, target, getWellRateVector(wellState, pu, wellName));
+                sign = -1;
+            const auto& ws = wellStateNupcol.well(well_index.value());
+            for (int phase = 0; phase < np; ++phase) {
+                rates[phase] = sign * ws.surface_rates[phase];
+            }
         }
-        return totalGuideRate;
+        wellState.setCurrentWellRates(wellName, rates);
+    }
+}
+
+void updateGroupProductionRates(const Group& group,
+                                const Schedule& schedule,
+                                const int reportStepIdx,
+                                const WellState<double>& wellState,
+                                GroupState<double>& group_state)
+{
+    for (const std::string& groupName : group.groups()) {
+        const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+        updateGroupProductionRates(groupTmp, schedule, reportStepIdx, wellState, group_state);
+    }
+    const int np = wellState.numPhases();
+    std::vector<double> rates(np, 0.0);
+    for (int phase = 0; phase < np; ++phase) {
+        rates[phase] = sumWellPhaseRates(false, group, schedule, wellState, reportStepIdx, phase, /*isInjector*/ false);
+    }
+    group_state.update_production_rates(group.name(), rates);
+}
+
+
+void updateREINForGroups(const Group& group,
+                         const Schedule& schedule,
+                         const int reportStepIdx,
+                         const PhaseUsage& pu,
+                         const SummaryState& st,
+                         const WellState<double>& wellState,
+                         GroupState<double>& group_state,
+                         bool sum_rank)
+{
+    const int np = wellState.numPhases();
+    for (const std::string& groupName : group.groups()) {
+        const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+        updateREINForGroups(groupTmp, schedule, reportStepIdx, pu, st, wellState, group_state, sum_rank);
     }
 
-
-
-    int groupControlledWells(const Schedule& schedule,
-                             const WellState<double>& well_state,
-                             const GroupState<double>& group_state,
-                             const int report_step,
-                             const std::string& group_name,
-                             const std::string& always_included_child,
-                             const bool is_production_group,
-                             const Phase injection_phase)
-    {
-        const Group& group = schedule.getGroup(group_name, report_step);
-        int num_wells = 0;
-        for (const std::string& child_group : group.groups()) {
-
-            bool included = (child_group == always_included_child);
-            if (is_production_group) {
-                const auto ctrl = group_state.production_control(child_group);
-                included = included || (ctrl == Group::ProductionCMode::FLD) || (ctrl == Group::ProductionCMode::NONE);
-            } else {
-                const auto ctrl = group_state.injection_control(child_group, injection_phase);
-                included = included || (ctrl == Group::InjectionCMode::FLD) || (ctrl == Group::InjectionCMode::NONE);
-            }
-
-            if (included) {
-                num_wells
-                    += groupControlledWells(schedule, well_state, group_state, report_step, child_group, always_included_child, is_production_group, injection_phase);
-            }
-        }
-        for (const std::string& child_well : group.wells()) {
-            bool included = (child_well == always_included_child);
-            if (is_production_group) {
-                included = included || well_state.isProductionGrup(child_well);
-            } else {
-                included = included || well_state.isInjectionGrup(child_well);
-            }
-            if (included) {
-                ++num_wells;
-            }
-        }
-        return num_wells;
+    std::vector<double> rein(np, 0.0);
+    for (int phase = 0; phase < np; ++phase) {
+        rein[phase] = sumWellPhaseRates(false, group, schedule, wellState, reportStepIdx, phase, /*isInjector*/ false);
     }
 
-    std::vector<std::string>
-    groupChainTopBot(const std::string& bottom, const std::string& top, const Schedule& schedule, const int report_step)
-    {
-        // Get initial parent, 'bottom' can be a well or a group.
-        std::string parent;
-        if (schedule.hasWell(bottom, report_step)) {
-            parent = schedule.getWell(bottom, report_step).groupName();
-        } else {
-            parent = schedule.getGroup(bottom, report_step).parent();
+    // add import rate and subtract consumption rate for group for gas
+    if (sum_rank) {
+        if (schedule[reportStepIdx].gconsump().has(group.name())) {
+            const auto& gconsump = schedule[reportStepIdx].gconsump().get(group.name(), st);
+            if (pu.phase_used[BlackoilPhases::Vapour]) {
+                rein[pu.phase_pos[BlackoilPhases::Vapour]] += gconsump.import_rate;
+                rein[pu.phase_pos[BlackoilPhases::Vapour]] -= gconsump.consumption_rate;
+            }
         }
-
-        // Build the chain from bottom to top.
-        std::vector<std::string> chain;
-        chain.push_back(bottom);
-        chain.push_back(parent);
-        while (parent != top) {
-            parent = schedule.getGroup(parent, report_step).parent();
-            chain.push_back(parent);
-        }
-        assert(chain.back() == top);
-
-        // Reverse order and return.
-        std::reverse(chain.begin(), chain.end());
-        return chain;
     }
 
+    group_state.update_injection_rein_rates(group.name(), rein);
+}
 
 
+template <class RegionalValues>
+void updateGpMaintTargetForGroups(const Group& group,
+                                  const Schedule& schedule,
+                                  const RegionalValues& regional_values,
+                                  const int reportStepIdx,
+                                  const double dt,
+                                  const WellState<double>& well_state,
+                                  GroupState<double>& group_state)
+{
+    for (const std::string& groupName : group.groups()) {
+        const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+        updateGpMaintTargetForGroups(groupTmp, schedule, regional_values, reportStepIdx, dt, well_state, group_state);
+    }
+    const auto& gpm = group.gpmaint();
+    if (!gpm)
+        return;
 
-    std::pair<bool, double> checkGroupConstraintsProd(const std::string& name,
-                                                      const std::string& parent,
-                                                      const Group& group,
-                                                      const WellState<double>& wellState,
-                                                      const GroupState<double>& group_state,
-                                                      const int reportStepIdx,
-                                                      const GuideRate* guideRate,
-                                                      const double* rates,
-                                                      const PhaseUsage& pu,
-                                                      const double efficiencyFactor,
-                                                      const Schedule& schedule,
-                                                      const SummaryState& summaryState,
-                                                      const std::vector<double>& resv_coeff,
-                                                      DeferredLogger& deferred_logger)
-    {
-        // When called for a well ('name' is a well name), 'parent'
-        // will be the name of 'group'. But if we recurse, 'name' and
-        // 'parent' will stay fixed while 'group' will be higher up
-        // in the group tree.
-        // efficiencyfactor is the well efficiency factor for the first group the well is
-        // part of. Later it is the accumulated factor including the group efficiency factor
-        // of the child of group.
+    const auto& region = gpm->region();
+    if (!region)
+        return;
 
-        const Group::ProductionCMode& currentGroupControl = group_state.production_control(group.name());
-
-        if (currentGroupControl == Group::ProductionCMode::FLD || currentGroupControl == Group::ProductionCMode::NONE) {
-            // Return if we are not available for parent group.
-            if (!group.productionGroupControlAvailable()) {
-                return std::make_pair(false, 1);
-            }
-            // Otherwise: check production share of parent's control.
-            const auto& parentGroup = schedule.getGroup(group.parent(), reportStepIdx);
-            return checkGroupConstraintsProd(name,
-                                             parent,
-                                             parentGroup,
-                                             wellState,
-                                             group_state,
-                                             reportStepIdx,
-                                             guideRate,
-                                             rates,
-                                             pu,
-                                             efficiencyFactor * group.getGroupEfficiencyFactor(),
-                                             schedule,
-                                             summaryState,
-                                             resv_coeff,
-                                             deferred_logger);
+    const auto [name, number] = *region;
+    const double error = gpm->pressure_target() - regional_values.at(name)->pressure(number);
+    double current_rate = 0.0;
+    const auto& pu = well_state.phaseUsage();
+    bool injection = true;
+    double sign = 1.0;
+    switch (gpm->flow_target()) {
+        case GPMaint::FlowTarget::RESV_PROD:
+        {
+            current_rate = -group_state.injection_vrep_rate(group.name());
+            injection = false;
+            sign = -1.0;
+            break;
         }
+        case GPMaint::FlowTarget::RESV_OINJ:
+        {
+            if (pu.phase_used[BlackoilPhases::Liquid])
+                current_rate = group_state.injection_reservoir_rates(group.name())[pu.phase_pos[BlackoilPhases::Liquid]];
 
-        // This can be false for FLD-controlled groups, we must therefore
-        // check for FLD first (done above).
-        if (!group.isProductionGroup()) {
-            return std::make_pair(false, 1.0);
+            break;
         }
+        case GPMaint::FlowTarget::RESV_WINJ:
+        {
+            if (pu.phase_used[BlackoilPhases::Aqua])
+                current_rate = group_state.injection_reservoir_rates(group.name())[pu.phase_pos[BlackoilPhases::Aqua]];
 
-        // If we are here, we are at the topmost group to be visited in the recursion.
-        // This is the group containing the control we will check against.
-
-        // gconsale may adjust the grat target.
-        // the adjusted rates is send to the targetCalculator
-        double gratTargetFromSales = 0.0;
-        if (group_state.has_grat_sales_target(group.name()))
-            gratTargetFromSales = group_state.grat_sales_target(group.name());
-
-        TargetCalculator tcalc(currentGroupControl, pu, resv_coeff, gratTargetFromSales, group.name(), group_state, group.has_gpmaint_control(currentGroupControl));
-        FractionCalculator fcalc(schedule, wellState, group_state, reportStepIdx, guideRate, tcalc.guideTargetMode(), pu, true, Phase::OIL);
-
-        auto localFraction = [&](const std::string& child) { return fcalc.localFraction(child, name); };
-
-        auto localReduction = [&](const std::string& group_name) {
-            const std::vector<double>& groupTargetReductions = group_state.production_reduction_rates(group_name);
-            return tcalc.calcModeRateFromRates(groupTargetReductions);
-        };
-
-        auto localCurrentRate = [&](const std::string& group_name) {
-            const std::vector<double>& groupSurfaceRates = group_state.production_rates(group_name);
-            return tcalc.calcModeRateFromRates(groupSurfaceRates);
-        };
-
-        std::optional<Group::ProductionControls> ctrl;
-        if (!group.has_gpmaint_control(currentGroupControl))
-            ctrl = group.productionControls(summaryState);
-
-        const double orig_target = tcalc.groupTarget(ctrl, deferred_logger);
-        // Assume we have a chain of groups as follows: BOTTOM -> MIDDLE -> TOP.
-        // Then ...
-        // TODO finish explanation.
-        const double current_rate
-            = -tcalc.calcModeRateFromRates(rates); // Switch sign since 'rates' are negative for producers.
-        const auto chain = groupChainTopBot(name, group.name(), schedule, reportStepIdx);
-        // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
-        const std::size_t num_ancestors = chain.size() - 1;
-        // we need to find out the level where the current well is applied to the local reduction
-        std::size_t local_reduction_level = 0;
-        for (std::size_t ii = 1; ii < num_ancestors; ++ii) {
-            const int num_gr_ctrl = groupControlledWells(schedule,
-                                                         wellState,
-                                                         group_state,
-                                                         reportStepIdx,
-                                                         chain[ii],
-                                                         "",
-                                                         /*is_producer*/ true,
-                                                         /*injectionPhaseNotUsed*/ Phase::OIL);
-            if (guideRate->has(chain[ii]) && num_gr_ctrl > 0) {
-                local_reduction_level = ii;
-            }
+            break;
         }
-        // check whether guide rate is violated
-        for (std::size_t ii = 1; ii < num_ancestors; ++ii) {
-            if (guideRate->has(chain[ii])) {
-                const auto& guided_group = chain[ii];
-                const double grefficiency
-                            = schedule.getGroup(guided_group, reportStepIdx).getGroupEfficiencyFactor();
-                const double currentRateFraction = grefficiency * localCurrentRate(guided_group) / (localCurrentRate(chain[ii-1]));
-                const double guiderateFraction = localFraction(guided_group);
-                // we add a factor here to avoid switching due to numerical instability
-                const double factor = 1.01;
-                if (currentRateFraction > (guiderateFraction * factor)) {
-                    return std::make_pair(true, guiderateFraction/currentRateFraction);
-                }
-            }
+        case GPMaint::FlowTarget::RESV_GINJ:
+        {
+            if (pu.phase_used[BlackoilPhases::Vapour])
+                current_rate = group_state.injection_reservoir_rates(group.name())[pu.phase_pos[BlackoilPhases::Vapour]];
+            break;
         }
-        double target = orig_target;
-        for (std::size_t ii = 0; ii < num_ancestors; ++ii) {
-            if ((ii == 0) || guideRate->has(chain[ii])) {
-                // Apply local reductions only at the control level
-                // (top) and for levels where we have a specified
-                // group guide rate.
-                if (local_reduction_level >= ii ) {
-                    target -= localReduction(chain[ii]);
-                }
-                // Add my reduction back at the level where it is included in the local reduction
-                if (local_reduction_level == ii ) {
-                    target += current_rate * efficiencyFactor;
-                }
-            }
-            target *= localFraction(chain[ii + 1]);
-        }
-        // Avoid negative target rates comming from too large local reductions.
-        const double target_rate = std::max(1e-12, target / efficiencyFactor);
-        double scale = 1.0;
-        if (current_rate > 1e-12)
-            scale = target_rate / current_rate;
+        case GPMaint::FlowTarget::SURF_OINJ:
+        {
+            if (pu.phase_used[BlackoilPhases::Liquid])
+                current_rate = group_state.injection_surface_rates(group.name())[pu.phase_pos[BlackoilPhases::Liquid]];
 
-        return std::make_pair(current_rate > target_rate, scale);
+            break;
+        }
+        case GPMaint::FlowTarget::SURF_WINJ:
+        {
+            if (pu.phase_used[BlackoilPhases::Aqua])
+                current_rate = group_state.injection_surface_rates(group.name())[pu.phase_pos[BlackoilPhases::Aqua]];
+
+            break;
+        }
+        case GPMaint::FlowTarget::SURF_GINJ:
+        {
+            if (pu.phase_used[BlackoilPhases::Vapour])
+                current_rate = group_state.injection_surface_rates(group.name())[pu.phase_pos[BlackoilPhases::Vapour]];
+
+            break;
+        }
+        default:
+            throw std::invalid_argument("Invalid Flow target type in GPMAINT");
+    }
+    auto& gpmaint_state = group_state.gpmaint(group.name());
+    // we only activate gpmaint if pressure is lower than the target regional pressure for injectors
+    // (i.e. error > 0) and higher for producers.
+    bool activate = (injection && error > 0) || (!injection && error < 0);
+    double rate = activate? gpm->rate(gpmaint_state, current_rate, error, dt) : 0.0;
+    group_state.update_gpmaint_target(group.name(), std::max(0.0, sign * rate));
+}
+
+
+
+
+std::map<std::string, double>
+computeNetworkPressures(const Opm::Network::ExtNetwork& network,
+                        const WellState<double>& well_state,
+                        const GroupState<double>& group_state,
+                        const VFPProdProperties& vfp_prod_props,
+                        const Schedule& schedule,
+                        const int report_time_step)
+{
+    // TODO: Only dealing with production networks for now.
+
+    if (!network.active()) {
+        return {};
     }
 
-    std::pair<bool, double> checkGroupConstraintsInj(const std::string& name,
-                                                     const std::string& parent,
-                                                     const Group& group,
-                                                     const WellState<double>& wellState,
-                                                     const GroupState<double>& group_state,
-                                                     const int reportStepIdx,
-                                                     const GuideRate* guideRate,
-                                                     const double* rates,
-                                                     Phase injectionPhase,
-                                                     const PhaseUsage& pu,
-                                                     const double efficiencyFactor,
-                                                     const Schedule& schedule,
-                                                     const SummaryState& summaryState,
-                                                     const std::vector<double>& resv_coeff,
-                                                     DeferredLogger& deferred_logger)
-    {
-        // When called for a well ('name' is a well name), 'parent'
-        // will be the name of 'group'. But if we recurse, 'name' and
-        // 'parent' will stay fixed while 'group' will be higher up
-        // in the group tree.
-        // efficiencyfactor is the well efficiency factor for the first group the well is
-        // part of. Later it is the accumulated factor including the group efficiency factor
-        // of the child of group.
-
-        auto currentGroupControl = group_state.injection_control(group.name(), injectionPhase);
-
-        if (currentGroupControl == Group::InjectionCMode::FLD || currentGroupControl == Group::InjectionCMode::NONE) {
-            // Return if we are not available for parent group.
-            if (!group.injectionGroupControlAvailable(injectionPhase)) {
-                return std::make_pair(false, 1);
+    std::map<std::string, double> node_pressures;
+    auto roots = network.roots();
+    for (const auto& root : roots) {
+        // Fixed pressure nodes of the network are the roots of trees.
+        // Leaf nodes must correspond to groups in the group structure.
+        // Let us first find all leaf nodes of the network. We also
+        // create a vector of all nodes, ordered so that a child is
+        // always after its parent.
+        std::stack<std::string> children;
+        std::set<std::string> leaf_nodes;
+        std::vector<std::string> root_to_child_nodes;
+        //children.push(network.root().name());
+        children.push(root.get().name());
+        while (!children.empty()) {
+            const auto node = children.top();
+            children.pop();
+            root_to_child_nodes.push_back(node);
+            auto branches = network.downtree_branches(node);
+            if (branches.empty()) {
+                leaf_nodes.insert(node);
             }
-            // Otherwise: check production share of parent's control.
-            const auto& parentGroup = schedule.getGroup(group.parent(), reportStepIdx);
-            return checkGroupConstraintsInj(name,
-                                             parent,
-                                             parentGroup,
-                                             wellState,
-                                            group_state,
-                                             reportStepIdx,
-                                             guideRate,
-                                             rates,
-                                             injectionPhase,
-                                             pu,
-                                             efficiencyFactor * group.getGroupEfficiencyFactor(),
-                                             schedule,
-                                             summaryState,
-                                             resv_coeff,
-                                             deferred_logger);
-        }
-
-        // This can be false for FLD-controlled groups, we must therefore
-        // check for FLD first (done above).
-        if (!group.isInjectionGroup()) {
-            return std::make_pair(false, 1.0);
-        }
-
-        // If we are here, we are at the topmost group to be visited in the recursion.
-        // This is the group containing the control we will check against.
-        double sales_target = 0;
-        if (schedule[reportStepIdx].gconsale().has(group.name())) {
-            const auto& gconsale = schedule[reportStepIdx].gconsale().get(group.name(), summaryState);
-            sales_target = gconsale.sales_target;
-        }
-        InjectionTargetCalculator tcalc(currentGroupControl, pu, resv_coeff, group.name(), sales_target, group_state, injectionPhase, group.has_gpmaint_control(injectionPhase, currentGroupControl), deferred_logger);
-        FractionCalculator fcalc(schedule, wellState, group_state, reportStepIdx, guideRate, tcalc.guideTargetMode(), pu, false, injectionPhase);
-
-        auto localFraction = [&](const std::string& child) { return fcalc.localFraction(child, name); };
-
-        auto localReduction = [&](const std::string& group_name) {
-            const std::vector<double>& groupTargetReductions = group_state.injection_reduction_rates(group_name);
-            return tcalc.calcModeRateFromRates(groupTargetReductions);
-        };
-
-        auto localCurrentRate = [&](const std::string& group_name) {
-            const std::vector<double>& groupSurfaceRates = group_state.injection_surface_rates(group_name);
-            return tcalc.calcModeRateFromRates(groupSurfaceRates);
-        };
-
-        std::optional<Group::InjectionControls> ctrl;
-        if (!group.has_gpmaint_control(injectionPhase, currentGroupControl))
-            ctrl = group.injectionControls(injectionPhase, summaryState);
-
-
-        const double orig_target = tcalc.groupTarget(ctrl, deferred_logger);
-        // Assume we have a chain of groups as follows: BOTTOM -> MIDDLE -> TOP.
-        // Then ...
-        // TODO finish explanation.
-        const double current_rate
-            = tcalc.calcModeRateFromRates(rates); // Switch sign since 'rates' are negative for producers.
-        const auto chain = groupChainTopBot(name, group.name(), schedule, reportStepIdx);
-        // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
-        const std::size_t num_ancestors = chain.size() - 1;
-        // we need to find out the level where the current well is applied to the local reduction
-        std::size_t local_reduction_level = 0;
-        for (std::size_t ii = 1; ii < num_ancestors; ++ii) {
-            const int num_gr_ctrl = groupControlledWells(schedule,
-                                                         wellState,
-                                                                 group_state,
-                                                                 reportStepIdx,
-                                                                 chain[ii],
-                                                                 "",
-                                                                 /*is_producer*/ false,
-                                                                 injectionPhase);
-            if (guideRate->has(chain[ii], injectionPhase) && num_gr_ctrl > 0) {
-                local_reduction_level = ii;
+            for (const auto& branch : branches) {
+                children.push(branch.downtree_node());
             }
         }
+        assert(children.empty());
 
-        // check whether guide rate is violated
-        for (std::size_t ii = 1; ii < num_ancestors; ++ii) {
-            if (guideRate->has(chain[ii], injectionPhase)) {
-                const auto& guided_group = chain[ii];
-                const double grefficiency
-                            = schedule.getGroup(guided_group, reportStepIdx).getGroupEfficiencyFactor();
-                const double currentRateFraction = grefficiency * localCurrentRate(guided_group) / (localCurrentRate(chain[ii-1]));
-                const double guiderateFraction = localFraction(guided_group);
-                // we add a factor here to avoid switching due to numerical instability
-                const double factor = 1.01;
-                if (currentRateFraction > (guiderateFraction * factor)) {
-                    return std::make_pair(true, guiderateFraction/currentRateFraction);
+        // Starting with the leaf nodes of the network, get the flow rates
+        // from the corresponding groups.
+        std::map<std::string, std::vector<double>> node_inflows;
+        for (const auto& node : leaf_nodes) {
+            node_inflows[node] = group_state.production_rates(node);
+            // Add the ALQ amounts to the gas rates if requested.
+            if (network.node(node).add_gas_lift_gas()) {
+                const auto& group = schedule.getGroup(node, report_time_step);
+                for (const std::string& wellname : group.wells()) {
+                    const Well& well = schedule.getWell(wellname, report_time_step);
+                    if (well.isInjector()) continue;
+                    // Here we use the efficiency unconditionally, but if WEFAC item 3
+                    // for the well is false (it defaults to true) then we should NOT use
+                    // the efficiency factor. Fixing this requires not only changing the
+                    // code here, but also:
+                    //    - Adding a member to the well for this flag, and setting it in Schedule::handleWEFAC().
+                    //    - Making the wells' maximum flows (i.e. not time-averaged by using a efficiency factor)
+                    //      available and using those (for wells with WEFAC(3) true only) when accumulating group
+                    //      rates, but ONLY for network calculations.
+                    const double efficiency = well.getEfficiencyFactor();
+                    node_inflows[node][BlackoilPhases::Vapour] += well_state.getALQ(wellname) * efficiency;
                 }
             }
         }
 
-        double target = orig_target;
-        for (std::size_t ii = 0; ii < num_ancestors; ++ii) {
-            if ((ii == 0) || guideRate->has(chain[ii], injectionPhase)) {
-                // Apply local reductions only at the control level
-                // (top) and for levels where we have a specified
-                // group guide rate.
-                if (local_reduction_level >= ii ) {
-                    target -= localReduction(chain[ii]);
-                }
-
-                // Add my reduction back at the level where it is included in the local reduction
-                if (local_reduction_level == ii ) {
-                    target += current_rate * efficiencyFactor;
-                }
-            }
-            target *= localFraction(chain[ii + 1]);
-        }
-        // Avoid negative target rates comming from too large local reductions.
-        const double target_rate = std::max(1e-12, target / efficiencyFactor);
-        double scale = 1.0;
-        if (current_rate > 1e-12)
-            scale = target_rate / current_rate;
-
-        return std::make_pair(current_rate > target_rate, scale);
-    }
-
-    std::pair<std::optional<std::string>, double>
-    worstOffendingWell(const Group& group,
-                       const Schedule& schedule,
-                       const int reportStepIdx,
-                       const Group::ProductionCMode& offendedControl,
-                       const PhaseUsage& pu,
-                       const Parallel::Communication& comm,
-                       const WellState<double>& wellState,
-                       DeferredLogger& deferred_logger)
-    {
-        std::pair<std::optional<std::string>, double> offending_well {std::nullopt, 0.0};
-        for (const std::string& child_group : group.groups()) {
-            const auto& this_group = schedule.getGroup(child_group, reportStepIdx);
-            const auto & offending_well_this = worstOffendingWell(this_group,
-                                                                 schedule,
-                                                                 reportStepIdx,
-                                                                 offendedControl,
-                                                                 pu,
-                                                                 comm,
-                                                                 wellState,
-                                                                 deferred_logger);
-            if (offending_well_this.second > offending_well.second) {
-                offending_well = offending_well_this;
-            }
-        }    
-
-        for (const std::string& child_well : group.wells()) {
-
-            const auto& well_index = wellState.index(child_well);
-            double violating_rate = 0.0;
-            double prefered_rate = 0.0;
-            if (well_index.has_value() && wellState.wellIsOwned(well_index.value(), child_well))
-            {
-                const auto& ws = wellState.well(child_well);
-                switch (offendedControl){
-                    case Group::ProductionCMode::ORAT:
-                        violating_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Liquid]];
-                        break;
-                    case Group::ProductionCMode::GRAT:
-                        violating_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Vapour]];
-                        break;
-                    case Group::ProductionCMode::WRAT:
-                        violating_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Aqua]];
-                        break;
-                    case Group::ProductionCMode::LRAT:
-                        assert(pu.phase_used[BlackoilPhases::Liquid]);
-                        assert(pu.phase_used[BlackoilPhases::Aqua]);
-                        violating_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Liquid]] +
-                                         ws.surface_rates[pu.phase_pos[BlackoilPhases::Aqua]];
-                        break;
-                    case Group::ProductionCMode::RESV:
-                        for (int p = 0; p < pu.num_phases; ++p) {
-                            violating_rate += ws.reservoir_rates[p];
-                        }
-                        break;
-                    case Group::ProductionCMode::NONE:
-                        break;
-                    case Group::ProductionCMode::FLD:
-                        break;
-                    case Group::ProductionCMode::PRBL:
-                        OPM_DEFLOG_THROW(std::runtime_error,
-                                         "Group " + group.name() +
-                                         "GroupProductionCMode PRBL not implemented", deferred_logger);
-                        break;    
-                    case Group::ProductionCMode::CRAT:
-                        OPM_DEFLOG_THROW(std::runtime_error,
-                                         "Group " + group.name() +
-                                         "GroupProductionCMode CRAT not implemented", deferred_logger);
-                        break;    
-                }
-                const auto preferred_phase = schedule.getWell(child_well, reportStepIdx).getPreferredPhase();
-                 switch (preferred_phase) {
-                    case Phase::OIL:
-                        prefered_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Liquid]];
-                        break;
-                    case Phase::GAS:
-                        prefered_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Vapour]];
-                        break;
-                    case Phase::WATER:
-                        prefered_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Aqua]];
-                        break;
-                    default:
-                        // No others supported.
-                        break;
+        // Accumulate in the network, towards the roots. Note that a
+        // root (i.e. fixed pressure node) can still be contributing
+        // flow towards other nodes in the network, i.e.  a node is
+        // the root of a subtree.
+        auto child_to_root_nodes = root_to_child_nodes;
+        std::reverse(child_to_root_nodes.begin(), child_to_root_nodes.end());
+        for (const auto& node : child_to_root_nodes) {
+            const auto upbranch = network.uptree_branch(node);
+            if (upbranch) {
+                // Add downbranch rates to upbranch.
+                std::vector<double>& up = node_inflows[(*upbranch).uptree_node()];
+                const std::vector<double>& down = node_inflows[node];
+                if (up.empty()) {
+                    up = down;
+                } else {
+                    assert (up.size() == down.size());
+                    for (std::size_t ii = 0; ii < up.size(); ++ii) {
+                        up[ii] += down[ii];
                     }
-            }
-            violating_rate = comm.sum(violating_rate);
-            if (violating_rate < 0 ) { // only check producing wells
-                prefered_rate = comm.sum(prefered_rate);
-                double fraction = prefered_rate < -1e-16 ? violating_rate / prefered_rate : 1.0;
-                if ( fraction > offending_well.second) {
-                        offending_well = {child_well, fraction};
                 }
             }
         }
-        return offending_well; 
+
+        // Going the other way (from roots to leafs), calculate the pressure
+        // at each node using VFP tables and rates.
+        //std::map<std::string, double> node_pressures;
+        for (const auto& node : root_to_child_nodes) {
+            auto press = network.node(node).terminal_pressure();
+            if (press) {
+                node_pressures[node] = *press;
+            } else {
+                const auto upbranch = network.uptree_branch(node);
+                assert(upbranch);
+                const double up_press = node_pressures[(*upbranch).uptree_node()];
+                const auto vfp_table = (*upbranch).vfp_table();
+                if (vfp_table) {
+                    // The rates are here positive, but the VFP code expects the
+                    // convention that production rates are negative, so we must
+                    // take a copy and flip signs.
+                    auto rates = node_inflows[node];
+                    for (auto& r : rates) { r *= -1.0; }
+                    assert(rates.size() == 3);
+                    const double alq = 0.0; // TODO: Do not ignore ALQ
+                    node_pressures[node] = vfp_prod_props.bhp(*vfp_table,
+                                                            rates[BlackoilPhases::Aqua],
+                                                            rates[BlackoilPhases::Liquid],
+                                                            rates[BlackoilPhases::Vapour],
+                                                            up_press,
+                                                            alq,
+                                                            0.0, //explicit_wfr
+                                                            0.0, //explicit_gfr
+                                                            false); //use_expvfp we dont support explicit lookup
+#define EXTRA_DEBUG_NETWORK 0
+#if EXTRA_DEBUG_NETWORK
+                    std::ostringstream oss;
+                    oss << "parent: " << (*upbranch).uptree_node() << "  child: " << node
+                        << "  rates = [ " << rates[0]*86400 << ", " << rates[1]*86400 << ", " << rates[2]*86400 << " ]"
+                        << "  p(parent) = " << up_press/1e5 << "  p(child) = " << node_pressures[node]/1e5 << std::endl;
+                    OpmLog::debug(oss.str());
+#endif
+                } else {
+                    // Table number specified as 9999 in the deck, no pressure loss.
+                    node_pressures[node] = up_press;
+                }
+            }
+        }
+    }
+    return node_pressures;
+}
+
+
+
+
+GuideRate::RateVector
+getWellRateVector(const WellState<double>& well_state,
+                  const PhaseUsage& pu,
+                  const std::string& name)
+{
+    return getGuideRateVector(well_state.currentWellRates(name), pu);
+}
+
+GuideRate::RateVector
+getProductionGroupRateVector(const GroupState<double>& group_state,
+                             const PhaseUsage& pu,
+                             const std::string& group_name)
+{
+    return getGuideRateVector(group_state.production_rates(group_name), pu);
+}
+
+double getGuideRate(const std::string& name,
+                    const Schedule& schedule,
+                    const WellState<double>& wellState,
+                    const GroupState<double>& group_state,
+                    const int reportStepIdx,
+                    const GuideRate* guideRate,
+                    const GuideRateModel::Target target,
+                    const PhaseUsage& pu)
+{
+    if (schedule.hasWell(name, reportStepIdx)) {
+        if (guideRate->has(name) || guideRate->hasPotentials(name)) {
+            return guideRate->get(name, target, getWellRateVector(wellState, pu, name));
+        } else {
+            return 0.0;
+        }
     }
 
-    template <class AverageRegionalPressureType>
-    void setRegionAveragePressureCalculator(const Group& group,
-                                            const Schedule& schedule,
-                                            const int reportStepIdx,
-                                            const FieldPropsManager& fp,
-                                            const PhaseUsage& pu,
-                                            std::map<std::string, std::unique_ptr<AverageRegionalPressureType>>& regionalAveragePressureCalculator)
-    {
-        for (const std::string& groupName : group.groups()) {
-            setRegionAveragePressureCalculator( schedule.getGroup(groupName, reportStepIdx), schedule,
-                                                reportStepIdx, fp, pu, regionalAveragePressureCalculator);
-        }
-        const auto& gpm = group.gpmaint();
-        if (!gpm)
-            return;
+    if (guideRate->has(name)) {
+        return guideRate->get(name, target, getProductionGroupRateVector(group_state, pu, name));
+    }
 
-        const auto& reg = gpm->region();
-        if (!reg)
-            return;
+    double totalGuideRate = 0.0;
+    const Group& group = schedule.getGroup(name, reportStepIdx);
 
-        if (regionalAveragePressureCalculator.count(reg->first) == 0) {
-            const std::string name = (reg->first.rfind("FIP", 0) == 0) ? reg->first : "FIP" + reg->first;
-            const auto& fipnum = fp.get_int(name);
-            regionalAveragePressureCalculator[reg->first] = std::make_unique<AverageRegionalPressureType>(pu,fipnum);
+    for (const std::string& groupName : group.groups()) {
+        const Group::ProductionCMode& currentGroupControl = group_state.production_control(groupName);
+        if (currentGroupControl == Group::ProductionCMode::FLD
+            || currentGroupControl == Group::ProductionCMode::NONE) {
+            // accumulate from sub wells/groups
+            totalGuideRate += getGuideRate(groupName, schedule, wellState, group_state, reportStepIdx, guideRate, target, pu);
         }
     }
 
-    void updateGuideRates(const Group& group,
-                          const Schedule& schedule,
-                          const SummaryState& summary_state,
-                          const PhaseUsage& pu,
-                          const int report_step,
-                          const double sim_time,
-                          WellState<double>& well_state,
-                          const GroupState<double>& group_state,
-                          const Parallel::Communication& comm,
-                          GuideRate* guide_rate,
-                          std::vector<double>& pot,
-                          Opm::DeferredLogger& deferred_logger)
-    {
-        guide_rate->updateGuideRateExpiration(sim_time, report_step);
-        updateGuideRateForProductionGroups(group, schedule, pu, report_step, sim_time, well_state, group_state, comm, guide_rate, pot);
-        updateGuideRatesForInjectionGroups(group, schedule, summary_state, pu, report_step, well_state, group_state, guide_rate, deferred_logger);
-        updateGuideRatesForWells(schedule, pu, report_step, sim_time, well_state, comm, guide_rate);
+    for (const std::string& wellName : group.wells()) {
+        const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
+
+        if (wellTmp.isInjector())
+            continue;
+
+        if (wellTmp.getStatus() == Well::Status::SHUT)
+            continue;
+
+        // Only count wells under group control or the ru
+        if (!wellState.isProductionGrup(wellName))
+            continue;
+
+        totalGuideRate += getGuideRate(wellName, schedule, wellState, group_state,
+                                       reportStepIdx, guideRate, target, pu);
+
+    }
+    return totalGuideRate;
+}
+
+
+double getGuideRateInj(const std::string& name,
+                       const Schedule& schedule,
+                       const WellState<double>& wellState,
+                       const GroupState<double>& group_state,
+                       const int reportStepIdx,
+                       const GuideRate* guideRate,
+                       const GuideRateModel::Target target,
+                       const Phase& injectionPhase,
+                       const PhaseUsage& pu)
+{
+    if (schedule.hasWell(name, reportStepIdx)) {
+        return getGuideRate(name, schedule, wellState, group_state,
+                            reportStepIdx, guideRate, target, pu);
     }
 
-    void updateGuideRateForProductionGroups(const Group& group,
-                                            const Schedule& schedule,
-                                            const PhaseUsage& pu,
-                                            const int reportStepIdx,
-                                            const double& simTime,
-                                            WellState<double>& wellState,
-                                            const GroupState<double>& group_state,
-                                            const Parallel::Communication& comm,
-                                            GuideRate* guideRate,
-                                            std::vector<double>& pot)
-    {
-        const int np = pu.num_phases;
-        for (const std::string& groupName : group.groups()) {
-            std::vector<double> thisPot(np, 0.0);
-            const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+    if (guideRate->has(name, injectionPhase)) {
+        return guideRate->get(name, injectionPhase);
+    }
 
-            // Note that group effiency factors for groupTmp are applied in updateGuideRateForGroups
-            updateGuideRateForProductionGroups(groupTmp, schedule, pu, reportStepIdx, simTime, wellState, group_state, comm, guideRate, thisPot);
+    double totalGuideRate = 0.0;
+    const Group& group = schedule.getGroup(name, reportStepIdx);
 
-            // accumulate group contribution from sub group unconditionally
-            const auto currentGroupControl = group_state.production_control(groupName);
-            if (currentGroupControl != Group::ProductionCMode::FLD
-                    && currentGroupControl != Group::ProductionCMode::NONE) {
-                continue;
-            }
-
-            // Apply group efficiency factor for this goup
-            auto gefac = groupTmp.getGroupEfficiencyFactor();
-
-            for (int phase = 0; phase < np; phase++) {
-                pot[phase] += gefac*thisPot[phase];
-            }
-
+    for (const std::string& groupName : group.groups()) {
+        const Group::InjectionCMode& currentGroupControl
+            = group_state.injection_control(groupName, injectionPhase);
+        if (currentGroupControl == Group::InjectionCMode::FLD
+            || currentGroupControl == Group::InjectionCMode::NONE) {
+            // accumulate from sub wells/groups
+            totalGuideRate += getGuideRateInj(groupName, schedule, wellState, group_state, reportStepIdx, guideRate, target, injectionPhase, pu);
         }
-        for (const std::string& wellName : group.wells()) {
-            const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
-            const auto wefac = wellTmp.getEfficiencyFactor();
+    }
 
-            if (wellTmp.isInjector())
-                continue;
+    for (const std::string& wellName : group.wells()) {
+        const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
 
-            if (wellTmp.getStatus() == Well::Status::SHUT)
-                continue;
-            const auto& well_index = wellState.index(wellName);
-            if (!well_index.has_value()) // the well is not found
-                continue;
+        if (!wellTmp.isInjector())
+            continue;
 
-            if (! wellState.wellIsOwned(well_index.value(), wellName) ) // Only sum once
-            {
-                continue;
-            }
+        if (wellTmp.getStatus() == Well::Status::SHUT)
+            continue;
 
-            const auto& ws = wellState.well(well_index.value());
-            // add contribution from wells unconditionally
-            for (int phase = 0; phase < np; phase++) {
-                pot[phase] += wefac * ws.well_potentials[phase];
-            }
+        // Only count wells under group control or the ru
+        if (!wellState.isInjectionGrup(wellName))
+            continue;
+
+        totalGuideRate += guideRate->get(wellName, target, getWellRateVector(wellState, pu, wellName));
+    }
+    return totalGuideRate;
+}
+
+
+
+int groupControlledWells(const Schedule& schedule,
+                         const WellState<double>& well_state,
+                         const GroupState<double>& group_state,
+                         const int report_step,
+                         const std::string& group_name,
+                         const std::string& always_included_child,
+                         const bool is_production_group,
+                         const Phase injection_phase)
+{
+    const Group& group = schedule.getGroup(group_name, report_step);
+    int num_wells = 0;
+    for (const std::string& child_group : group.groups()) {
+
+        bool included = (child_group == always_included_child);
+        if (is_production_group) {
+            const auto ctrl = group_state.production_control(child_group);
+            included = included || (ctrl == Group::ProductionCMode::FLD) || (ctrl == Group::ProductionCMode::NONE);
+        } else {
+            const auto ctrl = group_state.injection_control(child_group, injection_phase);
+            included = included || (ctrl == Group::InjectionCMode::FLD) || (ctrl == Group::InjectionCMode::NONE);
         }
 
+        if (included) {
+            num_wells
+                += groupControlledWells(schedule, well_state, group_state, report_step, child_group, always_included_child, is_production_group, injection_phase);
+        }
+    }
+    for (const std::string& child_well : group.wells()) {
+        bool included = (child_well == always_included_child);
+        if (is_production_group) {
+            included = included || well_state.isProductionGrup(child_well);
+        } else {
+            included = included || well_state.isInjectionGrup(child_well);
+        }
+        if (included) {
+            ++num_wells;
+        }
+    }
+    return num_wells;
+}
+
+std::vector<std::string>
+groupChainTopBot(const std::string& bottom, const std::string& top, const Schedule& schedule, const int report_step)
+{
+    // Get initial parent, 'bottom' can be a well or a group.
+    std::string parent;
+    if (schedule.hasWell(bottom, report_step)) {
+        parent = schedule.getWell(bottom, report_step).groupName();
+    } else {
+        parent = schedule.getGroup(bottom, report_step).parent();
+    }
+
+    // Build the chain from bottom to top.
+    std::vector<std::string> chain;
+    chain.push_back(bottom);
+    chain.push_back(parent);
+    while (parent != top) {
+        parent = schedule.getGroup(parent, report_step).parent();
+        chain.push_back(parent);
+    }
+    assert(chain.back() == top);
+
+    // Reverse order and return.
+    std::reverse(chain.begin(), chain.end());
+    return chain;
+}
+
+
+
+
+std::pair<bool, double> checkGroupConstraintsProd(const std::string& name,
+                                                  const std::string& parent,
+                                                  const Group& group,
+                                                  const WellState<double>& wellState,
+                                                  const GroupState<double>& group_state,
+                                                  const int reportStepIdx,
+                                                  const GuideRate* guideRate,
+                                                  const double* rates,
+                                                  const PhaseUsage& pu,
+                                                  const double efficiencyFactor,
+                                                  const Schedule& schedule,
+                                                  const SummaryState& summaryState,
+                                                  const std::vector<double>& resv_coeff,
+                                                  DeferredLogger& deferred_logger)
+{
+    // When called for a well ('name' is a well name), 'parent'
+    // will be the name of 'group'. But if we recurse, 'name' and
+    // 'parent' will stay fixed while 'group' will be higher up
+    // in the group tree.
+    // efficiencyfactor is the well efficiency factor for the first group the well is
+    // part of. Later it is the accumulated factor including the group efficiency factor
+    // of the child of group.
+
+    const Group::ProductionCMode& currentGroupControl = group_state.production_control(group.name());
+
+    if (currentGroupControl == Group::ProductionCMode::FLD || currentGroupControl == Group::ProductionCMode::NONE) {
+        // Return if we are not available for parent group.
+        if (!group.productionGroupControlAvailable()) {
+            return std::make_pair(false, 1);
+        }
+        // Otherwise: check production share of parent's control.
+        const auto& parentGroup = schedule.getGroup(group.parent(), reportStepIdx);
+        return checkGroupConstraintsProd(name,
+                                         parent,
+                                         parentGroup,
+                                         wellState,
+                                         group_state,
+                                         reportStepIdx,
+                                         guideRate,
+                                         rates,
+                                         pu,
+                                         efficiencyFactor * group.getGroupEfficiencyFactor(),
+                                         schedule,
+                                         summaryState,
+                                         resv_coeff,
+                                         deferred_logger);
+    }
+
+    // This can be false for FLD-controlled groups, we must therefore
+    // check for FLD first (done above).
+    if (!group.isProductionGroup()) {
+        return std::make_pair(false, 1.0);
+    }
+
+    // If we are here, we are at the topmost group to be visited in the recursion.
+    // This is the group containing the control we will check against.
+
+    // gconsale may adjust the grat target.
+    // the adjusted rates is send to the targetCalculator
+    double gratTargetFromSales = 0.0;
+    if (group_state.has_grat_sales_target(group.name()))
+        gratTargetFromSales = group_state.grat_sales_target(group.name());
+
+    TargetCalculator tcalc(currentGroupControl, pu, resv_coeff, gratTargetFromSales, group.name(), group_state, group.has_gpmaint_control(currentGroupControl));
+    FractionCalculator fcalc(schedule, wellState, group_state, reportStepIdx, guideRate, tcalc.guideTargetMode(), pu, true, Phase::OIL);
+
+    auto localFraction = [&](const std::string& child) { return fcalc.localFraction(child, name); };
+
+    auto localReduction = [&](const std::string& group_name) {
+        const std::vector<double>& groupTargetReductions = group_state.production_reduction_rates(group_name);
+        return tcalc.calcModeRateFromRates(groupTargetReductions);
+    };
+
+    auto localCurrentRate = [&](const std::string& group_name) {
+        const std::vector<double>& groupSurfaceRates = group_state.production_rates(group_name);
+        return tcalc.calcModeRateFromRates(groupSurfaceRates);
+    };
+
+    std::optional<Group::ProductionControls> ctrl;
+    if (!group.has_gpmaint_control(currentGroupControl))
+        ctrl = group.productionControls(summaryState);
+
+    const double orig_target = tcalc.groupTarget(ctrl, deferred_logger);
+    // Assume we have a chain of groups as follows: BOTTOM -> MIDDLE -> TOP.
+    // Then ...
+    // TODO finish explanation.
+    const double current_rate
+        = -tcalc.calcModeRateFromRates(rates); // Switch sign since 'rates' are negative for producers.
+    const auto chain = groupChainTopBot(name, group.name(), schedule, reportStepIdx);
+    // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
+    const std::size_t num_ancestors = chain.size() - 1;
+    // we need to find out the level where the current well is applied to the local reduction
+    std::size_t local_reduction_level = 0;
+    for (std::size_t ii = 1; ii < num_ancestors; ++ii) {
+        const int num_gr_ctrl = groupControlledWells(schedule,
+                                                     wellState,
+                                                     group_state,
+                                                     reportStepIdx,
+                                                     chain[ii],
+                                                     "",
+                                                     /*is_producer*/ true,
+                                                     /*injectionPhaseNotUsed*/ Phase::OIL);
+        if (guideRate->has(chain[ii]) && num_gr_ctrl > 0) {
+            local_reduction_level = ii;
+        }
+    }
+    // check whether guide rate is violated
+    for (std::size_t ii = 1; ii < num_ancestors; ++ii) {
+        if (guideRate->has(chain[ii])) {
+            const auto& guided_group = chain[ii];
+            const double grefficiency
+                        = schedule.getGroup(guided_group, reportStepIdx).getGroupEfficiencyFactor();
+            const double currentRateFraction = grefficiency * localCurrentRate(guided_group) / (localCurrentRate(chain[ii-1]));
+            const double guiderateFraction = localFraction(guided_group);
+            // we add a factor here to avoid switching due to numerical instability
+            const double factor = 1.01;
+            if (currentRateFraction > (guiderateFraction * factor)) {
+                return std::make_pair(true, guiderateFraction/currentRateFraction);
+            }
+        }
+    }
+    double target = orig_target;
+    for (std::size_t ii = 0; ii < num_ancestors; ++ii) {
+        if ((ii == 0) || guideRate->has(chain[ii])) {
+            // Apply local reductions only at the control level
+            // (top) and for levels where we have a specified
+            // group guide rate.
+            if (local_reduction_level >= ii ) {
+                target -= localReduction(chain[ii]);
+            }
+            // Add my reduction back at the level where it is included in the local reduction
+            if (local_reduction_level == ii ) {
+                target += current_rate * efficiencyFactor;
+            }
+        }
+        target *= localFraction(chain[ii + 1]);
+    }
+    // Avoid negative target rates comming from too large local reductions.
+    const double target_rate = std::max(1e-12, target / efficiencyFactor);
+    double scale = 1.0;
+    if (current_rate > 1e-12)
+        scale = target_rate / current_rate;
+
+    return std::make_pair(current_rate > target_rate, scale);
+}
+
+std::pair<bool, double> checkGroupConstraintsInj(const std::string& name,
+                                                 const std::string& parent,
+                                                 const Group& group,
+                                                 const WellState<double>& wellState,
+                                                 const GroupState<double>& group_state,
+                                                 const int reportStepIdx,
+                                                 const GuideRate* guideRate,
+                                                 const double* rates,
+                                                 Phase injectionPhase,
+                                                 const PhaseUsage& pu,
+                                                 const double efficiencyFactor,
+                                                 const Schedule& schedule,
+                                                 const SummaryState& summaryState,
+                                                 const std::vector<double>& resv_coeff,
+                                                 DeferredLogger& deferred_logger)
+{
+    // When called for a well ('name' is a well name), 'parent'
+    // will be the name of 'group'. But if we recurse, 'name' and
+    // 'parent' will stay fixed while 'group' will be higher up
+    // in the group tree.
+    // efficiencyfactor is the well efficiency factor for the first group the well is
+    // part of. Later it is the accumulated factor including the group efficiency factor
+    // of the child of group.
+
+    auto currentGroupControl = group_state.injection_control(group.name(), injectionPhase);
+
+    if (currentGroupControl == Group::InjectionCMode::FLD || currentGroupControl == Group::InjectionCMode::NONE) {
+        // Return if we are not available for parent group.
+        if (!group.injectionGroupControlAvailable(injectionPhase)) {
+            return std::make_pair(false, 1);
+        }
+        // Otherwise: check production share of parent's control.
+        const auto& parentGroup = schedule.getGroup(group.parent(), reportStepIdx);
+        return checkGroupConstraintsInj(name,
+                                         parent,
+                                         parentGroup,
+                                         wellState,
+                                        group_state,
+                                         reportStepIdx,
+                                         guideRate,
+                                         rates,
+                                         injectionPhase,
+                                         pu,
+                                         efficiencyFactor * group.getGroupEfficiencyFactor(),
+                                         schedule,
+                                         summaryState,
+                                         resv_coeff,
+                                         deferred_logger);
+    }
+
+    // This can be false for FLD-controlled groups, we must therefore
+    // check for FLD first (done above).
+    if (!group.isInjectionGroup()) {
+        return std::make_pair(false, 1.0);
+    }
+
+    // If we are here, we are at the topmost group to be visited in the recursion.
+    // This is the group containing the control we will check against.
+    double sales_target = 0;
+    if (schedule[reportStepIdx].gconsale().has(group.name())) {
+        const auto& gconsale = schedule[reportStepIdx].gconsale().get(group.name(), summaryState);
+        sales_target = gconsale.sales_target;
+    }
+    InjectionTargetCalculator tcalc(currentGroupControl, pu, resv_coeff, group.name(), sales_target, group_state, injectionPhase, group.has_gpmaint_control(injectionPhase, currentGroupControl), deferred_logger);
+    FractionCalculator fcalc(schedule, wellState, group_state, reportStepIdx, guideRate, tcalc.guideTargetMode(), pu, false, injectionPhase);
+
+    auto localFraction = [&](const std::string& child) { return fcalc.localFraction(child, name); };
+
+    auto localReduction = [&](const std::string& group_name) {
+        const std::vector<double>& groupTargetReductions = group_state.injection_reduction_rates(group_name);
+        return tcalc.calcModeRateFromRates(groupTargetReductions);
+    };
+
+    auto localCurrentRate = [&](const std::string& group_name) {
+        const std::vector<double>& groupSurfaceRates = group_state.injection_surface_rates(group_name);
+        return tcalc.calcModeRateFromRates(groupSurfaceRates);
+    };
+
+    std::optional<Group::InjectionControls> ctrl;
+    if (!group.has_gpmaint_control(injectionPhase, currentGroupControl))
+        ctrl = group.injectionControls(injectionPhase, summaryState);
+
+
+    const double orig_target = tcalc.groupTarget(ctrl, deferred_logger);
+    // Assume we have a chain of groups as follows: BOTTOM -> MIDDLE -> TOP.
+    // Then ...
+    // TODO finish explanation.
+    const double current_rate
+        = tcalc.calcModeRateFromRates(rates); // Switch sign since 'rates' are negative for producers.
+    const auto chain = groupChainTopBot(name, group.name(), schedule, reportStepIdx);
+    // Because 'name' is the last of the elements, and not an ancestor, we subtract one below.
+    const std::size_t num_ancestors = chain.size() - 1;
+    // we need to find out the level where the current well is applied to the local reduction
+    std::size_t local_reduction_level = 0;
+    for (std::size_t ii = 1; ii < num_ancestors; ++ii) {
+        const int num_gr_ctrl = groupControlledWells(schedule,
+                                                     wellState,
+                                                             group_state,
+                                                             reportStepIdx,
+                                                             chain[ii],
+                                                             "",
+                                                             /*is_producer*/ false,
+                                                             injectionPhase);
+        if (guideRate->has(chain[ii], injectionPhase) && num_gr_ctrl > 0) {
+            local_reduction_level = ii;
+        }
+    }
+
+    // check whether guide rate is violated
+    for (std::size_t ii = 1; ii < num_ancestors; ++ii) {
+        if (guideRate->has(chain[ii], injectionPhase)) {
+            const auto& guided_group = chain[ii];
+            const double grefficiency
+                        = schedule.getGroup(guided_group, reportStepIdx).getGroupEfficiencyFactor();
+            const double currentRateFraction = grefficiency * localCurrentRate(guided_group) / (localCurrentRate(chain[ii-1]));
+            const double guiderateFraction = localFraction(guided_group);
+            // we add a factor here to avoid switching due to numerical instability
+            const double factor = 1.01;
+            if (currentRateFraction > (guiderateFraction * factor)) {
+                return std::make_pair(true, guiderateFraction/currentRateFraction);
+            }
+        }
+    }
+
+    double target = orig_target;
+    for (std::size_t ii = 0; ii < num_ancestors; ++ii) {
+        if ((ii == 0) || guideRate->has(chain[ii], injectionPhase)) {
+            // Apply local reductions only at the control level
+            // (top) and for levels where we have a specified
+            // group guide rate.
+            if (local_reduction_level >= ii ) {
+                target -= localReduction(chain[ii]);
+            }
+
+            // Add my reduction back at the level where it is included in the local reduction
+            if (local_reduction_level == ii ) {
+                target += current_rate * efficiencyFactor;
+            }
+        }
+        target *= localFraction(chain[ii + 1]);
+    }
+    // Avoid negative target rates comming from too large local reductions.
+    const double target_rate = std::max(1e-12, target / efficiencyFactor);
+    double scale = 1.0;
+    if (current_rate > 1e-12)
+        scale = target_rate / current_rate;
+
+    return std::make_pair(current_rate > target_rate, scale);
+}
+
+std::pair<std::optional<std::string>, double>
+worstOffendingWell(const Group& group,
+                   const Schedule& schedule,
+                   const int reportStepIdx,
+                   const Group::ProductionCMode& offendedControl,
+                   const PhaseUsage& pu,
+                   const Parallel::Communication& comm,
+                   const WellState<double>& wellState,
+                   DeferredLogger& deferred_logger)
+{
+    std::pair<std::optional<std::string>, double> offending_well {std::nullopt, 0.0};
+    for (const std::string& child_group : group.groups()) {
+        const auto& this_group = schedule.getGroup(child_group, reportStepIdx);
+        const auto & offending_well_this = worstOffendingWell(this_group,
+                                                             schedule,
+                                                             reportStepIdx,
+                                                             offendedControl,
+                                                             pu,
+                                                             comm,
+                                                             wellState,
+                                                             deferred_logger);
+        if (offending_well_this.second > offending_well.second) {
+            offending_well = offending_well_this;
+        }
+    }
+
+    for (const std::string& child_well : group.wells()) {
+
+        const auto& well_index = wellState.index(child_well);
+        double violating_rate = 0.0;
+        double prefered_rate = 0.0;
+        if (well_index.has_value() && wellState.wellIsOwned(well_index.value(), child_well))
+        {
+            const auto& ws = wellState.well(child_well);
+            switch (offendedControl){
+                case Group::ProductionCMode::ORAT:
+                    violating_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Liquid]];
+                    break;
+                case Group::ProductionCMode::GRAT:
+                    violating_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Vapour]];
+                    break;
+                case Group::ProductionCMode::WRAT:
+                    violating_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Aqua]];
+                    break;
+                case Group::ProductionCMode::LRAT:
+                    assert(pu.phase_used[BlackoilPhases::Liquid]);
+                    assert(pu.phase_used[BlackoilPhases::Aqua]);
+                    violating_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Liquid]] +
+                                     ws.surface_rates[pu.phase_pos[BlackoilPhases::Aqua]];
+                    break;
+                case Group::ProductionCMode::RESV:
+                    for (int p = 0; p < pu.num_phases; ++p) {
+                        violating_rate += ws.reservoir_rates[p];
+                    }
+                    break;
+                case Group::ProductionCMode::NONE:
+                    break;
+                case Group::ProductionCMode::FLD:
+                    break;
+                case Group::ProductionCMode::PRBL:
+                    OPM_DEFLOG_THROW(std::runtime_error,
+                                     "Group " + group.name() +
+                                     "GroupProductionCMode PRBL not implemented", deferred_logger);
+                    break;
+                case Group::ProductionCMode::CRAT:
+                    OPM_DEFLOG_THROW(std::runtime_error,
+                                     "Group " + group.name() +
+                                     "GroupProductionCMode CRAT not implemented", deferred_logger);
+                    break;
+            }
+            const auto preferred_phase = schedule.getWell(child_well, reportStepIdx).getPreferredPhase();
+             switch (preferred_phase) {
+                case Phase::OIL:
+                    prefered_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Liquid]];
+                    break;
+                case Phase::GAS:
+                    prefered_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Vapour]];
+                    break;
+                case Phase::WATER:
+                    prefered_rate = ws.surface_rates[pu.phase_pos[BlackoilPhases::Aqua]];
+                    break;
+                default:
+                    // No others supported.
+                    break;
+                }
+        }
+        violating_rate = comm.sum(violating_rate);
+        if (violating_rate < 0 ) { // only check producing wells
+            prefered_rate = comm.sum(prefered_rate);
+            double fraction = prefered_rate < -1e-16 ? violating_rate / prefered_rate : 1.0;
+            if ( fraction > offending_well.second) {
+                    offending_well = {child_well, fraction};
+            }
+        }
+    }
+    return offending_well;
+}
+
+template <class AverageRegionalPressureType>
+void setRegionAveragePressureCalculator(const Group& group,
+                                        const Schedule& schedule,
+                                        const int reportStepIdx,
+                                        const FieldPropsManager& fp,
+                                        const PhaseUsage& pu,
+                                        std::map<std::string, std::unique_ptr<AverageRegionalPressureType>>& regionalAveragePressureCalculator)
+{
+    for (const std::string& groupName : group.groups()) {
+        setRegionAveragePressureCalculator( schedule.getGroup(groupName, reportStepIdx), schedule,
+                                            reportStepIdx, fp, pu, regionalAveragePressureCalculator);
+    }
+    const auto& gpm = group.gpmaint();
+    if (!gpm)
+        return;
+
+    const auto& reg = gpm->region();
+    if (!reg)
+        return;
+
+    if (regionalAveragePressureCalculator.count(reg->first) == 0) {
+        const std::string name = (reg->first.rfind("FIP", 0) == 0) ? reg->first : "FIP" + reg->first;
+        const auto& fipnum = fp.get_int(name);
+        regionalAveragePressureCalculator[reg->first] = std::make_unique<AverageRegionalPressureType>(pu,fipnum);
+    }
+}
+
+void updateGuideRates(const Group& group,
+                      const Schedule& schedule,
+                      const SummaryState& summary_state,
+                      const PhaseUsage& pu,
+                      const int report_step,
+                      const double sim_time,
+                      WellState<double>& well_state,
+                      const GroupState<double>& group_state,
+                      const Parallel::Communication& comm,
+                      GuideRate* guide_rate,
+                      std::vector<double>& pot,
+                      Opm::DeferredLogger& deferred_logger)
+{
+    guide_rate->updateGuideRateExpiration(sim_time, report_step);
+    updateGuideRateForProductionGroups(group, schedule, pu, report_step, sim_time, well_state, group_state, comm, guide_rate, pot);
+    updateGuideRatesForInjectionGroups(group, schedule, summary_state, pu, report_step, well_state, group_state, guide_rate, deferred_logger);
+    updateGuideRatesForWells(schedule, pu, report_step, sim_time, well_state, comm, guide_rate);
+}
+
+void updateGuideRateForProductionGroups(const Group& group,
+                                        const Schedule& schedule,
+                                        const PhaseUsage& pu,
+                                        const int reportStepIdx,
+                                        const double& simTime,
+                                        WellState<double>& wellState,
+                                        const GroupState<double>& group_state,
+                                        const Parallel::Communication& comm,
+                                        GuideRate* guideRate,
+                                        std::vector<double>& pot)
+{
+    const int np = pu.num_phases;
+    for (const std::string& groupName : group.groups()) {
+        std::vector<double> thisPot(np, 0.0);
+        const Group& groupTmp = schedule.getGroup(groupName, reportStepIdx);
+
+        // Note that group effiency factors for groupTmp are applied in updateGuideRateForGroups
+        updateGuideRateForProductionGroups(groupTmp, schedule, pu, reportStepIdx, simTime, wellState, group_state, comm, guideRate, thisPot);
+
+        // accumulate group contribution from sub group unconditionally
+        const auto currentGroupControl = group_state.production_control(groupName);
+        if (currentGroupControl != Group::ProductionCMode::FLD
+                && currentGroupControl != Group::ProductionCMode::NONE) {
+            continue;
+        }
+
+        // Apply group efficiency factor for this goup
+        auto gefac = groupTmp.getGroupEfficiencyFactor();
+
+        for (int phase = 0; phase < np; phase++) {
+            pot[phase] += gefac*thisPot[phase];
+        }
+
+    }
+    for (const std::string& wellName : group.wells()) {
+        const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
+        const auto wefac = wellTmp.getEfficiencyFactor();
+
+        if (wellTmp.isInjector())
+            continue;
+
+        if (wellTmp.getStatus() == Well::Status::SHUT)
+            continue;
+        const auto& well_index = wellState.index(wellName);
+        if (!well_index.has_value()) // the well is not found
+            continue;
+
+        if (! wellState.wellIsOwned(well_index.value(), wellName) ) // Only sum once
+        {
+            continue;
+        }
+
+        const auto& ws = wellState.well(well_index.value());
+        // add contribution from wells unconditionally
+        for (int phase = 0; phase < np; phase++) {
+            pot[phase] += wefac * ws.well_potentials[phase];
+        }
+    }
+
+    std::array<double,3> potentials{};
+    auto& [oilPot, gasPot, waterPot] = potentials;
+    if (pu.phase_used[BlackoilPhases::Liquid])
+        oilPot = pot[pu.phase_pos[BlackoilPhases::Liquid]];
+
+    if (pu.phase_used[BlackoilPhases::Vapour])
+        gasPot = pot[pu.phase_pos[BlackoilPhases::Vapour]];
+
+    if (pu.phase_used[BlackoilPhases::Aqua])
+        waterPot = pot[pu.phase_pos[BlackoilPhases::Aqua]];
+
+    comm.sum(potentials.data(), potentials.size());
+    const UnitSystem& unit_system = schedule.getUnits();
+    oilPot = unit_system.from_si(UnitSystem::measure::liquid_surface_rate, oilPot);
+    waterPot = unit_system.from_si(UnitSystem::measure::liquid_surface_rate, waterPot);
+    gasPot = unit_system.from_si(UnitSystem::measure::gas_surface_rate, gasPot);
+    guideRate->compute(group.name(), reportStepIdx, simTime, oilPot, gasPot, waterPot);
+}
+
+void updateGuideRatesForWells(const Schedule& schedule,
+                              const PhaseUsage& pu,
+                              const int reportStepIdx,
+                              const double& simTime,
+                              const WellState<double>& wellState,
+                              const Parallel::Communication& comm,
+                              GuideRate* guideRate)
+{
+    for (const auto& well : schedule.getWells(reportStepIdx)) {
         std::array<double,3> potentials{};
-        auto& [oilPot, gasPot, waterPot] = potentials;
-        if (pu.phase_used[BlackoilPhases::Liquid])
-            oilPot = pot[pu.phase_pos[BlackoilPhases::Liquid]];
+        auto& [oilpot, gaspot, waterpot] = potentials;
 
-        if (pu.phase_used[BlackoilPhases::Vapour])
-            gasPot = pot[pu.phase_pos[BlackoilPhases::Vapour]];
+        const auto& well_index = wellState.index(well.name());
+        if (well_index.has_value() && wellState.wellIsOwned(well_index.value(), well.name()))
+        {
+            // the well is found and owned
+            const auto& ws = wellState.well(well_index.value());
+            const auto& wpot = ws.well_potentials;
+            if (pu.phase_used[BlackoilPhases::Liquid] > 0)
+                oilpot = wpot[pu.phase_pos[BlackoilPhases::Liquid]];
 
-        if (pu.phase_used[BlackoilPhases::Aqua])
-            waterPot = pot[pu.phase_pos[BlackoilPhases::Aqua]];
+            if (pu.phase_used[BlackoilPhases::Vapour] > 0)
+                gaspot = wpot[pu.phase_pos[BlackoilPhases::Vapour]];
 
+            if (pu.phase_used[BlackoilPhases::Aqua] > 0)
+                waterpot = wpot[pu.phase_pos[BlackoilPhases::Aqua]];
+        }
         comm.sum(potentials.data(), potentials.size());
         const UnitSystem& unit_system = schedule.getUnits();
-        oilPot = unit_system.from_si(UnitSystem::measure::liquid_surface_rate, oilPot);
-        waterPot = unit_system.from_si(UnitSystem::measure::liquid_surface_rate, waterPot);
-        gasPot = unit_system.from_si(UnitSystem::measure::gas_surface_rate, gasPot);
-        guideRate->compute(group.name(), reportStepIdx, simTime, oilPot, gasPot, waterPot);
+        oilpot = unit_system.from_si(UnitSystem::measure::liquid_surface_rate, oilpot);
+        waterpot = unit_system.from_si(UnitSystem::measure::liquid_surface_rate, waterpot);
+        gaspot = unit_system.from_si(UnitSystem::measure::gas_surface_rate, gaspot);
+        guideRate->compute(well.name(), reportStepIdx, simTime, oilpot, gaspot, waterpot);
     }
+}
 
-    void updateGuideRatesForWells(const Schedule& schedule,
-                                  const PhaseUsage& pu,
-                                  const int reportStepIdx,
-                                  const double& simTime,
-                                  const WellState<double>& wellState,
-                                  const Parallel::Communication& comm,
-                                  GuideRate* guideRate)
-    {
-        for (const auto& well : schedule.getWells(reportStepIdx)) {
-            std::array<double,3> potentials{};
-            auto& [oilpot, gaspot, waterpot] = potentials;
-
-            const auto& well_index = wellState.index(well.name());
-            if (well_index.has_value() && wellState.wellIsOwned(well_index.value(), well.name()))
-            {
-                // the well is found and owned
-                const auto& ws = wellState.well(well_index.value());
-                const auto& wpot = ws.well_potentials;
-                if (pu.phase_used[BlackoilPhases::Liquid] > 0)
-                    oilpot = wpot[pu.phase_pos[BlackoilPhases::Liquid]];
-
-                if (pu.phase_used[BlackoilPhases::Vapour] > 0)
-                    gaspot = wpot[pu.phase_pos[BlackoilPhases::Vapour]];
-
-                if (pu.phase_used[BlackoilPhases::Aqua] > 0)
-                    waterpot = wpot[pu.phase_pos[BlackoilPhases::Aqua]];
-            }
-            comm.sum(potentials.data(), potentials.size());
-            const UnitSystem& unit_system = schedule.getUnits();
-            oilpot = unit_system.from_si(UnitSystem::measure::liquid_surface_rate, oilpot);
-            waterpot = unit_system.from_si(UnitSystem::measure::liquid_surface_rate, waterpot);
-            gaspot = unit_system.from_si(UnitSystem::measure::gas_surface_rate, gaspot);
-            guideRate->compute(well.name(), reportStepIdx, simTime, oilpot, gaspot, waterpot);
-        }
-    }
-
- using AvgP = RegionAverageCalculator::AverageRegionalPressure<BlackOilFluidSystem<double>,std::vector<int>>;
- using AvgPMap = std::map<std::string, std::unique_ptr<AvgP>>;
- template void WellGroupHelpers::updateGpMaintTargetForGroups<AvgPMap>(const Group&,
-                                                                    const Schedule&,
-                                                                    const AvgPMap&,
-                                                                    int,
-                                                                    double,
-                                                                    const WellState<double>&,
-                                                                    GroupState<double>&);
- template void WellGroupHelpers::setRegionAveragePressureCalculator<AvgP>(const Group&,
-                                            const Schedule&,
-                                            const int,
-                                            const FieldPropsManager&,
-                                            const PhaseUsage&,
-                                            AvgPMap&);
-} // namespace WellGroupHelpers
-
-} // namespace Opm
+using AvgP = RegionAverageCalculator::AverageRegionalPressure<BlackOilFluidSystem<double>,std::vector<int>>;
+using AvgPMap = std::map<std::string, std::unique_ptr<AvgP>>;
+template void WellGroupHelpers::
+    updateGpMaintTargetForGroups<AvgPMap>(const Group&,
+                                          const Schedule&,
+                                          const AvgPMap&,
+                                          int,
+                                          double,
+                                          const WellState<double>&,
+                                          GroupState<double>&);
+template void WellGroupHelpers::
+    setRegionAveragePressureCalculator<AvgP>(const Group&,
+                                             const Schedule&,
+                                             const int,
+                                             const FieldPropsManager&,
+                                             const PhaseUsage&,
+                                             AvgPMap&);
+} // namespace Opm::WellGroupHelpers

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -43,6 +43,7 @@ class FieldPropsManager;
 
 namespace Network { class ExtNetwork; }
 
+template<class Scalar>
 class WellGroupHelpers
 {
 public:
@@ -50,41 +51,41 @@ public:
                               const Schedule& schedule,
                               const SummaryState& summaryState,
                               const int reportStepIdx,
-                              GroupState<double>& group_state);
+                              GroupState<Scalar>& group_state);
 
     static void accumulateGroupEfficiencyFactor(const Group& group,
                                                 const Schedule& schedule,
                                                 const int reportStepIdx,
-                                                double& factor);
+                                                Scalar& factor);
 
-    static double sumWellSurfaceRates(const Group& group,
+    static Scalar sumWellSurfaceRates(const Group& group,
                                       const Schedule& schedule,
-                                      const WellState<double>& wellState,
+                                      const WellState<Scalar>& wellState,
                                       const int reportStepIdx,
                                       const int phasePos,
                                       const bool injector);
 
     /// Returns the name of the worst offending well and its fraction (i.e. violated_phase / preferred_phase)
-    static std::pair<std::optional<std::string>, double>
+    static std::pair<std::optional<std::string>, Scalar>
     worstOffendingWell(const Group& group,
                        const Schedule& schedule,
                        const int reportStepIdx,
                        const Group::ProductionCMode& offendedControl,
                        const PhaseUsage& pu,
                        const Parallel::Communication& comm,
-                       const WellState<double>& wellState,
+                       const WellState<Scalar>& wellState,
                        DeferredLogger& deferred_logger);
 
-    static double sumWellResRates(const Group& group,
+    static Scalar sumWellResRates(const Group& group,
                                   const Schedule& schedule,
-                                  const WellState<double>& wellState,
+                                  const WellState<Scalar>& wellState,
                                   const int reportStepIdx,
                                   const int phasePos,
                                   const bool injector);
 
-    static double sumSolventRates(const Group& group,
+    static Scalar sumSolventRates(const Group& group,
                                   const Schedule& schedule,
-                                  const WellState<double>& wellState,
+                                  const WellState<Scalar>& wellState,
                                   const int reportStepIdx,
                                   const bool injector);
 
@@ -94,9 +95,9 @@ public:
                                            const bool isInjector,
                                            const PhaseUsage& pu,
                                            const GuideRate& guide_rate,
-                                           const WellState<double>& wellState,
-                                           GroupState<double>& group_state,
-                                           std::vector<double>& groupTargetReduction);
+                                           const WellState<Scalar>& wellState,
+                                           GroupState<Scalar>& group_state,
+                                           std::vector<Scalar>& groupTargetReduction);
 
     static void updateGuideRates(const Group& group,
                                  const Schedule& schedule,
@@ -104,29 +105,29 @@ public:
                                  const PhaseUsage& pu,
                                  int report_step,
                                  double sim_time,
-                                 WellState<double>& well_state,
-                                 const GroupState<double>& group_state,
+                                 WellState<Scalar>& well_state,
+                                 const GroupState<Scalar>& group_state,
                                  const Parallel::Communication& comm,
                                  GuideRate* guide_rate,
-                                 std::vector<double>& pot,
-                                 DeferredLogger& deferred_logge);
+                                 std::vector<Scalar>& pot,
+                                 DeferredLogger& deferred_logger);
 
     static void updateGuideRateForProductionGroups(const Group& group,
                                                    const Schedule& schedule,
                                                    const PhaseUsage& pu,
                                                    const int reportStepIdx,
                                                    const double& simTime,
-                                                   WellState<double>& wellState,
-                                                   const GroupState<double>& group_state,
+                                                   WellState<Scalar>& wellState,
+                                                   const GroupState<Scalar>& group_state,
                                                    const Parallel::Communication& comm,
                                                    GuideRate* guideRate,
-                                                   std::vector<double>& pot);
+                                                   std::vector<Scalar>& pot);
 
     static void updateGuideRatesForWells(const Schedule& schedule,
                                          const PhaseUsage& pu,
                                          const int reportStepIdx,
                                          const double& simTime,
-                                         const WellState<double>& wellState,
+                                         const WellState<Scalar>& wellState,
                                          const Parallel::Communication& comm,
                                          GuideRate* guideRate);
 
@@ -135,16 +136,16 @@ public:
                                                    const SummaryState& summaryState,
                                                    const PhaseUsage& pu,
                                                    const int reportStepIdx,
-                                                   const WellState<double>& wellState,
-                                                   const GroupState<double>& group_state,
+                                                   const WellState<Scalar>& wellState,
+                                                   const GroupState<Scalar>& group_state,
                                                    GuideRate* guideRate,
                                                    DeferredLogger& deferred_logger);
 
     static void updateVREPForGroups(const Group& group,
                                     const Schedule& schedule,
                                     const int reportStepIdx,
-                                    const WellState<double>& wellState,
-                                    GroupState<double>& group_state);
+                                    const WellState<Scalar>& wellState,
+                                    GroupState<Scalar>& group_state);
 
     template <class RegionalValues>
     static void updateGpMaintTargetForGroups(const Group& group,
@@ -152,81 +153,82 @@ public:
                                              const RegionalValues& regional_values,
                                              const int reportStepIdx,
                                              const double dt,
-                                             const WellState<double>& well_state,
-                                             GroupState<double>& group_state);
+                                             const WellState<Scalar>& well_state,
+                                             GroupState<Scalar>& group_state);
 
     static void updateReservoirRatesInjectionGroups(const Group& group,
                                                     const Schedule& schedule,
                                                     const int reportStepIdx,
-                                                    const WellState<double>& wellState,
-                                                    GroupState<double>& group_state);
+                                                    const WellState<Scalar>& wellState,
+                                                    GroupState<Scalar>& group_state);
 
     static void updateSurfaceRatesInjectionGroups(const Group& group,
                                                   const Schedule& schedule,
                                                   const int reportStepIdx,
-                                                  const WellState<double>& wellState,
-                                                  GroupState<double>& group_state);
+                                                  const WellState<Scalar>& wellState,
+                                                  GroupState<Scalar>& group_state);
 
     static void updateWellRates(const Group& group,
                                 const Schedule& schedule,
                                 const int reportStepIdx,
-                                const WellState<double>& wellStateNupcol,
-                                WellState<double>& wellState);
+                                const WellState<Scalar>& wellStateNupcol,
+                                WellState<Scalar>& wellState);
 
     static void updateGroupProductionRates(const Group& group,
                                            const Schedule& schedule,
                                            const int reportStepIdx,
-                                           const WellState<double>& wellState,
-                                           GroupState<double>& group_state);
+                                           const WellState<Scalar>& wellState,
+                                           GroupState<Scalar>& group_state);
 
-    static void updateWellRatesFromGroupTargetScale(const double scale,
+    static void updateWellRatesFromGroupTargetScale(const Scalar scale,
                                                     const Group& group,
                                                     const Schedule& schedule,
                                                     const int reportStepIdx,
                                                     bool isInjector,
-                                                    const GroupState<double>& group_state,
-                                                    WellState<double>& wellState);
+                                                    const GroupState<Scalar>& group_state,
+                                                    WellState<Scalar>& wellState);
 
     static void updateREINForGroups(const Group& group,
                                     const Schedule& schedule,
                                     const int reportStepIdx,
                                     const PhaseUsage& pu,
                                     const SummaryState& st,
-                                    const WellState<double>& wellState,
-                                    GroupState<double>& group_state,
+                                    const WellState<Scalar>& wellState,
+                                    GroupState<Scalar>& group_state,
                                     bool sum_rank);
 
-    static std::map<std::string, double>
+
+    static std::map<std::string, Scalar>
     computeNetworkPressures(const Network::ExtNetwork& network,
-                            const WellState<double>& well_state,
-                            const GroupState<double>& group_state,
+                            const WellState<Scalar>& well_state,
+                            const GroupState<Scalar>& group_state,
                             const VFPProdProperties& vfp_prod_props,
                             const Schedule& schedule,
                             const int report_time_step);
 
     static GuideRate::RateVector
-    getWellRateVector(const WellState<double>& well_state,
+    getWellRateVector(const WellState<Scalar>& well_state,
                       const PhaseUsage& pu,
                       const std::string& name);
 
     static GuideRate::RateVector
-    getProductionGroupRateVector(const GroupState<double>& group_state,
+    getProductionGroupRateVector(const GroupState<Scalar>& group_state,
                                  const PhaseUsage& pu,
                                  const std::string& group_name);
 
-    static double getGuideRate(const std::string& name,
+    static Scalar getGuideRate(const std::string& name,
                                const Schedule& schedule,
-                               const WellState<double>& wellState,
-                               const GroupState<double>& group_state,
+                               const WellState<Scalar>& wellState,
+                               const GroupState<Scalar>& group_state,
                                const int reportStepIdx,
                                const GuideRate* guideRate,
                                const GuideRateModel::Target target,
                                const PhaseUsage& pu);
 
-    static double getGuideRateInj(const std::string& name,
+    static Scalar getGuideRateInj(const std::string& name,
                                   const Schedule& schedule,
-                                  const WellState<double>& wellState,
-                                  const GroupState<double>& group_state,
+                                  const WellState<Scalar>& wellState,
+                                  const GroupState<Scalar>& group_state,
                                   const int reportStepIdx,
                                   const GuideRate* guideRate,
                                   const GuideRateModel::Target target,
@@ -234,29 +236,29 @@ public:
                                   const PhaseUsage& pu);
 
     static int groupControlledWells(const Schedule& schedule,
-                                    const WellState<double>& well_state,
-                                    const GroupState<double>& group_state,
+                                    const WellState<Scalar>& well_state,
+                                    const GroupState<Scalar>& group_state,
                                     const int report_step,
                                     const std::string& group_name,
                                     const std::string& always_included_child,
                                     const bool is_production_group,
                                     const Phase injection_phase);
 
-    static std::pair<bool, double>
+    static std::pair<bool, Scalar>
     checkGroupConstraintsInj(const std::string& name,
                              const std::string& parent,
                              const Group& group,
-                             const WellState<double>& wellState,
-                             const GroupState<double>& group_state,
+                             const WellState<Scalar>& wellState,
+                             const GroupState<Scalar>& group_state,
                              const int reportStepIdx,
                              const GuideRate* guideRate,
-                             const double* rates,
+                             const Scalar* rates,
                              Phase injectionPhase,
                              const PhaseUsage& pu,
-                             const double efficiencyFactor,
+                             const Scalar efficiencyFactor,
                              const Schedule& schedule,
                              const SummaryState& summaryState,
-                             const std::vector<double>& resv_coeff,
+                             const std::vector<Scalar>& resv_coeff,
                              DeferredLogger& deferred_logger);
 
     static std::vector<std::string>
@@ -265,20 +267,20 @@ public:
                      const Schedule& schedule,
                      const int report_step);
 
-    static std::pair<bool, double>
+    static std::pair<bool, Scalar>
     checkGroupConstraintsProd(const std::string& name,
                               const std::string& parent,
                               const Group& group,
-                              const WellState<double>& wellState,
-                              const GroupState<double>& group_state,
+                              const WellState<Scalar>& wellState,
+                              const GroupState<Scalar>& group_state,
                               const int reportStepIdx,
                               const GuideRate* guideRate,
-                              const double* rates,
+                              const Scalar* rates,
                               const PhaseUsage& pu,
-                              const double efficiencyFactor,
+                              const Scalar efficiencyFactor,
                               const Schedule& schedule,
                               const SummaryState& summaryState,
-                              const std::vector<double>& resv_coeff,
+                              const std::vector<Scalar>& resv_coeff,
                               DeferredLogger& deferred_logger);
 
     template <class AverageRegionalPressureType>

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -29,8 +29,7 @@
 #include <string>
 #include <vector>
 
-namespace Opm
-{
+namespace Opm {
 
 class DeferredLogger;
 class Group;
@@ -44,262 +43,259 @@ class FieldPropsManager;
 
 namespace Network { class ExtNetwork; }
 
-namespace WellGroupHelpers
-{
+namespace WellGroupHelpers {
 
+void setCmodeGroup(const Group& group,
+                   const Schedule& schedule,
+                   const SummaryState& summaryState,
+                   const int reportStepIdx,
+                   GroupState<double>& group_state);
 
+void accumulateGroupEfficiencyFactor(const Group& group,
+                                     const Schedule& schedule,
+                                     const int reportStepIdx,
+                                     double& factor);
 
-    void setCmodeGroup(const Group& group,
-                       const Schedule& schedule,
-                       const SummaryState& summaryState,
-                       const int reportStepIdx,
-                       GroupState<double>& group_state);
-
-    void accumulateGroupEfficiencyFactor(const Group& group,
-                                         const Schedule& schedule,
-                                         const int reportStepIdx,
-                                         double& factor);
-
-    double sumWellSurfaceRates(const Group& group,
-                               const Schedule& schedule,
-                               const WellState<double>& wellState,
-                               const int reportStepIdx,
-                               const int phasePos,
-                               const bool injector);
-
-    double sumWellResRates(const Group& group,
+double sumWellSurfaceRates(const Group& group,
                            const Schedule& schedule,
                            const WellState<double>& wellState,
                            const int reportStepIdx,
                            const int phasePos,
                            const bool injector);
 
-    double sumSolventRates(const Group& group,
-                           const Schedule& schedule,
-                           const WellState<double>& wellState,
-                           const int reportStepIdx,
-                           const bool injector);
+double sumWellResRates(const Group& group,
+                       const Schedule& schedule,
+                       const WellState<double>& wellState,
+                       const int reportStepIdx,
+                       const int phasePos,
+                       const bool injector);
 
-    void updateGroupTargetReduction(const Group& group,
-                                    const Schedule& schedule,
-                                    const int reportStepIdx,
-                                    const bool isInjector,
-                                    const PhaseUsage& pu,
-                                    const GuideRate& guide_rate,
-                                    const WellState<double>& wellState,
-                                    GroupState<double>& group_state,
-                                    std::vector<double>& groupTargetReduction);
+double sumSolventRates(const Group& group,
+                       const Schedule& schedule,
+                       const WellState<double>& wellState,
+                       const int reportStepIdx,
+                       const bool injector);
 
-    void updateGuideRates(const Group& group,
-                          const Schedule& schedule,
-                          const SummaryState& summary_state,
-                          const PhaseUsage& pu,
-                          int report_step,
-                          double sim_time,
-                          WellState<double>& well_state,
-                          const GroupState<double>& group_state,
-                          const Parallel::Communication& comm,
-                          GuideRate* guide_rate,
-                          std::vector<double>& pot,
-                          Opm::DeferredLogger& deferred_logge);
+void updateGroupTargetReduction(const Group& group,
+                                const Schedule& schedule,
+                                const int reportStepIdx,
+                                const bool isInjector,
+                                const PhaseUsage& pu,
+                                const GuideRate& guide_rate,
+                                const WellState<double>& wellState,
+                                GroupState<double>& group_state,
+                                std::vector<double>& groupTargetReduction);
 
-    void updateGuideRateForProductionGroups(const Group& group,
-                                            const Schedule& schedule,
-                                            const PhaseUsage& pu,
-                                            const int reportStepIdx,
-                                            const double& simTime,
-                                            WellState<double>& wellState,
-                                            const GroupState<double>& group_state,
-                                            const Parallel::Communication& comm,
-                                            GuideRate* guideRate,
-                                            std::vector<double>& pot);
+void updateGuideRates(const Group& group,
+                      const Schedule& schedule,
+                      const SummaryState& summary_state,
+                      const PhaseUsage& pu,
+                      int report_step,
+                      double sim_time,
+                      WellState<double>& well_state,
+                      const GroupState<double>& group_state,
+                      const Parallel::Communication& comm,
+                      GuideRate* guide_rate,
+                      std::vector<double>& pot,
+                      Opm::DeferredLogger& deferred_logge);
 
-    void updateGuideRatesForWells(const Schedule& schedule,
-                                  const PhaseUsage& pu,
-                                  const int reportStepIdx,
-                                  const double& simTime,
-                                  const WellState<double>& wellState,
-                                  const Parallel::Communication& comm,
-                                  GuideRate* guideRate);
+void updateGuideRateForProductionGroups(const Group& group,
+                                        const Schedule& schedule,
+                                        const PhaseUsage& pu,
+                                        const int reportStepIdx,
+                                        const double& simTime,
+                                        WellState<double>& wellState,
+                                        const GroupState<double>& group_state,
+                                        const Parallel::Communication& comm,
+                                        GuideRate* guideRate,
+                                        std::vector<double>& pot);
 
-    void updateGuideRatesForInjectionGroups(const Group& group,
-                                            const Schedule& schedule,
-                                            const SummaryState& summaryState,
-                                            const Opm::PhaseUsage& pu,
-                                            const int reportStepIdx,
-                                            const WellState<double>& wellState,
-                                            const GroupState<double>& group_state,
-                                            GuideRate* guideRate,
-                                            Opm::DeferredLogger& deferred_logger);
+void updateGuideRatesForWells(const Schedule& schedule,
+                              const PhaseUsage& pu,
+                              const int reportStepIdx,
+                              const double& simTime,
+                              const WellState<double>& wellState,
+                              const Parallel::Communication& comm,
+                              GuideRate* guideRate);
 
-    void updateVREPForGroups(const Group& group,
-                             const Schedule& schedule,
-                             const int reportStepIdx,
-                             const WellState<double>& wellState,
-                             GroupState<double>& group_state);
+void updateGuideRatesForInjectionGroups(const Group& group,
+                                        const Schedule& schedule,
+                                        const SummaryState& summaryState,
+                                        const Opm::PhaseUsage& pu,
+                                        const int reportStepIdx,
+                                        const WellState<double>& wellState,
+                                        const GroupState<double>& group_state,
+                                        GuideRate* guideRate,
+                                        Opm::DeferredLogger& deferred_logger);
 
-    void updateReservoirRatesInjectionGroups(const Group& group,
-                                             const Schedule& schedule,
-                                             const int reportStepIdx,
-                                             const WellState<double>& wellState,
-                                             GroupState<double>& group_state);
-
-    void updateSurfaceRatesInjectionGroups(const Group& group,
-                                           const Schedule& schedule,
-                                           const int reportStepIdx,
-                                           const WellState<double>& wellState,
-                                           GroupState<double>& group_state);
-
-    void updateWellRates(const Group& group,
+void updateVREPForGroups(const Group& group,
                          const Schedule& schedule,
                          const int reportStepIdx,
-                         const WellState<double>& wellStateNupcol,
-                         WellState<double>& wellState);
+                         const WellState<double>& wellState,
+                         GroupState<double>& group_state);
 
-    void updateGroupProductionRates(const Group& group,
-                                    const Schedule& schedule,
-                                    const int reportStepIdx,
-                                    const WellState<double>& wellState,
-                                    GroupState<double>& group_state);
+void updateReservoirRatesInjectionGroups(const Group& group,
+                                         const Schedule& schedule,
+                                         const int reportStepIdx,
+                                         const WellState<double>& wellState,
+                                         GroupState<double>& group_state);
 
-    void updateWellRatesFromGroupTargetScale(const double scale,
-                                             const Group& group,
-                                             const Schedule& schedule,
-                                             const int reportStepIdx,
-                                             bool isInjector,
-                                             const GroupState<double>& group_state,
-                                             WellState<double>& wellState);
+void updateSurfaceRatesInjectionGroups(const Group& group,
+                                       const Schedule& schedule,
+                                       const int reportStepIdx,
+                                       const WellState<double>& wellState,
+                                       GroupState<double>& group_state);
 
-    void updateREINForGroups(const Group& group,
-                             const Schedule& schedule,
-                             const int reportStepIdx,
-                             const PhaseUsage& pu,
-                             const SummaryState& st,
-                             const WellState<double>& wellState,
-                             GroupState<double>& group_state,
-                             bool sum_rank);
+void updateWellRates(const Group& group,
+                     const Schedule& schedule,
+                     const int reportStepIdx,
+                     const WellState<double>& wellStateNupcol,
+                     WellState<double>& wellState);
 
-    
-    /// Returns the name of the worst offending well and its fraction
-    /// (i.e. violated_phase / preferred_phase)
-    std::pair<std::optional<std::string>, double>
-    worstOffendingWell(const Group& group,
-                       const Schedule& schedule,
-                       const int reportStepIdx,
-                       const Group::ProductionCMode& offendedControl,
-                       const PhaseUsage& pu,
-                       const Parallel::Communication& comm,
-                       const WellState<double>& wellState,
-                       DeferredLogger& deferred_logger);
+void updateGroupProductionRates(const Group& group,
+                                const Schedule& schedule,
+                                const int reportStepIdx,
+                                const WellState<double>& wellState,
+                                GroupState<double>& group_state);
 
-    template <class RegionalValues>
-    void updateGpMaintTargetForGroups(const Group& group,
-                                      const Schedule& schedule,
-                                      const RegionalValues& regional_values,
-                                      const int reportStepIdx,
-                                      const double dt,
-                                      const WellState<double>& well_state,
-                                      GroupState<double>& group_state);
+void updateWellRatesFromGroupTargetScale(const double scale,
+                                         const Group& group,
+                                         const Schedule& schedule,
+                                         const int reportStepIdx,
+                                         bool isInjector,
+                                         const GroupState<double>& group_state,
+                                         WellState<double>& wellState);
 
-    std::map<std::string, double>
-    computeNetworkPressures(const Opm::Network::ExtNetwork& network,
-                            const WellState<double>& well_state,
-                            const GroupState<double>& group_state,
-                            const VFPProdProperties& vfp_prod_props,
-                            const Schedule& schedule,
-                            const int report_time_step);
+void updateREINForGroups(const Group& group,
+                         const Schedule& schedule,
+                         const int reportStepIdx,
+                         const PhaseUsage& pu,
+                         const SummaryState& st,
+                         const WellState<double>& wellState,
+                         GroupState<double>& group_state,
+                         bool sum_rank);
 
-    GuideRate::RateVector
-    getWellRateVector(const WellState<double>& well_state,
-                      const PhaseUsage& pu,
-                      const std::string& name);
 
-    GuideRate::RateVector
-    getProductionGroupRateVector(const GroupState<double>& group_state,
-                                 const PhaseUsage& pu,
-                                 const std::string& group_name);
+/// Returns the name of the worst offending well and its fraction
+/// (i.e. violated_phase / preferred_phase)
+std::pair<std::optional<std::string>, double>
+worstOffendingWell(const Group& group,
+                   const Schedule& schedule,
+                   const int reportStepIdx,
+                   const Group::ProductionCMode& offendedControl,
+                   const PhaseUsage& pu,
+                   const Parallel::Communication& comm,
+                   const WellState<double>& wellState,
+                   DeferredLogger& deferred_logger);
 
-    double getGuideRate(const std::string& name,
-                        const Schedule& schedule,
-                        const WellState<double>& wellState,
+template <class RegionalValues>
+void updateGpMaintTargetForGroups(const Group& group,
+                                  const Schedule& schedule,
+                                  const RegionalValues& regional_values,
+                                  const int reportStepIdx,
+                                  const double dt,
+                                  const WellState<double>& well_state,
+                                  GroupState<double>& group_state);
+
+std::map<std::string, double>
+computeNetworkPressures(const Opm::Network::ExtNetwork& network,
+                        const WellState<double>& well_state,
                         const GroupState<double>& group_state,
-                        const int reportStepIdx,
-                        const GuideRate* guideRate,
-                        const GuideRateModel::Target target,
-                        const PhaseUsage& pu);
+                        const VFPProdProperties& vfp_prod_props,
+                        const Schedule& schedule,
+                        const int report_time_step);
+
+GuideRate::RateVector
+getWellRateVector(const WellState<double>& well_state,
+                  const PhaseUsage& pu,
+                  const std::string& name);
+
+GuideRate::RateVector
+getProductionGroupRateVector(const GroupState<double>& group_state,
+                             const PhaseUsage& pu,
+                             const std::string& group_name);
+
+double getGuideRate(const std::string& name,
+                    const Schedule& schedule,
+                    const WellState<double>& wellState,
+                    const GroupState<double>& group_state,
+                    const int reportStepIdx,
+                    const GuideRate* guideRate,
+                    const GuideRateModel::Target target,
+                    const PhaseUsage& pu);
 
 
-    double getGuideRateInj(const std::string& name,
-                           const Schedule& schedule,
-                           const WellState<double>& wellState,
-                           const GroupState<double>& group_state,
-                           const int reportStepIdx,
-                           const GuideRate* guideRate,
-                           const GuideRateModel::Target target,
-                           const Phase& injectionPhase,
-                           const PhaseUsage& pu);
+double getGuideRateInj(const std::string& name,
+                       const Schedule& schedule,
+                       const WellState<double>& wellState,
+                       const GroupState<double>& group_state,
+                       const int reportStepIdx,
+                       const GuideRate* guideRate,
+                       const GuideRateModel::Target target,
+                       const Phase& injectionPhase,
+                       const PhaseUsage& pu);
 
-    int groupControlledWells(const Schedule& schedule,
-                             const WellState<double>& well_state,
-                             const GroupState<double>& group_state,
-                             const int report_step,
-                             const std::string& group_name,
-                             const std::string& always_included_child,
-                             const bool is_production_group,
-                             const Phase injection_phase);
-
-
-    std::pair<bool, double> checkGroupConstraintsInj(const std::string& name,
-                                                     const std::string& parent,
-                                                     const Group& group,
-                                                     const WellState<double>& wellState,
-                                                     const GroupState<double>& group_state,
-                                                     const int reportStepIdx,
-                                                     const GuideRate* guideRate,
-                                                     const double* rates,
-                                                     Phase injectionPhase,
-                                                     const PhaseUsage& pu,
-                                                     const double efficiencyFactor,
-                                                     const Schedule& schedule,
-                                                     const SummaryState& summaryState,
-                                                     const std::vector<double>& resv_coeff,
-                                                     DeferredLogger& deferred_logger);
+int groupControlledWells(const Schedule& schedule,
+                         const WellState<double>& well_state,
+                         const GroupState<double>& group_state,
+                         const int report_step,
+                         const std::string& group_name,
+                         const std::string& always_included_child,
+                         const bool is_production_group,
+                         const Phase injection_phase);
 
 
+std::pair<bool, double> checkGroupConstraintsInj(const std::string& name,
+                                                 const std::string& parent,
+                                                 const Group& group,
+                                                 const WellState<double>& wellState,
+                                                 const GroupState<double>& group_state,
+                                                 const int reportStepIdx,
+                                                 const GuideRate* guideRate,
+                                                 const double* rates,
+                                                 Phase injectionPhase,
+                                                 const PhaseUsage& pu,
+                                                 const double efficiencyFactor,
+                                                 const Schedule& schedule,
+                                                 const SummaryState& summaryState,
+                                                 const std::vector<double>& resv_coeff,
+                                                 DeferredLogger& deferred_logger);
 
 
 
 
-    std::vector<std::string> groupChainTopBot(const std::string& bottom,
-                                              const std::string& top,
-                                              const Schedule& schedule,
-                                              const int report_step);
+
+
+std::vector<std::string> groupChainTopBot(const std::string& bottom,
+                                          const std::string& top,
+                                          const Schedule& schedule,
+                                          const int report_step);
 
 
 
 
-    std::pair<bool, double> checkGroupConstraintsProd(const std::string& name,
-                                                      const std::string& parent,
-                                                      const Group& group,
-                                                      const WellState<double>& wellState,
-                                                      const GroupState<double>& group_state,
-                                                      const int reportStepIdx,
-                                                      const GuideRate* guideRate,
-                                                      const double* rates,
-                                                      const PhaseUsage& pu,
-                                                      const double efficiencyFactor,
-                                                      const Schedule& schedule,
-                                                      const SummaryState& summaryState,
-                                                      const std::vector<double>& resv_coeff,
-                                                      DeferredLogger& deferred_logger);
+std::pair<bool, double> checkGroupConstraintsProd(const std::string& name,
+                                                  const std::string& parent,
+                                                  const Group& group,
+                                                  const WellState<double>& wellState,
+                                                  const GroupState<double>& group_state,
+                                                  const int reportStepIdx,
+                                                  const GuideRate* guideRate,
+                                                  const double* rates,
+                                                  const PhaseUsage& pu,
+                                                  const double efficiencyFactor,
+                                                  const Schedule& schedule,
+                                                  const SummaryState& summaryState,
+                                                  const std::vector<double>& resv_coeff,
+                                                  DeferredLogger& deferred_logger);
 
-    template <class AverageRegionalPressureType>
-    void setRegionAveragePressureCalculator(const Group& group,
-                                            const Schedule& schedule,
-                                            const int reportStepIdx,
-                                            const FieldPropsManager& fp,
-                                            const PhaseUsage& pu,
-                                            std::map<std::string, std::unique_ptr<AverageRegionalPressureType>>& regionalAveragePressureCalculator);
+template <class AverageRegionalPressureType>
+void setRegionAveragePressureCalculator(const Group& group,
+                                        const Schedule& schedule,
+                                        const int reportStepIdx,
+                                        const FieldPropsManager& fp,
+                                        const PhaseUsage& pu,
+                                        std::map<std::string, std::unique_ptr<AverageRegionalPressureType>>& regionalAveragePressureCalculator);
 
 
 } // namespace WellGroupHelpers

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -43,262 +43,252 @@ class FieldPropsManager;
 
 namespace Network { class ExtNetwork; }
 
-namespace WellGroupHelpers {
-
-void setCmodeGroup(const Group& group,
-                   const Schedule& schedule,
-                   const SummaryState& summaryState,
-                   const int reportStepIdx,
-                   GroupState<double>& group_state);
-
-void accumulateGroupEfficiencyFactor(const Group& group,
-                                     const Schedule& schedule,
-                                     const int reportStepIdx,
-                                     double& factor);
-
-double sumWellSurfaceRates(const Group& group,
-                           const Schedule& schedule,
-                           const WellState<double>& wellState,
-                           const int reportStepIdx,
-                           const int phasePos,
-                           const bool injector);
-
-double sumWellResRates(const Group& group,
-                       const Schedule& schedule,
-                       const WellState<double>& wellState,
-                       const int reportStepIdx,
-                       const int phasePos,
-                       const bool injector);
-
-double sumSolventRates(const Group& group,
-                       const Schedule& schedule,
-                       const WellState<double>& wellState,
-                       const int reportStepIdx,
-                       const bool injector);
-
-void updateGroupTargetReduction(const Group& group,
-                                const Schedule& schedule,
-                                const int reportStepIdx,
-                                const bool isInjector,
-                                const PhaseUsage& pu,
-                                const GuideRate& guide_rate,
-                                const WellState<double>& wellState,
-                                GroupState<double>& group_state,
-                                std::vector<double>& groupTargetReduction);
-
-void updateGuideRates(const Group& group,
-                      const Schedule& schedule,
-                      const SummaryState& summary_state,
-                      const PhaseUsage& pu,
-                      int report_step,
-                      double sim_time,
-                      WellState<double>& well_state,
-                      const GroupState<double>& group_state,
-                      const Parallel::Communication& comm,
-                      GuideRate* guide_rate,
-                      std::vector<double>& pot,
-                      Opm::DeferredLogger& deferred_logge);
-
-void updateGuideRateForProductionGroups(const Group& group,
-                                        const Schedule& schedule,
-                                        const PhaseUsage& pu,
-                                        const int reportStepIdx,
-                                        const double& simTime,
-                                        WellState<double>& wellState,
-                                        const GroupState<double>& group_state,
-                                        const Parallel::Communication& comm,
-                                        GuideRate* guideRate,
-                                        std::vector<double>& pot);
-
-void updateGuideRatesForWells(const Schedule& schedule,
-                              const PhaseUsage& pu,
+class WellGroupHelpers
+{
+public:
+    static void setCmodeGroup(const Group& group,
+                              const Schedule& schedule,
+                              const SummaryState& summaryState,
                               const int reportStepIdx,
-                              const double& simTime,
-                              const WellState<double>& wellState,
-                              const Parallel::Communication& comm,
-                              GuideRate* guideRate);
+                              GroupState<double>& group_state);
 
-void updateGuideRatesForInjectionGroups(const Group& group,
-                                        const Schedule& schedule,
-                                        const SummaryState& summaryState,
-                                        const Opm::PhaseUsage& pu,
-                                        const int reportStepIdx,
-                                        const WellState<double>& wellState,
-                                        const GroupState<double>& group_state,
-                                        GuideRate* guideRate,
-                                        Opm::DeferredLogger& deferred_logger);
+    static void accumulateGroupEfficiencyFactor(const Group& group,
+                                                const Schedule& schedule,
+                                                const int reportStepIdx,
+                                                double& factor);
 
-void updateVREPForGroups(const Group& group,
-                         const Schedule& schedule,
-                         const int reportStepIdx,
-                         const WellState<double>& wellState,
-                         GroupState<double>& group_state);
+    static double sumWellSurfaceRates(const Group& group,
+                                      const Schedule& schedule,
+                                      const WellState<double>& wellState,
+                                      const int reportStepIdx,
+                                      const int phasePos,
+                                      const bool injector);
 
-void updateReservoirRatesInjectionGroups(const Group& group,
-                                         const Schedule& schedule,
+    /// Returns the name of the worst offending well and its fraction (i.e. violated_phase / preferred_phase)
+    static std::pair<std::optional<std::string>, double>
+    worstOffendingWell(const Group& group,
+                       const Schedule& schedule,
+                       const int reportStepIdx,
+                       const Group::ProductionCMode& offendedControl,
+                       const PhaseUsage& pu,
+                       const Parallel::Communication& comm,
+                       const WellState<double>& wellState,
+                       DeferredLogger& deferred_logger);
+
+    static double sumWellResRates(const Group& group,
+                                  const Schedule& schedule,
+                                  const WellState<double>& wellState,
+                                  const int reportStepIdx,
+                                  const int phasePos,
+                                  const bool injector);
+
+    static double sumSolventRates(const Group& group,
+                                  const Schedule& schedule,
+                                  const WellState<double>& wellState,
+                                  const int reportStepIdx,
+                                  const bool injector);
+
+    static void updateGroupTargetReduction(const Group& group,
+                                           const Schedule& schedule,
+                                           const int reportStepIdx,
+                                           const bool isInjector,
+                                           const PhaseUsage& pu,
+                                           const GuideRate& guide_rate,
+                                           const WellState<double>& wellState,
+                                           GroupState<double>& group_state,
+                                           std::vector<double>& groupTargetReduction);
+
+    static void updateGuideRates(const Group& group,
+                                 const Schedule& schedule,
+                                 const SummaryState& summary_state,
+                                 const PhaseUsage& pu,
+                                 int report_step,
+                                 double sim_time,
+                                 WellState<double>& well_state,
+                                 const GroupState<double>& group_state,
+                                 const Parallel::Communication& comm,
+                                 GuideRate* guide_rate,
+                                 std::vector<double>& pot,
+                                 DeferredLogger& deferred_logge);
+
+    static void updateGuideRateForProductionGroups(const Group& group,
+                                                   const Schedule& schedule,
+                                                   const PhaseUsage& pu,
+                                                   const int reportStepIdx,
+                                                   const double& simTime,
+                                                   WellState<double>& wellState,
+                                                   const GroupState<double>& group_state,
+                                                   const Parallel::Communication& comm,
+                                                   GuideRate* guideRate,
+                                                   std::vector<double>& pot);
+
+    static void updateGuideRatesForWells(const Schedule& schedule,
+                                         const PhaseUsage& pu,
                                          const int reportStepIdx,
+                                         const double& simTime,
                                          const WellState<double>& wellState,
-                                         GroupState<double>& group_state);
+                                         const Parallel::Communication& comm,
+                                         GuideRate* guideRate);
 
-void updateSurfaceRatesInjectionGroups(const Group& group,
-                                       const Schedule& schedule,
-                                       const int reportStepIdx,
-                                       const WellState<double>& wellState,
-                                       GroupState<double>& group_state);
+    static void updateGuideRatesForInjectionGroups(const Group& group,
+                                                   const Schedule& schedule,
+                                                   const SummaryState& summaryState,
+                                                   const PhaseUsage& pu,
+                                                   const int reportStepIdx,
+                                                   const WellState<double>& wellState,
+                                                   const GroupState<double>& group_state,
+                                                   GuideRate* guideRate,
+                                                   DeferredLogger& deferred_logger);
 
-void updateWellRates(const Group& group,
-                     const Schedule& schedule,
-                     const int reportStepIdx,
-                     const WellState<double>& wellStateNupcol,
-                     WellState<double>& wellState);
+    static void updateVREPForGroups(const Group& group,
+                                    const Schedule& schedule,
+                                    const int reportStepIdx,
+                                    const WellState<double>& wellState,
+                                    GroupState<double>& group_state);
 
-void updateGroupProductionRates(const Group& group,
+    template <class RegionalValues>
+    static void updateGpMaintTargetForGroups(const Group& group,
+                                             const Schedule& schedule,
+                                             const RegionalValues& regional_values,
+                                             const int reportStepIdx,
+                                             const double dt,
+                                             const WellState<double>& well_state,
+                                             GroupState<double>& group_state);
+
+    static void updateReservoirRatesInjectionGroups(const Group& group,
+                                                    const Schedule& schedule,
+                                                    const int reportStepIdx,
+                                                    const WellState<double>& wellState,
+                                                    GroupState<double>& group_state);
+
+    static void updateSurfaceRatesInjectionGroups(const Group& group,
+                                                  const Schedule& schedule,
+                                                  const int reportStepIdx,
+                                                  const WellState<double>& wellState,
+                                                  GroupState<double>& group_state);
+
+    static void updateWellRates(const Group& group,
                                 const Schedule& schedule,
                                 const int reportStepIdx,
-                                const WellState<double>& wellState,
-                                GroupState<double>& group_state);
+                                const WellState<double>& wellStateNupcol,
+                                WellState<double>& wellState);
 
-void updateWellRatesFromGroupTargetScale(const double scale,
-                                         const Group& group,
-                                         const Schedule& schedule,
-                                         const int reportStepIdx,
-                                         bool isInjector,
-                                         const GroupState<double>& group_state,
-                                         WellState<double>& wellState);
+    static void updateGroupProductionRates(const Group& group,
+                                           const Schedule& schedule,
+                                           const int reportStepIdx,
+                                           const WellState<double>& wellState,
+                                           GroupState<double>& group_state);
 
-void updateREINForGroups(const Group& group,
-                         const Schedule& schedule,
-                         const int reportStepIdx,
-                         const PhaseUsage& pu,
-                         const SummaryState& st,
-                         const WellState<double>& wellState,
-                         GroupState<double>& group_state,
-                         bool sum_rank);
+    static void updateWellRatesFromGroupTargetScale(const double scale,
+                                                    const Group& group,
+                                                    const Schedule& schedule,
+                                                    const int reportStepIdx,
+                                                    bool isInjector,
+                                                    const GroupState<double>& group_state,
+                                                    WellState<double>& wellState);
 
+    static void updateREINForGroups(const Group& group,
+                                    const Schedule& schedule,
+                                    const int reportStepIdx,
+                                    const PhaseUsage& pu,
+                                    const SummaryState& st,
+                                    const WellState<double>& wellState,
+                                    GroupState<double>& group_state,
+                                    bool sum_rank);
 
-/// Returns the name of the worst offending well and its fraction
-/// (i.e. violated_phase / preferred_phase)
-std::pair<std::optional<std::string>, double>
-worstOffendingWell(const Group& group,
-                   const Schedule& schedule,
-                   const int reportStepIdx,
-                   const Group::ProductionCMode& offendedControl,
-                   const PhaseUsage& pu,
-                   const Parallel::Communication& comm,
-                   const WellState<double>& wellState,
-                   DeferredLogger& deferred_logger);
+    static std::map<std::string, double>
+    computeNetworkPressures(const Network::ExtNetwork& network,
+                            const WellState<double>& well_state,
+                            const GroupState<double>& group_state,
+                            const VFPProdProperties& vfp_prod_props,
+                            const Schedule& schedule,
+                            const int report_time_step);
 
-template <class RegionalValues>
-void updateGpMaintTargetForGroups(const Group& group,
+    static GuideRate::RateVector
+    getWellRateVector(const WellState<double>& well_state,
+                      const PhaseUsage& pu,
+                      const std::string& name);
+
+    static GuideRate::RateVector
+    getProductionGroupRateVector(const GroupState<double>& group_state,
+                                 const PhaseUsage& pu,
+                                 const std::string& group_name);
+
+    static double getGuideRate(const std::string& name,
+                               const Schedule& schedule,
+                               const WellState<double>& wellState,
+                               const GroupState<double>& group_state,
+                               const int reportStepIdx,
+                               const GuideRate* guideRate,
+                               const GuideRateModel::Target target,
+                               const PhaseUsage& pu);
+
+    static double getGuideRateInj(const std::string& name,
                                   const Schedule& schedule,
-                                  const RegionalValues& regional_values,
+                                  const WellState<double>& wellState,
+                                  const GroupState<double>& group_state,
                                   const int reportStepIdx,
-                                  const double dt,
-                                  const WellState<double>& well_state,
-                                  GroupState<double>& group_state);
+                                  const GuideRate* guideRate,
+                                  const GuideRateModel::Target target,
+                                  const Phase& injectionPhase,
+                                  const PhaseUsage& pu);
 
-std::map<std::string, double>
-computeNetworkPressures(const Opm::Network::ExtNetwork& network,
-                        const WellState<double>& well_state,
-                        const GroupState<double>& group_state,
-                        const VFPProdProperties& vfp_prod_props,
-                        const Schedule& schedule,
-                        const int report_time_step);
+    static int groupControlledWells(const Schedule& schedule,
+                                    const WellState<double>& well_state,
+                                    const GroupState<double>& group_state,
+                                    const int report_step,
+                                    const std::string& group_name,
+                                    const std::string& always_included_child,
+                                    const bool is_production_group,
+                                    const Phase injection_phase);
 
-GuideRate::RateVector
-getWellRateVector(const WellState<double>& well_state,
-                  const PhaseUsage& pu,
-                  const std::string& name);
-
-GuideRate::RateVector
-getProductionGroupRateVector(const GroupState<double>& group_state,
+    static std::pair<bool, double>
+    checkGroupConstraintsInj(const std::string& name,
+                             const std::string& parent,
+                             const Group& group,
+                             const WellState<double>& wellState,
+                             const GroupState<double>& group_state,
+                             const int reportStepIdx,
+                             const GuideRate* guideRate,
+                             const double* rates,
+                             Phase injectionPhase,
                              const PhaseUsage& pu,
-                             const std::string& group_name);
+                             const double efficiencyFactor,
+                             const Schedule& schedule,
+                             const SummaryState& summaryState,
+                             const std::vector<double>& resv_coeff,
+                             DeferredLogger& deferred_logger);
 
-double getGuideRate(const std::string& name,
-                    const Schedule& schedule,
-                    const WellState<double>& wellState,
-                    const GroupState<double>& group_state,
-                    const int reportStepIdx,
-                    const GuideRate* guideRate,
-                    const GuideRateModel::Target target,
-                    const PhaseUsage& pu);
+    static std::vector<std::string>
+    groupChainTopBot(const std::string& bottom,
+                     const std::string& top,
+                     const Schedule& schedule,
+                     const int report_step);
 
+    static std::pair<bool, double>
+    checkGroupConstraintsProd(const std::string& name,
+                              const std::string& parent,
+                              const Group& group,
+                              const WellState<double>& wellState,
+                              const GroupState<double>& group_state,
+                              const int reportStepIdx,
+                              const GuideRate* guideRate,
+                              const double* rates,
+                              const PhaseUsage& pu,
+                              const double efficiencyFactor,
+                              const Schedule& schedule,
+                              const SummaryState& summaryState,
+                              const std::vector<double>& resv_coeff,
+                              DeferredLogger& deferred_logger);
 
-double getGuideRateInj(const std::string& name,
-                       const Schedule& schedule,
-                       const WellState<double>& wellState,
-                       const GroupState<double>& group_state,
-                       const int reportStepIdx,
-                       const GuideRate* guideRate,
-                       const GuideRateModel::Target target,
-                       const Phase& injectionPhase,
-                       const PhaseUsage& pu);
-
-int groupControlledWells(const Schedule& schedule,
-                         const WellState<double>& well_state,
-                         const GroupState<double>& group_state,
-                         const int report_step,
-                         const std::string& group_name,
-                         const std::string& always_included_child,
-                         const bool is_production_group,
-                         const Phase injection_phase);
-
-
-std::pair<bool, double> checkGroupConstraintsInj(const std::string& name,
-                                                 const std::string& parent,
-                                                 const Group& group,
-                                                 const WellState<double>& wellState,
-                                                 const GroupState<double>& group_state,
-                                                 const int reportStepIdx,
-                                                 const GuideRate* guideRate,
-                                                 const double* rates,
-                                                 Phase injectionPhase,
-                                                 const PhaseUsage& pu,
-                                                 const double efficiencyFactor,
-                                                 const Schedule& schedule,
-                                                 const SummaryState& summaryState,
-                                                 const std::vector<double>& resv_coeff,
-                                                 DeferredLogger& deferred_logger);
-
-
-
-
-
-
-std::vector<std::string> groupChainTopBot(const std::string& bottom,
-                                          const std::string& top,
-                                          const Schedule& schedule,
-                                          const int report_step);
-
-
-
-
-std::pair<bool, double> checkGroupConstraintsProd(const std::string& name,
-                                                  const std::string& parent,
-                                                  const Group& group,
-                                                  const WellState<double>& wellState,
-                                                  const GroupState<double>& group_state,
-                                                  const int reportStepIdx,
-                                                  const GuideRate* guideRate,
-                                                  const double* rates,
-                                                  const PhaseUsage& pu,
-                                                  const double efficiencyFactor,
-                                                  const Schedule& schedule,
-                                                  const SummaryState& summaryState,
-                                                  const std::vector<double>& resv_coeff,
-                                                  DeferredLogger& deferred_logger);
-
-template <class AverageRegionalPressureType>
-void setRegionAveragePressureCalculator(const Group& group,
-                                        const Schedule& schedule,
-                                        const int reportStepIdx,
-                                        const FieldPropsManager& fp,
-                                        const PhaseUsage& pu,
-                                        std::map<std::string, std::unique_ptr<AverageRegionalPressureType>>& regionalAveragePressureCalculator);
-
-
-} // namespace WellGroupHelpers
+    template <class AverageRegionalPressureType>
+    static void setRegionAveragePressureCalculator(const Group& group,
+                                                   const Schedule& schedule,
+                                                   const int reportStepIdx,
+                                                   const FieldPropsManager& fp,
+                                                   const PhaseUsage& pu,
+                                                   std::map<std::string, std::unique_ptr<AverageRegionalPressureType>>& regionalAveragePressureCalculator);
+};
 
 } // namespace Opm
 


### PR DESCRIPTION
Make WellGroupHelpers and some related classes templates over the Scalar type.
To avoid having to explicitly instance every single function (now template) in there I have changed WellGroupHelpers from a namespace to a class with static members.

Extracted from https://github.com/OPM/opm-simulators/pull/5286