### PR TITLE
Python gas-water simulator

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -888,6 +888,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/flow/SolutionContainers.hpp
   opm/simulators/flow/SubDomain.hpp
   opm/simulators/flow/TTagFlowProblemTPFA.hpp
+  opm/simulators/flow/TTagFlowProblemGasWater.hpp
   opm/simulators/flow/TracerContainer.hpp
   opm/simulators/flow/TracerModel.hpp
   opm/simulators/flow/Transmissibility.hpp

--- a/flow/flow_gaswater.cpp
+++ b/flow/flow_gaswater.cpp
@@ -33,11 +33,6 @@
 
 namespace Opm {
 namespace Properties {
-namespace TTag {
-struct FlowGasWaterProblem {
-    using InheritsFrom = std::tuple<FlowProblem>;
-};
-}
 
 template<class TypeTag>
 struct Linearizer<TypeTag, TTag::FlowGasWaterProblem> { using type = TpfaLinearizer<TypeTag>; };
@@ -95,6 +90,17 @@ int flowGasWaterMainStandalone(int argc, char** argv)
     // Destruct mainObject as the destructor calls MPI_Finalize!
     mainObject.reset();
     return ret;
+}
+
+std::unique_ptr<FlowMain<Properties::TTag::FlowGasWaterProblem>>
+flowGasWaterMainInit(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    resetLocale();
+
+    return std::make_unique<FlowMain<Properties::TTag::FlowGasWaterProblem>>(
+        argc, argv, outputCout, outputFiles);
 }
 
 }

--- a/opm/simulators/flow/TTagFlowProblemGasWater.hpp
+++ b/opm/simulators/flow/TTagFlowProblemGasWater.hpp
@@ -1,4 +1,6 @@
 /*
+  Copyright 2025 Equinor ASA.
+
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -14,25 +16,29 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FLOW_GASWATER_HPP
-#define FLOW_GASWATER_HPP
 
-#include <opm/simulators/flow/TTagFlowProblemGasWater.hpp>
+#ifndef TTAG_FLOW_PROBLEM_GASWATER_HPP
+#define TTAG_FLOW_PROBLEM_GASWATER_HPP
 
-#include <memory>
+#include <tuple>
 
 namespace Opm {
+namespace Properties {
+namespace TTag {
 
-//! \brief Main function used in flow binary.
-int flowGasWaterMain(int argc, char** argv, bool outputCout, bool outputFiles);
+    struct FlowProblem;
 
-//! \brief Main function used in flow_gaswater binary.
-int flowGasWaterMainStandalone(int argc, char** argv);
-
-template<class TypeTag> class FlowMain;
-
-std::unique_ptr<FlowMain<Properties::TTag::FlowGasWaterProblem>>
-flowGasWaterMainInit(int argc, char** argv, bool outputCout, bool outputFiles);
+    /// Specialised type tag for simulations that can use the customised
+    /// assembly process for TPFA discretisation schemes.
+    ///
+    /// All properties are otherwise the same as for the regular
+    /// FlowProblem.
+    struct FlowGasWaterProblem {
+      using InheritsFrom = std::tuple<FlowProblem>;
+  };
 }
 
-#endif // FLOW_GASWATER_HPP
+
+} // namespace Opm::Properties::TTag
+}
+#endif // TTAG_FLOW_PROBLEM_TPFA_HPP

--- a/opm/simulators/flow/python/PyBlackOilSimulator.hpp
+++ b/opm/simulators/flow/python/PyBlackOilSimulator.hpp
@@ -55,7 +55,8 @@ public:
         std::shared_ptr<Opm::Deck> deck,
         std::shared_ptr<Opm::EclipseState> state,
         std::shared_ptr<Opm::Schedule> schedule,
-        std::shared_ptr<Opm::SummaryConfig> summary_config);
+        std::shared_ptr<Opm::SummaryConfig> summary_config,
+        const std::vector<std::string>& args);
     void advance(int report_step);
     bool checkSimulationFinished();
     int currentStep();

--- a/opm/simulators/flow/python/PyGasWaterSimulator.hpp
+++ b/opm/simulators/flow/python/PyGasWaterSimulator.hpp
@@ -1,0 +1,109 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_PY_GAS_WATER_SIMULATOR_HEADER_INCLUDED
+#define OPM_PY_GAS_WATER_SIMULATOR_HEADER_INCLUDED
+
+#include <python/simulators/PyMainGW.hpp>
+
+#include <opm/models/utils/parametersystem.hpp>
+#include <opm/models/utils/propertysystem.hh>
+
+#include <opm/simulators/flow/FlowMain.hpp>
+#include <opm/simulators/flow/TTagFlowProblemGasWater.hpp>
+#include <opm/simulators/flow/python/PyFluidState.hpp>
+#include <opm/simulators/flow/python/PyMaterialState.hpp>
+#include <opm/simulators/flow/python/Pybind11Exporter.hpp>
+
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Opm::Pybind {
+
+class PyGasWaterSimulator
+{
+private:
+    using TypeTag = Opm::Properties::TTag::FlowGasWaterProblem;
+    using Simulator = Opm::GetPropType<TypeTag, Opm::Properties::Simulator>;
+
+public:
+    PyGasWaterSimulator(const std::string& deckFilename,
+                        const std::vector<std::string>& args);
+    PyGasWaterSimulator(
+        std::shared_ptr<Opm::Deck> deck,
+        std::shared_ptr<Opm::EclipseState> state,
+        std::shared_ptr<Opm::Schedule> schedule,
+        std::shared_ptr<Opm::SummaryConfig> summary_config);
+    void advance(int report_step);
+    bool checkSimulationFinished();
+    int currentStep();
+    py::array_t<double> getFluidStateVariable(const std::string &name) const;
+    py::array_t<double> getCellVolumes();
+    double getDT();
+    py::array_t<double> getPorosity();
+    py::array_t<double> getPrimaryVariable(const std::string &variable) const;
+    py::array_t<int> getPrimaryVarMeaning(const std::string &variable) const;
+    std::map<std::string, int> getPrimaryVarMeaningMap(const std::string &variable) const;
+    int run();
+    void setPorosity(
+         py::array_t<double, py::array::c_style | py::array::forcecast> array);
+    void setPrimaryVariable(
+        const std::string &idx_name,
+        py::array_t<double,
+        py::array::c_style | py::array::forcecast> array);
+    void setupMpi(bool init_mpi, bool finalize_mpi);
+    int step();
+    int stepCleanup();
+    int stepInit();
+
+private:
+    Opm::FlowMain<TypeTag>& getFlowMain() const;
+    PyFluidState<TypeTag>& getFluidState() const;
+    PyMaterialState<TypeTag>& getMaterialState() const;
+
+    const std::string deck_filename_;
+    bool has_run_init_ = false;
+    bool has_run_cleanup_ = false;
+    bool mpi_init_ = true;
+    bool mpi_finalize_ = true;
+    //bool debug_ = false;
+    // This *must* be declared before other pointers
+    // to simulator objects. This in order to deinitialize
+    // MPI at the correct time (ie after the other objects).
+    std::unique_ptr<Opm::PyMain> main_;
+
+    std::unique_ptr<Opm::FlowMain<TypeTag>> flow_main_;
+    Simulator* simulator_;
+    std::unique_ptr<PyFluidState<TypeTag>> fluid_state_;
+    std::unique_ptr<PyMaterialState<TypeTag>> material_state_;
+    std::shared_ptr<Opm::Deck> deck_;
+    std::shared_ptr<Opm::EclipseState> eclipse_state_;
+    std::shared_ptr<Opm::Schedule> schedule_;
+    std::shared_ptr<Opm::SummaryConfig> summary_config_;
+    std::vector<std::string> args_;
+};
+
+} // namespace Opm::Pybind
+#endif // OPM_PY_BLACKOIL_SIMULATOR_HEADER_INCLUDED

--- a/opm/simulators/flow/python/PyGasWaterSimulator.hpp
+++ b/opm/simulators/flow/python/PyGasWaterSimulator.hpp
@@ -55,7 +55,8 @@ public:
         std::shared_ptr<Opm::Deck> deck,
         std::shared_ptr<Opm::EclipseState> state,
         std::shared_ptr<Opm::Schedule> schedule,
-        std::shared_ptr<Opm::SummaryConfig> summary_config);
+        std::shared_ptr<Opm::SummaryConfig> summary_config,
+        const std::vector<std::string>& args);
     void advance(int report_step);
     bool checkSimulationFinished();
     int currentStep();
@@ -92,7 +93,7 @@ private:
     // This *must* be declared before other pointers
     // to simulator objects. This in order to deinitialize
     // MPI at the correct time (ie after the other objects).
-    std::unique_ptr<Opm::PyMain> main_;
+    std::unique_ptr<Opm::PyMainGW> main_;
 
     std::unique_ptr<Opm::FlowMain<TypeTag>> flow_main_;
     Simulator* simulator_;

--- a/opm/simulators/flow/python/Pybind11Exporter.hpp
+++ b/opm/simulators/flow/python/Pybind11Exporter.hpp
@@ -11,6 +11,7 @@ namespace py = pybind11;
 namespace Opm::Pybind {
     void export_all(py::module& m);
     void export_PyBlackOilSimulator(py::module& m);
+    void export_PyGasWaterSimulator(py::module& m);
 }
 
 #endif //OPM_PYBIND11_EXPORTER_HEADER_INCLUDED

--- a/python/docstrings_gw_simulators.json
+++ b/python/docstrings_gw_simulators.json
@@ -1,0 +1,83 @@
+{
+    "PyGasWaterSimulator":{
+        "type": "class",
+        "signature": "opm.simulators.GasWaterSimulator",
+        "doc": "The GasWaterSimulator class to run simulations using a given Deck."
+    },
+    "PyGasWaterSimulator_filename_constructor": {
+        "signature": "opm.simulators.GasWaterSimulator.__init__(deck_filename: str) -> GasWaterSimulator",
+        "doc": "Constructor using a deck file name.\n\n:param deck_filename: The file name of the deck to be used for the simulation.\n:type deck_filename: str\n:return: The GasWaterSimulator.\n:type return: GasWaterSimulator"
+    },
+    "PyGasWaterSimulator_objects_constructor": {
+        "signature": "opm.simulators.GasWaterSimulator.__init__(deck: Deck, state: EclipseState, schedule: Schedule, summary_config: SummaryConfig) -> GasWaterSimulator",
+        "doc": "Constructor using Deck, EclipseState, Schedule, and SummaryConfig objects.\n\n:param deck: Deck object.\n:type deck: Deck\n:param state: EclipseState object.\n:type state: EclipseState\n:param schedule: Schedule object.\n:type schedule: Schedule\n:param summary_config: SummaryConfig object.\n:type summary_config: SummaryConfig\n:return: The GasWaterSimulator.\n:type return: GasWaterSimulator"
+    },
+    "advance": {
+        "signature": "opm.simulators.GasWaterSimulator.advance(report_step: int) -> None",
+        "doc": "Advances the simulation to a specific report step.\n\n:param report_step: Target report step to advance to.\n:type report_step: int"
+    },
+    "checkSimulationFinished": {
+        "signature": "opm.simulators.GasWaterSimulator.check_simulation_finished() -> bool",
+        "doc": "Checks if the simulation has finished.\n\n:return: True if the simulation is finished, False otherwise.\n:type return: bool"
+    },
+    "currentStep": {
+        "signature": "opm.simulators.GasWaterSimulator.current_step() -> int",
+        "doc": "Gets the current simulation step.\n\n:return: The current step number."
+    },
+    "getCellVolumes": {
+        "signature": "opm.simulators.GasWaterSimulator.get_cell_volumes() -> NDArray[float]",
+        "doc": "Retrieves the cell volumes of the simulation grid.\n\n:return: An array of cell volumes.\n:type return: NDArray[float]"
+    },
+    "getDT": {
+        "signature": "opm.simulators.GasWaterSimulator.get_dt() -> float",
+        "doc": "Gets the timestep size of the last completed step.\n\n:return: Timestep size in days.\n:type return: float"
+    },
+    "getFluidStateVariable": {
+        "signature": "opm.simulators.GasWaterSimulator.get_fluid_state_variable(name: str) -> NDArray[float]",
+        "doc": "Retrieves a fluid state variable for the simulation grid.\n\n:param name: The name of the variable. Valid names are 'pw' (pressure water), 'pg' (pressure gas), 'po' (pressure oil), 'rho_w' (density water), 'rho_g' (density gas), 'rho_o' (density oil)'Rs' (soultion gas-oil ratio), 'Rv' (volatile gas-oil ratio), 'Sw' (water saturation), 'Sg' (gas saturation), 'So' (oil saturation), and 'T' (temperature).\n:type name: str\n\n:return: An array of fluid state variables.\n:type return: NDArray[float]"
+    },
+    "getPorosity": {
+        "signature": "opm.simulators.GasWaterSimulator.get_porosity() -> NDArray[float]",
+        "doc": "Retrieves the porosity values of the simulation grid.\n\n:return: An array of porosity values.\n:type return: numpy.ndarray"
+    },
+    "getPrimaryVarMeaning": {
+        "signature": "opm.simulators.GasWaterSimulator.get_primary_var_meaning(variable: str) -> NDArray[int]",
+        "doc": "Retrieves the primary variable meaning of the simulation grid.\n\n:param variable: The name of the variable. Valid names are 'pressure', 'water', 'gas', and 'brine'.\n:type variable: str\n\n:return: An array of primary variable meanings. See ``get_primary_variable_meaning_map()`` for more information.\n:type return: NDArray[int]"
+    },
+    "getPrimaryVarMeaningMap": {
+        "signature": "opm.simulators.GasWaterSimulator.get_primary_var_meaning_map(variable: str) -> dict[str, int]",
+        "doc": "Retrieves the primary variable meaning map for each primary variable.\n\n:param variable: The name of the variable. Valid names are 'pressure', 'water', 'gas', and 'brine'.\n:type variable: str\n\n:return: A dictionary of primary variable meanings. The keys are the primary variable meanings and the values are the corresponding integer codes. The integer codes are used to represent the primary variable meanings in the simulation grid. For variable name 'pressure', the valid keys are: 'Po', 'Pg', and 'Pw', for variable name 'water', the valid keys are: 'Sw', 'Rvw', 'Rsw', and 'Disabled', for variable name 'gas', the valid keys are: 'Sg', 'Rs', 'Rv', and 'Disabled', for variable name 'brine', the valid keys are: 'Cs', 'Sp', and 'Disabled'.\n:type return: dict[str, int]"
+    },
+    "getPrimaryVariable": {
+        "signature": "opm.simulators.GasWaterSimulator.get_primary_variable(variable: str) -> NDArray[float]",
+        "doc": "Retrieves the primary variable's values for the simulation grid.\n\n:param variable: The name of the variable. Valid names are 'pressure', 'water', 'gas', and 'brine'.\n:type variable: str\n\n:return: An array of primary variable values. See ``get_primary_variable_meaning()`` for more information.\n:type return: NDArray[float]"
+    },
+    "run": {
+        "signature": "opm.simulators.GasWaterSimulator.run() -> int",
+        "doc": "Runs the simulation to completion with the provided deck file or previously set deck.\n\n:return: EXIT_SUCCESS if the simulation completes successfully."
+    },
+    "setPorosity": {
+        "signature": "opm.simulators.GasWaterSimulator.set_porosity(array: NDArray[float]) -> None",
+        "doc": "Sets the porosity values for the simulation grid.\n\n:param array: An array of porosity values to be set.\n:type array: NDArray[float]"
+    },
+    "setPrimaryVariable": {
+        "signature": "opm.simulators.GasWaterSimulator.set_primary_variable(variable: str, value: NDArray[float]) -> None",
+        "doc": "Sets the primary variable's values for the simulation grid.\n\n:param variable: The name of the variable. Valid names are 'pressure', 'water', 'gas', and 'brine'.\n:type variable: str\n:param value: An array of primary variable values to be set. See ``get_primary_variable()`` for more information.\n:type value: NDArray[float]"
+    },
+    "setupMpi": {
+        "signature": "opm.simulators.GasWaterSimulator.mpi_init(init: bool, finalize: bool) -> None",
+        "doc": "Sets MPI up for parallel simulation. This method should be called before any other method.\n\n:param init: Whether to call ``MPI_Init()`` or not.\n:param finalize: Whether to call ``MPI_Finalize()```when the simulator object goes out of scope.\n\n:return: None"
+    },
+    "step": {
+        "signature": "opm.simulators.GasWaterSimulator.step() -> int",
+        "doc": "Executes the next simulation report step.\n\n:return: Result of the simulation step."
+    },
+    "stepCleanup": {
+        "signature": "opm.simulators.GasWaterSimulator.step_cleanup() -> int",
+        "doc": "Performs cleanup after the last simulation step.\n\n:return: EXIT_SUCCESS if cleanup is successful."
+    },
+    "stepInit": {
+        "signature": "opm.simulators.GasWaterSimulator.step_init() -> int",
+        "doc": "Initializes the simulation before taking the first report step. This method should be called before the first call to ``step()``\n\n:return: EXIT_SUCCESS if the initialization is successful."
+    }
+}

--- a/python/docstrings_gw_simulators.json
+++ b/python/docstrings_gw_simulators.json
@@ -5,12 +5,12 @@
         "doc": "The GasWaterSimulator class to run simulations using a given Deck."
     },
     "PyGasWaterSimulator_filename_constructor": {
-        "signature": "opm.simulators.GasWaterSimulator.__init__(deck_filename: str) -> GasWaterSimulator",
-        "doc": "Constructor using a deck file name.\n\n:param deck_filename: The file name of the deck to be used for the simulation.\n:type deck_filename: str\n:return: The GasWaterSimulator.\n:type return: GasWaterSimulator"
+        "signature": "opm.simulators.GasWaterSimulator.__init__(deck_filename: str, args: list[str] = []) -> GasWaterSimulator",
+        "doc": "Constructor using a deck file name.\n\n:param deck_filename: The file name of the deck to be used for the simulation.\n:type deck_filename: str\n:param args: Simulator options.\n:type args: list[str]\n:return: The GasWaterSimulator.\n:type return: GasWaterSimulator"
     },
     "PyGasWaterSimulator_objects_constructor": {
-        "signature": "opm.simulators.GasWaterSimulator.__init__(deck: Deck, state: EclipseState, schedule: Schedule, summary_config: SummaryConfig) -> GasWaterSimulator",
-        "doc": "Constructor using Deck, EclipseState, Schedule, and SummaryConfig objects.\n\n:param deck: Deck object.\n:type deck: Deck\n:param state: EclipseState object.\n:type state: EclipseState\n:param schedule: Schedule object.\n:type schedule: Schedule\n:param summary_config: SummaryConfig object.\n:type summary_config: SummaryConfig\n:return: The GasWaterSimulator.\n:type return: GasWaterSimulator"
+        "signature": "opm.simulators.GasWaterSimulator.__init__(deck: Deck, state: EclipseState, schedule: Schedule, summary_config: SummaryConfig, args: list[str] = []) -> GasWaterSimulator",
+        "doc": "Constructor using Deck, EclipseState, Schedule, and SummaryConfig objects.\n\n:param deck: Deck object.\n:type deck: Deck\n:param state: EclipseState object.\n:type state: EclipseState\n:param schedule: Schedule object.\n:type schedule: Schedule\n:param summary_config: SummaryConfig object.\n:type summary_config: SummaryConfig\n:param args: Simulator options.\n:type args: list[str]\n:return: The GasWaterSimulator.\n:type return: GasWaterSimulator"
     },
     "advance": {
         "signature": "opm.simulators.GasWaterSimulator.advance(report_step: int) -> None",

--- a/python/docstrings_simulators.json
+++ b/python/docstrings_simulators.json
@@ -5,12 +5,12 @@
         "doc": "The BlackOilSimulator class to run simulations using a given Deck."
     },
     "PyBlackOilSimulator_filename_constructor": {
-        "signature": "opm.simulators.BlackOilSimulator.__init__(deck_filename: str) -> BlackOilSimulator",
-        "doc": "Constructor using a deck file name.\n\n:param deck_filename: The file name of the deck to be used for the simulation.\n:type deck_filename: str\n:return: The BlackOilSimulator.\n:type return: BlackOilSimulator"
+        "signature": "opm.simulators.BlackOilSimulator.__init__(deck_filename: str, args: list[str] = []) -> BlackOilSimulator",
+        "doc": "Constructor using a deck file name.\n\n:param deck_filename: The file name of the deck to be used for the simulation.\n:type deck_filename: str\n:param args: Simulator options.\n:type args: list[str]\n:return: The BlackOilSimulator.\n:type return: BlackOilSimulator"
     },
     "PyBlackOilSimulator_objects_constructor": {
-        "signature": "opm.simulators.BlackOilSimulator.__init__(deck: Deck, state: EclipseState, schedule: Schedule, summary_config: SummaryConfig) -> BlackOilSimulator",
-        "doc": "Constructor using Deck, EclipseState, Schedule, and SummaryConfig objects.\n\n:param deck: Deck object.\n:type deck: Deck\n:param state: EclipseState object.\n:type state: EclipseState\n:param schedule: Schedule object.\n:type schedule: Schedule\n:param summary_config: SummaryConfig object.\n:type summary_config: SummaryConfig\n:return: The BlackOilSimulator.\n:type return: BlackOilSimulator"
+        "signature": "opm.simulators.BlackOilSimulator.__init__(deck: Deck, state: EclipseState, schedule: Schedule, summary_config: SummaryConfig, args: list[str] = []) -> BlackOilSimulator",
+        "doc": "Constructor using Deck, EclipseState, Schedule, and SummaryConfig objects.\n\n:param deck: Deck object.\n:type deck: Deck\n:param state: EclipseState object.\n:type state: EclipseState\n:param schedule: Schedule object.\n:type schedule: Schedule\n:param summary_config: SummaryConfig object.\n:type summary_config: SummaryConfig\n:param args: Simulator options.\n:type args: list[str]\n:return: The BlackOilSimulator.\n:type return: BlackOilSimulator"
     },
     "advance": {
         "signature": "opm.simulators.BlackOilSimulator.advance(report_step: int) -> None",

--- a/python/opm/simulators/__init__.py
+++ b/python/opm/simulators/__init__.py
@@ -10,3 +10,4 @@
 #  but could be possible future extensions..
 #
 from .simulators import BlackOilSimulator
+from .simulators import GasWaterSimulator

--- a/python/simulators/CMakeLists.txt
+++ b/python/simulators/CMakeLists.txt
@@ -3,6 +3,8 @@ set(PYTHON_OPM_SIMULATORS_PACKAGE_PATH ${PROJECT_BINARY_DIR}/python/opm/simulato
 # Set the path to the input docstrings.json file and the output .hpp file
 set(PYTHON_DOCSTRINGS_FILE "${PROJECT_SOURCE_DIR}/python/docstrings_simulators.json")
 set(PYTHON_DOCSTRINGS_GENERATED_HPP "${PROJECT_BINARY_DIR}/python/PyBlackOilSimulatorDoc.hpp")
+set(PYTHON_GW_DOCSTRINGS_FILE "${PROJECT_SOURCE_DIR}/python/docstrings_gw_simulators.json")
+set(PYTHON_GW_DOCSTRINGS_GENERATED_HPP "${PROJECT_BINARY_DIR}/python/PyGasWaterSimulatorDoc.hpp")
 #  Note: If the new find_package(Python3) is used in the top level CMakeLists.txt, the variable
 #    ${PYTHON_EXECUTABLE} is set there to ${Python3_EXECUTABLE}
 #
@@ -20,6 +22,14 @@ add_custom_command(
     DEPENDS ${PYTHON_DOCSTRINGS_FILE}
     COMMENT "Generating PyBlackOilSimulatorDoc.hpp from JSON file"
 )
+add_custom_command(
+    OUTPUT ${PYTHON_GW_DOCSTRINGS_GENERATED_HPP}
+    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_SOURCE_DIR}
+            ${PYTHON_EXECUTABLE} ${PYTHON_GENERATE_DOCSTRINGS_PY}
+            ${PYTHON_GW_DOCSTRINGS_FILE} ${PYTHON_GW_DOCSTRINGS_GENERATED_HPP} PYGASWATERSIMULATORDOC_HPP "Opm::Pybind::DocStrings"
+    DEPENDS ${PYTHON_GW_DOCSTRINGS_FILE}
+    COMMENT "Generating PyGasWaterSimulatorDoc.hpp from JSON file"
+)
 # NOTE: The variable ${PYBIND11_SYSTEM} is set in python/CMakeLists.txt
 #   to the value "SYSTEM" or unset, depending on the current version of Pybind11.
 #   The value is then forwarded to target_include_directories(), see
@@ -31,7 +41,9 @@ pybind11_add_module(simulators ${PYBIND11_SYSTEM}
   $<TARGET_OBJECTS:moduleVersion>
   Pybind11Exporter.cpp
   PyBlackOilSimulator.cpp
+  PyGasWaterSimulator.cpp
   ${PYTHON_DOCSTRINGS_GENERATED_HPP}  # Include the generated .hpp as a source file
+  ${PYTHON_GW_DOCSTRINGS_GENERATED_HPP}  # Include the generated .hpp as a source file
   )
 
 set_target_properties( simulators PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PYTHON_OPM_SIMULATORS_PACKAGE_PATH} )

--- a/python/simulators/PyBlackOilSimulator.cpp
+++ b/python/simulators/PyBlackOilSimulator.cpp
@@ -63,12 +63,14 @@ PyBlackOilSimulator::PyBlackOilSimulator(
     std::shared_ptr<Opm::Deck> deck,
     std::shared_ptr<Opm::EclipseState> state,
     std::shared_ptr<Opm::Schedule> schedule,
-    std::shared_ptr<Opm::SummaryConfig> summary_config
+    std::shared_ptr<Opm::SummaryConfig> summary_config,
+    const std::vector<std::string>& args
 )
     : deck_{std::move(deck)}
     , eclipse_state_{std::move(state)}
     , schedule_{std::move(schedule)}
     , summary_config_{std::move(summary_config)}
+    , args_{args}
 {
 }
 
@@ -303,8 +305,11 @@ void export_PyBlackOilSimulator(py::module& m)
              std::shared_ptr<Opm::Deck>,
              std::shared_ptr<Opm::EclipseState>,
              std::shared_ptr<Opm::Schedule>,
-             std::shared_ptr<Opm::SummaryConfig>>(),
-             PyBlackOilSimulator_objects_constructor_docstring)
+             std::shared_ptr<Opm::SummaryConfig>,
+             const std::vector<std::string>&>(),
+             PyBlackOilSimulator_objects_constructor_docstring,
+             py::arg("Deck"), py::arg("EclipseState"), py::arg("Schedule"), py::arg("SummaryConfig"),
+             py::arg("args") = std::vector<std::string>{})
         .def("advance", &PyBlackOilSimulator::advance, advance_docstring, py::arg("report_step"))
         .def("check_simulation_finished", &PyBlackOilSimulator::checkSimulationFinished,
              checkSimulationFinished_docstring)

--- a/python/simulators/PyGasWaterSimulator.cpp
+++ b/python/simulators/PyGasWaterSimulator.cpp
@@ -88,12 +88,14 @@ PyGasWaterSimulator::PyGasWaterSimulator(
     std::shared_ptr<Opm::Deck> deck,
     std::shared_ptr<Opm::EclipseState> state,
     std::shared_ptr<Opm::Schedule> schedule,
-    std::shared_ptr<Opm::SummaryConfig> summary_config
+    std::shared_ptr<Opm::SummaryConfig> summary_config,
+    const std::vector<std::string>& args
 )
     : deck_{std::move(deck)}
     , eclipse_state_{std::move(state)}
     , schedule_{std::move(schedule)}
     , summary_config_{std::move(summary_config)}
+    , args_{args}
 {
 }
 
@@ -242,7 +244,7 @@ int PyGasWaterSimulator::stepInit()
         }
     }
     if (this->deck_) {
-        this->main_ = std::make_unique<Opm::PyMain>(
+        this->main_ = std::make_unique<Opm::PyMainGW>(
             this->deck_->getDataFile(),
             this->eclipse_state_,
             this->schedule_,
@@ -252,7 +254,7 @@ int PyGasWaterSimulator::stepInit()
         );
     }
     else {
-        this->main_ = std::make_unique<Opm::PyMain>(
+        this->main_ = std::make_unique<Opm::PyMainGW>(
             this->deck_filename_,
             this->mpi_init_,
             this->mpi_finalize_
@@ -328,8 +330,11 @@ void export_PyGasWaterSimulator(py::module& m)
              std::shared_ptr<Opm::Deck>,
              std::shared_ptr<Opm::EclipseState>,
              std::shared_ptr<Opm::Schedule>,
-             std::shared_ptr<Opm::SummaryConfig>>(),
-             PyGasWaterSimulator_objects_constructor_docstring)
+             std::shared_ptr<Opm::SummaryConfig>,
+             const std::vector<std::string>&>(),
+             PyGasWaterSimulator_objects_constructor_docstring,
+             py::arg("Deck"), py::arg("EclipseState"), py::arg("Schedule"), py::arg("SummaryConfig"),  
+             py::arg("args") = std::vector<std::string>{})
         .def("advance", &PyGasWaterSimulator::advance, advance_docstring, py::arg("report_step"))
         .def("check_simulation_finished", &PyGasWaterSimulator::checkSimulationFinished,
              checkSimulationFinished_docstring)

--- a/python/simulators/PyGasWaterSimulator.cpp
+++ b/python/simulators/PyGasWaterSimulator.cpp
@@ -1,0 +1,359 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/simulators/flow/FlowMain.hpp>
+//#include <opm/simulators/flow/python/PyFluidState.hpp>
+#include <opm/simulators/flow/python/PyMaterialState.hpp>
+#include <opm/simulators/flow/python/PyGasWaterSimulator.hpp>
+// NOTE: This file will be generated at compile time and placed in the build directory
+// See python/generate_docstring_hpp.py, and python/simulators/CMakeLists.txt for details
+#include <PyGasWaterSimulatorDoc.hpp>
+// NOTE: EXIT_SUCCESS, EXIT_FAILURE is defined in cstdlib
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+namespace Opm {
+    namespace Properties {
+        
+        //! The indices required by the model
+        template<class TypeTag>
+        struct Indices<TypeTag, TTag::FlowGasWaterProblem>
+        {
+            private:
+                // it is unfortunately not possible to simply use 'TypeTag' here because this leads
+                // to cyclic definitions of some properties. if this happens the compiler error
+                // messages unfortunately are *really* confusing and not really helpful.
+                using BaseTypeTag = TTag::FlowProblem;
+                using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
+            
+            public:
+                using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
+                                                    getPropValue<TypeTag, Properties::EnableExtbo>(),
+                                                    getPropValue<TypeTag, Properties::EnablePolymer>(),
+                                                    getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                                    getPropValue<TypeTag, Properties::EnableFoam>(),
+                                                    getPropValue<TypeTag, Properties::EnableBrine>(),
+                                                    /*PVOffset=*/0,
+                                                    /*disabledCompIdx=*/FluidSystem::oilCompIdx,
+                                                    getPropValue<TypeTag, Properties::EnableMICP>()>;
+        };
+    }
+
+std::unique_ptr<FlowMain<Properties::TTag::FlowGasWaterProblem>>
+flowGasWaterMainInit(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    resetLocale();
+
+    return std::make_unique<FlowMain<Properties::TTag::FlowGasWaterProblem>>(
+        argc, argv, outputCout, outputFiles);
+}
+
+}
+
+namespace py = pybind11;
+
+namespace Opm::Pybind {
+PyGasWaterSimulator::PyGasWaterSimulator(const std::string& deck_filename,
+                                         const std::vector<std::string>& args)
+    : deck_filename_{deck_filename}
+    , args_{args}
+{
+}
+
+PyGasWaterSimulator::PyGasWaterSimulator(
+    std::shared_ptr<Opm::Deck> deck,
+    std::shared_ptr<Opm::EclipseState> state,
+    std::shared_ptr<Opm::Schedule> schedule,
+    std::shared_ptr<Opm::SummaryConfig> summary_config
+)
+    : deck_{std::move(deck)}
+    , eclipse_state_{std::move(state)}
+    , schedule_{std::move(schedule)}
+    , summary_config_{std::move(summary_config)}
+{
+}
+
+// Public methods alphabetically sorted
+// ------------------------------------
+
+void PyGasWaterSimulator::advance(int report_step)
+{
+    while (currentStep() < report_step) {
+        step();
+    }
+}
+
+bool PyGasWaterSimulator::checkSimulationFinished()
+{
+    return getFlowMain().getSimTimer()->done();
+}
+
+// This returns the report step number that will be executed next time step()
+//   is called.
+int PyGasWaterSimulator::currentStep()
+{
+    return getFlowMain().getSimTimer()->currentStepNum();
+    // NOTE: this->simulator_->episodeIndex() would also return the current
+    // report step number, but this number is always delayed by 1 step relative
+    // to this->flow_main_->getSimTimer()->currentStepNum()
+    // See details in runStep() in file SimulatorFullyImplicitBlackoilEbos.hpp
+}
+
+py::array_t<double> PyGasWaterSimulator::getCellVolumes() {
+    auto vector = getMaterialState().getCellVolumes();
+    return py::array(vector.size(), vector.data());
+}
+
+double PyGasWaterSimulator::getDT() {
+    return getFlowMain().getPreviousReportStepSize();
+}
+
+py::array_t<double> PyGasWaterSimulator::getPorosity()
+{
+    auto vector = getMaterialState().getPorosity();
+    return py::array(vector.size(), vector.data());
+}
+
+py::array_t<double>
+PyGasWaterSimulator::
+getFluidStateVariable(const std::string &name) const
+{
+    auto vector = getFluidState().getFluidStateVariable(name);
+    return py::array(vector.size(), vector.data());
+}
+
+py::array_t<double>
+PyGasWaterSimulator::
+getPrimaryVariable(const std::string &variable) const
+{
+    auto vector = getFluidState().getPrimaryVariable(variable);
+    return py::array(vector.size(), vector.data());
+}
+
+py::array_t<int>
+PyGasWaterSimulator::
+getPrimaryVarMeaning(const std::string &variable) const
+{
+    auto vector = getFluidState().getPrimaryVarMeaning(variable);
+    return py::array(vector.size(), vector.data());
+}
+
+std::map<std::string, int>
+PyGasWaterSimulator::
+getPrimaryVarMeaningMap(const std::string &variable) const
+{
+
+    return getFluidState().getPrimaryVarMeaningMap(variable);
+}
+
+int PyGasWaterSimulator::run()
+{
+    auto main_object = Opm::Main( this->deck_filename_ );
+    return main_object.runStatic<Opm::Properties::TTag::FlowGasWaterProblem>();
+}
+
+void PyGasWaterSimulator::setPorosity( py::array_t<double,
+    py::array::c_style | py::array::forcecast> array)
+{
+    std::size_t size_ = array.size();
+    const double *poro = array.data();
+    getMaterialState().setPorosity(poro, size_);
+}
+
+void
+PyGasWaterSimulator::
+setPrimaryVariable(
+    const std::string &variable,
+    py::array_t<double,
+    py::array::c_style | py::array::forcecast> array
+)
+{
+    std::size_t size_ = array.size();
+    const double *data = array.data();
+    getFluidState().setPrimaryVariable(variable, data, size_);
+}
+
+void PyGasWaterSimulator::setupMpi(bool mpi_init, bool mpi_finalize)
+{
+    if (this->has_run_init_) {
+        throw std::logic_error("mpi_init() called after step_init()");
+    }
+    this->mpi_init_ = mpi_init;
+    this->mpi_finalize_ = mpi_finalize;
+}
+
+int PyGasWaterSimulator::step()
+{
+    if (!this->has_run_init_) {
+        throw std::logic_error("step() called before step_init()");
+    }
+    if (this->has_run_cleanup_) {
+        throw std::logic_error("step() called after step_cleanup()");
+    }
+    if(checkSimulationFinished()) {
+        throw std::logic_error("step() called, but simulation is done");
+    }
+    //if (this->debug_)
+    //    this->mainEbos_->getSimTimer()->report(std::cout);
+    auto result = getFlowMain().executeStep();
+    return result;
+}
+
+int PyGasWaterSimulator::stepCleanup()
+{
+    this->has_run_cleanup_ = true;
+    return getFlowMain().executeStepsCleanup();
+}
+
+int PyGasWaterSimulator::stepInit()
+{
+
+    if (this->has_run_init_) {
+        // Running step_init() multiple times is not implemented yet,
+        if (this->has_run_cleanup_) {
+            throw std::logic_error("step_init() called again");
+        }
+        else {
+            return EXIT_SUCCESS;
+        }
+    }
+    if (this->deck_) {
+        this->main_ = std::make_unique<Opm::PyMain>(
+            this->deck_->getDataFile(),
+            this->eclipse_state_,
+            this->schedule_,
+            this->summary_config_,
+            this->mpi_init_,
+            this->mpi_finalize_
+        );
+    }
+    else {
+        this->main_ = std::make_unique<Opm::PyMain>(
+            this->deck_filename_,
+            this->mpi_init_,
+            this->mpi_finalize_
+        );
+    }
+    this->main_->setArguments(args_);
+    int exit_code = EXIT_SUCCESS;
+    this->flow_main_ = this->main_->initFlowGasWater(exit_code);
+    if (this->flow_main_) {
+        int result = this->flow_main_->executeInitStep();
+        this->has_run_init_ = true;
+        this->simulator_ = this->flow_main_->getSimulatorPtr();
+        this->fluid_state_ = std::make_unique<PyFluidState<TypeTag>>(this->simulator_);
+        this->material_state_ = std::make_unique<PyMaterialState<TypeTag>>(this->simulator_);
+        return result;
+    }
+    else {
+        return exit_code;
+    }
+}
+
+// Private methods alphabetically sorted
+// ------------------------------------
+
+Opm::FlowMain<typename Opm::Pybind::PyGasWaterSimulator::TypeTag>&
+         PyGasWaterSimulator::getFlowMain() const
+{
+    if (this->flow_main_) {
+        return *this->flow_main_;
+    }
+    else {
+        throw std::runtime_error("BlackOilSimulator not initialized: "
+            "Cannot get reference to FlowMain object" );
+    }
+}
+
+PyFluidState<typename PyGasWaterSimulator::TypeTag>&
+PyGasWaterSimulator::
+getFluidState() const
+{
+    if (this->fluid_state_) {
+        return *this->fluid_state_;
+    }
+    else {
+        throw std::runtime_error("BlackOilSimulator not initialized: "
+            "Cannot get reference to FlowMainEbos object" );
+    }
+}
+
+PyMaterialState<typename PyGasWaterSimulator::TypeTag>&
+PyGasWaterSimulator::getMaterialState() const
+{
+    if (this->material_state_) {
+        return *this->material_state_;
+    }
+    else {
+        throw std::runtime_error("BlackOilSimulator not initialized: "
+            "Cannot get reference to FlowMain object" );
+    }
+}
+
+// Exported functions
+void export_PyGasWaterSimulator(py::module& m)
+{
+    using namespace Opm::Pybind::DocStrings;
+
+    py::class_<PyGasWaterSimulator>(m, "GasWaterSimulator")
+        .def(py::init<const std::string&,
+                      const std::vector<std::string>&>(),
+             PyGasWaterSimulator_filename_constructor_docstring,
+             py::arg("filename"), py::arg("args") = std::vector<std::string>{})
+        .def(py::init<
+             std::shared_ptr<Opm::Deck>,
+             std::shared_ptr<Opm::EclipseState>,
+             std::shared_ptr<Opm::Schedule>,
+             std::shared_ptr<Opm::SummaryConfig>>(),
+             PyGasWaterSimulator_objects_constructor_docstring)
+        .def("advance", &PyGasWaterSimulator::advance, advance_docstring, py::arg("report_step"))
+        .def("check_simulation_finished", &PyGasWaterSimulator::checkSimulationFinished,
+             checkSimulationFinished_docstring)
+        .def("current_step", &PyGasWaterSimulator::currentStep, currentStep_docstring)
+        .def("get_cell_volumes", &PyGasWaterSimulator::getCellVolumes, getCellVolumes_docstring)
+        .def("get_dt", &PyGasWaterSimulator::getDT, getDT_docstring)
+        .def("get_fluidstate_variable", &PyGasWaterSimulator::getFluidStateVariable,
+            py::return_value_policy::copy, getFluidStateVariable_docstring, py::arg("name"))
+        .def("get_porosity", &PyGasWaterSimulator::getPorosity, getPorosity_docstring)
+        .def("get_primary_variable_meaning", &PyGasWaterSimulator::getPrimaryVarMeaning,
+            py::return_value_policy::copy, getPrimaryVarMeaning_docstring, py::arg("variable"))
+        .def("get_primary_variable_meaning_map", &PyGasWaterSimulator::getPrimaryVarMeaningMap,
+            py::return_value_policy::copy, getPrimaryVarMeaningMap_docstring, py::arg("variable"))
+        .def("get_primary_variable", &PyGasWaterSimulator::getPrimaryVariable,
+            py::return_value_policy::copy, getPrimaryVariable_docstring, py::arg("variable"))
+        .def("run", &PyGasWaterSimulator::run, run_docstring)
+        .def("set_porosity", &PyGasWaterSimulator::setPorosity, setPorosity_docstring, py::arg("array"))
+        .def("set_primary_variable", &PyGasWaterSimulator::setPrimaryVariable,
+            py::arg("variable"), setPrimaryVariable_docstring, py::arg("value"))
+        .def("setup_mpi", &PyGasWaterSimulator::setupMpi, setupMpi_docstring, py::arg("init"), py::arg("finalize"))
+        .def("step", &PyGasWaterSimulator::step, step_docstring)
+        .def("step_cleanup", &PyGasWaterSimulator::stepCleanup, stepCleanup_docstring)
+        .def("step_init", &PyGasWaterSimulator::stepInit, stepInit_docstring);
+}
+
+} // namespace Opm::Pybind
+

--- a/python/simulators/PyMainGW.hpp
+++ b/python/simulators/PyMainGW.hpp
@@ -1,0 +1,100 @@
+/*
+  Copyright 2013, 2014, 2015 SINTEF ICT, Applied Mathematics.
+  Copyright 2014 Dr. Blatt - HPC-Simulation-Software & Services
+  Copyright 2015 IRIS AS
+  Copyright 2014 STATOIL ASA.
+  Copyright 2023 Inria
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_PYMAIN_HEADER_INCLUDED
+#define OPM_PYMAIN_HEADER_INCLUDED
+
+#include <opm/simulators/flow/FlowMain.hpp>
+#include <opm/simulators/flow/Main.hpp>
+#include <opm/simulators/flow/TTagFlowProblemGasWater.hpp>
+
+#include <flow/flow_gaswater.hpp>
+
+#include <cstddef>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Opm {
+
+// ----------------- Python Main class -----------------
+// Adds a python-only initialization method
+class PyMain : public Main
+{
+public:
+    using FlowMainType = FlowMain<Properties::TTag::FlowGasWaterProblem>;
+
+    using Main::Main;
+
+    void setArguments(const std::vector<std::string>& args)
+    {
+        if (args.empty()) {
+            return;
+        }
+
+        // We have the two arguments previously setup (binary name and input
+        // case name) by the main class plus whichever args are in the
+        // parameter that was passed from the python side.
+        this->argc_ = 2 + args.size();
+
+        // Setup our vector of char*'s
+        argv_python_.resize(2 + args.size());
+        argv_python_[0] = argv_[0];
+        argv_python_[1] = argv_[1];
+        for (std::size_t i = 0; i < args.size(); ++i) {
+            argv_python_[i+2] = const_cast<char*>(args[i].c_str());
+        }
+
+        // Finally set the main class' argv pointer to the combined
+        // parameter list.
+        this->argv_ = argv_python_.data();
+    }
+
+    // To be called from the Python interface code.  Only do the
+    // initialization and then return a pointer to the FlowMain object that
+    // can later be accessed directly from the Python interface to
+    // e.g. advance the simulator one report step
+    std::unique_ptr<FlowMainType> initFlowGasWater(int& exitCode)
+    {
+        exitCode = EXIT_SUCCESS;
+
+        if (this->initialize_<Properties::TTag::FlowEarlyBird>(exitCode, true)) {
+            // TODO: check that this deck really represents a blackoil
+            // case. E.g. check that number of phases == 3
+            this->setupVanguard();
+
+            return flowGasWaterMainInit
+                (argc_, argv_, outputCout_, outputFiles_);
+        }
+
+        // NOTE: exitCode was set by initialize_() above;
+        return {}; // nullptr
+    }
+
+private:
+    std::vector<char*> argv_python_{};
+};
+
+} // namespace Opm
+
+#endif // OPM_PYMAIN_HEADER_INCLUDED

--- a/python/simulators/PyMainGW.hpp
+++ b/python/simulators/PyMainGW.hpp
@@ -20,8 +20,8 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef OPM_PYMAIN_HEADER_INCLUDED
-#define OPM_PYMAIN_HEADER_INCLUDED
+#ifndef OPM_PYMAINGW_HEADER_INCLUDED
+#define OPM_PYMAINGW_HEADER_INCLUDED
 
 #include <opm/simulators/flow/FlowMain.hpp>
 #include <opm/simulators/flow/Main.hpp>
@@ -39,7 +39,7 @@ namespace Opm {
 
 // ----------------- Python Main class -----------------
 // Adds a python-only initialization method
-class PyMain : public Main
+class PyMainGW : public Main
 {
 public:
     using FlowMainType = FlowMain<Properties::TTag::FlowGasWaterProblem>;
@@ -97,4 +97,4 @@ private:
 
 } // namespace Opm
 
-#endif // OPM_PYMAIN_HEADER_INCLUDED
+#endif // OPM_PYMAINGW_HEADER_INCLUDED

--- a/python/simulators/Pybind11Exporter.cpp
+++ b/python/simulators/Pybind11Exporter.cpp
@@ -3,6 +3,7 @@
 
 void Opm::Pybind::export_all(py::module& m) {
     export_PyBlackOilSimulator(m);
+    export_PyGasWaterSimulator(m);
 }
 
 PYBIND11_MODULE(simulators, m)


### PR DESCRIPTION
Added a Python gas-water simulator to be able to run f.ex. CO2-/H2STORE data files. Also added the option to input command-line arguments in constructor so both ways of instantiating the simulator classes have that ability.

I open this PR in draft mode because most of the code is duplicate of the PyBlackOilSimulator implementation, which is not optimal. I've made futile attempts at making a base simulator that the other Python simulators can inherit. If anybody have suggestions on how to make a base simulator (or want to take up the mantle?), I'm happy to hear them!