### PR TITLE
Extract addLgrs, invoke it before loadBalance

### DIFF
--- a/opm/models/io/basevanguard.hh
+++ b/opm/models/io/basevanguard.hh
@@ -110,6 +110,17 @@ public:
         updateGridView_();
     }
 
+    /*!
+     * \brief Add LGRs to the grid, if any. Only supported for CpGrid - for now.
+     */
+    void addLgrs()
+    {
+        if(&asImp_() != this) { // this check prevents an infinite-recursion warning
+            asImp_().addLgrs();
+            updateGridView_();
+        }
+    }
+
 protected:
     // this method should be called after the grid has been allocated
     void finalizeInit_()

--- a/opm/models/utils/simulator.hh
+++ b/opm/models/utils/simulator.hh
@@ -172,6 +172,18 @@ public:
         checkParallelException("Allocating the simulation vanguard failed: ",
                                exceptionThrown, what);
 
+        // Only relevant for CpGrid
+        if (verbose_)
+            std::cout << "Adding LGRs, if any\n" << std::flush;
+
+        try
+        { vanguard_->addLgrs(); }
+        catch (const std::exception& e) {
+            catchAction(e, verbose_);
+        }
+        checkParallelException("Adding LGRs to the simulation vanguard failed: ",
+                               exceptionThrown, what);
+
         if (verbose_)
             std::cout << "Distributing the vanguard's data\n" << std::flush;
 
@@ -182,6 +194,7 @@ public:
         }
         checkParallelException("Could not distribute the vanguard data: ",
                                exceptionThrown, what);
+        
 
         if (verbose_)
             std::cout << "Allocating the model\n" << std::flush;

--- a/opm/simulators/flow/AluGridVanguard.hpp
+++ b/opm/simulators/flow/AluGridVanguard.hpp
@@ -196,7 +196,12 @@ public:
             globalTrans_->update(false, TransmissibilityType::TransUpdateQuantities::Trans,
                                  [&](unsigned int i) { return gridEquilIdxToGridIdx(i);});
         }
-        
+
+    }
+
+    void addLgrs()
+    {
+    // do nothing: AluGrid with LGRs not supported yet!
     }
 
     template<class DataHandle>

--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -247,9 +247,23 @@ public:
 #endif
     }
 
+    /*!
+     * \brief Add LGRs and update Leaf Grid View in the simulation grid.
+     */
+    void addLgrs()
+    {
+        // Check if input file contains Lgrs.
+        //
+        // If there are lgrs, create the grid with them, and update the leaf grid view.
+        if (const auto& lgrs = this->eclState().getLgrs(); lgrs.size() > 0) {
+            OpmLog::info("\nAdding LGRs to the grid and updating its leaf grid view");
+            this->addLgrsUpdateLeafView(lgrs, lgrs.size(), *this->grid_);
+        }
+    }
+
     unsigned int gridEquilIdxToGridIdx(unsigned int elemIndex) const {
-         return elemIndex;
-     }
+        return elemIndex;
+    }
 
     unsigned int gridIdxToEquilGridIdx(unsigned int elemIndex) const {
         return elemIndex;

--- a/opm/simulators/flow/GenericCpGridVanguard.cpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.cpp
@@ -481,15 +481,6 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Eclips
 
     cartesianIndexMapper_ = std::make_unique<CartesianIndexMapper>(*grid_);
 
-    // --- Add LGRs and update Leaf Grid View ---
-    // Check if input file contains Lgrs.
-    //
-    // If there are lgrs, create the grid with them, and update the leaf grid view.
-    if (const auto& lgrs = eclState.getLgrs(); lgrs.size() > 0) {
-        OpmLog::info("\nAdding LGRs to the grid and updating its leaf grid view");
-        this->addLgrsUpdateLeafView(lgrs, lgrs.size(), *this->grid_);
-    }
-
 #if HAVE_MPI
     if (this->grid_->comm().size() > 1) {
         // Numerical aquifers generate new NNCs during grid processing.  We
@@ -520,7 +511,7 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Eclips
     }
 #endif
 
-    // --- Copy grid with LGRs to equilGrid_ ---
+    // --- Copy grid to equilGrid_ ---
     // We use separate grid objects: one for the calculation of the initial
     // condition via EQUIL and one for the actual simulation. The reason is
     // that the EQUIL code is allergic to distributed grids and the

--- a/opm/simulators/flow/PolyhedralGridVanguard.hpp
+++ b/opm/simulators/flow/PolyhedralGridVanguard.hpp
@@ -164,6 +164,10 @@ public:
     { /* do nothing: PolyhedralGrid is not parallel! */
     }
 
+    void addLgrs()
+    { /* do nothing: PolyhedralGrid with LGRs not supported yet! */
+    }
+
     /*!
      * \brief Returns the object which maps a global element index of the simulation grid
      *        to the corresponding element index of the logically Cartesian index.


### PR DESCRIPTION
This PR extracts "adding lgrs" from GenericCpGridVanguard::doCreateGrids_() and moves this into the Simulator constructor body, before load balancing, model and problem initialization. 

Not relevant for the Reference Manual.