### PR TITLE
update well controls for new wells

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -515,6 +515,9 @@ namespace Opm {
                         != this->prevWellState().well(well->name()).status;
 
                 if (event || dyn_status_change) {
+                    // We first constrain the solution on the targets
+                    const auto mode = WellInterface<TypeTag>::IndividualOrGroup::Both;
+                    well->updateWellControl(simulator_, mode, this->wellState(), this->groupState(), local_deferredLogger);
                     try {
                         well->updateWellStateWithTarget(simulator_, this->groupState(), this->wellState(), local_deferredLogger);
                         well->calculateExplicitQuantities(simulator_, this->wellState(), local_deferredLogger);


### PR DESCRIPTION
The initial rates may be very large when calling update well controls first; they are limited to their maximum. 