### PR TITLE
Tag 'BASIC=0' as allowed in RPTRST

### DIFF
--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -211,7 +211,7 @@ partiallySupported()
          {
             "RPTRST",
             {
-               {1,{false, allow_values<std::string> {"ALLPROPS", "BASIC=1", "BASIC=2", "BASIC=3", "BASIC=4", "BASIC=5", "BASIC=6", "DEN", "KRG", "KRO", "KRW", "RSSAT", "RVSAT", "VISC"}, "RPTRST(RPTRST): invalid option or unsupported integer control format"}}, // MNEMONIC_LIST
+               {1,{false, allow_values<std::string> {"ALLPROPS", "BASIC=0", "BASIC=1", "BASIC=2", "BASIC=3", "BASIC=4", "BASIC=5", "BASIC=6", "DEN", "KRG", "KRO", "KRW", "RSSAT", "RVSAT", "VISC"}, "RPTRST(RPTRST): invalid option or unsupported integer control format"}}, // MNEMONIC_LIST
             },
          },
          {


### PR DESCRIPTION
Since it appears to be allowed and working: 

https://github.com/OPM/opm-common/blob/95795867abc0a2a9a8af1a568387fd4799b0de10/opm/input/eclipse/Schedule/RSTConfig.cpp#L647-L648
