### PR TITLE
Chase UDQConfig::Eval() API Change

### DIFF
--- a/opm/simulators/flow/ActionHandler.cpp
+++ b/opm/simulators/flow/ActionHandler.cpp
@@ -294,6 +294,7 @@ evalUDQAssignments(const unsigned episodeIdx,
 {
     this->schedule_[episodeIdx].udq()
         .eval_assign(this->schedule_.wellMatcher(episodeIdx),
+                     this->schedule_[episodeIdx].group_order(),
                      this->schedule_.segmentMatcherFactory(episodeIdx),
                      this->summaryState_,
                      udq_state);

--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -675,9 +675,10 @@ evalSummary(const int                                            reportStepNum,
         // step we are currently on.
         const auto udq_step = reportStepNum - 1;
 
-        this->schedule_.getUDQConfig(udq_step)
+        this->schedule_[udq_step].udq()
             .eval(udq_step,
                   this->schedule_.wellMatcher(udq_step),
+                  this->schedule_[udq_step].group_order(),
                   this->schedule_.segmentMatcherFactory(udq_step),
                   [es = std::cref(this->eclState_)]() {
                       return std::make_unique<RegionSetMatcher>


### PR DESCRIPTION
Following PR OPM/opm-common#4433, we must now pass a `GroupOrder` object into `eval()` in order to support group name pattern matching in group level UDQ assignments.