### PR TITLE
Emit Converged in Zero Iteration Messages at Elevated Verbosity Level

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1746,7 +1746,7 @@ namespace Opm
                 message.append(fmt::format("   (A relaxed tolerance was used after {} iterations)",
                                            this->param_.strict_inner_iter_wells_));
             }
-            deferred_logger.debug(message);
+            deferred_logger.debug(message, OpmLog::defaultDebugVerbosityLevel + ((it == 0) && (switch_count == 0)));
         } else {
             this->wellStatus_ = well_status_orig;
             this->operability_status_ = operability_orig;            


### PR DESCRIPTION
That way, the .DBG file won't be flooded with messages of the form

> Well P-1 converged in 0 inner iterations (0 control/status switches)

unless the user specifically requests such messages.

Missed in commit 93f483f35 (PR #6350).