### PR TITLE
Activate New Regression Tests for ACTIONX Name Matching

### DIFF
--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -165,6 +165,16 @@ add_test_compare_parallel_simulation(CASENAME numerical_aquifer_3d_1aqu
                                      DIR aquifer-num
                                      TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr_trueimpes --enable-drift-compensation=false --relaxed-max-pv-fraction=0.0)
 
+foreach(templ_case RANGE 1 6)
+  add_test_compare_parallel_simulation(CASENAME actionx_well_templ_0${templ_case}
+    FILENAME ACTIONX_WELL_TEMPL-0${templ_case}
+    SIMULATOR flow
+    ABS_TOL ${abs_tol_parallel}
+    REL_TOL ${rel_tol_parallel}
+    DIR actionx
+  )
+endforeach()
+
 add_test_compare_parallel_simulation(CASENAME actionx_m1
                                      FILENAME ACTIONX_M1
                                      SIMULATOR flow

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -573,6 +573,16 @@ foreach(eqreg_case RANGE 1 6)
   )
 endforeach()
 
+foreach(templ_case RANGE 1 6)
+  add_test_compareECLFiles(CASENAME actionx_well_templ_0${templ_case}
+    FILENAME ACTIONX_WELL_TEMPL-0${templ_case}
+    SIMULATOR flow
+    ABS_TOL ${abs_tol}
+    REL_TOL ${rel_tol}
+    DIR actionx
+  )
+endforeach()
+
 add_test_compareECLFiles(CASENAME udq_uadd
                          FILENAME UDQ_M1
                          SIMULATOR flow


### PR DESCRIPTION
Following PRs OPM/opm-common#4345 and OPM/opm-common#4350, this commit puts all example models from OPM/opm-tests#1240 into the simulator's suite of regression tests.