### PR TITLE
Remove assigning to self

### DIFF
--- a/tests/gpuistl/test_GpuVector.cpp
+++ b/tests/gpuistl/test_GpuVector.cpp
@@ -151,7 +151,6 @@ BOOST_AUTO_TEST_CASE(TestDot)
     for (size_t i = 0; i < dataA.size(); ++i) {
         correctAnswer += dataA[i] * dataB[i];
     }
-    correctAnswer = correctAnswer;
     BOOST_CHECK_EQUAL(correctAnswer, dot);
 }
 


### PR DESCRIPTION
Removes a warning from a `.cpp` file. The assignment should not have been there to begin with (it probably came about during debugging)