### PR TITLE
adding enableBrine and enableFoam in the Indices

### DIFF
--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -43,8 +43,8 @@ template<unsigned numSolventsV,
          unsigned numExtbosV,
          unsigned numPolymersV,
          unsigned numEnergyV,
-         bool enableFoam,
-         bool enableBrine,
+         bool enableFoamV,
+         bool enableBrineV,
          unsigned PVOffset,
          unsigned canonicalCompIdx,
          unsigned numMICPsV>
@@ -66,6 +66,12 @@ struct BlackOilOnePhaseIndices
 
     //! Shall energy be conserved?
     static constexpr bool enableEnergy = numEnergyV > 0;
+
+    //! is foam enabled?
+    static constexpr bool enableFoam = enableFoamV;
+
+    //! is brine enabled?
+    static constexpr bool enableBrine = enableBrineV;
 
     //! Is MICP involved?
     static constexpr bool enableMICP = numMICPsV > 0;

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -43,8 +43,8 @@ template<unsigned numSolventsV,
          unsigned numExtbosV,
          unsigned numPolymersV,
          unsigned numEnergyV,
-         bool enableFoam,
-         bool enableBrine,
+         bool enableFoamV,
+         bool enableBrineV,
          unsigned PVOffset,
          unsigned disabledCanonicalCompIdx,
          unsigned numMICPsV>
@@ -66,6 +66,12 @@ struct BlackOilTwoPhaseIndices
 
     //! Shall energy be conserved?
     static constexpr bool enableEnergy = numEnergyV > 0;
+
+    //! is foam enabled?
+    static constexpr bool enableFoam = enableFoamV;
+
+    //! is brine enabled?
+    static constexpr bool enableBrine = enableBrineV;
 
     //! Is MICP involved?
     static constexpr bool enableMICP = numMICPsV > 0;

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -39,8 +39,8 @@ template<unsigned numSolventsV,
          unsigned numExtbosV,
          unsigned numPolymersV,
          unsigned numEnergyV,
-         bool enableFoam,
-         bool enableBrine,
+         bool enableFoamV,
+         bool enableBrineV,
          unsigned PVOffset,
          unsigned numMICPsV>
 struct BlackOilVariableAndEquationIndices
@@ -64,6 +64,12 @@ struct BlackOilVariableAndEquationIndices
 
     //! Shall energy be conserved?
     static constexpr bool enableEnergy = numEnergyV > 0;
+
+    //! is foam enabled?
+    static constexpr bool enableFoam = enableFoamV;
+
+    //! is brine enabled?
+    static constexpr bool enableBrine = enableBrineV;
 
     //! Is MICP involved?
     static constexpr bool enableMICP = numMICPsV > 0;


### PR DESCRIPTION
at the moment, it is relying on PhaseUsage. It is revealed during the efforts to remove the usage of PhaseUsage. 