### PR TITLE
Using the CriticalException in PreconditionerFactory and ISTLSolver

### DIFF
--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -378,11 +378,11 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         void prepare(const Matrix& M, Vector& b)
         {
             OPM_TIMEBLOCK(istlSolverPrepare);
-            OPM_BEGIN_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR();
+            try {
                 initPrepare(M,b);
 
                 prepareFlexibleSolver();
-            OPM_END_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR();
+            } OPM_CATCH_AND_RETHROW_AS_CRITICAL_ERROR("This is likely due to a faulty linear solver JSON specification. Check for errors related to missing nodes.");
         }
 
 

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -25,6 +25,7 @@
 #include <dune/istl/owneroverlapcopy.hh>
 #include <dune/istl/solver.hh>
 
+#include <opm/common/CriticalError.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/Exceptions.hpp>
 #include <opm/common/TimingMacros.hpp>
@@ -377,10 +378,11 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         void prepare(const Matrix& M, Vector& b)
         {
             OPM_TIMEBLOCK(istlSolverPrepare);
+            OPM_BEGIN_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR();
+                initPrepare(M,b);
 
-            initPrepare(M,b);
-
-            prepareFlexibleSolver();
+                prepareFlexibleSolver();
+            OPM_END_TRY_CATCH_RETHROW_AS_CRITICAL_ERROR();
         }
 
 

--- a/opm/simulators/linalg/PreconditionerFactory_impl.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory_impl.hpp
@@ -20,7 +20,6 @@
 
 #include <config.h>
 
-#include <opm/common/CriticalError.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/TimingMacros.hpp>
 
@@ -777,7 +776,7 @@ PreconditionerFactory<Operator, Comm>::create(const Operator& op,
                                               const std::function<Vector()>& weightsCalculator,
                                               std::size_t pressureIndex)
 {
-    OPM_TRY_THROW_AS_CRITICAL_ERROR(return instance().doCreate(op, prm, weightsCalculator, pressureIndex));
+    return instance().doCreate(op, prm, weightsCalculator, pressureIndex);
 }
 
 template <class Operator, class Comm>
@@ -788,7 +787,7 @@ PreconditionerFactory<Operator, Comm>::create(const Operator& op,
                                               const Comm& comm,
                                               std::size_t pressureIndex)
 {
-    OPM_TRY_THROW_AS_CRITICAL_ERROR(return instance().doCreate(op, prm, weightsCalculator, pressureIndex, comm));
+    return instance().doCreate(op, prm, weightsCalculator, pressureIndex, comm);
 }
 
 
@@ -799,7 +798,7 @@ PreconditionerFactory<Operator, Comm>::create(const Operator& op,
                                               const Comm& comm,
                                               std::size_t pressureIndex)
 {
-    OPM_TRY_THROW_AS_CRITICAL_ERROR(return instance().doCreate(op, prm, std::function<Vector()>(), pressureIndex, comm));
+    return instance().doCreate(op, prm, std::function<Vector()>(), pressureIndex, comm);
 }
 
 template <class Operator, class Comm>

--- a/opm/simulators/linalg/PreconditionerFactory_impl.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory_impl.hpp
@@ -20,6 +20,7 @@
 
 #include <config.h>
 
+#include <opm/common/CriticalError.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/TimingMacros.hpp>
 
@@ -776,7 +777,7 @@ PreconditionerFactory<Operator, Comm>::create(const Operator& op,
                                               const std::function<Vector()>& weightsCalculator,
                                               std::size_t pressureIndex)
 {
-    return instance().doCreate(op, prm, weightsCalculator, pressureIndex);
+    OPM_TRY_THROW_AS_CRITICAL_ERROR(return instance().doCreate(op, prm, weightsCalculator, pressureIndex));
 }
 
 template <class Operator, class Comm>
@@ -787,7 +788,7 @@ PreconditionerFactory<Operator, Comm>::create(const Operator& op,
                                               const Comm& comm,
                                               std::size_t pressureIndex)
 {
-    return instance().doCreate(op, prm, weightsCalculator, pressureIndex, comm);
+    OPM_TRY_THROW_AS_CRITICAL_ERROR(return instance().doCreate(op, prm, weightsCalculator, pressureIndex, comm));
 }
 
 
@@ -798,7 +799,7 @@ PreconditionerFactory<Operator, Comm>::create(const Operator& op,
                                               const Comm& comm,
                                               std::size_t pressureIndex)
 {
-    return instance().doCreate(op, prm, std::function<Vector()>(), pressureIndex, comm);
+    OPM_TRY_THROW_AS_CRITICAL_ERROR(return instance().doCreate(op, prm, std::function<Vector()>(), pressureIndex, comm));
 }
 
 template <class Operator, class Comm>


### PR DESCRIPTION
This pull request uses the new `CriticalError` exception class introduced the [opm-common PR 4467]( https://github.com/OPM/opm-common/pull/4467) to rethrow some exceptions happening in the initialisation of the linear solver as critical.

I am open to discussion if this is the correct level to introduce this exception. The reasoning behind the `prepare` choice was simply that in `initPrepare`, one access ```"preconditioner.type"``` which can lead to exceptions with ill-formed JSON input. It is also doubtful that any error occurring in `prepare` can be fixed by retrying with a smaller timestep.
