### PR TITLE
Report CNV Violation Pore-Volume Fraction to INFOITER

### DIFF
--- a/opm/simulators/flow/BlackoilModelNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelNldd.hpp
@@ -656,6 +656,7 @@ private:
                 } else if (res[ii] > tol[ii]) {
                     report.setReservoirFailed({types[ii], CR::Severity::Normal, compIdx});
                 }
+
                 report.setReservoirConvergenceMetric(types[ii], compIdx, res[ii]);
             }
         }

--- a/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
+++ b/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
@@ -24,6 +24,7 @@
 #include <opm/simulators/timestepping/ConvergenceReport.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <condition_variable>
 #include <cstddef>
@@ -40,11 +41,43 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <tuple>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 namespace {
+
+    auto fixedHeaders() noexcept
+    {
+        using namespace std::literals::string_literals;
+
+        return std::array {
+            "ReportStep"s,
+            "TimeStep"s,
+            "Time"s,
+            "CnvErrPvFrac"s,
+            "Iteration"s,
+        };
+    }
+
+    template <typename HeaderSequence>
+    auto maxHeaderSize(const HeaderSequence& headers)
+    {
+        using sz_t = std::remove_cv_t<std::remove_reference_t<
+            decltype(std::declval<HeaderSequence>().front().size())>>;
+
+        if (headers.empty()) {
+            return sz_t{0};
+        }
+
+        return std::accumulate(headers.begin(), headers.end(), sz_t{1},
+                               [](const auto m, const auto& header)
+                               {
+                                   return std::max(m, header.size() + 1);
+                               });
+    }
 
     std::string
     formatMetricColumn(const Opm::ConvergenceOutputThread::ComponentToPhaseName& getPhaseName,
@@ -65,45 +98,49 @@ namespace {
             [&getPhaseName](const std::string::size_type                              maxChar,
                             const Opm::ConvergenceReport::ReservoirConvergenceMetric& metric)
         {
-            return std::max(maxChar, formatMetricColumn(getPhaseName, metric).size());
+            return std::max(maxChar, formatMetricColumn(getPhaseName, metric).size() + 1);
         });
     }
 
-    std::string::size_type
+    std::pair<std::string::size_type, std::string::size_type>
     writeConvergenceHeader(std::ostream&                                             os,
                            const Opm::ConvergenceOutputThread::ComponentToPhaseName& getPhaseName,
                            const Opm::ConvergenceReportQueue::OutputRequest&         firstRequest)
     {
-        const auto minColSize = std::string::size_type{11};
+        const auto initial_headers = fixedHeaders();
+        const auto minColSize = maxHeaderSize(initial_headers);
 
-        os << std::right << std::setw(minColSize) << "ReportStep" << ' '
-           << std::right << std::setw(minColSize) << "TimeStep"   << ' '
-           << std::right << std::setw(minColSize) << "Time"       << ' '
-           << std::right << std::setw(minColSize) << "Iteration";
+        {
+            auto leadingSpace = false;
 
-        const auto& metrics = firstRequest.reports.front().reservoirConvergence();
-        const auto  maxChar = maxColHeaderSize(minColSize, getPhaseName, metrics);
+            for (const auto& columnHeader : initial_headers) {
+                if (leadingSpace) { os << ' '; }
+                os << std::right << std::setw(minColSize) << columnHeader;
+                leadingSpace = true;
+            }
+        }
+
+        const auto& metrics    = firstRequest.reports.front().reservoirConvergence();
+        const auto  headerSize = maxColHeaderSize(minColSize, getPhaseName, metrics);
 
         for (const auto& metric : metrics) {
-            os << std::right << std::setw(maxChar + 1)
+            os << std::right << std::setw(headerSize)
                << formatMetricColumn(getPhaseName, metric);
         }
 
         // Note: Newline character intentionally placed in separate output
         // request to not influence right-justification of column header.
-        os << std::right << std::setw(maxChar + 1) << "WellStatus" << '\n';
+        os << std::right << std::setw(headerSize) << "WellStatus" << '\n';
 
-        return maxChar;
+        return { minColSize, headerSize };
     }
-
 
     void writeConvergenceRequest(std::ostream&                                           os,
                                  const Opm::ConvergenceOutputThread::ConvertToTimeUnits& convertTime,
-                                 std::string::size_type                                  colSize,
+                                 const std::string::size_type                            firstColSize,
+                                 const std::string::size_type                            colSize,
                                  const Opm::ConvergenceReportQueue::OutputRequest&       request)
     {
-        const auto firstColSize = std::string::size_type{11};
-
         os.setf(std::ios_base::scientific);
 
         auto iter = 0;
@@ -112,19 +149,23 @@ namespace {
                << std::setw(firstColSize)          << request.currentStep << ' '
                << std::setprecision(4)             << std::setw(firstColSize)
                << convertTime(report.reportTime()) << ' '
+               << std::setprecision(4)             << std::setw(firstColSize)
+               << report.cnvViolatedPvFraction()   << ' '
                << std::setw(firstColSize)          << iter;
 
             for (const auto& metric : report.reservoirConvergence()) {
-                os << std::setprecision(4) << std::setw(colSize + 1) << metric.value();
+                os << std::setprecision(4) << std::setw(colSize) << metric.value();
             }
 
-            os << std::right << std::setw(colSize + 1)
+            os << std::right << std::setw(colSize)
                << (report.wellFailed() ? "FAIL" : "CONV");
+
             if (report.wellFailed()) {
                 for (const auto& wf : report.wellFailures()) {
-                    os << " " << to_string(wf);
+                    os << ' ' << to_string(wf);
                 }
             }
+
             os << '\n';
 
             ++iter;
@@ -160,6 +201,7 @@ private:
     ComponentToPhaseName getPhaseName_{};
     ConvertToTimeUnits convertTime_{};
     std::optional<std::ofstream> infoIter_{};
+    std::string::size_type firstColSize_{0};
     std::string::size_type colSize_{0};
     bool haveOutputIterHeader_{false};
     bool finalRequestWritten_{false};
@@ -203,7 +245,7 @@ writeIterInfo(const std::vector<ConvergenceReportQueue::OutputRequest>& requests
     }
 
     if (! this->haveOutputIterHeader_) {
-        this->colSize_ =
+        std::tie(this->firstColSize_, this->colSize_) =
             writeConvergenceHeader(this->infoIter_.value(),
                                    this->getPhaseName_,
                                    requests.front());
@@ -213,6 +255,7 @@ writeIterInfo(const std::vector<ConvergenceReportQueue::OutputRequest>& requests
     for (const auto& request : requests) {
         writeConvergenceRequest(this->infoIter_.value(),
                                 this->convertTime_,
+                                this->firstColSize_,
                                 this->colSize_,
                                 request);
 

--- a/tests/test_tuning_XXXMBE.cpp
+++ b/tests/test_tuning_XXXMBE.cpp
@@ -149,9 +149,8 @@ BOOST_AUTO_TEST_CASE(CheckMassBalanceWithinXXXMBE)
 		BOOST_TEST_MESSAGE("---------------------------------------------------------------------------");
 
 
-		BOOST_CHECK( max_mb[0] < 1.0e-6 );
-		BOOST_CHECK( max_mb[1] < 1.0e-8 );
-		BOOST_CHECK( max_mb[2] < 1.0e-10 );
+		BOOST_CHECK_MESSAGE( max_mb[0] < 1.0e-6, "max_mb[0] (= " << max_mb[0] << ") is not strictly less than 1.0e-6" );
+		BOOST_CHECK_MESSAGE( max_mb[1] < 1.0e-8, "max_mb[1] (= " << max_mb[1] << ") is not strictly less than 1.0e-8"  );
+		BOOST_CHECK_MESSAGE( max_mb[2] < 1.0e-10, "max_mb[2] (= " << max_mb[1] << ") is not strictly less than 1.0e-10"  );
   
 }
-


### PR DESCRIPTION
This commit includes the fraction of pore-volume whose CNV targets are violated as a new per-iteration quantity in the INFOITER file (`--output-extra-convergence-info=iteration`), with the column header `CnvErrPvFrac`.  We collect the values which are already calculated in
```
BlackoilModel<>::getReservoirConvergence()
```
and store these as a pair of numerator and denominator in the `ConvergenceReport` class.  Note that we need both the numerator and the denominator in order to aggregate contributions from multiple ranks.

While here, also make a few more objects 'const' and calculate column widths directly instead of the maximum number of characters in `writeConvergenceHeader()`.