### PR TITLE
Correctly mark data files with ODBL and DBCL license

### DIFF
--- a/tests/TESTTIMER.DATA
+++ b/tests/TESTTIMER.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 RUNSPEC
 
 START

--- a/tests/TESTWELLMODEL.DATA
+++ b/tests/TESTWELLMODEL.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 RUNSPEC
 
 DIMENS

--- a/tests/capillary.DATA
+++ b/tests/capillary.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 -- Most of the following sections are not actually needed by the test,
 -- but it is required by the Eclipse reference manual that they are
 -- present. Also, the higher level opm-parser classes

--- a/tests/capillarySwatinit.DATA
+++ b/tests/capillarySwatinit.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 -- Most of the following sections are not actually needed by the test,
 -- but it is required by the Eclipse reference manual that they are
 -- present. Also, the higher level opm-parser classes

--- a/tests/capillary_overlap.DATA
+++ b/tests/capillary_overlap.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 NOECHO
 
 RUNSPEC   ======

--- a/tests/deadfluids.DATA
+++ b/tests/deadfluids.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 -- Most of the following sections are not actually needed by the test,
 -- but it is required by the Eclipse reference manual that they are
 -- present. Also, the higher level opm-parser classes

--- a/tests/equil_base.DATA
+++ b/tests/equil_base.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 RUNSPEC
 
 WATER

--- a/tests/equil_capillary.DATA
+++ b/tests/equil_capillary.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 -- Most of the following sections are not actually needed by the test,
 -- but it is required by the Eclipse reference manual that they are
 -- present. Also, the higher level opm-parser classes

--- a/tests/equil_capillary_overlap.DATA
+++ b/tests/equil_capillary_overlap.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 NOECHO
 
 RUNSPEC   ======

--- a/tests/equil_capillary_swatinit.DATA
+++ b/tests/equil_capillary_swatinit.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 -- Most of the following sections are not actually needed by the test,
 -- but it is required by the Eclipse reference manual that they are
 -- present. Also, the higher level opm-parser classes

--- a/tests/equil_co2store_go.DATA
+++ b/tests/equil_co2store_go.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 NOECHO
 
 RUNSPEC   ======

--- a/tests/equil_co2store_gw.DATA
+++ b/tests/equil_co2store_gw.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 NOECHO
 
 RUNSPEC   ======

--- a/tests/equil_deadfluids.DATA
+++ b/tests/equil_deadfluids.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 -- Most of the following sections are not actually needed by the test,
 -- but it is required by the Eclipse reference manual that they are
 -- present. Also, the higher level opm-parser classes

--- a/tests/equil_humidwetgas.DATA
+++ b/tests/equil_humidwetgas.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 NOECHO
 
 RUNSPEC   ======

--- a/tests/equil_liveoil.DATA
+++ b/tests/equil_liveoil.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 NOECHO
 
 RUNSPEC   ======

--- a/tests/equil_liveoil_grid.DATA
+++ b/tests/equil_liveoil_grid.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 WATER
 OIL
 GAS

--- a/tests/equil_pbvd_and_pdvd.DATA
+++ b/tests/equil_pbvd_and_pdvd.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 NOECHO
 
 RUNSPEC   ======

--- a/tests/equil_rsvd_and_rvvd.DATA
+++ b/tests/equil_rsvd_and_rvvd.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 NOECHO
 
 RUNSPEC   ======

--- a/tests/equil_rsvd_and_rvvd_and_rvwvd.DATA
+++ b/tests/equil_rsvd_and_rvvd_and_rvwvd.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 NOECHO
 
 RUNSPEC   ======

--- a/tests/equil_wetgas.DATA
+++ b/tests/equil_wetgas.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 NOECHO
 
 RUNSPEC   ======

--- a/tests/liveoil.DATA
+++ b/tests/liveoil.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 RUNSPEC
 
 TABDIMS

--- a/tests/msw.data
+++ b/tests/msw.data
@@ -1,22 +1,10 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
 
 --  Copyright 2015 SINTEF ICT, Applied Mathematics.
 --  Copyright 2016 Statoil ASA.
-
---  This file is part of the Open Porous Media project (OPM).
-
---  OPM is free software: you can redistribute it and/or modify
---  it under the terms of the GNU General Public License as published by
---  the Free Software Foundation, either version 3 of the License, or
---  (at your option) any later version.
-
---  OPM is distributed in the hope that it will be useful,
---  but WITHOUT ANY WARRANTY; without even the implied warranty of
---  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
---  GNU General Public License for more details.
-
---  You should have received a copy of the GNU General Public License
---  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-
 
 -- geophysics and fluid properties are copied from Norne
 

--- a/tests/relpermDiagnostics.DATA
+++ b/tests/relpermDiagnostics.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 
 RUNSPEC
 

--- a/tests/satfuncEPS_B.DATA
+++ b/tests/satfuncEPS_B.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 NOECHO
 
 RUNSPEC   ======

--- a/tests/testBlackoilState3.DATA
+++ b/tests/testBlackoilState3.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 RUNSPEC
 
 TITLE

--- a/tests/testFluid.DATA
+++ b/tests/testFluid.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 OIL
 WATER
 GAS

--- a/tests/wells_group.data
+++ b/tests/wells_group.data
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 RUNSPEC
 
 OIL

--- a/tests/wells_manager_data.data
+++ b/tests/wells_manager_data.data
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 RUNSPEC
 
 OIL

--- a/tests/wells_manager_data_expanded.data
+++ b/tests/wells_manager_data_expanded.data
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 OIL
 GAS
 WATER

--- a/tests/wells_manager_data_wellSTOP.data
+++ b/tests/wells_manager_data_wellSTOP.data
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 RUNSPEC
 
 OIL

--- a/tests/wells_no_perforation.data
+++ b/tests/wells_no_perforation.data
@@ -1,22 +1,10 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
 
 --  Copyright 2015 SINTEF ICT, Applied Mathematics.
 --  Copyright 2016 Statoil ASA.
-
---  This file is part of the Open Porous Media project (OPM).
-
---  OPM is free software: you can redistribute it and/or modify
---  it under the terms of the GNU General Public License as published by
---  the Free Software Foundation, either version 3 of the License, or
---  (at your option) any later version.
-
---  OPM is distributed in the hope that it will be useful,
---  but WITHOUT ANY WARRANTY; without even the implied warranty of
---  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
---  GNU General Public License for more details.
-
---  You should have received a copy of the GNU General Public License
---  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-
 
 -- geophysics and fluid properties are copied from Norne
 

--- a/tests/wells_stopped.data
+++ b/tests/wells_stopped.data
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 RUNSPEC
 
 OIL

--- a/tests/wetgas.DATA
+++ b/tests/wetgas.DATA
@@ -1,3 +1,9 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+
 RUNSPEC
 
 TABDIMS


### PR DESCRIPTION
tests/wells_no_perforation.data and tests/msw.data were falsely marked as GPLv3, the rest was missing lincense marks.