### PR TITLE
hacking to register the parameter ForceDisableFluidInPlaceOutput

### DIFF
--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -1857,6 +1857,8 @@ INSTANTIATE_TYPE(float)
     template<class T> using FS##NUM = GenericOilGasFluidSystem<T, NUM>; \
     template class GenericOutputBlackoilModule<FS##NUM<double>>;
 
+INSTANTIATE_COMP(0) // \Note: to register the parameter ForceDisableFluidInPlaceOutput
+
 INSTANTIATE_COMP(2)
 INSTANTIATE_COMP(3)
 INSTANTIATE_COMP(4)

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -141,13 +141,6 @@ public:
     }
 
     /*!
-     * \brief Register all run-time parameters for the Vtk output module.
-     */
-    static void registerParameters()
-    {
-    }
-
-    /*!
      * \brief Allocate memory for the scalar fields we would like to
      *        write to ECL output files
      */


### PR DESCRIPTION
Instantiating FluidSystem<0> at this stage due to how it is implemented. 



After https://github.com/OPM/opm-simulators/pull/5882, the flowexp_comp can not be run anymore. 

Not totally sure this is the proper fix, but just bring it up here to start the conversation. 