### PR TITLE
clang-format now adds newline at the end of file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,6 +14,7 @@
         ColumnLimit: 120,
         Cpp11BracedListStyle: true,
         FixNamespaceComments: true,
+        InsertNewlineAtEOF: true,
         MaxEmptyLinesToKeep: 5,
         NamespaceIndentation: Inner,
 }


### PR DESCRIPTION
Note that this change requires clang-format 16 or newer.