### PR TITLE
remove unused fipnum argument

### DIFF
--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -350,7 +350,7 @@ public:
                 events.hasEvent(ScheduleEvents::PRODUCTION_UPDATE) ||
                 events.hasEvent(ScheduleEvents::INJECTION_UPDATE) ||
                 events.hasEvent(ScheduleEvents::WELL_STATUS_CHANGE);
-            auto stepReport = adaptiveTimeStepping_->step(timer, *solver_, event, nullptr, tuningUpdater);
+            auto stepReport = adaptiveTimeStepping_->step(timer, *solver_, event, tuningUpdater);
             report_ += stepReport;
             //Pass simulation report to eclwriter for summary output
             simulator_.problem().setSimulationReport(report_);

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -180,8 +180,7 @@ void registerAdaptiveParameters();
         SimulatorReport step(const SimulatorTimer& simulatorTimer,
                              Solver& solver,
                              const bool isEvent,
-                             const std::vector<int>* fipnum = nullptr,
-                             const std::function<bool()> tuningUpdater = [](){return false;})
+                             const std::function<bool()> tuningUpdater)
         {
             // Maybe update tuning
             tuningUpdater();
@@ -336,9 +335,6 @@ void registerAdaptiveParameters();
                     // to write it as this will be done by the simulator
                     // anyway.
                     if (!substepTimer.done()) {
-                        if (fipnum) {
-                            solver.computeFluidInPlace(*fipnum);
-                        }
                         time::StopWatch perfTimer;
                         perfTimer.start();
 


### PR DESCRIPTION
also allows to drop the default value for the tuningUpdater callback