### PR TITLE
Fix index bug in gpubridge separate wells

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -222,7 +222,7 @@ extract(WellContributions<Scalar>& wellContribs) const
     Cvals.reserve(BnumBlocks * numEq * numWellEq);
     for (auto rowC = duneC_.begin(); rowC != duneC_.end(); ++rowC) {
         for (auto colC = rowC->begin(), endC = rowC->end(); colC != endC; ++colC) {
-            Ccols.emplace_back(colC.index());
+            Ccols.emplace_back(cells_[colC.index()]);
             for (int i = 0; i < numWellEq; ++i) {
                 for (int j = 0; j < numEq; ++j) {
                     Cvals.emplace_back((*colC)[i][j]);
@@ -252,7 +252,7 @@ extract(WellContributions<Scalar>& wellContribs) const
         for (auto rowB = duneB_.begin(); rowB != duneB_.end(); ++rowB) {
             int sizeRow = 0;
             for (auto colB = rowB->begin(), endB = rowB->end(); colB != endB; ++colB) {
-                Bcols.emplace_back(colB.index());
+                Bcols.emplace_back(cells_[colB.index()]);
                 for (int i = 0; i < numWellEq; ++i) {
                     for (int j = 0; j < numEq; ++j) {
                         Bvals.emplace_back((*colB)[i][j]);

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -207,7 +207,7 @@ extract(const int numStaticWellEq,
     for (auto colC = duneC_[0].begin(),
               endC = duneC_[0].end(); colC != endC; ++colC )
     {
-        colIndices.emplace_back(colC.index());
+        colIndices.emplace_back(cells_[colC.index()]);
         for (int i = 0; i < numStaticWellEq; ++i) {
             for (int j = 0; j < numEq; ++j) {
                 nnzValues.emplace_back((*colC)[i][j]);
@@ -236,7 +236,7 @@ extract(const int numStaticWellEq,
     for (auto colB = duneB_[0].begin(),
               endB = duneB_[0].end(); colB != endB; ++colB )
     {
-        colIndices.emplace_back(colB.index());
+        colIndices.emplace_back(cells_[colB.index()]);
         for (int i = 0; i < numStaticWellEq; ++i) {
             for (int j = 0; j < numEq; ++j) {
                 nnzValues.emplace_back((*colB)[i][j]);


### PR DESCRIPTION
Gpubridge separate wells implementation requires the global index. Fix needed after the update to using local indexes introduced in PR #5341