### PR TITLE
added: support WCYCLE

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -180,10 +180,10 @@ void registerAdaptiveParameters();
         SimulatorReport step(const SimulatorTimer& simulatorTimer,
                              Solver& solver,
                              const bool isEvent,
-                             const std::function<bool()> tuningUpdater)
+                             const std::function<bool(const double, const double, const int)> tuningUpdater)
         {
             // Maybe update tuning
-            tuningUpdater();
+            tuningUpdater(simulatorTimer.simulationTimeElapsed(), suggestedNextTimestep_, 0);
             SimulatorReport report;
             const double timestep = simulatorTimer.currentStepLength();
 
@@ -215,7 +215,9 @@ void registerAdaptiveParameters();
                 // Maybe update tuning
                 // get current delta t
                 auto oldValue = suggestedNextTimestep_;
-                if (tuningUpdater()) {
+                if (tuningUpdater(substepTimer.simulationTimeElapsed(),
+                                  substepTimer.currentStepLength(),
+                                  substepTimer.currentStepNum())) {
                     // Use provideTimeStepEstimate to make we sure don't simulate longer than the report step is.
                     substepTimer.provideTimeStepEstimate(suggestedNextTimestep_);
                     suggestedNextTimestep_ = oldValue;

--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -672,7 +672,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"WCONINJP", {true, std::nullopt}},
         {"WCUTBACK", {true, std::nullopt}},
         {"WCUTBACT", {true, std::nullopt}},
-        {"WCYCLE", {true, std::nullopt}},
         {"WDRILTIM", {true, std::nullopt}},
         {"WDRILPRI", {true, std::nullopt}},
         {"WDRILRES", {true, std::nullopt}},

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -450,7 +450,7 @@ template<class Scalar> class WellContributions;
             // Keep track of the domain of each well, if using subdomains.
             std::map<std::string, int> well_domain_;
 
-            // Store the local index of the wells perforated cells in the domain, if using sumdomains
+            // Store the local index of the wells perforated cells in the domain, if using subdomains
             SparseTable<int> well_local_cells_;
 
             const Grid& grid() const

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1575,7 +1575,8 @@ calculateEfficiencyFactors(const int reportStepIdx)
 {
     for (auto& well : well_container_generic_) {
         const Well& wellEcl = well->wellEcl();
-        Scalar well_efficiency_factor = wellEcl.getEfficiencyFactor();
+        Scalar well_efficiency_factor = wellEcl.getEfficiencyFactor() *
+                                        wellState()[well->name()].efficiency_scaling_factor;
         WellGroupHelpers<Scalar>::accumulateGroupEfficiencyFactor(schedule().getGroup(wellEcl.groupName(),
                                                                                       reportStepIdx),
                                                                   schedule(),

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -205,6 +205,9 @@ public:
 
     const GuideRate& guideRate() const { return guideRate_; }
 
+    const std::map<std::string, double>& wellOpenTimes() const { return well_open_times_; }
+    const std::map<std::string, double>& wellCloseTimes() const { return well_close_times_; }
+
     bool reportStepStarts() const { return report_step_starts_; }
 
     bool shouldBalanceNetwork(const int reportStepIndex,
@@ -467,6 +470,12 @@ protected:
 
     std::vector<Well> wells_ecl_;
     std::vector<std::vector<PerforationData<Scalar>>> well_perf_data_;
+
+    // Times at which wells were opened (for WCYCLE)
+    std::map<std::string, double> well_open_times_;
+
+    // Times at which wells were shut (for WCYCLE)
+    std::map<std::string, double> well_close_times_;
 
     /// Connection index mappings
     class ConnectionIndexMap

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -648,7 +648,8 @@ namespace Opm {
             // some preparation before the well can be used
             well->init(&this->phase_usage_, depth_, gravity_, B_avg_, true);
 
-            Scalar well_efficiency_factor = wellEcl.getEfficiencyFactor();
+            Scalar well_efficiency_factor = wellEcl.getEfficiencyFactor() *
+                                            this->wellState()[well_name].efficiency_scaling_factor;
             WellGroupHelpers<Scalar>::accumulateGroupEfficiencyFactor(this->schedule().getGroup(wellEcl.groupName(),
                                                                                                 timeStepIdx),
                                                                       this->schedule(),

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -33,6 +33,7 @@
 #include <opm/input/eclipse/Schedule/Network/Balance.hpp>
 #include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvgDynamicSourceData.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
@@ -177,6 +178,11 @@ namespace Opm {
         const auto& events = this->schedule()[reportStepIdx].wellgroup_events();
         for (auto& wellPtr : this->well_container_) {
             const bool well_opened_this_step = this->report_step_starts_ && events.hasEvent(wellPtr->name(), effective_events_mask);
+            if (well_opened_this_step && this->wellState().well(wellPtr->name()).status == Well::Status::OPEN) {
+                this->well_open_times_.insert_or_assign(wellPtr->name(), this->simulator_.time());
+                this->well_close_times_.erase(wellPtr->name());
+            }
+
             wellPtr->init(&this->phase_usage_, this->depth_, this->gravity_, this->B_avg_, well_opened_this_step);
         }
     }
@@ -672,8 +678,8 @@ namespace Opm {
                 GLiftEclWells ecl_well_map;
                 initGliftEclWellMap(ecl_well_map);
                 well->wellTesting(simulator_, simulationTime, this->wellState(),
-                                  this->groupState(), this->wellTestState(), this->phase_usage_, 
-                                  ecl_well_map, deferred_logger);
+                                  this->groupState(), this->wellTestState(), this->phase_usage_,
+                                  ecl_well_map, this->well_open_times_, deferred_logger);
             } catch (const std::exception& e) {
                 const std::string msg = fmt::format("Exception during testing of well: {}. The well will not open.\n Exception message: {}", wellEcl.name(), e.what());
                 deferred_logger.warning("WELL_TESTING_FAILED", msg);
@@ -919,6 +925,13 @@ namespace Opm {
         if (nw > 0) {
             well_container_.reserve(nw);
 
+            const auto& wmatcher = this->schedule().wellMatcher(report_step);
+            const auto& wcycle = this->schedule()[report_step].wcycle.get();
+            const auto cycle_states = wcycle.wellStatus(this->simulator_.time(),
+                                                         wmatcher,
+                                                         this->well_open_times_,
+                                                         this->well_close_times_);
+
             for (int w = 0; w < nw; ++w) {
                 const Well& well_ecl = this->wells_ecl_[w];
 
@@ -940,6 +953,8 @@ namespace Opm {
                         this->wellState().shutWell(w);
                     }
 
+                    this->well_open_times_.erase(well_name);
+                    this->well_close_times_.erase(well_name);
                     continue;
                 }
 
@@ -957,6 +972,9 @@ namespace Opm {
                         if (!closed_this_step) {
                             this->wellTestState().open_well(well_name);
                             this->wellTestState().open_completions(well_name);
+                            this->well_open_times_.insert_or_assign(well_name,
+                                                                    this->simulator_.time());
+                            this->well_close_times_.erase(well_name);
                         }
                         events.clearEvent(ScheduleEvents::REQUEST_OPEN_WELL);
                     }
@@ -970,12 +988,16 @@ namespace Opm {
                     if (well_ecl.getAutomaticShutIn()) {
                         // shut wells are not added to the well container
                         this->wellState().shutWell(w);
+                        this->well_close_times_.erase(well_name);
+                        this->well_open_times_.erase(well_name);
                         continue;
                     } else {
                         if (!well_ecl.getAllowCrossFlow()) {
                             // stopped wells where cross flow is not allowed
                             // are not added to the well container
                             this->wellState().shutWell(w);
+                            this->well_close_times_.erase(well_name);
+                            this->well_open_times_.erase(well_name);
                             continue;
                         }
                         // stopped wells are added to the container but marked as stopped
@@ -993,19 +1015,55 @@ namespace Opm {
                         // Treat as shut, do not add to container.
                         local_deferredLogger.debug(fmt::format("  Well {} gets shut due to having zero rate constraint and disallowing crossflow ", well_ecl.name()) );
                         this->wellState().shutWell(w);
+                        this->well_close_times_.erase(well_name);
+                        this->well_open_times_.erase(well_name);
                         continue;
                     }
                 }
 
                 if (well_status == Well::Status::STOP) {
                     this->wellState().stopWell(w);
+                    this->well_close_times_.erase(well_name);
+                    this->well_open_times_.erase(well_name);
                     wellIsStopped = true;
+                }
+
+                if (!wcycle.empty()) {
+                    const auto it = cycle_states.find(well_name);
+                    if (it != cycle_states.end()) {
+                        if (!it->second) {
+                            this->wellState().shutWell(w);
+                            continue;
+                        } else {
+                            this->wellState().openWell(w);
+                        }
+                    }
                 }
 
                 well_container_.emplace_back(this->createWellPointer(w, report_step));
 
-                if (wellIsStopped)
+                if (wellIsStopped) {
                     well_container_.back()->stopWell();
+                    this->well_close_times_.erase(well_name);
+                    this->well_open_times_.erase(well_name);
+                }
+            }
+
+            if (!wcycle.empty()) {
+                auto schedule_open = [this, report_step](const std::string& name)
+                {
+                    const auto& wg_events = this->schedule()[report_step].wellgroup_events();
+                    return wg_events.hasEvent(name, ScheduleEvents::REQUEST_OPEN_WELL);
+                };
+                for (const auto& [wname, wscale] : wcycle.efficiencyScale(this->simulator_.time(),
+                                                                          this->simulator_.timeStepSize(),
+                                                                          wmatcher,
+                                                                          this->well_open_times_,
+                                                                          schedule_open))
+                {
+                    this->wellState()[wname].efficiency_scaling_factor = wscale;
+                    this->schedule_.add_event(ScheduleEvents::WELLGROUP_EFFICIENCY_UPDATE, report_step);
+                }
             }
         }
 

--- a/opm/simulators/wells/GasLiftGroupInfo.cpp
+++ b/opm/simulators/wells/GasLiftGroupInfo.cpp
@@ -584,7 +584,8 @@ initializeGroupRatesRecursive_(const Group& group)
                 if (well->isProducer()) {
                     auto [sw_oil_rate, sw_gas_rate, sw_water_rate, sw_oil_pot, sw_gas_pot, sw_water_pot] = getProducerWellRates_(well, index);
                     auto sw_alq = this->well_state_.getALQ(well_name);
-                    Scalar factor = well->getEfficiencyFactor();
+                    const Scalar factor = well->getEfficiencyFactor() *
+                                          this->well_state_[well_name].efficiency_scaling_factor;
                     oil_rate += (factor * sw_oil_rate);
                     gas_rate += (factor * sw_gas_rate);
                     water_rate += (factor * sw_water_rate);
@@ -705,7 +706,8 @@ initializeWell2GroupMapRecursive_(const Group& group,
             if (checkDoGasLift) {
                 const auto &well = this->schedule_.getWell(
                     well_name, this->report_step_idx_);
-                Scalar wfac = well.getEfficiencyFactor();
+                const Scalar wfac = well.getEfficiencyFactor() *
+                                    this->well_state_[well_name].efficiency_scaling_factor;
                 auto [itr, success] = this->well_group_map_.insert(
                       {well_name, /*empty vector*/ {}});
                 assert(success);

--- a/opm/simulators/wells/GasLiftStage2.hpp
+++ b/opm/simulators/wells/GasLiftStage2.hpp
@@ -209,6 +209,7 @@ protected:
     {
         SurplusState(GasLiftStage2& parent_,
                      const Group& group_,
+                     const WellState<Scalar>& well_state_,
                      Scalar oil_rate_,
                      Scalar gas_rate_,
                      Scalar water_rate_,
@@ -222,6 +223,7 @@ protected:
                      std::optional<Scalar> max_total_gas_)
             : parent{parent_}
             , group{group_}
+            , well_state(well_state_)
             , oil_rate{oil_rate_}
             , gas_rate{gas_rate_}
             , water_rate{water_rate_}
@@ -238,6 +240,7 @@ protected:
 
         GasLiftStage2 &parent;
         const Group &group;
+        const WellState<Scalar>& well_state;
         Scalar oil_rate;
         Scalar gas_rate;
         Scalar water_rate;

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -60,6 +60,7 @@ public:
         serializer(bhp);
         serializer(thp);
         serializer(temperature);
+        serializer(efficiency_scaling_factor);
         serializer(phase_mixing_rates);
         serializer(well_potentials);
         serializer(productivity_index);
@@ -88,6 +89,7 @@ public:
     Scalar bhp{0};
     Scalar thp{0};
     Scalar temperature{0};
+    Scalar efficiency_scaling_factor{1.0};
 
     // filtration injection concentration
     Scalar filtrate_conc{0};

--- a/opm/simulators/wells/WellAssemble.cpp
+++ b/opm/simulators/wells/WellAssemble.cpp
@@ -66,7 +66,8 @@ assembleControlEqProd(const WellState<Scalar>& well_state,
 {
     const auto current = well_state.well(well_.indexOfWell()).production_cmode;
     const auto& pu = well_.phaseUsage();
-    const Scalar efficiencyFactor = well_.wellEcl().getEfficiencyFactor();
+    const Scalar efficiencyFactor = well_.wellEcl().getEfficiencyFactor() *
+                                    well_state[well_.name()].efficiency_scaling_factor;
 
     switch (current) {
     case Well::ProducerCMode::ORAT: {
@@ -208,7 +209,8 @@ assembleControlEqInj(const WellState<Scalar>& well_state,
     auto current = well_state.well(well_.indexOfWell()).injection_cmode;
     const InjectorType injectorType = controls.injector_type;
     const auto& pu = well_.phaseUsage();
-    const Scalar efficiencyFactor = well_.wellEcl().getEfficiencyFactor();
+    const Scalar efficiencyFactor = well_.wellEcl().getEfficiencyFactor() *
+                                    well_state[well_.name()].efficiency_scaling_factor;
 
     switch (current) {
     case Well::InjectorCMode::RATE: {

--- a/opm/simulators/wells/WellGroupConstraints.cpp
+++ b/opm/simulators/wells/WellGroupConstraints.cpp
@@ -150,7 +150,8 @@ checkGroupConstraints(WellState<Scalar>& well_state,
             // check, skipping over only the single group parent whose
             // control is the active one for the well (if any).
             const auto& group = schedule.getGroup(well.groupName(), well_.currentStep());
-            const Scalar efficiencyFactor = well.getEfficiencyFactor();
+            const Scalar efficiencyFactor = well.getEfficiencyFactor() *
+                                            well_state[well.name()].efficiency_scaling_factor;
             const std::pair<bool, Scalar> group_constraint =
                 this->checkGroupConstraintsInj(group, well_state,
                                                group_state, efficiencyFactor,
@@ -181,7 +182,8 @@ checkGroupConstraints(WellState<Scalar>& well_state,
             // check, skipping over only the single group parent whose
             // control is the active one for the well (if any).
             const auto& group = schedule.getGroup(well.groupName(), well_.currentStep());
-            const Scalar efficiencyFactor = well.getEfficiencyFactor();
+            const Scalar efficiencyFactor = well.getEfficiencyFactor() *
+                                            well_state[well.name()].efficiency_scaling_factor;
             const std::pair<bool, Scalar> group_constraint =
                 this->checkGroupConstraintsProd(group, well_state,
                                                 group_state, efficiencyFactor,

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -115,7 +115,8 @@ namespace Opm {
             if (wellEcl.getStatus() == Opm::Well::Status::SHUT)
                 continue;
 
-            Scalar factor = wellEcl.getEfficiencyFactor();
+            const Scalar factor = wellEcl.getEfficiencyFactor() *
+                                  wellState[wellEcl.name()].efficiency_scaling_factor;
             const auto& ws = wellState.well(well_index.value());
             if (res_rates) {
                 const auto& well_rates = ws.reservoir_rates;
@@ -265,7 +266,8 @@ sumSolventRates(const Group& group,
             continue;
 
         const auto& ws = wellState.well(well_index.value());
-        const Scalar factor = wellEcl.getEfficiencyFactor();
+        const Scalar factor = wellEcl.getEfficiencyFactor() *
+                              wellState[wellEcl.name()].efficiency_scaling_factor;
         if (injector)
             rate += factor * ws.sum_solvent_rates();
         else
@@ -455,8 +457,10 @@ updateGroupTargetReduction(const Group& group,
             continue;
         }
 
-        const Scalar efficiency = wellTmp.getEfficiencyFactor();
-        // add contributino from wells not under group control
+        const Scalar efficiency = wellTmp.getEfficiencyFactor() *
+                                  wellState[wellTmp.name()].efficiency_scaling_factor;
+
+        // add contribution from wells not under group control
         const auto& ws = wellState.well(well_index.value());
         if (isInjector) {
             if (ws.injection_cmode != Well::InjectorCMode::GRUP)
@@ -868,7 +872,8 @@ computeNetworkPressures(const Network::ExtNetwork& network,
                     //    - Making the wells' maximum flows (i.e. not time-averaged by using a efficiency factor)
                     //      available and using those (for wells with WEFAC(3) true only) when accumulating group
                     //      rates, but ONLY for network calculations.
-                    const Scalar efficiency = well.getEfficiencyFactor();
+                    const Scalar efficiency = well.getEfficiencyFactor() *
+                                              well_state[well.name()].efficiency_scaling_factor;
                     node_inflows[node][BlackoilPhases::Vapour] += well_state.getALQ(wellname) * efficiency;
                 }
             }

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -301,6 +301,7 @@ public:
                      WellTestState& welltest_state,
                      const PhaseUsage& phase_usage,
                      GLiftEclWells& ecl_well_map,
+                     std::map<std::string, double>& open_times,
                      DeferredLogger& deferred_logger);
 
     void checkWellOperability(const Simulator& simulator,

--- a/opm/simulators/wells/WellInterfaceFluidSystem.cpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.cpp
@@ -318,7 +318,8 @@ zeroGroupRateTarget(const SummaryState& summary_state,
 {
     const auto& well = this->well_ecl_;
     const auto& group = schedule.getGroup(well.groupName(), this->currentStep());
-    const Scalar efficiencyFactor = well.getEfficiencyFactor();
+    const Scalar efficiencyFactor = well.getEfficiencyFactor() *
+                                    well_state[well.name()].efficiency_scaling_factor;
     if (this->isInjector()) {
         // Check injector under group control
         const auto& controls = well.injectionControls(summary_state);

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -384,6 +384,7 @@ namespace Opm
                 WellTestState& well_test_state,
                 const PhaseUsage& phase_usage,
                 GLiftEclWells& ecl_well_map,
+                std::map<std::string, double>& open_times,
                 DeferredLogger& deferred_logger)
     {
         deferred_logger.info(" well " + this->name() + " is being tested");
@@ -480,6 +481,7 @@ namespace Opm
             // set the status of the well_state to open
             ws.open();
             well_state = well_state_copy;
+            open_times.try_emplace(this->name(), well_test_state.lastTestTime(this->name()));
         }
     }
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1240,7 +1240,8 @@ namespace Opm
             {
                 assert(well.isAvailableForGroupControl());
                 const auto& group = schedule.getGroup(well.groupName(), this->currentStep());
-                const Scalar efficiencyFactor = well.getEfficiencyFactor();
+                const Scalar efficiencyFactor = well.getEfficiencyFactor() *
+                                                well_state[well.name()].efficiency_scaling_factor;
                 std::optional<Scalar> target =
                         this->getGroupInjectionTargetRate(group,
                                                           well_state,
@@ -1464,7 +1465,8 @@ namespace Opm
             {
                 assert(well.isAvailableForGroupControl());
                 const auto& group = schedule.getGroup(well.groupName(), this->currentStep());
-                const Scalar efficiencyFactor = well.getEfficiencyFactor();
+                const Scalar efficiencyFactor = well.getEfficiencyFactor() *
+                                                well_state[well.name()].efficiency_scaling_factor;
                 Scalar scale = this->getGroupProductionTargetRate(group,
                                                                   well_state,
                                                                   group_state,

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -519,6 +519,7 @@ WellState<Scalar>::report(const int* globalCellIdxMap,
         well.bhp = ws.bhp;
         well.thp = ws.thp;
         well.temperature = ws.temperature;
+        well.efficiency_scaling_factor = ws.efficiency_scaling_factor;
         well.filtrate.rate = ws.sum_filtrate_rate();
         well.filtrate.total = ws.sum_filtrate_total();
         well.filtrate.concentration = ws.filtrate_conc;

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -583,6 +583,17 @@ foreach(templ_case RANGE 1 6)
   )
 endforeach()
 
+foreach(wcycle_case RANGE 0 7)
+  add_test_compareECLFiles(CASENAME WCYCLE-${wcycle_case}
+    FILENAME WCYCLE-${wcycle_case}
+    SIMULATOR flow
+    ABS_TOL ${abs_tol}
+    REL_TOL ${rel_tol}
+    DIR wcycle
+    TEST_ARGS --enable-tuning=true
+  )
+endforeach()
+
 add_test_compareECLFiles(CASENAME udq_uadd
                          FILENAME UDQ_M1
                          SIMULATOR flow


### PR DESCRIPTION
This adds support for WCYCLE. This is a keyword for cycling wells on / off, with time step control and efficiency factor scalings. Support for all of this is a bit of a layer violation in flow, I have tried to keep it as tight as possible, but it has to be split in two parts as we have to select time step before we open / close wells. In particular I have to provide a callback to look into the schedule to check if a well will be opened at a report step in order to avoid unwanted cycling.

Downstream of https://github.com/OPM/opm-common/pull/4371