### PR TITLE
Add include to get fmt::join.

### DIFF
--- a/opm/simulators/wells/GuideRateHandler.cpp
+++ b/opm/simulators/wells/GuideRateHandler.cpp
@@ -31,6 +31,7 @@
 #include <utility>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace Opm {
 


### PR DESCRIPTION
Needed because of bug in some versions of libfmt.