### PR TITLE
Fix for --enable-dry-run=1 --output-extra-convergence-info=steps,iterations

### DIFF
--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -159,11 +159,13 @@ public:
                 { return std::string_view { compNames.name(compIdx) }; }
             };
 
-            this->convergence_output_.
-                startThread(this->simulator_.vanguard().eclState(),
-                            Parameters::Get<Parameters::OutputExtraConvergenceInfo>(),
-                            R"(OutputExtraConvergenceInfo (--output-extra-convergence-info))",
-                            getPhaseName);
+            if (!simulator_.vanguard().eclState().getIOConfig().initOnly()) {
+                this->convergence_output_.
+                    startThread(this->simulator_.vanguard().eclState(),
+                                Parameters::Get<Parameters::OutputExtraConvergenceInfo>(),
+                                R"(OutputExtraConvergenceInfo (--output-extra-convergence-info))",
+                                getPhaseName);
+            }
         }
     }
 


### PR DESCRIPTION
For dry runs, skip the call to convergence output.