### PR TITLE
Fix Build on Older Compilers

### DIFF
--- a/opm/models/utils/terminal.cpp
+++ b/opm/models/utils/terminal.cpp
@@ -30,6 +30,7 @@
 
 #include <csignal>
 #include <iostream>
+#include <string.h>             // strsignal()
 #include <sys/ioctl.h>
 #include <unistd.h>
 


### PR DESCRIPTION
The `strsignal()` function is declared in `<string.h>` on those.