### PR TITLE
Do not write initial FIP for CpGrid with LGRs for now

### DIFF
--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -562,8 +562,16 @@ public:
         // the initial solution.
         this->thresholdPressures_.finishInit();
 
-        if (this->simulator().episodeIndex() == 0) {
-            eclWriter_->writeInitialFIPReport();
+        // For CpGrid with LGRs, ecl-output is not supported yet.
+        const auto& grid = this->simulator().vanguard().gridView().grid();
+
+        using GridType = std::remove_cv_t<std::remove_reference_t<decltype(grid)>>;
+        constexpr bool isCpGrid = std::is_same_v<GridType, Dune::CpGrid>;
+        // Skip - for now -  calculate the initial fip values for CpGrid with LGRs.
+        if (!isCpGrid || (grid.maxLevel() == 0)) {
+            if (this->simulator().episodeIndex() == 0) {
+                eclWriter_->writeInitialFIPReport();
+            }
         }
     }
 


### PR DESCRIPTION
Unfortunately, for CpGrid with LGRs we need to skip - for now - the computation of initial FIP. This affects the "always calculate initial FIP" done in OPM/opm-simulators#5784 in the sense that CpGrid with LGRs is excluded for the moment. 

 