### PR TITLE
Fix to broken build in clang

### DIFF
--- a/opm/simulators/utils/MPISerializer.hpp
+++ b/opm/simulators/utils/MPISerializer.hpp
@@ -43,12 +43,12 @@ public:
     //! \param data Class to broadcast
     //! \param root Process to broadcast from
     template<class T>
-    void broadcast(T& data, int root = 0)
+    void broadcast(T& data, unsigned root = 0)
     {
         if (m_comm.size() == 1)
             return;
 
-        if (m_comm.rank() == root) {
+        if (m_comm.rank() == int(root)) {
             try {
                 this->pack(data);
                 m_comm.broadcast(&m_packSize, 1, root);


### PR DESCRIPTION
This is the error (macOS, clang):

```
/Users/dmar/Github/opm/opm-simulators/opm/simulators/wells/ParallelWellInfo.cpp:642:13: error: call to member function 'broadcast' is ambiguous
  642 |         ser.broadcast(rankWithFirstPerf_, res);
/Users/dmar/Github/opm/opm-simulators/opm/simulators/utils/MPISerializer.hpp:46:10: note: candidate function [with T = const int]
   46 |     void broadcast(T& data, int root = 0)
      |          ^
/Users/dmar/Github/opm/opm-simulators/opm/simulators/utils/MPISerializer.hpp:73:10: note: candidate function [with Args = <int &>]
   73 |     void broadcast(int root, Args&&... args)
```

This 'hack 'fixes the building (for sure there is a more elegant (proper) fix, if someone has one, please do a PR and I will close this one. 