### PR TITLE
Prevent zero division

### DIFF
--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -336,7 +336,7 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
     if (nperf != 0)
         cell_weights /= nperf;
     else {
-        // Edge case: the well has no active perforations on this rank (duneC_.size==0).
+        // duneC_.size==0, which can happen e.g. if a well has no active perforations on this rank.
         // Add positive weight to diagonal to regularize Jacobian (other row entries are 0).
         // Row's variable has no observable effect, since there are no perforations.
         cell_weights = 1.;

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -333,7 +333,14 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
             nperf += 1;
         }
     }
-    cell_weights /= nperf;
+    if (nperf != 0)
+        cell_weights /= nperf;
+    else {
+        // Edge case: the well has no active perforations on this rank (duneC_.size==0).
+        // Add positive weight to diagonal to regularize Jacobian (other row entries are 0).
+        // Row's variable has no observable effect, since there are no perforations.
+        cell_weights = 1.;
+    }
 
     BVectorWell  bweights(1);
     std::size_t blockSz = duneD_[0][0].N();


### PR DESCRIPTION
This bug concerns cprw linear solver (the default one) in the situation when a well has no active perforations on some rank. Other linear solvers are fine.

The diagonal element of the coarse (pressure) system's Jacobian for the well equation is normally calculated from the average cell weight over well's perforations. If there are no perforations we end up dividing zero by zero. This fix prevents the zero division and also adds a positive number to the Jacobian's diagonal. Other entries of that row are zero, so this regularizes the matrix. Since the well has no active perforations, the value of the variable has no effect on the solution. (Any nonzero value on the diagonal would work - tested with 1 and 1e-100).