### PR TITLE
Remove virtual/override pattern in recycleFirstIterationStorage

### DIFF
--- a/opm/models/discretization/common/fvbaseproblem.hh
+++ b/opm/models/discretization/common/fvbaseproblem.hh
@@ -189,7 +189,7 @@ public:
      * This is only relevant if the storage cache is enabled and is usually the case,
      * i.e., this method only needs to be overwritten in rare corner cases.
      */
-    virtual bool recycleFirstIterationStorage() const
+    bool recycleFirstIterationStorage() const
     { return true; }
 
     /*!
@@ -201,7 +201,7 @@ public:
      */
      unsigned intensiveQuantityHistorySize() const
      {
-         if (Parameters::Get<Parameters::EnableStorageCache>() && recycleFirstIterationStorage()) {
+         if (Parameters::Get<Parameters::EnableStorageCache>() && asImp_().recycleFirstIterationStorage()) {
              return 1;
          }
          return 2;

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -875,7 +875,7 @@ public:
      * or DRVDT are active. Nor if the porosity is changes between timesteps
      * using a pore volume multiplier (i.e., poreVolumeMultiplier() != 1.0)
      */
-    bool recycleFirstIterationStorage() const override
+    bool recycleFirstIterationStorage() const
     {
         int episodeIdx = this->episodeIndex();
         return !this->mixControls_.drsdtActive(episodeIdx) &&


### PR DESCRIPTION
Follow up from https://github.com/OPM/opm-simulators/pull/6357 to quell compiler complaints about no virtual destructor. It now follows the curiously recurring template pattern (`asImp_`) as used other places.