### PR TITLE
fixed: always calculate initial FIP

### DIFF
--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -327,6 +327,14 @@ outputInjLog(std::size_t reportStepNum)
 
 template<class FluidSystem>
 Inplace GenericOutputBlackoilModule<FluidSystem>::
+calc_initial_inplace(const Parallel::Communication& comm)
+{
+    // calling accumulateRegionSums() updates InitialInplace_ as a side effect
+    return this->accumulateRegionSums(comm);
+}
+
+template<class FluidSystem>
+Inplace GenericOutputBlackoilModule<FluidSystem>::
 calc_inplace(std::map<std::string, double>& miscSummaryData,
              std::map<std::string, std::vector<double>>& regionData,
              const Parallel::Communication& comm)

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -95,6 +95,9 @@ public:
     // write injection report to output
     void outputInjLog(std::size_t reportStepNum);
 
+    // calculate Initial Fluid In Place
+    Inplace calc_initial_inplace(const Parallel::Communication& comm);
+
     // calculate Fluid In Place
     Inplace calc_inplace(std::map<std::string, double>& miscSummaryData,
                          std::map<std::string, std::vector<double>>& regionData,


### PR DESCRIPTION
this can be used by various Schedule keywords even if FIP is not in RPTSOL