### PR TITLE
Disambiguate two identical tests.

### DIFF
--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -85,7 +85,7 @@ add_test_compare_parallel_simulation(CASENAME spe3
                                      SIMULATOR flow
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${coarse_rel_tol_parallel}
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7)
+                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7 --partition-method=1)
 
 add_test_compare_parallel_simulation(CASENAME spe3_partition_method_3
                                      FILENAME SPE3CASE1


### PR DESCRIPTION
The changed test used `partition-method=1` before the `partition-method=3` became the default option. To test the other partitioning method I added a test almost identical to the one touched by this PR with the only difference being the partitioning method. (That test starts at line 90, it is just below this one.) Changing the default partitioning method made these two tests identical. This PR makes them different again.