### PR TITLE
Add nonstatic blackoilfluidsystem

### DIFF
--- a/opm/models/blackoil/blackoilenergymodules.hh
+++ b/opm/models/blackoil/blackoilenergymodules.hh
@@ -384,10 +384,12 @@ public:
      * \brief Compute the intensive quantities needed to handle energy conservation
      *
      */
+    template <class FluidSystemT = FluidSystem>
     void updateEnergyQuantities_(const ElementContext& elemCtx,
                                  unsigned dofIdx,
                                  unsigned timeIdx,
-                                 const typename FluidSystem::template ParameterCache<Evaluation>& paramCache)
+                                 const typename FluidSystem::template ParameterCache<Evaluation>& paramCache,
+                                 const FluidSystemT& fluidSystem = FluidSystemT{})
     {
         auto& fs = asImp_().fluidState_;
 
@@ -398,7 +400,7 @@ public:
                 continue;
             }
 
-            const auto& h = FluidSystem::enthalpy(fs, paramCache, phaseIdx);
+            const auto& h = fluidSystem.enthalpy(fs, paramCache, phaseIdx);
             fs.setEnthalpy(phaseIdx, h);
         }
 
@@ -479,10 +481,12 @@ public:
         }
     }
 
+    template <class FluidSystemT = FluidSystem>
     void updateEnergyQuantities_(const ElementContext&,
                                  unsigned,
                                  unsigned,
-                                 const typename FluidSystem::template ParameterCache<Evaluation>&)
+                                 const typename FluidSystem::template ParameterCache<Evaluation>&,
+                                 const FluidSystemT&)
     { }
 
     const Evaluation& rockInternalEnergy() const

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -558,7 +558,7 @@ public:
 
         fluidState_.setPvtRegionIndex(pvtRegionIdx);
 
-        updateTempSalt(elemCtx, dofIdx, timeIdx, fluidSystem);
+        updateTempSalt(elemCtx, dofIdx, timeIdx);
         updateSaturations(elemCtx, dofIdx, timeIdx, fluidSystem);
         updateRelpermAndPressures(elemCtx, dofIdx, timeIdx, fluidSystem);
 

--- a/opm/models/flash/flashintensivequantities.hh
+++ b/opm/models/flash/flashintensivequantities.hh
@@ -101,7 +101,7 @@ public:
      * \copydoc IntensiveQuantities::update
      */
     template <class DynamicFluidSystem = FluidSystem>
-    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx, const DynamicFluidSystem& fluidSystem = DynamicFluidSystem{})
+    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx, [[maybe_unused]] const DynamicFluidSystem& fluidSystem = DynamicFluidSystem{})
     {
         ParentType::update(elemCtx, dofIdx, timeIdx);
         EnergyIntensiveQuantities::updateTemperatures_(fluidState_, elemCtx, dofIdx, timeIdx);

--- a/opm/models/flash/flashintensivequantities.hh
+++ b/opm/models/flash/flashintensivequantities.hh
@@ -100,7 +100,8 @@ public:
     /*!
      * \copydoc IntensiveQuantities::update
      */
-    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
+    template <class DynamicFluidSystem = FluidSystem>
+    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx, const DynamicFluidSystem& fluidSystem = DynamicFluidSystem{})
     {
         ParentType::update(elemCtx, dofIdx, timeIdx);
         EnergyIntensiveQuantities::updateTemperatures_(fluidState_, elemCtx, dofIdx, timeIdx);

--- a/opm/models/immiscible/immiscibleintensivequantities.hh
+++ b/opm/models/immiscible/immiscibleintensivequantities.hh
@@ -90,7 +90,8 @@ public:
     /*!
      * \copydoc IntensiveQuantities::update
      */
-    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
+    template <class DynamicFluidSystem = FluidSystem>
+    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx, const DynamicFluidSystem& fluidSystem = DynamicFluidSystem{})
     {
         ParentType::update(elemCtx, dofIdx, timeIdx);
         EnergyIntensiveQuantities::updateTemperatures_(fluidState_, elemCtx, dofIdx, timeIdx);

--- a/opm/models/ncp/ncpintensivequantities.hh
+++ b/opm/models/ncp/ncpintensivequantities.hh
@@ -97,9 +97,11 @@ public:
     /*!
      * \brief IntensiveQuantities::update
      */
+    template <class DynamicFluidSystem = FluidSystem>
     void update(const ElementContext& elemCtx,
                 unsigned dofIdx,
-                unsigned timeIdx)
+                unsigned timeIdx,
+                const DynamicFluidSystem& fluidSystem = DynamicFluidSystem{})
     {
         ParentType::update(elemCtx, dofIdx, timeIdx);
         ParentType::checkDefined();

--- a/opm/models/ptflash/flashintensivequantities.hh
+++ b/opm/models/ptflash/flashintensivequantities.hh
@@ -102,7 +102,8 @@ public:
     /*!
      * \copydoc IntensiveQuantities::update
      */
-    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
+    template <class DynamicFluidSystem = FluidSystem>
+    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx, const DynamicFluidSystem& fluidSystem = DynamicFluidSystem{})
     {
         ParentType::update(elemCtx, dofIdx, timeIdx);
         EnergyIntensiveQuantities::updateTemperatures_(fluidState_, elemCtx, dofIdx, timeIdx);

--- a/opm/models/ptflash/flashintensivequantities.hh
+++ b/opm/models/ptflash/flashintensivequantities.hh
@@ -103,7 +103,7 @@ public:
      * \copydoc IntensiveQuantities::update
      */
     template <class DynamicFluidSystem = FluidSystem>
-    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx, const DynamicFluidSystem& fluidSystem = DynamicFluidSystem{})
+    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx, [[maybe_unused]] const DynamicFluidSystem& fluidSystem = DynamicFluidSystem{})
     {
         ParentType::update(elemCtx, dofIdx, timeIdx);
         EnergyIntensiveQuantities::updateTemperatures_(fluidState_, elemCtx, dofIdx, timeIdx);

--- a/opm/models/pvs/pvsintensivequantities.hh
+++ b/opm/models/pvs/pvsintensivequantities.hh
@@ -106,7 +106,7 @@ public:
      * \copydoc ImmiscibleIntensiveQuantities::update
      */
     template <class DynamicFluidSystem = FluidSystem>
-    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx, const DynamicFluidSystem& fluidSystem = DynamicFluidSystem{})
+    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx, [[maybe_unused]] const DynamicFluidSystem& fluidSystem = DynamicFluidSystem{})
     {
         ParentType::update(elemCtx, dofIdx, timeIdx);
         EnergyIntensiveQuantities::updateTemperatures_(fluidState_, elemCtx, dofIdx, timeIdx);

--- a/opm/models/pvs/pvsintensivequantities.hh
+++ b/opm/models/pvs/pvsintensivequantities.hh
@@ -105,7 +105,8 @@ public:
     /*!
      * \copydoc ImmiscibleIntensiveQuantities::update
      */
-    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
+    template <class DynamicFluidSystem = FluidSystem>
+    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx, const DynamicFluidSystem& fluidSystem = DynamicFluidSystem{})
     {
         ParentType::update(elemCtx, dofIdx, timeIdx);
         EnergyIntensiveQuantities::updateTemperatures_(fluidState_, elemCtx, dofIdx, timeIdx);

--- a/opm/models/richards/richardsintensivequantities.hh
+++ b/opm/models/richards/richardsintensivequantities.hh
@@ -84,7 +84,8 @@ public:
     /*!
      * \copydoc IntensiveQuantities::update
      */
-    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
+    template <class DynamicFluidSystem = FluidSystem>
+    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx, const DynamicFluidSystem& fluidSystem = DynamicFluidSystem{})
     {
         ParentType::update(elemCtx, dofIdx, timeIdx);
 

--- a/opm/simulators/flow/FIBlackoilModel.hpp
+++ b/opm/simulators/flow/FIBlackoilModel.hpp
@@ -105,12 +105,7 @@ public:
     {
 
         using DynamicFluidSystem = std::remove_reference_t<decltype(LocalFluidSystem::getNonStatic())>;
-        // static constexpr bool use_dynamic_fluidsystem = is_a_dynamic_blackoil_system<DynamicFluidSystem>;
-
         DynamicFluidSystem* fluidSystemInstance = &LocalFluidSystem::getNonStatic();
-        // if constexpr (use_dynamic_fluidsystem) {
-        //     fluidSystemInstance = &LocalFluidSystem::getNonStatic();
-        // }
 
         this->invalidateIntensiveQuantitiesCache(timeIdx);
         OPM_BEGIN_PARALLEL_TRY_CATCH();


### PR DESCRIPTION
Add support for a dynamically allocated `BlackOilFluidSystem` (BOFS) object. The purpose of this is to avoid dependence on statically allocated data when later BOFS on the GPU.