### PR TITLE
set newton tolerance to be 1.e-7 for compositional running

### DIFF
--- a/opm/simulators/flow/FlowProblemComp.hpp
+++ b/opm/simulators/flow/FlowProblemComp.hpp
@@ -93,6 +93,9 @@ public:
     static void registerParameters()
     {
         FlowProblemType::registerParameters();
+
+        // tighter tolerance is needed for compositional modeling here
+        Parameters::SetDefault<Parameters::NewtonTolerance<Scalar>>(1e-7);
     }
 
 


### PR DESCRIPTION
the master branch is 1.e-2, which is too slack. It might be a mistake introduced during the refactoring. 