### PR TITLE
Report Connection Level Fracturing Statistics to I/O Layer

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -423,6 +423,7 @@ list (APPEND TEST_SOURCE_FILES
   tests/test_region_phase_pvaverage.cpp
   tests/test_relpermdiagnostics.cpp
   tests/test_RestartSerialization.cpp
+  tests/test_RunningStatistics.cpp
   tests/test_rstconv.cpp
   tests/test_stoppedwells.cpp
   tests/test_SymmTensor.cpp
@@ -1018,6 +1019,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/BlackoilWellModelWBP.hpp
   opm/simulators/wells/ConnectionIndexMap.hpp
   opm/simulators/wells/ConnFiltrateData.hpp
+  opm/simulators/wells/ConnFracStatistics.hpp
   opm/simulators/wells/FractionCalculator.hpp
   opm/simulators/wells/GasLiftCommon.hpp
   opm/simulators/wells/GasLiftGroupInfo.hpp
@@ -1048,6 +1050,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/RatioCalculator.hpp
   opm/simulators/wells/RegionAttributeHelpers.hpp
   opm/simulators/wells/RegionAverageCalculator.hpp
+  opm/simulators/wells/RunningStatistics.hpp
   opm/simulators/wells/RuntimePerforation.hpp
   opm/simulators/wells/SingleWellState.hpp
   opm/simulators/wells/StandardWell.hpp

--- a/opm/simulators/wells/ConnFracStatistics.hpp
+++ b/opm/simulators/wells/ConnFracStatistics.hpp
@@ -1,0 +1,139 @@
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_CONNFRACSTATISTICS_HPP
+#define OPM_CONNFRACSTATISTICS_HPP
+
+#include <opm/simulators/wells/RunningStatistics.hpp>
+
+#include <array>
+#include <cstddef>
+#include <type_traits>
+
+namespace Opm {
+
+/// Collection of fracturing statistics measures at the connection level.
+///
+/// \tparam Scalar Statistics element type.  Typically a built-in arithmetic
+/// type like \c float or \c double.
+template <typename Scalar>
+class ConnFracStatistics
+{
+public:
+    /// Known quantities for which this collection provides statistics
+    /// measures.
+    enum class Quantity : std::size_t
+    {
+        /// Fracture pressure
+        Pressure,
+
+        /// Fracture flow rate
+        FlowRate,
+
+        /// Fracture width
+        Width,
+
+        // -------------------------------------------------------------
+        // Helper.  Must be last enumerator.
+        NumQuantities,
+    };
+
+    /// Sample point representation.
+    ///
+    /// Client code must populate an object of this type in order to collect
+    /// statistics.
+    using SamplePoint = std::array
+        <Scalar, static_cast<std::underlying_type_t<Quantity>>(Quantity::NumQuantities)>;
+
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(this->quantity_);
+    }
+
+    /// Reset internal counters to prepare for calculating a new set of
+    /// sample statistics.
+    void reset()
+    {
+        for (auto& q : this->quantity_) { q.reset(); }
+    }
+
+    /// Include new element into sample.
+    ///
+    /// Updates internal statistics counters.
+    ///
+    /// \param[in] samplePoint Collection of sample values for the
+    /// fracturing of the current well/reservoir connection.
+    void addSamplePoint(const SamplePoint& samplePoint)
+    {
+        for (auto qIdx = 0*samplePoint.size(); qIdx < samplePoint.size(); ++qIdx) {
+            this->quantity_[qIdx].addSamplePoint(samplePoint[qIdx]);
+        }
+    }
+
+    /// Retrieve collection of sample statistics for a single quantity.
+    ///
+    /// \param[in] q Quantity for which to retrieve sample statistics.
+    ///
+    /// \return Sample statistics for quantity \p q.
+    const RunningStatistics<Scalar>& statistics(const Quantity q) const
+    {
+        return this->quantity_[ static_cast<std::underlying_type_t<Quantity>>(q) ];
+    }
+
+    /// Create a serialisation test object.
+    static ConnFracStatistics serializationTestObject()
+    {
+        auto stat = ConnFracStatistics{};
+
+        stat.quantity_
+            .fill(RunningStatistics<Scalar>::serializationTestObject());
+
+        return stat;
+    }
+
+    /// Equality predicate.
+    ///
+    /// \param[in] that Object against which \code *this \endcode will
+    /// be tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p that.
+    bool operator==(const ConnFracStatistics& that) const
+    {
+        return this->quantity_ == that.quantity_;
+    }
+
+private:
+    using StatArray = std::array<
+    RunningStatistics<Scalar>,
+    static_cast<std::underlying_type_t<Quantity>>(Quantity::NumQuantities)
+    >;
+
+    /// Collection of connection level fracturing statistics.
+    StatArray quantity_{};
+};
+
+} // namespace Opm
+
+#endif // OPM_CONNFRACSTATISTICS_HPP

--- a/opm/simulators/wells/PerfData.cpp
+++ b/opm/simulators/wells/PerfData.cpp
@@ -83,6 +83,7 @@ PerfData<Scalar> PerfData<Scalar>::serializationTestObject()
     result.skin_pressure = {27.0, 28.0};
     result.water_velocity = {29.0, 30.0};
     result.filtrate_data = ConnFiltrateData<Scalar>::serializationTestObject();
+    result.connFracStatistics.assign(3, ConnFracStatistics<Scalar>::serializationTestObject());
 
     return result;
 }
@@ -124,6 +125,7 @@ bool PerfData<Scalar>::try_assign(const PerfData& other)
     this->skin_pressure = other.skin_pressure;
     this->water_velocity = other.water_velocity;
     this->filtrate_data = other.filtrate_data;
+    this->connFracStatistics = other.connFracStatistics;
 
     return true;
 }
@@ -152,6 +154,7 @@ bool PerfData<Scalar>::operator==(const PerfData& rhs) const
         && (this->skin_pressure == rhs.skin_pressure)
         && (this->water_velocity == rhs.water_velocity)
         && (this->filtrate_data == rhs.filtrate_data)
+        && (this->connFracStatistics == rhs.connFracStatistics)
         ;
 }
 

--- a/opm/simulators/wells/PerfData.hpp
+++ b/opm/simulators/wells/PerfData.hpp
@@ -21,6 +21,7 @@
 #define OPM_PERFDATA_HEADER_INCLUDED
 
 #include <opm/simulators/wells/ConnFiltrateData.hpp>
+#include <opm/simulators/wells/ConnFracStatistics.hpp>
 
 #include <cstddef>
 #include <vector>
@@ -71,6 +72,7 @@ public:
         serializer(skin_pressure);
         serializer(water_velocity);
         serializer(filtrate_data);
+        serializer(connFracStatistics);
     }
 
     bool operator==(const PerfData&) const;
@@ -105,6 +107,7 @@ public:
     std::vector<Scalar> water_velocity{};
 
     ConnFiltrateData<Scalar> filtrate_data{};
+    std::vector<ConnFracStatistics<Scalar>> connFracStatistics{};
 };
 
 } // namespace Opm

--- a/opm/simulators/wells/RunningStatistics.hpp
+++ b/opm/simulators/wells/RunningStatistics.hpp
@@ -1,0 +1,163 @@
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_RUNNING_STATISTICS_HPP
+#define OPM_RUNNING_STATISTICS_HPP
+
+#include <cmath>
+#include <limits>
+#include <optional>
+
+namespace Opm {
+
+/// Facility for calculating simple sample statistics without having full
+/// sample available.
+///
+/// \tparam Scalar Sample element type.  Typically a built-in arithmetic
+/// type like \c float or \c double.
+template <typename Scalar>
+class RunningStatistics
+{
+public:
+    /// Convert between byte array and object representation.
+    ///
+    /// \tparam Serializer Byte array conversion protocol.
+    ///
+    /// \param[in,out] serializer Byte array conversion object.
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(this->sampleSize_);
+        serializer(this->min_);
+        serializer(this->max_);
+        serializer(this->mean_);
+        serializer(this->totalVariance_);
+    }
+
+    /// Create a serialisation test object.
+    static RunningStatistics serializationTestObject()
+    {
+        auto stat = RunningStatistics{};
+
+        stat.sampleSize_ = 12;
+        stat.min_ = -static_cast<Scalar>(1);
+        stat.max_ =  static_cast<Scalar>(2);
+        stat.mean_ = static_cast<Scalar>(0.03);
+        stat.totalVariance_ = static_cast<Scalar>(0.4);
+
+        return stat;
+    }
+
+    /// Equality predicate.
+    ///
+    /// \param[in] that Object against which \code *this \endcode will
+    /// be tested for equality.
+    ///
+    /// \return Whether or not \code *this \endcode is the same as \p that.
+    bool operator==(const RunningStatistics& that) const
+    {
+        return (this->sampleSize_ == that.sampleSize_)
+            && (this->min_ == that.min_)
+            && (this->max_ == that.max_)
+            && (this->mean_ == that.mean_)
+            && (this->totalVariance_ == that.totalVariance_)
+            ;
+    }
+
+    /// Reset internal counters to prepare for calculating a new set of
+    /// sample statistics.
+    void reset()
+    {
+        this->sampleSize_ = 0;
+        this->min_ = std::numeric_limits<Scalar>::max();
+        this->max_ = std::numeric_limits<Scalar>::lowest();
+        this->mean_ = Scalar{};
+        this->totalVariance_ = Scalar{};
+    }
+
+    /// Include new element into sample.
+    ///
+    /// Updates internal statistics counters.
+    ///
+    /// \param[in] x Sample point.
+    void addSamplePoint(const Scalar x)
+    {
+        if (x < this->min_) { this->min_ = x; }
+        if (x > this->max_) { this->max_ = x; }
+
+        // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+
+        ++this->sampleSize_;
+
+        const auto d1 = x - this->mean();
+        this->mean_ += d1 / this->sampleSize_;
+
+        const auto d2 = x - this->mean();
+        this->totalVariance_ += d1 * d2;
+    }
+
+    /// Retrieve current sample size.
+    ///
+    /// Effectively returns the number of calls to addSamplePoint() since
+    /// object was constructed or since the previous call to reset().
+    std::size_t sampleSize() const { return this->sampleSize_; }
+
+    /// Retrieve smallest sample value seen so far.
+    Scalar min() const { return this->min_; }
+
+    /// Retrieve largest sample value seen so far.
+    Scalar max() const { return this->max_; }
+
+    /// Retrieve arithmetic average of all sample points seen so far.
+    Scalar mean() const { return this->mean_; }
+
+    /// Retrieve unbiased standard deviation of all sample points seen so
+    /// far.
+    ///
+    /// Returns nullopt if number of sample points is less than two.
+    std::optional<Scalar> stdev() const
+    {
+        if (this->sampleSize_ < 2) {
+            return {};
+        }
+
+        using std::sqrt;
+        return sqrt(this->totalVariance_ / (this->sampleSize_ - 1));
+    }
+
+private:
+    /// Current sample size.
+    std::size_t sampleSize_{};
+
+    /// Smallest sample value seen so far.
+    Scalar min_ { std::numeric_limits<Scalar>::max() };
+
+    /// Largest sample value seen so far.
+    Scalar max_ { std::numeric_limits<Scalar>::lowest() };
+
+    /// Arithmetic average of all sample points seen so far.
+    Scalar mean_{};
+
+    /// Variance measure.  In particular, N-1 * Var{x_i}.
+    Scalar totalVariance_{};
+};
+
+} // namespace Opm
+
+#endif // OPM_RUNNING_STATISTICS_HPP

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -55,6 +55,7 @@ namespace Opm
 
 template<class Scalar> class ParallelWellInfo;
 template<class Scalar> struct PerforationData;
+template<class Scalar> class ConnFracStatistics;
 class Schedule;
 enum class WellStatus;
 
@@ -456,6 +457,9 @@ private:
 
     void reportConnectionFilterCake(const std::size_t well_index,
                                     std::vector<data::Connection>& connections) const;
+
+    void reportFractureStatistics(const std::vector<ConnFracStatistics<Scalar>>& stats,
+                                  std::vector<data::Connection>& connections) const;
 };
 
 } // namespace Opm

--- a/tests/test_ParallelSerialization.cpp
+++ b/tests/test_ParallelSerialization.cpp
@@ -144,7 +144,10 @@
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableSchema.hpp>
 #include <opm/output/data/Aquifer.hpp>
+#include <opm/output/data/Wells.hpp>
 #include <opm/output/eclipse/RestartValue.hpp>
+#include <opm/simulators/wells/ConnFracStatistics.hpp>
+#include <opm/simulators/wells/RunningStatistics.hpp>
 #include <opm/simulators/utils/MPISerializer.hpp>
 
 template<class T>
@@ -195,12 +198,17 @@ TEST_FOR_TYPE(BCConfig)
 TEST_FOR_TYPE(BrineDensityTable)
 TEST_FOR_TYPE(ColumnSchema)
 TEST_FOR_TYPE(Connection)
+TEST_FOR_TYPE_NAMED(ConnFracStatistics<double>, ConnFracStatisticsDouble)
+TEST_FOR_TYPE_NAMED(ConnFracStatistics<float>, ConnFracStatisticsFloat)
 TEST_FOR_TYPE_NAMED_OBJ(data::AquiferData, AquiferData_CarterTracy, serializationTestObjectC)
 TEST_FOR_TYPE_NAMED_OBJ(data::AquiferData, AquiferData_Fetkovich, serializationTestObjectF)
 TEST_FOR_TYPE_NAMED_OBJ(data::AquiferData, AquiferData_Numeric, serializationTestObjectN)
 TEST_FOR_TYPE_NAMED(data::CarterTracyData, CarterTracyData)
 TEST_FOR_TYPE_NAMED(data::CellData, CellData)
 TEST_FOR_TYPE_NAMED(data::Connection, dataConnection)
+TEST_FOR_TYPE_NAMED(data::ConnectionFiltrate, dataConnectionFiltrate)
+TEST_FOR_TYPE_NAMED(data::ConnectionFracturing::Statistics, dataConnectionFracturingStatistics)
+TEST_FOR_TYPE_NAMED(data::ConnectionFracturing, dataConnectionFracturing)
 TEST_FOR_TYPE_NAMED(data::CurrentControl, CurrentControl)
 TEST_FOR_TYPE_NAMED(data::FetkovichData, FetkovichData)
 TEST_FOR_TYPE_NAMED(data::GroupAndNetworkValues, GroupAndNetworkValues)
@@ -275,6 +283,8 @@ TEST_FOR_TYPE(RockTable)
 TEST_FOR_TYPE(RocktabTable)
 TEST_FOR_TYPE(Rock2dtrTable)
 TEST_FOR_TYPE(Rock2dTable)
+TEST_FOR_TYPE_NAMED(RunningStatistics<double>, RunningStatisticsDouble)
+TEST_FOR_TYPE_NAMED(RunningStatistics<float>, RunningStatisticsFloat)
 TEST_FOR_TYPE(Runspec)
 TEST_FOR_TYPE(Schedule)
 TEST_FOR_TYPE(ScheduleDeck)

--- a/tests/test_RunningStatistics.cpp
+++ b/tests/test_RunningStatistics.cpp
@@ -1,0 +1,216 @@
+/*
+  Copyright 2023 Equinor.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE Running_Statistics
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/simulators/wells/RunningStatistics.hpp>
+
+#include <boost/mpl/list.hpp>
+
+#include <cstddef>
+#include <initializer_list>
+#include <limits>
+#include <optional>
+
+namespace {
+
+#if FLOW_INSTANTIATE_FLOAT
+    using Types = boost::mpl::list<float, double>;
+#else
+    using Types = boost::mpl::list<double>;
+#endif  // FLOW_INSTANTIATE_FLOAT
+
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(Empty, Scalar, Types)
+{
+    const auto rstat = Opm::RunningStatistics<Scalar>{};
+
+    BOOST_CHECK_EQUAL(rstat.sampleSize(), std::size_t{0});
+    BOOST_CHECK_MESSAGE(! (rstat.min() < std::numeric_limits<Scalar>::max()),
+                        "Minimum value must not be less than Scalar::max() in empty sample");
+    BOOST_CHECK_MESSAGE(! (rstat.max() > std::numeric_limits<Scalar>::min()),
+                        "Maximum value must not be greater than Scalar::min() in empty sample");
+    BOOST_CHECK_MESSAGE(! rstat.stdev().has_value(),
+                        "Standard deviation must not exist in empty sample");
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(SinglePoint, Scalar, Types)
+{
+    auto rstat = Opm::RunningStatistics<Scalar>{};
+
+    const auto samplePoint = static_cast<Scalar>(17.29);
+    rstat.addSamplePoint(samplePoint);
+
+    BOOST_CHECK_EQUAL(rstat.sampleSize(), std::size_t{1});
+    BOOST_CHECK_CLOSE(rstat.min(), samplePoint, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(rstat.max(), samplePoint, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(rstat.mean(), samplePoint, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_MESSAGE(! rstat.stdev().has_value(),
+                        "Standard deviation must not exist in single point sample");
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(Constant_Sampled_Twice, Scalar, Types)
+{
+    auto rstat = Opm::RunningStatistics<Scalar>{};
+
+    const auto samplePoint = static_cast<Scalar>(17.29);
+    rstat.addSamplePoint(samplePoint);
+    rstat.addSamplePoint(samplePoint);
+
+    BOOST_CHECK_EQUAL(rstat.sampleSize(), std::size_t{2});
+    BOOST_CHECK_CLOSE(rstat.min(), samplePoint, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(rstat.max(), samplePoint, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(rstat.mean(), samplePoint, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_MESSAGE(rstat.stdev().has_value(),
+                        "Standard deviation must exist in two-point sample");
+    BOOST_CHECK_CLOSE(*rstat.stdev(), static_cast<Scalar>(0), static_cast<Scalar>(1.0e-8));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(Constant_Sampled_Twice_Reset, Scalar, Types)
+{
+    auto rstat = Opm::RunningStatistics<Scalar>{};
+
+    const auto samplePoint = static_cast<Scalar>(17.29);
+    rstat.addSamplePoint(samplePoint);
+    rstat.addSamplePoint(samplePoint);
+
+    BOOST_CHECK_EQUAL(rstat.sampleSize(), std::size_t{2});
+
+    rstat.reset();
+
+    BOOST_CHECK_EQUAL(rstat.sampleSize(), std::size_t{0});
+    BOOST_CHECK_MESSAGE(! (rstat.min() < std::numeric_limits<Scalar>::max()),
+                        "Minimum value must not be less than Scalar::max() in reset() sample");
+    BOOST_CHECK_MESSAGE(! (rstat.max() > std::numeric_limits<Scalar>::min()),
+                        "Maximum value must not be greater than Scalar::min() in reset() sample");
+    BOOST_CHECK_MESSAGE(! rstat.stdev().has_value(),
+                        "Standard deviation must not exist in reset() sample");
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(Two_Samples_Zero_Avg, Scalar, Types)
+{
+    auto rstat = Opm::RunningStatistics<Scalar>{};
+
+    const auto samplePoint = static_cast<Scalar>(17.29);
+    rstat.addSamplePoint(  samplePoint);
+    rstat.addSamplePoint(- samplePoint);
+
+    BOOST_CHECK_EQUAL(rstat.sampleSize(), std::size_t{2});
+    BOOST_CHECK_CLOSE(rstat.min(), - samplePoint, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(rstat.max(),   samplePoint, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(rstat.mean(), static_cast<Scalar>(0), static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(*rstat.stdev(), static_cast<Scalar>(24.451752493), static_cast<Scalar>(1.0e-5));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(One_Two_Five_Repetitions, Scalar, Types)
+{
+    auto rstat = Opm::RunningStatistics<Scalar>{};
+
+    const auto rpt = 5;
+    const auto one = static_cast<Scalar>(1);
+    const auto two = static_cast<Scalar>(2);
+
+    for (auto i = 0*rpt; i < rpt; ++i) { rstat.addSamplePoint(one); }
+    for (auto i = 0*rpt; i < rpt; ++i) { rstat.addSamplePoint(two); }
+
+    BOOST_CHECK_EQUAL(rstat.sampleSize(), 2 * static_cast<std::size_t>(rpt));
+    BOOST_CHECK_CLOSE(rstat.min(), one, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(rstat.max(), two, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(rstat.mean(), static_cast<Scalar>(1.5), static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(*rstat.stdev(), static_cast<Scalar>(5.27046276695e-01), static_cast<Scalar>(1.0e-8));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(One_Two_Five_Repetitions_Interleaved, Scalar, Types)
+{
+    auto rstat = Opm::RunningStatistics<Scalar>{};
+
+    const auto rpt = 5;
+    const auto one = static_cast<Scalar>(1);
+    const auto two = static_cast<Scalar>(2);
+
+    for (auto i = 0*rpt; i < rpt; ++i) {
+        rstat.addSamplePoint(one);
+        rstat.addSamplePoint(two);
+    }
+
+    BOOST_CHECK_EQUAL(rstat.sampleSize(), 2 * static_cast<std::size_t>(rpt));
+    BOOST_CHECK_CLOSE(rstat.min(), one, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(rstat.max(), two, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(rstat.mean(), static_cast<Scalar>(1.5), static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(*rstat.stdev(), static_cast<Scalar>(5.27046276695e-01), static_cast<Scalar>(1.0e-8));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(One_Two_Twenty_Repetitions, Scalar, Types)
+{
+    auto rstat = Opm::RunningStatistics<Scalar>{};
+
+    const auto rpt = 20;
+    const auto one = static_cast<Scalar>(1);
+    const auto two = static_cast<Scalar>(2);
+
+    for (auto i = 0*rpt; i < rpt; ++i) { rstat.addSamplePoint(one); }
+    for (auto i = 0*rpt; i < rpt; ++i) { rstat.addSamplePoint(two); }
+
+    BOOST_CHECK_EQUAL(rstat.sampleSize(), 2 * static_cast<std::size_t>(rpt));
+    BOOST_CHECK_CLOSE(rstat.min(), one, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(rstat.max(), two, static_cast<Scalar>(1.0e-8));
+    BOOST_CHECK_CLOSE(rstat.mean(), static_cast<Scalar>(1.5), static_cast<Scalar>(1.0e-5));
+    BOOST_CHECK_CLOSE(*rstat.stdev(), static_cast<Scalar>(5.06369683542e-01), static_cast<Scalar>(5.0e-5));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(RandN_50, Scalar, Types)
+{
+    auto rstat = Opm::RunningStatistics<Scalar>{};
+
+    for (const auto& samplePoint : {
+            // Values from Octave (RANDN([50, 1]))
+
+            -5.983051973110e-01, -2.129185497807e-01, -5.160782188139e-01,
+            -5.405962754204e-02, 1.081538561527e+00, -5.444361014868e-01,
+            6.802216201756e-01, -1.732112159825e+00, -1.681240838370e+00,
+            9.026897835500e-01, -2.510481192847e-01, 2.503216953163e+00,
+            2.096538154630e+00, -1.157169480540e+00, 2.777014458586e-01,
+            3.206654292492e-01, 2.720894169117e+00, 3.394916550830e-01,
+            1.603500564897e+00, 1.305786976012e+00, 3.358587787445e-01,
+            1.688835457016e+00, 6.464543963139e-01, -8.880888352071e-01,
+            1.785948404587e+00, 7.344602418137e-01, 1.272049108856e+00,
+            3.618201220834e-02, -1.254183439007e+00, 8.551411128509e-01,
+            2.002540536438e+00, -8.442308733039e-01, -5.880385774749e-01,
+            5.134590162252e-01, 2.242601346140e-01, -1.632624091153e+00,
+            -2.041052498197e-01, 8.535062014928e-01, 1.218406596883e-01,
+            4.866545018493e-01, -1.249277350665e+00, -5.014606488004e-01,
+            2.795291286626e-01, -6.459643961814e-01, -1.061751877930e+00,
+            -1.422156588627e+00, 1.026939772058e-01, -3.551330895391e-01,
+            8.945851907053e-01, -2.250951241491e-01,
+        })
+    {
+        rstat.addSamplePoint(static_cast<Scalar>(samplePoint));
+    }
+
+    BOOST_CHECK_EQUAL(rstat.sampleSize(), std::size_t{50});
+    BOOST_CHECK_CLOSE(rstat.min(), static_cast<Scalar>(-1.732112159824814), static_cast<Scalar>(1.0e-6));
+    BOOST_CHECK_CLOSE(rstat.max(), static_cast<Scalar>(2.720894169117450), static_cast<Scalar>(1.0e-6));
+    BOOST_CHECK_CLOSE(rstat.mean(), static_cast<Scalar>(0.1809353147544384), static_cast<Scalar>(5.0e-5));
+    BOOST_CHECK_CLOSE(*rstat.stdev(), static_cast<Scalar>(1.097155256132325), static_cast<Scalar>(1.0e-6));
+}


### PR DESCRIPTION
Populates the new `data::Connection::fract` data member from PR OPM/opm-common#4388.

To this end, introduce two helper classes to compute statistics of a running sample:

  * `RunningStatistics` calculates basic statics measures of a running sample
  * `ConnFracStatistics` aggregates those measures for connection level fracture pressure, fracture width, and flow rate