### PR TITLE
Fix memory bug in setPrimaryVars for MSW

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2237,7 +2237,7 @@ namespace Opm
         constexpr int num_eq = MSWEval::numWellEq;
         std::array<Scalar, num_eq> tmp;
         for (int ii = 0; ii < num_seg; ++ii) {
-            const auto start = it + num_seg * num_eq;
+            const auto start = it + ii * num_eq;
             std::copy(start, start + num_eq, tmp.begin());
             this->primary_variables_.setValue(ii, tmp);
         }


### PR DESCRIPTION
Sets the correct start of memcpy to 

```cpp
for (int ii = 0; ii < num_seg; ++ii) {
     const auto start = it + ii * num_eq;
```

such that it starts from `segment_index * num_eq` instead of `num_seg * num_eq`.

Note that this function is only used when using the NLDD nonlinear solver, where we have an unconverged local NLDD domain, which has a multisegment well on that domain. This was exposed after #5341 was merged which motivated to try NLDD with more complex cases.