### PR TITLE
Fix to write residuals

### DIFF
--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -1060,7 +1060,8 @@ doAllocBuffers(const unsigned bufferSize,
                                        // we need to check if the main keyword is defined. If so,
                                        // call the handler with required set to true
                                        if (!required && (entry.phaseType == EntryPhaseType::NGWO ||
-                                                         entry.phaseType == EntryPhaseType::NGasWatOil))
+                                                         entry.phaseType == EntryPhaseType::NGasWatOil ||
+                                                         entry.phaseType == EntryPhaseType::None))
                                        {
                                            auto it = rstKeywords.find(std::string(entry.kw));
                                            if (it != rstKeywords.end() && it->second > 0) {


### PR DESCRIPTION
This fixes the writing of residuals (e.g., for a gas water system the current master only writes the residuals for the gas phase).