### PR TITLE
Link MainDispatchDynamic to LibFMT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,6 +541,10 @@ set_property(TARGET moduleVersion PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_library(MainDispatchDynamic OBJECT opm/simulators/flow/MainDispatchDynamic.cpp)
 set_property(TARGET MainDispatchDynamic PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+if(TARGET fmt::fmt)
+  target_link_libraries(MainDispatchDynamic fmt::fmt)
+endif()
+
 # Strictly we only depend on the update-version target,
 # but this is not exposed in a super-build.
 add_dependencies(moduleVersion opmsimulators)


### PR DESCRIPTION
Some code in implementation depends on the libfmt headers.