### PR TITLE
Update THP also for zero-rate wells

### DIFF
--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
@@ -214,7 +214,6 @@ template<class FluidSystem, class Indices>
 void MultisegmentWellPrimaryVariables<FluidSystem,Indices>::
 copyToWellState(const MultisegmentWellGeneric<Scalar>& mswell,
                 const Scalar rho,
-                const bool stop_or_zero_rate_target,
                 WellState<Scalar>& well_state,
                 const SummaryState& summary_state,
                 DeferredLogger& deferred_logger) const
@@ -406,7 +405,7 @@ copyToWellState(const MultisegmentWellGeneric<Scalar>& mswell,
     // Note: for the ALQ value, in the StandardWell, WellInterfaceGeneric::getALQ(well_state) is used.
     // We might want to unify the way regarding AQL value.
     WellBhpThpCalculator(well_)
-        .updateThp(rho, stop_or_zero_rate_target, [this, &summary_state]() { return well_.wellEcl().alq_value(summary_state); },
+        .updateThp(rho, [this, &summary_state]() { return well_.wellEcl().alq_value(summary_state); },
                    {FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx),
                     FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx),
                     FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)},

--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
@@ -105,7 +105,6 @@ public:
     //! \brief Copy values to well state.
     void copyToWellState(const MultisegmentWellGeneric<Scalar>& mswell,
                          const Scalar rho,
-                         const bool stop_or_zero_rate_target,
                          WellState<Scalar>& well_state,
                          const SummaryState& summary_state,
                          DeferredLogger& deferred_logger) const;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -701,7 +701,6 @@ namespace Opm
 
         const auto& summary_state = simulator.vanguard().summaryState();
         this->primary_variables_.copyToWellState(*this, getRefDensity(),
-                                                 stop_or_zero_rate_target,
                                                  well_state,
                                                  summary_state,
                                                  deferred_logger);

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -345,8 +345,7 @@ namespace Opm
                                           const bool stop_or_zero_rate_target,
                                           DeferredLogger& deferred_logger);
 
-        void updateWellStateFromPrimaryVariables(const bool stop_or_zero_rate_target,
-                                                 WellState<Scalar>& well_state,
+        void updateWellStateFromPrimaryVariables(WellState<Scalar>& well_state,
                                                  const SummaryState& summary_state,
                                                  DeferredLogger& deferred_logger) const;
 

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -68,8 +68,7 @@ extendEval(const Eval& in) const
 template<class FluidSystem, class Indices>
 void
 StandardWellEval<FluidSystem,Indices>::
-updateWellStateFromPrimaryVariables(const bool stop_or_zero_rate_target,
-                                    WellState<Scalar>& well_state,
+updateWellStateFromPrimaryVariables(WellState<Scalar>& well_state,
                                     const SummaryState& summary_state,
                                     DeferredLogger& deferred_logger) const
 {
@@ -77,7 +76,6 @@ updateWellStateFromPrimaryVariables(const bool stop_or_zero_rate_target,
 
     WellBhpThpCalculator(baseif_).
             updateThp(connections_.rho(),
-                      stop_or_zero_rate_target,
                       [this,&well_state]() { return this->baseif_.getALQ(well_state); },
                       {FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx),
                        FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx),

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -93,8 +93,7 @@ protected:
               const int num_cells,
               const bool has_polymermw);
 
-    void updateWellStateFromPrimaryVariables(const bool stop_or_zero_rate_target,
-                                             WellState<Scalar>& well_state,
+    void updateWellStateFromPrimaryVariables(WellState<Scalar>& well_state,
                                              const SummaryState& summary_state,
                                              DeferredLogger& deferred_logger) const;
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -711,7 +711,7 @@ namespace Opm
         updatePrimaryVariablesNewton(dwells, stop_or_zero_rate_target, deferred_logger);
 
         const auto& summary_state = simulator.vanguard().summaryState();
-        updateWellStateFromPrimaryVariables(stop_or_zero_rate_target, well_state, summary_state, deferred_logger);
+        updateWellStateFromPrimaryVariables(well_state, summary_state, deferred_logger);
         Base::calculateReservoirRates(simulator.vanguard().eclState().runspec().co2Storage(), well_state.well(this->index_of_well_));
     }
 
@@ -745,12 +745,11 @@ namespace Opm
     template<typename TypeTag>
     void
     StandardWell<TypeTag>::
-    updateWellStateFromPrimaryVariables(const bool stop_or_zero_rate_target,
-                                        WellState<Scalar>& well_state,
+    updateWellStateFromPrimaryVariables(WellState<Scalar>& well_state,
                                         const SummaryState& summary_state,
                                         DeferredLogger& deferred_logger) const
     {
-        this->StdWellEval::updateWellStateFromPrimaryVariables(stop_or_zero_rate_target, well_state, summary_state, deferred_logger);
+        this->StdWellEval::updateWellStateFromPrimaryVariables(well_state, summary_state, deferred_logger);
 
         // other primary variables related to polymer injectivity study
         if constexpr (Base::has_polymermw) {

--- a/opm/simulators/wells/WellBhpThpCalculator.cpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.cpp
@@ -304,7 +304,6 @@ computeBhpAtThpLimitInj(const std::function<std::vector<Scalar>(const Scalar)>& 
 template<class Scalar>
 void WellBhpThpCalculator<Scalar>::
 updateThp(const Scalar rho,
-          const bool stop_or_zero_rate_target,
           const std::function<Scalar()>& alq_value,
           const std::array<unsigned,3>& active,
           WellState<Scalar>& well_state,
@@ -317,7 +316,7 @@ updateThp(const Scalar rho,
     auto& ws = well_state.well(well_.indexOfWell());
 
     // When there is no vaild VFP table provided, we set the thp to be zero.
-    if (!well_.isVFPActive(deferred_logger) || stop_or_zero_rate_target) {
+    if (!well_.isVFPActive(deferred_logger)) {
         ws.thp = 0;
         return;
     }

--- a/opm/simulators/wells/WellBhpThpCalculator.hpp
+++ b/opm/simulators/wells/WellBhpThpCalculator.hpp
@@ -82,7 +82,6 @@ public:
 
     //! \brief Update THP.
     void updateThp(const Scalar rho,
-                   const bool stop_or_zero_rate_target,
                    const std::function<Scalar()>& alq_value,
                    const std::array<unsigned,3>& active,
                    WellState<Scalar>& well_state,


### PR DESCRIPTION
In `updateThp`, the thp is set to zero if the well is stopped or set to zero rate (individual or group). This is problematic for cases where e.g., a well _temporarily_ gets assiged a zero rate from group as the zero thp subsequently will be interpreted as a thp-limit violation. This PR simply suggests to always update thp as long as the vfp is active (we have reasonnable fallbacks for zero rate vfp-interpolation).    