### PR TITLE
Make wellModelMatrixAdapter serial only

### DIFF
--- a/opm/simulators/linalg/FlexibleSolver_impl.hpp
+++ b/opm/simulators/linalg/FlexibleSolver_impl.hpp
@@ -277,7 +277,7 @@ using OBM = Dune::BCRSMatrix<Opm::MatrixBlock<Scalar, N, N>>;
 template<class Scalar, int N>
 using SeqOpM = Dune::MatrixAdapter<OBM<Scalar,N>, BV<Scalar,N>, BV<Scalar,N>>;
 template<class Scalar, int N>
-using SeqOpW = Opm::WellModelMatrixAdapter<OBM<Scalar,N>, BV<Scalar,N>, BV<Scalar,N>, false>;
+using SeqOpW = Opm::WellModelMatrixAdapter<OBM<Scalar,N>, BV<Scalar,N>, BV<Scalar,N>>;
 
 #if HAVE_MPI
 

--- a/opm/simulators/linalg/ISTLSolver.cpp
+++ b/opm/simulators/linalg/ISTLSolver.cpp
@@ -145,7 +145,7 @@ void FlexibleSolverInfo<Matrix,Vector,Comm>::create(const Matrix& matrix,
             this->op_ = std::move(sop);
             this->solver_ = std::move(sol);
         } else {
-            using SeqOperatorType = WellModelMatrixAdapter<Matrix, Vector, Vector, false>;
+            using SeqOperatorType = WellModelMatrixAdapter<Matrix, Vector, Vector>;
             auto sop = std::make_unique<SeqOperatorType>(matrix, *wellOperator_);
             using FlexibleSolverType = Dune::FlexibleSolver<SeqOperatorType>;
             auto sol = std::make_unique<FlexibleSolverType>(*sop, prm,

--- a/opm/simulators/linalg/PreconditionerFactory_impl.hpp
+++ b/opm/simulators/linalg/PreconditionerFactory_impl.hpp
@@ -577,7 +577,7 @@ struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation> {
             }
 #endif
         }
-        if constexpr (std::is_same_v<O, WellModelMatrixAdapter<M, V, V, false>>) {
+        if constexpr (std::is_same_v<O, WellModelMatrixAdapter<M, V, V>>) {
             F::addCreator(
                 "cprw",
                 [](const O& op, const P& prm, const std::function<V()>& weightsCalculator, std::size_t pressureIndex) {
@@ -829,8 +829,7 @@ using OpBSeq = Dune::MatrixAdapter<Dune::BCRSMatrix<MatrixBlock<Scalar, Dim, Dim
 template<class Scalar, int Dim, bool overlap>
 using OpW = WellModelMatrixAdapter<Dune::BCRSMatrix<MatrixBlock<Scalar, Dim, Dim>>,
                                    Dune::BlockVector<Dune::FieldVector<Scalar, Dim>>,
-                                   Dune::BlockVector<Dune::FieldVector<Scalar, Dim>>,
-                                   overlap>;
+                                   Dune::BlockVector<Dune::FieldVector<Scalar, Dim>>>;
 
 template<class Scalar, int Dim, bool overlap>
 using OpWG = WellModelGhostLastMatrixAdapter<Dune::BCRSMatrix<MatrixBlock<Scalar, Dim, Dim>>,

--- a/tests/gpuistl/test_solver_adapter.cpp
+++ b/tests/gpuistl/test_solver_adapter.cpp
@@ -77,7 +77,7 @@ createSolverAdapterWithMatrix(const size_t N = 10)
     auto sp = std::make_shared<Dune::ScalarProduct<Vector>>();
     auto prm = Opm::PropertyTree();
     prm.put<double>("relaxation", 1.0);
-    prm.put<std::string>("type", "CUILU0");
+    prm.put<std::string>("type", "GPUILU0");
     auto prec = PrecondFactory::create(*op, prm);
     auto solverAdapter = std::make_shared<SolverAdapter>(*op, *sp, prec, 1.0, 10, 0, Dune::Amg::SequentialInformation());
 


### PR DESCRIPTION
# Remove parallel functionality from WellModelMatrixAdapter

## Description
This PR simplifies the `WellModelMatrixAdapter` by removing its parallel/MPI-specific functionality, since parallel operations are now handled by `WellModelGhostLastMatrixAdapter`.

## Motivation
The parallel functionality in `WellModelMatrixAdapter` was redundant since `WellModelGhostLastMatrixAdapter` is now used for all parallel operations. This change simplifies the codebase by removing unused functionality and makes the intended usage of each adapter class clearer. This is also motivated by the ongoing work to get well operators into the GPUIstl framework, where this hybrid serial/parallel class was causing issues. Another option for keeping this functionality is to split this into a serial and a parallel version, but I did not want to introduce a new class that is not actually used.

### Test update
When testing this locally I noticed a test that is only run if a GPU is available, which was failing for me but has not been executed and failed on jenkins. 