### PR TITLE
Dont include temporary stopped wells among the wells considered for group control

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1317,7 +1317,15 @@ updateAndCommunicateGroupData(const int reportStepIdx,
 
     // This builds some necessary lookup structures, so it must be called
     // before we copy to well_state_nupcol_.
-    this->wellState().updateGlobalIsGrup(comm_);
+    // Wells may be temporarily stopped due to convergence or operability issues
+    // during local well solves. Temporarily stopped wells do not contribute
+    // to groups and are therefore not considered in the group target calculations.
+    std::vector<WellStatus> well_status(this->numLocalWells(), WellStatus::SHUT);
+    for (const auto& well : well_container_generic_) {
+        well_status[well->indexOfWell()] = well->wellStatus();
+    }
+
+    this->wellState().updateGlobalIsGrup(comm_, well_status);
 
     if (iterationIdx < nupcol) {
         OPM_TIMEBLOCK(updateNupcol);

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -365,10 +365,7 @@ namespace Opm {
         this->resetWGState();
 
         const int reportStepIdx = simulator_.episodeIndex();
-        this->updateAndCommunicateGroupData(reportStepIdx,
-                                            simulator_.model().newtonMethod().numIterations(),
-                                            param_.nupcol_group_rate_tolerance_, /*update_wellgrouptarget*/ false,
-                                            local_deferredLogger);
+
 
         this->wellState().updateWellsDefaultALQ(this->schedule(), reportStepIdx, this->summaryState());
         this->wellState().gliftTimeStepInit();
@@ -381,6 +378,13 @@ namespace Opm {
 
             // create the well container
             createWellContainer(reportStepIdx);
+
+            // we need to update the group data after the well is created
+            // to make sure we get the correct mapping.
+            this->updateAndCommunicateGroupData(reportStepIdx,
+                                    simulator_.model().newtonMethod().numIterations(),
+                                    param_.nupcol_group_rate_tolerance_, /*update_wellgrouptarget*/ false,
+                                    local_deferredLogger);
 
             // Wells are active if they are active wells on at least one process.
             const Grid& grid = simulator_.vanguard().grid();

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -119,6 +119,7 @@ public:
 
     void stopWell() { this->wellStatus_ = Well::Status::STOP; }
     void openWell() { this->wellStatus_ = Well::Status::OPEN; }
+    Well::Status wellStatus() { return this->wellStatus_;}
 
     bool wellIsStopped() const { return this->wellStatus_ == Well::Status::STOP; }
 

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -1021,16 +1021,19 @@ void WellState<Scalar, IndexTraits>::communicateGroupRates(const Parallel::Commu
 }
 
 template<typename Scalar, typename IndexTraits>
-void WellState<Scalar, IndexTraits>::updateGlobalIsGrup(const Parallel::Communication& comm)
+void WellState<Scalar, IndexTraits>::updateGlobalIsGrup(const Parallel::Communication& comm,  const std::vector<WellStatus>& well_status)
 {
     this->global_well_info.value().clear();
     for (std::size_t well_index = 0; well_index < this->size(); well_index++) {
         const auto& ws = this->well(well_index);
+        // We cannot use the well status directly from the well state here as well, may
+        // be temporarily stopped due to convergence or operability issues
+        const auto& this_well_status = well_status[well_index];
         this->global_well_info.value().update_efficiency_scaling_factor(well_index, ws.efficiency_scaling_factor);
         if (ws.producer)
-            this->global_well_info.value().update_producer(well_index, ws.status, ws.production_cmode);
+            this->global_well_info.value().update_producer(well_index, this_well_status, ws.production_cmode);
         else
-            this->global_well_info.value().update_injector(well_index, ws.status, ws.injection_cmode);
+            this->global_well_info.value().update_injector(well_index, this_well_status, ws.injection_cmode);
     }
     this->global_well_info.value().communicate(comm);
 }

--- a/opm/simulators/wells/WellState.hpp
+++ b/opm/simulators/wells/WellState.hpp
@@ -179,7 +179,8 @@ public:
 
     void communicateGroupRates(const Parallel::Communication& comm);
 
-    void updateGlobalIsGrup(const Parallel::Communication& comm);
+    void updateGlobalIsGrup(const Parallel::Communication& comm,
+                            const std::vector<WellStatus>& well_status);
     void updateEfficiencyScalingFactor(const std::string& wellName,
                                        const Scalar value);
 


### PR DESCRIPTION
Wells may be temporarily stopped due to convergence or operability issues during local well solves. Temporarily stopped wells do not contribute to groups and are therefore not considered in the group target calculations.