### PR TITLE
Fix output files for distributed wells

### DIFF
--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -38,6 +38,10 @@
 
 #include <opm/simulators/utils/ParallelCommunication.hpp>
 
+#if HAVE_MPI
+#include <opm/simulators/utils/MPISerializer.hpp>
+#endif
+
 #include <opm/grid/common/p2pcommunicator.hh>
 
 #include <algorithm>
@@ -620,6 +624,11 @@ WellState<Scalar>::report(const int* globalCellIdxMap,
             const auto seg_no = ws.segments.segment_number()[seg_ix];
             well.segments[seg_no] = this->reportSegmentResults(well_index, seg_ix, seg_no);
         }
+    #if HAVE_MPI
+        Parallel::MpiSerializer ser(ws.parallel_info.get().communication());
+        ser.broadcast(Parallel::RootRank{0}, well);
+    #endif
+
     }
 
     return res;

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -533,8 +533,7 @@ WellState<Scalar>::report(const int* globalCellIdxMap,
         const auto& wv = ws.surface_rates;
         const auto& wname = this->name(well_index);
 
-        auto dummyWell = data::Well{};
-        auto& well = ws.parallel_info.get().isOwner() ? res[wname] : dummyWell;
+        auto& well = res[wname];
 
         well.bhp = ws.bhp;
         well.thp = ws.thp;

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -36,6 +36,17 @@ add_test_compare_parallel_simulation(CASENAME spe9_dist_z
                                      REL_TOL ${rel_tol_parallel}
                                      TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --enable-drift-compensation=false)
 
+# A test for distributed standard wells with 8 processes. We load distribute only along the z-axis
+add_test_compare_parallel_simulation(CASENAME spe9_dist_z_8
+                                     FILENAME SPE9_CP_SHORT
+                                     POSTFIX 8
+                                     DIR spe9
+                                     SIMULATOR flow_distribute_z
+                                     ABS_TOL ${abs_tol_parallel}
+                                     REL_TOL ${rel_tol_parallel}
+                                     MPI_PROCS 8
+                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --enable-drift-compensation=false)
+
 # A test for distributed multisegment wells. We load distribute only along the z-axis
 add_test_compare_parallel_simulation(CASENAME msw-simple
                                      FILENAME MSW-SIMPLE # this file contains one Multisegment well without branches that is distributed across several processes


### PR DESCRIPTION
Without the changes in this PR, the newly added test is failing: https://github.com/OPM/opm-simulators/pull/6232