### PR TITLE
Implement Property Tree Put/Get for std::size_t

### DIFF
--- a/opm/simulators/linalg/PropertyTree.cpp
+++ b/opm/simulators/linalg/PropertyTree.cpp
@@ -23,12 +23,11 @@
 
 #include <boost/property_tree/json_parser.hpp>
 
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <ostream>
 #include <string>
-
-#include <stddef.h>
 
 namespace Opm {
 
@@ -102,23 +101,24 @@ PropertyTree& PropertyTree::operator=(const PropertyTree& tree)
   return *this;
 }
 
+template void PropertyTree::put(const std::string& key, const std::string& value);
+template void PropertyTree::put(const std::string& key, const double& value);
+template void PropertyTree::put(const std::string& key, const float& value);
+template void PropertyTree::put(const std::string& key, const int& value);
+template void PropertyTree::put(const std::string& key, const std::size_t& value);
+
 template std::string PropertyTree::get(const std::string& key) const;
 template double PropertyTree::get(const std::string& key) const;
 template float PropertyTree::get(const std::string& key) const;
 template int PropertyTree::get(const std::string& key) const;
-template size_t PropertyTree::get(const std::string& key) const;
+template std::size_t PropertyTree::get(const std::string& key) const;
 template bool PropertyTree::get(const std::string& key) const;
 
 template std::string PropertyTree::get(const std::string& key, const std::string& defValue) const;
 template double PropertyTree::get(const std::string& key, const double& defValue) const;
 template float PropertyTree::get(const std::string& key, const float& defValue) const;
 template int PropertyTree::get(const std::string& key, const int& defValue) const;
-template size_t PropertyTree::get(const std::string& key, const size_t& defValue) const;
+template std::size_t PropertyTree::get(const std::string& key, const std::size_t& defValue) const;
 template bool PropertyTree::get(const std::string& key, const bool& defValue) const;
-
-template void PropertyTree::put(const std::string& key, const std::string& value);
-template void PropertyTree::put(const std::string& key, const float& value);
-template void PropertyTree::put(const std::string& key, const double& value);
-template void PropertyTree::put(const std::string& key, const int& value);
 
 } // namespace Opm

--- a/tests/test_propertytree.cpp
+++ b/tests/test_propertytree.cpp
@@ -36,9 +36,11 @@
 
 #include <opm/common/utility/FileSystem.hpp>
 
+#include <cstddef>
 #include <filesystem>
 #include <fstream>
 #include <ios>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -86,6 +88,21 @@ BOOST_AUTO_TEST_CASE(Top_Node_Only)
         const auto dd = t.get("dd", -1.618f);
         BOOST_CHECK_CLOSE(dd, -1.618f, 1.0e-6f);
     }
+}
+
+BOOST_AUTO_TEST_CASE(Size_T)
+{
+    auto t = Opm::PropertyTree{};
+
+    t.put("s.ramanujan", std::size_t{1729});
+    BOOST_CHECK_EQUAL(t.get<std::size_t>("s.ramanujan"), std::size_t{1729});
+
+    t.put("m", static_cast<std::size_t>(-1));
+    BOOST_CHECK_EQUAL(t.get<std::size_t>("m"), std::numeric_limits<std::size_t>::max());
+
+    // Conversion: int -> std::size_t
+    t.put("n", -1);
+    BOOST_CHECK_EQUAL(t.get<std::size_t>("n"), std::numeric_limits<std::size_t>::max());
 }
 
 BOOST_AUTO_TEST_CASE(Missing_Keys)


### PR DESCRIPTION
This replaces the original specialisations for "bare" `size_t` from the `<stddef.h>` header.

While here, also reorder the specialisations to match declaration order in the header.