### PR TITLE
FIX gas-water restart

### DIFF
--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -497,19 +497,18 @@ public:
         const auto gasActive = FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx);
         const auto waterActive = FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx);
         const auto enableSwatinit = simulator_.vanguard().eclState().fieldProps().has_double("SWATINIT");
-        const auto opm_rst_file = Parameters::Get<Parameters::EnableOpmRstFile>();
-        const auto read_temp = enableEnergy || (opm_rst_file && enableTemperature);
 
         std::vector<RestartKey> solutionKeys {
             {"PRESSURE", UnitSystem::measure::pressure},
             {"SWAT",     UnitSystem::measure::identity,    waterActive},
             {"SGAS",     UnitSystem::measure::identity,    gasActive},
-            {"TEMP",     UnitSystem::measure::temperature, read_temp},
+            {"TEMP",     UnitSystem::measure::temperature, enableEnergy},
             {"SSOLVENT", UnitSystem::measure::identity,    enableSolvent},
 
             {"RS",  UnitSystem::measure::gas_oil_ratio, FluidSystem::enableDissolvedGas()},
             {"RV",  UnitSystem::measure::oil_gas_ratio, FluidSystem::enableVaporizedOil()},
             {"RVW", UnitSystem::measure::oil_gas_ratio, FluidSystem::enableVaporizedWater()},
+            {"RSW", UnitSystem::measure::gas_oil_ratio, FluidSystem::enableDissolvedGasInWater()},
 
             {"SGMAX", UnitSystem::measure::identity, enableNonWettingHysteresis && oilActive && gasActive},
             {"SHMAX", UnitSystem::measure::identity, enableWettingHysteresis && oilActive && gasActive},

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -802,9 +802,9 @@ setRestart(const data::Solution& sol,
             rswSol_[elemIdx] = sol.data<double>("RSWSOL")[globalDofIndex];
 
     }
-
-    assert(!saturation_[oilPhaseIdx].empty());
-    saturation_[oilPhaseIdx][elemIdx] = so;
+    if (!saturation_[oilPhaseIdx].empty())  {
+        saturation_[oilPhaseIdx][elemIdx] = so;
+    }
 
     auto assign = [elemIdx, globalDofIndex, &sol](const std::string& name,
                                                   ScalarBuffer& data)

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -1146,12 +1146,18 @@ public:
             MaterialLaw::capillaryPressures(pc, matParams, fs);
             Valgrind::CheckDefined(this->fluidPressure_[elemIdx]);
             Valgrind::CheckDefined(pc);
-            assert(FluidSystem::phaseIsActive(oilPhaseIdx));
+            const auto& pressure = this->fluidPressure_[elemIdx];
             for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 if (!FluidSystem::phaseIsActive(phaseIdx))
                     continue;
 
-                fs.setPressure(phaseIdx, this->fluidPressure_[elemIdx] + (pc[phaseIdx] - pc[oilPhaseIdx]));
+                if (Indices::oilEnabled)
+                    fs.setPressure(phaseIdx, pressure + (pc[phaseIdx] - pc[oilPhaseIdx]));
+                else if (Indices::gasEnabled)
+                    fs.setPressure(phaseIdx, pressure + (pc[phaseIdx] - pc[gasPhaseIdx]));
+                else if (Indices::waterEnabled)
+                    //single (water) phase
+                    fs.setPressure(phaseIdx, pressure);
             }
         }
 


### PR DESCRIPTION
This removes and fixes some parts in the restart that asserts that there is an oil component to allow for restarts for gas-water cases. 

@bska I add the release tag since this is a bug fix. 