### PR TITLE
Add Regression Tests for UDA Compatibility

### DIFF
--- a/parallelTests.cmake
+++ b/parallelTests.cmake
@@ -265,6 +265,15 @@ add_test_compare_parallel_simulation(CASENAME numerical_aquifer_3d_1aqu
                                      DIR aquifer-num
                                      TEST_ARGS --enable-tuning=true --tolerance-cnv=0.00003 --time-step-control=pid --linear-solver=cpr_trueimpes --enable-drift-compensation=false --relaxed-max-pv-fraction=0.0)
 
+add_test_compare_parallel_simulation(CASENAME 6_uda_model5_stdw
+  FILENAME 6_UDA_MODEL5_STDW
+  SIMULATOR flow
+  ABS_TOL ${abs_tol_parallel}
+  REL_TOL ${rel_tol_parallel}
+  DIR model5
+  TEST_ARGS --enable-tuning=true
+)
+
 foreach(templ_case RANGE 1 6)
   add_test_compare_parallel_simulation(CASENAME actionx_well_templ_0${templ_case}
     FILENAME ACTIONX_WELL_TEMPL-0${templ_case}

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -1072,6 +1072,16 @@ add_test_compareECLFiles(CASENAME 01_vappars
                          REL_TOL ${rel_tol}
                          DIR vappars)
 
+add_test_compareECLFiles(CASENAME 6_uda_model5_stdw
+  FILENAME 6_UDA_MODEL5_STDW
+  SIMULATOR flow
+  ABS_TOL ${abs_tol}
+  REL_TOL ${rel_tol}
+  DIR model5
+  RESTART_STEP 1
+  TEST_ARGS --enable-tuning=true
+)
+
 set(_mult_cases
   MULTFLT-01
   MULTFLT-02


### PR DESCRIPTION
Following PR OPM/opm-common#4439, we can activate most of the aspects of the model in PR OPM/opm-tests#1299.