### PR TITLE
Remove intensive quantities cache for time idx 1

### DIFF
--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -839,6 +839,7 @@ public:
     const EqVector& cachedStorage(unsigned globalIdx, unsigned timeIdx) const
     {
         assert(enableStorageCache_);
+        assert(storageCacheUpToDate_[timeIdx][globalIdx] != 0);
         return storageCache_[timeIdx][globalIdx];
     }
 
@@ -857,6 +858,48 @@ public:
     {
         assert(enableStorageCache_);
         storageCache_[timeIdx][globalIdx] = value;
+        storageCacheUpToDate_[timeIdx][globalIdx] = 1;
+    }
+
+    /*!
+     * \brief Returns true if the storage cache entry for a given DOF and time index is up to date.
+     *
+     * \param globalIdx The global space index for the entity
+     * \param timeIdx The index used by the time discretization
+     */
+    bool storageCacheIsUpToDate(unsigned globalIdx, unsigned timeIdx) const
+    {
+        if (!enableStorageCache_) {
+            return false;
+        }
+        return storageCacheUpToDate_[timeIdx][globalIdx] != 0;
+    }
+
+    /*!
+     * \brief Invalidate the storage cache for a given DOF and time index.
+     *
+     * \param globalIdx The global space index for the entity
+     * \param timeIdx The index used by the time discretization
+     */
+    void invalidateStorageCacheEntry(unsigned globalIdx, unsigned timeIdx) const
+    {
+        if (enableStorageCache_) {
+            storageCacheUpToDate_[timeIdx][globalIdx] = 0;
+        }
+    }
+
+    /*!
+     * \brief Invalidate the whole storage cache for a given time index.
+     *
+     * \param timeIdx The index used by the time discretization
+     */
+    void invalidateStorageCache(unsigned timeIdx) const
+    {
+        if (enableStorageCache_) {
+            std::fill(storageCacheUpToDate_[timeIdx].begin(),
+                      storageCacheUpToDate_[timeIdx].end(),
+                      /*value=*/0);
+        }
     }
 
     /*!
@@ -1840,6 +1883,7 @@ protected:
             const std::size_t numDof = asImp_().numGridDof();
             for (unsigned timeIdx = 0; timeIdx < historySize; ++timeIdx) {
                 storageCache_[timeIdx].resize(numDof);
+                storageCacheUpToDate_[timeIdx].resize(numDof, /*value=*/0);
             }
         }
 
@@ -1935,6 +1979,9 @@ protected:
     std::vector<bool> isLocalDof_;
 
     mutable std::array<GlobalEqVector, historySize> storageCache_;
+
+    // while these are logically bools, concurrent writes to vector<bool> are not thread safe.
+    mutable std::array<std::vector<unsigned char>, historySize> storageCacheUpToDate_;
 
     bool enableGridAdaptation_;
     bool enableIntensiveQuantityCache_;

--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -330,6 +330,7 @@ class FvBaseDiscretization
     enum {
         numEq = getPropValue<TypeTag, Properties::NumEq>(),
         historySize = getPropValue<TypeTag, Properties::TimeDiscHistorySize>(),
+        intensiveCacheSize = 1,
     };
 
     using IntensiveQuantitiesVector = std::vector<IntensiveQuantities,
@@ -413,14 +414,16 @@ public:
 
         PrimaryVariables::init();
         const std::size_t numDof = asImp_().numGridDof();
-        for (unsigned timeIdx = 0; timeIdx < historySize; ++timeIdx) {
+        for (unsigned timeIdx = 0; timeIdx < intensiveCacheSize; ++timeIdx) {
             if (storeIntensiveQuantities()) {
                 intensiveQuantityCache_[timeIdx].resize(numDof);
                 intensiveQuantityCacheUpToDate_[timeIdx].resize(numDof, /*value=*/false);
             }
-
+        }
+        for (unsigned timeIdx = 0; timeIdx < historySize; ++timeIdx) {
             if (enableStorageCache_) {
                 storageCache_[timeIdx].resize(numDof);
+                storageCacheUpToDate_[timeIdx].resize(numDof, /*value=*/false);
             }
         }
 
@@ -525,7 +528,7 @@ public:
         resizeAndResetIntensiveQuantitiesCache_();
         if (storeIntensiveQuantities()) {
             // invalidate all cached intensive quantities
-            for (unsigned timeIdx = 0; timeIdx < historySize; ++timeIdx) {
+            for (unsigned timeIdx = 0; timeIdx < intensiveCacheSize; ++timeIdx) {
                 invalidateIntensiveQuantitiesCache(timeIdx);
             }
         }
@@ -658,6 +661,8 @@ public:
             return nullptr;
         }
 
+        assert(timeIdx == 0);
+
         // With the storage cache enabled, usually only the
         // intensive quantities for the most recent time step are
         // cached. However, this may be false for some Problem
@@ -685,6 +690,8 @@ public:
         if (!storeIntensiveQuantities()) {
             return;
         }
+
+        assert(timeIdx == 0);
 
         intensiveQuantityCache_[timeIdx][globalIdx] = intQuants;
         intensiveQuantityCacheUpToDate_[timeIdx][globalIdx] = 1;
@@ -715,6 +722,8 @@ public:
      */
     void invalidateIntensiveQuantitiesCache(unsigned timeIdx) const
     {
+        assert(timeIdx == 0);
+
         if (storeIntensiveQuantities()) {
             std::fill(intensiveQuantityCacheUpToDate_[timeIdx].begin(),
                       intensiveQuantityCacheUpToDate_[timeIdx].end(),
@@ -782,6 +791,7 @@ public:
      */
     void shiftIntensiveQuantityCache(unsigned numSlots = 1)
     {
+        // TODO: Consider removing this method as it i not needed when we only have one time step in the cache.
         if (!storeIntensiveQuantities()) {
             return;
         }
@@ -797,8 +807,7 @@ public:
         }
 
         assert(numSlots > 0);
-
-        for (unsigned timeIdx = 0; timeIdx < historySize - numSlots; ++timeIdx) {
+        for (unsigned timeIdx = 0; timeIdx < intensiveCacheSize - numSlots; ++timeIdx) {
             intensiveQuantityCache_[timeIdx + numSlots] = intensiveQuantityCache_[timeIdx];
             intensiveQuantityCacheUpToDate_[timeIdx + numSlots] = intensiveQuantityCacheUpToDate_[timeIdx];
         }
@@ -1890,7 +1899,7 @@ protected:
         // allocate the intensive quantities cache
         if (storeIntensiveQuantities()) {
             const std::size_t numDof = asImp_().numGridDof();
-            for(unsigned timeIdx = 0; timeIdx < historySize; ++timeIdx) {
+            for(unsigned timeIdx = 0; timeIdx < intensiveCacheSize; ++timeIdx) {
                 intensiveQuantityCache_[timeIdx].resize(numDof);
                 intensiveQuantityCacheUpToDate_[timeIdx].resize(numDof);
                 invalidateIntensiveQuantitiesCache(timeIdx);
@@ -1965,10 +1974,10 @@ protected:
 
     // cur is the current iterative solution, prev the converged
     // solution of the previous time step
-    mutable std::array<IntensiveQuantitiesVector, historySize> intensiveQuantityCache_;
+    mutable std::array<IntensiveQuantitiesVector, intensiveCacheSize> intensiveQuantityCache_;
 
     // while these are logically bools, concurrent writes to vector<bool> are not thread safe.
-    mutable std::array<std::vector<unsigned char>, historySize> intensiveQuantityCacheUpToDate_;
+    mutable std::array<std::vector<unsigned char>, intensiveCacheSize> intensiveQuantityCacheUpToDate_;
 
     mutable std::array<std::unique_ptr<DiscreteFunction>, historySize> solution_;
 

--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -816,10 +816,10 @@ private:
                         }
                     }
                     else {
-                        Dune::FieldVector<Scalar, numEq> tmp;
-                        const IntensiveQuantities intQuantOld = model_().intensiveQuantities(globI, 1);
-                        LocalResidual::computeStorage(tmp, intQuantOld);
-                        model_().updateCachedStorage(globI, /*timeIdx=*/1, tmp);
+                        // For the current implementation, the storage cache for timeIdx 1 should already be up to date.
+                        // TODO: Check if we need to update the storage cache for timeIdx 1 explicitly somewhere else to
+                        // easier support new models/Newton methods.
+                        assert(model_().storageCacheIsUpToDate(globI, 1));
                     }
                 }
                 res -= model_().cachedStorage(globI, 1);

--- a/opm/simulators/flow/FIBlackoilModel.hpp
+++ b/opm/simulators/flow/FIBlackoilModel.hpp
@@ -187,6 +187,8 @@ public:
                       "Run without intensive quantites not enabled: "
                       "Use --enable-intensive-quantity=true");
         }
+
+        assert(timeIdx == 0);
         const auto* intquant = this->cachedIntensiveQuantities(globalIdx, timeIdx);
         if (!intquant) {
             OPM_THROW(std::logic_error, "Intensive quantites need to be updated in code");


### PR DESCRIPTION
The `intensiveQuantitiesCache` is an important optimisation measure that avoids recalculating the properties several times. However, it takes up a significant amount of memory, which was measured to be around 20 % of the peak memory allocations for the entire simulation.  So it is important to use strictly what is necessary.

With our current implementation, having an `intensiveQuantitiesCache` for both timeIdx 0 (the current timestep) and 1 (the previous timestep) is not needed, as we only need it for timeIdx 0. Removing the cache for timeIdx 1 halves the memory use of this cache. This amounts to **reducing the peak memory use of the entire simulator by 10 %**, without any performance degradation.

Setting this as a draft for now, as we need to verify that the updating of the `storageCache` for timeIdx 1 is done elsewhere in a safe way that such that developers that want to add new models do not have to find out if this is updated or not.