### PR TITLE
Fixing --enable-dry-run=1

### DIFF
--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -641,10 +641,12 @@ public:
         }
         if constexpr (enableConvectiveMixing) {
             // The ifs are here is to avoid extra calculations for
-            // cases without CO2STORE and DRSDTCON.
-            if (problem.simulator().vanguard().eclState().runspec().co2Storage()) {
-                if (problem.drsdtconIsActive(globalSpaceIdx, problem.simulator().episodeIndex())) {
-                    asImp_().updateSaturatedDissolutionFactor_();
+            // cases with dry runs and without CO2STORE and DRSDTCON.
+            if (!problem.simulator().vanguard().eclState().getIOConfig().initOnly()) {
+                if (problem.simulator().vanguard().eclState().runspec().co2Storage()) {
+                    if (problem.drsdtconIsActive(globalSpaceIdx, problem.simulator().episodeIndex())) {
+                        asImp_().updateSaturatedDissolutionFactor_();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Without this PR, the simulation with `--enable-dry-run=1` will fail to end with a message (using a case with `CO2STORE`):

> Simulation aborted as program threw an unexpected exception: InvalideAndUpdateIntensiveQuantities: state errorvector

With this PR, the simulation finishes as it used to:

> ================ Simulation turned off ===============