### PR TITLE
should not use phase index for canonicalToActiveComponentIndex()

### DIFF
--- a/opm/simulators/wells/MultisegmentWellAssemble.cpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.cpp
@@ -279,9 +279,7 @@ assemblePressureEq(const int seg,
                    const int outlet_segment_index,
                    const EvalWell& pressure_equation,
                    const EvalWell& outlet_pressure,
-                   Equations& eqns1,
-                   bool wfrac,
-                   bool gfrac) const
+                   Equations& eqns1) const
 {
     /*
         This method does *not* need communication.
@@ -290,10 +288,10 @@ assemblePressureEq(const int seg,
     eqns.residual()[seg][SPres] += pressure_equation.value();
     eqns.D()[seg][seg][SPres][SPres] += pressure_equation.derivative(SPres + Indices::numEq);
     eqns.D()[seg][seg][SPres][WQTotal] += pressure_equation.derivative(WQTotal + Indices::numEq);
-    if (wfrac) {
+    if (has_wfrac_variable) {
         eqns.D()[seg][seg_upwind][SPres][WFrac] += pressure_equation.derivative(WFrac + Indices::numEq);
     }
-    if (gfrac) {
+    if (has_gfrac_variable) {
         eqns.D()[seg][seg_upwind][SPres][GFrac] += pressure_equation.derivative(GFrac + Indices::numEq);
     }
 

--- a/opm/simulators/wells/MultisegmentWellAssemble.hpp
+++ b/opm/simulators/wells/MultisegmentWellAssemble.hpp
@@ -107,9 +107,7 @@ public:
                             const int outlet_segment_index,
                             const EvalWell& pressure_equation,
                             const EvalWell& outlet_pressure,
-                            Equations& eqns,
-                            bool wfrac = has_wfrac_variable,
-                            bool gfrac = has_gfrac_variable) const;
+                            Equations& eqns) const;
 
     //! \brief Assembles a trivial equation.
     void assembleTrivialEq(const int seg,

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -368,9 +368,7 @@ assembleICDPressureEq(const int seg,
     MultisegmentWellAssemble(baseif_).
         assemblePressureEq(seg, seg_upwind, outlet_segment_index,
                            pressure_equation, outlet_pressure,
-                           linSys_,
-                           FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx),
-                           FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx));
+                           linSys_);
 
     assembleAccelerationAndHydroPressureLosses(seg, well_state, use_average_density);
 }

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -933,10 +933,10 @@ mixtureDensity(const int seg) const
             continue;
         }
 
-        const auto compIdx = Indices::
-            canonicalToActiveComponentIndex(phIdx);
+        const auto active_comp_index = Indices::
+             canonicalToActiveComponentIndex(FluidSystem::solventComponentIndex(phIdx));
 
-        mixDens += q[compIdx].value() * rho[compIdx].value();
+        mixDens += q[active_comp_index].value() * rho[active_comp_index].value();
     }
 
     return mixDens;
@@ -977,7 +977,7 @@ mixtureDensityWithExponents(const AutoICD& aicd, const int seg) const
     for (const auto& [fsPhaseIdx, densityExponent] : densityExponents) {
         if (FluidSystem::phaseIsActive(fsPhaseIdx)) {
             const auto compIdx = Indices::
-                canonicalToActiveComponentIndex(fsPhaseIdx);
+                canonicalToActiveComponentIndex(FluidSystem::solventComponentIndex(fsPhaseIdx));
 
             // exp = (aicd.*densityExponent)() in native syntax.
             const auto exp = std::invoke(densityExponent, aicd);


### PR DESCRIPTION
it is a testing PR.  raising concern when developing https://github.com/OPM/opm-simulators/pull/5818 . 