### PR TITLE
Regression test for the partitioner with GraphOfGrid

### DIFF
--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -256,6 +256,13 @@ add_test_compareECLFiles(CASENAME spe3
                          REL_TOL ${coarse_rel_tol}
                          TEST_ARGS --tolerance-wells=1e-6 --newton-max-iterations=20)
 
+add_test_compareECLFiles(CASENAME spe3_partitionmethod3
+                         FILENAME SPE3CASE1
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${coarse_rel_tol}
+                         TEST_ARGS --partition-method=3)
+
 add_test_compareECLFiles(CASENAME spe9
                          FILENAME SPE9_CP_SHORT
                          SIMULATOR flow

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -256,11 +256,12 @@ add_test_compareECLFiles(CASENAME spe3
                          REL_TOL ${coarse_rel_tol}
                          TEST_ARGS --tolerance-wells=1e-6 --newton-max-iterations=20)
 
-add_test_compareECLFiles(CASENAME spe3_partitionmethod3
+add_test_compareECLFiles(CASENAME spe3
                          FILENAME SPE3CASE1
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol}
+                         PREFIX partitionMethod3
                          TEST_ARGS --partition-method=3)
 
 add_test_compareECLFiles(CASENAME spe9


### PR DESCRIPTION
Add a regression test for the new partitioner that uses graph representation of the grid in which a well is represented by a single cell. The test uses SPE3CASE1 grid which has wells with multiple cells (unlike SPE1 or SPE5).