### PR TITLE
remove unused lambda capture

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -231,7 +231,7 @@ template<class Scalar> class WellContributions;
 
                 this->assignWellTargets(wsrpt);
 
-                this->assignDynamicWellStatus(wsrpt, this->reportStepIndex());
+                this->assignDynamicWellStatus(wsrpt);
 
                 // Assigning (a subset of the) property values in shut
                 // connections should be the last step of wellData().

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1125,10 +1125,9 @@ assignInjectionWellTargets(const Well& well, data::WellControlLimits& limits) co
 
 template<class Scalar>
 void BlackoilWellModelGeneric<Scalar>::
-assignDynamicWellStatus(data::Wells& wsrpt,
-                        const int reportStepIndex) const
+assignDynamicWellStatus(data::Wells& wsrpt) const
 {
-    this->loopOwnedWells([this, reportStepIndex, &wsrpt]
+    this->loopOwnedWells([this, &wsrpt]
                          (const auto wellID,
                           const Well& well)
     {

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -395,10 +395,7 @@ protected:
     ///
     /// \param[in,out] wsrpt Well solution object.  On exit, holds current
     /// values for \code data::Well::dynamicStatus \endcode.
-    ///
-    /// \param[in] reportStepIdx Zero-based index of current report step.
-    void assignDynamicWellStatus(data::Wells& wsrpt,
-                                 const int reportStepIdx) const;
+    void assignDynamicWellStatus(data::Wells& wsrpt) const;
 
     /// Assign basic result quantities for shut connections of wells owned
     /// by current rank.


### PR DESCRIPTION
this renders reportStepIndex unused, so remove it from interface.

Quells a clang warning