### PR TITLE
Add support for GRUPSLAV keyword

### DIFF
--- a/opm/simulators/flow/FlowGenericVanguard.cpp
+++ b/opm/simulators/flow/FlowGenericVanguard.cpp
@@ -149,7 +149,7 @@ void FlowGenericVanguard::readDeck(const std::string& filename)
                   modelParams_.actionState_,
                   modelParams_.wtestState_,
                   modelParams_.eclSummaryConfig_,
-                  nullptr, "normal", "normal", "100", false, false, {});
+                  nullptr, "normal", "normal", "100", false, false, {}, /*slaveMode=*/false);
     modelParams_.setupTime_ = setupTimer.stop();
 }
 

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -50,8 +50,8 @@ namespace Opm::Parameters {
 
 // Do not merge parallel output files or warn about them
 struct EnableLoggingFalloutWarning { static constexpr bool value = false; };
-
 struct OutputInterval { static constexpr int value = 1; };
+struct Slave { static constexpr bool value = false; };
 
 } // namespace Opm::Parameters
 
@@ -102,6 +102,9 @@ namespace Opm {
                  "In that case it will be appended to the *.DBG or *.PRT files");
 
             ThreadManager::registerParameters();
+            Parameters::Register<Parameters::Slave>
+                ("Specify if the simulation is a slave simulation in a master-slave simulation");
+            Parameters::Hide<Parameters::Slave>();
             Simulator::registerParameters();
 
             // register the base parameters

--- a/opm/simulators/flow/Main.cpp
+++ b/opm/simulators/flow/Main.cpp
@@ -204,6 +204,7 @@ void Main::readDeck(const std::string& deckFilename,
                     const std::string& inputSkipMode,
                     const std::size_t numThreads,
                     const int output_param,
+                    const bool slaveMode,
                     const std::string& parameters,
                     std::string_view moduleVersion,
                     std::string_view compileTimestamp)
@@ -238,7 +239,8 @@ void Main::readDeck(const std::string& deckFilename,
                   inputSkipMode,
                   init_from_restart_file,
                   outputCout_,
-                  outputInterval);
+                  outputInterval,
+                  slaveMode);
 
     verifyValidCellGeometry(FlowGenericVanguard::comm(), *this->eclipseState_);
 

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -417,6 +417,7 @@ private:
         try {
             this->readDeck(deckFilename,
                            outputDir,
+<<<<<<< HEAD
                            Parameters::Get<Parameters::OutputMode>(),
                            !Parameters::Get<Parameters::SchedRestart>(),
                            Parameters::Get<Parameters::EnableLoggingFalloutWarning>(),
@@ -425,6 +426,16 @@ private:
                            Parameters::Get<Parameters::InputSkipMode>(),
                            getNumThreads(),
                            Parameters::Get<Parameters::EclOutputInterval>(),
+=======
+                           Parameters::get<PreTypeTag, Properties::OutputMode>(),
+                           !Parameters::get<PreTypeTag, Properties::SchedRestart>(),
+                           Parameters::get<PreTypeTag, Properties::EnableLoggingFalloutWarning>(),
+                           Parameters::get<PreTypeTag, Properties::ParsingStrictness>(),
+                           Parameters::get<PreTypeTag, Properties::InputSkipMode>(),
+                           getNumThreads<PreTypeTag>(),
+                           Parameters::get<PreTypeTag, Properties::EclOutputInterval>(),
+                           Parameters::get<PreTypeTag, Properties::Slave>(),
+>>>>>>> f322d7f66 (Add support for GRUPSLAV keyword)
                            cmdline_params,
                            Opm::moduleVersion(),
                            Opm::compileTimestamp());
@@ -701,6 +712,7 @@ private:
                   const std::string& inputSkipMode,
                   const std::size_t numThreads,
                   const int output_param,
+                  const bool slaveMode,
                   const std::string& parameters,
                   std::string_view moduleVersion,
                   std::string_view compileTimestamp);

--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -230,6 +230,13 @@ partiallySupported()
             },
          },
          {
+            "SLAVES",
+            {
+                {1,{true, [](const std::string& val){ return val.size()<=8;}, "SLAVES(SLAVE_RESERVOIR): Only names of slave reservoirs of up to 8 characters are supported."}},
+                {3,{true, allow_values<std::string> {}, "SLAVES(HOST_NAME): should be defaulted. A specific host name is not implemented yet"}}, // HOST_NAME
+            },
+         },
+         {
             "TABDIMS",
             {
                {20,{false, allow_values<std::string> {}, "TABDIMS(NOTUSED): should be defaulted (1*) - ignored as not used"}}, // ITEM20_NOT_USED
@@ -453,6 +460,12 @@ partiallySupported()
                {6,{false, allow_values<int> {1}, "REGDIMS(NTCREG): COAL regions not supported - value ignored"}}, // NTCREG
                {8,{false, allow_values<int> {0}, "REGDIMS(NWKDREG): should be equal to 0 - value ignored"}}, // MAX_OPERATE_DWORK
                {9,{false, allow_values<int> {0}, "REGDIMS(NWKIREG): should be equal to 0 - value ignored"}}, // MAX_OPERATE_IWORK
+            },
+         },
+         {
+            "SLAVES",
+            {
+               {5,{true, [](int x) { return x >= 1; }, "SLAVES(NUM_PE): only values greater than or equal to 1 are supported"}}, // NUM_PE
             },
          },
          {

--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -244,7 +244,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"GRAVDRM", {true, std::nullopt}},
         {"GRDREACH", {true, std::nullopt}},
         {"GRUPRIG", {true, std::nullopt}},
-        {"GRUPSLAV", {true, std::nullopt}},
         {"GRUPTARG", {true, std::nullopt}},
         {"GSATINJE", {true, std::nullopt}},
         {"GSEPCOND", {true, std::nullopt}},

--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -570,7 +570,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"SKRORW", {true, std::nullopt}},
         {"SKRW", {true, std::nullopt}},
         {"SKRWR", {true, std::nullopt}},
-        {"SLAVES", {true, std::nullopt}},
         {"SMULTX", {true, std::nullopt}},
         {"SMULTY", {true, std::nullopt}},
         {"SMULTZ", {true, std::nullopt}},

--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -243,7 +243,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"GRAVDRB", {true, std::nullopt}},
         {"GRAVDRM", {true, std::nullopt}},
         {"GRDREACH", {true, std::nullopt}},
-        {"GRUPMAST", {true, std::nullopt}},
         {"GRUPRIG", {true, std::nullopt}},
         {"GRUPSLAV", {true, std::nullopt}},
         {"GRUPTARG", {true, std::nullopt}},

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -95,7 +95,8 @@ void readDeck(Parallel::Communication         comm,
               const std::string&              inputSkipMode,
               bool                            initFromRestart,
               bool                            checkDeck,
-              const std::optional<int>&       outputInterval);
+              const std::optional<int>&       outputInterval,
+              bool                            slaveMode);
 
 void verifyValidCellGeometry(Parallel::Communication comm,
                              const EclipseState&     eclipseState);


### PR DESCRIPTION
Builds on #5437 and #5436. Depends on upstream https://github.com/OPM/opm-common/pull/4123. This keywords does not do anything yet, see https://github.com/OPM/opm-simulators/pull/5436 for more information.
 