### PR TITLE
BUGFIX Fix no wells case

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1690,7 +1690,7 @@ assignMassGasRate(data::Wells& wsrpt,
     using rt = data::Rates::opt;
     for (auto& wrpt : wsrpt) {
         auto& well_rates = wrpt.second.rates;
-        const auto w_mass_rate = well_rates.get(rt::gas) * gasDensity;
+        const auto w_mass_rate = well_rates.get(rt::gas, 0.0) * gasDensity;
         well_rates.set(rt::mass_gas, w_mass_rate);
     }
 }


### PR DESCRIPTION
Cases with CO2STORE and was broken by https://github.com/OPM/opm-simulators/pull/5528. This is a fix. 