### PR TITLE
Instatiate preconditioners directly with GPU matrices

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -345,6 +345,8 @@ if (HAVE_CUDA)
   ADD_CUDA_OR_HIP_FILE(PUBLIC_HEADER_FILES opm/simulators/linalg gpu_smart_pointer.hpp)
   ADD_CUDA_OR_HIP_FILE(PUBLIC_HEADER_FILES opm/simulators/linalg gpu_resources.hpp)
   ADD_CUDA_OR_HIP_FILE(PUBLIC_HEADER_FILES opm/simulators/linalg detail/is_gpu_pointer.hpp)
+  ADD_CUDA_OR_HIP_FILE(PUBLIC_HEADER_FILES opm/simulators/linalg PreconditionerCPUMatrixToGPUMatrix.hpp)
+  
   if(MPI_FOUND)
     ADD_CUDA_OR_HIP_FILE(PUBLIC_HEADER_FILES opm/simulators/linalg GpuOwnerOverlapCopy.hpp)
   endif()

--- a/opm/simulators/linalg/StandardPreconditioners_gpu_serial.hpp
+++ b/opm/simulators/linalg/StandardPreconditioners_gpu_serial.hpp
@@ -116,14 +116,14 @@ private:
         Dune::BCRSMatrix<BlockType> matrix(N, N, numberOfNonZeroes, Dune::BCRSMatrix<BlockType>::row_wise);
         for (auto row = matrix.createbegin(); row != matrix.createend(); ++row) {
 
-            for (std::size_t j = rowIndices[row.index()]; j != rowIndices[row.index() + 1]; ++j) {
+            for (auto j = rowIndices[row.index()]; j != rowIndices[row.index() + 1]; ++j) {
                 const auto columnIndex = columnIndices[j];
                 row.insert(columnIndex);
             }
         }
 
         for (std::size_t i = 0; i < N; ++i) {
-            for (std::size_t j = rowIndices[i]; j != rowIndices[i + 1]; ++j) {
+            for (auto j = rowIndices[i]; j != rowIndices[i + 1]; ++j) {
                 const auto columnIndex = columnIndices[j];
                 // Now it gets a bit tricky, first we need to fetch the block matrix
                 BlockType blockMatrix;

--- a/opm/simulators/linalg/StandardPreconditioners_gpu_serial.hpp
+++ b/opm/simulators/linalg/StandardPreconditioners_gpu_serial.hpp
@@ -18,19 +18,155 @@
 #define OPM_STANDARDPRECONDITIONERS_GPU_SERIAL_HEADER
 
 
-namespace Opm {
+#include <dune/istl/bcrsmatrix.hh>
+#include <type_traits>
+
+
+namespace Opm
+{
 
 
 template <class Operator>
-struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation, typename std::enable_if_t<Opm::is_gpu_operator_v<Operator>>> 
+struct StandardPreconditioners<Operator,
+                               Dune::Amg::SequentialInformation,
+                               typename std::enable_if_t<Opm::is_gpu_operator_v<Operator>>> 
 {
+
+    using O = Operator;
+    using C = Dune::Amg::SequentialInformation;
+    using F = PreconditionerFactory<O, C>;
+    using M = typename F::Matrix;
+    using V = typename F::Vector;
+    using P = PropertyTree;
+    using PrecPtr = typename F::PrecPtr;
+
+    using field_type = typename V::field_type;
+
+    static constexpr int maxblocksize = 6;
     static void add()
     {
-        // No standard preconditioners for this type of operator.
+        F::addCreator("ILU0", [](const O& op, const P& prm, const std::function<V()>&, std::size_t) {
+            const double w = prm.get<double>("relaxation", 1.0);
+            using GpuILU0 =
+                typename gpuistl::GpuSeqILU0<M, gpuistl::GpuVector<field_type>, gpuistl::GpuVector<field_type>>;
+            return std::make_shared<GpuILU0>(op.getmat(), w);
+        });
+
+        F::addCreator("JAC", [](const O& op, const P& prm, const std::function<V()>&, std::size_t) {
+            const double w = prm.get<double>("relaxation", 1.0);
+            using GPUJac = typename gpuistl::GpuJac<M, gpuistl::GpuVector<field_type>, gpuistl::GpuVector<field_type>>;
+            return std::make_shared<GPUJac>(op.getmat(), w);
+        });
+
+        // The next two (OPMILU0 and DILU) are the GPU preconditioners that need CPU matrices.
+        // Since we are not storing the block size compile time for the GPU matrices 
+        // **and** we need the CPU matrix for the creation, we need to
+        // dispatch the creation of the preconditioner based on the block size. 
+        //
+        // Note that this dispatching is not needed in the future, since we will have a constructor taking GPU matrices directly.
+        F::addCreator("OPMILU0", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t) {
+            return dispatchOnBlockSize<maxblocksize>(op, [&](const auto& cpuMatrix) {
+                const bool split_matrix = prm.get<bool>("split_matrix", true);
+                const bool tune_gpu_kernels = prm.get<bool>("tune_gpu_kernels", true);
+                const int mixed_precision_scheme = prm.get<int>("mixed_precision_scheme", 0);
+                using CPUMatrixType = std::remove_const_t<std::remove_reference_t<decltype(cpuMatrix)>>;
+                using GPUILU0 =
+                    typename gpuistl::OpmGpuILU0<CPUMatrixType, gpuistl::GpuVector<field_type>, gpuistl::GpuVector<field_type>>;
+
+                return std::make_shared<GPUILU0>(op.getmat(), cpuMatrix, split_matrix, tune_gpu_kernels, mixed_precision_scheme);
+            });
+        });
+
+        F::addCreator("DILU", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t) {
+            return dispatchOnBlockSize<maxblocksize>(op, [&](const auto& cpuMatrix) {
+                const bool split_matrix = prm.get<bool>("split_matrix", true);
+                const bool tune_gpu_kernels = prm.get<bool>("tune_gpu_kernels", true);
+                const int mixed_precision_scheme = prm.get<int>("mixed_precision_scheme", 0);
+                using CPUMatrixType = std::remove_const_t<std::remove_reference_t<decltype(cpuMatrix)>>;
+                using GPUDILU =
+                    typename gpuistl::GpuDILU<CPUMatrixType, gpuistl::GpuVector<field_type>, gpuistl::GpuVector<field_type>>;
+                return std::make_shared<GPUDILU>(op.getmat(), cpuMatrix, split_matrix, tune_gpu_kernels, mixed_precision_scheme);
+            });
+        });
     }
+
+private:
+
+    /**
+     * This function creates a CPU matrix from the operator holding a GPU matrix.
+     * 
+     * This is a workaround for now since some of the GPU preconditioners need a 
+     * CPU matrix for the intial setup (graph coloring). The CPU matrix is only
+     * used in the constructor, **not** in the update function or the apply function.
+     */
+    template<class BlockType>
+    static Dune::BCRSMatrix<BlockType> makeCPUMatrix(const O& op) {
+        // TODO: Make this more efficient. Maybe we can simply copy the memory areas directly?
+        //       Do note that this function is anyway going away when we have a GPU
+        //       constructor for the preconditioners, so it is not a priority.
+        const auto& gpuMatrix = op.getmat();
+
+        const auto nonZeros = gpuMatrix.getNonZeroValues().asStdVector();
+        const auto rowIndices = gpuMatrix.getRowIndices().asStdVector();
+        const auto columnIndices = gpuMatrix.getColumnIndices().asStdVector();
+
+        const auto numberOfNonZeroes = gpuMatrix.nonzeroes();
+        const auto N = gpuMatrix.N();
+
+        Dune::BCRSMatrix<BlockType> matrix(N, N, numberOfNonZeroes, Dune::BCRSMatrix<BlockType>::row_wise);
+        for (auto row = matrix.createbegin(); row != matrix.createend(); ++row) {
+
+            for (std::size_t j = rowIndices[row.index()]; j != rowIndices[row.index() + 1]; ++j) {
+                const auto columnIndex = columnIndices[j];
+                row.insert(columnIndex);
+            }
+        }
+
+        for (std::size_t i = 0; i < N; ++i) {
+            for (std::size_t j = rowIndices[i]; j != rowIndices[i + 1]; ++j) {
+                const auto columnIndex = columnIndices[j];
+                // Now it gets a bit tricky, first we need to fetch the block matrix
+                BlockType blockMatrix;
+                constexpr static auto rows = BlockType::rows;
+
+                for (std::size_t k = 0; k < rows; ++k) {
+                    for (std::size_t l = 0; l < rows; ++l) {
+                        blockMatrix[k][l] = nonZeros[j * rows * rows + k * rows + l];
+                    }
+                }
+                matrix[i][columnIndex] = blockMatrix;
+            }
+        }
+
+        return matrix;
+    }
+
+    /**
+     * This function dispatches the creation of the preconditioner based on the block size.
+     * 
+     * Note that this is needed since the GPU operators/matrices do not hold the block size compile time.
+     * 
+     * Also note that this function is not expected to be used in the future, since we will 
+     * have a GPU constructor for the preconditioners (DILU and OPMILU0), hence removing the need
+     * for a CPU matrix and for this function.
+     */
+    template<int blocksizeCompileTime, class CreateType>
+    static PrecPtr dispatchOnBlockSize(const O& op, CreateType create) {
+        if (op.getmat().blockSize() == blocksizeCompileTime) {
+            const auto cpuMatrix = makeCPUMatrix<Dune::FieldMatrix<field_type, blocksizeCompileTime, blocksizeCompileTime>>(op);
+            return create(cpuMatrix);
+        } 
+        if constexpr (blocksizeCompileTime > 1) {
+            return dispatchOnBlockSize<blocksizeCompileTime - 1>(op, create);
+        }
+        else {
+            throw std::runtime_error(fmt::format("Unsupported block size: {}. Max blocksize supported is {}.", op.getmat().blockSize(), maxblocksize));
+        }
+    }
+    
 };
 
 
 } // namespace Opm
 
-#endif // OPM_STANDARDPRECONDITIONERS_GPU_MPI_HEADER
+#endif // OPM_STANDARDPRECONDITIONERS_GPU_SERIAL_HEADER

--- a/opm/simulators/linalg/StandardPreconditioners_mpi.hpp
+++ b/opm/simulators/linalg/StandardPreconditioners_mpi.hpp
@@ -21,6 +21,10 @@
 #ifndef OPM_STANDARDPRECONDITIONERS_MPI_HEADER
 #define OPM_STANDARDPRECONDITIONERS_MPI_HEADER
 
+#if HAVE_CUDA
+#include <opm/simulators/linalg/gpuistl/PreconditionerCPUMatrixToGPUMatrix.hpp>
+#endif
+
 
 namespace Opm {
 
@@ -319,10 +323,14 @@ struct StandardPreconditioners
             const double w = prm.get<double>("relaxation", 1.0);
             using field_type = typename V::field_type;
             using GpuJac =
-                typename gpuistl::GpuJac<M, gpuistl::GpuVector<field_type>, gpuistl::GpuVector<field_type>>;
-            auto gpuJac = std::make_shared<GpuJac>(op.getmat(), w);
+                typename gpuistl::GpuJac<gpuistl::GpuSparseMatrix<field_type>, gpuistl::GpuVector<field_type>, gpuistl::GpuVector<field_type>>;
+            
+            using MatrixOwner = Opm::gpuistl::PreconditionerCPUMatrixToGPUMatrix<gpuistl::GpuVector<field_type>, 
+                gpuistl::GpuVector<field_type>, GpuJac, M>;
+           
+            auto gpuJac = std::make_shared<MatrixOwner>(op.getmat(), w);
 
-            auto adapted = std::make_shared<gpuistl::PreconditionerAdapter<V, V, GpuJac>>(gpuJac);
+            auto adapted = std::make_shared<gpuistl::PreconditionerAdapter<V, V, MatrixOwner>>(gpuJac);
             auto wrapped = std::make_shared<gpuistl::GpuBlockPreconditioner<V, V, Comm>>(adapted, comm);
             return wrapped;
         });
@@ -333,9 +341,14 @@ struct StandardPreconditioners
             const int mixed_precision_scheme = prm.get<int>("mixed_precision_scheme", 0);
             using field_type = typename V::field_type;
             using GpuDILU = typename gpuistl::GpuDILU<M, gpuistl::GpuVector<field_type>, gpuistl::GpuVector<field_type>>;
-            auto gpuDILU = std::make_shared<GpuDILU>(op.getmat(), split_matrix, tune_gpu_kernels, mixed_precision_scheme);
+            using MatrixOwner = Opm::gpuistl::PreconditionerCPUMatrixToGPUMatrix<gpuistl::GpuVector<field_type>, 
+                gpuistl::GpuVector<field_type>, GpuDILU, M>;
+        
+            // Note: op.getmat() is passed twice, because the GpuDILU needs both the CPU and GPU matrix.
+            // The first argument will be converted to a GPU matrix, and the second one is used as a CPU matrix.
+            auto gpuDILU = std::make_shared<MatrixOwner>(op.getmat(), op.getmat(), split_matrix, tune_gpu_kernels, mixed_precision_scheme);
 
-            auto adapted = std::make_shared<gpuistl::PreconditionerAdapter<V, V, GpuDILU>>(gpuDILU);
+            auto adapted = std::make_shared<gpuistl::PreconditionerAdapter<V, V, MatrixOwner>>(gpuDILU);
             auto wrapped = std::make_shared<gpuistl::GpuBlockPreconditioner<V, V, Comm>>(adapted, comm);
             return wrapped;
         });
@@ -346,9 +359,15 @@ struct StandardPreconditioners
             const int mixed_precision_scheme = prm.get<int>("mixed_precision_scheme", 0);
             using field_type = typename V::field_type;
             using OpmGpuILU0 = typename gpuistl::OpmGpuILU0<M, gpuistl::GpuVector<field_type>, gpuistl::GpuVector<field_type>>;
-            auto gpuilu0 = std::make_shared<OpmGpuILU0>(op.getmat(), split_matrix, tune_gpu_kernels, mixed_precision_scheme);
 
-            auto adapted = std::make_shared<gpuistl::PreconditionerAdapter<V, V, OpmGpuILU0>>(gpuilu0);
+            using MatrixOwner = Opm::gpuistl::PreconditionerCPUMatrixToGPUMatrix<gpuistl::GpuVector<field_type>, 
+                gpuistl::GpuVector<field_type>, OpmGpuILU0, M>;
+    
+            // Note: op.getmat() is passed twice, because the OPMGPUILU0 needs both the CPU and GPU matrix.
+            // The first argument will be converted to a GPU matrix, and the second one is used as a CPU matrix.
+            auto gpuilu0 = std::make_shared<MatrixOwner>(op.getmat(), op.getmat(), split_matrix, tune_gpu_kernels, mixed_precision_scheme);
+
+            auto adapted = std::make_shared<gpuistl::PreconditionerAdapter<V, V, MatrixOwner>>(gpuilu0);
             auto wrapped = std::make_shared<gpuistl::GpuBlockPreconditioner<V, V, Comm>>(adapted, comm);
             return wrapped;
         });

--- a/opm/simulators/linalg/StandardPreconditioners_serial.hpp
+++ b/opm/simulators/linalg/StandardPreconditioners_serial.hpp
@@ -21,6 +21,9 @@
 #ifndef OPM_STANDARDPRECONDITIONERS_SERIAL_HPP
 #define OPM_STANDARDPRECONDITIONERS_SERIAL_HPP
 
+#if HAVE_CUDA
+#include <opm/simulators/linalg/gpuistl/PreconditionerCPUMatrixToGPUMatrix.hpp>
+#endif
 
 namespace Opm {
 
@@ -248,9 +251,13 @@ struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation, typen
             const double w = prm.get<double>("relaxation", 1.0);
             using field_type = typename V::field_type;
             using GPUJac =
-                typename gpuistl::GpuJac<M, gpuistl::GpuVector<field_type>, gpuistl::GpuVector<field_type>>;
-            return std::make_shared<gpuistl::PreconditionerAdapter<V, V, GPUJac>>(
-                std::make_shared<GPUJac>(op.getmat(), w));
+                typename gpuistl::GpuJac<gpuistl::GpuSparseMatrix<field_type>,
+                    gpuistl::GpuVector<field_type>, gpuistl::GpuVector<field_type>>;
+            
+            using MatrixOwner = Opm::gpuistl::PreconditionerCPUMatrixToGPUMatrix<gpuistl::GpuVector<field_type>, 
+                gpuistl::GpuVector<field_type>, GPUJac, M>;
+            return std::make_shared<gpuistl::PreconditionerAdapter<V, V, MatrixOwner>>(
+                std::make_shared<MatrixOwner>(op.getmat(), w));
         });
 
         F::addCreator("OPMGPUILU0", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t) {
@@ -260,9 +267,14 @@ struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation, typen
 
             using field_type = typename V::field_type;
             using GPUILU0 = typename gpuistl::OpmGpuILU0<M, gpuistl::GpuVector<field_type>, gpuistl::GpuVector<field_type>>;
-
-            return std::make_shared<gpuistl::PreconditionerAdapter<V, V, GPUILU0>>(std::make_shared<GPUILU0>(op.getmat(), split_matrix, tune_gpu_kernels, mixed_precision_scheme));
+            using MatrixOwner = Opm::gpuistl::PreconditionerCPUMatrixToGPUMatrix<gpuistl::GpuVector<field_type>, 
+                gpuistl::GpuVector<field_type>, GPUILU0, M>;
+            return std::make_shared<gpuistl::PreconditionerAdapter<V, V, MatrixOwner>>(
+                // Note: op.getmat() is passed twice, because the ILU0 needs both the CPU and GPU matrix. 
+                // The first argument will be converted to a GPU matrix, and the second one is used as a CPU matrix.
+                std::make_shared<MatrixOwner>(op.getmat(), op.getmat(), split_matrix, tune_gpu_kernels, mixed_precision_scheme));
         });
+
 
         F::addCreator("GPUDILU", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t) {
             const bool split_matrix = prm.get<bool>("split_matrix", true);
@@ -270,7 +282,12 @@ struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation, typen
             const int mixed_precision_scheme = prm.get<int>("mixed_precision_scheme", 0);
             using field_type = typename V::field_type;
             using GPUDILU = typename gpuistl::GpuDILU<M, gpuistl::GpuVector<field_type>, gpuistl::GpuVector<field_type>>;
-            return std::make_shared<gpuistl::PreconditionerAdapter<V, V, GPUDILU>>(std::make_shared<GPUDILU>(op.getmat(), split_matrix, tune_gpu_kernels, mixed_precision_scheme));
+            using MatrixOwner = Opm::gpuistl::PreconditionerCPUMatrixToGPUMatrix<gpuistl::GpuVector<field_type>, 
+                gpuistl::GpuVector<field_type>, GPUDILU, M>;
+            return std::make_shared<gpuistl::PreconditionerAdapter<V, V, MatrixOwner>>(
+                // Note: op.getmat() is passed twice, because the DILU needs both the CPU and GPU matrix. 
+                // The first argument will be converted to a GPU matrix, and the second one is used as a CPU matrix.
+                std::make_shared<MatrixOwner>(op.getmat(), op.getmat(), split_matrix, tune_gpu_kernels, mixed_precision_scheme));
         });
 
         F::addCreator("GPUDILUFloat", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t) {
@@ -282,10 +299,18 @@ struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation, typen
             using VTo = Dune::BlockVector<Dune::FieldVector<float, block_type::dimension>>;
             using matrix_type_to = typename Dune::BCRSMatrix<Dune::FieldMatrix<float, block_type::dimension, block_type::dimension>>;
             using GpuDILU = typename gpuistl::GpuDILU<matrix_type_to, gpuistl::GpuVector<float>, gpuistl::GpuVector<float>>;
-            using Adapter = typename gpuistl::PreconditionerAdapter<VTo, VTo, GpuDILU>;
+            using MatrixOwner = Opm::gpuistl::PreconditionerCPUMatrixToGPUMatrix<gpuistl::GpuVector<float>, 
+                gpuistl::GpuVector<float>, GpuDILU, matrix_type_to>;
+            using Adapter = typename gpuistl::PreconditionerAdapter<VTo, VTo, MatrixOwner>;
             using Converter = typename gpuistl::PreconditionerConvertFieldTypeAdapter<Adapter, M, V, V>;
+
+           
             auto converted = std::make_shared<Converter>(op.getmat());
-            auto adapted = std::make_shared<Adapter>(std::make_shared<GpuDILU>(converted->getConvertedMatrix(), split_matrix, tune_gpu_kernels, mixed_precision_scheme));
+            // Note: converted->getConvertedMatrix() is passed twice, because the DILU needs both the CPU and GPU matrix. 
+            // The first argument will be converted to a GPU matrix, and the second one is used as a CPU matrix.
+            auto adapted = std::make_shared<Adapter>(std::make_shared<MatrixOwner>(
+                converted->getConvertedMatrix(), converted->getConvertedMatrix(),
+                split_matrix, tune_gpu_kernels, mixed_precision_scheme));
             converted->setUnderlyingPreconditioner(adapted);
             return converted;
         });

--- a/opm/simulators/linalg/gpuistl/GpuDILU.cpp
+++ b/opm/simulators/linalg/gpuistl/GpuDILU.cpp
@@ -42,12 +42,11 @@ namespace Opm::gpuistl
 {
 
 template <class M, class X, class Y, int l>
-GpuDILU<M, X, Y, l>::GpuDILU(const M& A, bool splitMatrix, bool tuneKernels, int mixedPrecisionScheme)
-    : m_cpuMatrix(A)
-    , m_levelSets(Opm::getMatrixRowColoring(m_cpuMatrix, Opm::ColoringType::LOWER))
+GpuDILU<M, X, Y, l>::GpuDILU(const typename GpuDILU<M, X, Y, l>::GPUMatrix& gpuMatrix, const M& cpuMatrix, bool splitMatrix, bool tuneKernels, int mixedPrecisionScheme)
+    : m_levelSets(Opm::getMatrixRowColoring(cpuMatrix, Opm::ColoringType::LOWER))
     , m_reorderedToNatural(detail::createReorderedToNatural(m_levelSets))
     , m_naturalToReordered(detail::createNaturalToReordered(m_levelSets))
-    , m_gpuMatrix(GpuSparseMatrix<field_type>::fromMatrix(m_cpuMatrix, true))
+    , m_gpuMatrix(gpuMatrix)
     , m_gpuNaturalToReorder(m_naturalToReordered)
     , m_gpuReorderToNatural(m_reorderedToNatural)
     , m_gpuDInv(m_gpuMatrix.N() * m_gpuMatrix.blockSize() * m_gpuMatrix.blockSize())
@@ -57,29 +56,29 @@ GpuDILU<M, X, Y, l>::GpuDILU(const M& A, bool splitMatrix, bool tuneKernels, int
 {
     // TODO: Should in some way verify that this matrix is symmetric, only do it debug mode?
     // Some sanity check
-    OPM_ERROR_IF(A.N() != m_gpuMatrix.N(),
-                 fmt::format("CuSparse matrix not same size as DUNE matrix. {} vs {}.", m_gpuMatrix.N(), A.N()));
-    OPM_ERROR_IF(A[0][0].N() != m_gpuMatrix.blockSize(),
+    OPM_ERROR_IF(cpuMatrix.N() != m_gpuMatrix.N(),
+                 fmt::format("CuSparse matrix not same size as DUNE matrix. {} vs {}.", m_gpuMatrix.N(), cpuMatrix.N()));
+    OPM_ERROR_IF(cpuMatrix[0][0].N() != m_gpuMatrix.blockSize(),
                  fmt::format("CuSparse matrix not same blocksize as DUNE matrix. {} vs {}.",
                              m_gpuMatrix.blockSize(),
-                             A[0][0].N()));
-    OPM_ERROR_IF(A.N() * A[0][0].N() != m_gpuMatrix.dim(),
+                             cpuMatrix[0][0].N()));
+    OPM_ERROR_IF(cpuMatrix.N() * cpuMatrix[0][0].N() != m_gpuMatrix.dim(),
                  fmt::format("CuSparse matrix not same dimension as DUNE matrix. {} vs {}.",
                              m_gpuMatrix.dim(),
-                             A.N() * A[0][0].N()));
-    OPM_ERROR_IF(A.nonzeroes() != m_gpuMatrix.nonzeroes(),
+                             cpuMatrix.N() * cpuMatrix[0][0].N()));
+    OPM_ERROR_IF(cpuMatrix.nonzeroes() != m_gpuMatrix.nonzeroes(),
                  fmt::format("CuSparse matrix not same number of non zeroes as DUNE matrix. {} vs {}. ",
                              m_gpuMatrix.nonzeroes(),
-                             A.nonzeroes()));
+                             cpuMatrix.nonzeroes()));
     if (m_splitMatrix) {
-        m_gpuMatrixReorderedDiag = std::make_unique<GpuVector<field_type>>(blocksize_ * blocksize_ * m_cpuMatrix.N());
+        m_gpuMatrixReorderedDiag = std::make_unique<GpuVector<field_type>>(blocksize_ * blocksize_ * cpuMatrix.N());
         std::tie(m_gpuMatrixReorderedLower, m_gpuMatrixReorderedUpper)
-            = detail::extractLowerAndUpperMatrices<M, field_type, GpuSparseMatrix<field_type>>(m_cpuMatrix,
+            = detail::extractLowerAndUpperMatrices<M, field_type, GpuSparseMatrix<field_type>>(cpuMatrix,
                                                                                               m_reorderedToNatural);
     }
     else {
         m_gpuMatrixReordered = detail::createReorderedMatrix<M, field_type, GpuSparseMatrix<field_type>>(
-            m_cpuMatrix, m_reorderedToNatural);
+            cpuMatrix, m_reorderedToNatural);
     }
 
     if (m_mixedPrecisionScheme != MatrixStorageMPScheme::DOUBLE_DIAG_DOUBLE_OFFDIAG) {
@@ -204,7 +203,7 @@ GpuDILU<M, X, Y, l>::apply(X& v, const Y& d, int lowerSolveThreadBlockSize, int 
         levelStartIdx += numOfRowsInLevel;
     }
 
-    levelStartIdx = m_cpuMatrix.N();
+    levelStartIdx = m_gpuMatrix.N();
     //  upper triangular solve: (D + U_A) v = Dy
     for (int level = m_levelSets.size() - 1; level >= 0; --level) {
         const int numOfRowsInLevel = m_levelSets[level].size();
@@ -283,7 +282,6 @@ GpuDILU<M, X, Y, l>::update()
 {
     OPM_TIMEBLOCK(prec_update);
     {
-        m_gpuMatrix.updateNonzeroValues(m_cpuMatrix); // send updated matrix to the gpu
         reorderAndSplitMatrix(m_moveThreadBlockSize);
         computeDiagonal(m_DILUFactorizationThreadBlockSize);
     }
@@ -297,7 +295,6 @@ GpuDILU<M, X, Y, l>::update(int moveThreadBlockSize, int factorizationBlockSize)
     OPM_GPU_SAFE_CALL(cudaEventRecord(m_before.get(), 0));
     OPM_GPU_SAFE_CALL(cudaStreamWaitEvent(m_stream.get(), m_before.get(), 0));
 
-    m_gpuMatrix.updateNonzeroValues(m_cpuMatrix); // send updated matrix to the gpu
     reorderAndSplitMatrix(moveThreadBlockSize);
     computeDiagonal(factorizationBlockSize);
 
@@ -446,7 +443,7 @@ GpuDILU<M, X, Y, l>::tuneThreadBlockSizes()
 }
 
 } // namespace Opm::gpuistl
-#define INSTANTIATE_CUDILU_DUNE(realtype, blockdim)                                                                    \
+#define INSTANTIATE_CUDILU_DUNE(realtype, blockdim)                                                                      \
     template class ::Opm::gpuistl::GpuDILU<Dune::BCRSMatrix<Dune::FieldMatrix<realtype, blockdim, blockdim>>,            \
                                          ::Opm::gpuistl::GpuVector<realtype>,                                            \
                                          ::Opm::gpuistl::GpuVector<realtype>>;                                           \

--- a/opm/simulators/linalg/gpuistl/GpuJac.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuJac.hpp
@@ -100,15 +100,16 @@ public:
 
 private:
     //! \brief Reference to the underlying matrix
-    const M& m_cpuMatrix;
+    const M& m_matrix;
     //! \brief The relaxation factor to use.
     const field_type m_relaxationFactor;
-    //! \brief The A matrix stored on the gpu
-    GpuSparseMatrix<field_type> m_gpuMatrix;
     //! \brief the diagonal of cuMatrix inverted, and then flattened to fit in a vector
     GpuVector<field_type> m_diagInvFlattened;
 
     void invertDiagonalAndFlatten();
+
+    template<int blocksize>
+    void dispatchInvertDiagonalAndFlatten();
 };
 } // end namespace Opm::gpuistl
 

--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrix.cpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrix.cpp
@@ -16,6 +16,7 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "opm/simulators/linalg/gpuistl/detail/gpu_safe_call.hpp"
 #include <cuda.h>
 #include <dune/common/fmatrix.hh>
 #include <dune/common/fvector.hh>
@@ -95,6 +96,21 @@ GpuSparseMatrix<T>::GpuSparseMatrix(const GpuVector<int>& rowIndices,
     , m_cusparseHandle(detail::CuSparseHandle::getInstance())
 {
 }
+
+template<class T>
+GpuSparseMatrix<T>::GpuSparseMatrix(const GpuSparseMatrix<T>& other)
+    : m_nonZeroElements(other.m_nonZeroElements)
+    , m_columnIndices(other.m_columnIndices)
+    , m_rowIndices(other.m_rowIndices)
+    , m_numberOfNonzeroBlocks(other.m_numberOfNonzeroBlocks)
+    , m_numberOfRows(other.m_numberOfRows)
+    , m_blockSize(other.m_blockSize)
+    , m_matrixDescription(other.m_matrixDescription)
+    , m_cusparseHandle(detail::CuSparseHandle::getInstance())
+{
+    
+}
+
 
 template <class T>
 GpuSparseMatrix<T>::~GpuSparseMatrix()
@@ -181,6 +197,16 @@ GpuSparseMatrix<T>::updateNonzeroValues(const MatrixType& matrix, bool copyNonZe
         const T* newNonZeroElements = static_cast<const T*>(&((matrix[0][0][0][0])));
         m_nonZeroElements.copyFromHost(newNonZeroElements, nonzeroes() * blockSize() * blockSize());
     }
+}
+
+template <class T>
+void
+GpuSparseMatrix<T>::updateNonzeroValues(const GpuSparseMatrix<T>& matrix)
+{
+    OPM_ERROR_IF(nonzeroes() != matrix.nonzeroes(), "Matrix does not have the same number of non-zero elements.");
+    OPM_ERROR_IF(matrix.N() != N(), "Matrix does not have the same number of rows.");
+
+    m_nonZeroElements.copyFromDevice(matrix.getNonZeroValues());
 }
 
 template <typename T>

--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrix.cpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrix.cpp
@@ -206,7 +206,7 @@ GpuSparseMatrix<T>::updateNonzeroValues(const GpuSparseMatrix<T>& matrix)
     OPM_ERROR_IF(nonzeroes() != matrix.nonzeroes(), "Matrix does not have the same number of non-zero elements.");
     OPM_ERROR_IF(matrix.N() != N(), "Matrix does not have the same number of rows.");
 
-    m_nonZeroElements.copyFromDevice(matrix.getNonZeroValues());
+    m_nonZeroElements.copyFromDeviceToDevice(matrix.getNonZeroValues());
 }
 
 template <typename T>

--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrix.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrix.hpp
@@ -47,6 +47,8 @@ template <typename T>
 class GpuSparseMatrix
 {
 public:
+    using field_type = T;
+
     //! Create the sparse matrix specified by the raw data.
     //!
     //! \note Prefer to use the constructor taking a const reference to a matrix instead.
@@ -81,14 +83,10 @@ public:
                    const GpuVector<int>& columnIndices,
                    size_t blockSize);
 
-    /**
-     * We don't want to be able to copy this for now (too much hassle in copying the cusparse resources)
-     */
-    GpuSparseMatrix(const GpuSparseMatrix&) = delete;
+    GpuSparseMatrix(const GpuSparseMatrix&);
 
-    /**
-     * We don't want to be able to copy this for now (too much hassle in copying the cusparse resources)
-     */
+    // We want to have this as non-mutable as possible, that is we do not want 
+    // to deal with changing matrix sizes and sparsity patterns.
     GpuSparseMatrix& operator=(const GpuSparseMatrix&) = delete;
 
     virtual ~GpuSparseMatrix();
@@ -292,6 +290,13 @@ public:
      */
     template <class MatrixType>
     void updateNonzeroValues(const MatrixType& matrix, bool copyNonZeroElementsDirectly = false);
+
+    /**
+     * @brief updateNonzeroValues updates the non-zero values by using the non-zero values of the supplied matrix
+     * @param matrix the matrix to extract the non-zero values from
+     * @note This assumes the given matrix has the same sparsity pattern.
+     */
+     void updateNonzeroValues(const GpuSparseMatrix<T>& matrix);
 
 private:
     GpuVector<T> m_nonZeroElements;

--- a/opm/simulators/linalg/gpuistl/GpuVector.cpp
+++ b/opm/simulators/linalg/gpuistl/GpuVector.cpp
@@ -302,7 +302,7 @@ GpuVector<T>::copyToHost(std::vector<T>& data) const
 
 template <class T>
 void
-GpuVector<T>::copyFromDevice(const GpuVector<T>& data) const
+GpuVector<T>::copyFromDeviceToDevice(const GpuVector<T>& data) const
 {
     assertHasElements();
     assertSameSize(data);

--- a/opm/simulators/linalg/gpuistl/GpuVector.cpp
+++ b/opm/simulators/linalg/gpuistl/GpuVector.cpp
@@ -300,6 +300,19 @@ GpuVector<T>::copyToHost(std::vector<T>& data) const
     copyToHost(data.data(), data.size());
 }
 
+template <class T>
+void
+GpuVector<T>::copyFromDevice(const GpuVector<T>& data) const
+{
+    assertHasElements();
+    assertSameSize(data);
+
+    OPM_GPU_SAFE_CALL(cudaMemcpy(m_dataOnDevice,
+                                data.m_dataOnDevice,
+                                detail::to_size_t(m_numberOfElements) * sizeof(T),
+                                cudaMemcpyDeviceToDevice));
+}
+
 template <typename T>
 void
 GpuVector<T>::prepareSendBuf(GpuVector<T>& buffer, const GpuVector<int>& indexSet) const

--- a/opm/simulators/linalg/gpuistl/GpuVector.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuVector.hpp
@@ -103,6 +103,24 @@ public:
     GpuVector& operator=(const GpuVector<T>& other);
 
     /**
+     * @brief GpuVector allocates new GPU memory of the same size as bvector and copies the content of the bvector to
+     * this newly allocated memory.
+     *
+     * @note This does CPU to GPU transfer.
+     * @note This does synchronous transfer.
+     *
+     * @note For now bvector.dim() needs to be within the limits of int due to restrctions of CuBlas.
+     *
+     * @param bvector the vector to copy from
+     */
+    template<int BlockDimension>
+    explicit GpuVector(const Dune::BlockVector<Dune::FieldVector<T, BlockDimension>>& bvector)
+        : GpuVector(bvector.dim())
+    {
+        copyFromHost(bvector);
+    }
+
+    /**
      * @brief operator= sets the whole vector equal to the scalar value.
      *
      * @note This does asynchronous operations
@@ -231,6 +249,12 @@ public:
      * @note This assumes that the size of this vector is equal to the size of the input vector.
      */
     void copyToHost(std::vector<T>& data) const;
+
+    /**
+     * @brief copyFromDevice copies data from the GPU memory of other to this vector
+     * @param other the vector to copy from
+     */
+    void copyFromDevice(const GpuVector<T>& other) const;
 
     void prepareSendBuf(GpuVector<T>& buffer, const GpuVector<int>& indexSet) const;
     void syncFromRecvBuf(GpuVector<T>& buffer, const GpuVector<int>& indexSet) const;

--- a/opm/simulators/linalg/gpuistl/GpuVector.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuVector.hpp
@@ -251,10 +251,10 @@ public:
     void copyToHost(std::vector<T>& data) const;
 
     /**
-     * @brief copyFromDevice copies data from the GPU memory of other to this vector
+     * @brief copyFromDeviceToDevice copies data from the GPU memory of other to this vector
      * @param other the vector to copy from
      */
-    void copyFromDevice(const GpuVector<T>& other) const;
+    void copyFromDeviceToDevice(const GpuVector<T>& other) const;
 
     void prepareSendBuf(GpuVector<T>& buffer, const GpuVector<int>& indexSet) const;
     void syncFromRecvBuf(GpuVector<T>& buffer, const GpuVector<int>& indexSet) const;

--- a/opm/simulators/linalg/gpuistl/OpmGpuILU0.hpp
+++ b/opm/simulators/linalg/gpuistl/OpmGpuILU0.hpp
@@ -35,20 +35,21 @@ namespace Opm::gpuistl
 {
 //! \brief ILU0 preconditioner on the GPU.
 //!
-//! \tparam M The matrix type to operate on
+//! \tparam CPUMatrixT Type of the matrix on the CPU
 //! \tparam X Type of the update
 //! \tparam Y Type of the defect
 //! \tparam l Ignored. Just there to have the same number of template arguments
 //!    as other preconditioners.
 //!
+//! \todo Remove the reliance on CPUMatrix. We should be able to use the GPU matrix type
+//!    directly.
+//!
 //! \note We assume X and Y are both GpuVector<real_type>, but we leave them as template
 //! arguments in case of future additions.
-template <class M, class X, class Y, int l = 1>
+template <class CPUMatrixT, class X, class Y, int l = 1>
 class OpmGpuILU0 : public Dune::PreconditionerWithUpdate<X, Y>
 {
 public:
-    //! \brief The matrix type the preconditioner is for.
-    using matrix_type = typename std::remove_const<M>::type;
     //! \brief The domain type of the preconditioner.
     using domain_type = X;
     //! \brief The range type of the preconditioner.
@@ -56,9 +57,13 @@ public:
     //! \brief The field type of the preconditioner.
     using field_type = typename X::field_type;
     //! \brief The GPU matrix type
-    using GpuMat = GpuSparseMatrix<field_type>;
+    using GpuMatrix = GpuSparseMatrix<field_type>;
     //! \brief The Float matrix type for mixed precision
     using FloatMat = GpuSparseMatrix<float>;
+
+    //! \brief The matrix type the preconditioner is for.
+    using matrix_type = GpuMatrix;
+    
 
     //! \brief Constructor.
     //!
@@ -66,7 +71,7 @@ public:
     //! \param A The matrix to operate on.
     //! \param w The relaxation factor.
     //!
-    explicit OpmGpuILU0(const M& A, bool splitMatrix, bool tuneKernels, int mixedPrecisionScheme);
+    explicit OpmGpuILU0(const GpuMatrix& gpuMatrix, const CPUMatrixT& cpuMatrix, bool splitMatrix, bool tuneKernels, int mixedPrecisionScheme);
 
     //! \brief Prepare the preconditioner.
     //! \note Does nothing at the time being.
@@ -116,10 +121,9 @@ private:
     void apply(X& v, const Y& d, int lowerSolveThreadBlockSize, int upperSolveThreadBlockSize);
     //! \brief Updates the matrix data.
     void update(int moveThreadBlockSize, int factorizationThreadBlockSize);
-    //! \brief Reference to the underlying matrix
-    const M& m_cpuMatrix;
+
     //! \brief size_t describing the dimensions of the square block elements
-    static constexpr const size_t blocksize_ = matrix_type::block_type::cols;
+    static constexpr const size_t blocksize_ = CPUMatrixT::block_type::cols;
     //! \brief SparseTable storing each row by level
     Opm::SparseTable<size_t> m_levelSets;
     //! \brief converts from index in reordered structure to index natural ordered structure
@@ -127,11 +131,11 @@ private:
     //! \brief converts from index in natural ordered structure to index reordered strucutre
     std::vector<int> m_naturalToReordered;
     //! \brief The A matrix stored on the gpu, and its reordred version
-    GpuMat m_gpuMatrix;
-    std::unique_ptr<GpuMat> m_gpuReorderedLU;
+    const GpuMatrix& m_gpuMatrix;
+    std::unique_ptr<GpuMatrix> m_gpuReorderedLU;
     //! \brief If matrix splitting is enabled, then we store the lower and upper part separately
-    std::unique_ptr<GpuMat> m_gpuMatrixReorderedLower;
-    std::unique_ptr<GpuMat> m_gpuMatrixReorderedUpper;
+    std::unique_ptr<GpuMatrix> m_gpuMatrixReorderedLower;
+    std::unique_ptr<GpuMatrix> m_gpuMatrixReorderedUpper;
     //! \brief If mixed precision is enabled, store a float matrix
     std::unique_ptr<FloatMat> m_gpuMatrixReorderedLowerFloat;
     std::unique_ptr<FloatMat> m_gpuMatrixReorderedUpperFloat;

--- a/opm/simulators/linalg/gpuistl/PreconditionerCPUMatrixToGPUMatrix.hpp
+++ b/opm/simulators/linalg/gpuistl/PreconditionerCPUMatrixToGPUMatrix.hpp
@@ -116,7 +116,7 @@ public:
     }
 
 private:
-    CPUMatrixType m_cpuMatrix;
+    const CPUMatrixType& m_cpuMatrix;
     GpuSparseMatrix<field_type> m_gpuMatrix;
 
     //! \brief the underlying preconditioner to use

--- a/opm/simulators/linalg/gpuistl/PreconditionerCPUMatrixToGPUMatrix.hpp
+++ b/opm/simulators/linalg/gpuistl/PreconditionerCPUMatrixToGPUMatrix.hpp
@@ -1,0 +1,127 @@
+/*
+  Copyright 2025 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_PRECONDITIONERCPUMATRIXTOGPUMATRIX_HPP
+#define OPM_PRECONDITIONERCPUMATRIXTOGPUMATRIX_HPP
+#include "opm/simulators/linalg/gpuistl/GpuSparseMatrix.hpp"
+#include <dune/istl/preconditioner.hh>
+#include <opm/simulators/linalg/PreconditionerWithUpdate.hpp>
+#include <opm/simulators/linalg/gpuistl/GpuVector.hpp>
+#include <opm/simulators/linalg/gpuistl/PreconditionerHolder.hpp>
+#include <opm/simulators/linalg/gpuistl/detail/preconditioner_should_call_post_pre.hpp>
+
+
+namespace Opm::gpuistl
+{
+//!\brief Convert a CPU matrix to a GPU matrix and use a CUDA preconditioner on the GPU
+//!
+//! The use case is having a CPU matrix created by a CPU simulator being solved by a GPU BICGSTAB solver.
+//!
+//! \tparam X the domain type (should be on the GPU). Typicall a GpuVector
+//! \tparam Y the range type (should be on the GPU). Typicall a GpuVector
+//! \tparam CudaPreconditionerType the preconditioner taking GpuVector<real_type>  as arguments to apply
+//!         **and** expecting a GPU matrix as **the first argument** to its constructor.
+//! \tparam CPUMatrixType the type of the CPU matrix. This is the type that will be copied to the GPU.
+template <class X, class Y, class CudaPreconditionerType, class CPUMatrixType>
+class PreconditionerCPUMatrixToGPUMatrix : public Dune::PreconditionerWithUpdate<X, Y>
+{
+public:
+    //! \brief The domain type of the preconditioner.
+    using domain_type = X;
+    //! \brief The range type of the preconditioner.
+    using range_type = Y;
+    //! \brief The field type of the preconditioner.
+    using field_type = typename X::field_type;
+
+
+    template <typename... Args>
+    explicit PreconditionerCPUMatrixToGPUMatrix(const CPUMatrixType& A, Args&&... args)
+        : m_cpuMatrix(A)
+        , m_gpuMatrix(GpuSparseMatrix<field_type>::fromMatrix(A))
+        , m_underlyingPreconditioner(m_gpuMatrix, std::forward<Args>(args)...)
+    {
+    }
+
+
+    //! \brief Prepare the preconditioner.
+    //!
+    //! Currently not supported.
+    void pre([[maybe_unused]] X& x, [[maybe_unused]] Y& b) override
+    {
+        static_assert(!detail::shouldCallPreconditionerPre<CudaPreconditionerType>(),
+                      "We currently do not support Preconditioner::pre().");
+    }
+
+
+    //! \brief Apply the preconditoner.
+    //!
+    //! \copydoc Preconditioner::apply(X&,const Y&)
+    void apply(X& v, const Y& d) override
+    {
+        m_underlyingPreconditioner.apply(v, d);
+    }
+
+
+    //! \brief Clean up.
+    //!
+    //! Currently not supported.
+    void post([[maybe_unused]] X& x) override
+    {
+        static_assert(!detail::shouldCallPreconditionerPost<CudaPreconditionerType>(),
+                      "We currently do not support Preconditioner::post().");
+    }
+
+
+    //! Category of the preconditioner (see SolverCategory::Category)
+    Dune::SolverCategory::Category category() const override
+    {
+        return m_underlyingPreconditioner.category();
+    }
+
+    //! Copies the CPU matrix to the GPU matrix
+    //! then calls the GPU preconditioner update function
+    void update() override
+    {
+        m_gpuMatrix.updateNonzeroValues(m_cpuMatrix, true);
+        m_underlyingPreconditioner.update();
+    }
+
+    static constexpr bool shouldCallPre()
+    {
+        return detail::shouldCallPreconditionerPost<CudaPreconditionerType>();
+    }
+    static constexpr bool shouldCallPost()
+    {
+        return detail::shouldCallPreconditionerPre<CudaPreconditionerType>();
+    }
+
+    virtual bool hasPerfectUpdate() const override
+    {
+        return m_underlyingPreconditioner.hasPerfectUpdate();
+    }
+
+private:
+    CPUMatrixType m_cpuMatrix;
+    GpuSparseMatrix<field_type> m_gpuMatrix;
+
+    //! \brief the underlying preconditioner to use
+    CudaPreconditionerType m_underlyingPreconditioner;
+};
+} // end namespace Opm::gpuistl
+
+#endif // OPM_PRECONDITIONERCPUMATRIXTOGPUMATRIX_HPP

--- a/opm/simulators/linalg/gpuistl/detail/CuSparseResource.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/CuSparseResource.hpp
@@ -76,8 +76,8 @@ public:
      */
     ~CuSparseResource();
 
-    // This should not be copyable.
-    CuSparseResource(const CuSparseResource&) = delete;
+    CuSparseResource(const CuSparseResource&);
+
     CuSparseResource& operator=(const CuSparseResource&) = delete;
 
     /**

--- a/opm/simulators/linalg/gpuistl/detail/CuSparseResource_impl.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/CuSparseResource_impl.hpp
@@ -94,6 +94,13 @@ CuSparseResource<T>::CuSparseResource()
 }
 
 template <class T>
+CuSparseResource<T>::CuSparseResource(const CuSparseResource& other)
+    : CuSparseResource<T>(other.m_creator, other.m_deleter)
+{
+    *m_resource = other.m_resource;
+}
+
+template <class T>
 CuSparseResource<T>::~CuSparseResource()
 {
     // TODO: This should probably not use this macro since it will disguise the

--- a/opm/simulators/linalg/gpuistl/detail/gpusparse_matrix_operations.cu
+++ b/opm/simulators/linalg/gpuistl/detail/gpusparse_matrix_operations.cu
@@ -29,7 +29,7 @@ namespace
 {
     template <class T, int blocksize>
     __global__ void cuMoveDataToReordered(
-        T* srcMatrix, int* srcRowIndices, T* dstMatrix, int* dstRowIndices, int* indexConversion, size_t numberOfRows)
+        const T* srcMatrix, const int* srcRowIndices, T* dstMatrix, int* dstRowIndices, int* indexConversion, size_t numberOfRows)
     {
         const auto srcRow = blockDim.x * blockIdx.x + threadIdx.x;
         if (srcRow < numberOfRows) {
@@ -50,9 +50,9 @@ namespace
     }
 
     template <class T, int blocksize>
-    __global__ void cuMoveDataToReorderedSplit(T* srcMatrix,
-                                               int* srcRowIndices,
-                                               int* srcColumnIndices,
+    __global__ void cuMoveDataToReorderedSplit(const T* srcMatrix,
+                                               const int* srcRowIndices,
+                                               const int* srcColumnIndices,
                                                T* dstLowerMatrix,
                                                int* dstLowerRowIndices,
                                                T* dstUpperMatrix,
@@ -101,8 +101,8 @@ namespace
 
 template <class T, int blocksize>
 void
-copyMatDataToReordered(T* srcMatrix,
-                       int* srcRowIndices,
+copyMatDataToReordered(const T* srcMatrix,
+                       const int* srcRowIndices,
                        T* dstMatrix,
                        int* dstRowIndices,
                        int* naturalToReordered,
@@ -118,9 +118,9 @@ copyMatDataToReordered(T* srcMatrix,
 
 template <class T, int blocksize>
 void
-copyMatDataToReorderedSplit(T* srcMatrix,
-                            int* srcRowIndices,
-                            int* srcColumnIndices,
+copyMatDataToReorderedSplit(const T* srcMatrix,
+                            const int* srcRowIndices,
+                            const int* srcColumnIndices,
                             T* dstLowerMatrix,
                             int* dstLowerRowIndices,
                             T* dstUpperMatrix,
@@ -146,8 +146,8 @@ copyMatDataToReorderedSplit(T* srcMatrix,
 }
 
 #define INSTANTIATE_KERNEL_WRAPPERS(T, blocksize)                                                                      \
-    template void copyMatDataToReordered<T, blocksize>(T*, int*, T*, int*, int*, size_t, int);                         \
-    template void copyMatDataToReorderedSplit<T, blocksize>(T*, int*, int*, T*, int*, T*, int*, T*, int*, size_t, int);
+    template void copyMatDataToReordered<T, blocksize>(const T*, const int*, T*, int*, int*, size_t, int);                         \
+    template void copyMatDataToReorderedSplit<T, blocksize>(const T*, const int*, const int*, T*, int*, T*, int*, T*, int*, size_t, int);
 
 INSTANTIATE_KERNEL_WRAPPERS(float, 1);
 INSTANTIATE_KERNEL_WRAPPERS(float, 2);

--- a/opm/simulators/linalg/gpuistl/detail/gpusparse_matrix_operations.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/gpusparse_matrix_operations.hpp
@@ -33,8 +33,8 @@ namespace Opm::gpuistl::detail
  * @param numberOfRows The number of rows in the matrices
  */
 template <class T, int blocksize>
-void copyMatDataToReordered(T* srcMatrix,
-                            int* srcRowIndices,
+void copyMatDataToReordered(const T* srcMatrix,
+                            const int* srcRowIndices,
                             T* dstMatrix,
                             int* dstRowIndices,
                             int* naturalToReordered,
@@ -56,9 +56,9 @@ void copyMatDataToReordered(T* srcMatrix,
  * @param numberOfRows The number of rows in the matrices
  */
 template <class T, int blocksize>
-void copyMatDataToReorderedSplit(T* srcMatrix,
-                                 int* srcRowIndices,
-                                 int* srcColumnIndices,
+void copyMatDataToReorderedSplit(const T* srcMatrix,
+                                 const int* srcRowIndices,
+                                 const int* srcColumnIndices,
                                  T* dstLowerMatrix,
                                  int* dstLowerRowIndices,
                                  T* dstUpperMatrix,

--- a/opm/simulators/linalg/gpuistl/detail/preconditionerKernels/JacKernels.cu
+++ b/opm/simulators/linalg/gpuistl/detail/preconditionerKernels/JacKernels.cu
@@ -29,7 +29,7 @@ namespace
 {
     template <class T, int blocksize>
     __global__ void
-    cuInvertDiagonalAndFlatten(T* matNonZeroValues, int* rowIndices, int* colIndices, size_t numberOfRows, T* vec)
+    cuInvertDiagonalAndFlatten(const T* matNonZeroValues, const int* rowIndices, const int* colIndices, size_t numberOfRows, T* vec)
     {
         const auto row = blockDim.x * blockIdx.x + threadIdx.x;
 
@@ -44,7 +44,7 @@ namespace
             }
 
             // diagBlock points to the start of where the diagonal block is stored
-            T* diagBlock = &matNonZeroValues[blocksize * blocksize * nnzIdx];
+            const T* diagBlock = &matNonZeroValues[blocksize * blocksize * nnzIdx];
             // vecBlock points to the start of the block element in the vector where the inverse of the diagonal block
             // element should be stored
             T* vecBlock = &vec[blocksize * blocksize * row];
@@ -56,7 +56,7 @@ namespace
 
 template <class T, int blocksize>
 void
-invertDiagonalAndFlatten(T* mat, int* rowIndices, int* colIndices, size_t numberOfRows, T* vec)
+invertDiagonalAndFlatten(const T* mat, const int* rowIndices, const int* colIndices, size_t numberOfRows, T* vec)
 {
     if (blocksize <= 3) {
         int threadBlockSize
@@ -70,7 +70,7 @@ invertDiagonalAndFlatten(T* mat, int* rowIndices, int* colIndices, size_t number
 }
 
 #define INSTANTIATE_KERNEL_WRAPPERS(T, blocksize)                                                                      \
-    template void invertDiagonalAndFlatten<T, blocksize>(T*, int*, int*, size_t, T*);
+    template void invertDiagonalAndFlatten<T, blocksize>(const T*, const int*, const int*, size_t, T*);
 
 INSTANTIATE_KERNEL_WRAPPERS(float, 1);
 INSTANTIATE_KERNEL_WRAPPERS(float, 2);

--- a/opm/simulators/linalg/gpuistl/detail/preconditionerKernels/JacKernels.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/preconditionerKernels/JacKernels.hpp
@@ -32,7 +32,7 @@ namespace Opm::gpuistl::detail::JAC
  * @param[out] vec Pointer to the vector where the inverse of the diagonal matrix should be stored
  */
 template <class T, int blocksize>
-void invertDiagonalAndFlatten(T* mat, int* rowIndices, int* colIndices, size_t numberOfRows, T* vec);
+void invertDiagonalAndFlatten(const T* mat, const int* rowIndices, const int* colIndices, size_t numberOfRows, T* vec);
 
 } // namespace Opm::gpuistl::detail::JAC
 #endif

--- a/opm/simulators/linalg/is_gpu_operator.hpp
+++ b/opm/simulators/linalg/is_gpu_operator.hpp
@@ -50,6 +50,31 @@ struct is_gpu_operator
 template <typename T>
 static constexpr bool is_gpu_operator_v = is_gpu_operator<T>::value;
 
+
+/**
+ * \brief Check if a given operator is a GPU matrix.
+ *
+ * This is used to check if the matrix is a GPU matrix, which is used
+ * in say the preconditioners to specialize
+ *
+ * \tparam T The type of the matrix to check.
+ */
+ template <typename T>
+ struct is_gpu_matrix
+ {
+ #if HAVE_CUDA
+
+     static constexpr bool value
+         = std::is_same_v<T, Opm::gpuistl::GpuSparseMatrix<typename T::field_type>>;
+ #else
+     // If CUDA is not enabled, we assume that the matrix is not a GPU matrix.
+     static constexpr bool value = false;
+ #endif
+ };
+ 
+ template <typename T>
+ static constexpr bool is_gpu_matrix_v = is_gpu_matrix<T>::value;
+
 } // namespace Opm
 
 #endif // OPM_IS_GPU_OPERATOR_HEADER

--- a/tests/gpuistl/test_preconditioner_factory_gpu.cpp
+++ b/tests/gpuistl/test_preconditioner_factory_gpu.cpp
@@ -13,6 +13,7 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "opm/simulators/linalg/PropertyTree.hpp"
 #include <boost/test/tools/old/interface.hpp>
 #include <config.h>
 #include <cstddef>
@@ -28,13 +29,14 @@
 #include <opm/simulators/linalg/PreconditionerFactory_impl.hpp>
 
 using Scalar = double;
-constexpr static int Dim = 3;
-using MatrixTypeCPU = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, Dim, Dim>>;
-// using VectorType = Dune::BlockVector<Dune::FieldVector<Scalar, Dim>>;
+constexpr static int Dim = 1;
+
 using CommSeq = Dune::Amg::SequentialInformation;
-// using GpuOperator = Dune::MatrixAdapter<MatrixType,
-//                                    VectorType,
-//                                    VectorType>;
+
+using MatrixTypeCPU = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, Dim, Dim>>;
+using VectorCPU = Dune::BlockVector<Dune::FieldVector<Scalar, 1>>;
+using CpuOperatorType = Dune::MatrixAdapter<MatrixTypeCPU, VectorCPU, VectorCPU>;
+using FactoryTypeCpu = Opm::PreconditionerFactory<CpuOperatorType, CommSeq>;
 
 using GpuMatrixType = Opm::gpuistl::GpuSparseMatrix<Scalar>;
 using GpuVectorType = Opm::gpuistl::GpuVector<Scalar>;
@@ -45,36 +47,77 @@ BOOST_AUTO_TEST_CASE(TestMatrixAdapter)
 {
     const std::size_t N = 10;
     const std::size_t nonZeroes = N * 3 - 2;
-    MatrixTypeCPU matrix(N, N, nonZeroes, MatrixTypeCPU::row_wise);
-    for (auto row = matrix.createbegin(); row != matrix.createend(); ++row) {
-        // Add nonzeros for left neighbour, diagonal and right neighbour
-        if (row.index() > 0) {
-            row.insert(row.index() - 1);
+
+    // The name of the preconditioner on the GPU directly (key) and
+    // the name of the wrapped preconditioner (value).
+    auto preconditionerPairs = std::map<std::string, std::string> {
+        {"ILU0", "GPUILU0"},
+        {"JAC", "GPUJAC"},
+        {"OPMILU0", "OPMGPUILU0"},
+        {"DILU", "GPUDILU"},
+    };
+
+    for (const auto& [gpuPreconditionerName, wrappedPreconditionerName] : preconditionerPairs) {
+        MatrixTypeCPU matrix(N, N, nonZeroes, MatrixTypeCPU::row_wise);
+        for (auto row = matrix.createbegin(); row != matrix.createend(); ++row) {
+            // Add nonzeros for left neighbour, diagonal and right neighbour
+            if (row.index() > 0) {
+                row.insert(row.index() - 1);
+            }
+            row.insert(row.index());
+            if (row.index() < matrix.N() - 1) {
+                row.insert(row.index() + 1);
+            }
         }
-        row.insert(row.index());
-        if (row.index() < matrix.N() - 1) {
-            row.insert(row.index() + 1);
+
+        for (std::size_t i = 0; i < N; ++i) {
+            matrix[i][i] = -2;
+            if (i < int(N) - 1) {
+                matrix[i][i + 1] = 1;
+            }
+
+            if (i > 0) {
+                matrix[i][i - 1] = 1;
+            }
+        }
+        GpuMatrixType gpuMatrix = GpuMatrixType::fromMatrix(matrix);
+        GpuOperatorType gpuOp(gpuMatrix);
+
+        CpuOperatorType cpuOp(matrix);
+
+
+
+        Opm::PropertyTree prm;
+        prm.put(std::string("type"), gpuPreconditionerName);
+        Opm::PropertyTree prmCPU;
+        prmCPU.put(std::string("type"), wrappedPreconditionerName);
+
+
+        auto preconditionerGPU = FactoryTypeGpu::create(gpuOp, prm);
+        auto preconditionerWrapped = FactoryTypeCpu::create(cpuOp, prmCPU);
+
+
+        // check for the standard basis {e_i}
+        // (e_i=(0,...,0, 1 (i-th place), 0, ..., 0))
+        for (std::size_t i = 0; i < N; ++i) {
+            VectorCPU inputVector(N);
+            inputVector[i][0] = 1.0;
+            VectorCPU outputVectorWrapped(N);
+            auto outputVectorGPU = Opm::gpuistl::GpuVector<Scalar>(N);
+            auto inputVectorGPU = Opm::gpuistl::GpuVector<Scalar>(inputVector);
+            preconditionerGPU->apply(outputVectorGPU, inputVectorGPU);
+            preconditionerWrapped->apply(outputVectorWrapped, inputVector);
+
+            auto outputVectorgGPUonCPU = outputVectorGPU.asDuneBlockVector<Dim>();
+
+            for (std::size_t component = 0; component < N; ++component) {
+                BOOST_TEST(outputVectorWrapped[component][0] == outputVectorgGPUonCPU[component][0],
+                           "Component " << component << " of the output vector is not equal to the expected value."
+                                        << "\nExpected: " << outputVectorWrapped[component][0]
+                                        << ",\nbut got: " << outputVectorgGPUonCPU[component][0]
+                                        << "\nfor preconditioner: " << gpuPreconditionerName
+                                        << " and wrapped preconditioner: " << wrappedPreconditionerName);
+            }
         }
     }
-
-    for (std::size_t i = 0; i < N; ++i) {
-        matrix[i][i] = -2;
-        if (i < int(N) - 1) {
-            matrix[i][i + 1] = 1;
-        }
-
-        if (i > 0) {
-            matrix[i][i - 1] = 1;
-        }
-    }
-    GpuMatrixType gpuMatrix = GpuMatrixType::fromMatrix(matrix);
-    Dune::MatrixAdapter<GpuMatrixType, GpuVectorType, GpuVectorType> gpuOp(gpuMatrix);
-
-    Opm::PropertyTree prm;
-    prm.put(std::string("preconditioner"), std::string("DILU"));
-    auto weightsCalculator = []() { return GpuVectorType(N); };
-
-    // TODO: Once the GPU preconditioners are implemented, we can remove the check throw
-    // and actually test the preconditioner creation.
-    BOOST_CHECK_THROW(FactoryTypeGpu::create(gpuOp, prm, weightsCalculator), std::invalid_argument);
 }

--- a/tests/gpuistl/test_preconditioner_factory_gpu.cpp
+++ b/tests/gpuistl/test_preconditioner_factory_gpu.cpp
@@ -28,18 +28,18 @@
 #include <opm/simulators/linalg/PreconditionerFactory.hpp>
 #include <opm/simulators/linalg/PreconditionerFactory_impl.hpp>
 
-using Scalar = double;
+using ScalarT = double;
 constexpr static int Dim = 1;
 
 using CommSeq = Dune::Amg::SequentialInformation;
 
-using MatrixTypeCPU = Dune::BCRSMatrix<Dune::FieldMatrix<Scalar, Dim, Dim>>;
-using VectorCPU = Dune::BlockVector<Dune::FieldVector<Scalar, 1>>;
+using MatrixTypeCPU = Dune::BCRSMatrix<Dune::FieldMatrix<ScalarT, Dim, Dim>>;
+using VectorCPU = Dune::BlockVector<Dune::FieldVector<ScalarT, 1>>;
 using CpuOperatorType = Dune::MatrixAdapter<MatrixTypeCPU, VectorCPU, VectorCPU>;
 using FactoryTypeCpu = Opm::PreconditionerFactory<CpuOperatorType, CommSeq>;
 
-using GpuMatrixType = Opm::gpuistl::GpuSparseMatrix<Scalar>;
-using GpuVectorType = Opm::gpuistl::GpuVector<Scalar>;
+using GpuMatrixType = Opm::gpuistl::GpuSparseMatrix<ScalarT>;
+using GpuVectorType = Opm::gpuistl::GpuVector<ScalarT>;
 using GpuOperatorType = Dune::MatrixAdapter<GpuMatrixType, GpuVectorType, GpuVectorType>;
 using FactoryTypeGpu = Opm::PreconditionerFactory<GpuOperatorType, CommSeq>;
 
@@ -103,8 +103,8 @@ BOOST_AUTO_TEST_CASE(TestMatrixAdapter)
             VectorCPU inputVector(N);
             inputVector[i][0] = 1.0;
             VectorCPU outputVectorWrapped(N);
-            auto outputVectorGPU = Opm::gpuistl::GpuVector<Scalar>(N);
-            auto inputVectorGPU = Opm::gpuistl::GpuVector<Scalar>(inputVector);
+            auto outputVectorGPU = Opm::gpuistl::GpuVector<ScalarT>(N);
+            auto inputVectorGPU = Opm::gpuistl::GpuVector<ScalarT>(inputVector);
             preconditionerGPU->apply(outputVectorGPU, inputVectorGPU);
             preconditionerWrapped->apply(outputVectorWrapped, inputVector);
 


### PR DESCRIPTION
This pull request makes the GPU preconditioners hold the GPU matrix as a reference (instead of owning it as a value). The motivation for this change is three-fold:

1) Reduce the memory usage on the GPU when more than just the preconditioner is using the matrix on the GPU, for instance when the full linear solver loop runs on the GPU, which is the case now with `gpubicgstab`.
2) Reduce host-to-device copy overhead.
3) Reduce the responsibility of the GPU Preconditioners. 

### Introducing the `PreconditionerCPUMatrixToGPUMatrix` adapter
We still need something to copy the matrix from the CPU to the GPU in the setting where we assemble the matrix on the CPU (which is always at the time of writing). This is done through the added class `Opm::gpuistl::PreconditionerCPUMatrixToGPUMatrix` which responsibility is owning the GPU matrix and copying the CPU matrix to the GPU matrix on calls to `update`.  

The GPU preconditioners have been augmented in such a way that they now all store a reference to their GPU matrix. 

### Dependency on CPU matrix
In the case of `GPUDILU` and `OPMGPUILU0`, we still need the matrix on the CPU for the construction. This necessitates the following, temporary fixes (temporary until we figure out if and how we should create it from a GPU matrix): 

1)  `GPUDILU` and `OPMGPUILU0` both take the CPU **and** GPU matrix as a constructor parameter. Note that it is only holding a reference to the GPU matrix after its creation. To keep the compilation simple, we keep the CPUMatrix template argument for these preconditioners for now.

2) Since we need the CPU matrix to create the aforementioned GPU conditioners, we create the CPU matrix on the fly for the preconditioner factory creating GPU preconditioners.

### Smaller changes

To accommodate said changes, we have made some smaller adjustments:

1) `GpuSparseMatrix` is now copyable
2)  `GpuSparseMatrix` is can now copy nonzero values from `GpuSparseMatrix`
3) `GpuVector` can now be constructor from a DUNE BlockVector
4) `GpuVector` can now transfer values from `GpuVector`
5) Some const-correctness changes in the kernels being called from the GPU preconditioners now that the GPU matrix is a const reference.

### Unit test for correctness

To the test the implementation, a unit test comparing the wrapped and non-wrapped preconditioners for the GPU has been added. This is in addition to the already existing unit tests for the GPU preconditioners testing them against the CPU variants.

## To manual
Reorganisational changes to the code structure of gpu-ISTL to accommodate less memory consumption and fewer host-to-device copies in the future.