### PR TITLE
Revise Mixture Density Method for No-Flow Producers

### DIFF
--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -267,12 +267,13 @@ namespace Opm
                              WellState<Scalar>& well_state,
                              DeferredLogger& deferred_logger);
 
-        // calculate the properties for the well connections
-        // to calulate the pressure difference between well connections.
         using WellConnectionProps = typename StdWellEval::StdWellConnections::Properties;
-        void computePropertiesForWellConnectionPressures(const Simulator& simulator,
-                                                         const WellState<Scalar>& well_state,
-                                                         WellConnectionProps& props) const;
+
+        // Compute connection level PVT properties needed to calulate the
+        // pressure difference between well connections.
+        WellConnectionProps
+        computePropertiesForWellConnectionPressures(const Simulator& simulator,
+                                                    const WellState<Scalar>& well_state) const;
 
         void computeWellConnectionDensitesPressures(const Simulator& simulator,
                                                     const WellState<Scalar>& well_state,

--- a/opm/simulators/wells/StandardWellConnections.hpp
+++ b/opm/simulators/wells/StandardWellConnections.hpp
@@ -66,18 +66,22 @@ public:
         std::function<Scalar(int)>     solventRefDensity{};
     };
 
+    struct DensityPropertyFunctions
+    {
+        std::function<void(int, const std::vector<int>&, std::vector<Scalar>&)> mobility{};
+        std::function<void(int, const std::vector<int>&, std::vector<Scalar>&)> densityInCell{};
+    };
+
     Properties
     computePropertiesForPressures(const WellState<Scalar>&         well_state,
                                   const PressurePropertyFunctions& propFunc) const;
 
     //! \brief Compute connection properties (densities, pressure drop, ...)
-    void computeProperties(const WellState<Scalar>& well_state,
-                           const std::function<Scalar(int,int)>& invB,
-                           const std::function<Scalar(int,int)>& mobility,
-                           const std::function<Scalar(int)>& solventInverseFormationVolumeFactor,
-                           const std::function<Scalar(int)>& solventMobility,
-                           const Properties& props,
-                           DeferredLogger& deferred_logger);
+    void computeProperties(const bool                      stop_or_zero_rate_target,
+                           const WellState<Scalar>&        well_state,
+                           const DensityPropertyFunctions& prop_func,
+                           const Properties&               props,
+                           DeferredLogger&                 deferred_logger);
 
     //! \brief Returns density for first perforation.
     Scalar rho() const
@@ -139,6 +143,8 @@ private:
     void computeDensities(const std::vector<Scalar>& perfComponentRates,
                           const Properties& props,
                           DeferredLogger& deferred_logger);
+
+    void computeDensitiesForStoppedProducer(const DensityPropertyFunctions& prop_func);
 
     std::vector<Scalar>
     calculatePerforationOutflow(const std::vector<Scalar>& perfComponentRates) const;

--- a/opm/simulators/wells/StandardWellConnections.hpp
+++ b/opm/simulators/wells/StandardWellConnections.hpp
@@ -57,13 +57,18 @@ public:
         std::vector<Scalar> surf_dens_perf{};
     };
 
-    void computePropertiesForPressures(const WellState<Scalar>& well_state,
-                                       const std::function<Scalar(int,int)>& getTemperature,
-                                       const std::function<Scalar(int)>& getSaltConcentration,
-                                       const std::function<int(int)>& pvtRegionIdx,
-                                       const std::function<Scalar(int)>& solventInverseFormationVolumeFactor,
-                                       const std::function<Scalar(int)>& solventRefDensity,
-                                       Properties& props) const;
+    struct PressurePropertyFunctions
+    {
+        std::function<Scalar(int,int)> getTemperature{};
+        std::function<Scalar(int)>     getSaltConcentration{};
+        std::function<int(int)>        pvtRegionIdx{};
+        std::function<Scalar(int)>     solventInverseFormationVolumeFactor{};
+        std::function<Scalar(int)>     solventRefDensity{};
+    };
+
+    Properties
+    computePropertiesForPressures(const WellState<Scalar>&         well_state,
+                                  const PressurePropertyFunctions& propFunc) const;
 
     //! \brief Compute connection properties (densities, pressure drop, ...)
     void computeProperties(const WellState<Scalar>& well_state,

--- a/opm/simulators/wells/StandardWellConnections.hpp
+++ b/opm/simulators/wells/StandardWellConnections.hpp
@@ -25,7 +25,9 @@
 
 #include <opm/simulators/wells/StandardWellPrimaryVariables.hpp>
 
+#include <array>
 #include <functional>
+#include <tuple>
 #include <variant>
 #include <vector>
 
@@ -36,6 +38,7 @@ class DeferredLogger;
 enum class Phase;
 template<class FluidSystem, class Indices> class WellInterfaceIndices;
 template<class Scalar> class WellState;
+template<class Scalar> class PerfData;
 
 template<class FluidSystem, class Indices>
 class StandardWellConnections
@@ -46,12 +49,12 @@ public:
 
     struct Properties
     {
-        std::vector<Scalar> b_perf;
-        std::vector<Scalar> rsmax_perf;
-        std::vector<Scalar> rvmax_perf;
-        std::vector<Scalar> rvwmax_perf;
-        std::vector<Scalar> rswmax_perf;
-        std::vector<Scalar> surf_dens_perf;
+        std::vector<Scalar> b_perf{};
+        std::vector<Scalar> rsmax_perf{};
+        std::vector<Scalar> rvmax_perf{};
+        std::vector<Scalar> rvwmax_perf{};
+        std::vector<Scalar> rswmax_perf{};
+        std::vector<Scalar> surf_dens_perf{};
     };
 
     void computePropertiesForPressures(const WellState<Scalar>& well_state,
@@ -131,6 +134,19 @@ private:
     void computeDensities(const std::vector<Scalar>& perfComponentRates,
                           const Properties& props,
                           DeferredLogger& deferred_logger);
+
+    std::vector<Scalar>
+    calculatePerforationOutflow(const std::vector<Scalar>& perfComponentRates) const;
+
+    void initialiseConnectionMixture(const int                  num_comp,
+                                     const int                  perf,
+                                     const std::vector<Scalar>& q_out_perf,
+                                     const std::vector<Scalar>& currentMixture,
+                                     std::vector<Scalar>&       previousMixture) const;
+
+    std::vector<Scalar>
+    copyInPerforationRates(const Properties&       props,
+                           const PerfData<Scalar>& perf_data) const;
 
     const WellInterfaceIndices<FluidSystem,Indices>& well_; //!< Reference to well interface
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1477,10 +1477,10 @@ namespace Opm
                             const WellState<Scalar>& well_state,
                             DeferredLogger& deferred_logger) const
     {
-        // Check if well is stopped or under zero rate control, either directly or from group
-        return (this->wellIsStopped() || wellUnderZeroRateTarget(simulator,
-                                                                 well_state,
-                                                                 deferred_logger));
+        // Check if well is stopped or under zero rate control, either
+        // directly or from group.
+        return this->wellIsStopped()
+            || this->wellUnderZeroRateTarget(simulator, well_state, deferred_logger);
     }
 
     template<typename TypeTag>


### PR DESCRIPTION
This PR switches the approach introduced in commit eeb1b7e36c9ae3c30ba5d262fa623dc0eea2e10b (PR #3169) to using a mobility weighted average of cell level densities for the connection level mixture densities in no-flow producing wells.  We also use the recent `stoppedOrZeroRateTarget()` predicate to identify those no-flow producing wells instead of inspecting the connection flow rates.

The mobility weighted average gives a more monotone pressure buildup for the stopped wells and this is usually what the engineer wants. This revised approach furthermore needs fewer cell-level dynamic properties so simplify the `computeProperties()` signature by introducing a structure for the property callback functions and update the callers accordingly.

While here, also refactor parts of the `StandardWellConnections` code to aid future maintenance, mostly by splitting out parts of the existing `computePropertiesForPressures()` member function to several other helper functions.