### PR TITLE
LevelCartesianIndexMapper constructor for AluGrid taking only a grid as an argument

### DIFF
--- a/opm/simulators/flow/AluGridVanguard.hpp
+++ b/opm/simulators/flow/AluGridVanguard.hpp
@@ -238,9 +238,10 @@ public:
     /*!
      * \brief Returns the object which maps a global element index of the simulation grid
      *        to the corresponding element index of the level logically Cartesian index.
+     *        No refinement is supported for AluGrid so it coincides with CartesianIndexMapper.
      */
     const LevelCartesianIndexMapper levelCartesianIndexMapper() const
-    { return LevelCartesianIndexMapper(*grid_, *cartesianIndexMapper_); }
+    { return LevelCartesianIndexMapper(*cartesianIndexMapper_); }
 
     /*!
      * \brief Returns mapper from compressed to cartesian indices for the EQUIL grid

--- a/opm/simulators/flow/PolyhedralGridVanguard.hpp
+++ b/opm/simulators/flow/PolyhedralGridVanguard.hpp
@@ -174,9 +174,10 @@ public:
     /*!
      * \brief Returns the object which maps a global element index of the simulation grid
      *        to the corresponding element index of the level logically Cartesian index.
+     *        No refinement is supported for AluGrid so it coincides with CartesianIndexMapper.
      */
     const LevelCartesianIndexMapper levelCartesianIndexMapper() const
-    { return LevelCartesianIndexMapper(*grid_); }
+    { return LevelCartesianIndexMapper(*cartesianIndexMapper_); }
 
     /*!
      * \brief Returns mapper from compressed to cartesian indices for the EQUIL grid


### PR DESCRIPTION
Minor refactor was made to LevelCartesianIndexMapper AluGrid specialization, removing the first unused argument from its constructor.

Design issue identified with the help of OPM/opm-simulators#5712.

Not relevant for the Reference Manual.
