### PR TITLE
Fix and improve nldd timing and output reporting

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -112,6 +112,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/flow/MechContainer.cpp
   opm/simulators/flow/MICPContainer.cpp
   opm/simulators/flow/MixingRateControls.cpp
+  opm/simulators/flow/NlddReporting.cpp
   opm/simulators/flow/NonlinearSolver.cpp
   opm/simulators/flow/partitionCells.cpp
   opm/simulators/flow/RFTContainer.cpp
@@ -882,6 +883,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/flow/MICPContainer.hpp
   opm/simulators/flow/MixingRateControls.hpp
   opm/simulators/flow/NewTranFluxModule.hpp
+  opm/simulators/flow/NlddReporting.hpp
   opm/simulators/flow/NonlinearSolver.hpp
   opm/simulators/flow/OutputBlackoilModule.hpp
   opm/simulators/flow/OutputCompositionalModule.hpp

--- a/opm/simulators/flow/Banners.cpp
+++ b/opm/simulators/flow/Banners.cpp
@@ -116,8 +116,7 @@ void printFlowTrailer(int nprocs,
                       int nthreads,
                       const double total_setup_time,
                       const double deck_read_time,
-                      const SimulatorReport& report,
-                      const SimulatorReportSingle& localsolves_report)
+                      const SimulatorReport& report)
 {
     std::ostringstream ss;
     ss << "\n\n================    End of simulation     ===============\n\n";
@@ -126,12 +125,6 @@ void printFlowTrailer(int nprocs,
     ss << fmt::format("Setup time:                 {:9.2f} s\n", total_setup_time);
     ss << fmt::format("  Deck input:               {:9.2f} s\n", deck_read_time);
     report.reportFullyImplicit(ss);
-
-    if (localsolves_report.total_linearizations > 0) {
-        ss << "======  Accumulated local solve data  ======\n";
-        localsolves_report.reportFullyImplicit(ss);
-    }
-
     OpmLog::info(ss.str());
 }
 

--- a/opm/simulators/flow/Banners.hpp
+++ b/opm/simulators/flow/Banners.hpp
@@ -44,8 +44,7 @@ void printFlowTrailer(int nprocs,
                       int nthreads,
                       const double total_setup_time,
                       const double deck_read_time,
-                      const SimulatorReport& report,
-                      const SimulatorReportSingle& localsolves_report);
+                      const SimulatorReport& report);
 
 } // namespace Opm
 

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -265,6 +265,9 @@ public:
     /// return the statistics of local solves accumulated for each domain on this rank
     std::vector<SimulatorReport> domainAccumulatedReports() const;
 
+    /// Write the number of nonlinear iterations per cell to a file in ResInsight compatible format
+    void writeNonlinearIterationsPerCell(const std::filesystem::path& odir) const;
+
     const std::vector<StepReport>& stepReports() const
     { return convergence_reports_; }
 

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -260,10 +260,10 @@ public:
     { return failureReport_; }
 
     /// return the statistics of local solves accumulated for this rank
-    SimulatorReport localAccumulatedReports() const;
+    const SimulatorReport& localAccumulatedReports() const;
 
     /// return the statistics of local solves accumulated for each domain on this rank
-    std::vector<SimulatorReport> domainAccumulatedReports() const;
+    const std::vector<SimulatorReport>& domainAccumulatedReports() const;
 
     /// Write the number of nonlinear iterations per cell to a file in ResInsight compatible format
     void writeNonlinearIterationsPerCell(const std::filesystem::path& odir) const;

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -259,8 +259,8 @@ public:
     const SimulatorReportSingle& failureReport() const
     { return failureReport_; }
 
-    /// return the statistics if the nonlinearIteration() method failed
-    SimulatorReportSingle localAccumulatedReports() const;
+    /// return the statistics of local solves accumulated for this rank
+    SimulatorReport localAccumulatedReports() const;
 
     const std::vector<StepReport>& stepReports() const
     { return convergence_reports_; }
@@ -300,6 +300,10 @@ public:
     //! \brief Returns const reference to component names.
     const ComponentName& compNames() const
     { return compNames_; }
+
+    //! \brief Returns true if an NLDD solver exists
+    bool hasNlddSolver() const 
+    { return nlddSolver_ != nullptr; }
 
 protected:
     // ---------  Data members  ---------

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -262,6 +262,9 @@ public:
     /// return the statistics of local solves accumulated for this rank
     SimulatorReport localAccumulatedReports() const;
 
+    /// return the statistics of local solves accumulated for each domain on this rank
+    std::vector<SimulatorReport> domainAccumulatedReports() const;
+
     const std::vector<StepReport>& stepReports() const
     { return convergence_reports_; }
 

--- a/opm/simulators/flow/BlackoilModelNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelNldd.hpp
@@ -380,6 +380,17 @@ public:
         return report;
     }
 
+    void logWells()
+    {
+        for (size_t i = 0; i < domain_reports_accumulated_.size(); ++i) {
+            auto& domain_report = domain_reports_accumulated_[i];
+            domain_report.success.num_wells = 0;
+        }
+        for (const auto& [wname, domain] : wellModel_.well_domain()) {
+            domain_reports_accumulated_[domain].success.num_wells++;
+        }
+    }
+
     /// return the statistics of local solves accumulated for this rank
     const SimulatorReport& localAccumulatedReports() const
     {
@@ -387,8 +398,9 @@ public:
     }
 
     /// return the statistics of local solves accumulated for each domain on this rank
-    const std::vector<SimulatorReport>& domainAccumulatedReports() const
+    std::vector<SimulatorReport>& domainAccumulatedReports()
     {
+        logWells();
         return domain_reports_accumulated_;
     }
 
@@ -469,6 +481,14 @@ private:
         local_reports_accumulated_.success.num_domains = num_domains;
         local_reports_accumulated_.success.num_overlap_cells = overlap_cells;
         local_reports_accumulated_.success.num_owned_cells = owned_cells;
+
+        // Set statistics for each domain report
+        for (size_t i = 0; i < domain_reports_accumulated_.size(); ++i) {
+            auto& domain_report = domain_reports_accumulated_[i];
+            domain_report.success.num_domains = 1;
+            domain_report.success.num_overlap_cells = 0;
+            domain_report.success.num_owned_cells = domains_[i].cells.size();
+        }
 
         // Gather data from all ranks
         std::vector<int> all_owned(comm.size());

--- a/opm/simulators/flow/BlackoilModelNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelNldd.hpp
@@ -450,7 +450,7 @@ private:
                                 modelSimulator.timeStepSize(),
                                 domain);
             // Assemble reservoir locally.
-            report += this->assembleReservoirDomain(domain);
+            this->assembleReservoirDomain(domain);
             report.assemble_time += detailTimer.stop();
         }
         detailTimer.reset();
@@ -514,7 +514,7 @@ private:
             wellModel_.assemble(modelSimulator.model().newtonMethod().numIterations(),
                                 modelSimulator.timeStepSize(),
                                 domain);
-            report += this->assembleReservoirDomain(domain);
+            this->assembleReservoirDomain(domain);
             report.assemble_time += detailTimer.stop();
 
             // Check for local convergence.
@@ -560,11 +560,10 @@ private:
     }
 
     /// Assemble the residual and Jacobian of the nonlinear system.
-    SimulatorReportSingle assembleReservoirDomain(const Domain& domain)
+    void assembleReservoirDomain(const Domain& domain)
     {
         // -------- Mass balance equations --------
         model_.simulator().model().linearizer().linearizeDomain(domain);
-        return model_.wellModel().lastReport();
     }
 
     //! \brief Solve the linearized system for a domain.

--- a/opm/simulators/flow/BlackoilModel_impl.hpp
+++ b/opm/simulators/flow/BlackoilModel_impl.hpp
@@ -977,21 +977,24 @@ computeFluidInPlace(const std::vector<int>& /*fipnum*/) const
 }
 
 template <class TypeTag>
-SimulatorReport
+const SimulatorReport&
 BlackoilModel<TypeTag>::
 localAccumulatedReports() const
 {
-    return hasNlddSolver() ? nlddSolver_->localAccumulatedReports()
-                           : SimulatorReport{};
+    if (!hasNlddSolver()) {
+        OPM_THROW(std::runtime_error, "Cannot get local reports from a model without NLDD solver");
+    }
+    return nlddSolver_->localAccumulatedReports();
 }
 
 template <class TypeTag>
-std::vector<SimulatorReport>
+const std::vector<SimulatorReport>&
 BlackoilModel<TypeTag>::
 domainAccumulatedReports() const
 {
-    return hasNlddSolver() ? nlddSolver_->domainAccumulatedReports()
-                           : std::vector<SimulatorReport>{};
+    if (!nlddSolver_)
+        OPM_THROW(std::runtime_error, "Cannot get domain reports from a model without NLDD solver");
+    return nlddSolver_->domainAccumulatedReports();
 }
 
 template <class TypeTag>

--- a/opm/simulators/flow/BlackoilModel_impl.hpp
+++ b/opm/simulators/flow/BlackoilModel_impl.hpp
@@ -125,7 +125,7 @@ prepareStep(const SimulatorTimerInterface& timer)
         //updateEquationsScaling();
     }
 
-    if (nlddSolver_) {
+    if (hasNlddSolver()) {
         nlddSolver_->prepareStep();
     }
 
@@ -977,12 +977,12 @@ computeFluidInPlace(const std::vector<int>& /*fipnum*/) const
 }
 
 template <class TypeTag>
-SimulatorReportSingle
+SimulatorReport
 BlackoilModel<TypeTag>::
 localAccumulatedReports() const
 {
-    return nlddSolver_ ? nlddSolver_->localAccumulatedReports()
-                       : SimulatorReportSingle{};
+    return hasNlddSolver() ? nlddSolver_->localAccumulatedReports()
+                           : SimulatorReport{};
 }
 
 template <class TypeTag>
@@ -990,8 +990,8 @@ void
 BlackoilModel<TypeTag>::
 writePartitions(const std::filesystem::path& odir) const
 {
-    if (this->nlddSolver_ != nullptr) {
-        this->nlddSolver_->writePartitions(odir);
+    if (hasNlddSolver()) {
+        nlddSolver_->writePartitions(odir);
         return;
     }
 

--- a/opm/simulators/flow/BlackoilModel_impl.hpp
+++ b/opm/simulators/flow/BlackoilModel_impl.hpp
@@ -997,6 +997,16 @@ domainAccumulatedReports() const
 template <class TypeTag>
 void
 BlackoilModel<TypeTag>::
+writeNonlinearIterationsPerCell(const std::filesystem::path& odir) const
+{
+    if (hasNlddSolver()) {
+        nlddSolver_->writeNonlinearIterationsPerCell(odir);
+    }
+}
+
+template <class TypeTag>
+void
+BlackoilModel<TypeTag>::
 writePartitions(const std::filesystem::path& odir) const
 {
     if (hasNlddSolver()) {

--- a/opm/simulators/flow/BlackoilModel_impl.hpp
+++ b/opm/simulators/flow/BlackoilModel_impl.hpp
@@ -986,6 +986,15 @@ localAccumulatedReports() const
 }
 
 template <class TypeTag>
+std::vector<SimulatorReport>
+BlackoilModel<TypeTag>::
+domainAccumulatedReports() const
+{
+    return hasNlddSolver() ? nlddSolver_->domainAccumulatedReports()
+                           : std::vector<SimulatorReport>{};
+}
+
+template <class TypeTag>
 void
 BlackoilModel<TypeTag>::
 writePartitions(const std::filesystem::path& odir) const

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -392,18 +392,42 @@ namespace Opm {
         void runSimulatorAfterSim_(SimulatorReport &report)
         {
             if (simulator_->model().hasNlddSolver()) {
-                // Create a deferred logger and add the report with rank as tag
-                DeferredLogger local_log;
-                std::ostringstream ss;
-                ss << "======  Accumulated local solve data for rank " << mpi_rank_ << " ======\n";
-                simulator_->model().localAccumulatedReports().reportNLDD(ss);
-                // Use rank number as tag to ensure correct ordering
-                local_log.debug(fmt::format("{:05d}", mpi_rank_), ss.str());
+                {
+                    // Create a deferred logger and add the report with rank as tag
+                    DeferredLogger local_log;
+                    std::ostringstream ss;
 
-                // Gather all logs and output them in sorted order
-                auto global_log = gatherDeferredLogger(local_log, FlowGenericVanguard::comm());
-                if (this->output_cout_) {
-                    global_log.logMessages();
+                    // Accumulate reports per domain
+                    const auto& domain_reports = simulator_->model().domainAccumulatedReports();
+                    for (size_t i = 0; i < domain_reports.size(); ++i) {
+                        const auto& dr = domain_reports[i];
+                        ss << "======  Accumulated local solve data for domain " << i << " on rank " << mpi_rank_ << " ======\n";
+                        dr.reportNLDD(ss);
+                        // Use combined rank and domain index as tag to ensure global uniqueness and correct ordering
+                        local_log.debug(fmt::format("R{:05d}D{:05d}", mpi_rank_, i), ss.str());
+                        ss.str(""); // Clear the stringstream
+                        ss.clear(); // Clear any error flags
+                    }
+                    // Gather all logs and output them in sorted order
+                    auto global_log = gatherDeferredLogger(local_log, FlowGenericVanguard::comm());
+                    if (this->output_cout_) {
+                        global_log.logMessages();
+                    }
+                }
+                {
+                    // Create a deferred logger and add the report with rank as tag
+                    DeferredLogger local_log;
+                    std::ostringstream ss;
+                    ss << "======  Accumulated local solve data for rank " << mpi_rank_ << " ======\n";
+                    simulator_->model().localAccumulatedReports().reportNLDD(ss);
+                    // Use rank number as tag to ensure correct ordering
+                    local_log.debug(fmt::format("{:05d}", mpi_rank_), ss.str());
+
+                    // Gather all logs and output them in sorted order
+                    auto global_log = gatherDeferredLogger(local_log, FlowGenericVanguard::comm());
+                    if (this->output_cout_) {
+                        global_log.logMessages();
+                    }
                 }
             }
 

--- a/opm/simulators/flow/FlowMain.hpp
+++ b/opm/simulators/flow/FlowMain.hpp
@@ -393,6 +393,10 @@ namespace Opm {
         {
             if (simulator_->model().hasNlddSolver()) {
                 {
+                    // Write the number of nonlinear iterations per cell to a file in ResInsight compatible format
+                    const auto& odir = eclState().getIOConfig().getOutputDir();
+                    simulator_->model().writeNonlinearIterationsPerCell(odir);
+
                     // Create a deferred logger and add the report with rank as tag
                     DeferredLogger local_log;
                     std::ostringstream ss;

--- a/opm/simulators/flow/NlddReporting.cpp
+++ b/opm/simulators/flow/NlddReporting.cpp
@@ -1,0 +1,90 @@
+/*
+  Copyright 2025, SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#include <opm/simulators/flow/NlddReporting.hpp>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/simulators/timestepping/SimulatorReport.hpp>
+#include <opm/simulators/utils/DeferredLogger.hpp>
+#include <opm/simulators/utils/ParallelCommunication.hpp>
+
+#include <fmt/format.h>
+
+#include <sstream>
+#include <vector>
+
+namespace Opm {
+
+/**
+ * Reports NLDD statistics after simulation.
+ *
+ * @param domain_reports The accumulated reports per domain
+ * @param local_report The accumulated reports per rank
+ * @param output_cout Whether to output to cout
+ * @param comm The communication object for parallel runs
+ */
+void reportNlddStatistics(const std::vector<SimulatorReport>& domain_reports,
+                          const SimulatorReport& local_report,
+                          const bool output_cout,
+                          const Parallel::Communication& comm)
+{
+    const auto& mpi_rank = comm.rank();
+    {
+        // Create a deferred logger and add the report with rank as tag
+        DeferredLogger local_log;
+        std::ostringstream ss;
+
+        // Accumulate reports per domain
+        const auto dr_size = domain_reports.size();
+        for (auto i = 0*dr_size; i < dr_size; ++i) {
+            const auto& dr = domain_reports[i];
+            ss << "======  Accumulated local solve data for domain " << i << " on rank " << mpi_rank << " ======\n";
+            dr.reportNLDD(ss);
+            // Use combined rank and domain index as tag to ensure global uniqueness and correct ordering
+            local_log.debug(fmt::format("R{:05d}D{:05d}", mpi_rank, i), ss.str());
+            ss.str(""); // Clear the stringstream
+            ss.clear(); // Clear any error flags
+        }
+        // Gather all logs and output them in sorted order
+        auto global_log = gatherDeferredLogger(local_log, comm);
+        if (output_cout) {
+            global_log.logMessages();
+        }
+    }
+
+    {
+        // Create a deferred logger and add the report with rank as tag
+        DeferredLogger local_log;
+        std::ostringstream ss;
+        ss << "======  Accumulated local solve data for rank " << mpi_rank << " ======\n";
+        local_report.reportNLDD(ss);
+        // Use rank number as tag to ensure correct ordering
+        local_log.debug(fmt::format("{:05d}", mpi_rank), ss.str());
+
+        // Gather all logs and output them in sorted order
+        auto global_log = gatherDeferredLogger(local_log, comm);
+        if (output_cout) {
+            global_log.logMessages();
+        }
+    }
+}
+
+} // namespace Opm

--- a/opm/simulators/flow/NlddReporting.hpp
+++ b/opm/simulators/flow/NlddReporting.hpp
@@ -1,0 +1,325 @@
+/*
+  Copyright 2025, SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_NLDD_REPORTING_HEADER_INCLUDED
+#define OPM_NLDD_REPORTING_HEADER_INCLUDED
+
+#include <dune/grid/common/gridenums.hh>
+#include <dune/grid/common/partitionset.hh>
+
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/simulators/timestepping/SimulatorReport.hpp>
+#include <opm/simulators/utils/DeferredLogger.hpp>
+#include <opm/simulators/utils/ParallelCommunication.hpp>
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <numeric>
+#include <sstream>
+#include <vector>
+
+namespace Opm {
+
+/**
+ * Reports NLDD statistics after simulation.
+ *
+ * @param domain_reports The accumulated reports per domain
+ * @param local_report The accumulated reports per rank
+ * @param output_cout Whether to output to cout
+ * @param comm The communication object for parallel runs
+ */
+void reportNlddStatistics(const std::vector<SimulatorReport>& domain_reports,
+                          const SimulatorReport& local_report,
+                          const bool output_cout,
+                          const Parallel::Communication& comm);
+
+/**
+ * Writes the number of nonlinear iterations per cell to a file in ResInsight compatible format
+ *
+ * @param odir The output directory
+ * @param domains The subdomains
+ * @param domain_reports The accumulated reports per domain
+ * @param grid The grid
+ * @param elementMapper The element mapper
+ * @param cartMapper The cartesian index mapper
+ */
+template <class Grid, class Domain, class ElementMapper, class CartMapper>
+void writeNonlinearIterationsPerCell(
+    const std::filesystem::path& odir,
+    const std::vector<Domain>& domains,
+    const std::vector<SimulatorReport>& domain_reports,
+    const Grid& grid,
+    const ElementMapper& elementMapper,
+    const CartMapper& cartMapper)
+{
+    const auto& dims = cartMapper.cartesianDimensions();
+    const auto total_size = dims[0] * dims[1] * dims[2];
+    const auto& comm = grid.comm();
+    const int rank = comm.rank();
+
+    // Create a cell-to-iterations mapping for this process
+    std::vector<int> cell_iterations(grid.size(0), 0);
+
+    // Populate the mapping with iteration counts for each domain
+    const auto ds = domains.size();
+    for (auto domain_idx = 0*ds; domain_idx < ds; ++domain_idx) {
+        const auto& domain = domains[domain_idx];
+        const auto& report = domain_reports[domain_idx];
+        const int iterations = report.success.total_newton_iterations + 
+                              report.failure.total_newton_iterations;
+
+        for (const int cell_idx : domain.cells) {
+            cell_iterations[cell_idx] = iterations;
+        }
+    }
+
+    // Create a full-sized vector initialized with zeros (indicating inactive cells)
+    auto full_iterations = std::vector<int>(total_size, 0);
+
+    // Convert local cell indices to cartesian indices
+    const auto& gridView = grid.leafGridView();
+    for (const auto& cell : elements(gridView, Dune::Partitions::interior)) {
+        const int cell_idx = elementMapper.index(cell);
+        const int cart_idx = cartMapper.cartesianIndex(cell_idx);
+        full_iterations[cart_idx] = cell_iterations[cell_idx];
+    }
+
+    // Gather all iteration data using max operation
+    comm.max(full_iterations.data(), full_iterations.size());
+
+    // Only rank 0 writes the file
+    if (rank == 0) {
+        auto fname = odir / "ResInsight_nonlinear_iterations.txt";
+        std::ofstream resInsightFile { fname };
+        // Write header
+        resInsightFile << "NLDD_ITER" << '\n';
+
+        // Write all cells, including inactive ones
+        for (const auto& val : full_iterations) {
+            resInsightFile << val << '\n';
+        }
+        resInsightFile << "/" << '\n';
+    }
+}
+
+/**
+ * Writes the partition vector to a file in ResInsight compatible format and a partition file for each rank
+ *
+ * @param odir The output directory
+ * @param domains Vector of domains
+ * @param grid The grid
+ * @param elementMapper The element mapper
+ * @param cartMapper The cartesian index mapper
+ */
+template <class Grid, class Domain, class ElementMapper, class CartMapper>
+void writePartitions(
+    const std::filesystem::path& odir,
+    const std::vector<Domain>& domains,
+    const Grid& grid,
+    const ElementMapper& elementMapper,
+    const CartMapper& cartMapper)
+{
+    const auto& dims = cartMapper.cartesianDimensions();
+    const auto total_size = dims[0] * dims[1] * dims[2];
+    const auto& comm = grid.comm();
+    const int rank = comm.rank();
+
+    const auto& partition_vector = reconstitutePartitionVector(domains, grid);
+
+    // Create a full-sized vector initialized with -1 (indicating inactive cells)
+    auto full_partition = std::vector<int>(total_size, -1);
+
+    // Fill active cell values for this rank
+    auto i = 0;
+    for (const auto& cell : elements(grid.leafGridView(), Dune::Partitions::interior)) {
+        full_partition[cartMapper.cartesianIndex(elementMapper.index(cell))] = partition_vector[i++];
+    }
+
+    // Gather all partitions using max operation
+    comm.max(full_partition.data(), full_partition.size());
+
+    // Only rank 0 writes the file
+    if (rank == 0) {
+        auto fname = odir / "ResInsight_compatible_partition.txt";
+        std::ofstream resInsightFile { fname };
+
+        // Write header
+        resInsightFile << "NLDD_DOM" << '\n';
+
+        // Write all cells, including inactive ones
+        for (const auto& val : full_partition) {
+            resInsightFile << val << '\n';
+        }
+        resInsightFile << "/" << '\n';
+    }
+
+    const auto nDigit = 1 + static_cast<int>(std::floor(std::log10(comm.size())));
+    auto partition_fname = odir / fmt::format("{1:0>{0}}", nDigit, rank);
+    std::ofstream pfile { partition_fname };
+
+    auto cell_index = 0;
+    for (const auto& cell : elements(grid.leafGridView(), Dune::Partitions::interior)) {
+        pfile << rank << ' '
+              << cartMapper.cartesianIndex(elementMapper.index(cell)) << ' '
+              << partition_vector[cell_index++] << '\n';
+    }
+}
+
+/**
+ * Prints a summary of domain distribution across ranks
+ *
+ * @param partition_vector The partition vector
+ * @param domains The subdomains
+ * @param local_reports_accumulated The accumulated reports per rank
+ * @param domain_reports_accumulated The accumulated reports per domain
+ * @param grid The grid
+ * @param num_wells The number of wells
+ */
+template <class Grid, class Domain>
+void printDomainDistributionSummary(
+    const std::vector<int>& partition_vector,
+    const std::vector<Domain>& domains,
+    SimulatorReport& local_reports_accumulated,
+    std::vector<SimulatorReport>& domain_reports_accumulated,
+    const Grid& grid,
+    int num_wells)
+{
+    const auto& gridView = grid.leafGridView();
+    const auto& comm = grid.comm();
+    const int rank = comm.rank();
+
+    const int num_domains = domains.size();
+    const int owned_cells = partition_vector.size();
+
+    // Count overlap cells using grid view iteration
+    int overlap_cells = std::count_if(elements(gridView).begin(), elements(gridView).end(),
+                                      [](const auto& cell) { return cell.partitionType() == Dune::OverlapEntity; });
+
+    // Store data for summary output
+    local_reports_accumulated.success.num_wells = num_wells;
+    local_reports_accumulated.success.num_domains = num_domains;
+    local_reports_accumulated.success.num_overlap_cells = overlap_cells;
+    local_reports_accumulated.success.num_owned_cells = owned_cells;
+
+    // Set statistics for each domain report
+    const auto dr_size = domain_reports_accumulated.size();
+    for (auto i = 0*dr_size; i < dr_size; ++i) {
+        auto& domain_report = domain_reports_accumulated[i];
+        domain_report.success.num_domains = 1;
+        domain_report.success.num_overlap_cells = 0;
+        domain_report.success.num_owned_cells = domains[i].cells.size();
+    }
+
+    // Gather data from all ranks
+    std::vector<int> all_owned(comm.size());
+    std::vector<int> all_overlap(comm.size());
+    std::vector<int> all_wells(comm.size());
+    std::vector<int> all_domains(comm.size());
+
+    comm.gather(&owned_cells, all_owned.data(), 1, 0);
+    comm.gather(&overlap_cells, all_overlap.data(), 1, 0);
+    comm.gather(&num_wells, all_wells.data(), 1, 0);
+    comm.gather(&num_domains, all_domains.data(), 1, 0);
+
+    if (rank == 0) {
+        std::ostringstream ss;
+        ss << "\nNLDD domain distribution summary:\n"
+        << "  rank   owned cells   overlap cells   total cells   wells   domains\n"
+        << "--------------------------------------------------------------------\n";
+
+        int total_owned = 0;
+        int total_overlap = 0;
+        int total_wells = 0;
+        int total_domains = 0;
+
+        for (int r = 0; r < comm.size(); ++r) {
+            ss << std::setw(6) << r
+            << std::setw(13) << all_owned[r]
+            << std::setw(15) << all_overlap[r]
+            << std::setw(14) << (all_owned[r] + all_overlap[r])
+            << std::setw(8) << all_wells[r]
+            << std::setw(9) << all_domains[r] << '\n';
+
+            total_owned += all_owned[r];
+            total_overlap += all_overlap[r];
+            total_wells += all_wells[r];
+            total_domains += all_domains[r];
+        }
+
+        ss << "--------------------------------------------------------------------\n"
+        << "   sum"
+        << std::setw(13) << total_owned
+        << std::setw(15) << total_overlap
+        << std::setw(14) << (total_owned + total_overlap)
+        << std::setw(8) << total_wells
+        << std::setw(9) << total_domains << '\n';
+
+        OpmLog::info(ss.str());
+    }
+}
+
+/**
+ * Reconstructs the partition vector that maps each grid cell to its corresponding domain ID,
+ * accounting for domain distribution across MPI ranks.
+ *
+ * @param domains Vector of domains
+ * @param grid The grid
+ * @return The reconstructed partition vector
+ */
+template <class Grid, class Domain>
+std::vector<int> reconstitutePartitionVector(
+    const std::vector<Domain>& domains,
+    const Grid& grid)
+{
+    const auto& comm = grid.comm();
+    const int rank = comm.rank();
+
+    auto numD = std::vector<int>(comm.size() + 1, 0);
+    numD[rank + 1] = static_cast<int>(domains.size());
+    comm.sum(numD.data(), numD.size());
+    std::partial_sum(numD.begin(), numD.end(), numD.begin());
+
+    auto p = std::vector<int>(grid.size(0));
+    auto maxCellIdx = std::numeric_limits<int>::min();
+
+    auto d = numD[rank];
+    for (const auto& domain : domains) {
+        for (const auto& cell : domain.cells) {
+            p[cell] = d;
+            if (cell > maxCellIdx) {
+                maxCellIdx = cell;
+            }
+        }
+
+        ++d;
+    }
+
+    p.erase(p.begin() + maxCellIdx + 1, p.end());
+    return p;
+}
+
+} // namespace Opm
+
+#endif // OPM_NLDD_REPORTING_HEADER_INCLUDED

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -33,9 +33,9 @@ namespace Opm
     SimulatorReportSingle SimulatorReportSingle::serializationTestObject()
     {
         return SimulatorReportSingle{1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
-                                     7.0, 8.0, 9.0, 10.0, 11.0,
-                                     12, 13, 14, 15, 16, 17,
-                                     true, false, 18, 19.0, 20.0};
+                                     7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+                                     13, 14, 15, 16, 17, 18,
+                                     true, false, 19, 20.0, 21.0};
     }
 
     bool SimulatorReportSingle::operator==(const SimulatorReportSingle& rhs) const
@@ -49,6 +49,7 @@ namespace Opm
                this->assemble_time_well == rhs.assemble_time_well &&
                this->linear_solve_setup_time == rhs.linear_solve_setup_time &&
                this->linear_solve_time == rhs.linear_solve_time &&
+               this->local_solve_time == rhs.local_solve_time &&
                this->update_time == rhs.update_time &&
                this->output_write_time == rhs.output_write_time &&
                this->total_well_iterations == rhs.total_well_iterations &&
@@ -70,6 +71,7 @@ namespace Opm
         transport_time += sr.transport_time;
         linear_solve_setup_time += sr.linear_solve_setup_time;
         linear_solve_time += sr.linear_solve_time;
+        local_solve_time += sr.local_solve_time;
         solver_time += sr.solver_time;
         assemble_time += sr.assemble_time;
         pre_post_time += sr.pre_post_time;
@@ -106,14 +108,16 @@ namespace Opm
                           linear_solve_time);
     }
 
+    // Helper lambda to avoid division by zero
+    auto noZero = [](auto val)
+    {
+        if (val == decltype(val){0})
+            return decltype(val){1};
+        return val;
+    };
+
     void SimulatorReportSingle::reportFullyImplicit(std::ostream& os, const SimulatorReportSingle* failureReport) const
     {
-        auto noZero = [](auto val)
-        {
-            if (val == decltype(val){0})
-                return decltype(val){1};
-            return val;
-        };
         // Disabling this output as it is redundant with the solver_time, now
         // output as "Simulation time". Usually very small difference between them.
         // os << fmt::format("Total time:                 {:9.2f} s\n", total_time);
@@ -159,6 +163,17 @@ namespace Opm
                                 100*failureReport->linear_solve_setup_time/noZero(t));
             }
             os << std::endl;
+
+            if (local_solve_time > 0.0) {
+                t = local_solve_time + (failureReport ? failureReport->local_solve_time : 0.0);
+                os << fmt::format("  Local solve time:           {:7.2f} s", t);
+                if (failureReport) {
+                  os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                                    failureReport->local_solve_time,
+                                    100*failureReport->local_solve_time/noZero(t));
+                }
+                os << std::endl;
+            }
 
             t = update_time + (failureReport ? failureReport->update_time : 0.0);
             os << fmt::format("  Props/update time:          {:7.2f} s", t);
@@ -210,6 +225,97 @@ namespace Opm
         os << std::endl;
     }
 
+
+    void SimulatorReportSingle::reportNLDD(std::ostream& os, const SimulatorReportSingle* failureReport) const
+    {
+        double t = total_time + (failureReport ? failureReport->total_time : 0.0);
+        os << fmt::format("Total time:                   {:9.2f} s\n", t);
+
+        t = pre_post_time + (failureReport ? failureReport->pre_post_time : 0.0);
+        os << fmt::format("  Pre/post time:                {:7.2f} s\n", t);
+
+        t = solver_time + (failureReport ? failureReport->solver_time : 0.0);
+        os << fmt::format("  Solver time:                {:9.2f} s", t);
+        if (failureReport) {
+            os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                            failureReport->solver_time,
+                            100*failureReport->solver_time/noZero(t));
+        }
+        os << std::endl;
+
+        t = assemble_time + (failureReport ? failureReport->assemble_time : 0.0);
+        os << fmt::format("    Assembly time:            {:9.2f} s", t);
+        if (failureReport) {
+            os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                            failureReport->assemble_time,
+                            100*failureReport->assemble_time/noZero(t));
+            }
+        os << std::endl;
+
+        t = assemble_time_well + (failureReport ? failureReport->assemble_time_well : 0.0);
+        os << fmt::format("      Well assembly:            {:7.2f} s", t);
+        if (failureReport) {
+            os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                            failureReport->assemble_time_well,
+                            100*failureReport->assemble_time_well/noZero(t));
+        }
+        os << std::endl;
+
+        t = linear_solve_time + (failureReport ? failureReport->linear_solve_time : 0.0);
+        os << fmt::format("    Linear solve time:        {:9.2f} s", t);
+        if (failureReport) {
+            os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                            failureReport->linear_solve_time,
+                            100*failureReport->linear_solve_time/noZero(t));
+        }
+        os << std::endl;
+
+        t = linear_solve_setup_time + (failureReport ? failureReport->linear_solve_setup_time : 0.0);
+        os << fmt::format("      Linear setup:             {:7.2f} s", t);
+        if (failureReport) {
+            os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                            failureReport->linear_solve_setup_time,
+                            100*failureReport->linear_solve_setup_time/noZero(t));
+        }
+        os << std::endl;
+
+        t = update_time + (failureReport ? failureReport->update_time : 0.0);
+        os << fmt::format("    Props/update time:          {:7.2f} s", t);
+        if (failureReport) {
+            os << fmt::format(" (Wasted: {:2.1f} s; {:2.1f}%)",
+                            failureReport->update_time,
+                            100*failureReport->update_time/noZero(t));
+        }
+        os << std::endl;
+
+        int n = total_linearizations + (failureReport ? failureReport->total_linearizations : 0);
+        os << fmt::format("Overall Linearizations:       {:7}", n);
+        if (failureReport) {
+          os << fmt::format("   (Wasted: {:5}; {:2.1f}%)",
+                            failureReport->total_linearizations,
+                            100.0*failureReport->total_linearizations/noZero(n));
+        }
+        os << std::endl;
+
+        n = total_newton_iterations + (failureReport ? failureReport->total_newton_iterations : 0);
+        os << fmt::format("Overall Nonlinear Iterations: {:7}", n);
+        if (failureReport) {
+          os << fmt::format("   (Wasted: {:5}; {:2.1f}%)",
+                            failureReport->total_newton_iterations,
+                            100.0*failureReport->total_newton_iterations/noZero(n));
+        }
+        os << std::endl;
+
+        n = total_linear_iterations + (failureReport ? failureReport->total_linear_iterations : 0);
+        os << fmt::format("Overall Linear Iterations:    {:7}", n);
+        if (failureReport) {
+          os << fmt::format("   (Wasted: {:5}; {:2.1f}%)",
+                            failureReport->total_linear_iterations,
+                            100.0*failureReport->total_linear_iterations/noZero(n));
+        }
+        os << std::endl;
+    }
+
     SimulatorReport SimulatorReport::serializationTestObject()
     {
         return SimulatorReport{SimulatorReportSingle::serializationTestObject(),
@@ -247,6 +353,11 @@ namespace Opm
         success.reportFullyImplicit(os, &failure);
     }
 
+    void SimulatorReport::reportNLDD(std::ostream& os) const
+    {
+        success.reportNLDD(os, &failure);
+    }
+
     void SimulatorReport::fullReports(std::ostream& os) const
     {
         os << "  Time(day)  TStep(day)  Assembly    LSetup    LSolve    Update    Output WellIt Lins NewtIt LinIt Conv\n";
@@ -261,6 +372,7 @@ namespace Opm
             os << std::setw(9) << sr.assemble_time << " ";
             os << std::setw(9) << sr.linear_solve_setup_time << " ";
             os << std::setw(9) << sr.linear_solve_time << " ";
+            os << std::setw(9) << sr.local_solve_time << " ";
             os << std::setw(9) << sr.update_time << " ";
             os << std::setw(9) << sr.output_write_time << " ";
             os.precision(6);

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -41,6 +41,7 @@ namespace Opm
         double assemble_time_well = 0.0;
         double linear_solve_setup_time = 0.0;
         double linear_solve_time = 0.0;
+        double local_solve_time = 0.0;
         double update_time = 0.0;
         double output_write_time = 0.0;
 
@@ -67,7 +68,7 @@ namespace Opm
         void reportStep(std::ostream& os) const;
         /// Print a report suitable for the end of a fully implicit case, leaving out the pressure/transport time.
         void reportFullyImplicit(std::ostream& os, const SimulatorReportSingle* failedReport = nullptr) const;
-
+        void reportNLDD(std::ostream& os, const SimulatorReportSingle* failedReport = nullptr) const;
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
@@ -80,6 +81,7 @@ namespace Opm
             serializer(assemble_time_well);
             serializer(linear_solve_setup_time);
             serializer(linear_solve_time);
+            serializer(local_solve_time);
             serializer(update_time);
             serializer(output_write_time);
             serializer(total_well_iterations);
@@ -108,6 +110,7 @@ namespace Opm
         void operator+=(const SimulatorReportSingle& sr);
         void operator+=(const SimulatorReport& sr);
         void reportFullyImplicit(std::ostream& os) const;
+        void reportNLDD(std::ostream& os) const;
         void fullReports(std::ostream& os) const;
 
         template<class Serializer>

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -59,6 +59,16 @@ namespace Opm
         double global_time = 0.0;
         double timestep_length = 0.0;
 
+        // NLDD specific data
+        int num_domains = 0;
+        int num_wells = 0;
+        int num_overlap_cells = 0;
+        int num_owned_cells = 0;
+        int converged_domains = 0;
+        int unconverged_domains = 0;
+        int accepted_unconverged_domains = 0;
+
+
         static SimulatorReportSingle serializationTestObject();
 
         bool operator==(const SimulatorReportSingle&) const;
@@ -95,6 +105,13 @@ namespace Opm
             serializer(exit_status);
             serializer(global_time);
             serializer(timestep_length);
+            serializer(num_domains);
+            serializer(num_wells);
+            serializer(num_overlap_cells);
+            serializer(num_owned_cells);
+            serializer(converged_domains);
+            serializer(unconverged_domains);
+            serializer(accepted_unconverged_domains);
         }
     };
 

--- a/opm/simulators/wells/BlackoilWellModelNldd.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNldd.hpp
@@ -117,6 +117,18 @@ public:
     void recoverWellSolutionAndUpdateWellState(const BVector& x,
                                                const int domainIdx);
 
+    // Get number of wells on this rank
+    int numLocalWells() const 
+    {
+        return wellModel_.numLocalWells(); 
+    }
+
+    // Get number of wells on this rank
+    int numLocalWellsEnd() const 
+    {
+        return wellModel_.numLocalWellsEnd(); 
+    }
+
 private:
     BlackoilWellModel<TypeTag>& wellModel_;
 

--- a/opm/simulators/wells/BlackoilWellModelNldd_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNldd_impl.hpp
@@ -40,6 +40,7 @@ assemble(const int /*iterationIdx*/,
          const double dt,
          const Domain& domain)
 {
+    OPM_TIMEBLOCK(assemble);
     // We assume that calculateExplicitQuantities() and
     // prepareTimeStep() have been called already for the entire
     // well model, so we do not need to do it here (when
@@ -57,6 +58,7 @@ assembleWellEq(const double dt,
                const Domain& domain,
                DeferredLogger& deferred_logger)
 {
+    OPM_TIMEBLOCK(assembleWellEq);
     for (const auto& well : wellModel_.localNonshutWells()) {
         if (this->well_domain().at(well->name()) == domain.index) {
             well->assembleWellEq(wellModel_.simulator(),
@@ -176,6 +178,7 @@ BlackoilWellModelNldd<TypeTag>::
 updateWellControls(DeferredLogger& deferred_logger,
                    const Domain& domain)
 {
+    OPM_TIMEBLOCK(updateWellControls);
     if (!wellModel_.wellsActive()) {
         return;
     }

--- a/opm/simulators/wells/WellConnectionAuxiliaryModule.hpp
+++ b/opm/simulators/wells/WellConnectionAuxiliaryModule.hpp
@@ -116,6 +116,7 @@ public:
                          SparseMatrixAdapter& jacobian,
                          GlobalEqVector& res)
     {
+        OPM_TIMEBLOCK(wellLinearizeDomain);
         // Note: no point in trying to do a parallel gathering
         // try/catch here, as this function is not called in
         // parallel but for each individual domain of each rank.


### PR DESCRIPTION
# Improving reporting of NLDD

## Changes
This PR fixes some bugs that were present in the Non-Linear Domain Decomposition (NLDD) reporting and improves how statistics from the NLDD solver are collected, displayed, and analyzed. 

The key improvements are:

1. Fixed a bug that the simulation summary reported the NLDD summary for rank 0 only. Now, it only reports the total local solve time in the simulation summary, and more detailed reports are shown in the DBG file. Removing the breakdown from the final summary report is motivated by the fact that this does not make sense for NLDD in parallel, where all the ranks have to wait for the slowest rank. Instead, we now output detailed reports per domain and per rank in the DBG file, which makes more sense.
2. There were also some inconsistencies in the NLDD assembly reporting, which have been fixed.
3. Better reporting structure: Changed `BlackoilModel::localAccumulatedReports()` from returning a simple `SimulatorReportSingle` to a more comprehensive `SimulatorReport` that can track both successful and failed solves.
4. Per-domain statistics: Added a new method `BlackoilModel::domainAccumulatedReports()` that provides detailed statistics for each individual domain on the current rank.
5. Cell-level visualization: Implemented `BlackoilModel::writeNonlinearIterationsPerCell()` to generate ResInsight-compatible files showing nonlinear iteration counts at the cell level.
6. Added a helper method `BlackoilModel::hasNlddSolver()` that makes it cleaner to check if an NLDD solver exists before attempting to use it.
7. Created an NLDD-specific report writer with more details, used for rank- and domain-level statistics.


## New Features
### 1. Domain Distribution Summary
The solver now provides a summary of how cells, wells and domains are distributed across ranks:

```
NLDD domain distribution summary:
  rank   owned cells   overlap cells   total cells   wells   domains
--------------------------------------------------------------------
     0         9682           2227         11909       5       12
     1        11809           1777         13586      14       12
     2        12131            536         12667      12       14
     3        10809            590         11399       5       13
--------------------------------------------------------------------
   sum        44431           5130         49561      36       51
```

### 2. Per-Domain Performance Reports
Each domain's performance is now reported with detailed statistics in the DBG file:

```
======  Accumulated local solve data for domain 0 on rank 1 ======
Owned + overlap cells:          1086
Number of wells:                   2
Number of domains:                 1
-------------------------------------------------------
Total time:                        0.00 s
  Pre/post/wait time:              0.00 s
  Solver time:                     2.87 s (Wasted: 0.1 s; 1.9%)
    Assembly time:                 1.39 s (Wasted: 0.0 s; 1.5%)
      Well assembly:               0.06 s (Wasted: 0.0 s; 1.3%)
    Linear solve time:             0.45 s (Wasted: 0.0 s; 2.3%)
      Linear setup:                0.19 s (Wasted: 0.0 s; 2.3%)
    Props/update time:             1.02 s (Wasted: 0.0 s; 2.2%)
Overall Linearizations:          1250   (Wasted:    22; 1.8%)
Overall Nonlinear Iterations:     787   (Wasted:    21; 2.7%)
Overall Linear Iterations:       1253   (Wasted:    12; 1.0%)
-------------------------------------------------------
Converged domain solves:         462
  Accepted with relaxed tol:       0
Unconverged domain solves:         1
```

### 3. Per rank statistics
Detailed NLDD statistics accumulated per rank is now shown per rank in the DBG file (what was former shown in the simulation summary).

```
======  Accumulated local solve data for rank 1 ======
Owned + overlap cells:         13586
Number of wells:                  14
Number of domains:                12
-------------------------------------------------------
Total time:                       31.76 s
  Pre/post/wait time:              2.10 s
  Solver time:                    29.66 s (Wasted: 0.1 s; 0.2%)
    Assembly time:                13.91 s (Wasted: 0.0 s; 0.1%)
      Well assembly:               0.30 s (Wasted: 0.0 s; 0.2%)
    Linear solve time:             5.35 s (Wasted: 0.0 s; 0.2%)
      Linear setup:                1.92 s (Wasted: 0.0 s; 0.2%)
    Props/update time:            10.22 s (Wasted: 0.0 s; 0.2%)
Overall Linearizations:         14517   (Wasted:    22; 0.2%)
Overall Nonlinear Iterations:    8961   (Wasted:    21; 0.2%)
Overall Linear Iterations:      13370   (Wasted:    12; 0.1%)
-------------------------------------------------------
Converged domain solves:        5555
  Accepted with relaxed tol:       0
Unconverged domain solves:         1
```

### 4. Visualisation Capabilities
The PR adds the ability to visualise nonlinear iteration counts:

- **Cell-level NLDD iteration count**: A ResInsight-compatible output file that allows visualisation of nonlinear iteration counts per cell, helping identify problematic regions in the model.

![ResInsight_nonlinear_iterations](https://github.com/user-attachments/assets/1933f073-32fb-4e5e-9a27-411080a2aa12)

- **Domain-level performance**: The new detailed domain statistics make it possible to analyse the NLDD method in more detail and create useful plots like the one below.

![NORNE_ATW2013_nonlinear](https://github.com/user-attachments/assets/a687a049-4584-4f44-b112-37b803954026)

## Implementation Details
- The implementation extends the existing `SimulatorReport` structures for domain-specific performance reporting. A dedicated one can be created for NLDD to avoid having some unused fields during the current default Newton method. However, there is quite a lot of functionality built around it for things like adding reports and etc. So, I kept it as one report to avoid too much duplication.
- To produce the NLDD statistics there is a significant amount of processing that needs to be done. However, all the processing-intensive and global calls are only done once per simulation, and I argue that the value it provides justifies the cost.
- In the NLDD domain statistics report, there are the three following fields: 
- Total time: Total time spent in NLDD for this domain
- Pre/post/wait time: Total time spent preparing for NLDD solve and waiting for other ranks to finish
- Solver time: Total time spent doing an actual solve for this domain
- The total solve time will therefore be around the same for all domains and about the same as the local solve time in the simulations summary. Whereas the pre/post/wait time will differ based on the workload on that rank.