### PR TITLE
Rename the functions globalToLocal, localToGlobal, activeToLocal and …

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEquations.cpp
+++ b/opm/simulators/wells/MultisegmentWellEquations.cpp
@@ -110,7 +110,7 @@ init(const int numPerfs,
               end = duneC_.createend(); row != end; ++row) {
         // the number of the row corresponds to the segment number now.
         for (const int& perf : perforations[row.index()]) {
-            const int local_perf_index = pw_info_.activeToLocal(perf);
+            const int local_perf_index = pw_info_.activePerfToLocalPerf(perf);
             if (local_perf_index < 0) // then the perforation is not on this process
                 continue;
             row.insert(local_perf_index);
@@ -122,7 +122,7 @@ init(const int numPerfs,
               end = duneB_.createend(); row != end; ++row) {
         // the number of the row corresponds to the segment number now.
         for (const int& perf : perforations[row.index()]) {
-            const int local_perf_index = pw_info_.activeToLocal(perf);
+            const int local_perf_index = pw_info_.activePerfToLocalPerf(perf);
             if (local_perf_index < 0) // then the perforation is not on this process
                 continue;
             row.insert(local_perf_index);

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -108,7 +108,7 @@ MultisegmentWellSegments(const int numSegments,
             perforations_[segment_index].push_back(i_perf_wells);
             well.perfDepth()[i_perf_wells] = connection.depth();
             const Scalar segment_depth = segment_set[segment_index].depth();
-            int local_perf_index = parallel_well_info.activeToLocal(i_perf_wells);
+            int local_perf_index = parallel_well_info.activePerfToLocalPerf(i_perf_wells);
             if (local_perf_index > -1) // If local_perf_index == -1, then the perforation is not on this process
                 local_perforation_depth_diffs_[local_perf_index] = well_.perfDepth()[i_perf_wells] - segment_depth;
             i_perf_wells++;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -144,7 +144,7 @@ namespace Opm
             // This variable loops over the number_of_local_perforations_ of *this* process, hence it is *local*.
             const int cell_idx = this->well_cells_[local_perf_index];
             // Here we need to access the perf_depth_ at the global perforation index though!
-            this->cell_perforation_depth_diffs_[local_perf_index] = depth_arg[cell_idx] - this->perf_depth_[this->pw_info_.localToActive(local_perf_index)];
+            this->cell_perforation_depth_diffs_[local_perf_index] = depth_arg[cell_idx] - this->perf_depth_[this->pw_info_.localPerfToActivePerf(local_perf_index)];
         }
     }
 
@@ -363,7 +363,7 @@ namespace Opm
         const auto& segment_pressure = segments_copy.pressure;
         for (int seg = 0; seg < nseg; ++seg) {
             for (const int perf : this->segments_.perforations()[seg]) {
-                const int local_perf_index = this->pw_info_.activeToLocal(perf);
+                const int local_perf_index = this->pw_info_.activePerfToLocalPerf(perf);
                 if (local_perf_index < 0) // then the perforation is not on this process
                     continue;
                 const int cell_idx = this->well_cells_[local_perf_index];
@@ -908,7 +908,7 @@ namespace Opm
                     PerforationRates<Scalar>& perf_rates,
                     DeferredLogger& deferred_logger) const
     {
-        const int local_perf_index = this->pw_info_.activeToLocal(perf);
+        const int local_perf_index = this->pw_info_.activePerfToLocalPerf(perf);
         if (local_perf_index < 0) // then the perforation is not on this process
             return;
 
@@ -1272,7 +1272,7 @@ namespace Opm
                                                  seg_dp);
             seg_dp[seg] = dp;
             for (const int perf : this->segments_.perforations()[seg]) {
-                const int local_perf_index = this->pw_info_.activeToLocal(perf);
+                const int local_perf_index = this->pw_info_.activePerfToLocalPerf(perf);
                 if (local_perf_index < 0) // then the perforation is not on this process
                     continue;
                 std::vector<Scalar> mob(this->num_components_, 0.0);
@@ -1792,7 +1792,7 @@ namespace Opm
             auto& perf_rates = perf_data.phase_rates;
             auto& perf_press_state = perf_data.pressure;
             for (const int perf : this->segments_.perforations()[seg]) {
-                const int local_perf_index = this->pw_info_.activeToLocal(perf);
+                const int local_perf_index = this->pw_info_.activePerfToLocalPerf(perf);
                 if (local_perf_index < 0) // then the perforation is not on this process
                     continue;
                 const int cell_idx = this->well_cells_[local_perf_index];
@@ -1947,7 +1947,7 @@ namespace Opm
         for (int seg = 0; seg < nseg; ++seg) {
             const EvalWell segment_pressure = this->primary_variables_.getSegmentPressure(seg);
             for (const int perf : this->segments_.perforations()[seg]) {
-                const int local_perf_index = this->pw_info_.activeToLocal(perf);
+                const int local_perf_index = this->pw_info_.activePerfToLocalPerf(perf);
                 if (local_perf_index < 0) // then the perforation is not on this process
                     continue;
 
@@ -2157,7 +2157,7 @@ namespace Opm
         const int nseg = this->numberOfSegments();
         for (int seg = 0; seg < nseg; ++seg) {
             for (const int perf : this->segments_.perforations()[seg]) {
-                const int local_perf_index = this->pw_info_.activeToLocal(perf);
+                const int local_perf_index = this->pw_info_.activePerfToLocalPerf(perf);
                 if (local_perf_index < 0) // then the perforation is not on this process
                     continue;
 
@@ -2189,7 +2189,7 @@ namespace Opm
             // calculating the perforation rate for each perforation that belongs to this segment
             const Scalar seg_pressure = getValue(this->primary_variables_.getSegmentPressure(seg));
             for (const int perf : this->segments_.perforations()[seg]) {
-                const int local_perf_index = this->pw_info_.activeToLocal(perf);
+                const int local_perf_index = this->pw_info_.activePerfToLocalPerf(perf);
                 if (local_perf_index < 0) // then the perforation is not on this process
                     continue;
 

--- a/opm/simulators/wells/ParallelWellInfo.cpp
+++ b/opm/simulators/wells/ParallelWellInfo.cpp
@@ -528,7 +528,7 @@ ParallelWellInfo<Scalar>::ParallelWellInfo(const std::pair<std::string, bool>& w
 }
 
 template<class Scalar>
-void ParallelWellInfo<Scalar>::setActiveToLocalMap(const std::unordered_map<int,int> active_to_local_map) const {
+void ParallelWellInfo<Scalar>::setActivePerfToLocalPerfMap(const std::unordered_map<int,int> active_to_local_map) const {
     //active_to_local_map_ is marked as mutable
     active_to_local_map_ = active_to_local_map;
     for (const auto& [key, value] : active_to_local_map) {
@@ -537,7 +537,7 @@ void ParallelWellInfo<Scalar>::setActiveToLocalMap(const std::unordered_map<int,
 }
 
 template<class Scalar>
-int ParallelWellInfo<Scalar>::localToActive(std::size_t localIndex) const {
+int ParallelWellInfo<Scalar>::localPerfToActivePerf(std::size_t localIndex) const {
     if (comm_->size() == 1)
         return localIndex;
     auto it = local_to_active_map_.find(localIndex);
@@ -547,7 +547,7 @@ int ParallelWellInfo<Scalar>::localToActive(std::size_t localIndex) const {
 }
 
 template<class Scalar>
-int ParallelWellInfo<Scalar>::activeToLocal(const int activeIndex) const {
+int ParallelWellInfo<Scalar>::activePerfToLocalPerf(const int activeIndex) const {
     if (comm_->size() == 1)
         return activeIndex;
     auto it = active_to_local_map_.find(activeIndex);
@@ -557,7 +557,7 @@ int ParallelWellInfo<Scalar>::activeToLocal(const int activeIndex) const {
 }
 
 template<class Scalar>
-int ParallelWellInfo<Scalar>::localToGlobal(std::size_t localIndex) const {
+int ParallelWellInfo<Scalar>::localPerfToGlobalPerf(std::size_t localIndex) const {
     if(globalPerfCont_)
         return globalPerfCont_->localToGlobal(localIndex);
     else // If globalPerfCont_ is not set up, then this is a sequential run and local and global indices are the same.
@@ -565,7 +565,7 @@ int ParallelWellInfo<Scalar>::localToGlobal(std::size_t localIndex) const {
 }
 
 template<class Scalar>
-int ParallelWellInfo<Scalar>::globalToLocal(const int globalIndex) const {
+int ParallelWellInfo<Scalar>::globalPerfToLocalPerf(const int globalIndex) const {
     if(globalPerfCont_)
         return globalPerfCont_->globalToLocal(globalIndex);
     else // If globalPerfCont_ is not set up, then this is a sequential run and local and global indices are the same.

--- a/opm/simulators/wells/ParallelWellInfo.hpp
+++ b/opm/simulators/wells/ParallelWellInfo.hpp
@@ -217,11 +217,16 @@ public:
     /// \brief Collectively decide which rank has first perforation.
     void communicateFirstPerforation(bool hasFirst);
 
-    void setActiveToLocalMap(const std::unordered_map<int,int> active_to_local_map) const;
-    int activeToLocal(const int activeIndex) const;
-    int localToActive(std::size_t localIndex) const;
-    int globalToLocal(const int globalIndex) const;
-    int localToGlobal(std::size_t localIndex) const;
+    // \brief Set the activePerfToLocalPerf-Map for multisegment wells, to be called from WellState::initWellStateMSWell
+    void setActivePerfToLocalPerfMap(const std::unordered_map<int,int> active_to_local_map) const;
+    // \brief Convert a global active perforation index to a local active perforation index
+    int activePerfToLocalPerf(const int activeIndex) const;
+    // \brief Convert a local active perforation index to a global active perforation index
+    int localPerfToActivePerf(std::size_t localIndex) const;
+    // \brief Convert a global perforation index to a local perforation index
+    int globalPerfToLocalPerf(const int globalIndex) const;
+    // \brief Convert a local perforation index to a global perforation index
+    int localPerfToGlobalPerf(std::size_t localIndex) const;
 
     /// If the well does not have any open connections the member rankWithFirstPerf
     /// is not initialized, and no broadcast is performed. In this case the argument

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -719,15 +719,15 @@ void WellState<Scalar>::initWellStateMSWell(const std::vector<Well>& wells_ecl,
                     }
 
                     segment_perforations[segment_index].push_back(n_activeperf);
-                    if (ws.parallel_info.get().globalToLocal(perf) > -1) {
+                    if (ws.parallel_info.get().globalPerfToLocalPerf(perf) > -1) {
                         active_perf_index_local_to_global.insert({n_activeperf_local, n_activeperf});
-                        active_to_local.insert({n_activeperf, ws.parallel_info.get().globalToLocal(perf)});
+                        active_to_local.insert({n_activeperf, ws.parallel_info.get().globalPerfToLocalPerf(perf)});
                         n_activeperf_local++;
                     }
                     n_activeperf++;
                 }
             }
-            ws.parallel_info.get().setActiveToLocalMap(active_to_local);
+            ws.parallel_info.get().setActivePerfToLocalPerfMap(active_to_local);
 
             // Check if the multi-segment well is distributed across several processes by comparing the local number
             // of active perforations (ws.perf_data.size()) with the total number of active perforations (n_activeperf).
@@ -914,7 +914,7 @@ calculateSegmentRatesBeforeSum(const ParallelWellInfo<Scalar>& pw_info,
     }
     // contributions from the perforations belong to this segment
     for (const int& perf : segment_perforations[segment]) {
-        auto local_perf = pw_info.activeToLocal(perf);
+        auto local_perf = pw_info.activePerfToLocalPerf(perf);
         // If local_perf == -1, then the perforation is not on this process.
         // The perforation of the other processes are added in calculateSegmentRates.
         if (local_perf > -1) {


### PR DESCRIPTION
…localToActive of the ParallelWellInfo to make clear what they do