### PR TITLE
Ensure default ALQ is set for all production wells on all processes

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -451,7 +451,7 @@ namespace Opm {
         this->updateAndCommunicateGroupData(reportStepIdx,
                                             simulator_.model().newtonMethod().numIterations());
 
-        this->wellState().updateWellsDefaultALQ(this->wells_ecl_, this->summaryState());
+        this->wellState().updateWellsDefaultALQ(this->schedule(), reportStepIdx, this->summaryState());
         this->wellState().gliftTimeStepInit();
 
         const double simulationTime = simulator_.time();

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -424,7 +424,9 @@ void WellState<Scalar>::init(const std::vector<Scalar>& cellPressures,
         }
     }
 
-    updateWellsDefaultALQ(wells_ecl, summary_state);
+    // ALQ state needs to be defined for all wells, otherwise alqstate.packSize() will be different
+    // on each process, and the comm.sum call in communicateGroupRates will fail.
+    updateWellsDefaultALQ(schedule.getWells(report_step), summary_state);
 }
 
 template<class Scalar>

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -424,9 +424,7 @@ void WellState<Scalar>::init(const std::vector<Scalar>& cellPressures,
         }
     }
 
-    // ALQ state needs to be defined for all wells, otherwise alqstate.packSize() will be different
-    // on each process, and the comm.sum call in communicateGroupRates will fail.
-    updateWellsDefaultALQ(schedule.getWells(report_step), summary_state);
+    updateWellsDefaultALQ(schedule, report_step, summary_state);
 }
 
 template<class Scalar>
@@ -1030,19 +1028,19 @@ bool WellState<Scalar>::wellIsOwned(const std::string& wellName) const
     return wellIsOwned(well_index.value(), wellName);
 }
 
-template<class Scalar>
-void WellState<Scalar>::
-updateWellsDefaultALQ(const std::vector<Well>& wells_ecl,
-                      const SummaryState& summary_state)
+template <typename Scalar>
+void WellState<Scalar>::updateWellsDefaultALQ(const Schedule& schedule,
+                                              const int report_step,
+                                              const SummaryState& summary_state)
 {
-    const int nw = wells_ecl.size();
-    for (int i = 0; i<nw; i++) {
-        const Well &well = wells_ecl[i];
-        if (well.isProducer()) {
-            // NOTE: This is the value set in item 12 of WCONPROD, or with WELTARG
-            auto alq = well.alq_value(summary_state);
-            this->alq_state.update_default(well.name(), alq);
+    const auto wells = schedule.wellNames(report_step);
+    for (const auto& wname : wells) {
+        const auto& well = schedule.getWell(wname, report_step);
+        if (! well.isProducer()) {
+            continue;
         }
+        const auto alq = well.alq_value(summary_state);
+        this->alq_state.update_default(wname, alq);
     }
 }
 

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -227,8 +227,9 @@ public:
     // reset current_alq and update default_alq. ALQ is used for
     // constant lift gas injection and for gas lift optimization
     // (THP controlled wells).
-    void updateWellsDefaultALQ(const std::vector<Well>& wells_ecl,
-                               const SummaryState& summary_state);
+    void updateWellsDefaultALQ(const Schedule& schedule,
+                              const int report_step,
+                              const SummaryState& summary_state);
 
     int wellNameToGlobalIdx(const std::string& name)
     {


### PR DESCRIPTION
Fixes an MPI bug for cases where a well switches from producer to injector at the restart step. 