### PR TITLE
Fix WCYCLE for multiple blocks

### DIFF
--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -590,7 +590,7 @@ foreach(templ_case RANGE 1 6)
   )
 endforeach()
 
-foreach(wcycle_case RANGE 0 7)
+foreach(wcycle_case RANGE 0 8)
   add_test_compareECLFiles(CASENAME WCYCLE-${wcycle_case}
     FILENAME WCYCLE-${wcycle_case}
     SIMULATOR flow


### PR DESCRIPTION
This fixes WCYCLE when there are multiple WCYCLE blocks, multiple cycling well and these are combined with manual WELOPEN statements. Downstream of https://github.com/OPM/opm-common/pull/4426 and requires https://github.com/OPM/opm-tests/pull/1282