### PR TITLE
Tracer: add some structs for well rate output and avoid complex keys

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1085,6 +1085,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/wells/WellProdIndexCalculator.hpp
   opm/simulators/wells/WellState.hpp
   opm/simulators/wells/WellTest.hpp
+  opm/simulators/wells/WellTracerRate.hpp
   opm/simulators/wells/WGState.hpp
 )
 if (USE_GPU_BRIDGE)

--- a/opm/simulators/flow/GenericTracerModel.hpp
+++ b/opm/simulators/flow/GenericTracerModel.hpp
@@ -32,11 +32,12 @@
 
 #include <opm/grid/common/CartesianIndexMapper.hpp>
 
+#include <opm/input/eclipse/EclipseState/Phase.hpp>
+
 #include <opm/models/blackoil/blackoilmodel.hh>
 
 #include <opm/simulators/linalg/matrixblock.hh>
-
-#include <opm/input/eclipse/EclipseState/Phase.hpp>
+#include <opm/simulators/wells/WellTracerRate.hpp>
 
 #include <array>
 #include <cstddef>
@@ -44,6 +45,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace Opm {
@@ -88,12 +90,18 @@ public:
     /*!
     * \brief Return well tracer rates
     */
-    const std::map<std::pair<std::string, std::string>, Scalar>&
-    getWellTracerRates() const {return wellTracerRate_;}
-    const std::map<std::pair<std::string, std::string>, Scalar>&
-    getWellFreeTracerRates() const {return wellFreeTracerRate_;}
-    const std::map<std::pair<std::string, std::string>, Scalar>&
-    getWellSolTracerRates() const {return wellSolTracerRate_;}
+    const std::unordered_map<int, std::vector<WellTracerRate<Scalar>>>&
+    getWellTracerRates() const
+    { return wellTracerRate_; }
+
+    const std::unordered_map<int, std::vector<WellTracerRate<Scalar>>>&
+    getWellFreeTracerRates() const
+    { return wellFreeTracerRate_; }
+
+    const std::unordered_map<int, std::vector<WellTracerRate<Scalar>>>&
+    getWellSolTracerRates() const
+    { return wellSolTracerRate_; }
+
     const std::map<std::tuple<std::string, std::string, std::size_t>, Scalar>&
     getMswTracerRates() const {return mSwTracerRate_;}
 
@@ -145,10 +153,10 @@ protected:
     std::vector<TracerVectorSingle> freeTracerConcentration_;
     std::vector<TracerVectorSingle> solTracerConcentration_;
 
-    // <wellName, tracerName> -> wellRate
-    std::map<std::pair<std::string, std::string>, Scalar> wellTracerRate_;
-    std::map<std::pair<std::string, std::string>, Scalar> wellFreeTracerRate_;
-    std::map<std::pair<std::string, std::string>, Scalar> wellSolTracerRate_;
+    // well_index -> tracer rates
+    std::unordered_map<int, std::vector<WellTracerRate<Scalar>>> wellTracerRate_;
+    std::unordered_map<int, std::vector<WellTracerRate<Scalar>>> wellFreeTracerRate_;
+    std::unordered_map<int, std::vector<WellTracerRate<Scalar>>> wellSolTracerRate_;
 
     // <wellName, tracerName, segNum> -> wellRate
     std::map<std::tuple<std::string, std::string, std::size_t>, Scalar> mSwTracerRate_;

--- a/opm/simulators/flow/GenericTracerModel.hpp
+++ b/opm/simulators/flow/GenericTracerModel.hpp
@@ -42,7 +42,6 @@
 #include <array>
 #include <cstddef>
 #include <functional>
-#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -102,7 +101,7 @@ public:
     getWellSolTracerRates() const
     { return wellSolTracerRate_; }
 
-    const std::map<std::tuple<std::string, std::string, std::size_t>, Scalar>&
+    const std::unordered_map<int, std::vector<MSWellTracerRate<Scalar>>>&
     getMswTracerRates() const {return mSwTracerRate_;}
 
     template<class Serializer>
@@ -158,8 +157,7 @@ protected:
     std::unordered_map<int, std::vector<WellTracerRate<Scalar>>> wellFreeTracerRate_;
     std::unordered_map<int, std::vector<WellTracerRate<Scalar>>> wellSolTracerRate_;
 
-    // <wellName, tracerName, segNum> -> wellRate
-    std::map<std::tuple<std::string, std::string, std::size_t>, Scalar> mSwTracerRate_;
+    std::unordered_map<int, std::vector<MSWellTracerRate<Scalar>>> mSwTracerRate_;
 
     /// \brief Function returning the cell centers
     std::function<std::array<double,dimWorld>(int)> centroids_;

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -216,7 +216,7 @@ template<class Scalar> class WellContributions;
                     this->assignWellTracerRates(wsrpt, tracerRates, this->reportStepIndex());
                     this->assignWellTracerRates(wsrpt, freeTracerRates, this->reportStepIndex());
                     this->assignWellTracerRates(wsrpt, solTracerRates, this->reportStepIndex());
-                    this->assignMswTracerRates(wsrpt, mswTracerRates);
+                    this->assignMswTracerRates(wsrpt, mswTracerRates, this->reportStepIndex());
                 }
 
                 BlackoilWellModelGuideRates(*this)

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -213,9 +213,9 @@ template<class Scalar> class WellContributions;
                     const auto& mswTracerRates = simulator_.problem()
                         .tracerModel().getMswTracerRates();
 
-                    this->assignWellTracerRates(wsrpt, tracerRates);
-                    this->assignWellTracerRates(wsrpt, freeTracerRates);
-                    this->assignWellTracerRates(wsrpt, solTracerRates);
+                    this->assignWellTracerRates(wsrpt, tracerRates, this->reportStepIndex());
+                    this->assignWellTracerRates(wsrpt, freeTracerRates, this->reportStepIndex());
+                    this->assignWellTracerRates(wsrpt, solTracerRates, this->reportStepIndex());
                     this->assignMswTracerRates(wsrpt, mswTracerRates);
                 }
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1847,20 +1847,22 @@ assignMassGasRate(data::Wells& wsrpt,
 template<class Scalar>
 void BlackoilWellModelGeneric<Scalar>::
 assignWellTracerRates(data::Wells& wsrpt,
-                      const WellTracerRates& wellTracerRates) const
+                      const WellTracerRates& wellTracerRates,
+                      const unsigned reportStep) const
 {
-    if (wellTracerRates.empty())
+    if (wellTracerRates.empty()) {
         return; // no tracers
+    }
 
     for (const auto& wTR : wellTracerRates) {
-        std::string wellName = wTR.first.first;
-        auto xwPos = wsrpt.find(wellName);
+        const auto& eclWell = schedule_.getWell(wTR.first, reportStep);
+        auto xwPos = wsrpt.find(eclWell.name());
         if (xwPos == wsrpt.end()) { // No well results.
             continue;
         }
-        std::string tracerName = wTR.first.second;
-        Scalar rate = wTR.second;
-        xwPos->second.rates.set(data::Rates::opt::tracer, rate, tracerName);
+        for (const auto& tr : wTR.second) {
+            xwPos->second.rates.set(data::Rates::opt::tracer, tr.rate, tr.name);
+        }
     }
 }
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -32,7 +32,6 @@
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
-
 #include <opm/simulators/wells/BlackoilWellModelWBP.hpp>
 #include <opm/simulators/wells/ConnectionIndexMap.hpp>
 #include <opm/simulators/wells/ParallelPAvgDynamicSourceData.hpp>
@@ -40,6 +39,7 @@
 #include <opm/simulators/wells/PerforationData.hpp>
 #include <opm/simulators/wells/WellFilterCake.hpp>
 #include <opm/simulators/wells/WellProdIndexCalculator.hpp>
+#include <opm/simulators/wells/WellTracerRate.hpp>
 #include <opm/simulators/wells/WGState.hpp>
 
 #include <cstddef>
@@ -449,12 +449,15 @@ protected:
     std::vector<std::string> getWellsForTesting(const int timeStepIdx,
                                                 const double simulationTime);
 
-    using WellTracerRates = std::map<std::pair<std::string, std::string>, Scalar>;
+    using WellTracerRates = std::unordered_map<int, std::vector<WellTracerRate<Scalar>>>;
     void assignWellTracerRates(data::Wells& wsrpt,
-                               const WellTracerRates& wellTracerRates) const;
+                               const WellTracerRates& wellTracerRates,
+                               const unsigned reportStep) const;
+
     using MswTracerRates = std::map<std::tuple<std::string, std::string, std::size_t>, Scalar>;
     void assignMswTracerRates(data::Wells& wsrpt,
                               const MswTracerRates& mswTracerRates) const;
+
     void assignMassGasRate(data::Wells& wsrpt,
                            const Scalar& gasDensity) const;
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -454,9 +454,10 @@ protected:
                                const WellTracerRates& wellTracerRates,
                                const unsigned reportStep) const;
 
-    using MswTracerRates = std::map<std::tuple<std::string, std::string, std::size_t>, Scalar>;
+    using MswTracerRates = std::unordered_map<int, std::vector<MSWellTracerRate<Scalar>>>;
     void assignMswTracerRates(data::Wells& wsrpt,
-                              const MswTracerRates& mswTracerRates) const;
+                              const MswTracerRates& mswTracerRates,
+                              const unsigned reportStep) const;
 
     void assignMassGasRate(data::Wells& wsrpt,
                            const Scalar& gasDensity) const;

--- a/opm/simulators/wells/WellTracerRate.hpp
+++ b/opm/simulators/wells/WellTracerRate.hpp
@@ -1,0 +1,59 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#ifndef OPM_WELL_TRACER_RATE_HPP
+#define OPM_WELL_TRACER_RATE_HPP
+
+#include <string>
+
+namespace Opm {
+
+template<class Scalar>
+struct WellTracerRate
+{
+    std::string name{};
+    Scalar rate{};
+
+    WellTracerRate() = default;
+
+    WellTracerRate(const std::string& n, const Scalar r)
+        : name(n), rate(r)
+    {}
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(name);
+        serializer(rate);
+    }
+
+    bool operator==(const WellTracerRate& that) const
+    {
+        return
+               this->name == that.name
+            && this->rate == that.rate;
+    }
+};
+
+} // namespace Opm
+
+#endif // OPM_WELL_TRACER_RATE_HPP

--- a/opm/simulators/wells/WellTracerRate.hpp
+++ b/opm/simulators/wells/WellTracerRate.hpp
@@ -24,6 +24,7 @@
 #define OPM_WELL_TRACER_RATE_HPP
 
 #include <string>
+#include <unordered_map>
 
 namespace Opm {
 
@@ -47,6 +48,33 @@ struct WellTracerRate
     }
 
     bool operator==(const WellTracerRate& that) const
+    {
+        return
+               this->name == that.name
+            && this->rate == that.rate;
+    }
+};
+
+template<class Scalar>
+struct MSWellTracerRate
+{
+    std::string name{};
+    std::unordered_map<int,Scalar> rate{};
+
+    MSWellTracerRate() = default;
+
+    MSWellTracerRate(const std::string& n)
+        : name(n)
+    {}
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(name);
+        serializer(rate);
+    }
+
+    bool operator==(const MSWellTracerRate& that) const
     {
         return
                this->name == that.name

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -425,7 +425,7 @@ public:
     {
         GenericTracerModelTest result(gridView, eclState, cartMapper, dofMapper, centroids);
         result.tracerConcentration_ = {{{1.0, 2.0}}, {{3.0, 4.0}}, {{5.0, 6.0}}};
-        result.wellTracerRate_.insert({{"foo", "bar"}, 4.0});
+        result.wellTracerRate_.emplace(1, std::vector{Opm::WellTracerRate<double>{"foo", 4.0}});
 
         return result;
     }


### PR DESCRIPTION
Not really inner-loopy so not much gained in terms of efficiency. But seems to yield, if anything, a small speedup

# Timings for NORNE_ATW2013 [5 runs]
|     Revision      |tracerAdvance|tracerAssemble|Pre/post step|p-value(tracerAssemble)|
|-------------------|-------------|--------------|-------------|----------------------:|
|tracer_rate_structs|31.91 +- 0.27|25.72 +- 0.22 |53.72 +- 0.35|                   0.04|
|master             |32.68 +- 0.23|26.31 +- 0.20 |54.69 +- 0.33|                       |

# Timings for NORNE_ATW2013_1A_MSW [5 runs]
|     Revision      |tracerAdvance|tracerAssemble|Pre/post step|p-value(tracerAssemble)|
|-------------------|-------------|--------------|-------------|----------------------:|
|tracer_rate_structs|35.27 +- 0.11|31.19 +- 0.10 |61.14 +- 0.20|                   0.09|
|master             |35.80 +- 0.26|31.61 +- 0.23 |62.16 +- 0.37|                       |
