### PR TITLE
Correct a keyword in a message

### DIFF
--- a/opm/simulators/flow/FlowGenericVanguard.cpp
+++ b/opm/simulators/flow/FlowGenericVanguard.cpp
@@ -351,7 +351,7 @@ void FlowGenericVanguard::init()
                 std::string message =
                         std::string("Option --allow-distributed-wells=true in a model with\n")
                         + "multisegment wells. This feature is still experimental. You can\n"
-                        + "set --enable-multisegment-wells=false to treat the existing \n"
+                        + "set --use-multisegment-well=false to treat the existing \n"
                         + "multisegment wells as standard wells.";
                 OpmLog::info(message);
             }


### PR DESCRIPTION
When `--allowDistributedWells=true` is set in a problem with multisegment wells, program outputs a message where the command line argument `--use-multisegment-well` is misnamed.