### PR TITLE
Remove UNIFOUT keyword from python test data file SPE1CASE1.DATA

### DIFF
--- a/python/test_data/SPE1CASE1a/SPE1CASE1.DATA
+++ b/python/test_data/SPE1CASE1a/SPE1CASE1.DATA
@@ -59,8 +59,6 @@ WELLDIMS
 -- 	   - there must be two wells in a group as there are two wells in total
    2 1 1 2 /
 
-UNIFOUT
-
 GRID
 
 -- The INIT keyword is used to request an .INIT file. The .INIT file

--- a/python/test_data/SPE1CASE1b/SPE1CASE1.DATA
+++ b/python/test_data/SPE1CASE1b/SPE1CASE1.DATA
@@ -59,8 +59,6 @@ WELLDIMS
 -- 	   - there must be two wells in a group as there are two wells in total
    2 1 1 2 /
 
-UNIFOUT
-
 GRID
 
 -- The INIT keyword is used to request an .INIT file. The .INIT file


### PR DESCRIPTION
With this keyword, the SPE1CASE1.UNRST file could not be read in correctly at some point, until I've added a check in opm-models that checks this, this went unnoticed probably.