### PR TITLE
Avoid memory leak from the *unique_ptr<X>.release() antipattern.

### DIFF
--- a/opm/simulators/flow/FlowGenericVanguard.hpp
+++ b/opm/simulators/flow/FlowGenericVanguard.hpp
@@ -174,8 +174,8 @@ public:
     const UDQState& udqState() const
     { return *udqState_; }
 
-    WellTestState transferWTestState() {
-        return *this->wtestState_.release();
+    std::unique_ptr<WellTestState> transferWTestState() {
+        return std::move(this->wtestState_);
     }
 
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -186,7 +186,7 @@ getWellEcl(const std::string& well_name) const
 template<class Scalar>
 void BlackoilWellModelGeneric<Scalar>::
 initFromRestartFile(const RestartValue& restartValues,
-                    WellTestState wtestState,
+                    std::unique_ptr<WellTestState> wtestState,
                     const std::size_t numCells,
                     bool handle_ms_well)
 {

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -156,7 +156,7 @@ public:
                         const SummaryState& st);
 
     void initFromRestartFile(const RestartValue& restartValues,
-                             WellTestState wtestState,
+                             std::unique_ptr<WellTestState> wtestState,
                              const std::size_t numCells,
                              bool handle_ms_well);
 

--- a/opm/simulators/wells/WGState.cpp
+++ b/opm/simulators/wells/WGState.cpp
@@ -46,10 +46,10 @@ serializationTestObject(const ParallelWellInfo<Scalar>& pinfo)
 }
 
 template<class Scalar>
-void WGState<Scalar>::wtest_state(WellTestState wtest_state)
+void WGState<Scalar>::wtest_state(std::unique_ptr<WellTestState> wtest_state)
 {
-    wtest_state.filter_wells( this->well_state.wells() );
-    this->well_test_state = std::move(wtest_state);
+    wtest_state->filter_wells( this->well_state.wells() );
+    this->well_test_state = std::move(*wtest_state);
 }
 
 template<class Scalar>

--- a/opm/simulators/wells/WGState.hpp
+++ b/opm/simulators/wells/WGState.hpp
@@ -24,6 +24,8 @@
 #include <opm/simulators/wells/GroupState.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 
+#include <memory>
+
 namespace Opm {
 
 template<class Scalar> class ParallelWellInfo;
@@ -41,7 +43,7 @@ struct WGState
 
     static WGState serializationTestObject(const ParallelWellInfo<Scalar>& pinfo);
 
-    void wtest_state(WellTestState wtest_state);
+    void wtest_state(std::unique_ptr<WellTestState> wtest_state);
 
     WellState<Scalar> well_state;
     GroupState<Scalar> group_state;


### PR DESCRIPTION
The transferWTestState() function leaks the originally pointed to object and returns a copy.

Changed to move the unique_ptr all the way to the destination.