### PR TITLE
Fix tracercontainer in flowexp_comp

### DIFF
--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -125,7 +125,6 @@ GenericOutputBlackoilModule(const EclipseState& eclState,
     , enableSaltPrecipitation_(enableSaltPrecipitation)
     , enableExtbo_(enableExtbo)
     , enableMICP_(enableMICP)
-    , tracerC_(eclState_)
     , flowsC_(schedule, summaryConfig)
     , rftC_(eclState_, schedule_,
             [this](const std::string& wname)
@@ -481,7 +480,7 @@ assignToSolution(data::Solution& sol)
     this->fipC_.outputRestart(sol);
 
     // Tracers
-    this->tracerC_.outputRestart(sol);
+    this->tracerC_.outputRestart(sol, eclState_.tracer());
 }
 
 template<class FluidSystem>
@@ -915,7 +914,7 @@ doAllocBuffers(const unsigned bufferSize,
     }
 
     // tracers
-    this->tracerC_.allocate(bufferSize);
+    this->tracerC_.allocate(bufferSize, eclState_.tracer());
 
     //Warn for any unhandled keyword
     if (log) {

--- a/opm/simulators/flow/MICPContainer.hpp
+++ b/opm/simulators/flow/MICPContainer.hpp
@@ -31,7 +31,7 @@
 namespace Opm {
 
 namespace data { class Solution; }
-template<class Scalar> class MICPSolutionContainer;
+template<class Scalar> struct MICPSolutionContainer;
 
 template<class Scalar>
 class MICPContainer

--- a/opm/simulators/flow/TracerContainer.cpp
+++ b/opm/simulators/flow/TracerContainer.cpp
@@ -23,7 +23,7 @@
 #include <config.h>
 #include <opm/simulators/flow/TracerContainer.hpp>
 
-#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
 
 #include <opm/material/fluidsystems/BlackOilDefaultIndexTraits.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
@@ -38,9 +38,9 @@ namespace Opm {
 
 template<class FluidSystem>
 void TracerContainer<FluidSystem>::
-allocate(const unsigned bufferSize)
+allocate(const unsigned bufferSize,
+         const TracerConfig& tracers)
 {
-    const auto& tracers = eclState_.tracer();
     if (!tracers.empty()) {
         allocated_ = true;
         freeConcentrations_.resize(tracers.size());
@@ -93,13 +93,13 @@ assignSolConcentrations(const unsigned globalDofIdx,
 
 template<class FluidSystem>
 void TracerContainer<FluidSystem>::
-outputRestart(data::Solution& sol)
+outputRestart(data::Solution& sol,
+              const TracerConfig& tracers)
 {
     if (!this->allocated_) {
         return;
     }
 
-    const auto& tracers = this->eclState_.tracer();
     std::for_each(tracers.begin(), tracers.end(),
                     [idx = 0, &sol, this](const auto& tracer) mutable
                     {

--- a/opm/simulators/flow/TracerContainer.hpp
+++ b/opm/simulators/flow/TracerContainer.hpp
@@ -32,7 +32,7 @@
 namespace Opm {
 
 namespace data { class Solution; }
-class EclipseState;
+class TracerConfig;
 
 template<class FluidSystem>
 class TracerContainer
@@ -41,11 +41,8 @@ class TracerContainer
     using ScalarBuffer = std::vector<Scalar>;
 
 public:
-    TracerContainer(const EclipseState& eclState)
-        : eclState_(eclState)
-    {}
-
-    void allocate(const unsigned bufferSize);
+    void allocate(const unsigned bufferSize,
+                  const TracerConfig& tracers);
 
     using AssignFunction = std::function<Scalar(const unsigned)>;
 
@@ -55,11 +52,10 @@ public:
     void assignSolConcentrations(const unsigned globalDofIdx,
                                  const AssignFunction& concentration);
 
-    void outputRestart(data::Solution& sol);
+    void outputRestart(data::Solution& sol,
+                       const TracerConfig& tracers);
 
 private:
-    const EclipseState& eclState_;
-
     std::vector<ScalarBuffer> freeConcentrations_{};
     std::vector<ScalarBuffer> solConcentrations_{};
     bool allocated_{false};


### PR DESCRIPTION
I cannot explain this, but this fixes the problem. 

For some reason, we get calls to tracerC_ where the eclState_ reference member is nullptr. By not holding this as a member this is avoided. I cannot figure out how tracerC_ gets in such a state.