### PR TITLE
Now formatting struct with braces on newline

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@
         AlwaysBreakTemplateDeclarations: Yes,
         BinPackArguments: false,
         BinPackParameters: false,
-        BreakBeforeBraces: Linux,
+        BreakBeforeBraces: Custom,
         BreakConstructorInitializers: BeforeComma,
         ColumnLimit: 120,
         Cpp11BracedListStyle: true,
@@ -17,4 +17,9 @@
         InsertNewlineAtEOF: true,
         MaxEmptyLinesToKeep: 5,
         NamespaceIndentation: Inner,
+	BraceWrapping: {
+		       AfterStruct: true,
+		       AfterClass: true,
+		       AfterFunction: true
+	}
 }


### PR DESCRIPTION
There seems to be a consensus that `struct` definitions should have their opening brace on a newline. The current `.clang-format` file places the brace on the same line as the struct (derived from `BreakBeforeBraces: Linux,`). This PR makes the brace come on a newline.

That is, the old version format as

```C++
struct Somestruct {
```

whereas this format as 

```C++
struct Somestruct
{
```
