### PR TITLE
Fix modifications of TRANX/Y/Z in parallel (e.g. MULTIPLY of TRANX in EDIT)

### DIFF
--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -853,8 +853,7 @@ createTransmissibilityArrays_(const std::array<bool,3>& is_tran)
             unsigned c2 = elemMapper.index(intersection.outside());
             int gc1 = cartMapper_.cartesianIndex(c1);
             int gc2 = cartMapper_.cartesianIndex(c2);
-
-            if (c1 > c2)
+            if (std::tie(gc1, c1) > std::tie(gc2, c2))
                 continue; // we only need to handle each connection once, thank you.
 
             auto isID = details::isId(c1, c2);
@@ -917,7 +916,7 @@ resetTransmissibilityFromArrays_(const std::array<bool,3>& is_tran,
             unsigned c2 = elemMapper.index(intersection.outside());
             int gc1 = cartMapper_.cartesianIndex(c1);
             int gc2 = cartMapper_.cartesianIndex(c2);
-            if (c1 > c2)
+            if (std::tie(gc1, c1) > std::tie(gc2, c2))
                 continue; // we only need to handle each connection once, thank you.
 
             auto isID = details::isId(c1, c2);


### PR DESCRIPTION
Once the simulator has computed the transmissibilities from the grid and the properties, we check whether the transmissibilties were explicitly modified in the deck. If that is the case, we create TRANX/TRANY/TRANZ from the calculated values and apply the modifications (`Transmissibility::updateFromEclState`). This allows the user to overwrite values, multiply them with a scalar, etc.

In a parallel run there was a bug. we assumed that the local ordering of the elements is the same as when they would ordered by cartesian index. This does not hold in parallel as the elements in the ghost/overlap layer will have a higher index than the other ones. Due to this values in the created arrays where were wrong (at the wrong place) for ghost/overlap elements. We might have overwritten values for interior cells when we created those arrays which lead to wrong transmissibilities.

This PR fixes this.

(edited by @blattms)