### PR TITLE
removing unused releaseGlobalTransmissibility()

### DIFF
--- a/opm/simulators/flow/AluGridVanguard.hpp
+++ b/opm/simulators/flow/AluGridVanguard.hpp
@@ -256,11 +256,6 @@ public:
         return *globalTrans_;
     }
 
-    void releaseGlobalTransmissibility()
-    {
-        globalTrans_.reset();
-    }
-
     const std::vector<int>& globalCell()
     {
         return cartesianCellId_;

--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -212,11 +212,6 @@ public:
         return *globalTrans_;
     }
 
-    void releaseGlobalTransmissibility()
-    {
-        globalTrans_.reset();
-    }
-
     /*!
      * \brief Distribute the simulation grid over multiple processes
      *


### PR DESCRIPTION
from AluGridVanguard and CpGridVanguard.
they exist is becaluse of typo in the function name. There is another releaseGlobalTransmissibilities() function actually gets used.