### PR TITLE
OutputBlackoilModule::processElement: use a table for data extraction

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -875,6 +875,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/flow/NonlinearSolver.hpp
   opm/simulators/flow/OutputBlackoilModule.hpp
   opm/simulators/flow/OutputCompositionalModule.hpp
+  opm/simulators/flow/OutputExtractor.hpp
   opm/simulators/flow/partitionCells.hpp
   opm/simulators/flow/PolyhedralGridVanguard.hpp
   opm/simulators/flow/priVarsPacking.hpp

--- a/opm/simulators/flow/DamarisWriter.hpp
+++ b/opm/simulators/flow/DamarisWriter.hpp
@@ -457,14 +457,6 @@ private:
         }
         damarisOutputModule_->clearExtractors();
         }
-        if(!simulator_.model().linearizer().getFlowsInfo().empty()){
-            OPM_TIMEBLOCK(prepareFlowsData);
-            for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {
-                elemCtx.updatePrimaryStencil(elem);
-                elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
-                damarisOutputModule_->processElementFlows(elemCtx);
-            }
-        }
         {
         OPM_TIMEBLOCK(prepareBlockData);
         for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {

--- a/opm/simulators/flow/DamarisWriter.hpp
+++ b/opm/simulators/flow/DamarisWriter.hpp
@@ -448,12 +448,14 @@ private:
         OPM_BEGIN_PARALLEL_TRY_CATCH();
         {
         OPM_TIMEBLOCK(prepareCellBasedData);
+        damarisOutputModule_->setupExtractors();
         for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {
             elemCtx.updatePrimaryStencil(elem);
             elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
 
             damarisOutputModule_->processElement(elemCtx);
         }
+        damarisOutputModule_->clearExtractors();
         }
         if(!simulator_.model().linearizer().getFlowsInfo().empty()){
             OPM_TIMEBLOCK(prepareFlowsData);

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -737,16 +737,6 @@ private:
             this->outputModule_->accumulateDensityParallel();
         }
 
-        if (! this->simulator_.model().linearizer().getFlowsInfo().empty()) {
-            OPM_TIMEBLOCK(prepareFlowsData);
-            for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {
-                elemCtx.updatePrimaryStencil(elem);
-                elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
-
-                this->outputModule_->processElementFlows(elemCtx);
-            }
-        }
-
         {
             OPM_TIMEBLOCK(prepareBlockData);
             for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -737,17 +737,6 @@ private:
             this->outputModule_->accumulateDensityParallel();
         }
 
-        if constexpr (enableMech) {
-            if (simulator_.vanguard().eclState().runspec().mech()) {
-                OPM_TIMEBLOCK(prepareMechData);
-                for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {
-                    elemCtx.updatePrimaryStencil(elem);
-                    elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
-                    outputModule_->processElementMech(elemCtx);
-                }
-            }
-        }
-
         if (! this->simulator_.model().linearizer().getFlowsInfo().empty()) {
             OPM_TIMEBLOCK(prepareFlowsData);
             for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -725,13 +725,14 @@ private:
             OPM_TIMEBLOCK(prepareCellBasedData);
 
             this->outputModule_->prepareDensityAccumulation();
-
+            this->outputModule_->setupExtractors();
             for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {
                 elemCtx.updatePrimaryStencil(elem);
                 elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
 
                 this->outputModule_->processElement(elemCtx);
             }
+            this->outputModule_->clearExtractors();
 
             this->outputModule_->accumulateDensityParallel();
         }

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -89,6 +89,7 @@ class OutputBlackOilModule : public GenericOutputBlackoilModule<GetPropType<Type
     using MaterialLawParams = GetPropType<TypeTag, Properties::MaterialLawParams>;
     using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
     using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+    using FluidState = typename IntensiveQuantities::FluidState;
     using GridView = GetPropType<TypeTag, Properties::GridView>;
     using Element = typename GridView::template Codim<0>::Entity;
     using ElementIterator = typename GridView::template Codim<0>::Iterator;
@@ -258,8 +259,6 @@ public:
         for (unsigned dofIdx = 0; dofIdx < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++dofIdx) {
             const auto& intQuants = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0);
             const auto& fs = intQuants.fluidState();
-
-            using FluidState = std::remove_cv_t<std::remove_reference_t<decltype(fs)>>;
 
             const unsigned globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
             const unsigned pvtRegionIdx = elemCtx.primaryVars(dofIdx, /*timeIdx=*/0).pvtRegionIndex();
@@ -1293,9 +1292,6 @@ private:
             const auto& up = elemCtx
                 .intensiveQuantities(extQuant.upstreamIndex(oilPhaseIdx), timeIdx);
 
-            using FluidState = std::remove_cv_t<std::remove_reference_t<
-                decltype(up.fluidState())>>;
-
             const auto pvtReg = up.pvtRegionIndex();
 
             const auto bO = getValue(getInvB_<FluidSystem, FluidState, Scalar>
@@ -1319,9 +1315,6 @@ private:
             const auto& up = elemCtx
                 .intensiveQuantities(extQuant.upstreamIndex(gasPhaseIdx), timeIdx);
 
-            using FluidState = std::remove_cv_t<std::remove_reference_t<
-                decltype(up.fluidState())>>;
-
             const auto pvtReg = up.pvtRegionIndex();
 
             const auto bG = getValue(getInvB_<FluidSystem, FluidState, Scalar>
@@ -1344,9 +1337,6 @@ private:
         if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
             const auto& up = elemCtx
                 .intensiveQuantities(extQuant.upstreamIndex(waterPhaseIdx), timeIdx);
-
-            using FluidState = std::remove_cv_t<std::remove_reference_t<
-                decltype(up.fluidState())>>;
 
             const auto pvtReg = up.pvtRegionIndex();
 

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -258,8 +258,8 @@ public:
             return;
         }
 
-        const auto& problem = elemCtx.simulator().problem();
-        const auto& modelResid = elemCtx.simulator().model().linearizer().residual();
+        const auto& problem = simulator_.problem();
+        const auto& modelResid = simulator_.model().linearizer().residual();
         const auto& matLawManager = problem.materialLawManager();
         using Entry = typename Extractor::Entry;
         using ExtractContext = typename Extractor::Context;
@@ -332,7 +332,7 @@ public:
             },
             Entry{ScalarEntry{&this->bubblePointPressure_,
                   [&failedCells = this->failedCellsPb_,
-                   &vanguard = elemCtx.simulator().vanguard()](const ExtractContext& ectx)
+                   &vanguard = simulator_.vanguard()](const ExtractContext& ectx)
                   {
                       try {
                           return getValue(FluidSystem::bubblePointPressure(ectx.fs,
@@ -346,7 +346,7 @@ public:
             },
             Entry{ScalarEntry{&this->dewPointPressure_,
                   [&failedCells = this->failedCellsPd_,
-                   &vanguard = elemCtx.simulator().vanguard()](const ExtractContext& ectx)
+                   &vanguard = simulator_.vanguard()](const ExtractContext& ectx)
                   {
                       try {
                           return getValue(FluidSystem::dewPointPressure(ectx.fs,
@@ -395,7 +395,7 @@ public:
                   { return getValue(ectx.intQuants.permFactor()); }}
             },
             Entry{ScalarEntry{&this->rPorV_,
-                  [&model = elemCtx.simulator().model()](const ExtractContext& ectx)
+                  [&model = simulator_.model()](const ExtractContext& ectx)
                   {
                       const auto totVolume = model.dofTotalVolume(ectx.globalDofIdx);
                       return totVolume * getValue(ectx.intQuants.porosity());
@@ -602,7 +602,7 @@ public:
                   FluidSystem::phaseIsActive(oilPhaseIdx) &&
                   FluidSystem::phaseIsActive(gasPhaseIdx)
             },
-            Entry{[&model = elemCtx.simulator().model(), this](const ExtractContext& ectx)
+            Entry{[&model = simulator_.model(), this](const ExtractContext& ectx)
                   {
                       // Note: We intentionally exclude effects of rock
                       // compressibility by using referencePorosity() here.
@@ -661,9 +661,10 @@ public:
                                    ectx.intQuants.calciteConcentration().value());
                   }, this->micpC_.allocated()
             },
-            Entry{[&rftC = this->rftC_, &elemCtx](const ExtractContext& ectx)
+            Entry{[&rftC = this->rftC_,
+                   &vanguard = simulator_.vanguard()](const ExtractContext& ectx)
                   {
-                      const auto cartesianIdx = elemCtx.simulator().vanguard().cartesianIndex(ectx.globalDofIdx);
+                      const auto cartesianIdx = vanguard.cartesianIndex(ectx.globalDofIdx);
                       rftC.assign(cartesianIdx,
                                   [&fs = ectx.fs]() { return getValue(fs.pressure(oilPhaseIdx)); },
                                   [&fs = ectx.fs]() { return getValue(fs.saturation(waterPhaseIdx)); },
@@ -688,28 +689,28 @@ public:
             Entry{ScalarEntry{&this->rv_,
                   [&problem](const ExtractContext& ectx)
                   { return problem.initialFluidState(ectx.globalDofIdx).Rv(); }},
-                  elemCtx.simulator().episodeIndex() < 0 &&
+                  simulator_.episodeIndex() < 0 &&
                   FluidSystem::phaseIsActive(oilPhaseIdx) &&
                   FluidSystem::phaseIsActive(gasPhaseIdx)
             },
             Entry{ScalarEntry{&this->rs_,
                   [&problem](const ExtractContext& ectx)
                   { return problem.initialFluidState(ectx.globalDofIdx).Rs(); }},
-                  elemCtx.simulator().episodeIndex() < 0 &&
+                  simulator_.episodeIndex() < 0 &&
                   FluidSystem::phaseIsActive(oilPhaseIdx) &&
                   FluidSystem::phaseIsActive(gasPhaseIdx)
             },
             Entry{ScalarEntry{&this->rsw_,
                   [&problem](const ExtractContext& ectx)
                   { return problem.initialFluidState(ectx.globalDofIdx).Rsw(); }},
-                  elemCtx.simulator().episodeIndex() < 0 &&
+                  simulator_.episodeIndex() < 0 &&
                   FluidSystem::phaseIsActive(oilPhaseIdx) &&
                   FluidSystem::phaseIsActive(gasPhaseIdx)
             },
             Entry{ScalarEntry{&this->rvw_,
                   [&problem](const ExtractContext& ectx)
                   { return problem.initialFluidState(ectx.globalDofIdx).Rvw(); }},
-                  elemCtx.simulator().episodeIndex() < 0 &&
+                  simulator_.episodeIndex() < 0 &&
                   FluidSystem::phaseIsActive(oilPhaseIdx) &&
                   FluidSystem::phaseIsActive(gasPhaseIdx)
             },
@@ -722,7 +723,7 @@ public:
                                                   phase,
                                                   ectx.intQuants.pvtRegionIndex());
                   }},
-                  elemCtx.simulator().episodeIndex() < 0 &&
+                  simulator_.episodeIndex() < 0 &&
                   FluidSystem::phaseIsActive(oilPhaseIdx) &&
                   FluidSystem::phaseIsActive(gasPhaseIdx)
             },
@@ -734,7 +735,7 @@ public:
                                                                        phase,
                                                                        ectx.intQuants.pvtRegionIndex());
                   }},
-                  elemCtx.simulator().episodeIndex() < 0 &&
+                  simulator_.episodeIndex() < 0 &&
                   FluidSystem::phaseIsActive(oilPhaseIdx) &&
                   FluidSystem::phaseIsActive(gasPhaseIdx)
             },
@@ -746,7 +747,7 @@ public:
                                                     phase,
                                                     ectx.intQuants.pvtRegionIndex());
                   }},
-                  elemCtx.simulator().episodeIndex() < 0 &&
+                  simulator_.episodeIndex() < 0 &&
                   FluidSystem::phaseIsActive(oilPhaseIdx) &&
                   FluidSystem::phaseIsActive(gasPhaseIdx)
             },

--- a/opm/simulators/flow/OutputExtractor.hpp
+++ b/opm/simulators/flow/OutputExtractor.hpp
@@ -1,0 +1,111 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::OutputBlackOilModule
+ */
+#ifndef OPM_OUTPUT_EXTRACTORS_HPP
+#define OPM_OUTPUT_EXTRACTORS_HPP
+
+#include <opm/models/common/multiphasebaseproperties.hh>
+#include <opm/models/discretization/common/fvbaseproperties.hh>
+#include <opm/models/utils/basicproperties.hh>
+#include <opm/models/utils/propertysystem.hh>
+
+#include <array>
+#include <variant>
+#include <vector>
+
+namespace Opm::detail {
+
+//! \brief Wrapping struct holding types used for element-level data extraction.
+template<class TypeTag>
+struct Extractor
+{
+    using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
+    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
+    using FluidState = typename IntensiveQuantities::FluidState;
+    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+    static constexpr int numPhases = FluidSystem::numPhases;
+
+    //! \brief Struct holding hysteresis parameters.
+    struct HysteresisParams
+    {
+        Scalar somax{}; //!< Max oil saturation
+        Scalar swmax{}; //!< Max water saturation
+        Scalar swmin{}; //!< Min water saturation
+        Scalar sgmax{}; //!< Max gas saturation
+        Scalar shmax{}; //!< Max something
+        Scalar somin{}; //!< Min oil saturation
+    };
+
+    //! \brief Context passed to extractor functions.
+    struct Context
+    {
+        unsigned globalDofIdx; //!< Global degree-of-freedom index
+        unsigned pvtRegionIdx; //!< pvt region for dof
+        int episodeIndex;      //!< Current report step
+        const FluidState& fs;  //!< Fluid state for cell
+        const IntensiveQuantities& intQuants; //!< Intensive quantities for cell
+        const HysteresisParams& hParams; //!< Hysteresis parameters for cell
+    };
+
+    /// Callback for extractors handling their own assignements
+    using AssignFunc = std::function<void(const Context&)>;
+
+    /// Callback for extractors assigned to a scalar buffer
+    /// Return value to store in buffer
+    using ScalarFunc = std::function<Scalar(const Context&)>;
+
+    /// Callback for extractors assigned to a phase buffer
+    /// Returns value to store in buffer for requested phase
+    using PhaseFunc = std::function<Scalar(const unsigned /*phase*/, const Context&)>;
+
+    using ScalarBuffer = std::vector<Scalar>; //!< A scalar buffer
+    using PhaseArray = std::array<ScalarBuffer,numPhases>; //!< An array of buffers, one for each phase
+
+    //! \brief A scalar extractor descriptor.
+    struct ScalarEntry
+    {
+        ScalarBuffer* data; //!< Buffer to store data in
+        ScalarFunc extract; //!< Function to call for extraction
+    };
+
+    //! \brief A phase buffer extractor descriptor.
+    struct PhaseEntry
+    {
+        PhaseArray* data; //!< Array of buffers to store data in
+        PhaseFunc extract; //!< Function to call for extraction
+    };
+
+    //! \brief Descriptor for extractors
+    struct Entry
+    {
+        std::variant<AssignFunc, ScalarEntry, PhaseEntry> data; //!< Extractor
+        bool condition = true; //!< Additional condition for enabling extractor
+    };
+};
+
+} // namespace Opm::detail
+
+#endif // OPM_OUTPUT_EXTRACTORS_HPP


### PR DESCRIPTION
This applies the same strategy as https://github.com/OPM/opm-simulators/pull/5994 but to the extraction of element level data, with the same merits.

This is a hotter loop, so we may pay a cost for the increased abstraction. Should be tested on some large models