### PR TITLE
Dont stop force shut wells

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1477,6 +1477,7 @@ forceShutWellByName(const std::string& wellname,
             }
             wellTestState().close_well(wellname, WellTestConfig::Reason::PHYSICAL, simulation_time);
             well_was_shut = 1;
+            force_shut_wells_.push_back(well->indexOfWell());
             break;
         }
     }
@@ -1516,6 +1517,20 @@ inferLocalShutWells()
             this->local_shut_wells_.push_back(wellID);
         }
     }
+}
+
+template<class Scalar>
+bool BlackoilWellModelGeneric<Scalar>::
+isForceShutWell(int wellId) const
+{
+    return std::count(force_shut_wells_.begin(), force_shut_wells_.end(), wellId) > 0;
+}
+
+template<class Scalar>
+void BlackoilWellModelGeneric<Scalar>::
+removeFromForceShutWell(int wellId)
+{
+    std::remove(force_shut_wells_.begin(), force_shut_wells_.end(), wellId);
 }
 
 template<class Scalar>
@@ -2077,6 +2092,7 @@ operator==(const BlackoilWellModelGeneric& rhs) const
         && this->report_step_starts_ == rhs.report_step_starts_
         && this->last_run_wellpi_ == rhs.last_run_wellpi_
         && this->local_shut_wells_ == rhs.local_shut_wells_
+        && this->force_shut_wells_ == rhs.force_shut_wells_
         && this->closed_this_step_ == rhs.closed_this_step_
         && this->node_pressures_ == rhs.node_pressures_
         && this->prev_inj_multipliers_ == rhs.prev_inj_multipliers_

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -213,6 +213,9 @@ public:
                              const double simulation_time,
                              const bool dont_shut_grup_wells);
 
+    bool isForceShutWell(int wellId) const;
+    void removeFromForceShutWell(int wellId);
+
     const std::vector<PerforationData<Scalar>>& perfData(const int well_idx) const
     { return well_perf_data_[well_idx]; }
 
@@ -249,6 +252,7 @@ public:
         serializer(report_step_starts_);
         serializer(last_run_wellpi_);
         serializer(local_shut_wells_);
+        serializer(force_shut_wells_);
         serializer(closed_this_step_);
         serializer(guideRate_);
         serializer(node_pressures_);
@@ -494,6 +498,7 @@ protected:
     std::vector<WellInterfaceGeneric<Scalar>*> well_container_generic_{};
 
     std::vector<int> local_shut_wells_{};
+    std::vector<int> force_shut_wells_{};
 
     std::vector<ParallelWellInfo<Scalar>> parallel_well_info_;
     std::vector<std::reference_wrapper<ParallelWellInfo<Scalar>>> local_parallel_well_info_;

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -290,7 +290,7 @@ public:
 
     // TODO: theoretically, it should be a const function
     // Simulator is not const is because that assembleWellEq is non-const Simulator
-    void wellTesting(const Simulator& simulator,
+    bool wellTesting(const Simulator& simulator,
                      const double simulation_time,
                      /* const */ WellState<Scalar>& well_state,
                      const GroupState<Scalar>& group_state,

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -379,7 +379,7 @@ namespace Opm
     }
 
     template<typename TypeTag>
-    void
+    bool
     WellInterface<TypeTag>::
     wellTesting(const Simulator& simulator,
                 const double simulation_time,
@@ -427,7 +427,7 @@ namespace Opm
             if (!converged) {
                 const auto msg = fmt::format("WTEST: Well {} is not solvable (physical)", this->name());
                 deferred_logger.debug(msg);
-                return;
+                return false;
             }
 
 
@@ -435,7 +435,7 @@ namespace Opm
             if ( !this->isOperableAndSolvable() ) {
                 const auto msg = fmt::format("WTEST: Well {} is not operable (physical)", this->name());
                 deferred_logger.debug(msg);
-                return;
+                return false;
             }
             std::vector<Scalar> potentials;
             try {
@@ -445,7 +445,7 @@ namespace Opm
                                                     "failed during testing for re-opening: ",
                                                     this->name(), e.what());
                 deferred_logger.info(msg);
-                return;
+                return false;
             }
             const int np = well_state_copy.numPhases();
             for (int p = 0; p < np; ++p) {
@@ -486,7 +486,9 @@ namespace Opm
             ws.open();
             well_state = well_state_copy;
             open_times.try_emplace(this->name(), well_test_state.lastTestTime(this->name()));
+            return true;
         }
+        return false;
     }
 
 

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -320,6 +320,7 @@ public:
         report_step_starts_ = true;
         last_run_wellpi_ = 1;
         local_shut_wells_ = {2, 3};
+        force_shut_wells_ = {4, 5};
         closed_this_step_ = {"test1", "test2"};
         guideRate_.setSerializationTestData();
         node_pressures_ = {{"test3", 4.0}};


### PR DESCRIPTION
If a well is shut due to repeated convergence issues we actually shut it and not just stopped. This fixes an issue reported by @erikhide on NORNE_ATW2013_3B_STDW.DATA where the simulator just retries the timestep forever.  