### PR TITLE
Silence various warnings.

### DIFF
--- a/flowexperimental/comp/wells/CompWell.hpp
+++ b/flowexperimental/comp/wells/CompWell.hpp
@@ -91,7 +91,7 @@ public:
     void init() override;
 
     void calculateExplicitQuantities(const Simulator& simulator,
-                                     const SingleCompWellState<Scalar>& well_state);
+                                     const SingleCompWellState<Scalar>& well_state) override;
 
     void updatePrimaryVariables(const Simulator& simulator,
                                 const SingleCompWellState<Scalar>& well_state) override;
@@ -105,18 +105,18 @@ public:
 
     bool iterateWellEq(const Simulator& simulator,
                        const Scalar dt,
-                       SingleCompWellState<Scalar>& well_state);
+                       SingleCompWellState<Scalar>& well_state) override;
 
     void solveEqAndUpdateWellState(SingleCompWellState<Scalar>& well_state);
 
     void apply(BVector& r) const override;
 
     void recoverWellSolutionAndUpdateWellState(const BVector& x,
-                                               SingleCompWellState<Scalar>& well_state);
+                                               SingleCompWellState<Scalar>& well_state) override;
 
     bool getConvergence() const override;
 
-    void addWellContributions(SparseMatrixAdapter&) const;
+    void addWellContributions(SparseMatrixAdapter&) const override;
 
 private:
 

--- a/flowexperimental/comp/wells/CompWellInterface.hpp
+++ b/flowexperimental/comp/wells/CompWellInterface.hpp
@@ -48,6 +48,10 @@ public:
                       const int index_of_well,
                       const std::vector<CompConnectionData>& well_connection_data);
 
+    virtual ~CompWellInterface() = default;
+
+    virtual void init();
+
     const std::string& name() const;
 
     virtual void calculateExplicitQuantities(const Simulator& simulator,
@@ -93,7 +97,6 @@ protected:
     std::vector<int> saturation_table_number_;
 
     // std::string name_;
-    virtual void init();
 
 };
 

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -474,7 +474,7 @@ void WellInterfaceGeneric<Scalar>::setRepRadiusPerfLength()
 
     const WellConnections& connections = well_ecl_.getConnections();
     const std::size_t num_conns = connections.size();
-    int num_active_connections = 0;
+    [[maybe_unused]] int num_active_connections = 0;
     auto my_next_perf = perf_data_->begin();
     for (std::size_t c = 0; c < num_conns; ++c) {
         if (my_next_perf == perf_data_->end())


### PR DESCRIPTION
Adding a virtual destructor, adding override qualifiers, and marking as [[maybe_unused]] a variable only read in an assert().