### PR TITLE
Necessary to compile with my Hypre install.

### DIFF
--- a/opm/simulators/linalg/HyprePreconditioner.hpp
+++ b/opm/simulators/linalg/HyprePreconditioner.hpp
@@ -393,7 +393,7 @@ private:
     HYPRE_BigInt* cols_device_ = nullptr; //!< Device array for column indices.
     HYPRE_Real* values_device_ = nullptr; //!< Device array for matrix values.
 
-    std::vector<int> indices_; //!< Indices vector for copying vectors to/from Hypre.
+    std::vector<HYPRE_BigInt> indices_; //!< Indices vector for copying vectors to/from Hypre.
     HYPRE_BigInt* indices_device_ = nullptr; //!< Device array for indices.
     HYPRE_Int N_ = -1; //!< Number of rows in the matrix.
     HYPRE_Int nnz_ = -1; //!< Number of non-zero elements in the matrix.


### PR DESCRIPTION
HYPRE_Bigint are 64 bit integers on some platforms by default, and can be configured as such in any case. The HYPRE API asks for HYPRE_BigInt* so it is better to use that type rather than int.