### PR TITLE
Also check operability for wells without thp control

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -569,8 +569,8 @@ namespace Opm
         const double dt = simulator.timeStepSize();
         // solve equations
         bool converged = false;
-        if (this->well_ecl_.isProducer() && this->wellHasTHPConstraints(summary_state)) {
-            converged = well_copy.solveWellWithTHPConstraint(simulator, dt, inj_controls, prod_controls, well_state_copy, group_state, deferred_logger);
+        if (this->well_ecl_.isProducer()) {
+            converged = well_copy.solveWellWithOperabilityCheck(simulator, dt, inj_controls, prod_controls, well_state_copy, group_state, deferred_logger);
         } else {
             converged = well_copy.iterateWellEqWithSwitching(simulator, dt, inj_controls, prod_controls, well_state_copy, group_state, deferred_logger);
         }

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1640,8 +1640,8 @@ namespace Opm
         const double dt = simulator.timeStepSize();
         // iterate to get a solution at the given bhp.
         bool converged = false;
-        if (this->well_ecl_.isProducer() && this->wellHasTHPConstraints(summary_state)) {
-            converged = well_copy.solveWellWithTHPConstraint(simulator, dt, inj_controls, prod_controls, well_state_copy, group_state, deferred_logger);
+        if (this->well_ecl_.isProducer()) {
+            converged = well_copy.solveWellWithOperabilityCheck(simulator, dt, inj_controls, prod_controls, well_state_copy, group_state, deferred_logger);
         } else {
             converged = well_copy.iterateWellEqWithSwitching(simulator, dt, inj_controls, prod_controls, well_state_copy, group_state, deferred_logger);
         }

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -422,13 +422,13 @@ protected:
                               const GroupState<Scalar>& group_state,
                               DeferredLogger& deferred_logger);
 
-    bool solveWellWithTHPConstraint(const Simulator& simulator,
-                                    const double dt,
-                                    const Well::InjectionControls& inj_controls,
-                                    const Well::ProductionControls& prod_controls,
-                                    WellState<Scalar>& well_state,
-                                    const GroupState<Scalar>& group_state,
-                                    DeferredLogger& deferred_logger);
+    bool solveWellWithOperabilityCheck(const Simulator& simulator,
+                                       const double dt,
+                                       const Well::InjectionControls& inj_controls,
+                                       const Well::ProductionControls& prod_controls,
+                                       WellState<Scalar>& well_state,
+                                       const GroupState<Scalar>& group_state,
+                                       DeferredLogger& deferred_logger);
 
     std::optional<Scalar>
     estimateOperableBhp(const Simulator& ebos_simulator,


### PR DESCRIPTION
In NORNE_ATW2013_1A_MSW and NORNE_ATW2013_1A_STW
there is no THP control, and the operability check does not work. It will instead cut the time step until it closes the wells due to repeated convergence issues. 

This PR adds the new operability check introduced for the controlled wells to wells without the THP controls. 

The issue reported on slow runs on the above-mentioned models is fixed with this PR. See also https://github.com/OPM/opm-simulators/pull/6069, which is no longer needed. 


![image](https://github.com/user-attachments/assets/a003a0c1-ba9c-44ce-a623-5135e8bdd4da)
