### PR TITLE
Add gpudilu mixed precision

### DIFF
--- a/opm/simulators/linalg/gpuistl/GpuDILU.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuDILU.hpp
@@ -133,6 +133,7 @@ private:
     std::unique_ptr<FloatMat> m_gpuMatrixReorderedLowerFloat;
     std::unique_ptr<FloatMat> m_gpuMatrixReorderedUpperFloat;
     std::unique_ptr<FloatVec> m_gpuMatrixReorderedDiagFloat;
+    std::unique_ptr<FloatVec> m_gpuDInvFloat;
     //! row conversion from natural to reordered matrix indices stored on the GPU
     GpuVector<int> m_gpuNaturalToReorder;
     //! row conversion from reordered to natural matrix indices stored on the GPU

--- a/opm/simulators/linalg/gpuistl/GpuDILU.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuDILU.hpp
@@ -53,6 +53,8 @@ public:
     using field_type = typename X::field_type;
     //! \brief The GPU matrix type
     using CuMat = GpuSparseMatrix<field_type>;
+    using FloatMat = GpuSparseMatrix<float>;
+    using FloatVec = GpuVector<float>;
 
     //! \brief Constructor.
     //!
@@ -60,7 +62,7 @@ public:
     //! \param A The matrix to operate on.
     //! \param w The relaxation factor.
     //!
-    explicit GpuDILU(const M& A, bool splitMatrix, bool tuneKernels);
+    explicit GpuDILU(const M& A, bool splitMatrix, bool tuneKernels, bool storeFactorizationAsFloat);
 
     //! \brief Prepare the preconditioner.
     //! \note Does nothing at the time being.
@@ -127,6 +129,10 @@ private:
     std::unique_ptr<CuMat> m_gpuMatrixReorderedUpper;
     //! \brief If matrix splitting is enabled, we also store the diagonal separately
     std::unique_ptr<GpuVector<field_type>> m_gpuMatrixReorderedDiag;
+    //! \brief If mixed precision is enabled, store a float matrix
+    std::unique_ptr<FloatMat> m_gpuMatrixReorderedLowerFloat;
+    std::unique_ptr<FloatMat> m_gpuMatrixReorderedUpperFloat;
+    std::unique_ptr<FloatVec> m_gpuMatrixReorderedDiagFloat;
     //! row conversion from natural to reordered matrix indices stored on the GPU
     GpuVector<int> m_gpuNaturalToReorder;
     //! row conversion from reordered to natural matrix indices stored on the GPU
@@ -137,6 +143,8 @@ private:
     bool m_splitMatrix;
     //! \brief Bool storing whether or not we will tune the threadblock sizes. Only used for AMD cards
     bool m_tuneThreadBlockSizes;
+    //! \brief Bool storing whether or not we will store the factorization as float. Only used for mixed precision
+    bool m_storeFactorizationAsFloat;
     //! \brief variables storing the threadblocksizes to use if using the tuned sizes and AMD cards
     //! The default value of -1 indicates that we have not calibrated and selected a value yet
     int m_upperSolveThreadBlockSize = -1;

--- a/opm/simulators/linalg/gpuistl/detail/deviceBlockOperations.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/deviceBlockOperations.hpp
@@ -159,7 +159,7 @@ mmv(const T* a, const T* b, T* c)
 // dst -= A*B*C
 template <class T, int blocksize>
 __device__ __forceinline__ void
-mmx2Subtraction(T* A, T* B, T* C, T* dst)
+mmx2Subtraction(const T* A, const T* B, const T* C, T* dst)
 {
 
     T tmp[blocksize * blocksize] = {0};
@@ -250,6 +250,19 @@ mvMixedGeneral(const MatrixScalar* A, const VectorScalar* b, ResultScalar* c)
     for (int i = 0; i < blocksize; ++i) {
         c[i] = 0;
 
+        for (int j = 0; j < blocksize; ++j) {
+            c[i] += ResultScalar(ComputeScalar(A[i * blocksize + j]) * ComputeScalar(b[j]));
+        }
+    }
+}
+
+// TODO: consider merging with existing block operations
+// mixed precision general version of c += Ab
+template <int blocksize, class MatrixScalar, class VectorScalar, class ResultScalar, class ComputeScalar>
+__device__ __forceinline__ void
+umvMixedGeneral(const MatrixScalar* A, const VectorScalar* b, ResultScalar* c)
+{
+    for (int i = 0; i < blocksize; ++i) {
         for (int j = 0; j < blocksize; ++j) {
             c[i] += ResultScalar(ComputeScalar(A[i * blocksize + j]) * ComputeScalar(b[j]));
         }

--- a/opm/simulators/linalg/gpuistl/detail/preconditionerKernels/DILUKernels.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/preconditionerKernels/DILUKernels.hpp
@@ -71,16 +71,16 @@ void solveLowerLevelSet(T* reorderedMat,
  * @param d Stores the defect
  * @param [out] v Will store the results of the lower solve
  */
-template <class T, int blocksize>
-void solveLowerLevelSetSplit(T* reorderedUpperMat,
+template <int blocksize, class LinearSolverScalar, class MatrixScalar>
+void solveLowerLevelSetSplit(MatrixScalar* reorderedUpperMat,
                              int* rowIndices,
                              int* colIndices,
                              int* indexConversion,
                              int startIdx,
                              int rowsInLevelSet,
-                             const T* dInv,
-                             const T* d,
-                             T* v,
+                             const MatrixScalar* dInv,
+                             const LinearSolverScalar* d,
+                             LinearSolverScalar* v,
                              int threadBlockSize);
 
 /**
@@ -124,15 +124,15 @@ void solveUpperLevelSet(T* reorderedMat,
  * @param [out] v Will store the results of the lower solve. To begin with it should store the output from the lower
  * solve
  */
-template <class T, int blocksize>
-void solveUpperLevelSetSplit(T* reorderedUpperMat,
+template <int blocksize, class LinearSolverScalar, class MatrixScalar>
+void solveUpperLevelSetSplit(MatrixScalar* reorderedUpperMat,
                              int* rowIndices,
                              int* colIndices,
                              int* indexConversion,
                              int startIdx,
                              int rowsInLevelSet,
-                             const T* dInv,
-                             T* v,
+                             const MatrixScalar* dInv,
+                             LinearSolverScalar* v,
                              int threadBlockSize);
 
 /**
@@ -161,7 +161,6 @@ void computeDiluDiagonal(T* reorderedMat,
                          int rowsInLevelSet,
                          T* dInv,
                          int threadBlockSize);
-template <class T, int blocksize>
 
 /**
  * @brief Computes the ILU0 of the diagonal elements of the split reordered matrix and stores it in a reordered vector
@@ -184,18 +183,22 @@ template <class T, int blocksize>
  * function
  * @param [out] dInv The diagonal matrix used by the Diagonal ILU preconditioner
  */
-void computeDiluDiagonalSplit(T* reorderedLowerMat,
+template <int blocksize, class InputScalar, class OutputScalar, bool copyResultToOtherMatrix>
+void computeDiluDiagonalSplit(const InputScalar* srcReorderedLowerMat,
                               int* lowerRowIndices,
                               int* lowerColIndices,
-                              T* reorderedUpperMat,
+                              const InputScalar* srcReorderedUpperMat,
                               int* upperRowIndices,
                               int* upperColIndices,
-                              T* diagonal,
+                              const InputScalar* srcDiagonal,
                               int* reorderedToNatural,
                               int* naturalToReordered,
                               int startIdx,
                               int rowsInLevelSet,
-                              T* dInv,
+                              InputScalar* dInv,
+                              OutputScalar* dstDiagonal,
+                              OutputScalar* dstLowerMat,
+                              OutputScalar* dstUpperMat,
                               int threadBlockSize);
 
 } // namespace Opm::gpuistl::detail::DILU

--- a/tests/gpuistl/test_GpuDILU.cpp
+++ b/tests/gpuistl/test_GpuDILU.cpp
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(TestDiluApply)
 
     // Initialize preconditioner objects
     Dune::MultithreadDILU<Sp1x1BlockMatrix, B1x1Vec, B1x1Vec> cpudilu(matA);
-    auto gpudilu = GpuDilu1x1(matA, true, true);
+    auto gpudilu = GpuDilu1x1(matA, true, true, false);
 
     // Use the apply
     gpudilu.apply(d_output, d_input);
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(TestDiluApplyBlocked)
 
     // init matrix with 2x2 blocks
     Sp2x2BlockMatrix matA = get2x2BlockTestMatrix();
-    auto gpudilu = GpuDilu2x2(matA, true, true);
+    auto gpudilu = GpuDilu2x2(matA, true, true, false);
     Dune::MultithreadDILU<Sp2x2BlockMatrix, B2x2Vec, B2x2Vec> cpudilu(matA);
 
     // create input/output buffers for the apply
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(TestDiluInitAndUpdateLarge)
 {
     // create gpu dilu preconditioner
     Sp1x1BlockMatrix matA = get1x1BlockTestMatrix();
-    auto gpudilu = GpuDilu1x1(matA, true, true);
+    auto gpudilu = GpuDilu1x1(matA, true, true, false);
 
     matA[0][0][0][0] = 11.0;
     matA[0][1][0][0] = 12.0;


### PR DESCRIPTION
This PR adds mixed precision to GPU DILU in the style of GPU ILU0 (https://github.com/OPM/opm-simulators/pull/5552)
Basically add a flag that will store the factorization as a float after it is computed in double, cast it back to double inside the preconditioner apply to maintain maximum precision while halving the memory read required in the apply