### PR TITLE
Throw if bhp is NaN in findTHP

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -262,9 +262,20 @@ namespace Opm
             return;
         }
 
-        BVectorWell xw(1);
-        this->linSys_.recoverSolutionWell(x, xw);
-        updateWellState(simulator, xw, well_state, deferred_logger);
+        try {
+            BVectorWell xw(1);
+            this->linSys_.recoverSolutionWell(x, xw);
+
+            updateWellState(simulator, xw, well_state, deferred_logger);
+        }
+        catch (const NumericalProblem& exp) {
+            // Add information about the well and log to deferred logger
+            // (Logging done inside of recoverSolutionWell() (i.e. by UMFpack) will only be seen if
+            // this is the process with rank zero)
+            deferred_logger.problem("In MultisegmentWell::recoverWellSolutionAndUpdateWellState for well "
+                                    + this->name() +": "+exp.what());
+            throw;
+        }
     }
 
 

--- a/opm/simulators/wells/VFPHelpers.cpp
+++ b/opm/simulators/wells/VFPHelpers.cpp
@@ -21,6 +21,7 @@
 #include <opm/simulators/wells/VFPHelpers.hpp>
 
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/densead/Math.hpp>
@@ -368,6 +369,9 @@ findTHP(const std::vector<Scalar>& bhp_array,
 {
     int nthp = thp_array.size();
 
+    if (std::isnan(bhp)) {
+        throw NumericalProblem("findTHP: Error bhp is nan");
+    }
     Scalar thp = -1e100;
 
     //Check that our thp axis is sorted


### PR DESCRIPTION
The canary died.

```
//Canary in a coal mine: shouldn't really be required
            assert(found == true);
            static_cast<void>(found); //Silence compiler warning
```
If bhp_arg is NaN we trigger this assert.
 