### PR TITLE
fixing compilation related to conversion from std::optional

### DIFF
--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -334,11 +334,11 @@ updateGuideRatesForInjectionGroups(const Group& group,
                              deferred_logger);
         }
 
-        const UnitSystem& unit_system = schedule.getUnits();
         if (guideRateValue) {
+            const UnitSystem& unit_system = schedule.getUnits();
             guideRateValue = unit_system.from_si(UnitSystem::measure::rate, *guideRateValue);
         }
-        guideRate->compute(group.name(), phase, reportStepIdx, guideRateValue);
+        guideRate->compute(group.name(), phase, reportStepIdx, guideRateValue.value_or(0.0));
     }
 }
 


### PR DESCRIPTION
The following compilation error did not show up with the master branch, but it showed up when I tried to compile https://github.com/OPM/opm-simulators/pull/5851 and it caused some hassle. 

Not sure what is the exact reason, but just propose a solution here for discussion. 

```
/home/kaib/OPM-devel3/opm/opm-common/opm/input/eclipse/Schedule/Group/GuideRate.hpp:125:10: note: candidate: ‘void Opm::GuideRate::compute(const std::string&, const Opm::Phase&, std::size_t, double)’
  125 |     void compute(const std::string& wgname,
      |          ^~~~~~~
/home/kaib/OPM-devel3/opm/opm-common/opm/input/eclipse/Schedule/Group/GuideRate.hpp:128:37: note:   no known conversion for argument 4 from ‘std::optional<double>’ to ‘double’
  128 |                  const double       guide_rate);
      |                  ~~~~~~~~~~~~~~~~~~~^~~~~~~~~
```
