### PR TITLE
Enable WTMULT as an Input Operation

### DIFF
--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -738,7 +738,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"WTADD", {true, std::nullopt}},
         {"WTEMPQ", {true, std::nullopt}},
         {"WTHPMAX", {true, std::nullopt}},
-        {"WTMULT", {true, std::nullopt}},
         {"ZIPPY2", {false, std::nullopt}},
         {"ZIPP2OFF", {false, std::nullopt}},
         {"ZMFVD", {false, std::nullopt}},        


### PR DESCRIPTION
Basic support for this keyword was added in commit OPM/opm-common@5e3e20c552c10f69f0717d19fe88c13119ec3e71 (PR OPM/opm-common#2763) and this PR enables running models which use that basic support. Advanced uses, such as including user-defined arguments for the multipliers, will still be rejected at the input level.