### PR TITLE
moving flowPhaseToModelPhaseIdx to WellInterfaceIndices

### DIFF
--- a/opm/simulators/wells/WellInterfaceFluidSystem.cpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.cpp
@@ -225,23 +225,6 @@ checkConstraints(WellState<Scalar>& well_state,
 }
 
 template<typename FluidSystem>
-int
-WellInterfaceFluidSystem<FluidSystem>::
-flowPhaseToModelPhaseIdx(const int phaseIdx) const
-{
-    const auto& pu = this->phaseUsage();
-    if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx) && pu.phase_pos[Water] == phaseIdx)
-        return FluidSystem::waterPhaseIdx;
-    if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) && pu.phase_pos[Oil] == phaseIdx)
-        return FluidSystem::oilPhaseIdx;
-    if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx) && pu.phase_pos[Gas] == phaseIdx)
-        return FluidSystem::gasPhaseIdx;
-
-    // for other phases return the index
-    return phaseIdx;
-}
-
-template<typename FluidSystem>
 std::optional<typename WellInterfaceFluidSystem<FluidSystem>::Scalar>
 WellInterfaceFluidSystem<FluidSystem>::
 getGroupInjectionTargetRate(const Group& group,

--- a/opm/simulators/wells/WellInterfaceFluidSystem.hpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.hpp
@@ -59,8 +59,6 @@ public:
     using Scalar = typename FluidSystem::Scalar;
     using ModelParameters = typename WellInterfaceGeneric<Scalar>::ModelParameters;
 
-    int flowPhaseToModelPhaseIdx(const int phaseIdx) const;
-
     static constexpr int Water = BlackoilPhases::Aqua;
     static constexpr int Oil = BlackoilPhases::Liquid;
     static constexpr int Gas = BlackoilPhases::Vapour;

--- a/opm/simulators/wells/WellInterfaceIndices.cpp
+++ b/opm/simulators/wells/WellInterfaceIndices.cpp
@@ -92,6 +92,25 @@ modelCompIdxToFlowCompIdx(const int compIdx) const
     return compIdx;
 }
 
+
+template<typename FluidSystem, class Indices>
+int
+WellInterfaceIndices<FluidSystem, Indices>::
+flowPhaseToModelPhaseIdx(const int phaseIdx) const
+{
+    const auto& pu = this->phaseUsage();
+    if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx) && pu.phase_pos[Water] == phaseIdx)
+        return FluidSystem::waterPhaseIdx;
+    if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx) && pu.phase_pos[Oil] == phaseIdx)
+        return FluidSystem::oilPhaseIdx;
+    if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx) && pu.phase_pos[Gas] == phaseIdx)
+        return FluidSystem::gasPhaseIdx;
+
+    // for other phases return the index
+    return phaseIdx;
+}
+
+
 template<class FluidSystem, class Indices>
 typename WellInterfaceIndices<FluidSystem,Indices>::Scalar
 WellInterfaceIndices<FluidSystem,Indices>::

--- a/opm/simulators/wells/WellInterfaceIndices.hpp
+++ b/opm/simulators/wells/WellInterfaceIndices.hpp
@@ -42,6 +42,7 @@ public:
 
     int flowPhaseToModelCompIdx(const int phaseIdx) const;
     int modelCompIdxToFlowCompIdx(const int compIdx) const;
+    int flowPhaseToModelPhaseIdx(const int phaseIdx) const;
     Scalar scalingFactor(const int phaseIdx) const;
 
     template <class EvalWell>


### PR DESCRIPTION
so it will be together with other index conversion functions. it is not a significant deal, while it makes easier to find them. 

originally, I thought there are only two of them since WellInterfaceIndices class only has two of them. 