### PR TITLE
dont switch from GRUP if check_group_constrains_well_iterations=false

### DIFF
--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -307,8 +307,10 @@ namespace Opm
                     
                     const bool hasGroupControl = this->isInjector() ? inj_controls.hasControl(Well::InjectorCMode::GRUP) :
                                                                       prod_controls.hasControl(Well::ProducerCMode::GRUP);
-
-                    changed = this->checkIndividualConstraints(ws, summary_state, deferred_logger, inj_controls, prod_controls);
+                    bool isGroupControl = ws.production_cmode == Well::ProducerCMode::GRUP || ws.injection_cmode == Well::InjectorCMode::GRUP; 
+                    if (! (isGroupControl && !this->param_.check_group_constraints_inner_well_iterations_)) {
+                        changed = this->checkIndividualConstraints(ws, summary_state, deferred_logger, inj_controls, prod_controls);
+                    }
                     if (hasGroupControl && this->param_.check_group_constraints_inner_well_iterations_) {
                         changed = changed || this->checkGroupConstraints(well_state, group_state, schedule, summary_state,deferred_logger);
                     }


### PR DESCRIPTION
As the code is now switching to/from GRUP in the local iterations is problematic as the group reduction rates (the combined rates of all wells that are not on group rate) are not updated. With this PR, individual controls are not checked if the well is on GRUP if check-group-constrains-well-iterations=false. 

I would also suggested to set check-group-constrains-well-iterations=false as default while fixing the reduction rate.  