### PR TITLE
FlowProblem(Blackoil|Comp): Return a reference to EclWriter

### DIFF
--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -539,14 +539,14 @@ private:
         // If FLOWS/FLORES is set in any RPTRST in the schedule, then we initializate the sparse tables
         // For now, do the same also if any block flows are requested (TODO: only save requested cells...)
         // If DISPERC is in the deck, we initialize the sparse table here as well.
-        const bool anyFlows = simulator_().problem().eclWriter()->outputModule().getFlows().anyFlows();
-        const bool anyFlores = simulator_().problem().eclWriter()->outputModule().getFlows().anyFlores();
+        const bool anyFlows = simulator_().problem().eclWriter().outputModule().getFlows().anyFlows();
+        const bool anyFlores = simulator_().problem().eclWriter().outputModule().getFlows().anyFlores();
         const bool enableDispersion = simulator_().vanguard().eclState().getSimulationConfig().rock_config().dispersion();
         if (((!anyFlows || !flowsInfo_.empty()) && (!anyFlores || !floresInfo_.empty())) && !enableDispersion) {
             return;
         }
         const auto& model = model_();
-        const auto& nncOutput = simulator_().problem().eclWriter()->getOutputNnc();
+        const auto& nncOutput = simulator_().problem().eclWriter().getOutputNnc();
         Stencil stencil(gridView_(), model_().dofMapper());
         unsigned numCells = model.numTotalDof();
         std::unordered_multimap<int, std::pair<int, int>> nncIndices;
@@ -641,9 +641,9 @@ public:
 
     void updateFlowsInfo() {
         OPM_TIMEBLOCK(updateFlows);
-        const bool enableFlows = simulator_().problem().eclWriter()->outputModule().getFlows().hasFlows() ||
-                                  simulator_().problem().eclWriter()->outputModule().getFlows().hasBlockFlows();
-        const bool enableFlores = simulator_().problem().eclWriter()->outputModule().getFlows().hasFlores();
+        const bool enableFlows = simulator_().problem().eclWriter().outputModule().getFlows().hasFlows() ||
+                                 simulator_().problem().eclWriter().outputModule().getFlows().hasBlockFlows();
+        const bool enableFlores = simulator_().problem().eclWriter().outputModule().getFlows().hasFlores();
         if (!enableFlows && !enableFlores) {
             return;
         }
@@ -724,7 +724,7 @@ private:
         // We do not call resetSystem_() here, since that will set
         // the full system to zero, not just our part.
         // Instead, that must be called before starting the linearization.
-        const bool& enableDispersion = simulator_().vanguard().eclState().getSimulationConfig().rock_config().dispersion();
+        const bool enableDispersion = simulator_().vanguard().eclState().getSimulationConfig().rock_config().dispersion();
         const unsigned int numCells = domain.cells.size();
         const bool on_full_domain = (numCells == model_().numTotalDof());
 

--- a/opm/simulators/flow/BlackoilModel_impl.hpp
+++ b/opm/simulators/flow/BlackoilModel_impl.hpp
@@ -141,7 +141,7 @@ prepareStep(const SimulatorTimerInterface& timer)
         return -1;
     };
     const auto& schedule = simulator_.vanguard().schedule();
-    auto& rst_conv = simulator_.problem().eclWriter()->mutableOutputModule().getConv();
+    auto& rst_conv = simulator_.problem().eclWriter().mutableOutputModule().getConv();
     rst_conv.init(simulator_.vanguard().globalNumCells(),
                   schedule[timer.reportStepNum()].rst_config(),
                   {getIdx(FluidSystem::oilPhaseIdx),
@@ -245,7 +245,7 @@ nonlinearIteration(const int iteration,
                                                            nonlinear_solver);
     }
 
-    auto& rst_conv = simulator_.problem().eclWriter()->mutableOutputModule().getConv();
+    auto& rst_conv = simulator_.problem().eclWriter().mutableOutputModule().getConv();
     rst_conv.update(simulator_.model().linearizer().residual());
 
     return result;

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -445,7 +445,7 @@ public:
     {
         // After the solution is updated, the values in output module needs
         // also updated.
-        this->eclWriter()->mutableOutputModule().invalidateLocalData();
+        this->eclWriter().mutableOutputModule().invalidateLocalData();
 
         // For CpGrid with LGRs, ecl/vtk output is not supported yet.
         const auto& grid = this->simulator().vanguard().gridView().grid();
@@ -822,10 +822,11 @@ public:
     }
 
 
-    const std::unique_ptr<EclWriterType>& eclWriter() const
-    {
-        return eclWriter_;
-    }
+    const EclWriterType& eclWriter() const
+    { return *eclWriter_; }
+
+    EclWriterType& eclWriter()
+    { return *eclWriter_; }
 
     /*!
      * \brief Returns the maximum value of the gas dissolution factor at the current time

--- a/opm/simulators/flow/FlowProblemComp.hpp
+++ b/opm/simulators/flow/FlowProblemComp.hpp
@@ -417,8 +417,11 @@ public:
         return thresholdPressures_;
     }
 
-    const std::unique_ptr<EclWriterType>& eclWriter() const
-    { return eclWriter_; }
+    const EclWriterType& eclWriter() const
+    { return *eclWriter_; }
+
+    EclWriterType& eclWriter()
+    { return *eclWriter_; }
 
     // TODO: do we need this one?
     template<class Serializer>

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -117,7 +117,7 @@ public:
                    simulator.vanguard().summaryState(),
                    moduleVersionName(),
                    [this](const int idx)
-                   { return simulator_.problem().eclWriter()->collectOnIORank().localIdxToGlobalIdx(idx); },
+                   { return simulator_.problem().eclWriter().collectOnIORank().localIdxToGlobalIdx(idx); },
                    simulator.vanguard().grid().comm(),
                    getPropValue<TypeTag, Properties::EnableEnergy>(),
                    getPropValue<TypeTag, Properties::EnableTemperature>(),
@@ -188,7 +188,7 @@ public:
                              log,
                              isRestart,
                              &problem.materialLawManager()->hysteresisConfig(),
-                             problem.eclWriter()->getOutputNnc().size());
+                             problem.eclWriter().getOutputNnc().size());
     }
 
     void processElementMech(const ElementContext& elemCtx)

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -98,7 +98,7 @@ public:
                    simulator.vanguard().summaryState(),
                    moduleVersionName(),
                    [this](const int idx)
-                   { return simulator_.problem().eclWriter()->collectOnIORank().localIdxToGlobalIdx(idx); },
+                   { return simulator_.problem().eclWriter().collectOnIORank().localIdxToGlobalIdx(idx); },
                    simulator.vanguard().grid().comm(),
                    getPropValue<TypeTag, Properties::EnableEnergy>(),
                    getPropValue<TypeTag, Properties::EnableTemperature>(),


### PR DESCRIPTION
the pointer is allocated in the ctor, so the fact that it is a unique_ptr
can be kept as an implementation detail. furthermore, the previous
accessor did not properly enforce constness, as a const unique_ptr<EclWriter>
only applies const to the pointer class, not the data the pointer points to.

Sits on top of https://github.com/OPM/opm-simulators/pull/6000