### PR TITLE
refactoring the function actionOnBrokenConstraints

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelConstraints.cpp
+++ b/opm/simulators/wells/BlackoilWellModelConstraints.cpp
@@ -467,19 +467,19 @@ actionOnBrokenConstraints(const Group& group,
         wellModel_.groupState().production_control(group.name());
 
     // We switch to higher groups independently of the given group limit action in GCONPROD item 7
-//    if (newControl == Group::ProductionCMode::FLD && oldControl != Group::ProductionCMode::FLD) {
-//        // If newControl is FLD, the group should be subject to higher order controls
-//        assert(group.productionGroupControlAvailable());
-//        group_state.production_control(group.name(), newControl);
-//        if (wellModel_.comm().rank() == 0) {
-//            const std::string message = fmt::format("Switching production control mode for group {} from {} to {}",
-//            group.name(),
-//            Group::ProductionCMode2String(oldControl),
-//            Group::ProductionCMode2String(newControl));
-//            deferred_logger.debug(message);
-//        }
-//        return true;
-//    }
+    if (newControl == Group::ProductionCMode::FLD && oldControl != Group::ProductionCMode::FLD) {
+        // If newControl is FLD, the group should be subject to higher order controls
+        assert(group.productionGroupControlAvailable());
+        group_state.production_control(group.name(), newControl);
+        if (wellModel_.comm().rank() == 0) {
+            const std::string message = fmt::format("Switching production control mode for group {} from {} to {}",
+            group.name(),
+            Group::ProductionCMode2String(oldControl),
+            Group::ProductionCMode2String(newControl));
+            deferred_logger.debug(message);
+        }
+        return true;
+    }
 
     bool changed = false;
     std::string ss;

--- a/opm/simulators/wells/BlackoilWellModelConstraints.cpp
+++ b/opm/simulators/wells/BlackoilWellModelConstraints.cpp
@@ -466,6 +466,15 @@ actionOnBrokenConstraints(const Group& group,
     const Group::ProductionCMode oldControl =
         wellModel_.groupState().production_control(group.name());
 
+    if (!(newControl != oldControl || newControl == Group::ProductionCMode::FLD)) {
+        throw std::runtime_error(fmt::format(
+                "Group {}: newControl {} and oldControl {} are the same",
+                group.name(),
+                Group::ProductionCMode2String(newControl),
+                Group::ProductionCMode2String(oldControl)
+        ));
+    }
+
     // We switch to higher groups independently of the given group limit action in GCONPROD item 7
     if (newControl == Group::ProductionCMode::FLD && oldControl != Group::ProductionCMode::FLD) {
         // If newControl is FLD, the group should be subject to higher order controls
@@ -498,11 +507,12 @@ actionOnBrokenConstraints(const Group& group,
     case Group::ProductionCMode::LRAT:
         action = group_limit_action.liquid;
         break;
-    case Group::ProductionCMode::FLD:
+//    case Group::ProductionCMode::FLD:
         // do nothing for now
-        break;
+//        break;
     default:
-        // TODO: double check whether this is the case
+        // FLD is handled here also
+        // We should NOT have come here with NONE
         action = Group::ExceedAction::RATE;
     }
 

--- a/opm/simulators/wells/BlackoilWellModelConstraints.cpp
+++ b/opm/simulators/wells/BlackoilWellModelConstraints.cpp
@@ -507,9 +507,16 @@ actionOnBrokenConstraints(const Group& group,
     case Group::ProductionCMode::LRAT:
         action = group_limit_action.liquid;
         break;
-//    case Group::ProductionCMode::FLD:
-        // do nothing for now
-//        break;
+    case Group::ProductionCMode::FLD: {
+        // this line looks matters for the restart running of 6_UDA_MODEL5_STDW
+        const auto msg = fmt::format(
+                "Group {}: newControl {} and oldControl {}, what we shuld do with this FLD broken constraint?",
+                group.name(),
+                Group::ProductionCMode2String(newControl),
+                Group::ProductionCMode2String(oldControl));
+        std::cout << msg << std::endl;
+        break;
+    }
     default:
         // FLD is handled here also
         // We should NOT have come here with NONE


### PR DESCRIPTION
based on the new understanding, the code logic is simpler. And the control switching only happens when the action is `RATE`. 

it depends on https://github.com/OPM/opm-common/pull/4609 . 