### PR TITLE
Distributed wells: density

### DIFF
--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -321,6 +321,7 @@ namespace Opm
                                            std::vector<Scalar>& well_potentials,
                                            DeferredLogger& deferred_logger) const;               
 
+        // communicate and return the density at the perforation[0] of the rank owning this well
         Scalar getRefDensity() const override;
 
         // get the mobility for specific perforation

--- a/opm/simulators/wells/StandardWellConnections.hpp
+++ b/opm/simulators/wells/StandardWellConnections.hpp
@@ -84,12 +84,6 @@ public:
                            const Properties&               props,
                            DeferredLogger&                 deferred_logger);
 
-    //! \brief Returns density for first perforation.
-    Scalar rho() const
-    {
-        return this->rho(0);
-    }
-
     //! \brief Returns density for specific perforation/connection.
     //!
     //! \param[in] i Connection index

--- a/opm/simulators/wells/StandardWellEval.cpp
+++ b/opm/simulators/wells/StandardWellEval.cpp
@@ -70,21 +70,6 @@ extendEval(const Eval& in) const
 template<class FluidSystem, class Indices>
 void
 StandardWellEval<FluidSystem,Indices>::
-updateWellStateFromPrimaryVariables(WellState<Scalar, IndexTraits>& well_state,
-                                    const SummaryState& summary_state,
-                                    DeferredLogger& deferred_logger) const
-{
-    this->primary_variables_.copyToWellState(well_state, deferred_logger);
-
-    WellBhpThpCalculator(baseif_).
-            updateThp(connections_.rho(),
-                      [this,&well_state]() { return this->baseif_.getALQ(well_state); },
-                      well_state, summary_state, deferred_logger);
-}
-
-template<class FluidSystem, class Indices>
-void
-StandardWellEval<FluidSystem,Indices>::
 computeAccumWell()
 {
     for (std::size_t eq_idx = 0; eq_idx < F0_.size(); ++eq_idx) {

--- a/opm/simulators/wells/StandardWellEval.hpp
+++ b/opm/simulators/wells/StandardWellEval.hpp
@@ -92,10 +92,6 @@ protected:
               const std::vector<Scalar>& depth_arg,
               const bool has_polymermw);
 
-    void updateWellStateFromPrimaryVariables(WellState<Scalar, IndexTraits>& well_state,
-                                             const SummaryState& summary_state,
-                                             DeferredLogger& deferred_logger) const;
-
     PrimaryVariables primary_variables_; //!< Primary variables for well
 
     // the saturations in the well bore under surface conditions at the beginning of the time step


### PR DESCRIPTION
The density is tied to a perforation, which makes it rank-specific and it is thus a potential risk for distributed wells. After all, this PR is a result of tracing a deadlock.

To solve the issue, the function `getRefDensity` now uses the well-owner's perforation (index 0) instead of each rank using its own. Unfortunately, `getRefDensity` now communicates.

Furthermore, this PR includes the removal of the function `rho()` that gives an illusion that it does not depend on the perforation. Calling `rho(size_t)` with specified perforation remained untouched.

Finally, the method `updateWellStateFromPrimaryVariables` in `StandardWellEval` was using `rho()` but did not have access to `getRefDensity` or the well's communicator. It seems that method was used only once in the `opm-simulators`, so I just moved its innards to that place (where `getRefDensity` is available) and removed the method.

There is one edge-case that remains unresolved, although I am unsure if can even happen. `getRefDensity` is using owner's perforation, so we assume that the owning rank has at least one perforation. Currently it is possible for non-owning ranks to have no perforations (probably a bug) and I put an assert in place to check if it happens.