### PR TITLE
limiting max time step to 10 days for PYACTION_WCONPROD

### DIFF
--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -717,7 +717,8 @@ if (opm-common_EMBEDDED_PYTHON)
                            SIMULATOR flow
                            ABS_TOL ${abs_tol}
                            REL_TOL ${rel_tol}
-                           DIR udq_actionx)
+                           DIR udq_actionx
+                           TEST_ARGS --solver-max-time-step-in-days=10)
 endif()
 
 add_test_compareECLFiles(CASENAME multxyz_model2


### PR DESCRIPTION
to make the regression checking more stable.

it was investigated during the checking for the regression failures for https://github.com/OPM/opm-simulators/pull/5232 . 