### PR TITLE
Allow change of target constraint

### DIFF
--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -1211,20 +1211,6 @@ groupControlledWells(const Schedule& schedule,
                                                         pu);
 
             if (group_guide_rate > 0) {
-                // Guide rate is not default for the auto choke group
-                // Scalar gratTargetFromSales = 0.0;
-                // if (group_state.has_grat_sales_target(control_group_name))
-                //     gratTargetFromSales = group_state.grat_sales_target(control_group_name);
-
-                // std::vector<Scalar> resv_coeff(pu.num_phases, 1.0);
-                // WGHelpers::TargetCalculator tcalc(control_group_cmode,
-                //                                 pu,
-                //                                 resv_coeff,
-                //                                 gratTargetFromSales,
-                //                                 group.name(),
-                //                                 group_state,
-                //                                 group.has_gpmaint_control(control_group_cmode));
-                // auto deferred_logger = Opm::DeferredLogger();
                 const auto& ctrl = control_group.productionControls(summary_state);
                 const auto& control_group_target = tcalc.groupTarget(ctrl, deferred_logger);
 


### PR DESCRIPTION
This PR enhances current functionality for the situation of having autochoke groups in the network. Besides a rate target additional rate constraints may be specified for a parent group in` GCONPROD`. For example

```
GCONPROD    
‘AB’         'ORAT'   10000.0   5500.0   1*    10000.0   'RATE'  'YES'   10000.0  'LIQ'    'RATE'   'RATE'   'RATE'   3* /    
‘A’          'FLD'    1*        1*       1*    1*        'RATE'  'YES'   5000.0   'LIQ'    'RATE'   'RATE'   'RATE'   3* 
‘B’          'FLD'    1*        1*       1*    1*        'RATE'  'YES'   5000.0   'LIQ'    'RATE'   'RATE'   'RATE'   3* 
```
Here parent group  AB has an oil rate target of 10000 m3/day and a water rate constraint of 5500 m3/day.  The children groups may be auto choke groups. If the water rate constraint gets broken it becomes the target.
This behavior has been tested on a field case.

The PR depends on the upstream PR https://github.com/OPM/opm-common/pull/4622 . 