### PR TITLE
only allocate trans_ for globalTrans_

### DIFF
--- a/opm/simulators/flow/AluGridVanguard.hpp
+++ b/opm/simulators/flow/AluGridVanguard.hpp
@@ -190,7 +190,7 @@ public:
                                                                  getPropValue<TypeTag,
                                                                  Properties::EnableDispersion>());
             // Re-ordering  for ALUGrid
-            globalTrans_->update(false, [&](unsigned int i) { return gridEquilIdxToGridIdx(i);});
+            globalTrans_->update(false, true, [&](unsigned int i) { return gridEquilIdxToGridIdx(i);});
         }
         
     }
@@ -351,6 +351,10 @@ protected:
     std::unique_ptr<CartesianIndexMapper> cartesianIndexMapper_;
     std::unique_ptr<EquilCartesianIndexMapper> equilCartesianIndexMapper_;
     std::unique_ptr<Factory> factory_;
+    // \Note: this globalTrans_ is used for domain decomposition and INIT file output.
+    // It only contains trans_ due to permeability and does not contain thermalHalfTrans_,
+    // diffusivity_ abd dispersivity_. The main reason is to reduce the memory usage for rank 0
+    // during parallel running.
     std::unique_ptr<TransmissibilityType> globalTrans_;
     int mpiRank;
 };

--- a/opm/simulators/flow/AluGridVanguard.hpp
+++ b/opm/simulators/flow/AluGridVanguard.hpp
@@ -190,7 +190,8 @@ public:
                                                                  getPropValue<TypeTag,
                                                                  Properties::EnableDispersion>());
             // Re-ordering  for ALUGrid
-            globalTrans_->update(false, true, [&](unsigned int i) { return gridEquilIdxToGridIdx(i);});
+            globalTrans_->update(false, TransmissibilityType::TransUpdateQuantities::Trans,
+                                 [&](unsigned int i) { return gridEquilIdxToGridIdx(i);});
         }
         
     }

--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -285,7 +285,7 @@ protected:
                                                     getPropValue<TypeTag, Properties::EnableEnergy>(),
                                                     getPropValue<TypeTag, Properties::EnableDiffusion>(),
                                                     getPropValue<TypeTag, Properties::EnableDispersion>()));
-        globalTrans_->update(false);
+        globalTrans_->update(false, true);
     }
 
     double getTransmissibility(unsigned I, unsigned J) const override
@@ -306,6 +306,10 @@ protected:
         this->doFilterConnections_(this->schedule());
     }
 
+    // \Note: this globalTrans_ is used for domain decomposition and INIT file output.
+    // It only contains trans_ due to permeability and does not contain thermalHalfTrans_,
+    // diffusivity_ abd dispersivity_. The main reason is to reduce the memory usage for rank 0
+    // during parallel running.
     std::unique_ptr<TransmissibilityType> globalTrans_;
 };
 

--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -285,7 +285,7 @@ protected:
                                                     getPropValue<TypeTag, Properties::EnableEnergy>(),
                                                     getPropValue<TypeTag, Properties::EnableDiffusion>(),
                                                     getPropValue<TypeTag, Properties::EnableDispersion>()));
-        globalTrans_->update(false, true);
+        globalTrans_->update(false, TransmissibilityType::TransUpdateQuantities::Trans);
     }
 
     double getTransmissibility(unsigned I, unsigned J) const override

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -538,7 +538,8 @@ public:
             };
 
             // re-compute all quantities which may possibly be affected.
-            transmissibilities_.update(true, false, equilGridToGrid);
+            using TransUpdateQuantities = typename Vanguard::TransmissibilityType::TransUpdateQuantities;
+            transmissibilities_.update(true, TransUpdateQuantities::All, equilGridToGrid);
             this->referencePorosity_[1] = this->referencePorosity_[0];
             updateReferencePorosity_();
             updatePffDofData_();
@@ -700,8 +701,9 @@ public:
                 .applyActions(episodeIdx, simulator.time() + simulator.timeStepSize(),
                               [this](const bool global)
             {
+                using TransUpdateQuantities = typename Vanguard::TransmissibilityType::TransUpdateQuantities;
                 this->transmissibilities_
-                    .update(global, false, [&vg = this->simulator().vanguard()]
+                    .update(global,  TransUpdateQuantities::All, [&vg = this->simulator().vanguard()]
                             (const unsigned int i)
                     {
                         return vg.gridIdxToEquilGridIdx(i);

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -538,7 +538,7 @@ public:
             };
 
             // re-compute all quantities which may possibly be affected.
-            transmissibilities_.update(true, equilGridToGrid);
+            transmissibilities_.update(true, false, equilGridToGrid);
             this->referencePorosity_[1] = this->referencePorosity_[0];
             updateReferencePorosity_();
             updatePffDofData_();
@@ -701,7 +701,7 @@ public:
                               [this](const bool global)
             {
                 this->transmissibilities_
-                    .update(global, [&vg = this->simulator().vanguard()]
+                    .update(global, false, [&vg = this->simulator().vanguard()]
                             (const unsigned int i)
                     {
                         return vg.gridIdxToEquilGridIdx(i);

--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -128,7 +128,7 @@ public:
      */
     void finishInit(const std::function<unsigned int(unsigned int)>& map = {})
     {
-        this->update(true, false, map, /*applyNncMultRegT = */ true);
+        this->update(true, TransUpdateQuantities::All, map, /*applyNncMultRegT = */ true);
     }
 
     /*!
@@ -138,10 +138,12 @@ public:
      *   processes.  Also, this updates the "thermal half
      *   transmissibilities" if energy is enabled.
      *
-     * \param[in] onlyTrans Whether we only allocate and upate trans_ without considering
+     * \param[in] trans Indicating whether we only allocate and upate trans_ without considering
      *   thermalHalfTrans_, diffusivity_, dispersivity_. For many usage, we only need trans_,
      *   e.g. weights for domain decomposition, INIT file output. It might change following
      *   further development.
+     *     Trans  only update the trans_, which is related to permeability
+     *     All    upate rans_, thermalHalfTrans_, diffusivity_ and dispersivity_.
      *
      * \param[in] map Undocumented.
      *
@@ -152,7 +154,9 @@ public:
      *   numerical aquifers.  Default value: \c false, meaning do not apply
      *   regional multipliers to explicit NNCs.
      */
-    void update(bool global, bool onlyTrans = false, const std::function<unsigned int(unsigned int)>& map = {}, bool applyNncMultRegT = false);
+    enum class TransUpdateQuantities { Trans, All };
+    void update(bool global, TransUpdateQuantities update_quantities = TransUpdateQuantities::All,
+                const std::function<unsigned int(unsigned int)>& map = {}, bool applyNncMultRegT = false);
 
 protected:
     void updateFromEclState_(bool global);

--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -128,7 +128,7 @@ public:
      */
     void finishInit(const std::function<unsigned int(unsigned int)>& map = {})
     {
-        this->update(true, map, /*applyNncMultRegT = */ true);
+        this->update(true, false, map, /*applyNncMultRegT = */ true);
     }
 
     /*!
@@ -137,6 +137,11 @@ public:
      * \param[in] global Whether or not to call \c update() on all
      *   processes.  Also, this updates the "thermal half
      *   transmissibilities" if energy is enabled.
+     *
+     * \param[in] onlyTrans Whether we only allocate and upate trans_ without considering
+     *   thermalHalfTrans_, diffusivity_, dispersivity_. For many usage, we only need trans_,
+     *   e.g. weights for domain decomposition, INIT file output. It might change following
+     *   further development.
      *
      * \param[in] map Undocumented.
      *
@@ -147,7 +152,7 @@ public:
      *   numerical aquifers.  Default value: \c false, meaning do not apply
      *   regional multipliers to explicit NNCs.
      */
-    void update(bool global, const std::function<unsigned int(unsigned int)>& map = {}, bool applyNncMultRegT = false);
+    void update(bool global, bool onlyTrans = false, const std::function<unsigned int(unsigned int)>& map = {}, bool applyNncMultRegT = false);
 
 protected:
     void updateFromEclState_(bool global);

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -159,7 +159,8 @@ dispersivity(unsigned elemIdx1, unsigned elemIdx2) const
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
 void Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
-update(bool global, const std::function<unsigned int(unsigned int)>& map, const bool applyNncMultregT)
+update(bool global, const bool onlyTrans,
+       const std::function<unsigned int(unsigned int)>& map, const bool applyNncMultregT)
 {
     const auto& cartDims = cartMapper_.cartesianDimensions();
     const auto& transMult = eclState_.getTransMult();
@@ -208,7 +209,7 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
     transBoundary_.clear();
 
     // if energy is enabled, let's do the same for the "thermal half transmissibilities"
-    if (enableEnergy_) {
+    if (enableEnergy_ && !onlyTrans) {
         thermalHalfTrans_.clear();
         thermalHalfTrans_.reserve(numElements*6*1.05);
 
@@ -216,14 +217,14 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
     }
 
     // if diffusion is enabled, let's do the same for the "diffusivity"
-    if (updateDiffusivity) {
+    if (updateDiffusivity && !onlyTrans) {
         diffusivity_.clear();
         diffusivity_.reserve(numElements*3*1.05);
         extractPorosity_();
     }
 
     // if dispersion is enabled, let's do the same for the "dispersivity"
-    if (updateDispersivity) {
+    if (updateDispersivity && !onlyTrans) {
         dispersivity_.clear();
         dispersivity_.reserve(numElements*3*1.05);
         extractDispersion_();
@@ -283,7 +284,7 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
 
                 // for boundary intersections we also need to compute the thermal
                 // half transmissibilities
-                if (enableEnergy_) {
+                if (enableEnergy_ && !onlyTrans) {
                     Scalar transBoundaryEnergyIs;
                     computeHalfDiffusivity_(transBoundaryEnergyIs,
                                             faceAreaNormal,
@@ -334,15 +335,15 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
                 // *added to* by applyNncToGridTrans_() later.
                 assert(outsideFaceIdx == -1);
                 trans_[details::isId(elemIdx, outsideElemIdx)] = 0.0;
-                if (enableEnergy_){
+                if (enableEnergy_  && !onlyTrans){
                     thermalHalfTrans_[details::directionalIsId(elemIdx, outsideElemIdx)] = 0.0;
                     thermalHalfTrans_[details::directionalIsId(outsideElemIdx, elemIdx)] = 0.0;
                 }
 
-                if (updateDiffusivity) {
+                if (updateDiffusivity && !onlyTrans) {
                     diffusivity_[details::isId(elemIdx, outsideElemIdx)] = 0.0;
                 }
-                if (updateDispersivity) {
+                if (updateDispersivity && !onlyTrans) {
                     dispersivity_[details::isId(elemIdx, outsideElemIdx)] = 0.0;
                 }
                 continue;
@@ -459,7 +460,7 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
             trans_[details::isId(elemIdx, outsideElemIdx)] = trans;
 
             // update the "thermal half transmissibility" for the intersection
-            if (enableEnergy_) {
+            if (enableEnergy_ && !onlyTrans) {
 
                 Scalar halfDiffusivity1;
                 Scalar halfDiffusivity2;
@@ -484,7 +485,7 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
            }
 
             // update the "diffusive half transmissibility" for the intersection
-            if (updateDiffusivity) {
+            if (updateDiffusivity && !onlyTrans) {
 
                 Scalar halfDiffusivity1;
                 Scalar halfDiffusivity2;
@@ -520,7 +521,7 @@ update(bool global, const std::function<unsigned int(unsigned int)>& map, const 
            }
 
            // update the "dispersivity half transmissibility" for the intersection
-            if (updateDispersivity) {
+            if (updateDispersivity && !onlyTrans) {
 
                 Scalar halfDispersivity1;
                 Scalar halfDispersivity2;

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -159,9 +159,11 @@ dispersivity(unsigned elemIdx1, unsigned elemIdx2) const
 
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
 void Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
-update(bool global, const bool onlyTrans,
+update(bool global, const TransUpdateQuantities update_quantities,
        const std::function<unsigned int(unsigned int)>& map, const bool applyNncMultregT)
 {
+    // whether only update the permeability related transmissibility
+    const bool onlyTrans = (update_quantities == TransUpdateQuantities::Trans);
     const auto& cartDims = cartMapper_.cartesianDimensions();
     const auto& transMult = eclState_.getTransMult();
     const auto& comm = gridView_.comm();


### PR DESCRIPTION
others are not needed for globalTrans_ for now. It will help to flatten the peak memory usage for rank 0 during a parallel running.