### PR TITLE
fixed: argument order differ in prototype and implementation

### DIFF
--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -216,8 +216,8 @@ public:
     /// \brief Compute the number of Newtons required by each cell in order to
     /// satisfy the solution change convergence criteria at the last time step.
     void convergencePerCell(const std::vector<Scalar>& B_avg,
-                            const double tol_cnv,
                             const double dt,
+                            const double tol_cnv,
                             const double tol_cnv_energy,
                             const int iteration);
 

--- a/opm/simulators/flow/LogOutputHelper.hpp
+++ b/opm/simulators/flow/LogOutputHelper.hpp
@@ -99,7 +99,7 @@ public:
 private:
     struct ConnData
     {
-        ConnData(const Connection& conn);
+        explicit ConnData(const Connection& conn);
 
         int I, J, K;
         std::vector<Scalar> data;


### PR DESCRIPTION
And quell another SCA warning