### PR TITLE
WIP Refactor guiderate computations

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1425,6 +1425,12 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                                               well_state);
 
     int number_of_wells_under_this_group = 0;
+    std::vector<std::string> next_sub_group_with_guide_rate;
+
+    std::vector<bool> prod = {true, false, false, false};
+    const Phase all[] = { Phase::OIL, Phase::WATER, Phase::OIL, Phase::GAS };
+    for (int i = 0; i<4; i++) {
+
     WellGroupHelpers<Scalar>::updateGuideRate("FIELD",
                                               schedule(),
                                               well_state,
@@ -1433,7 +1439,11 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                                               guideRate_,
                                               WGHelpers::TargetCalculator<Scalar>::guideTargetMode(this->groupState().production_control("FIELD")),
                                               number_of_wells_under_this_group,
+                                              next_sub_group_with_guide_rate,
+                                              prod[i], 
+                                              all[i],
                                               this->phase_usage_);
+    }
 
     // Set ALQ for off-process wells to zero
     for (const auto& wname : schedule().wellNames(reportStepIdx)) {

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1424,15 +1424,15 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                                               well_state_nupcol,
                                               well_state);
 
-    int number_of_wells_under_this_group = 0;
-    std::vector<std::string> next_sub_group_with_guide_rate;
 
     std::vector<bool> prod = {true, false, false, false};
     const Phase all[] = { Phase::OIL, Phase::WATER, Phase::OIL, Phase::GAS };
     std::vector<GuideRateModel::Target> targets = {WGHelpers::TargetCalculator<Scalar>::guideTargetMode(this->groupState().production_control("FIELD")),GuideRateModel::Target::WAT,
         GuideRateModel::Target::OIL,GuideRateModel::Target::GAS };
 
-    for (int i = 0; i<4; i++) {
+    for (int i = 0; i < 4; i++) {
+        int number_of_wells_under_this_group = 0;
+        std::vector<std::string> next_sub_group_with_guide_rate;
         WellGroupHelpers<Scalar>::updateGuideRate("FIELD",
                                               schedule(),
                                               well_state,

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -65,6 +65,7 @@
 #include <opm/simulators/wells/WellGroupHelpers.hpp>
 #include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 #include <opm/simulators/wells/WellState.hpp>
+#include <opm/simulators/wells/TargetCalculator.hpp>
 
 #if HAVE_MPI
 #include <opm/simulators/utils/MPISerializer.hpp>
@@ -1422,6 +1423,17 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                                               reportStepIdx,
                                               well_state_nupcol,
                                               well_state);
+
+    int number_of_wells_under_this_group = 0;
+    WellGroupHelpers<Scalar>::updateGuideRate("FIELD",
+                                              schedule(),
+                                              well_state,
+                                              this->groupState(),
+                                              reportStepIdx,
+                                              guideRate_,
+                                              WGHelpers::TargetCalculator<Scalar>::guideTargetMode(this->groupState().production_control("FIELD")),
+                                              number_of_wells_under_this_group,
+                                              this->phase_usage_);
 
     // Set ALQ for off-process wells to zero
     for (const auto& wname : schedule().wellNames(reportStepIdx)) {

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1429,18 +1429,20 @@ updateAndCommunicateGroupData(const int reportStepIdx,
 
     std::vector<bool> prod = {true, false, false, false};
     const Phase all[] = { Phase::OIL, Phase::WATER, Phase::OIL, Phase::GAS };
-    for (int i = 0; i<4; i++) {
+    std::vector<GuideRateModel::Target> targets = {WGHelpers::TargetCalculator<Scalar>::guideTargetMode(this->groupState().production_control("FIELD")),GuideRateModel::Target::WAT,
+        GuideRateModel::Target::OIL,GuideRateModel::Target::GAS };
 
-    WellGroupHelpers<Scalar>::updateGuideRate("FIELD",
+    for (int i = 0; i<4; i++) {
+        WellGroupHelpers<Scalar>::updateGuideRate("FIELD",
                                               schedule(),
                                               well_state,
                                               this->groupState(),
                                               reportStepIdx,
                                               guideRate_,
-                                              WGHelpers::TargetCalculator<Scalar>::guideTargetMode(this->groupState().production_control("FIELD")),
+                                              targets[i],
                                               number_of_wells_under_this_group,
                                               next_sub_group_with_guide_rate,
-                                              prod[i], 
+                                              prod[i],
                                               all[i],
                                               this->phase_usage_);
     }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -474,6 +474,11 @@ namespace Opm {
                                                    &this->guideRate_,
                                                    pot,
                                                    local_deferredLogger);
+
+                                                   this->updateAndCommunicateGroupData(reportStepIdx,
+                                                    simulator_.model().newtonMethod().numIterations(),
+                                                    param_.nupcol_group_rate_tolerance_,
+                                                    local_deferredLogger);
         std::string exc_msg;
         auto exc_type = ExceptionType::NONE;
         // update gpmaint targets
@@ -515,6 +520,7 @@ namespace Opm {
                 }
             }
         }
+
         // Catch clauses for all errors setting exc_type and exc_msg
         OPM_PARALLEL_CATCH_CLAUSE(exc_type, exc_msg);
 
@@ -1244,7 +1250,9 @@ namespace Opm {
         OPM_TIMEFUNCTION();
         const int iterationIdx = simulator_.model().newtonMethod().numIterations();
         const int reportStepIdx = simulator_.episodeIndex();
+        std::cout << "start " << std::endl;
         this->updateAndCommunicateGroupData(reportStepIdx, iterationIdx, param_.nupcol_group_rate_tolerance_, local_deferredLogger);
+        std::cout << "end " << std::endl;
         const auto [more_inner_network_update, network_imbalance] =
                 updateNetworks(mandatory_network_balance,
                                local_deferredLogger,

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1250,9 +1250,7 @@ namespace Opm {
         OPM_TIMEFUNCTION();
         const int iterationIdx = simulator_.model().newtonMethod().numIterations();
         const int reportStepIdx = simulator_.episodeIndex();
-        std::cout << "start " << std::endl;
         this->updateAndCommunicateGroupData(reportStepIdx, iterationIdx, param_.nupcol_group_rate_tolerance_, local_deferredLogger);
-        std::cout << "end " << std::endl;
         const auto [more_inner_network_update, network_imbalance] =
                 updateNetworks(mandatory_network_balance,
                                local_deferredLogger,

--- a/opm/simulators/wells/FractionCalculator.cpp
+++ b/opm/simulators/wells/FractionCalculator.cpp
@@ -91,14 +91,14 @@ localFraction(const std::string& name,
         return 1.0;
 
     if (total_guide_rate == 0 ) {
-        std::cout << name << " total_guide_rate is zero " << my_guide_rate << " " << num_active_groups << " " << always_included_child <<  std::endl;
+        //std::cout << name << " total_guide_rate is zero " << my_guide_rate << " " << num_active_groups << " " << always_included_child <<  std::endl;
         // if the total guide rate is zero (for instance due to netv = 0) we use the potentials
         // to distribute the group rate
         always_use_potentials = true;
 
         const Scalar my_pot = guideRate(name, always_included_child, always_use_potentials);
         const Scalar my_total_pot = guideRateSum(parent_group, always_included_child, always_use_potentials).first;
-        std::cout << my_pot << " " << my_total_pot << std::endl;
+        //std::cout << my_pot << " " << my_total_pot << std::endl;
         return my_pot / my_total_pot;
     }
     return my_guide_rate / total_guide_rate;

--- a/opm/simulators/wells/FractionCalculator.cpp
+++ b/opm/simulators/wells/FractionCalculator.cpp
@@ -200,54 +200,48 @@ guideRateSum(const Group& group,
         //child_rate = guideRate(always_included_child, always_included_child, always_use_potentials);
 
     }
-    auto gs_rates = this->group_state_.prod_guide_rates(group.name());
-    auto group_cont_wells = this->group_state_.number_of_wells_under_this_control(group.name());
-    auto next_subgroup_with_guiderate = this->group_state_.sub_group_with_guiderate(group.name());
-
-    bool hasWell = schedule_.hasWell(always_included_child, report_step_);
-    std::cout << is_producer_ << " " << always_included_child << " " << group.name() << " " << hasWell << " " << always_use_potentials << std::endl;
-    if (hasWell && !well_state_.isProductionGrup(always_included_child)) {
-        //const auto chain = WellGroupHelpers<Scalar>::groupChainTopBot(always_included_child, group.name(), schedule_, report_step_);
-        if (group_cont_wells > 0)
-            child_rate = guideRate(always_included_child, always_included_child, always_use_potentials);
-        else {
-            const auto& well = schedule_.getWell(always_included_child, report_step_);
-            bool stop = false;
-            auto gr_name = well.groupName();
-            while (!stop) {
-                std::cout << "iterate " <<gr_name << std::endl;
-                auto it = std::find(next_subgroup_with_guiderate.begin(), next_subgroup_with_guiderate.end(), gr_name);
-                if (it != next_subgroup_with_guiderate.end()) {
-                    std::cout << "found it " << gr_name << std::endl;
-                    child_rate = guideRate(gr_name, always_included_child, always_use_potentials);
-                    break;
+    const auto& gs_rates = is_producer_? this->group_state_.prod_guide_rates(group.name()) : this->group_state_.inj_guide_rates(group.name(), injection_phase_);
+    auto group_cont_wells = is_producer_? this->group_state_.number_of_wells_under_this_control(group.name()) : this->group_state_.number_of_wells_under_this_inj_control(group.name(), injection_phase_) ;
+    const auto& next_subgroup_with_guiderate = is_producer_? this->group_state_.sub_group_with_guiderate(group.name()) : this->group_state_.sub_group_inj_with_guiderate(group.name(), injection_phase_);
+    child_rate = 0.0;        
+    bool isWell = schedule_.hasWell(always_included_child, report_step_);
+    //std::cout << is_producer_ << " " << gs_rates << " " << group_cont_wells << " " << always_included_child << " " << group.name() << " " << isWell << " " << always_use_potentials << std::endl;
+    if (isWell) {
+        bool already_included = is_producer_? well_state_.isProductionGrup(always_included_child) : well_state_.isInjectionGrup(always_included_child);
+        if (!already_included) {
+            //const auto chain = WellGroupHelpers<Scalar>::groupChainTopBot(always_included_child, group.name(), schedule_, report_step_);
+            if (group_cont_wells > 0)
+                child_rate = guideRate(always_included_child, always_included_child, always_use_potentials);
+            else {
+                const auto& well = schedule_.getWell(always_included_child, report_step_);
+                bool stop = false;
+                auto gr_name = well.groupName();
+                while (!stop) {
+                    auto it = std::find(next_subgroup_with_guiderate.begin(), next_subgroup_with_guiderate.end(), gr_name);
+                    if (it != next_subgroup_with_guiderate.end()) {
+                        child_rate = guideRate(gr_name, always_included_child, always_use_potentials);
+                        break;
+                    }
+                    const auto& group2 = schedule_.getGroup(gr_name, report_step_);
+                    if (gr_name == group.name())
+                        stop = true;
+                    
+                    gr_name = group2.parent();
                 }
-                
-                const auto& group2 = schedule_.getGroup(gr_name, report_step_);
-                gr_name = group2.parent();
-                if (gr_name == "FIELD")
-                    stop = true;
             }
         }
-        //else if (next_subgroup_with_guiderate != ""){
-            //child_rate = guideRate(next_subgroup_with_guiderate, always_included_child, always_use_potentials);
-            //std::cout << "subguiderate " << next_subgroup_with_guiderate << " " << child_rate << std::endl;
-            //guide_rate_->has(well.groupName());
-            //guide_rate_->get(name, target_, getGroupRateVector(name));
-            //child_rate = guideRate(group., always_included_child, always_use_potentials);
-        //}
     }
 
    //else if (this->group_state_.has_prod_guide_rates(always_included_child) && always_included_child != group.name()) 
             //child_rate = this->group_state_.prod_guide_rates(always_included_child);
 
     //if (hasWell && !well_state_.isProductionGrup(always_included_child)) {
-    gs_rates += child_rate;
+    //gs_rates += child_rate;
     //}
     //if (group_cont_wells == 0)
     //    gs_rates = 0.0;
 
-    if (is_producer_ && std::abs(total_guide_rate - gs_rates) > 0.1)
+    if (is_producer_ && std::abs(total_guide_rate - gs_rates - child_rate) > 0.1)
         std::cout << "BUG " << group.name() << " " << group_cont_wells << " " << gs_rates << " " << child_rate << " " << total_guide_rate << " " << always_included_child << std::endl;
 
     return {total_guide_rate, number_of_included_well_or_groups};

--- a/opm/simulators/wells/GroupState.cpp
+++ b/opm/simulators/wells/GroupState.cpp
@@ -447,7 +447,7 @@ template<class Scalar>
 bool GroupState<Scalar>::
 has_prod_guide_rates(const std::string& gname) const
 {
-    return (this->m_number_of_wells_under_this_control.count(gname) > 0);
+    return (this->m_prod_guide_rates.count(gname) > 0);
 }
 
 
@@ -503,6 +503,92 @@ bool GroupState<Scalar>::
 has_sub_group_with_guiderate(const std::string& gname) const
 {
     return (this->m_sub_group_with_guiderate.count(gname) > 0);
+}
+
+//-------------------------------------------------------------------------
+
+
+
+//-------------------------------------------------------------------------
+
+template<class Scalar>
+void GroupState<Scalar>::
+update_inj_guide_rates(const std::string& gname, Phase phase, Scalar target)
+{
+    this->m_inj_guide_rates[{phase, gname}] = target;
+}
+
+template<class Scalar>
+Scalar GroupState<Scalar>::
+inj_guide_rates(const std::string& gname, Phase phase) const
+{
+    auto group_iter = this->m_inj_guide_rates.find({phase, gname});
+    if (group_iter == this->m_inj_guide_rates.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+template<class Scalar>
+bool GroupState<Scalar>::
+has_inj_guide_rates(const std::string& gname, Phase phase) const
+{
+    return (this->m_inj_guide_rates.count({phase, gname}) > 0);
+}
+
+
+//-------------------------------------------------------------------------
+
+template<class Scalar>
+void GroupState<Scalar>::
+update_number_of_wells_under_this_inj_control(const std::string& gname, Phase phase, int number)
+{
+    this->m_number_of_wells_under_this_inj_control[{phase, gname}] = number;
+}
+
+template<class Scalar>
+int GroupState<Scalar>::
+number_of_wells_under_this_inj_control(const std::string& gname, Phase phase) const
+{
+    auto group_iter = this->m_number_of_wells_under_this_inj_control.find({phase, gname});
+    if (group_iter == this->m_number_of_wells_under_this_inj_control.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+template<class Scalar>
+bool GroupState<Scalar>::
+has_number_of_wells_under_this_inj_control(const std::string& gname, Phase phase) const
+{
+    return (this->m_number_of_wells_under_this_inj_control.count({phase, gname}) > 0);
+}
+
+//-------------------------------------------------------------------------
+
+template<class Scalar>
+void GroupState<Scalar>::
+update_sub_group_inj_with_guiderate(const std::string& gname, Phase phase, const std::vector<std::string>& subname)
+{
+    this->m_sub_group_inj_with_guiderate[{phase, gname}] = subname;
+}
+
+template<class Scalar>
+const std::vector<std::string>& GroupState<Scalar>::
+sub_group_inj_with_guiderate(const std::string& gname, Phase phase) const
+{
+    auto group_iter = this->m_sub_group_inj_with_guiderate.find({phase, gname});
+    if (group_iter == this->m_sub_group_inj_with_guiderate.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+template<class Scalar>
+bool GroupState<Scalar>::
+has_sub_group_inj_with_guiderate(const std::string& gname,Phase phase) const
+{
+    return (this->m_sub_group_inj_with_guiderate.count({phase, gname}) > 0);
 }
 
 //-------------------------------------------------------------------------

--- a/opm/simulators/wells/GroupState.cpp
+++ b/opm/simulators/wells/GroupState.cpp
@@ -52,6 +52,7 @@ GroupState<Scalar> GroupState<Scalar>::serializationTestObject()
     result.m_prod_guide_rates = {{"test8", 12.0}, {"test9", 13.0}};
     result.m_grat_sales_target = {{"test10", 14.0}};
     result.m_number_of_wells_under_this_control = {{"test10", 3}};
+    result.m_sub_group_with_guiderate = {{"test10", {"test10s"}}};
     result.m_gpmaint_target = {{"test11", 15.0}};
     result.injection_controls = {{{Phase::FOAM, "test12"}, Group::InjectionCMode::REIN}};
     result.gpmaint_state.add("foo", GPMaint::State::serializationTestObject());
@@ -77,7 +78,8 @@ bool GroupState<Scalar>::operator==(const GroupState& other) const
            this->gpmaint_state == other.gpmaint_state &&
            this->m_gconsump_rates == other.m_gconsump_rates &&
            this->m_prod_guide_rates == other.m_prod_guide_rates &&
-           this->m_number_of_wells_under_this_control == m_number_of_wells_under_this_control;
+           this->m_number_of_wells_under_this_control == m_number_of_wells_under_this_control &&
+           this->m_sub_group_with_guiderate == m_sub_group_with_guiderate;
 }
 
 //-------------------------------------------------------------------------
@@ -476,6 +478,32 @@ has_number_of_wells_under_this_control(const std::string& gname) const
     return (this->m_number_of_wells_under_this_control.count(gname) > 0);
 }
 
+//-------------------------------------------------------------------------
+
+template<class Scalar>
+void GroupState<Scalar>::
+update_sub_group_with_guiderate(const std::string& gname, const std::vector<std::string>& subname)
+{
+    this->m_sub_group_with_guiderate[gname] = subname;
+}
+
+template<class Scalar>
+const std::vector<std::string>& GroupState<Scalar>::
+sub_group_with_guiderate(const std::string& gname) const
+{
+    auto group_iter = this->m_sub_group_with_guiderate.find(gname);
+    if (group_iter == this->m_sub_group_with_guiderate.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+template<class Scalar>
+bool GroupState<Scalar>::
+has_sub_group_with_guiderate(const std::string& gname) const
+{
+    return (this->m_sub_group_with_guiderate.count(gname) > 0);
+}
 
 //-------------------------------------------------------------------------
 

--- a/opm/simulators/wells/GroupState.cpp
+++ b/opm/simulators/wells/GroupState.cpp
@@ -49,7 +49,9 @@ GroupState<Scalar> GroupState<Scalar>::serializationTestObject()
     result.inj_resv_rates = {{"test6", {9.0, 10.0}}};
     result.inj_rein_rates = {{"test7", {11.0}}};
     result.inj_vrep_rate = {{"test8", 12.0}, {"test9", 13.0}};
+    result.m_prod_guide_rates = {{"test8", 12.0}, {"test9", 13.0}};
     result.m_grat_sales_target = {{"test10", 14.0}};
+    result.m_number_of_wells_under_this_control = {{"test10", 3}};
     result.m_gpmaint_target = {{"test11", 15.0}};
     result.injection_controls = {{{Phase::FOAM, "test12"}, Group::InjectionCMode::REIN}};
     result.gpmaint_state.add("foo", GPMaint::State::serializationTestObject());
@@ -73,7 +75,9 @@ bool GroupState<Scalar>::operator==(const GroupState& other) const
            this->m_grat_sales_target == other.m_grat_sales_target &&
            this->injection_controls == other.injection_controls &&
            this->gpmaint_state == other.gpmaint_state &&
-           this->m_gconsump_rates == other.m_gconsump_rates;
+           this->m_gconsump_rates == other.m_gconsump_rates &&
+           this->m_prod_guide_rates == other.m_prod_guide_rates &&
+           this->m_number_of_wells_under_this_control == m_number_of_wells_under_this_control;
 }
 
 //-------------------------------------------------------------------------
@@ -415,6 +419,63 @@ injection_control(const std::string& gname, Phase phase) const
 
     return group_iter->second;
 }
+
+
+//-------------------------------------------------------------------------
+
+template<class Scalar>
+void GroupState<Scalar>::
+update_prod_guide_rates(const std::string& gname, Scalar target)
+{
+    this->m_prod_guide_rates[gname] = target;
+}
+
+template<class Scalar>
+Scalar GroupState<Scalar>::
+prod_guide_rates(const std::string& gname) const
+{
+    auto group_iter = this->m_prod_guide_rates.find(gname);
+    if (group_iter == this->m_prod_guide_rates.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+template<class Scalar>
+bool GroupState<Scalar>::
+has_prod_guide_rates(const std::string& gname) const
+{
+    return (this->m_number_of_wells_under_this_control.count(gname) > 0);
+}
+
+
+//-------------------------------------------------------------------------
+
+template<class Scalar>
+void GroupState<Scalar>::
+update_number_of_wells_under_this_control(const std::string& gname, int number)
+{
+    this->m_number_of_wells_under_this_control[gname] = number;
+}
+
+template<class Scalar>
+int GroupState<Scalar>::
+number_of_wells_under_this_control(const std::string& gname) const
+{
+    auto group_iter = this->m_number_of_wells_under_this_control.find(gname);
+    if (group_iter == this->m_number_of_wells_under_this_control.end())
+        throw std::logic_error("No such group");
+
+    return group_iter->second;
+}
+
+template<class Scalar>
+bool GroupState<Scalar>::
+has_number_of_wells_under_this_control(const std::string& gname) const
+{
+    return (this->m_number_of_wells_under_this_control.count(gname) > 0);
+}
+
 
 //-------------------------------------------------------------------------
 

--- a/opm/simulators/wells/GroupState.hpp
+++ b/opm/simulators/wells/GroupState.hpp
@@ -116,6 +116,19 @@ public:
     void update_sub_group_with_guiderate(const std::string& gname, const std::vector<std::string>& subgname);
     const std::vector<std::string>& sub_group_with_guiderate(const std::string& gname) const;
 
+
+    bool has_inj_guide_rates(const std::string& gname, Phase phase) const;
+    void update_inj_guide_rates(const std::string& gname, Phase phase, Scalar target);
+    Scalar inj_guide_rates(const std::string& gname, Phase phase) const;
+
+    bool has_number_of_wells_under_this_inj_control(const std::string& gname, Phase phase) const;
+    void update_number_of_wells_under_this_inj_control(const std::string& gname, Phase phase, int number);
+    int number_of_wells_under_this_inj_control(const std::string& gname, Phase phase) const;
+
+    bool has_sub_group_inj_with_guiderate(const std::string& gname, Phase phase) const;
+    void update_sub_group_inj_with_guiderate(const std::string& gname, Phase phase, const std::vector<std::string>& subgname);
+    const std::vector<std::string>& sub_group_inj_with_guiderate(const std::string& gname, Phase phase) const;
+
     void update_gconsump(const Schedule& schedule, const int report_step, const SummaryState& summary_state);
     const std::pair<Scalar, Scalar>& gconsump_rates(const std::string& gname) const;
 
@@ -220,6 +233,9 @@ public:
         serializer(m_prod_guide_rates);
         serializer(m_number_of_wells_under_this_control);
         serializer(m_sub_group_with_guiderate); //will this work???
+        serializer(m_inj_guide_rates);
+        serializer(m_number_of_wells_under_this_inj_control);
+        serializer(m_sub_group_inj_with_guiderate); //will this work???
     }
 
 private:
@@ -240,7 +256,9 @@ private:
     std::map<std::string, int> m_number_of_wells_under_this_control;
     std::map<std::string, std::vector<std::string>> m_sub_group_with_guiderate;
 
-
+    std::map<std::pair<Phase, std::string>, Scalar> m_inj_guide_rates;
+    std::map<std::pair<Phase, std::string>, int> m_number_of_wells_under_this_inj_control;
+    std::map<std::pair<Phase, std::string>, std::vector<std::string>> m_sub_group_inj_with_guiderate;
 
     std::map<std::pair<Phase, std::string>, Group::InjectionCMode> injection_controls;
     WellContainer<GPMaint::State> gpmaint_state;

--- a/opm/simulators/wells/GroupState.hpp
+++ b/opm/simulators/wells/GroupState.hpp
@@ -112,6 +112,10 @@ public:
     void update_number_of_wells_under_this_control(const std::string& gname, int number);
     int number_of_wells_under_this_control(const std::string& gname) const;
 
+    bool has_sub_group_with_guiderate(const std::string& gname) const;
+    void update_sub_group_with_guiderate(const std::string& gname, const std::vector<std::string>& subgname);
+    const std::vector<std::string>& sub_group_with_guiderate(const std::string& gname) const;
+
     void update_gconsump(const Schedule& schedule, const int report_step, const SummaryState& summary_state);
     const std::pair<Scalar, Scalar>& gconsump_rates(const std::string& gname) const;
 
@@ -147,6 +151,7 @@ public:
             iterateContainer(inj_resv_rates, func);
             iterateContainer(inj_rein_rates, func);
             iterateContainer(inj_surface_rates, func);
+            //iterateContainer(m_sub_group_with_guiderate, func);
         };
 
         // Compute the size of the data.
@@ -214,6 +219,7 @@ public:
         serializer(m_gconsump_rates);
         serializer(m_prod_guide_rates);
         serializer(m_number_of_wells_under_this_control);
+        serializer(m_sub_group_with_guiderate); //will this work???
     }
 
 private:
@@ -232,6 +238,8 @@ private:
     std::map<std::string, Scalar> group_thp;
     std::map<std::string, Scalar> m_prod_guide_rates;
     std::map<std::string, int> m_number_of_wells_under_this_control;
+    std::map<std::string, std::vector<std::string>> m_sub_group_with_guiderate;
+
 
 
     std::map<std::pair<Phase, std::string>, Group::InjectionCMode> injection_controls;

--- a/opm/simulators/wells/GroupState.hpp
+++ b/opm/simulators/wells/GroupState.hpp
@@ -104,6 +104,14 @@ public:
     void injection_control(const std::string& gname, Phase phase, Group::InjectionCMode cmode);
     Group::InjectionCMode injection_control(const std::string& gname, Phase phase) const;
 
+    bool has_prod_guide_rates(const std::string& gname) const;
+    void update_prod_guide_rates(const std::string& gname, Scalar target);
+    Scalar prod_guide_rates(const std::string& gname) const;
+
+    bool has_number_of_wells_under_this_control(const std::string& gname) const;
+    void update_number_of_wells_under_this_control(const std::string& gname, int number);
+    int number_of_wells_under_this_control(const std::string& gname) const;
+
     void update_gconsump(const Schedule& schedule, const int report_step, const SummaryState& summary_state);
     const std::pair<Scalar, Scalar>& gconsump_rates(const std::string& gname) const;
 
@@ -204,6 +212,8 @@ public:
         serializer(injection_controls);
         serializer(gpmaint_state);
         serializer(m_gconsump_rates);
+        serializer(m_prod_guide_rates);
+        serializer(m_number_of_wells_under_this_control);
     }
 
 private:
@@ -220,6 +230,9 @@ private:
     std::map<std::string, Scalar> m_grat_sales_target;
     std::map<std::string, Scalar> m_gpmaint_target;
     std::map<std::string, Scalar> group_thp;
+    std::map<std::string, Scalar> m_prod_guide_rates;
+    std::map<std::string, int> m_number_of_wells_under_this_control;
+
 
     std::map<std::pair<Phase, std::string>, Group::InjectionCMode> injection_controls;
     WellContainer<GPMaint::State> gpmaint_state;

--- a/opm/simulators/wells/TargetCalculator.cpp
+++ b/opm/simulators/wells/TargetCalculator.cpp
@@ -136,7 +136,13 @@ template<class Scalar>
 GuideRateModel::Target
 TargetCalculator<Scalar>::guideTargetMode() const
 {
-    switch (cmode_) {
+    return guideTargetMode(cmode_);
+}
+template<class Scalar>
+GuideRateModel::Target
+TargetCalculator<Scalar>::guideTargetMode(const Group::ProductionCMode& cmode)
+{
+    switch (cmode) {
     case Group::ProductionCMode::ORAT:
         return GuideRateModel::Target::OIL;
     case Group::ProductionCMode::WRAT:
@@ -149,7 +155,7 @@ TargetCalculator<Scalar>::guideTargetMode() const
         return GuideRateModel::Target::RES;
     default:
         // Should never be here.
-        assert(false);
+        //assert(false);
         return GuideRateModel::Target::NONE;
     }
 }

--- a/opm/simulators/wells/TargetCalculator.cpp
+++ b/opm/simulators/wells/TargetCalculator.cpp
@@ -269,6 +269,19 @@ InjectionTargetCalculator<Scalar>::guideTargetMode() const
     return target_;
 }
 
+template<class Scalar>
+GuideRateModel::Target
+InjectionTargetCalculator<Scalar>::guideTargetMode(const Phase& phase)
+{
+    switch (phase) {
+    case(Phase::OIL): return GuideRateModel::Target::OIL;
+    case(Phase::WATER): return GuideRateModel::Target::WAT;
+    case(Phase::GAS): return GuideRateModel::Target::GAS;
+    default: throw std::logic_error("Invalid injection phase in InjectionTargetCalculator");
+    }
+    return GuideRateModel::Target::GAS;
+}
+
 #define INSTANTIATE_TARGET_CALCULATOR(T,...) \
     template __VA_ARGS__                     \
     TargetCalculator<T>::calcModeRateFromRates(const __VA_ARGS__* rates) const;

--- a/opm/simulators/wells/TargetCalculator.hpp
+++ b/opm/simulators/wells/TargetCalculator.hpp
@@ -63,6 +63,7 @@ public:
                        DeferredLogger& deferred_logger) const;
 
     GuideRateModel::Target guideTargetMode() const;
+    static GuideRateModel::Target guideTargetMode(const Group::ProductionCMode& cmode);
 
 private:
     Group::ProductionCMode cmode_;
@@ -100,6 +101,8 @@ public:
                        DeferredLogger& deferred_logger) const;
 
     GuideRateModel::Target guideTargetMode() const;
+
+    GuideRateModel::Target guideTargetMode(const Group::InjectionCMode& cmode) const;
 
 private:
     Group::InjectionCMode cmode_;

--- a/opm/simulators/wells/TargetCalculator.hpp
+++ b/opm/simulators/wells/TargetCalculator.hpp
@@ -102,7 +102,7 @@ public:
 
     GuideRateModel::Target guideTargetMode() const;
 
-    GuideRateModel::Target guideTargetMode(const Group::InjectionCMode& cmode) const;
+    static GuideRateModel::Target guideTargetMode(const Phase& phase);
 
 private:
     Group::InjectionCMode cmode_;

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -1124,7 +1124,7 @@ updateGuideRate(const std::string& name,
         const auto guiderate = guideRate.get(name, target, getProductionGroupRateVector(group_state, pu, name));
         std::cout << "has guide rate " << name << " " << guiderate << " " << number_of_wells_under_this_group_control << std::endl;
         std::cout << "setup " << name << " " <<totalGuideRate << " " << number_of_wells_under_this_group_control << std::endl;
-        group_state.update_prod_guide_rates(name, totalGuideRate);
+        group_state.update_prod_guide_rates(name, guiderate);
         group_state.update_number_of_wells_under_this_control(name, number_of_wells_under_this_group_control);
         number_of_wells_under_this_group_control = 0;
         if (totalGuideRate == 0 )

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -1088,8 +1088,9 @@ updateGuideRate(const std::string& name,
                 const Phase injection_phase,
                 const PhaseUsage& pu)
 {
-    if (schedule.hasWell(name, reportStepIdx)) {
-        if (guideRate.has(name) || guideRate.hasPotentials(name)) {
+    if (schedule.hasWell(name, reportStepIdx)) { 
+        // if NONE there is no group controls
+        if (target != GuideRateModel::Target::NONE && (guideRate.has(name) || guideRate.hasPotentials(name))) {
             return guideRate.get(name, target, getWellRateVector(wellState, pu, name));
         } else {
             //std::cout << name << "what " << std::endl;
@@ -1132,7 +1133,7 @@ updateGuideRate(const std::string& name,
             //std::cout << name << " dont accumualte? " << groupName << std::endl;
             std::vector<std::string> next_sub_group_with_guide_rate2;
             updateGuideRate(groupName, schedule, wellState, group_state, reportStepIdx, guideRate, target, 
-                number_of_wells_under_this_group_control, next_sub_group_with_guide_rate2, is_production_group, injection_phase, pu);
+                number_of_wells_under_this_group_control2, next_sub_group_with_guide_rate2, is_production_group, injection_phase, pu);
         }
     }
 
@@ -1148,8 +1149,6 @@ updateGuideRate(const std::string& name,
         if (wellTmp.getStatus() == Well::Status::SHUT)
             continue;
 
-        number_of_wells_under_this_group_control++;
-
         //std::cout << "hello " << wellName << " " << updateGuideRate(wellName, schedule, wellState, group_state,
         //    reportStepIdx, guideRate, target, number_of_wells_under_this_group_control, next_sub_group_with_guide_rate, pu) << std::endl;
         // Only count wells under group control or the ru
@@ -1158,7 +1157,7 @@ updateGuideRate(const std::string& name,
         if (!is_production_group && !wellState.isInjectionGrup(wellName))
             continue;
 
-
+        number_of_wells_under_this_group_control++;
         //if (wellState.well(wellName).production_cmode != Well::ProducerCMode::GRUP)
         //    continue;
         //if ((ws.production_cmode != Well::ProducerCMode::GRUP)){

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -1148,6 +1148,8 @@ updateGuideRate(const std::string& name,
         if (wellTmp.getStatus() == Well::Status::SHUT)
             continue;
 
+        number_of_wells_under_this_group_control++;
+
         //std::cout << "hello " << wellName << " " << updateGuideRate(wellName, schedule, wellState, group_state,
         //    reportStepIdx, guideRate, target, number_of_wells_under_this_group_control, next_sub_group_with_guide_rate, pu) << std::endl;
         // Only count wells under group control or the ru
@@ -1156,7 +1158,6 @@ updateGuideRate(const std::string& name,
         if (!is_production_group && !wellState.isInjectionGrup(wellName))
             continue;
 
-        number_of_wells_under_this_group_control++;
 
         //if (wellState.well(wellName).production_cmode != Well::ProducerCMode::GRUP)
         //    continue;
@@ -1187,7 +1188,7 @@ updateGuideRate(const std::string& name,
         else if (!is_production_group && guideRate.has(name,injection_phase))
             guiderate = guideRate.get(name, injection_phase);
 
-        //std::cout << "has guide rate " << name << " " << totalGuideRate << " " << number_of_wells_under_this_group_control << std::endl;
+        std::cout << "has guide rate " << name << " " << totalGuideRate << " " << number_of_wells_under_this_group_control << std::endl;
         //std::cout << "setup " << name << " " <<totalGuideRate << " " << number_of_wells_under_this_group_control << " " << std::endl;
 
         number_of_wells_under_this_group_control = 0;

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -1126,8 +1126,7 @@ updateGuideRate(const std::string& name,
                 const Group::ProductionCMode& currentGroupControl = group_state.production_control(groupName);
                 target = WGHelpers::TargetCalculator<Scalar>::guideTargetMode(currentGroupControl);
             } else {
-                //const Group::InjectionCMode& currentGroupControl = group_state.injection_control(groupName, injection_phase);
-                //target = WGHelpers::TargetCalculator<Scalar>::guideTargetMode(currentGroupControl);
+                target = WGHelpers::InjectionTargetCalculator<Scalar>::guideTargetMode(injection_phase);
             }
             int number_of_wells_under_this_group_control2 = 0;
             //std::cout << name << " dont accumualte? " << groupName << std::endl;
@@ -1167,6 +1166,12 @@ updateGuideRate(const std::string& name,
 
     for (const std::string& wellName : group.wells()) {
         const auto& wellTmp = schedule.getWell(wellName, reportStepIdx);
+
+        if (is_production_group && wellTmp.isInjector())
+            continue;
+
+        if (!is_production_group && !wellTmp.isInjector())
+            continue;
 
         if (wellTmp.getStatus() == Well::Status::SHUT)
             continue;

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -1187,7 +1187,7 @@ updateGuideRate(const std::string& name,
         else if (!is_production_group && guideRate.has(name,injection_phase))
             guiderate = guideRate.get(name, injection_phase);
 
-        std::cout << "has guide rate " << name << " " << totalGuideRate << " " << number_of_wells_under_this_group_control << std::endl;
+        //std::cout << "has guide rate " << name << " " << totalGuideRate << " " << number_of_wells_under_this_group_control << std::endl;
         //std::cout << "setup " << name << " " <<totalGuideRate << " " << number_of_wells_under_this_group_control << " " << std::endl;
 
         number_of_wells_under_this_group_control = 0;
@@ -1488,17 +1488,23 @@ checkGroupConstraintsProd(const std::string& name,
     // we need to find out the level where the current well is applied to the local reduction
     std::size_t local_reduction_level = 0;
     for (std::size_t ii = 1; ii < num_ancestors; ++ii) {
-        const int num_gr_ctrl = groupControlledWells(schedule,
-                                                     wellState,
-                                                     group_state,
-                                                     summaryState,
-                                                     guideRate,
-                                                     reportStepIdx,
-                                                     chain[ii],
-                                                     "",
-                                                     /*is_producer*/ true,
-                                                     /*injectionPhaseNotUsed*/ Phase::OIL);
-        if (guideRate->has(chain[ii]) && num_gr_ctrl > 0) {
+        //const int num_gr_ctrl = groupControlledWells(schedule,
+        //                                             wellState,
+        //                                             group_state,
+        //                                             summaryState,
+        //                                             guideRate,
+        //                                             reportStepIdx,
+        //                                             chain[ii],
+        //                                             "",
+        //                                             /*is_producer*/ true,
+        //                                             /*injectionPhaseNotUsed*/ Phase::OIL);
+        
+        const auto& group_cont_wells = group_state.number_of_wells_under_this_control(chain[ii]);
+        //if (guideRate->has(chain[ii]) && group_cont_wells != num_gr_ctrl )
+        //    std::cout << "group_cont_wells "<< chain[ii]<< " " << group_cont_wells <<  " " << num_gr_ctrl << " " << guideRate->has(chain[ii]) << std::endl;
+
+
+        if (guideRate->has(chain[ii]) && group_cont_wells > 0) {
             local_reduction_level = ii;
         }
     }
@@ -1668,16 +1674,17 @@ checkGroupConstraintsInj(const std::string& name,
     // we need to find out the level where the current well is applied to the local reduction
     std::size_t local_reduction_level = 0;
     for (std::size_t ii = 1; ii < num_ancestors; ++ii) {
-        const int num_gr_ctrl = groupControlledWells(schedule,
-                                                     wellState,
-                                                     group_state,
-                                                     summaryState,
-                                                     guideRate,
-                                                     reportStepIdx,
-                                                     chain[ii],
-                                                     "",
-                                                     /*is_producer*/ false,
-                                                     injectionPhase);
+        //const int num_gr_ctrl = groupControlledWells(schedule,
+        //                                             wellState,
+        //                                             group_state,
+        //                                             summaryState,
+        //                                             guideRate,
+        //                                             reportStepIdx,
+        //                                             chain[ii],
+        //                                             "",
+        //                                             /*is_producer*/ false,
+        //                                             injectionPhase);
+        const auto& num_gr_ctrl = group_state.number_of_wells_under_this_inj_control(chain[ii], injectionPhase);
         if (guideRate->has(chain[ii], injectionPhase) && num_gr_ctrl > 0) {
             local_reduction_level = ii;
         }

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -242,24 +242,15 @@ public:
                                  const PhaseUsage& pu,
                                  const std::string& group_name);
 
-    static Scalar getGuideRate(const std::string& name,
+    static Scalar updateGuideRate(const std::string& name,
                                const Schedule& schedule,
                                const WellState<Scalar>& wellState,
-                               const GroupState<Scalar>& group_state,
+                               GroupState<Scalar>& group_state,
                                const int reportStepIdx,
-                               const GuideRate* guideRate,
-                               const GuideRateModel::Target target,
+                               const GuideRate& guideRate,
+                               Opm::GuideRateModel::Target target,
+                               int& number_of_wells_under_this_group_control,
                                const PhaseUsage& pu);
-
-    static Scalar getGuideRateInj(const std::string& name,
-                                  const Schedule& schedule,
-                                  const WellState<Scalar>& wellState,
-                                  const GroupState<Scalar>& group_state,
-                                  const int reportStepIdx,
-                                  const GuideRate* guideRate,
-                                  const GuideRateModel::Target target,
-                                  const Phase& injectionPhase,
-                                  const PhaseUsage& pu);
 
     static int groupControlledWells(const Schedule& schedule,
                                     const WellState<Scalar>& well_state,

--- a/opm/simulators/wells/WellGroupHelpers.hpp
+++ b/opm/simulators/wells/WellGroupHelpers.hpp
@@ -250,6 +250,9 @@ public:
                                const GuideRate& guideRate,
                                Opm::GuideRateModel::Target target,
                                int& number_of_wells_under_this_group_control,
+                               std::vector<std::string>& next_sub_group_with_guide_rate,
+                               const bool is_production_group,
+                               const Phase injection_phase,
                                const PhaseUsage& pu);
 
     static int groupControlledWells(const Schedule& schedule,


### PR DESCRIPTION
The aim is to remove the usage of wellState from the fraction calculator (see https://github.com/OPM/opm-simulators/pull/6245)  and avoid recomputing guiderates.

Still needs a lot more testing and cleanup....