### PR TITLE
Preconditioner: add another template parameter for the apply constants

### DIFF
--- a/opm/simulators/linalg/gpubridge/Preconditioner.hpp
+++ b/opm/simulators/linalg/gpubridge/Preconditioner.hpp
@@ -36,7 +36,7 @@ enum PreconditionerType {
 
 template<class Scalar> class BlockedMatrix;
 
-template<class Scalar, unsigned int block_size>
+template<class Scalar, unsigned int block_size, class ApplyScalar = Scalar>
 class Preconditioner
 {
 protected:
@@ -46,25 +46,19 @@ protected:
     int nnzb = 0;    // number of blocks of the matrix
     int verbosity = 0;
 
-    Preconditioner(int verbosity_) :
-    verbosity(verbosity_)
-    {};
+    Preconditioner(int verbosity_)
+        : verbosity(verbosity_)
+    {}
 
 public:
-
     virtual ~Preconditioner() = default;
     
     static std::unique_ptr<Preconditioner> create(PreconditionerType type,
                                                   bool opencl_ilu_parallel,
                                                   int verbosity);
 
-#if HAVE_OPENCL
     // apply preconditioner, x = prec(y)
-    virtual void apply(const cl::Buffer& y, cl::Buffer& x) = 0;
-#endif
-
-    // apply preconditioner, x = prec(y)
-    virtual void apply(Scalar& y, Scalar& x) = 0;
+    virtual void apply(const ApplyScalar& y, ApplyScalar& x) = 0;
 
     // analyze matrix, e.g. the sparsity pattern
     // probably only called once

--- a/opm/simulators/linalg/gpubridge/opencl/openclBILU0.hpp
+++ b/opm/simulators/linalg/gpubridge/opencl/openclBILU0.hpp
@@ -103,7 +103,6 @@ public:
     // via Lz = y
     // and Ux = z
     void apply(const cl::Buffer& y, cl::Buffer& x) override;
-    void apply(Scalar&, Scalar&) override {}
 
     std::tuple<std::vector<int>, std::vector<int>, std::vector<int>>
     get_preconditioner_structure()

--- a/opm/simulators/linalg/gpubridge/opencl/openclBISAI.hpp
+++ b/opm/simulators/linalg/gpubridge/opencl/openclBISAI.hpp
@@ -125,7 +125,6 @@ public:
 
     // apply preconditioner, x = prec(y)
     void apply(const cl::Buffer& y, cl::Buffer& x) override;
-    void apply(Scalar&, Scalar&) override {}
 };
 
 /// Similar function to csrPatternToCsc. It gives an offset map from CSR to CSC instead of the full CSR to CSC conversion.

--- a/opm/simulators/linalg/gpubridge/opencl/openclCPR.hpp
+++ b/opm/simulators/linalg/gpubridge/opencl/openclCPR.hpp
@@ -95,7 +95,6 @@ public:
     // applies blocked ilu0
     // also applies amg for pressure component
     void apply(const cl::Buffer& y, cl::Buffer& x) override;
-    void apply(Scalar&, Scalar&) override {}
 
     bool create_preconditioner(BlockedMatrix<Scalar>* mat) override;
     bool create_preconditioner(BlockedMatrix<Scalar>* mat,

--- a/opm/simulators/linalg/gpubridge/opencl/openclPreconditioner.hpp
+++ b/opm/simulators/linalg/gpubridge/opencl/openclPreconditioner.hpp
@@ -28,7 +28,7 @@ namespace Opm::Accelerator {
 template<class Scalar> class BlockedMatrix;
 
 template <class Scalar, unsigned int block_size>
-class openclPreconditioner : public Preconditioner<Scalar, block_size>
+class openclPreconditioner : public Preconditioner<Scalar, block_size, cl::Buffer>
 {
 
 protected:
@@ -37,9 +37,9 @@ protected:
     std::vector<cl::Event> events;
     cl_int err;
 
-    openclPreconditioner(int verbosity_) :
-    Preconditioner<Scalar, block_size>(verbosity_)
-    {};
+    openclPreconditioner(int verbosity_)
+        : Preconditioner<Scalar, block_size, cl::Buffer>(verbosity_)
+    {}
 
 public:
     virtual ~openclPreconditioner() = default;
@@ -48,14 +48,6 @@ public:
 
     // nested Preconditioners might need to override this
     virtual void setOpencl(std::shared_ptr<cl::Context>& context, std::shared_ptr<cl::CommandQueue>& queue);
-
-    // apply preconditioner, x = prec(y)
-    virtual void apply(const cl::Buffer& y, cl::Buffer& x) = 0;
- 
-    // create/update preconditioner, probably used every linear solve
-    // the version with two params can be overloaded, if not, it will default to using the one param version
-    virtual bool create_preconditioner(BlockedMatrix<Scalar> *mat) = 0;
-    virtual bool create_preconditioner(BlockedMatrix<Scalar> *mat, BlockedMatrix<Scalar> *jacMat) = 0;
 };
 } //namespace Opm
 

--- a/opm/simulators/linalg/gpubridge/rocm/rocsparseBILU0.cpp
+++ b/opm/simulators/linalg/gpubridge/rocm/rocsparseBILU0.cpp
@@ -326,7 +326,8 @@ update_system_on_gpu(Scalar *d_Avals) {
 
 template <class Scalar, unsigned int block_size>
 void rocsparseBILU0<Scalar, block_size>::
-apply(Scalar& y, Scalar& x) {
+apply(const Scalar& y, Scalar& x)
+{
     Scalar one  = 1.0;
 
     Timer t_apply;

--- a/opm/simulators/linalg/gpubridge/rocm/rocsparseBILU0.hpp
+++ b/opm/simulators/linalg/gpubridge/rocm/rocsparseBILU0.hpp
@@ -94,13 +94,8 @@ public:
     /// and Ux = z
     /// \param[in]  y  Input y vector
     /// \param[out] x  Output x vector
-    void apply(Scalar& y,
+    void apply(const Scalar& y,
                Scalar& x) override;
-
-#if HAVE_OPENCL
-    // apply preconditioner, x = prec(y)
-    void apply(const cl::Buffer&, cl::Buffer&) override {}
-#endif
 
     /// Copy matrix A values to GPU
     /// \param[in]  mVals  Input values

--- a/opm/simulators/linalg/gpubridge/rocm/rocsparseCPR.cpp
+++ b/opm/simulators/linalg/gpubridge/rocm/rocsparseCPR.cpp
@@ -306,7 +306,7 @@ apply_amg(const Scalar& y,
 
 template <class Scalar, unsigned int block_size>
 void rocsparseCPR<Scalar, block_size>::
-apply(Scalar& y,
+apply(const Scalar &y,
       Scalar& x)
 {
     Dune::Timer t_bilu0;

--- a/opm/simulators/linalg/gpubridge/rocm/rocsparseCPR.hpp
+++ b/opm/simulators/linalg/gpubridge/rocm/rocsparseCPR.hpp
@@ -113,13 +113,8 @@ public:
     /// also applies amg for pressure component
     /// \param[in]  y  Input y vector
     /// \param[out] x  Output x vector
-    void apply(Scalar& y,
+    void apply(const Scalar& y,
                Scalar& x) override;
-    
-#if HAVE_OPENCL
-    // apply preconditioner, x = prec(y)
-    void apply(const cl::Buffer&, cl::Buffer&) override {}
-#endif
     
     /// Copy matrix A values to GPU
     /// \param[in]  mVals  Input values

--- a/opm/simulators/linalg/gpubridge/rocm/rocsparsePreconditioner.hpp
+++ b/opm/simulators/linalg/gpubridge/rocm/rocsparsePreconditioner.hpp
@@ -55,26 +55,16 @@ public:
     static std::unique_ptr<rocsparsePreconditioner<Scalar, block_size>> create(PreconditionerType type, 
                                                                                int verbosity);
 
-    // apply preconditioner, x = prec(y)
-    virtual void apply(Scalar& y, Scalar& x) = 0;
- 
-    // create/update preconditioner, probably used every linear solve
-    // the version with two params can be overloaded, if not, it will default to using the one param version
-    virtual bool create_preconditioner(BlockedMatrix<Scalar> *mat) = 0;
-    
-    virtual bool create_preconditioner(BlockedMatrix<Scalar> *mat,
-                                       BlockedMatrix<Scalar> *jacMat) = 0;
-    
     virtual bool initialize(std::shared_ptr<BlockedMatrix<Scalar>> matrix,
                             std::shared_ptr<BlockedMatrix<Scalar>> jacMatrix,
-                            rocsparse_int *d_Arows,
-                            rocsparse_int *d_Acols) = 0;
+                            rocsparse_int* d_Arows,
+                            rocsparse_int* d_Acols) = 0;
     
-    virtual void copy_system_to_gpu(Scalar *b)=0;
+    virtual void copy_system_to_gpu(Scalar* b) = 0;
 
     /// Update linear system to GPU
     /// \param[in] b              input vector, contains N values
-    virtual void update_system_on_gpu(Scalar *b)=0;
+    virtual void update_system_on_gpu(Scalar* b) = 0;
     
     void set_matrix_analysis(rocsparse_mat_descr descr_L,
                              rocsparse_mat_descr descr_U);


### PR DESCRIPTION
use this to have this be cl::Buffer for openclPreconditioner

there is no code using Preconditioner in a base class context and this cleans up ifdefs and overloads