### PR TITLE
store the composition fractions in SingleWellState 

### DIFF
--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -49,6 +49,7 @@ SingleWellState(const std::string& name_,
     , surface_rates(pu_.num_phases)
     , reservoir_rates(pu_.num_phases)
     , prev_surface_rates(pu_.num_phases)
+    , composition_fractions(pu_.num_phases)
     , perf_data(perf_input.size(), pressure_first_connection, !is_producer, pu_.num_phases)
     , trivial_group_target(false)
 {
@@ -100,6 +101,7 @@ void SingleWellState<Scalar>::shut()
     std::fill(this->productivity_index.begin(), this->productivity_index.end(), 0);
     std::fill(this->implicit_ipr_a.begin(), this->implicit_ipr_a.end(), 0);
     std::fill(this->implicit_ipr_b.begin(), this->implicit_ipr_b.end(), 0);
+    // TODO: should we set the compostion_fractions also?
 
     auto& connpi = this->perf_data.prod_index;
     connpi.assign(connpi.size(), 0);
@@ -372,6 +374,7 @@ bool SingleWellState<Scalar>::operator==(const SingleWellState& rhs) const
            this->surface_rates == rhs.surface_rates &&
            this->reservoir_rates == rhs.reservoir_rates &&
            this->prev_surface_rates == rhs.prev_surface_rates &&
+           this->composition_fractions == rhs.composition_fractions &&
            this->perf_data == rhs.perf_data &&
            this->filtrate_conc == rhs.filtrate_conc &&
            this->trivial_group_target == rhs.trivial_group_target &&

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -70,6 +70,7 @@ public:
         serializer(reservoir_rates);
         serializer(prev_surface_rates);
         serializer(trivial_group_target);
+        serializer(composition_fractions);
         serializer(segments);
         serializer(events);
         serializer(injection_cmode);
@@ -109,6 +110,11 @@ public:
     std::vector<Scalar> surface_rates;
     std::vector<Scalar> reservoir_rates;
     std::vector<Scalar> prev_surface_rates;
+    // volume fractions of compositions in the wellbore under the surface condition
+    // for now, it is only for StandardWell
+    // for multi-segment wells, it should be based on the segments, and this should be
+    // the values for the top segments depending on how we want to do it
+    std::vector<Scalar> composition_fractions;
     PerfData<Scalar> perf_data;
     bool trivial_group_target;
     SegmentState<Scalar> segments;

--- a/opm/simulators/wells/StandardWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.cpp
@@ -407,6 +407,9 @@ copyToWellState(WellState<Scalar>& well_state,
         const Scalar g_total = value_[WQTotal];
         for (int p = 0; p < well_.numPhases(); ++p) {
             ws.surface_rates[p] = g_total * F[p];
+            // It should use value_ for this for consistencya, since value_ is more updated at this point
+            const auto& comp_idx = well_.modelCompIdxToFlowCompIdx(p);
+            ws.composition_fractions[p] = surfaceVolumeFraction(comp_idx).value();
         }
     } else { // injectors
         for (int p = 0; p < well_.numPhases(); ++p) {

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -409,6 +409,7 @@ void WellState<Scalar>::init(const std::vector<Scalar>& cellPressures,
             }
 
             new_well.surface_rates = prev_well.surface_rates;
+	    new_well.composition_fractions = prev_well.composition_fractions;
             new_well.reservoir_rates = prev_well.reservoir_rates;
             new_well.well_potentials = prev_well.well_potentials;
 


### PR DESCRIPTION
And use it in the fluid property calculation within the wellbore when calculating the connection pressure drop. 

It only matters when the wells are SHUT-in and the surface_rates are all 0, under this situation, we can not calculate the fluid composition in the wellbore from the surface_rates. 

Current implementation is an incomplete implementation. It is only done for StandardWell, producers and did not implement for the solvent cases.  Solvent will be a phase and need a fraction also. 

There might be other things need to be done also. 

I put the PR here for information. 