### PR TITLE
Adjust test parameters for stability.

### DIFF
--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -139,7 +139,7 @@ add_test_compare_parallel_simulation(CASENAME aquflux_01
                                      ABS_TOL ${abs_tol}
                                      REL_TOL 0.04
                                      DIR aquifers
-                                     TEST_ARGS --enable-tuning=true --enable-drift-compensation=false --relaxed-max-pv-fraction=0.0)
+                                     TEST_ARGS --enable-tuning=true --enable-drift-compensation=false --relaxed-max-pv-fraction=0.0 --tolerance-cnv=1.0e-3)
 
 add_test_compare_parallel_simulation(CASENAME aquflux_02
                                      FILENAME AQUFLUX-02

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -299,7 +299,7 @@ add_test_compareECLFiles(CASENAME polymer_injectivity
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
-                         TEST_ARGS --tolerance-mb=1.e-7 --tolerance-wells=1.e-6)
+                         TEST_ARGS --tolerance-mb=1.e-7 --tolerance-wells=1.e-6 --linear-solver=ilu0)
 
 add_test_compareECLFiles(CASENAME polymer_simple2D
                          FILENAME 2D_THREEPHASE_POLY_HETER
@@ -1119,7 +1119,8 @@ add_test_compareECLFiles(CASENAME micp
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
-                         DIR micp)
+                         DIR micp
+                         TEST_ARGS --linear-solver=ilu0)
 
 add_test_compareECLFiles(CASENAME 0_base_model6
                          FILENAME 0_BASE_MODEL6


### PR DESCRIPTION
The necessity of ILU0 for MICP and injectivity runs must be handled by either error message of fix, this just works around the issue by forcing the tests to run with ILU0.

This PR should eliminate three test errors for #5157.