### PR TITLE
fixed: properly disable SFC ordering in alugrid

### DIFF
--- a/flow/flow_blackoil_alugrid.cpp
+++ b/flow/flow_blackoil_alugrid.cpp
@@ -26,6 +26,8 @@
 #include <opm/grid/CpGrid.hpp>
 #include <opm/grid/cpgrid/GridHelpers.hpp>
 
+#define DISABLE_ALUGRID_SFC_ORDERING 1
+
 // these are not explicitly instanced in library
 #include <opm/simulators/flow/AluGridVanguard.hpp>
 #include <opm/simulators/flow/CollectDataOnIORank_impl.hpp>


### PR DESCRIPTION
This define seem to have fell out at some point.