### PR TITLE
add changes to fix the order

### DIFF
--- a/flow/flow_blackoil_alugrid.cpp
+++ b/flow/flow_blackoil_alugrid.cpp
@@ -17,9 +17,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <config.h>
-// The default in dune-ALUGrird is "DISABLE_ALUGRID_SFC_ORDERING is false"
-#undef DISABLE_ALUGRID_SFC_ORDERING
-#undef USE_ALUGRID_SFC_ORDERING
+// By default, dune-ALUGrid uses Space-Filling Curve (SFC) ordering
+// for cells to optimize data access patterns for adaptive mesh refinements/coarsening.
+// However, if you want to use Cartesian ordering, as is used in OPM, you
+// can switch to it by defining the macro #define DISABLE_SFC_ORDERING 1.
+// This will change the default cell order to Cartesian.
+// Note that this option is not available for pre-built or installed versions of dune-ALUGrid.
+// To enable changig to Cartesian ordering, you will need to rebuild dune-ALUGrid from source, ensuring 
+// the build configuration allows disabling SFC ordering from OPM.
+// For more details, refer to the files gridfactory.hh and aluinline.hh located in the dune-alugrid/3d/
 
 #include <dune/alugrid/grid.hh>
 #include <opm/simulators/flow/Main.hpp>

--- a/flow/flow_blackoil_alugrid.cpp
+++ b/flow/flow_blackoil_alugrid.cpp
@@ -17,6 +17,9 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <config.h>
+// The default in dune-ALUGrird is "DISABLE_ALUGRID_SFC_ORDERING is false"
+#undef DISABLE_ALUGRID_SFC_ORDERING
+#undef USE_ALUGRID_SFC_ORDERING
 
 #include <dune/alugrid/grid.hh>
 #include <opm/simulators/flow/Main.hpp>

--- a/opm/simulators/flow/AluGridVanguard.hpp
+++ b/opm/simulators/flow/AluGridVanguard.hpp
@@ -325,8 +325,7 @@ protected:
 
         factory_ = std::make_unique<Factory>();
         grid_ = factory_->convert(*equilGrid_, cartesianCellId_, ordering_);
-        OpmLog::warning("Space Filling Curve Ordering (SFCO) is used");
-        OpmLog::warning("Add '#define DISABLE_ALUGRID_SFC_ORDERING 1'  to disable SFC reordering");
+        OpmLog::warning("Space Filling Curve (SFC) ordering is enabled: see flow_blackoil_alugrid for more informations on disabling/enabling SFC reordering");
         equilGridToGrid_.resize(ordering_.size());
         for (std::size_t index = 0; index < ordering_.size(); ++index) {
             equilGridToGrid_[ordering_[index]] = index;

--- a/opm/simulators/flow/AluGridVanguard.hpp
+++ b/opm/simulators/flow/AluGridVanguard.hpp
@@ -325,7 +325,8 @@ protected:
 
         factory_ = std::make_unique<Factory>();
         grid_ = factory_->convert(*equilGrid_, cartesianCellId_, ordering_);
-        OpmLog::warning("Space Filling Curve Ordering is not yet supported: DISABLE_ALUGRID_SFC_ORDERING is enabled");
+        OpmLog::warning("Space Filling Curve Ordering (SFCO) is used");
+        OpmLog::warning("Add '#define DISABLE_ALUGRID_SFC_ORDERING 1'  to disable SFC reordering");
         equilGridToGrid_.resize(ordering_.size());
         for (std::size_t index = 0; index < ordering_.size(); ++index) {
             equilGridToGrid_[ordering_[index]] = index;

--- a/opm/simulators/wells/RateConverter.hpp
+++ b/opm/simulators/wells/RateConverter.hpp
@@ -134,7 +134,7 @@ namespace Opm {
                     const auto& fs = intQuants.fluidState();
                     // use pore volume weighted averages.
                     const Scalar pv_cell =
-                            simulator.model().dofTotalVolume(cellIdx)
+                            simulator.model().dofTotalVolume(simulator.vanguard().gridEquilIdxToGridIdx(cellIdx))
                             * intQuants.porosity().value();
 
                     // only count oil and gas filled parts of the domain

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -1496,7 +1496,7 @@ if(BUILD_FLOW_POLY_GRID)
                            DIR spe1)
 endif()
 
-if(dune-alugrid_FOUND AND BUILD_FLOW_ALU_GRID)
+if(dune-alugrid_FOUND AND BUILD_FLOW_ALU_GRID AND MPI_FOUND)
   add_test_compareECLFiles(CASENAME spe12_alugrid
                            FILENAME SPE1CASE2
                            SIMULATOR flow_blackoil_alugrid

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -1501,7 +1501,7 @@ if(dune-alugrid_FOUND AND BUILD_FLOW_ALU_GRID)
                            FILENAME SPE1CASE2
                            SIMULATOR flow_blackoil_alugrid
                            ABS_TOL ${abs_tol}
-                           REL_TOL ${coarse_rel_tol}
+                           REL_TOL ${rel_tol}
                            DIR spe1)
 endif()
 

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -1492,7 +1492,7 @@ if(BUILD_FLOW_POLY_GRID)
                            FILENAME SPE1CASE2
                            SIMULATOR flow_blackoil_polyhedralgrid
                            ABS_TOL ${abs_tol}
-                           REL_TOL ${rel_tol}
+                           REL_TOL ${coarse_rel_tol}
                            DIR spe1)
 endif()
 
@@ -1501,7 +1501,7 @@ if(dune-alugrid_FOUND AND BUILD_FLOW_ALU_GRID)
                            FILENAME SPE1CASE2
                            SIMULATOR flow_blackoil_alugrid
                            ABS_TOL ${abs_tol}
-                           REL_TOL ${rel_tol}
+                           REL_TOL ${coarse_rel_tol}
                            DIR spe1)
 endif()
 

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -1492,7 +1492,7 @@ if(BUILD_FLOW_POLY_GRID)
                            FILENAME SPE1CASE2
                            SIMULATOR flow_blackoil_polyhedralgrid
                            ABS_TOL ${abs_tol}
-                           REL_TOL ${coarse_rel_tol}
+                           REL_TOL ${rel_tol}
                            DIR spe1)
 endif()
 
@@ -1502,13 +1502,7 @@ if(dune-alugrid_FOUND AND BUILD_FLOW_ALU_GRID)
                            SIMULATOR flow_blackoil_alugrid
                            ABS_TOL ${abs_tol}
                            REL_TOL ${coarse_rel_tol}
-                           DIR spe1
-                           TEST_ARGS --linear-solver=ilu0
-                                     --tolerance-mb=1e-6
-                                     --min-strict-cnv-iter=0
-                                     --local-well-solve-control-switching=false
-                                     --use-implicit-ipr=false
-                                     --enable-drift-compensation=true)
+                           DIR spe1)
 endif()
 
 if(BUILD_FLOW_FLOAT_VARIANTS)


### PR DESCRIPTION
This PR enables SFC (Space-Filling Curve) reordering in AluGrid as the default choice. The changes has been tested both with and without MPI across multiple cases from the opm-tests and opm-data!

