### PR TITLE
Cleanup: simplify standard well equations

### DIFF
--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -345,8 +345,9 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
         //NB! use this options without treating pressure controlled separated
         //NB! calculate quasiimpes well weights NB do not work well with trueimpes reservoir weights
         Scalar abs_max = 0;
-        DiagMatrixBlockWellType inv_diag_block = invDuneD_[0][0];
+        const DiagMatrixBlockWellType& inv_diag_block = invDuneD_[0][0];
         for (std::size_t i = 0; i < blockSz; ++i) {
+            // calculate (D^-T*rhs)[i] where rhs is unit vector e_{bhp_var_index}
             bweights[0][i] = inv_diag_block[bhp_var_index][i];
             abs_max = std::max(abs_max, std::fabs(bweights[0][i]));
         }

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -346,10 +346,8 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
         //NB! calculate quasiimpes well weights NB do not work well with trueimpes reservoir weights
         Scalar abs_max = 0;
         DiagMatrixBlockWellType inv_diag_block = invDuneD_[0][0];
-        DiagMatrixBlockWellType inv_diag_block_transpose =
-            Opm::wellhelpers::transposeDenseDynMatrix(inv_diag_block);
         for (std::size_t i = 0; i < blockSz; ++i) {
-            bweights[0][i] = inv_diag_block_transpose[i][bhp_var_index];
+            bweights[0][i] = inv_diag_block[bhp_var_index][i];
             abs_max = std::max(abs_max, std::fabs(bweights[0][i]));
         }
         assert(abs_max > 0.0);

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -345,17 +345,11 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
         //NB! use this options without treating pressure controlled separated
         //NB! calculate quasiimpes well weights NB do not work well with trueimpes reservoir weights
         Scalar abs_max = 0;
-        BVectorWell rhs(1);
-        rhs[0].resize(blockSz);
-        rhs[0][bhp_var_index] = 1.0;
         DiagMatrixBlockWellType inv_diag_block = invDuneD_[0][0];
         DiagMatrixBlockWellType inv_diag_block_transpose =
             Opm::wellhelpers::transposeDenseDynMatrix(inv_diag_block);
         for (std::size_t i = 0; i < blockSz; ++i) {
-            bweights[0][i] = 0;
-            for (std::size_t j = 0; j < blockSz; ++j) {
-                bweights[0][i] += inv_diag_block_transpose[i][j] * rhs[0][j];
-            }
+            bweights[0][i] = inv_diag_block_transpose[i][bhp_var_index];
             abs_max = std::max(abs_max, std::fabs(bweights[0][i]));
         }
         assert(abs_max > 0.0);


### PR DESCRIPTION
I just stumbled upon this while studying cprw solver. The code can be simplified in two ways:

1. The vector `rhs` has exactly one nonzero element equal to 1. The `for` loop accumulating elements multiplied by `rhs` can be thus simplified to an assignment.
2. The transposed `inv_diag_block` matrix does not have to be constructed. We access its elements, so swapping indices suffices.