### PR TITLE
Skip allocTrans when !(enableEclOutput || loadBalancerSet == 0 || partitionJacobiBlocks)

### DIFF
--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -233,7 +233,7 @@ public:
                              this->imbalanceTol(),
                              this->gridView(), this->schedule(),
                              this->eclState(), this->parallelWells_,
-                             this->numJacobiBlocks());
+                             this->numJacobiBlocks(), this->enableEclOutput());
 #endif
 
         this->updateGridView_();

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -65,9 +65,6 @@
 
 namespace Opm::Parameters {
 
-// enable the ECL output by default
-struct EnableEclOutput { static constexpr bool value = true; };
-
 // If available, write the ECL output in a non-blocking manner
 struct EnableAsyncEclOutput { static constexpr bool value = true; };
 

--- a/opm/simulators/flow/FlowBaseVanguard.hpp
+++ b/opm/simulators/flow/FlowBaseVanguard.hpp
@@ -139,6 +139,7 @@ public:
         externalPartitionFile_ = Parameters::Get<Parameters::ExternalPartition>();
 #endif
         enableDistributedWells_ = Parameters::Get<Parameters::AllowDistributedWells>();
+        enableEclOutput_ = Parameters::Get<Parameters::EnableEclOutput>();
         allow_splitting_inactive_wells_ = Parameters::Get<Parameters::AllowSplittingInactiveWells>();
         ignoredKeywords_ = Parameters::Get<Parameters::IgnoreKeywords>();
         int output_param = Parameters::Get<Parameters::EclOutputInterval>();

--- a/opm/simulators/flow/FlowGenericVanguard.cpp
+++ b/opm/simulators/flow/FlowGenericVanguard.cpp
@@ -390,6 +390,8 @@ void FlowGenericVanguard::registerParameters_()
         ("The number of report steps that ought to be skipped between two writes of ECL results");
     Parameters::Register<Parameters::EnableDryRun>
         ("Specify if the simulation ought to be actually run, or just pretended to be");
+    Parameters::Register<Parameters::EnableEclOutput>
+        ("Write binary output which is compatible with the commercial Eclipse simulator");
     Parameters::Register<Parameters::EnableOpmRstFile>
         ("Include OPM-specific keywords in the ECL restart file to "
          "enable restart of OPM simulators from these files");

--- a/opm/simulators/flow/FlowGenericVanguard.hpp
+++ b/opm/simulators/flow/FlowGenericVanguard.hpp
@@ -53,6 +53,7 @@ struct AllowSplittingInactiveWells { static constexpr bool value = true; };
 struct EclOutputInterval { static constexpr int value = -1; };
 struct EdgeWeightsMethod  { static constexpr int value = 1; };
 struct EnableDryRun { static constexpr auto value = "auto"; };
+struct EnableEclOutput { static constexpr auto value = true; };
 struct EnableOpmRstFile { static constexpr bool value = false; };
 struct ExternalPartition { static constexpr auto* value = ""; };
 
@@ -292,6 +293,12 @@ public:
     { return enableDistributedWells_; }
 
     /*!
+     * \brief Wheter to write binary output which is compatible with the commercial Eclipse simulator.
+     */
+    bool enableEclOutput() const
+    { return enableEclOutput_; }
+
+    /*!
      * \brief Returns vector with name and whether the has local perforated cells
      *        for all wells.
      *
@@ -362,6 +369,7 @@ protected:
     std::string externalPartitionFile_{};
 #endif
     bool enableDistributedWells_;
+    bool enableEclOutput_;
     bool allow_splitting_inactive_wells_;
 
     std::string ignoredKeywords_;

--- a/opm/simulators/flow/FlowProblemParameters.cpp
+++ b/opm/simulators/flow/FlowProblemParameters.cpp
@@ -42,9 +42,6 @@ void registerFlowProblemParameters()
     Parameters::Register<Parameters::EnableWriteAllSolutions>
        ("Write all solutions to disk instead of only the ones for the "
         "report steps");
-    Parameters::Register<Parameters::EnableEclOutput>
-        ("Write binary output which is compatible with the commercial "
-         "Eclipse simulator");
 #if HAVE_DAMARIS
     Parameters::Register<Parameters::EnableDamarisOutput>
         ("Write a specific variable using Damaris in a separate core");

--- a/opm/simulators/flow/GenericCpGridVanguard.hpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.hpp
@@ -167,7 +167,8 @@ protected:
                         const Schedule&                          schedule,
                         EclipseState&                            eclState,
                         FlowGenericVanguard::ParallelWellStruct& parallelWells,
-                        const int                                numJacobiBlocks);
+                        const int                                numJacobiBlocks,
+                        const bool                               enableEclOutput);
 
     void distributeFieldProps_(EclipseState& eclState);
 


### PR DESCRIPTION
If the partition is loaded by `--external-partition` and `--enable-ecl-output=0`, then the expensive `allocTrans()` can be skipped.