### PR TITLE
Fix really stupid communication mistake

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -152,7 +152,7 @@ apply(const BVector& x, BVector& Ax) const
 
     duneB_.mv(x, Bx);
 
-    if (this->pw_info_.communication().size() == 1) {
+    if (this->pw_info_.communication().size() > 1) {
         // We need to communicate here to get the contributions from all segments
         this->pw_info_.communication().sum(Bx.data(), Bx.size());
     }

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -44,7 +44,7 @@ add_test_compare_parallel_simulation(CASENAME msw-simple
                                      ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
                                      REL_TOL 1e-5
                                      MPI_PROCS 4
-                                     TEST_ARGS --solver-max-time-step-in-days=10 --allow-distributed-wells=true)
+                                     TEST_ARGS --solver-max-time-step-in-days=15 --allow-distributed-wells=true)
 
 add_test_compare_parallel_simulation(CASENAME msw-3d
                                      FILENAME MSW-3D # this file contains one Multisegment well with branches that is distributed across several processes


### PR DESCRIPTION
Now I can use solver-max-time-step-in-days=15 instead of solver-max-time-step-in-days=10 in the test msw-simple (this test without the fix from this PR is failing in #5821) 