### PR TITLE
tpfalinearizer: Add conditional storage for energy, diffusion and dispersion

### DIFF
--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -33,6 +33,7 @@
 
 #include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
+#include <opm/material/common/ConditionalStorage.hpp>
 
 #include <opm/models/blackoil/blackoilbrinemodules.hh>
 #include <opm/models/blackoil/blackoilconvectivemixingmodule.hh>
@@ -132,10 +133,10 @@ public:
         FaceDir::DirEnum faceDir;
         double Vin;
         double Vex;
-        double inAlpha;
-        double outAlpha;
-        double diffusivity;
-        double dispersivity;
+        ConditionalStorage<enableEnergy, double> inAlpha;
+        ConditionalStorage<enableEnergy, double> outAlpha;
+        ConditionalStorage<enableDiffusion, double> diffusivity;
+        ConditionalStorage<enableDispersion, double> dispersivity;
     };
 
     struct ModuleParams


### PR DESCRIPTION
The member `neighborInfo_` is used to make the `tpfalinearizer` faster, by storing all the required data in a struct that is fast to access. It contains an instance of the struct `ResidualNBInfo` for every neighbour of every cell. For this reason, it takes up a significant amount of memory. Recent profiling measured this to be around 8 % of the peak heap memory allocations. Removing a double in this struct will save 6 * 8 bytes = 48 bytes per cell. So any members we don't need here should not be stored. 

For this reason I made the members that are required for `energy`, `diffusion` and `dispersion` conditional.

There might be more chances to reduce the memory use here, but this has to be carefully evaluated to not make this critical code slower.
- One example is to remove `Vin` and `Vex` and instead just look them up the global array. -
- `faceDir` is for most cases not needed as this is just for directional mobilities, but I did not find a simple way to remove it.
- `thpres` could potentially be stored in float instead. Maybe `dZg` as well.

