### PR TITLE
DirectionalMobility: janitoring

### DIFF
--- a/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
+++ b/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
@@ -129,7 +129,7 @@ class BlackOilIntensiveQuantitiesGlobalIndex
     using FluxIntensiveQuantities = typename FluxModule::FluxIntensiveQuantities;
     using DiffusionIntensiveQuantities = BlackOilDiffusionIntensiveQuantities<TypeTag, enableDiffusion>;
 
-    using DirectionalMobilityPtr = Opm::Utility::CopyablePtr<DirectionalMobility<TypeTag, Evaluation>>;
+    using DirectionalMobilityPtr = Utility::CopyablePtr<DirectionalMobility<TypeTag>>;
 
 public:
     using FluidState = BlackOilFluidState<Evaluation,

--- a/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
+++ b/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
@@ -424,13 +424,13 @@ public:
     {
         using Dir = FaceDir::DirEnum;
         if (dirMob_) {
-            switch(facedir) {
+            switch (facedir) {
             case Dir::XPlus:
-                return dirMob_->mobilityX_[phaseIdx];
+                return dirMob_->getArray(0)[phaseIdx];
             case Dir::YPlus:
-                return dirMob_->mobilityY_[phaseIdx];
+                return dirMob_->getArray(1)[phaseIdx];
             case Dir::ZPlus:
-                return dirMob_->mobilityZ_[phaseIdx];
+                return dirMob_->getArray(2)[phaseIdx];
             default:
                 throw std::runtime_error("Unexpected face direction");
             }

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -131,7 +131,7 @@ class BlackOilIntensiveQuantities
     using DiffusionIntensiveQuantities = BlackOilDiffusionIntensiveQuantities<TypeTag, enableDiffusion>;
     using DispersionIntensiveQuantities = BlackOilDispersionIntensiveQuantities<TypeTag, enableDispersion>;
 
-    using DirectionalMobilityPtr = Utility::CopyablePtr<DirectionalMobility<TypeTag, Evaluation>>;
+    using DirectionalMobilityPtr = Utility::CopyablePtr<DirectionalMobility<TypeTag>>;
     using BrineModule = BlackOilBrineModule<TypeTag>;
     using BrineIntQua = BlackOilBrineIntensiveQuantities<TypeTag, enableSaltPrecipitation>;
     using MICPIntQua = BlackOilMICPIntensiveQuantities<TypeTag, enableMICP>;

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -647,16 +647,16 @@ public:
     {
         using Dir = FaceDir::DirEnum;
         if (dirMob_) {
-            switch(facedir) {
+            switch (facedir) {
                 case Dir::XMinus:
                 case Dir::XPlus:
-                    return dirMob_->mobilityX_[phaseIdx];
+                    return dirMob_->getArray(0)[phaseIdx];
                 case Dir::YMinus:
                 case Dir::YPlus:
-                    return dirMob_->mobilityY_[phaseIdx];
+                    return dirMob_->getArray(1)[phaseIdx];
                 case Dir::ZMinus:
                 case Dir::ZPlus:
-                    return dirMob_->mobilityZ_[phaseIdx];
+                    return dirMob_->getArray(2)[phaseIdx];
                 default:
                     throw std::runtime_error("Unexpected face direction");
             }

--- a/opm/models/common/directionalmobility.hh
+++ b/opm/models/common/directionalmobility.hh
@@ -38,20 +38,21 @@
 namespace Opm {
 
 template <class TypeTag>
-struct DirectionalMobility
+class DirectionalMobility
 {
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
     using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
 
+public:
     using array_type = std::array<Evaluation,numPhases>;
+
+    DirectionalMobility() = default;
 
     DirectionalMobility(const array_type& mX,
                         const array_type& mY,
                         const array_type& mZ)
         : mobility_{mX, mY, mZ}
     {}
-
-    DirectionalMobility() = default;
 
     const array_type& getArray(unsigned index) const
     {
@@ -67,6 +68,7 @@ struct DirectionalMobility
         return const_cast<array_type&>(std::as_const(*this).getArray(index));
     }
 
+private:
     std::array<array_type,3> mobility_{};
 };
 

--- a/opm/models/common/directionalmobility.hh
+++ b/opm/models/common/directionalmobility.hh
@@ -28,14 +28,15 @@
 
 #include <opm/models/common/multiphasebaseproperties.hh>
 #include <opm/models/utils/propertysystem.hh>
-#include <opm/material/densead/Evaluation.hpp>
 
 #include <array>
 #include <stdexcept>
 
 namespace Opm {
+
 template <class TypeTag, class Evaluation>
-struct DirectionalMobility {
+struct DirectionalMobility
+{
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
     // TODO: This (line below) did not work. I get error: ‘Evaluation’ is not a member of ‘Opm::Properties’
     //  when compiling the tracer model (eclgenerictracermodel.cc). 
@@ -43,26 +44,36 @@ struct DirectionalMobility {
     //using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
 
     using array_type = std::array<Evaluation,numPhases>;
-    DirectionalMobility(const DirectionalMobility& other)
-        : mobilityX_{other.mobilityX_}, mobilityY_{other.mobilityY_}, mobilityZ_{other.mobilityZ_} {}
-    DirectionalMobility(const array_type& mX, const array_type& mY, const array_type& mZ)
-        : mobilityX_{mX}, mobilityY_{mY}, mobilityZ_{mZ} {}
-    DirectionalMobility() : mobilityX_{}, mobilityY_{}, mobilityZ_{} {}
-    array_type& getArray(int index) {
-        switch(index) {
-            case 0:
-                return mobilityX_;
-            case 1:
-                return mobilityY_;
-            case 2:
-                return mobilityZ_;
-            default:
-                throw std::runtime_error("Unexpected mobility array index");
+
+    DirectionalMobility(const array_type& mX,
+                        const array_type& mY,
+                        const array_type& mZ)
+        : mobilityX_{mX}
+        , mobilityY_{mY}
+        , mobilityZ_{mZ}
+    {}
+
+    DirectionalMobility() = default;
+
+    array_type& getArray(int index)
+    {
+        switch (index) {
+        case 0:
+            return mobilityX_;
+        case 1:
+            return mobilityY_;
+        case 2:
+            return mobilityZ_;
+        default:
+            throw std::runtime_error("Unexpected mobility array index");
         }
     }
-    array_type mobilityX_;
-    array_type mobilityY_;
-    array_type mobilityZ_;
+
+    array_type mobilityX_{};
+    array_type mobilityY_{};
+    array_type mobilityZ_{};
 };
+
 } // namespace Opm
+
 #endif

--- a/opm/models/common/directionalmobility.hh
+++ b/opm/models/common/directionalmobility.hh
@@ -32,6 +32,8 @@
 
 #include <array>
 #include <stdexcept>
+#include <string>
+#include <utility>
 
 namespace Opm {
 
@@ -46,30 +48,26 @@ struct DirectionalMobility
     DirectionalMobility(const array_type& mX,
                         const array_type& mY,
                         const array_type& mZ)
-        : mobilityX_{mX}
-        , mobilityY_{mY}
-        , mobilityZ_{mZ}
+        : mobility_{mX, mY, mZ}
     {}
 
     DirectionalMobility() = default;
 
-    array_type& getArray(int index)
+    const array_type& getArray(unsigned index) const
     {
-        switch (index) {
-        case 0:
-            return mobilityX_;
-        case 1:
-            return mobilityY_;
-        case 2:
-            return mobilityZ_;
-        default:
-            throw std::runtime_error("Unexpected mobility array index");
+        if (index > 2) {
+            throw std::runtime_error("Unexpected mobility array index " + std::to_string(index));
         }
+
+        return mobility_[index];
     }
 
-    array_type mobilityX_{};
-    array_type mobilityY_{};
-    array_type mobilityZ_{};
+    array_type& getArray(unsigned index)
+    {
+        return const_cast<array_type&>(std::as_const(*this).getArray(index));
+    }
+
+    std::array<array_type,3> mobility_{};
 };
 
 } // namespace Opm

--- a/opm/models/common/directionalmobility.hh
+++ b/opm/models/common/directionalmobility.hh
@@ -27,6 +27,7 @@
 #define OPM_MODELS_DIRECTIONAL_MOBILITY_HH
 
 #include <opm/models/common/multiphasebaseproperties.hh>
+#include <opm/models/discretization/common/fvbaseproperties.hh>
 #include <opm/models/utils/propertysystem.hh>
 
 #include <array>
@@ -34,14 +35,11 @@
 
 namespace Opm {
 
-template <class TypeTag, class Evaluation>
+template <class TypeTag>
 struct DirectionalMobility
 {
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
-    // TODO: This (line below) did not work. I get error: ‘Evaluation’ is not a member of ‘Opm::Properties’
-    //  when compiling the tracer model (eclgenerictracermodel.cc). 
-    //  QuickFix: I am adding Evaluation as a class template parameter..
-    //using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
+    using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
 
     using array_type = std::array<Evaluation,numPhases>;
 

--- a/opm/models/common/multiphasebaseproblem.hh
+++ b/opm/models/common/multiphasebaseproblem.hh
@@ -70,7 +70,7 @@ class MultiPhaseBaseProblem
     using SolidEnergyLawParams = GetPropType<TypeTag, Properties::SolidEnergyLawParams>;
     using ThermalConductionLawParams = GetPropType<TypeTag, Properties::ThermalConductionLawParams>;
     using MaterialLawParams = typename GetPropType<TypeTag, Properties::MaterialLaw>::Params;
-    using DirectionalMobilityPtr = Opm::Utility::CopyablePtr<DirectionalMobility<TypeTag, Evaluation>>;
+    using DirectionalMobilityPtr = Utility::CopyablePtr<DirectionalMobility<TypeTag>>;
 
     enum { dimWorld = GridView::dimensionworld };
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -164,7 +164,7 @@ protected:
 
 
     using TracerModel = GetPropType<TypeTag, Properties::TracerModel>;
-    using DirectionalMobilityPtr = Utility::CopyablePtr<DirectionalMobility<TypeTag, Evaluation>>;
+    using DirectionalMobilityPtr = Utility::CopyablePtr<DirectionalMobility<TypeTag>>;
 
 public:
     using BaseType::briefDescription;
@@ -794,7 +794,7 @@ public:
         {
             using Dir = FaceDir::DirEnum;
             constexpr int ndim = 3;
-            dirMob = std::make_unique<DirectionalMobility<TypeTag, Evaluation>>();
+            dirMob = std::make_unique<DirectionalMobility<TypeTag>>();
             Dir facedirs[ndim] = {Dir::XPlus, Dir::YPlus, Dir::ZPlus};
             for (int i = 0; i<ndim; i++) {
                 const auto& materialParams = materialLawParams(globalSpaceIdx, facedirs[i]);


### PR DESCRIPTION
Some tidy ups, remove unnecessary template parameter, simplify storage, make it a class.