### PR TITLE
Make local solver in NLDD a runtime specified ISTLSolver

### DIFF
--- a/opm/simulators/flow/BlackoilModelNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelNldd.hpp
@@ -160,14 +160,11 @@ public:
             // only. This must be addressed before going parallel.
             const auto& eclState = model_.simulator().vanguard().eclState();
             FlowLinearSolverParameters loc_param;
+            loc_param.is_nldd_local_solver_ = true;
             loc_param.init(eclState.getSimulationConfig().useCPR());
             // Override solver type with umfpack if small domain.
-            // Otherwise hardcode to ILU0
             if (domains_[index].cells.size() < 200) {
                 loc_param.linsolver_ = "umfpack";
-            } else {
-                loc_param.linsolver_ = "ilu0";
-                loc_param.linear_solver_reduction_ = 1e-2;
             }
             loc_param.linear_solver_print_json_definition_ = false;
             const bool force_serial = true;

--- a/opm/simulators/linalg/FlowLinearSolverParameters.hpp
+++ b/opm/simulators/linalg/FlowLinearSolverParameters.hpp
@@ -63,9 +63,11 @@ struct LinearSolverBackend<TypeTag, TTag::FlowIstlSolverParams>
 namespace Opm::Parameters {
 
 struct LinearSolverReduction { static constexpr double value = 1e-2; };
+struct NlddLocalLinearSolverReduction { static constexpr double value = 1e-2; };
 struct RelaxedLinearSolverReduction { static constexpr double value = 1e-2; };
 struct IluRelaxation { static constexpr double value = 0.9; };
 struct LinearSolverMaxIter { static constexpr int value = 200; };
+struct NlddLocalLinearSolverMaxIter { static constexpr int value = 200; };
 struct LinearSolverRestart { static constexpr int value = 40; };
 struct IluFillinLevel { static constexpr int value = 0; };
 struct MiluVariant { static constexpr auto value = "ILU"; };
@@ -75,6 +77,7 @@ struct UseGmres { static constexpr bool value = false; };
 struct LinearSolverIgnoreConvergenceFailure { static constexpr bool value = false; };
 struct ScaleLinearSystem { static constexpr bool value = false; };
 struct LinearSolver { static constexpr auto value = "cprw"; };
+struct NlddLocalLinearSolver { static constexpr auto value = "ilu0"; };
 struct LinearSolverPrintJsonDefinition { static constexpr auto value = true; };
 struct CprReuseSetup { static constexpr int value = 4; };
 struct CprReuseInterval { static constexpr int value = 30; };
@@ -103,6 +106,7 @@ struct FlowLinearSolverParameters
     bool   newton_use_gmres_;
     bool   ignoreConvergenceFailure_;
     bool scale_linear_system_;
+    bool is_nldd_local_solver_;
     std::string linsolver_;
     bool linear_solver_print_json_definition_;
     int cpr_reuse_setup_;

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -238,12 +238,20 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
                 }
                 // ------------
             } else {
-                // Do a normal linear solver setup.
                 assert(parameters_.size() == 1);
                 assert(prm_.empty());
-                prm_.push_back(setupPropertyTree(parameters_[0],
-                                                 Parameters::IsSet<Parameters::LinearSolverMaxIter>(),
-                                                 Parameters::IsSet<Parameters::LinearSolverReduction>()));
+
+                // Do a normal linear solver setup.
+                if (parameters_[0].is_nldd_local_solver_) {
+                    prm_.push_back(setupPropertyTree(parameters_[0],
+                                                     Parameters::IsSet<Parameters::NlddLocalLinearSolverMaxIter>(),
+                                                     Parameters::IsSet<Parameters::NlddLocalLinearSolverReduction>()));
+                }
+                else {
+                    prm_.push_back(setupPropertyTree(parameters_[0],
+                                                     Parameters::IsSet<Parameters::LinearSolverMaxIter>(),
+                                                     Parameters::IsSet<Parameters::LinearSolverReduction>()));
+                }
             }
             flexibleSolver_.resize(prm_.size());
 


### PR DESCRIPTION
For the NLDD nonlinear solver, we are solving a linear system locally for each subdomain. Currently the linear solver for this task is hardcoded to use ilu0 and default max iterations and reduction tolerance. For more flexibility and easier experiments I propose we set this as a command line argument using the non-invasive changes in this PR.