### PR TITLE
Revert #5613 but keep as option

### DIFF
--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -72,6 +72,7 @@ BlackoilModelParameters<Scalar>::BlackoilModelParameters()
     use_average_density_ms_wells_ = Parameters::Get<Parameters::UseAverageDensityMsWells>();
     local_well_solver_control_switching_ = Parameters::Get<Parameters::LocalWellSolveControlSwitching>();
     use_implicit_ipr_ = Parameters::Get<Parameters::UseImplicitIpr>();
+    check_group_constraints_inner_well_iterations_ = Parameters::Get<Parameters::CheckGroupConstraintsInnerWellIterations>();
     nonlinear_solver_ = Parameters::Get<Parameters::NonlinearSolver>();
     const auto approach = Parameters::Get<Parameters::LocalSolveApproach>();
     if (approach == "jacobi") {
@@ -195,6 +196,8 @@ void BlackoilModelParameters<Scalar>::registerParameters()
         ("Allow control switching during local well solutions");
     Parameters::Register<Parameters::UseImplicitIpr>
         ("Compute implict IPR for stability checks and stable solution search");
+    Parameters::Register<Parameters::CheckGroupConstraintsInnerWellIterations>
+        ("Allow checking of group constraints during inner well iterations");        
     Parameters::Register<Parameters::NetworkMaxStrictIterations>
         ("Maximum iterations in network solver before relaxing tolerance");
     Parameters::Register<Parameters::NetworkMaxIterations>

--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -115,6 +115,7 @@ struct MaximumNumberOfWellSwitches { static constexpr int value = 3; };
 struct UseAverageDensityMsWells { static constexpr bool value = false; };
 struct LocalWellSolveControlSwitching { static constexpr bool value = true; };
 struct UseImplicitIpr { static constexpr bool value = true; };
+struct CheckGroupConstraintsInnerWellIterations { static constexpr bool value = true; };
 
 // Network solver parameters
 struct NetworkMaxStrictIterations { static constexpr int value = 100; };
@@ -259,6 +260,9 @@ public:
 
     /// Whether to use implicit IPR for thp stability checks and solution search
     bool use_implicit_ipr_;
+
+    /// Whether to allow checking/changing to group controls during inner well iterations
+    bool check_group_constraints_inner_well_iterations_; 
 
     /// Maximum number of iterations in the network solver before relaxing tolerance
     int network_max_strict_iterations_;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -279,6 +279,7 @@ namespace Opm
                                              const bool fixed_status)
     {
         const auto& summary_state = simulator.vanguard().summaryState();
+        const auto& schedule = simulator.vanguard().schedule();
         auto& ws = well_state.well(this->index_of_well_);
         std::string from;
         if (this->isInjector()) {
@@ -300,18 +301,17 @@ namespace Opm
             } else {
                 bool changed = false;
                 if (!fixed_control) {
-                    // We don't allow changing to group controls here since this may lead to inconsistencies
-                    // in the group handling which in turn may result in excessive back and forth switching.
-                    // If we are to allow this change, one needs to make sure all necessary information propagates  
-                    // properly, but for now, we simply disallow it. The commented code below is kept for future reference  
+                    // Changing to group controls here may lead to inconsistencies in the group handling which in turn 
+                    // may result in excessive back and forth switching. However, we currently allow this by default.
+                    // The switch check_group_constraints_inner_well_iterations_ is a temporary solution.
                     
-                    // const bool hasGroupControl = this->isInjector() ? inj_controls.hasControl(Well::InjectorCMode::GRUP) :
-                    //                                                   prod_controls.hasControl(Well::ProducerCMode::GRUP);
+                    const bool hasGroupControl = this->isInjector() ? inj_controls.hasControl(Well::InjectorCMode::GRUP) :
+                                                                      prod_controls.hasControl(Well::ProducerCMode::GRUP);
 
                     changed = this->checkIndividualConstraints(ws, summary_state, deferred_logger, inj_controls, prod_controls);
-                    // if (hasGroupControl) {
-                    //     changed = changed || this->checkGroupConstraints(well_state, group_state, schedule, summary_state,deferred_logger);
-                    // }
+                    if (hasGroupControl && param_.check_group_constraints_inner_well_iterations_) {
+                        changed = changed || this->checkGroupConstraints(well_state, group_state, schedule, summary_state,deferred_logger);
+                    }
 
                     if (changed) {
                         const bool thp_controlled = this->isInjector() ? ws.injection_cmode == Well::InjectorCMode::THP :


### PR DESCRIPTION
Unfortunately #5613 not only solved problems, but also created a few. 

As a (hopefully) temporary solution, this PR reverts to behaviour before 5613 by default, but adds parameter `check_group_constraints_inner_well_iterations_` which if set to `false` includes changes in 5613.    