### PR TITLE
Emit Converged in Zero Iteration Messages at Elevated Verbosity Level

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1568,7 +1568,10 @@ namespace Opm
             sstr << "     Well " << this->name() << " converged in " << it << " inner iterations.";
             if (relax_convergence)
                 sstr << "      (A relaxed tolerance was used after "<< this->param_.strict_inner_iter_wells_ << " iterations)";
-            deferred_logger.debug(sstr.str());
+
+            // Output "converged in 0 inner iterations" messages only at
+            // elevated verbosity levels.
+            deferred_logger.debug(sstr.str(), OpmLog::defaultDebugVerbosityLevel + (it == 0));
         } else {
             std::ostringstream sstr;
             sstr << "     Well " << this->name() << " did not converge in " << it << " inner iterations.";


### PR DESCRIPTION
That way, the .DBG file won't have significant number of

> Well P-1 converged in 0 inner iterations

messages unless the user specifically requests such messages.

This commit leverages the debug level support introduced in PRs OPM/opm-common#4643 and #6341.