### PR TITLE
Use initial pressure if ROCKOPTS item 2 is STORE

### DIFF
--- a/opm/simulators/flow/FlowGenericProblem.hpp
+++ b/opm/simulators/flow/FlowGenericProblem.hpp
@@ -246,15 +246,6 @@ public:
     Scalar rockCompressibility(unsigned globalSpaceIdx) const;
 
     /*!
-     * Direct access to rock reference pressure.
-     *
-     * While the above overload could be implemented in terms of this method,
-     * that would require always looking up the global space index, which
-     * is not always needed.
-     */
-    Scalar rockReferencePressure(unsigned globalSpaceIdx) const;
-
-    /*!
      * \brief Direct indexed access to the porosity.
      *
      * For the FlowProblem, this method is identical to referencePorosity(). The intensive

--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -204,7 +204,6 @@ partiallySupported()
             "ROCKOPTS",
             {
                {1,{true, allow_values<std::string> {"PRESSURE"}, "ROCKOPTS: only the PRESSURE options are supported"}}, 
-               {2,{true, allow_values<std::string> {"NOSTORE"}, "ROCKOPTS: only the NOSTORE options are supported"}}, 
                {3,{true, allow_values<std::string> {"PVTNUM", "ROCKNUM"}, "ROCKOPTS: only PVTNUM and ROCKNUM are supported"}}, 
             },
          },


### PR DESCRIPTION
If ROCKOPTS item 2 is equal to STORE, initial pressure is used in ROCK and ROCKTAB. For ROCK, the reference pressure input is replaced by initial pressure of the cell, while for ROCKTAB, effective pressure  (i.e. P_eff = P - P_init) will be used in the ROCKTAB table. Note that OVERBURD is ignored if ROCKOPTS item 2 is equal to STORE.

Depends on https://github.com/OPM/opm-common/pull/4370