### PR TITLE
Reduce osscilations between stop and open

### DIFF
--- a/flowexperimental/flowexp.hpp
+++ b/flowexperimental/flowexp.hpp
@@ -168,6 +168,7 @@ public:
         Parameters::Hide<Parameters::MaxInnerIterMsWells>();
         Parameters::Hide<Parameters::MaxNewtonIterationsWithInnerWellIterations>();
         Parameters::Hide<Parameters::MaxInnerIterWells>();
+        Parameters::Hide<Parameters::MaxWellStatusSwitchInInnerIterWells>();
         Parameters::Hide<Parameters::MaxSinglePrecisionDays<Scalar>>();
         Parameters::Hide<Parameters::MinStrictCnvIter>();
         Parameters::Hide<Parameters::MinStrictMbIter>();

--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -62,6 +62,7 @@ BlackoilModelParameters<Scalar>::BlackoilModelParameters()
     max_niter_inner_well_iter_ = Parameters::Get<Parameters::MaxNewtonIterationsWithInnerWellIterations>();
     shut_unsolvable_wells_ = Parameters::Get<Parameters::ShutUnsolvableWells>();
     max_inner_iter_wells_ = Parameters::Get<Parameters::MaxInnerIterWells>();
+    max_well_status_switch_ = Parameters::Get<Parameters::MaxWellStatusSwitchInInnerIterWells>();
     maxSinglePrecisionTimeStep_ = Parameters::Get<Parameters::MaxSinglePrecisionDays<Scalar>>() * 24 * 60 * 60;
     min_strict_cnv_iter_ = Parameters::Get<Parameters::MinStrictCnvIter>();
     min_strict_mb_iter_ = Parameters::Get<Parameters::MinStrictMbIter>();
@@ -183,6 +184,8 @@ void BlackoilModelParameters<Scalar>::registerParameters()
         ("Shut unsolvable wells");
     Parameters::Register<Parameters::MaxInnerIterWells>
         ("Maximum number of inner iterations for standard wells");
+    Parameters::Register<Parameters::MaxWellStatusSwitchInInnerIterWells>
+        ("Maximum number of status switching (shut<->open) in inner iterations for wells");
     Parameters::Register<Parameters::AlternativeWellRateInit>
         ("Use alternative well rate initialization procedure");
     Parameters::Register<Parameters::RegularizationFactorWells<Scalar>>

--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -103,6 +103,7 @@ struct MaxPressureChangeMsWells { static constexpr Scalar value = 10*1e5; };
 struct MaxNewtonIterationsWithInnerWellIterations { static constexpr int value = 8; };
 struct MaxInnerIterMsWells { static constexpr int value = 100; };
 struct MaxInnerIterWells { static constexpr int value = 50; };
+struct MaxWellStatusSwitchInInnerIterWells { static constexpr int value = 99; };
 struct ShutUnsolvableWells { static constexpr bool value = true; };
 struct AlternativeWellRateInit { static constexpr bool value = true; };
 struct StrictOuterIterWells { static constexpr int value = 6; };
@@ -322,6 +323,9 @@ public:
 
     /// Maximum number of iterations in the well/group switch algorithm
     int well_group_constraints_max_iterations_;
+
+    /// Maximum number of status switches (open<->shut> in local well iterations
+    int max_well_status_switch_;
 
     /// Nonlinear solver type: newton or nldd.
     std::string nonlinear_solver_;

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2385,6 +2385,8 @@ namespace Opm
         // The optimal number here is subject to further investigation, but it has been observerved
         // that unless this number is >1, we may get stuck in a cycle
         constexpr int min_its_after_switch = 4;
+        // We also want to restrict the number of status switches to avoid oscillation between STOP<->OPEN
+        const int max_status_switch = this->param_.max_well_status_switch_;
         int its_since_last_switch = min_its_after_switch;
         int switch_count= 0;
         // if we fail to solve eqs, we reset status/operability before leaving
@@ -2406,7 +2408,7 @@ namespace Opm
         this->operability_status_.solvable = true;
         do {
             its_since_last_switch++;
-            if (allow_switching && its_since_last_switch >= min_its_after_switch){
+            if (allow_switching && its_since_last_switch >= min_its_after_switch && status_switch_count < max_status_switch){
                 const Scalar wqTotal = this->primary_variables_.eval(WQTotal).value();
                 changed = this->updateWellControlAndStatusLocalIteration(simulator, well_state, group_state,
                                                                          inj_controls, prod_controls, wqTotal,
@@ -2423,6 +2425,9 @@ namespace Opm
                     break;
                 } else {
                     final_check = false;
+                }
+                if (status_switch_count == max_status_switch) {
+                    this->wellStatus_ = well_status_orig;
                 }
             }
 


### PR DESCRIPTION
Add a cap on the number of allowed switches per local well solve. (set to 3) 
