### PR TITLE
Make pre-solve network optional

### DIFF
--- a/flowexperimental/flowexp.hpp
+++ b/flowexperimental/flowexp.hpp
@@ -172,6 +172,7 @@ public:
         Parameters::Hide<Parameters::MinStrictCnvIter>();
         Parameters::Hide<Parameters::MinStrictMbIter>();
         Parameters::Hide<Parameters::SolveWelleqInitially>();
+        Parameters::Hide<Parameters::PreSolveNetwork>();
         Parameters::Hide<Parameters::UpdateEquationsScaling>();
         Parameters::Hide<Parameters::UseUpdateStabilization>();
         Parameters::Hide<Parameters::MatrixAddWellContributions>();

--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -66,6 +66,7 @@ BlackoilModelParameters<Scalar>::BlackoilModelParameters()
     min_strict_cnv_iter_ = Parameters::Get<Parameters::MinStrictCnvIter>();
     min_strict_mb_iter_ = Parameters::Get<Parameters::MinStrictMbIter>();
     solve_welleq_initially_ = Parameters::Get<Parameters::SolveWelleqInitially>();
+    pre_solve_network_ = Parameters::Get<Parameters::PreSolveNetwork>();
     update_equations_scaling_ = Parameters::Get<Parameters::UpdateEquationsScaling>();
     use_update_stabilization_ = Parameters::Get<Parameters::UseUpdateStabilization>();
     matrix_add_well_contributions_ = Parameters::Get<Parameters::MatrixAddWellContributions>();
@@ -196,6 +197,8 @@ void BlackoilModelParameters<Scalar>::registerParameters()
          "number of Newton iterations are reached.");
     Parameters::Register<Parameters::SolveWelleqInitially>
         ("Fully solve the well equations before each iteration of the reservoir model");
+    Parameters::Register<Parameters::PreSolveNetwork>
+        ("Pre solve and iterate the network model at start-up");
     Parameters::Register<Parameters::UpdateEquationsScaling>
         ("Update scaling factors for mass balance equations during the run");
     Parameters::Register<Parameters::UseUpdateStabilization>

--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -87,6 +87,7 @@ struct MaxSinglePrecisionDays { static constexpr Scalar value = 20.0; };
 struct MinStrictCnvIter { static constexpr int value = -1; };
 struct MinStrictMbIter { static constexpr int value = -1; };
 struct SolveWelleqInitially { static constexpr bool value = true; };
+struct PreSolveNetwork { static constexpr bool value = true; };
 struct UpdateEquationsScaling { static constexpr bool value = false; };
 struct UseUpdateStabilization { static constexpr bool value = true; };
 struct MatrixAddWellContributions { static constexpr bool value = false; };
@@ -253,6 +254,9 @@ public:
 
     /// Solve well equation initially
     bool solve_welleq_initially_;
+
+    /// Pre solve and iterate network model
+    bool pre_solve_network_;
 
     /// Update scaling factors for mass balance equations
     bool update_equations_scaling_;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2062,7 +2062,7 @@ namespace Opm {
 
         // Rebalance the network initially if any wells in the network have status changes
         // (Need to check this before clearing events)
-        const bool do_prestep_network_rebalance = this->needPreStepNetworkRebalance(episodeIdx);
+        const bool do_prestep_network_rebalance = param_.pre_solve_network_ && this->needPreStepNetworkRebalance(episodeIdx);
 
         for (const auto& well : well_container_) {
             auto& events = this->wellState().well(well->indexOfWell()).events;


### PR DESCRIPTION
This replaces https://github.com/OPM/opm-simulators/pull/6014 make make the pre-solve optional. 