### PR TITLE
Fixed brace locations when compiling without CUDA

### DIFF
--- a/opm/simulators/linalg/FlexibleSolver_impl.hpp
+++ b/opm/simulators/linalg/FlexibleSolver_impl.hpp
@@ -229,16 +229,15 @@ namespace Dune
                         maxiter, // maximum number of iterations
                         verbosity,
                         comm));
-                }
+        #endif
+               }
             }
         }
-        #endif
         if (!linsolver_) {
             OPM_THROW(std::invalid_argument,
                       "Properties: Solver " + solver_type + " not known.");
         }
     }
-    
 
 
     // For now, the only direct solver we support is UMFPACK from SuiteSparse.


### PR DESCRIPTION
An error was introduced in the previous PR where the build would fail without CUDA. This PR should fix that.