### PR TITLE
Use well rates from well_state_nupcol instead of previous_well_state in updateWellRates

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1384,11 +1384,10 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                                                          well_state_nupcol,
                                                          this->groupState());
 
-    // We use the rates from the previous time-step to reduce oscillations
     WellGroupHelpers<Scalar>::updateWellRates(fieldGroup,
                                               schedule(),
                                               reportStepIdx,
-                                              this->prevWellState(),
+                                              well_state_nupcol,
                                               well_state);
 
     // Set ALQ for off-process wells to zero


### PR DESCRIPTION
The previous_well_state was used to avoid oscillations long time ago. Using the nupcol rates aligns more with what we do elsewhere in the code and will be more accurate in particular at startup of wells. Test failures are expected. A qualitative look at the failed tests indicates that results looks more plausible. 