### PR TITLE
Added set -e to hipify_file.sh

### DIFF
--- a/bin/hipify_file.sh
+++ b/bin/hipify_file.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e # Make sure the script fails if a command fails
 
 # the script is intended to be run like this: bash hipify_file.sh ${PROJECT_BUILD_DIR} ${PROJECT_BINARY_DIR}
 # it should be run automatically on the correct files through cmake


### PR DESCRIPTION
If something fails to hipify (eg. because `hipify_perl` is misisng), the `hipify_file.sh` script will not fail but simply carry on. This PR adds the `set -e` command at the start of the script to make it return a non-zero return value if any command fails. 