### PR TITLE
Further updates and fixes to general controller

### DIFF
--- a/opm/simulators/flow/NonlinearSolver.hpp
+++ b/opm/simulators/flow/NonlinearSolver.hpp
@@ -176,8 +176,9 @@ struct NonlinearSolverParameters
                 OPM_THROW_NOLOG(TooManyIterations, msg);
             }
             auto relativeChange = model_->relativeChange();
-            if (timeStepControl && !timeStepControl->timeStepAccepted(relativeChange)) {
+            if (timeStepControl && !timeStepControl->timeStepAccepted(relativeChange, timer.currentStepLength())) {
                 report.converged = false;
+                report.time_step_rejected = true;
                 failureReport_ = report;
 
                 std::string msg = "Relative change in solution for time step was " + std::to_string(relativeChange) + ", which is larger than the tolerance accepted by the timestepping algorithm.";

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
@@ -142,6 +142,19 @@ void registerAdaptiveParameters()
     Parameters::Register<Parameters::TimeStepControlRejectCompletedStep>
         ("(Only applicable for the general 3rd order controller.) Include rejection of completed "
          "time steps if the relative change is larger than the time step control tolerance");
+    Parameters::Register<Parameters::TimeStepControlToleranceTestVersion>
+        ("(Only applicable for the general 3rd order controller.) Ways to decide if the time step "
+         "should be rejected. Options: 'standard' and 'control-error-filtering'. The standard "
+         "version compares relative change to tolerance directly to decide if the time step should "
+         "be rejected, while the control-error-filtering version compares the relative change "
+         "between the current and proposed next time steps to the max-reduction-time-step parameter.");
+    Parameters::Register<Parameters::TimeStepControlMaxReductionTimeStep>
+        ("(Only applicable for the general 3rd order controller, using "
+         "time-step-control-tolerance-test-version choice 'control-error-filtering') If the relative "
+         "change in time step size for the next time step is larger than this parameter, the time "
+         "step will be rejected.");
+    Parameters::Register<Parameters::TimeStepControlParameters>
+        ("TODO!");
 }
 
 std::tuple<TimeStepControlType, std::unique_ptr<TimeStepControlInterface>, bool>
@@ -222,11 +235,17 @@ createController(const UnitSystem& unitSystem)
          [tol]() {
              const double safetyFactor = Parameters::Get<Parameters::TimeStepControlSafetyFactor>(); // 0.8
              const bool rejectCompletedStep = Parameters::Get<Parameters::TimeStepControlRejectCompletedStep>(); // false
+             const std::string toleranceTestVersion = Parameters::Get<Parameters::TimeStepControlToleranceTestVersion>(); // "standard"
+             const double maxReductionTimeStep = Parameters::Get<Parameters::TimeStepControlMaxReductionTimeStep>(); // 0.1
+             const std::string parameters = Parameters::Get<Parameters::TimeStepControlParameters>(); // ""
              return RetVal{
                  TimeStepControlType::General3rdOrder,
                  std::make_unique<General3rdOrderController>(tol,
                                                              safetyFactor,
-                                                             rejectCompletedStep),
+                                                             rejectCompletedStep,
+                                                             toleranceTestVersion,
+                                                             maxReductionTimeStep,
+                                                             parameters),
                  false
              };
         }},

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
@@ -233,11 +233,12 @@ createController(const UnitSystem& unitSystem)
          }},
         {"general3rdorder",
          [tol]() {
-             const double safetyFactor = Parameters::Get<Parameters::TimeStepControlSafetyFactor>(); // 0.8
-             const bool rejectCompletedStep = Parameters::Get<Parameters::TimeStepControlRejectCompletedStep>(); // false
-             const std::string toleranceTestVersion = Parameters::Get<Parameters::TimeStepControlToleranceTestVersion>(); // "standard"
-             const double maxReductionTimeStep = Parameters::Get<Parameters::TimeStepControlMaxReductionTimeStep>(); // 0.1
-             const std::string parameters = Parameters::Get<Parameters::TimeStepControlParameters>(); // ""
+             const double safetyFactor = Parameters::Get<Parameters::TimeStepControlSafetyFactor>();
+             const bool rejectCompletedStep = Parameters::Get<Parameters::TimeStepControlRejectCompletedStep>();
+             const std::string toleranceTestVersion = Parameters::Get<Parameters::TimeStepControlToleranceTestVersion>();
+             const double maxReductionTimeStep = Parameters::Get<Parameters::TimeStepControlMaxReductionTimeStep>();
+             const std::string parameters = Parameters::Get<Parameters::TimeStepControlParameters>();
+             const bool verbose = Parameters::Get<Parameters::TimeStepVerbosity>();
              return RetVal{
                  TimeStepControlType::General3rdOrder,
                  std::make_unique<General3rdOrderController>(tol,
@@ -245,7 +246,8 @@ createController(const UnitSystem& unitSystem)
                                                              rejectCompletedStep,
                                                              toleranceTestVersion,
                                                              maxReductionTimeStep,
-                                                             parameters),
+                                                             parameters,
+                                                             verbose),
                  false
              };
         }},

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
@@ -147,14 +147,14 @@ void registerAdaptiveParameters()
          "should be rejected. Options: 'standard' and 'control-error-filtering'. The standard "
          "version compares relative change to tolerance directly to decide if the time step should "
          "be rejected, while the control-error-filtering version compares the relative change "
-         "between the current and proposed next time steps to the max-reduction-time-step parameter.");
+         "in time step size to the max-reduction-time-step parameter.");
     Parameters::Register<Parameters::TimeStepControlMaxReductionTimeStep>
-        ("(Only applicable for the general 3rd order controller, using "
-         "time-step-control-tolerance-test-version choice 'control-error-filtering') If the relative "
-         "change in time step size for the next time step is larger than this parameter, the time "
-         "step will be rejected.");
+        ("(Only applicable for the general 3rd order controller, using 'control-error-filtering' "
+         "as time-step-control-tolerance-test-version) If the (proposed) relative change in time "
+         "step size is larger than this parameter, the time step will be rejected.");
     Parameters::Register<Parameters::TimeStepControlParameters>
-        ("TODO!");
+        ("(Only applicable for the general 3rd order controller.) Parameters for the general "
+         "3rd order controller. Should be given as \"beta_1;beta_2;beta_3;alpha_2;alpha_3\".");
 }
 
 std::tuple<TimeStepControlType, std::unique_ptr<TimeStepControlInterface>, bool>

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.cpp
@@ -154,7 +154,7 @@ void registerAdaptiveParameters()
          "step size is larger than this parameter, the time step will be rejected.");
     Parameters::Register<Parameters::TimeStepControlParameters>
         ("(Only applicable for the general 3rd order controller.) Parameters for the general "
-         "3rd order controller. Should be given as \"beta_1;beta_2;beta_3;alpha_2;alpha_3\".");
+         "3rd order controller. Should be given as 'beta_1;beta_2;beta_3;alpha_2;alpha_3'.");
 }
 
 std::tuple<TimeStepControlType, std::unique_ptr<TimeStepControlInterface>, bool>

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -51,7 +51,7 @@ struct TimeStepControlSafetyFactor { static constexpr double value = 0.8; };
 struct TimeStepControlRejectCompletedStep { static constexpr bool value = false; };
 struct TimeStepControlToleranceTestVersion { static constexpr auto value = "standard"; };
 struct TimeStepControlMaxReductionTimeStep { static constexpr double value = 0.1; };
-struct TimeStepControlParameters { static constexpr auto value = "0.125;0.25;0.125;0.375;0.125"; };
+struct TimeStepControlParameters { static constexpr auto value = "0.125;0.25;0.125;0.75;0.25"; };
 
 } // namespace Opm::Parameters
 

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -49,6 +49,9 @@ struct MinTimeStepBeforeShuttingProblematicWellsInDays { static constexpr double
 struct MinTimeStepBasedOnNewtonIterations { static constexpr double value = 0.0; };
 struct TimeStepControlSafetyFactor { static constexpr double value = 0.8; };
 struct TimeStepControlRejectCompletedStep { static constexpr bool value = false; };
+struct TimeStepControlToleranceTestVersion { static constexpr auto value = "standard"; };
+struct TimeStepControlMaxReductionTimeStep { static constexpr double value = 0.1; };
+struct TimeStepControlParameters { static constexpr auto value = "0.125;0.25;0.125;0.375;0.125"; };
 
 } // namespace Opm::Parameters
 

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -825,7 +825,12 @@ run()
             this->substep_timer_.setLastStepFailed(true);
             checkTimeStepMaxRestartLimit_(restarts);
 
-            const double new_time_step = restartFactor_() * dt;
+            double new_time_step = restartFactor_() * dt;
+            if (substep_report.time_step_rejected) {
+                const double tol = Parameters::Get<Parameters::TimeStepControlTolerance>();
+                const double safetyFactor = Parameters::Get<Parameters::TimeStepControlSafetyFactor>();
+                new_time_step = std::sqrt(safetyFactor * tol / solver_().model().relativeChange()) * dt;
+            }
             checkTimeStepMinLimit_(new_time_step);
             bool wells_shut = false;
             if (new_time_step > minTimeStepBeforeClosingWells_()) {

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -829,7 +829,10 @@ run()
             if (substep_report.time_step_rejected) {
                 const double tol = Parameters::Get<Parameters::TimeStepControlTolerance>();
                 const double safetyFactor = Parameters::Get<Parameters::TimeStepControlSafetyFactor>();
-                new_time_step = std::sqrt(safetyFactor * tol / solver_().model().relativeChange()) * dt;
+                const double temp_time_step = std::sqrt(safetyFactor * tol / solver_().model().relativeChange()) * dt;
+                if (temp_time_step < dt) { // added in case suggested time step is not a reduction
+                    new_time_step = temp_time_step;
+                }
             }
             checkTimeStepMinLimit_(new_time_step);
             bool wells_shut = false;

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -35,7 +35,7 @@ namespace Opm
         return SimulatorReportSingle{1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
                                      7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
                                      13, 14, 15, 16, 17, 18,
-                                     true, false, 19, 20.0, 21.0,
+                                     true, false, false, 19, 20.0, 21.0,
                                      22, 23, 24, 25, 26, 27, 28};
     }
 
@@ -60,6 +60,7 @@ namespace Opm
                this->min_linear_iterations == rhs.min_linear_iterations &&
                this->max_linear_iterations == rhs.max_linear_iterations &&
                this->converged == rhs.converged &&
+               this->time_step_rejected == rhs.time_step_rejected &&
                this->well_group_control_changed == rhs.well_group_control_changed &&
                this->exit_status == rhs.exit_status &&
                this->global_time == rhs.global_time &&

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -53,6 +53,7 @@ namespace Opm
         unsigned int max_linear_iterations = 0;
 
         bool converged = false;
+        bool time_step_rejected = false;
         bool well_group_control_changed = false;
         int exit_status = EXIT_SUCCESS;
 
@@ -101,6 +102,7 @@ namespace Opm
             serializer(min_linear_iterations);
             serializer(max_linear_iterations);
             serializer(converged);
+            serializer(time_step_rejected);
             serializer(well_group_control_changed);
             serializer(exit_status);
             serializer(global_time);

--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -333,19 +333,23 @@ namespace Opm
         // Use an I controller after report time steps
         if (substepTimer.currentStepNum() < 3)
         {
-            controllerVersion_ = "I-controller";
+            controllerVersion_ = 0; // "I-controller"
             const double newDt = dt * timeStepFactor(errors_, timeSteps_);
-            if( verbose_ )
+            if (verbose_)
+            {
                 OpmLog::info(fmt::format("Computed step size (pow): {} days", unit::convert::to( newDt, unit::day )));
+            }
             return newDt;
         }
         // Use the general third order controller for all other time steps
         else
         {
-            controllerVersion_ = "3rdOrder";
+            controllerVersion_ = 1; // "3rdOrder";
             const double newDt = dt * timeStepFactor(errors_, timeSteps_);
-            if( verbose_ )
+            if (verbose_)
+            {
                 OpmLog::info(fmt::format("Computed step size (pow): {} days", unit::convert::to( newDt, unit::day )));
+            }
             return newDt;
         }
     }
@@ -353,7 +357,8 @@ namespace Opm
     double General3rdOrderController::
     timeStepFactor(const std::array<double, 3> errors, const std::array<double, 3> timeSteps) const
     {
-        if (controllerVersion_ == "3rdOrder")
+        // "3rdOrder"
+        if (controllerVersion_ == 1)
         {
             return std::pow(safetyFactor_ * tolerance_ / errors[2], beta_[0]) *
                    std::pow(safetyFactor_ * tolerance_ / errors[1], beta_[1]) *
@@ -361,10 +366,8 @@ namespace Opm
                    std::pow(timeSteps[2] / timeSteps[1], -alpha_[0]) *
                    std::pow(timeSteps[1] / timeSteps[0], -alpha_[1]);
         }
-        else if (controllerVersion_ == "I-controller")
-        {
-            return std::pow(safetyFactor_ * tolerance_ / errors[2], 0.35);
-        }
+        // "I-controller"
+        return std::pow(safetyFactor_ * tolerance_ / errors[2], 0.35);
     }
 
     bool General3rdOrderController::
@@ -375,14 +378,20 @@ namespace Opm
         // Reject time step if chosen tolerance test version fails
         if (toleranceTestVersion_ == "standard")
         {
-            if (rejectCompletedStep_ && error > tolerance_) { acceptTimeStep = false; }
+            if (rejectCompletedStep_ && error > tolerance_)
+            {
+                acceptTimeStep = false;
+            }
         }
         else if (toleranceTestVersion_ == "control-error-filtering")
         {
             const std::array<double, 3> tempErrors{errors_[0], errors_[1], error};
             const std::array<double, 3> tempTimeSteps{timeSteps_[0], timeSteps_[1], timeStep};
             double stepFactor = timeStepFactor(tempErrors, tempTimeSteps);
-            if (rejectCompletedStep_ && stepFactor < maxReductionTimeStep_) { acceptTimeStep = false; }
+            if (rejectCompletedStep_ && stepFactor < maxReductionTimeStep_)
+            {
+                acceptTimeStep = false;
+            }
         }
         else
         {
@@ -403,12 +412,16 @@ namespace Opm
             timeSteps_[2] = timeStep;
 
             for( int i = 0; i < 2; ++i )
+            {
                 assert(std::isfinite(errors_[i]));
+            }
             
             if (errors_[0] == 0 || errors_[1] == 0 || errors_[2] == 0.)
             {
                 if ( verbose_ )
+                {
                     OpmLog::info("The solution between time steps does not change, there is no time step constraint from the controller.");
+                }
                 return std::numeric_limits<double>::max();
             }
         }

--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -336,7 +336,7 @@ namespace Opm
     General3rdOrderController
     General3rdOrderController::serializationTestObject()
     {
-        General3rdOrderController result(1.0, 2.0, false, "", 3.0, "", false);
+        General3rdOrderController result(1.0, 2.0, false, "standard", 3.0, "0.125;0.25;0.125;0.75;0.25", false);
         result.errors_ = {2.0, 3.0};
 
         return result;

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -232,6 +232,7 @@ namespace Opm
             serializer(alpha_);
             serializer(controllerVersion_);
             serializer(toleranceTestVersion_);
+            serializer(maxReductionTimeStep_);
             serializer(verbose_);
         }
 
@@ -246,7 +247,7 @@ namespace Opm
         mutable std::array<double, 3> timeSteps_{};
         mutable std::array<double, 3> beta_{};
         mutable std::array<double, 3> alpha_{};
-        mutable std::string controllerVersion_ = "I-controller";
+        mutable int controllerVersion_ = 0;
         const std::string toleranceTestVersion_ = "";
         const double maxReductionTimeStep_ = 0.1;
         const bool verbose_ = false;

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -37,6 +37,16 @@ namespace Opm
       General3rdOrder,
     };
 
+    enum class ToleranceTestVersions {
+        Standard,
+        ControlErrorFiltering,
+    };
+
+    enum class InternalControlVersions {
+        IController,
+        General3rdOrder,
+    };
+
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
     ///
     ///  A simple iteration count based adaptive time step control.
@@ -66,7 +76,7 @@ namespace Opm
                                    const RelativeChangeInterface& /* relativeChange */,
                                    const AdaptiveSimulatorTimer& /* substepTimer */ ) const override;
         
-        bool timeStepAccepted(const double /* error */, const double /* timeStep */) const override { return true; }
+        bool timeStepAccepted(const double /* error */, const double /* timeStepJustCompleted */) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -119,7 +129,7 @@ namespace Opm
                                    const RelativeChangeInterface& relativeChange,
                                    const AdaptiveSimulatorTimer& /* substepTimer */ ) const override;
 
-        bool timeStepAccepted(const double /* error */, const double /* timeStep */) const override { return true; }
+        bool timeStepAccepted(const double /* error */, const double /* timeStepJustCompleted */) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -170,7 +180,7 @@ namespace Opm
                                    const RelativeChangeInterface& relativeChange,
                                    const AdaptiveSimulatorTimer& /* substepTimer */ ) const override;
 
-        bool timeStepAccepted(const double /* error */, const double /* timeStep */) const override { return true; }
+        bool timeStepAccepted(const double /* error */, const double /* timeStepJustCompleted */) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -204,9 +214,9 @@ namespace Opm
         General3rdOrderController( const double tolerance = 1e-3,
                                    const double safetyFactor = 0.8,
                                    const bool rejectCompletedStep = false,
-                                   const std::string toleranceTestVersion = "",
+                                   const std::string& toleranceTestVersion = "",
                                    const double maxReductionTimeStep = 0.1,
-                                   const std::string parameters = "",
+                                   const std::string& parameters = "",
                                    const bool verbose = false);
 
         static General3rdOrderController serializationTestObject();
@@ -216,9 +226,9 @@ namespace Opm
                                    const RelativeChangeInterface& /* relativeChange */,
                                    const AdaptiveSimulatorTimer& substepTimer) const override;
 
-        double timeStepFactor(const std::array<double, 3> errors, const std::array<double, 3> timeSteps) const;
+        double timeStepFactor(const std::array<double, 3>& errors, const std::array<double, 3>& timeSteps) const;
 
-        bool timeStepAccepted(const double error, const double timeStep) const override;
+        bool timeStepAccepted(const double error, const double timeStepJustCompleted) const override;
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -240,15 +250,15 @@ namespace Opm
 
 
     protected:
-        const double tolerance_ = 1e-3;
+        const double tolerance_ = 0.1;
         const double safetyFactor_ = 0.8;
         const bool rejectCompletedStep_ = false;
         mutable std::array<double, 3> errors_{};
         mutable std::array<double, 3> timeSteps_{};
-        mutable std::array<double, 3> beta_{};
-        mutable std::array<double, 3> alpha_{};
-        mutable int controllerVersion_ = 0;
-        const std::string toleranceTestVersion_ = "";
+        mutable std::array<double, 3> beta_{0.125, 0.25, 0.125};
+        mutable std::array<double, 2> alpha_{0.75, 0.25};
+        mutable InternalControlVersions controllerVersion_{InternalControlVersions::IController};
+        ToleranceTestVersions toleranceTestVersion_{ToleranceTestVersions::Standard};
         const double maxReductionTimeStep_ = 0.1;
         const bool verbose_ = false;
     };
@@ -280,7 +290,7 @@ namespace Opm
                                    const RelativeChangeInterface& /*relativeChange */,
                                    const AdaptiveSimulatorTimer& substepTimer) const override;
 
-        bool timeStepAccepted(const double /* error */, const double /* timeStep */) const override { return true; }
+        bool timeStepAccepted(const double /* error */, const double /* timeStepJustCompleted */) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -66,7 +66,7 @@ namespace Opm
                                    const RelativeChangeInterface& /* relativeChange */,
                                    const AdaptiveSimulatorTimer& /* substepTimer */ ) const override;
         
-        bool timeStepAccepted(const double /* error */) const override { return true; }
+        bool timeStepAccepted(const double /* error */, const double /* timeStep */) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -119,7 +119,7 @@ namespace Opm
                                    const RelativeChangeInterface& relativeChange,
                                    const AdaptiveSimulatorTimer& /* substepTimer */ ) const override;
 
-        bool timeStepAccepted(const double /* error */) const override { return true; }
+        bool timeStepAccepted(const double /* error */, const double /* timeStep */) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -170,7 +170,7 @@ namespace Opm
                                    const RelativeChangeInterface& relativeChange,
                                    const AdaptiveSimulatorTimer& /* substepTimer */ ) const override;
 
-        bool timeStepAccepted(const double /* error */) const override { return true; }
+        bool timeStepAccepted(const double /* error */, const double /* timeStep */) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -204,16 +204,21 @@ namespace Opm
         General3rdOrderController( const double tolerance = 1e-3,
                                    const double safetyFactor = 0.8,
                                    const bool rejectCompletedStep = false,
-                                   const bool verbose = false );
+                                   const std::string toleranceTestVersion = "",
+                                   const double maxReductionTimeStep = 0.1,
+                                   const std::string parameters = "",
+                                   const bool verbose = false);
 
         static General3rdOrderController serializationTestObject();
 
         double computeTimeStepSize(const double dt,
-                                   const int /*iterations */,
-                                   const RelativeChangeInterface& relativeChange,
+                                   const int /* iterations */,
+                                   const RelativeChangeInterface& /* relativeChange */,
                                    const AdaptiveSimulatorTimer& substepTimer) const override;
 
-        bool timeStepAccepted(const double error) const override;
+        double timeStepFactor(const std::array<double, 3> errors, const std::array<double, 3> timeSteps) const;
+
+        bool timeStepAccepted(const double error, const double timeStep) const override;
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -223,6 +228,10 @@ namespace Opm
             serializer(rejectCompletedStep_);
             serializer(errors_);
             serializer(timeSteps_);
+            serializer(beta_);
+            serializer(alpha_);
+            serializer(controllerVersion_);
+            serializer(toleranceTestVersion_);
             serializer(verbose_);
         }
 
@@ -233,9 +242,13 @@ namespace Opm
         const double tolerance_ = 1e-3;
         const double safetyFactor_ = 0.8;
         const bool rejectCompletedStep_ = false;
-        mutable std::vector<double> errors_{};
-        mutable std::vector<double> timeSteps_{};
-        mutable int counterSinceFailure_ = 0;
+        mutable std::array<double, 3> errors_{};
+        mutable std::array<double, 3> timeSteps_{};
+        mutable std::array<double, 3> beta_{};
+        mutable std::array<double, 3> alpha_{};
+        mutable std::string controllerVersion_ = "I-controller";
+        const std::string toleranceTestVersion_ = "";
+        const double maxReductionTimeStep_ = 0.1;
         const bool verbose_ = false;
     };
 
@@ -266,7 +279,7 @@ namespace Opm
                                    const RelativeChangeInterface& /*relativeChange */,
                                    const AdaptiveSimulatorTimer& substepTimer) const override;
 
-        bool timeStepAccepted(const double /* error */) const override { return true; }
+        bool timeStepAccepted(const double /* error */, const double /* timeStep */) const override { return true; }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -211,13 +211,15 @@ namespace Opm
     public:
         static constexpr TimeStepControlType Type = TimeStepControlType::General3rdOrder;
 
-        General3rdOrderController( const double tolerance = 1e-3,
-                                   const double safetyFactor = 0.8,
-                                   const bool rejectCompletedStep = false,
-                                   const std::string& toleranceTestVersion = "",
-                                   const double maxReductionTimeStep = 0.1,
-                                   const std::string& parameters = "",
-                                   const bool verbose = false);
+        General3rdOrderController() = default;
+
+        General3rdOrderController( const double tolerance,
+                                   const double safetyFactor,
+                                   const bool rejectCompletedStep,
+                                   const std::string& toleranceTestVersion,
+                                   const double maxReductionTimeStep,
+                                   const std::string& parameters,
+                                   const bool verbose);
 
         static General3rdOrderController serializationTestObject();
 

--- a/opm/simulators/timestepping/TimeStepControlInterface.hpp
+++ b/opm/simulators/timestepping/TimeStepControlInterface.hpp
@@ -60,7 +60,7 @@ namespace Opm
         /// \return suggested time step size for the next step
         virtual double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& relativeChange , const AdaptiveSimulatorTimer& substepTimer) const = 0;
 
-        virtual bool timeStepAccepted(const double error) const = 0;
+        virtual bool timeStepAccepted(const double error, const double timeStep) const = 0;
 
         /// virtual destructor (empty)
         virtual ~TimeStepControlInterface () {}

--- a/opm/simulators/timestepping/TimeStepControlInterface.hpp
+++ b/opm/simulators/timestepping/TimeStepControlInterface.hpp
@@ -60,7 +60,9 @@ namespace Opm
         /// \return suggested time step size for the next step
         virtual double computeTimeStepSize( const double dt, const int iterations, const RelativeChangeInterface& relativeChange , const AdaptiveSimulatorTimer& substepTimer) const = 0;
 
-        virtual bool timeStepAccepted(const double error, const double timeStep) const = 0;
+        /// For the general 3rd order controller, the internal shifting of errors and time steps happens here, and
+        /// hence this method needs to be called for (after) each time step
+        virtual bool timeStepAccepted(const double error, const double timeStepJustCompleted) const = 0;
 
         /// virtual destructor (empty)
         virtual ~TimeStepControlInterface () {}


### PR DESCRIPTION
This PR includes a different reduction in time step size if tolerance test fails (than if we get numerical difficulties), the possibility to set controller parameters for the general 3rd order controller, the option to use control error filtering as tolerance test instead of comparing relative change directly to the tolerance, as well as adjustments/fixes to the general 3rd order controller code.