### PR TITLE
clean up terminal output

### DIFF
--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -915,11 +915,11 @@ namespace Opm
         const bool well_operable = this->operability_status_.isOperableAndSolvable();
 
         if (!well_operable && old_well_operable) {
-            deferred_logger.info(" well " + this->name() + " gets STOPPED during iteration ");
+            deferred_logger.debug(" well " + this->name() + " gets STOPPED during iteration ");
             this->stopWell();
             changed_to_stopped_this_step_ = true;
         } else if (well_operable && !old_well_operable) {
-            deferred_logger.info(" well " + this->name() + " gets REVIVED during iteration ");
+            deferred_logger.debug(" well " + this->name() + " gets REVIVED during iteration ");
             this->openWell();
             changed_to_stopped_this_step_ = false;
             this->changed_to_open_this_step_ = true;


### PR DESCRIPTION
Output of stopping / reviving of wells has a tendency of filling the terminal output. Move it to .DBG . If the wells end up stopping/shutting after the timestep. This will still be reported to the terminal/PRT.  