### PR TITLE
Fix to 2025.04-r1 build candidate in clang

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -507,7 +507,7 @@ run()
  * Private class SubStepper private methods
  ************************************************/
 
-
+#ifdef RESERVOIR_COUPLING_ENABLED
 template<class TypeTag>
 template<class Solver>
 bool
@@ -525,6 +525,7 @@ isReservoirCouplingSlave_() const
 {
     return this->adaptive_time_stepping_.reservoir_coupling_slave_ != nullptr;
 }
+#endif
 
 template<class TypeTag>
 template<class Solver>


### PR DESCRIPTION
While testing 2025.04-r1, this issue appears, and this PR fixes this. 