### PR TITLE
Use if constexpr to handle conditionally stored members.

### DIFF
--- a/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
+++ b/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
@@ -146,11 +146,11 @@ public:
 
     BlackOilIntensiveQuantitiesGlobalIndex()
     {
-        if (compositionSwitchEnabled) {
+        if constexpr (compositionSwitchEnabled) {
             fluidState_.setRs(0.0);
             fluidState_.setRv(0.0);
         }
-        if (enableVapwat) {
+        if constexpr (enableVapwat) {
             fluidState_.setRvw(0.0);
         }
     }
@@ -301,17 +301,19 @@ public:
             }
         }
 
-        if (priVars.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Rvw) {
-            const auto& Rvw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx);
-            fluidState_.setRvw(Rvw);
-        } else {
-            //NB! should save the indexing for later evaluation
-            if (FluidSystem::enableVaporizedWater()) { // Add Sg > 0? i.e. if only water set rv = 0)
-                OPM_TIMEBLOCK_LOCAL(UpdateSaturatedRv);
-                const Evaluation& RvwSat = FluidSystem::saturatedVaporizationFactor(fluidState_,
-                                                            gasPhaseIdx,
-                                                            pvtRegionIdx);
-                fluidState_.setRvw(RvwSat);
+        if constexpr (enableVapwat) {
+            if (priVars.primaryVarsMeaningWater() == PrimaryVariables::WaterMeaning::Rvw) {
+                const auto& Rvw = priVars.makeEvaluation(Indices::waterSwitchIdx, timeIdx);
+                fluidState_.setRvw(Rvw);
+            } else {
+                //NB! should save the indexing for later evaluation
+                if (FluidSystem::enableVaporizedWater()) { // Add Sg > 0? i.e. if only water set rv = 0)
+                    OPM_TIMEBLOCK_LOCAL(UpdateSaturatedRv);
+                    const Evaluation& RvwSat = FluidSystem::saturatedVaporizationFactor(fluidState_,
+                                                                                        gasPhaseIdx,
+                                                                                        pvtRegionIdx);
+                    fluidState_.setRvw(RvwSat);
+                }
             }
         }
 

--- a/opm/models/discretization/ecfv/ecfvstencil.hh
+++ b/opm/models/discretization/ecfv/ecfvstencil.hh
@@ -159,11 +159,11 @@ public:
         {
             exteriorIdx_ = static_cast<unsigned short>(localNeighborIdx);
 
-            if (needNormal) {
+            if constexpr (needNormal) {
                 (*normal_) = intersection.centerUnitOuterNormal();
             }
             const auto& geometry = intersection.geometry();
-            if (needIntegrationPos) {
+            if constexpr (needIntegrationPos) {
                 (*integrationPos_) = geometry.center();
             }
             area_ = geometry.volume();

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -115,6 +115,9 @@ class OutputBlackOilModule : public GenericOutputBlackoilModule<GetPropType<Type
     static constexpr int waterCompIdx = FluidSystem::waterCompIdx;
     enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
     enum { enableMICP = getPropValue<TypeTag, Properties::EnableMICP>() };
+    enum { enableVapwat = getPropValue<TypeTag, Properties::EnableVapwat>() };
+    enum { enableDisgasInWater = getPropValue<TypeTag, Properties::EnableDisgasInWater>() };
+    enum { enableDissolvedGas = Indices::compositionSwitchIdx >= 0 };
 
     template<int idx, class VectorType>
     static Scalar value_or_zero(const VectorType& v)
@@ -533,14 +536,20 @@ public:
 
         if (!this->temperature_.empty())
             fs.setTemperature(this->temperature_[elemIdx]);
-        if (!this->rs_.empty())
-            fs.setRs(this->rs_[elemIdx]);
-        if (!this->rsw_.empty())
-            fs.setRsw(this->rsw_[elemIdx]);
-        if (!this->rv_.empty())
-            fs.setRv(this->rv_[elemIdx]);
-        if (!this->rvw_.empty())
-            fs.setRvw(this->rvw_[elemIdx]);
+        if constexpr (enableDissolvedGas) {
+            if (!this->rs_.empty())
+                fs.setRs(this->rs_[elemIdx]);
+            if (!this->rv_.empty())
+                fs.setRv(this->rv_[elemIdx]);
+        }
+        if constexpr (enableDisgasInWater) {
+            if (!this->rsw_.empty())
+                fs.setRsw(this->rsw_[elemIdx]);
+        }
+        if constexpr (enableVapwat) {
+            if (!this->rvw_.empty())
+                fs.setRvw(this->rvw_[elemIdx]);
+        }
     }
 
     void initHysteresisParams(Simulator& simulator, unsigned elemIdx) const


### PR DESCRIPTION
Also added some more convenience enums to avoid repeated getPropValue() clutter.

Downstream of https://github.com/OPM/opm-common/pull/4651