### PR TITLE
Make sure all errors from parsing show up in the log files.

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -617,7 +617,10 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
 
     if (*errorGuard) { // errors encountered
         parseSuccess = 0;
-        errorGuard->dump();
+        if (failureMessage.size()) {
+            failureMessage += std::string("\n");
+        }
+        failureMessage += errorGuard->dump();
         errorGuard->clear();
     }
 


### PR DESCRIPTION
Currently, some errors from parsing, like topology errors when processing sections, are not included in the log files or the final standard output before aborting. If there are no other errors the user will only see a line like this without further explanation: "Error: Unrecoverable errors while loading input:"

With this commit now print the string returned by ErrorGuard::dump to the logs and standard output. Hence the user might see somthing like this:

```
Error: Unrecoverable error while loading input: SECTION_TOPOLOGY_ERROR: The GRID section must be followed by EDIT or PROPS instead of GRID at: SPE1CASE2_ERR.DATA, line: 108
```

Depends on OPM/opm-common#4305.