### PR TITLE
Added --expt-relaxed-constexpr to test_gpuBlackOilFluidSystem

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -535,6 +535,7 @@ if (HAVE_CUDA)
       tests/gpuistl/test_gpu_ad.cu
       tests/gpuistl/test_gpu_linear_two_phase_material.cu
       tests/gpuistl/test_gpuPvt.cu
+      tests/gpuistl/test_gpuBlackOilFluidSystem
     )
 
     foreach(file ${CU_FILES_NEEDING_RELAXED_CONSTEXPR})


### PR DESCRIPTION
To avoid a warning, we need to add `--expt-relaxed-constexpr` when compiling `test_gpuBlackOilFluidSystem`.