### PR TITLE
relocating mixControls_ form FlowGenericProblem to FlowProblem

### DIFF
--- a/opm/simulators/flow/FlowGenericProblem.hpp
+++ b/opm/simulators/flow/FlowGenericProblem.hpp
@@ -32,7 +32,6 @@
 #include <opm/material/common/UniformXTabulated2DFunction.hpp>
 #include <opm/material/common/Tabulated1DFunction.hpp>
 
-#include <opm/simulators/flow/MixingRateControls.hpp>
 #include <opm/simulators/flow/SolutionContainers.hpp>
 
 #include <array>
@@ -289,7 +288,6 @@ public:
         serializer(solventSaturation_);
         serializer(solventRsw_);
         serializer(micp_);
-        serializer(mixControls_);
     }
 
 protected:
@@ -363,8 +361,6 @@ protected:
     std::vector<Scalar> solventSaturation_;
     std::vector<Scalar> solventRsw_;
     MICPSolutionContainer<Scalar> micp_;
-
-    MixingRateControls<FluidSystem> mixControls_;
 
     // time stepping parameters
     bool enableTuning_;

--- a/opm/simulators/flow/FlowGenericProblem_impl.hpp
+++ b/opm/simulators/flow/FlowGenericProblem_impl.hpp
@@ -86,7 +86,6 @@ FlowGenericProblem(const EclipseState& eclState,
     : eclState_(eclState)
     , schedule_(schedule)
     , gridView_(gridView)
-    , mixControls_(schedule)
     , lookUpData_(gridView)
 {
 }
@@ -107,7 +106,6 @@ serializationTestObject(const EclipseState& eclState,
     result.solventRsw_ = {18.0};
     result.polymer_ = PolymerSolutionContainer<Scalar>::serializationTestObject();
     result.micp_ = MICPSolutionContainer<Scalar>::serializationTestObject();
-    result.mixControls_ = MixingRateControls<FluidSystem>::serializationTestObject(schedule);
 
     return result;
 }
@@ -475,9 +473,6 @@ beginTimeStep_(bool enableExperiments,
                << ", date = " << date;
         OpmLog::info(ss.str());
     }
-
-    // update explicit quantities between timesteps.
-    this->mixControls_.updateExplicitQuantities(episodeIdx, timeStepSize);
 }
 
 template<class GridView, class FluidSystem>
@@ -607,14 +602,7 @@ solventRsw(unsigned elemIdx) const
     return solventRsw_[elemIdx];
 }
 
-template<class GridView, class FluidSystem>
-typename FlowGenericProblem<GridView,FluidSystem>::Scalar
-FlowGenericProblem<GridView,FluidSystem>::
-drsdtcon(unsigned elemIdx, int episodeIdx) const
-{
-    return this->mixControls_.drsdtcon(elemIdx, episodeIdx,
-                                       this->pvtRegionIndex(elemIdx));
-}
+
 
 template<class GridView, class FluidSystem>
 typename FlowGenericProblem<GridView,FluidSystem>::Scalar
@@ -762,8 +750,7 @@ operator==(const FlowGenericProblem& rhs) const
            this->solventSaturation_ == rhs.solventSaturation_ &&
            this->solventRsw_ == rhs.solventRsw_ &&
            this->polymer_ == rhs.polymer_ &&
-           this->micp_ == rhs.micp_ &&
-           this->mixControls_ == rhs.mixControls_;
+           this->micp_ == rhs.micp_;
 }
 
 } // namespace Opm

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -73,6 +73,7 @@
 #include <opm/simulators/flow/FlowGenericProblem.hpp>
 #include <opm/simulators/flow/FlowProblemProperties.hpp>
 #include <opm/simulators/flow/FlowThresholdPressure.hpp>
+#include <opm/simulators/flow/MixingRateControls.hpp>
 #include <opm/simulators/flow/NewTranFluxModule.hpp>
 #include <opm/simulators/flow/OutputBlackoilModule.hpp>
 #include <opm/simulators/flow/TracerModel.hpp>
@@ -307,6 +308,7 @@ public:
         , aquiferModel_(simulator)
         , pffDofData_(simulator.gridView(), this->elementMapper())
         , tracerModel_(simulator)
+        , mixControls_(simulator.vanguard().schedule())
         , actionHandler_(simulator.vanguard().eclState(),
                          simulator.vanguard().schedule(),
                          simulator.vanguard().actionState(),
@@ -627,19 +629,20 @@ public:
     void beginTimeStep()
     {
         OPM_TIMEBLOCK(beginTimeStep);
-        int episodeIdx = this->episodeIndex();
+        const int episodeIdx = this->episodeIndex();
+        const int timeStepSize = this->simulator().timeStepSize();
 
         this->beginTimeStep_(enableExperiments,
                              episodeIdx,
                              this->simulator().timeStepIndex(),
                              this->simulator().startTime(),
                              this->simulator().time(),
-                             this->simulator().timeStepSize(),
+                             timeStepSize,
                              this->simulator().endTime());
 
         // update maximum water saturation and minimum pressure
         // used when ROCKCOMP is activated
-        asImp_().updateExplicitQuantities_();
+        asImp_().updateExplicitQuantities_(episodeIdx, timeStepSize);
 
         if (nonTrivialBoundaryConditions()) {
             this->model().linearizer().updateBoundaryConditionData();
@@ -1897,14 +1900,21 @@ public:
         serializer(wellModel_);
         serializer(aquiferModel_);
         serializer(tracerModel_);
+        serializer(mixControls_);
         serializer(*materialLawManager_);
         serializer(*eclWriter_);
+    }
+
+    Scalar drsdtcon(unsigned elemIdx, int episodeIdx) const
+    {
+        return this->mixControls_.drsdtcon(elemIdx, episodeIdx,
+                                           this->pvtRegionIndex(elemIdx));
     }
 private:
     Implementation& asImp_()
     { return *static_cast<Implementation *>(this); }
 protected:
-    void updateExplicitQuantities_()
+    void updateExplicitQuantities_(int episodeIdx, int timeStepSize)
     {
         OPM_TIMEBLOCK(updateExplicitQuantities);
         const bool invalidateFromMaxWaterSat = updateMaxWaterSaturation_();
@@ -1930,6 +1940,7 @@ protected:
             updateMaxPolymerAdsorption_();
 
         updateRockCompTransMultVal_();
+        mixControls_.updateExplicitQuantities(episodeIdx, timeStepSize);
     }
 
     template<class UpdateFunc>
@@ -2883,6 +2894,7 @@ private:
 
     PffGridVector<GridView, Stencil, PffDofData_, DofMapper> pffDofData_;
     TracerModel tracerModel_;
+    MixingRateControls<FluidSystem> mixControls_;
 
     ActionHandler<Scalar> actionHandler_;
 


### PR DESCRIPTION
so FlowGenericProblem can be used for non-blackoil setting. mixControls_ for now is designed for blackoil setting. 