### PR TITLE
Add End-of-Episode Predicate to Flow Problem Classes

### DIFF
--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -473,10 +473,11 @@ public:
     virtual void writeOutput(bool verbose)
     {
         OPM_TIMEBLOCK(problemWriteOutput);
-        // use the generic code to prepare the output fields and to
-        // write the desired VTK files.
+
         if (Parameters::Get<Parameters::EnableWriteAllSolutions>() ||
-            this->simulator().episodeWillBeOver()) {
+            this->episodeWillBeOver())
+        {
+            // Create VTK output as needed.
             ParentType::writeOutput(verbose);
         }
     }
@@ -1719,6 +1720,13 @@ protected:
     BCData<int> bcindex_;
     bool nonTrivialBoundaryConditions_ = false;
     bool first_step_ = true;
+
+    /// Whether or not the current episode will end at the end of the
+    /// current time step.
+    virtual bool episodeWillBeOver() const
+    {
+        return this->simulator().episodeWillBeOver();
+    }
 };
 
 } // namespace Opm


### PR DESCRIPTION
This is arguably a hack.  The default implementation in terms of [`Simulator<>::episodeWillBeOver()`](https://github.com/OPM/opm-simulators/blob/cb049fcd657b48a47508db1a708b1c65f31204ac/opm/models/utils/simulator.hh#L555) is known to have non-trivial false negatives in certain regression tests.  These are in turn possibly related to using the simulation start time point (often a large number of seconds) and subtracting values of similar size.  The custom implementation in `FlowProblemBlackoil<>` uses a floating-point comparison involving `Schedule::seconds()` instead, thereby reducing the size of the numbers involved.  We're still vulnerable to "catastrophic cancellation" errors, but potentially less so.

A complete fix for the problem may involve switching to representing the simulated time variable as an integer instead of a floating-point type.