### PR TITLE
Fix runs with distributed MSWells with only shut perforations on one process

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -845,10 +845,6 @@ namespace Opm
     MultisegmentWell<TypeTag>::
     addWellContributions(SparseMatrixAdapter& jacobian) const
     {
-        if (this->number_of_local_perforations_ == 0) {
-            // If there are no open perforations on this process, there are no contributions to the jacobian.
-            return;
-        }
         this->linSys_.extract(jacobian);
     }
 
@@ -862,10 +858,6 @@ namespace Opm
                              const bool use_well_weights,
                              const WellState<Scalar>& well_state) const
     {
-        if (this->number_of_local_perforations_ == 0) {
-            // If there are no open perforations on this process, there are no contributions the cpr pressure matrix.
-            return;
-        }
         // Add the pressure contribution to the cpr system for the well
         this->linSys_.extractCPRPressureMatrix(jacobian,
                                                weights,

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -57,7 +57,7 @@ add_test_compare_parallel_simulation(CASENAME msw-simple-1-shut-perforation-bord
                                      TEST_ARGS --solver-max-time-step-in-days=15 --allow-distributed-wells=true)
 
 
-# A test for distributed multisegment wells with only shut perforations on one process. We load distribute only along the z-axis
+# A test for distributed multisegment wells with only one open perforation. We load distribute only along the z-axis
 add_test_compare_parallel_simulation(CASENAME msw-simple-shut-perforations
                                      FILENAME MSW-SIMPLE-SHUT-PERFORATIONS # this file contains one Multisegment well without branches that is distributed across several processes
                                      DIR msw
@@ -67,6 +67,25 @@ add_test_compare_parallel_simulation(CASENAME msw-simple-shut-perforations
                                      MPI_PROCS 4
                                      TEST_ARGS --solver-max-time-step-in-days=15 --allow-distributed-wells=true)
 
+# A test for distributed multisegment wells with only shut perforations on rank 0, where the well is distributed across ranks 0 and 1. We load distribute only along the z-axis
+add_test_compare_parallel_simulation(CASENAME msw-simple-5-shut-perforations
+                                     FILENAME MSW-SIMPLE-5-SHUT-PERFORATIONS # this file contains one Multisegment well without branches that is distributed across several processes
+                                     DIR msw
+                                     SIMULATOR flow_distribute_z
+                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
+                                     REL_TOL 1e-5
+                                     MPI_PROCS 4
+                                     TEST_ARGS --solver-max-time-step-in-days=15 --allow-distributed-wells=true)
+
+# A test for distributed multisegment wells with only shut perforations on rank 1, where the well is distributed across ranks 0 and 1. We load distribute only along the z-axis
+add_test_compare_parallel_simulation(CASENAME msw-simple-7-shut-perforations
+                                     FILENAME MSW-SIMPLE-7-SHUT-PERFORATIONS # this file contains one Multisegment well without branches that is distributed across several processes
+                                     DIR msw
+                                     SIMULATOR flow_distribute_z
+                                     ABS_TOL 1e4 # the absolute tolerance is pretty high here, yet in this case, we are only interested in the relative tolerance
+                                     REL_TOL 1e-5
+                                     MPI_PROCS 4
+                                     TEST_ARGS --solver-max-time-step-in-days=15 --allow-distributed-wells=true)
 
 add_test_compare_parallel_simulation(CASENAME msw-3d
                                      FILENAME MSW-3D # this file contains one Multisegment well with branches that is distributed across several processes


### PR DESCRIPTION
Fixes the tests added in https://github.com/OPM/opm-tests/pull/1330.
Without the fix from this PR, the tests fail (see #6176).

This PR is not relevant for the reference manual.