### PR TITLE
Fix RFT output for shut distributed wells 

### DIFF
--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -407,32 +407,30 @@ template<class FluidSystem>
 void GenericOutputBlackoilModule<FluidSystem>::
 accumulateRftDataParallel(const Parallel::Communication& comm) {
     if (comm.size() > 1) {
-        collectRftMapOnRoot(oilConnectionPressures_, comm);
-        collectRftMapOnRoot(waterConnectionSaturations_, comm);
-        collectRftMapOnRoot(gasConnectionSaturations_, comm);
+        gatherAndUpdateRftMap(oilConnectionPressures_, comm);
+        gatherAndUpdateRftMap(waterConnectionSaturations_, comm);
+        gatherAndUpdateRftMap(gasConnectionSaturations_, comm);
     }
 }
 
 template<class FluidSystem>
 void GenericOutputBlackoilModule<FluidSystem>::
-collectRftMapOnRoot(std::map<std::size_t, Scalar>& local_map, const Parallel::Communication& comm) {
+gatherAndUpdateRftMap(std::map<std::size_t, Scalar>& local_map, const Parallel::Communication& comm) {
 
     std::vector<std::pair<int, Scalar>> pairs(local_map.begin(), local_map.end());
     std::vector<std::pair<int, Scalar>> all_pairs;
     std::vector<int> offsets;
 
-    std::tie(all_pairs, offsets) = Opm::gatherv(pairs, comm, 0);
+    std::tie(all_pairs, offsets) = Opm::allGatherv(pairs, comm);
 
-    // Insert/update map values on root
-    if (comm.rank() == 0) {
-        for (auto i=static_cast<std::size_t>(offsets[1]); i<all_pairs.size(); ++i) {
-            const auto& key_value = all_pairs[i];
-            if (auto candidate = local_map.find(key_value.first); candidate != local_map.end()) {
-                const Scalar prev_value = candidate->second;
-                candidate->second = std::max(prev_value, key_value.second);
-            } else {
-                local_map[key_value.first] = key_value.second;
-            }
+    // Update maps on all ranks
+    for (auto i=static_cast<std::size_t>(offsets[0]); i<all_pairs.size(); ++i) {
+        const auto& key_value = all_pairs[i];
+        if (auto candidate = local_map.find(key_value.first); candidate != local_map.end()) {
+            const Scalar prev_value = candidate->second;
+            candidate->second = std::max(prev_value, key_value.second);
+        } else {
+            local_map[key_value.first] = key_value.second;
         }
     }
 }

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -387,7 +387,7 @@ protected:
 
     virtual bool isDefunctParallelWell(std::string wname) const = 0;
 
-    void collectRftMapOnRoot(std::map<std::size_t, Scalar>& local_map, const Parallel::Communication& comm);
+    void gatherAndUpdateRftMap(std::map<std::size_t, Scalar>& local_map, const Parallel::Communication& comm);
 
     const EclipseState& eclState_;
     const Schedule& schedule_;


### PR DESCRIPTION
and also for permanently inactive wells that are split across processors (partition method 3 issue only).

To see the issue for shut distributed wells, run attached example ([shut-distributed-wells-rft-issue.tar.gz](https://github.com/user-attachments/files/18209079/shut-distributed-wells-rft-issue.tar.gz)) as:
>```sh
> mpirun -np 4 flow \
>    --external-partiton=part4.txt \
>    --allow-distributed-wells=true \
>    TEST-RFT-SHUT-DISTRIBUTED-WELL.DATA
>```
and for inactive wells split across processors with partition method 3 (where root does not appear to contain all cells):
>```sh
> mpirun -np 3 flow \
>    --partition-method=3 \
>    --allow-distributed-wells=true \
>    TEST-RFT-INACTIVE-SPLIT-WELL-PARTMETHOD3.DATA
>```
In these cases current master outputs 0 for RFT data for some connections of well INJE01/INJE02 respectively, whereas this PR ensures that all connections get actual values.

The solution here is a quick fix within the current framework, and should at some point be revised to avoid some global communication and adding the well data multiple times for shut distributed and split permanently inactive wells.