### PR TITLE
Remove unused num_cells argument from well equations

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -177,8 +177,7 @@ namespace Opm {
         const auto& events = this->schedule()[reportStepIdx].wellgroup_events();
         for (auto& wellPtr : this->well_container_) {
             const bool well_opened_this_step = this->report_step_starts_ && events.hasEvent(wellPtr->name(), effective_events_mask);
-            wellPtr->init(&this->phase_usage_, this->depth_, this->gravity_,
-                          this->local_num_cells_, this->B_avg_, well_opened_this_step);
+            wellPtr->init(&this->phase_usage_, this->depth_, this->gravity_, this->B_avg_, well_opened_this_step);
         }
     }
 
@@ -645,7 +644,7 @@ namespace Opm {
 
             WellInterfacePtr well = createWellForWellTest(well_name, timeStepIdx, deferred_logger);
             // some preparation before the well can be used
-            well->init(&this->phase_usage_, depth_, gravity_, local_num_cells_, B_avg_, true);
+            well->init(&this->phase_usage_, depth_, gravity_, B_avg_, true);
 
             Scalar well_efficiency_factor = wellEcl.getEfficiencyFactor();
             WellGroupHelpers<Scalar>::accumulateGroupEfficiencyFactor(this->schedule().getGroup(wellEcl.groupName(),
@@ -2593,8 +2592,7 @@ namespace Opm {
             auto wellPtr = this->template createTypedWellPointer
                 <StandardWell<TypeTag>>(shutWell, reportStepIdx);
 
-            wellPtr->init(&this->phase_usage_, this->depth_, this->gravity_,
-                          this->local_num_cells_, this->B_avg_, true);
+            wellPtr->init(&this->phase_usage_, this->depth_, this->gravity_, this->B_avg_, true);
 
             this->calculateProductivityIndexValues(wellPtr.get(), deferred_logger);
         }

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -81,7 +81,6 @@ namespace Opm {
         void init(const PhaseUsage* phase_usage_arg,
                   const std::vector<Scalar>& depth_arg,
                   const Scalar gravity_arg,
-                  const int num_cells,
                   const std::vector<Scalar>& B_avg,
                   const bool changed_to_open_this_step) override;
 

--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -55,8 +55,7 @@ MultisegmentWellEquations(const MultisegmentWellGeneric<Scalar>& well)
 
 template<class Scalar, int numWellEq, int numEq>
 void MultisegmentWellEquations<Scalar,numWellEq,numEq>::
-init(const int num_cells,
-     const int numPerfs,
+init(const int numPerfs,
      const std::vector<int>& cells,
      const std::vector<std::vector<int>>& segment_inlets,
      const std::vector<std::vector<int>>& perforations)

--- a/opm/simulators/wells/MultisegmentWellEquations.hpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.hpp
@@ -70,13 +70,11 @@ public:
     MultisegmentWellEquations(const MultisegmentWellGeneric<Scalar>& well);
 
     //! \brief Setup sparsity pattern for the matrices.
-    //! \param num_cells Total number of cells
     //! \param numPerfs Number of perforations
     //! \param cells Cell indices for perforations
     //! \param segment_inlets Cell indices for segment inlets
     //! \param segment_perforations Cell indices for segment perforations
-    void init(const int num_cells,
-              const int numPerfs,
+    void init(const int numPerfs,
               const std::vector<int>& cells,
               const std::vector<std::vector<int>>& segment_inlets,
               const std::vector<std::vector<int>>& segment_perforations);

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -67,9 +67,9 @@ MultisegmentWellEval(WellInterfaceIndices<FluidSystem,Indices>& baseif)
 template<typename FluidSystem, typename Indices>
 void
 MultisegmentWellEval<FluidSystem,Indices>::
-initMatrixAndVectors(const int num_cells)
+initMatrixAndVectors()
 {
-    linSys_.init(num_cells, baseif_.numPerfs(),
+    linSys_.init(baseif_.numPerfs(),
                  baseif_.cells(), segments_.inlets(),
                  segments_.perforations());
     primary_variables_.resize(this->numberOfSegments());

--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -71,7 +71,7 @@ public:
 protected:
     MultisegmentWellEval(WellInterfaceIndices<FluidSystem,Indices>& baseif);
 
-    void initMatrixAndVectors(const int num_cells);
+    void initMatrixAndVectors();
 
     void assembleDefaultPressureEq(const int seg,
                                    WellState<Scalar>& well_state,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -118,11 +118,10 @@ namespace Opm
     init(const PhaseUsage* phase_usage_arg,
          const std::vector<Scalar>& depth_arg,
          const Scalar gravity_arg,
-         const int num_cells,
          const std::vector< Scalar >& B_avg,
          const bool changed_to_open_this_step)
     {
-        Base::init(phase_usage_arg, depth_arg, gravity_arg, num_cells, B_avg, changed_to_open_this_step);
+        Base::init(phase_usage_arg, depth_arg, gravity_arg, B_avg, changed_to_open_this_step);
 
         // TODO: for StandardWell, we need to update the perf depth here using depth_arg.
         // for MultisegmentWell, it is much more complicated.
@@ -134,7 +133,7 @@ namespace Opm
 
         // \Note: we do not update the depth here. And it looks like for now, we only have the option to use
         // specified perforation depth
-        this->initMatrixAndVectors(num_cells);
+        this->initMatrixAndVectors();
 
         // calculate the depth difference between the perforations and the perforated grid block
         for (int perf = 0; perf < this->number_of_perforations_; ++perf) {

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -133,7 +133,6 @@ namespace Opm
         virtual void init(const PhaseUsage* phase_usage_arg,
                           const std::vector<Scalar>& depth_arg,
                           const Scalar gravity_arg,
-                          const int num_cells,
                           const std::vector<Scalar>& B_avg,
                           const bool changed_to_open_this_step) override;
 

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -52,8 +52,7 @@ StandardWellEquations(const ParallelWellInfo<Scalar>& parallel_well_info)
 
 template<class Scalar, int numEq>
 void StandardWellEquations<Scalar,numEq>::
-init(const int num_cells,
-     const int numWellEq,
+init(const int numWellEq,
      const int numPerfs,
      const std::vector<int>& cells)
 {

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -68,12 +68,10 @@ public:
     StandardWellEquations(const ParallelWellInfo<Scalar>& parallel_well_info);
 
     //! \brief Setup sparsity pattern for the matrices.
-    //! \param num_cells Total number of cells
     //! \param numWellEq Number of well equations
     //! \param numPerfs Number of perforations
     //! \param cells Cell indices for perforations
-    void init(const int num_cells,
-              const int numWellEq,
+    void init(const int numWellEq,
               const int numPerfs,
               const std::vector<int>& cells);
 

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -179,7 +179,6 @@ void
 StandardWellEval<FluidSystem,Indices>::
 init(std::vector<Scalar>& perf_depth,
      const std::vector<Scalar>& depth_arg,
-     const int num_cells,
      const bool has_polymermw)
 {
     perf_depth.resize(baseif_.numPerfs(), 0.);
@@ -203,7 +202,7 @@ init(std::vector<Scalar>& perf_depth,
     primary_variables_.resize(numWellEq);
 
     // setup sparsity pattern for the matrices
-    this->linSys_.init(num_cells, numWellEq, baseif_.numPerfs(), baseif_.cells());
+    this->linSys_.init(numWellEq, baseif_.numPerfs(), baseif_.cells());
 }
 
 template<class Scalar>

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -90,7 +90,6 @@ protected:
 
     void init(std::vector<Scalar>& perf_depth,
               const std::vector<Scalar>& depth_arg,
-              const int num_cells,
               const bool has_polymermw);
 
     void updateWellStateFromPrimaryVariables(WellState<Scalar>& well_state,

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -96,12 +96,11 @@ namespace Opm
     init(const PhaseUsage* phase_usage_arg,
          const std::vector<Scalar>& depth_arg,
          const Scalar gravity_arg,
-         const int num_cells,
          const std::vector< Scalar >& B_avg,
          const bool changed_to_open_this_step)
     {
-        Base::init(phase_usage_arg, depth_arg, gravity_arg, num_cells, B_avg, changed_to_open_this_step);
-        this->StdWellEval::init(this->perf_depth_, depth_arg, num_cells, Base::has_polymermw);
+        Base::init(phase_usage_arg, depth_arg, gravity_arg, B_avg, changed_to_open_this_step);
+        this->StdWellEval::init(this->perf_depth_, depth_arg, Base::has_polymermw);
     }
 
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -146,7 +146,6 @@ public:
     virtual void init(const PhaseUsage* phase_usage_arg,
                       const std::vector<Scalar>& depth_arg,
                       const Scalar gravity_arg,
-                      const int num_cells,
                       const std::vector<Scalar>& B_avg,
                       const bool changed_to_open_this_step);
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -93,7 +93,6 @@ namespace Opm
     init(const PhaseUsage* phase_usage_arg,
          const std::vector<Scalar>& /* depth_arg */,
          const Scalar gravity_arg,
-         const int /* num_cells */,
          const std::vector<Scalar>& B_avg,
          const bool changed_to_open_this_step)
     {


### PR DESCRIPTION
The `num_cells` argument is no longer used (and should not have been there to begin with as cells is already an argument and can be used to get the number of cells). This removes the warnings that #5341 introduced.