### PR TITLE
Use formattedErrors() and simplify.

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -617,10 +617,7 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
 
     if (*errorGuard) { // errors encountered
         parseSuccess = 0;
-        if (failureMessage.size()) {
-            failureMessage += std::string("\n");
-        }
-        failureMessage += errorGuard->dump();
+        failureMessage += errorGuard->formattedErrors();
         errorGuard->clear();
     }
 
@@ -628,7 +625,7 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
 
     if (! parseSuccess) {
         if (comm.rank() == 0) {
-            OpmLog::error(fmt::format("Unrecoverable errors while loading input: {}", failureMessage));
+            OpmLog::error(fmt::format("Unrecoverable errors while loading input:\n{}", failureMessage));
         }
 
 #if HAVE_MPI


### PR DESCRIPTION
No longer calling dump() means we avoid the extra dumping to stderr of the warnings and errors.

Downstream from OPM/opm-common#4362