### PR TITLE
fix python package versioning

### DIFF
--- a/python/generate-pypi-package.sh
+++ b/python/generate-pypi-package.sh
@@ -27,7 +27,6 @@ DIR=`pwd`
 # Setup opm modules
 git clone https://github.com/OPM/opm-common
 git clone https://github.com/OPM/opm-grid
-git clone https://github.com/OPM/opm-models
 git clone https://github.com/OPM/opm-simulators
 git clone https://github.com/OPM/opm-utilities
 
@@ -38,26 +37,6 @@ mkdir -p /tmp/opm/wheelhouse
 
 for tag in ${!python_versions[@]}
 do
-    # Build opm-common bindings
-    pushd opm-common
-    # Delete the folder if it already exists
-    if [ -d $tag ]; then
-      rm -rf $tag
-    fi
-    mkdir $tag && cd $tag
-    cmake -DPYTHON_EXECUTABLE=${python_versions[$tag]} -DWITH_NATIVE=0 \
-      -DOPM_ENABLE_PYTHON=ON -DOPM_PYTHON_PACKAGE_VERSION_TAG=${VERSION_TAG} ..
-
-    # make step is necessary until the generated ParserKeywords/*.hpp are generated in the Python step
-    cmake --build . --target opmcommon_python -- -j${BUILD_JOBS}
-    cd python
-    echo -e "include opm/*\ninclude opm/io/summary/__init__.py" > MANIFEST.in
-    cat MANIFEST.in
-    ${python_versions[$tag]} setup.py sdist bdist_wheel --plat-name manylinux_2_28_x86_64 --python-tag $tag
-    ${python_versions[$tag]} -m auditwheel repair dist/*$tag*.whl
-    cp dist/*$tag*.whl /tmp/opm/wheelhouse
-    popd
-
     # Delete the folder if it already exists
     if [ -d $tag ]; then
       rm -rf $tag
@@ -66,11 +45,21 @@ do
     cmake -DPYTHON_EXECUTABLE=${python_versions[$tag]} -DWITH_NATIVE=0 -DBoost_USE_STATIC_LIBS=1 \
     -DOPM_ENABLE_PYTHON=ON -DOPM_PYTHON_PACKAGE_VERSION_TAG=${VERSION_TAG} -DBLA_STATIC=1 -DBLAS_LIBRARIES=/usr/lib64/libblas.a -DSUITESPARSE_USE_STATIC=1 -DCMAKE_DISABLE_FIND_PACKAGE_QuadMath=1 ..
 
-    # make step is necessary until the generated ParserKeywords/*.hpp are generated in the Python step
-    cmake --build . --target simulators -- -j${BUILD_JOBS}
+    cmake --build . --target opmcommon_python simulators --parallel ${BUILD_JOBS}
+
+    # Package opm-common bindings
+    cd opm-common/python
+    echo -e "include opm/*\ninclude opm/io/summary/__init__.py" > MANIFEST.in
+    cat MANIFEST.in
+    ${python_versions[$tag]} setup.py sdist bdist_wheel --plat-name manylinux_2_28_x86_64 --python-tag $tag
+    ${python_versions[$tag]} -m auditwheel repair dist/*$tag*.whl
+    cp dist/*$tag*.whl /tmp/opm/wheelhouse
+    cd ../..
+
     cd opm-simulators/python
     ${python_versions[$tag]} setup.py sdist bdist_wheel --plat-name manylinux_2_28_x86_64 --python-tag $tag
     ${python_versions[$tag]} -m auditwheel repair dist/*$tag*.whl
     cp dist/*$tag*.whl /tmp/opm/wheelhouse
+
     popd
 done

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -97,6 +97,9 @@ file(COPY ${PROJECT_SOURCE_DIR}/python/README.md DESTINATION ${PROJECT_BINARY_DI
 file(COPY ${PROJECT_SOURCE_DIR}/python/MANIFEST.in DESTINATION ${PROJECT_BINARY_DIR}/python)
 file(COPY ${PROJECT_SOURCE_DIR}/python/pyproject.toml DESTINATION ${PROJECT_BINARY_DIR}/python)
 
+
+set(opm-simulators_PYTHON_PACKAGE_VERSION ${OPM_PYTHON_PACKAGE_VERSION_TAG})
+
 # Generate versioned setup.py
 configure_file(${PROJECT_SOURCE_DIR}/python/setup.py.in
                 ${PROJECT_BINARY_DIR}/python/setup.py.tmp @ONLY)


### PR DESCRIPTION
i forgot the package version tag in last iteration.

remove opm-models cloning as it is no longer required
optimize build a little by building both bindings in one build directory