### PR TITLE
Reveal error in g2l map in partitionCells for the NLDD solver

### DIFF
--- a/opm/simulators/flow/partitionCells.cpp
+++ b/opm/simulators/flow/partitionCells.cpp
@@ -249,7 +249,9 @@ ZoltanPartitioner::connectElements(const GridView&                              
 {
     auto g2l = std::unordered_map<int, int>{};
 
-    for (const auto& element : elements(grid_view, Dune::Partitions::interior)) {
+    // For Dune::Partitions::interior, even more global indices are not found in the connectWells functions,
+    // yet the std::invalid_argument at the end of connectWells is not thrown...
+    for (const auto& element : elements(grid_view, Dune::Partitions::all)) {
         {
             const auto c = zoltan_ctrl.index(element);
             g2l.insert_or_assign(zoltan_ctrl.local_to_global(c), c);
@@ -295,6 +297,7 @@ void ZoltanPartitioner::connectWells(const Comm                          comm,
         for (const auto& conn : well.getConnections()) {
             auto locPos = g2l.find(conn.global_index());
             if (locPos == g2l.end()) {
+                std::cout << "on rank " << comm.rank() << ", well " << well.name() << ": looking for global_index: " << conn.global_index() << " - not found " << std::endl;
                 ++otherProc;
                 continue;
             }

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -213,6 +213,14 @@ add_test_compare_parallel_simulation(CASENAME rxft
                                      DIR rxft_smry
                                      TEST_ARGS --enable-tuning=true --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --enable-drift-compensation=false)
 
+add_test_compare_parallel_simulation(CASENAME compdat_nldd
+                                     FILENAME COMPDAT_SHORT
+                                     SIMULATOR flow
+                                     ABS_TOL ${abs_tol_parallel}
+                                     REL_TOL ${rel_tol_parallel}
+                                     DIR actionx
+                                     TEST_ARGS --nonlinear-solver=nldd --matrix-add-well-contributions=true)
+
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-comparison.sh "")
 
 add_test_compareSeparateECLFiles(CASENAME actionx_compdat_1_proc


### PR DESCRIPTION
I'm looking into a bug happening when using the NLDD solver.
The actual bug happens in situations where well connections are added through an ACTIONX with the COMPDAT keyword and need to be taken into account by the solver and the grid partitioner and I plan to fix it in PR #5505.

My current problem even occurs when running the simulator with a deck without an ACTIONX, i.e. with this deck (https://github.com/OPM/opm-tests/blob/master/actionx/COMPDAT_SHORT.DATA):
There is a global2local (g2l) map (created in the function connectElements of the ZoltanPartitioner in [partitionCells.cpp](https://github.com/OPM/opm-simulators/blob/master/opm/simulators/flow/partitionCells.cpp#L250)) which does not seem to contain the correct elements when running the simulation in parallel, or the elements that are queried on each process are not right.
I've also added a failing test for this:
https://ci.opm-project.org/job/opm-simulators-PR-builder/6469/testReport/junit/(root)/mpi/compareParallelSim_flow_COMPDAT_SHORT/
Maybe the error went unnoticed until now, see this comment: https://github.com/OPM/opm-simulators/pull/5508/files#diff-8e157d0d44a0cf2ae336f54feae615c8007dfa70b7d065b0311a0f25d5971625R252

Am I doing something wrong here or why does that happen?