### PR TITLE
Fix python setup.py warnings

### DIFF
--- a/python/docker/scripts/generate-pypi-package.sh
+++ b/python/docker/scripts/generate-pypi-package.sh
@@ -8,6 +8,10 @@
 #
 set -e
 
+# Silence pip's root-user warning inside manylinux build containers. This is a
+# controlled, ephemeral environment and we intentionally run as root.
+export PIP_ROOT_USER_ACTION=ignore
+
 VERSION_COMMON=${1:-"master"}
 VERSION_GRID=${2:-"master"}
 VERSION_SIMULATORS=${3:-"master"}
@@ -85,7 +89,10 @@ fi
 for python_bin in ${python_versions[*]}
 do
   ${python_bin} -m pip install pip --upgrade
-  ${python_bin} -m pip install wheel setuptools twine pytest-runner auditwheel scikit-build cmake numpy
+  # NOTE (2025-09-12): Removed pytest-runner; we no longer use setup_requires
+  # and do not need it at build time. Keep the minimal toolchain for wheel
+  # building and auditwheel repair.
+  ${python_bin} -m pip install wheel setuptools twine auditwheel scikit-build cmake numpy
 done
 
 DIR=`pwd`

--- a/python/docker/scripts/generate-pypi-package.sh
+++ b/python/docker/scripts/generate-pypi-package.sh
@@ -142,7 +142,14 @@ do
 
     # Package opm-common bindings
     cd opm-common/python
-    ${python_versions[$tag]} setup.py sdist bdist_wheel --plat-name $MANYLINUX_PLATFORM --python-tag $tag
+    # NOTE (2025-09-12): Switch to the modern PEP 517 build frontend.
+    # - Avoids setuptools deprecation warnings from direct setup.py usage.
+    # - Uses isolated builds honoring pyproject.toml build-system requires.
+    # - We intentionally drop --plat-name/--python-tag; environment tags and
+    #   auditwheel will set/normalize these appropriately.
+    # Ensure the 'build' frontend is available for this interpreter.
+    ${python_versions[$tag]} -m pip -q install --upgrade build
+    ${python_versions[$tag]} -m build --sdist --wheel
 
     # Set LD_LIBRARY_PATH so auditwheel can find and bundle OPM libraries, important when using shared==1
     export LD_LIBRARY_PATH="${PWD}/../lib:${PWD}/../../opm-grid/lib:${PWD}/../../opm-simulators/lib:$LD_LIBRARY_PATH"
@@ -152,7 +159,8 @@ do
 
     # Package opm-simulators bindings
     cd opm-simulators/python
-    ${python_versions[$tag]} setup.py sdist bdist_wheel --plat-name $MANYLINUX_PLATFORM --python-tag $tag
+    # (build already installed for this interpreter above)
+    ${python_versions[$tag]} -m build --sdist --wheel
 
     # Set LD_LIBRARY_PATH so auditwheel can find and bundle OPM libraries, important when using shared==1
     export LD_LIBRARY_PATH="${PWD}/../lib:${PWD}/../../opm-common/lib:${PWD}/../../opm-grid/lib:$LD_LIBRARY_PATH"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,11 +1,14 @@
 [build-system]
+# NOTE: Setuptools >=61 fully supports pyproject-based builds and is the common
+# floor for projects that may later adopt PEP 621 metadata. Keeping scikit-build
+# classic for now; full migration is tracked in the TODO below.
 requires= [
-  "setuptools>=42",
+  "setuptools>=61",
   "scikit-build>=0.13",
   "cmake>=3.15",
   "ninja"
 ]
-# NOTE (2025-09-12): Explicitly declare the backend used by `python -m build`.
+# Used by `python -m build` (PEP 517).
 build-backend = "setuptools.build_meta"
 
 # TODO (modernization): Consider migrating to scikit-build-core and PEP 621.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,3 +5,11 @@ requires= [
   "cmake>=3.15",
   "ninja"
 ]
+# NOTE (2025-09-12): Explicitly declare the backend used by `python -m build`.
+build-backend = "setuptools.build_meta"
+
+# TODO (modernization): Consider migrating to scikit-build-core and PEP 621.
+# - Move metadata to a [project] table (name, version, description, authors,
+#   license-expression), drop setup.py.in, and configure builds under
+#   [tool.scikit-build] or [tool.scikit-build-core]. This would further reduce
+#   legacy behavior and simplify the build.

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -35,11 +35,13 @@ setup(
             ],
     package_data={'opm' : ['$<TARGET_FILE_NAME:simulators>']},
     include_package_data=True,
-    license='Open Source',
+    # SPDX license expression to replace deprecated license classifier usage.
+    license='GPL-3.0-or-later',
     install_requires=requires,
     python_requires='>=3.8',
+    # NOTE (2025-09-12): Remove deprecated license classifier in favor of
+    # SPDX license expression above. Keep non-license classifiers only.
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     ],
 )

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -14,6 +14,12 @@ with open("README.md", "r") as fh:
 with open("requirements.txt", "r") as fh:
     requires = [line.rstrip() for line in fh]
 
+# NOTE (2025-09-12): Removed legacy `setup_requires` and `test_suite` arguments.
+# - `setup_requires` triggers setuptools' deprecated fetch_build_eggs path
+#   (_DeprecatedInstaller). We build via PEP 517 (see pyproject.toml with
+#   scikit-build), so build-time deps must be declared there instead.
+# - `test_suite` is not a supported distribution option and produced
+#   "Unknown distribution option: 'test_suite'" warnings.
 setup(
     name='opm-simulators',
     version = '@opm-simulators_VERSION@' + '@opm-simulators_PYTHON_PACKAGE_VERSION@',
@@ -30,8 +36,6 @@ setup(
     package_data={'opm' : ['$<TARGET_FILE_NAME:simulators>']},
     include_package_data=True,
     license='Open Source',
-    test_suite='tests',
-    setup_requires=["pytest-runner", 'setuptools_scm'],
     install_requires=requires,
     python_requires='>=3.8',
     classifiers=[


### PR DESCRIPTION
From private communication with @akva2: When building the python modules in the docker container (see [python/docker](https://github.com/OPM/opm-simulators/tree/master/python/docker)) some warnings were shown when running `python setup.py`, see [generate-pypi-package.sh](https://github.com/OPM/opm-simulators/blob/00e9b6b276e0f5d0f9e4cdf619987a327c40294c/python/docker/scripts/generate-pypi-package.sh#L145). Try to modernize to use [pypa/build](https://build.pypa.io/en/stable/) instead to get rid of warnings, see also companion PR https://github.com/OPM/opm-common/pull/4732

Example warning:
```
#16 959.8 /opt/python/cp312-cp312/lib/python3.12/site-packages/setuptools/_distutils/cmd.py:90: SetuptoolsDeprecationWarning: setup.py install is deprecated.
#16 959.8 !!
#16 959.8 
#16 959.8         ********************************************************************************
#16 959.8         Please avoid running ``setup.py`` directly.
#16 959.8         Instead, use pypa/build, pypa/installer or other
#16 959.8         standards-based tools.
#16 959.8 
#16 959.8         By 2025-Oct-31, you need to update your project and remove deprecated calls
#16 959.8         or your builds will no longer be supported.
#16 959.8 
#16 959.8         See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
#16 959.8         ********************************************************************************
#16 959.8 
#16 959.8 !!

```