### PR TITLE
Quell c++-20 warnings

### DIFF
--- a/examples/problems/co2injectionproblem.hh
+++ b/examples/problems/co2injectionproblem.hh
@@ -212,8 +212,8 @@ class Co2InjectionProblem : public GetPropType<TypeTag, Properties::BaseProblem>
     enum { liquidPhaseIdx = FluidSystem::liquidPhaseIdx };
     enum { CO2Idx = FluidSystem::CO2Idx };
     enum { BrineIdx = FluidSystem::BrineIdx };
-    enum { conti0EqIdx = Indices::conti0EqIdx };
-    enum { contiCO2EqIdx = conti0EqIdx + CO2Idx };
+    static constexpr int conti0EqIdx = Indices::conti0EqIdx;
+    static constexpr int contiCO2EqIdx = conti0EqIdx + CO2Idx;
 
     using PrimaryVariables = GetPropType<TypeTag, Properties::PrimaryVariables>;
     using RateVector = GetPropType<TypeTag, Properties::RateVector>;

--- a/opm/models/blackoil/blackoilpolymermodules.hh
+++ b/opm/models/blackoil/blackoilpolymermodules.hh
@@ -591,7 +591,9 @@ public:
         const Scalar& maxAdsorbtion = PolymerModule::plyrockMaxAdsorbtion(elemCtx, dofIdx, timeIdx);
         const auto& plyadsAdsorbedPolymer = PolymerModule::plyadsAdsorbedPolymer(elemCtx, dofIdx, timeIdx);
         polymerAdsorption_ = plyadsAdsorbedPolymer.eval(polymerConcentration_, /*extrapolate=*/true);
-        if (PolymerModule::plyrockAdsorbtionIndex(elemCtx, dofIdx, timeIdx) == BlackOilPolymerParams<Scalar>::NoDesorption) {
+        if (static_cast<int>(PolymerModule::plyrockAdsorbtionIndex(elemCtx, dofIdx, timeIdx)) ==
+            BlackOilPolymerParams<Scalar>::NoDesorption)
+        {
             const Scalar& maxPolymerAdsorption = elemCtx.problem().maxPolymerAdsorption(elemCtx, dofIdx, timeIdx);
             polymerAdsorption_ = std::max(Evaluation(maxPolymerAdsorption) , polymerAdsorption_);
         }

--- a/opm/models/flash/flashindices.hh
+++ b/opm/models/flash/flashindices.hh
@@ -45,7 +45,7 @@ class FlashIndices
     : public EnergyIndices<PVOffset + getPropValue<TypeTag, Properties::NumComponents>(),
                            getPropValue<TypeTag, Properties::EnableEnergy>()>
 {
-    enum { numComponents = getPropValue<TypeTag, Properties::NumComponents>() };
+    static constexpr int numComponents = getPropValue<TypeTag, Properties::NumComponents>();
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     using EnergyIndices = Opm::EnergyIndices<PVOffset + numComponents, enableEnergy>;
 

--- a/opm/models/immiscible/immiscibleindices.hh
+++ b/opm/models/immiscible/immiscibleindices.hh
@@ -43,7 +43,7 @@ struct ImmiscibleIndices
     : public EnergyIndices<PVOffset + getPropValue<TypeTag, Properties::NumPhases>(),
                            getPropValue<TypeTag, Properties::EnableEnergy>()>
 {
-    enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
+    static constexpr int numPhases = getPropValue<TypeTag, Properties::NumPhases>();
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     using EnergyIndices = Opm::EnergyIndices<PVOffset + numPhases, enableEnergy>;
 

--- a/opm/models/ncp/ncpindices.hh
+++ b/opm/models/ncp/ncpindices.hh
@@ -48,8 +48,8 @@ struct NcpIndices
 {
 private:
     using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
-    enum { numPhases = FluidSystem::numPhases };
-    enum { numComponents = FluidSystem::numComponents };
+    static constexpr int numPhases = FluidSystem::numPhases;
+    static constexpr int numComponents = FluidSystem::numComponents;
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
 
     using EnergyIndices = Opm::EnergyIndices<PVOffset + numComponents + numPhases, enableEnergy>;

--- a/opm/models/ncp/ncpmodel.hh
+++ b/opm/models/ncp/ncpmodel.hh
@@ -232,13 +232,13 @@ class NcpModel
     using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
     using Indices = GetPropType<TypeTag, Properties::Indices>;
 
-    enum { numPhases = FluidSystem::numPhases };
-    enum { numComponents = FluidSystem::numComponents };
-    enum { fugacity0Idx = Indices::fugacity0Idx };
+    static constexpr int numPhases = FluidSystem::numPhases;
+    static constexpr int numComponents = FluidSystem::numComponents;
+    static constexpr int fugacity0Idx = Indices::fugacity0Idx;
     enum { pressure0Idx = Indices::pressure0Idx };
     enum { saturation0Idx = Indices::saturation0Idx };
-    enum { conti0EqIdx = Indices::conti0EqIdx };
-    enum { ncp0EqIdx = Indices::ncp0EqIdx };
+    static constexpr int conti0EqIdx = Indices::conti0EqIdx;
+    static constexpr int ncp0EqIdx = Indices::ncp0EqIdx;
     enum { enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>() };
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
 

--- a/opm/models/ptflash/flashindices.hh
+++ b/opm/models/ptflash/flashindices.hh
@@ -46,7 +46,7 @@ class FlashIndices
     : public EnergyIndices<PVOffset + getPropValue<TypeTag, Properties::NumComponents>(),
                            getPropValue<TypeTag, Properties::EnableEnergy>()>
 {
-    enum { numComponents = getPropValue<TypeTag, Properties::NumComponents>() };
+    static constexpr int numComponents = getPropValue<TypeTag, Properties::NumComponents>();
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     using EnergyIndices = Opm::EnergyIndices<PVOffset + numComponents, enableEnergy>;
 

--- a/opm/models/pvs/pvsindices.hh
+++ b/opm/models/pvs/pvsindices.hh
@@ -46,7 +46,7 @@ class PvsIndices
     : public EnergyIndices<PVOffset + getPropValue<TypeTag, Properties::NumComponents>(),
                            getPropValue<TypeTag, Properties::EnableEnergy>()>
 {
-    enum { numComponents = getPropValue<TypeTag, Properties::NumComponents>() };
+    static constexpr int numComponents = getPropValue<TypeTag, Properties::NumComponents>();
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     using EnergyIndices = Opm::EnergyIndices<PVOffset + numComponents, enableEnergy>;
 

--- a/opm/simulators/flow/RegionPhasePVAverage.cpp
+++ b/opm/simulators/flow/RegionPhasePVAverage.cpp
@@ -212,5 +212,6 @@ Opm::RegionPhasePoreVolAverage::valueArrayIndex(const Ix      start,
                                                 const AvgType type,
                                                 const Element element) const
 {
-    return start + type*Element::NumElem + element;
+    return start + static_cast<Ix>(type) * static_cast<Ix>(Element::NumElem)
+                 + static_cast<Ix>(element);
 }

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -553,7 +553,7 @@ void registerAdaptiveParameters();
             return serializationTestObject_<SimpleIterationCountTimeStepControl>();
         }
 
-        bool operator==(const AdaptiveTimeStepping<TypeTag>& rhs)
+        bool operator==(const AdaptiveTimeStepping<TypeTag>& rhs) const
         {
             if (timeStepControlType_ != rhs.timeStepControlType_ ||
                 (timeStepControl_ && !rhs.timeStepControl_) ||

--- a/opm/simulators/utils/MPIPacker.hpp
+++ b/opm/simulators/utils/MPIPacker.hpp
@@ -34,6 +34,9 @@ namespace Opm::Mpi {
 
 namespace detail {
 
+template <typename T>
+constexpr bool is_pod_v = std::is_standard_layout_v<T> && std::is_trivial_v<T>;
+
 std::size_t mpi_buffer_size(const std::size_t bufsize, const std::size_t position);
 
 //! \brief Abstract struct for packing which is (partially) specialized for specific types.
@@ -199,7 +202,7 @@ struct Packer
     template<class T>
     std::size_t packSize(const T& data) const
     {
-        return detail::Packing<std::is_pod_v<T>,T>::packSize(data, m_comm);
+        return detail::Packing<detail::is_pod_v<T>,T>::packSize(data, m_comm);
     }
 
     //! \brief Calculates the pack size for an array.
@@ -209,7 +212,7 @@ struct Packer
     template<class T>
     std::size_t packSize(const T* data, std::size_t n) const
     {
-        static_assert(std::is_pod_v<T>, "Array packing not supported for non-pod data");
+        static_assert(detail::is_pod_v<T>, "Array packing not supported for non-pod data");
         return detail::Packing<true,T>::packSize(data, n, m_comm);
     }
 
@@ -223,7 +226,7 @@ struct Packer
               std::vector<char>& buffer,
               std::size_t& position) const
     {
-        detail::Packing<std::is_pod_v<T>,T>::pack(data, buffer, position, m_comm);
+        detail::Packing<detail::is_pod_v<T>,T>::pack(data, buffer, position, m_comm);
     }
 
     //! \brief Pack an array.
@@ -238,7 +241,7 @@ struct Packer
               std::vector<char>& buffer,
               std::size_t& position) const
     {
-        static_assert(std::is_pod_v<T>, "Array packing not supported for non-pod data");
+        static_assert(detail::is_pod_v<T>, "Array packing not supported for non-pod data");
         detail::Packing<true,T>::pack(data, n, buffer, position, m_comm);
     }
 
@@ -252,7 +255,7 @@ struct Packer
                 const std::vector<char>& buffer,
                 std::size_t& position) const
     {
-        detail::Packing<std::is_pod_v<T>,T>::unpack(data, buffer, position, m_comm);
+        detail::Packing<detail::is_pod_v<T>,T>::unpack(data, buffer, position, m_comm);
     }
 
     //! \brief Unpack an array.
@@ -267,7 +270,7 @@ struct Packer
                 const std::vector<char>& buffer,
                 std::size_t& position) const
     {
-        static_assert(std::is_pod_v<T>, "Array packing not supported for non-pod data");
+        static_assert(detail::is_pod_v<T>, "Array packing not supported for non-pod data");
         detail::Packing<true,T>::unpack(data, n, buffer, position, m_comm);
     }
 


### PR DESCRIPTION
- use constexpr instead of anonymous enums
- avoid use of std::is_pod_v
- mark comparison operator const
- add some casts to avoid enum arithmetics

