### PR TITLE
 For oscillation detection we only count gr switching after nupcol. 

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelConstraints.hpp
+++ b/opm/simulators/wells/BlackoilWellModelConstraints.hpp
@@ -79,6 +79,7 @@ public:
     bool updateGroupIndividualControl(const Group& group,
                                       const int reportStepIdx,
                                       const int max_number_of_group_switch,
+                                      const bool update_group_switching_log,
                                       std::map<std::string, std::array<std::vector<Group::InjectionCMode>, 3>>& switched_inj,
                                       std::map<std::string, std::vector<Group::ProductionCMode>>& switched_prod,
                                       std::map<std::string, std::pair<std::string, std::string>>& closed_offending_wells,

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -439,7 +439,8 @@ protected:
     bool checkGroupHigherConstraints(const Group& group,
                                      DeferredLogger& deferred_logger,
                                      const int reportStepIdx,
-                                     const int max_number_of_group_switch);
+                                     const int max_number_of_group_switch,
+                                     const bool update_group_switching_log);
 
     void updateAndCommunicateGroupData(const int reportStepIdx,
                                        const int iterationIdx,

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1936,8 +1936,9 @@ namespace Opm {
         bool changed = false;
         // restrict the number of group switches but only after nupcol iterations.
         const int nupcol = this->schedule()[reportStepIdx].nupcol();
-        const int max_number_of_group_switches = iterationIdx < nupcol ? 9999 : param_.max_number_of_group_switches_;
-        bool changed_hc = this->checkGroupHigherConstraints( group, deferred_logger, reportStepIdx, max_number_of_group_switches);
+        const int max_number_of_group_switches = param_.max_number_of_group_switches_;
+        const bool update_group_switching_log = iterationIdx >= nupcol;
+        const bool changed_hc = this->checkGroupHigherConstraints(group, deferred_logger, reportStepIdx, max_number_of_group_switches, update_group_switching_log);
         if (changed_hc) {
             changed = true;
             updateAndCommunicate(reportStepIdx, iterationIdx, deferred_logger);
@@ -1948,6 +1949,7 @@ namespace Opm {
                 updateGroupIndividualControl(group,
                                              reportStepIdx,
                                              max_number_of_group_switches,
+                                             update_group_switching_log,
                                              this->switched_inj_groups_,
                                              this->switched_prod_groups_,
                                              this->closed_offending_wells_,


### PR DESCRIPTION
This will make the behaviour for groups similar to wells. 