### PR TITLE
Convergence monitors

### DIFF
--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -392,6 +392,7 @@ namespace Opm {
                 // For each iteration we store in a vector the norms of the residual of
                 // the mass balance for each active phase, the well flux and the well equations.
                 residual_norms_history_.clear();
+                total_penaltyCard_.reset();
                 current_relaxation_ = 1.0;
                 dx_old_ = 0.0;
                 convergence_reports_.push_back({timer.reportStepNum(), timer.currentStepNum(), {}});

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -1154,12 +1154,10 @@ namespace Opm {
 
         total_penaltyCard_ += report.getPenaltyCard();
 
-
-
         if (param_.convergence_monitoring_ && (total_penaltyCard_.total() > param_.convergence_monitoring_cutoff_)) {
             report.setReservoirFailed({ConvergenceReport::ReservoirFailure::Type::ConvergenceMonitorFailure,
-                                        ConvergenceReport::Severity::ConvergenceMonitorFailure,
-                                        -1}); // -1 indicates it's not specific to any component
+                                       ConvergenceReport::Severity::ConvergenceMonitorFailure,
+                                       -1}); // -1 indicates it's not specific to any component
         }
     }
 

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -1151,7 +1151,9 @@ namespace Opm {
 
         total_penaltyCard_ += report.getPenaltyCard();
 
-        if (total_penaltyCard_.total() > param_.convergence_monitoring_cutoff_) {
+
+
+        if (param_.convergence_monitoring_ && (total_penaltyCard_.total() > param_.convergence_monitoring_cutoff_)) {
             report.setReservoirFailed({ConvergenceReport::ReservoirFailure::Type::ConvergenceMonitorFailure,
                                         ConvergenceReport::Severity::ConvergenceMonitorFailure,
                                         -1}); // -1 indicates it's not specific to any component
@@ -1179,9 +1181,8 @@ namespace Opm {
                 OPM_TIMEBLOCK(getWellConvergence);
                 report += wellModel().getWellConvergence(B_avg, /*checkWellGroupControls*/report.converged());
             }
-            if (param_.convergence_monitoring_) {
-                checkCardPenalty(report, iteration);
-            }
+
+            checkCardPenalty(report, iteration);
 
             return report;
         }

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -366,10 +366,13 @@ namespace Opm {
 
                 // Throw if any NaN or too large residual found.
                 if (severity == ConvergenceReport::Severity::NotANumber) {
+                    failureReport_ += report;
                     OPM_THROW_PROBLEM(NumericalProblem, "NaN residual found!");
                 } else if (severity == ConvergenceReport::Severity::TooLarge) {
+                    failureReport_ += report;
                     OPM_THROW_NOLOG(NumericalProblem, "Too large residual found!");
                 } else if (severity == ConvergenceReport::Severity::ConvergenceMonitorFailure) {
+                    failureReport_ += report;
                     OPM_THROW_PROBLEM(ConvergenceMonitorFailure, "Total penalty count exceeded cut-off-limit of " + std::to_string(param_.convergence_monitoring_cutoff_));
                 }
             }

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -1172,6 +1172,15 @@ namespace Opm {
             }
             // check card penalty, and add to report
             checkCardPenalty(report, iteration);
+
+            int cut_off_limit = 30;
+            if (total_penaltyCard_.total() > cut_off_limit) {
+                report.setReservoirFailed({ConvergenceReport::ReservoirFailure::Type::ConvergenceMonitorFailure,
+                                            ConvergenceReport::Severity::TooLarge,
+                                            -1}); // -1 indicates it's not specific to any component
+                throw ConvergenceMonitorFailure("Total penalty count exceeded cut-off-limit of " + std::to_string(cut_off_limit) + ". Cutting timestep.");
+            }
+
             return report;
         }
 

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -369,6 +369,8 @@ namespace Opm {
                     OPM_THROW_PROBLEM(NumericalProblem, "NaN residual found!");
                 } else if (severity == ConvergenceReport::Severity::TooLarge) {
                     OPM_THROW_NOLOG(NumericalProblem, "Too large residual found!");
+                } else if (severity == ConvergenceReport::Severity::ConvergenceMonitorFailure) {
+                    OPM_THROW_PROBLEM(ConvergenceMonitorFailure, "Total penalty count exceeded cut-off-limit of " + std::to_string(param_.convergence_monitoring_cutoff_));
                 }
             }
             report.update_time += perfTimer.stop();
@@ -1148,9 +1150,8 @@ namespace Opm {
 
         if (total_penaltyCard_.total() > param_.convergence_monitoring_cutoff_) {
             report.setReservoirFailed({ConvergenceReport::ReservoirFailure::Type::ConvergenceMonitorFailure,
-                                        ConvergenceReport::Severity::TooLarge,
+                                        ConvergenceReport::Severity::ConvergenceMonitorFailure,
                                         -1}); // -1 indicates it's not specific to any component
-            throw ConvergenceMonitorFailure("Total penalty count exceeded cut-off-limit of " + std::to_string(param_.convergence_monitoring_cutoff_) + ". Cutting timestep.");
         }
     }
 

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -1127,6 +1127,10 @@ namespace Opm {
             }
         }
 
+        if (report.wellFailures().size() > 0) {
+            report.addLargeWellResidualsPenalty();
+        }
+
         total_penaltyCard_ += report.getPenaltyCard();
 
     }

--- a/opm/simulators/flow/BlackoilModelNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelNldd.hpp
@@ -678,7 +678,7 @@ private:
                     report.setReservoirFailed({types[ii], CR::Severity::Normal, compIdx});
                 }
 
-                report.setReservoirConvergenceMetric(types[ii], compIdx, res[ii]);
+                report.setReservoirConvergenceMetric(types[ii], compIdx, res[ii], tol[ii]);
             }
         }
 

--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -94,6 +94,10 @@ BlackoilModelParameters<Scalar>::BlackoilModelParameters()
     network_max_iterations_ = Parameters::Get<Parameters::NetworkMaxIterations>();
     local_domain_ordering_ = domainOrderingMeasureFromString(Parameters::Get<Parameters::LocalDomainsOrderingMeasure>());
     write_partitions_ = Parameters::Get<Parameters::DebugEmitCellPartition>();
+
+    convergence_monitoring_ = Parameters::Get<Parameters::ConvergenceMonitoring>();
+    convergence_monitoring_cutoff_ = Parameters::Get<Parameters::ConvergenceMonitoringCutOff>();
+    convergence_monitoring_decay_factor_ = Parameters::Get<Parameters::ConvergenceMonitoringDecayFactor<Scalar>>();
 }
 
 template<class Scalar>
@@ -227,6 +231,13 @@ void BlackoilModelParameters<Scalar>::registerParameters()
          "and  'residual'.");
     Parameters::Register<Parameters::DebugEmitCellPartition>
         ("Whether or not to emit cell partitions as a debugging aid.");
+
+    Parameters::Register<Parameters::ConvergenceMonitoring>
+        ("Enable convergence monitoring");
+    Parameters::Register<Parameters::ConvergenceMonitoringCutOff>
+        ("Cut off limit for convergence monitoring");
+    Parameters::Register<Parameters::ConvergenceMonitoringDecayFactor<Scalar>>
+        ("Decay factor for convergence monitoring");
 
     Parameters::Hide<Parameters::DebugEmitCellPartition>();
 

--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -137,6 +137,11 @@ struct LocalDomainsPartitioningImbalance { static constexpr Scalar value = 1.03;
 struct LocalDomainsPartitioningMethod { static constexpr auto value = "zoltan"; };
 struct LocalDomainsOrderingMeasure { static constexpr auto value = "maxpressure"; };
 
+struct ConvergenceMonitoring { static constexpr bool value = false; };
+struct ConvergenceMonitoringCutOff { static constexpr int value = 30; };
+template<class Scalar>
+struct ConvergenceMonitoringDecayFactor { static constexpr Scalar value = 0.75; };
+
 } // namespace Opm::Parameters
 
 namespace Opm {
@@ -283,6 +288,13 @@ public:
     DomainOrderingMeasure local_domain_ordering_{DomainOrderingMeasure::MaxPressure};
 
     bool write_partitions_{false};
+
+    /// Whether to enable convergence monitoring
+    bool convergence_monitoring_;
+    /// Cut-off limit for convergence monitoring
+    int convergence_monitoring_cutoff_;
+    /// Decay factor used in convergence monitoring
+    Scalar convergence_monitoring_decay_factor_;
 
     /// Construct from user parameters or defaults.
     BlackoilModelParameters();

--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -138,7 +138,7 @@ struct LocalDomainsPartitioningMethod { static constexpr auto value = "zoltan"; 
 struct LocalDomainsOrderingMeasure { static constexpr auto value = "maxpressure"; };
 
 struct ConvergenceMonitoring { static constexpr bool value = false; };
-struct ConvergenceMonitoringCutOff { static constexpr int value = 30; };
+struct ConvergenceMonitoringCutOff { static constexpr int value = 6; };
 template<class Scalar>
 struct ConvergenceMonitoringDecayFactor { static constexpr Scalar value = 0.75; };
 

--- a/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
+++ b/opm/simulators/flow/ExtraConvergenceOutputThread.cpp
@@ -65,6 +65,9 @@ namespace {
             "CnvCellCntConv"s,
             "CnvCellCntRelax"s,
             "CnvCellCntUnconv"s,
+            "PenaltyNonConv"s,
+            "PenaltyDecay"s,
+            "PenaltyWellRes"s,
         };
     }
 
@@ -190,6 +193,17 @@ namespace {
         }
     }
 
+    void writePenaltyCount(std::ostream&                 os,
+                           const std::string::size_type  firstColSize,
+                           const Opm::ConvergenceReport& report)
+    {
+        const auto& penaltyCard = report.getPenaltyCard();
+
+        os << ' ' << std::setw(firstColSize) << penaltyCard.nonConverged;
+        os << ' ' << std::setw(firstColSize) << penaltyCard.distanceDecay;
+        os << ' ' << std::setw(firstColSize) << penaltyCard.largeWellResiduals;
+    }
+
     void writeReservoirConvergence(std::ostream&                 os,
                                    const std::string::size_type  colSize,
                                    const Opm::ConvergenceReport& report)
@@ -228,6 +242,8 @@ namespace {
             writeTimeColumns(os, convertTime, firstColSize, iter, report, request);
 
             writeCnvPvSplit(os, expectNumCnvSplit, firstColSize, report);
+
+            writePenaltyCount(os, firstColSize, report);
 
             writeReservoirConvergence(os, colSize, report);
             writeWellConvergence(os, colSize, report);

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -249,6 +249,7 @@ void registerAdaptiveParameters();
                 }
                 catch (const ConvergenceMonitorFailure& e) {
                     causeOfFailure = "Convergence monitor failure";
+                    substepReport = solver.failureReport();
                 }
                 catch (const LinearSolverProblem& e) {
                     substepReport = solver.failureReport();

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -247,6 +247,9 @@ void registerAdaptiveParameters();
                     logException_(e, solverVerbose_);
                     // since linearIterations is < 0 this will restart the solver
                 }
+                catch (const ConvergenceMonitorFailure& e) {
+                    causeOfFailure = "Convergence monitor failure";
+                }
                 catch (const LinearSolverProblem& e) {
                     substepReport = solver.failureReport();
                     causeOfFailure = "Linear solver convergence failure";

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -248,8 +248,8 @@ void registerAdaptiveParameters();
                     // since linearIterations is < 0 this will restart the solver
                 }
                 catch (const ConvergenceMonitorFailure& e) {
-                    causeOfFailure = "Convergence monitor failure";
                     substepReport = solver.failureReport();
+                    causeOfFailure = "Convergence monitor failure";
                 }
                 catch (const LinearSolverProblem& e) {
                     substepReport = solver.failureReport();

--- a/opm/simulators/timestepping/ConvergenceReport.cpp
+++ b/opm/simulators/timestepping/ConvergenceReport.cpp
@@ -97,4 +97,10 @@ namespace Opm
     }
 
 
+    std::string to_string(const ConvergenceReport::PenaltyCard& pc)
+    {
+        return fmt::format("PenaltyCard {{ NonConverged: {}, DistanceDecay: {}, LargeWellResiduals: {}, Total: {} }}",
+                           pc.nonConverged, pc.distanceDecay, pc.largeWellResiduals, pc.total());
+    }
+
 } // namespace Opm

--- a/opm/simulators/timestepping/ConvergenceReport.cpp
+++ b/opm/simulators/timestepping/ConvergenceReport.cpp
@@ -59,6 +59,8 @@ namespace Opm
             return "TooLarge";
         case S::NotANumber:
             return "NotANumber";
+        case S::ConvergenceMonitorFailure:
+            return "ConvergenceMonitorFailure";
         }
         throw std::logic_error("Unknown ConvergenceReport::Severity");
     }

--- a/opm/simulators/timestepping/ConvergenceReport.hpp
+++ b/opm/simulators/timestepping/ConvergenceReport.hpp
@@ -62,6 +62,13 @@ namespace Opm
                 return nonConverged + distanceDecay + largeWellResiduals;
             }
 
+            void reset()
+            {
+                nonConverged = 0;
+                distanceDecay = 0;
+                largeWellResiduals = 0;
+            }
+
             PenaltyCard& operator+=(const PenaltyCard& other) {
                 nonConverged += other.nonConverged;
                 distanceDecay += other.distanceDecay;

--- a/opm/simulators/timestepping/ConvergenceReport.hpp
+++ b/opm/simulators/timestepping/ConvergenceReport.hpp
@@ -191,6 +191,43 @@ namespace Opm
             std::string well_name_ {};
         };
 
+        class WellConvergenceMetric
+        {
+        public:
+            // Default constructor needed for object serialisation.  Don't
+            // use this for anything else.
+            WellConvergenceMetric() = default;
+
+            WellConvergenceMetric(WellFailure::Type t, Severity s, int phase, double value, const std::string& well_name)
+                : type_(t), severity_(s), phase_(phase), value_(value), well_name_(well_name)
+            {}
+
+            WellFailure::Type type() const { return type_; }
+            Severity severity() const { return severity_; }
+            int phase() const { return phase_; }
+            double value() const { return value_; }
+            const std::string& wellName() const { return well_name_; }
+
+            template <typename Serializer>
+            void serializeOp(Serializer& serializer)
+            {
+                serializer(this->type_);
+                serializer(this->severity_);
+                serializer(this->phase_);
+                serializer(this->value_);
+                serializer(this->well_name_);
+            }
+
+        private:
+            // Note to maintainers: If you change this list of data members,
+            // then please update serializeOp() accordingly.
+            WellFailure::Type type_ { WellFailure::Type::Invalid };
+            Severity severity_ { Severity::None };
+            int phase_ { -1 };
+            double value_ { 0.0 };
+            std::string well_name_ {};
+        };
+
         // ----------- Mutating member functions -----------
 
         ConvergenceReport()
@@ -231,6 +268,12 @@ namespace Opm
             this->res_convergence_.emplace_back(std::forward<Args>(args)...);
         }
 
+        template <typename... Args>
+        void setWellConvergenceMetric(Args&&... args)
+        {
+            this->well_convergence_.emplace_back(std::forward<Args>(args)...);
+        }
+
         void setWellGroupTargetsViolated(const bool wellGroupTargetsViolated)
         {
             wellGroupTargetsViolated_ = wellGroupTargetsViolated;
@@ -250,6 +293,7 @@ namespace Opm
             res_failures_.insert(res_failures_.end(), other.res_failures_.begin(), other.res_failures_.end());
             well_failures_.insert(well_failures_.end(), other.well_failures_.begin(), other.well_failures_.end());
             res_convergence_.insert(res_convergence_.end(), other.res_convergence_.begin(), other.res_convergence_.end());
+            well_convergence_.insert(well_convergence_.end(), other.well_convergence_.begin(), other.well_convergence_.end());
             assert(reservoirFailed() != res_failures_.empty());
             assert(wellFailed() != well_failures_.empty());
             wellGroupTargetsViolated_ = (wellGroupTargetsViolated_ || other.wellGroupTargetsViolated_);
@@ -316,6 +360,11 @@ namespace Opm
             return well_failures_;
         }
 
+        const std::vector<WellConvergenceMetric>& wellConvergence() const
+        {
+            return well_convergence_;
+        }
+
         const PenaltyCard& getPenaltyCard() const
         {
             return penaltyCard_;
@@ -360,6 +409,7 @@ namespace Opm
             serializer(this->res_failures_);
             serializer(this->well_failures_);
             serializer(this->res_convergence_);
+            serializer(this->well_convergence_);
             serializer(this->wellGroupTargetsViolated_);
             serializer(this->cnvPvSplit_);
             serializer(this->eligiblePoreVolume_);
@@ -375,6 +425,7 @@ namespace Opm
         std::vector<ReservoirFailure> res_failures_;
         std::vector<WellFailure> well_failures_;
         std::vector<ReservoirConvergenceMetric> res_convergence_;
+        std::vector<WellConvergenceMetric> well_convergence_;
         bool wellGroupTargetsViolated_;
         CnvPvSplit cnvPvSplit_{};
         double eligiblePoreVolume_{};

--- a/opm/simulators/timestepping/ConvergenceReport.hpp
+++ b/opm/simulators/timestepping/ConvergenceReport.hpp
@@ -51,6 +51,7 @@ namespace Opm
             Normal     = 1,
             TooLarge   = 2,
             NotANumber = 3,
+            ConvergenceMonitorFailure = 4,
         };
 
         struct PenaltyCard {

--- a/opm/simulators/timestepping/ConvergenceReport.hpp
+++ b/opm/simulators/timestepping/ConvergenceReport.hpp
@@ -129,13 +129,14 @@ namespace Opm
             // use this for anything else.
             ReservoirConvergenceMetric() = default;
 
-            ReservoirConvergenceMetric(ReservoirFailure::Type t, int phase, double value)
-                : type_(t), phase_(phase), value_(value)
+            ReservoirConvergenceMetric(ReservoirFailure::Type t, int phase, double value, double tolerance)
+                : type_(t), phase_(phase), value_(value), tolerance_(tolerance)
             {}
 
             ReservoirFailure::Type type() const { return type_; }
             int phase() const { return phase_; }
             double value() const { return value_; }
+            double tolerance() const { return tolerance_; }
 
             template <typename Serializer>
             void serializeOp(Serializer& serializer)
@@ -143,6 +144,7 @@ namespace Opm
                 serializer(this->type_);
                 serializer(this->phase_);
                 serializer(this->value_);
+                serializer(this->tolerance_);
             }
 
         private:
@@ -151,6 +153,7 @@ namespace Opm
             ReservoirFailure::Type type_ { ReservoirFailure::Type::Invalid };
             int phase_ { -1 };
             double value_ { 0.0 };
+            double tolerance_ { 0.0 };
         };
 
         class WellFailure

--- a/opm/simulators/timestepping/ConvergenceReport.hpp
+++ b/opm/simulators/timestepping/ConvergenceReport.hpp
@@ -45,13 +45,13 @@ namespace Opm
             ReservoirFailed = 1 << 0,
             WellFailed      = 1 << 1,
         };
-
+        // More severe problems should have higher numbers
         enum struct Severity {
             None       = 0,
             Normal     = 1,
-            TooLarge   = 2,
-            NotANumber = 3,
-            ConvergenceMonitorFailure = 4,
+            ConvergenceMonitorFailure = 2,
+            TooLarge   = 3,
+            NotANumber = 4,
         };
 
         struct PenaltyCard {

--- a/opm/simulators/timestepping/ConvergenceReport.hpp
+++ b/opm/simulators/timestepping/ConvergenceReport.hpp
@@ -53,6 +53,31 @@ namespace Opm
             NotANumber = 3,
         };
 
+        struct PenaltyCard {
+            int nonConverged{0};
+            int distanceDecay{0};
+            int largeWellResiduals{0};
+
+            int total() const {
+                return nonConverged + distanceDecay + largeWellResiduals;
+            }
+
+            PenaltyCard& operator+=(const PenaltyCard& other) {
+                nonConverged += other.nonConverged;
+                distanceDecay += other.distanceDecay;
+                largeWellResiduals += other.largeWellResiduals;
+                return *this;
+            }
+
+            template <typename Serializer>
+            void serializeOp(Serializer& serializer)
+            {
+                serializer(nonConverged);
+                serializer(distanceDecay);
+                serializer(largeWellResiduals);
+            }
+        };
+
         using CnvPvSplit = std::pair<
             std::vector<double>,
             std::vector<int>>;
@@ -291,6 +316,26 @@ namespace Opm
             return well_failures_;
         }
 
+        const PenaltyCard& getPenaltyCard() const
+        {
+            return penaltyCard_;
+        }
+
+        void addNonConvergedPenalty()
+        {
+            penaltyCard_.nonConverged++;
+        }
+
+        void addDistanceDecayPenalty()
+        {
+            penaltyCard_.distanceDecay++;
+        }
+
+        void addLargeWellResidualsPenalty()
+        {
+            penaltyCard_.largeWellResiduals++;
+        }
+
         Severity severityOfWorstFailure() const
         {
             // A function to get the worst of two severities.
@@ -318,6 +363,7 @@ namespace Opm
             serializer(this->wellGroupTargetsViolated_);
             serializer(this->cnvPvSplit_);
             serializer(this->eligiblePoreVolume_);
+            serializer(this->penaltyCard_);
         }
 
     private:
@@ -332,6 +378,7 @@ namespace Opm
         bool wellGroupTargetsViolated_;
         CnvPvSplit cnvPvSplit_{};
         double eligiblePoreVolume_{};
+        PenaltyCard penaltyCard_;
     };
 
     struct StepReport
@@ -348,6 +395,9 @@ namespace Opm
     std::string to_string(const ConvergenceReport::WellFailure::Type t);
 
     std::string to_string(const ConvergenceReport::WellFailure& wf);
+
+    std::string to_string(const ConvergenceReport::PenaltyCard& pc);
+
 
 
 } // namespace Opm

--- a/opm/simulators/timestepping/ConvergenceReport.hpp
+++ b/opm/simulators/timestepping/ConvergenceReport.hpp
@@ -92,7 +92,7 @@ namespace Opm
         class ReservoirFailure
         {
         public:
-            enum struct Type { Invalid, MassBalance, Cnv };
+            enum struct Type { Invalid, MassBalance, Cnv, ConvergenceMonitorFailure };
 
             // Default constructor needed for object serialisation.  Don't
             // use this for anything else.

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -134,13 +134,20 @@ getWellConvergence(const WellState<Scalar>& well_state,
 
         if (std::isnan(well_flux_residual[compIdx])) {
             report.setWellFailed({type, CR::Severity::NotANumber, compIdx, baseif_.name()});
+            report.setWellConvergenceMetric(type, CR::Severity::NotANumber, compIdx, well_flux_residual[compIdx], baseif_.name());
         } else if (well_flux_residual[compIdx] > maxResidualAllowed) {
             report.setWellFailed({type, CR::Severity::TooLarge, compIdx, baseif_.name()});
+            report.setWellConvergenceMetric(type, CR::Severity::TooLarge, compIdx, well_flux_residual[compIdx], baseif_.name());
         } else if (!relax_tolerance && well_flux_residual[compIdx] > tol_wells) {
             report.setWellFailed({type, CR::Severity::Normal, compIdx, baseif_.name()});
+            report.setWellConvergenceMetric(type, CR::Severity::Normal, compIdx, well_flux_residual[compIdx], baseif_.name());
         } else if (well_flux_residual[compIdx] > relaxed_tolerance_flow) {
             report.setWellFailed({type, CR::Severity::Normal, compIdx, baseif_.name()});
+            report.setWellConvergenceMetric(type, CR::Severity::Normal, compIdx, well_flux_residual[compIdx], baseif_.name());
+        } else {
+            report.setWellConvergenceMetric(CR::WellFailure::Type::Invalid, CR::Severity::None, compIdx, well_flux_residual[compIdx], baseif_.name());
         }
+
     }
 
     WellConvergence(baseif_).


### PR DESCRIPTION
# Implement Convergence Monitoring

This PR introduces a new convergence monitoring feature to improve the robustness and efficiency of the simulator. It is based on the following publication:

Lie, K., Moyner, O., Klemetsdal, Ø., Skaflestad, B., Moncorgé, A., & Kippe, V. (2024). Enhancing Performance of Complex Reservoir Models via Convergence Monitors. ECMOR, 2024(1), 1-9. (https://doi.org/10.3997/2214-4609.202437057)

The convergence monitoring system tracks the convergence behaviour across iterations, applying penalties for non-convergence. If the total penalty count exceeds the specified cut-off limit, the simulator will cut the timestep.

This feature allows early-exiting for steps that are not converging, saving wasted iterations and assembly.

This is the first version that will be iterated on before considering to merge it.