### PR TITLE
[fix] Do not count experiencing nans as error in PRT file.

### DIFF
--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -368,7 +368,7 @@ namespace Opm {
 
                 // Throw if any NaN or too large residual found.
                 if (severity == ConvergenceReport::Severity::NotANumber) {
-                    OPM_THROW(NumericalProblem, "NaN residual found!");
+                    OPM_THROW_PROBLEM(NumericalProblem, "NaN residual found!");
                 } else if (severity == ConvergenceReport::Severity::TooLarge) {
                     OPM_THROW_NOLOG(NumericalProblem, "Too large residual found!");
                 }


### PR DESCRIPTION
The simulation will just chop the time step and continue. Note, that the error count in the PRT file is used by engineers to decide whether a simulation was successfull. Hence the error count should not be increased here.

Downstream of OPM/opm-common#4113