### PR TITLE
Avoid buffers exceeding intmax in MPI calls

### DIFF
--- a/opm/simulators/utils/MPIPacker.cpp
+++ b/opm/simulators/utils/MPIPacker.cpp
@@ -70,7 +70,7 @@ packSize(const std::string& data, Parallel::MPIComm comm)
     MPI_Pack_size(1, Dune::MPITraits<std::size_t>::getType(), comm, &size);
     int totalSize = size;
     MPI_Pack_size(data.size(), MPI_CHAR, comm, &size);
-    return totalSize + size;
+    return static_cast<std::size_t>(totalSize + size);
 }
 
 void Packing<false,std::string>::
@@ -80,7 +80,7 @@ pack(const std::string& data,
      Parallel::MPIComm comm)
 {
     std::size_t length = data.size();
-    int int_position;
+    int int_position = 0;
     MPI_Pack(&length, 1, Dune::MPITraits<std::size_t>::getType(), buffer.data()+position,
              mpi_buffer_size(buffer.size(), position), &int_position, comm);
     MPI_Pack(data.data(), length, MPI_CHAR, buffer.data()+position, mpi_buffer_size(buffer.size(), position),
@@ -95,7 +95,7 @@ unpack(std::string& data,
        Opm::Parallel::MPIComm comm)
 {
     std::size_t length = 0;
-    int int_position;
+    int int_position = 0;
     MPI_Unpack(buffer.data()+position, mpi_buffer_size(buffer.size(), position), &int_position, &length, 1,
                Dune::MPITraits<std::size_t>::getType(), comm);
     std::vector<char> cStr(length+1, '\0');

--- a/opm/simulators/utils/MPIPacker.cpp
+++ b/opm/simulators/utils/MPIPacker.cpp
@@ -70,7 +70,7 @@ packSize(const std::string& data, Parallel::MPIComm comm)
     MPI_Pack_size(1, Dune::MPITraits<std::size_t>::getType(), comm, &size);
     int totalSize = size;
     MPI_Pack_size(data.size(), MPI_CHAR, comm, &size);
-    return static_cast<std::size_t>(totalSize + size);
+    return totalSize + size;
 }
 
 void Packing<false,std::string>::

--- a/opm/simulators/utils/MPIPacker.hpp
+++ b/opm/simulators/utils/MPIPacker.hpp
@@ -35,6 +35,7 @@ namespace Mpi {
 namespace detail {
 
 static std::size_t mpi_buffer_size(const std::size_t bufsize, const std::size_t position) {
+    assert (bufsize >= position);
     return static_cast<int>(std::min(bufsize-position,
                                      static_cast<std::size_t>(std::numeric_limits<int>::max())));
 }
@@ -71,7 +72,9 @@ struct Packing<true,T>
         assert ( n*sizeof(T) <= std::numeric_limits<int>::max() );
         int size = 0;
         MPI_Pack_size(n, Dune::MPITraits<T>::getType(), comm, &size);
-        return size;
+        assert (size >= 0);
+        assert (size < std::numeric_limits<int>::max() );
+        return static_cast<std::size_t>(size);
     }
 
     //! \brief Pack a POD.

--- a/opm/simulators/utils/MPIPacker.hpp
+++ b/opm/simulators/utils/MPIPacker.hpp
@@ -26,19 +26,26 @@
 
 #include <bitset>
 #include <cstddef>
+#include <limits>
 #include <string>
+
 
 namespace Opm {
 namespace Mpi {
 namespace detail {
+
+static std::size_t mpi_buffer_size(const std::size_t bufsize, const std::size_t position) {
+    return static_cast<int>(std::min(bufsize-position,
+                                     static_cast<std::size_t>(std::numeric_limits<int>::max())));
+}
 
 //! \brief Abstract struct for packing which is (partially) specialized for specific types.
 template <bool pod, class T>
 struct Packing
 {
     static std::size_t packSize(const T&, Parallel::MPIComm);
-    static void pack(const T&, std::vector<char>&, int&, Parallel::MPIComm);
-    static void unpack(T&, std::vector<char>&, int&, Parallel::MPIComm);
+    static void pack(const T&, std::vector<char>&, std::size_t&, Parallel::MPIComm);
+    static void unpack(T&, std::vector<char>&, std::size_t&, Parallel::MPIComm);
 };
 
 //! \brief Packaging for pod data.
@@ -59,6 +66,9 @@ struct Packing<true,T>
     //! \param comm The communicator to use
     static std::size_t packSize(const T*, std::size_t n, Parallel::MPIComm comm)
     {
+        // For now we do not handle the situation where a a single call to packSize/pack/unpack
+        // is likely to require an MPI_Pack_size value larger than intmax
+        assert ( n*sizeof(T) <= std::numeric_limits<int>::max() );
         int size = 0;
         MPI_Pack_size(n, Dune::MPITraits<T>::getType(), comm, &size);
         return size;
@@ -71,7 +81,7 @@ struct Packing<true,T>
     //! \param comm The communicator to use
     static void pack(const T& data,
                      std::vector<char>& buffer,
-                     int& position,
+                     std::size_t& position,
                      Parallel::MPIComm comm)
     {
         pack(&data, 1, buffer, position, comm);
@@ -86,11 +96,13 @@ struct Packing<true,T>
     static void pack(const T* data,
                      std::size_t n,
                      std::vector<char>& buffer,
-                     int& position,
+                     std::size_t& position,
                      Parallel::MPIComm comm)
     {
-        MPI_Pack(data, n, Dune::MPITraits<T>::getType(), buffer.data(),
-                 buffer.size(), &position, comm);
+        int int_position = 0;
+        MPI_Pack(data, n, Dune::MPITraits<T>::getType(), buffer.data()+position,
+                 mpi_buffer_size(buffer.size(), position), &int_position, comm);
+        position += int_position;
     }
 
     //! \brief Unpack a POD.
@@ -100,7 +112,7 @@ struct Packing<true,T>
     //! \param comm The communicator to use
     static void unpack(T& data,
                        std::vector<char>& buffer,
-                       int& position,
+                       std::size_t& position,
                        Parallel::MPIComm comm)
     {
         unpack(&data, 1, buffer, position, comm);
@@ -115,11 +127,13 @@ struct Packing<true,T>
     static void unpack(T* data,
                        std::size_t n,
                        std::vector<char>& buffer,
-                       int& position,
+                       std::size_t& position,
                        Parallel::MPIComm comm)
     {
-        MPI_Unpack(buffer.data(), buffer.size(), &position, data, n,
+        int int_position = 0;
+        MPI_Unpack(buffer.data()+position, mpi_buffer_size(buffer.size(), position), &int_position, data, n,
                    Dune::MPITraits<T>::getType(), comm);
+        position += int_position;
     }
 };
 
@@ -133,13 +147,13 @@ struct Packing<false,T>
         return 0;
     }
 
-    static void pack(const T&, std::vector<char>&, int&,
+    static void pack(const T&, std::vector<char>&, std::size_t&,
                      Parallel::MPIComm)
     {
       static_assert(!std::is_same_v<T,T>, "Packing not supported for type");
     }
 
-    static void unpack(T&, std::vector<char>&, int&,
+    static void unpack(T&, std::vector<char>&, std::size_t&,
                        Parallel::MPIComm)
     {
         static_assert(!std::is_same_v<T,T>, "Packing not supported for type");
@@ -151,8 +165,8 @@ template <std::size_t Size>
 struct Packing<false,std::bitset<Size>>
 {
     static std::size_t packSize(const std::bitset<Size>&, Opm::Parallel::MPIComm);
-    static void pack(const std::bitset<Size>&, std::vector<char>&, int&, Opm::Parallel::MPIComm);
-    static void unpack(std::bitset<Size>&, std::vector<char>&, int&, Opm::Parallel::MPIComm);
+    static void pack(const std::bitset<Size>&, std::vector<char>&, std::size_t&, Opm::Parallel::MPIComm);
+    static void unpack(std::bitset<Size>&, std::vector<char>&, std::size_t&, Opm::Parallel::MPIComm);
 };
 
 #define ADD_PACK_SPECIALIZATION(T) \
@@ -160,8 +174,8 @@ struct Packing<false,std::bitset<Size>>
     struct Packing<false,T> \
     { \
         static std::size_t packSize(const T&, Parallel::MPIComm); \
-        static void pack(const T&, std::vector<char>&, int&, Parallel::MPIComm); \
-        static void unpack(T&, std::vector<char>&, int&, Parallel::MPIComm); \
+        static void pack(const T&, std::vector<char>&, std::size_t&, Parallel::MPIComm); \
+        static void unpack(T&, std::vector<char>&, std::size_t&, Parallel::MPIComm); \
     };
 
 ADD_PACK_SPECIALIZATION(std::string)
@@ -207,7 +221,7 @@ struct Packer {
     template<class T>
     void pack(const T& data,
               std::vector<char>& buffer,
-              int& position) const
+              std::size_t& position) const
     {
         detail::Packing<std::is_pod_v<T>,T>::pack(data, buffer, position, m_comm);
     }
@@ -222,7 +236,7 @@ struct Packer {
     void pack(const T* data,
               std::size_t n,
               std::vector<char>& buffer,
-              int& position) const
+              std::size_t& position) const
     {
         static_assert(std::is_pod_v<T>, "Array packing not supported for non-pod data");
         detail::Packing<true,T>::pack(data, n, buffer, position, m_comm);
@@ -236,7 +250,7 @@ struct Packer {
     template<class T>
     void unpack(T& data,
                 std::vector<char>& buffer,
-                int& position) const
+                std::size_t& position) const
     {
         detail::Packing<std::is_pod_v<T>,T>::unpack(data, buffer, position, m_comm);
     }
@@ -251,7 +265,7 @@ struct Packer {
     void unpack(T* data,
                 std::size_t n,
                 std::vector<char>& buffer,
-                int& position) const
+                std::size_t& position) const
     {
         static_assert(std::is_pod_v<T>, "Array packing not supported for non-pod data");
         detail::Packing<true,T>::unpack(data, n, buffer, position, m_comm);

--- a/opm/simulators/utils/MPISerializer.hpp
+++ b/opm/simulators/utils/MPISerializer.hpp
@@ -52,7 +52,15 @@ public:
             try {
                 this->pack(data);
                 m_comm.broadcast(&m_packSize, 1, root);
-                m_comm.broadcast(m_buffer.data(), m_packSize, root);
+                const int maxChunkSize = std::numeric_limits<int>::max();
+                std::size_t remainingSize = m_packSize;
+                std::size_t pos = 0;
+                while (remainingSize > maxChunkSize) {
+                    m_comm.broadcast(m_buffer.data()+pos, maxChunkSize, root);
+                    pos += maxChunkSize;
+                    remainingSize -= maxChunkSize;
+                }
+                m_comm.broadcast(m_buffer.data()+pos, static_cast<int>(remainingSize), root);
             } catch (...) {
                 m_packSize = std::numeric_limits<size_t>::max();
                 m_comm.broadcast(&m_packSize, 1, root);
@@ -63,9 +71,16 @@ public:
             if (m_packSize == std::numeric_limits<size_t>::max()) {
                 throw std::runtime_error("Error detected in parallel serialization");
             }
-
             m_buffer.resize(m_packSize);
-            m_comm.broadcast(m_buffer.data(), m_packSize, root);
+            const int maxChunkSize = std::numeric_limits<int>::max();
+            std::size_t remainingSize = m_packSize;
+            std::size_t pos = 0;
+            while (remainingSize > maxChunkSize) {
+                m_comm.broadcast(m_buffer.data()+pos, maxChunkSize, root);
+                pos += maxChunkSize;
+                remainingSize -= maxChunkSize;
+            }
+            m_comm.broadcast(m_buffer.data()+pos, static_cast<int>(remainingSize), root);
             this->unpack(data);
         }
     }
@@ -80,7 +95,15 @@ public:
             try {
                 this->pack(std::forward<Args>(args)...);
                 m_comm.broadcast(&m_packSize, 1, root);
-                m_comm.broadcast(m_buffer.data(), m_packSize, root);
+                const int maxChunkSize = std::numeric_limits<int>::max();
+                std::size_t remainingSize = m_packSize;
+                std::size_t pos = 0;
+                while (remainingSize > maxChunkSize) {
+                    m_comm.broadcast(m_buffer.data()+pos, maxChunkSize, root);
+                    pos += maxChunkSize;
+                    remainingSize -= maxChunkSize;
+                }
+                m_comm.broadcast(m_buffer.data()+pos, static_cast<int>(remainingSize), root);
             } catch (...) {
                 m_packSize = std::numeric_limits<size_t>::max();
                 m_comm.broadcast(&m_packSize, 1, root);
@@ -92,7 +115,15 @@ public:
                 throw std::runtime_error("Error detected in parallel serialization");
             }
             m_buffer.resize(m_packSize);
-            m_comm.broadcast(m_buffer.data(), m_packSize, root);
+            const int maxChunkSize = std::numeric_limits<int>::max();
+            std::size_t remainingSize = m_packSize;
+            std::size_t pos = 0;
+            while (remainingSize > maxChunkSize) {
+                m_comm.broadcast(m_buffer.data()+pos, maxChunkSize, root);
+                pos += maxChunkSize;
+                remainingSize -= maxChunkSize;
+            }
+            m_comm.broadcast(m_buffer.data()+pos, static_cast<int>(remainingSize), root);
             this->unpack(std::forward<Args>(args)...);
         }
     }

--- a/opm/simulators/utils/SerializationPackers.cpp
+++ b/opm/simulators/utils/SerializationPackers.cpp
@@ -34,14 +34,14 @@ packSize(const boost::gregorian::date& data)
 
 void Packing<false,boost::gregorian::date>::
 pack(const boost::gregorian::date& data,
-     std::vector<char>& buffer, int& position)
+     std::vector<char>& buffer, std::size_t& position)
 {
     Packing<false,std::string>::pack(boost::gregorian::to_simple_string(data), buffer, position);
 }
 
 void Packing<false,boost::gregorian::date>::
 unpack(boost::gregorian::date& data,
-       std::vector<char>& buffer, int& position)
+       std::vector<char>& buffer, std::size_t& position)
 {
     std::string date;
     Packing<false,std::string>::unpack(date, buffer, position);

--- a/opm/simulators/utils/SerializationPackers.hpp
+++ b/opm/simulators/utils/SerializationPackers.hpp
@@ -35,10 +35,10 @@ struct Packing<false,boost::gregorian::date>
     static std::size_t packSize(const boost::gregorian::date& data);
 
     static void pack(const boost::gregorian::date& data,
-                     std::vector<char>& buffer, int& position);
+                     std::vector<char>& buffer, std::size_t& position);
 
     static void unpack(boost::gregorian::date& data,
-                       std::vector<char>& buffer, int& position);
+                       std::vector<char>& buffer, std::size_t& position);
 };
 
 }


### PR DESCRIPTION
Depends on https://github.com/OPM/opm-common/pull/4139