### PR TITLE
Zoltan partitioner with all perforated cells of a well merged to one vertex

### DIFF
--- a/opm/simulators/flow/GenericCpGridVanguard.cpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.cpp
@@ -158,7 +158,8 @@ doLoadBalance_(const Dune::EdgeWeightMethod             edgeWeightsMethod,
                FlowGenericVanguard::ParallelWellStruct& parallelWells,
                const int                                numJacobiBlocks)
 {
-    if (partitionMethod == Dune::PartitionMethod::zoltan && !this->zoltanParams().empty())
+    if ((partitionMethod == Dune::PartitionMethod::zoltan
+         || partitionMethod == Dune::PartitionMethod::zoltanGoG) && !this->zoltanParams().empty())
         this->grid_->setPartitioningParams(setupZoltanParams(this->zoltanParams()));
     if (partitionMethod == Dune::PartitionMethod::metis && !this->metisParams().empty())
         this->grid_->setPartitioningParams(setupMetisParams(this->metisParams()));


### PR DESCRIPTION
This adds a new option to partition for a parallel run.

Running flow with the parameter --partition-method=3 will use Zoltan partitioner with the grid represented by a graph (class GraphOfGrid [OPM/opm-grid#790](https://github.com/OPM/opm-grid/pull/790). All cells potentially perforated by a  well are represented by a single vertex, therefore the partitioning is unable to split a well into several processes.

This should lead to better partitioning results on problems with a complex well structure, where other partitioners might split wells over several processes after which some well cells have to be remapped (when distributed wells are not allowed).