### PR TITLE
fixed: well model could deadlock

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1130,9 +1130,12 @@ namespace Opm {
                 break;
             }
             ++iter;
+            OPM_BEGIN_PARALLEL_TRY_CATCH();
             for (auto& well : this->well_container_) {
                 well->solveEqAndUpdateWellState(simulator_, well_state, deferred_logger);
             }
+            OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel::doPreStepNetworkRebalance() failed: ",
+                                       this->simulator_.vanguard().grid().comm());
             this->initPrimaryVariablesEvaluation();
         } while (iter < max_iter);
 


### PR DESCRIPTION
if umfpack encounters a singular matrix on any process, the exception propagated up across communication boundaries leading to deadlock as the other processes tried to do global reductions.