### PR TITLE
Some lambda fixes

### DIFF
--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -1524,7 +1524,7 @@ protected:
         using ViolationLevel = typename Satfunc::PhaseChecks::
             SatfuncConsistencyCheckManager<Scalar>::ViolationLevel;
 
-        auto reportFailures = [&sfuncConsistencyChecks, this]
+        auto reportFailures = [&sfuncConsistencyChecks]
             (const ViolationLevel level)
         {
             sfuncConsistencyChecks.reportFailures

--- a/opm/simulators/utils/DamarisVar.cpp
+++ b/opm/simulators/utils/DamarisVar.cpp
@@ -272,13 +272,12 @@ bool DamarisVar<T>::TestType(const std::string& variable_name)
         has_error_ = true;
         return false;
     }
-    T test_id;
-    const std::type_info& t1 = typeid(test_id);
 
     auto check = [&variable_name,this](auto td)
     {
+        const std::type_info& t1 = typeid(T);
         const std::type_info& t2 = typeid(td);
-        if (t1 != t2) {
+        if (typeid(T) != t2) {
             formatTypeError(variable_name, t1.name(), t2.name());
             return false;
         }


### PR DESCRIPTION
- Remove an unused capture
- Restructure to avoid a capture that causes warnings in clang but is required by g++-14