### PR TITLE
Set correct target iterations in SimpleIterationTimestepControl

### DIFF
--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -84,7 +84,7 @@ namespace Opm
             dtEstimate *= decayrate_;
         }
         // increase the time step size if we are below the number of target iterations
-        else if ( iterations < target_iterations_-1 )
+        else if ( iterations < target_iterations_ )
         {
             dtEstimate *= growthrate_;
         }


### PR DESCRIPTION
For the simple iteration timestep controller, used for both the "iterationcount" and "newtoniterationcount" timestep controller, we are currently subtracting 1 from the target iterations. This is not correct and is misleading from the time-step-control-target-newton-iterations option. For example, if one set the target to 2 Newton iterations, which works well for NLDD, the timestep will not change.