### PR TITLE
Remove Unused FMT Header

### DIFF
--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -56,8 +56,6 @@
 #include <cstring>
 #include <utility>
 
-#include <fmt/format.h>
-
 namespace Opm {
 /*!
  * \ingroup BlackOilModel


### PR DESCRIPTION
Makes using the header from an installed location harder than it needs to be.