### PR TITLE
set minimum pressure in segments

### DIFF
--- a/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
+++ b/opm/simulators/wells/MultisegmentWellPrimaryVariables.hpp
@@ -167,7 +167,7 @@ private:
     const WellInterfaceIndices<FluidSystem,Indices>& well_; //!< Reference to well interface
 
     static constexpr double bhp_lower_limit = 1. * unit::barsa - 1. * unit::Pascal;
-    static constexpr double seg_pres_lower_limit = 0.;
+    static constexpr double seg_pres_lower_limit = 1. * unit::barsa - 1. * unit::Pascal;
 };
 
 }


### PR DESCRIPTION
For discussion. What is the motivation for allowing <1atm pressure in segments and not use the same minimum as for the top segment?