### PR TITLE
[FIX]: Build issue if OpenMP is not present

### DIFF
--- a/opm/simulators/linalg/ISTLSolverBda.cpp
+++ b/opm/simulators/linalg/ISTLSolverBda.cpp
@@ -124,7 +124,9 @@ apply(Vector& rhs,
 	      //NOTE: copyThread can safely write to jacMat because in solve_system both matrix and *blockJacobiForGPUILU0_ diagonal entries
 	      //are checked and potentially overwritten in replaceZeroDiagonal() by mainThread. However, no matter the thread writing sequence,
 	      //the final entry in jacMat is correct.
+#if HAVE_OPENMP
               copyThread = std::make_shared<std::thread>([&](){this->copyMatToBlockJac(matrix, *blockJacobiForGPUILU0_);});
+#endif // HAVE_OPENMP
 	    }
 	    else {
 	      this->copyMatToBlockJac(matrix, *blockJacobiForGPUILU0_);


### PR DESCRIPTION
Fix to the error:
```
/Users/dmar/Github/opm/opm-simulators/opm/simulators/linalg/ISTLSolverBda.cpp:127:15: error: use of undeclared identifier 'copyThread'
              copyThread = std::make_shared<std::thread>([&](){this->copyMatToBlockJac(matrix, *blockJacobiForGPUILU0_);});
              ^
/Users/dmar/Github/opm/opm-simulators/opm/simulators/linalg/ISTLSolverBda.cpp:127:50: error: no member named 'thread' in namespace 'std'
              copyThread = std::make_shared<std::thread>([&](){this->copyMatToBlockJac(matrix, *blockJacobiForGPUILU0_);});
``` 