### PR TITLE
Added tests for some central GPU macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -741,6 +741,7 @@ if(CUDA_FOUND)
                        gpu_resources
                        gpu_smart_pointers
                        is_gpu_pointer
+                       gpu_macros
                        PROPERTIES LABELS ${gpu_label})
 endif()
 

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -483,6 +483,8 @@ if (HAVE_CUDA)
   ADD_CUDA_OR_HIP_FILE(TEST_SOURCE_FILES tests test_gpu_smart_pointers.cu)
   ADD_CUDA_OR_HIP_FILE(TEST_SOURCE_FILES tests test_gpu_resources.cu)
   ADD_CUDA_OR_HIP_FILE(TEST_SOURCE_FILES tests test_is_gpu_pointer.cpp)
+  ADD_CUDA_OR_HIP_FILE(TEST_SOURCE_FILES tests test_gpu_macros.cu)
+  
 
   # for loop providing the flag --expt-relaxed-constexpr to fix some cuda issues with constexpr
   if(NOT CONVERT_CUDA_TO_HIP)

--- a/tests/gpuistl/test_gpu_macros.cu
+++ b/tests/gpuistl/test_gpu_macros.cu
@@ -1,0 +1,78 @@
+/*
+  Copyright 2025 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <config.h>
+#include <opm/common/utility/gpuDecorators.hpp>
+
+#define BOOST_TEST_MODULE TestGPUMacros
+
+
+#include <boost/test/unit_test.hpp>
+#include <opm/simulators/linalg/gpuistl/gpu_smart_pointer.hpp>
+namespace
+{
+
+__global__ void testKernelSetIfGPU(int* ptr) {
+    #if OPM_IS_INSIDE_DEVICE_FUNCTION
+    *ptr = 42;
+    #else
+    *ptr = 123;
+    #endif
+}
+
+__global__ void testKernelSetIfNotCPU(int* ptr) {
+    #if OPM_IS_INSIDE_HOST_FUNCTION
+    *ptr = 42;
+    #else
+    *ptr = 123;
+    #endif
+}
+
+
+} // namespace
+
+
+BOOST_AUTO_TEST_CASE(TestInsideDevice)
+{
+    auto sharedPtr = Opm::gpuistl::make_gpu_shared_ptr<int>(1);
+
+    testKernelSetIfGPU<<<1, 1>>>(sharedPtr.get());
+    auto valueFromDevice = Opm::gpuistl::copyFromGPU(sharedPtr);
+    BOOST_CHECK_EQUAL(valueFromDevice, 42);
+}
+
+BOOST_AUTO_TEST_CASE(TestOutsideHost)
+{
+    auto sharedPtr = Opm::gpuistl::make_gpu_shared_ptr<int>(1);
+
+    testKernelSetIfNotCPU<<<1, 1>>>(sharedPtr.get());
+    auto valueFromDevice = Opm::gpuistl::copyFromGPU(sharedPtr);
+    BOOST_CHECK_EQUAL(valueFromDevice, 123);
+}
+
+BOOST_AUTO_TEST_CASE(TestMacrosOnHost)
+{
+    #if OPM_IS_INSIDE_HOST_FUNCTION
+    BOOST_CHECK(true);
+    #else
+    BOOST_CHECK(false);
+    #endif
+
+    #if OPM_IS_INSIDE_DEVICE_FUNCTION
+    BOOST_CHECK(false);
+    #else
+    BOOST_CHECK(true);
+    #endif
+}


### PR DESCRIPTION
This adds a much needed unit test for the `OPM_IS_INSIDE_HOST_FUNCTION` and `OPM_IS_INSIDE_DEVICE_FUNCTION` macros.

This PR needs OPM/opm-common#4465