### PR TITLE
renaming calcRates to calcResvCoeff, and calcInjRates to calcInjResvCoeff.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -547,14 +547,14 @@ class WellContributions;
 
             void wellTesting(const int timeStepIdx, const double simulationTime, DeferredLogger& deferred_logger);
 
-            void calcRates(const int fipnum,
-                           const int pvtreg,
-                           const std::vector<Scalar>& production_rates,
-                           std::vector<Scalar>& resv_coeff) override;
+            void calcResvCoeff(const int fipnum,
+                               const int pvtreg,
+                               const std::vector<Scalar>& production_rates,
+                               std::vector<Scalar>& resv_coeff) override;
 
-            void calcInjRates(const int fipnum,
-                           const int pvtreg,
-                           std::vector<Scalar>& resv_coeff) override;
+            void calcInjResvCoeff(const int fipnum,
+                                  const int pvtreg,
+                                  std::vector<Scalar>& resv_coeff) override;
 
             void computeWellTemperature();
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -598,7 +598,7 @@ checkGroupHigherConstraints(const Group& group,
     if (!isField && group.isInjectionGroup()) {
         // Obtain rates for group.
         std::vector<Scalar> resv_coeff_inj(phase_usage_.num_phases, 0.0);
-        calcInjRates(fipnum, pvtreg, resv_coeff_inj);
+        calcInjResvCoeff(fipnum, pvtreg, resv_coeff_inj);
 
         for (int phasePos = 0; phasePos < phase_usage_.num_phases; ++phasePos) {
             const Scalar local_current_rate = WellGroupHelpers<Scalar>::sumWellSurfaceRates(group,
@@ -664,7 +664,7 @@ checkGroupHigherConstraints(const Group& group,
             rates[phasePos] = -comm_.sum(local_current_rate);
         }
         std::vector<Scalar> resv_coeff(phase_usage_.num_phases, 0.0);
-        calcRates(fipnum, pvtreg, this->groupState().production_rates(group.name()), resv_coeff);
+        calcResvCoeff(fipnum, pvtreg, this->groupState().production_rates(group.name()), resv_coeff);
         // Check higher up only if under individual (not FLD) control.
         const Group::ProductionCMode& currentControl = this->groupState().production_control(group.name());
         if (currentControl != Group::ProductionCMode::FLD && group.productionGroupControlAvailable()) {

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -339,13 +339,13 @@ protected:
     void setWsolvent(const Group& group,
                      const int reportStepIdx,
                      Scalar wsolvent);
-    virtual void calcRates(const int fipnum,
-                           const int pvtreg,
-                           const std::vector<Scalar>& production_rates,
-                           std::vector<Scalar>& resv_coeff) = 0;
-    virtual void calcInjRates(const int fipnum,
-                              const int pvtreg,
-                              std::vector<Scalar>& resv_coeff) = 0;
+    virtual void calcResvCoeff(const int fipnum,
+                               const int pvtreg,
+                               const std::vector<Scalar>& production_rates,
+                               std::vector<Scalar>& resv_coeff) = 0;
+    virtual void calcInjResvCoeff(const int fipnum,
+                                  const int pvtreg,
+                                  std::vector<Scalar>& resv_coeff) = 0;
 
     void assignShutConnections(data::Wells& wsrpt,
                                const int reportStepIndex) const;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2530,10 +2530,10 @@ namespace Opm {
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::
-    calcRates(const int fipnum,
-              const int pvtreg,
-              const std::vector<Scalar>& production_rates,
-              std::vector<Scalar>& resv_coeff)
+    calcResvCoeff(const int fipnum,
+                  const int pvtreg,
+                  const std::vector<Scalar>& production_rates,
+                  std::vector<Scalar>& resv_coeff)
     {
         rateConverter_->calcCoeff(fipnum, pvtreg, production_rates, resv_coeff);
     }
@@ -2541,9 +2541,9 @@ namespace Opm {
     template<typename TypeTag>
     void
     BlackoilWellModel<TypeTag>::
-    calcInjRates(const int fipnum,
-                 const int pvtreg,
-                 std::vector<Scalar>& resv_coeff)
+    calcInjResvCoeff(const int fipnum,
+                     const int pvtreg,
+                     std::vector<Scalar>& resv_coeff)
     {
         rateConverter_->calcInjCoeff(fipnum, pvtreg, resv_coeff);
     }

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -321,10 +321,10 @@ public:
         closed_offending_wells_ = {{"test4", {"test5", "test6"}}};
     }
 
-    void calcRates(const int, const int, const std::vector<double>&, std::vector<double>&) override
+    void calcResvCoeff(const int, const int, const std::vector<double>&, std::vector<double>&) override
     {}
 
-    void calcInjRates(const int, const int, std::vector<double>&) override
+    void calcInjResvCoeff(const int, const int, std::vector<double>&) override
     {}
 
     void computePotentials(const std::size_t,


### PR DESCRIPTION
We are not calculating any rates, so the original names are misleading. 

Saw this when reviewing other PRs. 