### PR TITLE
Compositional simulations with more cubic EOS formulations

### DIFF
--- a/examples/problems/co2ptflashproblem.hh
+++ b/examples/problems/co2ptflashproblem.hh
@@ -30,6 +30,8 @@
 
 #include <opm/common/Exceptions.hpp>
 
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
+
 #include <opm/material/components/SimpleCO2.hpp>
 #include <opm/material/components/C10.hpp>
 #include <opm/material/components/C1.hpp>
@@ -247,6 +249,11 @@ public:
     const DimVector& gravity() const
     {
         return gravity_;
+    }
+
+    Opm::CompositionalConfig::EOSType getEosType() const
+    {
+        return Opm::CompositionalConfig::EOSType::PR;
     }
 
     /*!

--- a/opm/models/ptflash/flashintensivequantities.hh
+++ b/opm/models/ptflash/flashintensivequantities.hh
@@ -178,7 +178,8 @@ public:
             const int spatialIdx = elemCtx.globalSpaceIndex(dofIdx, timeIdx);
             std::cout << " updating the intensive quantities for Cell " << spatialIdx << std::endl;
         }
-        FlashSolver::solve(fluidState_, flashTwoPhaseMethod, flashTolerance, flashVerbosity);
+        const auto& eos_type = problem.getEosType();
+        FlashSolver::solve(fluidState_, flashTwoPhaseMethod, flashTolerance, eos_type, flashVerbosity);
 
         if (flashVerbosity >= 5) {
             // printing of flash result after solve
@@ -203,7 +204,7 @@ public:
 
 
         // Update phases
-        typename FluidSystem::template ParameterCache<Evaluation> paramCache;
+        typename FluidSystem::template ParameterCache<Evaluation> paramCache(eos_type);
         paramCache.updatePhase(fluidState_, FluidSystem::oilPhaseIdx);
 
         const Scalar R = Opm::Constants<Scalar>::R;

--- a/opm/simulators/flow/FlowProblemComp.hpp
+++ b/opm/simulators/flow/FlowProblemComp.hpp
@@ -351,7 +351,7 @@ public:
             }
 
             {
-		const auto& eos_type = getEosType();
+		        const auto& eos_type = getEosType();
                 typename FluidSystem::template ParameterCache<Scalar> paramCache(eos_type);
                 paramCache.updatePhase(fs, FluidSystem::oilPhaseIdx);
                 paramCache.updatePhase(fs, FluidSystem::gasPhaseIdx);

--- a/opm/simulators/flow/FlowProblemComp.hpp
+++ b/opm/simulators/flow/FlowProblemComp.hpp
@@ -39,6 +39,7 @@
 
 #include <opm/material/thermal/EclThermalLawManager.hpp>
 
+#include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
 
 #include <algorithm>
 #include <functional>
@@ -103,7 +104,13 @@ public:
         // tighter tolerance is needed for compositional modeling here
         Parameters::SetDefault<Parameters::NewtonTolerance<Scalar>>(1e-7);
     }
-
+    
+    Opm::CompositionalConfig::EOSType getEosType() const
+    {
+        auto& simulator = this->simulator();
+        const auto& eclState = simulator.vanguard().eclState();
+        return eclState.compositionalConfig().eosType(0);
+    }
 
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
@@ -344,7 +351,8 @@ public:
             }
 
             {
-                typename FluidSystem::template ParameterCache<Scalar> paramCache;
+		const auto& eos_type = getEosType();
+                typename FluidSystem::template ParameterCache<Scalar> paramCache(eos_type);
                 paramCache.updatePhase(fs, FluidSystem::oilPhaseIdx);
                 paramCache.updatePhase(fs, FluidSystem::gasPhaseIdx);
                 fs.setDensity(FluidSystem::oilPhaseIdx, FluidSystem::density(fs, paramCache, FluidSystem::oilPhaseIdx));

--- a/opm/simulators/flow/FlowProblemComp.hpp
+++ b/opm/simulators/flow/FlowProblemComp.hpp
@@ -351,7 +351,7 @@ public:
             }
 
             {
-		        const auto& eos_type = getEosType();
+                const auto& eos_type = getEosType();
                 typename FluidSystem::template ParameterCache<Scalar> paramCache(eos_type);
                 paramCache.updatePhase(fs, FluidSystem::oilPhaseIdx);
                 paramCache.updatePhase(fs, FluidSystem::gasPhaseIdx);


### PR DESCRIPTION
Use the changes in https://github.com/OPM/opm-common/pull/4429 to accommodate for other EOS formulations given by the keyword `EOS`. Available EOS formulations are now `PR`, `PRCORR`, `RK` and `SRK`.