### PR TITLE
Fix BlackoilWellModel::hasWell mixups

### DIFF
--- a/opm/simulators/flow/ActionHandler.cpp
+++ b/opm/simulators/flow/ActionHandler.cpp
@@ -155,7 +155,7 @@ namespace {
 
         auto wellPI = std::vector<Scalar>(wellpi_wells.size());
         for (auto i = 0*wellpi_wells.size(); i < wellpi_wells.size(); ++i) {
-            if (wellModel.hasWell(wellpi_wells[i])) {
+            if (wellModel.hasLocalWell(wellpi_wells[i])) {
                 wellPI[i] = wellModel.wellPI(wellpi_wells[i]);
             }
         }

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -289,7 +289,7 @@ template<class Scalar> class WellContributions;
                                     const int iterationIdx);
 
             WellInterfacePtr getWell(const std::string& well_name) const;
-            bool hasWell(const std::string& well_name) const;
+            bool hasOpenLocalWell(const std::string& well_name) const;
 
             using PressureMatrix = Dune::BCRSMatrix<Opm::MatrixBlock<Scalar, 1, 1>>;
 

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -289,7 +289,6 @@ template<class Scalar> class WellContributions;
                                     const int iterationIdx);
 
             WellInterfacePtr getWell(const std::string& well_name) const;
-            bool hasOpenLocalWell(const std::string& well_name) const;
 
             using PressureMatrix = Dune::BCRSMatrix<Opm::MatrixBlock<Scalar, 1, 1>>;
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -149,10 +149,24 @@ template<class Scalar>
 bool BlackoilWellModelGeneric<Scalar>::
 hasWell(const std::string& wname) const
 {
-    return std::any_of(this->wells_ecl_.begin(), this->wells_ecl_.end(),
+    return std::any_of(this->wells_ecl_.begin(),
+                       this->wells_ecl_.end(),
         [&wname](const Well& well)
     {
         return well.name() == wname;
+    });
+}
+
+template<class Scalar>
+bool
+BlackoilWellModelGeneric<Scalar>::
+hasOpenLocalWell(const std::string& wname) const
+{
+    return std::any_of(well_container_generic_.begin(),
+                       well_container_generic_.end(),
+        [&wname](const auto* elem) -> bool
+    {
+        return elem->name() == wname;
     });
 }
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -147,7 +147,7 @@ numPhases() const
 
 template<class Scalar>
 bool BlackoilWellModelGeneric<Scalar>::
-hasWell(const std::string& wname) const
+hasLocalWell(const std::string& wname) const
 {
     return std::any_of(this->wells_ecl_.begin(),
                        this->wells_ecl_.end(),

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -105,7 +105,7 @@ public:
     bool wellsActive() const;
 
     //! \brief Returns true if well is defined and has connections on current rank.
-    bool hasWell(const std::string& wname) const;
+    bool hasLocalWell(const std::string& wname) const;
 
     //! \brief Returns true if well is defined, open and has connections on current rank.
     bool hasOpenLocalWell(const std::string& well_name) const;

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -103,7 +103,12 @@ public:
 
     /// return true if wells are available in the reservoir
     bool wellsActive() const;
+
+    //! \brief Returns true if well is defined and has connections on current rank.
     bool hasWell(const std::string& wname) const;
+
+    //! \brief Returns true if well is defined, open and has connections on current rank.
+    bool hasOpenLocalWell(const std::string& well_name) const;
 
     /// return true if network is active (at least one network well in prediction mode)
     bool networkActive() const;

--- a/opm/simulators/wells/BlackoilWellModelRestart.cpp
+++ b/opm/simulators/wells/BlackoilWellModelRestart.cpp
@@ -192,7 +192,9 @@ loadRestartGuideRates(const int                    report_step,
                       GuideRate&                   guide_rate) const
 {
     for (const auto& [well_name, rst_well] : rst_wells) {
-        if (!wellModel_.hasWell(well_name) || wellModel_.getWellEcl(well_name).isInjector()) {
+        if (!wellModel_.hasLocalWell(well_name) ||
+            wellModel_.getWellEcl(well_name).isInjector())
+        {
             continue;
         }
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2378,21 +2378,6 @@ namespace Opm {
         return *well;
     }
 
-    template<typename TypeTag>
-    bool
-    BlackoilWellModel<TypeTag>::
-    hasOpenLocalWell(const std::string& well_name) const
-    {
-        return std::any_of(well_container_.begin(), well_container_.end(),
-            [&well_name](const WellInterfacePtr& elem) -> bool
-        {
-            return elem->name() == well_name;
-        });
-    }
-
-
-
-
     template <typename TypeTag>
     int
     BlackoilWellModel<TypeTag>::

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2099,7 +2099,9 @@ namespace Opm {
         DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger, comm);
 
         for (const auto& [group_name, to] : this->closed_offending_wells_) {
-            if (this->hasWell(to.second) && !this->wasDynamicallyShutThisTimeStep(to.second)) {
+            if (this->hasOpenLocalWell(to.second) &&
+                !this->wasDynamicallyShutThisTimeStep(to.second))
+            {
                 wellTestState.close_well(to.second, WellTestConfig::Reason::GROUP, simulationTime);
                 this->updateClosedWellsThisStep(to.second);
                 const std::string msg =
@@ -2379,7 +2381,7 @@ namespace Opm {
     template<typename TypeTag>
     bool
     BlackoilWellModel<TypeTag>::
-    hasWell(const std::string& well_name) const
+    hasOpenLocalWell(const std::string& well_name) const
     {
         return std::any_of(well_container_.begin(), well_container_.end(),
             [&well_name](const WellInterfacePtr& elem) -> bool

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2086,9 +2086,19 @@ namespace Opm {
         for (const auto& well : well_container_) {
             const auto& wname = well->name();
             const auto wasClosed = wellTestState.well_is_closed(wname);
-            well->checkWellOperability(simulator_, this->wellState(), local_deferredLogger);
-            const bool under_zero_target = well->wellUnderZeroGroupRateTarget(this->simulator_, this->wellState(), local_deferredLogger);
-            well->updateWellTestState(this->wellState().well(wname), simulationTime, /*writeMessageToOPMLog=*/ true, under_zero_target, wellTestState, local_deferredLogger);
+            well->checkWellOperability(simulator_,
+                                       this->wellState(),
+                                       local_deferredLogger);
+            const bool under_zero_target =
+                well->wellUnderZeroGroupRateTarget(this->simulator_,
+                                                   this->wellState(),
+                                                   local_deferredLogger);
+            well->updateWellTestState(this->wellState().well(wname),
+                                      simulationTime,
+                                      /*writeMessageToOPMLog=*/ true,
+                                      under_zero_target,
+                                      wellTestState,
+                                      local_deferredLogger);
 
             if (!wasClosed && wellTestState.well_is_closed(wname)) {
                 this->closed_this_step_.insert(wname);
@@ -2096,16 +2106,20 @@ namespace Opm {
         }
 
         const Opm::Parallel::Communication comm = grid().comm();
-        DeferredLogger global_deferredLogger = gatherDeferredLogger(local_deferredLogger, comm);
+        DeferredLogger global_deferredLogger =
+            gatherDeferredLogger(local_deferredLogger, comm);
 
         for (const auto& [group_name, to] : this->closed_offending_wells_) {
             if (this->hasOpenLocalWell(to.second) &&
                 !this->wasDynamicallyShutThisTimeStep(to.second))
             {
-                wellTestState.close_well(to.second, WellTestConfig::Reason::GROUP, simulationTime);
+                wellTestState.close_well(to.second,
+                                         WellTestConfig::Reason::GROUP,
+                                         simulationTime);
                 this->updateClosedWellsThisStep(to.second);
                 const std::string msg =
-                    fmt::format("Procedure on exceeding {} limit is WELL for group {}. Well {} is {}.",
+                    fmt::format("Procedure on exceeding {} limit is WELL for group {}. "
+                                "Well {} is {}.",
                                 to.first,
                                 group_name,
                                 to.second,


### PR DESCRIPTION
this to avoid confusion as there is already a hasWell in BlackoilWellModelGeneric which queries the schedule.
1) the one in BlackoilWellModelGeneric is renamed to hasLocalWell, as this queries list of all wells having connections on rank
2) the one in BlackoilWellModel is renamed to hasOpenWell, as this queries list of all open wells having connection on rank

Also moves the definition of hasOpenWell to the generic class