### PR TITLE
Remove the if that discoordinates values on different ranks

### DIFF
--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -522,11 +522,6 @@ updateWellRatesFromGroupTargetScale(const Scalar scale,
         if (!well_index.has_value())
             continue;
 
-        if (! wellState.wellIsOwned(well_index.value(), wellName) ) // Only sum once
-        {
-            continue;
-        }
-
         // scale rates
         auto& ws = wellState.well(well_index.value());
         if (isInjector) {

--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -442,11 +442,6 @@ updateGroupTargetReduction(const Group& group,
         if (!well_index.has_value())
             continue;
 
-        if (! wellState.wellIsOwned(well_index.value(), wellName) ) // Only sum once
-        {
-            continue;
-        }
-
         const Scalar efficiency = wellTmp.getEfficiencyFactor() *
                                   wellState[wellTmp.name()].efficiency_scaling_factor;
 


### PR DESCRIPTION
When a well is distributed, we can run into a deadlock in _MultisegmentWellGeneric.cpp::scaleSegmentRatesWithWellRates_ when `segment_rates` differ between ranks and one rank picks an if-branch with a communication and the other without. The difference originates in the function _WellGroupHelpers.cpp:updateWellRatesFromGroupTargetScale_ that changes `surface_rates` only on the rank owning the well.

This commit makes all ranks change the `surface_rates`. It fixes a deadlock I encountered but needs further testing to see if it breaks something else. Alternative solution would be adding a communication copying the well from the owner to other ranks.