### PR TITLE
Don't Store EclipseState Reference in Convergence Output Object

### DIFF
--- a/opm/simulators/flow/SimulatorConvergenceOutput.cpp
+++ b/opm/simulators/flow/SimulatorConvergenceOutput.cpp
@@ -18,7 +18,9 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <config.h>
+
 #include <opm/simulators/flow/SimulatorConvergenceOutput.hpp>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
@@ -26,11 +28,17 @@
 
 #include <opm/simulators/flow/ConvergenceOutputConfiguration.hpp>
 
+#include <algorithm>
+#include <string_view>
+#include <utility>
+#include <vector>
+
 namespace Opm {
 
 void SimulatorConvergenceOutput::
-startThread(std::string_view convOutputOptions,
-            std::string_view optionName,
+startThread(const EclipseState&                           eclState,
+            std::string_view                              convOutputOptions,
+            std::string_view                              optionName,
             ConvergenceOutputThread::ComponentToPhaseName getPhaseName)
 {
     const auto config = ConvergenceOutputConfiguration {
@@ -42,14 +50,14 @@ startThread(std::string_view convOutputOptions,
     }
 
     auto convertTime = ConvergenceOutputThread::ConvertToTimeUnits {
-        [usys = eclState_.getUnits()](const double time)
+        [usys = eclState.getUnits()](const double time)
         { return usys.from_si(UnitSystem::measure::time, time); }
     };
 
     this->convergenceOutputQueue_.emplace();
     this->convergenceOutputObject_.emplace
-        (eclState_.getIOConfig().getOutputDir(),
-         eclState_.getIOConfig().getBaseName(),
+        (eclState.getIOConfig().getOutputDir(),
+         eclState.getIOConfig().getBaseName(),
          std::move(getPhaseName),
          std::move(convertTime),
          config, *this->convergenceOutputQueue_);
@@ -67,7 +75,7 @@ write(const std::vector<StepReport>& reports)
     }
 
     auto new_reports = std::vector<StepReport> {
-        reports.begin() + this->already_reported_steps_, reports.end()
+        reports.begin() + this->alreadyReportedSteps_, reports.end()
     };
 
     auto requests = std::vector<ConvergenceReportQueue::OutputRequest>{};
@@ -76,7 +84,8 @@ write(const std::vector<StepReport>& reports)
     for (auto&& report : new_reports) {
         requests.push_back({ report.report_step, report.current_step, std::move(report.report) });
     }
-    this->already_reported_steps_ = reports.size();
+
+    this->alreadyReportedSteps_ = reports.size();
 
     this->convergenceOutputQueue_->enqueue(std::move(requests));
 }

--- a/opm/simulators/flow/SimulatorConvergenceOutput.hpp
+++ b/opm/simulators/flow/SimulatorConvergenceOutput.hpp
@@ -32,19 +32,20 @@
 
 namespace Opm {
 
-class EclipseState;
-struct StepReport;
+    class EclipseState;
+    struct StepReport;
+
+} // namespace Opm
+
+namespace Opm {
 
 /// Class handling convergence history output for a simulator.
 class SimulatorConvergenceOutput
 {
 public:
-    explicit SimulatorConvergenceOutput(const EclipseState& eclState)
-        : eclState_(eclState)
-    {}
-
-    void startThread(std::string_view convOutputOptions,
-                     std::string_view optionName,
+    void startThread(const EclipseState& eclState,
+                     std::string_view    convOutputOptions,
+                     std::string_view    optionName,
                      ConvergenceOutputThread::ComponentToPhaseName getPhaseName);
 
     void write(const std::vector<StepReport>& reports);
@@ -52,9 +53,7 @@ public:
     void endThread();
 
 private:
-    const EclipseState& eclState_;
-
-    std::size_t already_reported_steps_ = 0;
+    std::vector<StepReport>::size_type alreadyReportedSteps_ = 0;
 
     std::optional<ConvergenceReportQueue> convergenceOutputQueue_{};
     std::optional<ConvergenceOutputThread> convergenceOutputObject_{};

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -139,7 +139,6 @@ public:
     /// \param[in] threshold_pressures_by_face   if nonempty, threshold pressures that inhibit flow
     explicit SimulatorFullyImplicitBlackoil(Simulator& simulator)
         : simulator_(simulator)
-        , convergence_output_(simulator_.vanguard().eclState())
         , serializer_(*this,
                       FlowGenericVanguard::comm(),
                       simulator_.vanguard().eclState().getIOConfig(),
@@ -160,8 +159,9 @@ public:
                 { return std::string_view { compNames.name(compIdx) }; }
             };
 
-            convergence_output_.
-                startThread(Parameters::Get<Parameters::OutputExtraConvergenceInfo>(),
+            this->convergence_output_.
+                startThread(this->simulator_.vanguard().eclState(),
+                            Parameters::Get<Parameters::OutputExtraConvergenceInfo>(),
                             R"(OutputExtraConvergenceInfo (--output-extra-convergence-info))",
                             getPhaseName);
         }
@@ -650,7 +650,7 @@ protected:
     std::unique_ptr<time::StopWatch> totalTimer_;
     std::unique_ptr<TimeStepper> adaptiveTimeStepping_;
 
-    SimulatorConvergenceOutput convergence_output_;
+    SimulatorConvergenceOutput convergence_output_{};
 
 #ifdef RESERVOIR_COUPLING_ENABLED
     bool slaveMode_{false};


### PR DESCRIPTION
The EclipseState reference is used only for `startThread()`, so we might as well request that the caller pass an object when calling the `startThread()` function instead of keeping a reference to the object throughout the simulation run.

While here, also rename the `already_reported_steps_` to camel case.