### PR TITLE
Relax Upper Bound Check for Mobile Displacing Oil

### DIFF
--- a/opm/simulators/utils/satfunc/ThreePointHorizontalConsistencyChecks.cpp
+++ b/opm/simulators/utils/satfunc/ThreePointHorizontalConsistencyChecks.cpp
@@ -31,7 +31,7 @@ template <typename Scalar>
 void Opm::Satfunc::PhaseChecks::ThreePointHorizontal::DisplacingOil_GO<Scalar>::
 testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
 {
-    // SGCR < 1-SOGCR-SWL < SGU
+    // SGCR < 1-SOGCR-SWL <= SGU
 
     this->swl_   = endPoints.Swl;
     this->sogcr_ = endPoints.Sogcr;
@@ -52,7 +52,7 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
     const auto sr = Scalar{1} - (this->sogcr_ + this->swl_);
 
     const auto low = ! (this->sgcr_ < sr);
-    const auto high = ! (sr < this->sgu_);
+    const auto high = sr > this->sgu_;
 
     if (low || high) {
         this->setViolated();
@@ -66,7 +66,7 @@ template <typename Scalar>
 void Opm::Satfunc::PhaseChecks::ThreePointHorizontal::DisplacingOil_OW<Scalar>::
 testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
 {
-    // SWCR < 1-SOWCR-SGL < SWU
+    // SWCR < 1-SOWCR-SGL <= SWU
 
     this->sgl_   = endPoints.Sgl;
     this->sowcr_ = endPoints.Sowcr;
@@ -87,7 +87,7 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
     const auto sr = Scalar{1} - (this->sowcr_ + this->sgl_);
 
     const auto low = ! (this->swcr_ < sr);
-    const auto high = ! (sr < this->swu_);
+    const auto high = sr > this->swu_;
 
     if (low || high) {
         this->setViolated();

--- a/opm/simulators/utils/satfunc/ThreePointHorizontalConsistencyChecks.hpp
+++ b/opm/simulators/utils/satfunc/ThreePointHorizontalConsistencyChecks.hpp
@@ -64,7 +64,7 @@ namespace Opm::Satfunc::PhaseChecks::ThreePointHorizontal {
         /// Textual representation of the consistency condition.
         std::string condition() const override
         {
-            return { "SGCR < 1-SOGCR-SWL < SGU" };
+            return { "SGCR < 1-SOGCR-SWL <= SGU" };
         }
 
         /// Retrieve names of the exported check values.
@@ -139,7 +139,7 @@ namespace Opm::Satfunc::PhaseChecks::ThreePointHorizontal {
         /// Textual representation of the consistency condition.
         std::string condition() const override
         {
-            return { "SWCR < 1-SOWCR-SGL < SWU" };
+            return { "SWCR < 1-SOWCR-SGL <= SWU" };
         }
 
         /// Retrieve names of the exported check values.

--- a/tests/test_SatfuncConsistencyCheckManager.cpp
+++ b/tests/test_SatfuncConsistencyCheckManager.cpp
@@ -1539,7 +1539,7 @@ SOWCR
 
     BOOST_CHECK_EQUAL(msg, R"(Consistency Problem:
   Mobile displacing oil in three point horizontally scaled oil/water system
-  SWCR < 1-SOWCR-SGL < SWU
+  SWCR < 1-SOWCR-SGL <= SWU
   Total Violations: 1
 
 List of Violations
@@ -1589,7 +1589,7 @@ SOGCR
 
     BOOST_CHECK_EQUAL(msg, R"(Consistency Problem:
   Mobile displacing oil in three point horizontally scaled gas/oil system
-  SGCR < 1-SOGCR-SWL < SGU
+  SGCR < 1-SOGCR-SWL <= SGU
   Total Violations: 1
 
 List of Violations

--- a/tests/test_ThreePointHorizontalSatfuncConsistencyChecks.cpp
+++ b/tests/test_ThreePointHorizontalSatfuncConsistencyChecks.cpp
@@ -890,8 +890,8 @@ BOOST_AUTO_TEST_CASE(Sr_Is_Upper_Bound)
         BOOST_CHECK_CLOSE(values[4], 0.7f, 1.0e-6f);
     }
 
-    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
-    BOOST_CHECK_MESSAGE(check.isCritical(), "Test must be violated at critical level");
+    BOOST_CHECK_MESSAGE(! check.isViolated(), "Test must NOT be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must NOT be violated at critical level");
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Displacing_Oil_in_Gas_Oil
@@ -1711,8 +1711,8 @@ BOOST_AUTO_TEST_CASE(Sr_Is_Upper_Bound)
         BOOST_CHECK_CLOSE(values[4], 0.7f, 1.0e-6f);
     }
 
-    BOOST_CHECK_MESSAGE(check.isViolated(), "Test must be violated");
-    BOOST_CHECK_MESSAGE(check.isCritical(), "Test must be violated at critical level");
+    BOOST_CHECK_MESSAGE(! check.isViolated(), "Test must NOT be violated");
+    BOOST_CHECK_MESSAGE(! check.isCritical(), "Test must NOT be violated at critical level");
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Displacing_Oil_in_Oil_Water


### PR DESCRIPTION
This PR switches from a strict inequality for the upper bound on the mobile displacing oil saturation in the three-point scaling method to allowing equality as well.  Some recent experience demonstrates that equality is okay in this case.