### PR TITLE
clean up some comments

### DIFF
--- a/opm/simulators/flow/EclGenericWriter.hpp
+++ b/opm/simulators/flow/EclGenericWriter.hpp
@@ -69,9 +69,6 @@ class EclGenericWriter
     using TransmissibilityType = Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>;
 
 public:
-    // The Simulator object should preferably have been const - the
-    // only reason that is not the case is due to the SummaryState
-    // object owned deep down by the vanguard.
     EclGenericWriter(const Schedule& schedule,
                      const EclipseState& eclState,
                      const SummaryConfig& summaryConfig,

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -85,11 +85,11 @@ class UDQState;
 /*!
  * \ingroup EclBlackOilSimulator
  *
- * \brief Collects necessary output values and pass it to opm-output.
+ * \brief Collects necessary output values and pass it to opm-common's ECL output.
  *
  * Caveats:
  * - For this class to do do anything meaningful, you will have to
- *   have the OPM module opm-output.
+ *   have the OPM module opm-common with ECL writing enabled.
  * - The only DUNE grid which is currently supported is Dune::CpGrid
  *   from the OPM module "opm-grid". Using another grid won't
  *   fail at compile time but you will provoke a fatal exception as


### PR DESCRIPTION
- simulator note was copied from the typetag dependent class (EclWriter)
- opm-output is no longer a separate module