### PR TITLE
make sure a well exists in the process before closing it due to group action

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2226,10 +2226,10 @@ namespace Opm {
         DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger, comm);
 
         for (const auto& [group_name, to] : this->closed_offending_wells_) {
-            if (!this->wasDynamicallyShutThisTimeStep(to.second)) {
+            if (this->hasWell(to.second) && !this->wasDynamicallyShutThisTimeStep(to.second)) {
                 wellTestState.close_well(to.second, WellTestConfig::Reason::GROUP, simulationTime);
                 this->updateClosedWellsThisStep(to.second);
-                const std::string msg = 
+                const std::string msg =
                     fmt::format("Procedure on exceeding {} limit is WELL for group {}. Well {} is {}.",
                                 to.first,
                                 group_name,


### PR DESCRIPTION
Otherwise, we might try to test a well that do not exist in the process, which will cause failure when trying to retrieve information from wells_ecl_. 