### PR TITLE
Add Regression/Restart Tests for Recent UDQ Work

### DIFF
--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -631,6 +631,16 @@ add_test_compareECLFiles(CASENAME reg_smry_in_fld_udq
                          DIR udq_actionx
                          TEST_ARGS --enable-tuning=true)
 
+# UDQ ASSIGN for subsets of group level UDQs.  Updates triggered from
+# ACTIONX blocks.
+add_test_compareECLFiles(CASENAME group_udq
+                         FILENAME UDQ_GRP-01
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR udq_actionx
+                         TEST_ARGS --solver-max-time-step-in-days=0.25)
+
 add_test_compareECLFiles(CASENAME udq_undefined_2
                          FILENAME UDQ-01
                          SIMULATOR flow

--- a/restartTests.cmake
+++ b/restartTests.cmake
@@ -92,6 +92,19 @@ add_test_compare_restarted_simulation(CASENAME network_01_reroute_restart
                                       DIR network
                                       TEST_ARGS --enable-tuning=true --local-well-solve-control-switching=true)
 
+# Restart run in which a UDQ defining expression has exactly 128
+# characters.  Verifies that we don't overflow the ZUDL character
+# limit in restart files.
+add_test_compare_restarted_simulation(CASENAME udq_reg_02
+  FILENAME UDQ_REG-02
+  SIMULATOR flow
+  ABS_TOL ${abs_tol_restart}
+  REL_TOL ${rel_tol_restart}
+  RESTART_STEP 2
+  DIR udq_actionx
+  TEST_ARGS --enable-tuning=true
+)
+
 # The dynamic MSW data is not written to /read from the restart file
 # We therefore accept significant deviation in the results.
 # Note also that we use --sched-restart=true since some necessary


### PR DESCRIPTION
In particular

1. Activate [`UDQ_REG-02`](https://github.com/OPM/opm-tests/blob/a07d04e7f01b101eb190407584d4dcec622d5bc4/udq_actionx/UDQ_REG-02.DATA) (OPM/opm-tests#1279) as a restart test to ensure that we do not overflow the `ZUDL` character limit (PR OPM/opm-common#4422).
2. Activate [`UDQ_GRP-01`](https://github.com/OPM/opm-tests/blob/a07d04e7f01b101eb190407584d4dcec622d5bc4/udq_actionx/UDQ_GRP-01.DATA) (OPM/opm-tests#1174) as a regression test to ensure that we continue to support assigning subsets of group level UDQs (PR OPM/opm-common#4433).