### PR TITLE
Prevent spurious warnings about NNCs when applying EDITNNC in parallel.

### DIFF
--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -226,17 +226,18 @@ protected:
     void applyNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianToCompressed);
 
     /// \brief Multiplies the grid transmissibilities according to EDITNNC.
-    void applyEditNncToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal);
+    void applyEditNncToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal, const bool warn);
 
     /// \brief Resets the grid transmissibilities according to EDITNNCR.
-    void applyEditNncrToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal);
+    void applyEditNncrToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal, const bool warn);
 
     void applyNncMultreg_(const std::unordered_map<std::size_t,int>& globalToLocal);
 
     void applyEditNncToGridTransHelper_(const std::unordered_map<std::size_t,int>& globalToLocal,
                                         const std::string& keyword, const std::vector<NNCdata>& nncs,
                                         const std::function<KeywordLocation(const NNCdata&)>& getLocation,
-                                        const std::function<void(Scalar&, const Scalar&)>& apply);
+                                        const std::function<void(Scalar&, const Scalar&)>& apply,
+                                        const bool warn);
 
     void extractPermeability_();
 
@@ -287,6 +288,7 @@ protected:
     bool enableEnergy_;
     bool enableDiffusivity_;
     bool enableDispersivity_;
+    bool warnEditNNC_ = true;
     std::unordered_map<std::uint64_t, Scalar> thermalHalfTrans_; //NB this is based on direction map size is ca 2*trans_ (diffusivity_)
     std::unordered_map<std::uint64_t, Scalar> diffusivity_;
     std::unordered_map<std::uint64_t, Scalar> dispersivity_;

--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -226,18 +226,17 @@ protected:
     void applyNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianToCompressed);
 
     /// \brief Multiplies the grid transmissibilities according to EDITNNC.
-    void applyEditNncToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal, const bool warn);
+    void applyEditNncToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal);
 
     /// \brief Resets the grid transmissibilities according to EDITNNCR.
-    void applyEditNncrToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal, const bool warn);
+    void applyEditNncrToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal);
 
     void applyNncMultreg_(const std::unordered_map<std::size_t,int>& globalToLocal);
 
     void applyEditNncToGridTransHelper_(const std::unordered_map<std::size_t,int>& globalToLocal,
                                         const std::string& keyword, const std::vector<NNCdata>& nncs,
                                         const std::function<KeywordLocation(const NNCdata&)>& getLocation,
-                                        const std::function<void(Scalar&, const Scalar&)>& apply,
-                                        const bool warn);
+                                        const std::function<void(Scalar&, const Scalar&)>& apply);
 
     void extractPermeability_();
 


### PR DESCRIPTION
If we use transmissibilities for loadbalancing, then we calculate transmissibilities twice. First on the global grid before loadbalancing and then on the local grid after that. This is the default. In this case all warnings will be shown correctly when calculating the global transmissibilities.

If the user requests the same weights for all faces (command line parameter --edge-weights-method=0) then the transmissibilities are only calculated on the loadbalanced grid. Unfortunately, in this case only rank 0 will issue warnings for his part including the false positives mentioned below.

Due to load balancing many NNCs might be stored on another process, but we still use all EDITNNC entries when computing transmissibilties locally. Hence when applying EDITNNC on the loadbalanced grid we will issue warnings for cases where there are no problems (e.g. NNC between two overlap cells.

With this PR we will only warn when computing the transmissibilities for the first time. For the default settings this will remove spurious and duplicate warnings.

Not that for --edge-weights-method=0 nothing changes and we will still see only warnings for the first rank including spurious one.