### PR TITLE
Bugfix/thread spawn

### DIFF
--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -125,13 +125,7 @@ struct MinTimeStepSize { static constexpr Scalar value = 0.0; };
 struct OutputDir { static constexpr auto value = ""; };
 
 //! \brief Number of threads per process.
-struct ThreadsPerProcess {
-#if _OPENMP
-  static constexpr int value = 2;
-#else
-  static constexpr int value = 1;
-#endif // _OPENMP
-};
+struct ThreadsPerProcess { static constexpr int value = 1; };
 
 } // namespace Opm::Parameters
 

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -125,7 +125,13 @@ struct MinTimeStepSize { static constexpr Scalar value = 0.0; };
 struct OutputDir { static constexpr auto value = ""; };
 
 //! \brief Number of threads per process.
-struct ThreadsPerProcess { static constexpr int value = 1; };
+struct ThreadsPerProcess {
+#if _OPENMP
+  static constexpr int value = 2;
+#else
+  static constexpr int value = 1;
+#endif // _OPENMP
+};
 
 } // namespace Opm::Parameters
 

--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -261,9 +261,9 @@ void BlackoilModelParameters<Scalar>::registerParameters()
 
     Parameters::Hide<Parameters::DebugEmitCellPartition>();
 
-    // if openMP is available, determine the number threads per process automatically.
+    // if openMP is available, use two threads per mpi rank by default
 #if _OPENMP
-    Parameters::SetDefault<Parameters::ThreadsPerProcess>(-1);
+    Parameters::SetDefault<Parameters::ThreadsPerProcess>(2);
 #endif
 }
 

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -310,10 +310,10 @@ namespace Opm {
                 }
             }
 
-            // We are not limiting this to the number of processes
-            // reported by OpenMP as on some hardware (and some OpenMPI
-            // versions) this will be 1 when run with mpirun
-            omp_set_num_threads(threads);
+            // Requesting -1 thread will let OMP automatically deduce the number
+            if (requested_threads != -1) {
+                omp_set_num_threads(threads);
+            }
 #endif
 
             using TM = GetPropType<TypeTag, Properties::ThreadManager>;

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -156,6 +156,9 @@ namespace Opm {
                 }
             }
 
+            // set the maximum limit on OMP threads
+            setMaxThreads();
+
             return status;
         }
 
@@ -278,6 +281,11 @@ namespace Opm {
             mpi_rank_ = comm.rank();
             mpi_size_ = comm.size();
 
+            setMaxThreads();
+        }
+
+        static void setMaxThreads()
+        {
 #if _OPENMP
             // If openMP is available, default to 2 threads per process unless
             // OMP_NUM_THREADS is set or command line --threads-per-process used.

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -302,10 +302,9 @@ namespace Opm {
                 if (result.ec == std::errc() && omp_num_threads > 0) {
                     // Set threads to omp_num_threads if it was successfully parsed and is positive
                     threads = omp_num_threads;
-                    // Warning in 'Main.hpp', where this code is duplicated
-                    // if (requested_threads > 0) {
-                    //     OpmLog::warning("Environment variable OMP_NUM_THREADS takes precedence over the --threads-per-process cmdline argument.");
-                    // }
+                    if (requested_threads > 0) {
+                        OpmLog::warning("Environment variable OMP_NUM_THREADS takes precedence over the --threads-per-process cmdline argument.");
+                    }
                 } else {
                     OpmLog::warning("Invalid value for OMP_NUM_THREADS environment variable.");
                 }

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -101,11 +101,10 @@ namespace Opm {
                 ("Developer option to see whether logging was on non-root processors. "
                  "In that case it will be appended to the *.DBG or *.PRT files");
 
-            ThreadManager::registerParameters();
-            Simulator::registerParameters();
-
             // register the base parameters
             registerAllParameters_<TypeTag>(/*finalizeRegistration=*/false);
+
+            Simulator::registerParameters();
 
             detail::hideUnusedParameters<Scalar>();
 

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -292,6 +292,7 @@ namespace Opm {
             // Issue a warning if both OMP_NUM_THREADS and --threads-per-process are set,
             // but let the environment variable take precedence.
             constexpr int default_threads = 2;
+            const bool isSet = Parameters::IsSet<Parameters::ThreadsPerProcess>();
             const int requested_threads = Parameters::Get<Parameters::ThreadsPerProcess>();
             int threads = requested_threads > 0 ? requested_threads : default_threads;
 
@@ -302,7 +303,7 @@ namespace Opm {
                 if (result.ec == std::errc() && omp_num_threads > 0) {
                     // Set threads to omp_num_threads if it was successfully parsed and is positive
                     threads = omp_num_threads;
-                    if (requested_threads > 0) {
+                    if (isSet) {
                         OpmLog::warning("Environment variable OMP_NUM_THREADS takes precedence over the --threads-per-process cmdline argument.");
                     }
                 } else {
@@ -311,7 +312,8 @@ namespace Opm {
             }
 
             // Requesting -1 thread will let OMP automatically deduce the number
-            if (requested_threads != -1) {
+            // but setting OMP_NUM_THREADS takes precedence.
+            if (env_var || !(isSet && requested_threads == -1)) {
                 omp_set_num_threads(threads);
             }
 #endif

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -731,6 +731,9 @@ private:
                     std::cout << ("Warning: Invalid value for OMP_NUM_THREADS environment variable.") << std::endl;
                 }
             }
+        } else {
+            // Set a limit to OMP threads. Defaults can saturate the whole machine.
+            omp_set_num_threads(threads);
         }
 
         first_time = false;

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -702,47 +702,11 @@ private:
 
     static int getNumThreads()
     {
-
-        int threads;
-
 #ifdef _OPENMP
-        // This function is called before the parallel OpenMP stuff gets initialized.
-        // That initialization happens after the deck is read and we want this message.
-        // Hence we duplicate the code of setupParallelism to get the number of threads.
-        static bool first_time = true;
-        constexpr int default_threads = 2;
-        const int requested_threads = Parameters::Get<Parameters::ThreadsPerProcess>();
-        threads = requested_threads > 0 ? requested_threads : default_threads;
-
-        const char* env_var = getenv("OMP_NUM_THREADS");
-        if (env_var) {
-            int omp_num_threads = -1;
-            auto result = std::from_chars(env_var, env_var + std::strlen(env_var), omp_num_threads);
-            const bool can_output = first_time && FlowGenericVanguard::comm().rank() == 0;
-            if (result.ec == std::errc() && omp_num_threads > 0) {
-                // Set threads to omp_num_threads if it was successfully parsed and is positive
-                threads = omp_num_threads;
-                if (can_output && requested_threads > 0) {
-                    std::cout << "Warning: Environment variable OMP_NUM_THREADS takes precedence over the --threads-per-process cmdline argument."
-                              << std::endl;
-                }
-            } else {
-                if (can_output) {
-                    std::cout << ("Warning: Invalid value for OMP_NUM_THREADS environment variable.") << std::endl;
-                }
-            }
-        }
-
-        if (threads != omp_get_max_threads()) {
-            // Set a limit to OMP threads. Defaults can saturate the whole machine.
-            omp_set_num_threads(threads);
-        }
-
-        first_time = false;
+        return omp_get_max_threads();
 #else
-        threads = 1;
+        return 1;
 #endif
-        return threads;
     }
 
 #if HAVE_DAMARIS

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -731,7 +731,9 @@ private:
                     std::cout << ("Warning: Invalid value for OMP_NUM_THREADS environment variable.") << std::endl;
                 }
             }
-        } else {
+        }
+
+        if (threads != omp_get_max_threads()) {
             // Set a limit to OMP threads. Defaults can saturate the whole machine.
             omp_set_num_threads(threads);
         }


### PR DESCRIPTION
Move the function setting the maximum number of threads to an earlier place, before the Deck is read which uses `#pragma parallel for`. This allows us to simplify the getNumThreads() in Main.hpp to just return the current maximum number of threads, so it no longer needs to guess the future setting.

In addition, `--threads-per-process=-1` is fixed to let OMP set the number of threads automatically, it is no longer rewritten to 2. The default number of threads is changed to 2 explicitly (it was -1 that got rewritten to 2). The change of defaults will require a change in the reference manual.