### PR TITLE
Add flow executable with simpler MaterialLawManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,6 +515,18 @@ opm_add_test(flow
   $<TARGET_OBJECTS:moduleVersion>
   )
 
+opm_add_test(flow_simple
+  ONLY_COMPILE
+  ALWAYS_ENABLE
+  DEFAULT_ENABLE_IF ${FLOW_DEFAULT_ENABLE_IF}
+  DEPENDS opmsimulators
+  LIBRARIES opmsimulators
+  SOURCES
+  flow/flow_simple.cpp
+  ${FLOW_TGTS}
+  $<TARGET_OBJECTS:moduleVersion>
+)
+
 opm_add_test(flow_blackoil_polyhedralgrid
   ONLY_COMPILE
   ALWAYS_ENABLE

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -99,6 +99,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/flow/Transmissibility.cpp
   opm/simulators/flow/ValidationFunctions.cpp
   opm/simulators/flow/equil/EquilibrationHelpers.cpp
+  opm/simulators/flow/equil/EquilibrationHelpersSimple.cpp
   opm/simulators/flow/equil/InitStateEquil.cpp
   opm/simulators/linalg/ExtractParallelGridInformationToISTL.cpp
   opm/simulators/linalg/FlexibleSolver1.cpp

--- a/flow/flow_simple.cpp
+++ b/flow/flow_simple.cpp
@@ -39,11 +39,12 @@ namespace Opm {
         };
 
 
+        // Skipping for now
         // SPE11C requires dispersion
-        template<class TypeTag>
-        struct EnableDispersion<TypeTag, TTag::EclFlowProblemTest> {
-            static constexpr bool value = true;
-        };
+        // template<class TypeTag>
+        // struct EnableDispersion<TypeTag, TTag::EclFlowProblemTest> {
+        //     static constexpr bool value = true;
+        // };
 
         template<class TypeTag>
         struct MaterialLaw<TypeTag, TTag::EclFlowProblemTest>

--- a/flow/flow_simple.cpp
+++ b/flow/flow_simple.cpp
@@ -20,7 +20,10 @@
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManagerSimple.hpp>
 
-// make TypeTag contain the simple materiallawmanager
+// do I need these?
+#include <opm/simulators/flow/equil/EquilibrationHelpers.hpp>
+#include <opm/simulators/flow/equil/InitStateEquil.hpp>
+
 namespace Opm {
     namespace Properties {
         namespace TTag {

--- a/flow/flow_simple.cpp
+++ b/flow/flow_simple.cpp
@@ -1,0 +1,58 @@
+/*
+  Copyright 2024, SINTEF AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMaterialLawManagerSimple.hpp>
+
+// make TypeTag contain the simple materiallawmanager
+namespace Opm {
+    namespace Properties {
+        namespace TTag {
+            struct EclFlowProblemTest {
+                using InheritsFrom = std::tuple<FlowProblem>;
+            };
+        }
+
+        template<class TypeTag>
+        struct MaterialLaw<TypeTag, TTag::EclFlowProblemTest>
+        {
+        private:
+            using Scalar = GetPropType<TypeTag, Properties::Scalar>;
+            using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+
+            using Traits = ThreePhaseMaterialTraits<Scalar,
+                                                    /*wettingPhaseIdx=*/FluidSystem::waterPhaseIdx,
+                                                    /*nonWettingPhaseIdx=*/FluidSystem::oilPhaseIdx,
+                                                    /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx>;
+        public:
+            using EclMaterialLawManager = ::Opm::EclMaterialLawManagerSimple<Traits>;
+            using type = typename EclMaterialLawManager::MaterialLaw;
+        };
+
+    };
+
+}
+
+int main(int argc, char** argv)
+{
+    using TypeTag = Opm::Properties::TTag::EclFlowProblemTest;
+    auto mainObject = Opm::Main(argc, argv);
+    return mainObject.runStatic<TypeTag>();
+//    return Opm::start<TypeTag>(argc, argv);
+}

--- a/flow/flow_simple.cpp
+++ b/flow/flow_simple.cpp
@@ -32,6 +32,19 @@ namespace Opm {
             };
         }
 
+        // SPE11C requires thermal/energy
+        template<class TypeTag>
+        struct EnableEnergy<TypeTag, TTag::EclFlowProblemTest> {
+            static constexpr bool value = true;
+        };
+
+
+        // SPE11C requires dispersion
+        template<class TypeTag>
+        struct EnableDispersion<TypeTag, TTag::EclFlowProblemTest> {
+            static constexpr bool value = true;
+        };
+
         template<class TypeTag>
         struct MaterialLaw<TypeTag, TTag::EclFlowProblemTest>
         {

--- a/opm/simulators/flow/EquilInitializer.hpp
+++ b/opm/simulators/flow/EquilInitializer.hpp
@@ -30,8 +30,6 @@
 
 #include <opm/grid/common/CartesianIndexMapper.hpp>
 
-#include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
-#include <opm/material/fluidmatrixinteractions/EclMaterialLawManagerSimple.hpp>
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 
 #include <opm/models/blackoil/blackoilproperties.hh>

--- a/opm/simulators/flow/EquilInitializer.hpp
+++ b/opm/simulators/flow/EquilInitializer.hpp
@@ -31,6 +31,7 @@
 #include <opm/grid/common/CartesianIndexMapper.hpp>
 
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMaterialLawManagerSimple.hpp>
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 
 #include <opm/models/blackoil/blackoilproperties.hh>

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -44,6 +44,7 @@
 #include <opm/material/common/Valgrind.hpp>
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMaterialLawManagerSimple.hpp>
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp>

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -43,8 +43,6 @@
 #include <opm/material/common/ConditionalStorage.hpp>
 #include <opm/material/common/Valgrind.hpp>
 #include <opm/material/densead/Evaluation.hpp>
-#include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
-#include <opm/material/fluidmatrixinteractions/EclMaterialLawManagerSimple.hpp>
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp>

--- a/opm/simulators/flow/FlowProblemProperties.hpp
+++ b/opm/simulators/flow/FlowProblemProperties.hpp
@@ -29,6 +29,7 @@
 #define OPM_FLOW_PROBLEM_PROPERTIES_HPP
 
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMaterialLawManagerSimple.hpp>
 #include <opm/material/thermal/EclThermalLawManager.hpp>
 
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>

--- a/opm/simulators/flow/FlowProblemProperties.hpp
+++ b/opm/simulators/flow/FlowProblemProperties.hpp
@@ -29,7 +29,6 @@
 #define OPM_FLOW_PROBLEM_PROPERTIES_HPP
 
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
-#include <opm/material/fluidmatrixinteractions/EclMaterialLawManagerSimple.hpp>
 #include <opm/material/thermal/EclThermalLawManager.hpp>
 
 #include <opm/models/discretization/ecfv/ecfvdiscretization.hh>

--- a/opm/simulators/flow/equil/EquilibrationHelpersSimple.cpp
+++ b/opm/simulators/flow/equil/EquilibrationHelpersSimple.cpp
@@ -1,0 +1,59 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+#include <opm/simulators/flow/equil/EquilibrationHelpers_impl.hpp>
+
+namespace Opm {
+namespace EQUIL {
+    
+template<class Scalar>
+using MatLaw = EclMaterialLawManagerSimple<ThreePhaseMaterialTraits<Scalar,0,1,2>>;
+template<class Scalar> using FS = BlackOilFluidSystem<Scalar>;
+
+#define INSTANTIATE_TYPE(T) \
+    template struct PcEq<FS<T>,MatLaw<T>>; \
+    template class EquilReg<T>; \
+    template T satFromPc<FS<T>,MatLaw<T>>(const MatLaw<T>&, \
+                                          const int,const int, \
+                                          const T,const bool); \
+    template T satFromSumOfPcs<FS<T>,MatLaw<T>>(const MatLaw<T>&,    \
+                                                const int,const int, \
+                                                const int,const T); \
+    template T satFromDepth<FS<T>,MatLaw<T>>(const MatLaw<T>&, \
+                                             const T,const T, \
+                                             const int,const int,const bool); \
+    template bool isConstPc<FS<T>,MatLaw<T>>(const MatLaw<T>&,const int,const int); \
+    template class Miscibility::PBVD<FS<T>>; \
+    template class Miscibility::PDVD<FS<T>>; \
+    template class Miscibility::RsVD<FS<T>>; \
+    template class Miscibility::RsSatAtContact<FS<T>>; \
+    template class Miscibility::RvSatAtContact<FS<T>>; \
+    template class Miscibility::RvwSatAtContact<FS<T>>; \
+    template class Miscibility::RvVD<FS<T>>; \
+    template class Miscibility::RvwVD<FS<T>>;
+
+INSTANTIATE_TYPE(double)
+
+} // namespace Equil
+} // namespace Opm

--- a/opm/simulators/flow/equil/EquilibrationHelpers_impl.hpp
+++ b/opm/simulators/flow/equil/EquilibrationHelpers_impl.hpp
@@ -26,6 +26,7 @@
 #include <opm/common/utility/numeric/RootFinders.hpp>
 
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMaterialLawManagerSimple.hpp>
 #include <opm/material/fluidstates/SimpleModularFluidState.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 

--- a/opm/simulators/flow/equil/InitStateEquil.cpp
+++ b/opm/simulators/flow/equil/InitStateEquil.cpp
@@ -39,25 +39,29 @@ namespace Opm {
 
 template<class Scalar>
 using MatLaw = EclMaterialLawManager<ThreePhaseMaterialTraits<Scalar,0,1,2>>;
+template<class Scalar>
+using MatLawSimple = EclMaterialLawManagerSimple<ThreePhaseMaterialTraits<Scalar,0,1,2>>;
 
 namespace EQUIL {
 namespace DeckDependent {
 
-#define INSTANTIATE_COMP(T, GridView, Mapper)                                      \
-    template class InitialStateComputer<BlackOilFluidSystem<T>,                    \
-                                        Dune::CpGrid,                              \
-                                        GridView,                                  \
-                                        Mapper,                                    \
-                                        Dune::CartesianIndexMapper<Dune::CpGrid>>; \
-    template InitialStateComputer<BlackOilFluidSystem<T>,                          \
-                                  Dune::CpGrid,                                    \
-                                  GridView,                                        \
-                                  Mapper,                                          \
-                                  Dune::CartesianIndexMapper<Dune::CpGrid>>::      \
-             InitialStateComputer(MatLaw<T>&,                                      \
-                                  const EclipseState&,                             \
-                                  const Dune::CpGrid&,                             \
-                                  const GridView&,                                 \
+#define INSTANTIATE_COMP_CLASS(T, GridView, Mapper) \
+    template class InitialStateComputer<BlackOilFluidSystem<T>, \
+                                        Dune::CpGrid, \
+                                        GridView, \
+                                        Mapper, \
+                                        Dune::CartesianIndexMapper<Dune::CpGrid>>;
+
+#define INSTANTIATE_COMP(T, GridView, Mapper, MatLaw) \
+    template InitialStateComputer<BlackOilFluidSystem<T>, \
+                                  Dune::CpGrid, \
+                                  GridView, \
+                                  Mapper, \
+                                  Dune::CartesianIndexMapper<Dune::CpGrid>>::\
+             InitialStateComputer(MatLaw<T>&, \
+                                  const EclipseState&, \
+                                  const Dune::CpGrid&, \
+                                  const GridView&, \
                                   const Dune::CartesianIndexMapper<Dune::CpGrid>&, \
                                   const T,                                         \
                                   const int,                                       \
@@ -65,11 +69,9 @@ namespace DeckDependent {
 
 using GridView = Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>;
 using Mapper = Dune::MultipleCodimMultipleGeomTypeMapper<GridView>;
-
-INSTANTIATE_COMP(double, GridView, Mapper)
-#if FLOW_INSTANTIATE_FLOAT
-INSTANTIATE_COMP(float, GridView, Mapper)
-#endif
+INSTANTIATE_COMP_CLASS(double, GridView, Mapper)
+INSTANTIATE_COMP(double, GridView, Mapper, MatLaw)
+INSTANTIATE_COMP(double, GridView, Mapper, MatLawSimple)
 
 #if HAVE_DUNE_FEM
 #if DUNE_VERSION_GTE(DUNE_FEM, 2, 9)
@@ -85,7 +87,9 @@ using GridViewFem = Dune::Fem::GridPart2GridViewImpl<
 #endif
 using MapperFem = Dune::MultipleCodimMultipleGeomTypeMapper<GridViewFem>;
 
-INSTANTIATE_COMP(double, GridViewFem, MapperFem)
+INSTANTIATE_COMP_CLASS(double, GridViewFem, MapperFem)
+INSTANTIATE_COMP(double, GridViewFem, MapperFem, MatLaw)
+INSTANTIATE_COMP(double, GridViewFem, MapperFem, MatLawSimple)
 
 #if FLOW_INSTANTIATE_FLOAT
 INSTANTIATE_COMP(float, GridViewFem, MapperFem)

--- a/opm/simulators/flow/equil/InitStateEquil_impl.hpp
+++ b/opm/simulators/flow/equil/InitStateEquil_impl.hpp
@@ -41,6 +41,7 @@
 #include <opm/input/eclipse/EclipseState/Tables/SaltpvdTable.hpp>
 
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMaterialLawManagerSimple.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 
 #include <opm/simulators/flow/equil/EquilibrationHelpers.hpp>


### PR DESCRIPTION
This PR adds a flow executable that will use the simple EclMaterialLawManager in opm-common to enable GPU support of property evaluation on simple flow cases