### PR TITLE
OutputBlackoilModule: move some more code to GenericOutputBlackoilModule

### DIFF
--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -48,6 +48,13 @@
 #include <utility>
 #include <vector>
 
+namespace Opm::Parameters {
+
+struct ForceDisableFluidInPlaceOutput { static constexpr bool value = false; };
+struct ForceDisableResvFluidInPlaceOutput { static constexpr bool value = false; };
+
+} // namespace Opm::Parameters
+
 namespace Opm {
 
 namespace data { class Solution; }
@@ -65,13 +72,20 @@ public:
     // Virtual destructor for safer inheritance.
     virtual ~GenericOutputBlackoilModule();
 
-     Scalar* getPRESSURE_ptr(void) {
-        return (this->fluidPressure_.data()) ;
-    };
+    Scalar* getPRESSURE_ptr()
+    {
+        return this->fluidPressure_.data();
+    }
 
-    int  getPRESSURE_size( void ) {
-        return (this->fluidPressure_.size()) ;
-    };
+    int getPRESSURE_size()
+    {
+        return this->fluidPressure_.size();
+    }
+
+    /*!
+     * \brief Register all run-time parameters for the Vtk output module.
+     */
+    static void registerParameters();
 
     void outputTimeStamp(const std::string& lbl,
                          double elapsed,

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -65,15 +65,7 @@
 #include <utility>
 #include <vector>
 
-namespace Opm::Parameters {
-
-struct ForceDisableFluidInPlaceOutput { static constexpr bool value = false; };
-struct ForceDisableResvFluidInPlaceOutput { static constexpr bool value = false; };
-
-} // namespace Opm::Parameters
-
-namespace Opm
-{
+namespace Opm {
 
 // forward declaration
 template <class TypeTag>
@@ -146,12 +138,6 @@ public:
 
         this->setupBlockData(isCartIdxOnThisRank);
 
-        this->forceDisableFipOutput_ =
-            Parameters::Get<Parameters::ForceDisableFluidInPlaceOutput>();
-
-        this->forceDisableFipresvOutput_ =
-            Parameters::Get<Parameters::ForceDisableResvFluidInPlaceOutput>();
-
         if (! Parameters::Get<Parameters::OwnerCellsFirst>()) {
             const std::string msg = "The output code does not support --owner-cells-first=false.";
             if (collectToIORank.isIORank()) {
@@ -174,19 +160,6 @@ public:
                          (const std::string& rsetName) -> decltype(auto)
                          { return fp.get().get_int(rsetName); });
         }
-    }
-
-    /*!
-     * \brief Register all run-time parameters for the Vtk output module.
-     */
-    static void registerParameters()
-    {
-        Parameters::Register<Parameters::ForceDisableFluidInPlaceOutput>
-            ("Do not print fluid-in-place values after each report step "
-             "even if requested by the deck.");
-        Parameters::Register<Parameters::ForceDisableResvFluidInPlaceOutput>
-            ("Do not print reservoir volumes values after each report step "
-             "even if requested by the deck.");
     }
 
     /*!


### PR DESCRIPTION
typetag less parameter system now allows us to initialize these variables in class that holds them.