### PR TITLE
Enqueue Convergence Output Only if Needed

### DIFF
--- a/opm/simulators/flow/SimulatorConvergenceOutput.cpp
+++ b/opm/simulators/flow/SimulatorConvergenceOutput.cpp
@@ -18,7 +18,9 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <config.h>
+
 #include <opm/simulators/flow/SimulatorConvergenceOutput.hpp>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
@@ -26,11 +28,17 @@
 
 #include <opm/simulators/flow/ConvergenceOutputConfiguration.hpp>
 
+#include <algorithm>
+#include <string_view>
+#include <utility>
+#include <vector>
+
 namespace Opm {
 
 void SimulatorConvergenceOutput::
-startThread(std::string_view convOutputOptions,
-            std::string_view optionName,
+startThread(const EclipseState&                           eclState,
+            std::string_view                              convOutputOptions,
+            std::string_view                              optionName,
             ConvergenceOutputThread::ComponentToPhaseName getPhaseName)
 {
     const auto config = ConvergenceOutputConfiguration {
@@ -42,14 +50,14 @@ startThread(std::string_view convOutputOptions,
     }
 
     auto convertTime = ConvergenceOutputThread::ConvertToTimeUnits {
-        [usys = eclState_.getUnits()](const double time)
+        [usys = eclState.getUnits()](const double time)
         { return usys.from_si(UnitSystem::measure::time, time); }
     };
 
     this->convergenceOutputQueue_.emplace();
     this->convergenceOutputObject_.emplace
-        (eclState_.getIOConfig().getOutputDir(),
-         eclState_.getIOConfig().getBaseName(),
+        (eclState.getIOConfig().getOutputDir(),
+         eclState.getIOConfig().getBaseName(),
          std::move(getPhaseName),
          std::move(convertTime),
          config, *this->convergenceOutputQueue_);
@@ -67,7 +75,7 @@ write(const std::vector<StepReport>& reports)
     }
 
     auto new_reports = std::vector<StepReport> {
-        reports.begin() + this->already_reported_steps_, reports.end()
+        reports.begin() + this->alreadyReportedSteps_, reports.end()
     };
 
     auto requests = std::vector<ConvergenceReportQueue::OutputRequest>{};
@@ -76,7 +84,8 @@ write(const std::vector<StepReport>& reports)
     for (auto&& report : new_reports) {
         requests.push_back({ report.report_step, report.current_step, std::move(report.report) });
     }
-    this->already_reported_steps_ = reports.size();
+
+    this->alreadyReportedSteps_ = reports.size();
 
     this->convergenceOutputQueue_->enqueue(std::move(requests));
 }

--- a/opm/simulators/flow/SimulatorConvergenceOutput.cpp
+++ b/opm/simulators/flow/SimulatorConvergenceOutput.cpp
@@ -70,7 +70,11 @@ startThread(const EclipseState&                           eclState,
 void SimulatorConvergenceOutput::
 write(const std::vector<StepReport>& reports)
 {
-    if (! this->convergenceOutputThread_.has_value()) {
+    if (! this->convergenceOutputThread_.has_value() ||
+        (reports.size() == this->alreadyReportedSteps_))
+    {
+        // Convergence output not requested or we've already output all
+        // known reports.  Nothing to do.
         return;
     }
 

--- a/opm/simulators/flow/SimulatorConvergenceOutput.cpp
+++ b/opm/simulators/flow/SimulatorConvergenceOutput.cpp
@@ -74,16 +74,18 @@ write(const std::vector<StepReport>& reports)
         return;
     }
 
-    auto new_reports = std::vector<StepReport> {
-        reports.begin() + this->alreadyReportedSteps_, reports.end()
-    };
+    const auto begin = reports.begin() + this->alreadyReportedSteps_;
+    const auto end = reports.end();
 
-    auto requests = std::vector<ConvergenceReportQueue::OutputRequest>{};
-    requests.reserve(new_reports.size());
+    auto requests = std::vector<ConvergenceReportQueue::OutputRequest>
+        (std::distance(begin, end));
 
-    for (auto&& report : new_reports) {
-        requests.push_back({ report.report_step, report.current_step, std::move(report.report) });
-    }
+    std::transform(begin, end, requests.begin(),
+                   [](const StepReport& report) {
+                       return ConvergenceReportQueue::OutputRequest {
+                           report.report_step, report.current_step, report.report
+                       };
+                   });
 
     this->alreadyReportedSteps_ = reports.size();
 

--- a/opm/simulators/flow/SimulatorConvergenceOutput.hpp
+++ b/opm/simulators/flow/SimulatorConvergenceOutput.hpp
@@ -32,19 +32,20 @@
 
 namespace Opm {
 
-class EclipseState;
-struct StepReport;
+    class EclipseState;
+    struct StepReport;
+
+} // namespace Opm
+
+namespace Opm {
 
 /// Class handling convergence history output for a simulator.
 class SimulatorConvergenceOutput
 {
 public:
-    explicit SimulatorConvergenceOutput(const EclipseState& eclState)
-        : eclState_(eclState)
-    {}
-
-    void startThread(std::string_view convOutputOptions,
-                     std::string_view optionName,
+    void startThread(const EclipseState& eclState,
+                     std::string_view    convOutputOptions,
+                     std::string_view    optionName,
                      ConvergenceOutputThread::ComponentToPhaseName getPhaseName);
 
     void write(const std::vector<StepReport>& reports);
@@ -52,9 +53,7 @@ public:
     void endThread();
 
 private:
-    const EclipseState& eclState_;
-
-    std::size_t already_reported_steps_ = 0;
+    std::vector<StepReport>::size_type alreadyReportedSteps_ = 0;
 
     std::optional<ConvergenceReportQueue> convergenceOutputQueue_{};
     std::optional<ConvergenceOutputThread> convergenceOutputObject_{};

--- a/opm/simulators/flow/SimulatorConvergenceOutput.hpp
+++ b/opm/simulators/flow/SimulatorConvergenceOutput.hpp
@@ -43,20 +43,69 @@ namespace Opm {
 class SimulatorConvergenceOutput
 {
 public:
+    /// Start convergence output thread.
+    ///
+    /// Thread starts only if explicitly requested in runtime user options.
+    ///
+    /// \param[in] eclState Static model object.  Needed to determine run's
+    /// output directory, base name, and unit conventions.
+    ///
+    /// \param[in] convOutputOptions Comma separated option string as
+    /// required by class ConvergenceOutputConfiguration.
+    ///
+    /// \param[in] optionName Name of command line option whose value is \p
+    /// convOutputOptions.  Used as diagnostic information only.
+    ///
+    /// \param[in] getPhaseName Callable object for converting component
+    /// indices into human readable component names.
     void startThread(const EclipseState& eclState,
                      std::string_view    convOutputOptions,
                      std::string_view    optionName,
                      ConvergenceOutputThread::ComponentToPhaseName getPhaseName);
 
+    /// Create convergence output requests.
+    ///
+    /// Must not be called before startThread() or after endThread().
+    ///
+    /// Only those reports which have not previously been emitted will be
+    /// output, and only if the run actually requests convergence output at
+    /// the non-linear iteration level.
+    ///
+    /// \param[in] reports All step reports generated in the simulation run
+    /// so far.  Class SimulatorConvergenceOutput maintains a record of
+    /// which reports have been emitted.
     void write(const std::vector<StepReport>& reports);
 
+    /// Request that convergence output thread be shut down.
+    ///
+    /// No additional output requests should be submitted to write() once
+    /// this function is called.
     void endThread();
 
 private:
+    /// Number of step reports which have already been output.
     std::vector<StepReport>::size_type alreadyReportedSteps_ = 0;
 
+    /// Communication channel between main thread creating output requests
+    /// and output thread actually writing those requests to file on disk.
+    ///
+    /// Nullopt unless convergence output has been requested at the
+    /// non-linear iteration level.
     std::optional<ConvergenceReportQueue> convergenceOutputQueue_{};
+
+    /// Output request controller object.
+    ///
+    /// Nullopt unless convergence output has been requested at the
+    /// non-linear iteration level.
     std::optional<ConvergenceOutputThread> convergenceOutputObject_{};
+
+    /// Output request thread.
+    ///
+    /// Calls output writing member functions on the
+    /// convergenceOutputObject_.
+    ///
+    /// Nullopt unless convergence output has been requested at the
+    /// non-linear iteration level.
     std::optional<std::thread> convergenceOutputThread_{};
 };
 

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -139,7 +139,6 @@ public:
     /// \param[in] threshold_pressures_by_face   if nonempty, threshold pressures that inhibit flow
     explicit SimulatorFullyImplicitBlackoil(Simulator& simulator)
         : simulator_(simulator)
-        , convergence_output_(simulator_.vanguard().eclState())
         , serializer_(*this,
                       FlowGenericVanguard::comm(),
                       simulator_.vanguard().eclState().getIOConfig(),
@@ -160,8 +159,9 @@ public:
                 { return std::string_view { compNames.name(compIdx) }; }
             };
 
-            convergence_output_.
-                startThread(Parameters::Get<Parameters::OutputExtraConvergenceInfo>(),
+            this->convergence_output_.
+                startThread(this->simulator_.vanguard().eclState(),
+                            Parameters::Get<Parameters::OutputExtraConvergenceInfo>(),
                             R"(OutputExtraConvergenceInfo (--output-extra-convergence-info))",
                             getPhaseName);
         }
@@ -650,7 +650,7 @@ protected:
     std::unique_ptr<time::StopWatch> totalTimer_;
     std::unique_ptr<TimeStepper> adaptiveTimeStepping_;
 
-    SimulatorConvergenceOutput convergence_output_;
+    SimulatorConvergenceOutput convergence_output_{};
 
 #ifdef RESERVOIR_COUPLING_ENABLED
     bool slaveMode_{false};


### PR DESCRIPTION
While here, also add Doxygen style documentation to the data members and member functions of class `SimulatorConvergenceOutput`.