### PR TITLE
Make Simulator Operations Generally Accessible

### DIFF
--- a/opm/simulators/flow/ActionHandler.hpp
+++ b/opm/simulators/flow/ActionHandler.hpp
@@ -99,7 +99,6 @@ public:
     void evalUDQAssignments(const unsigned episodeIdx,
                             UDQState& udq_state);
 
-private:
     /// Convey dynamic updates triggered by an action block back to the
     /// running simulator.
     ///
@@ -125,6 +124,7 @@ private:
                               const TransFunc& updateTrans,
                               bool& commit_wellstate);
 
+private:
     /// Static properties such as permeability and transmissibility.
     EclipseState& ecl_state_;
 

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -1704,7 +1704,6 @@ protected:
     BCData<int> bcindex_;
     bool nonTrivialBoundaryConditions_ = false;
     bool first_step_ = true;
-
 };
 
 } // namespace Opm

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -80,8 +80,10 @@ template <class TypeTag>
 class FlowProblemBlackoil : public FlowProblem<TypeTag>
 {
     // TODO: the naming of the Types might be able to be adjusted
+public:
     using FlowProblemType = FlowProblem<TypeTag>;
 
+private:
     using typename FlowProblemType::Scalar;
     using typename FlowProblemType::Simulator;
     using typename FlowProblemType::GridView;
@@ -436,11 +438,14 @@ public:
     void endTimeStep() override
     {
         FlowProblemType::endTimeStep();
+        this->endStepApplyAction();
+    }
 
-        // after the solution is updated, the values in output module needs also updated
+    void endStepApplyAction()
+    {
+        // After the solution is updated, the values in output module needs
+        // also updated.
         this->eclWriter()->mutableOutputModule().invalidateLocalData();
-
-        const bool isSubStep = !this->simulator().episodeWillBeOver();
 
         // For CpGrid with LGRs, ecl/vtk output is not supported yet.
         const auto& grid = this->simulator().vanguard().gridView().grid();
@@ -448,6 +453,8 @@ public:
         using GridType = std::remove_cv_t<std::remove_reference_t<decltype(grid)>>;
         constexpr bool isCpGrid = std::is_same_v<GridType, Dune::CpGrid>;
         if (!isCpGrid || (grid.maxLevel() == 0)) {
+            const bool isSubStep = !this->simulator().episodeWillBeOver();
+
             this->eclWriter_->evalSummaryState(isSubStep);
         }
 


### PR DESCRIPTION
In particular, this PR

1. Makes `ActionHandler::applySimulatorUpdate()` "public"
2. Splits the action processing part of `FlowProblemBlackoil::endTimeStep()` out to a separately callable member function, `FlowProblemBlackoil::endStepApplyAction()`.

Together, these provide hooks which make the simulator's event processing at the end of a converged time step customisable.

---

Extracted from #5801.