### PR TITLE
Cmake: Use upper case for COMPONENTS of FindSuiteSparse

### DIFF
--- a/opm-simulators-prereqs.cmake
+++ b/opm-simulators-prereqs.cmake
@@ -48,7 +48,7 @@ set (opm-simulators_DEPS
   # Look for MPI support
   "MPI"
   # Tim Davis' SuiteSparse archive
-  "SuiteSparse REQUIRED COMPONENTS umfpack"
+  "SuiteSparse REQUIRED COMPONENTS UMFPACK"
   # SuperLU direct solver
   "SuperLU"
   # ROCALUTION from ROCM framework


### PR DESCRIPTION
This is what DUNE uses since 2015 makes OPM modules usable as DUNE modules in all cases.

Downstream of OPM/opm-common#4349