### PR TITLE
Reorder Well Data Report Function

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1832,12 +1832,14 @@ getWellsForTesting(const int timeStepIdx,
 template<class Scalar>
 void BlackoilWellModelGeneric<Scalar>::
 assignMassGasRate(data::Wells& wsrpt,
-                  const Scalar& gasDensity) const
+                  const Scalar gasDensity) const
 {
     using rt = data::Rates::opt;
+
     for (auto& wrpt : wsrpt) {
         auto& well_rates = wrpt.second.rates;
         const auto w_mass_rate = well_rates.get(rt::gas, 0.0) * gasDensity;
+
         well_rates.set(rt::mass_gas, w_mass_rate);
     }
 }
@@ -1870,8 +1872,9 @@ assignMswTracerRates(data::Wells& wsrpt,
                      const MswTracerRates& mswTracerRates,
                      const unsigned reportStep) const
 {
-    if (mswTracerRates.empty())
+    if (mswTracerRates.empty()) {
         return;
+    }
 
     for (const auto& mswTR : mswTracerRates) {
         const auto& eclWell = schedule_.getWell(mswTR.first, reportStep);

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -461,7 +461,7 @@ protected:
                               const unsigned reportStep) const;
 
     void assignMassGasRate(data::Wells& wsrpt,
-                           const Scalar& gasDensity) const;
+                           const Scalar gasDensity) const;
 
     Schedule& schedule_;
     const SummaryState& summaryState_;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2351,6 +2351,22 @@ namespace Opm {
             }
         }
     }
+
+
+    template <typename TypeTag>
+    void BlackoilWellModel<TypeTag>::
+    assignWellTracerRates(data::Wells& wsrpt) const
+    {
+        const auto reportStepIdx = static_cast<unsigned int>(this->reportStepIndex());
+        const auto& trMod = this->simulator_.problem().tracerModel();
+
+        BlackoilWellModelGeneric<Scalar>::assignWellTracerRates(wsrpt, trMod.getWellTracerRates(), reportStepIdx);
+        BlackoilWellModelGeneric<Scalar>::assignWellTracerRates(wsrpt, trMod.getWellFreeTracerRates(), reportStepIdx);
+        BlackoilWellModelGeneric<Scalar>::assignWellTracerRates(wsrpt, trMod.getWellSolTracerRates(), reportStepIdx);
+
+        this->assignMswTracerRates(wsrpt, trMod.getMswTracerRates(), reportStepIdx);
+    }
+
 } // namespace Opm
 
-#endif
+#endif // OPM_BLACKOILWELLMODEL_IMPL_HEADER_INCLUDED


### PR DESCRIPTION
The shut connection handling should be the final stage of this reporting.  While here, also split the tracer rate assingments out to a separate helper function.