### PR TITLE
Calculate original FIP by reading restart data for step 0

### DIFF
--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -508,9 +508,9 @@ public:
 
         // the MICP processes change the porosity
         if constexpr (enableMICP){
-          Evaluation biofilm_ = priVars.makeEvaluation(Indices::biofilmConcentrationIdx, timeIdx, linearizationType);
-          Evaluation calcite_ = priVars.makeEvaluation(Indices::calciteConcentrationIdx, timeIdx, linearizationType);
-          porosity_ += - biofilm_ - calcite_;
+            Evaluation biofilm_ = priVars.makeEvaluation(Indices::biofilmConcentrationIdx, timeIdx, linearizationType);
+            Evaluation calcite_ = priVars.makeEvaluation(Indices::calciteConcentrationIdx, timeIdx, linearizationType);
+            porosity_ += - biofilm_ - calcite_;
         }
 
         // deal with salt-precipitation

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -1093,7 +1093,6 @@ protected:
         return true;
     }
 
-
     void readEclRestartSolution_()
     {
         // Throw an exception if the grid has LGRs. Refined grid are not supported for restart.

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -967,6 +967,113 @@ public:
         }
     }
 
+    //!\brief Read simulator solution state from the outputmodule (used with restart)
+    //! \param restart_step Step to read at
+    //! \param fip_init True to do limited simulator initialization
+    //! \details \a fip_init is used when calculating original FIP from restart state
+    void readSolutionFromOutputModule(const int restart_step, bool fip_init)
+    {
+        auto& simulator = this->simulator();
+        const auto& eclState = simulator.vanguard().eclState();
+
+        std::size_t numElems = this->model().numGridDof();
+        this->initialFluidStates_.resize(numElems);
+        if constexpr (enableSolvent) {
+            this->solventSaturation_.resize(numElems, 0.0);
+            this->solventRsw_.resize(numElems, 0.0);
+        }
+
+        if constexpr (enablePolymer)
+            this->polymer_.concentration.resize(numElems, 0.0);
+
+        if constexpr (enablePolymerMolarWeight) {
+            const std::string msg {"Support of the RESTART for polymer molecular weight "
+                                   "is not implemented yet. The polymer weight value will be "
+                                   "zero when RESTART begins"};
+            OpmLog::warning("NO_POLYMW_RESTART", msg);
+            this->polymer_.moleWeight.resize(numElems, 0.0);
+        }
+
+        if constexpr (enableMICP) {
+            this->micp_.resize(numElems);
+        }
+
+        // Initialize mixing controls before trying to set any lastRx valuesx
+        this->mixControls_.init(numElems, restart_step, eclState.runspec().tabdims().getNumPVTTables());
+
+        if constexpr (enableMICP) {
+            this->micp_ = this->eclWriter_->outputModule().getMICP().getSolution();
+        }
+
+        for (std::size_t elemIdx = 0; elemIdx < numElems; ++elemIdx) {
+            auto& elemFluidState = this->initialFluidStates_[elemIdx];
+            elemFluidState.setPvtRegionIndex(pvtRegionIndex(elemIdx));
+            this->eclWriter_->outputModule().initHysteresisParams(simulator, elemIdx);
+            this->eclWriter_->outputModule().assignToFluidState(elemFluidState, elemIdx);
+
+            // Note: Function processRestartSaturations_() mutates the
+            // 'ssol' argument--the value from the restart file--if solvent
+            // is enabled.  Then, store the updated solvent saturation into
+            // 'solventSaturation_'.  Otherwise, just pass a dummy value to
+            // the function and discard the unchanged result.  Do not index
+            // into 'solventSaturation_' unless solvent is enabled.
+            {
+                auto ssol = enableSolvent
+                            ? this->eclWriter_->outputModule().getSolventSaturation(elemIdx)
+                            : Scalar(0);
+
+                this->processRestartSaturations_(elemFluidState, ssol);
+
+                if constexpr (enableSolvent) {
+                    this->solventSaturation_[elemIdx] = ssol;
+                    this->solventRsw_[elemIdx] = this->eclWriter_->outputModule().getSolventRsw(elemIdx);
+                }
+            }
+
+            // For CO2STORE and H2STORE we need to set the initial temperature for isothermal simulations
+            bool isThermal = eclState.getSimulationConfig().isThermal();
+            bool needTemperature = (eclState.runspec().co2Storage() || eclState.runspec().h2Storage());
+            if (!isThermal && needTemperature) {
+                const auto& fp = simulator.vanguard().eclState().fieldProps();
+                elemFluidState.setTemperature(fp.get_double("TEMPI")[elemIdx]);
+            }
+
+            this->mixControls_.updateLastValues(elemIdx, elemFluidState.Rs(), elemFluidState.Rv());
+
+            if constexpr (enablePolymer)
+                this->polymer_.concentration[elemIdx] = this->eclWriter_->outputModule().getPolymerConcentration(elemIdx);
+            // if we need to restart for polymer molecular weight simulation, we need to add related here
+        }
+
+        const int episodeIdx = this->episodeIndex();
+        this->mixControls_.updateMaxValues(episodeIdx, simulator.timeStepSize());
+
+        // assign the restart solution to the current solution. note that we still need
+        // to compute real initial solution after this because the initial fluid states
+        // need to be correct for stuff like boundary conditions.
+        auto& sol = this->model().solution(/*timeIdx=*/0);
+        const auto& gridView = this->gridView();
+        ElementContext elemCtx(simulator);
+        for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {
+            elemCtx.updatePrimaryStencil(elem);
+            int elemIdx = elemCtx.globalSpaceIndex(/*spaceIdx=*/0, /*timeIdx=*/0);
+            this->initial(sol[elemIdx], elemCtx, /*spaceIdx=*/0, /*timeIdx=*/0);
+        }
+
+        // make sure that the ghost and overlap entities exhibit the correct
+        // solution. alternatively, this could be done in the loop above by also
+        // considering non-interior elements. Since the initial() method might not work
+        // 100% correctly for such elements, let's play safe and explicitly synchronize
+        // using message passing.
+        this->model().syncOverlap();
+
+        if (fip_init) {
+            this->updateReferencePorosity_();
+            this->mixControls_.init(this->model().numGridDof(),
+                                    this->episodeIndex(),
+                                    eclState.runspec().tabdims().getNumPVTTables());
+        }
+    }
 
     /*!
      * \copydoc BlackOilBaseProblem::thresholdPressure
@@ -1118,96 +1225,7 @@ protected:
         Scalar dt = std::min(this->eclWriter_->restartTimeStepSize(), simulator.episodeLength());
         simulator.setTimeStepSize(dt);
 
-        std::size_t numElems = this->model().numGridDof();
-        this->initialFluidStates_.resize(numElems);
-        if constexpr (enableSolvent) {
-            this->solventSaturation_.resize(numElems, 0.0);
-            this->solventRsw_.resize(numElems, 0.0);
-        }
-
-        if constexpr (enablePolymer)
-            this->polymer_.concentration.resize(numElems, 0.0);
-
-        if constexpr (enablePolymerMolarWeight) {
-            const std::string msg {"Support of the RESTART for polymer molecular weight "
-                                   "is not implemented yet. The polymer weight value will be "
-                                   "zero when RESTART begins"};
-            OpmLog::warning("NO_POLYMW_RESTART", msg);
-            this->polymer_.moleWeight.resize(numElems, 0.0);
-        }
-
-        if constexpr (enableMICP) {
-            this->micp_.resize(numElems);
-        }
-
-        // Initialize mixing controls before trying to set any lastRx valuesx
-        this->mixControls_.init(numElems, restart_step, eclState.runspec().tabdims().getNumPVTTables());
-
-        if constexpr (enableMICP) {
-            this->micp_ = this->eclWriter_->outputModule().getMICP().getSolution();
-        }
-
-        for (std::size_t elemIdx = 0; elemIdx < numElems; ++elemIdx) {
-            auto& elemFluidState = this->initialFluidStates_[elemIdx];
-            elemFluidState.setPvtRegionIndex(pvtRegionIndex(elemIdx));
-            this->eclWriter_->outputModule().initHysteresisParams(simulator, elemIdx);
-            this->eclWriter_->outputModule().assignToFluidState(elemFluidState, elemIdx);
-
-            // Note: Function processRestartSaturations_() mutates the
-            // 'ssol' argument--the value from the restart file--if solvent
-            // is enabled.  Then, store the updated solvent saturation into
-            // 'solventSaturation_'.  Otherwise, just pass a dummy value to
-            // the function and discard the unchanged result.  Do not index
-            // into 'solventSaturation_' unless solvent is enabled.
-            {
-                auto ssol = enableSolvent
-                            ? this->eclWriter_->outputModule().getSolventSaturation(elemIdx)
-                            : Scalar(0);
-
-                this->processRestartSaturations_(elemFluidState, ssol);
-
-                if constexpr (enableSolvent) {
-                    this->solventSaturation_[elemIdx] = ssol;
-                    this->solventRsw_[elemIdx] = this->eclWriter_->outputModule().getSolventRsw(elemIdx);
-                }
-            }
-
-            // For CO2STORE and H2STORE we need to set the initial temperature for isothermal simulations
-            bool isThermal = eclState.getSimulationConfig().isThermal();
-            bool needTemperature = (eclState.runspec().co2Storage() || eclState.runspec().h2Storage());
-            if (!isThermal && needTemperature) {
-                const auto& fp = simulator.vanguard().eclState().fieldProps();
-                elemFluidState.setTemperature(fp.get_double("TEMPI")[elemIdx]);
-            }
-
-            this->mixControls_.updateLastValues(elemIdx, elemFluidState.Rs(), elemFluidState.Rv());
-
-            if constexpr (enablePolymer)
-                this->polymer_.concentration[elemIdx] = this->eclWriter_->outputModule().getPolymerConcentration(elemIdx);
-            // if we need to restart for polymer molecular weight simulation, we need to add related here
-        }
-
-        const int episodeIdx = this->episodeIndex();
-        this->mixControls_.updateMaxValues(episodeIdx, simulator.timeStepSize());
-
-        // assign the restart solution to the current solution. note that we still need
-        // to compute real initial solution after this because the initial fluid states
-        // need to be correct for stuff like boundary conditions.
-        auto& sol = this->model().solution(/*timeIdx=*/0);
-        const auto& gridView = this->gridView();
-        ElementContext elemCtx(simulator);
-        for (const auto& elem : elements(gridView, Dune::Partitions::interior)) {
-            elemCtx.updatePrimaryStencil(elem);
-            int elemIdx = elemCtx.globalSpaceIndex(/*spaceIdx=*/0, /*timeIdx=*/0);
-            this->initial(sol[elemIdx], elemCtx, /*spaceIdx=*/0, /*timeIdx=*/0);
-        }
-
-        // make sure that the ghost and overlap entities exhibit the correct
-        // solution. alternatively, this could be done in the loop above by also
-        // considering non-interior elements. Since the initial() method might not work
-        // 100% correctly for such elements, let's play safe and explicitly synchronize
-        // using message passing.
-        this->model().syncOverlap();
+        this->readSolutionFromOutputModule(restart_step, false);
 
         this->eclWriter_->endRestart();
     }

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -236,11 +236,12 @@ outputMSWLog(std::size_t reportStepNum)
 }
 
 template<class FluidSystem>
-Inplace GenericOutputBlackoilModule<FluidSystem>::
+void GenericOutputBlackoilModule<FluidSystem>::
 calc_initial_inplace(const Parallel::Communication& comm)
 {
-    // calling accumulateRegionSums() updates InitialInplace_ as a side effect
-    return this->accumulateRegionSums(comm);
+    if (!this->initialInplace_.has_value()) {
+        this->initialInplace_ = this->accumulateRegionSums(comm);
+    }
 }
 
 template<class FluidSystem>
@@ -1058,15 +1059,6 @@ accumulateRegionSums(const Parallel::Communication& comm)
         makeRegionSum(inplace, region.first, comm);
     }
 
-    // The first time the outputFipLog function is run we store the inplace values in
-    // the initialInplace_ member. This has a problem:
-    //
-    //   o For restarted runs this is obviously wrong.
-    //
-    // Finally it is of course not desirable to mutate state in an output
-    // routine.
-    if (!this->initialInplace_.has_value())
-        this->initialInplace_ = inplace;
     return inplace;
 }
 

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -114,7 +114,7 @@ public:
     void outputMSWLog(std::size_t reportStepNum);
 
     // calculate Initial Fluid In Place
-    Inplace calc_initial_inplace(const Parallel::Communication& comm);
+    void calc_initial_inplace(const Parallel::Communication& comm);
 
     // calculate Fluid In Place
     Inplace calc_inplace(std::map<std::string, double>& miscSummaryData,

--- a/opm/simulators/flow/Transmissibility_impl.hpp
+++ b/opm/simulators/flow/Transmissibility_impl.hpp
@@ -687,7 +687,7 @@ extractPorosity_()
         }
     }
     else {
-        throw std::logic_error("Can't read the porosityfrom the ecl state. "
+        throw std::logic_error("Can't read the porosity from the ecl state. "
                                "(The PORO keywords are missing)");
     }
 }

--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -39,7 +39,7 @@ RestartValue loadParallelRestart(const EclipseIO* eclIO,
                                  SummaryState& summaryState,
                                  const std::vector<Opm::RestartKey>& solutionKeys,
                                  const std::vector<Opm::RestartKey>& extraKeys,
-                                 Parallel::Communication comm)
+                                 [[maybe_unused]] Parallel::Communication comm)
 {
 #if HAVE_MPI
     RestartValue restartValues{};
@@ -54,7 +54,6 @@ RestartValue loadParallelRestart(const EclipseIO* eclIO,
     ser.broadcast(0, restartValues, summaryState);
     return restartValues;
 #else
-    (void) comm;
     return eclIO->loadRestart(actionState, summaryState, solutionKeys, extraKeys);
 #endif
 }

--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -58,4 +58,27 @@ RestartValue loadParallelRestart(const EclipseIO* eclIO,
 #endif
 }
 
+data::Solution loadParallelRestartSolution(const EclipseIO* eclIO,
+                                           const std::vector<Opm::RestartKey>& solutionKeys,
+                                           [[maybe_unused]] Parallel::Communication comm,
+                                           const int step)
+{
+#if HAVE_MPI
+    data::Solution sol{};
+
+    if (eclIO)
+    {
+        assert(comm.rank() == 0);
+        sol = eclIO->loadRestartSolution(solutionKeys, step);
+    }
+
+    Parallel::MpiSerializer ser(comm);
+    ser.broadcast(0, sol);
+    return sol;
+#else
+    return eclIO->loadRestartSolution(solutionKeys, step);
+#endif
+}
+
+
 } // end namespace Opm

--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -32,8 +32,7 @@
 #include <opm/output/eclipse/RestartValue.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 
-namespace Opm
-{
+namespace Opm {
 
 RestartValue loadParallelRestart(const EclipseIO* eclIO,
                                  Action::State& actionState,

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -23,8 +23,7 @@
 
 #include <vector>
 
-namespace Opm
-{
+namespace Opm {
 
 class EclipseIO;
 class SummaryState;

--- a/opm/simulators/utils/ParallelRestart.hpp
+++ b/opm/simulators/utils/ParallelRestart.hpp
@@ -26,6 +26,7 @@
 namespace Opm {
 
 class EclipseIO;
+namespace data { class Solution; }
 class SummaryState;
 class RestartKey;
 class RestartValue;
@@ -41,6 +42,11 @@ RestartValue loadParallelRestart(const EclipseIO* eclIO,
                                  const std::vector<RestartKey>& solutionKeys,
                                  const std::vector<RestartKey>& extraKeys,
                                  Parallel::Communication comm);
+
+data::Solution loadParallelRestartSolution(const EclipseIO* eclIO,
+                                           const std::vector<RestartKey>& solutionKeys,
+                                           Parallel::Communication comm,
+                                           const int step);
 
 } // end namespace Opm
 


### PR DESCRIPTION
Currently the FIP table data in the restart file is not understood, and this meant that the original FIP was had zero values in a restart run. This adds a workaround for this; On restart we first try to load data for step 0. If there, we can use this to generate the OIP.

Downstream of https://github.com/OPM/opm-common/pull/4545