### PR TITLE
Remove #if HAVE_SUITESPARSE_UMFPACK in WellContributions.hpp

### DIFF
--- a/opm/simulators/linalg/gpubridge/MultisegmentWellContribution.hpp
+++ b/opm/simulators/linalg/gpubridge/MultisegmentWellContribution.hpp
@@ -26,9 +26,7 @@
 #include <cuda_runtime.h>
 #endif
 
-#if HAVE_SUITESPARSE_UMFPACK
-#include<umfpack.h>
-#endif
+#include <umfpack.h>
 #include <dune/common/version.hh>
 
 namespace Opm

--- a/opm/simulators/linalg/gpubridge/WellContributions.hpp
+++ b/opm/simulators/linalg/gpubridge/WellContributions.hpp
@@ -23,9 +23,7 @@
 #include <memory>
 #include <vector>
 
-#if HAVE_SUITESPARSE_UMFPACK
-#include<umfpack.h>
-#endif
+#include <umfpack.h>
 #include <dune/common/version.hh>
 
 namespace Opm {


### PR DESCRIPTION
The file needs the defines in `umfpack.h` further down the file which is not inside any `#if`.