### PR TITLE
Move parameter registration to translation units

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -91,6 +91,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/linalg/FlexibleSolver4.cpp
   opm/simulators/linalg/FlexibleSolver5.cpp
   opm/simulators/linalg/FlexibleSolver6.cpp
+  opm/simulators/linalg/FlowLinearSolverParameters.cpp
   opm/simulators/linalg/ISTLSolver.cpp
   opm/simulators/linalg/MILU.cpp
   opm/simulators/linalg/ParallelIstlInformation.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -64,6 +64,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/flow/ExtraConvergenceOutputThread.cpp
   opm/simulators/flow/FlowGenericProblem.cpp
   opm/simulators/flow/FlowGenericVanguard.cpp
+  opm/simulators/flow/FlowProblemParameters.cpp
   opm/simulators/flow/FlowUtils.cpp
   opm/simulators/flow/GenericCpGridVanguard.cpp
   opm/simulators/flow/GenericOutputBlackoilModule.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -57,6 +57,7 @@ endmacro()
 list (APPEND MAIN_SOURCE_FILES
   opm/simulators/flow/ActionHandler.cpp
   opm/simulators/flow/Banners.cpp
+  opm/simulators/flow/BlackoilModelParameters.cpp
   opm/simulators/flow/CollectDataOnIORank.cpp
   opm/simulators/flow/ConvergenceOutputConfiguration.cpp
   opm/simulators/flow/EclGenericWriter.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -106,6 +106,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/timestepping/AdaptiveSimulatorTimer.cpp
   opm/simulators/timestepping/AdaptiveTimeStepping.cpp
   opm/simulators/timestepping/ConvergenceReport.cpp
+  opm/simulators/timestepping/EclTimeSteppingParams.cpp
   opm/simulators/timestepping/SimulatorReport.cpp
   opm/simulators/timestepping/SimulatorTimer.cpp
   opm/simulators/timestepping/SimulatorTimerInterface.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -192,6 +192,7 @@ endif()
 
 if (Damaris_FOUND AND MPI_FOUND AND USE_DAMARIS_LIB)
   list (APPEND MAIN_SOURCE_FILES
+    opm/simulators/flow/DamarisParameters.cpp
     opm/simulators/flow/DamarisWriter.cpp
     opm/simulators/utils/DamarisKeywords.cpp
     opm/simulators/utils/DamarisOutputModule.cpp

--- a/flowexperimental/flowexp.hpp
+++ b/flowexperimental/flowexp.hpp
@@ -124,6 +124,7 @@ struct LinearSolverBackend<TypeTag, TTag::FlowExpTypeTag> {
 } // namespace Opm::Properties
 
 namespace Opm {
+
 template <class TypeTag>
 class FlowExpProblem : public FlowProblem<TypeTag> //, public FvBaseProblem<TypeTag>
 {
@@ -150,7 +151,7 @@ public:
     {
         ParentType::registerParameters();
 
-        BlackoilModelParameters<TypeTag>::registerParameters();
+        BlackoilModelParameters<double>::registerParameters();
         Parameters::Register<Parameters::EnableTerminalOutput>("Do *NOT* use!");
         Parameters::Hide<Parameters::DbhpMaxRel<Scalar>>();
         Parameters::Hide<Parameters::DwellFractionMax<Scalar>>();
@@ -204,6 +205,7 @@ public:
     // inherit the constructors
     using ParentType::FlowProblem;
 };
+
 }
 
 #endif

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -161,8 +161,6 @@ namespace Opm {
     {
     public:
         // ---------  Types and enums  ---------
-        using ModelParameters = BlackoilModelParameters<TypeTag>;
-
         using Simulator = GetPropType<TypeTag, Properties::Simulator>;
         using Grid = GetPropType<TypeTag, Properties::Grid>;
         using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
@@ -175,6 +173,7 @@ namespace Opm {
         using MaterialLaw = GetPropType<TypeTag, Properties::MaterialLaw>;
         using MaterialLawParams = GetPropType<TypeTag, Properties::MaterialLawParams>;
         using Scalar = GetPropType<TypeTag, Properties::Scalar>;
+        using ModelParameters = BlackoilModelParameters<Scalar>;
 
         static constexpr int numEq = Indices::numEq;
         static constexpr int contiSolventEqIdx = Indices::contiSolventEqIdx;

--- a/opm/simulators/flow/BlackoilModelNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelNldd.hpp
@@ -82,8 +82,8 @@ public:
     using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
     using Grid = GetPropType<TypeTag, Properties::Grid>;
     using Indices = GetPropType<TypeTag, Properties::Indices>;
-    using ModelParameters = BlackoilModelParameters<TypeTag>;
     using Scalar = GetPropType<TypeTag, Properties::Scalar>;
+    using ModelParameters = BlackoilModelParameters<Scalar>;
     using SolutionVector = GetPropType<TypeTag, Properties::SolutionVector>;
 
     using BVector = typename BlackoilModel<TypeTag>::BVector;

--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -1,0 +1,227 @@
+/*
+  Copyright 2015 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+#include <opm/simulators/flow/BlackoilModelParameters.hpp>
+
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+
+#include <opm/models/utils/parametersystem.hh>
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace Opm {
+
+template<class Scalar>
+BlackoilModelParameters<Scalar>::BlackoilModelParameters()
+{
+    dbhp_max_rel_ = Parameters::Get<Parameters::DbhpMaxRel<Scalar>>();
+    dwell_fraction_max_ = Parameters::Get<Parameters::DwellFractionMax<Scalar>>();
+    max_residual_allowed_ = Parameters::Get<Parameters::MaxResidualAllowed<Scalar>>();
+    relaxed_max_pv_fraction_ = Parameters::Get<Parameters::RelaxedMaxPvFraction<Scalar>>();
+    tolerance_mb_ = Parameters::Get<Parameters::ToleranceMb<Scalar>>();
+    tolerance_mb_relaxed_ = std::max(tolerance_mb_, Parameters::Get<Parameters::ToleranceMbRelaxed<Scalar>>());
+    tolerance_cnv_ = Parameters::Get<Parameters::ToleranceCnv<Scalar>>();
+    tolerance_cnv_relaxed_ = std::max(tolerance_cnv_, Parameters::Get<Parameters::ToleranceCnvRelaxed<Scalar>>());
+    tolerance_wells_ = Parameters::Get<Parameters::ToleranceWells<Scalar>>();
+    tolerance_well_control_ = Parameters::Get<Parameters::ToleranceWellControl<Scalar>>();
+    max_welleq_iter_ = Parameters::Get<Parameters::MaxWelleqIter>();
+    use_multisegment_well_ = Parameters::Get<Parameters::UseMultisegmentWell>();
+    tolerance_pressure_ms_wells_ = Parameters::Get<Parameters::TolerancePressureMsWells<Scalar>>();
+    relaxed_tolerance_flow_well_ = Parameters::Get<Parameters::RelaxedWellFlowTol<Scalar>>();
+    relaxed_tolerance_pressure_ms_well_ = Parameters::Get<Parameters::RelaxedPressureTolMsw<Scalar>>();
+    max_pressure_change_ms_wells_ = Parameters::Get<Parameters::MaxPressureChangeMsWells<Scalar>>();
+    max_inner_iter_ms_wells_ = Parameters::Get<Parameters::MaxInnerIterMsWells>();
+    strict_inner_iter_wells_ = Parameters::Get<Parameters::StrictInnerIterWells>();
+    strict_outer_iter_wells_ = Parameters::Get<Parameters::StrictOuterIterWells>();
+    regularization_factor_wells_ = Parameters::Get<Parameters::RegularizationFactorWells<Scalar>>();
+    max_niter_inner_well_iter_ = Parameters::Get<Parameters::MaxNewtonIterationsWithInnerWellIterations>();
+    shut_unsolvable_wells_ = Parameters::Get<Parameters::ShutUnsolvableWells>();
+    max_inner_iter_wells_ = Parameters::Get<Parameters::MaxInnerIterWells>();
+    maxSinglePrecisionTimeStep_ = Parameters::Get<Parameters::MaxSinglePrecisionDays<Scalar>>() * 24 * 60 * 60;
+    min_strict_cnv_iter_ = Parameters::Get<Parameters::MinStrictCnvIter>();
+    min_strict_mb_iter_ = Parameters::Get<Parameters::MinStrictMbIter>();
+    solve_welleq_initially_ = Parameters::Get<Parameters::SolveWelleqInitially>();
+    update_equations_scaling_ = Parameters::Get<Parameters::UpdateEquationsScaling>();
+    use_update_stabilization_ = Parameters::Get<Parameters::UseUpdateStabilization>();
+    matrix_add_well_contributions_ = Parameters::Get<Parameters::MatrixAddWellContributions>();
+    check_well_operability_ = Parameters::Get<Parameters::EnableWellOperabilityCheck>();
+    check_well_operability_iter_ = Parameters::Get<Parameters::EnableWellOperabilityCheckIter>();
+    max_number_of_well_switches_ = Parameters::Get<Parameters::MaximumNumberOfWellSwitches>();
+    use_average_density_ms_wells_ = Parameters::Get<Parameters::UseAverageDensityMsWells>();
+    local_well_solver_control_switching_ = Parameters::Get<Parameters::LocalWellSolveControlSwitching>();
+    use_implicit_ipr_ = Parameters::Get<Parameters::UseImplicitIpr>();
+    nonlinear_solver_ = Parameters::Get<Parameters::NonlinearSolver>();
+    const auto approach = Parameters::Get<Parameters::LocalSolveApproach>();
+    if (approach == "jacobi") {
+        local_solve_approach_ = DomainSolveApproach::Jacobi;
+    } else if (approach == "gauss-seidel") {
+        local_solve_approach_ = DomainSolveApproach::GaussSeidel;
+    } else {
+        throw std::runtime_error("Invalid domain solver approach '" + approach + "' specified.");
+    }
+
+    max_local_solve_iterations_ = Parameters::Get<Parameters::MaxLocalSolveIterations>();
+    local_tolerance_scaling_mb_ = Parameters::Get<Parameters::LocalToleranceScalingMb<Scalar>>();
+    local_tolerance_scaling_cnv_ = Parameters::Get<Parameters::LocalToleranceScalingCnv<Scalar>>();
+    nldd_num_initial_newton_iter_ = Parameters::Get<Parameters::NlddNumInitialNewtonIter>();
+    num_local_domains_ = Parameters::Get<Parameters::NumLocalDomains>();
+    local_domain_partition_imbalance_ = std::max(Scalar{1.0}, Parameters::Get<Parameters::LocalDomainsPartitioningImbalance<Scalar>>());
+    local_domain_partition_method_ = Parameters::Get<Parameters::LocalDomainsPartitioningMethod>();
+    deck_file_name_ = Parameters::Get<Parameters::EclDeckFileName>();
+    network_max_strict_iterations_ = Parameters::Get<Parameters::NetworkMaxStrictIterations>();
+    network_max_iterations_ = Parameters::Get<Parameters::NetworkMaxIterations>();
+    local_domain_ordering_ = domainOrderingMeasureFromString(Parameters::Get<Parameters::LocalDomainsOrderingMeasure>());
+    write_partitions_ = Parameters::Get<Parameters::DebugEmitCellPartition>();
+}
+
+template<class Scalar>
+void BlackoilModelParameters<Scalar>::registerParameters()
+{
+    Parameters::Register<Parameters::DbhpMaxRel<Scalar>>
+        ("Maximum relative change of the bottom-hole pressure in a single iteration");
+    Parameters::Register<Parameters::DwellFractionMax<Scalar>>
+        ("Maximum absolute change of a well's volume fraction in a single iteration");
+    Parameters::Register<Parameters::MaxResidualAllowed<Scalar>>
+        ("Absolute maximum tolerated for residuals without cutting the time step size");
+    Parameters::Register<Parameters::RelaxedMaxPvFraction<Scalar>>
+        ("The fraction of the pore volume of the reservoir "
+         "where the volumetric error (CNV) may be voilated "
+         "during strict Newton iterations.");
+    Parameters::Register<Parameters::ToleranceMb<Scalar>>
+        ("Tolerated mass balance error relative to total mass present");
+    Parameters::Register<Parameters::ToleranceMbRelaxed<Scalar>>
+        ("Relaxed tolerated mass balance error that applies for iterations "
+         "after the iterations with the strict tolerance");
+    Parameters::Register<Parameters::ToleranceCnv<Scalar>>
+        ("Local convergence tolerance (Maximum of local saturation errors)");
+    Parameters::Register<Parameters::ToleranceCnvRelaxed<Scalar>>
+        ("Relaxed local convergence tolerance that applies for iterations "
+         "after the iterations with the strict tolerance");
+    Parameters::Register<Parameters::ToleranceWells<Scalar>>
+        ("Well convergence tolerance");
+    Parameters::Register<Parameters::ToleranceWellControl<Scalar>>
+        ("Tolerance for the well control equations");
+    Parameters::Register<Parameters::MaxWelleqIter>
+        ("Maximum number of iterations to determine solution the well equations");
+    Parameters::Register<Parameters::UseMultisegmentWell>
+        ("Use the well model for multi-segment wells instead of the "
+         "one for single-segment wells");
+    Parameters::Register<Parameters::TolerancePressureMsWells<Scalar>>
+        ("Tolerance for the pressure equations for multi-segment wells");
+    Parameters::Register<Parameters::RelaxedWellFlowTol<Scalar>>
+        ("Relaxed tolerance for the well flow residual");
+    Parameters::Register<Parameters::RelaxedPressureTolMsw<Scalar>>
+        ("Relaxed tolerance for the MSW pressure solution");
+    Parameters::Register<Parameters::MaxPressureChangeMsWells<Scalar>>
+        ("Maximum relative pressure change for a single iteration "
+         "of the multi-segment well model");
+    Parameters::Register<Parameters::MaxInnerIterMsWells>
+        ("Maximum number of inner iterations for multi-segment wells");
+    Parameters::Register<Parameters::StrictInnerIterWells>
+        ("Number of inner well iterations with strict tolerance");
+    Parameters::Register<Parameters::StrictOuterIterWells>
+        ("Number of newton iterations for which wells are checked with strict tolerance");
+    Parameters::Register<Parameters::MaxNewtonIterationsWithInnerWellIterations>
+        ("Maximum newton iterations with inner well iterations");
+    Parameters::Register<Parameters::ShutUnsolvableWells>
+        ("Shut unsolvable wells");
+    Parameters::Register<Parameters::MaxInnerIterWells>
+        ("Maximum number of inner iterations for standard wells");
+    Parameters::Register<Parameters::AlternativeWellRateInit>
+        ("Use alternative well rate initialization procedure");
+    Parameters::Register<Parameters::RegularizationFactorWells<Scalar>>
+        ("Regularization factor for wells");
+    Parameters::Register<Parameters::MaxSinglePrecisionDays<Scalar>>
+        ("Maximum time step size where single precision floating point "
+         "arithmetic can be used solving for the linear systems of equations");
+    Parameters::Register<Parameters::MinStrictCnvIter>
+        ("Minimum number of Newton iterations before relaxed tolerances "
+         "can be used for the CNV convergence criterion");
+    Parameters::Register<Parameters::MinStrictMbIter>
+        ("Minimum number of Newton iterations before relaxed tolerances "
+         "can be used for the MB convergence criterion. "
+         "Default -1 means that the relaxed tolerance is used when maximum "
+         "number of Newton iterations are reached.");
+    Parameters::Register<Parameters::SolveWelleqInitially>
+        ("Fully solve the well equations before each iteration of the reservoir model");
+    Parameters::Register<Parameters::UpdateEquationsScaling>
+        ("Update scaling factors for mass balance equations during the run");
+    Parameters::Register<Parameters::UseUpdateStabilization>
+        ("Try to detect and correct oscillations or stagnation during the Newton method");
+    Parameters::Register<Parameters::MatrixAddWellContributions>
+        ("Explicitly specify the influences of wells between cells in "
+         "the Jacobian and preconditioner matrices");
+    Parameters::Register<Parameters::EnableWellOperabilityCheck>
+        ("Enable the well operability checking");
+    Parameters::Register<Parameters::EnableWellOperabilityCheckIter>
+        ("Enable the well operability checking during iterations");
+    Parameters::Register<Parameters::MaximumNumberOfWellSwitches>
+        ("Maximum number of times a well can switch to the same control");
+    Parameters::Register<Parameters::UseAverageDensityMsWells>
+        ("Approximate segment densitities by averaging over segment and its outlet");
+    Parameters::Register<Parameters::LocalWellSolveControlSwitching>
+        ("Allow control switching during local well solutions");
+    Parameters::Register<Parameters::UseImplicitIpr>
+        ("Compute implict IPR for stability checks and stable solution search");
+    Parameters::Register<Parameters::NetworkMaxStrictIterations>
+        ("Maximum iterations in network solver before relaxing tolerance");
+    Parameters::Register<Parameters::NetworkMaxIterations>
+        ("Maximum number of iterations in the network solver before giving up");
+    Parameters::Register<Parameters::NonlinearSolver>
+        ("Choose nonlinear solver. Valid choices are newton or nldd.");
+    Parameters::Register<Parameters::LocalSolveApproach>
+        ("Choose local solve approach. Valid choices are jacobi and gauss-seidel");
+    Parameters::Register<Parameters::MaxLocalSolveIterations>
+        ("Max iterations for local solves with NLDD nonlinear solver.");
+    Parameters::Register<Parameters::LocalToleranceScalingMb<Scalar>>
+        ("Set lower than 1.0 to use stricter convergence tolerance for local solves.");
+    Parameters::Register<Parameters::LocalToleranceScalingCnv<Scalar>>
+        ("Set lower than 1.0 to use stricter convergence tolerance for local solves.");
+    Parameters::Register<Parameters::NlddNumInitialNewtonIter>
+        ("Number of initial global Newton iterations when running the NLDD nonlinear solver.");
+    Parameters::Register<Parameters::NumLocalDomains>
+        ("Number of local domains for NLDD nonlinear solver.");
+    Parameters::Register<Parameters::LocalDomainsPartitioningImbalance<Scalar>>
+        ("Subdomain partitioning imbalance tolerance. 1.03 is 3 percent imbalance.");
+    Parameters::Register<Parameters::LocalDomainsPartitioningMethod>
+        ("Subdomain partitioning method. Allowed values are "
+         "'zoltan', "
+         "'simple', "
+         "and the name of a partition file ending with '.partition'.");
+    Parameters::Register<Parameters::LocalDomainsOrderingMeasure>
+        ("Subdomain ordering measure. Allowed values are "
+         "'maxpressure', "
+         "'averagepressure' "
+         "and  'residual'.");
+    Parameters::Register<Parameters::DebugEmitCellPartition>
+        ("Whether or not to emit cell partitions as a debugging aid.");
+
+    Parameters::Hide<Parameters::DebugEmitCellPartition>();
+
+    // if openMP is available, determine the number threads per process automatically.
+#if _OPENMP
+    Parameters::SetDefault<Parameters::ThreadsPerProcess>(-1);
+#endif
+}
+
+template struct BlackoilModelParameters<double>;
+
+} // namespace Opm

--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -20,16 +20,8 @@
 #ifndef OPM_BLACKOILMODELPARAMETERS_HEADER_INCLUDED
 #define OPM_BLACKOILMODELPARAMETERS_HEADER_INCLUDED
 
-#include <opm/models/discretization/common/fvbaseparameters.hh>
-#include <opm/models/discretization/common/fvbaseproperties.hh>
-
-#include <opm/models/utils/basicproperties.hh>
-#include <opm/models/utils/parametersystem.hh>
-
 #include <opm/simulators/flow/SubDomain.hpp>
 
-#include <algorithm>
-#include <stdexcept>
 #include <string>
 
 namespace Opm::Parameters {
@@ -138,12 +130,9 @@ struct LocalDomainsOrderingMeasure { static constexpr auto value = "maxpressure"
 namespace Opm {
 
 /// Solver parameters for the BlackoilModel.
-template <class TypeTag>
+template <class Scalar>
 struct BlackoilModelParameters
 {
-private:
-    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
-
 public:
     /// Max relative change in bhp in single iteration.
     Scalar dbhp_max_rel_;
@@ -276,197 +265,9 @@ public:
     bool write_partitions_{false};
 
     /// Construct from user parameters or defaults.
-    BlackoilModelParameters()
-    {
-        dbhp_max_rel_ = Parameters::Get<Parameters::DbhpMaxRel<Scalar>>();
-        dwell_fraction_max_ = Parameters::Get<Parameters::DwellFractionMax<Scalar>>();
-        max_residual_allowed_ = Parameters::Get<Parameters::MaxResidualAllowed<Scalar>>();
-        relaxed_max_pv_fraction_ = Parameters::Get<Parameters::RelaxedMaxPvFraction<Scalar>>();
-        tolerance_mb_ = Parameters::Get<Parameters::ToleranceMb<Scalar>>();
-        tolerance_mb_relaxed_ = std::max(tolerance_mb_, Parameters::Get<Parameters::ToleranceMbRelaxed<Scalar>>());
-        tolerance_cnv_ = Parameters::Get<Parameters::ToleranceCnv<Scalar>>();
-        tolerance_cnv_relaxed_ = std::max(tolerance_cnv_, Parameters::Get<Parameters::ToleranceCnvRelaxed<Scalar>>());
-        tolerance_wells_ = Parameters::Get<Parameters::ToleranceWells<Scalar>>();
-        tolerance_well_control_ = Parameters::Get<Parameters::ToleranceWellControl<Scalar>>();
-        max_welleq_iter_ = Parameters::Get<Parameters::MaxWelleqIter>();
-        use_multisegment_well_ = Parameters::Get<Parameters::UseMultisegmentWell>();
-        tolerance_pressure_ms_wells_ = Parameters::Get<Parameters::TolerancePressureMsWells<Scalar>>();
-        relaxed_tolerance_flow_well_ = Parameters::Get<Parameters::RelaxedWellFlowTol<Scalar>>();
-        relaxed_tolerance_pressure_ms_well_ = Parameters::Get<Parameters::RelaxedPressureTolMsw<Scalar>>();
-        max_pressure_change_ms_wells_ = Parameters::Get<Parameters::MaxPressureChangeMsWells<Scalar>>();
-        max_inner_iter_ms_wells_ = Parameters::Get<Parameters::MaxInnerIterMsWells>();
-        strict_inner_iter_wells_ = Parameters::Get<Parameters::StrictInnerIterWells>();
-        strict_outer_iter_wells_ = Parameters::Get<Parameters::StrictOuterIterWells>();
-        regularization_factor_wells_ = Parameters::Get<Parameters::RegularizationFactorWells<Scalar>>();
-        max_niter_inner_well_iter_ = Parameters::Get<Parameters::MaxNewtonIterationsWithInnerWellIterations>();
-        shut_unsolvable_wells_ = Parameters::Get<Parameters::ShutUnsolvableWells>();
-        max_inner_iter_wells_ = Parameters::Get<Parameters::MaxInnerIterWells>();
-        maxSinglePrecisionTimeStep_ = Parameters::Get<Parameters::MaxSinglePrecisionDays<Scalar>>() * 24 * 60 * 60;
-        min_strict_cnv_iter_ = Parameters::Get<Parameters::MinStrictCnvIter>();
-        min_strict_mb_iter_ = Parameters::Get<Parameters::MinStrictMbIter>();
-        solve_welleq_initially_ = Parameters::Get<Parameters::SolveWelleqInitially>();
-        update_equations_scaling_ = Parameters::Get<Parameters::UpdateEquationsScaling>();
-        use_update_stabilization_ = Parameters::Get<Parameters::UseUpdateStabilization>();
-        matrix_add_well_contributions_ = Parameters::Get<Parameters::MatrixAddWellContributions>();
-        check_well_operability_ = Parameters::Get<Parameters::EnableWellOperabilityCheck>();
-        check_well_operability_iter_ = Parameters::Get<Parameters::EnableWellOperabilityCheckIter>();
-        max_number_of_well_switches_ = Parameters::Get<Parameters::MaximumNumberOfWellSwitches>();
-        use_average_density_ms_wells_ = Parameters::Get<Parameters::UseAverageDensityMsWells>();
-        local_well_solver_control_switching_ = Parameters::Get<Parameters::LocalWellSolveControlSwitching>();
-        use_implicit_ipr_ = Parameters::Get<Parameters::UseImplicitIpr>();
-        nonlinear_solver_ = Parameters::Get<Parameters::NonlinearSolver>();
-        const auto approach = Parameters::Get<Parameters::LocalSolveApproach>();
-        if (approach == "jacobi") {
-            local_solve_approach_ = DomainSolveApproach::Jacobi;
-        } else if (approach == "gauss-seidel") {
-            local_solve_approach_ = DomainSolveApproach::GaussSeidel;
-        } else {
-            throw std::runtime_error("Invalid domain solver approach '" + approach + "' specified.");
-        }
+    BlackoilModelParameters();
 
-        max_local_solve_iterations_ = Parameters::Get<Parameters::MaxLocalSolveIterations>();
-        local_tolerance_scaling_mb_ = Parameters::Get<Parameters::LocalToleranceScalingMb<Scalar>>();
-        local_tolerance_scaling_cnv_ = Parameters::Get<Parameters::LocalToleranceScalingCnv<Scalar>>();
-        nldd_num_initial_newton_iter_ = Parameters::Get<Parameters::NlddNumInitialNewtonIter>();
-        num_local_domains_ = Parameters::Get<Parameters::NumLocalDomains>();
-        local_domain_partition_imbalance_ = std::max(Scalar{1.0}, Parameters::Get<Parameters::LocalDomainsPartitioningImbalance<Scalar>>());
-        local_domain_partition_method_ = Parameters::Get<Parameters::LocalDomainsPartitioningMethod>();
-        deck_file_name_ = Parameters::Get<Parameters::EclDeckFileName>();
-        network_max_strict_iterations_ = Parameters::Get<Parameters::NetworkMaxStrictIterations>();
-        network_max_iterations_ = Parameters::Get<Parameters::NetworkMaxIterations>();
-        local_domain_ordering_ = domainOrderingMeasureFromString(Parameters::Get<Parameters::LocalDomainsOrderingMeasure>());
-        write_partitions_ = Parameters::Get<Parameters::DebugEmitCellPartition>();
-    }
-
-    static void registerParameters()
-    {
-        Parameters::Register<Parameters::DbhpMaxRel<Scalar>>
-            ("Maximum relative change of the bottom-hole pressure in a single iteration");
-        Parameters::Register<Parameters::DwellFractionMax<Scalar>>
-            ("Maximum absolute change of a well's volume fraction in a single iteration");
-        Parameters::Register<Parameters::MaxResidualAllowed<Scalar>>
-            ("Absolute maximum tolerated for residuals without cutting the time step size");
-        Parameters::Register<Parameters::RelaxedMaxPvFraction<Scalar>>
-            ("The fraction of the pore volume of the reservoir "
-             "where the volumetric error (CNV) may be voilated "
-             "during strict Newton iterations.");
-        Parameters::Register<Parameters::ToleranceMb<Scalar>>
-            ("Tolerated mass balance error relative to total mass present");
-        Parameters::Register<Parameters::ToleranceMbRelaxed<Scalar>>
-            ("Relaxed tolerated mass balance error that applies for iterations "
-             "after the iterations with the strict tolerance");
-        Parameters::Register<Parameters::ToleranceCnv<Scalar>>
-            ("Local convergence tolerance (Maximum of local saturation errors)");
-        Parameters::Register<Parameters::ToleranceCnvRelaxed<Scalar>>
-            ("Relaxed local convergence tolerance that applies for iterations "
-             "after the iterations with the strict tolerance");
-        Parameters::Register<Parameters::ToleranceWells<Scalar>>
-            ("Well convergence tolerance");
-        Parameters::Register<Parameters::ToleranceWellControl<Scalar>>
-            ("Tolerance for the well control equations");
-        Parameters::Register<Parameters::MaxWelleqIter>
-            ("Maximum number of iterations to determine solution the well equations");
-        Parameters::Register<Parameters::UseMultisegmentWell>
-            ("Use the well model for multi-segment wells instead of the "
-             "one for single-segment wells");
-        Parameters::Register<Parameters::TolerancePressureMsWells<Scalar>>
-            ("Tolerance for the pressure equations for multi-segment wells");
-        Parameters::Register<Parameters::RelaxedWellFlowTol<Scalar>>
-            ("Relaxed tolerance for the well flow residual");
-        Parameters::Register<Parameters::RelaxedPressureTolMsw<Scalar>>
-            ("Relaxed tolerance for the MSW pressure solution");
-        Parameters::Register<Parameters::MaxPressureChangeMsWells<Scalar>>
-            ("Maximum relative pressure change for a single iteration "
-             "of the multi-segment well model");
-        Parameters::Register<Parameters::MaxInnerIterMsWells>
-            ("Maximum number of inner iterations for multi-segment wells");
-        Parameters::Register<Parameters::StrictInnerIterWells>
-            ("Number of inner well iterations with strict tolerance");
-        Parameters::Register<Parameters::StrictOuterIterWells>
-            ("Number of newton iterations for which wells are checked with strict tolerance");
-        Parameters::Register<Parameters::MaxNewtonIterationsWithInnerWellIterations>
-            ("Maximum newton iterations with inner well iterations");
-        Parameters::Register<Parameters::ShutUnsolvableWells>
-            ("Shut unsolvable wells");
-        Parameters::Register<Parameters::MaxInnerIterWells>
-            ("Maximum number of inner iterations for standard wells");
-        Parameters::Register<Parameters::AlternativeWellRateInit>
-            ("Use alternative well rate initialization procedure");
-        Parameters::Register<Parameters::RegularizationFactorWells<Scalar>>
-            ("Regularization factor for wells");
-        Parameters::Register<Parameters::MaxSinglePrecisionDays<Scalar>>
-            ("Maximum time step size where single precision floating point "
-             "arithmetic can be used solving for the linear systems of equations");
-        Parameters::Register<Parameters::MinStrictCnvIter>
-            ("Minimum number of Newton iterations before relaxed tolerances "
-             "can be used for the CNV convergence criterion");
-        Parameters::Register<Parameters::MinStrictMbIter>
-            ("Minimum number of Newton iterations before relaxed tolerances "
-             "can be used for the MB convergence criterion. "
-             "Default -1 means that the relaxed tolerance is used when maximum "
-             "number of Newton iterations are reached.");
-        Parameters::Register<Parameters::SolveWelleqInitially>
-            ("Fully solve the well equations before each iteration of the reservoir model");
-        Parameters::Register<Parameters::UpdateEquationsScaling>
-            ("Update scaling factors for mass balance equations during the run");
-        Parameters::Register<Parameters::UseUpdateStabilization>
-            ("Try to detect and correct oscillations or stagnation during the Newton method");
-        Parameters::Register<Parameters::MatrixAddWellContributions>
-            ("Explicitly specify the influences of wells between cells in "
-             "the Jacobian and preconditioner matrices");
-        Parameters::Register<Parameters::EnableWellOperabilityCheck>
-            ("Enable the well operability checking");
-        Parameters::Register<Parameters::EnableWellOperabilityCheckIter>
-            ("Enable the well operability checking during iterations");
-        Parameters::Register<Parameters::MaximumNumberOfWellSwitches>
-            ("Maximum number of times a well can switch to the same control");
-        Parameters::Register<Parameters::UseAverageDensityMsWells>
-            ("Approximate segment densitities by averaging over segment and its outlet");
-        Parameters::Register<Parameters::LocalWellSolveControlSwitching>
-            ("Allow control switching during local well solutions");
-        Parameters::Register<Parameters::UseImplicitIpr>
-            ("Compute implict IPR for stability checks and stable solution search");
-        Parameters::Register<Parameters::NetworkMaxStrictIterations>
-            ("Maximum iterations in network solver before relaxing tolerance");
-        Parameters::Register<Parameters::NetworkMaxIterations>
-            ("Maximum number of iterations in the network solver before giving up");
-        Parameters::Register<Parameters::NonlinearSolver>
-            ("Choose nonlinear solver. Valid choices are newton or nldd.");
-        Parameters::Register<Parameters::LocalSolveApproach>
-            ("Choose local solve approach. Valid choices are jacobi and gauss-seidel");
-        Parameters::Register<Parameters::MaxLocalSolveIterations>
-            ("Max iterations for local solves with NLDD nonlinear solver.");
-        Parameters::Register<Parameters::LocalToleranceScalingMb<Scalar>>
-            ("Set lower than 1.0 to use stricter convergence tolerance for local solves.");
-        Parameters::Register<Parameters::LocalToleranceScalingCnv<Scalar>>
-            ("Set lower than 1.0 to use stricter convergence tolerance for local solves.");
-        Parameters::Register<Parameters::NlddNumInitialNewtonIter>
-            ("Number of initial global Newton iterations when running the NLDD nonlinear solver.");
-        Parameters::Register<Parameters::NumLocalDomains>
-            ("Number of local domains for NLDD nonlinear solver.");
-        Parameters::Register<Parameters::LocalDomainsPartitioningImbalance<Scalar>>
-            ("Subdomain partitioning imbalance tolerance. 1.03 is 3 percent imbalance.");
-        Parameters::Register<Parameters::LocalDomainsPartitioningMethod>
-            ("Subdomain partitioning method. Allowed values are "
-             "'zoltan', "
-             "'simple', "
-             "and the name of a partition file ending with '.partition'.");
-        Parameters::Register<Parameters::LocalDomainsOrderingMeasure>
-            ("Subdomain ordering measure. Allowed values are "
-             "'maxpressure', "
-             "'averagepressure' "
-             "and  'residual'.");
-        Parameters::Register<Parameters::DebugEmitCellPartition>
-            ("Whether or not to emit cell partitions as a debugging aid.");
-
-
-        Parameters::Hide<Parameters::DebugEmitCellPartition>();
-
-        // if openMP is available, determine the number threads per process automatically.
-#if _OPENMP
-        Parameters::SetDefault<Parameters::ThreadsPerProcess>(-1);
-#endif
-    }
+    static void registerParameters();
 };
 
 } // namespace Opm

--- a/opm/simulators/flow/DamarisParameters.cpp
+++ b/opm/simulators/flow/DamarisParameters.cpp
@@ -1,0 +1,95 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2022 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2023 Inria, Bretagne–Atlantique Research Center
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+
+#include <opm/simulators/flow/DamarisParameters.hpp>
+
+#include <opm/models/utils/parametersystem.hh>
+
+namespace Opm {
+
+void registerDamarisParameters()
+{
+    Parameters::Register<Parameters::DamarisOutputHdfCollective>
+        ("Write output via Damaris using parallel HDF5 to "
+         "get single file and dataset per timestep instead "
+         "of one per Damaris core with multiple datasets.");
+    Parameters::Register<Parameters::DamarisSaveToHdf>
+        ("Set to false to prevent output to HDF5. "
+         "Uses collective output by default or "
+         "set --enable-damaris-collective=false to"
+         "use file per core (file per Damaris server).");
+    Parameters::Register<Parameters::DamarisSaveMeshToHdf>
+        ("Saves the mesh data to the HDF5 file (1st iteration only). "
+         "Will set  --damaris-output-hdf-collective to false "
+         "so will use file per core (file per Damaris server) output "
+        "(global sizes and offset values  of mesh variables are not being provided as yet).");
+    Parameters::Register<Parameters::DamarisPythonScript>
+        ("Set to the path and filename of a Python script to run on "
+         "Damaris server resources with access to OPM flow data.");
+    Parameters::Register<Parameters::DamarisPythonParaviewScript>
+        ("Set to the path and filename of a Paraview Python script "
+         "to run on Paraview Catalyst (1 or 2) on Damaris server "
+         "resources with access to OPM flow data.");
+    Parameters::Register<Parameters::DamarisSimName>
+        ("The name of the simulation to be used by Damaris. "
+         "If empty (the default) then Damaris uses \"opm-sim-<random-number>\". "
+         "This name is used for the Damaris HDF5 file name prefix. "
+         "Make unique if writing to the same output directory.");
+    Parameters::Register<Parameters::DamarisLogLevel>
+        ("The log level for the Damaris logging system (boost log based). "
+         "Levels are: [trace, debug, info, warning, error, fatal]. "
+         "Currently debug and info are useful. ");
+    Parameters::Register<Parameters::DamarisDaskFile>
+        ("The name of a Dask json configuration file (if using Dask for processing).");
+    Parameters::Register<Parameters::DamarisDedicatedCores>
+        ("Set the number of dedicated cores (MPI processes) "
+         "that should be used for Damaris processing (per node). "
+         "Must divide evenly into the number of simulation ranks (client ranks).");
+    Parameters::Register<Parameters::DamarisDedicatedNodes>
+        ("Set the number of dedicated nodes (full nodes) "
+         "that should be used for Damaris processing (per simulation). "
+         "Must divide evenly into the number of simulation nodes.");
+    Parameters::Register<Parameters::DamarisSharedMemorySizeBytes>
+        ("Set the size of the shared memory buffer used for IPC "
+         "between the simulation and the Damaris resources. "
+         "Needs to hold all the variables published, possibly over "
+         "multiple simulation iterations.");
+    Parameters::Register<Parameters::DamarisSharedMemoryName>
+        ("The name of the shared memory area to be used by Damaris for the current. "
+         "If empty (the default) then Damaris uses \"opm-damaris-<random-string>\". "
+         "This name should be unique if multiple simulations are running on "
+         "the same node/server as it is used for the Damaris shmem name and by "
+         "the Python Dask library to locate sections of variables.");
+    Parameters::Register<Parameters::DamarisLimitVariables>
+        ("A comma separated list of variable names that a user wants to pass "
+         "through via DamarisOutput::DamarisWriter::writeOutput)() to the "
+         "damaris_write() call. This can be used to limit the number of "
+         "variables being passed to the Damaris plugins (Paraview, Python and HDF5)");
+}
+
+} // namespace Opm

--- a/opm/simulators/flow/DamarisParameters.hpp
+++ b/opm/simulators/flow/DamarisParameters.hpp
@@ -50,4 +50,11 @@ struct DamarisLimitVariables  { static constexpr auto value = ""; };
 
 } // namespace Opm::Parameters
 
+namespace Opm {
+
+//! \brief Register damaris runtime parameters.
+void registerDamarisParameters();
+
+}
+
 #endif // OPM_DAMARIS_PARAMETERS_HPP

--- a/opm/simulators/flow/DamarisWriter.hpp
+++ b/opm/simulators/flow/DamarisWriter.hpp
@@ -105,62 +105,7 @@ class DamarisWriter : public EclGenericWriter<GetPropType<TypeTag, Properties::G
 public:
     static void registerParameters()
     {
-        Parameters::Register<Parameters::DamarisOutputHdfCollective>
-            ("Write output via Damaris using parallel HDF5 to "
-             "get single file and dataset per timestep instead "
-             "of one per Damaris core with multiple datasets.");
-        Parameters::Register<Parameters::DamarisSaveToHdf>
-            ("Set to false to prevent output to HDF5. "
-             "Uses collective output by default or "
-             "set --enable-damaris-collective=false to"
-             "use file per core (file per Damaris server).");
-        Parameters::Register<Parameters::DamarisSaveMeshToHdf>
-            ("Saves the mesh data to the HDF5 file (1st iteration only). "
-             "Will set  --damaris-output-hdf-collective to false "
-             "so will use file per core (file per Damaris server) output "
-            "(global sizes and offset values  of mesh variables are not being provided as yet).");
-        Parameters::Register<Parameters::DamarisPythonScript>
-            ("Set to the path and filename of a Python script to run on "
-             "Damaris server resources with access to OPM flow data.");
-        Parameters::Register<Parameters::DamarisPythonParaviewScript>
-            ("Set to the path and filename of a Paraview Python script "
-             "to run on Paraview Catalyst (1 or 2) on Damaris server "
-             "resources with access to OPM flow data.");
-        Parameters::Register<Parameters::DamarisSimName>
-            ("The name of the simulation to be used by Damaris. "
-             "If empty (the default) then Damaris uses \"opm-sim-<random-number>\". "
-             "This name is used for the Damaris HDF5 file name prefix. "
-             "Make unique if writing to the same output directory.");
-        Parameters::Register<Parameters::DamarisLogLevel>
-            ("The log level for the Damaris logging system (boost log based). "
-             "Levels are: [trace, debug, info, warning, error, fatal]. "
-             "Currently debug and info are useful. ");
-        Parameters::Register<Parameters::DamarisDaskFile>
-            ("The name of a Dask json configuration file (if using Dask for processing).");
-        Parameters::Register<Parameters::DamarisDedicatedCores>
-            ("Set the number of dedicated cores (MPI processes) "
-             "that should be used for Damaris processing (per node). "
-             "Must divide evenly into the number of simulation ranks (client ranks).");
-        Parameters::Register<Parameters::DamarisDedicatedNodes>
-            ("Set the number of dedicated nodes (full nodes) "
-             "that should be used for Damaris processing (per simulation). "
-             "Must divide evenly into the number of simulation nodes.");
-        Parameters::Register<Parameters::DamarisSharedMemorySizeBytes>
-            ("Set the size of the shared memory buffer used for IPC "
-             "between the simulation and the Damaris resources. "
-             "Needs to hold all the variables published, possibly over "
-             "multiple simulation iterations.");
-        Parameters::Register<Parameters::DamarisSharedMemoryName>
-            ("The name of the shared memory area to be used by Damaris for the current. "
-             "If empty (the default) then Damaris uses \"opm-damaris-<random-string>\". "
-             "This name should be unique if multiple simulations are running on "
-             "the same node/server as it is used for the Damaris shmem name and by "
-             "the Python Dask library to locate sections of variables.");
-        Parameters::Register<Parameters::DamarisLimitVariables>
-            ("A comma separated list of variable names that a user wants to pass "
-             "through via DamarisOutput::DamarisWriter::writeOutput)() to the "
-             "damaris_write() call. This can be used to limit the number of "
-             "variables being passed to the Damaris plugins (Paraview, Python and HDF5)");
+        registerDamarisParameters();
     }
 
     // The Simulator object should preferably have been const - the

--- a/opm/simulators/flow/FlowBaseVanguard.hpp
+++ b/opm/simulators/flow/FlowBaseVanguard.hpp
@@ -36,6 +36,7 @@
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 
+#include <opm/models/discretization/common/fvbaseparameters.hh>
 #include <opm/models/discretization/common/fvbaseproperties.hh>
 #include <opm/models/io/basevanguard.hh>
 #include <opm/models/utils/parametersystem.hh>

--- a/opm/simulators/flow/FlowBaseVanguard.hpp
+++ b/opm/simulators/flow/FlowBaseVanguard.hpp
@@ -70,42 +70,6 @@ struct EquilGrid { using type = UndefinedProperty; };
 
 } // namespace Opm::Properties
 
-namespace Opm::Parameters {
-
-struct AllowDistributedWells { static constexpr bool value = false; };
-struct EclOutputInterval { static constexpr int value = -1; };
-struct EdgeWeightsMethod  { static constexpr int value = 1; };
-struct EnableDryRun { static constexpr auto value = "auto"; };
-struct EnableOpmRstFile { static constexpr bool value = false; };
-struct ExternalPartition { static constexpr auto* value = ""; };
-
-template<class Scalar>
-struct ImbalanceTol { static constexpr Scalar value = 1.1; };
-
-struct IgnoreKeywords { static constexpr auto value = ""; };
-struct InputSkipMode { static constexpr auto value = "100"; };
-struct MetisParams { static constexpr auto value = "default"; };
-
-#if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
-struct NumJacobiBlocks { static constexpr int value = 0; };
-#endif
-
-struct OwnerCellsFirst { static constexpr bool value = true; };
-struct ParsingStrictness { static constexpr auto value = "normal"; };
-
- // 0: simple, 1: Zoltan, 2: METIS, see GridEnums.hpp
-struct PartitionMethod { static constexpr int value = 1; };
-
-struct SchedRestart{ static constexpr bool value = false; };
-struct SerialPartitioning{ static constexpr bool value = false; };
-
-template<class Scalar>
-struct ZoltanImbalanceTol { static constexpr Scalar value = 1.1; };
-
-struct ZoltanParams { static constexpr auto value = "graph"; };
-
-} // namespace Opm::Parameters
-
 namespace Opm {
 
 /*!
@@ -141,77 +105,7 @@ public:
      */
     static void registerParameters()
     {
-        Parameters::Register<Parameters::EclDeckFileName>
-            ("The name of the file which contains the ECL deck to be simulated");
-        Parameters::Register<Parameters::EclOutputInterval>
-            ("The number of report steps that ought to be skipped between two writes of ECL results");
-        Parameters::Register<Parameters::EnableDryRun>
-            ("Specify if the simulation ought to be actually run, or just pretended to be");
-        Parameters::Register<Parameters::EnableOpmRstFile>
-            ("Include OPM-specific keywords in the ECL restart file to "
-             "enable restart of OPM simulators from these files");
-        Parameters::Register<Parameters::IgnoreKeywords>
-            ("List of Eclipse keywords which should be ignored. As a ':' separated string.");
-        Parameters::Register<Parameters::ParsingStrictness>
-            ("Set strictness of parsing process. Available options are "
-             "normal (stop for critical errors), "
-             "high (stop for all errors) and "
-             "low (as normal, except do not stop due to unsupported "
-             "keywords even if marked critical");
-        Parameters::Register<Parameters::InputSkipMode>
-            ("Set compatibility mode for the SKIP100/SKIP300 keywords. Options are "
-             "100 (skip SKIP100..ENDSKIP, keep SKIP300..ENDSKIP) [default], "
-             "300 (skip SKIP300..ENDSKIP, keep SKIP100..ENDSKIP) and "
-             "all (skip both SKIP100..ENDSKIP and SKIP300..ENDSKIP) ");
-        Parameters::Register<Parameters::SchedRestart>
-            ("When restarting: should we try to initialize wells and "
-             "groups from historical SCHEDULE section.");
-        Parameters::Register<Parameters::EdgeWeightsMethod>
-            ("Choose edge-weighing strategy: 0=uniform, 1=trans, 2=log(trans).");
-
-#if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
-        Parameters::Register<Parameters::NumJacobiBlocks>
-            ("Number of blocks to be created for the Block-Jacobi preconditioner.");
-#endif
-
-        Parameters::Register<Parameters::OwnerCellsFirst>
-            ("Order cells owned by rank before ghost/overlap cells.");
-#if HAVE_MPI
-        Parameters::Register<Parameters::PartitionMethod>
-            ("Choose partitioning strategy: 0=simple, 1=Zoltan, 2=METIS.");
-        Parameters::Register<Parameters::SerialPartitioning>
-            ("Perform partitioning for parallel runs on a single process.");
-        Parameters::Register<Parameters::ZoltanImbalanceTol<Scalar>>
-            ("Tolerable imbalance of the loadbalancing provided by Zoltan. DEPRECATED: Use --imbalance-tol instead");
-        Parameters::Hide<Parameters::ZoltanImbalanceTol<Scalar>>();
-        Parameters::Register<Parameters::ZoltanParams>
-            ("Configuration of Zoltan partitioner. "
-             "Valid options are: graph, hypergraph or scotch. "
-             "Alternatively, you can request a configuration to be read "
-             "from a JSON file by giving the filename here, ending with '.json.' "
-             "See https://sandialabs.github.io/Zoltan/ug_html/ug.html "
-             "for available Zoltan options.");
-        Parameters::Hide<Parameters::ZoltanParams>();
-        Parameters::Register<Parameters::ImbalanceTol<Scalar>>
-            ("Tolerable imbalance of the loadbalancing (default: 1.1).");
-        Parameters::Register<Parameters::MetisParams>
-            ("Configuration of Metis partitioner. "
-             "You can request a configuration to be read "
-             "from a JSON file by giving the filename here, ending with '.json.' "
-             "See http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/manual.pdf"
-             "for available METIS options.");
-        Parameters::Register<Parameters::ExternalPartition>
-            ("Name of file from which to load an externally generated "
-             "partitioning of the model's active cells for MPI "
-             "distribution purposes. If empty, the built-in partitioning "
-             "method will be employed.");
-        Parameters::Hide<Parameters::ExternalPartition>();
-#endif
-        Parameters::Register<Parameters::AllowDistributedWells>
-            ("Allow the perforations of a well to be distributed to interior of multiple processes");
-        // register here for the use in the tests without BlackoilModelParameters
-        Parameters::Register<Parameters::UseMultisegmentWell>
-            ("Use the well model for multi-segment wells instead of the one for single-segment wells");
+        FlowGenericVanguard::registerParameters_<Scalar>();
     }
 
     /*!

--- a/opm/simulators/flow/FlowGenericVanguard.hpp
+++ b/opm/simulators/flow/FlowGenericVanguard.hpp
@@ -45,6 +45,42 @@
 #include <utility>
 #include <vector>
 
+namespace Opm::Parameters {
+
+struct AllowDistributedWells { static constexpr bool value = false; };
+struct EclOutputInterval { static constexpr int value = -1; };
+struct EdgeWeightsMethod  { static constexpr int value = 1; };
+struct EnableDryRun { static constexpr auto value = "auto"; };
+struct EnableOpmRstFile { static constexpr bool value = false; };
+struct ExternalPartition { static constexpr auto* value = ""; };
+
+template<class Scalar>
+struct ImbalanceTol { static constexpr Scalar value = 1.1; };
+
+struct IgnoreKeywords { static constexpr auto value = ""; };
+struct InputSkipMode { static constexpr auto value = "100"; };
+struct MetisParams { static constexpr auto value = "default"; };
+
+#if HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
+struct NumJacobiBlocks { static constexpr int value = 0; };
+#endif
+
+struct OwnerCellsFirst { static constexpr bool value = true; };
+struct ParsingStrictness { static constexpr auto value = "normal"; };
+
+ // 0: simple, 1: Zoltan, 2: METIS, see GridEnums.hpp
+struct PartitionMethod { static constexpr int value = 1; };
+
+struct SchedRestart{ static constexpr bool value = false; };
+struct SerialPartitioning{ static constexpr bool value = false; };
+
+template<class Scalar>
+struct ZoltanImbalanceTol { static constexpr Scalar value = 1.1; };
+
+struct ZoltanParams { static constexpr auto value = "graph"; };
+
+} // namespace Opm::Parameters
+
 namespace Opm {
 
 namespace Action { class State; }
@@ -291,6 +327,9 @@ protected:
     std::unordered_map<std::size_t, const NumericalAquiferCell*> allAquiferCells() const;
 
     void init();
+
+    template<class Scalar>
+    static void registerParameters_();
 
     double setupTime_;
 

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -103,91 +103,18 @@ namespace Opm {
             // register the base parameters
             registerAllParameters_<TypeTag>(/*finalizeRegistration=*/false);
 
-            // hide the parameters unused by flow. TODO: this is a pain to maintain
-            Parameters::Hide<Parameters::EnableGravity>();
-            Parameters::Hide<Parameters::EnableGridAdaptation>();
-
-            // this parameter is actually used in eWoms, but the flow well model
-            // hard-codes the assumption that the intensive quantities cache is enabled,
-            // so flow crashes. Let's hide the parameter for that reason.
-            Parameters::Hide<Parameters::EnableIntensiveQuantityCache>();
-
-            // thermodynamic hints are not implemented/required by the eWoms blackoil
-            // model
-            Parameters::Hide<Parameters::EnableThermodynamicHints>();
-
-            // in flow only the deck file determines the end time of the simulation
-            Parameters::Hide<Parameters::EndTime<Scalar>>();
-
-            // time stepping is not done by the eWoms code in flow
-            Parameters::Hide<Parameters::InitialTimeStepSize<Scalar>>();
-            Parameters::Hide<Parameters::MaxTimeStepDivisions>();
-            Parameters::Hide<Parameters::MaxTimeStepSize<Scalar>>();
-            Parameters::Hide<Parameters::MinTimeStepSize<Scalar>>();
-            Parameters::Hide<Parameters::PredeterminedTimeStepsFile>();
-
-            // flow also does not use the eWoms Newton method
-            Parameters::Hide<Parameters::NewtonMaxError<Scalar>>();
-            Parameters::Hide<Parameters::NewtonTolerance<Scalar>>();
-            Parameters::Hide<Parameters::NewtonTargetIterations>();
-            Parameters::Hide<Parameters::NewtonVerbose>();
-            Parameters::Hide<Parameters::NewtonWriteConvergence>();
-
-            // the default eWoms checkpoint/restart mechanism does not work with flow
-            Parameters::Hide<Parameters::RestartTime<Scalar>>();
-            Parameters::Hide<Parameters::RestartWritingInterval>();
-            // hide all vtk related it is not currently possible to do this dependet on if the vtk writing is used
-            //if(not(Parameters::Get<Parameters::EnableVtkOutput>())){
-                Parameters::Hide<Parameters::VtkWriteOilFormationVolumeFactor>();
-                Parameters::Hide<Parameters::VtkWriteOilSaturationPressure>();
-                Parameters::Hide<Parameters::VtkWriteOilVaporizationFactor>();
-                Parameters::Hide<Parameters::VtkWritePorosity>();
-                Parameters::Hide<Parameters::VtkWritePotentialGradients>();
-                Parameters::Hide<Parameters::VtkWritePressures>();
-                Parameters::Hide<Parameters::VtkWritePrimaryVars>();
-                Parameters::Hide<Parameters::VtkWritePrimaryVarsMeaning>();
-                Parameters::Hide<Parameters::VtkWriteProcessRank>();
-                Parameters::Hide<Parameters::VtkWriteRelativePermeabilities>();
-                Parameters::Hide<Parameters::VtkWriteSaturatedGasOilVaporizationFactor>();
-                Parameters::Hide<Parameters::VtkWriteSaturatedOilGasDissolutionFactor>();
-                Parameters::Hide<Parameters::VtkWriteSaturationRatios>();
-                Parameters::Hide<Parameters::VtkWriteSaturations>();
-                Parameters::Hide<Parameters::VtkWriteTemperature>();
-                Parameters::Hide<Parameters::VtkWriteViscosities>();
-                Parameters::Hide<Parameters::VtkWriteWaterFormationVolumeFactor>();
-                Parameters::Hide<Parameters::VtkWriteGasDissolutionFactor>();
-                Parameters::Hide<Parameters::VtkWriteGasFormationVolumeFactor>();
-                Parameters::Hide<Parameters::VtkWriteGasSaturationPressure>();
-                Parameters::Hide<Parameters::VtkWriteIntrinsicPermeabilities>();
-                Parameters::Hide<Parameters::VtkWriteTracerConcentration>();
-                Parameters::Hide<Parameters::VtkWriteExtrusionFactor>();
-                Parameters::Hide<Parameters::VtkWriteFilterVelocities>();
-                Parameters::Hide<Parameters::VtkWriteDensities>();
-                Parameters::Hide<Parameters::VtkWriteDofIndex>();
-                Parameters::Hide<Parameters::VtkWriteMobilities>();
-                //}
-            Parameters::Hide<Parameters::VtkWriteAverageMolarMasses>();
-            Parameters::Hide<Parameters::VtkWriteFugacities>();
-            Parameters::Hide<Parameters::VtkWriteFugacityCoeffs>();
-            Parameters::Hide<Parameters::VtkWriteMassFractions>();
-            Parameters::Hide<Parameters::VtkWriteMolarities>();
-            Parameters::Hide<Parameters::VtkWriteMoleFractions>();
-            Parameters::Hide<Parameters::VtkWriteTotalMassFractions>();
-            Parameters::Hide<Parameters::VtkWriteTotalMoleFractions>();
-
-            Parameters::Hide<Parameters::VtkWriteTortuosities>();
-            Parameters::Hide<Parameters::VtkWriteDiffusionCoefficients>();
-            Parameters::Hide<Parameters::VtkWriteEffectiveDiffusionCoefficients>();
-            
-            // hide average density option
-            Parameters::Hide<Parameters::UseAverageDensityMsWells>();
+            detail::hideUnusedParameters<Scalar>();
 
             Parameters::endRegistration();
 
             int mpiRank = comm.rank();
 
             // read in the command line parameters
-            int status = ::Opm::setupParameters_<TypeTag>(argc, const_cast<const char**>(argv), /*doRegistration=*/false, /*allowUnused=*/true, /*handleHelp=*/(mpiRank==0));
+            int status = ::Opm::setupParameters_<TypeTag>(argc,
+                                                          const_cast<const char**>(argv),
+                                                          /*doRegistration=*/false,
+                                                          /*allowUnused=*/true,
+                                                          /*handleHelp=*/(mpiRank==0));
             if (status == 0) {
 
                 // deal with unknown parameters.

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -220,52 +220,7 @@ public:
 #endif
 
         VtkTracerModule<TypeTag>::registerParameters();
-
-        Parameters::Register<Parameters::EnableWriteAllSolutions>
-           ("Write all solutions to disk instead of only the ones for the "
-            "report steps");
-        Parameters::Register<Parameters::EnableEclOutput>
-            ("Write binary output which is compatible with the commercial "
-             "Eclipse simulator");
-#if HAVE_DAMARIS
-        Parameters::Register<Parameters::EnableDamarisOutput>
-            ("Write a specific variable using Damaris in a separate core");
-#endif
-        Parameters::Register<Parameters::EclOutputDoublePrecision>
-            ("Tell the output writer to use double precision. Useful for 'perfect' restarts");
-        Parameters::Register<Parameters::RestartWritingInterval>
-            ("The frequencies of which time steps are serialized to disk");
-        Parameters::Register<Parameters::EnableDriftCompensation>
-            ("Enable partial compensation of systematic mass losses via "
-             "the source term of the next time step");
-        Parameters::Register<Parameters::OutputMode>
-            ("Specify which messages are going to be printed. "
-             "Valid values are: none, log, all (default)");
-        Parameters::Register<Parameters::NumPressurePointsEquil>
-            ("Number of pressure points (in each direction) in tables used for equilibration");
-        Parameters::Hide<Parameters::NumPressurePointsEquil>(); // Users will typically not need to modify this parameter..
-        Parameters::Register<Parameters::ExplicitRockCompaction>
-            ("Use pressure from end of the last time step when evaluating rock compaction");
-        Parameters::Hide<Parameters::ExplicitRockCompaction>(); // Users will typically not need to modify this parameter..
-
-        // By default, stop it after the universe will probably have stopped
-        // to exist. (the ECL problem will finish the simulation explicitly
-        // after it simulated the last episode specified in the deck.)
-        Parameters::SetDefault<Parameters::EndTime<Scalar>>(1e100);
-        // The chosen value means that the size of the first time step is the
-        // one of the initial episode (if the length of the initial episode is
-        // not millions of trillions of years, that is...)
-        Parameters::SetDefault<Parameters::InitialTimeStepSize<Scalar>>(3600*24);
-        // Disable the VTK output by default for this problem ...
-        Parameters::SetDefault<Parameters::EnableVtkOutput>(false);
-        // the cache for intensive quantities can be used for ECL problems and also yields a
-        // decent speedup...
-        Parameters::SetDefault<Parameters::EnableIntensiveQuantityCache>(true);
-        // the cache for the storage term can also be used and also yields a decent speedup
-        Parameters::SetDefault<Parameters::EnableStorageCache>(true);
-        // the default for the allowed volumetric error for oil per second
-        Parameters::SetDefault<Parameters::NewtonTolerance<Scalar>>(1e-2);
-        Parameters::SetDefault<Parameters::EnableGravity>(true);
+        registerFlowProblemParameters<Scalar>();
     }
 
 

--- a/opm/simulators/flow/FlowProblemParameters.cpp
+++ b/opm/simulators/flow/FlowProblemParameters.cpp
@@ -1,0 +1,91 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+#include <opm/simulators/flow/FlowProblemParameters.hpp>
+
+#include <opm/models/common/multiphasebaseparameters.hh>
+#include <opm/models/nonlinear/newtonmethodparameters.hh>
+#include <opm/models/utils/parametersystem.hh>
+
+#include <opm/simulators/flow/EclWriter.hpp>
+
+#if HAVE_DAMARIS
+#include <opm/simulators/flow/DamarisParameters.hpp>
+#endif
+
+namespace Opm {
+
+template<class Scalar>
+void registerFlowProblemParameters()
+{
+    Parameters::Register<Parameters::EnableWriteAllSolutions>
+       ("Write all solutions to disk instead of only the ones for the "
+        "report steps");
+    Parameters::Register<Parameters::EnableEclOutput>
+        ("Write binary output which is compatible with the commercial "
+         "Eclipse simulator");
+#if HAVE_DAMARIS
+    Parameters::Register<Parameters::EnableDamarisOutput>
+        ("Write a specific variable using Damaris in a separate core");
+#endif
+    Parameters::Register<Parameters::EclOutputDoublePrecision>
+        ("Tell the output writer to use double precision. Useful for 'perfect' restarts");
+    Parameters::Register<Parameters::RestartWritingInterval>
+        ("The frequencies of which time steps are serialized to disk");
+    Parameters::Register<Parameters::EnableDriftCompensation>
+        ("Enable partial compensation of systematic mass losses via "
+         "the source term of the next time step");
+    Parameters::Register<Parameters::OutputMode>
+        ("Specify which messages are going to be printed. "
+         "Valid values are: none, log, all (default)");
+    Parameters::Register<Parameters::NumPressurePointsEquil>
+        ("Number of pressure points (in each direction) in tables used for equilibration");
+    Parameters::Hide<Parameters::NumPressurePointsEquil>(); // Users will typically not need to modify this parameter..
+    Parameters::Register<Parameters::ExplicitRockCompaction>
+        ("Use pressure from end of the last time step when evaluating rock compaction");
+    Parameters::Hide<Parameters::ExplicitRockCompaction>(); // Users will typically not need to modify this parameter..
+
+    // By default, stop it after the universe will probably have stopped
+    // to exist. (the ECL problem will finish the simulation explicitly
+    // after it simulated the last episode specified in the deck.)
+    Parameters::SetDefault<Parameters::EndTime<Scalar>>(1e100);
+    // The chosen value means that the size of the first time step is the
+    // one of the initial episode (if the length of the initial episode is
+    // not millions of trillions of years, that is...)
+    Parameters::SetDefault<Parameters::InitialTimeStepSize<Scalar>>(3600*24);
+    // Disable the VTK output by default for this problem ...
+    Parameters::SetDefault<Parameters::EnableVtkOutput>(false);
+    // the cache for intensive quantities can be used for ECL problems and also yields a
+    // decent speedup...
+    Parameters::SetDefault<Parameters::EnableIntensiveQuantityCache>(true);
+    // the cache for the storage term can also be used and also yields a decent speedup
+    Parameters::SetDefault<Parameters::EnableStorageCache>(true);
+    // the default for the allowed volumetric error for oil per second
+    Parameters::SetDefault<Parameters::NewtonTolerance<Scalar>>(1e-2);
+    Parameters::SetDefault<Parameters::EnableGravity>(true);
+}
+
+template void registerFlowProblemParameters<double>();
+
+}

--- a/opm/simulators/flow/FlowProblemParameters.hpp
+++ b/opm/simulators/flow/FlowProblemParameters.hpp
@@ -32,7 +32,6 @@
 
 namespace Opm::Parameters {
 
-
 // Enable partial compensation of systematic mass losses via
 // the source term of the next time step
 struct EnableDriftCompensation { static constexpr bool value = false; };
@@ -51,5 +50,12 @@ struct OutputMode { static constexpr auto value = "all"; };
 struct RestartWritingInterval { static constexpr int value = 0xffffff; }; // disable
 
 } // namespace Opm::Parameters
+
+namespace Opm {
+
+template<class Scalar>
+void registerFlowProblemParameters();
+
+}
 
 #endif // OPM_FLOW_PROBLEM_PARAMETERS_HPP

--- a/opm/simulators/flow/FlowUtils.cpp
+++ b/opm/simulators/flow/FlowUtils.cpp
@@ -20,11 +20,26 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "opm/simulators/flow/BlackoilModelParameters.hpp"
+#include "opm/simulators/flow/FlowProblemParameters.hpp"
+#include "opm/simulators/flow/VtkTracerModule.hpp"
 #include <config.h>
 #include <opm/simulators/flow/FlowUtils.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/String.hpp>
+
+#include <opm/models/common/multiphasebaseparameters.hh>
+#include <opm/models/discretization/common/fvbaseparameters.hh>
+#include <opm/models/io/vtkblackoilmodule.hh>
+#include <opm/models/io/vtkcompositionmodule.hh>
+#include <opm/models/io/vtkdiffusionmodule.hh>
+#include <opm/models/io/vtkmultiphasemodule.hh>
+#include <opm/models/io/vtkprimaryvarsmodule.hh>
+#include <opm/models/io/vtktemperaturemodule.hh>
+#include <opm/models/nonlinear/newtonmethodparameters.hh>
+#include <opm/models/utils/basicparameters.hh>
+#include <opm/models/utils/parametersystem.hh>
 
 #include <opm/simulators/flow/ConvergenceOutputConfiguration.hpp>
 #include <opm/simulators/timestepping/SimulatorReport.hpp>
@@ -163,5 +178,90 @@ void checkAllMPIProcesses()
     }
 #endif
 }
+
+template<class Scalar>
+void hideUnusedParameters()
+{
+    // hide the parameters unused by flow. TODO: this is a pain to maintain
+    Parameters::Hide<Parameters::EnableGravity>();
+    Parameters::Hide<Parameters::EnableGridAdaptation>();
+
+    // this parameter is actually used in eWoms, but the flow well model
+    // hard-codes the assumption that the intensive quantities cache is enabled,
+    // so flow crashes. Let's hide the parameter for that reason.
+    Parameters::Hide<Parameters::EnableIntensiveQuantityCache>();
+
+    // thermodynamic hints are not implemented/required by the eWoms blackoil
+    // model
+    Parameters::Hide<Parameters::EnableThermodynamicHints>();
+
+    // in flow only the deck file determines the end time of the simulation
+    Parameters::Hide<Parameters::EndTime<Scalar>>();
+
+    // time stepping is not done by the eWoms code in flow
+    Parameters::Hide<Parameters::InitialTimeStepSize<Scalar>>();
+    Parameters::Hide<Parameters::MaxTimeStepDivisions>();
+    Parameters::Hide<Parameters::MaxTimeStepSize<Scalar>>();
+    Parameters::Hide<Parameters::MinTimeStepSize<Scalar>>();
+    Parameters::Hide<Parameters::PredeterminedTimeStepsFile>();
+
+    // flow also does not use the eWoms Newton method
+    Parameters::Hide<Parameters::NewtonMaxError<Scalar>>();
+    Parameters::Hide<Parameters::NewtonTolerance<Scalar>>();
+    Parameters::Hide<Parameters::NewtonTargetIterations>();
+    Parameters::Hide<Parameters::NewtonVerbose>();
+    Parameters::Hide<Parameters::NewtonWriteConvergence>();
+
+    // the default eWoms checkpoint/restart mechanism does not work with flow
+    Parameters::Hide<Parameters::RestartTime<Scalar>>();
+    Parameters::Hide<Parameters::RestartWritingInterval>();
+    // hide all vtk related it is not currently possible to do this dependet on if the vtk writing is used
+    //if(not(Parameters::Get<Parameters::EnableVtkOutput>())){
+        Parameters::Hide<Parameters::VtkWriteOilFormationVolumeFactor>();
+        Parameters::Hide<Parameters::VtkWriteOilSaturationPressure>();
+        Parameters::Hide<Parameters::VtkWriteOilVaporizationFactor>();
+        Parameters::Hide<Parameters::VtkWritePorosity>();
+        Parameters::Hide<Parameters::VtkWritePotentialGradients>();
+        Parameters::Hide<Parameters::VtkWritePressures>();
+        Parameters::Hide<Parameters::VtkWritePrimaryVars>();
+        Parameters::Hide<Parameters::VtkWritePrimaryVarsMeaning>();
+        Parameters::Hide<Parameters::VtkWriteProcessRank>();
+        Parameters::Hide<Parameters::VtkWriteRelativePermeabilities>();
+        Parameters::Hide<Parameters::VtkWriteSaturatedGasOilVaporizationFactor>();
+        Parameters::Hide<Parameters::VtkWriteSaturatedOilGasDissolutionFactor>();
+        Parameters::Hide<Parameters::VtkWriteSaturationRatios>();
+        Parameters::Hide<Parameters::VtkWriteSaturations>();
+        Parameters::Hide<Parameters::VtkWriteTemperature>();
+        Parameters::Hide<Parameters::VtkWriteViscosities>();
+        Parameters::Hide<Parameters::VtkWriteWaterFormationVolumeFactor>();
+        Parameters::Hide<Parameters::VtkWriteGasDissolutionFactor>();
+        Parameters::Hide<Parameters::VtkWriteGasFormationVolumeFactor>();
+        Parameters::Hide<Parameters::VtkWriteGasSaturationPressure>();
+        Parameters::Hide<Parameters::VtkWriteIntrinsicPermeabilities>();
+        Parameters::Hide<Parameters::VtkWriteTracerConcentration>();
+        Parameters::Hide<Parameters::VtkWriteExtrusionFactor>();
+        Parameters::Hide<Parameters::VtkWriteFilterVelocities>();
+        Parameters::Hide<Parameters::VtkWriteDensities>();
+        Parameters::Hide<Parameters::VtkWriteDofIndex>();
+        Parameters::Hide<Parameters::VtkWriteMobilities>();
+        //}
+    Parameters::Hide<Parameters::VtkWriteAverageMolarMasses>();
+    Parameters::Hide<Parameters::VtkWriteFugacities>();
+    Parameters::Hide<Parameters::VtkWriteFugacityCoeffs>();
+    Parameters::Hide<Parameters::VtkWriteMassFractions>();
+    Parameters::Hide<Parameters::VtkWriteMolarities>();
+    Parameters::Hide<Parameters::VtkWriteMoleFractions>();
+    Parameters::Hide<Parameters::VtkWriteTotalMassFractions>();
+    Parameters::Hide<Parameters::VtkWriteTotalMoleFractions>();
+
+    Parameters::Hide<Parameters::VtkWriteTortuosities>();
+    Parameters::Hide<Parameters::VtkWriteDiffusionCoefficients>();
+    Parameters::Hide<Parameters::VtkWriteEffectiveDiffusionCoefficients>();
+
+    // hide average density option
+    Parameters::Hide<Parameters::UseAverageDensityMsWells>();
+}
+
+template void hideUnusedParameters<double>();
 
 } // namespace Opm::detail

--- a/opm/simulators/flow/FlowUtils.hpp
+++ b/opm/simulators/flow/FlowUtils.hpp
@@ -40,6 +40,10 @@ void handleExtraConvergenceOutput(SimulatorReport& report,
                                   std::string_view output_dir,
                                   std::string_view base_name);
 
+//! \brief Hides unused runtime parameters.
+template<class Scalar>
+void hideUnusedParameters();
+
 } // namespace Opm::detail
 
 #endif // OPM_FLOW_UTILS_HEADER_INCLUDED

--- a/opm/simulators/flow/NonlinearSolver.cpp
+++ b/opm/simulators/flow/NonlinearSolver.cpp
@@ -28,8 +28,7 @@
 #include <cmath>
 #include <stdexcept>
 
-namespace Opm {
-namespace detail {
+namespace Opm::detail {
 
 template<class Scalar>
 void detectOscillations(const std::vector<std::vector<Scalar>>& residualHistory,
@@ -106,25 +105,40 @@ void stabilizeNonlinearUpdate(BVector& dx, BVector& dxOld,
     return;
 }
 
+template<class Scalar>
+void registerNonlinearParameters()
+{
+    Parameters::Register<Parameters::NewtonMaxRelax<Scalar>>
+        ("The maximum relaxation factor of a Newton iteration");
+    Parameters::Register<Parameters::NewtonMaxIterations>
+        ("The maximum number of Newton iterations per time step");
+    Parameters::Register<Parameters::NewtonMinIterations>
+        ("The minimum number of Newton iterations per time step");
+    Parameters::Register<Parameters::NewtonRelaxationType>
+        ("The type of relaxation used by Newton method");
+
+    Parameters::SetDefault<Parameters::NewtonMaxIterations>(20);
+}
+
 template<class Scalar, int Size>
 using BV = Dune::BlockVector<Dune::FieldVector<Scalar,Size>>;
 
-#define INSTANCE(T,Size) \
+#define INSTANTIATE(T,Size) \
     template void stabilizeNonlinearUpdate<BV<T,Size>,T>(BV<T,Size>&, BV<T,Size>&, \
                                                          const T, NonlinearRelaxType);
 
-#define INSTANCE_TYPE(T) \
+#define INSTANTIATE_TYPE(T) \
     template void detectOscillations(const std::vector<std::vector<T>>&, \
                                      const int, const int, const T, const int, \
                                      bool&, bool&); \
-    INSTANCE(T,1) \
-    INSTANCE(T,2) \
-    INSTANCE(T,3) \
-    INSTANCE(T,4) \
-    INSTANCE(T,5) \
-    INSTANCE(T,6)
+    template void registerNonlinearParameters<T>(); \
+    INSTANTIATE(T,1) \
+    INSTANTIATE(T,2) \
+    INSTANTIATE(T,3) \
+    INSTANTIATE(T,4) \
+    INSTANTIATE(T,5) \
+    INSTANTIATE(T,6)
 
-INSTANCE_TYPE(double)
+INSTANTIATE_TYPE(double)
 
-} // namespace detail
-} // namespace Opm
+} // namespace Opm::detail

--- a/opm/simulators/flow/NonlinearSolver.hpp
+++ b/opm/simulators/flow/NonlinearSolver.hpp
@@ -72,6 +72,9 @@ template <class BVector, class Scalar>
 void stabilizeNonlinearUpdate(BVector& dx, BVector& dxOld,
                               const Scalar omega, NonlinearRelaxType relaxType);
 
+template<class Scalar>
+void registerNonlinearParameters();
+
 }
 
     /// A nonlinear solver class suitable for general fully-implicit models,
@@ -115,16 +118,7 @@ void stabilizeNonlinearUpdate(BVector& dx, BVector& dxOld,
 
             static void registerParameters()
             {
-                Parameters::Register<Parameters::NewtonMaxRelax<Scalar>>
-                    ("The maximum relaxation factor of a Newton iteration");
-                Parameters::Register<Parameters::NewtonMaxIterations>
-                    ("The maximum number of Newton iterations per time step");
-                Parameters::Register<Parameters::NewtonMinIterations>
-                    ("The minimum number of Newton iterations per time step");
-                Parameters::Register<Parameters::NewtonRelaxationType>
-                    ("The type of relaxation used by Newton method");
-
-                Parameters::SetDefault<Parameters::NewtonMaxIterations>(20);
+                detail::registerNonlinearParameters<Scalar>();
             }
 
             void reset()

--- a/opm/simulators/linalg/FlowLinearSolverParameters.cpp
+++ b/opm/simulators/linalg/FlowLinearSolverParameters.cpp
@@ -1,0 +1,163 @@
+/*
+  Copyright 2015, 2020 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2015 IRIS AS
+  Copyright 2015 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015 NTNU
+  Copyright 2015 Statoil AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#include <opm/simulators/linalg/FlowLinearSolverParameters.hpp>
+#include <opm/simulators/linalg/linalgparameters.hh>
+#include <opm/models/utils/parametersystem.hh>
+
+namespace Opm {
+
+void FlowLinearSolverParameters::init(bool cprRequestedInDataFile)
+{
+    // TODO: these parameters have undocumented non-trivial dependencies
+    linear_solver_reduction_ = Parameters::Get<Parameters::LinearSolverReduction>();
+    relaxed_linear_solver_reduction_ = Parameters::Get<Parameters::RelaxedLinearSolverReduction>();
+    linear_solver_maxiter_ = Parameters::Get<Parameters::LinearSolverMaxIter>();
+    linear_solver_restart_ = Parameters::Get<Parameters::LinearSolverRestart>();
+    linear_solver_verbosity_ = Parameters::Get<Parameters::LinearSolverVerbosity>();
+    ilu_relaxation_ = Parameters::Get<Parameters::IluRelaxation>();
+    ilu_fillin_level_ = Parameters::Get<Parameters::IluFillinLevel>();
+    ilu_milu_ = convertString2Milu(Parameters::Get<Parameters::MiluVariant>());
+    ilu_redblack_ = Parameters::Get<Parameters::IluRedblack>();
+    ilu_reorder_sphere_ = Parameters::Get<Parameters::IluReorderSpheres>();
+    newton_use_gmres_ = Parameters::Get<Parameters::UseGmres>();
+    ignoreConvergenceFailure_ = Parameters::Get<Parameters::LinearSolverIgnoreConvergenceFailure>();
+    scale_linear_system_ = Parameters::Get<Parameters::ScaleLinearSystem>();
+    linsolver_ = Parameters::Get<Parameters::LinearSolver>();
+    linear_solver_print_json_definition_ = Parameters::Get<Parameters::LinearSolverPrintJsonDefinition>();
+    cpr_reuse_setup_  = Parameters::Get<Parameters::CprReuseSetup>();
+    cpr_reuse_interval_  = Parameters::Get<Parameters::CprReuseInterval>();
+
+    if (!Parameters::IsSet<Parameters::LinearSolver>() && cprRequestedInDataFile) {
+        linsolver_ = "cpr";
+    } else {
+        linsolver_ = Parameters::Get<Parameters::LinearSolver>();
+    }
+
+    accelerator_mode_ = Parameters::Get<Parameters::AcceleratorMode>();
+    bda_device_id_ = Parameters::Get<Parameters::BdaDeviceId>();
+    opencl_platform_id_ = Parameters::Get<Parameters::OpenclPlatformId>();
+    opencl_ilu_parallel_ = Parameters::Get<Parameters::OpenclIluParallel>();
+}
+
+void FlowLinearSolverParameters::registerParameters()
+{
+    Parameters::Register<Parameters::LinearSolverReduction>
+        ("The minimum reduction of the residual which the linear solver must achieve");
+    Parameters::Register<Parameters::RelaxedLinearSolverReduction>
+        ("The minimum reduction of the residual which the linear solver need to "
+         "achieve for the solution to be accepted");
+    Parameters::Register<Parameters::LinearSolverMaxIter>
+        ("The maximum number of iterations of the linear solver");
+    Parameters::Register<Parameters::LinearSolverRestart>
+        ("The number of iterations after which GMRES is restarted");
+    Parameters::Register<Parameters::LinearSolverVerbosity>
+        ("The verbosity level of the linear solver (0: off, 2: all)");
+    Parameters::Register<Parameters::IluRelaxation>
+        ("The relaxation factor of the linear solver's ILU preconditioner");
+    Parameters::Register<Parameters::IluFillinLevel>
+        ("The fill-in level of the linear solver's ILU preconditioner");
+    Parameters::Register<Parameters::MiluVariant>
+        ("Specify which variant of the modified-ILU preconditioner ought to be used. "
+         "Possible variants are: ILU (default, plain ILU), "
+         "MILU_1 (lump diagonal with dropped row entries), "
+         "MILU_2 (lump diagonal with the sum of the absolute values of the dropped row entries), "
+         "MILU_3 (if diagonal is positive add sum of dropped row entries, otherwise subtract them), "
+         "MILU_4 (if diagonal is positive add sum of dropped row entries, otherwise do nothing");
+    Parameters::Register<Parameters::IluRedblack>
+        ("Use red-black partitioning for the ILU preconditioner");
+    Parameters::Register<Parameters::IluReorderSpheres>
+        ("Whether to reorder the entries of the matrix in the red-black "
+         "ILU preconditioner in spheres starting at an edge. "
+         "If false the original ordering is preserved in each color. "
+         "Otherwise why try to ensure D4 ordering (in a 2D structured grid, "
+         "the diagonal elements are consecutive).");
+    Parameters::Register<Parameters::UseGmres>
+        ("Use GMRES as the linear solver");
+    Parameters::Register<Parameters::LinearSolverIgnoreConvergenceFailure>
+        ("Continue with the simulation like nothing happened "
+         "after the linear solver did not converge");
+    Parameters::Register<Parameters::ScaleLinearSystem>
+        ("Scale linear system according to equation scale and primary variable types");
+    Parameters::Register<Parameters::LinearSolver>
+        ("Configuration of solver. Valid options are: ilu0 (default), "
+         "dilu, cprw, cpr (an alias for cprw), cpr_quasiimpes, "
+         "cpr_trueimpes, cpr_trueimpesanalytic, amg or hybrid (experimental). "
+         "Alternatively, you can request a configuration to be read from a "
+         "JSON file by giving the filename here, ending with '.json.'");
+    Parameters::Register<Parameters::LinearSolverPrintJsonDefinition>
+        ("Write the JSON definition of the linear solver setup to the DBG file.");
+    Parameters::Register<Parameters::CprReuseSetup>
+        ("Reuse preconditioner setup. Valid options are "
+         "0: recreate the preconditioner for every linear solve, "
+         "1: recreate once every timestep, "
+         "2: recreate if last linear solve took more than 10 iterations, "
+         "3: never recreate, "
+         "4: recreated every CprReuseInterval");
+    Parameters::Register<Parameters::CprReuseInterval>
+        ("Reuse preconditioner interval. Used when CprReuseSetup is set to 4, "
+         "then the preconditioner will be fully recreated instead of reused "
+         "every N linear solve, where N is this parameter.");
+    Parameters::Register<Parameters::AcceleratorMode>
+        ("Choose a linear solver, usage: "
+         "'--accelerator-mode=[none|cusparse|opencl|amgcl|rocalution|rocsparse]'");
+    Parameters::Register<Parameters::BdaDeviceId>
+        ("Choose device ID for cusparseSolver or openclSolver, "
+         "use 'nvidia-smi' or 'clinfo' to determine valid IDs");
+    Parameters::Register<Parameters::OpenclPlatformId>
+        ("Choose platform ID for openclSolver, use 'clinfo' "
+         "to determine valid platform IDs");
+    Parameters::Register<Parameters::OpenclIluParallel>
+        ("Parallelize ILU decomposition and application on GPU");
+
+    Parameters::SetDefault<Parameters::LinearSolverVerbosity>(0);
+}
+
+void FlowLinearSolverParameters::reset()
+{
+    relaxed_linear_solver_reduction_ = 1e-2;
+    linear_solver_reduction_  = 1e-2;
+    linear_solver_maxiter_    = 200;
+    linear_solver_restart_    = 40;
+    linear_solver_verbosity_  = 0;
+    ilu_relaxation_           = 0.9;
+    ilu_fillin_level_         = 0;
+    ilu_milu_                 = MILU_VARIANT::ILU;
+    ilu_redblack_             = false;
+    ilu_reorder_sphere_       = false;
+    newton_use_gmres_         = false;
+    ignoreConvergenceFailure_ = false;
+    scale_linear_system_      = false;
+    linsolver_                = "cprw";
+    linear_solver_print_json_definition_ = true;
+    cpr_reuse_setup_          = 4;
+    cpr_reuse_interval_       = 30;
+    accelerator_mode_         = "none";
+    bda_device_id_            = 0;
+    opencl_platform_id_       = 0;
+    opencl_ilu_parallel_      = true;
+}
+
+} // namespace Opm

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
@@ -84,5 +84,59 @@ consistentlyFailingWells(const std::vector<StepReport>& sr)
     return failing_wells;
 }
 
+void registerAdaptiveParameters()
+{
+    // TODO: make sure the help messages are correct (and useful)
+    Parameters::Register<Parameters::SolverContinueOnConvergenceFailure>
+        ("Continue instead of stop when minimum solver time step is reached");
+    Parameters::Register<Parameters::SolverMaxRestarts>
+        ("The maximum number of breakdowns before a substep is given up and "
+         "the simulator is terminated");
+    Parameters::Register<Parameters::SolverVerbosity>
+        ("Specify the \"chattiness\" of the non-linear solver itself");
+    Parameters::Register<Parameters::TimeStepVerbosity>
+        ("Specify the \"chattiness\" during the time integration");
+    Parameters::Register<Parameters::InitialTimeStepInDays>
+        ("The size of the initial time step in days");
+    Parameters::Register<Parameters::FullTimeStepInitially>
+        ("Always attempt to finish a report step using a single substep");
+    Parameters::Register<Parameters::TimeStepControl>
+        ("The algorithm used to determine time-step sizes. "
+         "Valid options are: "
+         "'pid' (default), "
+         "'pid+iteration', "
+         "'pid+newtoniteration', "
+         "'iterationcount', "
+        "'newtoniterationcount' "
+        "and 'hardcoded'");
+    Parameters::Register<Parameters::TimeStepControlTolerance>
+        ("The tolerance used by the time step size control algorithm");
+    Parameters::Register<Parameters::TimeStepControlTargetIterations>
+        ("The number of linear iterations which the time step control scheme "
+         "should aim for (if applicable)");
+    Parameters::Register<Parameters::TimeStepControlTargetNewtonIterations>
+        ("The number of Newton iterations which the time step control scheme "
+         "should aim for (if applicable)");
+    Parameters::Register<Parameters::TimeStepControlDecayRate>
+        ("The decay rate of the time step size of the number of "
+         "target iterations is exceeded");
+    Parameters::Register<Parameters::TimeStepControlGrowthRate>
+        ("The growth rate of the time step size of the number of "
+         "target iterations is undercut");
+    Parameters::Register<Parameters::TimeStepControlDecayDampingFactor>
+        ("The decay rate of the time step decrease when the "
+         "target iterations is exceeded");
+    Parameters::Register<Parameters::TimeStepControlGrowthDampingFactor>
+        ("The growth rate of the time step increase when the "
+         "target iterations is undercut");
+    Parameters::Register<Parameters::TimeStepControlFileName>
+        ("The name of the file which contains the hardcoded time steps sizes");
+    Parameters::Register<Parameters::MinTimeStepBeforeShuttingProblematicWellsInDays>
+        ("The minimum time step size in days for which problematic wells are not shut");
+    Parameters::Register<Parameters::MinTimeStepBasedOnNewtonIterations>
+        ("The minimum time step size (in days for field and metric unit and hours for lab unit) "
+         "can be reduced to based on newton iteration counts");
+}
+
 } // namespace detail
 } // namespace Opm

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -79,6 +79,8 @@ void logTimer(const AdaptiveSimulatorTimer& substepTimer);
 
 std::set<std::string> consistentlyFailingWells(const std::vector<StepReport>& sr);
 
+void registerAdaptiveParameters();
+
 }
 
     // AdaptiveTimeStepping
@@ -170,56 +172,7 @@ std::set<std::string> consistentlyFailingWells(const std::vector<StepReport>& sr
         static void registerParameters()
         {
             registerEclTimeSteppingParameters<Scalar>();
-            // TODO: make sure the help messages are correct (and useful)
-            Parameters::Register<Parameters::SolverContinueOnConvergenceFailure>
-                ("Continue instead of stop when minimum solver time step is reached");
-            Parameters::Register<Parameters::SolverMaxRestarts>
-                ("The maximum number of breakdowns before a substep is given up and "
-                 "the simulator is terminated");
-            Parameters::Register<Parameters::SolverVerbosity>
-                ("Specify the \"chattiness\" of the non-linear solver itself");
-            Parameters::Register<Parameters::TimeStepVerbosity>
-                ("Specify the \"chattiness\" during the time integration");
-            Parameters::Register<Parameters::InitialTimeStepInDays>
-                ("The size of the initial time step in days");
-            Parameters::Register<Parameters::FullTimeStepInitially>
-                ("Always attempt to finish a report step using a single substep");
-            Parameters::Register<Parameters::TimeStepControl>
-                ("The algorithm used to determine time-step sizes. "
-                 "Valid options are: "
-                 "'pid' (default), "
-                 "'pid+iteration', "
-                 "'pid+newtoniteration', "
-                 "'iterationcount', "
-                "'newtoniterationcount' "
-                "and 'hardcoded'");
-            Parameters::Register<Parameters::TimeStepControlTolerance>
-                ("The tolerance used by the time step size control algorithm");
-            Parameters::Register<Parameters::TimeStepControlTargetIterations>
-                ("The number of linear iterations which the time step control scheme "
-                 "should aim for (if applicable)");
-            Parameters::Register<Parameters::TimeStepControlTargetNewtonIterations>
-                ("The number of Newton iterations which the time step control scheme "
-                 "should aim for (if applicable)");
-            Parameters::Register<Parameters::TimeStepControlDecayRate>
-                ("The decay rate of the time step size of the number of "
-                 "target iterations is exceeded");
-            Parameters::Register<Parameters::TimeStepControlGrowthRate>
-                ("The growth rate of the time step size of the number of "
-                 "target iterations is undercut");
-            Parameters::Register<Parameters::TimeStepControlDecayDampingFactor>
-                ("The decay rate of the time step decrease when the "
-                 "target iterations is exceeded");
-            Parameters::Register<Parameters::TimeStepControlGrowthDampingFactor>
-                ("The growth rate of the time step increase when the "
-                 "target iterations is undercut");
-            Parameters::Register<Parameters::TimeStepControlFileName>
-                ("The name of the file which contains the hardcoded time steps sizes");
-            Parameters::Register<Parameters::MinTimeStepBeforeShuttingProblematicWellsInDays>
-                ("The minimum time step size in days for which problematic wells are not shut");
-            Parameters::Register<Parameters::MinTimeStepBasedOnNewtonIterations>
-                ("The minimum time step size (in days for field and metric unit and hours for lab unit) "
-                 "can be reduced to based on newton iteration counts");
+            detail::registerAdaptiveParameters();
         }
 
         /** \brief  step method that acts like the solver::step method

--- a/opm/simulators/timestepping/EclTimeSteppingParams.cpp
+++ b/opm/simulators/timestepping/EclTimeSteppingParams.cpp
@@ -1,0 +1,56 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+
+#include <opm/simulators/timestepping/EclTimeSteppingParams.hpp>
+
+#include <opm/models/utils/parametersystem.hh>
+
+namespace Opm {
+
+template<class Scalar>
+void registerEclTimeSteppingParameters()
+{
+    Parameters::Register<Parameters::EnableTuning>
+        ("Honor some aspects of the TUNING keyword.");
+    Parameters::Register<Parameters::SolverGrowthFactor<Scalar>>
+        ("The factor time steps are elongated after a successful substep");
+    Parameters::Register<Parameters::SolverMaxGrowth<Scalar>>
+        ("The maximum factor time steps are elongated after a report step");
+    Parameters::Register<Parameters::SolverMaxTimeStepInDays<Scalar>>
+        ("The maximum size of a time step in days");
+    Parameters::Register<Parameters::SolverMinTimeStep<Scalar>>
+        ("The minimum size of a time step in days for field and "
+         "metric and hours for lab. If a step cannot converge without "
+         "getting cut below this step size the simulator will stop");
+    Parameters::Register<Parameters::SolverRestartFactor<Scalar>>
+        ("The factor time steps are elongated after restarts");
+    Parameters::Register<Parameters::TimeStepAfterEventInDays<Scalar>>
+        ("Time step size of the first time step after an event "
+         "occurs during the simulation in days");
+}
+
+template void registerEclTimeSteppingParameters<double>();
+
+} // namespace Opm

--- a/opm/simulators/timestepping/EclTimeSteppingParams.hpp
+++ b/opm/simulators/timestepping/EclTimeSteppingParams.hpp
@@ -23,9 +23,6 @@
 #ifndef OPM_ECL_TIMESTEPPING_PARAMS_HPP
 #define OPM_ECL_TIMESTEPPING_PARAMS_HPP
 
-#include <opm/models/utils/basicproperties.hh>
-#include <opm/models/utils/propertysystem.hh>
-
 namespace Opm::Parameters {
 
 struct EnableTuning { static constexpr bool value = false; };
@@ -47,31 +44,12 @@ struct SolverRestartFactor { static constexpr Scalar value = 0.33; };
 template<class Scalar>
 struct TimeStepAfterEventInDays { static constexpr Scalar value = -1.0; };
 
-} // namespace Opm::Properties
+} // namespace Opm::Parameters
 
 namespace Opm {
 
 template<class Scalar>
-void registerEclTimeSteppingParameters()
-{
-    Parameters::Register<Parameters::EnableTuning>
-        ("Honor some aspects of the TUNING keyword.");
-    Parameters::Register<Parameters::SolverGrowthFactor<Scalar>>
-        ("The factor time steps are elongated after a successful substep");
-    Parameters::Register<Parameters::SolverMaxGrowth<Scalar>>
-        ("The maximum factor time steps are elongated after a report step");
-    Parameters::Register<Parameters::SolverMaxTimeStepInDays<Scalar>>
-        ("The maximum size of a time step in days");
-    Parameters::Register<Parameters::SolverMinTimeStep<Scalar>>
-        ("The minimum size of a time step in days for field and "
-         "metric and hours for lab. If a step cannot converge without "
-         "getting cut below this step size the simulator will stop");
-    Parameters::Register<Parameters::SolverRestartFactor<Scalar>>
-        ("The factor time steps are elongated after restarts");
-    Parameters::Register<Parameters::TimeStepAfterEventInDays<Scalar>>
-        ("Time step size of the first time step after an event "
-         "occurs during the simulation in days");
-}
+void registerEclTimeSteppingParameters();
 
 } // namespace Opm
 

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -98,8 +98,6 @@ template<class Scalar> class WellContributions;
         {
         public:
             // ---------      Types      ---------
-            using ModelParameters = BlackoilModelParameters<TypeTag>;
-
             using Grid = GetPropType<TypeTag, Properties::Grid>;
             using EquilGrid = GetPropType<TypeTag, Properties::EquilGrid>;
             using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
@@ -117,6 +115,9 @@ template<class Scalar> class WellContributions;
                 typename BlackoilWellModelGeneric<Scalar>::GLiftWellStateMap;
             using GLiftEclWells = typename GasLiftGroupInfo<Scalar>::GLiftEclWells;
             using GLiftSyncGroups = typename GasLiftSingleWellGeneric<Scalar>::GLiftSyncGroups;
+
+            using ModelParameters = BlackoilModelParameters<Scalar>;
+
             constexpr static std::size_t pressureVarIndex = GetPropType<TypeTag, Properties::Indices>::pressureSwitchIdx;
             typedef typename BaseAuxiliaryModule<TypeTag>::NeighborSet NeighborSet;
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -74,8 +74,6 @@ class WellInterface : public WellInterfaceIndices<GetPropType<TypeTag, Propertie
     using Base = WellInterfaceIndices<GetPropType<TypeTag, Properties::FluidSystem>,
                                       GetPropType<TypeTag, Properties::Indices>>;
 public:
-    using ModelParameters = BlackoilModelParameters<TypeTag>;
-
     using Grid = GetPropType<TypeTag, Properties::Grid>;
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
     using Scalar = GetPropType<TypeTag, Properties::Scalar>;
@@ -104,6 +102,8 @@ public:
     using WellInterfaceFluidSystem<FluidSystem>::Gas;
     using WellInterfaceFluidSystem<FluidSystem>::Oil;
     using WellInterfaceFluidSystem<FluidSystem>::Water;
+
+    using ModelParameters = BlackoilModelParameters<Scalar>;
 
     static constexpr bool has_solvent = getPropValue<TypeTag, Properties::EnableSolvent>();
     static constexpr bool has_zFraction = getPropValue<TypeTag, Properties::EnableExtbo>();

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -513,7 +513,7 @@ struct AquiferFixture {
         };
         Opm::ThreadManager<TT>::registerParameters();
         AdaptiveTimeStepping<TT>::registerParameters();
-        BlackoilModelParameters<TT>::registerParameters();
+        BlackoilModelParameters<double>::registerParameters();
         Parameters::Register<Parameters::EnableTerminalOutput>("Do *NOT* use!");
         setupParameters_<TT>(2, argv, /*registerParams=*/true);
         Opm::FlowGenericVanguard::setCommunication(std::make_unique<Opm::Parallel::Communication>());

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -233,7 +233,7 @@ struct EquilFixture {
         using namespace Opm;
         FlowGenericVanguard::setCommunication(std::make_unique<Opm::Parallel::Communication>());
         Opm::ThreadManager<TypeTag>::registerParameters();
-        BlackoilModelParameters<TypeTag>::registerParameters();
+        BlackoilModelParameters<double>::registerParameters();
         AdaptiveTimeStepping<TypeTag>::registerParameters();
         Parameters::Register<Parameters::EnableTerminalOutput>("Dummy added for the well model to compile.");
         registerAllParameters_<TypeTag>();

--- a/tests/test_glift1.cpp
+++ b/tests/test_glift1.cpp
@@ -88,7 +88,7 @@ initSimulator(const char *filename)
     Parameters::reset();
     registerAllParameters_<TypeTag>(false);
     registerEclTimeSteppingParameters<double>();
-    BlackoilModelParameters<TypeTag>::registerParameters();
+    BlackoilModelParameters<double>::registerParameters();
     Parameters::Register<Parameters::EnableTerminalOutput>("Do *NOT* use!");
     Opm::Parameters::SetDefault<Opm::Parameters::ThreadsPerProcess>(2);
     Parameters::endRegistration();

--- a/tests/test_wellmodel.cpp
+++ b/tests/test_wellmodel.cpp
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(TestStandardWellInput) {
     const auto& wells_ecl = setup_test.schedule->getWells(setup_test.current_timestep);
     BOOST_CHECK_EQUAL( wells_ecl.size(), 2);
     const Opm::Well& well = wells_ecl[1];
-    const Opm::BlackoilModelParameters<Opm::Properties::TTag::FlowProblem> param;
+    const Opm::BlackoilModelParameters<double> param;
 
     // For the conversion between the surface volume rate and resrevoir voidage rate
     typedef Opm::BlackOilFluidSystem<double> FluidSystem;
@@ -156,11 +156,11 @@ BOOST_AUTO_TEST_CASE(TestBehavoir) {
 
     {
         const int nw = wells_ecl.size();
-        const Opm::BlackoilModelParameters<Opm::Properties::TTag::FlowProblem> param;
+        const Opm::BlackoilModelParameters<double> param;
 
         for (int w = 0; w < nw; ++w) {
             // For the conversion between the surface volume rate and resrevoir voidage rate
-            typedef Opm::BlackOilFluidSystem<double> FluidSystem;
+            using FluidSystem = Opm::BlackOilFluidSystem<double>;
             using RateConverterType = Opm::RateConverter::
                 SurfaceToReservoirVoidage<FluidSystem, std::vector<int> >;
             // Compute reservoir volumes for RESV controls.


### PR DESCRIPTION
To avoid compiling the code in every simulator object.