### PR TITLE
Changes in how the simulator handles NUPCOL

### DIFF
--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -102,6 +102,8 @@ BlackoilModelParameters<Scalar>::BlackoilModelParameters()
     convergence_monitoring_ = Parameters::Get<Parameters::ConvergenceMonitoring>();
     convergence_monitoring_cutoff_ = Parameters::Get<Parameters::ConvergenceMonitoringCutOff>();
     convergence_monitoring_decay_factor_ = Parameters::Get<Parameters::ConvergenceMonitoringDecayFactor<Scalar>>();
+
+    nupcol_group_rate_tolerance_ = Parameters::Get<Parameters::NupcolGroupRateTolerance<Scalar>>();
 }
 
 template<class Scalar>
@@ -250,6 +252,9 @@ void BlackoilModelParameters<Scalar>::registerParameters()
         ("Cut off limit for convergence monitoring");
     Parameters::Register<Parameters::ConvergenceMonitoringDecayFactor<Scalar>>
         ("Decay factor for convergence monitoring");
+
+    Parameters::Register<Parameters::NupcolGroupRateTolerance<Scalar>>
+        ("Tolerance for acceptable changes in VREP/RAIN group rates");
 
     Parameters::Hide<Parameters::DebugEmitCellPartition>();
 

--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -152,6 +152,9 @@ struct ConvergenceMonitoringCutOff { static constexpr int value = 6; };
 template<class Scalar>
 struct ConvergenceMonitoringDecayFactor { static constexpr Scalar value = 0.75; };
 
+template<class Scalar>
+struct NupcolGroupRateTolerance { static constexpr Scalar value = 0.001; };
+
 } // namespace Opm::Parameters
 
 namespace Opm {
@@ -314,6 +317,10 @@ public:
     int convergence_monitoring_cutoff_;
     /// Decay factor used in convergence monitoring
     Scalar convergence_monitoring_decay_factor_;
+
+    // Relative tolerance of group rates (VREP, REIN)
+    // If violated the nupcol wellstate is updated
+    Scalar nupcol_group_rate_tolerance_;
 
     /// Construct from user parameters or defaults.
     BlackoilModelParameters();

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1222,7 +1222,9 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                                                     phaseIdx,
                                                     /*isInjector*/ false);
                         }
-                        Scalar rel_change = std::abs( (gr_rate_nupcol - gr_rate) / (0.5*gr_rate_nupcol + 0.5*gr_rate));
+                        Scalar small_rate = 1e-12; // m3/s
+                        Scalar denominator = (0.5*gr_rate_nupcol + 0.5*gr_rate);
+                        Scalar rel_change = denominator > small_rate ? std::abs( (gr_rate_nupcol - gr_rate) / denominator) : 0.0;
                         if ( rel_change > tol_nupcol) {
                             this->updateNupcolWGState();
                             const std::string control_str = is_vrep? "VREP" : "REIN";

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1180,6 +1180,7 @@ template<class Scalar>
 void BlackoilWellModelGeneric<Scalar>::
 updateAndCommunicateGroupData(const int reportStepIdx,
                               const int iterationIdx,
+                              const Scalar tol_nupcol,
                               DeferredLogger& deferred_logger)
 {
     const Group& fieldGroup = schedule().getGroup("FIELD", reportStepIdx);
@@ -1192,7 +1193,6 @@ updateAndCommunicateGroupData(const int reportStepIdx,
     if (iterationIdx <= nupcol) {
         this->updateNupcolWGState();
     } else {
-        Scalar tol_nupcol = 0.01;
         for (const auto& gr_name : schedule().groupNames(reportStepIdx)) {
             const Phase all[] = { Phase::WATER, Phase::OIL, Phase::GAS };
             for (Phase phase : all) {

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -376,7 +376,8 @@ protected:
                                      const int reportStepIdx);
 
     void updateAndCommunicateGroupData(const int reportStepIdx,
-                                       const int iterationIdx);
+                                       const int iterationIdx,
+                                       DeferredLogger& deferred_logger);
 
     void inferLocalShutWells();
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -377,6 +377,7 @@ protected:
 
     void updateAndCommunicateGroupData(const int reportStepIdx,
                                        const int iterationIdx,
+                                       const Scalar tol_nupcol,
                                        DeferredLogger& deferred_logger);
 
     void inferLocalShutWells();

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -472,7 +472,9 @@ namespace Opm {
 
         const int reportStepIdx = simulator_.episodeIndex();
         this->updateAndCommunicateGroupData(reportStepIdx,
-                                            simulator_.model().newtonMethod().numIterations(), local_deferredLogger);
+                                            simulator_.model().newtonMethod().numIterations(),
+                                            param_.nupcol_group_rate_tolerance_,
+                                            local_deferredLogger);
 
         this->wellState().updateWellsDefaultALQ(this->schedule(), reportStepIdx, this->summaryState());
         this->wellState().gliftTimeStepInit();
@@ -2176,7 +2178,7 @@ namespace Opm {
 
         const int iterationIdx = simulator_.model().newtonMethod().numIterations();
         const auto& comm = simulator_.vanguard().grid().comm();
-        this->updateAndCommunicateGroupData(episodeIdx, iterationIdx, deferred_logger);
+        this->updateAndCommunicateGroupData(episodeIdx, iterationIdx, param_.nupcol_group_rate_tolerance_, deferred_logger);
 
         // network related
         bool more_network_update = false;
@@ -2430,7 +2432,7 @@ namespace Opm {
                          const int iterationIdx,
                          DeferredLogger& deferred_logger)
     {
-        this->updateAndCommunicateGroupData(reportStepIdx, iterationIdx, deferred_logger);
+        this->updateAndCommunicateGroupData(reportStepIdx, iterationIdx, param_.nupcol_group_rate_tolerance_, deferred_logger);
 
         // updateWellStateWithTarget might throw for multisegment wells hence we
         // have a parallel try catch here to thrown on all processes.
@@ -2442,7 +2444,7 @@ namespace Opm {
         }
         OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel::updateAndCommunicate failed: ",
                                    simulator_.gridView().comm())
-        this->updateAndCommunicateGroupData(reportStepIdx, iterationIdx, deferred_logger);
+        this->updateAndCommunicateGroupData(reportStepIdx, iterationIdx, param_.nupcol_group_rate_tolerance_, deferred_logger);
     }
 
     template<typename TypeTag>

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -472,7 +472,7 @@ namespace Opm {
 
         const int reportStepIdx = simulator_.episodeIndex();
         this->updateAndCommunicateGroupData(reportStepIdx,
-                                            simulator_.model().newtonMethod().numIterations());
+                                            simulator_.model().newtonMethod().numIterations(), local_deferredLogger);
 
         this->wellState().updateWellsDefaultALQ(this->schedule(), reportStepIdx, this->summaryState());
         this->wellState().gliftTimeStepInit();
@@ -2176,7 +2176,7 @@ namespace Opm {
 
         const int iterationIdx = simulator_.model().newtonMethod().numIterations();
         const auto& comm = simulator_.vanguard().grid().comm();
-        this->updateAndCommunicateGroupData(episodeIdx, iterationIdx);
+        this->updateAndCommunicateGroupData(episodeIdx, iterationIdx, deferred_logger);
 
         // network related
         bool more_network_update = false;
@@ -2430,7 +2430,7 @@ namespace Opm {
                          const int iterationIdx,
                          DeferredLogger& deferred_logger)
     {
-        this->updateAndCommunicateGroupData(reportStepIdx, iterationIdx);
+        this->updateAndCommunicateGroupData(reportStepIdx, iterationIdx, deferred_logger);
 
         // updateWellStateWithTarget might throw for multisegment wells hence we
         // have a parallel try catch here to thrown on all processes.
@@ -2442,7 +2442,7 @@ namespace Opm {
         }
         OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel::updateAndCommunicate failed: ",
                                    simulator_.gridView().comm())
-        this->updateAndCommunicateGroupData(reportStepIdx, iterationIdx);
+        this->updateAndCommunicateGroupData(reportStepIdx, iterationIdx, deferred_logger);
     }
 
     template<typename TypeTag>

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -75,14 +75,19 @@ namespace {
         return {oilRate, gasRate, waterRate};
     }
 
+} // namespace Anonymous
+
+namespace Opm {
+
     template<class Scalar>
-    Scalar sumWellPhaseRates(bool res_rates,
-                             const Opm::Group& group,
-                             const Opm::Schedule& schedule,
-                             const Opm::WellState<Scalar>& wellState,
-                             const int reportStepIdx,
-                             const int phasePos,
-                             const bool injector)
+    Scalar WellGroupHelpers<Scalar>::
+    sumWellPhaseRates(bool res_rates,
+                      const Opm::Group& group,
+                      const Opm::Schedule& schedule,
+                      const Opm::WellState<Scalar>& wellState,
+                      const int reportStepIdx,
+                      const int phasePos,
+                      const bool injector)
     {
 
         Scalar rate = 0.0;
@@ -128,9 +133,6 @@ namespace {
         }
         return rate;
     }
-} // namespace Anonymous
-
-namespace Opm {
 
 template<class Scalar>
 void WellGroupHelpers<Scalar>::

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -47,6 +47,15 @@ template<class Scalar>
 class WellGroupHelpers
 {
 public:
+
+    static Scalar sumWellPhaseRates(bool res_rates,
+                                    const Opm::Group& group,
+                                    const Opm::Schedule& schedule,
+                                    const Opm::WellState<Scalar>& wellState,
+                                    const int reportStepIdx,
+                                    const int phasePos,
+                                    const bool injector);
+
     static void setCmodeGroup(const Group& group,
                               const Schedule& schedule,
                               const SummaryState& summaryState,


### PR DESCRIPTION
1) Dont allow wells to change to GRUP when iter >NUPCOL
2) Update VREP even for iter > NUPCOL if it changes significantly. For now hardcoded to relative change > 0.01 (TODO make this a parameter. Update: DONE)

TODO


- [x] If this is a good idea for VREP it should be done for REIN etc.