### PR TITLE
InitStateEquil: remove template parameter from Comm

### DIFF
--- a/opm/simulators/flow/equil/InitStateEquil.cpp
+++ b/opm/simulators/flow/equil/InitStateEquil.cpp
@@ -76,11 +76,9 @@ INSTANCE_COMP(GridViewFem, MapperFem)
 
 namespace Details {
     template class PressureTable<BlackOilFluidSystem<double>,EquilReg>;
-    template void verticalExtent<std::vector<int>,
-                                 Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator>>(
-                                 const std::vector<int>&,
+    template void verticalExtent(const std::vector<int>&,
                                  const std::vector<std::pair<double,double>>&,
-                                 const Dune::CollectiveCommunication<Dune::MPIHelper::MPICommunicator>&,
+                                 const Parallel::Communication&,
                                  std::array<double,2>&);
 
     using MatLaw = EclMaterialLawManager<ThreePhaseMaterialTraits<double,0,1,2>>;

--- a/opm/simulators/flow/equil/InitStateEquil.hpp
+++ b/opm/simulators/flow/equil/InitStateEquil.hpp
@@ -34,6 +34,8 @@
 #include <opm/material/common/Tabulated1DFunction.hpp>
 #include <opm/material/fluidstates/SimpleModularFluidState.hpp>
 
+#include <opm/simulators/utils/ParallelCommunication.hpp>
+
 #include <array>
 #include <cstddef>
 #include <memory>
@@ -658,10 +660,10 @@ private:
 
 // ===========================================================================
 
-template <typename CellRange, typename Comm>
+template <typename CellRange>
 void verticalExtent(const CellRange&      cells,
                     const std::vector<std::pair<double, double>>& cellZMinMax,
-                    const Comm& comm,
+                    const Parallel::Communication& comm,
                     std::array<double,2>& span);
 
 template <class Element>

--- a/opm/simulators/flow/equil/InitStateEquil_impl.hpp
+++ b/opm/simulators/flow/equil/InitStateEquil_impl.hpp
@@ -60,10 +60,10 @@ namespace EQUIL {
 
 namespace Details {
 
-template <typename CellRange, typename Comm>
+template <typename CellRange>
 void verticalExtent(const CellRange&      cells,
                     const std::vector<std::pair<double, double>>& cellZMinMax,
-                    const Comm& comm,
+                    const Parallel::Communication& comm,
                     std::array<double,2>& span)
 {
     span[0] = std::numeric_limits<double>::max();

--- a/opm/simulators/linalg/PreconditionerWithUpdate.hpp
+++ b/opm/simulators/linalg/PreconditionerWithUpdate.hpp
@@ -91,7 +91,7 @@ struct GeneralPreconditionerMaker {
     virtual std::unique_ptr<
         Preconditioner<typename OriginalPreconditioner::domain_type, typename OriginalPreconditioner::range_type>>
     make() = 0;
-    virtual ~GeneralPreconditionerMaker(){};
+    virtual ~GeneralPreconditionerMaker() = default;
 };
 
 /// @brief Struct implementing a make function which creates a preconditioner


### PR DESCRIPTION
use Parallel::Communication directly

in the process this quells a deprecation warning for Dune::CollectiveCommunication usage.

replace #5348 

Also takes care of niggle https://github.com/OPM/opm-simulators/pull/5355#discussion_r1601241011