### PR TITLE
extending drsdtcon with regimes, and option for GAS/WATER

### DIFF
--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -140,6 +140,10 @@ template<class TypeTag>
 struct EnableDispersion<TypeTag, TTag::FlowProblem> {
     static constexpr bool value = false;
 };
+template<class TypeTag>
+struct EnableConvectiveMixing<TypeTag, TTag::FlowProblem> {
+    static constexpr bool value = true;
+};
 
 template<class TypeTag>
 struct WellModel<TypeTag, TTag::FlowProblem> {

--- a/opm/simulators/flow/EquilInitializer.hpp
+++ b/opm/simulators/flow/EquilInitializer.hpp
@@ -174,6 +174,7 @@ public:
                     const auto& h = FluidSystem::enthalpy(fluidState, phaseIdx, regionIdx);
                     fluidState.setEnthalpy(phaseIdx, h);
                 }
+
             }
 
             // set the salt concentration

--- a/opm/simulators/flow/EquilInitializer.hpp
+++ b/opm/simulators/flow/EquilInitializer.hpp
@@ -174,7 +174,6 @@ public:
                     const auto& h = FluidSystem::enthalpy(fluidState, phaseIdx, regionIdx);
                     fluidState.setEnthalpy(phaseIdx, h);
                 }
-
             }
 
             // set the salt concentration

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -145,6 +145,7 @@ class FlowProblem : public GetPropType<TypeTag, Properties::BaseProblem>
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     enum { enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>() };
     enum { enableDispersion = getPropValue<TypeTag, Properties::EnableDispersion>() };
+    enum { enableConvectiveMixing = getPropValue<TypeTag, Properties::EnableConvectiveMixing>() };
     enum { enableThermalFluxBoundaries = getPropValue<TypeTag, Properties::EnableThermalFluxBoundaries>() };
     enum { enableApiTracking = getPropValue<TypeTag, Properties::EnableApiTracking>() };
     enum { enableMICP = getPropValue<TypeTag, Properties::EnableMICP>() };
@@ -182,7 +183,7 @@ class FlowProblem : public GetPropType<TypeTag, Properties::BaseProblem>
     using MICPModule = BlackOilMICPModule<TypeTag>;
     using DispersionModule = BlackOilDispersionModule<TypeTag, enableDispersion>;
     using DiffusionModule = BlackOilDiffusionModule<TypeTag, enableDiffusion>;
-    using ConvectiveMixingModule = BlackOilConvectiveMixingModule<TypeTag>;
+    using ConvectiveMixingModule = BlackOilConvectiveMixingModule<TypeTag, enableConvectiveMixing>;
     using ModuleParams = typename BlackOilLocalResidualTPFA<TypeTag>::ModuleParams;
 
     using InitialFluidState = typename EquilInitializer<TypeTag>::ScalarFluidState;
@@ -537,8 +538,6 @@ public:
         auto& eclState = simulator.vanguard().eclState();
         const auto& schedule = simulator.vanguard().schedule();
         const auto& events = schedule[episodeIdx].events();
-
-
 
         if (episodeIdx >= 0 && events.hasEvent(ScheduleEvents::GEO_MODIFIER)) {
             // bring the contents of the keywords to the current state of the SCHEDULE

--- a/opm/simulators/flow/FlowProblemProperties.hpp
+++ b/opm/simulators/flow/FlowProblemProperties.hpp
@@ -256,6 +256,12 @@ struct EnableDispersion<TypeTag, TTag::FlowBaseProblem> {
     static constexpr bool value = false;
 };
 
+// Enable Convective Mixing
+template<class TypeTag>
+struct EnableConvectiveMixing<TypeTag, TTag::FlowBaseProblem> {
+    static constexpr bool value = true;
+};
+
 // only write the solutions for the report steps to disk
 template<class TypeTag>
 struct EnableWriteAllSolutions<TypeTag, TTag::FlowBaseProblem> {

--- a/opm/simulators/flow/MixingRateControls.cpp
+++ b/opm/simulators/flow/MixingRateControls.cpp
@@ -101,8 +101,7 @@ init(std::size_t numDof, int episodeIdx, const unsigned ntpvt)
     //TODO We may want to only allocate these properties only if active.
     //But since they may be activated at later time we need some more
     //intrastructure to handle it
-    if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) &&
-        FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {
+
         maxDRv_.resize(ntpvt, 1e30);
         lastRv_.resize(numDof, 0.0);
         maxDRs_.resize(ntpvt, 1e30);
@@ -113,7 +112,6 @@ init(std::size_t numDof, int episodeIdx, const unsigned ntpvt)
         if (this->drsdtConvective(episodeIdx)) {
             convectiveDrs_.resize(numDof, 1.0);
         }
-    }
 }
 
 template<class FluidSystem>
@@ -123,7 +121,7 @@ drsdtActive(int episodeIdx) const
     const auto& oilVaporizationControl = schedule_[episodeIdx].oilvap();
     const bool bothOilGasActive = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) &&
                                   FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
-    return (oilVaporizationControl.drsdtActive() && bothOilGasActive);
+    return (oilVaporizationControl.drsdtActive());
 }
 
 template<class FluidSystem>
@@ -133,7 +131,7 @@ drvdtActive(int episodeIdx) const
     const auto& oilVaporizationControl = schedule_[episodeIdx].oilvap();
     const bool bothOilGasActive = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) &&
                                   FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
-    return (oilVaporizationControl.drvdtActive() && bothOilGasActive);
+    return (oilVaporizationControl.drvdtActive());
 }
 
 template<class FluidSystem>
@@ -143,7 +141,7 @@ drsdtConvective(int episodeIdx) const
     const auto& oilVaporizationControl = schedule_[episodeIdx].oilvap();
     const bool bothOilGasActive = FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) &&
                                   FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
-    return (oilVaporizationControl.drsdtConvective() && bothOilGasActive);
+    return (oilVaporizationControl.drsdtConvective());
 }
 
 template<class FluidSystem>
@@ -273,29 +271,61 @@ updateConvectiveDRsDt_(const unsigned compressedDofIdx,
                        const Scalar p,
                        const Scalar rs,
                        const Scalar so,
+                       const Scalar sg,
                        const Scalar poro,
                        const Scalar permz,
                        const Scalar distZ,
                        const Scalar gravity,
+                       const Scalar salt,
+                       const Scalar Xhi,
+                       const Scalar Psi,
+                       const Scalar omegainn,
                        const int pvtRegionIndex)
 {
-    const Scalar rssat = FluidSystem::oilPvt().saturatedGasDissolutionFactor(pvtRegionIndex, t, p);
-    const Scalar saturatedInvB
-        = FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(pvtRegionIndex, t, p);
+    const Scalar rssat = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+        FluidSystem::waterPvt().saturatedGasDissolutionFactor(pvtRegionIndex, t, p, salt) : 
+        FluidSystem::oilPvt().saturatedGasDissolutionFactor(pvtRegionIndex, t, p);
+    const Scalar saturatedInvB = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+        FluidSystem::waterPvt().saturatedInverseFormationVolumeFactor(pvtRegionIndex, t, p, salt) :
+        FluidSystem::oilPvt().saturatedInverseFormationVolumeFactor(pvtRegionIndex, t, p);
     const Scalar rsZero = 0.0;
-    const Scalar pureDensity
-        = FluidSystem::oilPvt().inverseFormationVolumeFactor(pvtRegionIndex, t, p, rsZero)
-        * FluidSystem::oilPvt().oilReferenceDensity(pvtRegionIndex);
-    const Scalar saturatedDensity = saturatedInvB
-        * (FluidSystem::oilPvt().oilReferenceDensity(pvtRegionIndex)
-           + rssat * FluidSystem::referenceDensity(FluidSystem::gasPhaseIdx, pvtRegionIndex));
-    const Scalar deltaDensity = saturatedDensity - pureDensity;
-    const Scalar visc = FluidSystem::oilPvt().viscosity(pvtRegionIndex, t, p, rs);
+    const Scalar sg_max = 1.0;
+    const Scalar pureDensity = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+        (FluidSystem::waterPvt().inverseFormationVolumeFactor(pvtRegionIndex, t, p, rsZero, salt)
+        * FluidSystem::waterPvt().waterReferenceDensity(pvtRegionIndex)) :
+         (FluidSystem::oilPvt().inverseFormationVolumeFactor(pvtRegionIndex, t, p, rsZero)
+        * FluidSystem::oilPvt().oilReferenceDensity(pvtRegionIndex));
+    const Scalar saturatedDensity = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+        (saturatedInvB * (FluidSystem::waterPvt().waterReferenceDensity(pvtRegionIndex)
+        + rssat * FluidSystem::referenceDensity(FluidSystem::gasPhaseIdx, pvtRegionIndex))) :
+        (saturatedInvB * (FluidSystem::oilPvt().oilReferenceDensity(pvtRegionIndex)
+        + rssat * FluidSystem::referenceDensity(FluidSystem::gasPhaseIdx, pvtRegionIndex)));
+    Scalar deltaDensity = saturatedDensity - pureDensity;
+    const Scalar visc = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+        FluidSystem::waterPvt().viscosity(pvtRegionIndex, t, p, rs, salt) :
+        FluidSystem::oilPvt().viscosity(pvtRegionIndex, t, p, rs);
+
     // Note that for so = 0 this gives no limits (inf) for the dissolution rate
     // Also we restrict the effect of convective mixing to positive density differences
     // i.e. we only allow for fingers moving downward
+
+    Scalar co2Density = FluidSystem::gasPvt().inverseFormationVolumeFactor(pvtRegionIndex,
+         t,p,0.0 /*=Rv*/, 0.0 /*=Rvw*/) * FluidSystem::referenceDensity(FluidSystem::gasPhaseIdx, pvtRegionIndex);
+	Scalar factor = 1.0;
+	Scalar X = (rs - rssat * sg) / (rssat * ( 1.0 - sg));
+    Scalar omega = 0.0;
+	if ((rs >= (rssat * sg))){
+	    if(X > Psi){
+		    factor = 0.0;
+            omega = omegainn;
+        }
+	} else {
+	        factor /= Xhi;
+	        deltaDensity = (saturatedDensity - co2Density);
+	    }
+    
     convectiveDrs_[compressedDofIdx]
-        = permz * rssat * max(0.0, deltaDensity) * gravity / (so * visc * distZ * poro);
+        = factor * permz * rssat * max(0.0, deltaDensity) * gravity / ( std::max(sg_max - sg, 0.0) * visc * distZ * poro) + (omega/Xhi); 
 }
 
 template class MixingRateControls<BlackOilFluidSystem<double,BlackOilDefaultIndexTraits>>;

--- a/opm/simulators/flow/MixingRateControls.hpp
+++ b/opm/simulators/flow/MixingRateControls.hpp
@@ -117,20 +117,46 @@ public:
                 const int pvtRegionIdx,
                 const std::array<bool,3>& active)
     {
+        const auto& oilVaporizationControl = schedule_[episodeIdx].oilvap();
+
         if (active[0]) {
             // This implements the convective DRSDT as described in
             // Sandve et al. "Convective dissolution in field scale CO2 storage simulations using the OPM Flow
             // simulator" Submitted to TCCS 11, 2021
+            // modification and introduction of regimes following Mykkeltvedt et al. Submitted to TIMP 2024
             const auto& fs = iq.fluidState();
+
+            const auto& temperature = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+                getValue(fs.temperature(FluidSystem::waterPhaseIdx)) :
+                getValue(fs.temperature(FluidSystem::oilPhaseIdx));
+            const auto& pressure = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+                getValue(fs.pressure(FluidSystem::waterPhaseIdx)) :
+                getValue(fs.pressure(FluidSystem::oilPhaseIdx));
+
+            const auto& sLiquid = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+                getValue(fs.saturation(FluidSystem::waterPhaseIdx)) :
+                getValue(fs.saturation(FluidSystem::oilPhaseIdx));
+            
+            const auto& rs = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+                getValue(fs.Rsw()) :
+                getValue(fs.Rs());
+            
+            const auto& salt = getValue(fs.saltSaturation());
+
             this->updateConvectiveDRsDt_(compressedDofIdx,
-                                         getValue(fs.temperature(FluidSystem::oilPhaseIdx)),
-                                         getValue(fs.pressure(FluidSystem::oilPhaseIdx)),
-                                         getValue(fs.Rs()),
-                                         getValue(fs.saturation(FluidSystem::oilPhaseIdx)),
+                                         temperature,
+                                         pressure,
+                                         rs,
+                                         sLiquid,
+                                         getValue(fs.saturation(FluidSystem::gasPhaseIdx)),
                                          getValue(iq.porosity()),
                                          permZ,
                                          distZ,
                                          gravity,
+                                         salt,
+                                         oilVaporizationControl.getMaxDRSDT(fs.pvtRegionIndex()),
+                                         oilVaporizationControl.getPsi(fs.pvtRegionIndex()),
+                                         oilVaporizationControl.getOmega(fs.pvtRegionIndex()),
                                          fs.pvtRegionIndex());
         }
 
@@ -138,13 +164,14 @@ public:
             const auto& fs = iq.fluidState();
 
             using FluidState = typename std::decay<decltype(fs)>::type;
-
             const auto& oilVaporizationControl = schedule_[episodeIdx].oilvap();
             constexpr Scalar freeGasMinSaturation_ = 1e-7;
             if (oilVaporizationControl.getOption(pvtRegionIdx) ||
                 fs.saturation(FluidSystem::gasPhaseIdx) > freeGasMinSaturation_) {
                 lastRs_[compressedDofIdx]
-                    = BlackOil::template getRs_<FluidSystem, FluidState, Scalar>(fs, iq.pvtRegionIndex());
+                    = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+                    BlackOil::template getRsw_<FluidSystem, FluidState, Scalar>(fs, iq.pvtRegionIndex()) :
+                    BlackOil::template getRs_<FluidSystem, FluidState, Scalar>(fs, iq.pvtRegionIndex());
             }
             else
                 lastRs_[compressedDofIdx] = std::numeric_limits<Scalar>::infinity();
@@ -164,10 +191,15 @@ private:
                                 const Scalar p,
                                 const Scalar rs,
                                 const Scalar so,
+                                const Scalar sg,
                                 const Scalar poro,
                                 const Scalar permz,
                                 const Scalar distZ,
                                 const Scalar gravity,
+                                const Scalar salt,
+                                const Scalar Xhi,
+                                const Scalar Psi,
+                                const Scalar omegainn,
                                 const int pvtRegionIndex);
 
     std::vector<Scalar> lastRv_;


### PR DESCRIPTION
Extended the DRSDTCON to include more parameters that controls the regime and rate of convective mixing.
Included a convective term in the transport flux for the brine.
Also works for GAS/WATER (not only GAS/OIL as before)

Has corresponding PR in opm-models (OPM/opm-models#902) and opm-common (OPM/opm-common#4097)