### PR TITLE
Compiletime threephaseswitch

### DIFF
--- a/flow/flow_blackoil.cpp
+++ b/flow/flow_blackoil.cpp
@@ -38,6 +38,9 @@ namespace Opm {
         template<class TypeTag>
         struct EnableDiffusion<TypeTag, TTag::FlowProblemTPFA> { static constexpr bool value = false; };
 
+        template<class TypeTag>
+        struct AvoidElementContext<TypeTag, TTag::FlowProblemTPFA> { static constexpr bool value = true; };
+
     }
 }
 

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -178,17 +178,6 @@ public:
 
     BlackOilIntensiveQuantities& operator=(const BlackOilIntensiveQuantities& other) = default;
 
-    void updateTempSalt(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
-    {
-        if constexpr (enableTemperature || enableEnergy) {
-            asImp_().updateTemperature_(elemCtx, dofIdx, timeIdx);
-        }
-
-        if constexpr (enableBrine) {
-            asImp_().updateSaltConcentration_(elemCtx, dofIdx, timeIdx);
-        }
-    }
-
     void updateTempSalt(const Problem& problem,
                         const PrimaryVariables& priVars,
                         const unsigned globalSpaceIdx,
@@ -202,13 +191,6 @@ public:
         if constexpr (enableBrine) {
             asImp_().updateSaltConcentration_(priVars, timeIdx, lintype);
         }
-    }
-
-    void updateSaturations(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
-    {
-        const auto& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
-        const LinearizationType lintype = elemCtx.problem().model().linearizer().getLinearizationType();
-        this->updateSaturations(priVars, timeIdx, lintype);
     }
 
     void updateSaturations(const PrimaryVariables& priVars,
@@ -280,14 +262,6 @@ public:
         if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
             fluidState_.setSaturation(oilPhaseIdx, So);
         }
-    }
-
-    void updateRelpermAndPressures(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
-    {
-        const auto& problem = elemCtx.problem();
-        const auto& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
-        const unsigned globalSpaceIdx = elemCtx.globalSpaceIndex(dofIdx, timeIdx);
-        this->updateRelpermAndPressures(problem, priVars, globalSpaceIdx, timeIdx, elemCtx.linearizationType());
     }
 
     template <class ...Args>
@@ -367,14 +341,6 @@ public:
         if constexpr (enableSolvent) {
             asImp_().solventPostSatFuncUpdate_(problem, priVars, globalSpaceIdx, timeIdx, lintype);
         }
-    }
-
-    void updateRsRvRsw(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
-    {
-        const auto& problem = elemCtx.problem();
-        const auto& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
-        const unsigned globalSpaceIdx = elemCtx.globalSpaceIndex(dofIdx, timeIdx);
-        this->updateRsRvRsw(problem, priVars, globalSpaceIdx, timeIdx);
     }
 
     void updateRsRvRsw(const Problem& problem, const PrimaryVariables& priVars, const unsigned globalSpaceIdx, const unsigned timeIdx)

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -307,7 +307,7 @@ public:
         }
 
         // Phase relperms.
-        problem.updateRelperms(mobility_, dirMob_, fluidState_, globalSpaceIdx);
+        problem.template updateRelperms<FluidState, Args...>(mobility_, dirMob_, fluidState_, globalSpaceIdx);
 
         // now we compute all phase pressures
         using EvalArr = std::array<Evaluation, numPhases>;

--- a/opm/simulators/flow/FIBlackoilModel.hpp
+++ b/opm/simulators/flow/FIBlackoilModel.hpp
@@ -75,6 +75,8 @@ public:
                           ThreadManager::maxThreads())
     {
     }
+        // using Dispatch = EclMultiplexerDispatch<EclMultiplexerApproach::Default>;
+        // dofVars_[dofIdx].intensiveQuantities[timeIdx].template update<Dispatch>(/*context=*/asImp_(), dofIdx, timeIdx);
 
     void invalidateAndUpdateIntensiveQuantities(unsigned timeIdx) const
     {

--- a/opm/simulators/flow/FIBlackoilModel.hpp
+++ b/opm/simulators/flow/FIBlackoilModel.hpp
@@ -207,11 +207,34 @@ public:
 
 protected:
 
+    template <EclMultiplexerApproach ApproachArg>
+    using EMD = EclMultiplexerDispatch<ApproachArg>;
 
     void updateCachedIntQuants(const unsigned timeIdx) const
     {
-        using Dispatch = EclMultiplexerDispatch<EclMultiplexerApproach::Default>;
-        updateCachedIntQuantsLoop<>(timeIdx);
+        // Runtime dispatch on three-phase approach into loops with
+        // compile-time fixed approach.
+        switch (this->simulator_.problem().materialLawManager()->threePhaseApproach()) {
+        case EclMultiplexerApproach::Stone1:
+            updateCachedIntQuantsLoop<EclMultiplexerDispatch<EclMultiplexerApproach::Stone1>>(timeIdx);
+            break;
+
+        case EclMultiplexerApproach::Stone2:
+            updateCachedIntQuantsLoop<EMD<EclMultiplexerApproach::Stone2>>(timeIdx);
+            break;
+
+        case EclMultiplexerApproach::Default:
+            updateCachedIntQuantsLoop<EMD<EclMultiplexerApproach::Default>>(timeIdx);
+            break;
+
+        case EclMultiplexerApproach::TwoPhase:
+            updateCachedIntQuantsLoop<EMD<EclMultiplexerApproach::TwoPhase>>(timeIdx);
+            break;
+
+        case EclMultiplexerApproach::OnePhase:
+            updateCachedIntQuantsLoop<EMD<EclMultiplexerApproach::OnePhase>>(timeIdx);
+            break;
+        }
     }
 
     template <class ...Args>

--- a/opm/simulators/flow/FIBlackoilModel.hpp
+++ b/opm/simulators/flow/FIBlackoilModel.hpp
@@ -224,7 +224,13 @@ protected:
             break;
 
         case EclMultiplexerApproach::Default:
-            updateCachedIntQuantsLoop<EMD<EclMultiplexerApproach::Default>>(timeIdx);
+            if (this->simulator_.problem().materialLawManager()->satCurveIsAllPiecewiseLinear()) {
+                using PL = SatCurveMultiplexerDispatch<SatCurveMultiplexerApproach::PiecewiseLinear>;
+                updateCachedIntQuantsLoop<EMD<EclMultiplexerApproach::Default>, PL>(timeIdx);
+            } else {
+                // TODO: Might want to set LET here, but need to check if partial use of LET is possible.
+                updateCachedIntQuantsLoop<EMD<EclMultiplexerApproach::Default>>(timeIdx);
+            }
             break;
 
         case EclMultiplexerApproach::TwoPhase:

--- a/opm/simulators/flow/FlowBaseProblemProperties.hpp
+++ b/opm/simulators/flow/FlowBaseProblemProperties.hpp
@@ -77,6 +77,10 @@ struct EnableApiTracking { using type = UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct EnableDebuggingChecks { using type = Properties::UndefinedProperty; };
 
+// Avoid using ElementContext-based code if possible.
+template<class TypeTag, class MyTypeTag>
+struct AvoidElementContext { using type = Properties::UndefinedProperty; };
+
 // if thermal flux boundaries are enabled an effort is made to preserve the initial
 // thermal gradient specified via the TEMPVD keyword
 template<class TypeTag, class MyTypeTag>
@@ -240,6 +244,12 @@ struct EnableExperiments<TypeTag, TTag::FlowBaseProblem>
 template<class TypeTag>
 struct EnableDebuggingChecks<TypeTag, TTag::FlowBaseProblem>
 { static constexpr bool value = true; };
+
+// Most modules are implemented only in terms of element contexts,
+// so this must default to false.
+template<class TypeTag>
+struct AvoidElementContext<TypeTag, TTag::FlowBaseProblem>
+{ static constexpr bool value = false; };
 
 } // namespace Opm::Properties
 


### PR DESCRIPTION
The companion of https://github.com/OPM/opm-common/pull/4658, this does two things:
  - Avoid using an ElementContext just to evaluate IntensiveQuantities.
  - Demonstrate the compile time dispatch to select a particular three-phase model (EclipseDefault) to avoid run-time switching per cell.

The first seems to give a 5-10% speedup for the property calculations. The second will need to be expanded to give a significant speedup, and is just a proof of concept.

Update: this has now been modified to also perform a proper run-time dispatch on the threephase approach, demonstrating the goal of moving such dispatches out of the inner loop.