### PR TITLE
Enable New Saturation Function Consistency Checks

### DIFF
--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -247,9 +247,14 @@ public:
 
         this->explicitRockCompaction_ = Parameters::Get<Parameters::ExplicitRockCompaction>();
 
-        RelpermDiagnostics relpermDiagnostics{};
-        relpermDiagnostics.diagnosis(simulator.vanguard().eclState(),
-                                     simulator.vanguard().cartesianIndexMapper());
+        if (! Parameters::Get<Parameters::CheckSatfuncConsistency>()) {
+            // User did not enable the "new" saturation function consistency
+            // check module.  Run the original checker instead.  This is a
+            // temporary measure.
+            RelpermDiagnostics relpermDiagnostics{};
+            relpermDiagnostics.diagnosis(simulator.vanguard().eclState(),
+                                         simulator.vanguard().cartesianIndexMapper());
+        }
     }
 
     virtual ~FlowProblem() = default;

--- a/opm/simulators/flow/FlowProblemParameters.cpp
+++ b/opm/simulators/flow/FlowProblemParameters.cpp
@@ -66,6 +66,12 @@ void registerFlowProblemParameters()
         ("Use pressure from end of the last time step when evaluating rock compaction");
     Parameters::Hide<Parameters::ExplicitRockCompaction>(); // Users will typically not need to modify this parameter..
 
+    Parameters::Register<Parameters::CheckSatfuncConsistency>
+        ("Whether or not to check saturation function consistency requirements");
+
+    Parameters::Register<Parameters::NumSatfuncConsistencySamplePoints>
+        ("Maximum number of reported failures for each individual saturation function consistency check");
+
     // By default, stop it after the universe will probably have stopped
     // to exist. (the ECL problem will finish the simulation explicitly
     // after it simulated the last episode specified in the deck.)

--- a/opm/simulators/flow/FlowProblemParameters.hpp
+++ b/opm/simulators/flow/FlowProblemParameters.hpp
@@ -39,6 +39,13 @@ struct EnableDriftCompensation { static constexpr bool value = false; };
 // implicit or explicit pressure in rock compaction
 struct ExplicitRockCompaction { static constexpr bool value = false; };
 
+// Whether or not to check saturation function consistency requirements.
+struct CheckSatfuncConsistency { static constexpr bool value = false; };
+
+// Maximum number of reported failures for each saturation function
+// consistency check.
+struct NumSatfuncConsistencySamplePoints { static constexpr int value = 5; };
+
 // Parameterize equilibration accuracy
 struct NumPressurePointsEquil
 { static constexpr int value = ParserKeywords::EQLDIMS::DEPTH_NODES_P::defaultValue; };

--- a/opm/simulators/utils/satfunc/SatfuncConsistencyCheckManager.hpp
+++ b/opm/simulators/utils/satfunc/SatfuncConsistencyCheckManager.hpp
@@ -152,8 +152,8 @@ namespace Opm::Satfunc::PhaseChecks {
         /// Reports only those conditions/checks for which there is at least
         /// one violation.
         ///
-        /// In a parallel run it is only safe to call this function on the
-        /// root process defined by collectFailuresTo().
+        /// In a parallel run this function does nothing on ranks other than
+        /// the root process defined by collectFailuresTo().
         ///
         /// \param[in] level Report's severity level.
         ///

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -119,6 +119,7 @@ initSimulator(const char *filename)
     const char* argv[] = {
         "test_equil",
         filenameArg.c_str(),
+        "--check-satfunc-consistency=false",
     };
 
     Opm::setupParameters_<TypeTag>(/*argc=*/sizeof(argv)/sizeof(argv[0]), argv, /*registerParams=*/false);


### PR DESCRIPTION
Currently opt-in by the new parameter `CheckSatfuncConsistency` (command line option `--check-satfunc-consistency`), this PR hooks up the `SatfuncConsistencyCheckManager<>` pass to the `FlowProblem`.  I hope to make the parameter be "opt-out" at some point, but for now the new pass breaks one of the cases in our `benchmark` suite.

The new parameter `--num-satfunc-consistency-sample-points` allows the user to select the maximum number of reported failures for each individual consistency check.  By default, the simulator will report at most five failures for each check.

We check the unscaled curves if the run does not activate the end-point scaling option and the scaled curves otherwise.  At present we're limited to reversible and non-directional saturation functions for the drainage process, but those restrictions will be lifted in due time.