### PR TITLE
BlackoilModel: make wasSwitched_ private

### DIFF
--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -1378,7 +1378,6 @@ namespace Opm {
         ConvergenceReport::PenaltyCard total_penaltyCard_;
         double prev_distance_ = std::numeric_limits<double>::infinity();
         int prev_above_tolerance_ = 0;
-    public:
         std::vector<bool> wasSwitched_;
     };
 


### PR DESCRIPTION
No idea why this was public in the first place, but in any case there does not seem to be a reason any longer.