### PR TITLE
changed: use ilu0 for alugrid test

### DIFF
--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -1495,6 +1495,7 @@ if(dune-alugrid_FOUND AND BUILD_FLOW_ALU_GRID)
                            SIMULATOR flow_blackoil_alugrid
                            ABS_TOL ${abs_tol}
                            REL_TOL ${coarse_rel_tol}
-                           DIR spe1)
+                           DIR spe1
+                           TEST_ARGS --linear-solver=ilu0)
 endif()
 


### PR DESCRIPTION
Trying to see if this resolves the serial-differ-from-parallel fallout from the new defaults.