### PR TITLE
Add mobility thresholding to NLDD

### DIFF
--- a/opm/simulators/flow/BlackoilModelNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelNldd.hpp
@@ -239,6 +239,13 @@ public:
         // -----------   Set up reports and timer   -----------
         SimulatorReportSingle report;
 
+        if (iteration < model_.param().nldd_num_initial_newton_iter_) {
+            report = model_.nonlinearIterationNewton(iteration,
+                                                     timer,
+                                                     nonlinear_solver);
+            return report;
+        }
+
         model_.initialLinearization(report, iteration, nonlinear_solver.minIter(), nonlinear_solver.maxIter(), timer);
 
         if (report.converged) {

--- a/opm/simulators/flow/BlackoilModelNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelNldd.hpp
@@ -1102,7 +1102,7 @@ private:
         }
         const auto numActivePhases = FluidSystem::numActivePhases();
         for (const auto globalDofIdx : domain.cells) {
-            const auto& intQuants = *model_.simulator().model().cachedIntensiveQuantities(globalDofIdx, /*timeIdx=*/0);
+            const auto& intQuants = model_.simulator().model().intensiveQuantities(globalDofIdx, /* time_idx = */ 0);
 
             for (unsigned activePhaseIdx = 0; activePhaseIdx < numActivePhases; ++activePhaseIdx) {
                 const auto phaseIdx = FluidSystem::activeToCanonicalPhaseIdx(activePhaseIdx);
@@ -1145,7 +1145,7 @@ private:
 
         // Check mobility changes for all cells in the domain
         for (const auto globalDofIdx : domain.cells) {
-            const auto& intQuants = *model_.simulator().model().cachedIntensiveQuantities(globalDofIdx, /*timeIdx=*/0);
+            const auto& intQuants = model_.simulator().model().intensiveQuantities(globalDofIdx, /* time_idx = */ 0);
 
             // Calculate average previous mobility for normalization
             Scalar cellMob = 0.0;

--- a/opm/simulators/flow/BlackoilModelParameters.cpp
+++ b/opm/simulators/flow/BlackoilModelParameters.cpp
@@ -92,6 +92,7 @@ BlackoilModelParameters<Scalar>::BlackoilModelParameters()
     local_tolerance_scaling_mb_ = Parameters::Get<Parameters::LocalToleranceScalingMb<Scalar>>();
     local_tolerance_scaling_cnv_ = Parameters::Get<Parameters::LocalToleranceScalingCnv<Scalar>>();
     nldd_num_initial_newton_iter_ = Parameters::Get<Parameters::NlddNumInitialNewtonIter>();
+    nldd_relative_mobility_change_tol_ = Parameters::Get<Parameters::NlddRelativeMobilityChangeTol<Scalar>>();
     num_local_domains_ = Parameters::Get<Parameters::NumLocalDomains>();
     local_domains_partition_imbalance_ = std::max(Scalar{1.0}, Parameters::Get<Parameters::LocalDomainsPartitioningImbalance<Scalar>>());
     local_domains_partition_method_ = Parameters::Get<Parameters::LocalDomainsPartitioningMethod>();
@@ -246,6 +247,8 @@ void BlackoilModelParameters<Scalar>::registerParameters()
         ("Set lower than 1.0 to use stricter convergence tolerance for local solves.");
     Parameters::Register<Parameters::NlddNumInitialNewtonIter>
         ("Number of initial global Newton iterations when running the NLDD nonlinear solver.");
+    Parameters::Register<Parameters::NlddRelativeMobilityChangeTol<Scalar>>
+        ("Threshold for single cell relative mobility change in the NLDD solver");
     Parameters::Register<Parameters::NumLocalDomains>
         ("Number of local domains for NLDD nonlinear solver.");
     Parameters::Register<Parameters::LocalDomainsPartitioningImbalance<Scalar>>

--- a/opm/simulators/flow/BlackoilModelParameters.hpp
+++ b/opm/simulators/flow/BlackoilModelParameters.hpp
@@ -147,6 +147,8 @@ struct LocalToleranceScalingMb { static constexpr Scalar value = 1.0; };
 template<class Scalar>
 struct LocalToleranceScalingCnv { static constexpr Scalar value = 0.1; };
 struct NlddNumInitialNewtonIter { static constexpr int value = 1; };
+template<class Scalar>
+struct NlddRelativeMobilityChangeTol { static constexpr Scalar value = 0.1; };
 struct NumLocalDomains { static constexpr int value = 0; };
 
 template<class Scalar>
@@ -332,6 +334,8 @@ public:
     Scalar local_tolerance_scaling_cnv_;
 
     int nldd_num_initial_newton_iter_{1};
+    /// Threshold for single cell relative mobility change in NLDD
+    Scalar nldd_relative_mobility_change_tol_;
     int num_local_domains_{0};
     Scalar local_domains_partition_imbalance_{1.03};
     std::string local_domains_partition_method_;

--- a/opm/simulators/flow/BlackoilModel_impl.hpp
+++ b/opm/simulators/flow/BlackoilModel_impl.hpp
@@ -230,8 +230,7 @@ nonlinearIteration(const int iteration,
     }
 
     SimulatorReportSingle result;
-    if ((this->param_.nonlinear_solver_ != "nldd") ||
-        (iteration < this->param_.nldd_num_initial_newton_iter_))
+    if (this->param_.nonlinear_solver_ != "nldd")
     {
         result = this->nonlinearIterationNewton(iteration,
                                                 timer,

--- a/opm/simulators/flow/SubDomain.hpp
+++ b/opm/simulators/flow/SubDomain.hpp
@@ -71,10 +71,12 @@ namespace Opm
         std::vector<bool> interior;
         // Flag indicating if this domain should be skipped during solves
         bool skip;
+        // Flag indicating if this domain should be solved in the next iteration
+        bool needsSolving;
         // Enables subdomain solves and linearization using the generic linearization
         // approach (i.e. FvBaseLinearizer as opposed to TpfaLinearizer).
-        SubDomainIndices(const int i, std::vector<int>&& c, std::vector<bool>&& in, bool s)
-            : index(i), cells(std::move(c)), interior(std::move(in)), skip(s)
+        SubDomainIndices(const int i, std::vector<int>&& c, std::vector<bool>&& in, bool s, bool n)
+            : index(i), cells(std::move(c)), interior(std::move(in)), skip(s), needsSolving(n)
         {}
     };
 
@@ -86,7 +88,7 @@ namespace Opm
         Dune::SubGridPart<Grid> view;
         // Constructor that moves from its argument.
         SubDomain(const int i, std::vector<int>&& c, std::vector<bool>&& in, Dune::SubGridPart<Grid>&& v, bool s)
-            : SubDomainIndices(i, std::move(c), std::move(in), s)
+            : SubDomainIndices(i, std::move(c), std::move(in), s, true)
             , view(std::move(v))
         {}
     };

--- a/opm/simulators/flow/SubDomain.hpp
+++ b/opm/simulators/flow/SubDomain.hpp
@@ -71,12 +71,10 @@ namespace Opm
         std::vector<bool> interior;
         // Flag indicating if this domain should be skipped during solves
         bool skip;
-        // Flag indicating if this domain should be solved in the next iteration
-        bool needsSolving;
         // Enables subdomain solves and linearization using the generic linearization
         // approach (i.e. FvBaseLinearizer as opposed to TpfaLinearizer).
-        SubDomainIndices(const int i, std::vector<int>&& c, std::vector<bool>&& in, bool s, bool n)
-            : index(i), cells(std::move(c)), interior(std::move(in)), skip(s), needsSolving(n)
+        SubDomainIndices(const int i, std::vector<int>&& c, std::vector<bool>&& in, bool s)
+            : index(i), cells(std::move(c)), interior(std::move(in)), skip(s)
         {}
     };
 
@@ -88,7 +86,7 @@ namespace Opm
         Dune::SubGridPart<Grid> view;
         // Constructor that moves from its argument.
         SubDomain(const int i, std::vector<int>&& c, std::vector<bool>&& in, Dune::SubGridPart<Grid>&& v, bool s)
-            : SubDomainIndices(i, std::move(c), std::move(in), s, true)
+            : SubDomainIndices(i, std::move(c), std::move(in), s)
             , view(std::move(v))
         {}
     };

--- a/opm/simulators/timestepping/SimulatorReport.cpp
+++ b/opm/simulators/timestepping/SimulatorReport.cpp
@@ -36,7 +36,7 @@ namespace Opm
                                      7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
                                      13, 14, 15, 16, 17, 18,
                                      true, false, false, 19, 20.0, 21.0,
-                                     22, 23, 24, 25, 26, 27, 28};
+                                     22, 23, 24, 25, 26, 27, 28, 29};
     }
 
     bool SimulatorReportSingle::operator==(const SimulatorReportSingle& rhs) const
@@ -71,7 +71,8 @@ namespace Opm
                this->num_owned_cells == rhs.num_owned_cells &&
                this->converged_domains == rhs.converged_domains &&
                this->unconverged_domains == rhs.unconverged_domains &&
-               this->accepted_unconverged_domains == rhs.accepted_unconverged_domains;
+               this->accepted_unconverged_domains == rhs.accepted_unconverged_domains &&
+               this->skipped_domains == rhs.skipped_domains;
     }
 
     void SimulatorReportSingle::operator+=(const SimulatorReportSingle& sr)
@@ -100,7 +101,7 @@ namespace Opm
         converged_domains += sr.converged_domains;
         unconverged_domains += sr.unconverged_domains;
         accepted_unconverged_domains += sr.accepted_unconverged_domains;
-
+        skipped_domains += sr.skipped_domains;
         // It makes no sense adding time points. Therefore, do not 
         // overwrite the value of global_time which gets set in 
         // NonlinearSolver.hpp by the line:
@@ -332,6 +333,9 @@ namespace Opm
         }
         os << std::endl;
         os << fmt::format("-------------------------------------------------------\n");
+        n = skipped_domains + (failureReport ? failureReport->skipped_domains : 0);
+        os << fmt::format("Skipped domain solves:       {:7}", n);
+        os << std::endl;
         n = converged_domains + (failureReport ? failureReport->converged_domains : 0);
         os << fmt::format("Converged domain solves:     {:7}", n);
         os << std::endl;

--- a/opm/simulators/timestepping/SimulatorReport.hpp
+++ b/opm/simulators/timestepping/SimulatorReport.hpp
@@ -68,7 +68,7 @@ namespace Opm
         int converged_domains = 0;
         int unconverged_domains = 0;
         int accepted_unconverged_domains = 0;
-
+        int skipped_domains = 0;
 
         static SimulatorReportSingle serializationTestObject();
 
@@ -114,6 +114,7 @@ namespace Opm
             serializer(converged_domains);
             serializer(unconverged_domains);
             serializer(accepted_unconverged_domains);
+            serializer(skipped_domains);
         }
     };
 


### PR DESCRIPTION
# NLDD Solver: Skip Unchanged Subdomains Based on Mobility Changes

This PR introduces an a new feature to the NLDD (Nonlinear Domain Decomposition) solver that reduces the time spent on local solves by skipping subdomains that haven't changed significantly between iterations.

Mobility in reservoir simulation represents the ease with which a fluid phase can flow through porous media. It is calculated as the ratio of relative permeability to viscosity for each phase $\alpha$:
```math
\lambda_\alpha = \mathrm{kr}_\alpha / \mu_\alpha
```
Mobility changes indicate significant alterations in fluid flow characteristics, making it an effective indicator for determining when subdomain re-solving is necessary.

##  Details

#### Adaptive Domain Solving
- To determine if we need to solve a domain the relative change in mobility is compared to a previous value and if it is above a given tolerance, the domain is marked for needing solving.
- **Relative change calculation**: 
    `|current_mobility - previous_mobility| / average_cell_mobility > threshold`
- If we do an initial global Newton iteration (default), the change in mobility between before and after this global iteration will be used for the next NLDD iteration.
- If we start with an NLDD iteration all domains will be solved in the first iteration and the change in mobility between before and after this complete NLDD iteration will be used for the next NLDD iteration.
- Domains that required solving in the previous iteration are automatically marked for solving in the next iteration.

####  Reporting
- Added tracking of skipped domains in simulation reports

#### New Parameter
- `--nldd-relative-mobility-change-tol`: Threshold for relative mobility change detection (default: 0.1). By setting this parameter to 0, the mobility thresholding will be disabled.

### Performance Impact
- It has been tested on multiple real reservoir assets, where it reduced the local solve time.
- The reduction in local solve time is most significant for serial runs, for obvious reasons.

### Results on Norne

#### 1 MPI proc

##### Baseline

```
Number of MPI processes:         1
Threads per MPI process:        12
Setup time:                      1.88 s
  Deck input:                    1.25 s
Number of timesteps:           247
Simulation time:               143.50 s
  Assembly time:                12.50 s (Wasted: 0.0 s; 0.0%)
    Well assembly:               1.15 s (Wasted: 0.0 s; 0.0%)
  Linear solve time:            50.67 s (Wasted: 0.0 s; 0.0%)
    Linear setup:               19.21 s (Wasted: 0.0 s; 0.0%)
  Local solve time:             39.29 s (Wasted: 0.0 s; 0.0%)
  Props/update time:             9.04 s (Wasted: 0.0 s; 0.0%)
  Pre/post step:                29.03 s (Wasted: 0.0 s; 0.0%)
  Output write time:             0.38 s
Overall Linearizations:       1257      (Wasted:     0; 0.0%)
Overall Newton Iterations:     590      (Wasted:     0; 0.0%)
Overall Linear Iterations:    1531      (Wasted:     0; 0.0%)`
```
![NORNE_ATW2013_nonlinear_sorted_baseline_NT12](https://github.com/user-attachments/assets/9415faa6-e6a9-4d96-b2a1-3435ba23a944)



##### Mobility thresholding

```
Number of MPI processes:         1
Threads per MPI process:        12
Setup time:                      1.88 s
  Deck input:                    1.26 s
Number of timesteps:           247
Simulation time:               141.01 s
  Assembly time:                12.79 s (Wasted: 0.0 s; 0.0%)
    Well assembly:               1.15 s (Wasted: 0.0 s; 0.0%)
  Linear solve time:            51.64 s (Wasted: 0.0 s; 0.0%)
    Linear setup:               19.70 s (Wasted: 0.0 s; 0.0%)
  Local solve time:             34.92 s (Wasted: 0.0 s; 0.0%)
  Props/update time:             9.14 s (Wasted: 0.0 s; 0.0%)
  Pre/post step:                29.56 s (Wasted: 0.0 s; 0.0%)
  Output write time:             0.38 s
Overall Linearizations:       1273      (Wasted:     0; 0.0%)
Overall Newton Iterations:     605      (Wasted:     0; 0.0%)
Overall Linear Iterations:    1547      (Wasted:     0; 0.0%)
```

![NORNE_ATW2013_nonlinear_sorted_mob_thres_NT12](https://github.com/user-attachments/assets/74d20ce9-57a2-49ba-adbe-dbc1bb92e6a1)


#### 12 MPI proc

##### Baseline

```
Number of MPI processes:        12
Threads per MPI process:         1
Setup time:                      2.63 s
  Deck input:                    1.64 s
Number of timesteps:           247
Simulation time:                91.04 s
  Assembly time:                15.04 s (Wasted: 0.0 s; 0.0%)
    Well assembly:               0.84 s (Wasted: 0.0 s; 0.0%)
  Linear solve time:            27.88 s (Wasted: 0.0 s; 0.0%)
    Linear setup:               12.02 s (Wasted: 0.0 s; 0.0%)
  Local solve time:             17.32 s (Wasted: 0.0 s; 0.0%)
  Props/update time:             7.04 s (Wasted: 0.0 s; 0.0%)
  Pre/post step:                16.99 s (Wasted: 0.0 s; 0.0%)
  Output write time:             4.19 s
Overall Linearizations:       1409      (Wasted:     0; 0.0%)
Overall Newton Iterations:     675      (Wasted:     0; 0.0%)
Overall Linear Iterations:    2154      (Wasted:     0; 0.0%)
```
![NORNE_ATW2013_nonlinear_sorted_baseline_NP12](https://github.com/user-attachments/assets/d11e854f-be47-4f86-806e-e4849bf6105e)


##### Mobility thresholding

```
Number of MPI processes:        12
Threads per MPI process:         1
Setup time:                      2.61 s
  Deck input:                    1.57 s
Number of timesteps:           247
Simulation time:                90.13 s
  Assembly time:                15.43 s (Wasted: 0.0 s; 0.0%)
    Well assembly:               0.83 s (Wasted: 0.0 s; 0.0%)
  Linear solve time:            27.62 s (Wasted: 0.0 s; 0.0%)
    Linear setup:               11.83 s (Wasted: 0.0 s; 0.0%)
  Local solve time:             16.04 s (Wasted: 0.0 s; 0.0%)
  Props/update time:             7.13 s (Wasted: 0.0 s; 0.0%)
  Pre/post step:                17.19 s (Wasted: 0.0 s; 0.0%)
  Output write time:             4.14 s
Overall Linearizations:       1377      (Wasted:     0; 0.0%)
Overall Newton Iterations:     660      (Wasted:     0; 0.0%)
Overall Linear Iterations:    2115      (Wasted:     0; 0.0%)
```
![NORNE_ATW2013_nonlinear_sorted_mob_thres_NP12](https://github.com/user-attachments/assets/d435eaa5-5004-4388-a34b-6854c463c405)

