### PR TITLE
Mark pid+newtonteration as default time step control in help message.

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
@@ -103,9 +103,9 @@ void registerAdaptiveParameters()
     Parameters::Register<Parameters::TimeStepControl>
         ("The algorithm used to determine time-step sizes. "
          "Valid options are: "
-         "'pid' (default), "
+         "'pid', "
          "'pid+iteration', "
-         "'pid+newtoniteration', "
+         "'pid+newtoniteration' (default), "
          "'iterationcount', "
         "'newtoniterationcount' "
         "and 'hardcoded'");


### PR DESCRIPTION
This must have been the case for quite some time. It is what the PRT files says when we run without options.