### PR TITLE
Cut timestep if network imbalance is larger than a parameter

### DIFF
--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -102,6 +102,7 @@ BlackoilModelParameters<Scalar>::BlackoilModelParameters()
     network_max_sub_iterations_ = Parameters::Get<Parameters::NetworkMaxSubIterations>();
     network_pressure_update_damping_factor_ = Parameters::Get<Parameters::NetworkPressureUpdateDampingFactor<Scalar>>();
     network_max_pressure_update_in_bars_ = Parameters::Get<Parameters::NetworkMaxPressureUpdateInBars<Scalar>>();
+    network_max_pressure_imbalance_in_bars_ = Parameters::Get<Parameters::NetworkMaxPressureImbalanceInBars<Scalar>>();
     local_domains_ordering_ = domainOrderingMeasureFromString(Parameters::Get<Parameters::LocalDomainsOrderingMeasure>());
     write_partitions_ = Parameters::Get<Parameters::DebugEmitCellPartition>();
 
@@ -233,6 +234,8 @@ void BlackoilModelParameters<Scalar>::registerParameters()
         ("Damping factor in the inner network pressure update iterations");
     Parameters::Register<Parameters::NetworkMaxPressureUpdateInBars<Scalar>>
         ("Maximum pressure update in the inner network pressure update iterations");
+    Parameters::Register<Parameters::NetworkMaxPressureImbalanceInBars<Scalar>>
+        ("Maximum pressure imbalance allowed without chopping timesteps");
     Parameters::Register<Parameters::NonlinearSolver>
         ("Choose nonlinear solver. Valid choices are newton or nldd.");
     Parameters::Register<Parameters::LocalSolveApproach>

--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -136,6 +136,8 @@ template<class Scalar>
 struct NetworkPressureUpdateDampingFactor { static constexpr Scalar value = 0.1; };
 template<class Scalar>
 struct NetworkMaxPressureUpdateInBars { static constexpr Scalar value = 5.0; };
+template<class Scalar>
+struct NetworkMaxPressureImbalanceInBars { static constexpr Scalar value = 1.e9; };
 struct NonlinearSolver { static constexpr auto value = "newton"; };
 struct LocalSolveApproach { static constexpr auto value = "gauss-seidel"; };
 struct MaxLocalSolveIterations { static constexpr int value = 20; };
@@ -316,6 +318,9 @@ public:
 
     /// Maximum pressure update in the inner network pressure update iterations
     Scalar network_max_pressure_update_in_bars_;
+
+    /// Maximum allowed pressure imbalance without chopping the timestep
+    Scalar network_max_pressure_imbalance_in_bars_;
 
     /// Nonlinear solver type: newton or nldd.
     std::string nonlinear_solver_;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1209,6 +1209,15 @@ namespace Opm {
                         max_iteration, network_imbalance*1.0e-5, well_group_control_changed);
                     local_deferredLogger.debug(msg);
                 } else {
+                    const Scalar maximum_imbalance = param_.network_max_pressure_imbalance_in_bars_ * Opm::unit::barsa;
+                    if (network_imbalance > maximum_imbalance) {
+                        const std::string msg = fmt::format("Maximum of {:d} network iterations has been used and we stop the update. \n"
+                            "The imbalance is larger than the maximum allowed tolerance and the simulator will re-try with smaller time step. \n"
+                            "The maximum tolerance is {:.2e} bar and can be adjusted with --max-network-imbalance="
+                            "(imbalance = {:.2e} bar, ctrl_change = {})",
+                            max_iteration, maximum_imbalance*1.0e-5, network_imbalance*1.0e-5, well_group_control_changed);
+                        OPM_THROW_PROBLEM(NumericalProblem, msg);
+                    }
                     if (this->terminal_output_) {
                         const std::string msg = fmt::format("Maximum of {:d} network iterations has been used and we stop the update. \n"
                             "The simulator will continue with unconverged network results (imbalance = {:.2e} bar, ctrl_change = {})",


### PR DESCRIPTION
Accepting an unconverged network solution could lead to premature shutting of wells and it is therefore sometimes better to re-try the timestep. It is still unclear what a good default value is (maybe 1 bar?) As a starting point I suggest to add the parameter with a very large default value to make the option available. 