### PR TITLE
Only update target of group-controlled wells during updateAndCommunicate

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2437,8 +2437,12 @@ namespace Opm {
         OPM_BEGIN_PARALLEL_TRY_CATCH()
         // if a well or group change control it affects all wells that are under the same group
         for (const auto& well : well_container_) {
-            well->updateWellStateWithTarget(simulator_, this->groupState(),
-                                            this->wellState(), deferred_logger);
+            // We only want to update wells under group-control here
+            auto& ws = this->wellState().well(well->indexOfWell());
+            if (ws.production_cmode ==  Well::ProducerCMode::GRUP || ws.injection_cmode == Well::InjectorCMode::GRUP) {
+                well->updateWellStateWithTarget(simulator_, this->groupState(),
+                                                this->wellState(), deferred_logger);
+            }
         }
         OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel::updateAndCommunicate failed: ",
                                    simulator_.gridView().comm())


### PR DESCRIPTION
The `updateWellStateWithTarget` for all wells can be problematic here. In particular, this is the case for thp-wells, since in this case `updateWellStateWithTarget` only provides an _initial guess_ well-state. This means that at this stage, we may have converged thp-wells that after going through `updateWellStateWithTarget` are no longer convereged, which again may prevent overall convergence. 

I can't see that `updateAndCommunicateGroupData` changes any well control-modes, so there should be no reason to update the target of wells not under group control here?

This PR just skips the `updateWellStateWithTarget` for wells not under group control   