### PR TITLE
Added: Python test case with two simulators

### DIFF
--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -60,7 +60,7 @@ if(OPM_ENABLE_PYTHON_TESTS)
   #   splitting the python tests into multiple add_test() tests instead
   #   of having a single "python -m unittest" test call that will run all
   #   the tests in the "test" sub directory.
-  foreach(case_name IN ITEMS basic fluidstate_variables mpi primary_variables schedule throw)
+  foreach(case_name IN ITEMS basic fluidstate_variables mpi primary_variables schedule two_simulators throw)
     add_test(NAME python_${case_name}
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python
         COMMAND ${CMAKE_COMMAND}

--- a/python/simulators/PyBlackOilSimulator.cpp
+++ b/python/simulators/PyBlackOilSimulator.cpp
@@ -174,7 +174,7 @@ setPrimaryVariable(
 void PyBlackOilSimulator::setupMpi(bool mpi_init, bool mpi_finalize)
 {
     if (this->has_run_init_) {
-        throw std::logic_error("mpi_init() called after step_init()");
+        throw std::logic_error("setup_mpi() called after step_init()");
     }
     this->mpi_init_ = mpi_init;
     this->mpi_finalize_ = mpi_finalize;

--- a/python/test/test_basic.py
+++ b/python/test/test_basic.py
@@ -7,43 +7,6 @@ from .pytest_common import pushd
 class TestBasic(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # NOTE: Loading the below extension module involves loading a
-        #    a shared library like "simulators.cpython-37m-x86_64-linux-gnu.so"
-        #    It turns out Python cannot unload this module, see:
-        #
-        #  https://stackoverflow.com/a/8295590/2173773
-        #  https://bugs.python.org/issue34309
-        #
-        #    This is a problem when we want to create a new instance for each unit
-        #    test. For example, when creating the first instance, static variables in
-        #    in the shared object are initialized. However, when the
-        #    corresponding Python object is later deleted (when the test finishes),
-        #    the shared object is not unloaded and its static variables
-        #    stays the same. So when a second Python instance is created,
-        #    the same address is used for the static variables in the shared library
-        #    i.e. the static variables are referring to the same memory location
-        #    as for the first object (and they are not reinitialized).
-        #
-        #    Unfortunatly, this leads to undefined behavior since the C++ code
-        #    for flow simulation uses static variable to keep state information
-        #    and since it was not built under the assumption that it would
-        #    used as a shared library. It was assumed (?) that a flow simulation
-        #    was executed from an executable file (not library file) and only
-        #    executed once. To execute another simulation, it was assumed that
-        #    the executable would be restarted from a controlling program like
-        #    the Shell (which would reload and initialize the object into fresh memory).
-        #
-        #  TODO: Fix the C++ code such that it allows multiple runs whith the same
-        #     object file.
-        #
-        #  NOTE:  The result of the above is that we can only instantiate a
-        #    single simulator object during the unit tests.
-        #    This is not how the unittest module was supposed to be used. Usually one
-        #    would write multiple test_xxx() methods that are independent and
-        #    each method receives a new simulator object (also note that the order
-        #    in which each test_xxx() method is called by unittest is not defined).
-        #    However, as noted above this is not currently possible.
-        #
         test_dir = Path(os.path.dirname(__file__))
         cls.data_dir = test_dir.parent.joinpath("test_data/SPE1CASE1a")
 

--- a/python/test/test_fluidstate_variables.py
+++ b/python/test/test_fluidstate_variables.py
@@ -7,9 +7,6 @@ from .pytest_common import pushd
 class TestBasic(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # NOTE: See comment in test_basic.py for the reason why we are
-        #   only using a single test_all() function instead of splitting
-        #   it up in multiple test functions
         test_dir = Path(os.path.dirname(__file__))
         cls.data_dir = test_dir.parent.joinpath("test_data/SPE1CASE1a")
 

--- a/python/test/test_mpi.py
+++ b/python/test/test_mpi.py
@@ -7,9 +7,6 @@ from .pytest_common import pushd
 class TestBasic(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # NOTE: See comment in test_basic.py for the reason why we are
-        #   only using a single test_all() function instead of splitting
-        #   it up in multiple test functions
         test_dir = Path(os.path.dirname(__file__))
         cls.data_dir = test_dir.parent.joinpath("test_data/SPE1CASE1a")
 
@@ -21,14 +18,14 @@ class TestBasic(unittest.TestCase):
         with pushd(self.data_dir):
             sim = BlackOilSimulator("SPE1CASE1.DATA")
             sim.setup_mpi(init=True, finalize=False)
-            sim.step_init()  # This will create the OPM::Main() object which will call MPI_Init()
+            sim.step_init()  # This will create the Opm::Main() object which will call MPI_Init()
             assert True
 
     def test_02_mpi_no_init(self):
         with pushd(self.data_dir):
             sim = BlackOilSimulator("SPE1CASE1.DATA")
             sim.setup_mpi(init=False, finalize=True)
-            sim.step_init()  # This will create the OPM::Main() object which will not call MPI_Init()
+            sim.step_init()  # This will create the Opm::Main() object which will not call MPI_Init()
             # That this test runs shows that the simulator does not call
             # MPI_Init() a second time
             assert True

--- a/python/test/test_primary_variables.py
+++ b/python/test/test_primary_variables.py
@@ -7,9 +7,6 @@ from .pytest_common import pushd
 class TestBasic(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # NOTE: See comment in test_basic.py for the reason why we are
-        #   only using a single test_all() function instead of splitting
-        #   it up in multiple test functions
         test_dir = Path(os.path.dirname(__file__))
         cls.data_dir = test_dir.parent.joinpath("test_data/SPE1CASE1a")
 

--- a/python/test/test_throw.py
+++ b/python/test/test_throw.py
@@ -7,9 +7,6 @@ from .pytest_common import pushd
 class TestBasic(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # NOTE: See comment in test_basic.py for the reason why we are
-        #   only using a single test_all() function instead of splitting
-        #   it up in multiple test functions
         test_dir = Path(os.path.dirname(__file__))
         cls.data_dir = test_dir.parent.joinpath("test_data/SPE1CASE1a")
 

--- a/python/test/test_two_simulators.py
+++ b/python/test/test_two_simulators.py
@@ -1,0 +1,37 @@
+import os
+import time
+import unittest
+from pathlib import Path
+from opm.simulators import BlackOilSimulator
+from .pytest_common import pushd
+
+class TestBasic(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        test_dir = Path(os.path.dirname(__file__))
+        cls.data_dir = test_dir.parent.joinpath("test_data/SPE1CASE1a")
+
+
+    def test_all(self):
+        with pushd(self.data_dir):
+            sim1 = BlackOilSimulator("SPE1CASE1.DATA")
+            sim2 = BlackOilSimulator("SPE1CASE1.DATA")
+            sim1.setup_mpi(init=True, finalize=False)
+            sim2.setup_mpi(init=False, finalize=False)
+            sim1.step_init()
+            sim2.step_init()
+            sim1.step()
+            sim2.step()
+            poro = sim1.get_porosity()
+            sim1.set_porosity(poro * 0.95)
+            sim1.step()
+            sim2.step()
+            poro12 = sim1.get_porosity()
+            self.assertAlmostEqual(poro12[0], 0.285, places=7, msg='value of porosity 2')
+            poro22 = sim2.get_porosity()
+            self.assertAlmostEqual(poro22[0], 0.300, places=7, msg='value of porosity 2')
+            sim1.step_cleanup()
+            sim2.step_cleanup()
+
+
+


### PR DESCRIPTION
Added a test case to demonstrate that two simulators can be run simultaneously from Python. This is useful for simulating coupled reservoirs.