### PR TITLE
changed: don't store schedule keywords unless required in simulators

### DIFF
--- a/opm/simulators/flow/FlowGenericVanguard.cpp
+++ b/opm/simulators/flow/FlowGenericVanguard.cpp
@@ -149,7 +149,7 @@ void FlowGenericVanguard::readDeck(const std::string& filename)
                   modelParams_.actionState_,
                   modelParams_.wtestState_,
                   modelParams_.eclSummaryConfig_,
-                  nullptr, "normal", "normal", "100", false, false, {});
+                  nullptr, "normal", "normal", "100", false, false, false, {});
     modelParams_.setupTime_ = setupTimer.stop();
 }
 

--- a/opm/simulators/flow/Main.cpp
+++ b/opm/simulators/flow/Main.cpp
@@ -202,6 +202,7 @@ void Main::readDeck(const std::string& deckFilename,
                     const std::string& parsingStrictness,
                     const std::string& actionParsingStrictness,
                     const std::string& inputSkipMode,
+                    const bool keepKeywords,
                     const std::size_t numThreads,
                     const int output_param,
                     const std::string& parameters,
@@ -238,6 +239,7 @@ void Main::readDeck(const std::string& deckFilename,
                   inputSkipMode,
                   init_from_restart_file,
                   outputCout_,
+                  keepKeywords,
                   outputInterval);
 
     verifyValidCellGeometry(FlowGenericVanguard::comm(), *this->eclipseState_);

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -272,12 +272,13 @@ private:
 protected:
     /// \brief Initialize
     /// \param exitCode The exitCode of the program.
+    /// \param keepKeywords Keep Schedule keywords even if there are no actions
     ///
     /// \return Whether to actually run the simulator. I.e. true if
     /// parsing of command line was successful and no --help,
     /// --print-properties, or --print-parameters have been found.
     template <class TypeTagEarlyBird>
-    bool initialize_(int& exitCode)
+    bool initialize_(int& exitCode, bool keepKeywords = false)
     {
         Dune::Timer externalSetupTimer;
         externalSetupTimer.start();
@@ -404,6 +405,7 @@ protected:
                            Parameters::Get<Parameters::ParsingStrictness>(),
                            Parameters::Get<Parameters::ActionParsingStrictness>(),
                            Parameters::Get<Parameters::InputSkipMode>(),
+                           keepKeywords,
                            getNumThreads(),
                            Parameters::Get<Parameters::EclOutputInterval>(),
                            cmdline_params,
@@ -683,6 +685,7 @@ private:
                   const std::string& parsingStrictness,
                   const std::string& actionParsingStrictness,
                   const std::string& inputSkipMode,
+                  const bool keepKeywords,
                   const std::size_t numThreads,
                   const int output_param,
                   const std::string& parameters,

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -73,12 +73,10 @@
 #include <cstdlib>
 #include <cstdint>
 #include <filesystem>
-#include <functional>
 #include <memory>
 #include <regex>
 #include <sstream>
 #include <stdexcept>
-#include <unordered_map>
 #include <utility>
 
 namespace {
@@ -105,6 +103,7 @@ namespace {
                                 const bool                           initFromRestart,
                                 const std::optional<int>&            outputInterval,
                                 const bool                           lowActionParsingStrictness,
+                                const bool                           keepKeywords,
                                 Opm::EclipseState&                   eclipseState,
                                 std::shared_ptr<Opm::Python>         python,
                                 std::shared_ptr<Opm::Schedule>&      schedule,
@@ -152,7 +151,8 @@ namespace {
         if (schedule == nullptr) {
             schedule = std::make_shared<Opm::Schedule>
                 (deck, eclipseState, parseContext, errorGuard,
-                 std::move(python), lowActionParsingStrictness, outputInterval, init_state);
+                 std::move(python), lowActionParsingStrictness,
+                 keepKeywords, outputInterval, init_state);
         }
 
         // Read network pressures from restart
@@ -174,6 +174,7 @@ namespace {
                                         const Opm::EclipseState&             eclipseState,
                                         const Opm::ParseContext&             parseContext,
                                         const bool                           lowActionParsingStrictness,
+                                        const bool                           keepKeywords,
                                         std::shared_ptr<Opm::Python>         python,
                                         std::shared_ptr<Opm::Schedule>&      schedule,
                                         std::unique_ptr<Opm::UDQState>&      udqState,
@@ -184,7 +185,7 @@ namespace {
         if (schedule == nullptr) {
             schedule = std::make_shared<Opm::Schedule>
                 (deck, eclipseState, parseContext,
-                 errorGuard, std::move(python), lowActionParsingStrictness);
+                 errorGuard, std::move(python), lowActionParsingStrictness, keepKeywords);
         }
 
         udqState = std::make_unique<Opm::UDQState>
@@ -246,6 +247,7 @@ namespace {
                       const bool                           checkDeck,
                       const bool                           treatCriticalAsNonCritical,
                       const bool                           lowActionParsingStrictness,
+                      const bool                           keepKeywords,
                       const std::optional<int>&            outputInterval,
                       Opm::ErrorGuard&                     errorGuard)
     {
@@ -270,14 +272,15 @@ namespace {
         if (eclipseState->getInitConfig().restartRequested()) {
             loadObjectsFromRestart(deck, parser, *parseContext,
                                    initFromRestart, outputInterval,
-                                   lowActionParsingStrictness,
+                                   lowActionParsingStrictness, keepKeywords,
                                    *eclipseState, std::move(python),
                                    schedule, udqState, actionState, wtestState,
                                    errorGuard);
         }
         else {
             createNonRestartDynamicObjects(deck, *eclipseState, *parseContext,
-                                           lowActionParsingStrictness, std::move(python),
+                                           lowActionParsingStrictness, keepKeywords,
+                                           std::move(python),
                                            schedule, udqState, actionState, wtestState,
                                            errorGuard);
         }
@@ -535,6 +538,7 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
                    const std::string&              inputSkipMode,
                    const bool                      initFromRestart,
                    const bool                      checkDeck,
+                   const bool                      keepKeywords,
                    const std::optional<int>&       outputInterval)
 {
     auto errorGuard = std::make_unique<ErrorGuard>();
@@ -569,7 +573,7 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
                          eclipseState, schedule, udqState, actionState, wtestState,
                          summaryConfig, std::move(python), initFromRestart,
                          checkDeck, treatCriticalAsNonCritical, lowActionParsingStrictness,
-                         outputInterval, *errorGuard);
+                         keepKeywords, outputInterval, *errorGuard);
 
             // Update schedule so that re-parsing after actions use same strictness
             assert(schedule);

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -98,6 +98,7 @@ void readDeck(Parallel::Communication         comm,
               const std::string&              inputSkipMode,
               bool                            initFromRestart,
               bool                            checkDeck,
+              bool                            keepKeywords,
               const std::optional<int>&       outputInterval);
 
 void verifyValidCellGeometry(Parallel::Communication comm,

--- a/python/simulators/PyMain.hpp
+++ b/python/simulators/PyMain.hpp
@@ -42,7 +42,7 @@ public:
     std::unique_ptr<FlowMainType> initFlowBlackoil(int& exitCode)
     {
         exitCode = EXIT_SUCCESS;
-        if (initialize_<Properties::TTag::FlowEarlyBird>(exitCode)) {
+        if (initialize_<Properties::TTag::FlowEarlyBird>(exitCode, true)) {
             // TODO: check that this deck really represents a blackoil
             // case. E.g. check that number of phases == 3
             this->setupVanguard();


### PR DESCRIPTION
in the python simulator we cannot make this decision up front since the schedule can be modified from python code so we have to do the safe thing

Downstream of https://github.com/OPM/opm-common/pull/4234