### PR TITLE
Remove the MOD4_GRP regression test

### DIFF
--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -982,13 +982,6 @@ add_test_compareECLFiles(CASENAME 9_4d_grpctl_msw_model2
                          REL_TOL ${rel_tol}
                          DIR model2)
 
-add_test_compareECLFiles(CASENAME model4_group
-                         FILENAME MOD4_GRP
-                         SIMULATOR flow
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR model4)
-
 add_test_compareECLFiles(CASENAME model4_udq_group
                          FILENAME MOD4_UDQ_ACTIONX
                          SIMULATOR flow


### PR DESCRIPTION
Removing the test as it is broken. More specifically, the last part of the simulation is unstable with oscillating results, making regression assessment futile. See #4855 for further discussion and details.

I did not see where to turn off data updating, maybe that is handled automatically these days?