### PR TITLE
Add Regression Test for Undefined UDQ Variables

### DIFF
--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -585,6 +585,13 @@ add_test_compareECLFiles(CASENAME reg_smry_in_fld_udq
                          DIR udq_actionx
                          TEST_ARGS --enable-tuning=true)
 
+add_test_compareECLFiles(CASENAME udq_undefined_2
+                         FILENAME UDQ-01
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR actionx)
+
 add_test_compareECLFiles(CASENAME cskin-01
                          FILENAME CSKIN-01
                          SIMULATOR flow


### PR DESCRIPTION
Undefined UDQs get the value in `UDQPARAM(3)`.  The UDQ-01 test model triggers an action block [if and only if](https://github.com/OPM/opm-tests/blob/1925c493cc8e4a4bb905c5bfc09da731391c3123/actionx/UDQ-01.DATA#L206) we implement that behaviour.