### PR TITLE
Remove the need for add well contributions to matrix for NLDD

### DIFF
--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -242,9 +242,6 @@ namespace Opm {
             convergence_reports_.reserve(300); // Often insufficient, but avoids frequent moves.
             // TODO: remember to fix!
             if (param_.nonlinear_solver_ == "nldd") {
-                if (!param_.matrix_add_well_contributions_) {
-                    OPM_THROW(std::runtime_error, "The --nonlinear-solver=nldd option can only be used with --matrix-add-well-contributions=true");
-                }
                 if (terminal_output) {
                     OpmLog::info("Using Non-Linear Domain Decomposition solver (nldd).");
                 }

--- a/opm/simulators/flow/BlackoilModelNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelNldd.hpp
@@ -169,6 +169,7 @@ public:
             loc_param.linear_solver_print_json_definition_ = false;
             const bool force_serial = true;
             domain_linsolvers_.emplace_back(model_.simulator(), loc_param, force_serial);
+            domain_linsolvers_.back().setDomainIndex(index);
         }
 
         assert(int(domains_.size()) == num_domains);

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -352,8 +352,6 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                 // Outch! We need to be able to scale the linear system! Hence const_cast
                 matrix_ = const_cast<Matrix*>(&M);
 
-                is_nldd_local_solver_ = parameters_[activeSolverNum_].is_nldd_local_solver_;
-
                 useWellConn_ = Parameters::Get<Parameters::MatrixAddWellContributions>();
                 // setup sparsity pattern for jacobi matrix for preconditioner (only used for openclSolver)
             } else {
@@ -452,9 +450,14 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
 
         const CommunicationType* comm() const { return comm_.get(); }
 
-        void setDomainIndex(int index)
+        void setDomainIndex(const int index)
         {
             domainIndex_ = index;
+        }
+
+        bool isNlddLocalSolver() const
+        {
+            return parameters_[activeSolverNum_].is_nldd_local_solver_;
         }
 
     protected:
@@ -497,7 +500,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             OPM_TIMEBLOCK(flexibleSolverPrepare);
             if (shouldCreateSolver()) {
                 if (!useWellConn_) {
-                    if (is_nldd_local_solver_) {
+                    if (isNlddLocalSolver()) {
                         auto wellOp = std::make_unique<DomainWellModelAsLinearOperator<WellModel, Vector, Vector>>(simulator_.problem().wellModel());
                         wellOp->setDomainIndex(domainIndex_);
                         flexibleSolver_[activeSolverNum_].wellOperator_ = std::move(wellOp);
@@ -664,8 +667,6 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         std::vector<detail::FlexibleSolverInfo<Matrix,Vector,CommunicationType>> flexibleSolver_;
         std::vector<int> overlapRows_;
         std::vector<int> interiorRows_;
-
-        bool is_nldd_local_solver_;
 
         int domainIndex_ = -1;
 

--- a/opm/simulators/linalg/WellOperators.hpp
+++ b/opm/simulators/linalg/WellOperators.hpp
@@ -123,8 +123,44 @@ public:
         return wellMod_.numLocalWellsEnd();
     }
 
-private:
+protected:
     const WellModel& wellMod_;
+};
+
+
+template <class WellModel, class X, class Y>
+class DomainWellModelAsLinearOperator : public WellModelAsLinearOperator<WellModel, X, Y>
+{
+public:
+    using WBase = WellModelAsLinearOperator<WellModel, X, Y>;
+    using WBase::WBase;  // inherit all constructors from the base class
+    using field_type = typename WBase::field_type;
+    using PressureMatrix = typename WBase::PressureMatrix;
+
+    void setDomainIndex(int index) { domainIndex_ = index; }
+
+    void apply(const X& x, Y& y) const override
+    {
+        OPM_TIMEBLOCK(apply);
+        this->wellMod_.applyDomain(x, y, domainIndex_);
+    }
+
+    void applyscaleadd(field_type alpha, const X& x, Y& y) const override
+    {
+        OPM_TIMEBLOCK(applyscaleadd);
+        this->wellMod_.applyScaleAddDomain(alpha, x, y, domainIndex_);
+    }
+
+    void addWellPressureEquations(PressureMatrix& jacobian,
+                                  const X& weights,
+                                  const bool use_well_weights) const override
+    {
+        OPM_TIMEBLOCK(addWellPressureEquations);
+        this->wellMod_.addWellPressureEquationsDomain(jacobian, weights, use_well_weights, domainIndex_);
+    }
+
+private:
+    int domainIndex_ = -1;
 };
 
 /*!

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -300,6 +300,8 @@ template<class Scalar> class WellContributions;
             // subtract B*inv(D)*C * x from A*x
             void apply(const BVector& x, BVector& Ax) const;
 
+            void applyDomain(const BVector& x, BVector& Ax, int domainIndex) const;
+
 #if COMPILE_BDA_BRIDGE
             // accumulate the contributions of all Wells in the WellContributions object
             void getWellContributions(WellContributions<Scalar>& x) const;
@@ -307,6 +309,8 @@ template<class Scalar> class WellContributions;
 
             // apply well model with scaling of alpha
             void applyScaleAdd(const Scalar alpha, const BVector& x, BVector& Ax) const;
+
+            void applyScaleAddDomain(const Scalar alpha, const BVector& x, BVector& Ax, int domainIndex) const;
 
             // Check if well equations is converged.
             ConvergenceReport getWellConvergence(const std::vector<Scalar>& B_avg, const bool checkWellGroupControls = false) const;
@@ -357,6 +361,9 @@ template<class Scalar> class WellContributions;
             using PressureMatrix = Dune::BCRSMatrix<Opm::MatrixBlock<Scalar, 1, 1>>;
 
             void addWellPressureEquations(PressureMatrix& jacobian, const BVector& weights,const bool use_well_weights) const;
+
+            void addWellPressureEquationsDomain(PressureMatrix& jacobian, const BVector& weights,const bool use_well_weights, int domainIndex) const;
+
 
             void addWellPressureEquationsStruct(PressureMatrix& jacobian) const;
 

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -591,6 +591,11 @@ template<class Scalar> class WellContributions;
 
         private:
             BlackoilWellModel(Simulator& simulator, const PhaseUsage& pu);
+
+            mutable BVector x_local_;
+            mutable BVector Ax_local_;
+            mutable BVector res_local_;
+            mutable GlobalEqVector linearize_res_local_;
         };
 
 

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -33,6 +33,8 @@
 #include <string>
 #include <vector>
 
+#include <opm/grid/utility/SparseTable.hpp>
+
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRate.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
@@ -445,8 +447,8 @@ template<class Scalar> class WellContributions;
             // Keep track of the domain of each well, if using subdomains.
             std::map<std::string, int> well_domain_;
 
-            // Store the global index of the cells in the domain, if using sumdomains
-            std::vector<std::vector<int>> domains_cells_;
+            // Store the local index of the wells perforated cells in the domain, if using sumdomains
+            SparseTable<int> well_local_cells_;
 
             const Grid& grid() const
             { return simulator_.vanguard().grid(); }

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -302,7 +302,7 @@ template<class Scalar> class WellContributions;
             // subtract B*inv(D)*C * x from A*x
             void apply(const BVector& x, BVector& Ax) const;
 
-            void applyDomain(const BVector& x, BVector& Ax, int domainIndex) const;
+            void applyDomain(const BVector& x, BVector& Ax, const int domainIndex) const;
 
 #if COMPILE_BDA_BRIDGE
             // accumulate the contributions of all Wells in the WellContributions object
@@ -312,7 +312,7 @@ template<class Scalar> class WellContributions;
             // apply well model with scaling of alpha
             void applyScaleAdd(const Scalar alpha, const BVector& x, BVector& Ax) const;
 
-            void applyScaleAddDomain(const Scalar alpha, const BVector& x, BVector& Ax, int domainIndex) const;
+            void applyScaleAddDomain(const Scalar alpha, const BVector& x, BVector& Ax, const int domainIndex) const;
 
             // Check if well equations is converged.
             ConvergenceReport getWellConvergence(const std::vector<Scalar>& B_avg, const bool checkWellGroupControls = false) const;
@@ -364,7 +364,10 @@ template<class Scalar> class WellContributions;
 
             void addWellPressureEquations(PressureMatrix& jacobian, const BVector& weights,const bool use_well_weights) const;
 
-            void addWellPressureEquationsDomain(PressureMatrix& jacobian, const BVector& weights,const bool use_well_weights, int domainIndex) const;
+            void addWellPressureEquationsDomain([[maybe_unused]] PressureMatrix& jacobian,
+                                                [[maybe_unused]] const BVector& weights,
+                                                [[maybe_unused]] const bool use_well_weights,
+                                                [[maybe_unused]] const int domainIndex) const;
 
 
             void addWellPressureEquationsStruct(PressureMatrix& jacobian) const;
@@ -594,6 +597,10 @@ template<class Scalar> class WellContributions;
         private:
             BlackoilWellModel(Simulator& simulator, const PhaseUsage& pu);
 
+            // These members are used to avoid reallocation in specific functions
+            // (e.g., apply, applyDomain) instead of using local variables.
+            // Their state is not relevant between function calls, so they can
+            // (and must) be mutable, as the functions using them are const.
             mutable BVector x_local_;
             mutable BVector Ax_local_;
             mutable BVector res_local_;

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -441,6 +441,9 @@ template<class Scalar> class WellContributions;
             // Keep track of the domain of each well, if using subdomains.
             std::map<std::string, int> well_domain_;
 
+            // Store the global index of the cells in the domain, if using sumdomains
+            std::vector<std::vector<int>> domains_cells_;
+
             const Grid& grid() const
             { return simulator_.vanguard().grid(); }
 

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -297,9 +297,6 @@ template<class Scalar> class WellContributions;
                 return this->computeWellBlockAveragePressures();
             }
 
-            // subtract Binv(D)rw from r;
-            void apply( BVector& r) const;
-
             // subtract B*inv(D)*C * x from A*x
             void apply(const BVector& x, BVector& Ax) const;
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1734,48 +1734,6 @@ namespace Opm {
 
     }
 
-
-    template<typename TypeTag>
-    void
-    BlackoilWellModel<TypeTag>::
-    apply(BVector& r) const
-    {
-        BVector r_local;
-        for (auto& well : well_container_) {
-            auto cells = well->cells();
-            r_local.resize(cells.size());
-
-            if (this->param_.nonlinear_solver_ == "nldd") {
-                // transfer global cells index to local subdomain cells index
-
-                auto domain_cells = domains_cells_[well_domain_.at(well->name())];
-
-                // Assuming domain_cells is sorted
-                for (size_t i = 0; i < cells.size(); ++i) {
-                    auto it = std::lower_bound(domain_cells.begin(), domain_cells.end(), cells[i]);
-                    if (it != domain_cells.end() && *it == cells[i]) {
-                        // Found the cell, get the index
-                        auto local_index = std::distance(domain_cells.begin(), it);
-                        cells[i] = local_index;
-                    } else {
-                        std::cerr << "Cell value " << cells[i] << " not found in domain_cells." << std::endl;
-                    }
-                }
-            }
-
-            for (size_t i = 0; i < cells.size(); ++i) {
-                r_local[i] = r[cells[i]];
-            }
-
-            well->apply(r_local);
-
-            for (size_t i = 0; i < cells.size(); ++i) {
-                r[cells[i]] = r_local[i];
-            }
-        }
-    }
-
-
     // Ax = A x - C D^-1 B x
     template<typename TypeTag>
     void

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1760,7 +1760,7 @@ namespace Opm {
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::
-    applyDomain(const BVector& x, BVector& Ax, int domainIndex) const
+    applyDomain(const BVector& x, BVector& Ax, const int domainIndex) const
     {
         for (size_t well_index = 0; well_index < well_container_.size(); ++well_index) {
             auto& well = well_container_[well_index];
@@ -1849,7 +1849,7 @@ namespace Opm {
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::
-    applyScaleAddDomain(const Scalar alpha, const BVector& x, BVector& Ax, int domainIndex) const
+    applyScaleAddDomain(const Scalar alpha, const BVector& x, BVector& Ax, const int domainIndex) const
     {
         if (this->well_container_.empty()) {
             return;
@@ -1879,11 +1879,11 @@ namespace Opm {
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::
-    addWellPressureEquations(PressureMatrix& jacobian, const BVector& weights,const bool use_well_weights) const
+    addWellPressureEquations(PressureMatrix& jacobian, const BVector& weights, const bool use_well_weights) const
     {
-        int nw =  this->numLocalWellsEnd();
+        int nw = this->numLocalWellsEnd();
         int rdofs = local_num_cells_;
-        for ( int i = 0; i < nw; i++ ){
+        for ( int i = 0; i < nw; i++ ) {
             int wdof = rdofs + i;
             jacobian[wdof][wdof] = 1.0;// better scaling ?
         }
@@ -1896,20 +1896,23 @@ namespace Opm {
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::
-    addWellPressureEquationsDomain(PressureMatrix& jacobian, const BVector& weights,const bool use_well_weights, int domainIndex) const
+    addWellPressureEquationsDomain([[maybe_unused]] PressureMatrix& jacobian,
+                                   [[maybe_unused]] const BVector& weights,
+                                   [[maybe_unused]] const bool use_well_weights,
+                                   [[maybe_unused]] const int domainIndex) const
     {
         throw std::logic_error("CPRW is not yet implemented for NLDD subdomains");
         // To fix this function, rdofs should be the size of the domain, and the nw should be the number of wells in the domain
-        // int nw =  this->numLocalWellsEnd(); // should number of wells in the domain
+        // int nw = this->numLocalWellsEnd(); // should number of wells in the domain
         // int rdofs = local_num_cells_;  // should be the size of the domain
-        // for ( int i = 0; i < nw; i++ ){
+        // for ( int i = 0; i < nw; i++ ) {
         //     int wdof = rdofs + i;
         //     jacobian[wdof][wdof] = 1.0;// better scaling ?
         // }
 
         // for ( const auto& well : well_container_ ) {
         //     if (well_domain_.at(well->name()) == domainIndex) {
-                    // weights should be the size of the domain
+                   // weights should be the size of the domain
         //         well->addWellPressureEquations(jacobian, weights, pressureVarIndex, use_well_weights, this->wellState());
         //     }
         // }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1969,8 +1969,15 @@ namespace Opm {
         DeferredLogger local_deferredLogger;
         OPM_BEGIN_PARALLEL_TRY_CATCH();
         {
+            BVector x_local;
             for (auto& well : well_container_) {
-                well->recoverWellSolutionAndUpdateWellState(simulator_, x, this->wellState(), local_deferredLogger);
+                auto cells = well->cells();
+                x_local.resize(cells.size());
+
+                for (size_t i = 0; i < cells.size(); ++i) {
+                    x_local[i] = x[cells[i]];
+                }
+                well->recoverWellSolutionAndUpdateWellState(simulator_, x_local, this->wellState(), local_deferredLogger);
             }
         }
         OPM_END_PARALLEL_TRY_CATCH_LOG(local_deferredLogger,
@@ -1988,9 +1995,16 @@ namespace Opm {
         // try/catch here, as this function is not called in
         // parallel but for each individual domain of each rank.
         DeferredLogger local_deferredLogger;
+        BVector x_local;
         for (auto& well : well_container_) {
             if (well_domain_.at(well->name()) == domain.index) {
-                well->recoverWellSolutionAndUpdateWellState(simulator_, x,
+                auto cells = well->cells();
+                x_local.resize(cells.size());
+
+                for (size_t i = 0; i < cells.size(); ++i) {
+                    x_local[i] = x[cells[i]];
+                }
+                well->recoverWellSolutionAndUpdateWellState(simulator_, x_local,
                                                             this->wellState(),
                                                             local_deferredLogger);
             }

--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -78,8 +78,8 @@ init(const int num_cells,
         }
         duneD_.setSize(well_.numberOfSegments(), well_.numberOfSegments(), nnz_d);
     }
-    duneB_.setSize(well_.numberOfSegments(), num_cells, numPerfs);
-    duneC_.setSize(well_.numberOfSegments(), num_cells, numPerfs);
+    duneB_.setSize(well_.numberOfSegments(), numPerfs, numPerfs);
+    duneC_.setSize(well_.numberOfSegments(), numPerfs, numPerfs);
 
     // we need to add the off diagonal ones
     for (auto row = duneD_.createbegin(),
@@ -108,8 +108,7 @@ init(const int num_cells,
               end = duneC_.createend(); row != end; ++row) {
         // the number of the row corresponds to the segment number now.
         for (const int& perf : perforations[row.index()]) {
-            const int cell_idx = cells[perf];
-            row.insert(cell_idx);
+            row.insert(perf);
         }
     }
 
@@ -118,8 +117,7 @@ init(const int num_cells,
               end = duneB_.createend(); row != end; ++row) {
         // the number of the row corresponds to the segment number now.
         for (const int& perf : perforations[row.index()]) {
-            const int cell_idx = cells[perf];
-            row.insert(cell_idx);
+            row.insert(perf);
         }
     }
 

--- a/opm/simulators/wells/MultisegmentWellEquations.hpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.hpp
@@ -145,6 +145,9 @@ public:
     BVectorWell resWell_;
 
     const MultisegmentWellGeneric<Scalar>& well_; //!< Reference to well
+
+    // Store the global index of well perforated cells
+    std::vector<int> cells_;
 };
 
 }

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1904,7 +1904,7 @@ namespace Opm
                     this->connectionRates_[perf][comp_idx] = Base::restrictEval(cq_s_effective);
 
                     MultisegmentWellAssemble(*this).
-                        assemblePerforationEq(seg, cell_idx, comp_idx, cq_s_effective, this->linSys_);
+                        assemblePerforationEq(seg, perf, comp_idx, cq_s_effective, this->linSys_);
                 }
             }
 

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -62,8 +62,8 @@ init(const int num_cells,
     // B D] x_well]      res_well]
     // set the size of the matrices
     duneD_.setSize(1, 1, 1);
-    duneB_.setSize(1, num_cells, numPerfs);
-    duneC_.setSize(1, num_cells, numPerfs);
+    duneB_.setSize(1, numPerfs, numPerfs);
+    duneC_.setSize(1, numPerfs, numPerfs);
 
     for (auto row = duneD_.createbegin(),
               end = duneD_.createend(); row != end; ++row) {
@@ -76,29 +76,25 @@ init(const int num_cells,
     for (auto row = duneB_.createbegin(),
               end = duneB_.createend(); row != end; ++row) {
         for (int perf = 0 ; perf < numPerfs; ++perf) {
-            const int cell_idx = cells[perf];
-            row.insert(cell_idx);
+            row.insert(perf);
         }
     }
 
     for (int perf = 0 ; perf < numPerfs; ++perf) {
-        const int cell_idx = cells[perf];
         // the block size is run-time determined now
-        duneB_[0][cell_idx].resize(numWellEq, numEq);
+        duneB_[0][perf].resize(numWellEq, numEq);
     }
 
          // make the C^T matrix
     for (auto row = duneC_.createbegin(),
               end = duneC_.createend(); row != end; ++row) {
         for (int perf = 0; perf < numPerfs; ++perf) {
-            const int cell_idx = cells[perf];
-            row.insert(cell_idx);
+            row.insert(perf);
         }
     }
 
     for (int perf = 0; perf < numPerfs; ++perf) {
-        const int cell_idx = cells[perf];
-        duneC_[0][cell_idx].resize(numWellEq, numEq);
+        duneC_[0][perf].resize(numWellEq, numEq);
     }
 
     resWell_.resize(1);

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -111,6 +111,9 @@ init(const int num_cells,
     for (unsigned i = 0; i < duneD_.N(); ++i) {
         invDrw_[i].resize(numWellEq);
     }
+
+    // Store the global index of well perforated cells
+    cells_ = cells;
 }
 
 template<class Scalar, int numEq>
@@ -261,14 +264,17 @@ extract(SparseMatrixAdapter& jacobian) const
     for (auto colC = duneC_[0].begin(),
               endC = duneC_[0].end(); colC != endC; ++colC)
     {
-        const auto row_index = colC.index();
+        // map the well perforated cell index to global cell index
+        const auto row_index = this->cells_[colC.index()];
 
         for (auto colB = duneB_[0].begin(),
                   endB = duneB_[0].end(); colB != endB; ++colB)
         {
+            // map the well perforated cell index to global cell index
+            const auto col_index = this->cells_[colB.index()];
             detail::multMatrix(invDuneD_[0][0], (*colB), tmp);
             detail::negativeMultMatrixTransposed((*colC), tmp, tmpMat);
-            jacobian.addToBlock(row_index, colB.index(), tmpMat);
+            jacobian.addToBlock(row_index, col_index, tmpMat);
         }
     }
 }
@@ -307,22 +313,23 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
     int nperf = 0;
     auto cell_weights = weights[0];// not need for not(use_well_weights)
     cell_weights = 0.0;
-    assert(duneC_.M() == weights.size());
-    const int welldof_ind = duneC_.M() + well.indexOfWell();
+    const int number_cells = weights.size();
+    const int welldof_ind = number_cells + well.indexOfWell();
     // do not assume anything about pressure controlled with use_well_weights (work fine with the assumtion also)
     if (!well.isPressureControlled(well_state) || use_well_weights) {
         // make coupling for reservoir to well
         for (auto colC = duneC_[0].begin(),
                   endC = duneC_[0].end(); colC != endC; ++colC) {
-            const auto row_ind = colC.index();
-            const auto& bw = weights[row_ind];
+            // map the well perforated cell index to global cell index
+            const auto row_index = cells_[colC.index()];
+            const auto& bw = weights[row_index];
             Scalar matel = 0;
             assert((*colC).M() == bw.size());
             for (std::size_t i = 0; i < bw.size(); ++i) {
                 matel += (*colC)[bhp_var_index][i] * bw[i];
             }
 
-            jacobian[row_ind][welldof_ind] = matel;
+            jacobian[row_index][welldof_ind] = matel;
             cell_weights += bw;
             nperf += 1;
         }
@@ -381,7 +388,8 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
     if (!well.isPressureControlled(well_state) || use_well_weights) {
         for (auto colB = duneB_[0].begin(),
                   endB = duneB_[0].end(); colB != endB; ++colB) {
-            const auto col_index = colB.index();
+            // map the well perforated cell index to global cell index
+            const auto col_index = cells_[colB.index()];
             const auto& bw = bweights[0];
             Scalar matel = 0;
             for (std::size_t i = 0; i < bw.size(); ++i) {

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -150,6 +150,9 @@ private:
     // several vector used in the matrix calculation
     mutable BVectorWell Bx_;
     mutable BVectorWell invDrw_;
+
+    // Store the global index of well perforated cells
+    std::vector<int> cells_;
 };
 
 }

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -404,7 +404,6 @@ namespace Opm
                                                water_flux_s, deferred_logger);
                 }
             }
-            const int cell_idx = this->well_cells_[perf];
             for (int componentIdx = 0; componentIdx < this->num_components_; ++componentIdx) {
                 // the cq_s entering mass balance equations need to consider the efficiency factors.
                 const EvalWell cq_s_effective = cq_s[componentIdx] * this->well_efficiency_factor_;
@@ -414,7 +413,7 @@ namespace Opm
                 StandardWellAssemble<FluidSystem,Indices>(*this).
                     assemblePerforationEq(cq_s_effective,
                                           componentIdx,
-                                          cell_idx,
+                                          perf,
                                           this->primary_variables_.numWellEq(),
                                           this->linSys_);
 
@@ -430,7 +429,7 @@ namespace Opm
             if constexpr (has_zFraction) {
                 StandardWellAssemble<FluidSystem,Indices>(*this).
                     assembleZFracEq(cq_s_zfrac_effective,
-                                    cell_idx,
+                                    perf,
                                     this->primary_variables_.numWellEq(),
                                     this->linSys_);
             }
@@ -2132,7 +2131,7 @@ namespace Opm
                                       eq_wat_vel,
                                       pskin_index,
                                       wat_vel_index,
-                                      cell_idx,
+                                      perf,
                                       this->primary_variables_.numWellEq(),
                                       this->linSys_);
     }


### PR DESCRIPTION
The PR addresses the following changes:

1. Make well equations use only perforated cells. Previously, the B and C equations for the well equations had dimensions of the total number of cells but with only non-zero elements for the perforated cells. After this fix it only uses the perforated cells. This requires the global input vectors and matrices in the well operators to be mapped to a local vector for only the perforated cells.
2. Introduce a well operator for NLDD domains, such that when applying the well operator for NLDD, the necessary mapping from global cell indexes to the NLDD subdomain indexes is done and the well apply is only applied to wells on that is in the domain.

These two changes, has made these two new features possible:
1. Remove the need for using add well contributions to matrix for NLDD.
2. Add support for the CPRW preconditioner for NLDD.