### PR TITLE
Fix getName phase index for the RPTRST output

### DIFF
--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -905,14 +905,15 @@ doAllocBuffers(const unsigned bufferSize,
                                                }
                                            }
                                        }
-
+                                       unsigned phaseIdx = 0;
                                        for (int phase : phases) {
                                            if (FluidSystem::phaseIsActive(phase)) {
                                                handleScalarEntry((*v)[phase],
-                                                                 getName(entry.kw, entry.phaseType, phase),
+                                                                 getName(entry.kw, entry.phaseType, phaseIdx),
                                                                  entry.supported,
                                                                  required);
                                             }
+                                            ++phaseIdx;
                                        }
                                     }
                                  }, entry.data);


### PR DESCRIPTION
While testing `BG` and `KRG` in `RPTRST` for a `GASWATER` deck, then this issue came out (e.g., `KRG` would write the `WATKR`).  This commit fixes this. 