### PR TITLE
Implement 'RFIP' and 'SFIP' Mnemonics For RPTRST

### DIFF
--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -2,14 +2,17 @@
 // vi: set et ts=4 sw=4 sts=4:
 /*
   This file is part of the Open Porous Media project (OPM).
+
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 2 of the License, or
   (at your option) any later version.
+
   OPM is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
+
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
   Consult the COPYING file in the top-level source directory of this

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -2,14 +2,17 @@
 // vi: set et ts=4 sw=4 sts=4:
 /*
   This file is part of the Open Porous Media project (OPM).
+
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 2 of the License, or
   (at your option) any later version.
+
   OPM is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
+
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
   Consult the COPYING file in the top-level source directory of this
@@ -387,30 +390,30 @@ protected:
     InterRegFlowMap interRegionFlows_;
     LogOutputHelper<Scalar> logOutput_;
 
-    bool enableEnergy_;
-    bool enableTemperature_;
-    bool enableMech_;
+    bool enableEnergy_{false};
+    bool enableTemperature_{false};
+    bool enableMech_{false};
 
-    bool enableSolvent_;
-    bool enablePolymer_;
-    bool enableFoam_;
-    bool enableBrine_;
-    bool enableSaltPrecipitation_;
-    bool enableExtbo_;
-    bool enableMICP_;
+    bool enableSolvent_{false};
+    bool enablePolymer_{false};
+    bool enableFoam_{false};
+    bool enableBrine_{false};
+    bool enableSaltPrecipitation_{false};
+    bool enableExtbo_{false};
+    bool enableMICP_{false};
 
-    bool forceDisableFipOutput_;
-    bool forceDisableFipresvOutput_;
-    bool outputFipRestart_;
-    bool computeFip_;
+    bool forceDisableFipOutput_{false};
+    bool forceDisableFipresvOutput_{false};
+    bool outputFipRestart_{false};
+    bool computeFip_{false};
 
-    bool anyFlows_;
-    bool anyFlores_;
-    bool blockFlows_;
-    bool enableFlows_;
-    bool enableFlores_;
-    bool enableFlowsn_;
-    bool enableFloresn_;
+    bool anyFlows_{false};
+    bool anyFlores_{false};
+    bool blockFlows_{false};
+    bool enableFlows_{false};
+    bool enableFlores_{false};
+    bool enableFlowsn_{false};
+    bool enableFloresn_{false};
 
     std::unordered_map<Inplace::Phase, ScalarBuffer> fip_;
     std::unordered_map<std::string, std::vector<int>> regions_;
@@ -528,7 +531,7 @@ protected:
     std::vector<std::vector<int>> cnvData_; //!< Data for CNV_xxx arrays
 
     std::optional<Inplace> initialInplace_;
-    bool local_data_valid_;
+    bool local_data_valid_{false};
 
     std::optional<RegionPhasePoreVolAverage> regionAvgDensity_;
 };

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -404,8 +404,31 @@ protected:
 
     bool forceDisableFipOutput_{false};
     bool forceDisableFipresvOutput_{false};
-    bool outputFipRestart_{false};
     bool computeFip_{false};
+
+    struct OutputFIPRestart {
+        /// Whether or not run requests (surface condition) fluid-in-place
+        /// restart file output using the 'FIP' mnemonic.
+        bool noPrefix {false};
+
+        /// Whether or not run requests surface condition fluid-in-place
+        /// restart file output using the 'SFIP' mnemonic.
+        bool surface {false};
+
+        /// Whether or not run requests reservoir condition fluid-in-place
+        /// restart file output using the 'RFIP' mnemonic.
+        bool reservoir {false};
+
+        void clearBits()
+        {
+            this->noPrefix = this->surface = this->reservoir = false;
+        }
+
+        explicit operator bool() const
+        {
+            return this->noPrefix || this->surface || this->reservoir;
+        }
+    } outputFipRestart_{};
 
     bool anyFlows_{false};
     bool anyFlores_{false};


### PR DESCRIPTION
The `FIP` mnemonic continues to be an alias for 'SFIP' in the current implementation, and the output layer will create the `SFIP*` arrays as copies of `FIP*` if passed only the `FIP` arrays.

To this end, make `outputFipRestart_` into a structure that tracks which of the `*FIP` mnemonics have been requested, and insert the pertinent solution arrays into the data::Solution object when needed.

---

While here, also properly initialise the output module's `bool` flags and insert blank lines in the copyright header to make it more in line with the rest of the copyright statements in this repository.