### PR TITLE
keep privious well controls if not hist->pred or inj<->prod

### DIFF
--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -402,8 +402,10 @@ void WellState<Scalar>::init(const std::vector<Scalar>& cellPressures,
                 continue;
             }
 
-            // If new target is set using WCONPROD, WCONINJE etc. we use the new control
-            if (!new_well.events.hasEvent(WellState::event_mask)) {
+            // If we move from historical mode to prediction mode or from injector to producer
+            // we dont want to use the privious controls
+            if (!new_well.events.hasEvent(ScheduleEvents::HIST_TO_PRED) &&
+                !new_well.events.hasEvent(ScheduleEvents::WELL_SWITCHED_INJECTOR_PRODUCER)) {
                 new_well.injection_cmode = prev_well.injection_cmode;
                 new_well.production_cmode = prev_well.production_cmode;
             }


### PR DESCRIPTION
Sometimes, the user may change limits using WCONPROD, etc., without the intention of changing the controls. With this, we let the updateWellControl method decide whether to change controls. 

Depends on https://github.com/OPM/opm-common/pull/4696