### PR TITLE
Fix clang complaints about incorrect constexpr usage.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGasLift.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGasLift.hpp
@@ -86,6 +86,7 @@ class BlackoilWellModelGasLift :
     using Base = BlackoilWellModelGasLiftGeneric<GetPropType<TypeTag, Properties::Scalar>>;
 
 public:
+    using Base::glift_debug;
     using Scalar = GetPropType<TypeTag, Properties::Scalar>;
     using GLiftEclWells = typename GasLiftGroupInfo<Scalar>::GLiftEclWells;
     using GLiftOptWells = typename Base::GLiftOptWells;

--- a/opm/simulators/wells/BlackoilWellModelGasLift_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGasLift_impl.hpp
@@ -110,7 +110,7 @@ maybeDoGasLiftOptimize(const Simulator& simulator,
                                         simulator.episodeIndex(),
                                         deferred_logger);
 
-        if constexpr (this->glift_debug) {
+        if constexpr (glift_debug) {
             std::vector<WellInterfaceGeneric<Scalar>*> wc;
             wc.reserve(well_container.size());
             for (const auto& w : well_container) {
@@ -230,7 +230,7 @@ gasLiftOptimizationStage1(const Simulator& simulator,
                                           group_alq_rates[j]);
                 }
             }
-            if (this->glift_debug) {
+            if constexpr (glift_debug) {
                 int counter = 0;
                 if (comm.rank() == i) {
                     counter = wellState.gliftGetDebugCounter();

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1242,7 +1242,7 @@ namespace Opm {
     {
         DeferredLogger local_deferredLogger;
 
-        if constexpr (gaslift_.glift_debug) {
+        if constexpr (BlackoilWellModelGasLift<TypeTag>::glift_debug) {
             if (gaslift_.terminalOutput()) {
                 const std::string msg =
                     fmt::format("assemble() : iteration {}" , iterationIdx);


### PR DESCRIPTION
Also make one more if constexpr.

Error message was like this example:
```
/Users/atgeirr/opm/src/opm-simulators/opm/simulators/wells/BlackoilWellModelGasLift_impl.hpp:113:23: error: constexpr if condition is not a constant expression
  113 |         if constexpr (this->glift_debug) {
      |                       ^~~~~~~~~~~~~~~~~
```