### PR TITLE
Activate WELPI and WPIMULT for use in PyAction

### DIFF
--- a/pyactionComparisons.cmake
+++ b/pyactionComparisons.cmake
@@ -95,6 +95,16 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wefac_insert_kw
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
 
+add_test_compareSeparateECLFiles(CASENAME pyaction_welpi_insert_kw
+                                 DIR1 pyaction
+                                 FILENAME1 PYACTION_WELPI_INSERT_KW
+                                 DIR2 actionx
+                                 FILENAME2 ACTIONX_WELPI
+                                 SIMULATOR flow
+                                 ABS_TOL ${abs_tol}
+                                 REL_TOL ${rel_tol}
+                                 IGNORE_EXTRA_KW BOTH)
+
 add_test_compareSeparateECLFiles(CASENAME pyaction_wsegvalv_insert_kw
                                  DIR1 pyaction
                                  FILENAME1 PYACTION_WSEGVALV_INSERT_KW

--- a/pyactionComparisons.cmake
+++ b/pyactionComparisons.cmake
@@ -105,6 +105,16 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_welpi_insert_kw
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
 
+add_test_compareSeparateECLFiles(CASENAME pyaction_wpimult_insert_kw
+                                 DIR1 pyaction
+                                 FILENAME1 PYACTION_WPIMULT_INSERT_KW
+                                 DIR2 actionx
+                                 FILENAME2 ACTIONX_WPIMULT
+                                 SIMULATOR flow
+                                 ABS_TOL ${abs_tol}
+                                 REL_TOL ${rel_tol}
+                                 IGNORE_EXTRA_KW BOTH)
+
 add_test_compareSeparateECLFiles(CASENAME pyaction_wsegvalv_insert_kw
                                  DIR1 pyaction
                                  FILENAME1 PYACTION_WSEGVALV_INSERT_KW


### PR DESCRIPTION
For the reference manual: With this PR and https://github.com/OPM/opm-common/pull/4136, the keywords WELPI and WPIMULT can be used in the "insert keywords"-function in Pyaction.