### PR TITLE
[refactor] Remove unnecessary copy in axisCentroid and simply code.

### DIFF
--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -258,7 +258,7 @@ protected:
                                  const Scalar& poro) const;
 
     DimVector distanceVector_(const DimVector& faceCenter,
-                              const std::array<double,dimWorld>& cellCenter) const;
+                              const unsigned& cellIdx) const;
 
     void applyMultipliers_(Scalar& trans,
                            unsigned faceIdx,

--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -257,10 +257,8 @@ protected:
                                  const DimVector& distance,
                                  const Scalar& poro) const;
 
-    DimVector distanceVector_(const DimVector& center,
-                              int faceIdx, // in the reference element that contains the intersection
-                              unsigned elemIdx,
-                              const std::array<std::vector<DimVector>, dimWorld>& axisCentroids) const;
+    DimVector distanceVector_(const DimVector& faceCenter,
+                              const std::array<double,dimWorld>& cellCenter) const;
 
     void applyMultipliers_(Scalar& trans,
                            unsigned faceIdx,

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -253,7 +253,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
                                   faceAreaNormal,
                                   intersection.indexInInside(),
                                   distanceVector_(faceCenterInside,
-                                                  centroids_(elemIdx)),
+                                                  elemIdx),
                                   permeability_[elemIdx]);
 
                 // normally there would be two half-transmissibilities that would be
@@ -270,7 +270,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
                     computeHalfDiffusivity_(transBoundaryEnergyIs,
                                             faceAreaNormal,
                                             distanceVector_(faceCenterInside,
-                                                            centroids_(elemIdx)),
+                                                            elemIdx),
                                             1.0);
                     thermalHalfTransBoundary_[std::make_pair(elemIdx, boundaryIsIdx)] =
                         transBoundaryEnergyIs;
@@ -350,13 +350,13 @@ update(bool global, const TransUpdateQuantities update_quantities,
                               faceAreaNormal,
                               insideFaceIdx,
                               distanceVector_(faceCenterInside,
-                                              centroids_(elemIdx)),
+                                              elemIdx),
                               permeability_[elemIdx]);
             computeHalfTrans_(halfTrans2,
                               faceAreaNormal,
                               outsideFaceIdx,
                               distanceVector_(faceCenterOutside,
-                                              centroids_(outsideElemIdx)),
+                                              outsideElemIdx),
                               permeability_[outsideElemIdx]);
 
             applyNtg_(halfTrans1, insideFaceIdx, elemIdx, ntg);
@@ -443,12 +443,12 @@ update(bool global, const TransUpdateQuantities update_quantities,
                 computeHalfDiffusivity_(halfDiffusivity1,
                                         faceAreaNormal,
                                         distanceVector_(faceCenterInside,
-                                                        centroids_(elemIdx)),
+                                                        elemIdx),
                                         1.0);
                 computeHalfDiffusivity_(halfDiffusivity2,
                                         faceAreaNormal,
                                         distanceVector_(faceCenterOutside,
-                                                        centroids_(outsideElemIdx)),
+                                                        outsideElemIdx),
                                         1.0);
                 //TODO Add support for multipliers
                 thermalHalfTrans_[details::directionalIsId(elemIdx, outsideElemIdx)] = halfDiffusivity1;
@@ -464,12 +464,12 @@ update(bool global, const TransUpdateQuantities update_quantities,
                 computeHalfDiffusivity_(halfDiffusivity1,
                                         faceAreaNormal,
                                         distanceVector_(faceCenterInside,
-                                                        centroids_(elemIdx)),
+                                                        elemIdx),
                                         porosity_[elemIdx]);
                 computeHalfDiffusivity_(halfDiffusivity2,
                                         faceAreaNormal,
                                         distanceVector_(faceCenterOutside,
-                                                        centroids_(outsideElemIdx)),
+                                                        outsideElemIdx),
                                         porosity_[outsideElemIdx]);
 
                 applyNtg_(halfDiffusivity1, insideFaceIdx, elemIdx, ntg);
@@ -496,12 +496,12 @@ update(bool global, const TransUpdateQuantities update_quantities,
                 computeHalfDiffusivity_(halfDispersivity1,
                                         faceAreaNormal,
                                         distanceVector_(faceCenterInside,
-                                                        centroids_(elemIdx)),
+                                                        elemIdx),
                                         dispersion_[elemIdx]);
                 computeHalfDiffusivity_(halfDispersivity2,
                                         faceAreaNormal,
                                         distanceVector_(faceCenterOutside,
-                                                        centroids_(outsideElemIdx)),
+                                                        outsideElemIdx),
                                         dispersion_[outsideElemIdx]);
 
                 applyNtg_(halfDispersivity1, insideFaceIdx, elemIdx, ntg);
@@ -1283,8 +1283,9 @@ template<class Grid, class GridView, class ElementMapper, class CartesianIndexMa
 typename Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::DimVector
 Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
 distanceVector_(const DimVector& faceCenter,
-                const std::array<double,dimWorld>& cellCenter) const
+                const unsigned& cellIdx) const
 {
+    const auto& cellCenter = centroids_(cellIdx);
     DimVector x = faceCenter;
     for (unsigned dimIdx = 0; dimIdx < dimWorld; ++dimIdx)
         x[dimIdx] -= cellCenter[dimIdx];

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -182,25 +182,6 @@ update(bool global, const TransUpdateQuantities update_quantities,
     else
         extractPermeability_();
 
-    // calculate the axis specific centroids of all elements
-    std::array<std::vector<DimVector>, dimWorld> axisCentroids;
-
-    for (unsigned dimIdx = 0; dimIdx < dimWorld; ++dimIdx)
-        axisCentroids[dimIdx].resize(numElements);
-
-    for (const auto& elem : elements(gridView_)) {
-        unsigned elemIdx = elemMapper.index(elem);
-
-        // compute the axis specific "centroids" used for the transmissibilities. for
-        // consistency with the flow simulator, we use the element centers as
-        // computed by opm-parser's Opm::EclipseGrid class for all axes.
-        std::array<double, dimWorld> centroid = centroids_(elemIdx);
-
-        for (unsigned axisIdx = 0; axisIdx < dimWorld; ++axisIdx)
-            for (unsigned dimIdx = 0; dimIdx < dimWorld; ++dimIdx)
-                axisCentroids[axisIdx][elemIdx][dimIdx] = centroid[dimIdx];
-    }
-
     // reserving some space in the hashmap upfront saves quite a bit of time because
     // resizes are costly for hashmaps and there would be quite a few of them if we
     // would not have a rough idea of how large the final map will be (the rough idea
@@ -272,9 +253,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
                                   faceAreaNormal,
                                   intersection.indexInInside(),
                                   distanceVector_(faceCenterInside,
-                                                  intersection.indexInInside(),
-                                                  elemIdx,
-                                                  axisCentroids),
+                                                  centroids_(elemIdx)),
                                   permeability_[elemIdx]);
 
                 // normally there would be two half-transmissibilities that would be
@@ -291,9 +270,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
                     computeHalfDiffusivity_(transBoundaryEnergyIs,
                                             faceAreaNormal,
                                             distanceVector_(faceCenterInside,
-                                                            intersection.indexInInside(),
-                                                            elemIdx,
-                                                            axisCentroids),
+                                                            centroids_(elemIdx)),
                                             1.0);
                     thermalHalfTransBoundary_[std::make_pair(elemIdx, boundaryIsIdx)] =
                         transBoundaryEnergyIs;
@@ -373,17 +350,13 @@ update(bool global, const TransUpdateQuantities update_quantities,
                               faceAreaNormal,
                               insideFaceIdx,
                               distanceVector_(faceCenterInside,
-                                              intersection.indexInInside(),
-                                              elemIdx,
-                                              axisCentroids),
+                                              centroids_(elemIdx)),
                               permeability_[elemIdx]);
             computeHalfTrans_(halfTrans2,
                               faceAreaNormal,
                               outsideFaceIdx,
                               distanceVector_(faceCenterOutside,
-                                              intersection.indexInOutside(),
-                                              outsideElemIdx,
-                                              axisCentroids),
+                                              centroids_(outsideElemIdx)),
                               permeability_[outsideElemIdx]);
 
             applyNtg_(halfTrans1, insideFaceIdx, elemIdx, ntg);
@@ -470,16 +443,12 @@ update(bool global, const TransUpdateQuantities update_quantities,
                 computeHalfDiffusivity_(halfDiffusivity1,
                                         faceAreaNormal,
                                         distanceVector_(faceCenterInside,
-                                                        intersection.indexInInside(),
-                                                        elemIdx,
-                                                        axisCentroids),
+                                                        centroids_(elemIdx)),
                                         1.0);
                 computeHalfDiffusivity_(halfDiffusivity2,
                                         faceAreaNormal,
                                         distanceVector_(faceCenterOutside,
-                                                        intersection.indexInOutside(),
-                                                        outsideElemIdx,
-                                                        axisCentroids),
+                                                        centroids_(outsideElemIdx)),
                                         1.0);
                 //TODO Add support for multipliers
                 thermalHalfTrans_[details::directionalIsId(elemIdx, outsideElemIdx)] = halfDiffusivity1;
@@ -495,16 +464,12 @@ update(bool global, const TransUpdateQuantities update_quantities,
                 computeHalfDiffusivity_(halfDiffusivity1,
                                         faceAreaNormal,
                                         distanceVector_(faceCenterInside,
-                                                        intersection.indexInInside(),
-                                                        elemIdx,
-                                                        axisCentroids),
+                                                        centroids_(elemIdx)),
                                         porosity_[elemIdx]);
                 computeHalfDiffusivity_(halfDiffusivity2,
                                         faceAreaNormal,
                                         distanceVector_(faceCenterOutside,
-                                                        intersection.indexInOutside(),
-                                                        outsideElemIdx,
-                                                        axisCentroids),
+                                                        centroids_(outsideElemIdx)),
                                         porosity_[outsideElemIdx]);
 
                 applyNtg_(halfDiffusivity1, insideFaceIdx, elemIdx, ntg);
@@ -531,16 +496,12 @@ update(bool global, const TransUpdateQuantities update_quantities,
                 computeHalfDiffusivity_(halfDispersivity1,
                                         faceAreaNormal,
                                         distanceVector_(faceCenterInside,
-                                                        intersection.indexInInside(),
-                                                        elemIdx,
-                                                        axisCentroids),
+                                                        centroids_(elemIdx)),
                                         dispersion_[elemIdx]);
                 computeHalfDiffusivity_(halfDispersivity2,
                                         faceAreaNormal,
                                         distanceVector_(faceCenterOutside,
-                                                        intersection.indexInOutside(),
-                                                        outsideElemIdx,
-                                                        axisCentroids),
+                                                        centroids_(outsideElemIdx)),
                                         dispersion_[outsideElemIdx]);
 
                 applyNtg_(halfDispersivity1, insideFaceIdx, elemIdx, ntg);
@@ -1321,16 +1282,12 @@ computeHalfDiffusivity_(Scalar& halfDiff,
 template<class Grid, class GridView, class ElementMapper, class CartesianIndexMapper, class Scalar>
 typename Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::DimVector
 Transmissibility<Grid,GridView,ElementMapper,CartesianIndexMapper,Scalar>::
-distanceVector_(const DimVector& center,
-                int faceIdx, // in the reference element that contains the intersection
-                unsigned elemIdx,
-                const std::array<std::vector<DimVector>, dimWorld>& axisCentroids) const
+distanceVector_(const DimVector& faceCenter,
+                const std::array<double,dimWorld>& cellCenter) const
 {
-    assert(faceIdx >= 0);
-    unsigned dimIdx = faceIdx/2;
-    assert(dimIdx < dimWorld);
-    DimVector x = center;
-    x -= axisCentroids[dimIdx][elemIdx];
+    DimVector x = faceCenter;
+    for (unsigned dimIdx = 0; dimIdx < dimWorld; ++dimIdx)
+        x[dimIdx] -= cellCenter[dimIdx];
 
     return x;
 }


### PR DESCRIPTION
We stored 3 copies of each cell centroid in axisCentroid. This seemed to be a waste of memory and also made the function distanceVector_ hard to understand.

With this change we omit this copy of information and simplify distanceVector_