### PR TITLE
Fix a recent bug indexing in the CPRW cell weights.

### DIFF
--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -376,13 +376,21 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
             bweights[0][blockSz-1] = 1.0;
             diagElem = 1.0; // better scaling could have used the calculation below if weights were calculated
         } else {
-            for (std::size_t i = 0; i < blockSz; ++i) {
+            // The first (blockSz - 1) block weights will scale the
+            // conservation well equations, and is therefore set equal
+            // to the cell weights. The last one will scale the control
+            // equation, we set that to zero.
+            for (std::size_t i = 0; i < blockSz - 1; ++i) {
                 bweights[0][i] = cell_weights[i];
             }
             bweights[0][blockSz-1] = 0.0;
             diagElem = 0.0;
             const auto& locmat = duneD_[0][0];
-            for (std::size_t i = 0; i < blockSz; ++i) {
+            // For some models such as MICP, cell_weights.size() is larger than
+            // (blockSz - 1) since the model has more conserved quantities than
+            // the well model treats. We assume that the first (blockSz - 1)
+            // conserved quantities correspond to those treated in the well model.
+            for (std::size_t i = 0; i < blockSz - 1; ++i) {
                 diagElem += locmat[i][bhp_var_index] * cell_weights[i];
             }
 


### PR DESCRIPTION
The original fix assumed mistakenly that the well block size (number of equations and unknowns for the wells) would be smaller than the reservoir block size. This is wrong for most models, such as the 3-phase black oil model (4 vs 3).

Fix should handle this situation correctly, and adds explanations.

Note that I have not tested this with debug iterators, so it would be good to sanity check before merging.

Original (buggy) fix in #6091.