### PR TITLE
Reduce size of enums to save 15 bytes per cell.

### DIFF
--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -43,6 +43,8 @@
 
 #include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
 
+#include <cstdint>
+
 namespace Opm::Parameters {
 
 template<class Scalar>
@@ -122,33 +124,33 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag>
     static_assert(numComponents == 3, "The black-oil model assumes three components!");
 
 public:
-    enum class WaterMeaning {
+    enum class WaterMeaning : std::uint8_t {
         Sw,  // water saturation
         Rvw, // vaporized water
         Rsw, // dissolved gas in water
         Disabled, // The primary variable is not used
     };
 
-    enum class PressureMeaning {
+    enum class PressureMeaning : std::uint8_t {
         Po, // oil pressure
         Pg, // gas pressure
         Pw, // water pressure
     };
 
-    enum class GasMeaning {
+    enum class GasMeaning : std::uint8_t {
         Sg, // gas saturation
         Rs, // dissolved gas in oil
         Rv, // vapporized oil
         Disabled, // The primary variable is not used
     };
 
-    enum class BrineMeaning {
+    enum class BrineMeaning : std::uint8_t {
         Cs, // salt concentration
         Sp, // (precipitated) salt saturation
         Disabled, // The primary variable is not used
     };
 
-    enum class SolventMeaning {
+    enum class SolventMeaning : std::uint8_t {
         Ss, // solvent saturation
         Rsolw, // dissolved solvent in water
         Disabled, // The primary variable is not used

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -26,6 +26,7 @@
 #include <stdexcept>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace Opm {
 


### PR DESCRIPTION
This PR saves 75% on the enum storage in the primary variable objects without any other changes. One could probably devise a way to store these flags with fewer bits, but I am not sure it would be worth it.