### PR TITLE
Improve parallel network test.

### DIFF
--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -150,12 +150,12 @@ add_test_compare_parallel_simulation(CASENAME aquflux_02
                                      TEST_ARGS --enable-tuning=true)
 
 add_test_compare_parallel_simulation(CASENAME network_balance_01
-		                             FILENAME NETWORK-01
-		                             SIMULATOR flow
-		                             ABS_TOL 0.04
-		                             REL_TOL 0.02
-		                             DIR network
-		                             TEST_ARGS --enable-tuning=true)
+	                             FILENAME NETWORK-01
+	                             SIMULATOR flow
+	                             ABS_TOL ${abs_tol}
+	                             REL_TOL ${coarse_rel_tol_parallel}
+	                             DIR network
+	                             TEST_ARGS --enable-tuning=true --time-step-control=newtoniterationcount --time-step-control-growth-rate=3.0 --relaxed-max-pv-fraction=0.0 --tolerance-cnv=1e-3)
 
 add_test_compare_parallel_simulation(CASENAME numerical_aquifer_3d_1aqu
                                      FILENAME 3D_1AQU_3CELLS


### PR DESCRIPTION
The PID part of the timestep controller triggers and results in timestep sizes depending on the state of the simulation. This can lead to different timestepping for parallel and serial runs. Using only newton iteration count for timestep calculations addresses this.

Also, tighten CNV tolerances to avoid solution differences that are accepted by the simulator as within tolerances, but outside comparison tolerances.

Also also, reindent, no idea why it is different for the network tests.

I think the changes made to tolerances and timestepping would benefit other tests as well, coming in later PRs.