### PR TITLE
Make WELPI Infrastructure for ACTIONX Fully Private

### DIFF
--- a/opm/simulators/flow/ActionHandler.hpp
+++ b/opm/simulators/flow/ActionHandler.hpp
@@ -31,19 +31,20 @@
 #include <unordered_map>
 #include <vector>
 
+namespace Opm::Action {
+    class State;
+} // namespace Opm::Action
+
 namespace Opm {
-
-namespace Action {
-class ActionX;
-class State;
-}
-
 template<class Scalar> class BlackoilWellModelGeneric;
 class EclipseState;
 class Schedule;
 struct SimulatorUpdate;
 class SummaryState;
 class UDQState;
+} // namespace Opm
+
+namespace Opm {
 
 //! \brief Class handling Action support in simulator
 template<class Scalar>
@@ -53,6 +54,22 @@ public:
     //! \brief Function handle to update transmissiblities.
     using TransFunc = std::function<void(bool)>;
 
+    /// Constructor.
+    ///
+    /// \param[in,out] ecl_state Container of static properties such as
+    /// permeability and transmissibility.
+    ///
+    /// \param[in,out] schedule Container of dynamic objects, such as wells.
+    ///
+    /// \param[in,out] actionState Dynamic state object for all actions.
+    ///
+    /// \param[in,out] summaryState Dynamic state object for all summary
+    /// vectors.
+    ///
+    /// \param[in,out] wellModel Simulation wells on this rank.
+    ///
+    /// \param[in] comm MPI communicator object linking all simulation
+    /// ranks.
     ActionHandler(EclipseState& ecl_state,
                   Schedule& schedule,
                   Action::State& actionState,
@@ -60,36 +77,70 @@ public:
                   BlackoilWellModelGeneric<Scalar>& wellModel,
                   Parallel::Communication comm);
 
+    /// Run all pending actions.
+    ///
+    /// \param[in] reportStep Zero-based report step index.
+    ///
+    /// \param[in] sim_time Elapsed time since simulation start.
+    ///
+    /// \param[in] updateTrans Call-back for affecting transmissibility
+    /// updates.  Typically invoked if the action triggers a keyword like
+    /// MULTZ.
     void applyActions(int reportStep,
                       double sim_time,
                       const TransFunc& updateTrans);
 
-    //! \brief Evaluates UDQ assign statements.
+    /// \brief Evaluates UDQ assign statements.
+    ///
+    /// \param[in] episodeIdx Zero-based report step index.
+    ///
+    /// \param[in,out] udq_state Dynamic state of all user-defined
+    /// quantities.
     void evalUDQAssignments(const unsigned episodeIdx,
                             UDQState& udq_state);
 
-  private:
-    /*
-       This function is run after applyAction has been completed in the Schedule
-       implementation. The sim_update argument should have members & flags for
-       the simulator properties which need to be updated. This functionality is
-       probably not complete.
-    */
+private:
+    /// Convey dynamic updates triggered by an action block back to the
+    /// running simulator.
+    ///
+    /// This function is run after applyAction has been completed in the
+    /// Schedule implementation.  The sim_update argument should have
+    /// members & flags for the simulator properties which need to be
+    /// updated.  This functionality is probably not complete.
+    ///
+    /// \param[in] report_step Zero-based report step index.
+    ///
+    /// \param[in] sim_update Action's resulting simulator update.
+    ///
+    /// \param[in] updateTrans Call-back for affecting transmissibility
+    /// updates.  Typically invoked if the action triggers a keyword like
+    /// MULTZ.
+    ///
+    /// \param[out] commit_wellstate Whether or not the action affected any
+    /// simulation wells which, in turn, may require rebuilding internal
+    /// data structures in the simulator and therefore would require
+    /// preserving the dynamic well and group states prior to doing so.
     void applySimulatorUpdate(int report_step,
                               const SimulatorUpdate& sim_update,
-                              bool& commit_wellstate,
-                              const TransFunc& updateTrans);
+                              const TransFunc& updateTrans,
+                              bool& commit_wellstate);
 
-    std::unordered_map<std::string, Scalar>
-    fetchWellPI(int reportStep,
-                const Action::ActionX& action,
-                const std::vector<std::string>& matching_wells) const;
-
+    /// Static properties such as permeability and transmissibility.
     EclipseState& ecl_state_;
+
+    /// Dynamic objects such as wells.
     Schedule& schedule_;
+
+    /// Dynamic state for all actions--e.g., their run count.
     Action::State& actionState_;
+
+    /// Dynamic state for all user-defined quantities.
     SummaryState& summaryState_;
+
+    /// Simulation wells on this rank.
     BlackoilWellModelGeneric<Scalar>& wellModel_;
+
+    /// MPI communicator object linking all simulation ranks.
     Parallel::Communication comm_;
 };
 


### PR DESCRIPTION
This is in preparation of making the match set for `ACTIONX` more general.  Having a fully private `WELPI` framework means we can change the types more freely without having to rebuild all users of `ActionHandler`.

While here, also add Doxygen-style documentation to the `ActionHandler`.