### PR TITLE
Make CPR reuse setup option only apply to CPR

### DIFF
--- a/opm/simulators/linalg/DILU.hpp
+++ b/opm/simulators/linalg/DILU.hpp
@@ -162,6 +162,10 @@ public:
         return SolverCategory::sequential;
     }
 
+    virtual bool hasPerfectUpdate() const override {
+        return true;
+    }
+
 private:
     //! \brief The matrix we operate on.
     const M& A_;

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -495,6 +495,13 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             if (!flexibleSolver_[activeSolverNum_].solver_) {
                 return true;
             }
+
+            if (flexibleSolver_[activeSolverNum_].pre_->hasPerfectUpdate()) {
+                return false;
+            }
+
+            // For AMG based preconditioners, the hierarchy depends on the matrix values
+            // so it is recreated at certain intervals
             if (this->parameters_[activeSolverNum_].cpr_reuse_setup_ == 0) {
                 // Always recreate solver.
                 return true;
@@ -509,7 +516,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                 return this->iterations() > 10;
             }
             if (this->parameters_[activeSolverNum_].cpr_reuse_setup_ == 3) {
-                // Recreate solver if the last solve used more than 10 iterations.
+                // Never recreate the solver
                 return false;
             }
             if (this->parameters_[activeSolverNum_].cpr_reuse_setup_ == 4) {
@@ -518,7 +525,6 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                 const bool create = ((solveCount_ % step) == 0);
                 return create;
             }
-
             // If here, we have an invalid parameter.
             const bool on_io_rank = (simulator_.gridView().comm().rank() == 0);
             std::string msg = "Invalid value: " + std::to_string(this->parameters_[activeSolverNum_].cpr_reuse_setup_)
@@ -528,7 +534,6 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
             }
             throw std::runtime_error(msg);
 
-            // Never reached.
             return false;
         }
 

--- a/opm/simulators/linalg/OwningBlockPreconditioner.hpp
+++ b/opm/simulators/linalg/OwningBlockPreconditioner.hpp
@@ -74,6 +74,10 @@ public:
         orig_precond_.update();
     }
 
+    virtual bool hasPerfectUpdate() const override {
+        return orig_precond_.hasPerfectUpdate();
+    }
+
 private:
     OriginalPreconditioner orig_precond_;
     BlockPreconditioner<X, Y, Comm, OriginalPreconditioner> block_precond_;

--- a/opm/simulators/linalg/OwningTwoLevelPreconditioner.hpp
+++ b/opm/simulators/linalg/OwningTwoLevelPreconditioner.hpp
@@ -173,6 +173,10 @@ public:
         return linear_operator_.category();
     }
 
+    virtual bool hasPerfectUpdate() const override {
+        return false;
+    }
+
 private:
     using CoarseOperator = typename LevelTransferPolicy::CoarseOperator;
     using CoarseSolverPolicy = Dune::Amg::PressureSolverPolicy<CoarseOperator,

--- a/opm/simulators/linalg/ParallelOverlappingILU0.hpp
+++ b/opm/simulators/linalg/ParallelOverlappingILU0.hpp
@@ -144,6 +144,10 @@ public:
     using block_type = typename matrix_type::block_type;
     using size_type = typename matrix_type::size_type;
 
+    virtual bool hasPerfectUpdate() const override {
+        return true;
+    }
+
 protected:
     struct CRS
     {

--- a/opm/simulators/linalg/PreconditionerWithUpdate.hpp
+++ b/opm/simulators/linalg/PreconditionerWithUpdate.hpp
@@ -32,6 +32,9 @@ class PreconditionerWithUpdate : public Preconditioner<X, Y>
 {
 public:
     virtual void update() = 0;
+
+    // Force derived classes to define if preconditioner has perfect update
+    virtual bool hasPerfectUpdate() const = 0;
 };
 
 template <class OriginalPreconditioner>
@@ -71,6 +74,10 @@ public:
     // The update() function does nothing for a wrapped preconditioner.
     virtual void update() override
     {
+    }
+
+    virtual bool hasPerfectUpdate() const override {
+        return true;
     }
 
 private:
@@ -160,6 +167,10 @@ public:
     void update() override
     {
         orig_precond_ = preconditioner_maker_->make();
+    }
+
+    virtual bool hasPerfectUpdate() const override {
+        return true;
     }
 
 private:

--- a/opm/simulators/linalg/amgcpr.hh
+++ b/opm/simulators/linalg/amgcpr.hh
@@ -169,6 +169,10 @@ namespace Dune
         return category_;
       }
 
+      virtual bool hasPerfectUpdate() const override {
+          return false;
+      }
+
       /** \copydoc Preconditioner::post */
       void post(Domain& x);
 

--- a/opm/simulators/linalg/cuistl/CuBlockPreconditioner.hpp
+++ b/opm/simulators/linalg/cuistl/CuBlockPreconditioner.hpp
@@ -113,6 +113,10 @@ public:
         return m_preconditioner;
     }
 
+    virtual bool hasPerfectUpdate() const override {
+        return true;
+    }
+
 
 private:
     //! \brief a sequential preconditioner

--- a/opm/simulators/linalg/cuistl/CuDILU.hpp
+++ b/opm/simulators/linalg/cuistl/CuDILU.hpp
@@ -98,6 +98,10 @@ public:
         return false;
     }
 
+    virtual bool hasPerfectUpdate() const override {
+        return true;
+    }
+
 
 private:
     //! \brief Reference to the underlying matrix

--- a/opm/simulators/linalg/cuistl/CuJac.hpp
+++ b/opm/simulators/linalg/cuistl/CuJac.hpp
@@ -93,6 +93,10 @@ public:
         return false;
     }
 
+    virtual bool hasPerfectUpdate() const override {
+        return true;
+    }
+
 
 private:
     //! \brief Reference to the underlying matrix

--- a/opm/simulators/linalg/cuistl/CuSeqILU0.hpp
+++ b/opm/simulators/linalg/cuistl/CuSeqILU0.hpp
@@ -96,6 +96,10 @@ public:
         return false;
     }
 
+    virtual bool hasPerfectUpdate() const override {
+        return true;
+    }
+
 
 private:
     //! \brief Reference to the underlying matrix

--- a/opm/simulators/linalg/cuistl/OpmCuILU0.hpp
+++ b/opm/simulators/linalg/cuistl/OpmCuILU0.hpp
@@ -99,6 +99,10 @@ public:
         return false;
     }
 
+    virtual bool hasPerfectUpdate() const override {
+        return true;
+    }
+
 
 private:
     //! \brief Reference to the underlying matrix

--- a/opm/simulators/linalg/cuistl/PreconditionerAdapter.hpp
+++ b/opm/simulators/linalg/cuistl/PreconditionerAdapter.hpp
@@ -123,6 +123,10 @@ public:
         return m_underlyingPreconditioner;
     }
 
+    virtual bool hasPerfectUpdate() const override {
+        return m_underlyingPreconditioner->hasPerfectUpdate();
+    }
+
 private:
     //! \brief the underlying preconditioner to use
     std::shared_ptr<CudaPreconditionerType> m_underlyingPreconditioner;

--- a/opm/simulators/linalg/cuistl/PreconditionerConvertFieldTypeAdapter.hpp
+++ b/opm/simulators/linalg/cuistl/PreconditionerConvertFieldTypeAdapter.hpp
@@ -189,6 +189,10 @@ public:
         m_underlyingPreconditioner = conditioner;
     }
 
+    virtual bool hasPerfectUpdate() const override {
+        return m_underlyingPreconditioner->hasPerfectUpdate();
+    }
+
 
 private:
     void updateMatrix()

--- a/tests/cuistl/test_converttofloatadapter.cpp
+++ b/tests/cuistl/test_converttofloatadapter.cpp
@@ -110,6 +110,10 @@ public:
         return false;
     }
 
+    virtual bool hasPerfectUpdate() const override {
+        return false;
+    }
+
 
 private:
     const SpMatrixFloat& m_matrix;


### PR DESCRIPTION
The cpr-reuse-setup option is currently not limited to CPR and is being used for all preconditioners. The default option is to recreate the linear solver every 30th linear iteration. The motivation behind this option is that the AMG hierarchy depends on the values of the matrix, such that as the values of the matrix changes, the preconditioner should be updated. For preconditioners where the construction of the preconditioner only depends on the matrix structure, it is never needed to recreate the preconditioner, as the matrix structure should be constant throughout the simulation. 

I therefore suggest that we make this option only apply to CPR. This will also make the effect of the option match the name.