### PR TITLE
dont call beginTimeStep when restarting simulation after failing

### DIFF
--- a/opm/simulators/flow/BlackoilModel_impl.hpp
+++ b/opm/simulators/flow/BlackoilModel_impl.hpp
@@ -114,8 +114,11 @@ prepareStep(const SimulatorTimerInterface& timer)
     simulator_.setTimeStepSize(timer.currentStepLength());
     simulator_.model().newtonMethod().setIterationIndex(0);
 
-    simulator_.problem().beginTimeStep();
-
+    // we skip the presolving of wells,
+    // the optimization of gaslift and rebalancing of network
+    if (!lastStepFailed) {
+        simulator_.problem().beginTimeStep();
+    }
     unsigned numDof = simulator_.model().numGridDof();
     wasSwitched_.resize(numDof);
     std::fill(wasSwitched_.begin(), wasSwitched_.end(), false);


### PR DESCRIPTION
We do not want to redo the well testing, the pre-solving of wells, gas-lift optimization, network balancing, etc, after failed simulations

For now, this PR adds an if around the outer beginTimeStep. We may need a more fine-grained approach. However, initial testing on selected models is promising. 