### PR TITLE
For convective mixing, store the saturated dissolution factor.

### DIFF
--- a/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
+++ b/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
@@ -49,6 +49,7 @@
 #include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/blackoil/blackoildiffusionmodule.hh>
 #include <opm/models/blackoil/blackoilmicpmodules.hh>
+#include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
 #include <opm/models/common/directionalmobility.hh>
 
 #include <opm/utility/CopyablePtr.hpp>
@@ -78,6 +79,7 @@ class BlackOilIntensiveQuantitiesGlobalIndex
     , public BlackOilBrineIntensiveQuantities<TypeTag>
     , public BlackOilEnergyIntensiveQuantitiesGlobalIndex<TypeTag>
     , public BlackOilMICPIntensiveQuantities<TypeTag>
+    , public BlackOilConvectiveMixingIntensiveQuantities<TypeTag>
 {
     using ParentType = GetPropType<TypeTag, Properties::DiscIntensiveQuantities>;
     using Implementation = GetPropType<TypeTag, Properties::IntensiveQuantities>;
@@ -103,6 +105,7 @@ class BlackOilIntensiveQuantitiesGlobalIndex
     enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     enum { enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>() };
+    enum { enableConvectiveMixing = getPropValue<TypeTag, Properties::EnableConvectiveMixing>() };
     enum { enableMICP = getPropValue<TypeTag, Properties::EnableMICP>() };
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
     enum { numComponents = getPropValue<TypeTag, Properties::NumComponents>() };
@@ -381,6 +384,10 @@ public:
         porosity_ *= problem.template rockCompPoroMultiplier<Evaluation>(*this, globalSpaceIdx);
 
         rockCompTransMultiplier_ = problem.template rockCompTransMultiplier<Evaluation>(*this, globalSpaceIdx);
+
+        if constexpr (enableConvectiveMixing) {
+            asImp_().updateSaturatedDissolutionFactor_();
+        }
 
 #ifndef NDEBUG
         // some safety checks in debug mode

--- a/opm/models/blackoil/blackoilconvectivemixingmodule.hh
+++ b/opm/models/blackoil/blackoilconvectivemixingmodule.hh
@@ -289,15 +289,11 @@ public:
         const auto& liquidPhaseIdx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
             FluidSystem::waterPhaseIdx :
             FluidSystem::oilPhaseIdx;
-        const Evaluation SoMax = 0.0;
 
         //interiour
         const auto& t_in = intQuantsIn.fluidState().temperature(liquidPhaseIdx);
         const auto& p_in = intQuantsIn.fluidState().pressure(liquidPhaseIdx);
-        const auto& rssat_in = FluidSystem::saturatedDissolutionFactor(intQuantsIn.fluidState(),
-                                                            liquidPhaseIdx,
-                                                            intQuantsIn.pvtRegionIndex(),
-                                                            SoMax);
+        const auto& rssat_in = intQuantsIn.saturatedDissolutionFactor();
         const auto& salt_in = intQuantsIn.fluidState().saltSaturation();
 
         const auto bLiquidSatIn = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
@@ -315,10 +311,7 @@ public:
         //exteriour
         const auto t_ex = Opm::getValue(intQuantsEx.fluidState().temperature(liquidPhaseIdx));
         const auto p_ex = Opm::getValue(intQuantsEx.fluidState().pressure(liquidPhaseIdx));
-        const auto rssat_ex = Opm::getValue(FluidSystem::saturatedDissolutionFactor(intQuantsEx.fluidState(),
-                                                            liquidPhaseIdx,
-                                                            intQuantsEx.pvtRegionIndex(),
-                                                            SoMax));
+        const auto rssat_ex = Opm::getValue(intQuantsEx.saturatedDissolutionFactor());
         const auto salt_ex = Opm::getValue(intQuantsEx.fluidState().saltSaturation());
         const auto bLiquidSatEx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
             FluidSystem::waterPvt().inverseFormationVolumeFactor(intQuantsEx.pvtRegionIndex(), t_ex, p_ex, rssat_ex, salt_ex):
@@ -380,6 +373,52 @@ public:
             }
         }
     }
+};
+
+/*!
+ * \ingroup BlackOil
+ * \class Opm::BlackOilConvectiveMixingIntensiveQuantities
+ *
+ * \brief Provides the volumetric quantities required for the equations needed by the
+ *        convective mixing (DRSDTCON) model.
+ */
+template <class TypeTag, bool enableConvectiveMixingV = getPropValue<TypeTag, Properties::EnableConvectiveMixing>()>
+class BlackOilConvectiveMixingIntensiveQuantities
+{
+    using Implementation = GetPropType<TypeTag, Properties::IntensiveQuantities>;
+    using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
+    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+
+public:
+    /*!
+     * \brief Compute the intensive quantities needed to handle convective dissolution
+     *
+     */
+    void updateSaturatedDissolutionFactor_()
+    {
+        const auto liquidPhaseIdx = (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) ?
+            FluidSystem::waterPhaseIdx :
+            FluidSystem::oilPhaseIdx;
+        const Evaluation SoMax = 0.0;
+        saturatedDissolutionFactor_ = FluidSystem::saturatedDissolutionFactor(asImp_().fluidState(),
+                                                                              liquidPhaseIdx,
+                                                                              asImp_().pvtRegionIndex(),
+                                                                              SoMax);
+    }
+
+    const Evaluation& saturatedDissolutionFactor() const
+    { return saturatedDissolutionFactor_; }
+
+protected:
+    Implementation& asImp_()
+    { return *static_cast<Implementation*>(this); }
+
+    Evaluation saturatedDissolutionFactor_;
+};
+
+template <class TypeTag>
+class BlackOilConvectiveMixingIntensiveQuantities<TypeTag, false>
+{
 };
 
 }

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -603,7 +603,13 @@ public:
             asImp_().saltPropertiesUpdate_(elemCtx, dofIdx, timeIdx);
         }
         if constexpr (enableConvectiveMixing) {
-            asImp_().updateSaturatedDissolutionFactor_();
+            // The ifs are here is to avoid extra calculations for
+            // cases without CO2STORE and DRSDTCON.
+            if (problem.simulator().vanguard().eclState().runspec().co2Storage()) {
+                if (problem.drsdtconIsActive(globalSpaceIdx, problem.simulator().episodeIndex())) {
+                    asImp_().updateSaturatedDissolutionFactor_();
+                }
+            }
         }
 
         // update the quantities which are required by the chosen

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -38,6 +38,7 @@
 #include "blackoildiffusionmodule.hh"
 #include "blackoildispersionmodule.hh"
 #include "blackoilmicpmodules.hh"
+#include "blackoilconvectivemixingmodule.hh"
 
 #include <opm/common/TimingMacros.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
@@ -77,6 +78,7 @@ class BlackOilIntensiveQuantities
     , public BlackOilBrineIntensiveQuantities<TypeTag>
     , public BlackOilEnergyIntensiveQuantities<TypeTag>
     , public BlackOilMICPIntensiveQuantities<TypeTag>
+    , public BlackOilConvectiveMixingIntensiveQuantities<TypeTag>
 {
     using ParentType = GetPropType<TypeTag, Properties::DiscIntensiveQuantities>;
     using Implementation = GetPropType<TypeTag, Properties::IntensiveQuantities>;
@@ -104,6 +106,7 @@ class BlackOilIntensiveQuantities
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     enum { enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>() };
     enum { enableDispersion = getPropValue<TypeTag, Properties::EnableDispersion>() };
+    enum { enableConvectiveMixing = getPropValue<TypeTag, Properties::EnableConvectiveMixing>() };
     enum { enableMICP = getPropValue<TypeTag, Properties::EnableMICP>() };
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
     enum { numComponents = getPropValue<TypeTag, Properties::NumComponents>() };
@@ -598,6 +601,9 @@ public:
         }
         if constexpr (enableBrine) {
             asImp_().saltPropertiesUpdate_(elemCtx, dofIdx, timeIdx);
+        }
+        if constexpr (enableConvectiveMixing) {
+            asImp_().updateSaturatedDissolutionFactor_();
         }
 
         // update the quantities which are required by the chosen

--- a/opm/simulators/flow/FlowGenericProblem.hpp
+++ b/opm/simulators/flow/FlowGenericProblem.hpp
@@ -166,11 +166,6 @@ public:
     Scalar solventRsw(unsigned elemIdx) const;
 
     /*!
-     * \brief Returns the dynamic drsdt convective mixing value
-     */
-    Scalar drsdtcon(unsigned elemIdx, int episodeIdx) const;
-
-    /*!
      * \brief Returns the initial polymer concentration for a given a cell index
      */
     Scalar  polymerConcentration(unsigned elemIdx) const;

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -924,6 +924,11 @@ public:
                                            this->pvtRegionIndex(elemIdx));
     }
 
+    bool drsdtconIsActive(unsigned elemIdx, int episodeIdx) const
+    {
+        return this->mixControls_.drsdtConvective(episodeIdx, this->pvtRegionIndex(elemIdx));
+    }
+
     /*!
      * \copydoc FvBaseProblem::boundary
      *


### PR DESCRIPTION
Gives a significant speedup with DRSDTCON.

Same idea as OPM/opm-common#4364 and #5771, but with some differences. I managed to avoid noticing that one, or I would not have made this...