### PR TITLE
Dont iterate when computing bhp from thp for computing of the well potentials for gaslift optimization

### DIFF
--- a/opm/simulators/wells/GasLiftSingleWell_impl.hpp
+++ b/opm/simulators/wells/GasLiftSingleWell_impl.hpp
@@ -143,7 +143,8 @@ computeBhpAtThpLimit_(Scalar alq, bool debug_output) const
         this->simulator_,
         this->summary_state_,
         alq,
-        this->deferred_logger_);
+        this->deferred_logger_,
+        /*iterate_if_no_solution */ false);
     if (bhp_at_thp_limit) {
         if (*bhp_at_thp_limit < this->controls_.bhp_limit) {
             if (debug_output && this->debug) {

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -157,7 +157,8 @@ namespace Opm {
         computeBhpAtThpLimitProdWithAlq(const Simulator& simulator,
                                         const SummaryState& summary_state,
                                         const Scalar alq_value,
-                                        DeferredLogger& deferred_logger) const override;
+                                        DeferredLogger& deferred_logger,
+                                        bool iterate_if_no_solution) const override;
 
         std::vector<Scalar> getPrimaryVars() const override;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -2042,7 +2042,8 @@ namespace Opm
                                                simulator,
                                                summary_state,
                                                this->getALQ(well_state),
-                                               deferred_logger);
+                                               deferred_logger,
+                                               /*iterate_if_no_solution */ true);
     }
 
 
@@ -2053,7 +2054,8 @@ namespace Opm
     computeBhpAtThpLimitProdWithAlq(const Simulator& simulator,
                                     const SummaryState& summary_state,
                                     const Scalar alq_value,
-                                    DeferredLogger& deferred_logger) const
+                                    DeferredLogger& deferred_logger,
+                                    bool iterate_if_no_solution) const
     {
         // Make the frates() function.
         auto frates = [this, &simulator, &deferred_logger](const Scalar bhp) {
@@ -2078,6 +2080,9 @@ namespace Opm
 
        if (bhpAtLimit)
            return bhpAtLimit;
+
+        if (!iterate_if_no_solution)
+            return std::nullopt;
 
        auto fratesIter = [this, &simulator, &deferred_logger](const Scalar bhp) {
            // Solver the well iterations to see if we are

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -234,7 +234,8 @@ namespace Opm
         computeBhpAtThpLimitProdWithAlq(const Simulator& ebos_simulator,
                                         const SummaryState& summary_state,
                                         const Scalar alq_value,
-                                        DeferredLogger& deferred_logger) const override;
+                                        DeferredLogger& deferred_logger,
+                                        bool iterate_if_no_solution) const override;
 
         void updateIPRImplicit(const Simulator& simulator,
                                WellState<Scalar>& well_state,

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1699,7 +1699,7 @@ namespace Opm
     {
         Scalar bhp;
         auto bhp_at_thp_limit = computeBhpAtThpLimitProdWithAlq(
-                              simulator, summary_state, alq, deferred_logger);
+                              simulator, summary_state, alq, deferred_logger, /*iterate_if_no_solution */ true);
         if (bhp_at_thp_limit) {
             const auto& controls = this->well_ecl_.productionControls(summary_state);
             bhp = std::max(*bhp_at_thp_limit,
@@ -2213,7 +2213,8 @@ namespace Opm
         return computeBhpAtThpLimitProdWithAlq(simulator,
                                                summary_state,
                                                this->getALQ(well_state),
-                                               deferred_logger);
+                                               deferred_logger,
+                                               /*iterate_if_no_solution */ true);
     }
 
     template<typename TypeTag>
@@ -2222,7 +2223,8 @@ namespace Opm
     computeBhpAtThpLimitProdWithAlq(const Simulator& simulator,
                                     const SummaryState& summary_state,
                                     const Scalar alq_value,
-                                    DeferredLogger& deferred_logger) const
+                                    DeferredLogger& deferred_logger,
+                                    bool iterate_if_no_solution) const
     {
         // Make the frates() function.
         auto frates = [this, &simulator, &deferred_logger](const Scalar bhp) {
@@ -2260,6 +2262,8 @@ namespace Opm
             }
         }
 
+        if (!iterate_if_no_solution)
+            return std::nullopt;
 
         auto fratesIter = [this, &simulator, &deferred_logger](const Scalar bhp) {
             // Solver the well iterations to see if we are

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -190,7 +190,8 @@ public:
     computeBhpAtThpLimitProdWithAlq(const Simulator& ebos_simulator,
                                     const SummaryState& summary_state,
                                     const Scalar alq_value,
-                                    DeferredLogger& deferred_logger) const = 0;
+                                    DeferredLogger& deferred_logger,
+                                    bool iterate_if_no_solution) const = 0;
 
     /// using the solution x to recover the solution xw for wells and applying
     /// xw to update Well State

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1884,7 +1884,7 @@ namespace Opm
         const auto& summary_state = simulator.vanguard().summaryState();
 
         auto bhp_at_thp_limit = computeBhpAtThpLimitProdWithAlq(
-            simulator, summary_state, this->getALQ(well_state), deferred_logger);
+            simulator, summary_state, this->getALQ(well_state), deferred_logger, /*iterate_if_no_solution */ true);
         if (bhp_at_thp_limit) {
             std::vector<Scalar> rates(this->number_of_phases_, 0.0);
             if (thp_update_iterations) {


### PR DESCRIPTION
This gives a 10 times speed up of the gaslift optimization for many cases as we dont repeatedly try to compute bhp from thp for alq values that dont converge anyway. 