### PR TITLE
Temporarily Disable 1D_COMP Regression Test

### DIFF
--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -44,12 +44,12 @@ add_test_compareECLFiles(CASENAME spe1flowexp
                          REL_TOL ${rel_tol}
                          DIR spe1)
 
-add_test_compareECLFiles(CASENAME 1dcompositional
-                         FILENAME 1D_COMP
-                         SIMULATOR flowexp_comp
-                         ABS_TOL ${abs_tol}
-                         REL_TOL ${rel_tol}
-                         DIR compositional)
+# add_test_compareECLFiles(CASENAME 1dcompositional
+#                          FILENAME 1D_COMP
+#                          SIMULATOR flowexp_comp
+#                          ABS_TOL ${abs_tol}
+#                          REL_TOL ${rel_tol}
+#                          DIR compositional)
 
 add_test_compareECLFiles(CASENAME spe12
                          FILENAME SPE1CASE2


### PR DESCRIPTION
We're in the lead-up to creating release branches for 2025.04 and must not have a broken build.  We will re-enable the test once the underlying issue has been resolved.