### PR TITLE
Add missing return type to check_simulation_finished function of BlackOilSimulator.

### DIFF
--- a/python/docstrings_simulators.json
+++ b/python/docstrings_simulators.json
@@ -18,7 +18,7 @@
     },
     "checkSimulationFinished": {
         "signature": "opm.simulators.BlackOilSimulator.check_simulation_finished() -> bool",
-        "doc": "Checks if the simulation has finished.\n\n:return: True if the simulation is finished, False otherwise."
+        "doc": "Checks if the simulation has finished.\n\n:return: True if the simulation is finished, False otherwise.\n:type return: bool"
     },
     "currentStep": {
         "signature": "opm.simulators.BlackOilSimulator.current_step() -> int",


### PR DESCRIPTION
This PR is to test the automatic build of the python documentation at https://github.com/OPM/opm-python-documentation.