### PR TITLE
Add multi-threading to transmissibility calculation

### DIFF
--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -294,6 +294,8 @@ update(bool global, const TransUpdateQuantities update_quantities,
                                           MapBuilderInsertionMode::Insert_Or_Assign);
     ThreadSafeMapBuilder diffusivity(diffusivity_, 1,
                                      MapBuilderInsertionMode::Insert_Or_Assign);
+    ThreadSafeMapBuilder dispersivity(dispersivity_, 1,
+                                      MapBuilderInsertionMode::Insert_Or_Assign);
 
     // compute the transmissibilities for all intersections
     for (const auto& elem : elements(gridView_)) {
@@ -416,7 +418,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
                     diffusivity.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx), 0.0);
                 }
                 if (updateDispersivity && !onlyTrans) {
-                    dispersivity_.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx), 0.0);
+                    dispersivity.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx), 0.0);
                 }
                 continue;
             }
@@ -487,8 +489,8 @@ update(bool global, const TransUpdateQuantities update_quantities,
 
             // update the "dispersivity half transmissibility" for the intersection
             if (updateDispersivity && !onlyTrans) {
-                dispersivity_.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx),
-                                               computeHalfMean(halfDiff, dispersion_));
+                dispersivity.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx),
+                                              computeHalfMean(halfDiff, dispersion_));
             }
         }
     }
@@ -499,6 +501,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
     thermalHalfTransBoundary.finalize();
     thermalHalfTrans.finalize();
     diffusivity.finalize();
+    dispersivity.finalize();
 
     // Potentially overwrite and/or modify transmissibilities based on input from deck
     this->updateFromEclState_(global);

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -286,6 +286,8 @@ update(bool global, const TransUpdateQuantities update_quantities,
 
     ThreadSafeMapBuilder transBoundary(transBoundary_, 1,
                                        MapBuilderInsertionMode::Insert_Or_Assign);
+    ThreadSafeMapBuilder transMap(trans_, 1,
+                                  MapBuilderInsertionMode::Insert_Or_Assign);
 
     // compute the transmissibilities for all intersections
     for (const auto& elem : elements(gridView_)) {
@@ -398,7 +400,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
                 // NNC. Set zero transmissibility, as it will be
                 // *added to* by applyNncToGridTrans_() later.
                 assert(outside.faceIdx == -1);
-                trans_.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx), 0.0);
+                transMap.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx), 0.0);
                 if (enableEnergy_ && !onlyTrans) {
                     thermalHalfTrans_.insert_or_assign(details::directionalIsId(inside.elemIdx, outside.elemIdx), 0.0);
                     thermalHalfTrans_.insert_or_assign(details::directionalIsId(outside.elemIdx, inside.elemIdx), 0.0);
@@ -459,7 +461,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
                                                    outside.cartElemIdx,
                                                    faceIdToDir(inside.faceIdx));
 
-            trans_.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx), trans);
+            transMap.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx), trans);
 
             // update the "thermal half transmissibility" for the intersection
             if (enableEnergy_ && !onlyTrans) {
@@ -487,6 +489,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
     centroids_cache_.clear();
 
     transBoundary.finalize();
+    transMap.finalize();
 
     // Potentially overwrite and/or modify transmissibilities based on input from deck
     this->updateFromEclState_(global);

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -290,6 +290,8 @@ update(bool global, const TransUpdateQuantities update_quantities,
                                   MapBuilderInsertionMode::Insert_Or_Assign);
     ThreadSafeMapBuilder thermalHalfTransBoundary(thermalHalfTransBoundary_, 1,
                                                   MapBuilderInsertionMode::Insert_Or_Assign);
+    ThreadSafeMapBuilder thermalHalfTrans(thermalHalfTrans_, 1,
+                                          MapBuilderInsertionMode::Insert_Or_Assign);
 
     // compute the transmissibilities for all intersections
     for (const auto& elem : elements(gridView_)) {
@@ -404,8 +406,8 @@ update(bool global, const TransUpdateQuantities update_quantities,
                 assert(outside.faceIdx == -1);
                 transMap.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx), 0.0);
                 if (enableEnergy_ && !onlyTrans) {
-                    thermalHalfTrans_.insert_or_assign(details::directionalIsId(inside.elemIdx, outside.elemIdx), 0.0);
-                    thermalHalfTrans_.insert_or_assign(details::directionalIsId(outside.elemIdx, inside.elemIdx), 0.0);
+                    thermalHalfTrans.insert_or_assign(details::directionalIsId(inside.elemIdx, outside.elemIdx), 0.0);
+                    thermalHalfTrans.insert_or_assign(details::directionalIsId(outside.elemIdx, inside.elemIdx), 0.0);
                 }
 
                 if (updateDiffusivity && !onlyTrans) {
@@ -469,10 +471,10 @@ update(bool global, const TransUpdateQuantities update_quantities,
             if (enableEnergy_ && !onlyTrans) {
                 const auto half = computeHalf(halfDiff, 1.0, 1.0);
                 // TODO Add support for multipliers
-                thermalHalfTrans_.insert_or_assign(details::directionalIsId(inside.elemIdx, outside.elemIdx),
-                                                   half[0]);
-                thermalHalfTrans_.insert_or_assign(details::directionalIsId(outside.elemIdx, inside.elemIdx),
-                                                   half[1]);
+                thermalHalfTrans.insert_or_assign(details::directionalIsId(inside.elemIdx, outside.elemIdx),
+                                                  half[0]);
+                thermalHalfTrans.insert_or_assign(details::directionalIsId(outside.elemIdx, inside.elemIdx),
+                                                  half[1]);
             }
 
             // update the "diffusive half transmissibility" for the intersection
@@ -493,6 +495,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
     transBoundary.finalize();
     transMap.finalize();
     thermalHalfTransBoundary.finalize();
+    thermalHalfTrans.finalize();
 
     // Potentially overwrite and/or modify transmissibilities based on input from deck
     this->updateFromEclState_(global);

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -292,6 +292,8 @@ update(bool global, const TransUpdateQuantities update_quantities,
                                                   MapBuilderInsertionMode::Insert_Or_Assign);
     ThreadSafeMapBuilder thermalHalfTrans(thermalHalfTrans_, 1,
                                           MapBuilderInsertionMode::Insert_Or_Assign);
+    ThreadSafeMapBuilder diffusivity(diffusivity_, 1,
+                                     MapBuilderInsertionMode::Insert_Or_Assign);
 
     // compute the transmissibilities for all intersections
     for (const auto& elem : elements(gridView_)) {
@@ -411,7 +413,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
                 }
 
                 if (updateDiffusivity && !onlyTrans) {
-                    diffusivity_.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx), 0.0);
+                    diffusivity.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx), 0.0);
                 }
                 if (updateDispersivity && !onlyTrans) {
                     dispersivity_.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx), 0.0);
@@ -479,8 +481,8 @@ update(bool global, const TransUpdateQuantities update_quantities,
 
             // update the "diffusive half transmissibility" for the intersection
             if (updateDiffusivity && !onlyTrans) {
-                diffusivity_.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx),
-                                              computeHalfMean(halfDiff, porosity_));
+                diffusivity.insert_or_assign(details::isId(inside.elemIdx, outside.elemIdx),
+                                             computeHalfMean(halfDiff, porosity_));
             }
 
             // update the "dispersivity half transmissibility" for the intersection
@@ -496,6 +498,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
     transMap.finalize();
     thermalHalfTransBoundary.finalize();
     thermalHalfTrans.finalize();
+    diffusivity.finalize();
 
     // Potentially overwrite and/or modify transmissibilities based on input from deck
     this->updateFromEclState_(global);

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -288,6 +288,8 @@ update(bool global, const TransUpdateQuantities update_quantities,
                                        MapBuilderInsertionMode::Insert_Or_Assign);
     ThreadSafeMapBuilder transMap(trans_, 1,
                                   MapBuilderInsertionMode::Insert_Or_Assign);
+    ThreadSafeMapBuilder thermalHalfTransBoundary(thermalHalfTransBoundary_, 1,
+                                                  MapBuilderInsertionMode::Insert_Or_Assign);
 
     // compute the transmissibilities for all intersections
     for (const auto& elem : elements(gridView_)) {
@@ -358,7 +360,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
                         computeHalfDiffusivity_(faceAreaNormal,
                                                 distanceVector_(inside.faceCenter, inside.elemIdx),
                                                 1.0);
-                    thermalHalfTransBoundary_.insert_or_assign(std::make_pair(inside.elemIdx, boundaryIsIdx),
+                    thermalHalfTransBoundary.insert_or_assign(std::make_pair(inside.elemIdx, boundaryIsIdx),
                                                                transBoundaryEnergyIs);
                 }
 
@@ -490,6 +492,7 @@ update(bool global, const TransUpdateQuantities update_quantities,
 
     transBoundary.finalize();
     transMap.finalize();
+    thermalHalfTransBoundary.finalize();
 
     // Potentially overwrite and/or modify transmissibilities based on input from deck
     this->updateFromEclState_(global);


### PR DESCRIPTION
This adds multi-threading to the transmissibility calculations.

Downstream of https://github.com/OPM/opm-common/pull/4432
Downstream of https://github.com/OPM/opm-grid/pull/820