### PR TITLE
Expose CornerCells and OverlapLayers Load Balancing Settings

### DIFF
--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -227,6 +227,7 @@ public:
         }
 
         this->doLoadBalance_(this->edgeWeightsMethod(), this->ownersFirst(),
+                             this->addCorners(), this->numOverlap(),
                              this->partitionMethod(), this->serialPartitioning(),
                              this->enableDistributedWells(),
                              this->allow_splitting_inactive_wells_,

--- a/opm/simulators/flow/FlowGenericVanguard.cpp
+++ b/opm/simulators/flow/FlowGenericVanguard.cpp
@@ -118,6 +118,8 @@ FlowGenericVanguard::FlowGenericVanguard(SimulationModelParams&& params)
 
         ownersFirst_ = Parameters::Get<Parameters::OwnerCellsFirst>();
 #if HAVE_MPI
+        numOverlap_ = Parameters::Get<Parameters::NumOverlap>();
+        addCorners_ = Parameters::Get<Parameters::AddCorners>();
         partitionMethod_   = Dune::PartitionMethod(Parameters::Get<Parameters::PartitionMethod>());
         serialPartitioning_ = Parameters::Get<Parameters::SerialPartitioning>();
         zoltanParams_ = Parameters::Get<Parameters::ZoltanParams>();
@@ -452,8 +454,13 @@ void FlowGenericVanguard::registerParameters_()
     Parameters::Register<Parameters::OwnerCellsFirst>
         ("Order cells owned by rank before ghost/overlap cells.");
 #if HAVE_MPI
+    Parameters::Register<Parameters::AddCorners>
+        ("Add corners to partition.");
+    Parameters::Register<Parameters::NumOverlap>
+        ("Numbers of layers overlap in parallel partition");
     Parameters::Register<Parameters::PartitionMethod>
-        ("Choose partitioning strategy: 0=simple, 1=Zoltan, 2=METIS, 3=Zoltan with all cells of well represented by one vertex.");
+        ("Choose partitioning strategy: 0=simple, 1=Zoltan, 2=METIS, "
+         "3=Zoltan with all cells of well represented by one vertex.");
     Parameters::Register<Parameters::SerialPartitioning>
         ("Perform partitioning for parallel runs on a single process.");
     Parameters::Register<Parameters::ZoltanImbalanceTol<Scalar>>

--- a/opm/simulators/flow/GenericCpGridVanguard.hpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.hpp
@@ -158,6 +158,8 @@ protected:
 #if HAVE_MPI
     void doLoadBalance_(const Dune::EdgeWeightMethod             edgeWeightsMethod,
                         const bool                               ownersFirst,
+                        const bool                               addCorners,
+                        const int                                numOverlap,
                         const Dune::PartitionMethod              partitionMethod,
                         const bool                               serialPartitioning,
                         const bool                               enableDistributedWells,
@@ -177,6 +179,8 @@ private:
 
     void distributeGrid(const Dune::EdgeWeightMethod                          edgeWeightsMethod,
                         const bool                                            ownersFirst,
+                        const bool                                            addCorners,
+                        const int                                             numOverlap,
                         const Dune::PartitionMethod                           partitionMethod,
                         const bool                                            serialPartitioning,
                         const bool                                            enableDistributedWells,
@@ -190,6 +194,8 @@ private:
 
     void distributeGrid(const Dune::EdgeWeightMethod                          edgeWeightsMethod,
                         const bool                                            ownersFirst,
+                        const bool                                            addCorners,
+                        const int                                             numOverlap,
                         const Dune::PartitionMethod                           partitionMethod,
                         const bool                                            serialPartitioning,
                         const bool                                            enableDistributedWells,


### PR DESCRIPTION
We introduce two new run-time parameters,
```
AddCorners (--add-corners=BOOL, default 'false')
NumOverlap (--num-overlap=INT, default '1')
```
that are passed on to the grid's load-balancing engine as the `addCornerCells` and `overlapLayers` settings.

---

Extracted from #5801.