### PR TITLE
fixed: do not dereference invalid iterator

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -752,7 +752,11 @@ updateEclWells(const int timeStepIdx,
             auto pdIter = pd.begin();
 
             for (const auto& conn : well.getConnections()) {
-                if (conn.state() != Connection::State::SHUT) {
+                // Iterator needs to be bounds checked in case connections were added
+                // in the triggering actions. In that case the well_perf_data is not
+                // yet resized. The wellStructureChangedDynamically_ below
+                // however will trigger reinitialization on start of next time step.
+                if (conn.state() != Connection::State::SHUT && pdIter != pd.end()) {
                     pdIter->connection_transmissibility_factor = conn.CF();
                     ++pdIter;
                 }


### PR DESCRIPTION
if a well has connections added in an action, the well perf data is not yet initialized in the call to updateEclWells. it will however be reinitialized before the next time step so simply adding a bounds check here avoid the invalid dereference and the connection factor will take effect through the reinitialization.

ref e.g. https://ci.opm-project.org/job/opm-simulators-static-analysis/383/testReport/junit/(root)/debug_iterator/compareSeparateECLFiles_flow_pyaction_gruptree_insert_kw/