### PR TITLE
fixed: use constexpr formats and/or mark format strings runtime

### DIFF
--- a/opm/simulators/flow/KeywordValidation.cpp
+++ b/opm/simulators/flow/KeywordValidation.cpp
@@ -21,7 +21,6 @@
 #include "config.h"
 #endif // HAVE_CONFIG_H
 
-#include <map>
 #include <string>
 #include <type_traits>
 
@@ -36,20 +35,13 @@
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/simulators/flow/KeywordValidation.hpp>
 
-namespace Opm
-{
-
-
-
-namespace KeywordValidation
-{
-
+namespace Opm::KeywordValidation {
 
     std::string get_error_report(const std::vector<ValidationError>& errors, const bool include_noncritical, const bool include_critical)
     {
         const std::string keyword_format = "  {keyword}: keyword not supported\n";
-        const std::string item_format1 = "  {{keyword}}: invalid value '{}' for item {}\n";
-        const std::string item_format2 = "  {{keyword}}: invalid value '{}' in record {} for item {}\n";
+        constexpr std::string_view item_format1 = "  {{keyword}}: invalid value '{}' for item {}\n";
+        constexpr std::string_view item_format2 = "  {{keyword}}: invalid value '{}' in record {} for item {}\n";
         const std::string location_format = "  In file: {file}, line {line}\n";
 
         std::string report;
@@ -206,7 +198,4 @@ namespace KeywordValidation
         }
     }
 
-
-} // namespace KeywordValidation
-
-} // namespace Opm
+} // namespace Opm::KeywordValidation

--- a/opm/simulators/wells/GasLiftSingleWellGeneric.cpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.cpp
@@ -421,8 +421,8 @@ void GasLiftSingleWellGeneric<Scalar>::
 debugShowBhpAlqTable_()
 {
     Scalar alq = 0.0;
-    const std::string fmt_fmt1 {"{:^12s} {:^12s} {:^12s} {:^12s}"};
-    const std::string fmt_fmt2 {"{:>12.5g} {:>12.5g} {:>12.5g} {:>12.5g}"};
+    constexpr std::string_view fmt_fmt1 {"{:^12s} {:^12s} {:^12s} {:^12s}"};
+    constexpr std::string_view fmt_fmt2 {"{:>12.5g} {:>12.5g} {:>12.5g} {:>12.5g}"};
     const std::string header = fmt::format(fmt_fmt1, "ALQ", "BHP", "oil", "gas");
     displayDebugMessage_(header);
     auto max_it = 50;

--- a/opm/simulators/wells/GroupEconomicLimitsChecker.cpp
+++ b/opm/simulators/wells/GroupEconomicLimitsChecker.cpp
@@ -330,7 +330,7 @@ addPrintMessage(const std::string& msg,
         this->group_.name()
     );
     const std::string measure_name(this->unit_system_.name(measure));
-    const std::string message = fmt::format(msg,
+    const std::string message = fmt::format(fmt::runtime(msg),
                                          this->unit_system_.from_si(measure, value), measure_name,
                                          this->unit_system_.from_si(measure, limit), measure_name);
 


### PR DESCRIPTION
fmt wants to do compile time validation of format strings under c++-20. mark formatting strings constexpr where possible, and mark formats runtime to disable validation where not possible.