### PR TITLE
Fix to write vtk (if enabled) for dry runs in cases without oilPhase

### DIFF
--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -394,6 +394,7 @@ public:
 
         if (this->enableVtkOutput_() && eclState.getIOConfig().initOnly()) {
             simulator.setTimeStepSize(0.0);
+            simulator.model().applyInitialSolution();
             FlowProblemType::writeOutput(true);
         }
 


### PR DESCRIPTION
In #5499 this was tested for cases with oil. For a case without it, then some assertions fail (e.g., [updateRelpermAndPressures](https://github.com/OPM/opm-simulators/blob/96ec6ad143b4106ac601546e196ecb318faaca3f/opm/models/blackoil/blackoilintensivequantities.hh#L297)).

This PR fixes this.