### PR TITLE
Fix oscillations - continuation of #5607

### DIFF
--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -111,7 +111,7 @@ struct RelaxedWellFlowTol { static constexpr Scalar value = 1e-3; };
 template<class Scalar>
 struct RelaxedPressureTolMsw { static constexpr Scalar value = 1e4; };
 
-struct MaximumNumberOfWellSwitches { static constexpr int value = 3; };
+struct MaximumNumberOfWellSwitches { static constexpr int value = 10; };
 struct UseAverageDensityMsWells { static constexpr bool value = false; };
 struct LocalWellSolveControlSwitching { static constexpr bool value = true; };
 struct UseImplicitIpr { static constexpr bool value = true; };

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2083,7 +2083,7 @@ namespace Opm {
 
         int iter = 0;
         // iterate a few times to make sure all constrains are kept
-        while(!changed_well_group && iter < 5) {
+        while(!changed_well_group && iter < 3) {
             // Check group individual constraints.
             const int nupcol = this->schedule()[episodeIdx].nupcol();
             // don't switch group control when iterationIdx > nupcol

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2078,59 +2078,66 @@ namespace Opm {
             more_network_update = this->networkActive() && network_imbalance > tolerance;
         }
 
+
         bool changed_well_group = false;
-        // Check group individual constraints.
-        const int nupcol = this->schedule()[episodeIdx].nupcol();
-        // don't switch group control when iterationIdx > nupcol
-        // to avoid oscilations between group controls
-        if (iterationIdx <= nupcol) {
-            const Group& fieldGroup = this->schedule().getGroup("FIELD", episodeIdx);
-            changed_well_group = updateGroupControls(fieldGroup, deferred_logger, episodeIdx, iterationIdx);
-        }
-        // Check wells' group constraints and communicate.
-        bool changed_well_to_group = false;
-        {
-            // For MS Wells a linear solve is performed below and the matrix might be singular.
-            // We need to communicate the exception thrown to the others and rethrow.
-            OPM_BEGIN_PARALLEL_TRY_CATCH()
-                for (const auto& well : well_container_) {
-                    const auto mode = WellInterface<TypeTag>::IndividualOrGroup::Group;
-                    const bool changed_well = well->updateWellControl(simulator_, mode, this->wellState(), this->groupState(), deferred_logger);
-                    if (changed_well) {
-                        changed_well_to_group = changed_well || changed_well_to_group;
+
+        int iter = 0;
+        // iterate a few times to make sure all constrains are kept
+        while(!changed_well_group && iter < 5) {
+            // Check group individual constraints.
+            const int nupcol = this->schedule()[episodeIdx].nupcol();
+            // don't switch group control when iterationIdx > nupcol
+            // to avoid oscilations between group controls
+            if (iterationIdx <= nupcol) {
+                const Group& fieldGroup = this->schedule().getGroup("FIELD", episodeIdx);
+                changed_well_group = updateGroupControls(fieldGroup, deferred_logger, episodeIdx, iterationIdx);
+            }
+            // Check wells' group constraints and communicate.
+            bool changed_well_to_group = false;
+            {
+                // For MS Wells a linear solve is performed below and the matrix might be singular.
+                // We need to communicate the exception thrown to the others and rethrow.
+                OPM_BEGIN_PARALLEL_TRY_CATCH()
+                    for (const auto& well : well_container_) {
+                        const auto mode = WellInterface<TypeTag>::IndividualOrGroup::Group;
+                        const bool changed_well = well->updateWellControl(simulator_, mode, this->wellState(), this->groupState(), deferred_logger);
+                        if (changed_well) {
+                            changed_well_to_group = changed_well || changed_well_to_group;
+                        }
                     }
-                }
-            OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel: updating well controls failed: ",
-                                       simulator_.gridView().comm());
-        }
+                OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel: updating well controls failed: ",
+                                        simulator_.gridView().comm());
+            }
 
-        changed_well_to_group = comm.sum(static_cast<int>(changed_well_to_group));
-        if (changed_well_to_group) {
-            updateAndCommunicate(episodeIdx, iterationIdx, deferred_logger);
-            changed_well_group = true;
-        }
+            changed_well_to_group = comm.sum(static_cast<int>(changed_well_to_group));
+            if (changed_well_to_group) {
+                updateAndCommunicate(episodeIdx, iterationIdx, deferred_logger);
+                changed_well_group = true;
+            }
 
-        // Check individual well constraints and communicate.
-        bool changed_well_individual = false;
-        {
-            // For MS Wells a linear solve is performed below and the matrix might be singular.
-            // We need to communicate the exception thrown to the others and rethrow.
-            OPM_BEGIN_PARALLEL_TRY_CATCH()
-                for (const auto& well : well_container_) {
-                    const auto mode = WellInterface<TypeTag>::IndividualOrGroup::Individual;
-                    const bool changed_well = well->updateWellControl(simulator_, mode, this->wellState(), this->groupState(), deferred_logger);
-                    if (changed_well) {
-                        changed_well_individual = changed_well || changed_well_individual;
+            // Check individual well constraints and communicate.
+            bool changed_well_individual = false;
+            {
+                // For MS Wells a linear solve is performed below and the matrix might be singular.
+                // We need to communicate the exception thrown to the others and rethrow.
+                OPM_BEGIN_PARALLEL_TRY_CATCH()
+                    for (const auto& well : well_container_) {
+                        const auto mode = WellInterface<TypeTag>::IndividualOrGroup::Individual;
+                        const bool changed_well = well->updateWellControl(simulator_, mode, this->wellState(), this->groupState(), deferred_logger);
+                        if (changed_well) {
+                            changed_well_individual = changed_well || changed_well_individual;
+                        }
                     }
-                }
-            OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel: updating well controls failed: ",
-                                       simulator_.gridView().comm());
-        }
+                OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel: updating well controls failed: ",
+                                        simulator_.gridView().comm());
+            }
 
-        changed_well_individual = comm.sum(static_cast<int>(changed_well_individual));
-        if (changed_well_individual) {
-            updateAndCommunicate(episodeIdx, iterationIdx, deferred_logger);
-            changed_well_group = true;
+            changed_well_individual = comm.sum(static_cast<int>(changed_well_individual));
+            if (changed_well_individual) {
+                updateAndCommunicate(episodeIdx, iterationIdx, deferred_logger);
+                changed_well_group = true;
+            }
+            iter++;
         }
 
         // update wsolvent fraction for REIN wells

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2076,26 +2076,40 @@ namespace Opm
                                         this->getTHPConstraint(summary_state),
                                         deferred_logger);
 
-       if (bhpAtLimit)
-           return bhpAtLimit;
+        if (bhpAtLimit) {
+            auto v = frates(*bhpAtLimit);
+            if (std::all_of(v.cbegin(), v.cend(), [](Scalar i){ return i <= 0; }) ) {
+                return bhpAtLimit;
+            }
+        }
 
-       auto fratesIter = [this, &simulator, &deferred_logger](const Scalar bhp) {
-           // Solver the well iterations to see if we are
-           // able to get a solution with an update
-           // solution
-           std::vector<Scalar> rates(3);
-           computeWellRatesWithBhpIterations(simulator, bhp, rates, deferred_logger);
-           return rates;
-       };
+        auto fratesIter = [this, &simulator, &deferred_logger](const Scalar bhp) {
+            // Solver the well iterations to see if we are
+            // able to get a solution with an update
+            // solution
+            std::vector<Scalar> rates(3);
+            computeWellRatesWithBhpIterations(simulator, bhp, rates, deferred_logger);
+            return rates;
+        };
 
-       return WellBhpThpCalculator(*this).
-              computeBhpAtThpLimitProd(fratesIter,
-                                       summary_state,
-                                       this->maxPerfPress(simulator),
-                                       this->getRefDensity(),
-                                       alq_value,
-                                       this->getTHPConstraint(summary_state),
-                                       deferred_logger);
+        bhpAtLimit = WellBhpThpCalculator(*this).
+                computeBhpAtThpLimitProd(fratesIter,
+                                        summary_state,
+                                        this->maxPerfPress(simulator),
+                                        this->getRefDensity(),
+                                        alq_value,
+                                        this->getTHPConstraint(summary_state),
+                                        deferred_logger);
+        if (bhpAtLimit) {
+            // should we use fratesIter here since fratesIter is used in computeBhpAtThpLimitProd above?
+            auto v = frates(*bhpAtLimit);
+            if (std::all_of(v.cbegin(), v.cend(), [](Scalar i){ return i <= 0; }) ) {
+                return bhpAtLimit;
+            }
+        }
+
+        // we still don't get a valied solution.
+        return std::nullopt;
     }
 
     template<typename TypeTag>

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -571,7 +571,7 @@ getALQ(const WellState<Scalar>& well_state) const
 template<class Scalar>
 void WellInterfaceGeneric<Scalar>::
 reportWellSwitching(const SingleWellState<Scalar> &ws,
-                    DeferredLogger& deferred_logger) const
+                    DeferredLogger& deferred_logger)
 {
     if (well_control_log_.empty())
         return;
@@ -588,6 +588,7 @@ reportWellSwitching(const SingleWellState<Scalar> &ws,
         deferred_logger.info(fmt::format("    Well {} control mode changed from {} to {}",
                                          name(), from, to));
     }
+    well_control_log_.clear();
 }
 
 template<class Scalar>

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -162,7 +162,7 @@ public:
     bool isVFPActive(DeferredLogger& deferred_logger) const;
 
     void reportWellSwitching(const SingleWellState<Scalar>& ws,
-                             DeferredLogger& deferred_logger) const;
+                             DeferredLogger& deferred_logger);
 
     bool changedToOpenThisStep() const { return this->changed_to_open_this_step_; }
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -218,15 +218,25 @@ namespace Opm
             // only output frist time
             bool output = std::count(this->well_control_log_.begin(), this->well_control_log_.end(), from) == param_.max_number_of_well_switches_;
             if (output) {
-                std::ostringstream ss;
-                ss << "    The control mode for well " << this->name()
-                   << " is oscillating\n"
-                   << "    We don't allow for more than "
-                   << param_.max_number_of_well_switches_
-                   << " switches. The control is kept at " << from;
-                deferred_logger.info(ss.str());
-                // add one more to avoid outputting the same info again
-                this->well_control_log_.push_back(from);
+                bool changedInd = this->checkIndividualConstraints(ws, summaryState, deferred_logger);
+                if (changedInd) {
+                    std::string to;
+                    if (well.isInjector()) {
+                        to = WellInjectorCMode2String(ws.injection_cmode);
+                    } else {
+                        to = WellProducerCMode2String(ws.production_cmode);
+                    }
+                    std::ostringstream ss;
+                    ss << "    The control mode for well " << this->name()
+                    << " is oscillating.\n"
+                    << " We keep it at its individual control after  "
+                    << param_.max_number_of_well_switches_
+                    << " switches. The control is kept at " << to;
+                    deferred_logger.info(ss.str());
+                    // add one more to avoid outputting the same info again
+                    this->well_control_log_.push_back(to);
+                    return true;
+                }
             }
             return false;
         }

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -330,17 +330,7 @@ namespace Opm
         } else {
             from = WellProducerCMode2String(ws.production_cmode);
         }
-        bool oscillating = false;
-        for (const auto& key : this->well_control_log_) {
-            if (std::count(this->well_control_log_.begin(), this->well_control_log_.end(), key) >= param_.max_number_of_well_switches_) {
-                oscillating = true;
-                break;
-            }
-        }
-
-        //const bool oscillating = std::count(this->well_control_log_.begin(), this->well_control_log_.end(), from) >= param_.max_number_of_well_switches_;
-
-        if (oscillating || this->wellUnderZeroRateTarget(simulator, well_state, deferred_logger) || !(this->well_ecl_.getStatus() == WellStatus::OPEN)) {
+        if (this->wellUnderZeroRateTarget(simulator, well_state, deferred_logger) || !(this->well_ecl_.getStatus() == WellStatus::OPEN)) {
            return false;
         }
 
@@ -351,7 +341,14 @@ namespace Opm
                 return true;
             } else {
                 bool changed = false;
-                if (!fixed_control) {
+                bool oscillating = false;
+                for (const auto& key : this->well_control_log_) {
+                    if (std::count(this->well_control_log_.begin(), this->well_control_log_.end(), key) >= param_.max_number_of_well_switches_) {
+                        oscillating = true;
+                        break;
+                    }
+                }
+                if (!fixed_control && !oscillating) {
                     // We don't allow changing to group controls here since this may lead to inconsistencies
                     // in the group handling which in turn may result in excessive back and forth switching.
                     // If we are to allow this change, one needs to make sure all necessary information propagates  

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -363,7 +363,6 @@ namespace Opm
                     // }
 
                     if (changed) {
-                        this->well_control_log_.push_back(from);
                         const bool thp_controlled = this->isInjector() ? ws.injection_cmode == Well::InjectorCMode::THP :
                                                                         ws.production_cmode == Well::ProducerCMode::THP;
                         if (!thp_controlled){

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -212,33 +212,67 @@ namespace Opm
         } else {
             from = WellProducerCMode2String(ws.production_cmode);
         }
-        bool oscillating = std::count(this->well_control_log_.begin(), this->well_control_log_.end(), from) >= param_.max_number_of_well_switches_;
 
+        bool oscillating = false;
+        for (const auto& key : this->well_control_log_) {
+            if (std::count(this->well_control_log_.begin(), this->well_control_log_.end(), key) >= param_.max_number_of_well_switches_) {
+                oscillating = true;
+                break;
+            }
+        }
         if (oscillating) {
-            // only output frist time
-            bool output = std::count(this->well_control_log_.begin(), this->well_control_log_.end(), from) == param_.max_number_of_well_switches_;
-            if (output) {
-                bool changedInd = this->checkIndividualConstraints(ws, summaryState, deferred_logger);
-                if (changedInd) {
-                    std::string to;
+            if (from == "THP" || from == "BHP")
+                return false;
+
+            bool switched = false;
+            std::string to;
+            if (std::count(this->well_control_log_.begin(), this->well_control_log_.end(), "BHP") > 0) {
+                if (well.isInjector()) {
+                    ws.injection_cmode = Well::InjectorCMode::BHP;
+                } else {
+                    ws.production_cmode = Well::ProducerCMode::BHP;
+                }
+                to = "BHP";
+                updateWellStateWithTarget(simulator, group_state, well_state, deferred_logger);
+                updatePrimaryVariables(simulator, well_state, deferred_logger);
+                switched = true;
+
+            } else if (std::count(this->well_control_log_.begin(), this->well_control_log_.end(), "THP") > 0) {
+                if (well.isInjector()) {
+                    ws.injection_cmode = Well::InjectorCMode::THP;
+                } else { 
+                    ws.production_cmode = Well::ProducerCMode::THP;
+                }
+                to = "THP";
+                ws.thp = this->getTHPConstraint(summaryState);
+                updatePrimaryVariables(simulator, well_state, deferred_logger);
+                switched = true;
+            } else {
+                bool changed = this->checkIndividualConstraints(ws, summaryState, deferred_logger);
+                if (changed) {
                     if (well.isInjector()) {
                         to = WellInjectorCMode2String(ws.injection_cmode);
                     } else {
                         to = WellProducerCMode2String(ws.production_cmode);
                     }
-                    std::ostringstream ss;
-                    ss << "    The control mode for well " << this->name()
-                    << " is oscillating.\n"
-                    << " We keep it at its individual control after  "
-                    << param_.max_number_of_well_switches_
-                    << " switches. The control is kept at " << to;
-                    deferred_logger.info(ss.str());
-                    // add one more to avoid outputting the same info again
-                    this->well_control_log_.push_back(to);
-                    return true;
+                    switched = true;
+                } else {
+                    to = from;
                 }
             }
-            return false;
+            if (switched) {
+                this->well_control_log_.push_back(from);
+                std::ostringstream ss;
+                ss << "    The control mode for well " << this->name()
+                << " is oscillating.\n"
+                << "       The individual control is fixed after  "
+                << param_.max_number_of_well_switches_
+                << " switches. The control is kept at " << to;
+                deferred_logger.info(ss.str());
+                updateWellStateWithTarget(simulator, group_state, well_state, deferred_logger);
+                updatePrimaryVariables(simulator, well_state, deferred_logger);
+            }
+            return switched;
         }
         bool changed = false;
         if (iog == IndividualOrGroup::Individual) {
@@ -296,7 +330,15 @@ namespace Opm
         } else {
             from = WellProducerCMode2String(ws.production_cmode);
         }
-        const bool oscillating = std::count(this->well_control_log_.begin(), this->well_control_log_.end(), from) >= param_.max_number_of_well_switches_;
+        bool oscillating = false;
+        for (const auto& key : this->well_control_log_) {
+            if (std::count(this->well_control_log_.begin(), this->well_control_log_.end(), key) >= param_.max_number_of_well_switches_) {
+                oscillating = true;
+                break;
+            }
+        }
+
+        //const bool oscillating = std::count(this->well_control_log_.begin(), this->well_control_log_.end(), from) >= param_.max_number_of_well_switches_;
 
         if (oscillating || this->wellUnderZeroRateTarget(simulator, well_state, deferred_logger) || !(this->well_ecl_.getStatus() == WellStatus::OPEN)) {
            return false;
@@ -324,6 +366,7 @@ namespace Opm
                     // }
 
                     if (changed) {
+                        this->well_control_log_.push_back(from);
                         const bool thp_controlled = this->isInjector() ? ws.injection_cmode == Well::InjectorCMode::THP :
                                                                         ws.production_cmode == Well::ProducerCMode::THP;
                         if (!thp_controlled){


### PR DESCRIPTION
Continuing #5607 here due to vacation.
Updates:

- Increased default `maximum-number-of-well-switches` from 3 to 10 (see #5607)
- Removed suggested update of control-log during local iterations. Keeping track of switches during local iterations is not important wrt global convergence + the suggested update would also add an entry for every status switch (which is not desirable).