### PR TITLE
Correctly treat transmissibilities for PINCH option(4) ALL.

### DIFF
--- a/opm/simulators/flow/GenericCpGridVanguard.cpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.cpp
@@ -390,7 +390,7 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Eclips
 #endif
 
     // Note: removed_cells is guaranteed to be empty on ranks other than 0.
-    auto [removed_cells, pinchedNncData] =
+    auto removed_cells =
         this->grid_->processEclipseFormat(input_grid,
                                           &eclState,
                                           /*isPeriodic=*/false,

--- a/opm/simulators/flow/GenericCpGridVanguard.cpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.cpp
@@ -390,7 +390,7 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Eclips
 #endif
 
     // Note: removed_cells is guaranteed to be empty on ranks other than 0.
-    auto removed_cells =
+    auto [removed_cells, pinchedNncData] =
         this->grid_->processEclipseFormat(input_grid,
                                           &eclState,
                                           /*isPeriodic=*/false,
@@ -440,7 +440,7 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Eclips
         // when there is numerical aquifers, new NNC are generated during
         // grid processing we need to pass the NNC from root process to
         // other processes
-        if (has_numerical_aquifer && mpiSize > 1) {
+        if ((has_numerical_aquifer || !pinchedNncData.empty()) && mpiSize > 1) {
             auto nnc_input = eclState.getInputNNC();
             Parallel::MpiSerializer ser(grid_->comm());
             ser.broadcast(nnc_input);

--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -221,9 +221,12 @@ protected:
      *
      * \param cartesianToCompressed Vector containing the compressed index (or -1 for inactive
      *                              cells) as the element at the cartesian index.
+     * \param pinchOption4ALL Whether option 4 of PINCH is set to ALL. In this cases transmissibilities
+     *                        from the NNCs created by PINCH will overwrite.
      * \return Nothing.
      */
-    void applyNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianToCompressed);
+    void applyNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianToCompressed,
+                              bool pinchOption4ALL);
 
     /// \brief Multiplies the grid transmissibilities according to EDITNNC.
     void applyEditNncToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal);

--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -220,12 +220,15 @@ protected:
      *
      * \param cartesianToCompressed Vector containing the compressed index (or -1 for inactive
      *                              cells) as the element at the cartesian index.
-     * \param pinchOption4ALL Whether option 4 of PINCH is set to ALL. In this cases transmissibilities
-     *                        from the NNCs created by PINCH will overwrite.
      * \return Nothing.
      */
-    void applyNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianToCompressed,
-                              bool pinchOption4ALL);
+    void applyNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianToCompressed);
+
+    /// \brief Applies the previous calculate transmissibilities to the NNCs created via PINCH
+    ///
+    /// \param cartesianToCompressed Vector containing the compressed index (or -1 for inactive
+    ///                              cells) as the element at the cartesian index.
+    void applyPinchNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianToCompressed);
 
     /// \brief Multiplies the grid transmissibilities according to EDITNNC.
     void applyEditNncToGridTrans_(const std::unordered_map<std::size_t,int>& globalToLocal);

--- a/opm/simulators/flow/Transmissibility.hpp
+++ b/opm/simulators/flow/Transmissibility.hpp
@@ -172,8 +172,7 @@ protected:
                                unsigned insideCartElemIdx,
                                unsigned outsideCartElemIdx,
                                const TransMult& transMult,
-                               const std::array<int, dimWorld>& cartDims,
-                               bool pinchTop);
+                               const std::array<int, dimWorld>& cartDims);
 
     /// \brief Creates TRANS{XYZ} arrays for modification by FieldProps data
     ///

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -1048,12 +1048,9 @@ applyPinchNncToGridTrans_(const std::unordered_map<std::size_t,int>& cartesianTo
             continue;
 
         if (low == -1 || high == -1) {
-            // \todo Check why we end up here for some models in parallel
-            // Discard the NNC if it is between active cell and inactive cell
-            std::ostringstream sstr;
-            sstr << "PINCH NNC between active and inactive cells ("
-                 << low << " -> " << high << ") with globalcell is (" << c1 << "->" << c2 <<")";
-            OpmLog::warning(sstr.str());
+            // We can end up here if one of the cells is overlap/ghost, because those
+            // are lacking connections to other cells in the ghost/overlap.
+            // Hence discard the NNC if it is between active cell and inactive cell
             continue;
         }
 


### PR DESCRIPTION
In that case processEclipseFormat will create NNCs over the pinched out cells with correct transmissibilities. Those NNCs are marked as being created in PINCH and used to overwrite calculated transmissibilties for the horizontal intersections (transmissibilities of normal NNCs are usually added).

Note that the transmissibilities (without the multipliers) do not change later. Only the multipliers can change them in the schedule and that will still happen to some extend. Canges of MULTZ for pinched out cells will currently not be honored.

This is tested to work for all provided test cases.

Needs OPM/opm-common#4181 and OPM/opm-grid#756