### PR TITLE
Changes for parallel runs with multisegment wells that have shut perforations

### DIFF
--- a/opm/simulators/wells/MSWellHelpers.cpp
+++ b/opm/simulators/wells/MSWellHelpers.cpp
@@ -115,7 +115,11 @@ template<class X, class Y>
 void ParallellMSWellB<MatrixType>::
 mv (const X& x, Y& y) const
 {
-    B_.mv(x, y);
+    // x.size() == 0 indicates that there are no active perforations on this process.
+    // Then all contributions come from the communication below.
+    if (x.size() > 0) {
+        B_.mv(x, y);
+    }
 
     if (this->parallel_well_info_.communication().size() > 1)
     {

--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -157,22 +157,29 @@ apply(const BVector& x, BVector& Ax) const
     // the single process to complete the computation.
     // invDBx = duneD^-1 * Bx_
     const BVectorWell invDBx = mswellhelpers::applyUMFPack(*duneDSolver_, Bx);
-
-    // Ax = Ax - duneC_^T * invDBx
-    duneC_.mmtv(invDBx,Ax);
+    // Ax.size() == 0 indicates that there are no active perforations on this process.
+    // Then, Ax does not need to be updated by the following calculation.
+    if (Ax.size() > 0) {
+        // Ax = Ax - duneC_^T * invDBx
+        duneC_.mmtv(invDBx,Ax);
+    }
 }
 
 template<class Scalar, int numWellEq, int numEq>
 void MultisegmentWellEquations<Scalar,numWellEq,numEq>::
 apply(BVector& r) const
 {
-    // It is ok to do this on each process instead of only on one,
-    // because the other processes would remain idle while waiting for
-    // the single process to complete the computation.
-    // invDrw_ = duneD^-1 * resWell_
-    const BVectorWell invDrw = mswellhelpers::applyUMFPack(*duneDSolver_, resWell_);
-    // r = r - duneC_^T * invDrw
-    duneC_.mmtv(invDrw, r);
+    // r.size() == 0 indicates that there are no active perforations on this process.
+    // Then, r does not need to be updated by the following calculation.
+    if (r.size() > 0) {
+        // It is ok to do this on each process instead of only on one,
+        // because the other processes would remain idle while waiting for
+        // the single process to complete the computation.
+        // invDrw_ = duneD^-1 * resWell_
+        const BVectorWell invDrw = mswellhelpers::applyUMFPack(*duneDSolver_, resWell_);
+        // r = r - duneC_^T * invDrw
+        duneC_.mmtv(invDrw, r);
+    }
 }
 
 template<class Scalar, int numWellEq, int numEq>

--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -109,7 +109,7 @@ init(const int numPerfs,
               end = duneC_.createend(); row != end; ++row) {
         // the number of the row corresponds to the segment number now.
         for (const int& perf : perforations[row.index()]) {
-            const int local_perf_index = pw_info_.globalToLocal(perf);
+            const int local_perf_index = pw_info_.activeToLocal(perf);
             if (local_perf_index < 0) // then the perforation is not on this process
                 continue;
             row.insert(local_perf_index);
@@ -121,7 +121,7 @@ init(const int numPerfs,
               end = duneB_.createend(); row != end; ++row) {
         // the number of the row corresponds to the segment number now.
         for (const int& perf : perforations[row.index()]) {
-            const int local_perf_index = pw_info_.globalToLocal(perf);
+            const int local_perf_index = pw_info_.activeToLocal(perf);
             if (local_perf_index < 0) // then the perforation is not on this process
                 continue;
             row.insert(local_perf_index);

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -104,7 +104,7 @@ MultisegmentWellSegments(const int numSegments,
             perforations_[segment_index].push_back(i_perf_wells);
             well.perfDepth()[i_perf_wells] = connection.depth();
             const Scalar segment_depth = segment_set[segment_index].depth();
-            int local_perf_index = parallel_well_info.globalToLocal(i_perf_wells);
+            int local_perf_index = parallel_well_info.activeToLocal(i_perf_wells);
             if (local_perf_index > -1) // If local_perf_index == -1, then the perforation is not on this process
                 local_perforation_depth_diffs_[local_perf_index] = well_.perfDepth()[i_perf_wells] - segment_depth;
             i_perf_wells++;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1106,25 +1106,33 @@ namespace Opm
         // perforated cell
         // TODO: later to investigate how to handle the pvt region
         int pvt_region_index;
-        {
-            // using the first perforated cell, so we look for global index 0
+
+        Scalar fsTemperature;
+        using SaltConcType = typename std::decay<decltype(std::declval<decltype(simulator.model().intensiveQuantities(0, 0).fluidState())>().saltConcentration())>::type;
+        SaltConcType fsSaltConcentration;
+
+        if (this->well_cells_.size() > 0) {
+            // this->well_cells_ is empty if this process does not contain active perforations
+            // using the pvt region of first perforated cell, so we look for global index 0
+            // TODO: it should be a member of the WellInterface, initialized properly
             const int cell_idx = this->well_cells_[0];
             const auto& intQuants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
             const auto& fs = intQuants.fluidState();
 
-            // The following broadcast calls are neccessary to ensure that processes that do *not* contain
-            // the first perforation get the correct temperature, saltConcentration and pvt_region_index
-            auto fsTemperature = fs.temperature(FluidSystem::oilPhaseIdx).value();
-            fsTemperature = this->pw_info_.broadcastFirstPerforationValue(fsTemperature);
-            temperature.setValue(fsTemperature);
-
-            auto fsSaltConcentration = fs.saltConcentration();
-            fsSaltConcentration = this->pw_info_.broadcastFirstPerforationValue(fsSaltConcentration);
-            saltConcentration = this->extendEval(fsSaltConcentration);
-
+            fsTemperature = fs.temperature(FluidSystem::oilPhaseIdx).value();
+            fsSaltConcentration = fs.saltConcentration();
             pvt_region_index = fs.pvtRegionIndex();
-            pvt_region_index = this->pw_info_.broadcastFirstPerforationValue(pvt_region_index);
         }
+
+        // The following broadcast calls are neccessary to ensure that processes that do *not* contain
+        // the first perforation get the correct temperature, saltConcentration and pvt_region_index
+        fsTemperature = this->pw_info_.broadcastFirstPerforationValue(fsTemperature);
+        temperature.setValue(fsTemperature);
+
+        fsSaltConcentration = this->pw_info_.broadcastFirstPerforationValue(fsSaltConcentration);
+        saltConcentration = this->extendEval(fsSaltConcentration);
+
+        pvt_region_index = this->pw_info_.broadcastFirstPerforationValue(pvt_region_index);
 
         this->segments_.computeFluidProperties(temperature,
                                                saltConcentration,
@@ -1990,26 +1998,33 @@ namespace Opm
         EvalWell temperature;
         EvalWell saltConcentration;
         int pvt_region_index;
-        {
+
+        Scalar fsTemperature;
+        using SaltConcType = typename std::decay<decltype(std::declval<decltype(simulator.model().intensiveQuantities(0, 0).fluidState())>().saltConcentration())>::type;
+        SaltConcType fsSaltConcentration;
+
+        if (this->well_cells_.size() > 0) {
+            // this->well_cells_ is empty if this process does not contain active perforations
             // using the pvt region of first perforated cell, so we look for global index 0
             // TODO: it should be a member of the WellInterface, initialized properly
             const int cell_idx = this->well_cells_[0];
             const auto& intQuants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/0);
             const auto& fs = intQuants.fluidState();
 
-            // The following broadcast calls are neccessary to ensure that processes that do *not* contain
-            // the first perforation get the correct temperature, saltConcentration and pvt_region_index
-            auto fsTemperature = fs.temperature(FluidSystem::oilPhaseIdx).value();
-            fsTemperature = this->pw_info_.broadcastFirstPerforationValue(fsTemperature);
-            temperature.setValue(fsTemperature);
-
-            auto fsSaltConcentration = fs.saltConcentration();
-            fsSaltConcentration = this->pw_info_.broadcastFirstPerforationValue(fsSaltConcentration);
-            saltConcentration = this->extendEval(fsSaltConcentration);
-
+            fsTemperature = fs.temperature(FluidSystem::oilPhaseIdx).value();
+            fsSaltConcentration = fs.saltConcentration();
             pvt_region_index = fs.pvtRegionIndex();
-            pvt_region_index = this->pw_info_.broadcastFirstPerforationValue(pvt_region_index);
         }
+
+        // The following broadcast calls are neccessary to ensure that processes that do *not* contain
+        // the first perforation get the correct temperature, saltConcentration and pvt_region_index
+        fsTemperature = this->pw_info_.broadcastFirstPerforationValue(fsTemperature);
+        temperature.setValue(fsTemperature);
+
+        fsSaltConcentration = this->pw_info_.broadcastFirstPerforationValue(fsSaltConcentration);
+        saltConcentration = this->extendEval(fsSaltConcentration);
+
+        pvt_region_index = this->pw_info_.broadcastFirstPerforationValue(pvt_region_index);
 
         return this->segments_.getSurfaceVolume(temperature,
                                                 saltConcentration,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -844,6 +844,10 @@ namespace Opm
     MultisegmentWell<TypeTag>::
     addWellContributions(SparseMatrixAdapter& jacobian) const
     {
+        if (this->number_of_local_perforations_ == 0) {
+            // If there are no open perforations on this process, there are no contributions to the jacobian.
+            return;
+        }
         this->linSys_.extract(jacobian);
     }
 
@@ -857,6 +861,10 @@ namespace Opm
                              const bool use_well_weights,
                              const WellState<Scalar>& well_state) const
     {
+        if (this->number_of_local_perforations_ == 0) {
+            // If there are no open perforations on this process, there are no contributions the cpr pressure matrix.
+            return;
+        }
         // Add the pressure contribution to the cpr system for the well
         this->linSys_.extractCPRPressureMatrix(jacobian,
                                                weights,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -143,7 +143,7 @@ namespace Opm
             // This variable loops over the number_of_local_perforations_ of *this* process, hence it is *local*.
             const int cell_idx = this->well_cells_[local_perf_index];
             // Here we need to access the perf_depth_ at the global perforation index though!
-            this->cell_perforation_depth_diffs_[local_perf_index] = depth_arg[cell_idx] - this->perf_depth_[this->pw_info_.localToGlobal(local_perf_index)];
+            this->cell_perforation_depth_diffs_[local_perf_index] = depth_arg[cell_idx] - this->perf_depth_[this->pw_info_.localToActive(local_perf_index)];
         }
     }
 
@@ -351,7 +351,7 @@ namespace Opm
         const auto& segment_pressure = segments_copy.pressure;
         for (int seg = 0; seg < nseg; ++seg) {
             for (const int perf : this->segments_.perforations()[seg]) {
-                const int local_perf_index = this->pw_info_.globalToLocal(perf);
+                const int local_perf_index = this->pw_info_.activeToLocal(perf);
                 if (local_perf_index < 0) // then the perforation is not on this process
                     continue;
                 const int cell_idx = this->well_cells_[local_perf_index];
@@ -896,7 +896,7 @@ namespace Opm
                     PerforationRates<Scalar>& perf_rates,
                     DeferredLogger& deferred_logger) const
     {
-        const int local_perf_index = this->pw_info_.globalToLocal(perf);
+        const int local_perf_index = this->pw_info_.activeToLocal(perf);
         if (local_perf_index < 0) // then the perforation is not on this process
             return;
 
@@ -1284,7 +1284,7 @@ namespace Opm
                                                  seg_dp);
             seg_dp[seg] = dp;
             for (const int perf : this->segments_.perforations()[seg]) {
-                const int local_perf_index = this->pw_info_.globalToLocal(perf);
+                const int local_perf_index = this->pw_info_.activeToLocal(perf);
                 if (local_perf_index < 0) // then the perforation is not on this process
                     continue;
                 std::vector<Scalar> mob(this->num_components_, 0.0);
@@ -1795,7 +1795,7 @@ namespace Opm
             auto& perf_rates = perf_data.phase_rates;
             auto& perf_press_state = perf_data.pressure;
             for (const int perf : this->segments_.perforations()[seg]) {
-                const int local_perf_index = this->pw_info_.globalToLocal(perf);
+                const int local_perf_index = this->pw_info_.activeToLocal(perf);
                 if (local_perf_index < 0) // then the perforation is not on this process
                     continue;
                 const int cell_idx = this->well_cells_[local_perf_index];
@@ -1945,7 +1945,7 @@ namespace Opm
         for (int seg = 0; seg < nseg; ++seg) {
             const EvalWell segment_pressure = this->primary_variables_.getSegmentPressure(seg);
             for (const int perf : this->segments_.perforations()[seg]) {
-                const int local_perf_index = this->pw_info_.globalToLocal(perf);
+                const int local_perf_index = this->pw_info_.activeToLocal(perf);
                 if (local_perf_index < 0) // then the perforation is not on this process
                     continue;
 
@@ -2179,7 +2179,7 @@ namespace Opm
         const int nseg = this->numberOfSegments();
         for (int seg = 0; seg < nseg; ++seg) {
             for (const int perf : this->segments_.perforations()[seg]) {
-                const int local_perf_index = this->pw_info_.globalToLocal(perf);
+                const int local_perf_index = this->pw_info_.activeToLocal(perf);
                 if (local_perf_index < 0) // then the perforation is not on this process
                     continue;
 
@@ -2211,7 +2211,7 @@ namespace Opm
             // calculating the perforation rate for each perforation that belongs to this segment
             const Scalar seg_pressure = getValue(this->primary_variables_.getSegmentPressure(seg));
             for (const int perf : this->segments_.perforations()[seg]) {
-                const int local_perf_index = this->pw_info_.globalToLocal(perf);
+                const int local_perf_index = this->pw_info_.activeToLocal(perf);
                 if (local_perf_index < 0) // then the perforation is not on this process
                     continue;
 

--- a/opm/simulators/wells/ParallelWellInfo.cpp
+++ b/opm/simulators/wells/ParallelWellInfo.cpp
@@ -133,7 +133,7 @@ void GlobalPerfContainerFactory<Scalar>::buildLocalToGlobalMap() const {
 
 template<class Scalar>
 int GlobalPerfContainerFactory<Scalar>::localToGlobal(std::size_t localIndex) const {
-    if (local_indices_.size() == 0)
+    if (comm_.size() == 1)
         return localIndex;
     if (!l2g_map_built_)
         buildLocalToGlobalMap();
@@ -154,7 +154,7 @@ void GlobalPerfContainerFactory<Scalar>::buildGlobalToLocalMap() const {
 
 template<class Scalar>
 int GlobalPerfContainerFactory<Scalar>::globalToLocal(const int globalIndex) const {
-    if (local_indices_.size() == 0)
+    if (comm_.size() == 1)
         return globalIndex;
     if (!g2l_map_built_) {
         buildGlobalToLocalMap();

--- a/opm/simulators/wells/ParallelWellInfo.cpp
+++ b/opm/simulators/wells/ParallelWellInfo.cpp
@@ -524,6 +524,35 @@ ParallelWellInfo<Scalar>::ParallelWellInfo(const std::pair<std::string, bool>& w
 }
 
 template<class Scalar>
+void ParallelWellInfo<Scalar>::setActiveToLocalMap(const std::unordered_map<int,int> active_to_local_map) const {
+    //active_to_local_map_ is marked as mutable
+    active_to_local_map_ = active_to_local_map;
+    for (const auto& [key, value] : active_to_local_map) {
+        local_to_active_map_[value] = key;
+    }
+}
+
+template<class Scalar>
+int ParallelWellInfo<Scalar>::localToActive(std::size_t localIndex) const {
+    if (comm_->size() == 1)
+        return localIndex;
+    auto it = local_to_active_map_.find(localIndex);
+    if (it == local_to_active_map_.end())
+        return -1; // Active index not found
+    return it->second;
+}
+
+template<class Scalar>
+int ParallelWellInfo<Scalar>::activeToLocal(const int activeIndex) const {
+    if (comm_->size() == 1)
+        return activeIndex;
+    auto it = active_to_local_map_.find(activeIndex);
+    if (it == active_to_local_map_.end())
+        return -1; // Active index not found
+    return it->second;
+}
+
+template<class Scalar>
 int ParallelWellInfo<Scalar>::localToGlobal(std::size_t localIndex) const {
     if(globalPerfCont_)
         return globalPerfCont_->localToGlobal(localIndex);

--- a/opm/simulators/wells/ParallelWellInfo.hpp
+++ b/opm/simulators/wells/ParallelWellInfo.hpp
@@ -217,6 +217,9 @@ public:
     /// \brief Collectively decide which rank has first perforation.
     void communicateFirstPerforation(bool hasFirst);
 
+    void setActiveToLocalMap(const std::unordered_map<int,int> active_to_local_map) const;
+    int activeToLocal(const int activeIndex) const;
+    int localToActive(std::size_t localIndex) const;
     int globalToLocal(const int globalIndex) const;
     int localToGlobal(std::size_t localIndex) const;
 
@@ -342,6 +345,9 @@ private:
     std::unique_ptr<CommunicateAboveBelow<Scalar>> commAboveBelow_;
 
     std::unique_ptr<GlobalPerfContainerFactory<Scalar>> globalPerfCont_;
+
+    mutable std::unordered_map<int,int> active_to_local_map_; // Cache for active perforation index to local perforation index mapping
+    mutable std::unordered_map<int,int> local_to_active_map_; // Cache for local perforation index to active perforation index mapping
 };
 
 /// \brief Class checking that all connections are on active cells

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -685,10 +685,12 @@ void WellState<Scalar>::initWellStateMSWell(const std::vector<Well>& wells_ecl,
             ws.segments = SegmentState<Scalar>{np, segment_set};
             const int well_nseg = segment_set.size();
             int n_activeperf = 0;
+            int n_activeperf_local = 0;
 
             // we need to know for each segment, how many perforation it has and how many segments using it as outlet_segment
             // that is why I think we should use a well model to initialize the WellState here
             std::vector<std::vector<int>> segment_perforations(well_nseg);
+            std::unordered_map<int,int> active_perf_index_local_to_global = {};
             for (std::size_t perf = 0; perf < completion_set.size(); ++perf) {
                 const Connection& connection = completion_set.get(perf);
                 if (connection.state() == Connection::State::OPEN) {
@@ -702,6 +704,10 @@ void WellState<Scalar>::initWellStateMSWell(const std::vector<Well>& wells_ecl,
                     }
 
                     segment_perforations[segment_index].push_back(n_activeperf);
+                    if (ws.parallel_info.get().globalToLocal(perf) > -1) {
+                        active_perf_index_local_to_global.insert({n_activeperf_local, n_activeperf});
+                        n_activeperf_local++;
+                    }
                     n_activeperf++;
                 }
             }
@@ -737,7 +743,38 @@ void WellState<Scalar>::initWellStateMSWell(const std::vector<Well>& wells_ecl,
             }
 
             const auto& perf_rates = perf_data.phase_rates;
-            std::vector<Scalar> perforation_rates(perf_rates.begin(), perf_rates.end());
+            const auto& perf_press = perf_data.pressure;
+            // The function calculateSegmentRates as well as the loop filling the segment_pressure work
+            // with *global* containers. Now we create global vectors containing the phase_rates and
+            // pressures of all processes.
+            size_t number_of_global_perfs = 0;
+
+            if (ws.parallel_info.get().communication().size() > 1) {
+                number_of_global_perfs = ws.parallel_info.get().communication().sum(perf_data.size());
+            } else {
+                number_of_global_perfs = perf_data.size();
+            }
+
+            std::vector<Scalar> perforation_rates(number_of_global_perfs * np, 0.0);
+            std::vector<Scalar> perforation_pressures(number_of_global_perfs, 0.0);
+
+            assert(perf_data.size() == perf_press.size());
+            assert(perf_data.size() * np == perf_rates.size());
+            for (size_t perf = 0; perf < perf_data.size(); ++perf) {
+                if (active_perf_index_local_to_global.count(perf) > 0) {
+                    const int global_active_perf_index = active_perf_index_local_to_global.at(perf);
+                    perforation_pressures[global_active_perf_index] = perf_press[perf];
+                    for (int i = 0; i < np; i++) {
+                        perforation_rates[global_active_perf_index * np + i] = perf_rates[perf * np + i];
+                    }
+                } else {
+                    OPM_THROW(std::logic_error,fmt::format("Error when initializing MS Well state, there is no active perforation index for the local index {}", perf));
+                }
+            }
+            if (ws.parallel_info.get().communication().size() > 1) {
+                ws.parallel_info.get().communication().sum(perforation_rates.data(), perforation_rates.size());
+                ws.parallel_info.get().communication().sum(perforation_pressures.data(), perforation_pressures.size());
+            }
 
             calculateSegmentRates(ws.parallel_info, segment_inlets, segment_perforations, perforation_rates, np, 0 /* top segment */, ws.segments.rates);
 
@@ -750,38 +787,14 @@ void WellState<Scalar>::initWellStateMSWell(const std::vector<Well>& wells_ecl,
                 // top segment is always the first one, and its pressure is the well bhp
                 auto& segment_pressure = ws.segments.pressure;
                 segment_pressure[0] = ws.bhp;
-                const auto& perf_press = perf_data.pressure;
                 // The segment_indices contain the indices of the segments, that are only available on one process.
                 std::vector<int> segment_indices;
                 for (int seg = 1; seg < well_nseg; ++seg) {
                     if (!segment_perforations[seg].empty()) {
-                        const int first_perf = ws.parallel_info.get().globalToLocal(segment_perforations[seg][0]);
-                        if (first_perf > -1) { //-1 indicates that the global id is not on this process
-                            segment_pressure[seg] = perf_press[first_perf];
-                        } else {
-                            segment_pressure[seg] = 0.0; // setting this to 0 here, this will later be filled by the communication below
-                        }
+                        const int first_perf_global_index = segment_perforations[seg][0];
+                        segment_pressure[seg] = perforation_pressures[first_perf_global_index];
                         segment_indices.push_back(seg);
-                    }
-                }
-                if (ws.parallel_info.get().communication().size() > 1) {
-                    // Communicate the segment_pressure values
-                    std::vector<Scalar> values_to_combine(segment_indices.size(), 0.0);
-
-                    for (size_t i = 0; i < segment_indices.size(); ++i) {
-                        values_to_combine[i] = segment_pressure[segment_indices[i]];
-                    }
-                    ws.parallel_info.get().communication().sum(values_to_combine.data(), values_to_combine.size());
-
-                    // Now make segment_pressure equal across all processes
-                    for (size_t i = 0; i < segment_indices.size(); ++i) {
-                        segment_pressure[segment_indices[i]] = values_to_combine[i];
-                    }
-                }
-                // Before addressing the segments with !segment_perforations[seg].empty(), we need to communicate such that the
-                // vector segment_pressure contains info from all processes
-                for (int seg = 1; seg < well_nseg; ++ seg) {
-                    if (segment_perforations[seg].empty()) {
+                    } else {
                         // seg_press_.push_back(bhp); // may not be a good decision
                         // using the outlet segment pressure // it needs the ordering is correct
                         const int outlet_seg = segment_set[seg].outletSegment();

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -764,8 +764,8 @@ void WellState<Scalar>::initWellStateMSWell(const std::vector<Well>& wells_ecl,
             assert(perf_data.size() == perf_press.size());
             assert(perf_data.size() * np == perf_rates.size());
             for (size_t perf = 0; perf < perf_data.size(); ++perf) {
-                if (active_perf_index_local_to_global.count(perf) > 0) {
-                    const int global_active_perf_index = active_perf_index_local_to_global.at(perf);
+                if (auto candidate = active_perf_index_local_to_global.find(perf); candidate != active_perf_index_local_to_global.end()) {
+                    const int global_active_perf_index = candidate->second;
                     perforation_pressures[global_active_perf_index] = perf_press[perf];
                     for (int i = 0; i < np; i++) {
                         perforation_rates[global_active_perf_index * np + i] = perf_rates[perf * np + i];

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -46,6 +46,28 @@ add_test_compare_parallel_simulation(CASENAME msw-simple
                                      MPI_PROCS 4
                                      TEST_ARGS --solver-max-time-step-in-days=15 --allow-distributed-wells=true)
 
+# A test for distributed multisegment wells with one shut perforation at the process border. We load distribute only along the z-axis
+add_test_compare_parallel_simulation(CASENAME msw-simple-1-shut-perforation-border
+                                     FILENAME MSW-SIMPLE-1-SHUT-PERFORATION-BORDER # this file contains one Multisegment well without branches that is distributed across several processes
+                                     DIR msw
+                                     SIMULATOR flow_distribute_z
+                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
+                                     REL_TOL 1e-5
+                                     MPI_PROCS 4
+                                     TEST_ARGS --solver-max-time-step-in-days=15 --allow-distributed-wells=true)
+
+
+# A test for distributed multisegment wells with only shut perforations on one process. We load distribute only along the z-axis
+add_test_compare_parallel_simulation(CASENAME msw-simple-shut-perforations
+                                     FILENAME MSW-SIMPLE-SHUT-PERFORATIONS # this file contains one Multisegment well without branches that is distributed across several processes
+                                     DIR msw
+                                     SIMULATOR flow_distribute_z
+                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
+                                     REL_TOL 1e-5
+                                     MPI_PROCS 4
+                                     TEST_ARGS --solver-max-time-step-in-days=15 --allow-distributed-wells=true)
+
+
 add_test_compare_parallel_simulation(CASENAME msw-3d
                                      FILENAME MSW-3D # this file contains one Multisegment well with branches that is distributed across several processes
                                      DIR msw


### PR DESCRIPTION
This PR fixes parallel runs with multisegment wells that have SHUT perforations.
The tests added in the last commit of this PR fail without the changes before (https://github.com/OPM/opm-simulators/pull/6139).

In order to address such simulations, I've changed the behavior when accessing structures that work with only the OPEN perforations, like std::vector<std::vector<int>> perforations_ of MultisegmentWellSegments.
For this, an active_to_local_map_ is constructed in the function WellState<Scalar>::initWellStateMSWell. This map maps the global indices of the active perforations to the local indices of the active perforations.
This map and its conterpart local_to_active_map_ are added to the ParallelWellInfo class and then used by the functions: ParallelWellInfo<Scalar>::activeToLocal and ParallelWellInfo<Scalar>::localToActive.
I've decided to add the map as a mutable member of ParallelWellInfo, because this is the class it fits best, even if I had to declare the member mutable.

When there are only open perforations on a rank, the maps global_to_local_ and local_to_global_ coincide.

This PR is not relevant for the reference manual.