### PR TITLE
Log GLO Debug Messages to Debug Log Stream

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGasLift.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGasLift.cpp
@@ -42,7 +42,7 @@ gliftDebug([[maybe_unused]] const std::string& msg,
         if (terminal_output_) {
             const std::string message =
                 fmt::format("  GLIFT (DEBUG) : BlackoilWellModel : {}", msg);
-            deferred_logger.info(message);
+            deferred_logger.debug(message);
         }
     }
 }

--- a/opm/simulators/wells/GasLiftCommon.cpp
+++ b/opm/simulators/wells/GasLiftCommon.cpp
@@ -93,10 +93,10 @@ logMessage_(const std::string& prefix,
         "  {} ({}) :{} {}", prefix, type_str, rank, msg);
     switch (msg_type) {
     case MessageType::INFO:
-        this->deferred_logger_.info(message);
+        this->deferred_logger_.debug(message);
         break;
     case MessageType::WARNING:
-        this->deferred_logger_.info(message);
+        this->deferred_logger_.debug(message);
         break;
     default:
         throw std::runtime_error("This should not happen");

--- a/opm/simulators/wells/GasLiftSingleWellGeneric.cpp
+++ b/opm/simulators/wells/GasLiftSingleWellGeneric.cpp
@@ -1110,7 +1110,7 @@ logSuccess_(Scalar alq, const int iteration_idx)
                                             ((alq > this->orig_alq_) ? "increased" : "decreased"),
                                             this->orig_alq_,
                                             alq);
-    this->deferred_logger_.info(message);
+    this->deferred_logger_.debug(message);
 }
 
 template<class Scalar>


### PR DESCRIPTION
Otherwise, we risk overrunning the INFO (PRT file) stream message limits in runs with many timesteps.