### PR TITLE
fixed: use the eclipse grid from the eclipse state in test_nonnc 

### DIFF
--- a/tests/test_nonnc.cpp
+++ b/tests/test_nonnc.cpp
@@ -22,6 +22,8 @@
 #define BOOST_TEST_MODULE NONNCTest
 #define BOOST_TEST_NO_MAIN
 
+#include <boost/test/unit_test.hpp>
+
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
@@ -37,6 +39,31 @@ using namespace Opm;
 
 const int dimWorld = 3;
 const int cartDims[3] = {8,15,3};
+
+#if HAVE_MPI
+struct MPIError
+{
+    MPIError(std::string s, int e) : errorstring(std::move(s)), errorcode(e){}
+    std::string errorstring;
+    int errorcode;
+};
+
+void MPI_err_handler(MPI_Comm*, int* err_code, ...)
+{
+    std::vector<char> err_string(MPI_MAX_ERROR_STRING);
+    int err_length;
+    MPI_Error_string(*err_code, err_string.data(), &err_length);
+    std::string s(err_string.data(), err_length);
+    std::cerr << "An MPI Error ocurred:" << std::endl << s << std::endl;
+    throw MPIError(s, *err_code);
+}
+#endif
+
+bool
+init_unit_test_func()
+{
+    return true;
+}
 
 // Class extending EclTransmissibility, such that we can access the protected member trans_ to check its contents
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
@@ -59,10 +86,8 @@ class TestTransmissibility : public Transmissibility<Grid,GridView,ElementMapper
         }
 };
 
-int main(int argc, char** argv )
+BOOST_AUTO_TEST_CASE(NoNNC)
 {
-    Dune::MPIHelper::instance(argc, argv);
-
     using Grid = Dune::CpGrid;
     using GridView = Grid::LeafGridView;
     using ElementMapper = Dune::MultipleCodimMultipleGeomTypeMapper<GridView>;
@@ -85,7 +110,7 @@ int main(int argc, char** argv )
                                                360*1./
                                             TOPS
                                                360*100./
-                                            
+
                                             PORO
                                                0. 0.25 0. 357*0.25/
                                             PERMX
@@ -99,8 +124,8 @@ int main(int argc, char** argv )
                                             -- I1 J1 K1  I2 J2 K2 Trans
                                                 1  1  1   2  2  2  1000.0 / --- connection between 0 and 129
                                                 1  1  1   3  3  3  1000.0 / --- connection between 0 and 258
-                                            / 
-                                            
+                                            /
+
                                             END)");
     Grid grid;
     EclipseGrid eclGrid(deck);
@@ -108,7 +133,7 @@ int main(int argc, char** argv )
 
     grid.processEclipseFormat(&eclGrid, &eclState, false, false, false);
     const auto& gridView = grid.leafGridView();
-    
+
     CartesianIndexMapper cartMapper =  Dune::CartesianIndexMapper<Grid>(grid);
 
     auto centroids = [](int) { return std::array<double,Dune::CpGrid::dimensionworld>{}; };
@@ -123,11 +148,12 @@ int main(int argc, char** argv )
 
     auto transmissibilityMap = eclTransmissibility.getTransmissibilitymap();
 
-    // Check if the transmissibilities of the NNCs that were added manually are either not contained in the transmissibility array (because they might be on a different process) or 0.0
-    if (transmissibilityMap.count(details::isId(0,129)) > 0)
-        assert(eclTransmissibility.transmissibility(0,129) == 0.0);
-    if (transmissibilityMap.count(details::isId(0,258)) > 0)
-        assert(eclTransmissibility.transmissibility(0,258) == 0.0);
+    // Check that the transmissibilities of the NNCs that were added manually are
+    // not contained in the transmissibility array or 0.0
+    BOOST_CHECK(transmissibilityMap.count(details::isId(0,129)) == 0 ||
+                eclTransmissibility.transmissibility(0,129) == 0.0);
+    BOOST_CHECK(transmissibilityMap.count(details::isId(0,258)) == 0 ||
+                eclTransmissibility.transmissibility(0,258) == 0.0);
 
     // If there is a non-zero transmissibility in the map, ensure that it is form a neighboring connection
     for (auto&& trans : transmissibilityMap) {
@@ -136,8 +162,23 @@ int main(int argc, char** argv )
             const auto& elements = details::isIdReverse(id);
             int gc1 = std::min(cartMapper.cartesianIndex(elements.first), cartMapper.cartesianIndex(elements.second));
             int gc2 = std::max(cartMapper.cartesianIndex(elements.first), cartMapper.cartesianIndex(elements.second));
-            assert(gc2 - gc1 == 1 || gc2 - gc1 == cartDims[0] || gc2 - gc1 == cartDims[0]*cartDims[1] || gc2 - gc1 == 0);
+            BOOST_CHECK(gc2 - gc1 == 1 ||
+                        gc2 - gc1 == cartDims[0] ||
+                        gc2 - gc1 == cartDims[0]*cartDims[1] ||
+                        gc2 - gc1 == 0);
         }
     }
-    return 0;
+}
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+#if HAVE_MPI
+    // register a throwing error handler to allow for
+    // debugging with "catch throw" in gdb
+    MPI_Errhandler handler;
+    MPI_Comm_create_errhandler(MPI_err_handler, &handler);
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, handler);
+#endif
+    return boost::unit_test::unit_test_main(&init_unit_test_func, argc, argv);
 }

--- a/tests/test_nonnc.cpp
+++ b/tests/test_nonnc.cpp
@@ -128,10 +128,9 @@ BOOST_AUTO_TEST_CASE(NoNNC)
 
                                             END)");
     Grid grid;
-    EclipseGrid eclGrid(deck);
     EclipseState eclState(deck);
 
-    grid.processEclipseFormat(&eclGrid, &eclState, false, false, false);
+    grid.processEclipseFormat(&eclState.getInputGrid(), &eclState, false, false, false);
     const auto& gridView = grid.leafGridView();
 
     CartesianIndexMapper cartMapper =  Dune::CartesianIndexMapper<Grid>(grid);


### PR DESCRIPTION
if we use a separate instance the actnum arrays get out of sync. in
particular the two cells with PORV == 0 will not be marked as inactive
in the actnum array of the separate instance. this leads to a segfault
in lookUpData as the field props will have those cells filtered, while the grid
still has the cells active.

also convert to a boost unit test while at it.