### PR TITLE
Extract loop invariant in matrix assembly

### DIFF
--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -735,7 +735,7 @@ private:
         const unsigned int numCells = domain.cells.size();
         const bool on_full_domain = (numCells == model_().numTotalDof());
 
-        // Accumulation term independent of cell
+        // Fetch timestepsize used later in accumulation term.
         const double dt = simulator_().timeStepSize();
 
 #ifdef _OPENMP


### PR DESCRIPTION
The compiler probably notices this case of [hoisting](https://en.wikipedia.org/wiki/Loop-invariant_code_motion), but caught a loop-invariant being fetched each iteration from the simulator object within the linearizer. A second benefit is also to avoid use of the simulator object in code that we want to GPU-parallelize.