### PR TITLE
moving FluidSystem::waterEnabled runtime_error to CompWellInterface

### DIFF
--- a/flowexperimental/comp/wells/CompWellInterface_impl.hpp
+++ b/flowexperimental/comp/wells/CompWellInterface_impl.hpp
@@ -31,6 +31,10 @@ CompWellInterface(const Well& well,
     , reference_depth_(well.getRefDepth())
     , connectionRates_(number_of_connection_)
 {
+    if (FluidSystem::waterEnabled) {
+        throw std::runtime_error("the well model does not support water phase yet");
+    }
+
     {
         well_cells_.resize(number_of_connection_);
         well_index_.resize(number_of_connection_);

--- a/flowexperimental/comp/wells/CompWellModel_impl.hpp
+++ b/flowexperimental/comp/wells/CompWellModel_impl.hpp
@@ -44,10 +44,6 @@ CompWellModel<TypeTag>::CompWellModel(Simulator& simulator)
     , comp_well_states_(comp_config_)
 {
     local_num_cells_ = simulator.gridView().size(0);
-
-    if (FluidSystem::waterEnabled) {
-        throw std::runtime_error("the well model does not support water phase yet");
-    }
 }
 
 template <typename TypeTag>


### PR DESCRIPTION
having it in the CompWellModel makes it can not run the cases with water phase while without wells. 