### PR TITLE
WIP Log all actions

### DIFF
--- a/opm/simulators/flow/ActionHandler.cpp
+++ b/opm/simulators/flow/ActionHandler.cpp
@@ -211,7 +211,7 @@ applyActions(const int reportStep,
                                                 ecl_state_, summaryState_, wellpi);
 
         if (const auto pyRes = this->actionState_.python_result(pyaction->name());
-            !pyRes.has_value() || !*pyRes)
+            !pyRes.has_value())
         {
             logInactivePyAction(pyaction->name(), ts);
             continue;


### PR DESCRIPTION
While debugging some pyaction cases, I noticed that *pyRes returns false even if a pyaction is triggered. The `continue` results in the sim_state not being updated correctly (in addition to wrong output to the log). I tried to dig a bit deeper into why *pyRes was false in these cases, but didn't quite understand the logic. This can be reproduced with 
pyaction/PYACTION_GCONPROD_INSERT_KW.DATA. 

Any hint? @bska or @hakonhagland 
