### PR TITLE
Mark Solution Data as Invalid at the End of a Time Step

### DIFF
--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -707,7 +707,6 @@ namespace Opm {
             {
                 OPM_TIMEBLOCK(invalidateAndUpdateIntensiveQuantities);
                 simulator_.model().invalidateAndUpdateIntensiveQuantities(/*timeIdx=*/0);
-                simulator_.problem().eclWriter()->mutableOutputModule().invalidateLocalData();
             }
         }
 

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -399,6 +399,9 @@ public:
     {
         FlowProblemType::endTimeStep();
 
+        // after the solution is updated, the values in output module needs also updated
+        this->eclWriter()->mutableOutputModule().invalidateLocalData();
+
         const bool isSubStep = !this->simulator().episodeWillBeOver();
 
         // For CpGrid with LGRs, ecl/vtk output is not supported yet.


### PR DESCRIPTION
Without invalidating the output data, many quantities will not be evaluated/updated and output to RESTART files.

---

Backport of pr #5664 to 2024.10 release branch.