### PR TITLE
Better commandline naming

### DIFF
--- a/opm/simulators/flow/FlowGenericVanguard.hpp
+++ b/opm/simulators/flow/FlowGenericVanguard.hpp
@@ -74,7 +74,7 @@ struct ActionParsingStrictness { static constexpr auto value = "normal"; };
 
 /// 0: simple, 1: Zoltan, 2: METIS, 3: Zoltan with a all cells of a well
 /// represented by one vertex in the graph, see GridEnums.hpp
-struct PartitionMethod { static constexpr int value = 3; };
+struct PartitionMethod { static constexpr auto value = "zoltanwell"; };
 struct AddCorners { static constexpr bool value = false; };
 struct NumOverlap { static constexpr int value = 1; };
 

--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -132,21 +132,23 @@ add_test_compare_parallel_simulation(CASENAME spe9group
                                      REL_TOL ${coarse_rel_tol_parallel}
                                      TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8)
 
-add_test_compare_parallel_simulation(CASENAME spe3
+add_test_compare_parallel_simulation(CASENAME spe3_partition_method_zoltan
                                      FILENAME SPE3CASE1
-                                     SIMULATOR flow
-                                     ABS_TOL ${abs_tol_parallel}
-                                     REL_TOL ${coarse_rel_tol_parallel}
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7 --partition-method=1)
-
-add_test_compare_parallel_simulation(CASENAME spe3_partition_method_3
-                                     FILENAME SPE3CASE1
-                                     POSTFIX partition_method_3
+                                     POSTFIX partition_method_zoltan
                                      DIR spe3
                                      SIMULATOR flow
                                      ABS_TOL ${abs_tol_parallel}
                                      REL_TOL ${coarse_rel_tol_parallel}
-                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7 --partition-method=3)
+                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7 --partition-method=zoltan)
+
+add_test_compare_parallel_simulation(CASENAME spe3_partition_method_zoltanwell
+                                     FILENAME SPE3CASE1
+                                     POSTFIX partition_method_zoltanwell
+                                     DIR spe3
+                                     SIMULATOR flow
+                                     ABS_TOL ${abs_tol_parallel}
+                                     REL_TOL ${coarse_rel_tol_parallel}
+                                     TEST_ARGS --linear-solver-reduction=1e-7 --tolerance-cnv=5e-6 --tolerance-mb=1e-8 --tolerance-wells=1e-7 --partition-method=zoltanwell)
 
 add_test_compare_parallel_simulation(CASENAME spe1_solvent
                                      FILENAME SPE1CASE2_SOLVENT


### PR DESCRIPTION
Replace inscrutable integers for method choice with strings, in command line parameters. 

With this, we will write `--partition-method=metis` for example, instead of `--partition-method=2`, and `--edge-weights-method=uniform` instead of `--edge-weights-method=0`. The defaults have not been changed.

@vkip, @lisajulia, @michal-toth: if merged, this might affect what you are working on.

For the manual:
These command line options have changed in how they are specified, from taking integer arguments to choose a method, to taking string arguments. Defaults and behaviour is not changed here.
`--edge-weights-method` allowed values are `uniform`, `transmissibility`, or `logtrans`. Replacing 0, 1 and 2.
`--partition-method` allowed values are `simple`, `zoltan`, `metis`, or `zoltanwell`. Replacing 0-3.