### PR TITLE
Give a distributed well the same ID on different ranks

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -282,6 +282,9 @@ public:
             && pwInfoPos->isOwner();
     }
 
+    const auto& parallelWellInfo() const
+    { return parallel_well_info_; }
+
     const ConnectionIndexMap& connectionIndexMap(const std::size_t idx)
     { return conn_idx_map_[idx]; }
 


### PR DESCRIPTION
A distributed well was given different IDs in the coarse solver. As a result, the coarse system had a separate row for each part on a new rank. This PR gives the well an ID which is derived from its position in the `parallel_well_info_` which is consistent across ranks.

The change has no effect on the result of the simulation, the calculation of the residual is untouched - this bug did not affect it. However, the coarse level solver will no longer treat a distributed well as a collection of smaller wells (disconnecting parts on different ranks). We hope to get a performance boost.

Relevant edge case: When a well has no active perforations on one rank, we regularize the local coarse matrix by putting 1 on the diagonal (row is zero elsewhere). Accumulating across ranks thus can put a wrong weight on the diagonal of the coarse system's matrix. The well pressure correction coming from the coarse solve is not used, so I do not know how big issue it will be.