### PR TITLE
Bugfix: Avoid possible use of out-of-scope temporary.

### DIFF
--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
@@ -338,7 +338,7 @@ copyToWellState(const MultisegmentWellGeneric<Scalar>& mswell,
         std::transform(segments.phase_resv_rates.begin() + (seg + 0) * well_.numPhases(),
                        segments.phase_resv_rates.begin() + (seg + 1) * well_.numPhases(),
                        segments.phase_holdup.begin()     + (seg + 0) * well_.numPhases(),
-                       [tot_resv](const auto qr) { return std::clamp(qr / tot_resv, 0.0, 1.0); });
+                       [tot_resv](const auto qr) -> Scalar { return std::clamp(qr / tot_resv, 0.0, 1.0); });
 
         // 4) Local condition flow velocities for segments other than top segment.
         if (seg > 0) {

--- a/opm/simulators/wells/StandardWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.cpp
@@ -70,7 +70,7 @@ Scalar relaxationFactorFraction(const Scalar old_value,
         const std::string msg = fmt::format(" illegal fraction value {} {} is found for well {}", value_name, old_value, well_name);
         OPM_DEFLOG_PROBLEM(Opm::NumericalProblem, msg, deferred_logger);
     }
-    const Scalar& safe_old_value = std::clamp(old_value, Scalar{0.0}, Scalar{1.0});
+    const Scalar safe_old_value = std::clamp(old_value, Scalar{0.0}, Scalar{1.0});
 
     Scalar relaxation_factor = 1.;
 


### PR DESCRIPTION
Since std::clamp returns a reference we must be careful to not capture the return value by reference, when there is a temporary among the input parameters.

For the second change (adding the explicit Scalar return type to a lambda) this is strictly speaking not necessary, as the lambda's return type is not a reference, but that is obscure so the change is just done as to clarify.