### PR TITLE
Store and use last valid network pressure

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -2074,6 +2074,7 @@ operator==(const BlackoilWellModelGeneric& rhs) const
         && this->local_shut_wells_ == rhs.local_shut_wells_
         && this->closed_this_step_ == rhs.closed_this_step_
         && this->node_pressures_ == rhs.node_pressures_
+        && this->last_valid_node_pressures_ == rhs.last_valid_node_pressures_
         && this->prev_inj_multipliers_ == rhs.prev_inj_multipliers_
         && this->active_wgstate_ == rhs.active_wgstate_
         && this->last_valid_wgstate_ == rhs.last_valid_wgstate_

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -192,6 +192,7 @@ public:
     void commitWGState()
     {
         this->last_valid_wgstate_ = this->active_wgstate_;
+        this->last_valid_node_pressures_ = this->node_pressures_;
     }
 
     data::GroupAndNetworkValues groupAndNetworkData(const int reportStepIdx) const;
@@ -250,6 +251,7 @@ public:
         serializer(closed_this_step_);
         serializer(guideRate_);
         serializer(node_pressures_);
+        serializer(last_valid_node_pressures_);
         serializer(prev_inj_multipliers_);
         serializer(active_wgstate_);
         serializer(last_valid_wgstate_);
@@ -325,6 +327,7 @@ protected:
     void resetWGState()
     {
         this->active_wgstate_ = this->last_valid_wgstate_;
+        this->node_pressures_ = this->last_valid_node_pressures_;
     }
 
     /*
@@ -504,7 +507,11 @@ protected:
 
     GuideRate guideRate_;
     std::unique_ptr<VFPProperties<Scalar>> vfp_properties_{};
-    std::map<std::string, Scalar> node_pressures_; // Storing network pressures for output.
+
+    // Network pressures for output and initialization
+    std::map<std::string, Scalar> node_pressures_;
+    // Valid network pressures for output and initialization for safe restart after failed iterations
+    std::map<std::string, Scalar> last_valid_node_pressures_;
 
     // previous injection multiplier, it is used in the injection multiplier calculation for WINJMULT keyword
     std::unordered_map<std::string, std::vector<Scalar>> prev_inj_multipliers_;


### PR DESCRIPTION
We use the network pressures for initialization and want to save a valid network pressure we can restart from in case the iterations fails