### PR TITLE
Pick up infinite bhp in addition to nan

### DIFF
--- a/opm/simulators/wells/VFPHelpers.cpp
+++ b/opm/simulators/wells/VFPHelpers.cpp
@@ -369,8 +369,8 @@ findTHP(const std::vector<Scalar>& bhp_array,
 {
     int nthp = thp_array.size();
 
-    if (std::isnan(bhp)) {
-        throw NumericalProblem("findTHP: Error bhp is nan");
+    if (!std::isfinite(bhp)) {
+        throw NumericalProblem("findTHP: Error bhp is not finite");
     }
     Scalar thp = -1e100;
 


### PR DESCRIPTION
Reason: We still sometimes fail on the 'found == true' assertion (https://github.com/OPM/opm-simulators/blob/813de38be50a721b81250e01103a045ea25ed5f9/opm/simulators/wells/VFPHelpers.cpp#L425)