### PR TITLE
fixed: do not try to hide parameters that are not registered without MPI

### DIFF
--- a/opm/simulators/flow/FlowGenericVanguard.cpp
+++ b/opm/simulators/flow/FlowGenericVanguard.cpp
@@ -447,15 +447,15 @@ void FlowGenericVanguard::registerParameters_()
          "distribution purposes. If empty, the built-in partitioning "
          "method will be employed.");
     Parameters::Hide<Parameters::ExternalPartition>();
+
+    Parameters::Hide<Parameters::ZoltanImbalanceTol<Scalar>>();
+    Parameters::Hide<Parameters::ZoltanParams>();
 #endif
     Parameters::Register<Parameters::AllowDistributedWells>
         ("Allow the perforations of a well to be distributed to interior of multiple processes");
     // register here for the use in the tests without BlackoilModelParameters
     Parameters::Register<Parameters::UseMultisegmentWell>
         ("Use the well model for multi-segment wells instead of the one for single-segment wells");
-
-    Parameters::Hide<Parameters::ZoltanImbalanceTol<Scalar>>();
-    Parameters::Hide<Parameters::ZoltanParams>();
 }
 
 template void FlowGenericVanguard::registerParameters_<double>();


### PR DESCRIPTION
Whoopsie..