### PR TITLE
removing the unused and mistakenly defined function

### DIFF
--- a/opm/models/blackoil/blackoilenergymodules.hh
+++ b/opm/models/blackoil/blackoilenergymodules.hh
@@ -259,17 +259,6 @@ public:
     /*!
      * \brief Assign the energy specific primary variables to a PrimaryVariables object
      */
-    static void assignPrimaryVars(PrimaryVariables& priVars,
-                                  Scalar)
-    {
-        if constexpr (enableEnergy) {
-            priVars[temperatureIdx] = temperatureIdx;
-        }
-    }
-
-    /*!
-     * \brief Assign the energy specific primary variables to a PrimaryVariables object
-     */
     template <class FluidState>
     static void assignPrimaryVars(PrimaryVariables& priVars,
                                   const FluidState& fluidState)


### PR DESCRIPTION
assignPrimaryVars from blackoilenergymodules.

It looks that the function is intended to assign a value, while the definition is wrong and not used. 

We can always add a new and correct one when needed. 