### PR TITLE
Fix Consistency Check for Maximum Gas Saturation

### DIFF
--- a/opm/simulators/utils/satfunc/GasPhaseConsistencyChecks.cpp
+++ b/opm/simulators/utils/satfunc/GasPhaseConsistencyChecks.cpp
@@ -55,6 +55,8 @@ template <typename Scalar>
 void Opm::Satfunc::PhaseChecks::Gas::SGmax<Scalar>::
 testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
 {
+    // 0 < SGU <= 1
+
     this->sgu_ = endPoints.Sgu;
 
     if (! std::isfinite(this->sgu_)) {
@@ -64,8 +66,8 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    const auto low = this->sgu_ < Scalar{0};
-    const auto high = ! (this->sgu_ < Scalar{1});
+    const auto low = ! (this->sgu_ > Scalar{0});
+    const auto high = this->sgu_ > Scalar{1};
 
     if (low || high) {
         this->setViolated();

--- a/opm/simulators/utils/satfunc/GasPhaseConsistencyChecks.hpp
+++ b/opm/simulators/utils/satfunc/GasPhaseConsistencyChecks.hpp
@@ -104,13 +104,13 @@ namespace Opm::Satfunc::PhaseChecks::Gas {
         /// Descriptive textual summary of this check.
         std::string description() const override
         {
-            return { "Non-negative maximum gas saturation strictly less than one" };
+            return { "Positive maximum gas saturation must not exceed one" };
         }
 
         /// Textual representation of the consistency condition.
         std::string condition() const override
         {
-            return { "0 <= SGU < 1" };
+            return { "0 < SGU <= 1" };
         }
 
         /// Retrieve names of the exported check values.

--- a/tests/test_GasSatfuncConsistencyChecks.cpp
+++ b/tests/test_GasSatfuncConsistencyChecks.cpp
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(All_Good)
 
     {
         auto endPoints = Opm::EclEpsScalingPointsInfo<float>{};
-        endPoints.Sgu = 0.125f; // >= 0 && < 1
+        endPoints.Sgu = 0.125f; // > 0 && <= 1
 
         check.test(endPoints);
     }
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(Is_One)
 {
     auto check = Checks::SGmax<double>{};
     auto endPoints = Opm::EclEpsScalingPointsInfo<double>{};
-    endPoints.Sgu = 1.0; // >= 1
+    endPoints.Sgu = 1.0; // <= 1
 
     check.test(endPoints);
 
@@ -277,8 +277,8 @@ BOOST_AUTO_TEST_CASE(Is_One)
         BOOST_CHECK_CLOSE(value, 1.0, 1.0e-8);
     }
 
-    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
-    BOOST_CHECK_MESSAGE(check.isCritical(), "Test must be violated at critical level");
+    BOOST_CHECK_MESSAGE(! check.isViolated(), "Test must not be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must not be violated at critical level");
 }
 
 BOOST_AUTO_TEST_CASE(Exceeds_One)


### PR DESCRIPTION
The earlier condition
```math
0 \le S_{\mathrm{GU}} < 1
```
was not appropriate and would, for instance, fail the `NORNE_ATW2013` test case in which [`SGU` = 1](https://github.com/OPM/opm-data/blob/eaa2261683a97027e057c2bc49612ad1c86390b3/norne/INCLUDE/RELPERM/SCAL_NORNE.INC#L82) in the unscaled table for saturation region 1.  Revise the condition to be more in line with that of SWU, i.e., as
```math
0 < S_{\mathrm{GU}} \le 1
```
Pointy Hat: @bska