### PR TITLE
Regression test for --partition-method=3

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -194,12 +194,16 @@ endfunction()
 #   - This test class compares the output from a parallel simulation
 #     to the output from the serial instance of the same model.
 function(add_test_compare_parallel_simulation)
-  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR MPI_PROCS)
+  set(oneValueArgs CASENAME FILENAME SIMULATOR ABS_TOL REL_TOL DIR PREFIX MPI_PROCS)
   set(multiValueArgs TEST_ARGS)
   cmake_parse_arguments(PARAM "$" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
   if(NOT PARAM_DIR)
     set(PARAM_DIR ${PARAM_CASENAME})
+  endif()
+
+  if(NOT PARAM_PREFIX)
+    set(PARAM_PREFIX compareParallelSim)
   endif()
 
   if(PARAM_MPI_PROCS)
@@ -221,11 +225,11 @@ function(add_test_compare_parallel_simulation)
                   -n ${MPI_PROCS})
 
   # Add test that runs flow_mpi and outputs the results to file
-  opm_add_test(compareParallelSim_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
+  opm_add_test(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_FILENAME} NO_COMPILE
                EXE_NAME ${PARAM_SIMULATOR}
                DRIVER_ARGS ${DRIVER_ARGS}
                TEST_ARGS ${TEST_ARGS})
-  set_tests_properties(compareParallelSim_${PARAM_SIMULATOR}+${PARAM_FILENAME}
+  set_tests_properties(${PARAM_PREFIX}_${PARAM_SIMULATOR}+${PARAM_FILENAME}
                        PROPERTIES PROCESSORS ${MPI_PROCS})
 endfunction()
 

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -78,6 +78,15 @@ add_test_compare_parallel_simulation(CASENAME spe3
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7)
 
+add_test_compare_parallel_simulation(CASENAME spe3
+                                     FILENAME SPE3CASE1
+                                     PREFIX partition_method_3
+                                     SIMULATOR flow
+                                     ABS_TOL ${abs_tol_parallel}
+                                     REL_TOL ${coarse_rel_tol_parallel}
+                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7 --partition-method=3)
+
+
 add_test_compare_parallel_simulation(CASENAME spe1_solvent
                                      FILENAME SPE1CASE2_SOLVENT
                                      SIMULATOR flow

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -256,6 +256,13 @@ add_test_compareECLFiles(CASENAME spe3
                          REL_TOL ${coarse_rel_tol}
                          TEST_ARGS --tolerance-wells=1e-6 --newton-max-iterations=20)
 
+add_test_compareECLFiles(CASENAME spe3_partitionmethod3
+                         FILENAME SPE3CASE1
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${coarse_rel_tol}
+                         TEST_ARGS --partition-method=3)
+
 add_test_compareECLFiles(CASENAME spe9
                          FILENAME SPE9_CP_SHORT
                          SIMULATOR flow

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -256,11 +256,12 @@ add_test_compareECLFiles(CASENAME spe3
                          REL_TOL ${coarse_rel_tol}
                          TEST_ARGS --tolerance-wells=1e-6 --newton-max-iterations=20)
 
-add_test_compareECLFiles(CASENAME spe3_partitionmethod3
+add_test_compareECLFiles(CASENAME spe3
                          FILENAME SPE3CASE1
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${coarse_rel_tol}
+                         PREFIX partitionMethod3
                          TEST_ARGS --partition-method=3)
 
 add_test_compareECLFiles(CASENAME spe9


### PR DESCRIPTION
This PR contains regression test for the `flow` option `--partition-method=3`. This partitioning method represents each well by one cell, therefore a well can not be split over several subdomains by the partitioner. The regression test uses SPE3CASE1 which has wells that have multiple cells (unlike e.g. spe1 or spe5).

Since there is already a test for SPE3CASE1, we got a name conflict with the new test. We extended the macro generating the test to accept the PREFIX keyword, which enabled us to distinguish two tests (with different partitioners) comparing to the same file.