### PR TITLE
Allow GCONPROD item 11-13 to actually take effect.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelConstraints.cpp
+++ b/opm/simulators/wells/BlackoilWellModelConstraints.cpp
@@ -483,7 +483,7 @@ actionOnBrokenConstraints(const Group& group,
     std::string ss;
     switch (group_limit_action.allRates) {
     case Group::ExceedAction::NONE: {
-        if (oldControl != newControl && oldControl != Group::ProductionCMode::NONE) {
+        if (oldControl != newControl) {
             if ((group_limit_action.water == Group::ExceedAction::RATE &&
                  newControl == Group::ProductionCMode::WRAT) ||
                 (group_limit_action.gas == Group::ExceedAction::RATE &&


### PR DESCRIPTION
Support for GCONPROD item 11-13 was added in https://github.com/OPM/opm-common/pull/3601, https://github.com/OPM/opm-simulators/pull/4748 , but does not take effect (at least for a lot of cases). 

With this PR results are as expected on the attached tests. 
[gconprod_item11to13.tar.gz](https://github.com/user-attachments/files/15898172/gconprod_item11to13.tar.gz)
