### PR TITLE
removing undefined and unused function computeWellGroupTarget() from BlackoilWellModel

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -424,8 +424,7 @@ template<class Scalar> class WellContributions;
             bool updateWellControlsAndNetwork(const bool mandatory_network_balance,
                                               const double dt,
                                               DeferredLogger& local_deferredLogger);
-            
-            double computeWellGroupTarget(DeferredLogger& local_deferredLogger);
+
             bool computeWellGroupThp(const double dt, DeferredLogger& local_deferredLogger);
 
             /// Update rank's notion of intersecting wells and their


### PR DESCRIPTION
Saw this when reviewing another PR. 