### PR TITLE
Correct warning 

### DIFF
--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -263,8 +263,8 @@ public:
             this->updateCellDepths_();
             this->updateCellThickness_();
         }
-        else {
-            Opm::OpmLog::warning("Adding LGRs in parallel run is not supported yet.\n");
+        else if (this->grid_->comm().size() > 1) {
+            OpmLog::warning("Adding LGRs in parallel run is not supported yet.\n");
         }
     }
 


### PR DESCRIPTION

In OPM/opm-simulators#6235, a warning is logged in parallel runs even when the grid does not contain any LGRs. Issue found in https://github.com/OPM/opm-simulators/pull/6235#discussion_r2079157470

This PR implements the correction suggested in that comment. 

Not relevant for the reference manual. 