### PR TITLE
Reduce peak memory allocation when recreating linear solver

### DIFF
--- a/opm/simulators/linalg/ISTLSolver.cpp
+++ b/opm/simulators/linalg/ISTLSolver.cpp
@@ -107,6 +107,12 @@ void FlexibleSolverInfo<Matrix,Vector,Comm>::create(const Matrix& matrix,
         }
     }
 
+    // Delete the operator and solver here to avoid
+    // a large temporary memory peak from having two
+    // operators and solvers at the same time.
+    this->op_.reset();
+    this->solver_.reset();
+
     if (parallel) {
 #if HAVE_MPI
         if (!wellOperator_) {

--- a/opm/simulators/linalg/ISTLSolver.hpp
+++ b/opm/simulators/linalg/ISTLSolver.hpp
@@ -436,7 +436,7 @@ std::unique_ptr<Matrix> blockJacobiAdjacency(const Grid& grid,
         /// \copydoc NewtonIterationBlackoilInterface::parallelInformation
         const std::any& parallelInformation() const { return parallelInformation_; }
 
-        const CommunicationType* comm() const { return comm_.get(); }
+        const CommunicationType* comm() const override { return comm_.get(); }
 
         void setDomainIndex(const int index)
         {


### PR DESCRIPTION
By default, this happens every 30 linear solves. The current code holds the old solver in memory while constructing the new, leading to an unnecessary memory peak.