### PR TITLE
enableThresholdPressure_ initialized to be false

### DIFF
--- a/opm/simulators/flow/GenericThresholdPressure.hpp
+++ b/opm/simulators/flow/GenericThresholdPressure.hpp
@@ -110,7 +110,7 @@ protected:
     std::vector<Scalar> thpresftValues_;
     std::vector<int> cartElemFaultIdx_;
 
-    bool enableThresholdPressure_;
+    bool enableThresholdPressure_ {false};
 };
 
 } // namespace Opm


### PR DESCRIPTION
in GenericThresholdPressure

I saw some compiler dependent behavoir related to this with the flowexp_comp simulator. 