### PR TITLE
Move python initialization function

### DIFF
--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -174,26 +174,6 @@ public:
         return exitCode;
     }
 
-    using FlowMainType = FlowMain<Properties::TTag::FlowProblemTPFA>;
-    // To be called from the Python interface code. Only do the
-    // initialization and then return a pointer to the FlowMain
-    // object that can later be accessed directly from the Python interface
-    // to e.g. advance the simulator one report step
-    std::unique_ptr<FlowMainType> initFlowBlackoil(int& exitCode)
-    {
-        exitCode = EXIT_SUCCESS;
-        if (initialize_<Properties::TTag::FlowEarlyBird>(exitCode)) {
-            // TODO: check that this deck really represents a blackoil
-            // case. E.g. check that number of phases == 3
-            this->setupVanguard();
-            return flowBlackoilTpfaMainInit(
-                argc_, argv_, outputCout_, outputFiles_);
-        } else {
-            //NOTE: exitCode was set by initialize_() above;
-            return std::unique_ptr<FlowMainType>(); // nullptr
-        }
-    }
-
     //! \brief Used for test_outputdir.
     int justInitialize()
     {

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -289,6 +289,7 @@ private:
         return flowMain<TypeTag>(argc_, argv_, outputCout_, outputFiles_);
     }
 
+protected:
     /// \brief Initialize
     /// \param exitCode The exitCode of the program.
     ///
@@ -447,6 +448,9 @@ private:
         return true;
     }
 
+    void setupVanguard();
+
+private:
     // This function is an extreme special case, if the program has been invoked
     // *exactly* as:
     //
@@ -705,8 +709,6 @@ private:
                   std::string_view moduleVersion,
                   std::string_view compileTimestamp);
 
-    void setupVanguard();
-
     static int getNumThreads()
     {
 
@@ -751,11 +753,14 @@ private:
     void setupDamaris(const std::string& outputDir);
 #endif
 
+protected:
     int argc_{0};
     char** argv_{nullptr};
-    bool ownMPI_{true}; //!< True if we "own" MPI and should init / finalize
     bool outputCout_{false};
     bool outputFiles_{false};
+
+private:
+    bool ownMPI_{true}; //!< True if we "own" MPI and should init / finalize
     double setupTime_{0.0};
     std::string deckFilename_{};
     std::string flowProgName_{};

--- a/opm/simulators/flow/python/PyBlackOilSimulator.hpp
+++ b/opm/simulators/flow/python/PyBlackOilSimulator.hpp
@@ -20,7 +20,7 @@
 #ifndef OPM_PY_BLACKOIL_SIMULATOR_HEADER_INCLUDED
 #define OPM_PY_BLACKOIL_SIMULATOR_HEADER_INCLUDED
 
-#include <opm/simulators/flow/Main.hpp>
+#include <python/simulators/PyMain.hpp>
 #include <opm/simulators/flow/FlowMain.hpp>
 #include <opm/models/utils/propertysystem.hh>
 #include <opm/models/utils/parametersystem.hpp>
@@ -82,7 +82,7 @@ private:
     // This *must* be declared before other pointers
     // to simulator objects. This in order to deinitialize
     // MPI at the correct time (ie after the other objects).
-    std::unique_ptr<Opm::Main> main_;
+    std::unique_ptr<Opm::PyMain> main_;
 
     std::unique_ptr<Opm::FlowMain<TypeTag>> flow_main_;
     Simulator* simulator_;

--- a/python/simulators/PyBlackOilSimulator.cpp
+++ b/python/simulators/PyBlackOilSimulator.cpp
@@ -22,7 +22,6 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#include <opm/simulators/flow/Main.hpp>
 #include <opm/simulators/flow/FlowMain.hpp>
 //#include <opm/simulators/flow/python/PyFluidState.hpp>
 #include <opm/simulators/flow/python/PyMaterialState.hpp>
@@ -216,7 +215,7 @@ int PyBlackOilSimulator::stepInit()
         }
     }
     if (this->deck_) {
-        this->main_ = std::make_unique<Opm::Main>(
+        this->main_ = std::make_unique<Opm::PyMain>(
             this->deck_->getDataFile(),
             this->eclipse_state_,
             this->schedule_,
@@ -226,7 +225,7 @@ int PyBlackOilSimulator::stepInit()
         );
     }
     else {
-        this->main_ = std::make_unique<Opm::Main>(
+        this->main_ = std::make_unique<Opm::PyMain>(
             this->deck_filename_,
             this->mpi_init_,
             this->mpi_finalize_

--- a/python/simulators/PyMain.hpp
+++ b/python/simulators/PyMain.hpp
@@ -1,0 +1,60 @@
+/*
+  Copyright 2013, 2014, 2015 SINTEF ICT, Applied Mathematics.
+  Copyright 2014 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015 IRIS AS
+  Copyright 2014 STATOIL ASA.
+  Copyright 2023 Inria
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_PYMAIN_HEADER_INCLUDED
+#define OPM_PYMAIN_HEADER_INCLUDED
+
+#include <opm/simulators/flow/Main.hpp>
+
+namespace Opm {
+
+// ----------------- Python Main class -----------------
+// Adds a python-only initialization method
+class PyMain : public Main
+{
+public:
+    using Main::Main;
+
+    using FlowMainType = FlowMain<Properties::TTag::FlowProblemTPFA>;
+    // To be called from the Python interface code. Only do the
+    // initialization and then return a pointer to the FlowMain
+    // object that can later be accessed directly from the Python interface
+    // to e.g. advance the simulator one report step
+    std::unique_ptr<FlowMainType> initFlowBlackoil(int& exitCode)
+    {
+        exitCode = EXIT_SUCCESS;
+        if (initialize_<Properties::TTag::FlowEarlyBird>(exitCode)) {
+            // TODO: check that this deck really represents a blackoil
+            // case. E.g. check that number of phases == 3
+            this->setupVanguard();
+            return flowBlackoilTpfaMainInit(
+                argc_, argv_, outputCout_, outputFiles_);
+        } else {
+            //NOTE: exitCode was set by initialize_() above;
+            return std::unique_ptr<FlowMainType>(); // nullptr
+        }
+    }
+};
+
+} // namespace Opm
+
+#endif // OPM_PYMAIN_HEADER_INCLUDED


### PR DESCRIPTION
This saves us hundreds of MB per simulator object.

The entire blackoil simulator has been instanced (instanced, not built mind you) in every single simulator object due to the member type.