### PR TITLE
incorporate brine+energy simulator in flow

### DIFF
--- a/flow/flow_brine_energy.cpp
+++ b/flow/flow_brine_energy.cpp
@@ -32,11 +32,27 @@ template<class TypeTag>
 struct EnableEnergy<TypeTag, TTag::FlowBrineEnergyProblem> {
     static constexpr bool value = true;
 };
+}}
+
+
+namespace Opm {
+
+// ----------------- Main program -----------------
+
+int flowBrineEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    resetLocale();
+
+    FlowMain<Properties::TTag::FlowBrineEnergyProblem>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
 }
 
-int flowBrineEnergyMain(int argc, char** argv)
+int flowBrineEnergyMainStandalone(int argc, char** argv)
 {
-    using TypeTag = Opm::Properties::TTag::FlowBrineEnergyProblem;
+    using TypeTag = Properties::TTag::FlowBrineEnergyProblem;
     auto mainObject = std::make_unique<Opm::Main>(argc, argv);
     auto ret = mainObject->runStatic<TypeTag>();
     // Destruct mainObject as the destructor calls MPI_Finalize!

--- a/flow/flow_brine_energy.hpp
+++ b/flow/flow_brine_energy.hpp
@@ -19,7 +19,12 @@
 #define FLOW_BRINE_ENERGY_HPP
 
 namespace Opm {
-  int flowBrineEnergyMain(int argc, char** argv);
+
+  //! \brief Main function used in flow binary.
+  int flowBrineEnergyMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+  //! \brief Main function used in flow_brine_energy binary.
+  int flowBrineEnergyMainStandalone(int argc, char** argv);
 }
 
 #endif

--- a/flow/flow_brine_energy_main.cpp
+++ b/flow/flow_brine_energy_main.cpp
@@ -19,5 +19,5 @@
 
 int main(int argc, char** argv)
 {
-    return Opm::flowBrineEnergyMain(argc, argv);
+    return Opm::flowBrineEnergyMainStandalone(argc, argv);
 }

--- a/opm/simulators/flow/MainDispatchDynamic.cpp
+++ b/opm/simulators/flow/MainDispatchDynamic.cpp
@@ -27,6 +27,7 @@
 #include <flow/flow_blackoil.hpp>
 #include <flow/flow_blackoil_legacyassembly.hpp>
 #include <flow/flow_brine.hpp>
+#include <flow/flow_brine_energy.hpp>
 #include <flow/flow_brine_precsalt_vapwat.hpp>
 #include <flow/flow_brine_saltprecipitation.hpp>
 #include <flow/flow_energy.hpp>
@@ -388,6 +389,11 @@ int Opm::Main::runThermal(const Phases& phases)
         }
 
         return flowGasWaterEnergyMain(argc_, argv_, outputCout_, outputFiles_);
+    }
+
+    // brine-energy
+    if (phases.active(Phase::BRINE)) {
+        return flowBrineEnergyMain(argc_, argv_, outputCout_, outputFiles_);
     }
 
     return flowEnergyMain(argc_, argv_, outputCout_, outputFiles_);


### PR DESCRIPTION
Allow running brine + energy simulations with `flow`. This functionality relies on https://github.com/OPM/opm-common/pull/4656