### PR TITLE
Fixed indexing in control-error filtering

### DIFF
--- a/opm/simulators/timestepping/TimeStepControl.cpp
+++ b/opm/simulators/timestepping/TimeStepControl.cpp
@@ -413,8 +413,8 @@ namespace Opm
         }
         else if (toleranceTestVersion_ == ToleranceTestVersions::ControlErrorFiltering)
         {
-            const std::array<double, 3> tempErrors{errors_[0], errors_[1], error};
-            const std::array<double, 3> tempTimeSteps{timeSteps_[0], timeSteps_[1], timeStepJustCompleted};
+            const std::array<double, 3> tempErrors{errors_[1], errors_[2], error};
+            const std::array<double, 3> tempTimeSteps{timeSteps_[1], timeSteps_[2], timeStepJustCompleted};
             const double stepFactor = timeStepFactor(tempErrors, tempTimeSteps);
             if (rejectCompletedStep_ && stepFactor < maxReductionTimeStep_)
             {


### PR DESCRIPTION
I just realised that I made an indexing error in the control-error-filtering option (for the general-3rd-order controller) which can be used to test whether a completed time step should be rejected or not. The indexing should be correct now.