### PR TITLE
Default threads per process to two

### DIFF
--- a/flowexperimental/flowexp.hpp
+++ b/flowexperimental/flowexp.hpp
@@ -179,7 +179,7 @@ public:
         Parameters::Hide<Parameters::EnableTerminalOutput>();
 
         // if openMP is available, set the default the number of threads per process for the main
-        // simulation to 1 (instead of grabbing everything that is available).
+        // simulation to 2 (instead of grabbing everything that is available).
 #if _OPENMP
         Parameters::SetDefault<Parameters::ThreadsPerProcess>(2);
 #endif

--- a/modelTests.cmake
+++ b/modelTests.cmake
@@ -15,14 +15,14 @@ foreach(tgt lens_immiscible_ecfv_ad
   opm_add_test(${tgt}
                NO_COMPILE
                EXE_NAME $<TARGET_FILE:${tgt}>
-               TEST_ARGS --end-time=3000
+               TEST_ARGS --end-time=3000 --threads-per-process=1
                WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
 endforeach()
 
 opm_add_test(waterair_pvs_ni
              NO_COMPILE
              EXE_NAME $<TARGET_FILE:waterair_pvs_ni>
-             TEST_ARGS --grid-global-refinements=1
+             TEST_ARGS --grid-global-refinements=1 --threads-per-process=1
              WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
 
 set(PLAIN_TGT
@@ -83,7 +83,7 @@ foreach(tgt reservoir_blackoil_ecfv
   opm_add_test(${tgt}
                NO_COMPILE
                EXE_NAME $<TARGET_FILE:${tgt}>
-               TEST_ARGS --end-time=8750000
+               TEST_ARGS --end-time=8750000 --threads-per-process=1
                WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
 endforeach()
 
@@ -91,7 +91,7 @@ if(dune-alugrid_FOUND)
   opm_add_test(fracture_discretefracture
                NO_COMPILE
                EXE_NAME $<TARGET_FILE:fracture_discretefracture>
-               TEST_ARGS --end-time=400
+               TEST_ARGS --end-time=400 --threads-per-process=1
                WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
 endif()
 
@@ -99,19 +99,20 @@ if(dune-alugrid_FOUND AND dune-fem_FOUND)
   opm_add_test(finger_immiscible_ecfv_adaptive
                NO_COMPILE
                EXE_NAME $<TARGET_FILE:finger_immiscible_ecfv>
-               TEST_ARGS --enable-grid-adaptation=true --end-time=25e3 --enable-async-vtk-output=false
+               TEST_ARGS --enable-grid-adaptation=true --end-time=25e3 --enable-async-vtk-output=false --threads-per-process=1
                WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
 endif()
 
 opm_add_test(obstacle_immiscible_parameters
              NO_COMPILE
              EXE_NAME $<TARGET_FILE:obstacle_immiscible>
+             TEST_ARGS --threads-per-process=1
              DRIVER_ARGS --parameters
              WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
 
 opm_add_test(obstacle_pvs_restart
              NO_COMPILE
              EXE_NAME $<TARGET_FILE:obstacle_pvs>
-             TEST_ARGS --pvs-verbosity=2 --end-time=30000
+             TEST_ARGS --pvs-verbosity=2 --end-time=30000 --threads-per-process=1
              DRIVER_ARGS --restart
              WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/tests)

--- a/opm/models/discretization/common/fvbaseparameters.hh
+++ b/opm/models/discretization/common/fvbaseparameters.hh
@@ -125,7 +125,7 @@ struct MinTimeStepSize { static constexpr Scalar value = 0.0; };
 struct OutputDir { static constexpr auto value = ""; };
 
 //! \brief Number of threads per process.
-struct ThreadsPerProcess { static constexpr int value = 1; };
+struct ThreadsPerProcess { static constexpr int value = 2; };
 
 } // namespace Opm::Parameters
 


### PR DESCRIPTION
In https://github.com/OPM/opm-simulators/pull/5856 the default value has been changed  to two; however, by typying `flow --help`:

> --threads-per-process=INTEGER                 The maximum number of threads to be instantiated per process ('-1' means 'automatic'). Default: 1

This PR sets the displayed value to two.