### PR TITLE
Refactor some of the MSWell code

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEval.cpp
+++ b/opm/simulators/wells/MultisegmentWellEval.cpp
@@ -60,8 +60,8 @@ MultisegmentWellEval(WellInterfaceIndices<FluidSystem,Indices>& baseif, const Pa
     , linSys_(*this, pw_info)
     , primary_variables_(baseif)
     , segments_(this->numberOfSegments(), pw_info, baseif)
-    , cell_perforation_depth_diffs_(baseif_.numPerfs(), 0.0)
-    , cell_perforation_pressure_diffs_(baseif_.numPerfs(), 0.0)
+    , cell_perforation_depth_diffs_(baseif_.numLocalPerfs(), 0.0)
+    , cell_perforation_pressure_diffs_(baseif_.numLocalPerfs(), 0.0)
 {
 }
 
@@ -70,7 +70,7 @@ void
 MultisegmentWellEval<FluidSystem,Indices>::
 initMatrixAndVectors()
 {
-    linSys_.init(baseif_.numPerfs(),
+    linSys_.init(baseif_.numLocalPerfs(),
                  baseif_.cells(), segments_.inlets(),
                  segments_.perforations());
     primary_variables_.resize(this->numberOfSegments());

--- a/opm/simulators/wells/MultisegmentWellGeneric.cpp
+++ b/opm/simulators/wells/MultisegmentWellGeneric.cpp
@@ -64,7 +64,7 @@ scaleSegmentRatesWithWellRates(const std::vector<std::vector<int>>& segment_inle
     if (calculateSumTw) {
         // Due to various reasons, the well/top segment rate can be zero for this phase.
         // We can not scale this rate directly. The following approach is used to initialize the segment rates.
-        for (int perf = 0; perf < baseif_.numPerfs(); ++perf) {
+        for (int perf = 0; perf < baseif_.numLocalPerfs(); ++perf) {
             sumTw += baseif_.wellIndex()[perf];
         }
         // We need to communicate here to scale the perf_phaserate_scaled with the contribution of all segments
@@ -80,9 +80,9 @@ scaleSegmentRatesWithWellRates(const std::vector<std::vector<int>>& segment_inle
         } else { // In this case, we calculated sumTw
             // only handling this specific phase
             constexpr Scalar num_single_phase = 1;
-            std::vector<Scalar> perforation_rates(num_single_phase * baseif_.numPerfs(), 0.0);
+            std::vector<Scalar> perforation_rates(num_single_phase * baseif_.numLocalPerfs(), 0.0);
             const Scalar perf_phaserate_scaled = ws.surface_rates[phase] / sumTw;
-            for (int perf = 0; perf < baseif_.numPerfs(); ++perf) {
+            for (int perf = 0; perf < baseif_.numLocalPerfs(); ++perf) {
                 perforation_rates[perf] = baseif_.wellIndex()[perf] * perf_phaserate_scaled;
             }
 

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -64,6 +64,10 @@ MultisegmentWellSegments(const int numSegments,
                          WellInterfaceGeneric<Scalar>& well)
     : perforations_(numSegments)
     , local_perforation_depth_diffs_(well.numLocalPerfs(), 0.0)
+    // Generally, the info stored with the class MultisegmentWellSegments is global, i.e., the same across all
+    // processes, since segments do not have a 1:1 correspondence to the grid. All members of this class store
+    // global information, except for local_perforation_depth_diffs_, which is the only one that contains only
+    // local information. This is an exception and intentionally, since here, we only need the local entries.
     , inlets_(well.wellEcl().getSegments().size())
     , depth_diffs_(numSegments, 0.0)
     , densities_(numSegments, 0.0)

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -63,7 +63,7 @@ MultisegmentWellSegments(const int numSegments,
                          const ParallelWellInfo<Scalar>& parallel_well_info,
                          WellInterfaceGeneric<Scalar>& well)
     : perforations_(numSegments)
-    , local_perforation_depth_diffs_(well.numPerfs(), 0.0)
+    , local_perforation_depth_diffs_(well.numLocalPerfs(), 0.0)
     , inlets_(well.wellEcl().getSegments().size())
     , depth_diffs_(numSegments, 0.0)
     , densities_(numSegments, 0.0)
@@ -87,7 +87,7 @@ MultisegmentWellSegments(const int numSegments,
     // side
     int i_perf_wells = 0;
     // The perfDepth vector will contain the depths of all perforations across all processes of this well!
-    int num_perfs_whole_mswell = parallel_well_info.communication().sum(well.numPerfs());
+    int num_perfs_whole_mswell = parallel_well_info.communication().sum(well.numLocalPerfs());
     well.perfDepth().resize(num_perfs_whole_mswell, 0.0);
     const auto& segment_set = well_.wellEcl().getSegments();
     for (std::size_t perf = 0; perf < completion_set.size(); ++perf) {

--- a/opm/simulators/wells/StandardWellConnections.cpp
+++ b/opm/simulators/wells/StandardWellConnections.cpp
@@ -165,8 +165,8 @@ template<class FluidSystem, class Indices>
 StandardWellConnections<FluidSystem,Indices>::
 StandardWellConnections(const WellInterfaceIndices<FluidSystem,Indices>& well)
     : well_(well)
-    , perf_densities_(well.numPerfs())
-    , perf_pressure_diffs_(well.numPerfs())
+    , perf_densities_(well.numLocalPerfs())
+    , perf_pressure_diffs_(well.numLocalPerfs())
 {
 }
 
@@ -188,7 +188,7 @@ computePressureDelta()
     //    perforation for each well, for which it will be the
     //    difference to the reference (bhp) depth.
 
-    const int nperf = well_.numPerfs();
+    const int nperf = well_.numLocalPerfs();
     perf_pressure_diffs_.resize(nperf, 0.0);
     auto z_above = well_.parallelWellInfo().communicateAboveValues(well_.refDepth(), well_.perfDepth());
 
@@ -233,7 +233,7 @@ computeDensities(const std::vector<Scalar>& perfComponentRates,
         ? static_cast<Ix>(Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx))
         : static_cast<Ix>(-1);
 
-    const int nperf    = this->well_.numPerfs();
+    const int nperf    = this->well_.numLocalPerfs();
     const int num_comp = this->well_.numComponents();
 
     // 1. Compute the flow (in surface volume units for each component)
@@ -296,7 +296,7 @@ std::vector<typename StandardWellConnections<FluidSystem, Indices>::Scalar>
 StandardWellConnections<FluidSystem, Indices>::
 calculatePerforationOutflow(const std::vector<Scalar>& perfComponentRates) const
 {
-    const int nperf    = this->well_.numPerfs();
+    const int nperf    = this->well_.numLocalPerfs();
     const int num_comp = this->well_.numComponents();
 
     auto q_out_perf = std::vector<Scalar>(nperf * num_comp, Scalar{0});
@@ -440,7 +440,7 @@ computeDensitiesForStoppedProducer(const DensityPropertyFunctions& prop_func)
     auto mob = std::vector<Scalar>(np);
     auto rho = std::vector<Scalar>(np);
 
-    const auto nperf = this->well_.numPerfs();
+    const auto nperf = this->well_.numLocalPerfs();
     for (auto perf = 0*nperf; perf < nperf; ++perf) {
         const auto cell_idx = this->well_.cells()[perf];
 
@@ -467,7 +467,7 @@ computePropertiesForPressures(const WellState<Scalar>&         well_state,
 {
     auto props = Properties{};
 
-    const int nperf = well_.numPerfs();
+    const int nperf = well_.numLocalPerfs();
     const PhaseUsage& pu = well_.phaseUsage();
 
     props.b_perf        .resize(nperf * this->well_.numComponents());
@@ -629,7 +629,7 @@ copyInPerforationRates(const Properties&       props,
 {
     auto perfRates = std::vector<Scalar>(props.b_perf.size(), Scalar{0});
 
-    const int nperf = this->well_.numPerfs();
+    const int nperf = this->well_.numLocalPerfs();
     const int np    = this->well_.numPhases();
     const int nc    = this->well_.numComponents();
 

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -183,8 +183,8 @@ init(std::vector<Scalar>& perf_depth,
      const std::vector<Scalar>& depth_arg,
      const bool has_polymermw)
 {
-    perf_depth.resize(baseif_.numPerfs(), 0.);
-    for (int perf = 0; perf < baseif_.numPerfs(); ++perf) {
+    perf_depth.resize(baseif_.numLocalPerfs(), 0.);
+    for (int perf = 0; perf < baseif_.numLocalPerfs(); ++perf) {
         const int cell_idx = baseif_.cells()[perf];
         perf_depth[perf] = depth_arg[cell_idx];
     }
@@ -194,9 +194,9 @@ init(std::vector<Scalar>& perf_depth,
     if (has_polymermw) {
         if (baseif_.isInjector()) {
             // adding a primary variable for water perforation rate per connection
-            numWellEq += baseif_.numPerfs();
+            numWellEq += baseif_.numLocalPerfs();
             // adding a primary variable for skin pressure per connection
-            numWellEq += baseif_.numPerfs();
+            numWellEq += baseif_.numLocalPerfs();
         }
     }
 
@@ -204,7 +204,7 @@ init(std::vector<Scalar>& perf_depth,
     primary_variables_.resize(numWellEq);
 
     // setup sparsity pattern for the matrices
-    this->linSys_.init(numWellEq, baseif_.numPerfs(), baseif_.cells());
+    this->linSys_.init(numWellEq, baseif_.numLocalPerfs(), baseif_.cells());
 }
 
 template<class Scalar>

--- a/opm/simulators/wells/StandardWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.cpp
@@ -244,9 +244,9 @@ updatePolyMW(const WellState<Scalar>& well_state)
         const auto& perf_data = ws.perf_data;
         const auto& water_velocity = perf_data.water_velocity;
         const auto& skin_pressure = perf_data.skin_pressure;
-        for (int perf = 0; perf < well_.numPerfs(); ++perf) {
+        for (int perf = 0; perf < well_.numLocalPerfs(); ++perf) {
             value_[Bhp + 1 + perf] = water_velocity[perf];
-            value_[Bhp + 1 + well_.numPerfs() + perf] = skin_pressure[perf];
+            value_[Bhp + 1 + well_.numLocalPerfs() + perf] = skin_pressure[perf];
         }
     }
     setEvaluationsFromValues();
@@ -320,9 +320,9 @@ void StandardWellPrimaryVariables<FluidSystem,Indices>::
 updateNewtonPolyMW(const BVectorWell& dwells)
 {
     if (well_.isInjector()) {
-        for (int perf = 0; perf < well_.numPerfs(); ++perf) {
+        for (int perf = 0; perf < well_.numLocalPerfs(); ++perf) {
             const int wat_vel_index = Bhp + 1 + perf;
-            const int pskin_index = Bhp + 1 + well_.numPerfs() + perf;
+            const int pskin_index = Bhp + 1 + well_.numLocalPerfs() + perf;
 
             const Scalar relaxation_factor = 0.9;
             const Scalar dx_wat_vel = dwells[0][wat_vel_index];
@@ -450,9 +450,9 @@ copyToWellStatePolyMW(WellState<Scalar>& well_state) const
         auto& perf_data = ws.perf_data;
         auto& perf_water_velocity = perf_data.water_velocity;
         auto& perf_skin_pressure = perf_data.skin_pressure;
-        for (int perf = 0; perf < well_.numPerfs(); ++perf) {
+        for (int perf = 0; perf < well_.numLocalPerfs(); ++perf) {
             perf_water_velocity[perf] = value_[Bhp + 1 + perf];
-            perf_skin_pressure[perf] = value_[Bhp + 1 + well_.numPerfs() + perf];
+            perf_skin_pressure[perf] = value_[Bhp + 1 + well_.numLocalPerfs() + perf];
         }
     }
 }

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -158,7 +158,7 @@ namespace Opm
         Value skin_pressure = zeroElem();
         if (has_polymermw) {
             if (this->isInjector()) {
-                const int pskin_index = Bhp + 1 + this->numPerfs() + perf;
+                const int pskin_index = Bhp + 1 + this->numLocalPerfs() + perf;
                 skin_pressure = obtainN(this->primary_variables_.eval(pskin_index));
             }
         }

--- a/opm/simulators/wells/WellConvergence.cpp
+++ b/opm/simulators/wells/WellConvergence.cpp
@@ -133,7 +133,7 @@ checkConvergencePolyMW(const std::vector<Scalar>& res,
       const int dummy_component = -1;
       using CR = ConvergenceReport;
       const auto wat_vel_failure_type = CR::WellFailure::Type::MassBalance;
-      for (int perf = 0; perf < well_.numPerfs(); ++perf) {
+      for (int perf = 0; perf < well_.numLocalPerfs(); ++perf) {
           const Scalar wat_vel_residual = res[Bhp + 1 + perf];
           if (std::isnan(wat_vel_residual)) {
               report.setWellFailed({wat_vel_failure_type, CR::Severity::NotANumber, dummy_component, well_.name()});
@@ -147,8 +147,8 @@ checkConvergencePolyMW(const std::vector<Scalar>& res,
       // checking the convergence of the skin pressure
       const Scalar pskin_tol = 1000.; // 1000 pascal
       const auto pskin_failure_type = CR::WellFailure::Type::Pressure;
-      for (int perf = 0; perf < well_.numPerfs(); ++perf) {
-          const Scalar pskin_residual = res[Bhp + 1 + perf + well_.numPerfs()];
+      for (int perf = 0; perf < well_.numLocalPerfs(); ++perf) {
+          const Scalar pskin_residual = res[Bhp + 1 + perf + well_.numLocalPerfs()];
           if (std::isnan(pskin_residual)) {
               report.setWellFailed({pskin_failure_type, CR::Severity::NotANumber, dummy_component, well_.name()});
           } else if (pskin_residual > maxResidualAllowed * 10.) {

--- a/opm/simulators/wells/WellFilterCake.cpp
+++ b/opm/simulators/wells/WellFilterCake.cpp
@@ -74,7 +74,7 @@ applyCleaning(const WellInterfaceGeneric<Scalar>& well,
               DeferredLogger& deferred_logger)
 {
     const auto& connections = well.wellEcl().getConnections();
-    const auto nperf = well.numPerfs();
+    const auto nperf = well.numLocalPerfs();
     for (int perf = 0; perf < nperf; ++perf) {
         const auto perf_ecl_index = well.perforationData()[perf].ecl_index;
         const auto& connection = connections[perf_ecl_index];
@@ -124,7 +124,7 @@ updateSkinFactorsAndMultipliers(const WellInterfaceGeneric<Scalar>& well,
                   const std::size_t water_index,
                   DeferredLogger& deferred_logger)
 {
-    const auto nperf = well.numPerfs();
+    const auto nperf = well.numLocalPerfs();
     inj_fc_multiplier_.assign(nperf, 1.0);
 
     assert(well.isInjector());

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -467,7 +467,7 @@ protected:
     // get the mobility for specific perforation
     template<class Value, class Callback>
     void getMobility(const Simulator& simulator,
-                     const int perf,
+                     const int local_perf_index,
                      std::vector<Value>& mob,
                      Callback& extendEval,
                      [[maybe_unused]] DeferredLogger& deferred_logger) const;

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -129,7 +129,7 @@ public:
 
     int numPhases() const { return number_of_phases_; }
 
-    int numPerfs() const { return number_of_local_perforations_; }
+    int numLocalPerfs() const { return number_of_local_perforations_; }
 
     Scalar refDepth() const { return ref_depth_; }
 


### PR DESCRIPTION
First two commits: Rename local objects such that the name says "local" in them.
Last commit: Add comment about the only member local_perforation_depth_diffs_ of MultisegmentWellSegments that contains local information. I've thought about changing that in commit e55fa7642e6c136f76146ccc2ecba2b82bf65e22, yet after feedback from @blattms  (https://github.com/OPM/opm-simulators/pull/6250#pullrequestreview-2825618030), we're not going to do that.