### PR TITLE
Set the PYTHONPATH for the tests using python

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -59,7 +59,7 @@ endfunction()
 # Details:
 #   - This test class compares output from a simulation to reference files.
 function(add_test_compareECLFiles)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR DIR_PREFIX PREFIX RESTART_STEP RESTART_SCHED)
+  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR DIR_PREFIX PREFIX RESTART_STEP RESTART_SCHED ENVIRONMENT)
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_DIR)
@@ -84,6 +84,10 @@ function(add_test_compareECLFiles)
   if(PARAM_RESTART_SCHED)
    list(APPEND DRIVER_ARGS -h ${PARAM_RESTART_SCHED})
   endif()
+  if(PARAM_ENVIRONMENT)
+    list(APPEND DRIVER_ARGS -v ${PARAM_ENVIRONMENT})
+  endif()
+
   opm_add_test(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
                EXE_NAME ${PARAM_SIMULATOR}
                DRIVER_ARGS ${DRIVER_ARGS}
@@ -96,7 +100,7 @@ function(add_test_compareECLFiles)
 endfunction()
 
 function(add_test_compareSeparateECLFiles)
-  set(oneValueArgs CASENAME FILENAME1 FILENAME2 DIR1 DIR2 SIMULATOR ABS_TOL REL_TOL IGNORE_EXTRA_KW DIR_PREFIX PREFIX)
+  set(oneValueArgs CASENAME FILENAME1 FILENAME2 DIR1 DIR2 SIMULATOR ABS_TOL REL_TOL IGNORE_EXTRA_KW DIR_PREFIX PREFIX ENVIRONMENT)
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_PREFIX)
@@ -115,6 +119,9 @@ function(add_test_compareSeparateECLFiles)
                   -c ${COMPARE_ECL_COMMAND})
   if(PARAM_IGNORE_EXTRA_KW)
     list(APPEND DRIVER_ARGS -y ${PARAM_IGNORE_EXTRA_KW})
+  endif()
+  if(PARAM_ENVIRONMENT)
+    list(APPEND DRIVER_ARGS -v ${PARAM_ENVIRONMENT})
   endif()
   opm_add_test(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_CASENAME} NO_COMPILE
                EXE_NAME ${PARAM_SIMULATOR}

--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -96,7 +96,7 @@ function(add_test_compareECLFiles)
 endfunction()
 
 function(add_test_compareSeparateECLFiles)
-  set(oneValueArgs CASENAME FILENAME1 FILENAME2 DIR1 DIR2 SIMULATOR ABS_TOL REL_TOL IGNORE_EXTRA_KW DIR_PREFIX)
+  set(oneValueArgs CASENAME FILENAME1 FILENAME2 DIR1 DIR2 SIMULATOR ABS_TOL REL_TOL IGNORE_EXTRA_KW DIR_PREFIX PREFIX)
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
   if(NOT PARAM_PREFIX)

--- a/pyactionComparisons.cmake
+++ b/pyactionComparisons.cmake
@@ -5,6 +5,8 @@ opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-comparison.sh "")
 set(abs_tol 1e+5)
 set(rel_tol 2e-5)
 set(coarse_rel_tol 1e-2)
+set(PYTHON_PATH ${PROJECT_BINARY_DIR}/python:${opm-common_DIR}/python:$ENV{PYTHONPATH})
+
 add_test_compareSeparateECLFiles(CASENAME pyaction_gconprod_insert_kw
                                  DIR1 pyaction
                                  FILENAME1 PYACTION_GCONPROD_INSERT_KW
@@ -13,7 +15,8 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_gconprod_insert_kw
                                  SIMULATOR flow
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+                                 IGNORE_EXTRA_KW BOTH
+                                 ENVIRONMENT "PYTHONPATH=${PYTHON_PATH}")
 
 add_test_compareSeparateECLFiles(CASENAME pyaction_mult+_insert_kw
                                  DIR1 pyaction
@@ -23,7 +26,8 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_mult+_insert_kw
                                  SIMULATOR flow
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+                                 IGNORE_EXTRA_KW BOTH
+                                 ENVIRONMENT "PYTHONPATH=${PYTHON_PATH}")
 
 add_test_compareSeparateECLFiles(CASENAME pyaction_multx+_insert_kw
                                  DIR1 pyaction
@@ -33,7 +37,8 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_multx+_insert_kw
                                  SIMULATOR flow
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+                                 IGNORE_EXTRA_KW BOTH
+                                 ENVIRONMENT "PYTHONPATH=${PYTHON_PATH}")
 
 add_test_compareSeparateECLFiles(CASENAME pyaction_multx-_insert_kw
                                  DIR1 pyaction
@@ -43,7 +48,8 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_multx-_insert_kw
                                  SIMULATOR flow
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+                                 IGNORE_EXTRA_KW BOTH
+                                 ENVIRONMENT "PYTHONPATH=${PYTHON_PATH}")
 
 add_test_compareSeparateECLFiles(CASENAME pyaction_next_insert_kw
                                  DIR1 pyaction
@@ -53,7 +59,8 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_next_insert_kw
                                  SIMULATOR flow
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+                                 IGNORE_EXTRA_KW BOTH
+                                 ENVIRONMENT "PYTHONPATH=${PYTHON_PATH}")
 
 add_test_compareSeparateECLFiles(CASENAME pyaction_wconprod_insert_kw
                                  DIR1 pyaction
@@ -63,7 +70,8 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wconprod_insert_kw
                                  SIMULATOR flow
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+                                 IGNORE_EXTRA_KW BOTH
+                                 ENVIRONMENT "PYTHONPATH=${PYTHON_PATH}")
 
 add_test_compareSeparateECLFiles(CASENAME pyaction_wefac_insert_kw
                                  DIR1 pyaction
@@ -73,4 +81,5 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wefac_insert_kw
                                  SIMULATOR flow
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH)
+                                 IGNORE_EXTRA_KW BOTH
+                                 ENVIRONMENT "PYTHONPATH=${PYTHON_PATH}")

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -710,7 +710,8 @@ if (opm-common_EMBEDDED_PYTHON)
                            SIMULATOR flow
                            ABS_TOL ${abs_tol}
                            REL_TOL ${rel_tol}
-                           DIR udq_actionx)
+                           DIR udq_actionx
+                           ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/python:${opm-common_DIR}/python:$ENV{PYTHONPATH}")
 endif()
 
 add_test_compareECLFiles(CASENAME multxyz_model2

--- a/tests/run-comparison.sh
+++ b/tests/run-comparison.sh
@@ -17,12 +17,13 @@ then
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
   echo -e "\t\t -c <path>     Path to comparison tool"
   echo -e "\t\t -e <filename> Simulator binary to use"
+  echo -e "\t\t -v <envpath>  String of environment paths, e.g. 'ENV_VARIABLE=value;ANOTHER_ENV_VARIABLE=another_value'"
   exit 1
 fi
 
 RESTART_STEP=""
 OPTIND=1
-while getopts "i:j:f:g:r:b:a:t:c:e:y:" OPT
+while getopts "i:j:f:g:r:b:a:t:c:e:y:v:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH1=${OPTARG} ;;
@@ -36,11 +37,16 @@ do
     c) COMPARE_ECL_COMMAND=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
     y) IGNORE_EXTRA_KW=${OPTARG} ;;
+    v) ENVIRONMENT=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
 
+if test -n "$ENVIRONMENT"
+then
+  export ${ENVIRONMENT}
+fi
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}
 ${BINPATH}/${EXE_NAME} ${INPUT_DATA_PATH1}/${FILENAME1} ${TEST_ARGS} --output-dir=${RESULT_PATH}

--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -19,12 +19,13 @@ then
   echo -e "\tOptional options:"
   echo -e "\t\t -s <step>     Step to do restart testing from"
   echo -e "\t\t -h value      sched_restart value to use in restart test"
+  echo -e "\t\t -v <envpath>  String of environment paths, e.g. 'ENV_VARIABLE=value;ANOTHER_ENV_VARIABLE=another_value'"
   exit 1
 fi
 
 RESTART_STEP=""
 OPTIND=1
-while getopts "i:r:b:f:a:t:c:d:s:e:h:" OPT
+while getopts "i:r:b:f:a:t:c:d:s:e:h:v:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -38,10 +39,16 @@ do
     s) RESTART_STEP=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
     h) RESTART_SCHED=${OPTARG} ;;
+    v) ENVIRONMENT=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
 TEST_ARGS="$@"
+
+if test -n "$ENVIRONMENT"
+then
+  export ${ENVIRONMENT}
+fi
 
 mkdir -p ${RESULT_PATH}
 cd ${RESULT_PATH}


### PR DESCRIPTION
Add argument 'ENVIRONMENT' to add_test_compareSeparateECLFiles and use it to set the PYTHONPATH for the tests using python