### PR TITLE
Add Oil Phase Saturation Function Consistency Checks

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -188,6 +188,8 @@ list (APPEND MAIN_SOURCE_FILES
 
 if (HAVE_ECL_INPUT)
   list (APPEND MAIN_SOURCE_FILES
+    opm/simulators/utils/satfunc/OilPhaseConsistencyChecks.cpp
+    opm/simulators/utils/satfunc/PhaseCheckBase.cpp
     opm/simulators/utils/satfunc/SatfuncConsistencyChecks.cpp
   )
 endif()
@@ -372,6 +374,7 @@ list (APPEND TEST_SOURCE_FILES
 if (HAVE_ECL_INPUT)
   list(APPEND TEST_SOURCE_FILES
     tests/test_nonnc.cpp
+    tests/test_OilSatfuncConsistencyChecks.cpp
     tests/test_SatfuncConsistencyChecks.cpp
     tests/test_SatfuncConsistencyChecks_parallel.cpp
   )
@@ -977,6 +980,8 @@ endif()
 
 if (HAVE_ECL_INPUT)
   list (APPEND PUBLIC_HEADER_FILES
+    opm/simulators/utils/satfunc/OilPhaseConsistencyChecks.hpp
+    opm/simulators/utils/satfunc/PhaseCheckBase.hpp
     opm/simulators/utils/satfunc/SatfuncConsistencyChecks.hpp
   )
 endif()

--- a/opm/simulators/utils/satfunc/OilPhaseConsistencyChecks.cpp
+++ b/opm/simulators/utils/satfunc/OilPhaseConsistencyChecks.cpp
@@ -1,0 +1,264 @@
+/*
+  Copyright 2024 Equinor AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#include <opm/simulators/utils/satfunc/OilPhaseConsistencyChecks.hpp>
+
+#include <opm/simulators/utils/satfunc/PhaseCheckBase.hpp>
+
+#include <opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp>
+
+// ---------------------------------------------------------------------------
+
+template <typename Scalar>
+void Opm::Satfunc::PhaseChecks::Oil::SOcr_GO<Scalar>::
+testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
+{
+    this->sogcr_ = endPoints.Sogcr;
+
+    if (! std::isfinite(this->sogcr_)) {
+        this->setViolated();
+        this->setCritical();
+
+        return;
+    }
+
+    const auto low = this->sogcr_ < Scalar{0};
+    const auto high = ! (this->sogcr_ < Scalar{1});
+
+    if (low || high) {
+        this->setViolated();
+        this->setCritical();
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+template <typename Scalar>
+void Opm::Satfunc::PhaseChecks::Oil::SOmin_GO<Scalar>::
+testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
+{
+    this->swl_ = endPoints.Swl;
+    this->sgu_ = endPoints.Sgu;
+
+    if (! std::isfinite(this->swl_) ||
+        ! std::isfinite(this->sgu_))
+    {
+        this->setViolated();
+        this->setCritical();
+
+        return;
+    }
+
+    if (this->swl_ + this->sgu_ > Scalar{1}) {
+        this->setViolated();
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+template <typename Scalar>
+void Opm::Satfunc::PhaseChecks::Oil::MobileOil_GO_SGmin<Scalar>::
+testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
+{
+    this->swl_   = endPoints.Swl;
+    this->sgl_   = endPoints.Sgl;
+    this->sogcr_ = endPoints.Sogcr;
+
+    if (! std::isfinite(this->swl_) ||
+        ! std::isfinite(this->sgl_) ||
+        ! std::isfinite(this->sogcr_))
+    {
+        this->setViolated();
+        this->setCritical();
+
+        return;
+    }
+
+    if (! (this->sogcr_ < Scalar{1} - this->swl_ - this->sgl_)) {
+        this->setViolated();
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+template <typename Scalar>
+void Opm::Satfunc::PhaseChecks::Oil::MobileOil_GO_SGcr<Scalar>::
+testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
+{
+    this->swl_   = endPoints.Swl;
+    this->sgcr_  = endPoints.Sgcr;
+    this->sogcr_ = endPoints.Sogcr;
+
+    if (! std::isfinite(this->swl_) ||
+        ! std::isfinite(this->sgcr_) ||
+        ! std::isfinite(this->sogcr_))
+    {
+        this->setViolated();
+        this->setCritical();
+
+        return;
+    }
+
+    if (! (this->sogcr_ < Scalar{1} - this->swl_ - this->sgcr_)) {
+        this->setViolated();
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+template <typename Scalar>
+void Opm::Satfunc::PhaseChecks::Oil::SOcr_OW<Scalar>::
+testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
+{
+    this->sowcr_ = endPoints.Sowcr;
+
+    if (! std::isfinite(this->sowcr_)) {
+        this->setViolated();
+        this->setCritical();
+
+        return;
+    }
+
+    const auto low = this->sowcr_ < Scalar{0};
+    const auto high = ! (this->sowcr_ < Scalar{1});
+
+    if (low || high) {
+        this->setViolated();
+        this->setCritical();
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+template <typename Scalar>
+void Opm::Satfunc::PhaseChecks::Oil::SOmin_OW<Scalar>::
+testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
+{
+    this->sgl_ = endPoints.Sgl;
+    this->swu_ = endPoints.Swu;
+
+    if (! std::isfinite(this->sgl_) ||
+        ! std::isfinite(this->swu_))
+    {
+        this->setViolated();
+        this->setCritical();
+
+        return;
+    }
+
+    if (this->sgl_ + this->swu_ > Scalar{1}) {
+        this->setViolated();
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+template <typename Scalar>
+void Opm::Satfunc::PhaseChecks::Oil::MobileOil_OW_SWmin<Scalar>::
+testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
+{
+    this->swl_   = endPoints.Swl;
+    this->sgl_   = endPoints.Sgl;
+    this->sowcr_ = endPoints.Sowcr;
+
+    if (! std::isfinite(this->swl_) ||
+        ! std::isfinite(this->sgl_) ||
+        ! std::isfinite(this->sowcr_))
+    {
+        this->setViolated();
+        this->setCritical();
+
+        return;
+    }
+
+    if (! (this->sowcr_ < Scalar{1} - this->swl_ - this->sgl_)) {
+        this->setViolated();
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+template <typename Scalar>
+void Opm::Satfunc::PhaseChecks::Oil::MobileOil_OW_SWcr<Scalar>::
+testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
+{
+    this->sgl_   = endPoints.Sgl;
+    this->swcr_  = endPoints.Swcr;
+    this->sowcr_ = endPoints.Sowcr;
+
+    if (! std::isfinite(this->sgl_) ||
+        ! std::isfinite(this->swcr_) ||
+        ! std::isfinite(this->sowcr_))
+    {
+        this->setViolated();
+        this->setCritical();
+
+        return;
+    }
+
+    if (! (this->sowcr_ < Scalar{1} - this->swcr_ - this->sgl_)) {
+        this->setViolated();
+    }
+}
+
+// ===========================================================================
+// Explicit Specialisations of Individual Check Templates
+//
+// No other code below this separator
+// ===========================================================================
+
+template class Opm::Satfunc::PhaseChecks::Oil::SOcr_GO<float>;
+template class Opm::Satfunc::PhaseChecks::Oil::SOcr_GO<double>;
+
+// ---------------------------------------------------------------------------
+
+template class Opm::Satfunc::PhaseChecks::Oil::SOmin_GO<float>;
+template class Opm::Satfunc::PhaseChecks::Oil::SOmin_GO<double>;
+
+// ---------------------------------------------------------------------------
+
+template class Opm::Satfunc::PhaseChecks::Oil::MobileOil_GO_SGmin<float>;
+template class Opm::Satfunc::PhaseChecks::Oil::MobileOil_GO_SGmin<double>;
+
+// ---------------------------------------------------------------------------
+
+template class Opm::Satfunc::PhaseChecks::Oil::MobileOil_GO_SGcr<float>;
+template class Opm::Satfunc::PhaseChecks::Oil::MobileOil_GO_SGcr<double>;
+
+// ---------------------------------------------------------------------------
+
+template class Opm::Satfunc::PhaseChecks::Oil::SOcr_OW<float>;
+template class Opm::Satfunc::PhaseChecks::Oil::SOcr_OW<double>;
+
+// ---------------------------------------------------------------------------
+
+template class Opm::Satfunc::PhaseChecks::Oil::SOmin_OW<float>;
+template class Opm::Satfunc::PhaseChecks::Oil::SOmin_OW<double>;
+
+// ---------------------------------------------------------------------------
+
+template class Opm::Satfunc::PhaseChecks::Oil::MobileOil_OW_SWmin<float>;
+template class Opm::Satfunc::PhaseChecks::Oil::MobileOil_OW_SWmin<double>;
+
+// ---------------------------------------------------------------------------
+
+template class Opm::Satfunc::PhaseChecks::Oil::MobileOil_OW_SWcr<float>;
+template class Opm::Satfunc::PhaseChecks::Oil::MobileOil_OW_SWcr<double>;

--- a/opm/simulators/utils/satfunc/OilPhaseConsistencyChecks.hpp
+++ b/opm/simulators/utils/satfunc/OilPhaseConsistencyChecks.hpp
@@ -1,0 +1,533 @@
+/*
+  Copyright 2024 Equinor AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OIL_PHASE_CONSISTENCY_CHECKS_HPP_INCLUDED
+#define OIL_PHASE_CONSISTENCY_CHECKS_HPP_INCLUDED
+
+#include <opm/simulators/utils/satfunc/SatfuncConsistencyChecks.hpp>
+#include <opm/simulators/utils/satfunc/PhaseCheckBase.hpp>
+
+#include <cstddef>
+#include <string>
+
+namespace Opm::Satfunc::PhaseChecks::Oil {
+
+    /// Verify that critical oil saturation in gas/oil system is in valid range
+    ///
+    /// \tparam Scalar Element type.  Typically \c float or \c double.
+    template <typename Scalar>
+    class SOcr_GO : public PhaseCheckBase<Scalar>
+    {
+    public:
+        /// Number of \c Scalar values involved in the check.
+        std::size_t numExportedCheckValues() const override { return 1; };
+
+        /// Get a linearised copy of the \c Scalar values involved in the check.
+        ///
+        /// \param[in,out] exportedCheckValues Pointer to contiguous
+        ///    sequence of at least numExportedCheckValues() \c Scalars.
+        void exportCheckValues(Scalar* exportedCheckValues) const override
+        {
+            exportedCheckValues[0] = this->sogcr_;
+        }
+
+        /// Descriptive textual summary of this check.
+        std::string description() const override
+        {
+            return { "Non-negative critical oil saturation in G/O system" };
+        }
+
+        /// Textual representation of the consistency condition.
+        std::string condition() const override
+        {
+            return { "0 <= SOGCR < 1" };
+        }
+
+        /// Retrieve names of the exported check values.
+        ///
+        /// \param[in,out] headers Pointer to contiguous sequence of at
+        ///    least numExportedCheckValues() strings.
+        void columnNames(std::string* headers) const override
+        {
+            headers[0] = "SOGCR";
+        }
+
+    private:
+        /// Critical oil saturation in gas/oil system.
+        Scalar sogcr_;
+
+        /// Run check against a set of saturation function end-points.
+        ///
+        /// \param[in] endPoints Set of saturation function end-points.
+        ///    Might for instance be the scaled end-points of the drainage
+        ///    functions in a single grid block or the unscaled end-points
+        ///    of the tabulated saturation functions in a single saturation
+        ///    region.
+        void testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints) override;
+    };
+
+    /// Verify that minimum oil saturation in gas/oil system is in valid range
+    ///
+    /// \tparam Scalar Element type.  Typically \c float or \c double.
+    template <typename Scalar>
+    class SOmin_GO : public PhaseCheckBase<Scalar>
+    {
+    public:
+        /// Number of \c Scalar values involved in the check.
+        std::size_t numExportedCheckValues() const override { return 3; };
+
+        /// Get a linearised copy of the \c Scalar values involved in the check.
+        ///
+        /// \param[in,out] exportedCheckValues Pointer to contiguous
+        ///    sequence of at least numExportedCheckValues() \c Scalars.
+        void exportCheckValues(Scalar* exportedCheckValues) const override
+        {
+            exportedCheckValues[0] = this->swl_;
+            exportedCheckValues[1] = this->sgu_;
+            exportedCheckValues[2] = this->swl_ + this->sgu_;
+        }
+
+        /// Descriptive textual summary of this check.
+        std::string description() const override
+        {
+            return { "Non-negative minimum oil saturation in G/O system" };
+        }
+
+        /// Textual representation of the consistency condition.
+        std::string condition() const override
+        {
+            return { "SWL + SGU <= 1" };
+        }
+
+        /// Retrieve names of the exported check values.
+        ///
+        /// \param[in,out] headers Pointer to contiguous sequence of at
+        ///    least numExportedCheckValues() strings.
+        void columnNames(std::string* headers) const override
+        {
+            headers[0] = "SWL";
+            headers[1] = "SGU";
+            headers[2] = "SWL + SGU";
+        }
+
+    private:
+        /// Minimum (connate) water saturation in gas/oil system.
+        Scalar swl_;
+
+        /// Maximum gas saturation in gas/oil system.
+        Scalar sgu_;
+
+        /// Run check against a set of saturation function end-points.
+        ///
+        /// \param[in] endPoints Set of saturation function end-points.
+        ///    Might for instance be the scaled end-points of the drainage
+        ///    functions in a single grid block or the unscaled end-points
+        ///    of the tabulated saturation functions in a single saturation
+        ///    region.
+        void testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints) override;
+    };
+
+    /// Verify that critical oil saturation in gas/oil system is strictly
+    /// smaller than maximum oil saturation.
+    ///
+    /// \tparam Scalar Element type.  Typically \c float or \c double.
+    template <typename Scalar>
+    class MobileOil_GO_SGmin : public PhaseCheckBase<Scalar>
+    {
+    public:
+        /// Number of \c Scalar values involved in the check.
+        std::size_t numExportedCheckValues() const override { return 4; };
+
+        /// Get a linearised copy of the \c Scalar values involved in the check.
+        ///
+        /// \param[in,out] exportedCheckValues Pointer to contiguous
+        ///    sequence of at least numExportedCheckValues() \c Scalars.
+        void exportCheckValues(Scalar* exportedCheckValues) const override
+        {
+            exportedCheckValues[0] = this->swl_;
+            exportedCheckValues[1] = this->sgl_;
+            exportedCheckValues[2] = this->sogcr_;
+            exportedCheckValues[3] = Scalar{1} - (this->swl_ + this->sgl_);
+        }
+
+        /// Descriptive textual summary of this check.
+        std::string description() const override
+        {
+            return { "Mobile oil saturation in G/O system at minimum gas saturation" };
+        }
+
+        /// Textual representation of the consistency condition.
+        std::string condition() const override
+        {
+            return { "SOGCR < 1 - SWL - SGL" };
+        }
+
+        /// Retrieve names of the exported check values.
+        ///
+        /// \param[in,out] headers Pointer to contiguous sequence of at
+        ///    least numExportedCheckValues() strings.
+        void columnNames(std::string* headers) const override
+        {
+            headers[0] = "SWL";
+            headers[1] = "SGL";
+            headers[2] = "SOGCR";
+            headers[3] = "1 - SWL - SGL";
+        }
+
+    private:
+        /// Minimum water saturation.
+        Scalar swl_;
+
+        /// Minimum gas saturation.
+        Scalar sgl_;
+
+        /// Critical oil saturation in gas/oil system.
+        Scalar sogcr_;
+
+        /// Run check against a set of saturation function end-points.
+        ///
+        /// \param[in] endPoints Set of saturation function end-points.
+        ///    Might for instance be the scaled end-points of the drainage
+        ///    functions in a single grid block or the unscaled end-points
+        ///    of the tabulated saturation functions in a single saturation
+        ///    region.
+        void testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints) override;
+    };
+
+    /// Verify that critical oil saturation in gas/oil system is strictly
+    /// smaller than oil saturation at critical gas saturation.
+    ///
+    /// \tparam Scalar Element type.  Typically \c float or \c double.
+    template <typename Scalar>
+    class MobileOil_GO_SGcr : public PhaseCheckBase<Scalar>
+    {
+    public:
+        /// Number of \c Scalar values involved in the check.
+        std::size_t numExportedCheckValues() const override { return 4; };
+
+        /// Get a linearised copy of the \c Scalar values involved in the check.
+        ///
+        /// \param[in,out] exportedCheckValues Pointer to contiguous
+        ///    sequence of at least numExportedCheckValues() \c Scalars.
+        void exportCheckValues(Scalar* exportedCheckValues) const override
+        {
+            exportedCheckValues[0] = this->swl_;
+            exportedCheckValues[1] = this->sgcr_;
+            exportedCheckValues[2] = this->sogcr_;
+            exportedCheckValues[3] = Scalar{1} - (this->swl_ + this->sgcr_);
+        }
+
+        /// Descriptive textual summary of this check.
+        std::string description() const override
+        {
+            return { "Mobile oil saturation in G/O system at critical gas saturation" };
+        }
+
+        /// Textual representation of the consistency condition.
+        std::string condition() const override
+        {
+            return { "SOGCR < 1 - SWL - SGCR" };
+        }
+
+        /// Retrieve names of the exported check values.
+        ///
+        /// \param[in,out] headers Pointer to contiguous sequence of at
+        ///    least numExportedCheckValues() strings.
+        void columnNames(std::string* headers) const override
+        {
+            headers[0] = "SWL";
+            headers[1] = "SGCR";
+            headers[2] = "SOGCR";
+            headers[3] = "1 - SWL - SGCR";
+        }
+
+    private:
+        /// Minimum water saturation.
+        Scalar swl_;
+
+        /// Critical gas saturation.
+        Scalar sgcr_;
+
+        /// Critical oil saturation in gas/oil system
+        Scalar sogcr_;
+
+        /// Run check against a set of saturation function end-points.
+        ///
+        /// \param[in] endPoints Set of saturation function end-points.
+        ///    Might for instance be the scaled end-points of the drainage
+        ///    functions in a single grid block or the unscaled end-points
+        ///    of the tabulated saturation functions in a single saturation
+        ///    region.
+        void testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints) override;
+    };
+
+    // -----------------------------------------------------------------------
+
+    /// Verify that critical oil saturation in oil/water system is in valid range
+    ///
+    /// \tparam Scalar Element type.  Typically \c float or \c double.
+    template <typename Scalar>
+    class SOcr_OW : public PhaseCheckBase<Scalar>
+    {
+    public:
+        /// Number of \c Scalar values involved in the check.
+        std::size_t numExportedCheckValues() const override { return 1; };
+
+        /// Get a linearised copy of the \c Scalar values involved in the check.
+        ///
+        /// \param[in,out] exportedCheckValues Pointer to contiguous
+        ///    sequence of at least numExportedCheckValues() \c Scalars.
+        void exportCheckValues(Scalar* exportedCheckValues) const override
+        {
+            exportedCheckValues[0] = this->sowcr_;
+        }
+
+        /// Descriptive textual summary of this check.
+        std::string description() const override
+        {
+            return { "Non-negative critical oil saturation in O/W system" };
+        }
+
+        /// Textual representation of the consistency condition.
+        std::string condition() const override
+        {
+            return { "0 <= SOWCR < 1" };
+        }
+
+        /// Retrieve names of the exported check values.
+        ///
+        /// \param[in,out] headers Pointer to contiguous sequence of at
+        ///    least numExportedCheckValues() strings.
+        void columnNames(std::string* headers) const override
+        {
+            headers[0] = "SOWCR";
+        }
+
+    private:
+        /// Critical oil saturation in oil/water system.
+        Scalar sowcr_;
+
+        /// Run check against a set of saturation function end-points.
+        ///
+        /// \param[in] endPoints Set of saturation function end-points.
+        ///    Might for instance be the scaled end-points of the drainage
+        ///    functions in a single grid block or the unscaled end-points
+        ///    of the tabulated saturation functions in a single saturation
+        ///    region.
+        void testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints) override;
+    };
+
+    /// Verify that minimum oil saturation in oil/water system is in valid range
+    ///
+    /// \tparam Scalar Element type.  Typically \c float or \c double.
+    template <typename Scalar>
+    class SOmin_OW : public PhaseCheckBase<Scalar>
+    {
+    public:
+        /// Number of \c Scalar values involved in the check.
+        std::size_t numExportedCheckValues() const override { return 3; };
+
+        /// Get a linearised copy of the \c Scalar values involved in the check.
+        ///
+        /// \param[in,out] exportedCheckValues Pointer to contiguous
+        ///    sequence of at least numExportedCheckValues() \c Scalars.
+        void exportCheckValues(Scalar* exportedCheckValues) const override
+        {
+            exportedCheckValues[0] = this->sgl_;
+            exportedCheckValues[1] = this->swu_;
+            exportedCheckValues[2] = this->sgl_ + this->swu_;
+        }
+
+        /// Descriptive textual summary of this check.
+        std::string description() const override
+        {
+            return { "Non-negative minimum oil saturation in G/O system" };
+        }
+
+        /// Textual representation of the consistency condition.
+        std::string condition() const override
+        {
+            return { "SGL + SWU <= 1" };
+        }
+
+        /// Retrieve names of the exported check values.
+        ///
+        /// \param[in,out] headers Pointer to contiguous sequence of at
+        ///    least numExportedCheckValues() strings.
+        void columnNames(std::string* headers) const override
+        {
+            headers[0] = "SGL";
+            headers[1] = "SWU";
+            headers[2] = "SGL + SWU";
+        }
+
+    private:
+        /// Minimum gas saturation.  Typically zero.
+        Scalar sgl_;
+
+        /// Minimum (connate) saturation.
+        Scalar swu_;
+ 
+        /// Run check against a set of saturation function end-points.
+        ///
+        /// \param[in] endPoints Set of saturation function end-points.
+        ///    Might for instance be the scaled end-points of the drainage
+        ///    functions in a single grid block or the unscaled end-points
+        ///    of the tabulated saturation functions in a single saturation
+        ///    region.
+        void testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints) override;
+    };
+
+    /// Verify that critical oil saturation in oil/water system is strictly
+    /// smaller than maximum oil saturation.
+    ///
+    /// \tparam Scalar Element type.  Typically \c float or \c double.
+    template <typename Scalar>
+    class MobileOil_OW_SWmin : public PhaseCheckBase<Scalar>
+    {
+    public:
+        /// Number of \c Scalar values involved in the check.
+        std::size_t numExportedCheckValues() const override { return 4; };
+
+        /// Get a linearised copy of the \c Scalar values involved in the check.
+        ///
+        /// \param[in,out] exportedCheckValues Pointer to contiguous
+        ///    sequence of at least numExportedCheckValues() \c Scalars.
+        void exportCheckValues(Scalar* exportedCheckValues) const override
+        {
+            exportedCheckValues[0] = this->swl_;
+            exportedCheckValues[1] = this->sgl_;
+            exportedCheckValues[2] = this->sowcr_;
+            exportedCheckValues[3] = Scalar{1} - (this->swl_ + this->sgl_);
+        }
+
+        /// Descriptive textual summary of this check.
+        std::string description() const override
+        {
+            return { "Mobile oil saturation in O/W system at minimum water saturation" };
+        }
+
+        /// Textual representation of the consistency condition.
+        std::string condition() const override
+        {
+            return { "SOWCR < 1 - SWL - SGL" };
+        }
+
+        /// Retrieve names of the exported check values.
+        ///
+        /// \param[in,out] headers Pointer to contiguous sequence of at
+        ///    least numExportedCheckValues() strings.
+        void columnNames(std::string* headers) const override
+        {
+            headers[0] = "SWL";
+            headers[1] = "SGL";
+            headers[2] = "SOWCR";
+            headers[3] = "1 - SWL - SGL";
+        }
+
+    private:
+        /// Minimum (connate) water saturation.
+        Scalar swl_;
+
+        /// Minimum gas saturation.  Typically zero.
+        Scalar sgl_;
+
+        /// Critical oil saturation in oil/water system.
+        Scalar sowcr_;
+
+        /// Run check against a set of saturation function end-points.
+        ///
+        /// \param[in] endPoints Set of saturation function end-points.
+        ///    Might for instance be the scaled end-points of the drainage
+        ///    functions in a single grid block or the unscaled end-points
+        ///    of the tabulated saturation functions in a single saturation
+        ///    region.
+        void testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints) override;
+    };
+
+    /// Verify that critical oil saturation in oil/water system is strictly
+    /// smaller than oil saturation at critical water saturation.
+    ///
+    /// \tparam Scalar Element type.  Typically \c float or \c double.
+    template <typename Scalar>
+    class MobileOil_OW_SWcr : public PhaseCheckBase<Scalar>
+    {
+    public:
+        /// Number of \c Scalar values involved in the check.
+        std::size_t numExportedCheckValues() const override { return 4; };
+
+        /// Get a linearised copy of the \c Scalar values involved in the check.
+        ///
+        /// \param[in,out] exportedCheckValues Pointer to contiguous
+        ///    sequence of at least numExportedCheckValues() \c Scalars.
+        void exportCheckValues(Scalar* exportedCheckValues) const override
+        {
+            exportedCheckValues[0] = this->sgl_;
+            exportedCheckValues[1] = this->swcr_;
+            exportedCheckValues[2] = this->sowcr_;
+            exportedCheckValues[3] = Scalar{1} - this->swcr_ - this->sgl_;
+        }
+
+        /// Descriptive textual summary of this check.
+        std::string description() const override
+        {
+            return { "Mobile oil saturation in O/W system at critical water saturation" };
+        }
+
+        /// Textual representation of the consistency condition.
+        std::string condition() const override
+        {
+            return { "SOWCR < 1 - SWCR - SGL" };
+        }
+
+        /// Retrieve names of the exported check values.
+        ///
+        /// \param[in,out] headers Pointer to contiguous sequence of at
+        ///    least numExportedCheckValues() strings.
+        void columnNames(std::string* headers) const override
+        {
+            headers[0] = "SGL";
+            headers[1] = "SWCR";
+            headers[2] = "SOWCR";
+            headers[3] = "1 - SWCR - SGL";
+        }
+
+    private:
+        /// Minimum gas saturation.  Typically zero.
+        Scalar sgl_;
+
+        /// Critical water saturation.
+        Scalar swcr_;
+
+        /// Critical oil saturation in oil/water system.
+        Scalar sowcr_;
+
+        /// Run check against a set of saturation function end-points.
+        ///
+        /// \param[in] endPoints Set of saturation function end-points.
+        ///    Might for instance be the scaled end-points of the drainage
+        ///    functions in a single grid block or the unscaled end-points
+        ///    of the tabulated saturation functions in a single saturation
+        ///    region.
+        void testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints) override;
+    };
+
+} // namespace Opm::Satfunc::PhaseChecks::Oil
+
+#endif // OIL_PHASE_CONSISTENCY_CHECKS_HPP_INCLUDED

--- a/opm/simulators/utils/satfunc/PhaseCheckBase.cpp
+++ b/opm/simulators/utils/satfunc/PhaseCheckBase.cpp
@@ -1,0 +1,72 @@
+/*
+  Copyright 2024 Equinor AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#include <opm/simulators/utils/satfunc/PhaseCheckBase.hpp>
+
+namespace {
+    constexpr auto one_bit = static_cast<unsigned char>(1);
+    constexpr auto failed_bit = one_bit << 0u;
+    constexpr auto critical_bit = one_bit << 1u;
+}
+
+// ===========================================================================
+
+template <typename Scalar>
+void Opm::Satfunc::PhaseChecks::PhaseCheckBase<Scalar>::
+test(const EclEpsScalingPointsInfo<Scalar>& endPoints)
+{
+    this->flags_ = static_cast<unsigned char>(0);
+
+    this->testImpl(endPoints);
+}
+
+template <typename Scalar>
+bool Opm::Satfunc::PhaseChecks::PhaseCheckBase<Scalar>::isViolated() const
+{
+    return (this->flags_ & failed_bit) != 0;
+}
+
+template <typename Scalar>
+bool Opm::Satfunc::PhaseChecks::PhaseCheckBase<Scalar>::isCritical() const
+{
+    return (this->flags_ & critical_bit) != 0;
+}
+
+template <typename Scalar>
+void Opm::Satfunc::PhaseChecks::PhaseCheckBase<Scalar>::setViolated()
+{
+    this->flags_ |= failed_bit;
+}
+
+template <typename Scalar>
+void Opm::Satfunc::PhaseChecks::PhaseCheckBase<Scalar>::setCritical()
+{
+    this->flags_ |= critical_bit;
+}
+
+// ===========================================================================
+// Explicit Specialisations of PhaseCheckBase Templates
+//
+// No other code below this separator
+// ===========================================================================
+
+template class Opm::Satfunc::PhaseChecks::PhaseCheckBase<float>;
+template class Opm::Satfunc::PhaseChecks::PhaseCheckBase<double>;

--- a/opm/simulators/utils/satfunc/PhaseCheckBase.hpp
+++ b/opm/simulators/utils/satfunc/PhaseCheckBase.hpp
@@ -1,0 +1,88 @@
+/*
+  Copyright 2024 Equinor AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PHASE_CHECK_BASE_HPP_INCLUDED
+#define PHASE_CHECK_BASE_HPP_INCLUDED
+
+#include <opm/simulators/utils/satfunc/SatfuncConsistencyChecks.hpp>
+
+namespace Opm::Satfunc::PhaseChecks {
+
+    /// Base class for all phase saturation function consistency checks.
+    ///
+    /// Provides common implementation of parts of the public Check
+    /// interface in terms of packed flags.
+    ///
+    /// \tparam Scalar Element type.  Typically \c float or \c double.
+    template <typename Scalar>
+    class PhaseCheckBase : public SatfuncConsistencyChecks<Scalar>::Check
+    {
+    public:
+        /// Run specific check against a set of saturation function end-points.
+        ///
+        /// \param[in] endPoints Set of saturation function end-points.
+        ///    Might for instance be the scaled end-points of the drainage
+        ///    functions in a single grid block or the unscaled end-points
+        ///    of the tabulated saturation functions in a single saturation
+        ///    region.
+        void test(const EclEpsScalingPointsInfo<Scalar>& endPoints) override;
+
+        /// Whether or not last set of end-points violated this particular
+        /// check.
+        bool isViolated() const override;
+
+        /// Whether or not this check is critical to the simulator's ability
+        /// to run the case.
+        ///
+        /// Violating critical checks should typically stop the run.
+        bool isCritical() const override;
+
+    protected:
+        /// Mark check as violated.
+        ///
+        /// Intended to be called by derived types only.
+        void setViolated();
+
+        /// Mark check as violated at critical level.
+        ///
+        /// Intended to be called by derived types only.
+        void setCritical();
+
+    private:
+        /// Collection of violation flags.
+        ///
+        /// Packed bit fields.
+        unsigned char flags_{0};
+
+        /// Run specific check against a set of saturation function end-points.
+        ///
+        /// Actual test function.  Implemented in derived types and called
+        /// from the test() member function.
+        ///
+        /// \param[in] endPoints Set of saturation function end-points.
+        ///    Might for instance be the scaled end-points of the drainage
+        ///    functions in a single grid block or the unscaled end-points
+        ///    of the tabulated saturation functions in a single saturation
+        ///    region.
+        virtual void testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints) = 0;
+    };
+
+} // namespace Opm::Satfunc::PhaseChecks
+
+#endif // PHASE_CHECK_BASE_HPP_INCLUDED

--- a/opm/simulators/utils/satfunc/SatfuncConsistencyChecks.hpp
+++ b/opm/simulators/utils/satfunc/SatfuncConsistencyChecks.hpp
@@ -75,7 +75,7 @@ namespace Opm {
             /// Number of \c Scalar values involved in the check.
             virtual std::size_t numExportedCheckValues() const = 0;
 
-            /// Get a linearised copy of the \c Sclar values involved in the check.
+            /// Get a linearised copy of the \c Scalar values involved in the check.
             ///
             /// \param[in,out] exportedCheckValues Pointer to contiguous
             ///    sequence of at least numExportedCheckValues() \c Scalars.

--- a/tests/test_OilSatfuncConsistencyChecks.cpp
+++ b/tests/test_OilSatfuncConsistencyChecks.cpp
@@ -1,0 +1,2203 @@
+/*
+  Copyright 2024 Equinor AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE TestOilPhaseConsistencyChecks
+
+#ifndef HAVE_MPI
+// Suppress GCC diagnostics of the form
+//
+//   warning: "HAVE_MPI" is not defined, evaluates to 0
+//
+// when compiling with "-Wundef".
+#define HAVE_MPI 0
+#endif  // HAVE_MPI
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/utils/satfunc/OilPhaseConsistencyChecks.hpp>
+
+#include <opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp>
+
+#include <limits>
+#include <string>
+#include <vector>
+
+// ###########################################################################
+
+namespace Checks = Opm::Satfunc::PhaseChecks::Oil;
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Gas_Oil_System)
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Sogcr)
+
+BOOST_AUTO_TEST_CASE(All_Good)
+{
+    auto check = Checks::SOcr_GO<float>{};
+
+    BOOST_CHECK_EQUAL(check.numExportedCheckValues(), std::size_t{1});
+
+    {
+        auto column = std::string{};
+        check.columnNames(&column);
+
+        BOOST_CHECK_EQUAL(column, "SOGCR");
+    }
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Sogcr = 0.3f; // >= 0 && < 1
+
+        check.test(endPoints);
+    }
+
+    {
+        auto value = -0.1f;
+        check.exportCheckValues(&value);
+
+        BOOST_CHECK_CLOSE(value, 0.3f, 1.0e-6f);
+    }
+
+    BOOST_CHECK_MESSAGE(! check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Non_Finite)
+{
+    // NaN
+    if constexpr (std::numeric_limits<float>::has_quiet_NaN) {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Sogcr = std::numeric_limits<float>::quiet_NaN();
+
+        auto check = Checks::SOcr_GO<float>{};
+        check.test(endPoints);
+
+        auto value = -0.1f;
+        check.exportCheckValues(&value);
+
+        BOOST_CHECK_MESSAGE(std::isnan(value), "Sogcr value must be NaN");
+        BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+        BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+    }
+
+    // Inf
+    if constexpr (std::numeric_limits<float>::has_infinity) {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Sogcr = std::numeric_limits<float>::infinity();
+
+        auto check = Checks::SOcr_GO<float>{};
+        check.test(endPoints);
+
+        auto value = -0.1f;
+        check.exportCheckValues(&value);
+
+        BOOST_CHECK_MESSAGE(std::isinf(value), "Sogcr value must be Inf");
+        BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+        BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Negative)
+{
+    auto check = Checks::SOcr_GO<double>{};
+    auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+    endPoints.Sogcr = -0.01; // < 0
+
+    check.test(endPoints);
+
+    {
+        auto value = 1.0;
+        check.exportCheckValues(&value);
+
+        BOOST_CHECK_CLOSE(value, -0.01, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
+    BOOST_CHECK_MESSAGE(check.isCritical(), "Test must be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Is_One)
+{
+    auto check = Checks::SOcr_GO<double>{};
+    auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+    endPoints.Sogcr = 1.0; // >= 1
+
+    check.test(endPoints);
+
+    {
+        auto value = 0.0;
+        check.exportCheckValues(&value);
+
+        BOOST_CHECK_CLOSE(value, 1.0, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
+    BOOST_CHECK_MESSAGE(check.isCritical(), "Test must be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Exceeds_One)
+{
+    auto check = Checks::SOcr_GO<double>{};
+    auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+    endPoints.Sogcr = 1.2; // >= 1
+
+    check.test(endPoints);
+
+    {
+        auto value = 0.0;
+        check.exportCheckValues(&value);
+
+        BOOST_CHECK_CLOSE(value, 1.2, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
+    BOOST_CHECK_MESSAGE(check.isCritical(), "Test must be violated at critical level");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Sogcr
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(So_min)
+
+BOOST_AUTO_TEST_CASE(All_Good)
+{
+    auto check = Checks::SOmin_GO<double>{};
+
+    BOOST_CHECK_EQUAL(check.numExportedCheckValues(), std::size_t{3});
+
+    {
+        auto columns = std::vector<std::string>(3);
+        check.columnNames(columns.data());
+
+        BOOST_CHECK_EQUAL(columns[0], "SWL");
+        BOOST_CHECK_EQUAL(columns[1], "SGU");
+        BOOST_CHECK_EQUAL(columns[2], "SWL + SGU");
+    }
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Swl = 0.09;
+        endPoints.Sgu = 0.9;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(3);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.09, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.9 , 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.99, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(! check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Non_Finite)
+{
+    // NaN
+    if constexpr (std::numeric_limits<float>::has_quiet_NaN) {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgu = 0.75f;
+
+        auto check = Checks::SOmin_GO<float>{};
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(3);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[1], 0.75f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Swl + Sgu value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.75f;
+        endPoints.Sgu = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(3);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.75f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Sgu value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Swl + Sgu value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgu = std::numeric_limits<float>::quiet_NaN();
+
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(3);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Sgu value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Swl + Sgu value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+    }
+
+    // Inf
+    if constexpr (std::numeric_limits<float>::has_infinity) {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgu = 0.75f;
+
+        auto check = Checks::SOmin_GO<float>{};
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(3);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[1], 0.75f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Swl + Sgu value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.75f;
+        endPoints.Sgu = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(3);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.75f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Sgu value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Swl + Sgu value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgu = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(3);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Sgu value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Swl + Sgu value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Swl_TooLarge)
+{
+    auto check = Checks::SOmin_GO<double>{};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Swl = 0.15;
+        endPoints.Sgu = 0.9;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(3);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.15, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.9 , 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 1.05, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Sgu_TooLarge)
+{
+    auto check = Checks::SOmin_GO<double>{};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Swl = 0.1;
+        endPoints.Sgu = 0.95;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(3);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.1 , 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.95, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 1.05, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // So_min
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Mobile_Oil_Sgmin)
+
+BOOST_AUTO_TEST_CASE(All_Good)
+{
+    auto check = Checks::MobileOil_GO_SGmin<float>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    BOOST_CHECK_EQUAL(check.numExportedCheckValues(), expectNumExported);
+
+    {
+        auto columns = std::vector<std::string>(expectNumExported);
+        check.columnNames(columns.data());
+
+        BOOST_CHECK_EQUAL(columns[0], "SWL");
+        BOOST_CHECK_EQUAL(columns[1], "SGL");
+        BOOST_CHECK_EQUAL(columns[2], "SOGCR");
+        BOOST_CHECK_EQUAL(columns[3], "1 - SWL - SGL");
+    }
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Swl   = 0.15f;
+        endPoints.Sgl   = 0.01f;
+        endPoints.Sogcr = 0.15f;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<float>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.15f, 1.0e-6f);
+        BOOST_CHECK_CLOSE(values[1], 0.01f, 1.0e-6f);
+        BOOST_CHECK_CLOSE(values[2], 0.15f, 1.0e-6f);
+        BOOST_CHECK_CLOSE(values[3], 1.0f - 0.15f - 0.01, 1.0e-5f);
+    }
+
+    BOOST_CHECK_MESSAGE(! check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Non_Finite)
+{
+    // NaN
+    if constexpr (std::numeric_limits<float>::has_quiet_NaN) {
+        const auto expectNumExported = std::size_t{4};
+
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgl = 0.01f;
+        endPoints.Sogcr = 0.32f;
+
+        auto check = Checks::MobileOil_GO_SGmin<float>{};
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgl value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.6f;
+        endPoints.Sgl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sogcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Sgl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgl value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.6f;
+        endPoints.Sgl = 0.01f;
+        endPoints.Sogcr = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sogcr value must be NaN");
+            BOOST_CHECK_CLOSE  (values[3], 1.0f - 0.6f - 0.01f, 1.0e-6);
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sogcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Sgl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgl value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgl = 0.01f;
+        endPoints.Sogcr = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sogcr value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgl value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sogcr = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Sgl value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sogcr value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgl value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+    }
+
+    // Inf
+    if constexpr (std::numeric_limits<float>::has_infinity) {
+        const auto expectNumExported = std::size_t{4};
+
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgl = 0.01f;
+        endPoints.Sogcr = 0.32f;
+
+        auto check = Checks::MobileOil_GO_SGmin<float>{};
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgl value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.6f;
+        endPoints.Sgl = std::numeric_limits<float>::infinity();
+        endPoints.Sogcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Sgl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgl value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.6f;
+        endPoints.Sgl = 0.01f;
+        endPoints.Sogcr = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sogcr value must be Inf");
+            BOOST_CHECK_CLOSE  (values[3], 1.0f - 0.6f - 0.01f, 1.0e-6);
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgl = std::numeric_limits<float>::infinity();
+        endPoints.Sogcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Sgl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgl value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgl = 0.01f;
+        endPoints.Sogcr = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sogcr value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgl value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgl = std::numeric_limits<float>::infinity();
+        endPoints.Sogcr = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Sgl value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sogcr value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgl value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Swl_TooLarge)
+{
+    auto check = Checks::MobileOil_GO_SGmin<double>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Swl   = 0.70;
+        endPoints.Sgl   = 0.01;
+        endPoints.Sogcr = 0.32;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.70, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.01, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.32, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[3], 1.0 - 0.70 - 0.01, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Sgl_TooLarge)
+{
+    auto check = Checks::MobileOil_GO_SGmin<double>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Swl   = 0.65;
+        endPoints.Sgl   = 0.05;
+        endPoints.Sogcr = 0.32;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.65, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.05, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.32, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[3], 1.0 - 0.65 - 0.05, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Sogcr_TooLarge)
+{
+    auto check = Checks::MobileOil_GO_SGmin<double>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Swl   = 0.65;
+        endPoints.Sgl   = 0.04;
+        endPoints.Sogcr = 0.32;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.65, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.04, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.32, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[3], 1.0 - 0.65 - 0.04, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Mobile_Oil_Sgmin
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Mobile_Oil_Sgcr)
+
+BOOST_AUTO_TEST_CASE(All_Good)
+{
+    auto check = Checks::MobileOil_GO_SGcr<float>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    BOOST_CHECK_EQUAL(check.numExportedCheckValues(), expectNumExported);
+
+    {
+        auto columns = std::vector<std::string>(expectNumExported);
+        check.columnNames(columns.data());
+
+        BOOST_CHECK_EQUAL(columns[0], "SWL");
+        BOOST_CHECK_EQUAL(columns[1], "SGCR");
+        BOOST_CHECK_EQUAL(columns[2], "SOGCR");
+        BOOST_CHECK_EQUAL(columns[3], "1 - SWL - SGCR");
+    }
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Swl   = 0.15f;
+        endPoints.Sgcr  = 0.01f;
+        endPoints.Sogcr = 0.15f;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<float>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.15f, 1.0e-6f);
+        BOOST_CHECK_CLOSE(values[1], 0.01f, 1.0e-6f);
+        BOOST_CHECK_CLOSE(values[2], 0.15f, 1.0e-6f);
+        BOOST_CHECK_CLOSE(values[3], 1.0f - 0.15f - 0.01, 1.0e-5f);
+    }
+
+    BOOST_CHECK_MESSAGE(! check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Non_Finite)
+{
+    // NaN
+    if constexpr (std::numeric_limits<float>::has_quiet_NaN) {
+        const auto expectNumExported = std::size_t{4};
+
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgcr = 0.01f;
+        endPoints.Sogcr = 0.32f;
+
+        auto check = Checks::MobileOil_GO_SGcr<float>{};
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgcr value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.6f;
+        endPoints.Sgcr = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sogcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Sgcr value must be NaN");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgcr value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.6f;
+        endPoints.Sgcr = 0.01f;
+        endPoints.Sogcr = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sogcr value must be NaN");
+            BOOST_CHECK_CLOSE  (values[3], 1.0f - 0.6f - 0.01f, 1.0e-6);
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgcr = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sogcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Sgcr value must be NaN");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgcr value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgcr = 0.01f;
+        endPoints.Sogcr = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sogcr value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgcr value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgcr = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sogcr = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Sgu value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sogcr value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgcr value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+    }
+
+    // Inf
+    if constexpr (std::numeric_limits<float>::has_infinity) {
+        const auto expectNumExported = std::size_t{4};
+
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgcr = 0.01f;
+        endPoints.Sogcr = 0.32f;
+
+        auto check = Checks::MobileOil_GO_SGcr<float>{};
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgcr value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.6f;
+        endPoints.Sgcr = std::numeric_limits<float>::infinity();
+        endPoints.Sogcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Sgcr value must be Inf");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgcr value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.6f;
+        endPoints.Sgcr = 0.01f;
+        endPoints.Sogcr = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sogcr value must be Inf");
+            BOOST_CHECK_CLOSE  (values[3], 1.0f - 0.6f - 0.01f, 1.0e-6);
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgcr = std::numeric_limits<float>::infinity();
+        endPoints.Sogcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Sgcr value must be Inf");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgcr value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgcr = 0.01f;
+        endPoints.Sogcr = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sogcr value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgcr value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgcr = std::numeric_limits<float>::infinity();
+        endPoints.Sogcr = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Sgcr value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sogcr value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgcr value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Swl_TooLarge)
+{
+    auto check = Checks::MobileOil_GO_SGcr<double>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Swl   = 0.70;
+        endPoints.Sgcr  = 0.01;
+        endPoints.Sogcr = 0.32;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.70, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.01, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.32, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[3], 1.0 - 0.70 - 0.01, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Sgcr_TooLarge)
+{
+    auto check = Checks::MobileOil_GO_SGcr<double>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Swl   = 0.65;
+        endPoints.Sgcr  = 0.05;
+        endPoints.Sogcr = 0.32;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.65, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.05, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.32, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[3], 1.0 - 0.65 - 0.05, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Sogcr_TooLarge)
+{
+    auto check = Checks::MobileOil_GO_SGcr<double>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Swl   = 0.65;
+        endPoints.Sgcr  = 0.04;
+        endPoints.Sogcr = 0.32;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.65, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.04, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.32, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[3], 1.0 - 0.65 - 0.04, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Mobile_Oil_Sgcr
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE_END() // Gas_Oil_System
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Oil_Water_System)
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Sowcr)
+
+BOOST_AUTO_TEST_CASE(All_Good)
+{
+    auto check = Checks::SOcr_OW<float>{};
+
+    BOOST_CHECK_EQUAL(check.numExportedCheckValues(), std::size_t{1});
+
+    {
+        auto column = std::string{};
+        check.columnNames(&column);
+
+        BOOST_CHECK_EQUAL(column, "SOWCR");
+    }
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Sowcr = 0.3f; // >= 0 && < 1
+
+        check.test(endPoints);
+    }
+
+    {
+        auto value = -0.1f;
+        check.exportCheckValues(&value);
+
+        BOOST_CHECK_CLOSE(value, 0.3f, 1.0e-6f);
+    }
+
+    BOOST_CHECK_MESSAGE(! check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Non_Finite)
+{
+    // NaN
+    if constexpr (std::numeric_limits<float>::has_quiet_NaN) {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Sowcr = std::numeric_limits<float>::quiet_NaN();
+
+        auto check = Checks::SOcr_OW<float>{};
+        check.test(endPoints);
+
+        auto value = -0.1f;
+        check.exportCheckValues(&value);
+
+        BOOST_CHECK_MESSAGE(std::isnan(value), "Sowcr value must be NaN");
+        BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+        BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+    }
+
+    // Inf
+    if constexpr (std::numeric_limits<float>::has_infinity) {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Sowcr = std::numeric_limits<float>::infinity();
+
+        auto check = Checks::SOcr_OW<float>{};
+        check.test(endPoints);
+
+        auto value = -0.1f;
+        check.exportCheckValues(&value);
+
+        BOOST_CHECK_MESSAGE(std::isinf(value), "Sowcr value must be Inf");
+        BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+        BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Negative)
+{
+    auto check = Checks::SOcr_OW<double>{};
+    auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+    endPoints.Sowcr = -0.01; // < 0
+
+    check.test(endPoints);
+
+    {
+        auto value = 1.0;
+        check.exportCheckValues(&value);
+
+        BOOST_CHECK_CLOSE(value, -0.01, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
+    BOOST_CHECK_MESSAGE(check.isCritical(), "Test must be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Is_One)
+{
+    auto check = Checks::SOcr_OW<double>{};
+    auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+    endPoints.Sowcr = 1.0; // >= 1
+
+    check.test(endPoints);
+
+    {
+        auto value = 0.0;
+        check.exportCheckValues(&value);
+
+        BOOST_CHECK_CLOSE(value, 1.0, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
+    BOOST_CHECK_MESSAGE(check.isCritical(), "Test must be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Exceeds_One)
+{
+    auto check = Checks::SOcr_OW<double>{};
+    auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+    endPoints.Sowcr = 1.2; // >= 1
+
+    check.test(endPoints);
+
+    {
+        auto value = 0.0;
+        check.exportCheckValues(&value);
+
+        BOOST_CHECK_CLOSE(value, 1.2, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
+    BOOST_CHECK_MESSAGE(check.isCritical(), "Test must be violated at critical level");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Sowcr
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(So_min)
+
+BOOST_AUTO_TEST_CASE(All_Good)
+{
+    auto check = Checks::SOmin_OW<double>{};
+
+    BOOST_CHECK_EQUAL(check.numExportedCheckValues(), std::size_t{3});
+
+    {
+        auto columns = std::vector<std::string>(3);
+        check.columnNames(columns.data());
+
+        BOOST_CHECK_EQUAL(columns[0], "SGL");
+        BOOST_CHECK_EQUAL(columns[1], "SWU");
+        BOOST_CHECK_EQUAL(columns[2], "SGL + SWU");
+    }
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Sgl = 0.09;
+        endPoints.Swu = 0.9;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(3);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.09, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.9 , 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.99, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(! check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Non_Finite)
+{
+    // NaN
+    if constexpr (std::numeric_limits<float>::has_quiet_NaN) {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Sgl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Swu = 0.75f;
+
+        auto check = Checks::SOmin_OW<float>{};
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(3);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Sgl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[1], 0.75f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sgl + Swu value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = 0.75f;
+        endPoints.Swu = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(3);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.75f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Swu value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sgl + Swu value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Swu = std::numeric_limits<float>::quiet_NaN();
+
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(3);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Sgl value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Swu value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sgl + Swu value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+    }
+
+    // Inf
+    if constexpr (std::numeric_limits<float>::has_infinity) {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Sgl = std::numeric_limits<float>::infinity();
+        endPoints.Swu = 0.75f;
+
+        auto check = Checks::SOmin_OW<float>{};
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(3);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Sgl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[1], 0.75f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sgl + Swu value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = 0.75f;
+        endPoints.Swu = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(3);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.75f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Swu value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sgl + Swu value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = std::numeric_limits<float>::infinity();
+        endPoints.Swu = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(3);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Sgl value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Swu value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sgl + Swu value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Sgl_TooLarge)
+{
+    auto check = Checks::SOmin_OW<double>{};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Sgl = 0.15;
+        endPoints.Swu = 0.9;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(3);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.15, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.9 , 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 1.05, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Swu_TooLarge)
+{
+    auto check = Checks::SOmin_OW<double>{};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Sgl = 0.1;
+        endPoints.Swu = 0.95;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(3);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.1 , 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.95, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 1.05, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Mobile_Oil_Swmin)
+
+BOOST_AUTO_TEST_CASE(All_Good)
+{
+    auto check = Checks::MobileOil_OW_SWmin<float>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    BOOST_CHECK_EQUAL(check.numExportedCheckValues(), expectNumExported);
+
+    {
+        auto columns = std::vector<std::string>(expectNumExported);
+        check.columnNames(columns.data());
+
+        BOOST_CHECK_EQUAL(columns[0], "SWL");
+        BOOST_CHECK_EQUAL(columns[1], "SGL");
+        BOOST_CHECK_EQUAL(columns[2], "SOWCR");
+        BOOST_CHECK_EQUAL(columns[3], "1 - SWL - SGL");
+    }
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Swl   = 0.15f;
+        endPoints.Sgl   = 0.01f;
+        endPoints.Sowcr = 0.15f;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<float>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.15f, 1.0e-6f);
+        BOOST_CHECK_CLOSE(values[1], 0.01f, 1.0e-6f);
+        BOOST_CHECK_CLOSE(values[2], 0.15f, 1.0e-6f);
+        BOOST_CHECK_CLOSE(values[3], 1.0f - 0.15f - 0.01, 1.0e-5f);
+    }
+
+    BOOST_CHECK_MESSAGE(! check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Non_Finite)
+{
+    // NaN
+    if constexpr (std::numeric_limits<float>::has_quiet_NaN) {
+        const auto expectNumExported = std::size_t{4};
+
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgl = 0.01f;
+        endPoints.Sowcr = 0.32f;
+
+        auto check = Checks::MobileOil_OW_SWmin<float>{};
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgl value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.6f;
+        endPoints.Sgl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sowcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Sgl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgl value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.6f;
+        endPoints.Sgl = 0.01f;
+        endPoints.Sowcr = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sowcr value must be NaN");
+            BOOST_CHECK_CLOSE  (values[3], 1.0f - 0.6f - 0.01f, 1.0e-6);
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sowcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Sgl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgl value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgl = 0.01f;
+        endPoints.Sowcr = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sowcr value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgl value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sgl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sowcr = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Swl value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Sgl value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sowcr value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Swl - Sgl value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+    }
+
+    // Inf
+    if constexpr (std::numeric_limits<float>::has_infinity) {
+        const auto expectNumExported = std::size_t{4};
+
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgl = 0.01f;
+        endPoints.Sowcr = 0.32f;
+
+        auto check = Checks::MobileOil_OW_SWmin<float>{};
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgl value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.6f;
+        endPoints.Sgl = std::numeric_limits<float>::infinity();
+        endPoints.Sowcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Sgl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgl value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = 0.6f;
+        endPoints.Sgl = 0.01f;
+        endPoints.Sowcr = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sowcr value must be Inf");
+            BOOST_CHECK_CLOSE  (values[3], 1.0f - 0.6f - 0.01f, 1.0e-6);
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgl = std::numeric_limits<float>::infinity();
+        endPoints.Sowcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Sgl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgl value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgl = 0.01f;
+        endPoints.Sowcr = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sowcr value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgl value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Swl = std::numeric_limits<float>::infinity();
+        endPoints.Sgl = std::numeric_limits<float>::infinity();
+        endPoints.Sowcr = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Swl value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Sgl value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sowcr value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Swl - Sgl value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Swl_TooLarge)
+{
+    auto check = Checks::MobileOil_OW_SWmin<double>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Swl   = 0.70;
+        endPoints.Sgl   = 0.01;
+        endPoints.Sowcr = 0.32;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.70, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.01, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.32, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[3], 1.0 - 0.70 - 0.01, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Sgl_TooLarge)
+{
+    auto check = Checks::MobileOil_OW_SWmin<double>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Swl   = 0.65;
+        endPoints.Sgl   = 0.05;
+        endPoints.Sowcr = 0.32;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.65, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.05, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.32, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[3], 1.0 - 0.65 - 0.05, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Sowcr_TooLarge)
+{
+    auto check = Checks::MobileOil_OW_SWmin<double>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Swl   = 0.65;
+        endPoints.Sgl   = 0.04;
+        endPoints.Sowcr = 0.32;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.65, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.04, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.32, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[3], 1.0 - 0.65 - 0.04, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Mobile_Oil_Swmin
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Mobile_Oil_Swcr)
+
+BOOST_AUTO_TEST_CASE(All_Good)
+{
+    auto check = Checks::MobileOil_OW_SWcr<float>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    BOOST_CHECK_EQUAL(check.numExportedCheckValues(), expectNumExported);
+
+    {
+        auto columns = std::vector<std::string>(expectNumExported);
+        check.columnNames(columns.data());
+
+        BOOST_CHECK_EQUAL(columns[0], "SGL");
+        BOOST_CHECK_EQUAL(columns[1], "SWCR");
+        BOOST_CHECK_EQUAL(columns[2], "SOWCR");
+        BOOST_CHECK_EQUAL(columns[3], "1 - SWCR - SGL");
+    }
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Sgl   = 0.15f;
+        endPoints.Swcr  = 0.01f;
+        endPoints.Sowcr = 0.15f;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<float>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.15f, 1.0e-6f);
+        BOOST_CHECK_CLOSE(values[1], 0.01f, 1.0e-6f);
+        BOOST_CHECK_CLOSE(values[2], 0.15f, 1.0e-6f);
+        BOOST_CHECK_CLOSE(values[3], 1.0f - 0.15f - 0.01, 1.0e-5f);
+    }
+
+    BOOST_CHECK_MESSAGE(! check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Non_Finite)
+{
+    // NaN
+    if constexpr (std::numeric_limits<float>::has_quiet_NaN) {
+        const auto expectNumExported = std::size_t{4};
+
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Sgl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Swcr = 0.01f;
+        endPoints.Sowcr = 0.32f;
+
+        auto check = Checks::MobileOil_OW_SWcr<float>{};
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Sgl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Sgl - Swcr value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = 0.6f;
+        endPoints.Swcr = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sowcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Swcr value must be NaN");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Sgl - Swcr value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = 0.6f;
+        endPoints.Swcr = 0.01f;
+        endPoints.Sowcr = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sowcr value must be NaN");
+            BOOST_CHECK_CLOSE  (values[3], 1.0f - 0.6f - 0.01f, 1.0e-6);
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Swcr = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sowcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Sgl value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Swcr value must be NaN");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Sgl - Swcr value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Swcr = 0.01f;
+        endPoints.Sowcr = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Sgl value must be NaN");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sowcr value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Sgl - Swcr value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Swcr = std::numeric_limits<float>::quiet_NaN();
+        endPoints.Sowcr = std::numeric_limits<float>::quiet_NaN();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isnan(values[0]), "Sgl value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[1]), "Sgu value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[2]), "Sowcr value must be NaN");
+            BOOST_CHECK_MESSAGE(std::isnan(values[3]), "1 - Sgl - Swcr value must be NaN");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+    }
+
+    // Inf
+    if constexpr (std::numeric_limits<float>::has_infinity) {
+        const auto expectNumExported = std::size_t{4};
+
+        auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
+        endPoints.Sgl = std::numeric_limits<float>::infinity();
+        endPoints.Swcr = 0.01f;
+        endPoints.Sowcr = 0.32f;
+
+        auto check = Checks::MobileOil_OW_SWcr<float>{};
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Sgl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Sgl - Swcr value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = 0.6f;
+        endPoints.Swcr = std::numeric_limits<float>::infinity();
+        endPoints.Sowcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Swcr value must be Inf");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Sgl - Swcr value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = 0.6f;
+        endPoints.Swcr = 0.01f;
+        endPoints.Sowcr = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_CLOSE  (values[0], 0.6f, 1.0e-6f);
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sowcr value must be Inf");
+            BOOST_CHECK_CLOSE  (values[3], 1.0f - 0.6f - 0.01f, 1.0e-6);
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = std::numeric_limits<float>::infinity();
+        endPoints.Swcr = std::numeric_limits<float>::infinity();
+        endPoints.Sowcr = 0.32f;
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Sgl value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Swcr value must be Inf");
+            BOOST_CHECK_CLOSE  (values[2], 0.32f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Sgl - Swcr value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = std::numeric_limits<float>::infinity();
+        endPoints.Swcr = 0.01f;
+        endPoints.Sowcr = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Sgl value must be Inf");
+            BOOST_CHECK_CLOSE  (values[1], 0.01f, 1.0e-6f);
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sowcr value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Sgl - Swcr value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+
+        endPoints.Sgl = std::numeric_limits<float>::infinity();
+        endPoints.Swcr = std::numeric_limits<float>::infinity();
+        endPoints.Sowcr = std::numeric_limits<float>::infinity();
+        check.test(endPoints);
+
+        {
+            auto values = std::vector<float>(expectNumExported);
+            check.exportCheckValues(values.data());
+
+            BOOST_CHECK_MESSAGE(std::isinf(values[0]), "Sgl value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[1]), "Swcr value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[2]), "Sowcr value must be Inf");
+            BOOST_CHECK_MESSAGE(std::isinf(values[3]), "1 - Sgl - Swcr value must be Inf");
+
+            BOOST_CHECK_MESSAGE(check.isViolated(), "Check must be violated");
+            BOOST_CHECK_MESSAGE(check.isCritical(), "Check must be violated at critical level");
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Sgl_TooLarge)
+{
+    auto check = Checks::MobileOil_OW_SWcr<double>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Sgl   = 0.70;
+        endPoints.Swcr  = 0.01;
+        endPoints.Sowcr = 0.32;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.70, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.01, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.32, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[3], 1.0 - 0.70 - 0.01, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Swcr_TooLarge)
+{
+    auto check = Checks::MobileOil_OW_SWcr<double>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Sgl   = 0.65;
+        endPoints.Swcr  = 0.05;
+        endPoints.Sowcr = 0.32;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.65, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.05, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.32, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[3], 1.0 - 0.65 - 0.05, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_CASE(Sowcr_TooLarge)
+{
+    auto check = Checks::MobileOil_OW_SWcr<double>{};
+
+    const auto expectNumExported = std::size_t{4};
+
+    {
+        auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
+        endPoints.Sgl   = 0.65;
+        endPoints.Swcr  = 0.04;
+        endPoints.Sowcr = 0.32;
+
+        check.test(endPoints);
+    }
+
+    {
+        auto values = std::vector<double>(expectNumExported);
+        check.exportCheckValues(values.data());
+
+        BOOST_CHECK_CLOSE(values[0], 0.65, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[1], 0.04, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[2], 0.32, 1.0e-8);
+        BOOST_CHECK_CLOSE(values[3], 1.0 - 0.65 - 0.04, 1.0e-8);
+    }
+
+    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Mobile_Oil_Swcr
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE_END() // Oil_Water_System


### PR DESCRIPTION
This commit introduces a set of consistency checks for the oil phase saturation functions.  These plug into the framework introduced in commit c3939c544 (PR #5438).  We implement the following four checks for the gas/oil two-phase system

  * $0 \le S_{\mathrm{OG},\mathrm{CR}} < 1$
  * $S_{\mathrm{WL}} + S_{\mathrm{GU}} \le 1$
  * $S_{\mathrm{OG},\mathrm{CR}} < 1 - S_{\mathrm{WL}} - S_{\mathrm{GL}}$
  * $S_{\mathrm{OG},\mathrm{CR}} < 1 - S_{\mathrm{WL}} - S_{\mathrm{G},\mathrm{CR}}$

which all guarantee a non-negative (mobile) oil saturation in the gas/oil system.  Similarly, we implement the following four checks for the oil/water two-phase system

  - $0 \le S_{\mathrm{OW},\mathrm{CR}} < 1$
  - $S_{\mathrm{GL}} + S_{\mathrm{WU}} \le 1$
  - $S_{\mathrm{OW},\mathrm{CR}} < 1 - S_{\mathrm{WL}} - S_{\mathrm{GL}}$
  - $S_{\mathrm{OW},\mathrm{CR}} < 1 - S_{\mathrm{W},\mathrm{CR}} - S_{\mathrm{GL}}$

which provide the same guarantees as outlined above, but for the oil/water system.

We add a base class, `SOCheckBase<Scalar>`, which provides a common representation of the violated/critical predicates and implement the specific checks as derived types of this base class.