### PR TITLE
Handle empty or invalid OMP_NUM_THREADS by Flow default

### DIFF
--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -383,20 +383,27 @@ namespace Opm {
             mpi_size_ = comm.size();
 
 #if _OPENMP
-            // if openMP is available, default to 2 threads per process unless
-            // OMP_NUM_THREADS is set or command line --threads-per-process used
-            if (!getenv("OMP_NUM_THREADS"))
-            {
-                int threads = 2;
-                const int requested_threads = Parameters::get<TypeTag, Parameters::ThreadsPerProcess>();
-                if (requested_threads > 0)
-                    threads = requested_threads;
-
-                // We are not limiting this to the number of processes
-                // reported by OpenMP as on some hardware (and some OpenMPI
-                // versions) this will be 1 when run with mpirun
-                omp_set_num_threads(threads);
+            // If openMP is available, default to 2 threads per process unless
+            // OMP_NUM_THREADS is set or command line --threads-per-process used.
+            // Issue a warning if both OMP_NUM_THREADS and --threads-per-process are set,
+            // but let the environment variable take precedence.
+            const int default_threads = 2;
+            const int requested_threads = Parameters::get<TypeTag, Properties::ThreadsPerProcess>();
+            const char* env_var = getenv("OMP_NUM_THREADS");
+            int omp_num_threads = -1;
+            try {
+                omp_num_threads = std::stoi(env_var ? env_var : "");
+                // Warning in 'Main.hpp', where this code is duplicated
+                // if (requested_threads > 0) {
+                //    OpmLog::warning("Environment variable OMP_NUM_THREADS takes precedence over the --threads-per-process cmdline argument.");
+                // }
+            } catch (const std::invalid_argument& e) {
+                omp_num_threads = requested_threads > 0 ? requested_threads : default_threads;
             }
+            // We are not limiting this to the number of processes
+            // reported by OpenMP as on some hardware (and some OpenMPI
+            // versions) this will be 1 when run with mpirun
+            omp_set_num_threads(omp_num_threads);
 #endif
 
             using ThreadManager = GetPropType<TypeTag, Properties::ThreadManager>;

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -388,7 +388,7 @@ namespace Opm {
             // Issue a warning if both OMP_NUM_THREADS and --threads-per-process are set,
             // but let the environment variable take precedence.
             const int default_threads = 2;
-            const int requested_threads = Parameters::get<TypeTag, Properties::ThreadsPerProcess>();
+            const int requested_threads = Parameters::get<TypeTag, Parameters::ThreadsPerProcess>();
             const char* env_var = getenv("OMP_NUM_THREADS");
             int omp_num_threads = -1;
             try {

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -20,7 +20,7 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef OPM_MAIN_HEADER_INCLUDED
+#ifndef OPM_MAIN_HEADER_INCLUDEDp
 #define OPM_MAIN_HEADER_INCLUDED
 
 #include <flow/flow_blackoil.hpp>
@@ -715,7 +715,7 @@ private:
         // Hence we duplicate the code of setupParallelism to get the number of threads.
         static bool first_time = true;        
         const int default_threads = 2;
-        const int requested_threads = Parameters::get<TypeTag, Properties::ThreadsPerProcess>();
+        const int requested_threads = Parameters::get<TypeTag, Parameters::ThreadsPerProcess>();
         const char* env_var = getenv("OMP_NUM_THREADS");
         int omp_num_threads = -1;
         try {

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -713,21 +713,24 @@ private:
         // This function is called before the parallel OpenMP stuff gets initialized.
         // That initialization happends after the deck is read and we want this message.
         // Hence we duplicate the code of setupParallelism to get the number of threads.
-        if (std::getenv("OMP_NUM_THREADS")) {
-            threads =  omp_get_max_threads();
+        static bool first_time = true;        
+        const int default_threads = 2;
+        const int requested_threads = Parameters::get<TypeTag, Properties::ThreadsPerProcess>();
+        const char* env_var = getenv("OMP_NUM_THREADS");
+        int omp_num_threads = -1;
+        try {
+            omp_num_threads = std::stoi(env_var ? env_var : "");
+            if (first_time && requested_threads > 0 && FlowGenericVanguard::comm().rank()==0) {
+                std::cout << "Warning: Environment variable OMP_NUM_THREADS takes precedence over the --threads-per-process cmdline argument." << std::endl;
+            }
+        } catch (const std::invalid_argument& e) {
+            omp_num_threads = requested_threads > 0 ? requested_threads : default_threads;
         }
-        else {
-            threads = 2;
-
-            const int input_threads = Parameters::get<TypeTag, Parameters::ThreadsPerProcess>();
-
-            if (input_threads > 0)
-                threads = input_threads;
-        }
+        threads = omp_num_threads;
+        first_time = false;        
 #else
         threads = 1;
 #endif
-
         return threads;
     }
 

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -20,7 +20,7 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef OPM_MAIN_HEADER_INCLUDEDp
+#ifndef OPM_MAIN_HEADER_INCLUDED
 #define OPM_MAIN_HEADER_INCLUDED
 
 #include <flow/flow_blackoil.hpp>


### PR DESCRIPTION
Also warn early if valid value of OMP_NUM_THREADS overrides --threads-per-process.

Motivation: Situation where an empty (but defined) OMP_NUM_THREADS caused OMP to select number of threads based on hardware information, resulting in a poor choice. Appears safer to stick with Flow default in this case.