### PR TITLE
Enable New Saturation Function Consistency Checks by Default

### DIFF
--- a/opm/simulators/flow/FlowProblemParameters.hpp
+++ b/opm/simulators/flow/FlowProblemParameters.hpp
@@ -40,7 +40,7 @@ struct EnableDriftCompensation { static constexpr bool value = false; };
 struct ExplicitRockCompaction { static constexpr bool value = false; };
 
 // Whether or not to check saturation function consistency requirements.
-struct CheckSatfuncConsistency { static constexpr bool value = false; };
+struct CheckSatfuncConsistency { static constexpr bool value = true; };
 
 // Maximum number of reported failures for each saturation function
 // consistency check.


### PR DESCRIPTION
This is to gain experience ahead of making a decision for this setting in the next (2025.10) OPM release.