### PR TITLE
Remove explicit updating of well AD vars.

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -257,8 +257,8 @@ template<class Scalar> class WellContributions;
             // called at the beginning of a report step
             void beginReportStep(const int time_step);
 
-            // it should be able to go to prepareTimeStep(), however, the updateWellControls() and initPrimaryVariablesEvaluation()
-            // makes it a little more difficult. unless we introduce if (iterationIdx != 0) to avoid doing the above functions
+            // it should be able to go to prepareTimeStep(), however, the updateWellControls()
+            // makes it a little more difficult. unless we introduce if (iterationIdx != 0) to avoid doing the above function
             // twice at the beginning of the time step
             /// Calculating the explict quantities used in the well calculation. By explicit, we mean they are cacluated
             /// at the beginning of the time step and no derivatives are included in these quantities
@@ -266,7 +266,6 @@ template<class Scalar> class WellContributions;
             // some preparation work, mostly related to group control and RESV,
             // at the beginning of each time step (Not report step)
             void prepareTimeStep(DeferredLogger& deferred_logger);
-            void initPrimaryVariablesEvaluation() const;
 
             std::pair<bool, bool>
             updateWellControls(const bool mandatory_network_balance, DeferredLogger& deferred_logger, const bool relax_network_tolerance = false);

--- a/opm/simulators/wells/BlackoilWellModelNldd.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNldd.hpp
@@ -91,8 +91,6 @@ public:
         , wellModel_(model)
     {}
 
-    void initPrimaryVariablesEvaluation(const Domain& domain) const;
-
     void addWellPressureEquations(PressureMatrix& jacobian,
                                   const BVector& weights,
                                   const bool use_well_weights,

--- a/opm/simulators/wells/BlackoilWellModelNldd_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNldd_impl.hpp
@@ -47,7 +47,6 @@ assemble(const int /*iterationIdx*/,
 
     DeferredLogger local_deferredLogger;
     this->updateWellControls(local_deferredLogger, domain);
-    this->initPrimaryVariablesEvaluation(domain);
     this->assembleWellEq(dt, domain, local_deferredLogger);
 }
 
@@ -122,18 +121,6 @@ recoverWellSolutionAndUpdateWellState(const BVector& x,
     // be stored in the local_deferredlogger in a parallel case.
     if (wellModel_.terminalOutput()) {
         local_deferredLogger.logMessages();
-    }
-}
-
-template<typename TypeTag>
-void
-BlackoilWellModelNldd<TypeTag>::
-initPrimaryVariablesEvaluation(const Domain& domain) const
-{
-    for (auto& well : wellModel_.localNonshutWells()) {
-        if (this->well_domain().at(well->name()) == domain.index) {
-            well->initPrimaryVariablesEvaluation();
-        }
     }
 }
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1103,7 +1103,6 @@ namespace Opm {
             }
             OPM_END_PARALLEL_TRY_CATCH("BlackoilWellModel::doPreStepNetworkRebalance() failed: ",
                                        this->simulator_.vanguard().grid().comm());
-            this->initPrimaryVariablesEvaluation();
         } while (iter < max_iter);
 
         if (!converged) {
@@ -1239,9 +1238,6 @@ namespace Opm {
         bool alq_updated = false;
         OPM_BEGIN_PARALLEL_TRY_CATCH();
         {
-            // Set the well primary variables based on the value of well solutions
-            initPrimaryVariablesEvaluation();
-
             alq_updated = gaslift_.maybeDoGasLiftOptimize(simulator_,
                                                           well_container_,
                                                           this->wellState(),
@@ -1662,17 +1658,6 @@ namespace Opm {
 
 
     template<typename TypeTag>
-    void
-    BlackoilWellModel<TypeTag>::
-    initPrimaryVariablesEvaluation() const
-    {
-        for (auto& well : well_container_) {
-            well->initPrimaryVariablesEvaluation();
-        }
-    }
-
-
-    template<typename TypeTag>
     ConvergenceReport
     BlackoilWellModel<TypeTag>::
     getWellConvergence(const std::vector<Scalar>& B_avg, bool checkWellGroupControls) const
@@ -2084,7 +2069,6 @@ namespace Opm {
             if (events.hasEvent(WellState<Scalar>::event_mask)) {
                 well->updateWellStateWithTarget(simulator_, this->groupState(), this->wellState(), deferred_logger);
                 well->updatePrimaryVariables(simulator_, this->wellState(), deferred_logger);
-                well->initPrimaryVariablesEvaluation();
                 // There is no new well control change input within a report step,
                 // so next time step, the well does not consider to have effective events anymore.
                 events.clearEvent(WellState<Scalar>::event_mask);

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -86,8 +86,6 @@ namespace Opm {
                   const std::vector<Scalar>& B_avg,
                   const bool changed_to_open_this_step) override;
 
-        void initPrimaryVariablesEvaluation() override;
-
         /// updating the well state based the current control mode
         void updateWellStateWithTarget(const Simulator& simulator,
                                        const GroupState<Scalar>& group_state,

--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.cpp
@@ -54,7 +54,7 @@ resize(const int numSegments)
 
 template<class FluidSystem, class Indices>
 void MultisegmentWellPrimaryVariables<FluidSystem,Indices>::
-init()
+setEvaluationsFromValues()
 {
     for (std::size_t seg = 0; seg < value_.size(); ++seg) {
         for (int eq_idx = 0; eq_idx < numWellEq; ++eq_idx) {
@@ -152,7 +152,7 @@ update(const WellState<Scalar>& well_state,
             }
         }
     }
-    init();
+    setEvaluationsFromValues();
 }
 
 template<class FluidSystem, class Indices>
@@ -209,7 +209,7 @@ updateNewton(const BVectorWell& dwells,
     if (stop_or_zero_rate_target) {
         value_[0][WQTotal] = 0.;
     }
-    init();
+    setEvaluationsFromValues();
 }
 
 template<class FluidSystem, class Indices>

--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
@@ -81,9 +81,6 @@ public:
     //! \brief Resize values and evaluations.
     void resize(const int numSegments);
 
-    //! \brief Initialize evaluations from values.
-    void init();
-
     //! \brief Copy values from well state.
     void update(const WellState<Scalar>& well_state,
                 const bool stop_or_zero_rate_target);
@@ -149,6 +146,9 @@ public:
     void outputLowLimitPressureSegments(DeferredLogger& deferred_logger) const;
 
 private:
+    //! \brief Initialize evaluations from values.
+    void setEvaluationsFromValues();
+
     //! \brief Handle non-reasonable fractions due to numerical overshoot.
     void processFractions(const int seg);
 

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -150,18 +150,6 @@ namespace Opm
     template <typename TypeTag>
     void
     MultisegmentWell<TypeTag>::
-    initPrimaryVariablesEvaluation()
-    {
-        this->primary_variables_.init();
-    }
-
-
-
-
-
-    template <typename TypeTag>
-    void
-    MultisegmentWell<TypeTag>::
     updatePrimaryVariables(const Simulator& simulator,
                            const WellState<Scalar>& well_state,
                            DeferredLogger& deferred_logger)
@@ -732,7 +720,6 @@ namespace Opm
                                 DeferredLogger& deferred_logger)
     {
         updatePrimaryVariables(simulator, well_state, deferred_logger);
-        initPrimaryVariablesEvaluation();
         computePerfCellPressDiffs(simulator);
         computeInitialSegmentFluids(simulator);
     }
@@ -1582,7 +1569,6 @@ namespace Opm
                 deferred_logger.debug(sstr.str());
             }
             updateWellState(simulator, dx_well, well_state, deferred_logger, relaxation_factor);
-            initPrimaryVariablesEvaluation();
         }
 
         // TODO: we should decide whether to keep the updated well_state, or recover to use the old well_state
@@ -1774,7 +1760,6 @@ namespace Opm
                 }
             }
             updateWellState(simulator, dx_well, well_state, deferred_logger, relaxation_factor);
-            initPrimaryVariablesEvaluation();
         }
 
         if (converged) {

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -137,8 +137,6 @@ namespace Opm
                           const std::vector<Scalar>& B_avg,
                           const bool changed_to_open_this_step) override;
 
-        void initPrimaryVariablesEvaluation() override;
-
         /// check whether the well equations get converged for this well
         virtual ConvergenceReport getWellConvergence(const Simulator& simulator,
                                                      const WellState<Scalar>& well_state,

--- a/opm/simulators/wells/StandardWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.cpp
@@ -97,7 +97,7 @@ namespace Opm {
 
 template<class FluidSystem, class Indices>
 void StandardWellPrimaryVariables<FluidSystem,Indices>::
-init()
+setEvaluationsFromValues()
 {
     for (int eqIdx = 0; eqIdx < numWellEq_; ++eqIdx) {
         evaluation_[eqIdx] =
@@ -223,7 +223,7 @@ update(const WellState<Scalar>& well_state,
 
     // BHP
     value_[Bhp] = ws.bhp;
-    init();
+    setEvaluationsFromValues();
 }
 
 template<class FluidSystem, class Indices>
@@ -302,7 +302,7 @@ updateNewton(const BVectorWell& dwells,
     // so that bhp constaint can be an active control when needed.
     constexpr Scalar bhp_lower_limit = 1. * unit::barsa - 1. * unit::Pascal;
     value_[Bhp] = std::max(value_[Bhp] - dx1_limited, bhp_lower_limit);
-    init();
+    setEvaluationsFromValues();
 }
 
 template<class FluidSystem, class Indices>
@@ -322,7 +322,7 @@ updateNewtonPolyMW(const BVectorWell& dwells)
             value_[pskin_index] -= relaxation_factor * dx_pskin;
         }
     }
-    init();
+    setEvaluationsFromValues();
 }
 
 template<class FluidSystem, class Indices>

--- a/opm/simulators/wells/StandardWellPrimaryVariables.hpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.hpp
@@ -92,9 +92,6 @@ public:
         : well_(well)
     {}
 
-    //! \brief Initialize evaluations from values.
-    void init();
-
     //! \brief Resize values and evaluations.
     void resize(const int numWellEq);
 
@@ -151,6 +148,9 @@ public:
     { value_[idx] = val; }
 
 private:
+    //! \brief Initialize evaluations from values.
+    void setEvaluationsFromValues();
+
     //! \brief Calculate a relaxation factor for producers.
     //! \details To avoid overshoot of the fractions which might result in negative rates.
     Scalar relaxationFactorFractionsProducer(const BVectorWell& dwells,

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -88,17 +88,6 @@ namespace Opm
 
 
     template<typename TypeTag>
-    void StandardWell<TypeTag>::
-    initPrimaryVariablesEvaluation()
-    {
-        this->primary_variables_.init();
-    }
-
-
-
-
-
-    template<typename TypeTag>
     template<class Value>
     void
     StandardWell<TypeTag>::
@@ -1412,7 +1401,6 @@ namespace Opm
                                 DeferredLogger& deferred_logger)
     {
         updatePrimaryVariables(simulator, well_state, deferred_logger);
-        initPrimaryVariablesEvaluation();
         computeWellConnectionPressures(simulator, well_state, deferred_logger);
         this->computeAccumWell();
     }
@@ -1564,7 +1552,6 @@ namespace Opm
                     = sign * ws.well_potentials[phase];
         }
         well_copy.updatePrimaryVariables(simulator, well_state_copy, deferred_logger);
-        well_copy.initPrimaryVariablesEvaluation();
         well_copy.computeAccumWell();
 
         const double dt = simulator.timeStepSize();
@@ -1576,7 +1563,6 @@ namespace Opm
         }
         well_copy.updatePrimaryVariables(simulator, well_state_copy, deferred_logger);
         well_copy.computeWellConnectionPressures(simulator, well_state_copy, deferred_logger);
-        well_copy.initPrimaryVariablesEvaluation();
         well_copy.computeWellRatesWithBhp(simulator, bhp, well_flux, deferred_logger);
     }
 
@@ -2382,7 +2368,6 @@ namespace Opm
             // this function or we use different functions for the well testing purposes.
             // We don't allow for switching well controls while computing well potentials and testing wells
             // updateWellControl(simulator, well_state, deferred_logger);
-            initPrimaryVariablesEvaluation();
         } while (it < max_iter);
 
         return converged;
@@ -2478,7 +2463,6 @@ namespace Opm
 
             ++it;
             solveEqAndUpdateWellState(simulator, well_state, deferred_logger);
-            initPrimaryVariablesEvaluation();
 
         } while (it < max_iter);
 

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -151,8 +151,6 @@ public:
                       const std::vector<Scalar>& B_avg,
                       const bool changed_to_open_this_step);
 
-    virtual void initPrimaryVariablesEvaluation() = 0;
-
     virtual ConvergenceReport getWellConvergence(const Simulator& simulator,
                                                  const WellState<Scalar>& well_state,
                                                  const std::vector<Scalar>& B_avg,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -400,7 +400,6 @@ namespace Opm
         updateWellStateWithTarget(simulator, group_state, well_state_copy, deferred_logger);
         calculateExplicitQuantities(simulator, well_state_copy, deferred_logger);
         updatePrimaryVariables(simulator, well_state_copy, deferred_logger);
-        initPrimaryVariablesEvaluation();
 
         if (this->isProducer()) {
             const auto& schedule = simulator.vanguard().schedule();

--- a/tests/test_glift1.cpp
+++ b/tests/test_glift1.cpp
@@ -153,7 +153,6 @@ BOOST_AUTO_TEST_CASE(G1)
     well_model.calculateExplicitQuantities(deferred_logger);
     well_model.prepareTimeStep(deferred_logger);
     well_model.updateWellControls(false, deferred_logger);
-    well_model.initPrimaryVariablesEvaluation();
     Opm::WellInterface<TypeTag> *well_ptr = well_model.getWell("B-1H").get();
     StdWell *std_well = dynamic_cast<StdWell *>(well_ptr);
 


### PR DESCRIPTION
Now that the AD (Evaluation) primary variables in the well classes are always updated whenever the value primary variables are, we no longer need to remember to explicitly update them, simplifying the code and enabling removal of functions.

The init() function of the primary variable classes have been renamed to setEvaluationsFromValues() and made private.

Note that this PR should in principle not change a single bit of results. I will make some local checks to verify this, in addition to using Jenkins.