### PR TITLE
Add missing communication for parallel runs with MSWells

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -226,7 +226,7 @@ namespace Opm {
         // get the mobility for specific perforation
         template<class Value>
         void getMobility(const Simulator& simulator,
-                         const int perf,
+                         const int local_perf_index,
                          std::vector<Value>& mob,
                          DeferredLogger& deferred_logger) const;
 

--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -59,7 +59,7 @@ MultisegmentWellEval(WellInterfaceIndices<FluidSystem,Indices>& baseif, const Pa
     , baseif_(baseif)
     , linSys_(*this, pw_info)
     , primary_variables_(baseif)
-    , segments_(this->numberOfSegments(), pw_info.communication().sum(baseif.numPerfs()), baseif)
+    , segments_(this->numberOfSegments(), pw_info, baseif)
     , cell_perforation_depth_diffs_(baseif_.numPerfs(), 0.0)
     , cell_perforation_pressure_diffs_(baseif_.numPerfs(), 0.0)
 {

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -60,10 +60,10 @@ namespace Opm
 template<class FluidSystem, class Indices>
 MultisegmentWellSegments<FluidSystem,Indices>::
 MultisegmentWellSegments(const int numSegments,
-                         const int num_perfs_whole_mswell,
+                         const ParallelWellInfo<Scalar>& parallel_well_info,
                          WellInterfaceGeneric<Scalar>& well)
     : perforations_(numSegments)
-    , perforation_depth_diffs_(num_perfs_whole_mswell, 0.0)
+    , local_perforation_depth_diffs_(well.numPerfs(), 0.0)
     , inlets_(well.wellEcl().getSegments().size())
     , depth_diffs_(numSegments, 0.0)
     , densities_(numSegments, 0.0)
@@ -87,6 +87,7 @@ MultisegmentWellSegments(const int numSegments,
     // side
     int i_perf_wells = 0;
     // The perfDepth vector will contain the depths of all perforations across all processes of this well!
+    int num_perfs_whole_mswell = parallel_well_info.communication().sum(well.numPerfs());
     well.perfDepth().resize(num_perfs_whole_mswell, 0.0);
     const auto& segment_set = well_.wellEcl().getSegments();
     for (std::size_t perf = 0; perf < completion_set.size(); ++perf) {
@@ -103,7 +104,9 @@ MultisegmentWellSegments(const int numSegments,
             perforations_[segment_index].push_back(i_perf_wells);
             well.perfDepth()[i_perf_wells] = connection.depth();
             const Scalar segment_depth = segment_set[segment_index].depth();
-            perforation_depth_diffs_[i_perf_wells] = well_.perfDepth()[i_perf_wells] - segment_depth;
+            int local_perf_index = parallel_well_info.globalToLocal(i_perf_wells);
+            if (local_perf_index > -1) // If local_perf_index == -1, then the perforation is not on this process
+                local_perforation_depth_diffs_[local_perf_index] = well_.perfDepth()[i_perf_wells] - segment_depth;
             i_perf_wells++;
         }
     }
@@ -344,10 +347,10 @@ getHydroPressureLoss(const int seg,
 template<class FluidSystem, class Indices>
 typename MultisegmentWellSegments<FluidSystem,Indices>::Scalar
 MultisegmentWellSegments<FluidSystem,Indices>::
-getPressureDiffSegPerf(const int seg,
-                       const int perf) const
+getPressureDiffSegLocalPerf(const int seg,
+                            const int local_perf_index) const
 {
-    return well_.gravity() * densities_[seg].value() * perforation_depth_diffs_[perf];
+    return well_.gravity() * densities_[seg].value() * local_perforation_depth_diffs_[local_perf_index];
 }
 
 template<class FluidSystem, class Indices>

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -23,6 +23,7 @@
 #define OPM_MULTISEGMENTWELL_SEGMENTS_HEADER_INCLUDED
 
 #include <opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp>
+#include <opm/simulators/wells/ParallelWellInfo.hpp>
 
 #include <cstddef>
 #include <vector>
@@ -49,7 +50,7 @@ class MultisegmentWellSegments
 
 public:
     MultisegmentWellSegments(const int numSegments,
-                             const int num_perfs_whole_mswell,
+                             const ParallelWellInfo<Scalar>& parallel_well_info,
                              WellInterfaceGeneric<Scalar>& well);
 
     void computeFluidProperties(const EvalWell& temperature,
@@ -65,8 +66,8 @@ public:
                                   const int seg_side) const;
 
     //! Pressure difference between segment and perforation.
-    Scalar getPressureDiffSegPerf(const int seg,
-                                  const int perf) const;
+    Scalar getPressureDiffSegLocalPerf(const int seg,
+                                       const int local_perf_index) const;
 
     EvalWell getSurfaceVolume(const EvalWell& temperature,
                               const EvalWell& saltConcentration,
@@ -126,9 +127,9 @@ public:
         return densities_[seg];
     }
 
-    Scalar perforation_depth_diff(const int perf) const
+    Scalar local_perforation_depth_diff(const int local_perf_index) const
     {
-        return perforation_depth_diffs_[perf];
+        return local_perforation_depth_diffs_[local_perf_index];
     }
 
     void copyPhaseDensities(const PhaseUsage& pu,
@@ -152,7 +153,7 @@ private:
     // This vector contains the depth differences for *all* perforations across all processes
     // that this well lies on, its size is well.wellEcl().getConnections().size(),
     // also it works with *global* perforation indices!
-    std::vector<Scalar> perforation_depth_diffs_;
+    std::vector<Scalar> local_perforation_depth_diffs_;
 
     // the inlet segments for each segment. It is for convenience and efficiency reason
     std::vector<std::vector<int>> inlets_;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -749,9 +749,9 @@ namespace Opm
                             WellState<Scalar>& well_state,
                             DeferredLogger& deferred_logger) const
     {
-        auto fluidState = [&simulator, this](const int perf)
+        auto fluidState = [&simulator, this](const int local_perf_index)
         {
-            const auto cell_idx = this->well_cells_[perf];
+            const auto cell_idx = this->well_cells_[local_perf_index];
             return simulator.model()
                .intensiveQuantities(cell_idx, /*timeIdx=*/ 0).fluidState();
         };
@@ -789,7 +789,7 @@ namespace Opm
             // The subsetPerfID loops over 0 .. this->perf_data_->size().
             // *(this->perf_data_) contains info about the local processes only,
             // hence subsetPerfID is a local perf id and we can call getMobility
-            // directly with that.
+            // as well as fluidState directly with that.
             getMobility(simulator, static_cast<int>(subsetPerfID), mob, deferred_logger);
 
             const auto& fs = fluidState(subsetPerfID);

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -903,12 +903,12 @@ namespace Opm
 
         // pressure difference between the segment and the perforation
         const Value perf_seg_press_diff = this->gravity() * segment_density *
-                                          this->segments_.perforation_depth_diff(perf);
+                                          this->segments_.local_perforation_depth_diff(local_perf_index);
         // pressure difference between the perforation and the grid cell
         const Scalar cell_perf_press_diff = this->cell_perforation_pressure_diffs_[local_perf_index];
 
         // perforation pressure is the wellbore pressure corrected to perforation depth
-        // (positive sign due to convention in segments_.perforation_depth_diff() )
+        // (positive sign due to convention in segments_.local_perforation_depth_diff() )
         perf_press = segment_pressure + perf_seg_press_diff;
 
         // cell pressure corrected to perforation depth
@@ -1162,7 +1162,7 @@ namespace Opm
             // we can change this depending on what we want
             const Scalar segment_pres = this->primary_variables_.getSegmentPressure(seg).value();
             const Scalar perf_seg_press_diff = this->gravity() * this->segments_.density(seg).value()
-                                                               * this->segments_.perforation_depth_diff(local_perf_index);
+                                                               * this->segments_.local_perforation_depth_diff(local_perf_index);
             const Scalar perf_press = segment_pres + perf_seg_press_diff;
             const Scalar multiplier = this->getInjMult(local_perf_index, segment_pres, perf_press, deferred_logger);
             for (std::size_t i = 0; i < mob.size(); ++i) {
@@ -1279,7 +1279,7 @@ namespace Opm
                 const auto& int_quantities = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
                 const auto& fs = int_quantities.fluidState();
                 // pressure difference between the segment and the perforation
-                const Scalar perf_seg_press_diff = this->segments_.getPressureDiffSegPerf(seg, perf);
+                const Scalar perf_seg_press_diff = this->segments_.getPressureDiffSegLocalPerf(seg, local_perf_index);
                 // pressure difference between the perforation and the grid cell
                 const Scalar cell_perf_press_diff = this->cell_perforation_pressure_diffs_[local_perf_index];
                 const Scalar pressure_cell = this->getPerfCellPressure(fs).value();
@@ -2011,7 +2011,7 @@ namespace Opm
                 const auto& fs = intQuants.fluidState();
 
                 // pressure difference between the segment and the perforation
-                const EvalWell perf_seg_press_diff = this->segments_.getPressureDiffSegPerf(seg, perf);
+                const EvalWell perf_seg_press_diff = this->segments_.getPressureDiffSegLocalPerf(seg, local_perf_index);
                 // pressure difference between the perforation and the grid cell
                 const Scalar cell_perf_press_diff = this->cell_perforation_pressure_diffs_[local_perf_index];
 

--- a/opm/simulators/wells/ParallelWellInfo.cpp
+++ b/opm/simulators/wells/ParallelWellInfo.cpp
@@ -22,6 +22,7 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
+#include <opm/material/densead/Evaluation.hpp>
 
 #include <fmt/format.h>
 #include <cassert>
@@ -771,6 +772,11 @@ checkAllConnectionsFound()
 template<class Scalar> using dIter = typename std::vector<Scalar>::iterator;
 template<class Scalar> using cdIter = typename std::vector<Scalar>::const_iterator;
 
+#define INSTANTIATE_BROADCAST_FIRST_PERF_DENSEAD_EVALUATION(T, DIM)                 \
+    template Opm::DenseAd::Evaluation<T, DIM, 0u> Opm::ParallelWellInfo<T>::        \
+        broadcastFirstPerforationValue<Opm::DenseAd::Evaluation<T, DIM, 0u>>        \
+        (Opm::DenseAd::Evaluation<T, DIM, 0u> const&) const;
+
 #define INSTANTIATE_TYPE(T)                                                         \
     template class CheckDistributedWellConnections<T>;                              \
     template class CommunicateAboveBelow<T>;                                        \
@@ -780,10 +786,16 @@ template<class Scalar> using cdIter = typename std::vector<Scalar>::const_iterat
         ParallelWellInfo<T>::sumPerfValues<cdIter<T>>(cdIter<T>,cdIter<T>) const;   \
     template typename dIter<T>::value_type                                          \
         ParallelWellInfo<T>::sumPerfValues<dIter<T>>(dIter<T>,dIter<T>) const;      \
-     template int ParallelWellInfo<T>::                                             \
+    template int ParallelWellInfo<T>::                                              \
         broadcastFirstPerforationValue<int>(const int&) const;                      \
-     template T ParallelWellInfo<T>::                                               \
+    template T ParallelWellInfo<T>::                                                \
         broadcastFirstPerforationValue<T>(const T&) const;                          \
+    INSTANTIATE_BROADCAST_FIRST_PERF_DENSEAD_EVALUATION(T, 1)                       \
+    INSTANTIATE_BROADCAST_FIRST_PERF_DENSEAD_EVALUATION(T, 2)                       \
+    INSTANTIATE_BROADCAST_FIRST_PERF_DENSEAD_EVALUATION(T, 3)                       \
+    INSTANTIATE_BROADCAST_FIRST_PERF_DENSEAD_EVALUATION(T, 4)                       \
+    INSTANTIATE_BROADCAST_FIRST_PERF_DENSEAD_EVALUATION(T, 5)                       \
+    INSTANTIATE_BROADCAST_FIRST_PERF_DENSEAD_EVALUATION(T, 6)                       \
     template void CommunicateAboveBelow<T>::                                        \
         partialSumPerfValues<dIter<T>>(dIter<T>, dIter<T>) const;                   \
     template bool operator<(const ParallelWellInfo<T>&,                             \

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -396,7 +396,7 @@ namespace Opm
 
         auto& perf_data = ws.perf_data;
         auto& perf_rates = perf_data.phase_rates;
-        for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
+        for (int perf = 0; perf < this->number_of_local_perforations_; ++perf) {
             // Calculate perforation quantities.
             std::vector<EvalWell> cq_s(this->num_components_, {this->primary_variables_.numWellEq() + Indices::numEq, 0.0});
             EvalWell water_flux_s{this->primary_variables_.numWellEq() + Indices::numEq, 0.0};
@@ -778,7 +778,7 @@ namespace Opm
         std::fill(this->ipr_a_.begin(), this->ipr_a_.end(), 0.);
         std::fill(this->ipr_b_.begin(), this->ipr_b_.end(), 0.);
 
-        for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
+        for (int perf = 0; perf < this->number_of_local_perforations_; ++perf) {
             std::vector<Scalar> mob(this->num_components_, 0.0);
             getMobility(simulator, perf, mob, deferred_logger);
 
@@ -1061,7 +1061,7 @@ namespace Opm
     {
         bool all_drawdown_wrong_direction = true;
 
-        for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
+        for (int perf = 0; perf < this->number_of_local_perforations_; ++perf) {
             const int cell_idx = this->well_cells_[perf];
             const auto& intQuants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
             const auto& fs = intQuants.fluidState();
@@ -1308,7 +1308,7 @@ namespace Opm
             comm.sum(wellPI, np);
         }
 
-        assert ((static_cast<int>(subsetPerfID) == this->number_of_perforations_) &&
+        assert ((static_cast<int>(subsetPerfID) == this->number_of_local_perforations_) &&
                 "Internal logic error in processing connections for PI/II");
     }
 
@@ -1485,7 +1485,7 @@ namespace Opm
 
         const bool allow_cf = this->getAllowCrossFlow();
 
-        for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
+        for (int perf = 0; perf < this->number_of_local_perforations_; ++perf) {
             const int cell_idx = this->well_cells_[perf];
             const auto& intQuants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
             // flux for each perforation
@@ -2064,7 +2064,7 @@ namespace Opm
             auto& perf_water_throughput = well_state.well(this->index_of_well_)
                 .perf_data.water_throughput;
 
-            for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
+            for (int perf = 0; perf < this->number_of_local_perforations_; ++perf) {
                 const Scalar perf_water_vel =
                     this->primary_variables_.value(Bhp + 1 + perf);
 
@@ -2129,7 +2129,7 @@ namespace Opm
         const auto& perf_data = ws.perf_data;
         const auto& perf_water_throughput = perf_data.water_throughput;
         const Scalar throughput = perf_water_throughput[perf];
-        const int pskin_index = Bhp + 1 + this->number_of_perforations_ + perf;
+        const int pskin_index = Bhp + 1 + this->number_of_local_perforations_ + perf;
 
         EvalWell poly_conc(this->primary_variables_.numWellEq() + Indices::numEq, 0.0);
         poly_conc.setValue(this->wpolymer());
@@ -2253,7 +2253,7 @@ namespace Opm
         };
 
         Scalar max_pressure = 0.0;
-        for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
+        for (int perf = 0; perf < this->number_of_local_perforations_; ++perf) {
             const int cell_idx = this->well_cells_[perf];
             const auto& int_quants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
             const auto& fs = int_quants.fluidState();
@@ -2514,7 +2514,7 @@ namespace Opm
         std::vector<Scalar> well_q_s(this->num_components_, 0.);
         const EvalWell& bhp = this->primary_variables_.eval(Bhp);
         const bool allow_cf = this->getAllowCrossFlow() || openCrossFlowAvoidSingularity(simulator);
-        for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
+        for (int perf = 0; perf < this->number_of_local_perforations_; ++perf) {
             const int cell_idx = this->well_cells_[perf];
             const auto& intQuants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
             std::vector<Scalar> mob(this->num_components_, 0.);

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -253,7 +253,7 @@ updateInjMult(std::vector<Scalar>& inj_multipliers,
 
 template<class Scalar>
 Scalar WellInterfaceGeneric<Scalar>::
-getInjMult(const int perf,
+getInjMult(const int local_perf_index,
            const Scalar bhp,
            const Scalar perf_pres,
            DeferredLogger& dlogger) const
@@ -262,7 +262,7 @@ getInjMult(const int perf,
 
     Scalar multiplier = 1.;
 
-    const auto perf_ecl_index = this->perforationData()[perf].ecl_index;
+    const auto perf_ecl_index = this->perforationData()[local_perf_index].ecl_index;
     const bool is_wrev = this->well_ecl_.getInjMultMode() == Well::InjMultMode::WREV;
 
     const bool active_injmult = (is_wrev && this->well_ecl_.aciveWellInjMult()) ||

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -94,14 +94,14 @@ WellInterfaceGeneric(const Well& well,
 
     // We do not want to count SHUT perforations here, so
     // it would be wrong to use wells.getConnections().size().
-    // This is the number_of_perforations_ on this process only!
-    number_of_perforations_ = perf_data.size();
+    // This is the number_of_local_perforations_ on this process only!
+    number_of_local_perforations_ = perf_data.size();
 
     // perforations related
     {
-        well_cells_.resize(number_of_perforations_);
-        well_index_.resize(number_of_perforations_);
-        saturation_table_number_.resize(number_of_perforations_);
+        well_cells_.resize(number_of_local_perforations_);
+        well_index_.resize(number_of_local_perforations_);
+        saturation_table_number_.resize(number_of_local_perforations_);
         int perf = 0;
         for (const auto& pd : perf_data) {
             well_cells_[perf] = pd.cell_index;
@@ -462,7 +462,7 @@ setWellEfficiencyFactor(const Scalar efficiency_factor)
 template<class Scalar>
 void WellInterfaceGeneric<Scalar>::setRepRadiusPerfLength()
 {
-    const int nperf = number_of_perforations_;
+    const int nperf = number_of_local_perforations_;
 
     perf_rep_radius_.clear();
     perf_length_.clear();
@@ -535,7 +535,7 @@ template<class Scalar>
 void WellInterfaceGeneric<Scalar>::
 updatePerforatedCell(std::vector<bool>& is_cell_perforated)
 {
-    for (int perf_idx = 0; perf_idx < number_of_perforations_; ++perf_idx) {
+    for (int perf_idx = 0; perf_idx < number_of_local_perforations_; ++perf_idx) {
         is_cell_perforated[well_cells_[perf_idx]] = true;
     }
 }
@@ -707,7 +707,7 @@ void WellInterfaceGeneric<Scalar>::addPerforations(const std::vector<RuntimePerf
             this->saturation_table_number_
                 .push_back(this->saturation_table_number_.front());
 
-            ++this->number_of_perforations_;
+            ++this->number_of_local_perforations_;
         }
     }
 }

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -161,7 +161,7 @@ public:
 
     // Note:: for multisegment wells, bhp is actually segment pressure in practice based on observation
     // it might change in the future
-    Scalar getInjMult(const int perf, const Scalar bhp, const Scalar perf_pres, DeferredLogger& dlogger) const;
+    Scalar getInjMult(const int local_perf_index, const Scalar bhp, const Scalar perf_pres, DeferredLogger& dlogger) const;
 
     // whether a well is specified with a non-zero and valid VFP table number
     bool isVFPActive(DeferredLogger& deferred_logger) const;

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -129,7 +129,7 @@ public:
 
     int numPhases() const { return number_of_phases_; }
 
-    int numPerfs() const { return number_of_perforations_; }
+    int numPerfs() const { return number_of_local_perforations_; }
 
     Scalar refDepth() const { return ref_depth_; }
 
@@ -328,7 +328,7 @@ protected:
     std::vector<Scalar> well_index_;
 
     // number of the perforations for this well on this process
-    int number_of_perforations_;
+    int number_of_local_perforations_;
 
     // depth for each perforation
     std::vector<Scalar> perf_depth_;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -1599,6 +1599,8 @@ namespace Opm
         for (int perf = 0; perf < nperf; ++perf) {
             total_tw += this->well_index_[perf];
         }
+        total_tw = this->parallelWellInfo().communication().sum(total_tw);
+
         for (int perf = 0; perf < nperf; ++perf) {
             const int cell_idx = this->well_cells_[perf];
             const auto& intQuants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -76,7 +76,7 @@ namespace Opm
                                                   index_of_well,
                                                   perf_data)
     {
-        connectionRates_.resize(this->number_of_perforations_);
+        connectionRates_.resize(this->number_of_local_perforations_);
 
         if constexpr (has_solvent || has_zFraction) {
             if (well.isInjector()) {
@@ -934,7 +934,7 @@ namespace Opm
         if(!this->isOperableAndSolvable() && !this->wellIsStopped())
             return;
 
-        for (int perfIdx = 0; perfIdx < this->number_of_perforations_; ++perfIdx) {
+        for (int perfIdx = 0; perfIdx < this->number_of_local_perforations_; ++perfIdx) {
             if (this->cells()[perfIdx] == cellIdx) {
                 for (int i = 0; i < RateVector::dimension; ++i) {
                     rates[i] += connectionRates_[perfIdx][i];
@@ -947,7 +947,7 @@ namespace Opm
     typename WellInterface<TypeTag>::Scalar
     WellInterface<TypeTag>::volumetricSurfaceRateForConnection(int cellIdx, int phaseIdx) const
     {
-        for (int perfIdx = 0; perfIdx < this->number_of_perforations_; ++perfIdx) {
+        for (int perfIdx = 0; perfIdx < this->number_of_local_perforations_; ++perfIdx) {
             if (this->cells()[perfIdx] == cellIdx) {
                 const unsigned activeCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::solventComponentIndex(phaseIdx));
                 return connectionRates_[perfIdx][activeCompIdx].value();
@@ -1595,7 +1595,7 @@ namespace Opm
         // if we don't have any potentials we weight it using the mobilites
         // We only need approximation so we don't bother with the vapporized oil and dissolved gas
         Scalar total_tw = 0;
-        const int nperf = this->number_of_perforations_;
+        const int nperf = this->number_of_local_perforations_;
         for (int perf = 0; perf < nperf; ++perf) {
             total_tw += this->well_index_[perf];
         }
@@ -1762,7 +1762,7 @@ namespace Opm
 
         auto& d_factor = ws.perf_data.connection_d_factor;
 
-        for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
+        for (int perf = 0; perf < this->number_of_local_perforations_; ++perf) {
             const int cell_idx = this->well_cells_[perf];
             const auto& intQuants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
 
@@ -1828,7 +1828,7 @@ namespace Opm
         auto& tmult = ws.perf_data.connection_compaction_tmult;
         auto& ctf   = ws.perf_data.connection_transmissibility_factor;
 
-        for (int perf = 0; perf < this->number_of_perforations_; ++perf) {
+        for (int perf = 0; perf < this->number_of_local_perforations_; ++perf) {
             const int cell_idx = this->well_cells_[perf];
 
             const auto& intQuants = simulator.model()

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -239,6 +239,7 @@ void WellState<Scalar>::initSingleWell(const std::vector<Scalar>& cellPressures,
     if (!well_perf_data.empty()) {
         pressure_first_connection = cellPressures[well_perf_data[0].cell_index];
     }
+    // The following call is necessary to ensure that processes that do not contain the first perforation get the correct value
     pressure_first_connection = well_info.broadcastFirstPerforationValue(pressure_first_connection);
 
     if (well.isInjector()) {
@@ -246,6 +247,7 @@ void WellState<Scalar>::initSingleWell(const std::vector<Scalar>& cellPressures,
         if (!well_perf_data.empty()) {
             temperature_first_connection = cellTemperatures[well_perf_data[0].cell_index];
         }
+        // The following call is necessary to ensure that processes that do not contain the first perforation get the correct value
         temperature_first_connection = well_info.broadcastFirstPerforationValue(temperature_first_connection);
         this->initSingleInjector(well, well_info, pressure_first_connection, temperature_first_connection,
                                  well_perf_data, summary_state);

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -64,6 +64,15 @@ add_test_compare_parallel_simulation(CASENAME msw-3d-two-producers
                                      MPI_PROCS 4
                                      TEST_ARGS --allow-distributed-wells=true)
 
+add_test_compare_parallel_simulation(CASENAME msw-model-1-short
+                                     FILENAME MSW_MODEL_1_SHORT
+                                     DIR model1
+                                     SIMULATOR flow_distribute_z
+                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
+                                     REL_TOL 1e-4
+                                     MPI_PROCS 4
+                                     TEST_ARGS --allow-distributed-wells=true)
+
 add_test_compare_parallel_simulation(CASENAME spe9group
                                      FILENAME SPE9_CP_GROUP
                                      SIMULATOR flow


### PR DESCRIPTION
This PR adds communication to three spots where it was missing before (commits adb7223eeb97fa475e50b0721e1e460350d4216b, d454d03d38f809295ab22a7b2b8faf9f1c465d50 and  f0fbe62056c0dfeab59b8c978d00778026b3a522) and renames some variables to make it obvious if they contain local or global quantities.
With these changes, the test added in commit 3b68c4eb114ed63225065542ce4f96e5e5ec8174 passes. The test does not pass without these changes, see #5999, there the parallel simulation runs into a deadlock due to the missing communication.

This PR is not relevant for the reference manual.