### PR TITLE
Bugfix: Upon restart, do not try to restore segment info for inactive wells

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelRestart.cpp
+++ b/opm/simulators/wells/BlackoilWellModelRestart.cpp
@@ -256,7 +256,7 @@ loadRestartData(const data::Wells&                 rst_wells,
     {
         const auto& well_name = well_state.name(well_index);
 
-        this->loadRestartWellData(well_name, handle_ms_well, phs,
+        this->loadRestartWellData(well_name, handle_ms_well & !well_state.is_permanently_inactive_well(well_name), phs,
                                   rst_wells.at(well_name),
                                   wellModel_.perfData(well_index),
                                   well_state.well(well_index));

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -360,12 +360,12 @@ public:
         serializer(permanently_inactive_well_names_);
     }
 
-private:
-    bool enableDistributedWells_ = false;
-
     bool is_permanently_inactive_well(const std::string& wname) const {
         return std::find(this->permanently_inactive_well_names_.begin(), this->permanently_inactive_well_names_.end(), wname) != this->permanently_inactive_well_names_.end();
     }
+
+private:
+    bool enableDistributedWells_ = false;
 
     PhaseUsage phase_usage_;
 


### PR DESCRIPTION
Fallout from https://github.com/OPM/opm-simulators/pull/5751  (causes segfault if any well present in the restart is found to be inactive in the restarted run).