### PR TITLE
Update well event in wellState after pyaction

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1811,9 +1811,11 @@ updateWellPotentials(const int reportStepIdx,
                                              + ScheduleEvents::NEW_WELL
                                              + ScheduleEvents::PRODUCTION_UPDATE
                                              + ScheduleEvents::INJECTION_UPDATE;
-        const auto& events = schedule()[reportStepIdx].wellgroup_events();
-        const bool event = events.hasEvent(well->name(), ScheduleEvents::ACTIONX_WELL_EVENT) ||
-                           (report_step_starts_ && events.hasEvent(well->name(), effective_events_mask));
+        const auto& eventsSchedule = schedule()[reportStepIdx].wellgroup_events();
+        const auto& eventsWell = this->wellState().well(well->indexOfWell()).events;
+        const bool event = eventsSchedule.hasEvent(well->name(), ScheduleEvents::ACTIONX_WELL_EVENT) ||
+                           (report_step_starts_ && eventsSchedule.hasEvent(well->name(), effective_events_mask)) ||
+                           eventsWell.hasEvent(effective_events_mask);
         const bool needPotentialsForGuideRates = well->underPredictionMode() && (!onlyAfterEvent || event);
         const bool needPotentialsForOutput = !onlyAfterEvent && (needed_for_summary || write_restart_file);
         const bool compute_potential = needPotentialsForOutput || needPotentialsForGuideRates;

--- a/opm/simulators/wells/BlackoilWellModelGuideRates.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGuideRates.cpp
@@ -595,16 +595,16 @@ guideRateUpdateIsNeeded(const int reportStepIdx) const
         return well->changedToOpenThisStep();
     });
     if (!need_update && wellModel_.reportStepStarts()) {
-        const auto& events = wellModel_.schedule()[reportStepIdx].wellgroup_events();
         constexpr auto effective_events_mask = ScheduleEvents::WELL_STATUS_CHANGE
             + ScheduleEvents::INJECTION_TYPE_CHANGED
             + ScheduleEvents::WELL_SWITCHED_INJECTOR_PRODUCER
             + ScheduleEvents::NEW_WELL;
-
+        const auto& wellState = wellModel_.wellState();
         need_update = std::any_of(genWells.begin(), genWells.end(),
-            [&events](const WellInterfaceGeneric<Scalar>* well)
+            [wellState](const WellInterfaceGeneric<Scalar>* well)
         {
-            return events.hasEvent(well->name(), effective_events_mask);
+            const auto& events = wellState.well(well->name()).events;
+            return events.hasEvent(effective_events_mask);
         });
     }
     return wellModel_.comm().max(static_cast<int>(need_update));

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -509,11 +509,10 @@ namespace Opm {
                         + ScheduleEvents::WELL_SWITCHED_INJECTOR_PRODUCER
                         + ScheduleEvents::NEW_WELL;
 
-                const auto& events = this->schedule()[reportStepIdx].wellgroup_events();
-                const bool event = this->report_step_starts_ && events.hasEvent(well->name(), effective_events_mask);
+                const auto& events = this->wellState().well(well->indexOfWell()).events;
+                const bool event = this->report_step_starts_ && events.hasEvent(effective_events_mask);
                 const bool dyn_status_change = this->wellState().well(well->name()).status
                         != this->prevWellState().well(well->name()).status;
-
                 if (event || dyn_status_change) {
                     try {
                         well->updateWellStateWithTarget(simulator_, this->groupState(), this->wellState(), local_deferredLogger);

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -121,6 +121,9 @@ void SingleWellState<Scalar>::open()
 template<class Scalar>
 void SingleWellState<Scalar>::updateStatus(Well::Status new_status)
 {
+    if (new_status != this->status) {
+        this->events.addEvent(ScheduleEvents::WELL_STATUS_CHANGE);
+    }
     switch (new_status) {
     case Well::Status::OPEN:
         this->open();

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -391,6 +391,11 @@ void WellState<Scalar>::init(const std::vector<Scalar>& cellPressures,
             auto& new_well = this->well(w);
             new_well.init_timestep(prev_well);
 
+            // PYACTION and ACTIONX may have opened a well. We notify the
+            // simulator by adding a well event.
+            if ( prev_well.events.hasEvent(ScheduleEvents::WELL_STATUS_CHANGE))
+                new_well.events.addEvent(ScheduleEvents::WELL_STATUS_CHANGE);
+
             if (prev_well.status == Well::Status::SHUT) {
                 // Well was shut in previous state, do not use its values.
                 continue;


### PR DESCRIPTION
We will need potentials and guide rate as well as good initial conditions for wells open using PyAction. 