### PR TITLE
Allow calling BlackoilIntensiveQuantities::update() without an ElementContext

### DIFF
--- a/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
+++ b/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
@@ -321,7 +321,7 @@ public:
             if (!FluidSystem::phaseIsActive(phaseIdx)) {
                 continue;
             }
-            computeInverseFormationVolumeFactorAndViscosity(fluidState_, phaseIdx, pvtRegionIdx, SoMax);
+            computeInverseFormationVolumeFactorAndViscosity(fluidState_, phaseIdx, pvtRegionIdx);
         }
         Valgrind::CheckDefined(mobility_);
 
@@ -443,8 +443,7 @@ public:
 
     void computeInverseFormationVolumeFactorAndViscosity(FluidState& fluidState,
                                                          unsigned phaseIdx,
-                                                         unsigned pvtRegionIdx,
-                                                         const Evaluation& SoMax){
+                                                         unsigned pvtRegionIdx) {
         OPM_TIMEBLOCK_LOCAL(UpdateInverseFormationFactorAndViscosity);
         {
             OPM_TIMEBLOCK_LOCAL(UpdateFormationFactor);

--- a/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
+++ b/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
@@ -455,9 +455,6 @@ public:
             OPM_TIMEBLOCK_LOCAL(UpdateViscosity);
             typename FluidSystem::template ParameterCache<Evaluation> paramCache;
             paramCache.setRegionIndex(pvtRegionIdx);
-            if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
-                paramCache.setMaxOilSat(SoMax);
-            }
             paramCache.updateAll(fluidState_);
 
             const auto& mu = FluidSystem::viscosity(fluidState, paramCache, phaseIdx);

--- a/opm/models/blackoil/blackoilbrinemodules.hh
+++ b/opm/models/blackoil/blackoilbrinemodules.hh
@@ -387,7 +387,7 @@ public:
                                   unsigned timeIdx)
     {
         const PrimaryVariables& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
-        const LinearizationType lintype = elemCtx.problem().model().linearizer().getLinearizationType();
+        const LinearizationType lintype = elemCtx.linearizationType();
         updateSaltConcentration_(priVars, timeIdx, lintype);
     }
 

--- a/opm/models/blackoil/blackoilbrinemodules.hh
+++ b/opm/models/blackoil/blackoilbrinemodules.hh
@@ -258,9 +258,9 @@ public:
         }
     }
 
-    static const Scalar& referencePressure(const ElementContext& elemCtx,
-                                           unsigned scvIdx,
-                                           unsigned timeIdx)
+    static Scalar referencePressure(const ElementContext& elemCtx,
+                                    unsigned scvIdx,
+                                    unsigned timeIdx)
     {
         const unsigned pvtnumRegionIdx = elemCtx.problem().pvtRegionIndex(elemCtx, scvIdx, timeIdx);
         return params_.referencePressure_[pvtnumRegionIdx];
@@ -288,28 +288,28 @@ public:
     static const TabulatedFunction& permfactTable(unsigned satnumRegionIdx)
     { return params_.permfactTable_[satnumRegionIdx]; }
 
-    static const Scalar saltsolTable(const ElementContext& elemCtx,
-                                                  unsigned scvIdx,
-                                                  unsigned timeIdx)
+    static Scalar saltsolTable(const ElementContext& elemCtx,
+                               unsigned scvIdx,
+                               unsigned timeIdx)
     {
         const unsigned pvtnumRegionIdx = elemCtx.problem().pvtRegionIndex(elemCtx, scvIdx, timeIdx);
         return params_.saltsolTable_[pvtnumRegionIdx];
     }
 
-    static const Scalar saltsolTable(const unsigned pvtnumRegionIdx)
+    static Scalar saltsolTable(const unsigned pvtnumRegionIdx)
     {
         return params_.saltsolTable_[pvtnumRegionIdx];
     }
 
-    static const Scalar saltdenTable(const ElementContext& elemCtx,
-                                     unsigned scvIdx,
-                                     unsigned timeIdx)
+    static Scalar saltdenTable(const ElementContext& elemCtx,
+                               unsigned scvIdx,
+                               unsigned timeIdx)
     {
         const unsigned pvtnumRegionIdx = elemCtx.problem().pvtRegionIndex(elemCtx, scvIdx, timeIdx);
         return params_.saltdenTable_[pvtnumRegionIdx];
     }
 
-    static const Scalar saltdenTable(const unsigned pvtnumRegionIdx)
+    static Scalar saltdenTable(const unsigned pvtnumRegionIdx)
     {
         return params_.saltdenTable_[pvtnumRegionIdx];
     }
@@ -399,11 +399,8 @@ public:
         auto& fs = asImp_().fluidState_;
 
         if constexpr (enableSaltPrecipitation) {
-            const auto& saltsolTable = BrineModule::saltsolTable(pvtnumRegionIdx);
-            saltSolubility_ = saltsolTable;
-
-            const auto& saltdenTable = BrineModule::saltdenTable(pvtnumRegionIdx);
-            saltDensity_ = saltdenTable;
+            saltSolubility_ = BrineModule::saltsolTable(pvtnumRegionIdx);
+            saltDensity_ = BrineModule::saltdenTable(pvtnumRegionIdx);
 
             if (priVars.primaryVarsMeaningBrine() == PrimaryVariables::BrineMeaning::Sp) {
                 saltSaturation_ = priVars.makeEvaluation(saltConcentrationIdx, timeIdx, lintype);

--- a/opm/models/blackoil/blackoildiffusionmodule.hh
+++ b/opm/models/blackoil/blackoildiffusionmodule.hh
@@ -368,7 +368,7 @@ protected:
      */
     template <class FluidState>
     void update_(FluidState&,
-                 typename FluidSystem::template ParameterCache<typename FluidState::Scalar>&,
+                 const unsigned,
                  const ElementContext&,
                  unsigned,
                  unsigned)
@@ -452,7 +452,7 @@ protected:
      */
     template <class FluidState>
     void update_(FluidState& fluidState,
-                 typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
+                 const unsigned regionIdx,
                  const ElementContext& elemCtx,
                  unsigned dofIdx,
                  unsigned timeIdx)
@@ -463,12 +463,12 @@ protected:
         }
 
         const auto& intQuants = elemCtx.intensiveQuantities(dofIdx, timeIdx);
-        update_(fluidState, paramCache, intQuants);
+        update_(fluidState, regionIdx, intQuants);
     }
 
     template<class FluidState>
     void update_(FluidState& fluidState,
-                 typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
+                 const unsigned regionIdx,
                  const IntensiveQuantities& intQuants)
     {
         using Toolbox = MathToolbox<Evaluation>;
@@ -506,7 +506,7 @@ protected:
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 diffusionCoefficient_[phaseIdx][compIdx] =
                     FluidSystem::diffusionCoefficient(fluidState,
-                                                      paramCache,
+                                                      regionIdx,
                                                       phaseIdx,
                                                       compIdx);
             }

--- a/opm/models/blackoil/blackoildiffusionmodule.hh
+++ b/opm/models/blackoil/blackoildiffusionmodule.hh
@@ -503,10 +503,12 @@ protected:
                 1.0 / (intQuants.porosity() * intQuants.porosity()) *
                 Toolbox::pow(base, 10.0 / 3.0);
 
+            using PCache = typename FluidSystem::template ParameterCache<Scalar>;
+            PCache pcache(regionIdx);
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 diffusionCoefficient_[phaseIdx][compIdx] =
                     FluidSystem::diffusionCoefficient(fluidState,
-                                                      regionIdx,
+                                                      pcache,
                                                       phaseIdx,
                                                       compIdx);
             }

--- a/opm/models/blackoil/blackoilextbomodules.hh
+++ b/opm/models/blackoil/blackoilextbomodules.hh
@@ -422,7 +422,17 @@ public:
                           unsigned dofIdx,
                           unsigned timeIdx)
     {
-        const PrimaryVariables& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
+        zFractionUpdate_(elemCtx.primaryVars(dofIdx, timeIdx), timeIdx);
+    }
+
+    /*!
+     * \brief Compute extended pvt properties from table lookups.
+     *
+     *  At this point the pressures of the fluid state are correct.
+     */
+    void zFractionUpdate_(const PrimaryVariables& priVars,
+                          unsigned timeIdx)
+    {
         const unsigned pvtRegionIdx = priVars.pvtRegionIndex();
         const auto& fs = asImp_().fluidState_;
 

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -365,15 +365,15 @@ public:
         }
     }
 
-    Evaluation updateRsRvRsw(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
+    void updateRsRvRsw(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
     {
         const auto& problem = elemCtx.problem();
         const auto& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
         const unsigned globalSpaceIdx = elemCtx.globalSpaceIndex(dofIdx, timeIdx);
-        return this->updateRsRvRsw(problem, priVars, globalSpaceIdx, timeIdx);
+        this->updateRsRvRsw(problem, priVars, globalSpaceIdx, timeIdx);
     }
 
-    Evaluation updateRsRvRsw(const Problem& problem, const PrimaryVariables& priVars, const unsigned globalSpaceIdx, const unsigned timeIdx)
+    void updateRsRvRsw(const Problem& problem, const PrimaryVariables& priVars, const unsigned globalSpaceIdx, const unsigned timeIdx)
     {
         const unsigned pvtRegionIdx = priVars.pvtRegionIndex();
 
@@ -463,8 +463,6 @@ public:
                 }
             }
         }
-
-        return SoMax;
     }
 
     void updateMobilityAndInvB()
@@ -722,11 +720,8 @@ public:
 
         fluidState_.setPvtRegionIndex(pvtRegionIdx);
 
-        // updateTempSalt(elemCtx, dofIdx, timeIdx);
         updateTempSalt(problem, priVars, globalSpaceIdx, timeIdx, linearizationType);
-        // updateSaturations(elemCtx, dofIdx, timeIdx);
         updateSaturations(priVars, timeIdx, linearizationType);
-        // updateRelpermAndPressures(elemCtx, dofIdx, timeIdx);
         updateRelpermAndPressures(problem, priVars, globalSpaceIdx, timeIdx, linearizationType);
 
         // update extBO parameters
@@ -734,9 +729,7 @@ public:
                 // TODO: asImp_().zFractionUpdate_(elemCtx, dofIdx, timeIdx);
         }
 
-        // Evaluation SoMax = updateRsRvRsw(elemCtx, dofIdx, timeIdx);
-        Evaluation SoMax = updateRsRvRsw(problem, priVars, globalSpaceIdx, timeIdx);
-
+        updateRsRvRsw(problem, priVars, globalSpaceIdx, timeIdx);
         updateMobilityAndInvB();
         updatePhaseDensities();
 

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -654,16 +654,8 @@ public:
         if constexpr (enablePolymer) {
             asImp_().polymerPropertiesUpdate_(elemCtx, dofIdx, timeIdx);
         }
-
-        typename FluidSystem::template ParameterCache<Evaluation> paramCache;
-        paramCache.setRegionIndex(priVars.pvtRegionIndex());
-        if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
-            //paramCache.setMaxOilSat(SoMax);
-        }
-        paramCache.updateAll(fluidState_);
-
         if constexpr (enableEnergy) {
-            asImp_().updateEnergyQuantities_(elemCtx, dofIdx, timeIdx, paramCache);
+            asImp_().updateEnergyQuantities_(elemCtx, dofIdx, timeIdx);
         }
         if constexpr (enableFoam) {
             asImp_().foamPropertiesUpdate_(elemCtx, dofIdx, timeIdx);
@@ -692,7 +684,7 @@ public:
 
         // update the diffusion specific quantities of the intensive quantities
         if constexpr (enableDiffusion) {
-            DiffusionIntensiveQuantities::update_(fluidState_, paramCache, elemCtx, dofIdx, timeIdx);
+            DiffusionIntensiveQuantities::update_(fluidState_, priVars.pvtRegionIndex(), elemCtx, dofIdx, timeIdx);
         }
 
         // update the dispersion specific quantities of the intensive quantities

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -549,7 +549,6 @@ public:
 
     void updatePorosity(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
     {
-
         const auto& problem = elemCtx.problem();
         const auto& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
         const unsigned globalSpaceIdx = elemCtx.globalSpaceIndex(dofIdx, timeIdx);
@@ -639,7 +638,7 @@ public:
         const auto& problem = elemCtx.problem();
         const auto& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
         const unsigned globalSpaceIdx = elemCtx.globalSpaceIndex(dofIdx, timeIdx);
-        updatePart1(problem, priVars, globalSpaceIdx, timeIdx);
+        updateCommonPart(problem, priVars, globalSpaceIdx, timeIdx);
 
         updatePorosity(elemCtx, dofIdx, timeIdx);
 
@@ -695,6 +694,8 @@ public:
 
     void update(const Problem& problem, const PrimaryVariables& priVars, const unsigned globalSpaceIdx, const unsigned timeIdx)
     {
+        // This is the version of update() that does not use any ElementContext.
+        // It is limited by some modules that are not yet adapted to that.
         static_assert(!enableSolvent);
         static_assert(!enableExtbo);
         static_assert(!enablePolymer);
@@ -706,14 +707,15 @@ public:
         static_assert(!enableDispersion);
 
         this->extrusionFactor_ = 1.0;// to avoid fixing parent update
-        updatePart1(problem, priVars, globalSpaceIdx, timeIdx);
+        updateCommonPart(problem, priVars, globalSpaceIdx, timeIdx);
         // Porosity requires separate calls so this can be instantiated with ReservoirProblem from the examples/ directory.
         updatePorosity(problem, priVars, globalSpaceIdx, timeIdx);
 
         // TODO: Here we should do the parts for solvent etc. at the bottom of the other update() function.
     }
 
-    void updatePart1(const Problem& problem, const PrimaryVariables& priVars, const unsigned globalSpaceIdx, const unsigned timeIdx)
+    // This function updated the parts that are common to the IntensiveQuantities regardless of extensions used.
+    void updateCommonPart(const Problem& problem, const PrimaryVariables& priVars, const unsigned globalSpaceIdx, const unsigned timeIdx)
     {
         OPM_TIMEBLOCK_LOCAL(blackoilIntensiveQuanititiesUpdate);
 

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -728,7 +728,7 @@ public:
 
         // update extBO parameters
         if constexpr (enableExtbo) {
-                // TODO: asImp_().zFractionUpdate_(elemCtx, dofIdx, timeIdx);
+            asImp_().zFractionUpdate_(priVars, timeIdx);
         }
 
         updateRsRvRsw(problem, priVars, globalSpaceIdx, timeIdx);

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -211,7 +211,9 @@ public:
         this->updateSaturations(priVars, timeIdx, lintype);
     }
 
-    void updateSaturations(const PrimaryVariables& priVars, const unsigned timeIdx, const LinearizationType lintype)
+    void updateSaturations(const PrimaryVariables& priVars,
+                           const unsigned timeIdx,
+                           [[maybe_unused]] const LinearizationType lintype)
     {
         // extract the water and the gas saturations for convenience
         Evaluation Sw = 0.0;

--- a/opm/models/blackoil/blackoilsolventmodules.hh
+++ b/opm/models/blackoil/blackoilsolventmodules.hh
@@ -42,6 +42,8 @@
 #include <opm/models/common/multiphasebaseparameters.hh>
 #include <opm/models/common/quantitycallbacks.hh>
 
+#include <opm/models/discretization/common/linearizationtype.hh>
+
 #include <opm/models/io/vtkblackoilsolventmodule.hpp>
 
 #include <algorithm>
@@ -375,7 +377,8 @@ public:
     static const BrineH2Pvt& brineH2Pvt()
     { return params_.brineH2Pvt_; }
 
-    static const TabulatedFunction& ssfnKrg(const ElementContext& elemCtx,
+    template <class ElemContext>
+    static const TabulatedFunction& ssfnKrg(const ElemContext& elemCtx,
                                             unsigned scvIdx,
                                             unsigned timeIdx)
     {
@@ -384,7 +387,8 @@ public:
         return params_.ssfnKrg_[satnumRegionIdx];
     }
 
-    static const TabulatedFunction& ssfnKrs(const ElementContext& elemCtx,
+    template <class ElemContext>
+    static const TabulatedFunction& ssfnKrs(const ElemContext& elemCtx,
                                             unsigned scvIdx,
                                             unsigned timeIdx)
     {
@@ -393,7 +397,8 @@ public:
         return params_.ssfnKrs_[satnumRegionIdx];
     }
 
-    static const TabulatedFunction& sof2Krn(const ElementContext& elemCtx,
+    template <class ElemContext>
+    static const TabulatedFunction& sof2Krn(const ElemContext& elemCtx,
                                             unsigned scvIdx,
                                             unsigned timeIdx)
     {
@@ -402,7 +407,8 @@ public:
         return params_.sof2Krn_[satnumRegionIdx];
     }
 
-    static const TabulatedFunction& misc(const ElementContext& elemCtx,
+    template <class ElemContext>
+    static const TabulatedFunction& misc(const ElemContext& elemCtx,
                                          unsigned scvIdx,
                                          unsigned timeIdx)
     {
@@ -411,7 +417,8 @@ public:
         return params_.misc_[miscnumRegionIdx];
     }
 
-    static const TabulatedFunction& pmisc(const ElementContext& elemCtx,
+    template <class ElemContext>
+    static const TabulatedFunction& pmisc(const ElemContext& elemCtx,
                                           unsigned scvIdx,
                                           unsigned timeIdx)
     {
@@ -420,7 +427,8 @@ public:
         return params_.pmisc_[miscnumRegionIdx];
     }
 
-    static const TabulatedFunction& msfnKrsg(const ElementContext& elemCtx,
+    template <class ElemContext>
+    static const TabulatedFunction& msfnKrsg(const ElemContext& elemCtx,
                                              unsigned scvIdx,
                                              unsigned timeIdx)
     {
@@ -429,7 +437,8 @@ public:
         return params_.msfnKrsg_[satnumRegionIdx];
     }
 
-    static const TabulatedFunction& msfnKro(const ElementContext& elemCtx,
+    template <class ElemContext>
+    static const TabulatedFunction& msfnKro(const ElemContext& elemCtx,
                                             unsigned scvIdx,
                                             unsigned timeIdx)
     {
@@ -438,7 +447,8 @@ public:
         return params_.msfnKro_[satnumRegionIdx];
     }
 
-    static const TabulatedFunction& sorwmis(const ElementContext& elemCtx,
+    template <class ElemContext>
+    static const TabulatedFunction& sorwmis(const ElemContext& elemCtx,
                                             unsigned scvIdx,
                                             unsigned timeIdx)
     {
@@ -447,7 +457,8 @@ public:
         return params_.sorwmis_[miscnumRegionIdx];
     }
 
-    static const TabulatedFunction& sgcwmis(const ElementContext& elemCtx,
+    template <class ElemContext>
+    static const TabulatedFunction& sgcwmis(const ElemContext& elemCtx,
                                             unsigned scvIdx,
                                             unsigned timeIdx)
     {
@@ -456,7 +467,8 @@ public:
         return params_.sgcwmis_[miscnumRegionIdx];
     }
 
-    static const TabulatedFunction& tlPMixTable(const ElementContext& elemCtx,
+    template <class ElemContext>
+    static const TabulatedFunction& tlPMixTable(const ElemContext& elemCtx,
                                             unsigned scvIdx,
                                             unsigned timeIdx)
     {
@@ -465,7 +477,8 @@ public:
         return params_.tlPMixTable_[miscnumRegionIdx];
     }
 
-    static Scalar tlMixParamViscosity(const ElementContext& elemCtx,
+    template <class ElemContext>
+    static Scalar tlMixParamViscosity(const ElemContext& elemCtx,
                                       unsigned scvIdx,
                                       unsigned timeIdx)
     {
@@ -474,7 +487,9 @@ public:
         return params_.tlMixParamViscosity_[miscnumRegionIdx];
     }
 
-    static Scalar tlMixParamDensity(const ElementContext& elemCtx,
+
+    template <class ElemContext>
+    static Scalar tlMixParamDensity(const ElemContext& elemCtx,
                                     unsigned scvIdx,
                                     unsigned timeIdx)
     {
@@ -543,6 +558,7 @@ class BlackOilSolventIntensiveQuantities<TypeTag, /*enableSolventV=*/true>
     using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
     using MaterialLaw = GetPropType<TypeTag, Properties::MaterialLaw>;
     using Indices = GetPropType<TypeTag, Properties::Indices>;
+    using Problem = GetPropType<TypeTag, Properties::Problem>;
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
 
     using SolventModule = BlackOilSolventModule<TypeTag>;
@@ -566,12 +582,17 @@ public:
                                   unsigned timeIdx)
     {
         const PrimaryVariables& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
+        this->solventPreSatFuncUpdate_(priVars, timeIdx, elemCtx.linearizationType());
+    }
 
+    void solventPreSatFuncUpdate_(const PrimaryVariables& priVars,
+                                  const unsigned timeIdx,
+                                  const LinearizationType linearizationType)
+    {
         auto& fs = asImp_().fluidState_;
         solventSaturation_ = 0.0;
         if (priVars.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Ss) {
-            solventSaturation_ = priVars.makeEvaluation(solventSaturationIdx, timeIdx,
-                                                        elemCtx.linearizationType());
+            solventSaturation_ = priVars.makeEvaluation(solventSaturationIdx, timeIdx, linearizationType);
         }
 
         hydrocarbonSaturation_ = fs.saturation(gasPhaseIdx);
@@ -597,22 +618,43 @@ public:
                                    unsigned dofIdx,
                                    unsigned timeIdx)
     {
+        const PrimaryVariables& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
+        this->solventPostSatFuncUpdate_(elemCtx.problem(), priVars, elemCtx.globalSpaceIndex(dofIdx, timeIdx), timeIdx, elemCtx.linearizationType());
+    }
+
+    template <class Problem>
+    struct ProblemAndCellIndexOnlyContext
+    {
+        const Problem& problem_;
+        unsigned int index_;
+        const Problem& problem() const { return problem_; }
+        unsigned int globalSpaceIndex([[maybe_unused]] const unsigned int spaceIdx,
+                                      [[maybe_unused]] const unsigned int timeIdx) const
+        {
+            return index_;
+        }
+    };
+
+    void solventPostSatFuncUpdate_(const Problem& problem,
+                                   const PrimaryVariables& priVars,
+                                   const unsigned globalSpaceIdx,
+                                   const unsigned timeIdx,
+                                   const LinearizationType linearizationType)
+    {
         // revert the gas "saturation" of the fluid state back to the saturation of the
         // hydrocarbon gas.
         auto& fs = asImp_().fluidState_;
         fs.setSaturation(gasPhaseIdx, hydrocarbonSaturation_);
 
-        // update rsSolw. This needs to be done after the pressure is defined in the fluid state. 
+        // update rsSolw. This needs to be done after the pressure is defined in the fluid state.
         rsSolw_ = 0.0;
-        const PrimaryVariables& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
         if (priVars.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Ss) {
             rsSolw_ = SolventModule::solubilityLimit(asImp_().pvtRegionIndex(),
                                                      fs.temperature(waterPhaseIdx),
                                                      fs.pressure(waterPhaseIdx),
                                                      fs.saltConcentration());
         } else if (priVars.primaryVarsMeaningSolvent() == PrimaryVariables::SolventMeaning::Rsolw) {
-            rsSolw_ = priVars.makeEvaluation(solventSaturationIdx, timeIdx,
-                                             elemCtx.linearizationType());
+            rsSolw_ = priVars.makeEvaluation(solventSaturationIdx, timeIdx, linearizationType);
         }
 
         solventMobility_ = 0.0;
@@ -621,6 +663,9 @@ public:
         if (solventSaturation().value() < cutOff) {
             return;
         }
+
+        ProblemAndCellIndexOnlyContext<Problem> elemCtx{problem, globalSpaceIdx};
+        unsigned dofIdx = 0; // Dummy
 
         // Pressure effects on capillary pressure miscibility
         if (SolventModule::isMiscible()) {
@@ -633,14 +678,12 @@ public:
             const Evaluation& pgImisc = fs.pressure(gasPhaseIdx);
 
             // compute capillary pressure for miscible fluid
-            const auto& problem = elemCtx.problem();
             Evaluation pgMisc = 0.0;
             std::array<Evaluation, numPhases> pC;
             const auto& materialParams = problem.materialLawParams(elemCtx, dofIdx, timeIdx);
             MaterialLaw::capillaryPressures(pC, materialParams, fs);
 
             // oil is the reference phase for pressure
-            const auto linearizationType = elemCtx.linearizationType();
             if (priVars.primaryVarsMeaningPressure() == PrimaryVariables::PressureMeaning::Pg) {
                 pgMisc = priVars.makeEvaluation(Indices::pressureSwitchIdx, timeIdx,
                                                 linearizationType);

--- a/opm/models/blackoil/blackoilsolventmodules.hh
+++ b/opm/models/blackoil/blackoilsolventmodules.hh
@@ -622,6 +622,8 @@ public:
         this->solventPostSatFuncUpdate_(elemCtx.problem(), priVars, elemCtx.globalSpaceIndex(dofIdx, timeIdx), timeIdx, elemCtx.linearizationType());
     }
 
+private:
+    // This class is a private implementation detail.
     template <class Problem>
     struct ProblemAndCellIndexOnlyContext
     {
@@ -635,6 +637,7 @@ public:
         }
     };
 
+public:
     void solventPostSatFuncUpdate_(const Problem& problem,
                                    const PrimaryVariables& priVars,
                                    const unsigned globalSpaceIdx,

--- a/opm/simulators/aquifers/AquiferAnalytical.hpp
+++ b/opm/simulators/aquifers/AquiferAnalytical.hpp
@@ -194,7 +194,6 @@ public:
                 typename FluidSystem::template ParameterCache<FsScalar> paramCache;
                 const unsigned pvtRegionIdx = intQuants.pvtRegionIndex();
                 paramCache.setRegionIndex(pvtRegionIdx);
-                paramCache.setMaxOilSat(this->simulator_.problem().maxOilSaturation(cellIdx));
                 paramCache.updatePhase(fs, this->phaseIdx_());
                 const auto& h = FluidSystem::enthalpy(fs, paramCache, this->phaseIdx_());
                 fs.setEnthalpy(this->phaseIdx_(), h);

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -450,8 +450,7 @@ namespace Opm
                                 DeferredLogger& deferred_logger) const;
 
     private:
-        Eval connectionRateEnergy(const Scalar maxOilSaturation,
-                                  const std::vector<EvalWell>& cq_s,
+        Eval connectionRateEnergy(const std::vector<EvalWell>& cq_s,
                                   const IntensiveQuantities& intQuants,
                                   DeferredLogger& deferred_logger) const;
     };

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2603,7 +2603,6 @@ namespace Opm
                 typename FluidSystem::template ParameterCache<FsScalar> paramCache;
                 const unsigned pvtRegionIdx = intQuants.pvtRegionIndex();
                 paramCache.setRegionIndex(pvtRegionIdx);
-                paramCache.setMaxOilSat(maxOilSaturation);
                 paramCache.updatePhase(fs, phaseIdx);
 
                 const auto& rho = FluidSystem::density(fs, paramCache, phaseIdx);

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -542,8 +542,7 @@ namespace Opm
 
         if constexpr (has_energy) {
             connectionRates[perf][Indices::contiEnergyEqIdx] =
-                connectionRateEnergy(simulator.problem().maxOilSaturation(cell_idx),
-                                     cq_s, intQuants, deferred_logger);
+                connectionRateEnergy(cq_s, intQuants, deferred_logger);
         }
 
         if constexpr (has_polymer) {
@@ -2545,8 +2544,7 @@ namespace Opm
     template <typename TypeTag>
     typename StandardWell<TypeTag>::Eval
     StandardWell<TypeTag>::
-    connectionRateEnergy(const Scalar maxOilSaturation,
-                         const std::vector<EvalWell>& cq_s,
+    connectionRateEnergy(const std::vector<EvalWell>& cq_s,
                          const IntensiveQuantities& intQuants,
                          DeferredLogger& deferred_logger) const
     {


### PR DESCRIPTION
This is to make it a better fit for GPU code, but it should also allow some more optimizations on the CPU, such as doing static dispatch for the "multiplexed" (runtime switched) functions of the fluid and material subsystems.

Requires https://github.com/OPM/opm-common/pull/4657