### PR TITLE
Use Rank's Local Cells for Tracer Concentration Restart

### DIFF
--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -583,8 +583,8 @@ public:
 
                     for (auto elemIdx = 0*numElements; elemIdx < numElements; ++elemIdx) {
                         const auto globalIdx = this->collectOnIORank_.localIdxToGlobalIdx(elemIdx);
-                        tracer_model.setFreeTracerConcentration(tracer_index, globalIdx,
-                                                                free_tracer_solution[globalIdx]);
+                        tracer_model.setFreeTracerConcentration
+                            (tracer_index, elemIdx, free_tracer_solution[globalIdx]);
                     }
                 }
 
@@ -600,16 +600,15 @@ public:
 
                     for (auto elemIdx = 0*numElements; elemIdx < numElements; ++elemIdx) {
                         const auto globalIdx = this->collectOnIORank_.localIdxToGlobalIdx(elemIdx);
-                        tracer_model.setSolTracerConcentration(tracer_index, globalIdx,
-                                                               sol_tracer_solution[globalIdx]);
+                        tracer_model.setSolTracerConcentration
+                            (tracer_index, elemIdx, sol_tracer_solution[globalIdx]);
                     }
                 }
                 else {
                     tracer_model.setEnableSolTracers(tracer_index, false);
 
                     for (auto elemIdx = 0*numElements; elemIdx < numElements; ++elemIdx) {
-                        const auto globalIdx = this->collectOnIORank_.localIdxToGlobalIdx(elemIdx);
-                        tracer_model.setSolTracerConcentration(tracer_index, globalIdx, 0.0);
+                        tracer_model.setSolTracerConcentration(tracer_index, elemIdx, 0.0);
                     }
                 }
             }


### PR DESCRIPTION
The `globalIdx` generated by `localIdxToGlobalIdx()` is in the range zero to number of active cells in global model, not zero to number of active cells on rank.  Using `globalIdx` as an argument to `set*TracerConcentration()` therefore ends up indexing out-of-bounds for the internal arrays in the tracer model object in parallel restarted simulation runs.

The problem has been present since the restart support for tracers was added in commit e9c45f4ca (PR #3708).

This commit switches to using the `elemIdx` instead, as we already do when calling the output module's `setRestart()` member function. Following this, we are able to restart the standard Norne benchmark case (NORNE_ATW2013.DATA) in parallel.  The numerical results for the tracer concentrations are, however, a little questionable and will warrant further investigation.  Nevertheless, the tracer values are now the same in a parallel restarted run as in a sequential restarted run.