### PR TITLE
Split the operation duneB_.mmv(x, resWell) in recoverSolutionWell into its two parts

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -207,9 +207,13 @@ template<class Scalar, int numWellEq, int numEq>
 void MultisegmentWellEquations<Scalar,numWellEq,numEq>::
 recoverSolutionWell(const BVector& x, BVectorWell& xw) const
 {
-    BVectorWell resWell = resWell_;
+    BVectorWell Bx(duneB_.N());
+    duneB_.mv(x, Bx);
+
     // resWell = resWell - B * x
-    duneB_.mmv(x, resWell);
+    BVectorWell resWell = resWell_;
+    resWell -= Bx;
+
     // xw = D^-1 * resWell
     xw = mswellhelpers::applyUMFPack(*duneDSolver_, resWell);
 }


### PR DESCRIPTION
This is needed to later add communication for the multiplication  with the matrix duneB_, since here we go from cells to segments, and everything concerning segments is stored globally.