### PR TITLE
Refactor make view and copy to gpu

### DIFF
--- a/opm/simulators/linalg/gpuistl/GpuBuffer.cpp
+++ b/opm/simulators/linalg/gpuistl/GpuBuffer.cpp
@@ -200,12 +200,21 @@ template class GpuBuffer<float>;
 template class GpuBuffer<int>;
 
 template <class T>
+GpuView<T> make_view(GpuBuffer<T>& buf) {
+    return GpuView<T>(buf.data(), buf.size());
+}
+
+template GpuView<double> make_view(GpuBuffer<double>&);
+template GpuView<float> make_view(GpuBuffer<float>&);
+template GpuView<int> make_view(GpuBuffer<int>&);
+
+template <class T>
 GpuView<const T> make_view(const GpuBuffer<T>& buf) {
     return GpuView<const T>(buf.data(), buf.size());
 }
 
-template GpuView<const double> make_view<double>(const GpuBuffer<double>&);
-template GpuView<const float> make_view<float>(const GpuBuffer<float>&);
-template GpuView<const int> make_view<int>(const GpuBuffer<int>&);
+template GpuView<const double> make_view(const GpuBuffer<double>&);
+template GpuView<const float> make_view(const GpuBuffer<float>&);
+template GpuView<const int> make_view(const GpuBuffer<int>&);
 
 } // namespace Opm::gpuistl

--- a/opm/simulators/linalg/gpuistl/GpuBuffer.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuBuffer.hpp
@@ -230,6 +230,9 @@ private:
 };
 
 template <class T>
+GpuView<T> make_view(GpuBuffer<T>&);
+
+template <class T>
 GpuView<const T> make_view(const GpuBuffer<T>&);
 
 } // namespace Opm::gpuistl

--- a/tests/gpuistl/test_GpuBuffer.cu
+++ b/tests/gpuistl/test_GpuBuffer.cu
@@ -33,21 +33,23 @@
 
 BOOST_AUTO_TEST_CASE(TestMakeView)
 {
-    // test that we can create buffers and make views of the buffers using the pointer constructor
+    // check creation of buffers and views for mutable buffers
     auto buf = std::vector<int>({1, 2, 3, 4, 5, 6});
-    const auto gpubuf = ::Opm::gpuistl::GpuBuffer<int>(buf);
-    auto gpuview = ::Opm::gpuistl::GpuView<int>(buf.data(), buf.size());
-    bool gpuBufCreatedView = std::is_same<::Opm::gpuistl::GpuView<int>, decltype(gpuview)>::value;
-
+    auto gpubuf = ::Opm::gpuistl::GpuBuffer<int>(buf);
+    auto gpuview = ::Opm::gpuistl::make_view(gpubuf);
+    bool gpuBufCreatedView = std::is_same_v<::Opm::gpuistl::GpuView<int>, decltype(gpuview)>;
     BOOST_CHECK(gpuBufCreatedView);
 
-    // test that we can make views of buffers by using the GpuBuffer constructor
-    auto gpuview2 = ::Opm::gpuistl::make_view(gpubuf);
-    bool gpuBufCreatedView2 = std::is_same<::Opm::gpuistl::GpuView<const int>, decltype(gpuview2)>::value;
+    auto gpubufOnCpu = gpubuf.asStdVector();
+    BOOST_CHECK_EQUAL_COLLECTIONS(gpubufOnCpu.begin(), gpubufOnCpu.end(), buf.begin(), buf.end());
 
+    // check creation of buffers and views for const buffers
+    const auto buf2 = std::vector<int>({2, 3, 4, 5, 6});
+    const auto gpubuf2 = ::Opm::gpuistl::GpuBuffer<int>(buf2);
+    auto gpuview2 = ::Opm::gpuistl::make_view(gpubuf2);
+    bool gpuBufCreatedView2 = std::is_same_v<::Opm::gpuistl::GpuView<const int>, decltype(gpuview2)>;
     BOOST_CHECK(gpuBufCreatedView2);
 
-    // check that we retrieve the same values when pulling the data back to the cpu as a vector
-    auto gpuBufOnCpu = gpubuf.asStdVector();
-    BOOST_CHECK_EQUAL_COLLECTIONS(gpuBufOnCpu.begin(), gpuBufOnCpu.end(), buf.begin(), buf.end());
+    auto gpubufOnCpu2 = gpubuf2.asStdVector();
+    BOOST_CHECK_EQUAL_COLLECTIONS(gpubufOnCpu2.begin(), gpubufOnCpu2.end(), buf2.begin(), buf2.end());
 }

--- a/tests/gpuistl/test_gpuPvt.cu
+++ b/tests/gpuistl/test_gpuPvt.cu
@@ -172,7 +172,7 @@ BOOST_FIXTURE_TEST_CASE(TestEvaluateUniformTabulated2DFunctionOnGpu, Fixture) {
     Opm::UniformTabulated2DFunction<double> cpuTab(1.0, 6.0, 3, 1.0, 6.0, 2, tabData);
 
     // Move data to GPU buffer and create a view for GPU operations
-    Opm::UniformTabulated2DFunction<double, GpuB> gpuBufTab = Opm::gpuistl::copy_to_gpu<double, GpuB>(cpuTab);
+    Opm::UniformTabulated2DFunction<double, GpuB> gpuBufTab = Opm::gpuistl::copy_to_gpu<GpuB>(cpuTab);
     GpuTab gpuViewTab = Opm::gpuistl::make_view<GpuV>(gpuBufTab);
 
     // Evaluation points on the CPU

--- a/tests/gpuistl/test_gpuPvt.cu
+++ b/tests/gpuistl/test_gpuPvt.cu
@@ -26,8 +26,9 @@
 #include <cmath>
 
 using Evaluation = Opm::DenseAd::Evaluation<double, 3>;
-using GpuB = const Opm::gpuistl::GpuBuffer<double>;
-using GpuV = Opm::gpuistl::GpuView<const double>;
+using GpuB = Opm::gpuistl::GpuBuffer<double>;
+using GpuV = Opm::gpuistl::GpuView<double>;
+using ConstGpuV = Opm::gpuistl::GpuView<const double>;
 
 using GpuTab = Opm::UniformTabulated2DFunction<double, GpuV>;
 
@@ -268,9 +269,9 @@ BOOST_FIXTURE_TEST_CASE(TestCo2GasPvt, Fixture) {
     CpuCo2Pvt cpuCo2Pvt(salinities);
     double internalEnergyReference = cpuCo2Pvt.internalEnergy(1, temp, pressure, Evaluation(0.4), Evaluation(0.0)).value();
 
-    const GpuBufCo2Pvt gpuBufCo2Pvt = Opm::gpuistl::copy_to_gpu<double, GpuBufCo2Tables, GpuB>(cpuCo2Pvt);
-    const auto brineReferenceDensityCPUCopy = gpuBufCo2Pvt.getBrineReferenceDensity().asStdVector();
-    const GpuViewCo2Pvt gpuViewCo2Pvt = Opm::gpuistl::make_view<GpuV, GpuViewCO2Tables>(gpuBufCo2Pvt);
+    GpuBufCo2Pvt gpuBufCo2Pvt = Opm::gpuistl::copy_to_gpu<double, GpuBufCo2Tables, GpuB>(cpuCo2Pvt);
+    auto brineReferenceDensityCPUCopy = gpuBufCo2Pvt.getBrineReferenceDensity().asStdVector();
+    GpuViewCo2Pvt gpuViewCo2Pvt = Opm::gpuistl::make_view<GpuV, GpuViewCO2Tables>(gpuBufCo2Pvt);
 
     gpuComputedResultOnCpu = launchKernelAndRetrieveResult(co2GasPvtInternalEnergy, gpuViewCo2Pvt, gpuTemp, gpuPressure);
 
@@ -287,8 +288,8 @@ BOOST_FIXTURE_TEST_CASE(TestBrineCo2Pvt, Fixture) {
     CpuBrineCo2Pvt cpuBrineCo2Pvt(salinities);
     double internalEnergyReference = cpuBrineCo2Pvt.internalEnergy(1, temp, pressure, rs, saltConcentration).value();
 
-    const GpuBufBrineCo2Pvt gpuBufBrineCo2Pvt = Opm::gpuistl::copy_to_gpu<double, GpuBufCo2Tables, GpuB>(cpuBrineCo2Pvt);
-    const GpuViewBrineCo2Pvt gpuViewBrineCo2Pvt = Opm::gpuistl::make_view<GpuV, GpuViewCO2Tables>(gpuBufBrineCo2Pvt);
+    GpuBufBrineCo2Pvt gpuBufBrineCo2Pvt = Opm::gpuistl::copy_to_gpu<double, GpuBufCo2Tables, GpuB>(cpuBrineCo2Pvt);
+    GpuViewBrineCo2Pvt gpuViewBrineCo2Pvt = Opm::gpuistl::make_view<GpuV, GpuViewCO2Tables>(gpuBufBrineCo2Pvt);
 
     // Allocate memory for the result on the GPU
     double* resultOnGpu = nullptr;

--- a/tests/gpuistl/test_gpuPvt.cu
+++ b/tests/gpuistl/test_gpuPvt.cu
@@ -268,7 +268,7 @@ BOOST_FIXTURE_TEST_CASE(TestCo2GasPvt, Fixture) {
     CpuCo2Pvt cpuCo2Pvt(salinities);
     double internalEnergyReference = cpuCo2Pvt.internalEnergy(1, temp, pressure, Evaluation(0.4), Evaluation(0.0)).value();
 
-    GpuBufCo2Pvt gpuBufCo2Pvt = Opm::gpuistl::copy_to_gpu<double, GpuBufCo2Tables, GpuB>(cpuCo2Pvt);
+    GpuBufCo2Pvt gpuBufCo2Pvt = Opm::gpuistl::copy_to_gpu<GpuB, GpuBufCo2Tables>(cpuCo2Pvt);
     auto brineReferenceDensityCPUCopy = gpuBufCo2Pvt.getBrineReferenceDensity().asStdVector();
     GpuViewCo2Pvt gpuViewCo2Pvt = Opm::gpuistl::make_view<GpuV, GpuViewCO2Tables>(gpuBufCo2Pvt);
 

--- a/tests/gpuistl/test_gpuPvt.cu
+++ b/tests/gpuistl/test_gpuPvt.cu
@@ -28,7 +28,6 @@
 using Evaluation = Opm::DenseAd::Evaluation<double, 3>;
 using GpuB = Opm::gpuistl::GpuBuffer<double>;
 using GpuV = Opm::gpuistl::GpuView<double>;
-using ConstGpuV = Opm::gpuistl::GpuView<const double>;
 
 using GpuTab = Opm::UniformTabulated2DFunction<double, GpuV>;
 

--- a/tests/gpuistl/test_gpuPvt.cu
+++ b/tests/gpuistl/test_gpuPvt.cu
@@ -204,7 +204,7 @@ BOOST_FIXTURE_TEST_CASE(TestUseCO2OnGpu, Fixture) {
     // use the CO2 tables to aquire the viscosity at 290[K] and 2e5[Pa]
     double viscosityReference = Opm::CO2<double, Opm::CO2Tables<double, std::vector<double>>>::gasViscosity(co2Tables, temp, pressure, true).value();
 
-    GpuBufCo2Tables gpuBufCo2Table = Opm::gpuistl::copy_to_gpu<double, std::vector<double>, GpuB>(co2Tables);
+    GpuBufCo2Tables gpuBufCo2Table = Opm::gpuistl::copy_to_gpu<GpuB>(co2Tables);
     GpuViewCO2Tables gpuViewCo2Table = Opm::gpuistl::make_view<GpuV>(gpuBufCo2Table);
 
     gpuComputedResultOnCpu = launchKernelAndRetrieveResult(gpuCO2GasViscosity, gpuViewCo2Table, gpuTemp, gpuPressure);
@@ -252,7 +252,7 @@ BOOST_FIXTURE_TEST_CASE(TestBrine_CO2OnGPU, Fixture) {
     // use the CO2 tables to aquire the viscosity at 290[K] and 2e5[Pa]
     double viscosity = Opm::CO2<double, Opm::CO2Tables<double, std::vector<double>>>::gasViscosity(co2Tables, temp, pressure, true).value();
 
-    GpuBufCo2Tables gpuBufCo2Table = Opm::gpuistl::copy_to_gpu<double, std::vector<double>, GpuB>(co2Tables);
+    GpuBufCo2Tables gpuBufCo2Table = Opm::gpuistl::copy_to_gpu<GpuB>(co2Tables);
     GpuViewCO2Tables gpuViewCo2Table = Opm::gpuistl::make_view<GpuV>(gpuBufCo2Table);
 
     gpuComputedResultOnCpu = launchKernelAndRetrieveResult(brineCO2GasDiffCoeff, gpuViewCo2Table, gpuTemp, gpuPressure);

--- a/tests/gpuistl/test_gpuPvt.cu
+++ b/tests/gpuistl/test_gpuPvt.cu
@@ -287,7 +287,7 @@ BOOST_FIXTURE_TEST_CASE(TestBrineCo2Pvt, Fixture) {
     CpuBrineCo2Pvt cpuBrineCo2Pvt(salinities);
     double internalEnergyReference = cpuBrineCo2Pvt.internalEnergy(1, temp, pressure, rs, saltConcentration).value();
 
-    GpuBufBrineCo2Pvt gpuBufBrineCo2Pvt = Opm::gpuistl::copy_to_gpu<double, GpuBufCo2Tables, GpuB>(cpuBrineCo2Pvt);
+    GpuBufBrineCo2Pvt gpuBufBrineCo2Pvt = Opm::gpuistl::copy_to_gpu<GpuBufCo2Tables, GpuB>(cpuBrineCo2Pvt);
     GpuViewBrineCo2Pvt gpuViewBrineCo2Pvt = Opm::gpuistl::make_view<GpuV, GpuViewCO2Tables>(gpuBufBrineCo2Pvt);
 
     // Allocate memory for the result on the GPU

--- a/tests/gpuistl/test_gpu_linear_two_phase_material.cu
+++ b/tests/gpuistl/test_gpu_linear_two_phase_material.cu
@@ -44,11 +44,10 @@
   using Scalar = float;
   using ValueVector = std::vector<Scalar>;
   using GPUBuffer = Opm::gpuistl::GpuBuffer<Scalar>;
-  using GPUView = Opm::gpuistl::GpuView<const Scalar>;
+  using GPUView = Opm::gpuistl::GpuView<Scalar>;
 
   using TraitsT = Opm::TwoPhaseMaterialTraits<Scalar, 1, 2>;
   using CPUParams = Opm::PiecewiseLinearTwoPhaseMaterialParams<TraitsT>;
-  using constGPUBufferParams = Opm::PiecewiseLinearTwoPhaseMaterialParams<TraitsT, const GPUBuffer>;
   using GPUBufferParams = Opm::PiecewiseLinearTwoPhaseMaterialParams<TraitsT, GPUBuffer>;
   using GPUViewParams = Opm::PiecewiseLinearTwoPhaseMaterialParams<TraitsT, GPUView>;
 
@@ -73,7 +72,7 @@ BOOST_AUTO_TEST_CASE(TestSimpleInterpolation)
     cpuParams.setKrnSamples(cx, cy);
     cpuParams.finalize();
 
-    constGPUBufferParams gpuBufferParams = Opm::gpuistl::copy_to_gpu<const GPUBuffer>(cpuParams);
+    GPUBufferParams gpuBufferParams = Opm::gpuistl::copy_to_gpu<GPUBuffer>(cpuParams);
 
     GPUViewParams gpuViewParams = Opm::gpuistl::make_view<GPUView>(gpuBufferParams);
 


### PR DESCRIPTION
Avoids the unneeded `consts` propagating through the GPU types

connected to https://github.com/OPM/opm-common/pull/4482