### PR TITLE
Rerun UDQ Assignments After Action Processing

### DIFF
--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -707,6 +707,19 @@ public:
                         return vg.gridIdxToEquilGridIdx(i);
                     });
             });
+
+            // Rerun UDQ assignents following action processing to make sure
+            // that any UDQ ASSIGN operations triggered in action blocks
+            // take effect.  This is mainly to work around a shortcoming of
+            // the ScheduleState copy constructor which clears pending UDQ
+            // assignments under the assumption that all such assignments
+            // have been processed.  If an action block happens to trigger
+            // on the final time step of an episode and that action block
+            // runs a UDQ assignment, then that assignment would be dropped
+            // and the rest of the simulator will never see its effect
+            // without this hack.
+            this->actionHandler_
+                .evalUDQAssignments(episodeIdx, this->simulator().vanguard().udqState());
         }
 
         // deal with "clogging" for the MICP model


### PR DESCRIPTION
If an action block happens to run a UDQ ASSIGN operation and, furthermore, happens to run at the last time step of an episode then the ["clear pending assignments"](https://github.com/OPM/opm-common/blob/6af6865727aa4b513adf40b37f56656772fcf7f3/opm/input/eclipse/Schedule/ScheduleState.cpp#L160-L168) behaviour of the `ScheduleState` copy constructor leads to not performing the UDQ assignment at all.  This PR works around this problem by invoking the action handler's UDQ assignment function after processing all active action blocks.

The underlying problem has been present since at least PR OPM/opm-common#3587 which introduced the "clear pending assignments" behaviour of `ScheduleState`'s copy constructor.

While here, also make a few whitespace adjustments to `FlowProblem::endTimeStep()` to be more consistent with the rest of the implementation.