### PR TITLE
check the alternative_well_rate_init flag also for welltesting

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -568,7 +568,7 @@ namespace Opm {
             well->setGuideRate(&this->guideRate_);
 
             // initialize rates/previous rates to prevent zero fractions in vfp-interpolation
-            if (well->isProducer()) {
+            if (well->isProducer() && alternative_well_rate_init_) {
                 well->initializeProducerWellState(simulator_, this->wellState(), deferred_logger);
             }
             if (well->isVFPActive(deferred_logger)) {


### PR DESCRIPTION
For some models the alternative well initialization code does not work very well. Make it possible to also not use it during well testing. Since it is by default true this does not affect the results at all. 