### PR TITLE
Add mixed precision ilu0 on gpu

### DIFF
--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrix.cpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrix.cpp
@@ -82,6 +82,21 @@ GpuSparseMatrix<T>::GpuSparseMatrix(const T* nonZeroElements,
 }
 
 template <class T>
+GpuSparseMatrix<T>::GpuSparseMatrix(const GpuVector<int> rowIndices,
+                                  const GpuVector<int> columnIndices,
+                                  size_t blockSize)
+    : m_nonZeroElements(columnIndices.dim() * blockSize * blockSize)
+    , m_columnIndices(columnIndices)
+    , m_rowIndices(rowIndices)
+    , m_numberOfNonzeroBlocks(detail::to_int(columnIndices.dim()))
+    , m_numberOfRows(detail::to_int(rowIndices.dim()-1))
+    , m_blockSize(detail::to_int(blockSize))
+    , m_matrixDescription(detail::createMatrixDescription())
+    , m_cusparseHandle(detail::CuSparseHandle::getInstance())
+{
+}
+
+template <class T>
 GpuSparseMatrix<T>::~GpuSparseMatrix()
 {
     // empty

--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrix.cpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrix.cpp
@@ -82,8 +82,8 @@ GpuSparseMatrix<T>::GpuSparseMatrix(const T* nonZeroElements,
 }
 
 template <class T>
-GpuSparseMatrix<T>::GpuSparseMatrix(const GpuVector<int> rowIndices,
-                                  const GpuVector<int> columnIndices,
+GpuSparseMatrix<T>::GpuSparseMatrix(const GpuVector<int>& rowIndices,
+                                  const GpuVector<int>& columnIndices,
                                   size_t blockSize)
     : m_nonZeroElements(columnIndices.dim() * blockSize * blockSize)
     , m_columnIndices(columnIndices)

--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrix.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrix.hpp
@@ -67,6 +67,20 @@ public:
                    size_t blockSize,
                    size_t numberOfRows);
 
+    //! Create a sparse matrix by copying the sparsity structure of another matrix, not filling in the values
+    //!
+    //! \note Prefer to use the constructor taking a const reference to a matrix instead.
+    //!
+    //! \param[in] rowIndices      the row indices of the non-zero elements
+    //! \param[in] columnIndices   the column indices of the non-zero elements
+    //! \param[in] blockSize size of each block matrix (typically 3)
+    //!
+    //! \note We assume numberOfNonzeroBlocks, blockSize and numberOfRows all are representable as int due to
+    //!       restrictions in the current version of cusparse. This might change in future versions.
+    GpuSparseMatrix(const GpuVector<int> rowIndices,
+                   const GpuVector<int> columnIndices,
+                   size_t blockSize);
+
     /**
      * We don't want to be able to copy this for now (too much hassle in copying the cusparse resources)
      */

--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrix.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrix.hpp
@@ -77,8 +77,8 @@ public:
     //!
     //! \note We assume numberOfNonzeroBlocks, blockSize and numberOfRows all are representable as int due to
     //!       restrictions in the current version of cusparse. This might change in future versions.
-    GpuSparseMatrix(const GpuVector<int> rowIndices,
-                   const GpuVector<int> columnIndices,
+    GpuSparseMatrix(const GpuVector<int>& rowIndices,
+                   const GpuVector<int>& columnIndices,
                    size_t blockSize);
 
     /**

--- a/opm/simulators/linalg/gpuistl/detail/deviceBlockOperations.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/deviceBlockOperations.hpp
@@ -93,7 +93,7 @@ invBlockInPlace(T* __restrict__ block)
         T t14 = block[2] * block[6];
 
         T det = (t4 * block[8] - t6 * block[7] - t8 * block[8] + t10 * block[7] + t12 * block[5] - t14 * block[4]);
-        T t17 = T(T(1.0)) / det;
+        T t17 = T(1.0) / det;
 
         T matrix01 = block[1];
         T matrix00 = block[0];

--- a/opm/simulators/linalg/gpuistl/detail/deviceBlockOperations.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/deviceBlockOperations.hpp
@@ -230,8 +230,7 @@ matrixSubtraction(T* A, T* B)
     }
 }
 
-// TODO: possibly place somewhere else in this file
-// TODO: consider merging with existing block operations
+// B = A
 template<int blocksize, class ScalarInputType, class ScalarOutputType>
 __device__ __forceinline__ void
 moveBlock(const ScalarInputType* __restrict__ A, ScalarOutputType* __restrict__ B){
@@ -242,8 +241,8 @@ moveBlock(const ScalarInputType* __restrict__ A, ScalarOutputType* __restrict__ 
     }
 }
 
-// TODO: possibly place somewhere else in this file
 // TODO: consider merging with existing block operations
+// mixed precision general version of c = Ab
 template <int blocksize, class MatrixScalar, class VectorScalar, class ResultScalar, class ComputeScalar>
 __device__ __forceinline__ void
 mvMixedGeneral(const MatrixScalar* A, const VectorScalar* b, ResultScalar* c)
@@ -257,8 +256,8 @@ mvMixedGeneral(const MatrixScalar* A, const VectorScalar* b, ResultScalar* c)
     }
 }
 
-// TODO: possibly place somewhere else in this file
 // TODO: consider merging with existing block operations
+// Mixed precision general version of c -= Ab
 template <int blocksize, class MatrixScalar, class VectorScalar, class ResultScalar, class ComputeScalar>
 __device__ __forceinline__ void
 mmvMixedGeneral(const MatrixScalar* A, const VectorScalar* b, ResultScalar* c)

--- a/opm/simulators/linalg/gpuistl/detail/preconditionerKernels/ILU0Kernels.cu
+++ b/opm/simulators/linalg/gpuistl/detail/preconditionerKernels/ILU0Kernels.cu
@@ -120,17 +120,21 @@ namespace
         }
     }
 
-    template <class T, int blocksize>
-    __global__ void cuLUFactorizationSplit(T* reorderedLowerMat,
+    template <int blocksize, class InputScalar, class OutputScalar>
+    __global__ void cuLUFactorizationSplit(InputScalar* srcReorderedLowerMat,
                                            int* lowerRowIndices,
                                            int* lowerColIndices,
-                                           T* reorderedUpperMat,
+                                           InputScalar* srcReorderedUpperMat,
                                            int* upperRowIndices,
                                            int* upperColIndices,
-                                           T* diagonal,
+                                           InputScalar* srcDiagonal,
+                                           OutputScalar* dstReorderedLowerMat,
+                                           OutputScalar* dstReorderedUpperMat,
+                                           OutputScalar* dstDiagonal,
                                            int* reorderedToNatural,
                                            int* naturalToReordered,
                                            const int startIdx,
+                                           const bool copyResultToOtherMatrix,
                                            int rowsInLevelSet)
     {
         auto reorderedIdx = startIdx + blockDim.x * blockIdx.x + threadIdx.x;
@@ -155,9 +159,12 @@ namespace
 
                 // the DUNE implementation is inplace, and I need to take care to make sure
                 // this out of place implementation is equivalent
-                mmOverlap<T, blocksize>(&reorderedLowerMat[ij * scalarsInBlock],
-                                        &diagonal[j * scalarsInBlock],
-                                        &reorderedLowerMat[ij * scalarsInBlock]);
+                mmOverlap<InputScalar, blocksize>(&srcReorderedLowerMat[ij * scalarsInBlock],
+                                        &srcDiagonal[j * scalarsInBlock],
+                                        &srcReorderedLowerMat[ij * scalarsInBlock]);
+                if (copyResultToOtherMatrix){
+                    moveBlock<blocksize, InputScalar, OutputScalar>(&srcReorderedLowerMat[ij * scalarsInBlock], &dstReorderedLowerMat[ij * scalarsInBlock]);
+                }
 
                 // we have now accounted for an element under the diagonal and the diagonal element above it
                 // now iterate over the blocks that align in the
@@ -172,40 +179,53 @@ namespace
                 // the same block index might be found in the lower part of the matrix
                 while (!(ik == endOfRowIUpper && ikState == POSITION_TYPE::ABOVE_DIAG) && jk != endOfRowJ) {
 
-                    T* ikBlockPtr;
+                    InputScalar* ikBlockPtr;
+                    OutputScalar* dstIkBlockPtr;
                     int ikColumn;
                     if (ikState == POSITION_TYPE::UNDER_DIAG) {
-                        ikBlockPtr = &reorderedLowerMat[ik * scalarsInBlock];
+                        ikBlockPtr = &srcReorderedLowerMat[ik * scalarsInBlock];
+                        if (copyResultToOtherMatrix)
+                            dstIkBlockPtr = &dstReorderedLowerMat[ik * scalarsInBlock];
                         ikColumn = lowerColIndices[ik];
                     } else if (ikState == POSITION_TYPE::ON_DIAG) {
-                        ikBlockPtr = &diagonal[reorderedIdx * scalarsInBlock];
+                        ikBlockPtr = &srcDiagonal[reorderedIdx * scalarsInBlock];
+                        if (copyResultToOtherMatrix)
+                            dstIkBlockPtr = &dstDiagonal[reorderedIdx * scalarsInBlock];
                         ikColumn = naturalIdx;
                     } else { // ikState == POSITION_TYPE::ABOVE_DIAG
-                        ikBlockPtr = &reorderedUpperMat[ik * scalarsInBlock];
+                        ikBlockPtr = &srcReorderedUpperMat[ik * scalarsInBlock];
+                        if (copyResultToOtherMatrix)
+                            dstIkBlockPtr = &dstReorderedUpperMat[ik * scalarsInBlock];
                         ikColumn = upperColIndices[ik];
                     }
 
                     if (ikColumn == upperColIndices[jk]) {
                         // A_jk = A_ij * A_jk
-                        T tmp[scalarsInBlock] = {0};
+                        InputScalar tmp[scalarsInBlock] = {0};
 
-                        mmNoOverlap<T, blocksize>(
-                            &reorderedLowerMat[ij * scalarsInBlock], &reorderedUpperMat[jk * scalarsInBlock], tmp);
-                        matrixSubtraction<T, blocksize>(ikBlockPtr, tmp);
+                        mmNoOverlap<InputScalar, blocksize>(
+                            &srcReorderedLowerMat[ij * scalarsInBlock], &srcReorderedUpperMat[jk * scalarsInBlock], tmp);
+                        matrixSubtraction<InputScalar, blocksize>(ikBlockPtr, tmp);
                         incrementAcrossSplitStructure(ik, ikState, endOfRowILower, startOfRowIUpper);
-                        ;
                         ++jk;
                     } else {
                         if (ikColumn < upperColIndices[jk]) {
                             incrementAcrossSplitStructure(ik, ikState, endOfRowILower, startOfRowIUpper);
-                            ;
                         } else {
                             ++jk;
                         }
                     }
                 }
             }
-            invBlockInPlace<T, blocksize>(&diagonal[reorderedIdx * scalarsInBlock]);
+            invBlockInPlace<InputScalar, blocksize>(&srcDiagonal[reorderedIdx * scalarsInBlock]);
+            if (copyResultToOtherMatrix){
+                moveBlock<blocksize, InputScalar, OutputScalar>(&srcDiagonal[reorderedIdx * scalarsInBlock], &dstDiagonal[reorderedIdx * scalarsInBlock]);
+
+                // also move all values above the diagonal on this row
+                for (int block = startOfRowIUpper; block < endOfRowIUpper; ++block) {
+                    moveBlock<blocksize, InputScalar, OutputScalar>(&srcReorderedUpperMat[block * scalarsInBlock], &dstReorderedUpperMat[block * scalarsInBlock]);
+                }
+            }
         }
     }
 
@@ -266,15 +286,15 @@ namespace
         }
     }
 
-    template <class T, int blocksize>
-    __global__ void cuSolveLowerLevelSetSplit(T* mat,
+    template <int blocksize, class LinearSolverScalar, class MatrixScalar>
+    __global__ void cuSolveLowerLevelSetSplit(MatrixScalar* mat,
                                               int* rowIndices,
                                               int* colIndices,
                                               int* indexConversion,
                                               int startIdx,
                                               int rowsInLevelSet,
-                                              const T* d,
-                                              T* v)
+                                              const LinearSolverScalar* d,
+                                              LinearSolverScalar* v)
     {
         auto reorderedIdx = startIdx + (blockDim.x * blockIdx.x + threadIdx.x);
         if (reorderedIdx < rowsInLevelSet + startIdx) {
@@ -282,30 +302,31 @@ namespace
             const size_t nnzIdxLim = rowIndices[reorderedIdx + 1];
             const int naturalRowIdx = indexConversion[reorderedIdx];
 
-            T rhs[blocksize];
+            LinearSolverScalar rhs[blocksize];
             for (int i = 0; i < blocksize; i++) {
                 rhs[i] = d[naturalRowIdx * blocksize + i];
             }
 
             for (int block = nnzIdx; block < nnzIdxLim; ++block) {
                 const int col = colIndices[block];
-                mmv<T, blocksize>(&mat[block * blocksize * blocksize], &v[col * blocksize], rhs);
+                mmvMixedGeneral<blocksize, MatrixScalar, LinearSolverScalar, LinearSolverScalar, LinearSolverScalar>(
+                    &mat[block * blocksize * blocksize], &v[col * blocksize], rhs);
             }
             for (int i = 0; i < blocksize; ++i) {
-                v[naturalRowIdx * blocksize + i] = rhs[i];
+                v[naturalRowIdx * blocksize + i] = LinearSolverScalar(rhs[i]);
             }
         }
     }
 
-    template <class T, int blocksize>
-    __global__ void cuSolveUpperLevelSetSplit(T* mat,
+    template <int blocksize, class LinearSolverScalar, class MatrixScalar>
+    __global__ void cuSolveUpperLevelSetSplit(MatrixScalar* mat,
                                               int* rowIndices,
                                               int* colIndices,
                                               int* indexConversion,
                                               int startIdx,
                                               int rowsInLevelSet,
-                                              const T* dInv,
-                                              T* v)
+                                              const MatrixScalar* dInv,
+                                              LinearSolverScalar* v)
     {
         auto reorderedIdx = startIdx + (blockDim.x * blockIdx.x + threadIdx.x);
         if (reorderedIdx < rowsInLevelSet + startIdx) {
@@ -313,17 +334,17 @@ namespace
             const size_t nnzIdxLim = rowIndices[reorderedIdx + 1];
             const int naturalRowIdx = indexConversion[reorderedIdx];
 
-            T rhs[blocksize];
+            LinearSolverScalar rhs[blocksize];
             for (int i = 0; i < blocksize; i++) {
                 rhs[i] = v[naturalRowIdx * blocksize + i];
             }
 
             for (int block = nnzIdx; block < nnzIdxLim; ++block) {
                 const int col = colIndices[block];
-                mmv<T, blocksize>(&mat[block * blocksize * blocksize], &v[col * blocksize], rhs);
+                mmvMixedGeneral<blocksize, MatrixScalar, LinearSolverScalar, LinearSolverScalar, LinearSolverScalar>(&mat[block * blocksize * blocksize], &v[col * blocksize], rhs);
             }
 
-            mv<T, blocksize>(&dInv[reorderedIdx * blocksize * blocksize], rhs, &v[naturalRowIdx * blocksize]);
+            mvMixedGeneral<blocksize, MatrixScalar, LinearSolverScalar, LinearSolverScalar, LinearSolverScalar>(&dInv[reorderedIdx * blocksize * blocksize], rhs, &v[naturalRowIdx * blocksize]);
         }
     }
 } // namespace
@@ -365,41 +386,41 @@ solveUpperLevelSet(T* reorderedMat,
         reorderedMat, rowIndices, colIndices, indexConversion, startIdx, rowsInLevelSet, v);
 }
 
-template <class T, int blocksize>
+template <int blocksize, class LinearSolverScalar, class MatrixScalar>
 void
-solveLowerLevelSetSplit(T* reorderedMat,
+solveLowerLevelSetSplit(MatrixScalar* reorderedMat,
                         int* rowIndices,
                         int* colIndices,
                         int* indexConversion,
                         int startIdx,
                         int rowsInLevelSet,
-                        const T* d,
-                        T* v,
+                        const LinearSolverScalar* d,
+                        LinearSolverScalar* v,
                         int thrBlockSize)
 {
     int threadBlockSize = ::Opm::gpuistl::detail::getCudaRecomendedThreadBlockSize(
-        cuSolveLowerLevelSetSplit<T, blocksize>, thrBlockSize);
+        cuSolveLowerLevelSetSplit<blocksize, LinearSolverScalar, MatrixScalar>, thrBlockSize);
     int nThreadBlocks = ::Opm::gpuistl::detail::getNumberOfBlocks(rowsInLevelSet, threadBlockSize);
-    cuSolveLowerLevelSetSplit<T, blocksize><<<nThreadBlocks, threadBlockSize>>>(
+    cuSolveLowerLevelSetSplit<blocksize, LinearSolverScalar, MatrixScalar><<<nThreadBlocks, threadBlockSize>>>(
         reorderedMat, rowIndices, colIndices, indexConversion, startIdx, rowsInLevelSet, d, v);
 }
 // perform the upper solve for all rows in the same level set
-template <class T, int blocksize>
+template <int blocksize, class LinearSolverScalar, class MatrixScalar>
 void
-solveUpperLevelSetSplit(T* reorderedMat,
+solveUpperLevelSetSplit(MatrixScalar* reorderedMat,
                         int* rowIndices,
                         int* colIndices,
                         int* indexConversion,
                         int startIdx,
                         int rowsInLevelSet,
-                        const T* dInv,
-                        T* v,
+                        const MatrixScalar* dInv,
+                        LinearSolverScalar* v,
                         int thrBlockSize)
 {
     int threadBlockSize = ::Opm::gpuistl::detail::getCudaRecomendedThreadBlockSize(
-        cuSolveUpperLevelSetSplit<T, blocksize>, thrBlockSize);
+        cuSolveUpperLevelSetSplit<blocksize, LinearSolverScalar, MatrixScalar>, thrBlockSize);
     int nThreadBlocks = ::Opm::gpuistl::detail::getNumberOfBlocks(rowsInLevelSet, threadBlockSize);
-    cuSolveUpperLevelSetSplit<T, blocksize><<<nThreadBlocks, threadBlockSize>>>(
+    cuSolveUpperLevelSetSplit<blocksize, LinearSolverScalar, MatrixScalar><<<nThreadBlocks, threadBlockSize>>>(
         reorderedMat, rowIndices, colIndices, indexConversion, startIdx, rowsInLevelSet, dInv, v);
 }
 
@@ -421,34 +442,42 @@ LUFactorization(T* srcMatrix,
         srcMatrix, srcRowIndices, srcColumnIndices, naturalToReordered, reorderedToNatual, rowsInLevelSet, startIdx);
 }
 
-template <class T, int blocksize>
+template <int blocksize, class InputScalar, class OutputScalar>
 void
-LUFactorizationSplit(T* reorderedLowerMat,
+LUFactorizationSplit(InputScalar* srcReorderedLowerMat,
                      int* lowerRowIndices,
                      int* lowerColIndices,
-                     T* reorderedUpperMat,
+                     InputScalar* reorderedUpperMat,
                      int* upperRowIndices,
                      int* upperColIndices,
-                     T* diagonal,
+                     InputScalar* srcDiagonal,
+                     OutputScalar* dstReorderedLowerMat,
+                     OutputScalar* dstReorderedUpperMat,
+                     OutputScalar* dstDiagonal,
                      int* reorderedToNatural,
                      int* naturalToReordered,
                      const int startIdx,
                      int rowsInLevelSet,
+                     bool copyResultToOtherMatrix,
                      int thrBlockSize)
 {
     int threadBlockSize
-        = ::Opm::gpuistl::detail::getCudaRecomendedThreadBlockSize(cuLUFactorizationSplit<T, blocksize>, thrBlockSize);
+        = ::Opm::gpuistl::detail::getCudaRecomendedThreadBlockSize(cuLUFactorizationSplit<blocksize, InputScalar, OutputScalar>, thrBlockSize);
     int nThreadBlocks = ::Opm::gpuistl::detail::getNumberOfBlocks(rowsInLevelSet, threadBlockSize);
-    cuLUFactorizationSplit<T, blocksize><<<nThreadBlocks, threadBlockSize>>>(reorderedLowerMat,
+    cuLUFactorizationSplit<blocksize, InputScalar, OutputScalar><<<nThreadBlocks, threadBlockSize>>>(srcReorderedLowerMat,
                                                                              lowerRowIndices,
                                                                              lowerColIndices,
                                                                              reorderedUpperMat,
                                                                              upperRowIndices,
                                                                              upperColIndices,
-                                                                             diagonal,
+                                                                             srcDiagonal,
+                                                                             dstReorderedLowerMat,
+                                                                             dstReorderedUpperMat,
+                                                                             dstDiagonal,
                                                                              reorderedToNatural,
                                                                              naturalToReordered,
                                                                              startIdx,
+                                                                             copyResultToOtherMatrix,
                                                                              rowsInLevelSet);
 }
 
@@ -456,10 +485,12 @@ LUFactorizationSplit(T* reorderedLowerMat,
     template void solveUpperLevelSet<T, blocksize>(T*, int*, int*, int*, int, int, T*, int);                           \
     template void solveLowerLevelSet<T, blocksize>(T*, int*, int*, int*, int, int, const T*, T*, int);                 \
     template void LUFactorization<T, blocksize>(T*, int*, int*, int*, int*, size_t, int, int);                         \
-    template void LUFactorizationSplit<T, blocksize>(                                                                  \
-        T*, int*, int*, T*, int*, int*, T*, int*, int*, const int, int, int);                                          \
-    template void solveUpperLevelSetSplit<T, blocksize>(T*, int*, int*, int*, int, int, const T*, T*, int);            \
-    template void solveLowerLevelSetSplit<T, blocksize>(T*, int*, int*, int*, int, int, const T*, T*, int);
+    template void LUFactorizationSplit<blocksize, T, float>(                                                                  \
+        T*, int*, int*, T*, int*, int*, T*, float*, float*, float*, int*, int*, const int, int, bool, int);                                          \
+    template void LUFactorizationSplit<blocksize, T, double>(                                                                  \
+        T*, int*, int*, T*, int*, int*, T*, double*, double*, double*, int*, int*, const int, int, bool, int);             
+    // template void solveUpperLevelSetSplit<T, blocksize>(T*, int*, int*, int*, int, int, const T*, T*, int);            \
+    // template void solveLowerLevelSetSplit<T, blocksize>(T*, int*, int*, int*, int, int, const T*, T*, int);
 
 INSTANTIATE_KERNEL_WRAPPERS(float, 1);
 INSTANTIATE_KERNEL_WRAPPERS(float, 2);
@@ -473,4 +504,26 @@ INSTANTIATE_KERNEL_WRAPPERS(double, 3);
 INSTANTIATE_KERNEL_WRAPPERS(double, 4);
 INSTANTIATE_KERNEL_WRAPPERS(double, 5);
 INSTANTIATE_KERNEL_WRAPPERS(double, 6);
+
+#define INSTANTIATE_MIXED_PRECISION_KERNEL_WRAPPERS(blocksize) \
+    /* double preconditioner */\
+    template void solveLowerLevelSetSplit<blocksize, double, double>(double*, int*, int*, int*, int, int, const double*, double*, int); \
+    /* float matrix, double compute preconditioner */\
+    template void solveLowerLevelSetSplit<blocksize, double, float>(float*, int*, int*, int*, int, int, const double*, double*, int);   \
+    /* float preconditioner */\
+    template void solveLowerLevelSetSplit<blocksize, float, float>(float*, int*, int*, int*, int, int, const float*, float*, int);       \
+    \
+    /* double preconditioner */\
+    template void solveUpperLevelSetSplit<blocksize, double, double>(double*, int*, int*, int*, int, int, const double*, double*, int);            \
+    /* float matrix, double compute preconditioner */\
+    template void solveUpperLevelSetSplit<blocksize, double, float>(float*, int*, int*, int*, int, int, const float*, double*, int);            \
+    /* float preconditioner */\
+    template void solveUpperLevelSetSplit<blocksize, float, float>(float*, int*, int*, int*, int, int, const float*, float*, int);            \
+
+INSTANTIATE_MIXED_PRECISION_KERNEL_WRAPPERS(1);
+INSTANTIATE_MIXED_PRECISION_KERNEL_WRAPPERS(2);
+INSTANTIATE_MIXED_PRECISION_KERNEL_WRAPPERS(3);
+INSTANTIATE_MIXED_PRECISION_KERNEL_WRAPPERS(4);
+INSTANTIATE_MIXED_PRECISION_KERNEL_WRAPPERS(5);
+INSTANTIATE_MIXED_PRECISION_KERNEL_WRAPPERS(6);
 } // namespace Opm::gpuistl::detail::ILU0

--- a/opm/simulators/linalg/gpuistl/detail/preconditionerKernels/ILU0Kernels.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/preconditionerKernels/ILU0Kernels.hpp
@@ -176,7 +176,7 @@ void LUFactorization(T* reorderedMat,
  * function
  * @param threadBlockSize The number of threads per threadblock. Leave as -1 if no blocksize is already chosen
  */
-template <int blocksize, class InputScalar, class OutputScalar>
+template <int blocksize, class InputScalar, class OutputScalar, bool copyResultToOtherMatrix>
 void LUFactorizationSplit(InputScalar* srcReorderedLowerMat,
                           int* lowerRowIndices,
                           int* lowerColIndices,
@@ -191,7 +191,6 @@ void LUFactorizationSplit(InputScalar* srcReorderedLowerMat,
                           int* naturalToReordered,
                           int startIdx,
                           int rowsInLevelSet,
-                          bool copyResultToOtherMatrix,
                           int threadBlockSize);
 
 } // namespace Opm::gpuistl::detail::ILU0

--- a/opm/simulators/linalg/gpuistl/detail/preconditionerKernels/ILU0Kernels.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/preconditionerKernels/ILU0Kernels.hpp
@@ -89,15 +89,15 @@ void solveLowerLevelSet(T* reorderedMat,
  * solve
  * @param threadBlockSize The number of threads per threadblock. Leave as -1 if no blocksize is already chosen
  */
-template <class T, int blocksize>
-void solveUpperLevelSetSplit(T* reorderedMat,
+template <int blocksize, class LinearSolverScalar, class MatrixScalar>
+void solveUpperLevelSetSplit(MatrixScalar* reorderedMat,
                              int* rowIndices,
                              int* colIndices,
                              int* indexConversion,
                              int startIdx,
                              int rowsInLevelSet,
-                             const T* dInv,
-                             T* v,
+                             const MatrixScalar* dInv,
+                             LinearSolverScalar* v,
                              int threadBlockSize);
 
 /**
@@ -117,15 +117,15 @@ void solveUpperLevelSetSplit(T* reorderedMat,
  * solve
  * @param threadBlockSize The number of threads per threadblock. Leave as -1 if no blocksize is already chosen
  */
-template <class T, int blocksize>
-void solveLowerLevelSetSplit(T* reorderedLowerMat,
+template <int blocksize, class LinearSolverScalar, class MatrixScalar>
+void solveLowerLevelSetSplit(MatrixScalar* reorderedLowerMat,
                              int* rowIndices,
                              int* colIndices,
                              int* indexConversion,
                              int startIdx,
                              int rowsInLevelSet,
-                             const T* d,
-                             T* v,
+                             const LinearSolverScalar* d,
+                             LinearSolverScalar* v,
                              int threadBlockSize);
 
 /**
@@ -155,6 +155,7 @@ void LUFactorization(T* reorderedMat,
                      int threadBlockSize);
 
 /**
+ * TODO: update this doucmentation
  * @brief Computes the ILU0 factorization in-place of a bcsr matrix stored in a split format (lower, diagonal and upper
  * triangular part)
  * @param [out] reorderedLowerMat pointer to GPU memory containing nonzerovalues of the strictly lower triangular sparse
@@ -175,18 +176,22 @@ void LUFactorization(T* reorderedMat,
  * function
  * @param threadBlockSize The number of threads per threadblock. Leave as -1 if no blocksize is already chosen
  */
-template <class T, int blocksize>
-void LUFactorizationSplit(T* reorderedLowerMat,
+template <int blocksize, class InputScalar, class OutputScalar>
+void LUFactorizationSplit(InputScalar* srcReorderedLowerMat,
                           int* lowerRowIndices,
                           int* lowerColIndices,
-                          T* reorderedUpperMat,
+                          InputScalar* srcReorderedUpperMat,
                           int* upperRowIndices,
                           int* upperColIndices,
-                          T* diagonal,
+                          InputScalar* srcDiagonal,
+                          OutputScalar* dstReorderedLowerMat,
+                          OutputScalar* dstReorderedUpperMat,
+                          OutputScalar* dstDiagonal,
                           int* reorderedToNatural,
                           int* naturalToReordered,
                           int startIdx,
                           int rowsInLevelSet,
+                          bool copyResultToOtherMatrix,
                           int threadBlockSize);
 
 } // namespace Opm::gpuistl::detail::ILU0


### PR DESCRIPTION
This PR introduces a mixed precision version of ILU0 on the GPU.
By storing the factorized ILU matrix in float the apply function will be sped up as the memory transfers needed are faster. To ensure high accuracy the factorization is still computed in double, the result is just casted down later, and the result is casted back up to double inside the apply when the values are needed for computation. This has been shown to give significant speedups on very large cases (1.4 apply speedup on 8M cell spe11c), while there is little to none iteration count increase. This has been tested on spe1, spe11c (1M and 8M cells), Norne, and Sleipner.

### Simulation results (LIT = linear iterations, NIT = non-linear iterations, Apply = runtime of average apply in ms)

| ILU0 version (GPU = Pro W7900)       | SPE1 (LIT) | SPE1 (NIT) | SPE1 (Apply) | SPE11C 1M (LIT) | SPE11C 1M (NIT) | SPE11C 1M (Apply) | SPE11C 8M (LIT) | SPE11C 8M (NIT) | SPE11C 8M (Apply) |
|----------------------------------|------------|------------|--------------|-----------------|-----------------|------------------|-----------------|-----------------|-------------------|
| ILU0 FP64                        | 3080       | 411        | 0.32         | 64282           | 2650            | 4.32             | 233486          | 5222            | 20.01             |
| ILU0 FP32                        | 3078       | 407        | 0.30         | 104262          | 3425            | 3.47             | 369997          | 7674            | 13.82             |
| ILU0 Mixed Precison         | 3072       | 410        | 0.32         | 68150           | 2698            | 3.82             | 234932          | 5205            | 14.69             |

---

| ILU0 version (GPU = Pro W7900)       | Norne (LIT) | Norne (NIT) | Norne (Apply) | Sleipner (LIT) | Sleipner (NIT) | Sleipner (Apply) |
|----------------------------------|-------------|-------------|---------------|----------------|----------------|------------------|
| ILU0 FP64                        | 34851       | 2400        | 3.10          | 1146555        | 31432          | 5.57             |
| ILU0 FP32                        | 36775       | 2684        | 2.48          | 3498350        | 69670          | 5.00             |
| ILU0 Mixed Precision        | 35613       | 2636        | 3.35          | 1125122        | 31185          | 5.35             |

---