### PR TITLE
Pass on current well state to (implicit) potential calculations

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -250,6 +250,7 @@ namespace Opm {
                                     DeferredLogger& deferred_logger) const;
 
         bool computeWellPotentialsImplicit(const Simulator& simulator,
+                                           const WellState<Scalar>& well_state,
                                            std::vector<Scalar>& well_potentials,
                                            DeferredLogger& deferred_logger) const;
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -296,7 +296,7 @@ namespace Opm
         debug_cost_counter_ = 0;
         bool converged_implicit = false;
         if (this->param_.local_well_solver_control_switching_) {
-            converged_implicit = computeWellPotentialsImplicit(simulator, well_potentials, deferred_logger);
+            converged_implicit = computeWellPotentialsImplicit(simulator, well_state, well_potentials, deferred_logger);
             if (!converged_implicit) {
                 deferred_logger.debug("Implicit potential calculations failed for well "
                                        + this->name() + ",  reverting to original aproach.");
@@ -516,6 +516,7 @@ namespace Opm
     bool
     MultisegmentWell<TypeTag>::
     computeWellPotentialsImplicit(const Simulator& simulator,
+                                  const WellState<Scalar>& well_state,
                                   std::vector<Scalar>& well_potentials,
                                   DeferredLogger& deferred_logger) const
     {
@@ -526,7 +527,7 @@ namespace Opm
         well_copy.debug_cost_counter_ = 0;
 
         // store a copy of the well state, we don't want to update the real well state
-        WellState<Scalar> well_state_copy = simulator.problem().wellModel().wellState();
+        WellState<Scalar> well_state_copy = well_state;
         const auto& group_state = simulator.problem().wellModel().groupState();
         auto& ws = well_state_copy.well(this->index_of_well_);
         

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -325,6 +325,7 @@ namespace Opm
                                     const WellState<Scalar>& well_state) const;
 
         bool computeWellPotentialsImplicit(const Simulator& ebos_simulator,
+                                           const WellState<Scalar>& well_state,
                                            std::vector<Scalar>& well_potentials,
                                            DeferredLogger& deferred_logger) const;               
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1622,6 +1622,7 @@ namespace Opm
     bool
     StandardWell<TypeTag>::
     computeWellPotentialsImplicit(const Simulator& simulator,
+                                  const WellState<Scalar>& well_state,
                                   std::vector<Scalar>& well_potentials,
                                   DeferredLogger& deferred_logger) const
     {
@@ -1631,7 +1632,7 @@ namespace Opm
         StandardWell<TypeTag> well_copy(*this);
 
         // store a copy of the well state, we don't want to update the real well state
-        WellState<Scalar> well_state_copy = simulator.problem().wellModel().wellState();
+        WellState<Scalar> well_state_copy = well_state;
         const auto& group_state = simulator.problem().wellModel().groupState();
         auto& ws = well_state_copy.well(this->index_of_well_);
 
@@ -1762,7 +1763,7 @@ namespace Opm
         // group controlled wells with defaulted guiderates will have zero targets as
         // the potentials are used to compute the well fractions.
         if (this->param_.local_well_solver_control_switching_ && !(this->changed_to_open_this_step_ && this->wellUnderZeroRateTarget(simulator, well_state, deferred_logger))) {
-            converged_implicit = computeWellPotentialsImplicit(simulator, well_potentials, deferred_logger);
+            converged_implicit = computeWellPotentialsImplicit(simulator, well_state, well_potentials, deferred_logger);
         }
         if (!converged_implicit) {
             // does the well have a THP related constraint?


### PR DESCRIPTION
Implicit potential calculations makes a copy of the well-state and use that for initial guess. However, `WellTesting` also deals with a copy of the well-state, so when called from there we need to pass that copy as an argument (the currently used _actual_ well-state may have nonsense values at this stage and occasionally lead to convergence issues when used as initial guess)