### PR TITLE
Remove nnecessary check isInterior

### DIFF
--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -498,8 +498,7 @@ public:
 
                 Scalar dofVolume = stencil.subControlVolume(dofIdx).volume();
                 dofTotalVolume_[globalIdx] += dofVolume;
-                if (isInteriorElement)
-                    gridTotalVolume_ += dofVolume;
+                gridTotalVolume_ += dofVolume;
             }
         }
 


### PR DESCRIPTION
Iterate over the grid and evaluate initial condition skips non-interior cells, so it seems not necessary to double-check the Interior partition type before adding dofVolume to gridTotalVolume_

Not relevant for the Reference Manual