### PR TITLE
Remove unneeded broadcast() overload.

### DIFF
--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -276,8 +276,8 @@ extractOutputTransAndNNC(const std::function<unsigned int(unsigned int)>& map)
 #if HAVE_MPI
     if (collectOnIORank_.isParallel()) {
         const auto& comm = grid_.comm();
-        Opm::Parallel::MpiSerializer ser(comm);
-        ser.broadcast(0, outputNnc_);
+        Parallel::MpiSerializer ser(comm);
+        ser.broadcast(Parallel::RootRank{0}, outputNnc_);
     }
 #endif
 }

--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -277,7 +277,7 @@ extractOutputTransAndNNC(const std::function<unsigned int(unsigned int)>& map)
     if (collectOnIORank_.isParallel()) {
         const auto& comm = grid_.comm();
         Opm::Parallel::MpiSerializer ser(comm);
-        ser.broadcast(outputNnc_);
+        ser.broadcast(0, outputNnc_);
     }
 #endif
 }

--- a/opm/simulators/flow/GenericCpGridVanguard.cpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.cpp
@@ -498,7 +498,7 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Eclips
         if (eclState.aquifer().hasNumericalAquifer()) {
             auto nnc_input = eclState.getInputNNC();
             Parallel::MpiSerializer ser(this->grid_->comm());
-            ser.broadcast(nnc_input);
+            ser.broadcast(0, nnc_input);
 
             if (! isRoot) {
                 eclState.setInputNNC(nnc_input);
@@ -511,7 +511,7 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Eclips
         if (hasPinchNnc) {
             auto pinch_nnc = eclState.getPinchNNC();
             Parallel::MpiSerializer ser(this->grid_->comm());
-            ser.broadcast(pinch_nnc);
+            ser.broadcast(0, pinch_nnc);
 
             if (! isRoot) {
                 eclState.setPinchNNC(std::move(pinch_nnc));

--- a/opm/simulators/flow/GenericCpGridVanguard.cpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.cpp
@@ -498,7 +498,7 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Eclips
         if (eclState.aquifer().hasNumericalAquifer()) {
             auto nnc_input = eclState.getInputNNC();
             Parallel::MpiSerializer ser(this->grid_->comm());
-            ser.broadcast(0, nnc_input);
+            ser.broadcast(Parallel::RootRank{0}, nnc_input);
 
             if (! isRoot) {
                 eclState.setInputNNC(nnc_input);
@@ -511,7 +511,7 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::doCreateGrids_(Eclips
         if (hasPinchNnc) {
             auto pinch_nnc = eclState.getPinchNNC();
             Parallel::MpiSerializer ser(this->grid_->comm());
-            ser.broadcast(0, pinch_nnc);
+            ser.broadcast(Parallel::RootRank{0}, pinch_nnc);
 
             if (! isRoot) {
                 eclState.setPinchNNC(std::move(pinch_nnc));

--- a/opm/simulators/flow/partitionCells.cpp
+++ b/opm/simulators/flow/partitionCells.cpp
@@ -358,7 +358,7 @@ void ZoltanPartitioner::connectWells(const Comm                                 
 
     // Communicate Map to other processes, since it is only available on rank 0
     Opm::Parallel::MpiSerializer ser(comm);
-    ser.broadcast(possibleFutureConnections);
+    ser.broadcast(0, possibleFutureConnections);
 
     for (const auto& well : wells) {
         auto cellIx = std::vector<int>{};

--- a/opm/simulators/flow/partitionCells.cpp
+++ b/opm/simulators/flow/partitionCells.cpp
@@ -358,7 +358,7 @@ void ZoltanPartitioner::connectWells(const Comm                                 
 
     // Communicate Map to other processes, since it is only available on rank 0
     Opm::Parallel::MpiSerializer ser(comm);
-    ser.broadcast(0, possibleFutureConnections);
+    ser.broadcast(Opm::Parallel::RootRank{0}, possibleFutureConnections);
 
     for (const auto& well : wells) {
         auto cellIx = std::vector<int>{};

--- a/opm/simulators/utils/ParallelRestart.cpp
+++ b/opm/simulators/utils/ParallelRestart.cpp
@@ -51,7 +51,7 @@ RestartValue loadParallelRestart(const EclipseIO* eclIO,
     }
 
     Parallel::MpiSerializer ser(comm);
-    ser.broadcast(0, restartValues, summaryState);
+    ser.broadcast(Parallel::RootRank{0}, restartValues, summaryState);
     return restartValues;
 #else
     return eclIO->loadRestart(actionState, summaryState, solutionKeys, extraKeys);
@@ -73,7 +73,7 @@ data::Solution loadParallelRestartSolution(const EclipseIO* eclIO,
     }
 
     Parallel::MpiSerializer ser(comm);
-    ser.broadcast(0, sol);
+    ser.broadcast(Parallel::RootRank{0}, sol);
     return sol;
 #else
     return eclIO->loadRestartSolution(solutionKeys, step);

--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -77,15 +77,15 @@ void eclStateBroadcast(Parallel::Communication comm, EclipseState& eclState, Sch
                        Action::State& actionState,
                        WellTestState&  wtestState)
 {
-    Opm::Parallel::MpiSerializer ser(comm);
-    ser.broadcast(0, eclState, schedule, summaryConfig, udqState, actionState, wtestState);
+    Parallel::MpiSerializer ser(comm);
+    ser.broadcast(Parallel::RootRank{0}, eclState, schedule, summaryConfig, udqState, actionState, wtestState);
 }
 
 template <class T>
 void eclBroadcast(Parallel::Communication comm, T& data)
 {
-    ::Opm::Parallel::MpiSerializer ser(comm);
-    ser.broadcast(0, data);
+    Parallel::MpiSerializer ser(comm);
+    ser.broadcast(Parallel::RootRank{0}, data);
 }
 
 template void eclBroadcast(Parallel::Communication, TransMult&);

--- a/opm/simulators/utils/ParallelSerialization.cpp
+++ b/opm/simulators/utils/ParallelSerialization.cpp
@@ -85,7 +85,7 @@ template <class T>
 void eclBroadcast(Parallel::Communication comm, T& data)
 {
     ::Opm::Parallel::MpiSerializer ser(comm);
-    ser.broadcast(data);
+    ser.broadcast(0, data);
 }
 
 template void eclBroadcast(Parallel::Communication, TransMult&);

--- a/opm/simulators/utils/PropsDataHandle.hpp
+++ b/opm/simulators/utils/PropsDataHandle.hpp
@@ -75,7 +75,7 @@ public:
         }
 
         Parallel::MpiSerializer ser(comm);
-        ser.broadcast(0, *this);
+        ser.broadcast(Parallel::RootRank{0}, *this);
 
         m_no_data = m_intKeys.size() + m_doubleKeys.size();
 

--- a/opm/simulators/utils/PropsDataHandle.hpp
+++ b/opm/simulators/utils/PropsDataHandle.hpp
@@ -75,7 +75,7 @@ public:
         }
 
         Parallel::MpiSerializer ser(comm);
-        ser.broadcast(*this);
+        ser.broadcast(0, *this);
 
         m_no_data = m_intKeys.size() + m_doubleKeys.size();
 

--- a/opm/simulators/wells/BlackoilWellModelGasLift_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGasLift_impl.hpp
@@ -228,7 +228,7 @@ gasLiftOptimizationStage1(const Simulator& simulator,
             }
 #if HAVE_MPI
             Parallel::MpiSerializer ser(comm);
-            ser.broadcast(i, group_indexes, group_oil_rates,
+            ser.broadcast(Parallel::RootRank{i}, group_indexes, group_oil_rates,
                           group_gas_rates, group_water_rates, group_alq_rates);
 #endif
             if (comm.rank() != i) {

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1903,7 +1903,7 @@ getMaxWellConnections() const
 #if HAVE_MPI
     // Communicate Map to other processes, since it is only available on rank 0
     Parallel::MpiSerializer ser(comm_);
-    ser.broadcast(0, possibleFutureConnections);
+    ser.broadcast(Parallel::RootRank{0}, possibleFutureConnections);
 #endif
     // initialize the additional cell connections introduced by wells.
     for (const auto& well : schedule_wells)

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1903,7 +1903,7 @@ getMaxWellConnections() const
 #if HAVE_MPI
     // Communicate Map to other processes, since it is only available on rank 0
     Parallel::MpiSerializer ser(comm_);
-    ser.broadcast(possibleFutureConnections);
+    ser.broadcast(0, possibleFutureConnections);
 #endif
     // initialize the additional cell connections introduced by wells.
     for (const auto& well : schedule_wells)

--- a/opm/simulators/wells/ParallelWellInfo.cpp
+++ b/opm/simulators/wells/ParallelWellInfo.cpp
@@ -628,8 +628,8 @@ template<class Scalar>
 template<class T>
 T ParallelWellInfo<Scalar>::broadcastFirstPerforationValue(const T& t) const
 {
-    T res = t;
 #if HAVE_MPI
+    T res = t;
     if (rankWithFirstPerf_ >= 0) {
 #ifndef NDEBUG
         assert(rankWithFirstPerf_ < comm_->size());
@@ -639,7 +639,7 @@ T ParallelWellInfo<Scalar>::broadcastFirstPerforationValue(const T& t) const
 #endif
 
         Parallel::MpiSerializer ser(*comm_);
-        ser.broadcast(rankWithFirstPerf_, res);
+        ser.broadcast(Parallel::RootRank{rankWithFirstPerf_}, res);
 #ifndef NDEBUG
         comm_->barrier();
 #endif

--- a/opm/simulators/wells/WellConnectionAuxiliaryModule.hpp
+++ b/opm/simulators/wells/WellConnectionAuxiliaryModule.hpp
@@ -72,7 +72,7 @@ public:
 #if HAVE_MPI
         // Communicate Map to other processes, since it is only available on rank 0
         Parallel::MpiSerializer ser(lin_comm_);
-        ser.broadcast(possibleFutureConnections);
+        ser.broadcast(0, possibleFutureConnections);
 #endif
         // initialize the additional cell connections introduced by wells.
         for (const auto& well : schedule_wells)

--- a/opm/simulators/wells/WellConnectionAuxiliaryModule.hpp
+++ b/opm/simulators/wells/WellConnectionAuxiliaryModule.hpp
@@ -72,7 +72,7 @@ public:
 #if HAVE_MPI
         // Communicate Map to other processes, since it is only available on rank 0
         Parallel::MpiSerializer ser(lin_comm_);
-        ser.broadcast(0, possibleFutureConnections);
+        ser.broadcast(Parallel::RootRank{0}, possibleFutureConnections);
 #endif
         // initialize the additional cell connections introduced by wells.
         for (const auto& well : schedule_wells)

--- a/tests/test_broadcast.cpp
+++ b/tests/test_broadcast.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(BroadCast)
     size_t i1 = cc.rank() == 1 ? 8 : 0;
 
     Opm::Parallel::MpiSerializer ser(cc);
-    ser.broadcast(1, d, i, d1, i1);
+    ser.broadcast(Opm::Parallel::RootRank{1}, d, i, d1, i1);
 
     for (size_t c = 0; c < 3; ++c) {
         BOOST_CHECK_EQUAL(d[c], 1.0+c);


### PR DESCRIPTION
Addresses the same problem as #6173.

Note that this changes the order of arguments for some calls: now the root always comes first, there is no possible mixup between the root argument and the data arguments.

Most changes are due to no longer having a default argument for the root. I consider that a good thing in itself.

There was only a single case where the two-argument version of the deleted overload was used, so I actually had to change the order, and that was in MPISerializer itself.