### PR TITLE
Add Support for Edge Conformal Grid Processing

### DIFF
--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -314,7 +314,7 @@ public:
 protected:
     void createGrids_()
     {
-        this->doCreateGrids_(this->eclState());
+        this->doCreateGrids_(this->edgeConformal(), this->eclState());
     }
 
     void allocTrans() override

--- a/opm/simulators/flow/FlowGenericVanguard.cpp
+++ b/opm/simulators/flow/FlowGenericVanguard.cpp
@@ -134,6 +134,7 @@ FlowGenericVanguard::FlowGenericVanguard(SimulationModelParams&& params)
 #endif // HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
 
     ownersFirst_ = Parameters::Get<Parameters::OwnerCellsFirst>();
+    edgeConformal_ = Parameters::Get<Parameters::EdgeConformal>();
 
 #if HAVE_MPI
     numOverlap_ = Parameters::Get<Parameters::NumOverlap>();
@@ -487,6 +488,9 @@ void FlowGenericVanguard::registerParameters_()
 
     Parameters::Register<Parameters::OwnerCellsFirst>
         ("Order cells owned by rank before ghost/overlap cells.");
+    Parameters::Register<Parameters::EdgeConformal>
+        ("Edge conformal cornerpoint processing.");
+
 #if HAVE_MPI
     Parameters::Register<Parameters::AddCorners>
         ("Add corners to partition.");

--- a/opm/simulators/flow/FlowGenericVanguard.hpp
+++ b/opm/simulators/flow/FlowGenericVanguard.hpp
@@ -77,6 +77,7 @@ struct ActionParsingStrictness { static constexpr auto value = "normal"; };
 struct PartitionMethod { static constexpr auto value = "zoltanwell"; };
 struct AddCorners { static constexpr bool value = false; };
 struct NumOverlap { static constexpr int value = 1; };
+struct EdgeConformal { static constexpr bool value = false; };
 
 struct SchedRestart{ static constexpr bool value = false; };
 struct SerialPartitioning{ static constexpr bool value = false; };
@@ -259,6 +260,9 @@ public:
     bool ownersFirst() const
     { return ownersFirst_; }
 
+    bool edgeConformal() const
+    { return edgeConformal_; }
+
 #if HAVE_MPI
     bool addCorners() const
     { return addCorners_; }
@@ -372,6 +376,8 @@ protected:
 #endif // HAVE_OPENCL || HAVE_ROCSPARSE || HAVE_CUDA
 
     bool ownersFirst_;
+    bool edgeConformal_;
+
 #if HAVE_MPI
     bool addCorners_;
     int numOverlap_;

--- a/opm/simulators/flow/GenericCpGridVanguard.cpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.cpp
@@ -449,7 +449,8 @@ distributeGrid(const Dune::EdgeWeightMethod                          edgeWeights
 #endif  // HAVE_MPI
 
 template<class ElementMapper, class GridView, class Scalar>
-void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(EclipseState& eclState)
+void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::
+doCreateGrids_(const bool edge_conformal, EclipseState& eclState)
 {
     const auto isRoot = this->mpiRank == 0;
 
@@ -479,7 +480,8 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Eclips
                                &eclState,
                                /* isPeriodic = */ false,
                                /* flipNormals = */ false,
-                               /* clipZ = */ false);
+                               /* clipZ = */ false,
+                               edge_conformal);
 
     if (isRoot) {
         const auto& active_porv = eclState.fieldProps().porv(false);

--- a/opm/simulators/flow/GenericCpGridVanguard.hpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.hpp
@@ -216,7 +216,7 @@ protected:
 
     void allocCartMapper();
 
-    void doCreateGrids_(EclipseState& eclState);
+    void doCreateGrids_(bool edge_conformal, EclipseState& eclState);
     void addLgrsUpdateLeafView(const LgrCollection& lgrCollection,
                                const int lgrsSize,
                                Dune::CpGrid& grid);

--- a/opm/simulators/flow/PolyhedralGridVanguard.hpp
+++ b/opm/simulators/flow/PolyhedralGridVanguard.hpp
@@ -246,7 +246,8 @@ protected:
     {
         this->grid_ = std::make_unique<Grid>
             (this->eclState().getInputGrid(),
-             this->eclState().fieldProps().porv(true));
+             this->eclState().fieldProps().porv(true),
+             this->edgeConformal());
 
         this->cartesianIndexMapper_ =
             std::make_unique<CartesianIndexMapper>(*this->grid_);


### PR DESCRIPTION
This PR introduces a new run-time parameter,
```
EdgeConformal (--edge-conformal=BOOL, default 'false')
```
which, when set, activates the edge conformal processing mode in the low-level grid constructor.  Having edge conformal grids is very useful in the context of geo-mechanical fracturing processes.  The mode is available in both sequential and parallel configurations.

Depends on upstream PR OPM/opm-grid#814 and must be reviewed and merged alongside that upstream PR.