### PR TITLE
MPIPacker: mark buffer const in unpacker functions

### DIFF
--- a/opm/simulators/utils/MPIPacker.cpp
+++ b/opm/simulators/utils/MPIPacker.cpp
@@ -63,7 +63,7 @@ pack(const std::bitset<Size>& data,
 template<std::size_t Size>
 void Packing<false,std::bitset<Size>>::
 unpack(std::bitset<Size>& data,
-       std::vector<char>& buffer,
+       const std::vector<char>& buffer,
        std::size_t& position,
        Parallel::MPIComm comm)
 {
@@ -99,7 +99,7 @@ pack(const std::string& data,
 
 void Packing<false,std::string>::
 unpack(std::string& data,
-       std::vector<char>& buffer,
+       const std::vector<char>& buffer,
        std::size_t& position,
        Opm::Parallel::MPIComm comm)
 {
@@ -133,7 +133,7 @@ pack(const time_point& data,
 
 void Packing<false,time_point>::
 unpack(time_point& data,
-       std::vector<char>& buffer,
+       const std::vector<char>& buffer,
        std::size_t& position,
        Parallel::MPIComm comm)
 {

--- a/opm/simulators/utils/MPIPacker.hpp
+++ b/opm/simulators/utils/MPIPacker.hpp
@@ -42,7 +42,7 @@ struct Packing
 {
     static std::size_t packSize(const T&, Parallel::MPIComm);
     static void pack(const T&, std::vector<char>&, std::size_t&, Parallel::MPIComm);
-    static void unpack(T&, std::vector<char>&, std::size_t&, Parallel::MPIComm);
+    static void unpack(T&, const std::vector<char>&, std::size_t&, Parallel::MPIComm);
 };
 
 //! \brief Packaging for pod data.
@@ -109,7 +109,7 @@ struct Packing<true,T>
     //! \param position Position in buffer to use
     //! \param comm The communicator to use
     static void unpack(T& data,
-                       std::vector<char>& buffer,
+                       const std::vector<char>& buffer,
                        std::size_t& position,
                        Parallel::MPIComm comm)
     {
@@ -124,7 +124,7 @@ struct Packing<true,T>
     //! \param comm The communicator to use
     static void unpack(T* data,
                        std::size_t n,
-                       std::vector<char>& buffer,
+                       const std::vector<char>& buffer,
                        std::size_t& position,
                        Parallel::MPIComm comm)
     {
@@ -151,7 +151,7 @@ struct Packing<false,T>
       static_assert(!std::is_same_v<T,T>, "Packing not supported for type");
     }
 
-    static void unpack(T&, std::vector<char>&, std::size_t&,
+    static void unpack(T&, const std::vector<char>&, std::size_t&,
                        Parallel::MPIComm)
     {
         static_assert(!std::is_same_v<T,T>, "Packing not supported for type");
@@ -164,7 +164,8 @@ struct Packing<false,std::bitset<Size>>
 {
     static std::size_t packSize(const std::bitset<Size>&, Opm::Parallel::MPIComm);
     static void pack(const std::bitset<Size>&, std::vector<char>&, std::size_t&, Opm::Parallel::MPIComm);
-    static void unpack(std::bitset<Size>&, std::vector<char>&, std::size_t&, Opm::Parallel::MPIComm);
+    static void unpack(std::bitset<Size>&, const std::vector<char>&,
+                       std::size_t&, Opm::Parallel::MPIComm);
 };
 
 #define ADD_PACK_SPECIALIZATION(T) \
@@ -173,7 +174,7 @@ struct Packing<false,std::bitset<Size>>
     { \
         static std::size_t packSize(const T&, Parallel::MPIComm); \
         static void pack(const T&, std::vector<char>&, std::size_t&, Parallel::MPIComm); \
-        static void unpack(T&, std::vector<char>&, std::size_t&, Parallel::MPIComm); \
+        static void unpack(T&, const std::vector<char>&, std::size_t&, Parallel::MPIComm); \
     };
 
 ADD_PACK_SPECIALIZATION(std::string)
@@ -248,7 +249,7 @@ struct Packer
     //! \param position Position in buffer to use
     template<class T>
     void unpack(T& data,
-                std::vector<char>& buffer,
+                const std::vector<char>& buffer,
                 std::size_t& position) const
     {
         detail::Packing<std::is_pod_v<T>,T>::unpack(data, buffer, position, m_comm);
@@ -263,7 +264,7 @@ struct Packer
     template<class T>
     void unpack(T* data,
                 std::size_t n,
-                std::vector<char>& buffer,
+                const std::vector<char>& buffer,
                 std::size_t& position) const
     {
         static_assert(std::is_pod_v<T>, "Array packing not supported for non-pod data");

--- a/opm/simulators/utils/SerializationPackers.cpp
+++ b/opm/simulators/utils/SerializationPackers.cpp
@@ -41,7 +41,7 @@ pack(const boost::gregorian::date& data,
 
 void Packing<false,boost::gregorian::date>::
 unpack(boost::gregorian::date& data,
-       std::vector<char>& buffer, std::size_t& position)
+       const std::vector<char>& buffer, std::size_t& position)
 {
     std::string date;
     Packing<false,std::string>::unpack(date, buffer, position);

--- a/opm/simulators/utils/SerializationPackers.hpp
+++ b/opm/simulators/utils/SerializationPackers.hpp
@@ -38,7 +38,7 @@ struct Packing<false,boost::gregorian::date>
                      std::vector<char>& buffer, std::size_t& position);
 
     static void unpack(boost::gregorian::date& data,
-                       std::vector<char>& buffer, std::size_t& position);
+                       const std::vector<char>& buffer, std::size_t& position);
 };
 
 }


### PR DESCRIPTION
Same as https://github.com/OPM/opm-common/pull/4189 but for the mpi packer. Also contains a commit that is required by the former since it is extending the mempacker (hosted here as it is only used for restart serialization and we don't want to pull in boost date_time in opm-common in case you wonder).