### PR TITLE
avoid declaring t1 outside lambda

### DIFF
--- a/opm/simulators/utils/DamarisVar.cpp
+++ b/opm/simulators/utils/DamarisVar.cpp
@@ -272,13 +272,12 @@ bool DamarisVar<T>::TestType(const std::string& variable_name)
         has_error_ = true;
         return false;
     }
-    T test_id;
-    const std::type_info& t1 = typeid(test_id);
 
     auto check = [&variable_name,this](auto td)
     {
+        const std::type_info& t1 = typeid(T);
         const std::type_info& t2 = typeid(td);
-        if (t1 != t2) {
+        if (typeid(T) != t2) {
             formatTypeError(variable_name, t1.name(), t2.name());
             return false;
         }


### PR DESCRIPTION
clang doesn't want us to capture t1, and g++-14 requires us to capture t1. this workaround avoids warnings with both.

---

This PR back-ports parts of PR #5682 to the release branch ahead of the 2024.10 OPM release.