### PR TITLE
fixed: use a vector in mpibuffer 

### DIFF
--- a/opm/models/parallel/mpibuffer.hh
+++ b/opm/models/parallel/mpibuffer.hh
@@ -171,31 +171,31 @@ private:
     {
 #if HAVE_MPI
         // set the MPI data type
-        if (std::is_same<DataType, char>::value)
+        if (std::is_same_v<DataType, char>)
             mpiDataType_ = MPI_CHAR;
-        else if (std::is_same<DataType, unsigned char>::value)
+        else if (std::is_same_v<DataType, unsigned char>)
             mpiDataType_ = MPI_UNSIGNED_CHAR;
-        else if (std::is_same<DataType, short>::value)
+        else if (std::is_same_v<DataType, short>)
             mpiDataType_ = MPI_SHORT;
-        else if (std::is_same<DataType, unsigned short>::value)
+        else if (std::is_same_v<DataType, unsigned short>)
             mpiDataType_ = MPI_UNSIGNED_SHORT;
-        else if (std::is_same<DataType, int>::value)
+        else if (std::is_same_v<DataType, int>)
             mpiDataType_ = MPI_INT;
-        else if (std::is_same<DataType, unsigned>::value)
+        else if (std::is_same_v<DataType, unsigned>)
             mpiDataType_ = MPI_UNSIGNED;
-        else if (std::is_same<DataType, long>::value)
+        else if (std::is_same_v<DataType, long>)
             mpiDataType_ = MPI_LONG;
-        else if (std::is_same<DataType, unsigned long>::value)
+        else if (std::is_same_v<DataType, unsigned long>)
             mpiDataType_ = MPI_UNSIGNED_LONG;
-        else if (std::is_same<DataType, long long>::value)
+        else if (std::is_same_v<DataType, long long>)
             mpiDataType_ = MPI_LONG_LONG;
-        else if (std::is_same<DataType, unsigned long long>::value)
+        else if (std::is_same_v<DataType, unsigned long long>)
             mpiDataType_ = MPI_UNSIGNED_LONG_LONG;
-        else if (std::is_same<DataType, float>::value)
+        else if (std::is_same_v<DataType, float>)
             mpiDataType_ = MPI_FLOAT;
-        else if (std::is_same<DataType, double>::value)
+        else if (std::is_same_v<DataType, double>)
             mpiDataType_ = MPI_DOUBLE;
-        else if (std::is_same<DataType, long double>::value)
+        else if (std::is_same_v<DataType, long double>)
             mpiDataType_ = MPI_LONG_DOUBLE;
         else {
             mpiDataType_ = MPI_BYTE;

--- a/opm/models/parallel/mpibuffer.hh
+++ b/opm/models/parallel/mpibuffer.hh
@@ -33,7 +33,7 @@
 #endif
 
 #include <cassert>
-#include <stddef.h>
+#include <cstddef>
 #include <vector>
 
 namespace Opm {
@@ -51,7 +51,7 @@ public:
         updateMpiDataSize_();
     }
 
-    explicit MpiBuffer(size_t size)
+    explicit MpiBuffer(std::size_t size)
     {
         data_.resize(size);
 
@@ -62,7 +62,7 @@ public:
     /*!
      * \brief Set the size of the buffer
      */
-    void resize(size_t newSize)
+    void resize(std::size_t newSize)
     {
         data_.resize(newSize);
         updateMpiDataSize_();
@@ -145,13 +145,13 @@ public:
     /*!
      * \brief Returns the number of data objects in the buffer
      */
-    size_t size() const
+    std::size_t size() const
     { return data_.size(); }
 
     /*!
      * \brief Provide access to the buffer data.
      */
-    DataType& operator[](size_t i)
+    DataType& operator[](std::size_t i)
     {
         assert(i < data_.size());
         return data_[i];
@@ -160,7 +160,7 @@ public:
     /*!
      * \brief Provide access to the buffer data.
      */
-    const DataType& operator[](size_t i) const
+    const DataType& operator[](std::size_t i) const
     {
         assert(i < data_.size());
         return data_[i];
@@ -214,7 +214,7 @@ private:
 
     std::vector<DataType> data_;
 #if HAVE_MPI
-    size_t mpiDataSize_;
+    std::size_t mpiDataSize_;
     MPI_Datatype mpiDataType_;
     MPI_Request mpiRequest_;
     MPI_Status mpiStatus_;


### PR DESCRIPTION
this was being copied and it had pointer members

and change to std::size_t