### PR TITLE
Only indicate problems for exceptions whem updating well potentials,

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1542,9 +1542,9 @@ updateWellPotentials(const int reportStepIdx,
         }
         ++widx;
     }
-    logAndCheckForExceptionsAndThrow(deferred_logger, exc_type,
-                                     "computeWellPotentials() failed: " + exc_msg,
-                                     terminal_output_, comm_);
+    logAndCheckForProblemsAndThrow(deferred_logger, exc_type,
+                                   "updateWellPotentials() failed: " + exc_msg,
+                                   terminal_output_, comm_);
 }
 
 template<class Scalar>


### PR DESCRIPTION
Nearly all exceptions throw when computing well potentoals will not abort the simulator but result in timestep chops. Hence those should not be counted as errors (e.g. by calling the OPM_*THROW* macros) and be reported in the PRT file.

This change will cause at least two more  occurences (in MSWellHelpers) to be treated as problems. For this we added a new helper function.Nearly all exceptions throw when computing wells will not abort the simulator but result in timestep chops. Hence those should not be counted as errors (e.g. by calling the OPM_*THROW* macros) and be reported in the PRT file.