### PR TITLE
Add CompositionalContainer, a container for compositional data output

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -90,6 +90,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/flow/BlackoilModelParameters.cpp
   opm/simulators/flow/BlackoilModelConvergenceMonitor.cpp
   opm/simulators/flow/CollectDataOnIORank.cpp
+  opm/simulators/flow/CompositionalContainer.cpp
   opm/simulators/flow/ConvergenceOutputConfiguration.cpp
   opm/simulators/flow/EclGenericWriter.cpp
   opm/simulators/flow/ExtboContainer.cpp
@@ -821,6 +822,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/flow/BlackoilModelProperties.hpp
   opm/simulators/flow/CollectDataOnIORank.hpp
   opm/simulators/flow/CollectDataOnIORank_impl.hpp
+  opm/simulators/flow/CompositionalContainer.hpp
   opm/simulators/flow/ConvergenceOutputConfiguration.hpp
   opm/simulators/flow/countGlobalCells.hpp
   opm/simulators/flow/CpGridVanguard.hpp

--- a/opm/simulators/flow/CompositionalContainer.cpp
+++ b/opm/simulators/flow/CompositionalContainer.cpp
@@ -1,0 +1,29 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+#include <opm/simulators/flow/CompositionalContainer.hpp>
+
+
+namespace Opm {
+
+} // namespace Opm

--- a/opm/simulators/flow/CompositionalContainer.cpp
+++ b/opm/simulators/flow/CompositionalContainer.cpp
@@ -68,6 +68,20 @@ allocate(const unsigned bufferSize,
 
 template<class FluidSystem>
 void CompositionalContainer<FluidSystem>::
+assignMoleFractions(const unsigned globalDofIdx,
+                    const AssignFunction& fractions)
+{
+    if (moleFractions_.empty()) {
+        return;
+    }
+
+    std::for_each(moleFractions_.begin(), moleFractions_.end(),
+                  [&fractions, globalDofIdx, c = 0](auto& comp) mutable
+                  { comp[globalDofIdx] = fractions(c++); });
+}
+
+template<class FluidSystem>
+void CompositionalContainer<FluidSystem>::
 outputRestart(data::Solution& sol)
 {
     using DataEntry =

--- a/opm/simulators/flow/CompositionalContainer.cpp
+++ b/opm/simulators/flow/CompositionalContainer.cpp
@@ -82,6 +82,20 @@ assignMoleFractions(const unsigned globalDofIdx,
 
 template<class FluidSystem>
 void CompositionalContainer<FluidSystem>::
+assignOilFractions(const unsigned globalDofIdx,
+                   const AssignFunction& fractions)
+{
+    if (phaseMoleFractions_[oilPhaseIdx][0].empty()) {
+        return;
+    }
+    std::for_each(phaseMoleFractions_[oilPhaseIdx].begin(),
+                  phaseMoleFractions_[oilPhaseIdx].end(),
+                  [globalDofIdx, &fractions, c = 0](auto& comp) mutable
+                  { comp[globalDofIdx] = fractions(c++); });
+}
+
+template<class FluidSystem>
+void CompositionalContainer<FluidSystem>::
 outputRestart(data::Solution& sol)
 {
     using DataEntry =

--- a/opm/simulators/flow/CompositionalContainer.cpp
+++ b/opm/simulators/flow/CompositionalContainer.cpp
@@ -23,7 +23,63 @@
 #include <config.h>
 #include <opm/simulators/flow/CompositionalContainer.hpp>
 
+#include <opm/material/fluidsystems/BlackOilDefaultIndexTraits.hpp>
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
+#include <opm/material/fluidsystems/GenericOilGasFluidSystem.hpp>
 
 namespace Opm {
+
+template<class FluidSystem>
+void CompositionalContainer<FluidSystem>::
+allocate(const unsigned bufferSize,
+         std::map<std::string, int>& rstKeywords)
+{
+    if (auto& zmf = rstKeywords["ZMF"]; zmf > 0) {
+        zmf = 0;
+        this->allocated_ = true;
+        for (int i = 0; i < numComponents; ++i) {
+            moleFractions_[i].resize(bufferSize, 0.0);
+        }
+    }
+
+    if (auto& xmf = rstKeywords["XMF"]; xmf > 0 && FluidSystem::phaseIsActive(oilPhaseIdx)) {
+        this->allocated_ = true;
+        xmf = 0;
+        for (int i = 0; i < numComponents; ++i) {
+            phaseMoleFractions_[oilPhaseIdx][i].resize(bufferSize, 0.0);
+        }
+    }
+
+    if (auto& ymf = rstKeywords["YMF"]; ymf > 0 && FluidSystem::phaseIsActive(gasPhaseIdx)) {
+        this->allocated_ = true;
+        ymf = 0;
+        for (int i = 0; i < numComponents; ++i) {
+            phaseMoleFractions_[gasPhaseIdx][i].resize(bufferSize, 0.0);
+        }
+    }
+}
+
+template<class T> using FS = BlackOilFluidSystem<T,BlackOilDefaultIndexTraits>;
+
+#define INSTANTIATE_TYPE(T) \
+    template class CompositionalContainer<FS<T>>;
+
+INSTANTIATE_TYPE(double)
+
+#if FLOW_INSTANTIATE_FLOAT
+INSTANTIATE_TYPE(float)
+#endif
+
+#define INSTANTIATE_COMP(NUM) \
+    template<class T> using FS##NUM = GenericOilGasFluidSystem<T, NUM>; \
+    template class CompositionalContainer<FS##NUM<double>>;
+
+INSTANTIATE_COMP(0)
+INSTANTIATE_COMP(2)
+INSTANTIATE_COMP(3)
+INSTANTIATE_COMP(4)
+INSTANTIATE_COMP(5)
+INSTANTIATE_COMP(6)
+INSTANTIATE_COMP(7)
 
 } // namespace Opm

--- a/opm/simulators/flow/CompositionalContainer.cpp
+++ b/opm/simulators/flow/CompositionalContainer.cpp
@@ -68,6 +68,21 @@ allocate(const unsigned bufferSize,
 
 template<class FluidSystem>
 void CompositionalContainer<FluidSystem>::
+assignGasFractions(const unsigned globalDofIdx,
+                   const AssignFunction& fractions)
+{
+    if (phaseMoleFractions_[gasPhaseIdx][0].empty()) {
+        return;
+    }
+
+    std::for_each(phaseMoleFractions_[gasPhaseIdx].begin(),
+                  phaseMoleFractions_[gasPhaseIdx].end(),
+                  [globalDofIdx, &fractions, c = 0](auto& comp) mutable
+                  { comp[globalDofIdx] = fractions(c++); });
+}
+
+template<class FluidSystem>
+void CompositionalContainer<FluidSystem>::
 assignMoleFractions(const unsigned globalDofIdx,
                     const AssignFunction& fractions)
 {
@@ -88,6 +103,7 @@ assignOilFractions(const unsigned globalDofIdx,
     if (phaseMoleFractions_[oilPhaseIdx][0].empty()) {
         return;
     }
+
     std::for_each(phaseMoleFractions_[oilPhaseIdx].begin(),
                   phaseMoleFractions_[oilPhaseIdx].end(),
                   [globalDofIdx, &fractions, c = 0](auto& comp) mutable

--- a/opm/simulators/flow/CompositionalContainer.hpp
+++ b/opm/simulators/flow/CompositionalContainer.hpp
@@ -64,7 +64,8 @@ public:
     void assignOilFractions(const unsigned globalDofIdx,
                             const AssignFunction& fractions);
 
-    void outputRestart(data::Solution& sol);
+    void outputRestart(data::Solution& sol,
+                       ScalarBuffer& oil_saturation);
 
     bool allocated() const
     { return allocated_; }

--- a/opm/simulators/flow/CompositionalContainer.hpp
+++ b/opm/simulators/flow/CompositionalContainer.hpp
@@ -33,6 +33,8 @@
 
 namespace Opm {
 
+namespace data { class Solution; }
+
 template<class FluidSystem>
 class CompositionalContainer
 {
@@ -49,6 +51,8 @@ class CompositionalContainer
 public:
     void allocate(const unsigned bufferSize,
                   std::map<std::string, int>& rstKeywords);
+
+    void outputRestart(data::Solution& sol);
 
     bool allocated_ = false;
     // total mole fractions for each component

--- a/opm/simulators/flow/CompositionalContainer.hpp
+++ b/opm/simulators/flow/CompositionalContainer.hpp
@@ -27,6 +27,8 @@
 #define OPM_COMPOSITIONAL_CONTAINER_HPP
 
 #include <array>
+#include <map>
+#include <string>
 #include <vector>
 
 namespace Opm {
@@ -38,9 +40,17 @@ class CompositionalContainer
     using ScalarBuffer = std::vector<Scalar>;
 
     static constexpr int numComponents = FluidSystem::numComponents;
+
     static constexpr int numPhases = FluidSystem::numPhases;
+    static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
+    static constexpr int oilPhaseIdx = FluidSystem::oilPhaseIdx;
+    static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
 
 public:
+    void allocate(const unsigned bufferSize,
+                  std::map<std::string, int>& rstKeywords);
+
+    bool allocated_ = false;
     // total mole fractions for each component
     std::array<ScalarBuffer, numComponents> moleFractions_;
     // mole fractions for each component in each phase

--- a/opm/simulators/flow/CompositionalContainer.hpp
+++ b/opm/simulators/flow/CompositionalContainer.hpp
@@ -55,6 +55,9 @@ public:
 
     using AssignFunction = std::function<Scalar(const unsigned)>;
 
+    void assignGasFractions(const unsigned globalDofIdx,
+                            const AssignFunction& fractions);
+
     void assignMoleFractions(const unsigned globalDofIdx,
                              const AssignFunction& fractions);
 

--- a/opm/simulators/flow/CompositionalContainer.hpp
+++ b/opm/simulators/flow/CompositionalContainer.hpp
@@ -69,6 +69,7 @@ public:
     bool allocated() const
     { return allocated_; }
 
+private:
     bool allocated_ = false;
     // total mole fractions for each component
     std::array<ScalarBuffer, numComponents> moleFractions_;

--- a/opm/simulators/flow/CompositionalContainer.hpp
+++ b/opm/simulators/flow/CompositionalContainer.hpp
@@ -27,6 +27,7 @@
 #define OPM_COMPOSITIONAL_CONTAINER_HPP
 
 #include <array>
+#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -52,7 +53,15 @@ public:
     void allocate(const unsigned bufferSize,
                   std::map<std::string, int>& rstKeywords);
 
+    using AssignFunction = std::function<Scalar(const unsigned)>;
+
+    void assignMoleFractions(const unsigned globalDofIdx,
+                             const AssignFunction& fractions);
+
     void outputRestart(data::Solution& sol);
+
+    bool allocated() const
+    { return allocated_; }
 
     bool allocated_ = false;
     // total mole fractions for each component

--- a/opm/simulators/flow/CompositionalContainer.hpp
+++ b/opm/simulators/flow/CompositionalContainer.hpp
@@ -58,6 +58,9 @@ public:
     void assignMoleFractions(const unsigned globalDofIdx,
                              const AssignFunction& fractions);
 
+    void assignOilFractions(const unsigned globalDofIdx,
+                            const AssignFunction& fractions);
+
     void outputRestart(data::Solution& sol);
 
     bool allocated() const

--- a/opm/simulators/flow/CompositionalContainer.hpp
+++ b/opm/simulators/flow/CompositionalContainer.hpp
@@ -1,0 +1,52 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::OutputBlackOilModule
+ */
+#ifndef OPM_COMPOSITIONAL_CONTAINER_HPP
+#define OPM_COMPOSITIONAL_CONTAINER_HPP
+
+#include <array>
+#include <vector>
+
+namespace Opm {
+
+template<class FluidSystem>
+class CompositionalContainer
+{
+    using Scalar = typename FluidSystem::Scalar;
+    using ScalarBuffer = std::vector<Scalar>;
+
+    static constexpr int numComponents = FluidSystem::numComponents;
+    static constexpr int numPhases = FluidSystem::numPhases;
+
+public:
+    // total mole fractions for each component
+    std::array<ScalarBuffer, numComponents> moleFractions_;
+    // mole fractions for each component in each phase
+    std::array<std::array<ScalarBuffer, numComponents>, numPhases> phaseMoleFractions_;
+};
+
+} // namespace Opm
+
+#endif // OPM_COMPOSITIONAL_CONTAINER_HPP

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -527,36 +527,8 @@ assignToSolution(data::Solution& sol)
         DataEntry{"TMULT_RC", UnitSystem::measure::identity,           rockCompTransMultiplier_},
     };
 
-    // basically, for compositional, we can not use std::array for this.  We need to generate the ZMF1, ZMF2, and so on
-    // and also, we need to map these values.
-    // TODO: the following should go to a function
     if (this->isCompositional_) {
-        auto compositionalEntries = std::vector<DataEntry>{};
-        {
-            // ZMF
-            for (int i = 0; i < numComponents; ++i) {
-                const auto name = fmt::format("ZMF{}", i + 1);  // Generate ZMF1, ZMF2, ...
-                compositionalEntries.emplace_back(name, UnitSystem::measure::identity, compC_.moleFractions_[i]);
-            }
-
-            // XMF
-            for (int i = 0; i < numComponents; ++i) {
-                const auto name = fmt::format("XMF{}", i + 1);  // Generate XMF1, XMF2, ...
-                compositionalEntries.emplace_back(name, UnitSystem::measure::identity,
-                                                  compC_.phaseMoleFractions_[oilPhaseIdx][i]);
-            }
-
-            // YMF
-            for (int i = 0; i < numComponents; ++i) {
-                const auto name = fmt::format("YMF{}", i + 1);  // Generate YMF1, YMF2, ...
-                compositionalEntries.emplace_back(name, UnitSystem::measure::identity,
-                                                  compC_.phaseMoleFractions_[gasPhaseIdx][i]);
-            }
-        }
-
-        for (auto& array: compositionalEntries) {
-            doInsert(array, data::TargetType::RESTART_SOLUTION);
-        }
+        this->compC_.outputRestart(sol);
     }
 
     for (auto& array : baseSolutionVector) {

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -1294,26 +1294,7 @@ doAllocBuffers(const unsigned bufferSize,
     }
 
     if (this->isCompositional_) {
-        if (rstKeywords["ZMF"] > 0) {
-            rstKeywords["ZMF"] = 0;
-            for (int i = 0; i < numComponents; ++i) {
-                compC_.moleFractions_[i].resize(bufferSize, 0.0);
-            }
-        }
-
-        if (rstKeywords["XMF"] > 0 && FluidSystem::phaseIsActive(oilPhaseIdx)) {
-            rstKeywords["XMF"] = 0;
-            for (int i = 0; i < numComponents; ++i) {
-                compC_.phaseMoleFractions_[oilPhaseIdx][i].resize(bufferSize, 0.0);
-            }
-        }
-
-        if (rstKeywords["YMF"] > 0 && FluidSystem::phaseIsActive(gasPhaseIdx)) {
-            rstKeywords["YMF"] = 0;
-            for (int i = 0; i < numComponents; ++i) {
-                compC_.phaseMoleFractions_[gasPhaseIdx][i].resize(bufferSize, 0.0);
-            }
-        }
+        this->compC_.allocate(bufferSize, rstKeywords);
     }
 
 

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -536,21 +536,21 @@ assignToSolution(data::Solution& sol)
             // ZMF
             for (int i = 0; i < numComponents; ++i) {
                 const auto name = fmt::format("ZMF{}", i + 1);  // Generate ZMF1, ZMF2, ...
-                compositionalEntries.emplace_back(name, UnitSystem::measure::identity, moleFractions_[i]);
+                compositionalEntries.emplace_back(name, UnitSystem::measure::identity, compC_.moleFractions_[i]);
             }
 
             // XMF
             for (int i = 0; i < numComponents; ++i) {
                 const auto name = fmt::format("XMF{}", i + 1);  // Generate XMF1, XMF2, ...
                 compositionalEntries.emplace_back(name, UnitSystem::measure::identity,
-                                                  phaseMoleFractions_[oilPhaseIdx][i]);
+                                                  compC_.phaseMoleFractions_[oilPhaseIdx][i]);
             }
 
             // YMF
             for (int i = 0; i < numComponents; ++i) {
                 const auto name = fmt::format("YMF{}", i + 1);  // Generate YMF1, YMF2, ...
                 compositionalEntries.emplace_back(name, UnitSystem::measure::identity,
-                                                  phaseMoleFractions_[gasPhaseIdx][i]);
+                                                  compC_.phaseMoleFractions_[gasPhaseIdx][i]);
             }
         }
 
@@ -1297,21 +1297,21 @@ doAllocBuffers(const unsigned bufferSize,
         if (rstKeywords["ZMF"] > 0) {
             rstKeywords["ZMF"] = 0;
             for (int i = 0; i < numComponents; ++i) {
-                moleFractions_[i].resize(bufferSize, 0.0);
+                compC_.moleFractions_[i].resize(bufferSize, 0.0);
             }
         }
 
         if (rstKeywords["XMF"] > 0 && FluidSystem::phaseIsActive(oilPhaseIdx)) {
             rstKeywords["XMF"] = 0;
             for (int i = 0; i < numComponents; ++i) {
-                phaseMoleFractions_[oilPhaseIdx][i].resize(bufferSize, 0.0);
+                compC_.phaseMoleFractions_[oilPhaseIdx][i].resize(bufferSize, 0.0);
             }
         }
 
         if (rstKeywords["YMF"] > 0 && FluidSystem::phaseIsActive(gasPhaseIdx)) {
             rstKeywords["YMF"] = 0;
             for (int i = 0; i < numComponents; ++i) {
-                phaseMoleFractions_[gasPhaseIdx][i].resize(bufferSize, 0.0);
+                compC_.phaseMoleFractions_[gasPhaseIdx][i].resize(bufferSize, 0.0);
             }
         }
     }

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -32,6 +32,7 @@
 #include <opm/output/data/Wells.hpp>
 #include <opm/output/eclipse/Inplace.hpp>
 
+#include <opm/simulators/flow/CompositionalContainer.hpp>
 #include <opm/simulators/flow/ExtboContainer.hpp>
 #include <opm/simulators/flow/FIPContainer.hpp>
 #include <opm/simulators/flow/FlowsData.hpp>
@@ -468,10 +469,7 @@ protected:
     std::array<ScalarBuffer, numPhases> viscosity_;
     std::array<ScalarBuffer, numPhases> relativePermeability_;
 
-    // total mole fractions for each component
-    std::array<ScalarBuffer, numComponents> moleFractions_;
-    // mole fractions for each component in each phase
-    std::array<std::array<ScalarBuffer, numComponents>, numPhases> phaseMoleFractions_;
+    CompositionalContainer<FluidSystem> compC_;
     std::vector<ScalarBuffer> freeTracerConcentrations_;
     std::vector<ScalarBuffer> solTracerConcentrations_;
 

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -32,7 +32,6 @@
 #include <opm/output/data/Wells.hpp>
 #include <opm/output/eclipse/Inplace.hpp>
 
-#include <opm/simulators/flow/CompositionalContainer.hpp>
 #include <opm/simulators/flow/ExtboContainer.hpp>
 #include <opm/simulators/flow/FIPContainer.hpp>
 #include <opm/simulators/flow/FlowsData.hpp>
@@ -320,8 +319,7 @@ protected:
                                 bool enableBrine,
                                 bool enableSaltPrecipitation,
                                 bool enableExtbo,
-                                bool enableMICP,
-                                bool isCompositional = false);
+                                bool enableMICP);
 
     void doAllocBuffers(unsigned bufferSize,
                         unsigned reportStepNum,
@@ -330,11 +328,12 @@ protected:
                         const bool isRestart,
                         const bool vapparsActive = false,
                         const bool enablePCHysteresis = false,
-                        const bool enableNonWettingHysteresis =false,
+                        const bool enableNonWettingHysteresis = false,
                         const bool enableWettingHysteresis = false,
                         unsigned numTracers = 0,
                         const std::vector<bool>& enableSolTracers = {},
-                        unsigned numOutputNnc = 0);
+                        unsigned numOutputNnc = 0,
+                        std::map<std::string, int> rstKeywords = {});
 
     void makeRegionSum(Inplace& inplace,
                        const std::string& region_name,
@@ -391,7 +390,6 @@ protected:
     bool enableSaltPrecipitation_{false};
     bool enableExtbo_{false};
     bool enableMICP_{false};
-    bool isCompositional_{false};
 
     bool forceDisableFipOutput_{false};
     bool forceDisableFipresvOutput_{false};
@@ -469,7 +467,6 @@ protected:
     std::array<ScalarBuffer, numPhases> viscosity_;
     std::array<ScalarBuffer, numPhases> relativePermeability_;
 
-    CompositionalContainer<FluidSystem> compC_;
     std::vector<ScalarBuffer> freeTracerConcentrations_;
     std::vector<ScalarBuffer> solTracerConcentrations_;
 

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -57,8 +57,7 @@
 #include <vector>
 
 
-namespace Opm
-{
+namespace Opm {
 
 // forward declaration
 template <class TypeTag>
@@ -196,17 +195,16 @@ public:
                                                  [&fs](const unsigned compIdx)
                                                  { return getValue(fs.moleFraction(compIdx)); });
 
+                if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
+                    this->compC_.assignGasFractions(globalDofIdx,
+                                                    [&fs](const unsigned compIdx)
+                                                    { return getValue(fs.moleFraction(gasPhaseIdx, compIdx)); });
+                }
+
                 if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
                     this->compC_.assignOilFractions(globalDofIdx,
                                                     [&fs](const unsigned compIdx)
                                                     { return getValue(fs.moleFraction(oilPhaseIdx, compIdx)); });
-                }
-            }
-            // XMF and YMF
-            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-                if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
-                    if (this->compC_.phaseMoleFractions_[gasPhaseIdx][compIdx].empty()) continue;
-                    this->compC_.phaseMoleFractions_[gasPhaseIdx][compIdx][globalDofIdx] = getValue(fs.moleFraction(gasPhaseIdx, compIdx));
                 }
             }
 

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -191,10 +191,10 @@ public:
                 Valgrind::CheckDefined(this->saturation_[phaseIdx][globalDofIdx]);
             }
 
-            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-                if (this->compC_.moleFractions_[compIdx].empty()) continue;
-
-                this->compC_.moleFractions_[compIdx][globalDofIdx] = getValue(fs.moleFraction(compIdx));
+            if (this->compC_.allocated()) {
+                this->compC_.assignMoleFractions(globalDofIdx,
+                                                 [&fs](const unsigned compIdx)
+                                                 { return getValue(fs.moleFraction(compIdx)); });
             }
             // XMF and YMF
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -32,12 +32,16 @@
 #include <opm/simulators/utils/moduleVersion.hpp>
 
 #include <opm/common/Exceptions.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/TimingMacros.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 #include <opm/material/common/Valgrind.hpp>
+
+#include <opm/models/blackoil/blackoilproperties.hh>
+#include <opm/models/common/multiphasebaseproperties.hh>
 #include <opm/models/utils/parametersystem.hpp>
 #include <opm/models/utils/propertysystem.hh>
 
@@ -188,19 +192,19 @@ public:
             }
 
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-                if (this->moleFractions_[compIdx].empty()) continue;
+                if (this->compC_.moleFractions_[compIdx].empty()) continue;
 
-                this->moleFractions_[compIdx][globalDofIdx] = getValue(fs.moleFraction(compIdx));
+                this->compC_.moleFractions_[compIdx][globalDofIdx] = getValue(fs.moleFraction(compIdx));
             }
             // XMF and YMF
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
-                    if (this->phaseMoleFractions_[oilPhaseIdx][compIdx].empty()) continue;
-                    this->phaseMoleFractions_[oilPhaseIdx][compIdx][globalDofIdx] = getValue(fs.moleFraction(oilPhaseIdx, compIdx));
+                    if (this->compC_.phaseMoleFractions_[oilPhaseIdx][compIdx].empty()) continue;
+                    this->compC_.phaseMoleFractions_[oilPhaseIdx][compIdx][globalDofIdx] = getValue(fs.moleFraction(oilPhaseIdx, compIdx));
                 }
                 if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
-                    if (this->phaseMoleFractions_[gasPhaseIdx][compIdx].empty()) continue;
-                    this->phaseMoleFractions_[gasPhaseIdx][compIdx][globalDofIdx] = getValue(fs.moleFraction(gasPhaseIdx, compIdx));
+                    if (this->compC_.phaseMoleFractions_[gasPhaseIdx][compIdx].empty()) continue;
+                    this->compC_.phaseMoleFractions_[gasPhaseIdx][compIdx][globalDofIdx] = getValue(fs.moleFraction(gasPhaseIdx, compIdx));
                 }
             }
 

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -195,13 +195,15 @@ public:
                 this->compC_.assignMoleFractions(globalDofIdx,
                                                  [&fs](const unsigned compIdx)
                                                  { return getValue(fs.moleFraction(compIdx)); });
+
+                if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+                    this->compC_.assignOilFractions(globalDofIdx,
+                                                    [&fs](const unsigned compIdx)
+                                                    { return getValue(fs.moleFraction(oilPhaseIdx, compIdx)); });
+                }
             }
             // XMF and YMF
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-                if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
-                    if (this->compC_.phaseMoleFractions_[oilPhaseIdx][compIdx].empty()) continue;
-                    this->compC_.phaseMoleFractions_[oilPhaseIdx][compIdx][globalDofIdx] = getValue(fs.moleFraction(oilPhaseIdx, compIdx));
-                }
                 if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
                     if (this->compC_.phaseMoleFractions_[gasPhaseIdx][compIdx].empty()) continue;
                     this->compC_.phaseMoleFractions_[gasPhaseIdx][compIdx][globalDofIdx] = getValue(fs.moleFraction(gasPhaseIdx, compIdx));

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -118,13 +118,13 @@ template<class Scalar> class WellContributions;
 
             // TODO: where we should put these types, WellInterface or Well Model?
             // or there is some other strategy, like TypeTag
-            typedef Dune::FieldVector<Scalar, numEq    > VectorBlockType;
-            typedef Dune::BlockVector<VectorBlockType> BVector;
+            using VectorBlockType = Dune::FieldVector<Scalar, numEq>;
+            using BVector = Dune::BlockVector<VectorBlockType>;
 
-            typedef BlackOilPolymerModule<TypeTag> PolymerModule;
-            typedef BlackOilMICPModule<TypeTag> MICPModule;
+            using PolymerModule = BlackOilPolymerModule<TypeTag>;
+            using MICPModule = BlackOilMICPModule<TypeTag>;
 
-            // For the conversion between the surface volume rate and resrevoir voidage rate
+            // For the conversion between the surface volume rate and reservoir voidage rate
             using RateConverterType = RateConverter::
                 SurfaceToReservoirVoidage<FluidSystem, std::vector<int> >;
 


### PR DESCRIPTION
This adds a container for the compositional output. Furthermore it refactors the code a little such that the compositional output is completely contained within the compositional output module.

There is one additional unrelated commit that replaces some typedefs. I can separate that out if you want but it happend to sit in the tree on my laptop so..