### PR TITLE
Feature/py action insert kw welpi wpimult alternative

### DIFF
--- a/pyactionActionXComparisons.cmake
+++ b/pyactionActionXComparisons.cmake
@@ -125,6 +125,16 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_wefac_insert_kw
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
 
+add_test_compareSeparateECLFiles(CASENAME pyaction_welpi_insert_kw
+                                 DIR1 pyaction
+                                 FILENAME1 PYACTION_WELPI_INSERT_KW
+                                 DIR2 actionx
+                                 FILENAME2 ACTIONX_WELPI
+                                 SIMULATOR flow
+                                 ABS_TOL ${abs_tol}
+                                 REL_TOL ${rel_tol}
+                                 IGNORE_EXTRA_KW BOTH)
+
 add_test_compareSeparateECLFiles(CASENAME pyaction_wsegvalv_insert_kw
                                  DIR1 pyaction
                                  FILENAME1 PYACTION_WSEGVALV_INSERT_KW
@@ -252,6 +262,17 @@ if(MPI_FOUND)
                                    REL_TOL ${rel_tol}
                                    IGNORE_EXTRA_KW BOTH
                                    MPI_PROCS 4)
+
+  add_test_compareSeparateECLFiles(CASENAME pyaction_welpi_insert_kw_4_procs
+                                 DIR1 pyaction
+                                 FILENAME1 PYACTION_WELPI_INSERT_KW
+                                 DIR2 actionx
+                                 FILENAME2 ACTIONX_WELPI
+                                 SIMULATOR flow
+                                 ABS_TOL ${abs_tol}
+                                 REL_TOL ${rel_tol}
+                                 IGNORE_EXTRA_KW BOTH,
+                                 MPI_PROCS 4)
 
   add_test_compareSeparateECLFiles(CASENAME pyaction_wsegvalv_insert_kw_4_procs
                                    DIR1 pyaction

--- a/pyactionActionXComparisons.cmake
+++ b/pyactionActionXComparisons.cmake
@@ -135,6 +135,16 @@ add_test_compareSeparateECLFiles(CASENAME pyaction_welpi_insert_kw
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH)
 
+add_test_compareSeparateECLFiles(CASENAME pyaction_wpimult_insert_kw
+                                 DIR1 pyaction
+                                 FILENAME1 PYACTION_WPIMULT_INSERT_KW
+                                 DIR2 actionx
+                                 FILENAME2 ACTIONX_WPIMULT
+                                 SIMULATOR flow
+                                 ABS_TOL ${abs_tol}
+                                 REL_TOL ${rel_tol}
+                                 IGNORE_EXTRA_KW BOTH)
+
 add_test_compareSeparateECLFiles(CASENAME pyaction_wsegvalv_insert_kw
                                  DIR1 pyaction
                                  FILENAME1 PYACTION_WSEGVALV_INSERT_KW
@@ -272,6 +282,17 @@ if(MPI_FOUND)
                                  ABS_TOL ${abs_tol}
                                  REL_TOL ${rel_tol}
                                  IGNORE_EXTRA_KW BOTH,
+                                 MPI_PROCS 4)
+
+  add_test_compareSeparateECLFiles(CASENAME pyaction_wpimult_insert_kw_4_procs
+                                 DIR1 pyaction
+                                 FILENAME1 PYACTION_WPIMULT_INSERT_KW
+                                 DIR2 actionx
+                                 FILENAME2 ACTIONX_WPIMULT
+                                 SIMULATOR flow
+                                 ABS_TOL ${abs_tol}
+                                 REL_TOL ${rel_tol}
+                                 IGNORE_EXTRA_KW BOTH
                                  MPI_PROCS 4)
 
   add_test_compareSeparateECLFiles(CASENAME pyaction_wsegvalv_insert_kw_4_procs


### PR DESCRIPTION
Alternative to https://github.com/OPM/opm-simulators/pull/5467 as suggested by @bska in https://github.com/OPM/opm-common/pull/4136#issuecomment-2583291034.

For the reference manual: With this PR and https://github.com/OPM/opm-common/pull/4434, the keywords WELPI and WPIMULT can be used in the "insert keywords"-function in Pyaction.