### PR TITLE
Make Floating Point Existence Flag Initially Unset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,7 +323,7 @@ macro (config_hook)
     CXX_STANDARD 17
   )
 
-  set(HAVE_FLOATING_POINT_FROM_CHARS 0)
+  unset(HAVE_FLOATING_POINT_FROM_CHARS)
   if(have_float_from_chars)
     set(HAVE_FLOATING_POINT_FROM_CHARS 1)
   endif()


### PR DESCRIPTION
PR OPM/opm-common#4348 altered the OPM build system's handling of boolean flags and setting the flag to zero no longer works.