### PR TITLE
intersectWithIPR - add extrapolation for last interval whenever it applies

### DIFF
--- a/opm/simulators/wells/VFPHelpers.cpp
+++ b/opm/simulators/wells/VFPHelpers.cpp
@@ -551,10 +551,12 @@ intersectWithIPR(const VFPProdTable& table,
                  const std::function<Scalar(const Scalar)>& adjust_bhp)
 {
     // Given fixed thp, wfr, gfr and alq, this function finds a stable (-flo, bhp)-intersection
-    // between the ipr-line and bhp(flo) if such an intersection exists. For multiple stable
-    // intersections, the one corresponding the largest flo is returned.
+    // between the ipr-line and bhp(flo) from table, if such an intersection exists. For multiple 
+    // stable intersections, the one corresponding the largest flo is returned as long as this intersection
+    // lies within the tabulated values. If the ipr-line lies above all (flo, bhp) points, the intersection
+    // is determined by extrapolation based on the last two points. 
     // The adjust_bhp-function is used to adjust the vfp-table bhp-values to actual bhp-values due
-    // vfp/well ref-depth differences and/or WVFPDP-related pressure adjustments.
+    // to vfp/well ref-depth differences and/or WVFPDP-related pressure adjustments.
 
     // NOTE: ipr-line is q=b*bhp - a!
     // ipr is given for negative flo, so
@@ -591,8 +593,17 @@ intersectWithIPR(const VFPProdTable& table,
             w = std::clamp(w, Scalar{0.0}, Scalar{1.0}); // just to be safe (if y0~y1~0)
             flo_x = flo0 + w*(flo1 - flo0);
         }
-        flo0 = flo1;
-        y0 = y1;
+        if (i < flos.size()-1) { // check next interval
+            flo0 = flo1;
+            y0 = y1;
+        } else if (y1 < 0 && y0 < y1 && flo_x < 0) { // at last interval
+            // If y0 < y1 < 0, there is a stable intersection above the largest flo-value by 
+            // extrapolation. If no previous stable intersections were found, i.e., ipr-line lies 
+            // above all (flo, bhp) points, then we return this intersection. Otherwise, we don't 
+            // trust it (avoid vfp-extrapolation whenever possible)
+            Scalar w = -y0/(y1-y0); // w > 1.0
+            flo_x = flo0 + w*(flo1 - flo0);
+        }
     }
     // return (last) intersection if found (negative flo)
     if (flo_x >= 0) {


### PR DESCRIPTION
`intersectWithIPR` was mainly intended to find stable operating points for close to inoperable thp-wells. However, we may also end up here for other reasons, e.g., wells that don't converge because they are forced to operate at too high rate. In this case, if (flo, bhp) ipr-line lies above all points from table  (and hence is _very_ operable) , current code will return an empty intersection.
To prevent this, this PR simpy adds extrapolation based on the two largest flo-values such that an intersection is found also for this case.  