### PR TITLE
Autotune thread block size

### DIFF
--- a/opm/simulators/linalg/cuistl/CuDILU.cpp
+++ b/opm/simulators/linalg/cuistl/CuDILU.cpp
@@ -30,11 +30,15 @@
 #include <opm/simulators/linalg/cuistl/detail/safe_conversion.hpp>
 #include <opm/simulators/linalg/matrixblock.hh>
 #include <vector>
+#include <config.h>
+#include <chrono>
+#include <tuple>
+
 
 namespace
 {
 std::vector<int>
-createReorderedToNatural(Opm::SparseTable<size_t> levelSets)
+createReorderedToNatural(Opm::SparseTable<size_t>& levelSets)
 {
     auto res = std::vector<int>(Opm::cuistl::detail::to_size_t(levelSets.dataSize()));
     int globCnt = 0;
@@ -49,7 +53,7 @@ createReorderedToNatural(Opm::SparseTable<size_t> levelSets)
 }
 
 std::vector<int>
-createNaturalToReordered(Opm::SparseTable<size_t> levelSets)
+createNaturalToReordered(Opm::SparseTable<size_t>& levelSets)
 {
     auto res = std::vector<int>(Opm::cuistl::detail::to_size_t(levelSets.dataSize()));
     int globCnt = 0;
@@ -66,7 +70,7 @@ createNaturalToReordered(Opm::SparseTable<size_t> levelSets)
 template <class M, class field_type, class GPUM>
 void
 createReorderedMatrix(const M& naturalMatrix,
-                      std::vector<int> reorderedToNatural,
+                      std::vector<int>& reorderedToNatural,
                       std::unique_ptr<GPUM>& reorderedGpuMat)
 {
     M reorderedMatrix(naturalMatrix.N(), naturalMatrix.N(), naturalMatrix.nonzeroes(), M::row_wise);
@@ -84,7 +88,7 @@ createReorderedMatrix(const M& naturalMatrix,
 template <class M, class field_type, class GPUM>
 void
 extractLowerAndUpperMatrices(const M& naturalMatrix,
-                             std::vector<int> reorderedToNatural,
+                             std::vector<int>& reorderedToNatural,
                              std::unique_ptr<GPUM>& lower,
                              std::unique_ptr<GPUM>& upper)
 {
@@ -119,7 +123,7 @@ namespace Opm::cuistl
 {
 
 template <class M, class X, class Y, int l>
-CuDILU<M, X, Y, l>::CuDILU(const M& A, bool split_matrix)
+CuDILU<M, X, Y, l>::CuDILU(const M& A, bool splitMatrix, bool tuneKernels)
     : m_cpuMatrix(A)
     , m_levelSets(Opm::getMatrixRowColoring(m_cpuMatrix, Opm::ColoringType::LOWER))
     , m_reorderedToNatural(createReorderedToNatural(m_levelSets))
@@ -128,7 +132,8 @@ CuDILU<M, X, Y, l>::CuDILU(const M& A, bool split_matrix)
     , m_gpuNaturalToReorder(m_naturalToReordered)
     , m_gpuReorderToNatural(m_reorderedToNatural)
     , m_gpuDInv(m_gpuMatrix.N() * m_gpuMatrix.blockSize() * m_gpuMatrix.blockSize())
-    , m_splitMatrix(split_matrix)
+    , m_splitMatrix(splitMatrix)
+    , m_tuneThreadBlockSizes(tuneKernels)
 
 {
     // TODO: Should in some way verify that this matrix is symmetric, only do it debug mode?
@@ -156,6 +161,14 @@ CuDILU<M, X, Y, l>::CuDILU(const M& A, bool split_matrix)
             m_cpuMatrix, m_reorderedToNatural, m_gpuMatrixReordered);
     }
     computeDiagAndMoveReorderedData();
+
+    // HIP does currently not support automtically picking thread block sizes as well as CUDA
+    // So only when tuning and using hip should we do our own manual tuning
+#ifdef USE_HIP
+    if (m_tuneThreadBlockSizes){
+        tuneThreadBlockSizes();
+    }
+#endif
 }
 
 template <class M, class X, class Y, int l>
@@ -183,7 +196,8 @@ CuDILU<M, X, Y, l>::apply(X& v, const Y& d)
                     numOfRowsInLevel,
                     m_gpuDInv.data(),
                     d.data(),
-                    v.data());
+                    v.data(),
+                    m_applyThreadBlockSize);
             } else {
                 detail::computeLowerSolveLevelSet<field_type, blocksize_>(
                     m_gpuMatrixReordered->getNonZeroValues().data(),
@@ -194,7 +208,8 @@ CuDILU<M, X, Y, l>::apply(X& v, const Y& d)
                     numOfRowsInLevel,
                     m_gpuDInv.data(),
                     d.data(),
-                    v.data());
+                    v.data(),
+                    m_applyThreadBlockSize);
             }
             levelStartIdx += numOfRowsInLevel;
         }
@@ -213,7 +228,8 @@ CuDILU<M, X, Y, l>::apply(X& v, const Y& d)
                     levelStartIdx,
                     numOfRowsInLevel,
                     m_gpuDInv.data(),
-                    v.data());
+                    v.data(),
+                    m_applyThreadBlockSize);
             } else {
                 detail::computeUpperSolveLevelSet<field_type, blocksize_>(
                     m_gpuMatrixReordered->getNonZeroValues().data(),
@@ -223,7 +239,8 @@ CuDILU<M, X, Y, l>::apply(X& v, const Y& d)
                     levelStartIdx,
                     numOfRowsInLevel,
                     m_gpuDInv.data(),
-                    v.data());
+                    v.data(),
+                    m_applyThreadBlockSize);
             }
         }
     }
@@ -270,14 +287,16 @@ CuDILU<M, X, Y, l>::computeDiagAndMoveReorderedData()
                 m_gpuMatrixReorderedUpper->getRowIndices().data(),
                 m_gpuMatrixReorderedDiag->data(),
                 m_gpuNaturalToReorder.data(),
-                m_gpuMatrixReorderedLower->N());
+                m_gpuMatrixReorderedLower->N(),
+                m_updateThreadBlockSize);
         } else {
             detail::copyMatDataToReordered<field_type, blocksize_>(m_gpuMatrix.getNonZeroValues().data(),
                                                                    m_gpuMatrix.getRowIndices().data(),
                                                                    m_gpuMatrixReordered->getNonZeroValues().data(),
                                                                    m_gpuMatrixReordered->getRowIndices().data(),
                                                                    m_gpuNaturalToReorder.data(),
-                                                                   m_gpuMatrixReordered->N());
+                                                                   m_gpuMatrixReordered->N(),
+                                                                   m_updateThreadBlockSize);
         }
 
         int levelStartIdx = 0;
@@ -296,7 +315,8 @@ CuDILU<M, X, Y, l>::computeDiagAndMoveReorderedData()
                     m_gpuNaturalToReorder.data(),
                     levelStartIdx,
                     numOfRowsInLevel,
-                    m_gpuDInv.data());
+                    m_gpuDInv.data(),
+                    m_updateThreadBlockSize);
             } else {
                 detail::computeDiluDiagonal<field_type, blocksize_>(m_gpuMatrixReordered->getNonZeroValues().data(),
                                                                     m_gpuMatrixReordered->getRowIndices().data(),
@@ -305,11 +325,67 @@ CuDILU<M, X, Y, l>::computeDiagAndMoveReorderedData()
                                                                     m_gpuNaturalToReorder.data(),
                                                                     levelStartIdx,
                                                                     numOfRowsInLevel,
-                                                                    m_gpuDInv.data());
+                                                                    m_gpuDInv.data(),
+                                                                    m_updateThreadBlockSize);
             }
             levelStartIdx += numOfRowsInLevel;
         }
     }
+}
+
+template <class M, class X, class Y, int l>
+void
+CuDILU<M, X, Y, l>::tuneThreadBlockSizes()
+{
+    // TODO: generalize this code and put it somewhere outside of this class
+    auto start = std::chrono::high_resolution_clock::now();
+    long long bestApplyTime = __LONG_LONG_MAX__;
+    long long bestUpdateTime = __LONG_LONG_MAX__;
+    int bestApplyBlockSize = -1;
+    int bestUpdateBlockSize = -1;
+    int interval = 64;
+
+    //temporary buffers for the apply
+    CuVector<field_type> tmpV(m_gpuMatrix.N() * m_gpuMatrix.blockSize());
+    CuVector<field_type> tmpD(m_gpuMatrix.N() * m_gpuMatrix.blockSize());
+    tmpD = 1;
+
+    for (int thrBlockSize = interval; thrBlockSize <= 1024; thrBlockSize += interval){
+        // sometimes the first kernel launch kan be slower, so take the time twice
+        for (int i = 0; i < 2; ++i){
+
+            auto beforeUpdate = std::chrono::high_resolution_clock::now();
+            m_updateThreadBlockSize = thrBlockSize;
+            update();
+            std::ignore = cudaDeviceSynchronize();
+            auto afterUpdate = std::chrono::high_resolution_clock::now();
+            if (cudaSuccess == cudaGetLastError()){ // kernel launch was valid
+                long long durationInMicroSec = std::chrono::duration_cast<std::chrono::microseconds>(afterUpdate - beforeUpdate).count();
+                if (durationInMicroSec < bestUpdateTime){
+                    bestUpdateTime = durationInMicroSec;
+                    bestUpdateBlockSize = thrBlockSize;
+                }
+            }
+
+            auto beforeApply = std::chrono::high_resolution_clock::now();
+            m_applyThreadBlockSize = thrBlockSize;
+            apply(tmpV, tmpD);
+            std::ignore = cudaDeviceSynchronize();
+            auto afterApply = std::chrono::high_resolution_clock::now();
+            if (cudaSuccess == cudaGetLastError()){ // kernel launch was valid
+                long long durationInMicroSec = std::chrono::duration_cast<std::chrono::microseconds>(afterApply - beforeApply).count();
+                if (durationInMicroSec < bestApplyTime){
+                    bestApplyTime = durationInMicroSec;
+                    bestApplyBlockSize = thrBlockSize;
+                }
+            }
+        }
+    }
+
+    m_applyThreadBlockSize = bestApplyBlockSize;
+    m_updateThreadBlockSize = bestUpdateBlockSize;
+    auto end = std::chrono::high_resolution_clock::now();
+    long long durationInMicroSec = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
 }
 
 } // namespace Opm::cuistl

--- a/opm/simulators/linalg/cuistl/CuDILU.cpp
+++ b/opm/simulators/linalg/cuistl/CuDILU.cpp
@@ -338,7 +338,6 @@ void
 CuDILU<M, X, Y, l>::tuneThreadBlockSizes()
 {
     // TODO: generalize this code and put it somewhere outside of this class
-    auto start = std::chrono::high_resolution_clock::now();
     long long bestApplyTime = __LONG_LONG_MAX__;
     long long bestUpdateTime = __LONG_LONG_MAX__;
     int bestApplyBlockSize = -1;
@@ -384,8 +383,6 @@ CuDILU<M, X, Y, l>::tuneThreadBlockSizes()
 
     m_applyThreadBlockSize = bestApplyBlockSize;
     m_updateThreadBlockSize = bestUpdateBlockSize;
-    auto end = std::chrono::high_resolution_clock::now();
-    long long durationInMicroSec = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
 }
 
 } // namespace Opm::cuistl

--- a/opm/simulators/linalg/cuistl/CuDILU.cpp
+++ b/opm/simulators/linalg/cuistl/CuDILU.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 #include <config.h>
 #include <chrono>
+#include <limits>
 #include <tuple>
 
 
@@ -338,8 +339,8 @@ void
 CuDILU<M, X, Y, l>::tuneThreadBlockSizes()
 {
     // TODO: generalize this code and put it somewhere outside of this class
-    long long bestApplyTime = __LONG_LONG_MAX__;
-    long long bestUpdateTime = __LONG_LONG_MAX__;
+    long long bestApplyTime = std::numeric_limits<long long>::max();
+    long long bestUpdateTime = std::numeric_limits<long long>::max();
     int bestApplyBlockSize = -1;
     int bestUpdateBlockSize = -1;
     int interval = 64;

--- a/opm/simulators/linalg/cuistl/CuDILU.hpp
+++ b/opm/simulators/linalg/cuistl/CuDILU.hpp
@@ -66,7 +66,7 @@ public:
     //! \param A The matrix to operate on.
     //! \param w The relaxation factor.
     //!
-    explicit CuDILU(const M& A, bool split_matrix = true);
+    explicit CuDILU(const M& A, bool splitMatrix, bool tuneKernels);
 
     //! \brief Prepare the preconditioner.
     //! \note Does nothing at the time being.
@@ -87,6 +87,9 @@ public:
 
     //! \brief Compute the diagonal of the DILU, and update the data of the reordered matrix
     void computeDiagAndMoveReorderedData();
+
+    //! \brief function that will experimentally tune the thread block sizes of the important cuda kernels
+    void tuneThreadBlockSizes();
 
 
     //! \returns false
@@ -130,6 +133,12 @@ private:
     CuVector<field_type> m_gpuDInv;
     //! \brief Bool storing whether or not we should store matrices in a split format
     bool m_splitMatrix;
+    //! \brief Bool storing whether or not we will tune the threadblock sizes. Only used for AMD cards
+    bool m_tuneThreadBlockSizes;
+    //! \brief variables storing the threadblocksizes to use if using the tuned sizes and AMD cards
+    //! The default value of -1 indicates that we have not calibrated and selected a value yet
+    int m_applyThreadBlockSize = -1;
+    int m_updateThreadBlockSize = -1;
 };
 } // end namespace Opm::cuistl
 

--- a/opm/simulators/linalg/cuistl/detail/cusparse_matrix_operations.hpp
+++ b/opm/simulators/linalg/cuistl/detail/cusparse_matrix_operations.hpp
@@ -59,7 +59,8 @@ void computeLowerSolveLevelSet(T* reorderedMat,
                                int rowsInLevelSet,
                                const T* dInv,
                                const T* d,
-                               T* v);
+                               T* v,
+                               int threadBlockSize);
 
 /**
  * @brief Perform a lower solve on certain rows in a matrix that can safely be computed in parallel
@@ -86,7 +87,8 @@ void computeLowerSolveLevelSetSplit(T* reorderedUpperMat,
                                int rowsInLevelSet,
                                const T* dInv,
                                const T* d,
-                               T* v);
+                               T* v,
+                               int threadBlockSize);
 
 /**
  * @brief Perform an upper solve on certain rows in a matrix that can safely be computed in parallel
@@ -111,7 +113,8 @@ void computeUpperSolveLevelSet(T* reorderedMat,
                                int startIdx,
                                int rowsInLevelSet,
                                const T* dInv,
-                               T* v);
+                               T* v,
+                               int threadBlockSize);
 template <class T, int blocksize>
 
 /**
@@ -136,7 +139,8 @@ void computeUpperSolveLevelSetSplit(T* reorderedUpperMat,
                                int startIdx,
                                int rowsInLevelSet,
                                const T* dInv,
-                               T* v);
+                               T* v,
+                               int threadBlockSize);
 
 /**
  * @brief Computes the ILU0 of the diagonal elements of the reordered matrix and stores it in a reordered vector
@@ -162,7 +166,8 @@ void computeDiluDiagonal(T* reorderedMat,
                          int* naturalToReordered,
                          int startIdx,
                          int rowsInLevelSet,
-                         T* dInv);
+                         T* dInv,
+                         int threadBlockSize);
 template <class T, int blocksize>
 
 /**
@@ -197,7 +202,8 @@ void computeDiluDiagonalSplit(T* reorderedLowerMat,
                          int* naturalToReordered,
                          int startIdx,
                          int rowsInLevelSet,
-                         T* dInv);
+                         T* dInv,
+                         int threadBlockSize);
 
 /**
  * @brief Reorders the elements of a matrix by copying them from one matrix to another using a permutation list
@@ -211,7 +217,7 @@ void computeDiluDiagonalSplit(T* reorderedLowerMat,
  */
 template <class T, int blocksize>
 void copyMatDataToReordered(
-    T* srcMatrix, int* srcRowIndices, T* dstMatrix, int* dstRowIndices, int* naturalToReordered, size_t numberOfRows);
+    T* srcMatrix, int* srcRowIndices, T* dstMatrix, int* dstRowIndices, int* naturalToReordered, size_t numberOfRows, int threadBlockSize);
 
 /**
  * @brief Reorders the elements of a matrix by copying them from one matrix to a split matrix using a permutation list
@@ -229,7 +235,7 @@ void copyMatDataToReordered(
  */
 template <class T, int blocksize>
 void copyMatDataToReorderedSplit(
-    T* srcMatrix, int* srcRowIndices, int* srcColumnIndices, T* dstLowerMatrix, int* dstLowerRowIndices, T* dstUpperMatrix, int* dstUpperRowIndices, T* dstDiag, int* naturalToReordered, size_t numberOfRows);
+    T* srcMatrix, int* srcRowIndices, int* srcColumnIndices, T* dstLowerMatrix, int* dstLowerRowIndices, T* dstUpperMatrix, int* dstUpperRowIndices, T* dstDiag, int* naturalToReordered, size_t numberOfRows, int threadBlockSize);
 
 } // namespace Opm::cuistl::detail
 #endif

--- a/tests/cuistl/test_cudilu.cpp
+++ b/tests/cuistl/test_cudilu.cpp
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(TestDiluApply)
 
     // Initialize preconditioner objects
     Dune::MultithreadDILU<Sp1x1BlockMatrix, B1x1Vec, B1x1Vec> cpudilu(matA);
-    auto gpudilu = CuDilu1x1(matA);
+    auto gpudilu = CuDilu1x1(matA, true, true);
 
     // Use the apply
     gpudilu.apply(d_output, d_input);
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(TestDiluApplyBlocked)
 
     // init matrix with 2x2 blocks
     Sp2x2BlockMatrix matA = get2x2BlockTestMatrix();
-    auto gpudilu = CuDilu2x2(matA);
+    auto gpudilu = CuDilu2x2(matA, true, true);
     Dune::MultithreadDILU<Sp2x2BlockMatrix, B2x2Vec, B2x2Vec> cpudilu(matA);
 
     // create input/output buffers for the apply
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(TestDiluInitAndUpdateLarge)
 {
     // create gpu dilu preconditioner
     Sp1x1BlockMatrix matA = get1x1BlockTestMatrix();
-    auto gpudilu = CuDilu1x1(matA);
+    auto gpudilu = CuDilu1x1(matA, true, true);
 
     matA[0][0][0][0] = 11.0;
     matA[0][1][0][0] = 12.0;


### PR DESCRIPTION
Using cudaOccupancyMaxPotentialBlockSize/calibration to more dynamically pick the thread block size we see 1.3-1.5 speedup on linear iterations.

The calibration step is made more general and placed in a separate file in a following PR