### PR TITLE
Assign Shut Connection Data for Owned Wells Only

### DIFF
--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -157,7 +157,7 @@ GenericOutputBlackoilModule(const EclipseState& eclState,
     , flowsC_(schedule, summaryConfig)
     , rftC_(eclState_, schedule_,
             [this](const std::string& wname)
-            { return !isDefunctParallelWell(wname); })
+            { return this->isOwnedByCurrentRank(wname); })
     , rst_conv_(std::move(globalCell), comm)
     , local_data_valid_(false)
 {

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -330,7 +330,8 @@ protected:
     void setupExtraBlockData(const std::size_t        reportStepNum,
                              std::function<bool(int)> isCartIdxOnThisRank);
 
-    virtual bool isDefunctParallelWell(std::string wname) const = 0;
+    virtual bool isDefunctParallelWell(const std::string& wname) const = 0;
+    virtual bool isOwnedByCurrentRank(const std::string& wname) const = 0;
 
     const EclipseState& eclState_;
     const Schedule& schedule_;

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -597,7 +597,7 @@ private:
         Problem, std::void_t<decltype(std::declval<Problem>().geoMechModel())>
     > : public std::true_type {};
 
-    bool isDefunctParallelWell(std::string wname) const override
+    bool isDefunctParallelWell(const std::string& wname) const override
     {
         if (simulator_.gridView().comm().size() == 1)
             return false;
@@ -605,6 +605,11 @@ private:
         std::pair<std::string, bool> value {wname, true};
         auto candidate = std::lower_bound(parallelWells.begin(), parallelWells.end(), value);
         return candidate == parallelWells.end() || *candidate != value;
+    }
+
+    bool isOwnedByCurrentRank(const std::string& wname) const override
+    {
+        return this->simulator_.problem().wellModel().isOwner(wname);
     }
 
     void updateFluidInPlace_(const ElementContext& elemCtx, const unsigned dofIdx)

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -354,7 +354,7 @@ public:
     }
 
 private:
-    bool isDefunctParallelWell(std::string wname) const override
+    bool isDefunctParallelWell(const std::string& wname) const override
     {
         if (simulator_.gridView().comm().size() == 1)
             return false;
@@ -362,6 +362,14 @@ private:
         std::pair<std::string, bool> value {wname, true};
         auto candidate = std::lower_bound(parallelWells.begin(), parallelWells.end(), value);
         return candidate == parallelWells.end() || *candidate != value;
+    }
+
+    bool isOwnedByCurrentRank(const std::string& wname) const override
+    {
+        // Note: This statement is not correct for distributed wells and
+        // will need additional logic once those are supported for
+        // compositional flows.
+        return ! this->isDefunctParallelWell(wname);
     }
 
     void createLocalRegion_(std::vector<int>& region)

--- a/opm/simulators/flow/RFTContainer.cpp
+++ b/opm/simulators/flow/RFTContainer.cpp
@@ -85,19 +85,21 @@ addToWells(data::Wells& wellDatas,
         gatherAndUpdateMap(gasConnectionSaturations_, comm);
     }
 
-    for (const auto& well: schedule_.getWells(reportStepNum)) {
-
-        // don't bother with wells not on this process
-        if (!wellQuery_(well.name())) {
+    for (const auto& wname : this->schedule_.wellNames(reportStepNum)) {
+        // Don't bother with wells not on this process.
+        if (!wellQuery_(wname)) {
             continue;
         }
 
-        //add data infrastructure for shut wells
-        if (!wellDatas.count(well.name())) {
-            auto& wellData = wellDatas[well.name()];
-            wellData.connections.reserve(well.getConnections().size());
-            std::transform(well.getConnections().begin(),
-                           well.getConnections().end(),
+        // Add data infrastructure for shut wells.
+        if (!wellDatas.count(wname)) {
+            const auto& conns = this->schedule_[reportStepNum]
+                .wells(wname).getConnections();
+
+            auto& wellData = wellDatas[wname];
+            wellData.connections.reserve(conns.size());
+
+            std::transform(conns.begin(), conns.end(),
                            std::back_inserter(wellData.connections),
                            [](const auto& connection)
                            {
@@ -107,7 +109,7 @@ addToWells(data::Wells& wellDatas,
                            });
         }
 
-        data::Well& wellData = wellDatas.at(well.name());
+        data::Well& wellData = wellDatas.at(wname);
 
         auto cond_assign = [](double& dest, unsigned idx, const auto& map)
         {

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -220,6 +220,8 @@ template<class Scalar> class WellContributions;
 
                 this->assignWellTargets(wsrpt);
 
+                this->assignDynamicWellStatus(wsrpt, this->reportStepIndex());
+
                 // Assigning (a subset of the) property values in shut
                 // connections should be the last step of wellData().
                 this->assignShutConnections(wsrpt, this->reportStepIndex());

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -36,12 +36,14 @@
 #include <opm/simulators/wells/ConnectionIndexMap.hpp>
 #include <opm/simulators/wells/ParallelPAvgDynamicSourceData.hpp>
 #include <opm/simulators/wells/ParallelWBPCalculation.hpp>
+#include <opm/simulators/wells/ParallelWellInfo.hpp>
 #include <opm/simulators/wells/PerforationData.hpp>
 #include <opm/simulators/wells/WellFilterCake.hpp>
 #include <opm/simulators/wells/WellProdIndexCalculator.hpp>
 #include <opm/simulators/wells/WellTracerRate.hpp>
 #include <opm/simulators/wells/WGState.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <functional>
 #include <map>
@@ -61,7 +63,6 @@ namespace Opm {
     template<class Scalar> class GasLiftWellState;
     class Group;
     class GuideRateConfig;
-    template<class Scalar> class ParallelWellInfo;
     class RestartValue;
     class Schedule;
     struct SimulatorUpdate;
@@ -267,6 +268,17 @@ public:
     const ParallelWellInfo<Scalar>&
     parallelWellInfo(const std::size_t idx) const
     { return local_parallel_well_info_[idx].get(); }
+
+    bool isOwner(const std::string& wname) const
+    {
+        auto pwInfoPos = std::find_if(this->parallel_well_info_.begin(),
+                                      this->parallel_well_info_.end(),
+                                      [&wname](const auto& pwInfo)
+                                      { return pwInfo.name() == wname; });
+
+        return (pwInfoPos != this->parallel_well_info_.end())
+            && pwInfoPos->isOwner();
+    }
 
     const ConnectionIndexMap& connectionIndexMap(const std::size_t idx)
     { return conn_idx_map_[idx]; }

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -370,11 +370,33 @@ protected:
                                   const int pvtreg,
                                   std::vector<Scalar>& resv_coeff) = 0;
 
+    /// Assign dynamic well status for each well owned by current rank
+    ///
+    /// \param[in,out] wsrpt Well solution object.  On exit, holds current
+    /// values for \code data::Well::dynamicStatus \endcode.
+    ///
+    /// \param[in] reportStepIdx Zero-based index of current report step.
+    void assignDynamicWellStatus(data::Wells& wsrpt,
+                                 const int reportStepIdx) const;
+
+    /// Assign basic result quantities for shut connections of wells owned
+    /// by current rank.
+    ///
+    /// Mostly provided for summary file output purposes.  Applies to fully
+    /// shut/stopped wells and shut connections of open/flowing wells.
+    ///
+    /// \param[in,out] wsrpt Well solution object.  On exit, also contains a
+    /// few quantities, like the D factor, the Kh product and the CTF, for
+    /// shut connections.
+    ///
+    /// \param[in] reportStepIdx Zero-based index of current report step.
     void assignShutConnections(data::Wells& wsrpt,
                                const int reportStepIndex) const;
+
     void assignWellTargets(data::Wells& wsrpt) const;
     void assignProductionWellTargets(const Well& well, data::WellControlLimits& limits) const;
     void assignInjectionWellTargets(const Well& well, data::WellControlLimits& limits) const;
+
     void assignGroupControl(const Group& group,
                             data::GroupData& gdata) const;
     void assignGroupValues(const int reportStepIdx,
@@ -550,8 +572,25 @@ private:
 
     void updateEclWellsCTFFromAction(const int timeStepIdx,
                                      const SimulatorUpdate& sim_update);
-};
 
+    /// Run caller-defined code for each well owned by current rank
+    ///
+    /// 'const' version.
+    ///
+    /// \tparam LoopBody Call-back type for user-defined code.  Expected to
+    /// support a function call operator of the form
+    /// \code
+    ///   void operator()(const std::size_t i, const Well& well) const
+    /// \endcode
+    /// which will be invoked for each well owned by the local process.  The
+    /// parameters are the index into \c wells_ecl_ and the object at that
+    /// index, respectively.
+    ///
+    /// \param[in] loopBody Call-back function.  Typically defined as a
+    /// lambda expression.
+    template <typename LoopBody>
+    void loopOwnedWells(LoopBody&& loopBody) const;
+};
 
 } // namespace Opm
 


### PR DESCRIPTION
Otherwise, `BlackoilWellModel<>::wellData()` will generate reports for non-owned wells if the wells are distributed.  This, in turn, opens the door to race conditions when collecting contributions on the I/O rank.