### PR TITLE
Update second stage preconditioner for CPR instead of recreate

### DIFF
--- a/opm/simulators/linalg/OwningTwoLevelPreconditioner.hpp
+++ b/opm/simulators/linalg/OwningTwoLevelPreconditioner.hpp
@@ -183,28 +183,24 @@ private:
                                                                FlexibleSolver<CoarseOperator>,
                                                                LevelTransferPolicy>;
     using TwoLevelMethod
-        = Dune::Amg::TwoLevelMethodCpr<OperatorType, CoarseSolverPolicy, Dune::Preconditioner<VectorType, VectorType>>;
+        = Dune::Amg::TwoLevelMethodCpr<OperatorType, CoarseSolverPolicy, Dune::PreconditionerWithUpdate<VectorType, VectorType>>;
 
     // Handling parallel vs serial instantiation of preconditioner factory.
     template <class Comm>
     void updateImpl(const Comm*)
     {
         // Parallel case.
-        auto child = prm_.get_child_optional("finesmoother");
-        finesmoother_ = PrecFactory::create(linear_operator_, child ? *child : Opm::PropertyTree(), *comm_);
         twolevel_method_.updatePreconditioner(finesmoother_, coarseSolverPolicy_);
     }
 
     void updateImpl(const Dune::Amg::SequentialInformation*)
     {
         // Serial case.
-        auto child = prm_.get_child_optional("finesmoother");
-        finesmoother_ = PrecFactory::create(linear_operator_, child ? *child : Opm::PropertyTree());
         twolevel_method_.updatePreconditioner(finesmoother_, coarseSolverPolicy_);
     }
 
     const OperatorType& linear_operator_;
-    std::shared_ptr<Dune::Preconditioner<VectorType, VectorType>> finesmoother_;
+    std::shared_ptr<PreconditionerWithUpdate<VectorType, VectorType>> finesmoother_;
     const Communication* comm_;
     std::function<VectorType()> weightsCalculator_;
     VectorType weights_;

--- a/opm/simulators/linalg/twolevelmethodcpr.hh
+++ b/opm/simulators/linalg/twolevelmethodcpr.hh
@@ -472,8 +472,9 @@ public:
   void updatePreconditioner(std::shared_ptr<SmootherType> smoother,
                             CoarseLevelSolverPolicy& coarsePolicy)
   {
-    //assume new matrix is not reallocated the new precondition should anyway be made
     smoother_ = smoother;
+    // We assume the matrix has the same sparsity structure and memory locations throughout, only the values are changed.
+    smoother_->update();
     if (coarseSolver_) {
       policy_->calculateCoarseEntries(*operator_);
       coarsePolicy.setCoarseOperator(*policy_);


### PR DESCRIPTION
When using two level preconditioners in OPM (CPR like), it consists of two parts:
1. Extracting the pressure system and applying an AMG cycle on the scalar system.
2. Apply a block preconditioner on the complete system.

The second part is typically an ILU0 preconditioner, where we must perform a factorisation based on the values of the matrix. When the matrix values changes (but not the sparsity), this factorisation needs to be recomputed.

At the moment, this ILU0 preconditioner was recreated every single Newton iteration, which involves recreating the memory and other optimisations. This is not necessary, and only an update is needed. Which is what this PR changes it to. This is especially important when we start using GPU preconditioners with CPR, as these GPU preconditioners typically involve expensive GPU allocations, matrix analyis and autotuning.

After this update the linear setup time should be reduced for all simulations, since this is the default preconditioner setup in OPM. Below is a comparison on SPE10 before and after this fix, which shows a reduction of 20 % for the linear setup time.
![image](https://github.com/user-attachments/assets/f3a36306-50d8-4545-bbef-1544eb542784)
