### PR TITLE
Fix oscilations

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
@@ -33,7 +33,7 @@ void logTimer(const AdaptiveSimulatorTimer& substepTimer)
 }
 
 std::set<std::string>
-consistentlyFailingWells(const std::vector<StepReport>& sr)
+consistentlyFailingWells(const std::vector<StepReport>& sr, bool checkRepeatedFailures)
 {
     // If there are wells that cause repeated failures, we
     // close them, and restart the un-chopped timestep.
@@ -60,10 +60,10 @@ consistentlyFailingWells(const std::vector<StepReport>& sr)
     const int rep_step = sr.back().report_step;
     const int sub_step = sr.back().current_step;
     const int sr_size = sr.size();
-    if (sr_size >= num_steps) {
-        for (const auto& wf : wfs) {
-            failing_wells.insert(wf.wellName());
-        }
+    for (const auto& wf : wfs) {
+        failing_wells.insert(wf.wellName());
+    }
+    if (checkRepeatedFailures && sr_size >= num_steps) {
         for (int s = 1; s < num_steps; ++s) {
             const auto& srep = sr[sr_size - 1 - s];
             // Report must be from same report step and substep, otherwise we have

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -68,7 +68,7 @@ struct StepReport;
 namespace detail {
     void logTimer(const AdaptiveSimulatorTimer& substep_timer);
 
-    std::set<std::string> consistentlyFailingWells(const std::vector<StepReport>& sr);
+    std::set<std::string> consistentlyFailingWells(const std::vector<StepReport>& sr, bool checkRepeatedFailures);
     void registerAdaptiveParameters();
 
     std::tuple<TimeStepControlType, std::unique_ptr<TimeStepControlInterface>, bool>

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -906,10 +906,14 @@ AdaptiveTimeStepping<TypeTag>::SubStepIteration<Solver>::
 chopTimeStepOrCloseFailingWells_(const int new_time_step)
 {
     bool wells_shut = false;
-    // We are below the threshold, and will check if there are any wells we should close
-    // rather than chopping again.
-    std::set<std::string> failing_wells = detail::consistentlyFailingWells(
-                                         solver_().model().stepReports());
+    // We are below the threshold, and will check if there are any
+    // wells that failes repeatedly (that means that it fails in the last three steps)
+    // we should close rather than chopping again.
+    // If we already have chopped the timestep serveral times due to failed wells we also shut wells that
+    // fails only on this step.
+    bool checkRepeatedFailures = new_time_step > ( minTimeStepBeforeClosingWells_()*restartFactor_()*restartFactor_());
+    std::set<std::string> failing_wells = detail::consistentlyFailingWells(solver_().model().stepReports(), checkRepeatedFailures);
+
     if (failing_wells.empty()) {
         // Found no wells to close, chop the timestep
         chopTimeStep_(new_time_step);

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -749,7 +749,11 @@ run()
 
     // sub step time loop
     while (!this->substep_timer_.done()) {
-        maybeUpdateTuningAndTimeStep_();
+        // if we just chopped the timestep due to convergence i.e. restarts>0
+        // we dont what to update the next timestep based on Tuning
+        if (restarts == 0) {
+            maybeUpdateTuningAndTimeStep_();
+        }
         const double dt = this->substep_timer_.currentStepLength();
         if (timeStepVerbose_()) {
             detail::logTimer(this->substep_timer_);

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1938,10 +1938,10 @@ namespace Opm {
         bool changed_well_group = false;
 
         int iter = 0;
+        const Group& fieldGroup = this->schedule().getGroup("FIELD", episodeIdx);
         // iterate a few times to make sure all constrains are kept
         while(!changed_well_group && iter < 3) {
             // Check group individual constraints.
-            const Group& fieldGroup = this->schedule().getGroup("FIELD", episodeIdx);
             changed_well_group = updateGroupControls(fieldGroup, deferred_logger, episodeIdx, iterationIdx);
             
             // Check wells' group constraints and communicate.

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1939,7 +1939,7 @@ namespace Opm {
 
         int iter = 0;
         // iterate a few times to make sure all constrains are kept
-        while(!changed_well_group && iter < 5) {
+        while(!changed_well_group && iter < 3) {
             // Check group individual constraints.
             const Group& fieldGroup = this->schedule().getGroup("FIELD", episodeIdx);
             changed_well_group = updateGroupControls(fieldGroup, deferred_logger, episodeIdx, iterationIdx);

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -609,7 +609,7 @@ getALQ(const WellState<Scalar>& well_state) const
 template<class Scalar>
 void WellInterfaceGeneric<Scalar>::
 reportWellSwitching(const SingleWellState<Scalar> &ws,
-                    DeferredLogger& deferred_logger) const
+                    DeferredLogger& deferred_logger)
 {
     if (well_control_log_.empty())
         return;
@@ -626,6 +626,7 @@ reportWellSwitching(const SingleWellState<Scalar> &ws,
         deferred_logger.info(fmt::format("    Well {} control mode changed from {} to {}",
                                          name(), from, to));
     }
+    well_control_log_.clear();
 }
 
 template<class Scalar>

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -166,7 +166,7 @@ public:
     bool isVFPActive(DeferredLogger& deferred_logger) const;
 
     void reportWellSwitching(const SingleWellState<Scalar>& ws,
-                             DeferredLogger& deferred_logger) const;
+                             DeferredLogger& deferred_logger);
 
     bool changedToOpenThisStep() const { return this->changed_to_open_this_step_; }
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -223,15 +223,25 @@ namespace Opm
             // only output frist time
             bool output = std::count(this->well_control_log_.begin(), this->well_control_log_.end(), from) == this->param_.max_number_of_well_switches_;
             if (output) {
-                std::ostringstream ss;
-                ss << "    The control mode for well " << this->name()
-                   << " is oscillating\n"
-                   << "    We don't allow for more than "
-                   << this->param_.max_number_of_well_switches_
-                   << " switches. The control is kept at " << from;
-                deferred_logger.info(ss.str());
-                // add one more to avoid outputting the same info again
-                this->well_control_log_.push_back(from);
+                bool changedInd = this->checkIndividualConstraints(ws, summaryState, deferred_logger);
+                if (changedInd) {
+                    std::string to;
+                    if (well.isInjector()) {
+                        to = WellInjectorCMode2String(ws.injection_cmode);
+                    } else {
+                        to = WellProducerCMode2String(ws.production_cmode);
+                    }
+                    std::ostringstream ss;
+                    ss << "    The control mode for well " << this->name()
+                    << " is oscillating.\n"
+                    << " We keep it at its individual control after  "
+                    << param_.max_number_of_well_switches_
+                    << " switches. The control is kept at " << to;
+                    deferred_logger.info(ss.str());
+                    // add one more to avoid outputting the same info again
+                    this->well_control_log_.push_back(to);
+                    return true;
+                }
             }
             return false;
         }

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -265,7 +265,7 @@ namespace Opm
                 ss << "    The control mode for well " << this->name()
                 << " is oscillating.\n"
                 << "       The individual control is fixed after  "
-                << param_.max_number_of_well_switches_
+                << this->param_.max_number_of_well_switches_
                 << " switches. The control is kept at " << to;
                 deferred_logger.info(ss.str());
                 updateWellStateWithTarget(simulator, group_state, well_state, deferred_logger);
@@ -331,7 +331,14 @@ namespace Opm
         } else {
             from = WellProducerCMode2String(ws.production_cmode);
         }
-        if (this->wellUnderZeroRateTarget(simulator, well_state, deferred_logger) || !(this->well_ecl_.getStatus() == WellStatus::OPEN)) {
+        bool oscillating = false;
+        for (const auto& key : this->well_control_log_) {
+            if (std::count(this->well_control_log_.begin(), this->well_control_log_.end(), key) >= this->param_.max_number_of_well_switches_) {
+                oscillating = true;
+                break;
+            }
+        }
+        if (oscillating || this->wellUnderZeroRateTarget(simulator, well_state, deferred_logger) || !(this->well_ecl_.getStatus() == WellStatus::OPEN)) {
            return false;
         }
 
@@ -344,7 +351,7 @@ namespace Opm
                 bool changed = false;
                 bool oscillating = false;
                 for (const auto& key : this->well_control_log_) {
-                    if (std::count(this->well_control_log_.begin(), this->well_control_log_.end(), key) >= param_.max_number_of_well_switches_) {
+                    if (std::count(this->well_control_log_.begin(), this->well_control_log_.end(), key) >= this->param_.max_number_of_well_switches_) {
                         oscillating = true;
                         break;
                     }


### PR DESCRIPTION
WIP

- ads iterations to the well/group constrain check. replaces the remaining parts of https://github.com/OPM/opm-simulators/pull/3410/files

- Keep well at individual controls when oscillating. See discussion in https://github.com/OPM/opm-simulators/pull/5599

Needs a lot more testing....