### PR TITLE
Simplify GenericOutputBlackoilModule::doAllocBuffers

### DIFF
--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -27,9 +27,9 @@
 
 #include <opm/grid/common/CommunicationUtils.hpp>
 
+#include <opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/fluidsystems/BlackOilDefaultIndexTraits.hpp>
-
 #include <opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
@@ -55,7 +55,6 @@
 #include <cstddef>
 #include <functional>
 #include <initializer_list>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -752,9 +751,7 @@ doAllocBuffers(const unsigned bufferSize,
                const bool     substep,
                const bool     log,
                const bool     isRestart,
-               const bool     enablePCHysteresis,
-               const bool     enableNonWettingHysteresis,
-               const bool     enableWettingHysteresis,
+               const EclHysteresisConfig* hysteresisConfig,
                const unsigned numOutputNnc,
                std::map<std::string, int> rstKeywords)
 {
@@ -958,7 +955,7 @@ doAllocBuffers(const unsigned bufferSize,
         soMax_.resize(bufferSize, 0.0);
     }
 
-    if (enableNonWettingHysteresis) {
+    if (hysteresisConfig && hysteresisConfig->enableNonWettingHysteresis()) {
         if (FluidSystem::phaseIsActive(oilPhaseIdx)){
             if (FluidSystem::phaseIsActive(waterPhaseIdx)){
                 soMax_.resize(bufferSize, 0.0);
@@ -970,7 +967,7 @@ doAllocBuffers(const unsigned bufferSize,
             //TODO add support for gas-water 
         }
     }
-    if (enableWettingHysteresis) {
+    if (hysteresisConfig && hysteresisConfig->enableWettingHysteresis()) {
         if (FluidSystem::phaseIsActive(oilPhaseIdx)){
             if (FluidSystem::phaseIsActive(waterPhaseIdx)){
                 swMax_.resize(bufferSize, 0.0);
@@ -982,7 +979,7 @@ doAllocBuffers(const unsigned bufferSize,
             //TODO add support for gas-water 
         }
     }
-    if (enablePCHysteresis) {
+    if (hysteresisConfig && hysteresisConfig->enablePCHysteresis()) {
         if (FluidSystem::phaseIsActive(oilPhaseIdx)){
             if (FluidSystem::phaseIsActive(waterPhaseIdx)){
                 swmin_.resize(bufferSize, 0.0);

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -752,7 +752,6 @@ doAllocBuffers(const unsigned bufferSize,
                const bool     substep,
                const bool     log,
                const bool     isRestart,
-               const bool     vapparsActive,
                const bool     enablePCHysteresis,
                const bool     enableNonWettingHysteresis,
                const bool     enableWettingHysteresis,
@@ -953,6 +952,8 @@ doAllocBuffers(const unsigned bufferSize,
         this->micpC_.allocate(bufferSize);
     }
 
+    const bool vapparsActive = schedule_[std::max(reportStepNum, 0u)].oilvap().getType() ==
+                                  OilVaporizationProperties::OilVaporization::VAPPARS;
     if (vapparsActive) {
         soMax_.resize(bufferSize, 0.0);
     }

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -327,7 +327,6 @@ protected:
                         const bool substep,
                         const bool log,
                         const bool isRestart,
-                        const bool vapparsActive = false,
                         const bool enablePCHysteresis = false,
                         const bool enableNonWettingHysteresis = false,
                         const bool enableWettingHysteresis = false,

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -63,6 +63,7 @@ struct ForceDisableResvFluidInPlaceOutput { static constexpr bool value = false;
 namespace Opm {
 
 namespace data { class Solution; }
+class EclHysteresisConfig;
 class EclipseState;
 class Schedule;
 class SummaryConfig;
@@ -327,9 +328,7 @@ protected:
                         const bool substep,
                         const bool log,
                         const bool isRestart,
-                        const bool enablePCHysteresis = false,
-                        const bool enableNonWettingHysteresis = false,
-                        const bool enableWettingHysteresis = false,
+                        const EclHysteresisConfig* hysteresisConfig,
                         unsigned numOutputNnc = 0,
                         std::map<std::string, int> rstKeywords = {});
 

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -184,7 +184,6 @@ public:
                              substep,
                              log,
                              isRestart,
-                             problem.vapparsActive(std::max(simulator_.episodeIndex(), 0)),
                              problem.materialLawManager()->enablePCHysteresis(),
                              problem.materialLawManager()->enableNonWettingHysteresis(),
                              problem.materialLawManager()->enableWettingHysteresis(),

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -184,9 +184,7 @@ public:
                              substep,
                              log,
                              isRestart,
-                             problem.materialLawManager()->enablePCHysteresis(),
-                             problem.materialLawManager()->enableNonWettingHysteresis(),
-                             problem.materialLawManager()->enableWettingHysteresis(),
+                             &problem.materialLawManager()->hysteresisConfig(),
                              problem.eclWriter()->getOutputNnc().size());
     }
 
@@ -514,7 +512,7 @@ public:
 
             const auto& matLawManager = problem.materialLawManager();
             if (matLawManager->enableHysteresis()) {
-                if (FluidSystem::phaseIsActive(oilPhaseIdx) 
+                if (FluidSystem::phaseIsActive(oilPhaseIdx)
                     && FluidSystem::phaseIsActive(waterPhaseIdx)) {
                         Scalar somax;
                         Scalar swmax;
@@ -522,7 +520,7 @@ public:
 
                         matLawManager->oilWaterHysteresisParams(
                             somax, swmax, swmin, globalDofIdx);
-                
+
                     if (matLawManager->enableNonWettingHysteresis()) {
                         if (!this->soMax_.empty()) {
                             this->soMax_[globalDofIdx] = somax;
@@ -540,14 +538,14 @@ public:
                     }
                 }
 
-                if (FluidSystem::phaseIsActive(oilPhaseIdx) 
+                if (FluidSystem::phaseIsActive(oilPhaseIdx)
                     && FluidSystem::phaseIsActive(gasPhaseIdx)) {
                         Scalar sgmax;
                         Scalar shmax;
                         Scalar somin;
                         matLawManager->gasOilHysteresisParams(
                             sgmax, shmax, somin, globalDofIdx);
-                
+
                     if (matLawManager->enableNonWettingHysteresis()) {
                         if (!this->sgmax_.empty()) {
                             this->sgmax_[globalDofIdx] = sgmax;
@@ -565,7 +563,7 @@ public:
                     }
                 }
             } else {
-                
+
                 if (!this->soMax_.empty())
                     this->soMax_[globalDofIdx]
                         = std::max(getValue(fs.saturation(oilPhaseIdx)), problem.maxOilSaturation(globalDofIdx));
@@ -1162,7 +1160,7 @@ public:
         if (simulator.problem().materialLawManager()->enableHysteresis()) {
             auto matLawManager = simulator.problem().materialLawManager();
 
-            if (FluidSystem::phaseIsActive(oilPhaseIdx) 
+            if (FluidSystem::phaseIsActive(oilPhaseIdx)
                 && FluidSystem::phaseIsActive(waterPhaseIdx)) {
                     Scalar somax = 2.0;
                     Scalar swmax = -2.0;
@@ -1186,7 +1184,7 @@ public:
                 matLawManager->setOilWaterHysteresisParams(
                         somax, swmax, swmin, elemIdx);
             }
-            if (FluidSystem::phaseIsActive(oilPhaseIdx) 
+            if (FluidSystem::phaseIsActive(oilPhaseIdx)
                 && FluidSystem::phaseIsActive(gasPhaseIdx)) {
                     Scalar sgmax = 2.0;
                     Scalar shmax = -2.0;
@@ -1524,7 +1522,7 @@ private:
         {
             this->updateCO2InGas(globalDofIdx, pv, intQuants);
         }
-        
+
         if (this->fipC_.hasCo2InWater() &&
             (FluidSystem::phaseIsActive(waterPhaseIdx) ||
              FluidSystem::phaseIsActive(oilPhaseIdx)))

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -162,9 +162,7 @@ public:
         this->compC_.allocate(bufferSize, rstKeywords);
 
         this->doAllocBuffers(bufferSize, reportStepNum, substep, log, isRestart,
-                             /* enablePCHysteresis = */ false,
-                             /* enableNonWettingHysteresis =*/ false,
-                             /* enableWettingHysteresis =*/ false,
+                             /* hysteresisConfig = */ nullptr,
                              /* numOutputNnc =*/ 0,
                              std::move(rstKeywords));
     }

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -162,7 +162,6 @@ public:
         this->compC_.allocate(bufferSize, rstKeywords);
 
         this->doAllocBuffers(bufferSize, reportStepNum, substep, log, isRestart,
-                             /* vapparsActive =*/ false,
                              /* enablePCHysteresis = */ false,
                              /* enableNonWettingHysteresis =*/ false,
                              /* enableWettingHysteresis =*/ false,


### PR DESCRIPTION
Get rid of bool parameters. Note I have passed the hysteresis config as a pointer to allow passing a nullptr for CompositionalOutput. I'm not sure if this is strictly required or not.

Downstream of https://github.com/OPM/opm-common/pull/4485