### PR TITLE
fixed: don't run parallel pyaction tests without mpi

### DIFF
--- a/pyactionComparisons.cmake
+++ b/pyactionComparisons.cmake
@@ -25,17 +25,6 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_gconsump_insert_kw
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_gconsump_insert_kw_4_procs
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_GCONSUMP_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_GCONSUMP
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 4)
-
 add_test_compareSeparateECLFiles(CASENAME pyaction_gruptree_insert_kw
                                  DIR1 pyaction
                                  FILENAME1 PYACTION_GRUPTREE_INSERT_KW
@@ -56,17 +45,6 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_mult+_insert_kw
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_mult+_insert_kw_4_procs
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_MULT+_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_MULT+
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 4)
-
 add_test_compareSeparateECLFiles(CASENAME pyaction_multx+_insert_kw
                                  DIR1 pyaction
                                  FILENAME1 PYACTION_MULTX+_INSERT_KW
@@ -76,17 +54,6 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_multx+_insert_kw
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
-
-add_test_compareSeparateECLFiles(CASENAME pyaction_multx+_insert_kw_4_procs
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_MULTX+_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_MULTX+
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 4)
 
 add_test_compareSeparateECLFiles(CASENAME pyaction_multx-_insert_kw
                                  DIR1 pyaction
@@ -98,17 +65,6 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_multx-_insert_kw
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_multx-_insert_kw_4_procs
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_MULTX-_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_MULTX-
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 4)
-
 add_test_compareSeparateECLFiles(CASENAME pyaction_next_insert_kw
                                  DIR1 pyaction
                                  FILENAME1 PYACTION_NEXT_INSERT_KW
@@ -118,17 +74,6 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_next_insert_kw
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
-
-add_test_compareSeparateECLFiles(CASENAME pyaction_next_insert_kw_4_procs
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_NEXT_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_NEXT
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 4)
 
 add_test_compareSeparateECLFiles(CASENAME pyaction_wconprod_insert_kw
                                  DIR1 pyaction
@@ -160,17 +105,6 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wsegvalv_insert_kw
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_wsegvalv_insert_kw_4_procs
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WSEGVALV_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WSEGVALV
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 4)
-
 add_test_compareSeparateECLFiles(CASENAME actionx_wlist
                                  DIR1 udq_actionx
                                  FILENAME1 ACTIONX_M1
@@ -180,17 +114,6 @@ add_test_compareSeparateECLFiles(CASENAME actionx_wlist
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
-
-add_test_compareSeparateECLFiles(CASENAME actionx_wlist_4_procs
-                                 DIR1 udq_actionx
-                                 FILENAME1 ACTIONX_M1
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WLIST
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 4)
 
 add_test_compareSeparateECLFiles(CASENAME pyaction_wlist_insert_kw
                                  DIR1 pyaction
@@ -202,17 +125,6 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wlist_insert_kw
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_wlist_insert_kw_4_procs
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WLIST_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WLIST
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 4)
-
 add_test_compareSeparateECLFiles(CASENAME pyaction_wtest_insert_kw
                                  DIR1 pyaction
                                  FILENAME1 PYACTION_WTEST_INSERT_KW
@@ -222,17 +134,6 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wtest_insert_kw
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
-
-add_test_compareSeparateECLFiles(CASENAME pyaction_wtest_insert_kw_4_procs
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WTEST_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WTEST
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 4)
 
 add_test_compareSeparateECLFiles(CASENAME pyaction_WTMULT_insert_kw
                                  DIR1 pyaction
@@ -244,14 +145,114 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_WTMULT_insert_kw
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
 
-add_test_compareSeparateECLFiles(CASENAME pyaction_WTMULT_insert_kw_4_procs
-                                 DIR1 pyaction
-                                 FILENAME1 PYACTION_WTMULT_INSERT_KW
-                                 DIR2 actionx
-                                 FILENAME2 ACTIONX_WTMULT
-                                 SIMULATOR flow
-                                 ABS_TOL ${abs_tol}
-                                 REL_TOL ${rel_tol}
-                                 IGNORE_EXTRA_KW BOTH
-                                 MPI_PROCS 4)
+if(MPI_FOUND)
+  add_test_compareSeparateECLFiles(CASENAME pyaction_gconsump_insert_kw_4_procs
+                                   DIR1 pyaction
+                                   FILENAME1 PYACTION_GCONSUMP_INSERT_KW
+                                   DIR2 actionx
+                                   FILENAME2 ACTIONX_GCONSUMP
+                                   SIMULATOR flow
+                                   ABS_TOL ${abs_tol}
+                                   REL_TOL ${rel_tol}
+                                   IGNORE_EXTRA_KW BOTH
+                                   MPI_PROCS 4)
 
+  add_test_compareSeparateECLFiles(CASENAME pyaction_multx+_insert_kw_4_procs
+                                   DIR1 pyaction
+                                   FILENAME1 PYACTION_MULTX+_INSERT_KW
+                                   DIR2 actionx
+                                   FILENAME2 ACTIONX_MULTX+
+                                   SIMULATOR flow
+                                   ABS_TOL ${abs_tol}
+                                   REL_TOL ${rel_tol}
+                                   IGNORE_EXTRA_KW BOTH
+                                   MPI_PROCS 4)
+
+  add_test_compareSeparateECLFiles(CASENAME pyaction_mult+_insert_kw_4_procs
+                                   DIR1 pyaction
+                                   FILENAME1 PYACTION_MULT+_INSERT_KW
+                                   DIR2 actionx
+                                   FILENAME2 ACTIONX_MULT+
+                                   SIMULATOR flow
+                                   ABS_TOL ${abs_tol}
+                                   REL_TOL ${rel_tol}
+                                   IGNORE_EXTRA_KW BOTH
+                                   MPI_PROCS 4)
+
+  add_test_compareSeparateECLFiles(CASENAME pyaction_multx-_insert_kw_4_procs
+                                   DIR1 pyaction
+                                   FILENAME1 PYACTION_MULTX-_INSERT_KW
+                                   DIR2 actionx
+                                   FILENAME2 ACTIONX_MULTX-
+                                   SIMULATOR flow
+                                   ABS_TOL ${abs_tol}
+                                   REL_TOL ${rel_tol}
+                                   IGNORE_EXTRA_KW BOTH
+                                   MPI_PROCS 4)
+
+  add_test_compareSeparateECLFiles(CASENAME pyaction_next_insert_kw_4_procs
+                                   DIR1 pyaction
+                                   FILENAME1 PYACTION_NEXT_INSERT_KW
+                                   DIR2 actionx
+                                   FILENAME2 ACTIONX_NEXT
+                                   SIMULATOR flow
+                                   ABS_TOL ${abs_tol}
+                                   REL_TOL ${rel_tol}
+                                   IGNORE_EXTRA_KW BOTH
+                                   MPI_PROCS 4)
+
+  add_test_compareSeparateECLFiles(CASENAME pyaction_wsegvalv_insert_kw_4_procs
+                                   DIR1 pyaction
+                                   FILENAME1 PYACTION_WSEGVALV_INSERT_KW
+                                   DIR2 actionx
+                                   FILENAME2 ACTIONX_WSEGVALV
+                                   SIMULATOR flow
+                                   ABS_TOL ${abs_tol}
+                                   REL_TOL ${rel_tol}
+                                   IGNORE_EXTRA_KW BOTH
+                                   MPI_PROCS 4)
+
+  add_test_compareSeparateECLFiles(CASENAME pyaction_WTMULT_insert_kw_4_procs
+                                   DIR1 pyaction
+                                   FILENAME1 PYACTION_WTMULT_INSERT_KW
+                                   DIR2 actionx
+                                   FILENAME2 ACTIONX_WTMULT
+                                   SIMULATOR flow
+                                   ABS_TOL ${abs_tol}
+                                   REL_TOL ${rel_tol}
+                                   IGNORE_EXTRA_KW BOTH
+                                   MPI_PROCS 4)
+
+  add_test_compareSeparateECLFiles(CASENAME actionx_wlist_4_procs
+                                   DIR1 udq_actionx
+                                   FILENAME1 ACTIONX_M1
+                                   DIR2 actionx
+                                   FILENAME2 ACTIONX_WLIST
+                                   SIMULATOR flow
+                                   ABS_TOL ${abs_tol}
+                                   REL_TOL ${rel_tol}
+                                   IGNORE_EXTRA_KW BOTH
+                                   MPI_PROCS 4)
+
+  add_test_compareSeparateECLFiles(CASENAME pyaction_wlist_insert_kw_4_procs
+                                   DIR1 pyaction
+                                   FILENAME1 PYACTION_WLIST_INSERT_KW
+                                   DIR2 actionx
+                                   FILENAME2 ACTIONX_WLIST
+                                   SIMULATOR flow
+                                   ABS_TOL ${abs_tol}
+                                   REL_TOL ${rel_tol}
+                                   IGNORE_EXTRA_KW BOTH
+                                   MPI_PROCS 4)
+
+  add_test_compareSeparateECLFiles(CASENAME pyaction_wtest_insert_kw_4_procs
+                                   DIR1 pyaction
+                                   FILENAME1 PYACTION_WTEST_INSERT_KW
+                                   DIR2 actionx
+                                   FILENAME2 ACTIONX_WTEST
+                                   SIMULATOR flow
+                                   ABS_TOL ${abs_tol}
+                                   REL_TOL ${rel_tol}
+                                   IGNORE_EXTRA_KW BOTH
+                                   MPI_PROCS 4)
+endif()


### PR DESCRIPTION
Regression from https://github.com/OPM/opm-simulators/pull/5860

I would have caught this but had no time to review before it was merged.