### PR TITLE
Time step rejection if tolerance test fails

### DIFF
--- a/opm/simulators/flow/NonlinearSolver.hpp
+++ b/opm/simulators/flow/NonlinearSolver.hpp
@@ -35,6 +35,7 @@
 
 #include <opm/simulators/timestepping/SimulatorReport.hpp>
 #include <opm/simulators/timestepping/SimulatorTimerInterface.hpp>
+#include <opm/simulators/timestepping/TimeStepControl.hpp>
 
 #include <memory>
 
@@ -128,7 +129,7 @@ struct NonlinearSolverParameters
         }
 
 
-        SimulatorReportSingle step(const SimulatorTimerInterface& timer)
+        SimulatorReportSingle step(const SimulatorTimerInterface& timer, const TimeStepControlInterface& timeStepControl)
         {
             SimulatorReportSingle report;
             report.global_time = timer.simulationTimeElapsed();
@@ -173,6 +174,13 @@ struct NonlinearSolverParameters
 
                 std::string msg = "Solver convergence failure - Failed to complete a time step within " + std::to_string(maxIter()) + " iterations.";
                 OPM_THROW_NOLOG(TooManyIterations, msg);
+            }
+            if (!timeStepControl.timeStepAccepted(model_->relativeChange())) {
+                failureReport_ = report;
+                report.converged = false;
+
+                std::string msg = "Time step was too large. Tolerance test failed.";
+                OPM_THROW_NOLOG(TimeSteppingBreakdown, msg);
             }
 
             // Do model-specific post-step actions.

--- a/opm/simulators/flow/NonlinearSolver.hpp
+++ b/opm/simulators/flow/NonlinearSolver.hpp
@@ -175,11 +175,12 @@ struct NonlinearSolverParameters
                 std::string msg = "Solver convergence failure - Failed to complete a time step within " + std::to_string(maxIter()) + " iterations.";
                 OPM_THROW_NOLOG(TooManyIterations, msg);
             }
-            if (!timeStepControl.timeStepAccepted(model_->relativeChange())) {
+            auto relativeChange = model_->relativeChange();
+            if (!timeStepControl.timeStepAccepted(relativeChange)) {
                 report.converged = false;
                 failureReport_ = report;
 
-                std::string msg = "Time step was too large. Tolerance test failed.";
+                std::string msg = "Relative change in solution for time step was " + std::to_string(relativeChange) + ", which is larger than the tolerance accepted by the timestepping algorithm.";
                 OPM_THROW_NOLOG(TimeSteppingBreakdown, msg);
             }
 

--- a/opm/simulators/flow/NonlinearSolver.hpp
+++ b/opm/simulators/flow/NonlinearSolver.hpp
@@ -176,8 +176,8 @@ struct NonlinearSolverParameters
                 OPM_THROW_NOLOG(TooManyIterations, msg);
             }
             if (!timeStepControl.timeStepAccepted(model_->relativeChange())) {
-                failureReport_ = report;
                 report.converged = false;
+                failureReport_ = report;
 
                 std::string msg = "Time step was too large. Tolerance test failed.";
                 OPM_THROW_NOLOG(TimeSteppingBreakdown, msg);

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -468,7 +468,7 @@ public:
             simulator_.problem().setSimulationReport(report_);
         } else {
             // solve for complete report step
-            auto stepReport = solver_->step(timer);
+            auto stepReport = solver_->step(timer, adaptiveTimeStepping_->timeStepControl());
             report_ += stepReport;
             if (terminalOutput_) {
                 std::ostringstream ss;

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -468,7 +468,8 @@ public:
             simulator_.problem().setSimulationReport(report_);
         } else {
             // solve for complete report step
-            auto stepReport = solver_->step(timer, adaptiveTimeStepping_->timeStepControl());
+            solver_->disableAdaptiveTimeStepping();
+            auto stepReport = solver_->step(timer, *adaptiveTimeStepping_);
             report_ += stepReport;
             if (terminalOutput_) {
                 std::ostringstream ss;

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -468,8 +468,7 @@ public:
             simulator_.problem().setSimulationReport(report_);
         } else {
             // solve for complete report step
-            solver_->disableAdaptiveTimeStepping();
-            auto stepReport = solver_->step(timer, *adaptiveTimeStepping_);
+            auto stepReport = solver_->step(timer, nullptr);
             report_ += stepReport;
             if (terminalOutput_) {
                 std::ostringstream ss;

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
@@ -139,6 +139,9 @@ void registerAdaptiveParameters()
     Parameters::Register<Parameters::TimeStepControlSafetyFactor>
         ("Value to be multiplied with the time step control tolerance to ensure that the target "
          "relative change is lower than the tolerance");
+    Parameters::Register<Parameters::TimeStepControlRejectCompletedStep>
+        ("(Only applicable for the general 3rd order controller.) Include rejection of completed "
+         "time steps if the relative change is larger than the time step control tolerance");
 }
 
 std::tuple<TimeStepControlType, std::unique_ptr<TimeStepControlInterface>, bool>
@@ -218,10 +221,12 @@ createController(const UnitSystem& unitSystem)
         {"general3rdorder",
          [tol]() {
              const double safetyFactor = Parameters::Get<Parameters::TimeStepControlSafetyFactor>(); // 0.8
+             const bool rejectCompletedStep = Parameters::Get<Parameters::TimeStepControlRejectCompletedStep>(); // false
              return RetVal{
                  TimeStepControlType::General3rdOrder,
                  std::make_unique<General3rdOrderController>(tol,
-                                                             safetyFactor),
+                                                             safetyFactor,
+                                                             rejectCompletedStep),
                  false
              };
         }},

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -48,6 +48,7 @@ struct TimeStepControlFileName { static constexpr auto value = "timesteps"; };
 struct MinTimeStepBeforeShuttingProblematicWellsInDays { static constexpr double value = 0.01; };
 struct MinTimeStepBasedOnNewtonIterations { static constexpr double value = 0.0; };
 struct TimeStepControlSafetyFactor { static constexpr double value = 0.8; };
+struct TimeStepControlRejectCompletedStep { static constexpr bool value = false; };
 
 } // namespace Opm::Parameters
 

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -203,6 +203,7 @@ public:
 #endif
     void setSuggestedNextStep(const double x);
     double suggestedNextStep() const;
+    const TimeStepControlInterface& timeStepControl() const;
 
     template <class Solver>
     SimulatorReport step(const SimulatorTimer& simulator_timer,

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -1146,7 +1146,7 @@ runSubStep_()
     };
 
     try {
-        substep_report = solver_().step(this->substep_timer_, *this->adaptive_time_stepping_.time_step_control_);
+        substep_report = solver_().step(this->substep_timer_, this->adaptive_time_stepping_);
         if (solverVerbose_()) {
             // report number of linear iterations
             OpmLog::debug("Overall linear iterations used: "

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -821,7 +821,7 @@ run()
             report.success.converged = this->substep_timer_.done();
             this->substep_timer_.setLastStepFailed(false);
         }
-        else { // in case of no convergence
+        else { // in case of no convergence or time step tolerance test failure
             this->substep_timer_.setLastStepFailed(true);
             checkTimeStepMaxRestartLimit_(restarts);
 
@@ -1156,6 +1156,9 @@ runSubStep_()
     catch (const TooManyIterations& e) {
         handleFailure("Solver convergence failure - Iteration limit reached", e);
     }
+    catch (const TimeSteppingBreakdown& e) {
+        handleFailure("Time step was too large", e);
+    }
     catch (const ConvergenceMonitorFailure& e) {
         handleFailure("Convergence monitor failure", e, /*log_exception=*/false);
     }
@@ -1173,9 +1176,6 @@ runSubStep_()
     }
     catch (const Dune::MatrixBlockError& e) {
         handleFailure("Matrix block error", e);
-    }
-    catch (const TimeSteppingBreakdown& e) {
-        handleFailure("Time step was too large", e);
     }
 
     return substep_report;

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -1146,7 +1146,7 @@ runSubStep_()
     };
 
     try {
-        substep_report = solver_().step(this->substep_timer_, this->adaptive_time_stepping_);
+        substep_report = solver_().step(this->substep_timer_, &this->adaptive_time_stepping_.timeStepControl());
         if (solverVerbose_()) {
             // report number of linear iterations
             OpmLog::debug("Overall linear iterations used: "

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -1157,7 +1157,7 @@ runSubStep_()
         handleFailure("Solver convergence failure - Iteration limit reached", e);
     }
     catch (const TimeSteppingBreakdown& e) {
-        handleFailure("Time step was too large", e);
+        handleFailure(e.what(), e);
     }
     catch (const ConvergenceMonitorFailure& e) {
         handleFailure("Convergence monitor failure", e, /*log_exception=*/false);

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -327,6 +327,14 @@ suggestedNextStep() const
     return this->suggested_next_timestep_;
 }
 
+template<class TypeTag>
+const TimeStepControlInterface&
+AdaptiveTimeStepping<TypeTag>::
+timeStepControl() const
+{
+    return *this->time_step_control_;
+}
+
 
 template<class TypeTag>
 void
@@ -1138,7 +1146,7 @@ runSubStep_()
     };
 
     try {
-        substep_report = solver_().step(this->substep_timer_);
+        substep_report = solver_().step(this->substep_timer_, *this->adaptive_time_stepping_.time_step_control_);
         if (solverVerbose_()) {
             // report number of linear iterations
             OpmLog::debug("Overall linear iterations used: "
@@ -1165,6 +1173,9 @@ runSubStep_()
     }
     catch (const Dune::MatrixBlockError& e) {
         handleFailure("Matrix block error", e);
+    }
+    catch (const TimeSteppingBreakdown& e) {
+        handleFailure("Time step was too large", e);
     }
 
     return substep_report;

--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -361,6 +361,15 @@ namespace Opm
         }
     }
 
+    bool General3rdOrderController::
+    timeStepAccepted(const double error) const
+    {
+        if (error > tolerance_)
+            std::cout << "Error: " << error << std::endl;
+            return false;
+        return true;
+    }
+
     bool General3rdOrderController::operator==(const General3rdOrderController& ctrl) const
     {
         return this->tolerance_ == ctrl.tolerance_ &&

--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -291,9 +291,11 @@ namespace Opm
 
     General3rdOrderController::General3rdOrderController( const double tolerance,
                                                           const double safetyFactor,
+                                                          const bool rejectCompletedStep,
                                                           const bool verbose)
         : tolerance_( tolerance )
         , safetyFactor_( safetyFactor )
+        , rejectCompletedStep_( rejectCompletedStep )
         , errors_( 3, tolerance_ )
         , timeSteps_ ( 3, 1.0 )
         , verbose_( verbose )
@@ -364,7 +366,7 @@ namespace Opm
     bool General3rdOrderController::
     timeStepAccepted(const double error) const
     {
-        if (error > tolerance_)
+        if (rejectCompletedStep_ && error > tolerance_)
             return false;
         return true;
     }
@@ -373,6 +375,7 @@ namespace Opm
     {
         return this->tolerance_ == ctrl.tolerance_ &&
                this->safetyFactor_ == ctrl.safetyFactor_ &&
+               this->rejectCompletedStep_ == ctrl.rejectCompletedStep_ &&
                this->errors_ == ctrl.errors_ &&
                this->timeSteps_ == ctrl.timeSteps_ &&
                this->verbose_ == ctrl.verbose_;

--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -365,7 +365,6 @@ namespace Opm
     timeStepAccepted(const double error) const
     {
         if (error > tolerance_)
-            std::cout << "Error: " << error << std::endl;
             return false;
         return true;
     }

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -203,6 +203,7 @@ namespace Opm
 
         General3rdOrderController( const double tolerance = 1e-3,
                                    const double safetyFactor = 0.8,
+                                   const bool rejectCompletedStep = false,
                                    const bool verbose = false );
 
         static General3rdOrderController serializationTestObject();
@@ -219,6 +220,7 @@ namespace Opm
         {
             serializer(tolerance_);
             serializer(safetyFactor_);
+            serializer(rejectCompletedStep_);
             serializer(errors_);
             serializer(timeSteps_);
             serializer(verbose_);
@@ -230,6 +232,7 @@ namespace Opm
     protected:
         const double tolerance_ = 1e-3;
         const double safetyFactor_ = 0.8;
+        const bool rejectCompletedStep_ = false;
         mutable std::vector<double> errors_{};
         mutable std::vector<double> timeSteps_{};
         mutable int counterSinceFailure_ = 0;

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -65,6 +65,8 @@ namespace Opm
                                    const int iterations,
                                    const RelativeChangeInterface& /* relativeChange */,
                                    const AdaptiveSimulatorTimer& /* substepTimer */ ) const override;
+        
+        bool timeStepAccepted(const double error) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -117,6 +119,8 @@ namespace Opm
                                    const RelativeChangeInterface& relativeChange,
                                    const AdaptiveSimulatorTimer& /* substepTimer */ ) const override;
 
+        bool timeStepAccepted(const double error) const override { return true; }
+
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
@@ -166,6 +170,8 @@ namespace Opm
                                    const RelativeChangeInterface& relativeChange,
                                    const AdaptiveSimulatorTimer& /* substepTimer */ ) const override;
 
+        bool timeStepAccepted(const double error) const override { return true; }
+
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
@@ -205,6 +211,8 @@ namespace Opm
                                    const int /*iterations */,
                                    const RelativeChangeInterface& relativeChange,
                                    const AdaptiveSimulatorTimer& substepTimer) const override;
+
+        bool timeStepAccepted(const double error) const override;
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -254,6 +262,8 @@ namespace Opm
                                    const int /* iterations */,
                                    const RelativeChangeInterface& /*relativeChange */,
                                    const AdaptiveSimulatorTimer& substepTimer) const override;
+
+        bool timeStepAccepted(const double error) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -66,7 +66,7 @@ namespace Opm
                                    const RelativeChangeInterface& /* relativeChange */,
                                    const AdaptiveSimulatorTimer& /* substepTimer */ ) const override;
         
-        bool timeStepAccepted(const double error) const override { return true; }
+        bool timeStepAccepted(const double /* error */) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -119,7 +119,7 @@ namespace Opm
                                    const RelativeChangeInterface& relativeChange,
                                    const AdaptiveSimulatorTimer& /* substepTimer */ ) const override;
 
-        bool timeStepAccepted(const double error) const override { return true; }
+        bool timeStepAccepted(const double /* error */) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -170,7 +170,7 @@ namespace Opm
                                    const RelativeChangeInterface& relativeChange,
                                    const AdaptiveSimulatorTimer& /* substepTimer */ ) const override;
 
-        bool timeStepAccepted(const double error) const override { return true; }
+        bool timeStepAccepted(const double /* error */) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -266,7 +266,7 @@ namespace Opm
                                    const RelativeChangeInterface& /*relativeChange */,
                                    const AdaptiveSimulatorTimer& substepTimer) const override;
 
-        bool timeStepAccepted(const double error) const override { return true; }
+        bool timeStepAccepted(const double /* error */) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/simulators/timestepping/TimeStepControlInterface.hpp
+++ b/opm/simulators/timestepping/TimeStepControlInterface.hpp
@@ -60,6 +60,8 @@ namespace Opm
         /// \return suggested time step size for the next step
         virtual double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& relativeChange , const AdaptiveSimulatorTimer& substepTimer) const = 0;
 
+        virtual bool timeStepAccepted(const double error) const = 0;
+
         /// virtual destructor (empty)
         virtual ~TimeStepControlInterface () {}
     };


### PR DESCRIPTION
I've implemented rejection of a completed time step if the relative change is larger than the time step control tolerance (only for the general 3rd order controller). The code seems to work as it should, but I might have missed something, so please let me know if you find anything wrong.

An earlier version of this can be found in #5317, but the current one is up to date with the current master.