### PR TITLE
Install is_gpu_operator.hpp Header

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -965,6 +965,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/linalg/globalindices.hh
   opm/simulators/linalg/GraphColoring.hpp
   opm/simulators/linalg/ilufirstelement.hh
+  opm/simulators/linalg/is_gpu_operator.hpp
   opm/simulators/linalg/ISTLSolver.hpp
   opm/simulators/linalg/istlpreconditionerwrappers.hh
   opm/simulators/linalg/istlsolverwrappers.hh


### PR DESCRIPTION
Otherwise, the [StandardPreconditioners.hpp](https://github.com/OPM/opm-simulators/blob/ca92b6906c797278278feab3591b354cb1c1a01b/opm/simulators/linalg/StandardPreconditioners.hpp#L26) header is not usable from an installed location.