### PR TITLE
Handle WELPI from ACTIONX Separately From Constraints

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -601,6 +601,16 @@ protected:
 
 private:
     WellInterfaceGeneric<Scalar>* getGenWell(const std::string& well_name);
+
+    template <typename Iter, typename Body>
+    void wellUpdateLoop(Iter first, Iter last, const int timeStepIdx, Body&& body);
+
+    void updateEclWellsConstraints(const int timeStepIdx,
+                                   const SimulatorUpdate& sim_update,
+                                   const SummaryState& st);
+
+    void updateEclWellsCTFFromAction(const int timeStepIdx,
+                                     const SimulatorUpdate& sim_update);
 };
 
 


### PR DESCRIPTION
This commit switches to using the 'welpi_wells' information from the SimulatorUpdate structure as a basis to decide the wells for which it is safe/sufficient to update only the CTFs in response to an ACTIONX block running WELPI.  To this end, we split the actions of the existing member function updateEclWells() into two parts,

  1. updateEclWellsConstraints()
  2. updateEclWellsCTFFromAction()

in which the first handles well status and well control updates while the second deals with CTF updates in response to WELPI.  We do not run the second part if the well structure has changed--e.g., due to COMPDAT or WELOPEN--since the update loop depends on a static connection topology.

We add a new member function wellUpdateLoop() which will traverse a sequence of well names and invoke a loop body on those wells which exist in wells_ecl_.  This collects common operations needed for both the constraints and the CTF updates.

---

This PR back-ports #5697 to the release branch for OPM 2024.10.