### PR TITLE
Enable EQUALREG for Array Operations

### DIFF
--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -169,7 +169,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"EPSDBGS", {false, std::nullopt}},
         {"EPSDEBUG", {false, std::nullopt}},
         {"EQLZCORN", {true, std::nullopt}},
-        {"EQUALREG", {true, std::nullopt}},
         {"ESSNODE", {true, std::nullopt}},
         {"EXCAVATE", {true, std::nullopt}},
         {"EXCEL", {false, std::nullopt}},


### PR DESCRIPTION
The keyword's implementation has reached a point where we can justify its addition to the simulator's feature set.