### PR TITLE
Add support for merging well cells for NLDD partitioning

### DIFF
--- a/opm/simulators/flow/BlackoilModelNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelNldd.hpp
@@ -817,7 +817,7 @@ private:
         } else if (model_.param().local_solve_approach_ == DomainSolveApproach::GaussSeidel) {
             // Calculate the measure used to order the domains.
             std::vector<Scalar> measure_per_domain(domains_.size());
-            switch (model_.param().local_domain_ordering_) {
+            switch (model_.param().local_domains_ordering_) {
             case DomainOrderingMeasure::AveragePressure: {
                 // Use average pressures to order domains.
                 for (const auto& domain : domains_) {
@@ -856,7 +856,7 @@ private:
                 }
                 break;
             }
-            } // end of switch (model_.param().local_domain_ordering_)
+            } // end of switch (model_.param().local_domains_ordering_)
 
             // Sort by largest measure, keeping index order if equal.
             const auto& m = measure_per_domain;
@@ -991,7 +991,7 @@ private:
 
         auto zoltan_ctrl = ZoltanPartitioningControl<Element>{};
 
-        zoltan_ctrl.domain_imbalance = param.local_domain_partition_imbalance_;
+        zoltan_ctrl.domain_imbalance = param.local_domains_partition_imbalance_;
 
         zoltan_ctrl.index =
             [elementMapper = &this->model_.simulator().model().elementMapper()]
@@ -1008,7 +1008,7 @@ private:
         };
 
         // Forming the list of wells is expensive, so do this only if needed.
-        const auto need_wells = param.local_domain_partition_method_ == "zoltan";
+        const auto need_wells = param.local_domains_partition_method_ == "zoltan";
 
         const auto wells = need_wells
             ? this->model_.simulator().vanguard().schedule().getWellsatEnd()
@@ -1023,12 +1023,10 @@ private:
         const int num_domains = (param.num_local_domains_ > 0)
             ? param.num_local_domains_
             : detail::countGlobalCells(grid) / default_cells_per_domain;
-        // TODO: Make this a parameter
-        const int num_neighbor_levels = 1;
-        return ::Opm::partitionCells(param.local_domain_partition_method_,
+        return ::Opm::partitionCells(param.local_domains_partition_method_,
                                      num_domains, grid.leafGridView(), wells,
                                      possibleFutureConnectionSet, zoltan_ctrl,
-                                     num_neighbor_levels);
+                                     param.local_domains_partition_well_neighbor_levels_);
     }
 
     std::vector<int> reconstitutePartitionVector() const

--- a/opm/simulators/flow/BlackoilModelNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelNldd.hpp
@@ -991,10 +991,12 @@ private:
         const int num_domains = (param.num_local_domains_ > 0)
             ? param.num_local_domains_
             : detail::countGlobalCells(grid) / default_cells_per_domain;
-
+        // TODO: Make this a parameter
+        const int num_neighbor_levels = 1;
         return ::Opm::partitionCells(param.local_domain_partition_method_,
                                      num_domains, grid.leafGridView(), wells,
-                                     possibleFutureConnectionSet, zoltan_ctrl);
+                                     possibleFutureConnectionSet, zoltan_ctrl,
+                                     num_neighbor_levels);
     }
 
     std::vector<int> reconstitutePartitionVector() const

--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -93,15 +93,16 @@ BlackoilModelParameters<Scalar>::BlackoilModelParameters()
     local_tolerance_scaling_cnv_ = Parameters::Get<Parameters::LocalToleranceScalingCnv<Scalar>>();
     nldd_num_initial_newton_iter_ = Parameters::Get<Parameters::NlddNumInitialNewtonIter>();
     num_local_domains_ = Parameters::Get<Parameters::NumLocalDomains>();
-    local_domain_partition_imbalance_ = std::max(Scalar{1.0}, Parameters::Get<Parameters::LocalDomainsPartitioningImbalance<Scalar>>());
-    local_domain_partition_method_ = Parameters::Get<Parameters::LocalDomainsPartitioningMethod>();
+    local_domains_partition_imbalance_ = std::max(Scalar{1.0}, Parameters::Get<Parameters::LocalDomainsPartitioningImbalance<Scalar>>());
+    local_domains_partition_method_ = Parameters::Get<Parameters::LocalDomainsPartitioningMethod>();
+    local_domains_partition_well_neighbor_levels_ = Parameters::Get<Parameters::LocalDomainsPartitionWellNeighborLevels>();
     deck_file_name_ = Parameters::Get<Parameters::EclDeckFileName>();
     network_max_strict_outer_iterations_ = Parameters::Get<Parameters::NetworkMaxStrictOuterIterations>();
     network_max_outer_iterations_ = Parameters::Get<Parameters::NetworkMaxOuterIterations>();
     network_max_sub_iterations_ = Parameters::Get<Parameters::NetworkMaxSubIterations>();
     network_pressure_update_damping_factor_ = Parameters::Get<Parameters::NetworkPressureUpdateDampingFactor<Scalar>>();
     network_max_pressure_update_in_bars_ = Parameters::Get<Parameters::NetworkMaxPressureUpdateInBars<Scalar>>();
-    local_domain_ordering_ = domainOrderingMeasureFromString(Parameters::Get<Parameters::LocalDomainsOrderingMeasure>());
+    local_domains_ordering_ = domainOrderingMeasureFromString(Parameters::Get<Parameters::LocalDomainsOrderingMeasure>());
     write_partitions_ = Parameters::Get<Parameters::DebugEmitCellPartition>();
 
     monitor_params_.enabled_ = Parameters::Get<Parameters::ConvergenceMonitoring>();
@@ -253,6 +254,8 @@ void BlackoilModelParameters<Scalar>::registerParameters()
          "'zoltan', "
          "'simple', "
          "and the name of a partition file ending with '.partition'.");
+    Parameters::Register<Parameters::LocalDomainsPartitionWellNeighborLevels>
+        ("Number of neighbor levels around wells to include in the same domain during NLDD partitioning");
     Parameters::Register<Parameters::LocalDomainsOrderingMeasure>
         ("Subdomain ordering measure. Allowed values are "
          "'maxpressure', "

--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -152,12 +152,14 @@ template<class Scalar>
 struct LocalDomainsPartitioningImbalance { static constexpr Scalar value = 1.03; };
 
 struct LocalDomainsPartitioningMethod { static constexpr auto value = "zoltan"; };
+struct LocalDomainsPartitionWellNeighborLevels { static constexpr int value = 1; };
 struct LocalDomainsOrderingMeasure { static constexpr auto value = "maxpressure"; };
 
 struct ConvergenceMonitoring { static constexpr bool value = false; };
 struct ConvergenceMonitoringCutOff { static constexpr int value = 6; };
 template<class Scalar>
 struct ConvergenceMonitoringDecayFactor { static constexpr Scalar value = 0.75; };
+
 
 template<class Scalar>
 struct NupcolGroupRateTolerance { static constexpr Scalar value = 0.001; };
@@ -327,9 +329,10 @@ public:
 
     int nldd_num_initial_newton_iter_{1};
     int num_local_domains_{0};
-    Scalar local_domain_partition_imbalance_{1.03};
-    std::string local_domain_partition_method_;
-    DomainOrderingMeasure local_domain_ordering_{DomainOrderingMeasure::MaxPressure};
+    Scalar local_domains_partition_imbalance_{1.03};
+    std::string local_domains_partition_method_;
+    int local_domains_partition_well_neighbor_levels_{1};
+    DomainOrderingMeasure local_domains_ordering_{DomainOrderingMeasure::MaxPressure};
 
     bool write_partitions_{false};
 

--- a/opm/simulators/flow/partitionCells.cpp
+++ b/opm/simulators/flow/partitionCells.cpp
@@ -233,19 +233,6 @@ ZoltanPartitioner::partition(const int                                      num_
             num_domains = domainId + 1;
         }
     }
-
-    // Fix-up for an extreme case: Interior cells whose neighbours are all
-    // on a different rank--i.e., interior cells which do not have on-rank
-    // neighbours.  Make each such cell be a separate domain on this rank.
-    // Don't remove this code unless you've taken remedial action elsewhere
-    // to ensure the situation doesn't happen.  For what it's worth, we've
-    // seen this case occur in practice when testing on field cases.
-    for (auto& domainId : domains) {
-        if (domainId < 0) {
-            domainId = num_domains++;
-        }
-    }
-
     return partition;
 }
 

--- a/opm/simulators/flow/partitionCells.cpp
+++ b/opm/simulators/flow/partitionCells.cpp
@@ -113,7 +113,38 @@ public:
     void buildLocalGraph(const GridView&                                       grid_view,
                          const std::vector<Opm::Well>&                         wells,
                          const std::unordered_map<std::string, std::set<int>>& possibleFutureConnections,
-                         const Opm::ZoltanPartitioningControl<Element>&        zoltan_ctrl);
+                         const Opm::ZoltanPartitioningControl<Element>&        zoltan_ctrl,
+                         const int                                             num_neighbor_levels);
+
+    /// Find all neighbors of a given cell.
+    ///
+    /// \tparam GridView DUNE grid view type
+    ///
+    /// \param[in] grid_view Current rank's reachable cells.
+    /// \param[in] cell_index Index of the cell to find neighbors for.
+    /// \param[in] zoltan_ctrl Control parameters for on-rank subdomain partitioning.
+    ///
+    /// \return Set of neighbor cell indices.
+    template <class GridView, class Element>
+    std::set<int> findNeighbors(const GridView& grid_view,
+                               const int cell_index,
+                               const Opm::ZoltanPartitioningControl<Element>& zoltan_ctrl) const;
+
+    /// Connect neighbors of cells up to a specified level.
+    ///
+    /// \tparam GridView DUNE grid view type
+    ///
+    /// \param[in] grid_view Current rank's reachable cells.
+    /// \param[in] cells Initial set of cells.
+    /// \param[in] num_levels Number of neighbor levels to include.
+    /// \param[in] zoltan_ctrl Control parameters for on-rank subdomain partitioning.
+    ///
+    /// \return Set of all connected cells including neighbors up to specified level.
+    template <class GridView, class Element>
+    std::set<int> connectNeighbors(const GridView& grid_view,
+                                  const std::set<int>& cells,
+                                  const int num_levels,
+                                  const Opm::ZoltanPartitioningControl<Element>& zoltan_ctrl) const;
 
     /// Partition rank's interior cells into non-overlapping domains using
     /// the Zoltan graph partitioning software package.
@@ -182,11 +213,17 @@ private:
     ///
     /// \param[in] g2l Mapping from globally unique cell IDs to local,
     ///   on-rank active cell IDs.  Return value from \c connectElements().
-    template <typename Comm>
+    ///
+    /// \param[in] num_neighbor_levels Number of neighbor levels to include when connecting well cells.
+    ///   Default is 0, which means only direct well connections are considered.
+    template <typename Comm, class GridView, class Element>
     void connectWells(const Comm                                     comm,
+                      const GridView&                                grid_view,
                       const std::vector<Opm::Well>&                  wells,
                       std::unordered_map<std::string, std::set<int>> possibleFutureConnections,
-                      const std::unordered_map<int, int>&            g2l);
+                      const std::unordered_map<int, int>&            g2l,
+                      const Opm::ZoltanPartitioningControl<Element>& zoltan_ctrl,
+                      const int                                      num_neighbor_levels);
 };
 
 // Note: "grid_view.size(0)" is intentional here.  It is not an error.  The
@@ -203,9 +240,77 @@ template <class GridView, class Element>
 void ZoltanPartitioner::buildLocalGraph(const GridView&                                       grid_view,
                                         const std::vector<Opm::Well>&                         wells,
                                         const std::unordered_map<std::string, std::set<int>>& possibleFutureConnections,
-                                        const Opm::ZoltanPartitioningControl<Element>&        zoltan_ctrl)
+                                        const Opm::ZoltanPartitioningControl<Element>&        zoltan_ctrl,
+                                        const int                                             num_neighbor_levels)
 {
-    this->connectWells(grid_view.comm(), wells, possibleFutureConnections, this->connectElements(grid_view, zoltan_ctrl));
+    this->connectWells(grid_view.comm(), grid_view, wells, possibleFutureConnections,
+                      this->connectElements(grid_view, zoltan_ctrl), zoltan_ctrl, num_neighbor_levels);
+}
+
+template <class GridView, class Element>
+std::set<int> ZoltanPartitioner::findNeighbors(const GridView& grid_view,
+                                              const int cell_index,
+                                              const Opm::ZoltanPartitioningControl<Element>& zoltan_ctrl) const
+{
+    std::set<int> neighbors;
+
+    for (const auto& element : elements(grid_view, Dune::Partitions::interior)) {
+        if (zoltan_ctrl.index(element) != cell_index) {
+            continue;
+        }
+
+        for (const auto& is : intersections(grid_view, element)) {
+            if (!is.neighbor()) {
+                continue;
+            }
+
+            const auto& out = is.outside();
+            if (out.partitionType() != Dune::InteriorEntity) {
+                continue;
+            }
+
+            neighbors.insert(zoltan_ctrl.index(out));
+        }
+        break;
+    }
+
+    return neighbors;
+}
+
+template <class GridView, class Element>
+std::set<int> ZoltanPartitioner::connectNeighbors(const GridView& grid_view,
+                                                 const std::set<int>& cells,
+                                                 const int num_levels,
+                                                 const Opm::ZoltanPartitioningControl<Element>& zoltan_ctrl) const
+{
+    if (num_levels <= 0) {
+        return cells;
+    }
+    std::set<int> all_cells = cells;
+    std::set<int> frontier = cells;
+
+    for (int level = 0; level < num_levels; ++level) {
+        std::set<int> new_frontier;
+
+        for (const int cell : frontier) {
+            auto neighbors = findNeighbors(grid_view, cell, zoltan_ctrl);
+            new_frontier.insert(neighbors.begin(), neighbors.end());
+        }
+
+        // Remove cells we've already processed
+        for (const int cell : all_cells) {
+            new_frontier.erase(cell);
+        }
+
+        // If no new cells found, we can stop
+        if (new_frontier.empty()) {
+            break;
+        }
+
+        all_cells.insert(new_frontier.begin(), new_frontier.end());
+        frontier = std::move(new_frontier);
+    }
+    return all_cells;
 }
 
 template <class GridView, class Element>
@@ -275,11 +380,14 @@ ZoltanPartitioner::connectElements(const GridView&                              
     return g2l;
 }
 
-template <typename Comm>
+template <typename Comm, class GridView, class Element>
 void ZoltanPartitioner::connectWells(const Comm                                     comm,
+                                     const GridView&                                grid_view,
                                      const std::vector<Opm::Well>&                  wells,
                                      std::unordered_map<std::string, std::set<int>> possibleFutureConnections,
-                                     const std::unordered_map<int, int>&            g2l)
+                                     const std::unordered_map<int, int>&            g2l,
+                                     const Opm::ZoltanPartitioningControl<Element>& zoltan_ctrl,
+                                     const int                                      num_neighbor_levels)
 {
     auto distributedWells = 0;
 
@@ -290,6 +398,7 @@ void ZoltanPartitioner::connectWells(const Comm                                 
     for (const auto& well : wells) {
         auto cellIx = std::vector<int>{};
         auto otherProc = 0;
+        std::set<int> wellCells;
 
         for (const auto& conn : well.getConnections()) {
             auto locPos = g2l.find(conn.global_index());
@@ -297,7 +406,7 @@ void ZoltanPartitioner::connectWells(const Comm                                 
                 ++otherProc;
                 continue;
             }
-
+            wellCells.insert(locPos->second);
             cellIx.push_back(locPos->second);
         }
         const auto possibleFutureConnectionSetIt = possibleFutureConnections.find(well.name());
@@ -308,6 +417,7 @@ void ZoltanPartitioner::connectWells(const Comm                                 
                     ++otherProc;
                     continue;
                 }
+                wellCells.insert(locPos->second);
                 cellIx.push_back(locPos->second);
             }
         }
@@ -315,6 +425,13 @@ void ZoltanPartitioner::connectWells(const Comm                                 
         if ((otherProc > 0) && !cellIx.empty()) {
             ++distributedWells;
             continue;
+        }
+
+        // If neighbor levels > 0, expand the well cells to include neighbors
+        if (num_neighbor_levels > 0 && !wellCells.empty()) {
+            wellCells = connectNeighbors(grid_view, wellCells, num_neighbor_levels, zoltan_ctrl);
+            cellIx.clear();
+            cellIx.insert(cellIx.end(), wellCells.begin(), wellCells.end());
         }
 
         const auto nc = cellIx.size();
@@ -352,7 +469,8 @@ partitionCellsZoltan(const int                                             num_d
                      const GridView&                                       grid_view,
                      const std::vector<Opm::Well>&                         wells,
                      const std::unordered_map<std::string, std::set<int>>& possibleFutureConnections,
-                     const Opm::ZoltanPartitioningControl<Element>&        zoltan_ctrl)
+                     const Opm::ZoltanPartitioningControl<Element>&        zoltan_ctrl,
+                     const int                                             num_neighbor_levels)
 {
     if (num_domains <= 1) {     // No partitioning => every cell in domain zero.
         const auto num_interior_cells =
@@ -366,7 +484,8 @@ partitionCellsZoltan(const int                                             num_d
     }
 
     auto partitioner = ZoltanPartitioner { grid_view, zoltan_ctrl.local_to_global };
-    partitioner.buildLocalGraph(grid_view, wells, possibleFutureConnections, zoltan_ctrl);
+
+    partitioner.buildLocalGraph(grid_view, wells, possibleFutureConnections, zoltan_ctrl, num_neighbor_levels);
 
     return partitioner.partition(num_domains, grid_view, zoltan_ctrl);
 }
@@ -587,12 +706,13 @@ Opm::partitionCells(const std::string& method,
                     const GridView&    grid_view,
                     [[maybe_unused]] const std::vector<Well>&                              wells,
                     [[maybe_unused]] const std::unordered_map<std::string, std::set<int>>& possibleFutureConnections,
-                    [[maybe_unused]] const ZoltanPartitioningControl<Element>&             zoltan_ctrl)
+                    [[maybe_unused]] const ZoltanPartitioningControl<Element>&             zoltan_ctrl,
+                    const int                                             num_neighbor_levels)
 {
     if (method == "zoltan") {
 #if HAVE_MPI && HAVE_ZOLTAN
 
-        return partitionCellsZoltan(num_local_domains, grid_view, wells, possibleFutureConnections, zoltan_ctrl);
+        return partitionCellsZoltan(num_local_domains, grid_view, wells, possibleFutureConnections, zoltan_ctrl, num_neighbor_levels);
 
 #else // !HAVE_MPI || !HAVE_ZOLTAN
 
@@ -687,7 +807,8 @@ Opm::partitionCellsSimple(const int num_cells, const int num_domains)
                         const std::unordered_map<std::string, std::set<int>>&, \
                         const Opm::ZoltanPartitioningControl<                  \
                         typename std::remove_cv_t<std::remove_reference_t<     \
-                        decltype(std::declval<Grid>().leafGridView())>>::template Codim<0>::Entity>&)
+                        decltype(std::declval<Grid>().leafGridView())>>::template Codim<0>::Entity>&, \
+                        const int)
 
 // ---------------------------------------------------------------------------
 // Grid types built into Flow.

--- a/opm/simulators/flow/partitionCells.cpp
+++ b/opm/simulators/flow/partitionCells.cpp
@@ -460,7 +460,8 @@ This is not supported in the current NLDD implementation.)",
         };
     }
 
-    OPM_END_PARALLEL_TRY_CATCH(std::string { "ZoltanPartitioner::connectWells()" }, comm)
+    OPM_END_PARALLEL_TRY_CATCH(std::string{"ZoltanPartitioner::connectWells(): Distributed well detected. "
+                                          "This is not supported in the current NLDD implementation"}, comm)
 }
 
 template <class GridView, class Element>

--- a/opm/simulators/flow/partitionCells.cpp
+++ b/opm/simulators/flow/partitionCells.cpp
@@ -330,17 +330,9 @@ void ZoltanPartitioner::connectWells(const Comm                                 
             continue;
         }
 
-        const auto nc = cellIx.size();
-        for (auto ic1 = 0*nc; ic1 < nc; ++ic1) {
-            for (auto ic2 = ic1 + 1; ic2 < nc; ++ic2) {
-                this->partitioner_.registerConnection(cellIx[ic1], cellIx[ic2]);
-                this->partitioner_.registerConnection(cellIx[ic2], cellIx[ic1]);
-            }
-        }
-
-        if (! cellIx.empty()) {
-            // All cells intersected by a single well go in the same domain.
-            this->partitioner_.forceSameDomain(std::move(cellIx));
+        // Add all cells in this well to be merged into the first cell
+        if (!cellIx.empty()) {
+            this->partitioner_.mergeVertices(cellIx, cellIx.front());
         }
     }
 

--- a/opm/simulators/flow/partitionCells.cpp
+++ b/opm/simulators/flow/partitionCells.cpp
@@ -330,9 +330,17 @@ void ZoltanPartitioner::connectWells(const Comm                                 
             continue;
         }
 
-        // Add all cells in this well to be merged into the first cell
+        const auto nc = cellIx.size();
+        for (auto ic1 = 0*nc; ic1 < nc; ++ic1) {
+            for (auto ic2 = ic1 + 1; ic2 < nc; ++ic2) {
+                this->partitioner_.registerConnection(cellIx[ic1], cellIx[ic2]);
+                this->partitioner_.registerConnection(cellIx[ic2], cellIx[ic1]);
+            }
+        }
+
+        // Collect all cells for the well into a vertex group
         if (!cellIx.empty()) {
-            this->partitioner_.mergeVertices(cellIx, cellIx.front());
+            this->partitioner_.addVertexGroup(cellIx);
         }
     }
 

--- a/opm/simulators/flow/partitionCells.hpp
+++ b/opm/simulators/flow/partitionCells.hpp
@@ -84,6 +84,8 @@ struct ZoltanPartitioningControl
 /// \param[in] zoltan_ctrl Control parameters for local Zoltan-based
 ///    partitioning.  Not used unless \code method == "zoltan" \endcode.
 ///
+/// \param[in] num_neighbor_levels Number of neighbor levels to consider for partitioning.
+///
 /// \return Partition vector--subdomain ID for each cell in \p grid_view
 ///    traversal order for its interior cells--and the number of subdomains
 ///    on current rank.
@@ -94,7 +96,8 @@ partitionCells(const std::string&                                    method,
                const GridView&                                       grid_view,
                const std::vector<Well>&                              wells,
                const std::unordered_map<std::string, std::set<int>>& possibleFutureConnections,
-               const ZoltanPartitioningControl<Element>&             zoltan_ctrl);
+               const ZoltanPartitioningControl<Element>&             zoltan_ctrl,
+               const int                                             num_neighbor_levels = 0);
 
 /// Read a partitioning from file, assumed to contain one number per cell, its partition number.
 /// \return pair containing a partition vector (partition number for each cell), and the number of partitions.

--- a/opm/simulators/utils/ParallelNLDDPartitioningZoltan.hpp
+++ b/opm/simulators/utils/ParallelNLDDPartitioningZoltan.hpp
@@ -72,18 +72,6 @@ namespace Opm {
             this->conns_.emplace_back(c1, c2);
         }
 
-        /// Force collection of cells to be in same result domain.
-        ///
-        /// Mostly as a means to ensuring wells do not intersect multiple
-        /// domains/blocks.
-        ///
-        /// \param[in] cells Cell collection.  Typically those cells which
-        ///   are intersected by a single well.
-        void forceSameDomain(std::vector<int>&& cells)
-        {
-            this->sameDomain_.emplace_back(std::move(cells));
-        }
-
         /// Partition connectivity graph using Zoltan graph partitioning
         /// package.
         ///
@@ -99,9 +87,19 @@ namespace Opm {
         std::vector<int>
         partitionElements(const ZoltanParamMap& params) const;
 
+        /// Merge vertices into a single vertex.
+        ///
+        /// \param[in] vertices Vertices to merge.
+        ///
+        /// \param[in] target Target vertex.
+        void mergeVertices(const std::vector<int>& vertices, const int target);
+
     private:
         /// Connection/graph edge.
         using Connection = std::pair<std::size_t, std::size_t>;
+
+        /// Collection of vertices to be merged, mapping target vertex to list of vertices to merge into it
+        std::map<int, std::vector<int>> vertices_to_merge_{};
 
         /// MPI communication object.  Needed by Zoltan.
         Parallel::Communication comm_{};
@@ -116,12 +114,6 @@ namespace Opm {
 
         /// Connectivity graph edges.
         std::vector<Connection> conns_{};
-
-        /// Collections of vertices/cells which must be coalesced to the
-        /// same domain/block.  All vertices within a single collection will
-        /// be placed on the same domain, but cells from different
-        /// collections may be placed on different domains.
-        std::vector<std::vector<int>> sameDomain_{};
     };
 
 } // namespace Opm

--- a/opm/simulators/utils/ParallelNLDDPartitioningZoltan.hpp
+++ b/opm/simulators/utils/ParallelNLDDPartitioningZoltan.hpp
@@ -87,19 +87,16 @@ namespace Opm {
         std::vector<int>
         partitionElements(const ZoltanParamMap& params) const;
 
-        /// Merge vertices into a single vertex.
+        /// Add a group of vertices that should be merged together.
+        /// Must be called before compress().
         ///
-        /// \param[in] vertices Vertices to merge.
-        ///
-        /// \param[in] target Target vertex.
-        void mergeVertices(const std::vector<int>& vertices, const int target);
+        /// \param[in] vertices Vector of vertex IDs to merge
+        void addVertexGroup(const std::vector<int>& vertices);
 
     private:
         /// Connection/graph edge.
         using Connection = std::pair<std::size_t, std::size_t>;
-
-        /// Collection of vertices to be merged, mapping target vertex to list of vertices to merge into it
-        std::map<int, std::vector<int>> vertices_to_merge_{};
+        std::vector<std::vector<int>> vertexGroups_{};
 
         /// MPI communication object.  Needed by Zoltan.
         Parallel::Communication comm_{};

--- a/tests/test_partitionCells.cpp
+++ b/tests/test_partitionCells.cpp
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(PartitionCellsWithNonReachableCellsTest)
 {
     // Create a 3x3x3 grid where:
     // - cell (0,0,0) is isolated (surrounded by inactive cells)
-    // - cell (1,1,1) is isolated (surrounded by inactive cells)
+    // - cell (0,2,0) is isolated (surrounded by inactive cells)
     // - cells needed for wells are active
     // Grid structure (top view):
     //   Layer k=0:      Layer k=1:       Layer k=2:     W  = well cells
@@ -593,8 +593,7 @@ BOOST_AUTO_TEST_CASE(PartitionCellsWithNonReachableCellsTest)
                                                std::unordered_map<std::string, std::set<int>>{},
                                                zoltan_ctrl);
 
-    // we get 7 partitions because the two isolated cells are assigned each their own partition
-    BOOST_CHECK_EQUAL(num_part, 7);
+    BOOST_CHECK_EQUAL(num_part, 5);
     BOOST_CHECK_EQUAL(part.size(), 16);
 
     // For this test global indices != local indices, so we need to
@@ -604,6 +603,10 @@ BOOST_AUTO_TEST_CASE(PartitionCellsWithNonReachableCellsTest)
         const auto globalIndex = grid.globalCell()[zoltan_ctrl.index(element)];
         g2l[globalIndex] = zoltan_ctrl.index(element);
     }
+
+    // Verify that the two isolated cells are assigned to the -1 partition
+    BOOST_CHECK_EQUAL(part[g2l[ijkToGlobal(0,0,0)]], -1);
+    BOOST_CHECK_EQUAL(part[g2l[ijkToGlobal(0,2,0)]], -1);
 
     // Well 1: All cells should be in the same partition
     BOOST_CHECK(part[g2l[ijkToGlobal(1,1,1)]] == part[g2l[ijkToGlobal(1,1,2)]]);

--- a/tests/test_partitionCells.cpp
+++ b/tests/test_partitionCells.cpp
@@ -24,11 +24,80 @@
 #define BOOST_TEST_NO_MAIN
 #include <boost/test/unit_test.hpp>
 
-#include <opm/simulators/flow/partitionCells.hpp>
 #include <dune/grid/common/gridview.hh>
-#include <opm/grid/CpGrid.hpp>
 
+#include <opm/grid/common/WellConnections.hpp>
+#include <opm/grid/CpGrid.hpp>
+#include <opm/grid/utility/OpmWellType.hpp>
+
+#include <opm/input/eclipse/Schedule/Well/Connection.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
+
+#include <opm/simulators/flow/partitionCells.hpp>
+
+// Helper functions
+namespace {
+    Opm::Connection createConnection(int i, int j, int k) {
+        // Calculate global index from i,j,k coordinates
+        // For this 1D test grid, global_index is just i since j=k=0
+        std::size_t global_index = i;
+        return Opm::Connection(i, j, k,                           // i,j,k
+                             global_index,                        // global_index
+                             0,                                   // complnum
+                             Opm::Connection::State::OPEN,        // state
+                             Opm::Connection::Direction::Z,       // direction
+                             Opm::Connection::CTFKind::DeckValue, // kind
+                             0,                                   // satTableId
+                             0.0,                                 // depth
+                             Opm::Connection::CTFProperties(),    // properties
+                             0,                                   // sort_value
+                             false);                             // defaultSatTabId
+    }
+
+    Dune::cpgrid::OpmWellType createWell(const std::string& name) {
+        using namespace Opm;
+        return Dune::cpgrid::OpmWellType(name, name, 0, 0, 0, 0, 0.0, WellType(),
+                                        Well::ProducerCMode(), Connection::Order::TRACK,
+                                        UnitSystem::newMETRIC(),
+                                        0.0, 0.0, false, false, 0, Well::GasInflowEquation());
+    }
+
+    std::vector<Dune::cpgrid::OpmWellType> createWellsWithConnections(
+        const std::vector<std::pair<std::string, std::vector<int>>>& well_specs) {
+        std::vector<Dune::cpgrid::OpmWellType> wells;
+        for (const auto& [well_name, cell_indices] : well_specs) {
+            auto well_conn = std::make_shared<Opm::WellConnections>();
+            for (int idx : cell_indices) {
+                well_conn->add(createConnection(idx, 0, 0));
+            }
+            auto well = createWell(well_name);
+            well.updateConnections(well_conn, true);
+            wells.push_back(well);
+        }
+        return wells;
+    }
+
+    Dune::CpGrid createTestGrid(const std::array<int, 3>& dims, 
+                               const std::array<double, 3>& size) {
+        Dune::CpGrid grid;
+        grid.createCartesian(dims, size);
+        return grid;
+    }
+
+    template<typename Entity>
+    Opm::ZoltanPartitioningControl<Entity> createZoltanControl(const Dune::CpGrid& grid) {
+        Opm::ZoltanPartitioningControl<Entity> zoltan_ctrl;
+        zoltan_ctrl.domain_imbalance = 1.1;
+        zoltan_ctrl.index = [](const auto& element) {
+            return element.index();
+        };
+        zoltan_ctrl.local_to_global = [&grid](const int local_idx) {
+            return grid.globalCell()[local_idx];
+        };
+        return zoltan_ctrl;
+    }
+}
 
 BOOST_AUTO_TEST_CASE(FileBased)
 {
@@ -61,34 +130,19 @@ BOOST_AUTO_TEST_CASE(Simple2)
     BOOST_CHECK_EQUAL_COLLECTIONS(expected.begin(), expected.end(), part.begin(), part.end());
 }
 
-BOOST_AUTO_TEST_CASE(PartitionCellsTestSimple)
+
+BOOST_AUTO_TEST_CASE(PartitionCellsTest)
 {
-    // Create a 3x2x2 grid (12 cells total)
-    Dune::CpGrid grid;
-    std::array<int, 3> dims{{3, 4, 1}};
-    std::array<double, 3> size{{3.0, 4.0, 1.0}};
-    grid.createCartesian(dims, size);
-
-    // Setup Zoltan control parameters
+    auto grid = createTestGrid({3, 4, 1}, {3.0, 4.0, 1.0});
     using Entity = typename Dune::CpGrid::LeafGridView::template Codim<0>::Entity;
-    Opm::ZoltanPartitioningControl<Entity> zoltan_ctrl;
-    zoltan_ctrl.domain_imbalance = 1.1;  // Allow 10% imbalance
+    auto zoltan_ctrl = createZoltanControl<Entity>(grid);
 
-    // Initialize index function to return entity index
-    std::function<int(const Entity&)> index_func = [](const Entity& e) { return e.index(); };
-    zoltan_ctrl.index = index_func;
-
-    // Initialize local_to_global function to use index as global ID for this test
-    std::function<int(int)> l2g_func = [](int idx) { return idx; };
-    zoltan_ctrl.local_to_global = l2g_func;
-
-    // Test simple partitioning first
+    // Test simple partitioning
     {
         auto [part, num_part] = Opm::partitionCells("simple", 3, grid.leafGridView(),
                                                    std::vector<Opm::Well>{},
                                                    std::unordered_map<std::string, std::set<int>>{},
                                                    zoltan_ctrl);
-
         BOOST_CHECK_EQUAL(num_part, 3);
         BOOST_CHECK_EQUAL(part.size(), 12);
 
@@ -97,28 +151,6 @@ BOOST_AUTO_TEST_CASE(PartitionCellsTestSimple)
             BOOST_CHECK(p >= 0 && p < 3);
         }
     }
-}
-
-BOOST_AUTO_TEST_CASE(PartitionCellsTestZoltan)
-{
-    // Create a 3x2x2 grid (12 cells total)
-    Dune::CpGrid grid;
-    std::array<int, 3> dims{{3, 4, 1}};
-    std::array<double, 3> size{{3.0, 4.0, 1.0}};
-    grid.createCartesian(dims, size);
-
-    // Setup Zoltan control parameters
-    using Entity = typename Dune::CpGrid::LeafGridView::template Codim<0>::Entity;
-    Opm::ZoltanPartitioningControl<Entity> zoltan_ctrl;
-    zoltan_ctrl.domain_imbalance = 1.1;  // Allow 10% imbalance
-
-    // Initialize index function to return entity index
-    std::function<int(const Entity&)> index_func = [](const Entity& e) { return e.index(); };
-    zoltan_ctrl.index = index_func;
-
-    // Initialize local_to_global function to use index as global ID for this test
-    std::function<int(int)> l2g_func = [](int idx) { return idx; };
-    zoltan_ctrl.local_to_global = l2g_func;
 
 #if HAVE_MPI && HAVE_ZOLTAN
     // Test Zoltan partitioning
@@ -127,7 +159,6 @@ BOOST_AUTO_TEST_CASE(PartitionCellsTestZoltan)
                                                    std::vector<Opm::Well>{},
                                                    std::unordered_map<std::string, std::set<int>>{},
                                                    zoltan_ctrl);
-
         BOOST_CHECK_EQUAL(num_part, 3);
         BOOST_CHECK_EQUAL(part.size(), 12);
 
@@ -136,6 +167,98 @@ BOOST_AUTO_TEST_CASE(PartitionCellsTestZoltan)
             BOOST_CHECK(p >= 0 && p < 3);
         }
     }
+#endif
+}
+
+BOOST_AUTO_TEST_CASE(PartitionCellsWithWellMergeTest)
+{
+    // Create a 1D grid with 7 cells
+    // Visual representation of the grid and wells:
+    // Cell indices:    0    1    2    3    4    5    6
+    // Well layout:     W1---W1   |    W2---W2   |    |
+    // Expected:        Cell 0 and 1 should be merged
+    //                  Cell 3 and 4 should be merged
+    //                  Cells 2, 5, and 6 can be in any partition
+    auto grid = createTestGrid({7, 1, 1}, {7.0, 1.0, 1.0});
+
+    // Setup Zoltan control parameters
+    using Entity = typename Dune::CpGrid::LeafGridView::template Codim<0>::Entity;
+    auto zoltan_ctrl = createZoltanControl<Entity>(grid);
+
+    auto wells = createWellsWithConnections({
+        {"TESTW1", {0, 1}},    // Well 1 connects cells 0,1
+        {"TESTW2", {3, 4}}     // Well 2 connects cells 3,4
+    });
+
+    // Create well connections object
+    Dune::cpgrid::WellConnections wellConnections(wells, std::unordered_map<std::string, std::set<int>>{}, grid);
+
+#if HAVE_MPI && HAVE_ZOLTAN
+    // Test Zoltan partitioning with well cells
+    auto [part, num_part] = Opm::partitionCells("zoltan", 4, grid.leafGridView(),
+                                               wells,
+                                               std::unordered_map<std::string, std::set<int>>{},
+                                               zoltan_ctrl);
+
+    // Verify number of partitions
+    BOOST_CHECK_EQUAL(num_part, 4);
+    BOOST_CHECK_EQUAL(part.size(), 7);
+
+    // The key tests:
+    // 1. Cells 0 and 1 (well1) should be in the same partition
+    BOOST_CHECK_EQUAL(part[0], part[1]);
+
+    // 2. Cells 3 and 4 (well2) should be in the same partition
+    BOOST_CHECK_EQUAL(part[3], part[4]);
+
+    // 3. Cells 2, 5, and 6 can be in any partition, but well1 and well2 cells
+    // don't need to be in the same partition
+#endif
+}
+
+BOOST_AUTO_TEST_CASE(PartitionCellsWithOverlappingWellsTest)
+{
+    // Create a 1D grid with 7 cells
+    // Visual representation of the grid and wells:
+    // Cell indices:    0    1    2    3    4    5    6
+    // Well layout:          W1---W1---W1   |    |    |
+    //                                W2---W2
+    // Expected:        Cells 1,2,3 should be in same partition (Well 1)
+    //                  Cells 3,4 should be in same partition (Well 2)
+    //                  Therefore cells 1,2,3,4 should all end up in same partition
+
+    auto grid = createTestGrid({7, 1, 1}, {7.0, 1.0, 1.0});
+    using Entity = typename Dune::CpGrid::LeafGridView::template Codim<0>::Entity;
+    auto zoltan_ctrl = createZoltanControl<Entity>(grid);
+
+    auto wells = createWellsWithConnections({
+        {"TESTW1", {1, 2, 3}}, // Well 1 connects cells 1,2,3
+        {"TESTW2", {3, 4}}     // Well 2 connects cells 3,4
+    });
+
+#if HAVE_MPI && HAVE_ZOLTAN
+    // Test Zoltan partitioning with overlapping well cells
+    auto [part, num_part] = Opm::partitionCells("zoltan", 4, grid.leafGridView(),
+                                               wells,
+                                               std::unordered_map<std::string, std::set<int>>{},
+                                               zoltan_ctrl);
+
+    // Verify number of partitions
+    BOOST_CHECK_EQUAL(num_part, 4);
+    BOOST_CHECK_EQUAL(part.size(), 7);
+
+    // The key tests:
+    // 1. All cells connected by Well 1 should be in the same partition
+    BOOST_CHECK_EQUAL(part[1], part[2]);
+    BOOST_CHECK_EQUAL(part[2], part[3]);
+
+    // 2. All cells connected by Well 2 should be in the same partition
+    BOOST_CHECK_EQUAL(part[3], part[4]);
+
+    // 3. Due to the overlap at cell 3, all well-connected cells should be in the same partition
+    BOOST_CHECK_EQUAL(part[1], part[4]);
+
+    // 4. Cells 0, 5, and 6 can be in any partition
 #endif
 }
 

--- a/tests/test_partitionCells.cpp
+++ b/tests/test_partitionCells.cpp
@@ -1,5 +1,6 @@
 /*
-  Copyright 2021 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2021,2025 SINTEF Digital, Mathematics and Cybernetics.
+  Copyright 2025 Equinor ASA
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -19,11 +20,15 @@
 
 #include <config.h>
 
-#define BOOST_TEST_MODULE OPM_test_aspinPartition
+#define BOOST_TEST_MODULE OPM_test_partitionCells
+#define BOOST_TEST_NO_MAIN
 #include <boost/test/unit_test.hpp>
 
 #include <opm/simulators/flow/partitionCells.hpp>
+#include <dune/grid/common/gridview.hh>
+#include <opm/grid/CpGrid.hpp>
 
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 BOOST_AUTO_TEST_CASE(FileBased)
 {
@@ -54,6 +59,95 @@ BOOST_AUTO_TEST_CASE(Simple2)
     BOOST_CHECK_EQUAL(num_part, 7);
     std::vector<int> expected = { 0, 0, 1, 1, 2, 2, 3, 4, 5, 6 };
     BOOST_CHECK_EQUAL_COLLECTIONS(expected.begin(), expected.end(), part.begin(), part.end());
-
 }
 
+BOOST_AUTO_TEST_CASE(PartitionCellsTestSimple)
+{
+    // Create a 3x2x2 grid (12 cells total)
+    Dune::CpGrid grid;
+    std::array<int, 3> dims{{3, 4, 1}};
+    std::array<double, 3> size{{3.0, 4.0, 1.0}};
+    grid.createCartesian(dims, size);
+
+    // Setup Zoltan control parameters
+    using Entity = typename Dune::CpGrid::LeafGridView::template Codim<0>::Entity;
+    Opm::ZoltanPartitioningControl<Entity> zoltan_ctrl;
+    zoltan_ctrl.domain_imbalance = 1.1;  // Allow 10% imbalance
+
+    // Initialize index function to return entity index
+    std::function<int(const Entity&)> index_func = [](const Entity& e) { return e.index(); };
+    zoltan_ctrl.index = index_func;
+
+    // Initialize local_to_global function to use index as global ID for this test
+    std::function<int(int)> l2g_func = [](int idx) { return idx; };
+    zoltan_ctrl.local_to_global = l2g_func;
+
+    // Test simple partitioning first
+    {
+        auto [part, num_part] = Opm::partitionCells("simple", 3, grid.leafGridView(),
+                                                   std::vector<Opm::Well>{},
+                                                   std::unordered_map<std::string, std::set<int>>{},
+                                                   zoltan_ctrl);
+
+        BOOST_CHECK_EQUAL(num_part, 3);
+        BOOST_CHECK_EQUAL(part.size(), 12);
+
+        // Check that all partition numbers are valid
+        for (const auto& p : part) {
+            BOOST_CHECK(p >= 0 && p < 3);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(PartitionCellsTestZoltan)
+{
+    // Create a 3x2x2 grid (12 cells total)
+    Dune::CpGrid grid;
+    std::array<int, 3> dims{{3, 4, 1}};
+    std::array<double, 3> size{{3.0, 4.0, 1.0}};
+    grid.createCartesian(dims, size);
+
+    // Setup Zoltan control parameters
+    using Entity = typename Dune::CpGrid::LeafGridView::template Codim<0>::Entity;
+    Opm::ZoltanPartitioningControl<Entity> zoltan_ctrl;
+    zoltan_ctrl.domain_imbalance = 1.1;  // Allow 10% imbalance
+
+    // Initialize index function to return entity index
+    std::function<int(const Entity&)> index_func = [](const Entity& e) { return e.index(); };
+    zoltan_ctrl.index = index_func;
+
+    // Initialize local_to_global function to use index as global ID for this test
+    std::function<int(int)> l2g_func = [](int idx) { return idx; };
+    zoltan_ctrl.local_to_global = l2g_func;
+
+#if HAVE_MPI && HAVE_ZOLTAN
+    // Test Zoltan partitioning
+    {
+        auto [part, num_part] = Opm::partitionCells("zoltan", 3, grid.leafGridView(),
+                                                   std::vector<Opm::Well>{},
+                                                   std::unordered_map<std::string, std::set<int>>{},
+                                                   zoltan_ctrl);
+
+        BOOST_CHECK_EQUAL(num_part, 3);
+        BOOST_CHECK_EQUAL(part.size(), 12);
+
+        // Check that all partition numbers are valid
+        for (const auto& p : part) {
+            BOOST_CHECK(p >= 0 && p < 3);
+        }
+    }
+#endif
+}
+
+bool
+init_unit_test_func()
+{
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    Dune::MPIHelper::instance(argc, argv);
+    boost::unit_test::unit_test_main(&init_unit_test_func,
+                                     argc, argv);
+}


### PR DESCRIPTION
# NLDD Improvements for Partitioning and Better Handling of Wells and Isolated Cells

This PR introduces several improvements to the Nonlinear Domain Decomposition (NLDD) implementation, with a main focus on better handling cells perforated by wells during subdomain partitioning.

## Improvements

### Well Cell Merging
- Cells perforated by the same well are now merged into a single entity before partitioning
- This ensures that all perforated cells of a well stay in the same subdomain
- Prevents wells from being split across NLDD subdomains, which is a requirement for the NLDD implementation
- Creates naturally better partitions than the previous fix to manually move the distributed cells after partitioning
- Uses the new vertex merging functionality from https://github.com/OPM/opm-common/pull/4537 in opm-common

### Well Neighborhood Control
- Added a new method to grow partitions around wells
- Controlled with the parameter `local_domains_partition_well_neighbor_levels_` which specifies the number of levels of neighbours to merge into one entity:
  - A value of 0 keeps only the merged well cells in the subdomain
  - A value of 1 (default) adds immediate neighbours of cells perforated by the well
  - A value of 2 adds all the neighbours of the cells in the previous levels, etc.
- Improves numerical behaviour by creating more buffer cells around wells to avoid large changes on the boundary of domains and automatically places wells in the same NLDD subdomain if placed too close to each other

### Enhanced Partition Visualization
- Added generation of a ResInsight-compatible partition file for easy visualisation and debugging
- Follows expected format for input properties: https://resinsight.org/import/appendingadditionalproperties/
- The file includes all cells (active and inactive) with the NLDD global domainID

#### Code Consistency
- Renamed internal parameters for consistency (from `local_domain_*` to `local_domains_*`)

## Testing
- Added  a large suite of tests for NLDD partitioning
- The changes have been thoroughly tested on multiple complex field cases with various well configurations
- Tests show improved convergence behaviour with wells properly contained within subdomains
- Verified that isolated cells are correctly identified and handled in problematic cases
- Tested with various values of the well neighbour level parameter to confirm proper behaviour
- The ResInsight-compatible output files have been verified to work correctly with visualisation tools
