### PR TITLE
Switch default load balancer to Zoltan with vertex = all cells of a well

### DIFF
--- a/opm/simulators/flow/FlowGenericVanguard.cpp
+++ b/opm/simulators/flow/FlowGenericVanguard.cpp
@@ -425,7 +425,7 @@ void FlowGenericVanguard::registerParameters_()
         ("Order cells owned by rank before ghost/overlap cells.");
 #if HAVE_MPI
     Parameters::Register<Parameters::PartitionMethod>
-        ("Choose partitioning strategy: 0=simple, 1=Zoltan, 2=METIS.");
+        ("Choose partitioning strategy: 0=simple, 1=Zoltan, 2=METIS, 3=Zoltan with all cells of well represented by one vertex.");
     Parameters::Register<Parameters::SerialPartitioning>
         ("Perform partitioning for parallel runs on a single process.");
     Parameters::Register<Parameters::ZoltanImbalanceTol<Scalar>>

--- a/opm/simulators/flow/FlowGenericVanguard.hpp
+++ b/opm/simulators/flow/FlowGenericVanguard.hpp
@@ -71,8 +71,9 @@ struct OwnerCellsFirst { static constexpr bool value = true; };
 struct ParsingStrictness { static constexpr auto value = "normal"; };
 struct ActionParsingStrictness { static constexpr auto value = "normal"; };
 
- // 0: simple, 1: Zoltan, 2: METIS, see GridEnums.hpp
-struct PartitionMethod { static constexpr int value = 1; };
+/// 0: simple, 1: Zoltan, 2: METIS, 3: Zoltan with a all cells of a well
+/// represented by one vertex in the graph, see GridEnums.hpp
+struct PartitionMethod { static constexpr int value = 3; };
 
 struct SchedRestart{ static constexpr bool value = false; };
 struct SerialPartitioning{ static constexpr bool value = false; };

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -234,7 +234,7 @@ add_test_compare_parallel_simulation(CASENAME 3_a_mpi_multflt_mod2
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL 1.0e-3
                                      DIR model2
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=1.0e-3 --tolerance-mb=1e-8  --tolerance-mb-relaxed=1.0e-8 --newton-max-iterations=30)
+                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=1.0e-3 --tolerance-cnv-relaxed=1.0e-3 --tolerance-mb=1e-8  --tolerance-mb-relaxed=1.0e-8 --newton-max-iterations=30)
 
 add_test_compare_parallel_simulation(CASENAME rxft
                                      FILENAME TEST_RXFT

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -233,8 +233,8 @@ add_test_compare_parallel_simulation(CASENAME 3_a_mpi_multflt_mod2
                                      SIMULATOR flow
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL 1.0e-3
-                        			       DIR model2
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --newton-max-iterations=30 --enable-drift-compensation=false)
+                                     DIR model2
+                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=1.0e-3 --tolerance-mb=1e-8  --tolerance-mb-relaxed=1.0e-8 --newton-max-iterations=30)
 
 add_test_compare_parallel_simulation(CASENAME rxft
                                      FILENAME TEST_RXFT


### PR DESCRIPTION
The new loadbalancer approach will create a graph representing the grid where all cells that a well perforates are represented by one vertex. The weight of that cell will be the number of cells it represents. Also the weights of the faces will be added up due to the merging of cells. A cell that is not perforated by any well is still represented by one vertex with weight one.

In the old default approach the number of vertices in the grid was equal to the number of cells. Vertex weights were not used. For each well we added an edge between all its perforated cells for which we did set a very edge weight to force the cells to the same process during partitioning.

For realistic cases we have seen improvements across the board due to this. E.g. this resolved convergence issues on hard cases. Because of that this becomes the default with this.