### PR TITLE
Add in satellite production in reduction rates

### DIFF
--- a/opm/simulators/wells/FractionCalculator.cpp
+++ b/opm/simulators/wells/FractionCalculator.cpp
@@ -94,6 +94,11 @@ localFraction(const std::string& name,
         always_use_potentials = true;
         const Scalar my_pot = guideRate(name, always_included_child, always_use_potentials);
         const Scalar my_total_pot = guideRateSum(parent_group, always_included_child, always_use_potentials).first;
+        // if there are no wells on group-control, potential will still be zero
+        if (my_total_pot == 0) {
+            return 1.0;
+        }
+
         return my_pot / my_total_pot;
     }
     return my_guide_rate / total_guide_rate;


### PR DESCRIPTION
I guess satellite groups are only partly supported, but currently satellite production is only added into parent group production rates, and do not get added into reduction rates (so available rates for group control will be too high). This PR is just a simple fix, if prioritized at a later stage, we might want to reformulate this treatment (see comment in code) 

**Also**: guard against division by zero in fraction calculator (which may happen if no wells are on group-control)