### PR TITLE
adjust output and parameters in gpu autotuner

### DIFF
--- a/opm/simulators/linalg/gpuistl/detail/autotuner.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/autotuner.hpp
@@ -83,7 +83,7 @@ tuneThreadBlockSize(func& f, std::string descriptionOfFunction)
     }
 
     OpmLog::info(
-        fmt::format("{}: Tuned Blocksize: {} (fastest runtime: {}).", descriptionOfFunction, bestBlockSize, bestTime));
+        fmt::format("[Kernel tuning completed] {}: Tuned Blocksize = {}, Fastest Runtime = {}ms.", descriptionOfFunction, bestBlockSize, bestTime));
 
     return bestBlockSize;
 }


### PR DESCRIPTION
This PR refines the autotuning output a bit.
Additionally it changes the thread-block size used for the lower solve when tuning the upper triangular solve. That fixes confusing output that could make it look like the tuning was making the triangular solve slower when it wasn't.