### PR TITLE
Prepare OPM for DUNE 2.10

### DIFF
--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -288,7 +288,7 @@ public:
      */
     void gridChanged()
     {
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 8)
+#if DUNE_VERSION_GTE(DUNE_GRID, 2, 8)
                 elementMapper_.update(gridView_);
                 vertexMapper_.update(gridView_);
 #else

--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -288,13 +288,8 @@ public:
      */
     void gridChanged()
     {
-#if DUNE_VERSION_GTE(DUNE_GRID, 2, 8)
                 elementMapper_.update(gridView_);
                 vertexMapper_.update(gridView_);
-#else
-                elementMapper_.update();
-                vertexMapper_.update();
-#endif
 
         if (enableVtkOutput_())
             defaultVtkWriter_->gridChanged();

--- a/opm/models/io/vtkmultiwriter.hh
+++ b/opm/models/io/vtkmultiwriter.hh
@@ -164,13 +164,8 @@ public:
      */
     void gridChanged()
     {
-#if DUNE_VERSION_GTE(DUNE_GRID, 2, 8)
         elementMapper_.update(gridView_);
         vertexMapper_.update(gridView_);
-#else
-        elementMapper_.update();
-        vertexMapper_.update();
-#endif
     }
 
     /*!

--- a/opm/models/io/vtkmultiwriter.hh
+++ b/opm/models/io/vtkmultiwriter.hh
@@ -164,7 +164,7 @@ public:
      */
     void gridChanged()
     {
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 8)
+#if DUNE_VERSION_GTE(DUNE_GRID, 2, 8)
         elementMapper_.update(gridView_);
         vertexMapper_.update(gridView_);
 #else

--- a/opm/models/parallel/gridcommhandles.hh
+++ b/opm/models/parallel/gridcommhandles.hh
@@ -56,11 +56,7 @@ public:
         return codim == commCodim;
     }
 
-#if DUNE_VERSION_LT(DUNE_GRID, 2, 8)
-    bool fixedsize(int, int) const
-#else
     bool fixedSize(int, int) const
-#endif
     {
         // for each DOF we communicate a single value which has a
         // fixed size
@@ -120,11 +116,7 @@ public:
         return codim == commCodim;
     }
 
-#if DUNE_VERSION_LT(DUNE_GRID, 2, 8)
-    bool fixedsize(int, int) const
-#else
     bool fixedSize(int, int) const
-#endif
     {
         // for each DOF we communicate a single value which has a
         // fixed size
@@ -179,11 +171,7 @@ public:
         return codim == commCodim;
     }
 
-#if DUNE_VERSION_LT(DUNE_GRID, 2, 8)
-    bool fixedsize(int, int) const
-#else
     bool fixedSize(int, int) const
-#endif
     {
         // for each DOF we communicate a single value which has a
         // fixed size
@@ -240,11 +228,7 @@ public:
         return codim == commCodim;
     }
 
-#if DUNE_VERSION_LT(DUNE_GRID, 2, 8)
-    bool fixedsize(int, int) const
-#else
     bool fixedSize(int, int) const
-#endif
     {
         // for each DOF we communicate a single value which has a
         // fixed size

--- a/opm/simulators/flow/CollectDataOnIORank.hpp
+++ b/opm/simulators/flow/CollectDataOnIORank.hpp
@@ -55,7 +55,7 @@ template <class Grid, class EquilGrid, class GridView>
 class CollectDataOnIORank
 {
 public:
-    using CollectiveCommunication = typename Grid::CollectiveCommunication;
+    using CollectiveCommunication = typename Grid::Communication;
     using P2PCommunicatorType = Dune::Point2PointCommunicator<Dune::SimpleMessageBuffer>;
     using IndexMapType = std::vector<int>;
     using IndexMapStorageType = std::vector<IndexMapType>;

--- a/opm/simulators/linalg/ExtraSmoothers.hpp
+++ b/opm/simulators/linalg/ExtraSmoothers.hpp
@@ -20,7 +20,6 @@ namespace Amg
         static inline std::shared_ptr<MultithreadDILU<M, X, Y>> construct(Arguments& args) {
             return std::make_shared<MultithreadDILU<M, X, Y>>(args.getMatrix());
         }
-
     };
 
 } // namespace Amg

--- a/opm/simulators/linalg/elementborderlistfromgrid.hh
+++ b/opm/simulators/linalg/elementborderlistfromgrid.hh
@@ -78,11 +78,7 @@ class ElementBorderListFromGrid
         bool contains(int, int codim) const
         { return codim == 0; }
 
-#if DUNE_VERSION_LT(DUNE_GRID, 2, 8)
-        bool fixedsize(int, int) const
-#else
         bool fixedSize(int, int) const
-#endif
         { return true; }
 
         template <class EntityType>
@@ -172,11 +168,7 @@ class ElementBorderListFromGrid
         bool contains(int, int codim) const
         { return codim == 0; }
 
-#if DUNE_VERSION_LT(DUNE_GRID, 2, 8)
-        bool fixedsize(int, int) const
-#else
         bool fixedSize(int, int) const
-#endif
         { return true; }
 
         template <class EntityType>

--- a/opm/simulators/linalg/gpubridge/MultisegmentWellContribution.cpp
+++ b/opm/simulators/linalg/gpubridge/MultisegmentWellContribution.cpp
@@ -23,9 +23,9 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/TimingMacros.hpp>
 
-#if HAVE_UMFPACK
+#if HAVE_SUITESPARSE_UMFPACK
 #include <dune/istl/umfpack.hh>
-#endif // HAVE_UMFPACK
+#endif // HAVE_SUITESPARSE_UMFPACK
 
 namespace Opm {
 

--- a/opm/simulators/linalg/ilufirstelement.hh
+++ b/opm/simulators/linalg/ilufirstelement.hh
@@ -29,11 +29,7 @@
 namespace Opm
 {
 template<class K, int n, int m>
-#if DUNE_VERSION_GTE(DUNE_GRID, 2, 8)
 K& firstMatrixElement(MatrixBlock<K, n, m>& A)
-#else
-K& firstmatrixelement(MatrixBlock<K, n, m>& A)
-#endif
 { return A[0][0]; }
 }
 #endif // EWOMS_ILU_FIRSTELEMENT_HH

--- a/opm/simulators/linalg/matrixblock.hh
+++ b/opm/simulators/linalg/matrixblock.hh
@@ -269,7 +269,7 @@ struct MatrixDimension<Opm::MatrixBlock<Scalar, n, m> >
 { };
 
 
-#if HAVE_UMFPACK
+#if HAVE_SUITESPARSE_UMFPACK
 /// \brief UMFPack specialization for Opm::MatrixBlock to make AMG happy
 ///
 /// Without this the empty default implementation would be used.

--- a/opm/simulators/linalg/vertexborderlistfromgrid.hh
+++ b/opm/simulators/linalg/vertexborderlistfromgrid.hh
@@ -76,11 +76,7 @@ public:
     bool contains(int dim, int codim) const
     { return dim == codim; }
 
-#if DUNE_VERSION_LT(DUNE_GRID, 2, 8)
-    bool fixedsize(int, int) const
-#else
     bool fixedSize(int, int) const
-#endif
     { return true; }
 
     template <class EntityType>

--- a/opm/simulators/wells/MSWellHelpers.cpp
+++ b/opm/simulators/wells/MSWellHelpers.cpp
@@ -41,9 +41,9 @@
 #include <dune/istl/preconditioners.hh>
 #include <dune/istl/solvers.hh>
 
-#if HAVE_UMFPACK
+#if HAVE_SUITESPARSE_UMFPACK
 #include <dune/istl/umfpack.hh>
-#endif // HAVE_UMFPACK
+#endif // HAVE_SUITESPARSE_UMFPACK
 
 #include <cmath>
 #include <cstddef>
@@ -148,7 +148,7 @@ VectorType
 applyUMFPack(Dune::UMFPack<MatrixType>& linsolver,
              VectorType x)
 {
-#if HAVE_UMFPACK
+#if HAVE_SUITESPARSE_UMFPACK
     // The copy of x seems mandatory for calling UMFPack!
     VectorType y(x.size());
     y = 0.;
@@ -178,7 +178,7 @@ applyUMFPack(Dune::UMFPack<MatrixType>& linsolver,
     // this is not thread safe
     OPM_THROW(std::runtime_error, "Cannot use applyUMFPack() without UMFPACK. "
               "Reconfigure opm-simulators with SuiteSparse/UMFPACK support and recompile.");
-#endif // HAVE_UMFPACK
+#endif // HAVE_SUITESPARSE_UMFPACK
 }
 
 template <typename VectorType, typename MatrixType>
@@ -187,7 +187,7 @@ invertWithUMFPack(const int size,
                   const int bsize,
                   Dune::UMFPack<MatrixType>& linsolver)
 {
-#if HAVE_UMFPACK
+#if HAVE_SUITESPARSE_UMFPACK
     VectorType e(size);
     e = 0.0;
 
@@ -217,7 +217,7 @@ invertWithUMFPack(const int size,
     // this is not thread safe
     OPM_THROW(std::runtime_error, "Cannot use invertWithUMFPack() without UMFPACK. "
               "Reconfigure opm-simulators with SuiteSparse/UMFPACK support and recompile.");
-#endif // HAVE_UMFPACK
+#endif // HAVE_SUITESPARSE_UMFPACK
 }
 
 template <typename MatrixType, typename VectorType>

--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -178,7 +178,7 @@ apply(BVector& r) const
 template<class Scalar, int numWellEq, int numEq>
 void MultisegmentWellEquations<Scalar,numWellEq,numEq>::createSolver()
 {
-#if HAVE_UMFPACK
+#if HAVE_SUITESPARSE_UMFPACK
     if (duneDSolver_) {
         return;
     }


### PR DESCRIPTION
DUNE_VERSION_NEWER has been removed. Falling back to DUNE_VERSION_GTE which exists since at least DUNE 2.7.

Removed switches for older version than 2.7.