### PR TITLE
Cleaned up and fixed verbosity for time step controllers

### DIFF
--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -93,7 +93,7 @@ namespace Opm
         }
 
         if( verbose_ )
-            OpmLog::info(fmt::format("Computed time step size: {} days", unit::convert::to( dtEstimate, unit::day )));
+            OpmLog::info(fmt::format("Suggested next time step size: {} days", unit::convert::to( dtEstimate, unit::day )));
 
         return dtEstimate;
     }
@@ -195,7 +195,7 @@ namespace Opm
             // adjust dt by given tolerance
             const double newDt = dt * tol_ / error;
             if ( verbose_ )
-                    OpmLog::info(fmt::format("Computed time step size (from PID controller): {} days", unit::convert::to( newDt, unit::day )));
+                    OpmLog::info(fmt::format("Suggested next time step size (from PID controller): {} days", unit::convert::to( newDt, unit::day )));
             return newDt;
         }
         else if (errors_[0] == 0 || errors_[1] == 0 || errors_[2] == 0.)
@@ -214,7 +214,7 @@ namespace Opm
                                  std::pow( tol_         / errors_[ 2 ], kI ) *
                                  std::pow( errors_[1]*errors_[1]/errors_[ 0 ]/errors_[ 2 ], kD ));
             if( verbose_ )
-                OpmLog::info(fmt::format("Computed time step size (from PID controller): {} days", unit::convert::to( newDt, unit::day )));
+                OpmLog::info(fmt::format("Suggested next time step size (from PID controller): {} days", unit::convert::to( newDt, unit::day )));
             return newDt;
         }
     }
@@ -275,7 +275,7 @@ namespace Opm
         }
 
         if( verbose_ )
-            OpmLog::info(fmt::format("Computed time step size (from iteration target): {} days", unit::convert::to( dtEstimateIter, unit::day )));
+            OpmLog::info(fmt::format("Suggested next time step size (from iteration target): {} days", unit::convert::to( dtEstimateIter, unit::day )));
 
         return std::min(dtEstimatePID, dtEstimateIter);
     }
@@ -351,7 +351,7 @@ namespace Opm
     }
 
     double General3rdOrderController::
-    computeTimeStepSize(const double dt, const int /* iterations */, const RelativeChangeInterface& relChange, const AdaptiveSimulatorTimer& substepTimer) const
+    computeTimeStepSize(const double dt, const int /* iterations */, const RelativeChangeInterface& /* relChange */, const AdaptiveSimulatorTimer& substepTimer) const
     {
         for( int i = 0; i < 2; ++i )
         {
@@ -397,8 +397,8 @@ namespace Opm
 
         if (verbose_)
         {
-            OpmLog::info(fmt::format("Computed time step size: {} days", unit::convert::to( newDt, unit::day )));
-            OpmLog::info(fmt::format("Time step based on relative change: {}", relChange.relativeChange()));
+            OpmLog::info(fmt::format("Suggested next time step size: {} days", unit::convert::to( newDt, unit::day )));
+            OpmLog::info(fmt::format("Most recent relative change: {}", errors_[2]));
         }
         return newDt;
     }

--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -93,7 +93,7 @@ namespace Opm
         }
 
         if( verbose_ )
-            OpmLog::info(fmt::format("Suggested next time step size: {} days", unit::convert::to( dtEstimate, unit::day )));
+            OpmLog::info(fmt::format("Suggested next time step size (from controller): {} days", unit::convert::to( dtEstimate, unit::day )));
 
         return dtEstimate;
     }
@@ -397,7 +397,7 @@ namespace Opm
 
         if (verbose_)
         {
-            OpmLog::info(fmt::format("Suggested next time step size: {} days", unit::convert::to( newDt, unit::day )));
+            OpmLog::info(fmt::format("Suggested next time step size (from controller): {} days", unit::convert::to( newDt, unit::day )));
             OpmLog::info(fmt::format("Most recent relative change: {}", errors_[2]));
         }
         return newDt;

--- a/opm/simulators/timestepping/TimeStepControl.hpp
+++ b/opm/simulators/timestepping/TimeStepControl.hpp
@@ -248,7 +248,7 @@ namespace Opm
 
         double computeTimeStepSize(const double dt,
                                    const int /* iterations */,
-                                   const RelativeChangeInterface& relativeChange,
+                                   const RelativeChangeInterface& /* relativeChange */,
                                    const AdaptiveSimulatorTimer& substepTimer) const override;
 
         double timeStepFactor(const std::array<double, 3>& errors, const std::array<double, 3>& timeSteps) const;


### PR DESCRIPTION
The verbosity argument for the time step controllers wasn't used. I've cleaned up the code a bit and improved the feedback when verbosity is set to true. I also removed some default arguments, as well as comments about default values.

Question: Should `time-step-verbosity` be set to false by default, or should we keep it set to true?