### PR TITLE
move output of conv data into RSTConv class

### DIFF
--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -267,9 +267,6 @@ public:
 
     void writePartitions(const std::filesystem::path& odir) const;
 
-    const std::vector<std::vector<int>>& getConvCells() const
-    { return rst_conv_.getData(); }
-
     /// return the StandardWells object
     BlackoilWellModel<TypeTag>&
     wellModel()
@@ -323,8 +320,6 @@ protected:
 
     // Well Model
     BlackoilWellModel<TypeTag>& well_model_;
-
-    RSTConv rst_conv_; //!< Helper class for RPTRST CONV
 
     /// \brief Whether we print something to std::cout
     bool terminal_output_;

--- a/opm/simulators/flow/BlackoilModel_impl.hpp
+++ b/opm/simulators/flow/BlackoilModel_impl.hpp
@@ -59,8 +59,6 @@ BlackoilModel(Simulator& simulator,
     , phaseUsage_(phaseUsageFromDeck(eclState()))
     , param_( param )
     , well_model_ (well_model)
-    , rst_conv_(simulator_.problem().eclWriter()->collectOnIORank().localIdxToGlobalIdxMapping(),
-                grid_.comm())
     , terminal_output_ (terminal_output)
     , current_relaxation_(1.0)
     , dx_old_(simulator_.model().numGridDof())
@@ -143,14 +141,15 @@ prepareStep(const SimulatorTimerInterface& timer)
         return -1;
     };
     const auto& schedule = simulator_.vanguard().schedule();
-    rst_conv_.init(simulator_.vanguard().globalNumCells(),
-                   schedule[timer.reportStepNum()].rst_config(),
-                   {getIdx(FluidSystem::oilPhaseIdx),
-                    getIdx(FluidSystem::gasPhaseIdx),
-                    getIdx(FluidSystem::waterPhaseIdx),
-                    contiPolymerEqIdx,
-                    contiBrineEqIdx,
-                    contiSolventEqIdx});
+    auto& rst_conv = simulator_.problem().eclWriter()->mutableOutputModule().getConv();
+    rst_conv.init(simulator_.vanguard().globalNumCells(),
+                  schedule[timer.reportStepNum()].rst_config(),
+                  {getIdx(FluidSystem::oilPhaseIdx),
+                   getIdx(FluidSystem::gasPhaseIdx),
+                   getIdx(FluidSystem::waterPhaseIdx),
+                   contiPolymerEqIdx,
+                   contiBrineEqIdx,
+                   contiSolventEqIdx});
 
     return report;
 }
@@ -246,7 +245,8 @@ nonlinearIteration(const int iteration,
                                                            nonlinear_solver);
     }
 
-    rst_conv_.update(simulator_.model().linearizer().residual());
+    auto& rst_conv = simulator_.problem().eclWriter()->mutableOutputModule().getConv();
+    rst_conv.update(simulator_.model().linearizer().residual());
 
     return result;
 }
@@ -353,7 +353,6 @@ afterStep(const SimulatorTimerInterface&)
     Dune::Timer perfTimer;
     perfTimer.start();
     simulator_.problem().endTimeStep();
-    simulator_.problem().setConvData(rst_conv_.getData());
     report.pre_post_time += perfTimer.stop();
     return report;
 }

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -827,12 +827,7 @@ public:
         return eclWriter_;
     }
 
-    void setConvData(const std::vector<std::vector<int>>& data)
-    {
-        eclWriter_->mutableOutputModule().setCnvData(data);
-    }
-
-        /*!
+    /*!
      * \brief Returns the maximum value of the gas dissolution factor at the current time
      *        for a given degree of freedom.
      */

--- a/opm/simulators/flow/FlowProblemComp.hpp
+++ b/opm/simulators/flow/FlowProblemComp.hpp
@@ -417,6 +417,9 @@ public:
         return thresholdPressures_;
     }
 
+    const std::unique_ptr<EclWriterType>& eclWriter() const
+    { return eclWriter_; }
+
     // TODO: do we need this one?
     template<class Serializer>
     void serializeOp(Serializer& serializer)

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -41,6 +41,7 @@
 #include <opm/simulators/flow/MICPContainer.hpp>
 #include <opm/simulators/flow/RegionPhasePVAverage.hpp>
 #include <opm/simulators/flow/RFTContainer.hpp>
+#include <opm/simulators/flow/RSTConv.hpp>
 #include <opm/simulators/flow/TracerContainer.hpp>
 
 #include <opm/simulators/utils/ParallelCommunication.hpp>
@@ -271,16 +272,17 @@ public:
         local_data_valid_ = true;
     }
 
-    void setCnvData(const std::vector<std::vector<int>>& data)
-    {
-        cnvData_ = data;
-    }
-
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
         serializer(initialInplace_);
     }
+
+    RSTConv& getConv()
+    { return this->rst_conv_; }
+
+    const RSTConv& getConv() const
+    { return this->rst_conv_; }
 
     //! \brief Assign fields that are in global numbering to the solution.
     //! \detail This is used to add fields that for some reason cannot be collected
@@ -306,6 +308,8 @@ protected:
                                 const SummaryConfig& summaryConfig,
                                 const SummaryState& summaryState,
                                 const std::string& moduleVersionName,
+                                RSTConv::LocalToGlobalCellFunc globalCell,
+                                const Parallel::Communication& comm,
                                 bool enableEnergy,
                                 bool enableTemperature,
                                 bool enableMech,
@@ -467,9 +471,9 @@ protected:
     std::array<FlowsData<double>, 3> flowsn_;
 
     RFTContainer<FluidSystem> rftC_;
-    std::map<std::pair<std::string, int>, double> blockData_;
+    RSTConv rst_conv_; //!< Helper class for RPTRST CONV
 
-    std::vector<std::vector<int>> cnvData_; //!< Data for CNV_xxx arrays
+    std::map<std::pair<std::string, int>, double> blockData_;
 
     std::optional<Inplace> initialInplace_;
     bool local_data_valid_{false};

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -116,6 +116,9 @@ public:
                    smryCfg,
                    simulator.vanguard().summaryState(),
                    moduleVersionName(),
+                   [this](const int idx)
+                   { return simulator_.problem().eclWriter()->collectOnIORank().localIdxToGlobalIdx(idx); },
+                   simulator.vanguard().grid().comm(),
                    getPropValue<TypeTag, Properties::EnableEnergy>(),
                    getPropValue<TypeTag, Properties::EnableTemperature>(),
                    getPropValue<TypeTag, Properties::EnableMech>(),

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -97,6 +97,9 @@ public:
                    smryCfg,
                    simulator.vanguard().summaryState(),
                    moduleVersionName(),
+                   [this](const int idx)
+                   { return simulator_.problem().eclWriter()->collectOnIORank().localIdxToGlobalIdx(idx); },
+                   simulator.vanguard().grid().comm(),
                    getPropValue<TypeTag, Properties::EnableEnergy>(),
                    getPropValue<TypeTag, Properties::EnableTemperature>(),
                    getPropValue<TypeTag, Properties::EnableMech>(),

--- a/tests/test_rstconv.cpp
+++ b/tests/test_rstconv.cpp
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(RstConvTest)
         }
     }
 
-    Opm::RSTConv cnv(cellMapping, cc);
+    Opm::RSTConv cnv([&cellMapping](const int idx) { return cellMapping[idx]; }, cc);
     cnv.init(10*cc.size(), rst, sample.phase);
 
     cnv.update(residual);


### PR DESCRIPTION
move member from model to output module. this way we don't have to shuffle data around