### PR TITLE
Feature/ms wells fix restart file error

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -194,7 +194,7 @@ endfunction()
 #   - This test class compares the output from a parallel simulation
 #     to the output from the serial instance of the same model.
 function(add_test_compare_parallel_simulation)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR MPI_PROCS ONLY_SMRY)
+  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR MPI_PROCS)
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
@@ -211,21 +211,7 @@ function(add_test_compare_parallel_simulation)
   set(RESULT_PATH ${BASE_RESULT_PATH}/parallel/${PARAM_SIMULATOR}+${PARAM_CASENAME})
   set(TEST_ARGS ${OPM_TESTS_ROOT}/${PARAM_DIR}/${PARAM_FILENAME} ${PARAM_TEST_ARGS})
 
-  # Handle ONLY_SMRY flag (defaults to 0 if not provided)
-  if(PARAM_ONLY_SMRY)
-    if(${PARAM_ONLY_SMRY} EQUAL 1)
-      set(DRIVER_ARGS -s)
-    elseif(${PARAM_ONLY_SMRY} EQUAL 0)
-      set(DRIVER_ARGS "")
-    else()
-      message(FATAL_ERROR "ONLY_SMRY must be either 0 or 1.")
-    endif()
-  else()
-    set(DRIVER_ARGS "")
-  endif()
-
-  set(DRIVER_ARGS ${DRIVER_ARGS}
-                  -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
+  set(DRIVER_ARGS -i ${OPM_TESTS_ROOT}/${PARAM_DIR}
                   -r ${RESULT_PATH}
                   -b ${PROJECT_BINARY_DIR}/bin
                   -f ${PARAM_FILENAME}

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1892,6 +1892,11 @@ namespace Opm
                 }
             }
         }
+        // Accumulate dissolved gas and vaporized oil flow rates across all ranks sharing this well.
+        {
+            const auto& comm = this->parallel_well_info_.communication();
+            comm.sum(ws.phase_mixing_rates.data(), ws.phase_mixing_rates.size());
+        }
 
         if (this->parallel_well_info_.communication().size() > 1) {
             // accumulate resWell_ and duneD_ in parallel to get effects of all perforations (might be distributed)

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -41,7 +41,6 @@ add_test_compare_parallel_simulation(CASENAME msw-simple
                                      FILENAME MSW-SIMPLE # this file contains one Multisegment well without branches that is distributed across several processes
                                      DIR msw
                                      SIMULATOR flow_distribute_z
-                                     ONLY_SMRY 1
                                      ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
                                      REL_TOL 1e-5
                                      MPI_PROCS 4
@@ -51,7 +50,6 @@ add_test_compare_parallel_simulation(CASENAME msw-3d
                                      FILENAME MSW-3D # this file contains one Multisegment well with branches that is distributed across several processes
                                      DIR msw
                                      SIMULATOR flow_distribute_z
-                                     ONLY_SMRY 1
                                      ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
                                      REL_TOL 1e-4
                                      MPI_PROCS 4

--- a/tests/run-parallel-regressionTest.sh
+++ b/tests/run-parallel-regressionTest.sh
@@ -18,15 +18,13 @@ then
   echo -e "\t\t -e <filename> Simulator binary to use"
   echo -e "\tOptional options:"
   echo -e "\t\t -n <procs>    Number of MPI processes to use"
-  echo -e "\t\t -s            If given, compare only the SMRY file and skip comparison of the UNRST file."
   exit 1
 fi
 
 MPI_PROCS=4
 OPTIND=1
-ONLY_SUMMARY=false
 
-while getopts "i:r:b:f:a:t:c:e:n:s" OPT
+while getopts "i:r:b:f:a:t:c:e:n:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -38,7 +36,6 @@ do
     c) COMPARE_ECL_COMMAND=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
     n) MPI_PROCS=${OPTARG} ;;
-    s) ONLY_SUMMARY=true ;;
   esac
 done
 shift $(($OPTIND-1))
@@ -65,16 +62,12 @@ then
   ${COMPARE_ECL_COMMAND} -t SMRY -a -R ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
-if [ "$ONLY_SUMMARY" = false ]; then
-  echo "=== Executing comparison for restart file ==="
-  ${COMPARE_ECL_COMMAND} -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
-  if [ $? -ne 0 ]
-  then
-    ecode=1
-    ${COMPARE_ECL_COMMAND} -a -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
-  fi
-else
-  echo "=== Skipping comparison for restart file due to -s flag ==="
+echo "=== Executing comparison for restart file ==="
+${COMPARE_ECL_COMMAND} -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
+if [ $? -ne 0 ]
+then
+  ecode=1
+  ${COMPARE_ECL_COMMAND} -a -l -t UNRST ${RESULT_PATH}/${FILENAME} ${RESULT_PATH}/mpi/${FILENAME} ${ABS_TOL} ${REL_TOL}
 fi
 
 exit $ecode


### PR DESCRIPTION
Fix error in restart files for parallel runs and remove option to not compare them since this is not needed anymore now.
FYI: I used the undo debugger to trace this bug: https://docs.undo.io/GettingStartedWithUDB.html.

This bugfix repairs the known issues of PR #5746.