### PR TITLE
Expose finesmoother pre/post smooth parameters in CPR setup

### DIFF
--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -143,6 +143,8 @@ setupCPRW(const std::string& /*conf*/, const FlowLinearSolverParameters& p)
     prm.put("preconditioner.use_well_weights", "false"s);
     prm.put("preconditioner.add_wells", "true"s);
     prm.put("preconditioner.weight_type", "trueimpes"s);
+    prm.put("preconditioner.pre_smooth", 0);
+    prm.put("preconditioner.post_smooth", 1);
     prm.put("preconditioner.finesmoother.type", "ParOverILU0"s);
     prm.put("preconditioner.finesmoother.relaxation", 1.0);
     prm.put("preconditioner.verbosity", 0);
@@ -191,6 +193,8 @@ setupCPR(const std::string& conf, const FlowLinearSolverParameters& p)
     } else {
         prm.put("preconditioner.weight_type", "trueimpesanalytic"s);
     }
+    prm.put("preconditioner.pre_smooth", 0);
+    prm.put("preconditioner.post_smooth", 1);
     prm.put("preconditioner.finesmoother.type", "ParOverILU0"s);
     prm.put("preconditioner.finesmoother.relaxation", 1.0);
     prm.put("preconditioner.verbosity", 0);


### PR DESCRIPTION
# Expose finesmoother pre/post smooth parameters in CPR setup

The CPR AMG implementation in OPM has two sets of pre/post smoothing parameters:

1. AMG-level smoothing parameters that control smoothing operations between AMG levels
2. Fine-level smoothing parameters that control how many times the block preconditioner (currently ILU0) is applied before and after the AMG V-cycle

While the AMG-level parameters were already exposed, the fine-level parameters were hardcoded in `OwningTwoLevelPreconditioner` (defaulting to pre_smooth=0, post_smooth=1) and not visible in the JSON configuration tree that is printed in the DBG file.

This PR exposes these parameters by adding them to the CPRW and CPR setup, such that the resulting linear solver JSON tree will show up in the DBG file.


```json
{
    "maxiter": "20",
    "tol": "0.0050000000000000001",
    "verbosity": "0",
    "solver": "bicgstab",
    "preconditioner": {
        "type": "cprw",
        "use_well_weights": "false",
        "add_wells": "true",
        "weight_type": "trueimpes",
        "pre_smooth": "0",
        "post_smooth": "1",
        "finesmoother": {
            "type": "ParOverILU0",
            "relaxation": "1"
        },
        "verbosity": "0",
        "coarsesolver": {
            "maxiter": "1",
            "tol": "0.10000000000000001",
            "solver": "loopsolver",
            "verbosity": "0",
            "preconditioner": {
                "type": "amg",
                "alpha": "0.33333333333300003",
                "relaxation": "1",
                "iterations": "1",
                "coarsenTarget": "1200",
                "pre_smooth": "1",
                "post_smooth": "1",
                "beta": "0",
                "smoother": "ILU0",
                "verbosity": "0",
                "maxlevel": "15",
                "skip_isolated": "0",
                "accumulate": "1",
                "prolongationdamping": "1",
                "maxdistance": "2",
                "maxconnectivity": "15",
                "maxaggsize": "6",
                "minaggsize": "4"
            }
        }
    }
}
```

## Performance Tests

Initial testing shows significant potential for performance improvements by tuning these parameters:


- **SPE10 case**:
  - Tested with 12 mpi proc. With hardcoded timesteps and higher maxiter, to focus on performance and ensuring we are comparing as similar as possible linear systems between different options.
  - Using pre_smooth=1, post_smooth=3
  - 2.58x reduction in linear iterations
  - 1.34x overall simulation speedup
  
![spe10_performance_comparison_parallel](https://github.com/user-attachments/assets/b7dd93c9-729c-4543-87cf-7d24a4953a2d)
![spe10_iteration_comparison_parallel](https://github.com/user-attachments/assets/b9a6549e-86fe-4432-ae44-ef013b921367)

- **Norne case**:
  - Tested with 12 mpi proc
  - Shows reduction in linear iterations
  - No significant speedup due to ILU0 overhead on this small problem
  
![norne_iteration_comparison_parallel](https://github.com/user-attachments/assets/c04a30be-8d4a-42fc-bfa6-a4f9f95945a4)
![norne_performance_comparison_parallel](https://github.com/user-attachments/assets/a4109689-019b-4422-8467-276248df6ece)


Further testing across a broader range of cases is needed before considering changes to the default values.