### PR TITLE
Move addLgrs' call to support refinement on a distributed grid

### DIFF
--- a/opm/models/utils/simulator.hh
+++ b/opm/models/utils/simulator.hh
@@ -228,6 +228,18 @@ public:
         checkParallelException("Could not initialize the problem: ",
                                exceptionThrown, what);
 
+        // Potential place to add LGRs??
+        /*   if (verbose_)
+            std::cout << "Adding LGRs, if any\n" << std::flush;
+
+        try
+        { vanguard_->addLgrs(); } // Each Vanguard should have such a method, only supported for CpGrid though
+        catch (const std::exception& e) {
+            catchAction(e, verbose_);
+        }
+        checkParallelException("Could not add LGRs into the vanguard data: ",
+        exceptionThrown, what);*/
+
         setupTimer_.stop();
 
         if (verbose_)

--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -235,7 +235,7 @@ public:
                              this->eclState(), this->parallelWells_,
                              this->numJacobiBlocks(), this->enableEclOutput());
 #endif
-       
+
         // --- Add LGRs  ---
         // Check if input file contains Lgrs.
         const auto& lgrs = this-> eclState().getLgrs();

--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -235,6 +235,17 @@ public:
                              this->eclState(), this->parallelWells_,
                              this->numJacobiBlocks(), this->enableEclOutput());
 #endif
+       
+        // --- Add LGRs  ---
+        // Check if input file contains Lgrs.
+        const auto& lgrs = this-> eclState().getLgrs();
+        const auto lgrsSize = lgrs.size();
+        // If there are lgrs, create the grid with them, and update the leaf grid view.
+        if (lgrsSize)
+        {
+            OpmLog::info("\nAdding LGRs to the grid and updating its leaf grid view");
+            this->addLgrsUpdateLeafView(lgrs, lgrsSize, *(this->grid_));
+        }
 
         this->updateGridView_();
         this->updateCartesianToCompressedMapping_();

--- a/opm/simulators/flow/GenericCpGridVanguard.cpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.cpp
@@ -534,7 +534,7 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Eclips
         equilCartesianIndexMapper_ = std::make_unique<CartesianIndexMapper>(*equilGrid_);
         
         eclState.reset_actnum(UgGridHelpers::createACTNUM(*equilGrid_));
-        eclState.set_active_indices(this->grid_->globalCell());
+        eclState.set_active_indices(this->grid_->currentData().front()->globalCell());
     }
     
 


### PR DESCRIPTION
Moving the call of addLgrsUpdateLeafView, to allow adding LGRs on a [level zero] distributed CpGrid. 

This PR does not affect the serial runs and paves the way to support the parallel ones. 
 
Not relevant for the Reference Manual. 
