### PR TITLE
Chase API Update of UDQConfig's Evaluation Functions

### DIFF
--- a/opm/simulators/flow/ActionHandler.cpp
+++ b/opm/simulators/flow/ActionHandler.cpp
@@ -289,14 +289,11 @@ void ActionHandler<Scalar>::
 evalUDQAssignments(const unsigned episodeIdx,
                    UDQState& udq_state)
 {
-    const auto& udq = schedule_[episodeIdx].udq();
-
-    udq.eval_assign(episodeIdx,
-                    this->schedule_,
-                    this->schedule_.wellMatcher(episodeIdx),
-                    this->schedule_.segmentMatcherFactory(episodeIdx),
-                    this->summaryState_,
-                    udq_state);
+    this->schedule_[episodeIdx].udq()
+        .eval_assign(this->schedule_.wellMatcher(episodeIdx),
+                     this->schedule_.segmentMatcherFactory(episodeIdx),
+                     this->summaryState_,
+                     udq_state);
 }
 
 template class ActionHandler<double>;

--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -677,7 +677,6 @@ evalSummary(const int                                            reportStepNum,
 
         this->schedule_.getUDQConfig(udq_step)
             .eval(udq_step,
-                  this->schedule_,
                   this->schedule_.wellMatcher(udq_step),
                   this->schedule_.segmentMatcherFactory(udq_step),
                   [es = std::cref(this->eclState_)]() {

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -462,9 +462,12 @@ public:
                 .applyActions(episodeIdx, simulator.time() + simulator.timeStepSize(),
                               [this](const bool global)
             {
-                using TransUpdateQuantities = typename Vanguard::TransmissibilityType::TransUpdateQuantities;
+                using TransUpdateQuantities = typename
+                    Vanguard::TransmissibilityType::TransUpdateQuantities;
+
                 this->transmissibilities_
-                    .update(global,  TransUpdateQuantities::All, [&vg = this->simulator().vanguard()]
+                    .update(global, TransUpdateQuantities::All,
+                            [&vg = this->simulator().vanguard()]
                             (const unsigned int i)
                     {
                         return vg.gridIdxToEquilGridIdx(i);
@@ -482,15 +485,15 @@ public:
                 MICPModule::checkCloggingMICP(model, phi, globalDofIdx);
             }
         }
-
     }
+
     /*!
      * \brief Called by the simulator after the end of an episode.
      */
     void endEpisode() override
     {
         OPM_TIMEBLOCK(endEpisode);
-        const int episodeIdx = this->episodeIndex();
+
         // Rerun UDQ assignents following action processing on the final
         // time step of this episode to make sure that any UDQ ASSIGN
         // operations triggered in action blocks take effect.  This is
@@ -502,14 +505,15 @@ public:
         // assignment would be dropped and the rest of the simulator will
         // never see its effect without this hack.
         this->actionHandler_
-                .evalUDQAssignments(episodeIdx, this->simulator().vanguard().udqState());
+            .evalUDQAssignments(this->episodeIndex(), this->simulator().vanguard().udqState());
 
         FlowProblemType::endEpisode();
     }
 
-    void writeReports(const SimulatorTimer& timer) {
-        if (enableEclOutput_){
-            eclWriter_->writeReports(timer);
+    void writeReports(const SimulatorTimer& timer)
+    {
+        if (this->enableEclOutput_) {
+            this->eclWriter_->writeReports(timer);
         }
     }
 


### PR DESCRIPTION
Following PR OPM/opm-common#4317, the functions no longer use the `episodeIdx` or `Schedule` parameters.  Update callers accordingly.

While here, split some long lines and remove unneeded local objects.