### PR TITLE
fixed: make MainDispatchDynamic dependent on the opmcommon target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,6 +545,10 @@ if(TARGET fmt::fmt)
   target_link_libraries(MainDispatchDynamic fmt::fmt)
 endif()
 
+if(TARGET opmcommon)
+  add_dependencies(MainDispatchDynamic opmcommon)
+endif()
+
 if(USE_TRACY_PROFILER AND Tracy_FOUND)
   target_link_libraries(MainDispatchDynamic Tracy::TracyClient)
 endif()


### PR DESCRIPTION
if not parallel builds wll fail with the super-build