### PR TITLE
fixed: condition on MPI_FOUND, not USE_MPI

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1172,7 +1172,7 @@ if(dune-alugrid_FOUND)
     examples/fracture_discretefracture.cpp
   )
 endif()
-if(USE_MPI)
+if(MPI_FOUND)
   list (APPEND MAIN_SOURCE_FILES
     opm/simulators/flow/ReservoirCoupling.cpp
     opm/simulators/flow/ReservoirCouplingMaster.cpp


### PR DESCRIPTION
USE_XXX variables are user provided and should not be used to check whether or not a component is enabled (at least not those backed by some required library).

In particular the build system will configure a build without MPI if no mpi was found -> trouble.

Should fix nightly python packaging again, ref https://ci.opm-project.org/job/opm-nightly-pypi/1495/console