### PR TITLE
Support for RTPSCHED WELLS=2

### DIFF
--- a/opm/simulators/flow/CollectDataOnIORank.hpp
+++ b/opm/simulators/flow/CollectDataOnIORank.hpp
@@ -77,6 +77,7 @@ public:
     // gather solution to rank 0 for EclipseWriter
     void collect(const data::Solution&                                localCellData,
                  const std::map<std::pair<std::string, int>, double>& localBlockData,
+                 std::map<std::pair<std::string, int>, double>&       localExtraBlockData,
                  const data::Wells&                                   localWellData,
                  const data::WellBlockAveragePressures&               localWBPData,
                  const data::GroupAndNetworkValues&                   localGroupAndNetworkData,

--- a/opm/simulators/flow/CollectDataOnIORank_impl.hpp
+++ b/opm/simulators/flow/CollectDataOnIORank_impl.hpp
@@ -968,6 +968,7 @@ template <class Grid, class EquilGrid, class GridView>
 void CollectDataOnIORank<Grid,EquilGrid,GridView>::
 collect(const data::Solution&                                localCellData,
         const std::map<std::pair<std::string, int>, double>& localBlockData,
+        std::map<std::pair<std::string, int>, double>&       extraBlockData,
         const data::Wells&                                   localWellData,
         const data::WellBlockAveragePressures&               localWBPData,
         const data::GroupAndNetworkValues&                   localGroupAndNetworkData,
@@ -979,6 +980,7 @@ collect(const data::Solution&                                localCellData,
 {
     globalCellData_ = {};
     globalBlockData_.clear();
+    std::map<std::pair<std::string,int>,double> globalExtraBlockData;
     globalWellData_.clear();
     globalWBPData_.values.clear();
     globalGroupAndNetworkData_.clear();
@@ -1033,6 +1035,12 @@ collect(const data::Solution&                                localCellData,
                 this->isIORank()
     };
 
+    PackUnPackBlockData packUnpackExtraBlockData {
+        extraBlockData,
+        globalExtraBlockData,
+        this->isIORank()
+    };
+
     PackUnPackWBPData packUnpackWBPData {
         localWBPData,
         this->globalWBPData_,
@@ -1073,6 +1081,7 @@ collect(const data::Solution&                                localCellData,
     toIORankComm_.exchange(packUnpackWellData);
     toIORankComm_.exchange(packUnpackGroupAndNetworkData);
     toIORankComm_.exchange(packUnpackBlockData);
+    toIORankComm_.exchange(packUnpackExtraBlockData);
     toIORankComm_.exchange(packUnpackWBPData);
     toIORankComm_.exchange(packUnpackAquiferData);
     toIORankComm_.exchange(packUnpackWellTestState);
@@ -1084,6 +1093,8 @@ collect(const data::Solution&                                localCellData,
     // make sure every process is on the same page
     toIORankComm_.barrier();
 #endif
+
+    extraBlockData = globalExtraBlockData;
 }
 
 template <class Grid, class EquilGrid, class GridView>

--- a/opm/simulators/flow/CollectDataOnIORank_impl.hpp
+++ b/opm/simulators/flow/CollectDataOnIORank_impl.hpp
@@ -1017,14 +1017,14 @@ collect(const data::Solution&                                localCellData,
 
     PackUnPackWellData packUnpackWellData {
         localWellData,
-                this->globalWellData_,
-                this->isIORank()
+        this->globalWellData_,
+        this->isIORank()
     };
 
     PackUnPackGroupAndNetworkValues packUnpackGroupAndNetworkData {
         localGroupAndNetworkData,
-                this->globalGroupAndNetworkData_,
-                this->isIORank()
+        this->globalGroupAndNetworkData_,
+        this->isIORank()
     };
 
     PackUnPackBlockData packUnpackBlockData {
@@ -1041,8 +1041,8 @@ collect(const data::Solution&                                localCellData,
 
     PackUnPackAquiferData packUnpackAquiferData {
         localAquiferData,
-                this->globalAquiferData_,
-                this->isIORank()
+        this->globalAquiferData_,
+        this->isIORank()
     };
 
     PackUnPackWellTestState packUnpackWellTestState {

--- a/opm/simulators/flow/DamarisWriter.hpp
+++ b/opm/simulators/flow/DamarisWriter.hpp
@@ -448,7 +448,7 @@ private:
         OPM_BEGIN_PARALLEL_TRY_CATCH();
         {
         OPM_TIMEBLOCK(prepareCellBasedData);
-        damarisOutputModule_->setupExtractors();
+        damarisOutputModule_->setupExtractors(isSubStep, reportStepNum);
         for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {
             elemCtx.updatePrimaryStencil(elem);
             elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);

--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -33,10 +33,12 @@
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
+#include <opm/input/eclipse/Schedule/RPTConfig.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -399,7 +399,7 @@ public:
                                                timer.simulationTimeElapsed(),
                                                rstep,
                                                timer.currentDateTime());
-                outputModule_->outputProdLog(rstep - 1);
+                outputModule_->outputProdLog(rstep - 1, rpt.at("WELLS") > 1);
                 outputModule_->outputInjLog(rstep - 1, rpt.at("WELLS") > 1);
                 outputModule_->outputCumLog(rstep - 1);
             }

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -401,7 +401,7 @@ public:
                                                timer.currentDateTime());
                 outputModule_->outputProdLog(rstep - 1, rpt.at("WELLS") > 1);
                 outputModule_->outputInjLog(rstep - 1, rpt.at("WELLS") > 1);
-                outputModule_->outputCumLog(rstep - 1);
+                outputModule_->outputCumLog(rstep - 1, rpt.at("WELLS") > 1);
             }
 
             outputModule_->outputFipAndResvLog(inplace_,

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -203,7 +203,7 @@ public:
     {
         OPM_TIMEBLOCK(evalSummaryState);
         const int reportStepNum = simulator_.episodeIndex() + 1;
-        
+
         /*
           The summary data is not evaluated for timestep 0, that is
           implemented with a:
@@ -221,7 +221,7 @@ public:
           "Correct" in this context means unchanged behavior, might very
           well be more correct to actually remove this if test.
         */
-        
+
         if (reportStepNum == 0)
             return;
 
@@ -274,22 +274,22 @@ public:
             OPM_END_PARALLEL_TRY_CATCH("Collect to I/O rank: ",
                                        this->simulator_.vanguard().grid().comm());
         }
-        
+
 
         std::map<std::string, double> miscSummaryData;
         std::map<std::string, std::vector<double>> regionData;
         Inplace inplace;
-        
+
         {
             OPM_TIMEBLOCK(outputFipLogAndFipresvLog);
 
             inplace = outputModule_->calc_inplace(miscSummaryData, regionData, simulator_.gridView().comm());
-            
+
             if (this->collectOnIORank_.isIORank()){
                 inplace_ = inplace;
             }
         }
-        
+
         // Add TCPU
         if (totalCpuTime != 0.0) {
             miscSummaryData["TCPU"] = totalCpuTime;
@@ -379,28 +379,35 @@ public:
 
             if (this->collectOnIORank_.isIORank()) {
                 inplace_ = inplace;
-                
+
                 outputModule_->outputFipAndResvLog(inplace_, 0, 0.0, start_time,
                                                   false, simulator_.gridView().comm());
             }
         }
     }
 
-    void writeReports(const SimulatorTimer& timer) {
+    void writeReports(const SimulatorTimer& timer)
+    {
         auto rstep = timer.reportStepNum();
 
-        if ((rstep > 0) && (this->collectOnIORank_.isIORank())){
-
+        if ((rstep > 0) && (this->collectOnIORank_.isIORank())) {
             const auto& rpt = this->schedule_[rstep-1].rpt_config.get();
             if (rpt.contains("WELLS") && rpt.at("WELLS") > 0) {
-                outputModule_->outputTimeStamp("WELLS", timer.simulationTimeElapsed(), rstep, timer.currentDateTime());
-                outputModule_->outputProdLog(rstep-1);
-                outputModule_->outputInjLog(rstep-1);
-                outputModule_->outputCumLog(rstep-1);
+                outputModule_->outputTimeStamp("WELLS",
+                                               timer.simulationTimeElapsed(),
+                                               rstep,
+                                               timer.currentDateTime());
+                outputModule_->outputProdLog(rstep - 1);
+                outputModule_->outputInjLog(rstep - 1);
+                outputModule_->outputCumLog(rstep - 1);
             }
 
-            outputModule_->outputFipAndResvLog(inplace_, rstep, timer.simulationTimeElapsed(),
-                                               timer.currentDateTime(), false, simulator_.gridView().comm());
+            outputModule_->outputFipAndResvLog(inplace_,
+                                               rstep,
+                                               timer.simulationTimeElapsed(),
+                                               timer.currentDateTime(),
+                                               false,
+                                               simulator_.gridView().comm());
 
 
             OpmLog::note("");   // Blank line after all reports.
@@ -469,7 +476,7 @@ public:
         if (this->collectOnIORank_.isIORank()) {
             const Scalar curTime = simulator_.time() + simulator_.timeStepSize();
             const Scalar nextStepSize = simulator_.problem().nextTimeStepSize();
-            std::optional<int> timeStepIdx; 
+            std::optional<int> timeStepIdx;
             if (Parameters::Get<Parameters::EnableWriteAllSolutions>()) {
                 timeStepIdx = simulator_.timeStepIndex();
             }

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -247,8 +247,10 @@ public:
         if (this->collectOnIORank_.isParallel()) {
             OPM_BEGIN_PARALLEL_TRY_CATCH()
 
+            std::map<std::pair<std::string,int>,double> dummy;
             this->collectOnIORank_.collect({},
                                            outputModule_->getBlockData(),
+                                           dummy,
                                            localWellData,
                                            localWBP,
                                            localGroupAndNetworkData,
@@ -458,6 +460,7 @@ public:
 
             this->collectOnIORank_.collect(localCellData,
                                            this->outputModule_->getBlockData(),
+                                           this->outputModule_->getExtraBlockData(),
                                            localWellData,
                                            /* wbpData = */ {},
                                            localGroupAndNetworkData,
@@ -732,7 +735,7 @@ private:
             OPM_TIMEBLOCK(prepareCellBasedData);
 
             this->outputModule_->prepareDensityAccumulation();
-            this->outputModule_->setupExtractors();
+            this->outputModule_->setupExtractors(isSubStep, reportStepNum);
             for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {
                 elemCtx.updatePrimaryStencil(elem);
                 elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -400,7 +400,7 @@ public:
                                                rstep,
                                                timer.currentDateTime());
                 outputModule_->outputProdLog(rstep - 1);
-                outputModule_->outputInjLog(rstep - 1);
+                outputModule_->outputInjLog(rstep - 1, rpt.at("WELLS") > 1);
                 outputModule_->outputCumLog(rstep - 1);
             }
 

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -214,9 +214,13 @@ outputProdLog(std::size_t reportStepNum)
 
 template<class FluidSystem>
 void GenericOutputBlackoilModule<FluidSystem>::
-outputInjLog(std::size_t reportStepNum)
+outputInjLog(std::size_t reportStepNum,
+             const bool connData)
 {
-    this->logOutput_.injection(reportStepNum);
+    this->logOutput_.injection(reportStepNum,
+                               connData
+                                   ? this->extraBlockData_
+                                   : decltype(this->extraBlockData_){});
 }
 
 template<class FluidSystem>

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -200,9 +200,10 @@ accumulateDensityParallel()
 
 template<class FluidSystem>
 void GenericOutputBlackoilModule<FluidSystem>::
-outputCumLog(std::size_t reportStepNum)
+outputCumLog(std::size_t reportStepNum,
+             const bool connData)
 {
-    this->logOutput_.cumulative(reportStepNum);
+    this->logOutput_.cumulative(reportStepNum, connData);
 }
 
 template<class FluidSystem>

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -38,6 +38,7 @@
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 #include <opm/input/eclipse/Schedule/RFTConfig.hpp>
+#include <opm/input/eclipse/Schedule/RPTConfig.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
@@ -1156,6 +1157,23 @@ setupBlockData(std::function<bool(int)> isCartIdxOnThisRank)
                                      std::forward_as_tuple(node.keyword(),
                                                            node.number()),
                                      std::forward_as_tuple(0.0));
+        }
+    }
+}
+
+template<class FluidSystem>
+void GenericOutputBlackoilModule<FluidSystem>::
+setupExtraBlockData(const std::size_t        reportStepNum,
+                    std::function<bool(int)> isCartIdxOnThisRank)
+{
+    for (const auto& well : schedule_.getWells(reportStepNum - 1)) {
+        for (const auto& connection : well.getConnections()) {
+            if (isCartIdxOnThisRank(connection.global_index())) {
+                this->extraBlockData_.emplace(std::piecewise_construct,
+                                              std::forward_as_tuple("BPR",
+                                                                    connection.global_index() + 1),
+                                              std::forward_as_tuple(0.0));
+            }
         }
     }
 }

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -207,9 +207,13 @@ outputCumLog(std::size_t reportStepNum)
 
 template<class FluidSystem>
 void GenericOutputBlackoilModule<FluidSystem>::
-outputProdLog(std::size_t reportStepNum)
+outputProdLog(std::size_t reportStepNum,
+              const bool connData)
 {
-    this->logOutput_.production(reportStepNum);
+    this->logOutput_.production(reportStepNum,
+                                connData
+                                    ? this->extraBlockData_
+                                    : decltype(this->extraBlockData_){});
 }
 
 template<class FluidSystem>

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -102,7 +102,8 @@ public:
     void outputCumLog(std::size_t reportStepNum);
 
     // write production report to output
-    void outputProdLog(std::size_t reportStepNum);
+    void outputProdLog(std::size_t reportStepNum,
+                       const bool connData);
 
     // write injection report to output
     void outputInjLog(std::size_t reportStepNum,

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -213,6 +213,11 @@ public:
         return blockData_;
     }
 
+    std::map<std::pair<std::string, int>, double>& getExtraBlockData()
+    {
+        return extraBlockData_;
+    }
+
     const Inplace& initialInplace() const
     {
         return this->initialInplace_.value();
@@ -318,6 +323,8 @@ protected:
     static Scalar sum(const ScalarBuffer& v);
 
     void setupBlockData(std::function<bool(int)> isCartIdxOnThisRank);
+    void setupExtraBlockData(const std::size_t        reportStepNum,
+                             std::function<bool(int)> isCartIdxOnThisRank);
 
     virtual bool isDefunctParallelWell(std::string wname) const = 0;
 
@@ -420,6 +427,9 @@ protected:
     RSTConv rst_conv_; //!< Helper class for RPTRST CONV
 
     std::map<std::pair<std::string, int>, double> blockData_;
+    // Extra block data required for non-summary output reasons
+    // Example is the block pressures for RPTSCHED WELLS=2
+    std::map<std::pair<std::string, int>, double> extraBlockData_;
 
     std::optional<Inplace> initialInplace_;
     bool local_data_valid_{false};

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -105,7 +105,8 @@ public:
     void outputProdLog(std::size_t reportStepNum);
 
     // write injection report to output
-    void outputInjLog(std::size_t reportStepNum);
+    void outputInjLog(std::size_t reportStepNum,
+                      const bool connData);
 
     // calculate Initial Fluid In Place
     Inplace calc_initial_inplace(const Parallel::Communication& comm);

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -99,7 +99,8 @@ public:
     void accumulateDensityParallel();
 
     // write cumulative production and injection reports to output
-    void outputCumLog(std::size_t reportStepNum);
+    void outputCumLog(std::size_t reportStepNum,
+                      const bool connData);
 
     // write production report to output
     void outputProdLog(std::size_t reportStepNum,

--- a/opm/simulators/flow/LogOutputHelper.cpp
+++ b/opm/simulators/flow/LogOutputHelper.cpp
@@ -166,7 +166,8 @@ LogOutputHelper<Scalar>::LogOutputHelper(const EclipseState& eclState,
 
 template<class Scalar>
 void LogOutputHelper<Scalar>::
-cumulative(const std::size_t reportStepNum) const
+cumulative(const std::size_t reportStepNum,
+           const bool        withConns) const
 {
     this->beginCumulativeReport_();
 
@@ -190,7 +191,7 @@ cumulative(const std::size_t reportStepNum) const
         values[Ix::GasInj]          = isField ? st.get("FGIT", 0.0) : st.get_group_var(gname, "GGIT", 0.0);
         values[Ix::FluidResVolInj]  = isField ? st.get("FVIT", 0.0) : st.get_group_var(gname, "GVIT", 0.0);
 
-        this->outputCumulativeReportRecord_(values, names);
+        this->outputCumulativeReportRecord_(values, names, {});
     }
 
     for (const auto& wname : this->schedule_.wellNames(reportStepNum)) {
@@ -236,7 +237,24 @@ cumulative(const std::size_t reportStepNum) const
         values[Ix::GasInj]          = st.get_well_var(wname, "WGIT", 0.0);
         values[Ix::FluidResVolInj]  = st.get_well_var(wname, "WVIT", 0.0);
 
-        this->outputCumulativeReportRecord_(values, names);
+        std::vector<ConnData> connData;
+        if (withConns) {
+            for (const auto& connection : well.getConnections()) {
+                ConnData& conn = connData.emplace_back(connection);
+                conn.data.resize(WellCumDataType::numWCValues);
+                const auto gindex = connection.global_index() + 1;
+                conn.data[Ix::OilProd]         = conn_value_or_zero(st, wname, "COPT", gindex);
+                conn.data[Ix::WaterProd]       = conn_value_or_zero(st, wname, "CWPT", gindex);
+                conn.data[Ix::GasProd]         = conn_value_or_zero(st, wname, "CGPT", gindex);
+                conn.data[Ix::FluidResVolProd] = conn_value_or_zero(st, wname, "CVPT", gindex);
+                conn.data[Ix::OilInj]          = conn_value_or_zero(st, wname, "COIT", gindex);
+                conn.data[Ix::WaterInj]        = conn_value_or_zero(st, wname, "CWIT", gindex);
+                conn.data[Ix::GasInj]          = conn_value_or_zero(st, wname, "CGIT", gindex);
+                conn.data[Ix::FluidResVolInj]  = conn_value_or_zero(st, wname, "CVIT", gindex);
+            }
+        }
+
+        this->outputCumulativeReportRecord_(values, names, connData);
     }
 
     this->endCumulativeReport_();
@@ -705,7 +723,8 @@ void LogOutputHelper<Scalar>::endCumulativeReport_() const
 template<class Scalar>
 void LogOutputHelper<Scalar>::
 outputCumulativeReportRecord_(const std::vector<Scalar>& wellCum,
-                              const std::vector<std::string>& wellCumNames) const
+                              const std::vector<std::string>& wellCumNames,
+                              const std::vector<ConnData>& connData) const
 {
     std::ostringstream ss;
 
@@ -720,30 +739,45 @@ outputCumulativeReportRecord_(const std::vector<Scalar>& wellCum,
                           "");
     }
 
-    auto scaledValue = [&wellCum](const auto quantity)
+    auto scaledValue = [](const auto& wc, const auto quantity)
     {
         // Unit M*
-        return wellCum[quantity] / 1000.0;
+        return wc[quantity] / 1000.0;
     };
 
-    auto scaledGasValue = [&wellCum](const auto quantity)
+    auto scaledGasValue = [](const auto& wc, const auto quantity)
     {
         // Unit MM*
-        return wellCum[quantity] / (1000.0 * 1000.0);
+        return wc[quantity] / (1000.0 * 1000.0);
     };
 
     ss << fmt::format("{:>8}:{:>4}:{:>11.1f}:{:>11.1f}:{:>11.1f}:{:>11.1f}:"
                       "{:>11.1f}:{:>11.1f}:{:>11.1f}:{:>11.1f}:",
                       wellCumNames[WellCumDataType::WCId::WellType],
                       wellCumNames[WellCumDataType::WCId::WellCTRL],
-                      scaledValue(WellCumDataType::WCId::OilProd),
-                      scaledValue(WellCumDataType::WCId::WaterProd),
-                      scaledGasValue(WellCumDataType::WCId::GasProd),
-                      scaledValue(WellCumDataType::WCId::FluidResVolProd),
-                      scaledValue(WellCumDataType::WCId::OilInj),
-                      scaledValue(WellCumDataType::WCId::WaterInj),
-                      scaledGasValue(WellCumDataType::WCId::GasInj),
-                      scaledValue(WellCumDataType::WCId::FluidResVolInj));
+                      scaledValue(wellCum, WellCumDataType::WCId::OilProd),
+                      scaledValue(wellCum, WellCumDataType::WCId::WaterProd),
+                      scaledGasValue(wellCum, WellCumDataType::WCId::GasProd),
+                      scaledValue(wellCum, WellCumDataType::WCId::FluidResVolProd),
+                      scaledValue(wellCum, WellCumDataType::WCId::OilInj),
+                      scaledValue(wellCum, WellCumDataType::WCId::WaterInj),
+                      scaledGasValue(wellCum, WellCumDataType::WCId::GasInj),
+                      scaledValue(wellCum, WellCumDataType::WCId::FluidResVolInj));
+
+    for (const auto& conn : connData) {
+        ss << fmt::format("\n:  BLOCK :{0:>3},{1:>3},{2:>3}:{3:>8}:{3:>4}:",
+                          conn.I, conn.J, conn.K, "")
+           << fmt::format("{:>11.1f}:{:>11.1f}:{:>11.1f}:{:>11.1f}:"
+                          "{:>11.1f}:{:>11.1f}:{:>11.1f}:{:>11.1f}:",
+                          scaledValue(conn.data, WellCumDataType::WCId::OilProd),
+                          scaledValue(conn.data, WellCumDataType::WCId::WaterProd),
+                          scaledGasValue(conn.data, WellCumDataType::WCId::GasProd),
+                          scaledValue(conn.data, WellCumDataType::WCId::FluidResVolProd),
+                          scaledValue(conn.data, WellCumDataType::WCId::OilInj),
+                          scaledValue(conn.data, WellCumDataType::WCId::WaterInj),
+                          scaledGasValue(conn.data, WellCumDataType::WCId::GasInj),
+                          scaledValue(conn.data, WellCumDataType::WCId::FluidResVolInj));
+    }
 
     OpmLog::note(ss.str());
 }

--- a/opm/simulators/flow/LogOutputHelper.hpp
+++ b/opm/simulators/flow/LogOutputHelper.hpp
@@ -25,6 +25,7 @@
 #include <opm/output/eclipse/Inplace.hpp>
 
 #include <cstddef>
+#include <map>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -33,6 +34,7 @@
 
 namespace Opm {
 
+class Connection;
 class EclipseState;
 class Inplace;
 class Schedule;
@@ -62,7 +64,8 @@ public:
     void fipResv(const Inplace& inplace, const std::string& name) const;
 
     //! \brief Write injection report to output.
-    void injection(const std::size_t reportStepNum) const;
+    void injection(const std::size_t reportStepNum,
+                   const std::map<std::pair<std::string,int>, double>& block_pressures) const;
 
     //! \brief Write production report to output.
     void production(const std::size_t reportStepNum) const;
@@ -70,6 +73,14 @@ public:
     void timeStamp(const std::string& lbl, double elapsed, int rstep, boost::posix_time::ptime currentDate) const;
 
 private:
+    struct ConnData
+    {
+        ConnData(const Connection& conn);
+
+        int I, J, K;
+        std::vector<Scalar> data;
+    };
+
     void beginCumulativeReport_() const;
     void endCumulativeReport_() const;
     void outputCumulativeReportRecord_(const std::vector<Scalar>& wellCum,
@@ -87,7 +98,8 @@ private:
     void beginInjectionReport_() const;
     void endInjectionReport_() const;
     void outputInjectionReportRecord_(const std::vector<Scalar>& wellInj,
-                                      const std::vector<std::string>& wellInjNames) const;
+                                      const std::vector<std::string>& wellInjNames,
+                                      const std::vector<ConnData>& connData) const;
 
     void beginProductionReport_() const;
     void endProductionReport_() const;
@@ -130,7 +142,9 @@ private:
             GasRate = 4, // GR
             FluidResVol = 5, // FRV
             BHP = 6, // BHP
+            CPR = 6, // Connection pressure
             THP = 7, // THP
+            BPR = 7, // Block pressures for connections
             SteadyStateII = 8, // SteadyStateII
             WellName = 0, // WName
             CTRLModeOil = 1, // CTRLo

--- a/opm/simulators/flow/LogOutputHelper.hpp
+++ b/opm/simulators/flow/LogOutputHelper.hpp
@@ -49,7 +49,8 @@ public:
                     const std::string& moduleVersionName);
 
     //! \brief Write cumulative production and injection reports to output.
-    void cumulative(const std::size_t reportStepNum) const;
+    void cumulative(const std::size_t reportStepNum,
+                    const bool withConns) const;
 
     //! \brief Write error report to output.
     void error(const std::vector<int>& failedCellsPbub,
@@ -88,7 +89,8 @@ private:
     void beginCumulativeReport_() const;
     void endCumulativeReport_() const;
     void outputCumulativeReportRecord_(const std::vector<Scalar>& wellCum,
-                                       const std::vector<std::string>& wellCumNames) const;
+                                       const std::vector<std::string>& wellCumNames,
+                                       const std::vector<ConnData>& connData) const;
 
     void outputRegionFluidInPlace_(std::unordered_map<Inplace::Phase, Scalar> oip,
                                    std::unordered_map<Inplace::Phase, Scalar> cip,

--- a/opm/simulators/flow/LogOutputHelper.hpp
+++ b/opm/simulators/flow/LogOutputHelper.hpp
@@ -68,9 +68,13 @@ public:
                    const std::map<std::pair<std::string,int>, double>& block_pressures) const;
 
     //! \brief Write production report to output.
-    void production(const std::size_t reportStepNum) const;
+    void production(const std::size_t reportStepNum,
+                    const std::map<std::pair<std::string,int>, double>& block_pressures) const;
 
-    void timeStamp(const std::string& lbl, double elapsed, int rstep, boost::posix_time::ptime currentDate) const;
+    void timeStamp(const std::string& lbl,
+                   double elapsed,
+                   int rstep,
+                   boost::posix_time::ptime currentDate) const;
 
 private:
     struct ConnData
@@ -104,7 +108,8 @@ private:
     void beginProductionReport_() const;
     void endProductionReport_() const;
     void outputProductionReportRecord_(const std::vector<Scalar>& wellProd,
-                                       const std::vector<std::string>& wellProdNames) const;
+                                       const std::vector<std::string>& wellProdNames,
+                                       const std::vector<ConnData>& connData) const;
 
     void fipUnitConvert_(std::unordered_map<Inplace::Phase, Scalar>& fip) const;
     void pressureUnitConvert_(Scalar& pav) const;
@@ -169,7 +174,9 @@ private:
             GasOilRatio = 7, // GOR
             WatGasRatio = 8, // WGR
             BHP = 9, // BHP
+            CPR = 9, // Connection pressure
             THP = 10, // THP
+            BPR = 10, // Block pressures for connections
             SteadyStatePI = 11, // SteadyStatePI
             WellName = 0, // WName
             CTRLMode = 1, // CTRL

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -179,7 +179,8 @@ public:
     }
 
     //! \brief Setup list of active element-level data extractors
-    void setupExtractors()
+    void setupExtractors(const bool         /*isSubStep*/,
+                         const std::size_t  /*reportStepNum*/)
     {
         using Entry = typename Extractor::Entry;
         using ExtractContext = typename Extractor::Context;

--- a/tests/test_LogOutputHelper.cpp
+++ b/tests/test_LogOutputHelper.cpp
@@ -199,7 +199,89 @@ BOOST_FIXTURE_TEST_CASE(Cumulative, LogNoteFixture)
     st.update_well_var("INJ", "WVIT", 31.0e3);
 
     Opm::LogOutputHelper<double> helper(eclState, schedule, st, "dummy version");
-    helper.cumulative(0);
+    helper.cumulative(0, false);
+
+    const auto data = trimStream(str);
+    BOOST_CHECK_EQUAL(data, reference);
+}
+
+BOOST_FIXTURE_TEST_CASE(CumulativeW2, LogNoteFixture)
+{
+    const auto reference = std::string {
+        R"(============================================== CUMULATIVE PRODUCTION/INJECTION TOTALS ==============================================
+:  WELL  : LOCATION  :  WELL  :CTRL:    OIL    :   WATER   :    GAS    :   Prod    :    OIL    :   WATER   :    GAS    :    INJ    :
+:  NAME  :  (I,J,K)  :  TYPE  :MODE:   PROD    :   PROD    :   PROD    : RES.VOL.  :    INJ    :    INJ    :    INJ    : RES.VOL.  :
+:        :           :        :    :   MSTB    :   MSTB    :   MMSCF   :    MRB    :   MSTB    :   MSTB    :   MMSCF   :    MRB    :
+====================================================================================================================================
+:FIELD   :           :        :    :        1.0:        2.0:        3.0:        4.0:        5.0:        6.0:        7.0:        8.0:
+:G1      :           :        :    :        9.0:       10.0:       11.0:       12.0:       13.0:       14.0:       15.0:       15.0:
+:PROD    : 10, 10    :    PROD:ORAT:       16.0:       17.0:       18.0:       19.0:       20.0:       21.0:       22.0:       23.0:
+:  BLOCK :  2,  2,  1:        :    :       40.0:       41.0:       42.0:       43.0:       44.0:       45.0:       46.0:       47.0:
+:INJ     :  1,  1    :     INJ:GRAT:       24.0:       25.0:       26.0:       27.0:       28.0:       29.0:       30.0:       31.0:
+:  BLOCK :  1,  1,  1:        :    :       32.0:       33.0:       34.0:       35.0:       36.0:       37.0:       38.0:       39.0:
+:--------:-----------:--------:----:-----------:-----------:-----------:-----------:-----------:-----------:-----------:-----------:
+)"
+    };
+
+    // Note: Cumulative gas values--e.g., FGPT--multiplied by an additional
+    // factor of 1000, for a total multiplicative factor of one million, in
+    // order to produce the expected balance sheet output in MM* units.
+    st.set("FOPT", 1.0e3);
+    st.set("FWPT", 2.0e3);
+    st.set("FGPT", 3.0e6);
+    st.set("FVPT", 4.0e3);
+    st.set("FOIT", 5.0e3);
+    st.set("FWIT", 6.0e3);
+    st.set("FGIT", 7.0e6);
+    st.set("FVIT", 8.0e3);
+
+    st.update_group_var("G1", "GOPT",  9.0e3);
+    st.update_group_var("G1", "GWPT", 10.0e3);
+    st.update_group_var("G1", "GGPT", 11.0e6);
+    st.update_group_var("G1", "GVPT", 12.0e3);
+    st.update_group_var("G1", "GOIT", 13.0e3);
+    st.update_group_var("G1", "GWIT", 14.0e3);
+    st.update_group_var("G1", "GGIT", 15.0e6);
+    st.update_group_var("G1", "GVIT", 15.0e3);
+
+    st.update_well_var("PROD", "WOPT", 16.0e3);
+    st.update_well_var("PROD", "WWPT", 17.0e3);
+    st.update_well_var("PROD", "WGPT", 18.0e6);
+    st.update_well_var("PROD", "WVPT", 19.0e3);
+    st.update_well_var("PROD", "WOIT", 20.0e3);
+    st.update_well_var("PROD", "WWIT", 21.0e3);
+    st.update_well_var("PROD", "WGIT", 22.0e6);
+    st.update_well_var("PROD", "WVIT", 23.0e3);
+
+    st.update_well_var("INJ", "WOPT", 24.0e3);
+    st.update_well_var("INJ", "WWPT", 25.0e3);
+    st.update_well_var("INJ", "WGPT", 26.0e6);
+    st.update_well_var("INJ", "WVPT", 27.0e3);
+    st.update_well_var("INJ", "WOIT", 28.0e3);
+    st.update_well_var("INJ", "WWIT", 29.0e3);
+    st.update_well_var("INJ", "WGIT", 30.0e6);
+    st.update_well_var("INJ", "WVIT", 31.0e3);
+
+    st.update_conn_var("INJ", "COPT", 1, 32.0e3);
+    st.update_conn_var("INJ", "CWPT", 1, 33.0e3);
+    st.update_conn_var("INJ", "CGPT", 1, 34.0e6);
+    st.update_conn_var("INJ", "CVPT", 1, 35.0e3);
+    st.update_conn_var("INJ", "COIT", 1, 36.0e3);
+    st.update_conn_var("INJ", "CWIT", 1, 37.0e3);
+    st.update_conn_var("INJ", "CGIT", 1, 38.0e6);
+    st.update_conn_var("INJ", "CVIT", 1, 39.0e3);
+
+    st.update_conn_var("PROD", "COPT", 12, 40.0e3);
+    st.update_conn_var("PROD", "CWPT", 12, 41.0e3);
+    st.update_conn_var("PROD", "CGPT", 12, 42.0e6);
+    st.update_conn_var("PROD", "CVPT", 12, 43.0e3);
+    st.update_conn_var("PROD", "COIT", 12, 44.0e3);
+    st.update_conn_var("PROD", "CWIT", 12, 45.0e3);
+    st.update_conn_var("PROD", "CGIT", 12, 46.0e6);
+    st.update_conn_var("PROD", "CVIT", 12, 47.0e3);
+
+    Opm::LogOutputHelper<double> helper(eclState, schedule, st, "dummy version");
+    helper.cumulative(0, true);
 
     const auto data = trimStream(str);
     BOOST_CHECK_EQUAL(data, reference);


### PR DESCRIPTION
This adds support for RPTSCHED WELLS=2. In particular this appends connection level data to the injection/production/cumulative PRT logs.

Downstream of https://github.com/OPM/opm-common/pull/4532