### PR TITLE
fixed: use if constexpr to avoid compiler warning

### DIFF
--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -190,7 +190,10 @@ public:
         Evaluation Sw = 0.0;
         if constexpr (waterEnabled) {
             if (priVars.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Sw) {
-                Sw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx);
+                assert(Indices::waterSwitchIdx >= 0);
+                if constexpr (Indices::waterSwitchIdx >= 0) {
+                    Sw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx);
+                }
             } else if(priVars.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Rsw ||
                       priVars.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Disabled) {
                       // water is enabled but is not a primary variable i.e. one component/phase case
@@ -201,7 +204,10 @@ public:
         Evaluation Sg = 0.0;
         if constexpr (gasEnabled) {
             if (priVars.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Sg) {
-                Sg = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
+                assert(Indices::compositionSwitchIdx >= 0);
+                if constexpr (compositionSwitchEnabled) {
+                    Sg = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
+                }
             } else if (priVars.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Rv) {
                 Sg = 1.0 - Sw;
             } else if (priVars.primaryVarsMeaningGas() == PrimaryVariables::GasMeaning::Disabled) {


### PR DESCRIPTION
while we are never actually here without an index, compiler cannot know since the enum is a runtime argument

```
In member function ‘constexpr const std::array<_Tp, _Nm>::value_type& std::array<_Tp, _Nm>::operator[](size_type) const [with _Tp = double; long unsigned int _Nm = 3]’,
    inlined from ‘const K& Dune::FieldVector<K, SIZE>::operator[](size_type) const [with K = double; int SIZE = 3]’ at /usr/include/dune/common/fvector.hh:194:19,
    inlined from ‘Opm::BlackOilPrimaryVariables<TypeTag>::Evaluation Opm::BlackOilPrimaryVariables<TypeTag>::makeEvaluation(unsigned int, unsigned int, Opm::LinearizationType) const [with TypeTag = Opm::Properties::TTag::FlowGasWaterBrineProblem]’ at /home/akva/kode/opm/opm-simulators/opm/models/blackoil/blackoilprimaryvariables.hh:216:55,
    inlined from ‘void Opm::BlackOilIntensiveQuantities<TypeTag>::updateSaturations(const ElementContext&, unsigned int, unsigned int) [with TypeTag = Opm::Properties::TTag::FlowGasWaterBrineProblem]’ at /home/akva/kode/opm/opm-simulators/opm/models/blackoil/blackoilintensivequantities.hh:205:48,
    inlined from ‘void Opm::BlackOilIntensiveQuantities<TypeTag>::update(const ElementContext&, unsigned int, unsigned int) [with TypeTag = Opm::Properties::TTag::FlowGasWaterBrineProblem]’ at /home/akva/kode/opm/opm-simulators/opm/models/blackoil/blackoilintensivequantities.hh:553:26,
    inlined from ‘void Opm::FvBaseElementContext<TypeTag>::updateSingleIntQuants_(const PrimaryVariables&, unsigned int, unsigned int) [with TypeTag = Opm::Properties::TTag::FlowGasWaterBrineProblem]’ at /home/akva/kode/opm/opm-simulators/opm/models/discretization/common/fvbaseelementcontext.hh:584:61,
    inlined from ‘void Opm::FvBaseElementContext<TypeTag>::updateIntensiveQuantities_(unsigned int, size_t) [with TypeTag = Opm::Properties::TTag::FlowGasWaterBrineProblem]’ at /home/akva/kode/opm/opm-simulators/opm/models/discretization/common/fvbaseelementcontext.hh:567:39,
    inlined from ‘void Opm::FvBaseElementContext<TypeTag>::updatePrimaryIntensiveQuantities(unsigned int) [with TypeTag = Opm::Properties::TTag::FlowGasWaterBrineProblem]’ at /home/akva/kode/opm/opm-simulators/opm/models/discretization/common/fvbaseelementcontext.hh:213:33,
    inlined from ‘_ZNK3Opm15FIBlackOilModelINS_10Properties4TTag24FlowGasWaterBrineProblemEE38invalidateAndUpdateIntensiveQuantitiesEj._omp_fn.0’ at /home/akva/kode/opm/opm-simulators/opm/simulators/flow/FIBlackoilModel.hpp:93:61:
/usr/include/c++/14/array:219:24: warning: array subscript 4294957296 is above array bounds of ‘std::__array_traits<double, 3>::_Type’ {aka ‘const double [3]’} [-Warray-bounds=]
  219 |         return _M_elems[__n];
      |                ~~~~~~~~^
/usr/include/c++/14/array: In function ‘_ZNK3Opm15FIBlackOilModelINS_10Properties4TTag24FlowGasWaterBrineProblemEE38invalidateAndUpdateIntensiveQuantitiesEj._omp_fn.0’:
/usr/include/c++/14/array:115:55: note: while referencing ‘std::array<double, 3>::_M_elems’
  115 |       typename __array_traits<_Tp, _Nm>::_Type        _M_elems;
      |                                                       ^~~~~~~~
```