### PR TITLE
Make for-loop for properties use OMP also in the new implementation.

### DIFF
--- a/opm/simulators/flow/FIBlackoilModel.hpp
+++ b/opm/simulators/flow/FIBlackoilModel.hpp
@@ -254,6 +254,9 @@ protected:
     void updateCachedIntQuantsLoop(const unsigned timeIdx) const
     {
         const auto& elementMapper = this->simulator_.model().elementMapper();
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
         for (const auto& chunk : element_chunks_) {
             for (const auto& elem : chunk) {
                 this->template updateSingleCachedIntQuantUnchecked<Args...>(elementMapper.index(elem), timeIdx);


### PR DESCRIPTION
This was unfortunately forgotten in the work of https://github.com/OPM/opm-simulators/pull/6367

So since that was merged (earlier today), you might see a slowdown for multi-threaded runs, but should be restored (resulting in overall speed improvement) with this PR.