### PR TITLE
Also solve std for every inner iterations as default

### DIFF
--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -100,7 +100,7 @@ struct TolerancePressureMsWells { static constexpr Scalar value = 0.01*1e5; };
 template<class Scalar>
 struct MaxPressureChangeMsWells { static constexpr Scalar value = 10*1e5; };
 
-struct MaxNewtonIterationsWithInnerWellIterations { static constexpr int value = 8; };
+struct MaxNewtonIterationsWithInnerWellIterations { static constexpr int value = 99; };
 struct MaxInnerIterMsWells { static constexpr int value = 100; };
 struct MaxInnerIterWells { static constexpr int value = 50; };
 struct ShutUnsolvableWells { static constexpr bool value = true; };

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -851,7 +851,7 @@ namespace Opm
 
         // only use inner well iterations for the first newton iterations.
         const int iteration_idx = simulator.model().newtonMethod().numIterations();
-        if (iteration_idx < this->param_.max_niter_inner_well_iter_ || this->well_ecl_.isMultiSegment()) {
+        if (iteration_idx < this->param_.max_niter_inner_well_iter_) {
             const auto& ws = well_state.well(this->indexOfWell());
             const auto pmode_orig = ws.production_cmode;
             const auto imode_orig = ws.injection_cmode;


### PR DESCRIPTION
In master, we always solve inner iterations for MSwells but not StdWells. The lack of inner iterations for StdWells can lead to convergence issues for Newton.  This changes the default value to 99 and removes the check for MSWells, thus allowing not to solve MSWells during some Newton iterations.  