### PR TITLE
Make SolverAdapter explicitly depend on the communication object

### DIFF
--- a/opm/simulators/linalg/FlexibleSolver.hpp
+++ b/opm/simulators/linalg/FlexibleSolver.hpp
@@ -86,7 +86,8 @@ private:
                       const std::function<VectorType()> weightsCalculator, const Dune::Amg::SequentialInformation&,
                       std::size_t pressureIndex);
 
-    void initSolver(const Opm::PropertyTree& prm, const bool is_iorank);
+    template <class Comm>
+    void initSolver(const Opm::PropertyTree& prm, const Comm& comm);
 
     void recreateDirectSolver();
 

--- a/opm/simulators/linalg/FlexibleSolver_impl.hpp
+++ b/opm/simulators/linalg/FlexibleSolver_impl.hpp
@@ -153,10 +153,12 @@ namespace Dune
     }
 
     template <class Operator>
+    template <class Comm>
     void
     FlexibleSolver<Operator>::
-    initSolver(const Opm::PropertyTree& prm, const bool is_iorank)
+    initSolver(const Opm::PropertyTree& prm, const Comm& comm)
     {
+        const bool is_iorank = comm.communicator().rank() == 0;
         const double tol = prm.get<double>("tol", 1e-2);
         const int maxiter = prm.get<int>("maxiter", 200);
         const int verbosity = is_iorank ? prm.get<int>("verbosity", 0) : 0;
@@ -211,7 +213,8 @@ namespace Dune
                 preconditioner_,
                 tol, // desired residual reduction factor
                 maxiter, // maximum number of iterations
-                verbosity));
+                verbosity,
+                comm));
 #endif
         } else {
             OPM_THROW(std::invalid_argument,
@@ -256,7 +259,7 @@ namespace Dune
          std::size_t pressureIndex)
     {
         initOpPrecSp(op, prm, weightsCalculator, comm, pressureIndex);
-        initSolver(prm, comm.communicator().rank() == 0);
+        initSolver(prm, comm);
     }
 
 } // namespace Dune

--- a/tests/gpuistl/test_solver_adapter.cpp
+++ b/tests/gpuistl/test_solver_adapter.cpp
@@ -79,7 +79,7 @@ createSolverAdapterWithMatrix(const size_t N = 10)
     prm.put<double>("relaxation", 1.0);
     prm.put<std::string>("type", "CUILU0");
     auto prec = PrecondFactory::create(*op, prm);
-    auto solverAdapter = std::make_shared<SolverAdapter>(*op, *sp, prec, 1.0, 10, 0);
+    auto solverAdapter = std::make_shared<SolverAdapter>(*op, *sp, prec, 1.0, 10, 0, Dune::Amg::SequentialInformation());
 
     return std::make_tuple(matrixPtr, solverAdapter, op, sp);
 }


### PR DESCRIPTION
This fixes the MPI issues with CUDA/HIP/GPUISTL that were introduced with the `GhostLastMatrixAdapter` operator. The previous design of the SolverAdapter relied on the presence of the function `getCommunication` to determine if one should run the GPU solver with MPI. This updated version now decides this on the type of communication sent in. For a general communication type, it assumes it is an MPI run, while for `Dune::Amg::SequentialInformation`, it defaults to a serial (no MPI) run. 

The upside of this change is that any new, similar issues where the interface of the operator or communication changes will be detected at compile time and not runtime. 