### PR TITLE
fixed: don't fail build if there are no failures

### DIFF
--- a/tests/make_failure_report.sh
+++ b/tests/make_failure_report.sh
@@ -28,4 +28,7 @@ do
   $SOURCE_DIR/plot_well_comparison.py -r $OPM_TESTS_ROOT/$dir_name/opm-simulation-reference/$binary/$file_name -s $RESULT_DIR/tests/results/$binary+$test_name/$file_name -c $test_name -o plot
 done
 
-$SOURCE_DIR/plot_well_comparison.py  -o rename
+if test -n "$FAILED_TESTS"
+then
+  $SOURCE_DIR/plot_well_comparison.py  -o rename
+fi


### PR DESCRIPTION
Noticed https://ci.opm-project.org/job/opm-simulators-PR-builder/6898/console failed due to no failures..