### PR TITLE
WellModel: make a copy of events at start of time step

### DIFF
--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -425,7 +425,9 @@ public:
                                         wmatcher,
                                         this->wellModel_().wellOpenTimes(),
                                         this->wellModel_().wellCloseTimes(),
-                                        [timeStep, &wg_events = schedule[reportStep].wellgroup_events()](const std::string& name)
+                                        [timeStep,
+                                         &wg_events = this->wellModel_().reportStepStartEvents()]
+                                        (const std::string& name)
                                         {
                                             if (timeStep != 0) {
                                                 return false;

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -226,6 +226,7 @@ public:
 
     const std::map<std::string, double>& wellOpenTimes() const { return well_open_times_; }
     const std::map<std::string, double>& wellCloseTimes() const { return well_close_times_; }
+    const WellGroupEvents& reportStepStartEvents() const { return report_step_start_events_; }
 
     std::vector<int> getCellsForConnections(const Well& well) const;
 
@@ -523,6 +524,7 @@ protected:
     WGState<Scalar> active_wgstate_;
     WGState<Scalar> last_valid_wgstate_;
     WGState<Scalar> nupcol_wgstate_;
+    WellGroupEvents report_step_start_events_; //!< Well group events at start of report step
 
     bool wellStructureChangedDynamically_{false};
 


### PR DESCRIPTION
these can be modified during sub-stepping, and the wcycle code needs the original events for decision making

Noticed while working on https://github.com/OPM/opm-simulators/pull/6078 
This should be processed first.