### PR TITLE
Support WCONHIST/WCONINJ in ACTIONX

### DIFF
--- a/opm/simulators/wells/ALQState.cpp
+++ b/opm/simulators/wells/ALQState.cpp
@@ -42,6 +42,12 @@ ALQState<Scalar> ALQState<Scalar>::serializationTestObject()
 }
 
 template<class Scalar>
+void ALQState<Scalar>::insert(const std::string& wname)
+{
+    this->current_alq_.emplace(wname, 0.0);
+}
+
+template<class Scalar>
 Scalar ALQState<Scalar>::get(const std::string& wname) const
 {
     auto iter = this->current_alq_.find(wname);

--- a/opm/simulators/wells/ALQState.hpp
+++ b/opm/simulators/wells/ALQState.hpp
@@ -37,6 +37,7 @@ public:
 
     Scalar get(const std::string& wname) const;
     void update_default(const std::string& wname, Scalar value);
+    void insert(const std::string& wname);
     void set(const std::string& wname, Scalar value);
     bool oscillation(const std::string& wname) const;
     void update_count(const std::string& wname, bool increase);

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -867,7 +867,10 @@ updateEclWellsConstraints(const int              timeStepIdx,
         auto& ws = this->wellState().well(wellIdx);
 
         ws.updateStatus(well.getStatus());
-        ws.update_targets(well, st);
+        auto switchToProducer = ws.update_type_and_targets(well, st);
+        if (switchToProducer) {
+            this->wellState().switchToProducer(well.name());
+        }
     });
 }
 

--- a/opm/simulators/wells/PerfData.cpp
+++ b/opm/simulators/wells/PerfData.cpp
@@ -64,6 +64,7 @@ void PerfData<Scalar>::prepareInjectorContainers()
     this->water_velocity.resize(num_perf);
     this->filtrate_data.resize(num_perf);
 }
+
 template<class Scalar>
 PerfData<Scalar> PerfData<Scalar>::serializationTestObject()
 {

--- a/opm/simulators/wells/PerfData.cpp
+++ b/opm/simulators/wells/PerfData.cpp
@@ -51,13 +51,19 @@ PerfData<Scalar>::PerfData(const std::size_t num_perf,
     , ecl_index(num_perf)
 {
     if (injector) {
-        this->water_throughput.resize(num_perf);
-        this->skin_pressure.resize(num_perf);
-        this->water_velocity.resize(num_perf);
-        this->filtrate_data.resize(num_perf);
+        prepareInjectorContainers();
     }
 }
 
+template<class Scalar>
+void PerfData<Scalar>::prepareInjectorContainers()
+{
+    auto num_perf = pressure.size();
+    this->water_throughput.resize(num_perf);
+    this->skin_pressure.resize(num_perf);
+    this->water_velocity.resize(num_perf);
+    this->filtrate_data.resize(num_perf);
+}
 template<class Scalar>
 PerfData<Scalar> PerfData<Scalar>::serializationTestObject()
 {

--- a/opm/simulators/wells/PerfData.hpp
+++ b/opm/simulators/wells/PerfData.hpp
@@ -48,6 +48,11 @@ public:
     bool empty() const;
     bool try_assign(const PerfData& other);
 
+    /// \brief Make containers valid for injectors
+    ///
+    /// Needed if a producer is switched to an injector,
+    void prepareInjectorContainers();
+
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -329,25 +329,21 @@ update_type_and_targets(const Well& ecl_well, const SummaryState& st)
     bool switchedToProducer = false;
     if (this->producer != ecl_well.isProducer()) {
         // type has changed due to ACTIONX
-        // Make sure that we consistent with the ecl_well
+        // Make sure that we are consistent with the ecl_well
         switchedToProducer = this->producer = ecl_well.isProducer();
         if (switchedToProducer) {
             this->production_cmode = ecl_well.productionControls(st).cmode;
-            // clear injection rates
-            for(auto&& val: this->surface_rates) {
-                if (val > 0.0) {
-                    val = 0.0;
-                }
-            }
+            // clear injection rates (those are positive)
+            std::transform(this->surface_rates.begin(), this->surface_rates.end(),
+                           this->surface_rates.begin(),
+                           [](const Scalar& val){ return std::min(Scalar(), val);});
         } else {
             perf_data.prepareInjectorContainers();
             this->injection_cmode = ecl_well.injectionControls(st).cmode;
-            // clear production rates
-            for(auto&& val: this->surface_rates) {
-                if (val < 0.0) {
-                    val = 0.0;
-                }
-            }
+            // clear production rates (those are negative)
+            std::transform(this->surface_rates.begin(), this->surface_rates.end(),
+                           this->surface_rates.begin(),
+                           [](const Scalar& val){ return std::max(Scalar(), val);});
         }
     }
 

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -126,7 +126,12 @@ public:
     void reset_connection_factors(const std::vector<PerforationData<Scalar>>& new_perf_data);
     void update_producer_targets(const Well& ecl_well, const SummaryState& st);
     void update_injector_targets(const Well& ecl_well, const SummaryState& st);
-    void update_targets(const Well& ecl_well, const SummaryState& st);
+    /// \brief update the type of the well and the targets.
+    ///
+    /// This called after ACTIONX is executed to update well rates. The new status is
+    /// in ecl_well and st.
+    /// \return whether well was switched to a producer
+    bool update_type_and_targets(const Well& ecl_well, const SummaryState& st);
     void updateStatus(WellStatus status);
     void init_timestep(const SingleWellState& other);
     void shut();

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -277,6 +277,10 @@ public:
     void shutWell(int well_index);
     void stopWell(int well_index);
 
+    void switchToProducer(const std::string& name) {
+        alq_state.insert(name);
+    }
+
     /// The number of phases present.
     int numPhases() const
     {


### PR DESCRIPTION
Downstream of OPM/opm-common#4527

Comparison with other simulator looks good for the test cases actionx/ACTIONX_WCONINJH.DATA actionx/ACTIONX_WCONHIST.DATA

I needed to make the container set up for producers/injector to work for the other types.  This here seems to work if the ACTIONX is executed at the end of a report step. I am bit skeptical whether this also works during the time stepping. Maybe there is  a better way?