### PR TITLE
xxxPrimaryVariables: remove ctor from Scalar

### DIFF
--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -164,21 +164,6 @@ public:
     }
 
     /*!
-     * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(Scalar)
-     */
-    explicit BlackOilPrimaryVariables(Scalar value)
-        : ParentType(value)
-    {
-        Valgrind::SetUndefined(primaryVarsMeaningWater_);
-        Valgrind::SetUndefined(primaryVarsMeaningGas_);
-        Valgrind::SetUndefined(primaryVarsMeaningPressure_);
-        Valgrind::SetUndefined(primaryVarsMeaningBrine_);
-        Valgrind::SetUndefined(primaryVarsMeaningSolvent_);
-
-        pvtRegionIdx_ = 0;
-    }
-
-    /*!
      * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(const ImmisciblePrimaryVariables& )
      */
     BlackOilPrimaryVariables(const BlackOilPrimaryVariables& value) = default;
@@ -947,13 +932,8 @@ public:
     }
 
     BlackOilPrimaryVariables& operator=(const BlackOilPrimaryVariables& other) = default;
-    BlackOilPrimaryVariables& operator=(Scalar value)
-    {
-        for (unsigned i = 0; i < numEq; ++i)
-            (*this)[i] = value;
 
-        return *this;
-    }
+    using ParentType::operator=; //!< Import base class assignment operators.
 
     /*!
      * \brief Instruct valgrind to check the definedness of all attributes of this class.

--- a/opm/models/discretefracture/discretefractureprimaryvariables.hh
+++ b/opm/models/discretefracture/discretefractureprimaryvariables.hh
@@ -28,7 +28,7 @@
 #ifndef EWOMS_DISCRETE_FRACTURE_PRIMARY_VARIABLES_HH
 #define EWOMS_DISCRETE_FRACTURE_PRIMARY_VARIABLES_HH
 
-#include "discretefractureproperties.hh"
+#include <opm/models/discretefracture/discretefractureproperties.hh>
 
 #include <opm/models/immiscible/immiscibleprimaryvariables.hh>
 

--- a/opm/models/discretefracture/discretefractureprimaryvariables.hh
+++ b/opm/models/discretefracture/discretefractureprimaryvariables.hh
@@ -59,20 +59,14 @@ public:
     {}
 
     /*!
-     * \brief Constructor with assignment from scalar
-     *
-     * \param value The scalar value to which all entries of the vector will be set.
-     */
-    DiscreteFracturePrimaryVariables(Scalar value) : ParentType(value)
-    {}
-
-    /*!
      * \brief Copy constructor
      *
      * \param value The primary variables that will be duplicated.
      */
     DiscreteFracturePrimaryVariables(const DiscreteFracturePrimaryVariables& value) = default;
     DiscreteFracturePrimaryVariables& operator=(const DiscreteFracturePrimaryVariables& value) = default;
+
+    using ParentType::operator=; //!< Import base class assignment operators.
 
     /*!
      * \brief Directly retrieve the primary variables from an

--- a/opm/models/discretization/common/fvbaseprimaryvariables.hh
+++ b/opm/models/discretization/common/fvbaseprimaryvariables.hh
@@ -28,15 +28,15 @@
 #ifndef EWOMS_FV_BASE_PRIMARY_VARIABLES_HH
 #define EWOMS_FV_BASE_PRIMARY_VARIABLES_HH
 
-#include <type_traits>
+#include <dune/common/fvector.hh>
+#include <opm/models/discretization/common/fvbaseproperties.hh>
+#include <opm/models/discretization/common/linearizationtype.hh>
 
-#include "fvbaseproperties.hh"
-#include "linearizationtype.hh"
+#include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>
 
-#include <dune/common/fvector.hh>
-
 #include <stdexcept>
+#include <type_traits>
 
 namespace Opm {
 

--- a/opm/models/discretization/common/fvbaseprimaryvariables.hh
+++ b/opm/models/discretization/common/fvbaseprimaryvariables.hh
@@ -64,13 +64,6 @@ public:
     { Valgrind::SetUndefined(*this); }
 
     /*!
-     * \brief Construction from a scalar value
-     */
-    FvBasePrimaryVariables(Scalar value)
-        : ParentType(value)
-    { }
-
-    /*!
      * \brief Assignment from another primary variables object
      */
     FvBasePrimaryVariables(const FvBasePrimaryVariables& value) = default;
@@ -79,6 +72,8 @@ public:
      * \brief Assignment from another primary variables object
      */
     FvBasePrimaryVariables& operator=(const FvBasePrimaryVariables& value) = default;
+
+    using ParentType::operator=; //!< Import base class assignment operators.
 
     static void init()
     {

--- a/opm/models/flash/flashprimaryvariables.hh
+++ b/opm/models/flash/flashprimaryvariables.hh
@@ -73,11 +73,6 @@ public:
     /*!
      * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(Scalar)
      */
-    FlashPrimaryVariables(Scalar value) : ParentType(value)
-    {
-        Opm::Valgrind::CheckDefined(value);
-        Opm::Valgrind::SetDefined(*this);
-    }
 
     /*!
      * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(const
@@ -85,6 +80,8 @@ public:
      */
     FlashPrimaryVariables(const FlashPrimaryVariables& value) = default;
     FlashPrimaryVariables& operator=(const FlashPrimaryVariables& value) = default;
+
+    using ParentType::operator=; //!< Import base class assignment operators.
 
     /*!
      * \copydoc ImmisciblePrimaryVariables::assignMassConservative

--- a/opm/models/flash/flashprimaryvariables.hh
+++ b/opm/models/flash/flashprimaryvariables.hh
@@ -28,16 +28,10 @@
 #ifndef EWOMS_FLASH_PRIMARY_VARIABLES_HH
 #define EWOMS_FLASH_PRIMARY_VARIABLES_HH
 
-#include "flashindices.hh"
-
-#include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
 #include <opm/models/common/energymodule.hh>
+#include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
 
-#include <opm/material/constraintsolvers/NcpFlash.hpp>
-#include <opm/material/fluidstates/CompositionalFluidState.hpp>
 #include <opm/material/common/Valgrind.hpp>
-
-#include <dune/common/fvector.hh>
 
 #include <iostream>
 

--- a/opm/models/immiscible/immiscibleprimaryvariables.hh
+++ b/opm/models/immiscible/immiscibleprimaryvariables.hh
@@ -83,14 +83,6 @@ public:
     { Opm::Valgrind::SetUndefined(*this); }
 
     /*!
-     * \brief Constructor with assignment from scalar
-     *
-     * \param value The scalar value to which all entries of the vector will be set.
-     */
-    ImmisciblePrimaryVariables(Scalar value) : ParentType(value)
-    {}
-
-    /*!
      * \brief Copy constructor
      *
      * \param value The primary variables that will be duplicated.
@@ -103,6 +95,8 @@ public:
      * \param value The primary variables that will be duplicated.
      */
     ImmisciblePrimaryVariables& operator=(const ImmisciblePrimaryVariables& value) = default;
+
+    using ParentType::operator=; //!< Import base class assignment operators.
 
     /*!
      * \brief Set the primary variables from an arbitrary fluid state

--- a/opm/models/immiscible/immiscibleprimaryvariables.hh
+++ b/opm/models/immiscible/immiscibleprimaryvariables.hh
@@ -28,16 +28,15 @@
 #ifndef EWOMS_IMMISCIBLE_PRIMARY_VARIABLES_HH
 #define EWOMS_IMMISCIBLE_PRIMARY_VARIABLES_HH
 
-#include "immiscibleproperties.hh"
+#include <dune/common/fvector.hh>
 
-#include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
 #include <opm/models/common/energymodule.hh>
+#include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
+#include <opm/models/immiscible/immiscibleproperties.hh>
 
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/material/constraintsolvers/ImmiscibleFlash.hpp>
 #include <opm/material/fluidstates/ImmiscibleFluidState.hpp>
-#include <opm/material/common/Valgrind.hpp>
-
-#include <dune/common/fvector.hh>
 
 namespace Opm {
 

--- a/opm/models/ncp/ncpprimaryvariables.hh
+++ b/opm/models/ncp/ncpprimaryvariables.hh
@@ -28,16 +28,15 @@
 #ifndef EWOMS_NCP_PRIMARY_VARIABLES_HH
 #define EWOMS_NCP_PRIMARY_VARIABLES_HH
 
-#include "ncpproperties.hh"
+#include <dune/common/fvector.hh>
 
-#include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
 #include <opm/models/common/energymodule.hh>
+#include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
+#include <opm/models/ncp/ncpproperties.hh>
 
 #include <opm/material/constraintsolvers/NcpFlash.hpp>
-#include <opm/material/fluidstates/CompositionalFluidState.hpp>
 #include <opm/material/densead/Math.hpp>
-
-#include <dune/common/fvector.hh>
+#include <opm/material/fluidstates/CompositionalFluidState.hpp>
 
 namespace Opm {
 

--- a/opm/models/ncp/ncpprimaryvariables.hh
+++ b/opm/models/ncp/ncpprimaryvariables.hh
@@ -80,17 +80,13 @@ public:
     {}
 
     /*!
-     * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(Scalar)
-     */
-    NcpPrimaryVariables(Scalar value) : ParentType(value)
-    {}
-
-    /*!
      * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(const
      * ImmisciblePrimaryVariables& )
      */
     NcpPrimaryVariables(const NcpPrimaryVariables& value) = default;
     NcpPrimaryVariables& operator=(const NcpPrimaryVariables& value) = default;
+
+    using ParentType::operator=; //!< Import base class assignment operators.
 
     /*!
      * \copydoc ImmisciblePrimaryVariables::assignMassConservative

--- a/opm/models/ptflash/flashprimaryvariables.hh
+++ b/opm/models/ptflash/flashprimaryvariables.hh
@@ -28,16 +28,11 @@
 #ifndef OPM_PTFLASH_PRIMARY_VARIABLES_HH
 #define OPM_PTFLASH_PRIMARY_VARIABLES_HH
 
-#include "flashindices.hh"
-
-#include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
 #include <opm/models/common/energymodule.hh>
+#include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
+#include <opm/models/ptflash/flashindices.hh>
 
-#include <opm/material/constraintsolvers/NcpFlash.hpp>
-#include <opm/material/fluidstates/CompositionalFluidState.hpp>
 #include <opm/material/common/Valgrind.hpp>
-
-#include <dune/common/fvector.hh>
 
 #include <iostream>
 

--- a/opm/models/ptflash/flashprimaryvariables.hh
+++ b/opm/models/ptflash/flashprimaryvariables.hh
@@ -73,20 +73,13 @@ public:
     { Opm::Valgrind::SetDefined(*this); }
 
     /*!
-     * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(Scalar)
-     */
-    FlashPrimaryVariables(Scalar value) : ParentType(value)
-    {
-        Opm::Valgrind::CheckDefined(value);
-        Opm::Valgrind::SetDefined(*this);
-    }
-
-    /*!
      * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(const
      * ImmisciblePrimaryVariables& )
      */
     FlashPrimaryVariables(const FlashPrimaryVariables& value) = default;
     FlashPrimaryVariables& operator=(const FlashPrimaryVariables& value) = default;
+
+    using ParentType::operator=; //!< Import base class assignment operators.
 
     /*!
      * \copydoc ImmisciblePrimaryVariables::assignMassConservative

--- a/opm/models/pvs/pvsprimaryvariables.hh
+++ b/opm/models/pvs/pvsprimaryvariables.hh
@@ -85,17 +85,6 @@ public:
     { Valgrind::SetDefined(*this); }
 
     /*!
-     * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(Scalar)
-     */
-    explicit PvsPrimaryVariables(Scalar value) : ParentType(value)
-    {
-        Valgrind::CheckDefined(value);
-        Valgrind::SetDefined(*this);
-
-        phasePresence_ = 0;
-    }
-
-    /*!
      * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(const
      * ImmisciblePrimaryVariables& )
      */

--- a/opm/models/pvs/pvsprimaryvariables.hh
+++ b/opm/models/pvs/pvsprimaryvariables.hh
@@ -28,19 +28,17 @@
 #ifndef EWOMS_PVS_PRIMARY_VARIABLES_HH
 #define EWOMS_PVS_PRIMARY_VARIABLES_HH
 
-#include "pvsindices.hh"
-#include "pvsproperties.hh"
+#include <dune/common/fvector.hh>
 
 #include <opm/common/Exceptions.hpp>
 
-#include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
 #include <opm/models/common/energymodule.hh>
+#include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
+#include <opm/models/pvs/pvsproperties.hh>
 
 #include <opm/material/constraintsolvers/NcpFlash.hpp>
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
 #include <opm/material/common/Valgrind.hpp>
-
-#include <dune/common/fvector.hh>
 
 #include <iostream>
 

--- a/opm/models/richards/richardsprimaryvariables.hh
+++ b/opm/models/richards/richardsprimaryvariables.hh
@@ -79,17 +79,13 @@ public:
     { Opm::Valgrind::SetUndefined(*this); }
 
     /*!
-     * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(Scalar)
-     */
-    RichardsPrimaryVariables(Scalar value) : ParentType(value)
-    {}
-
-    /*!
      * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(const
      * ImmisciblePrimaryVariables& )
      */
     RichardsPrimaryVariables(const RichardsPrimaryVariables& value) = default;
     RichardsPrimaryVariables& operator=(const RichardsPrimaryVariables& value) = default;
+
+    using ParentType::operator=; //!< Import base class assignment operators.
 
     /*!
      * \brief Set the primary variables with the wetting phase

--- a/opm/models/richards/richardsprimaryvariables.hh
+++ b/opm/models/richards/richardsprimaryvariables.hh
@@ -28,15 +28,15 @@
 #ifndef EWOMS_RICHARDS_PRIMARY_VARIABLES_HH
 #define EWOMS_RICHARDS_PRIMARY_VARIABLES_HH
 
-#include "richardsproperties.hh"
+#include <dune/common/fvector.hh>
+
+#include <opm/models/richards/richardsproperties.hh>
 
 #include <opm/models/discretization/common/fvbaseprimaryvariables.hh>
 
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/material/constraintsolvers/ImmiscibleFlash.hpp>
 #include <opm/material/fluidstates/ImmiscibleFluidState.hpp>
-#include <opm/material/common/Valgrind.hpp>
-
-#include <dune/common/fvector.hh>
 
 namespace Opm {
 


### PR DESCRIPTION
these were only in use for assignments to a constant. 

Instead of detouring all of these assignments through a temporary, use the base field vector assignment operator to do inplace assignments.