### PR TITLE
Fix MPI parallel ISTLSolverGPUISTL and register parallel GPU preconditioners

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -366,7 +366,8 @@ if (HAVE_CUDA)
   ADD_CUDA_OR_HIP_FILE(PUBLIC_HEADER_FILES opm/simulators/linalg hypreinterface/HypreSetup.hpp)
   ADD_CUDA_OR_HIP_FILE(PUBLIC_HEADER_FILES opm/simulators/linalg hypreinterface/HypreUtils.hpp)
   ADD_CUDA_OR_HIP_FILE(PUBLIC_HEADER_FILES opm/simulators/linalg PinnedMemoryHolder.hpp)
- 
+  ADD_CUDA_OR_HIP_FILE(PUBLIC_HEADER_FILES opm/simulators/linalg detail/gpu_preconditioner_utils.hpp)
+
   if(MPI_FOUND)
     ADD_CUDA_OR_HIP_FILE(PUBLIC_HEADER_FILES opm/simulators/linalg GpuOwnerOverlapCopy.hpp)
     ADD_CUDA_OR_HIP_FILE(PUBLIC_HEADER_FILES opm/simulators/linalg GpuSender.hpp)

--- a/opm/simulators/linalg/StandardPreconditioners_gpu_mpi.hpp
+++ b/opm/simulators/linalg/StandardPreconditioners_gpu_mpi.hpp
@@ -17,17 +17,87 @@
 #ifndef OPM_STANDARDPRECONDITIONERS_GPU_MPI_HEADER
 #define OPM_STANDARDPRECONDITIONERS_GPU_MPI_HEADER
 
+#include <dune/istl/bcrsmatrix.hh>
+#include <string>
+
+#include <opm/simulators/linalg/PreconditionerFactory.hpp>
+#include <opm/simulators/linalg/PropertyTree.hpp>
+#include <opm/simulators/linalg/is_gpu_operator.hpp>
+
+#if HAVE_CUDA
+#include <opm/simulators/linalg/gpuistl/GpuDILU.hpp>
+#include <opm/simulators/linalg/gpuistl/GpuSeqILU0.hpp>
+#include <opm/simulators/linalg/gpuistl/GpuJac.hpp>
+#include <opm/simulators/linalg/gpuistl/OpmGpuILU0.hpp>
+#include <opm/simulators/linalg/gpuistl/GpuBlockPreconditioner.hpp>
+#include <opm/simulators/linalg/gpuistl/detail/gpu_preconditioner_utils.hpp>
+#endif
 
 namespace Opm {
 
-
 template <class Operator, class Comm>
-struct StandardPreconditioners<Operator, Comm, typename std::enable_if_t<Opm::is_gpu_operator_v<Operator>>> 
+struct StandardPreconditioners<Operator, Comm, typename std::enable_if_t<Opm::is_gpu_operator_v<Operator>>>
 {
+    using O = Operator;
+    using C = Comm;
+    using F = PreconditionerFactory<O, C>;
+    using M = typename F::Matrix;
+    using V = typename F::Vector;
+    using P = PropertyTree;
+    using PrecPtr = typename F::PrecPtr;
+
+    using field_type = typename V::field_type;
+
+    static constexpr int maxblocksize = 6;
+
     static void add()
     {
-        // No standard preconditioners for this type of operator.
+#if HAVE_CUDA
+        F::addCreator("ilu0", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
+            const double w = prm.get<double>("relaxation", 1.0);
+            using GpuILU0 = typename gpuistl::GpuSeqILU0<M, V, V>;
+            auto gpuPrec = std::make_shared<GpuILU0>(op.getmat(), w);
+            return std::make_shared<gpuistl::GpuBlockPreconditioner<V, V, C>>(gpuPrec, comm);
+        });
+
+        F::addCreator("jac", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
+            const double w = prm.get<double>("relaxation", 1.0);
+            using GpuJac = typename gpuistl::GpuJac<M, V, V>;
+            auto gpuPrec = std::make_shared<GpuJac>(op.getmat(), w);
+            return std::make_shared<gpuistl::GpuBlockPreconditioner<V, V, C>>(gpuPrec, comm);
+        });
+
+        F::addCreator("dilu", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t, const C& comm) -> PrecPtr {
+            return op.getmat().dispatchOnBlocksize([&](auto blockSizeVal) -> PrecPtr {
+                constexpr int blockSize = decltype(blockSizeVal)::value;
+                const auto cpuMatrix = gpuistl::detail::makeCPUMatrix<O, Dune::FieldMatrix<field_type, blockSize, blockSize>>(op);
+                const bool split_matrix = prm.get<bool>("split_matrix", true);
+                const bool tune_gpu_kernels = prm.get<bool>("tune_gpu_kernels", true);
+                const int mixed_precision_scheme = prm.get<int>("mixed_precision_scheme", 0);
+                const bool reorder = prm.get<bool>("reorder", true);
+                using CPUMatrixType = std::remove_const_t<std::remove_reference_t<decltype(cpuMatrix)>>;
+                using GPUDILU = typename gpuistl::GpuDILU<CPUMatrixType, V, V>;
+                auto gpuPrec = std::make_shared<GPUDILU>(op.getmat(), cpuMatrix, split_matrix, tune_gpu_kernels, mixed_precision_scheme, reorder);
+                return std::make_shared<gpuistl::GpuBlockPreconditioner<V, V, C>>(gpuPrec, comm);
+            });
+        });
+
+        F::addCreator("opmilu0", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t, const C& comm) -> PrecPtr {
+            return op.getmat().dispatchOnBlocksize([&](auto blockSizeVal) -> PrecPtr {
+                constexpr int blockSize = decltype(blockSizeVal)::value;
+                const auto cpuMatrix = gpuistl::detail::makeCPUMatrix<O, Dune::FieldMatrix<field_type, blockSize, blockSize>>(op);
+                const bool split_matrix = prm.get<bool>("split_matrix", true);
+                const bool tune_gpu_kernels = prm.get<bool>("tune_gpu_kernels", true);
+                const int mixed_precision_scheme = prm.get<int>("mixed_precision_scheme", 0);
+                using CPUMatrixType = std::remove_const_t<std::remove_reference_t<decltype(cpuMatrix)>>;
+                using GPUILU0 = typename gpuistl::OpmGpuILU0<CPUMatrixType, V, V>;
+                auto gpuPrec = std::make_shared<GPUILU0>(op.getmat(), cpuMatrix, split_matrix, tune_gpu_kernels, mixed_precision_scheme);
+                return std::make_shared<gpuistl::GpuBlockPreconditioner<V, V, C>>(gpuPrec, comm);
+            });
+        });
+#endif // HAVE_CUDA
     }
+
 };
 
 

--- a/opm/simulators/linalg/StandardPreconditioners_gpu_serial.hpp
+++ b/opm/simulators/linalg/StandardPreconditioners_gpu_serial.hpp
@@ -17,9 +17,12 @@
 #ifndef OPM_STANDARDPRECONDITIONERS_GPU_SERIAL_HEADER
 #define OPM_STANDARDPRECONDITIONERS_GPU_SERIAL_HEADER
 
+#include <opm/simulators/linalg/gpuistl/detail/gpu_preconditioner_utils.hpp>
 
 #include <dune/istl/bcrsmatrix.hh>
+
 #include <type_traits>
+
 
 
 namespace Opm
@@ -64,8 +67,10 @@ struct StandardPreconditioners<Operator,
         // dispatch the creation of the preconditioner based on the block size. 
         //
         // Note that this dispatching is not needed in the future, since we will have a constructor taking GPU matrices directly.
-        F::addCreator("opmilu0", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t) {
-            return dispatchOnBlockSize<maxblocksize>(op, [&](const auto& cpuMatrix) {
+        F::addCreator("opmilu0", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t) -> PrecPtr {
+            return op.getmat().dispatchOnBlocksize([&](auto blockSizeVal) -> PrecPtr {
+                constexpr int blockSize = decltype(blockSizeVal)::value;
+                const auto cpuMatrix = gpuistl::detail::makeCPUMatrix<O, Dune::FieldMatrix<field_type, blockSize, blockSize>>(op);
                 const bool split_matrix = prm.get<bool>("split_matrix", true);
                 const bool tune_gpu_kernels = prm.get<bool>("tune_gpu_kernels", true);
                 const int mixed_precision_scheme = prm.get<int>("mixed_precision_scheme", 0);
@@ -77,8 +82,10 @@ struct StandardPreconditioners<Operator,
             });
         });
 
-        F::addCreator("dilu", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t) {
-            return dispatchOnBlockSize<maxblocksize>(op, [&](const auto& cpuMatrix) {
+        F::addCreator("dilu", [](const O& op, [[maybe_unused]] const P& prm, const std::function<V()>&, std::size_t) -> PrecPtr {
+            return op.getmat().dispatchOnBlocksize([&](auto blockSizeVal) -> PrecPtr {
+                constexpr int blockSize = decltype(blockSizeVal)::value;
+                const auto cpuMatrix = gpuistl::detail::makeCPUMatrix<O, Dune::FieldMatrix<field_type, blockSize, blockSize>>(op);
                 const bool split_matrix = prm.get<bool>("split_matrix", true);
                 const bool tune_gpu_kernels = prm.get<bool>("tune_gpu_kernels", true);
                 const int mixed_precision_scheme = prm.get<int>("mixed_precision_scheme", 0);
@@ -125,79 +132,6 @@ struct StandardPreconditioners<Operator,
     }
 
 
-private:
-
-    /**
-     * This function creates a CPU matrix from the operator holding a GPU matrix.
-     * 
-     * This is a workaround for now since some of the GPU preconditioners need a 
-     * CPU matrix for the intial setup (graph coloring). The CPU matrix is only
-     * used in the constructor, **not** in the update function or the apply function.
-     */
-    template<class BlockType>
-    static Dune::BCRSMatrix<BlockType> makeCPUMatrix(const O& op) {
-        // TODO: Make this more efficient. Maybe we can simply copy the memory areas directly?
-        //       Do note that this function is anyway going away when we have a GPU
-        //       constructor for the preconditioners, so it is not a priority.
-        const auto& gpuMatrix = op.getmat();
-
-        const auto nonZeros = gpuMatrix.getNonZeroValues().asStdVector();
-        const auto rowIndices = gpuMatrix.getRowIndices().asStdVector();
-        const auto columnIndices = gpuMatrix.getColumnIndices().asStdVector();
-
-        const auto numberOfNonZeroes = gpuMatrix.nonzeroes();
-        const auto N = gpuMatrix.N();
-
-        Dune::BCRSMatrix<BlockType> matrix(N, N, numberOfNonZeroes, Dune::BCRSMatrix<BlockType>::row_wise);
-        for (auto row = matrix.createbegin(); row != matrix.createend(); ++row) {
-
-            for (auto j = rowIndices[row.index()]; j != rowIndices[row.index() + 1]; ++j) {
-                const auto columnIndex = columnIndices[j];
-                row.insert(columnIndex);
-            }
-        }
-
-        for (std::size_t i = 0; i < N; ++i) {
-            for (auto j = rowIndices[i]; j != rowIndices[i + 1]; ++j) {
-                const auto columnIndex = columnIndices[j];
-                // Now it gets a bit tricky, first we need to fetch the block matrix
-                BlockType blockMatrix;
-                constexpr static auto rows = BlockType::rows;
-
-                for (std::size_t k = 0; k < rows; ++k) {
-                    for (std::size_t l = 0; l < rows; ++l) {
-                        blockMatrix[k][l] = nonZeros[j * rows * rows + k * rows + l];
-                    }
-                }
-                matrix[i][columnIndex] = blockMatrix;
-            }
-        }
-
-        return matrix;
-    }
-
-    /**
-     * This function dispatches the creation of the preconditioner based on the block size.
-     * 
-     * Note that this is needed since the GPU operators/matrices do not hold the block size compile time.
-     * 
-     * Also note that this function is not expected to be used in the future, since we will 
-     * have a GPU constructor for the preconditioners (DILU and OPMILU0), hence removing the need
-     * for a CPU matrix and for this function.
-     */
-    template<int blocksizeCompileTime, class CreateType>
-    static PrecPtr dispatchOnBlockSize(const O& op, CreateType create) {
-        if (op.getmat().blockSize() == blocksizeCompileTime) {
-            const auto cpuMatrix = makeCPUMatrix<Dune::FieldMatrix<field_type, blocksizeCompileTime, blocksizeCompileTime>>(op);
-            return create(cpuMatrix);
-        } 
-        if constexpr (blocksizeCompileTime > 1) {
-            return dispatchOnBlockSize<blocksizeCompileTime - 1>(op, create);
-        }
-        else {
-            throw std::runtime_error(fmt::format("Unsupported block size: {}. Max blocksize supported is {}.", op.getmat().blockSize(), maxblocksize));
-        }
-    }
     
 };
 

--- a/opm/simulators/linalg/gpuistl/detail/gpu_preconditioner_utils.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/gpu_preconditioner_utils.hpp
@@ -1,0 +1,90 @@
+/*
+  Copyright 2025 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_GPUISTL_DETAIL_GPU_PRECONDITIONER_UTILS_HEADER
+#define OPM_GPUISTL_DETAIL_GPU_PRECONDITIONER_UTILS_HEADER
+
+#include <opm/simulators/linalg/gpuistl/GpuSparseMatrix.hpp>
+
+#include <dune/istl/bcrsmatrix.hh>
+
+
+namespace Opm::gpuistl::detail {
+
+/**
+ * @brief Utility functions for GPU preconditioner creation
+ *
+ * These functions are temporary workarounds needed because some GPU preconditioners
+ * require CPU matrices for initial setup (e.g., graph coloring). They will be
+ * removed once GPU preconditioners have native GPU constructors.
+ */
+
+
+/**
+ * This function creates a CPU matrix from the operator holding a GPU matrix.
+ *
+ * This is a workaround for now since some of the GPU preconditioners need a 
+ * CPU matrix for the initial setup (graph coloring). The CPU matrix is only
+ * used in the constructor, **not** in the update function or the apply function.
+ */
+template<class Operator, class BlockType>
+Dune::BCRSMatrix<BlockType> makeCPUMatrix(const Operator& op) {
+    // TODO: Make this more efficient. Maybe we can simply copy the memory areas directly?
+    //       Do note that this function is anyway going away when we have a GPU
+    //       constructor for the preconditioners, so it is not a priority.
+    const auto& gpuMatrix = op.getmat();
+
+    const auto nonZeros = gpuMatrix.getNonZeroValues().asStdVector();
+    const auto rowIndices = gpuMatrix.getRowIndices().asStdVector();
+    const auto columnIndices = gpuMatrix.getColumnIndices().asStdVector();
+
+    const auto numberOfNonZeroes = gpuMatrix.nonzeroes();
+    const auto N = gpuMatrix.N();
+
+    Dune::BCRSMatrix<BlockType> matrix(N, N, numberOfNonZeroes, Dune::BCRSMatrix<BlockType>::row_wise);
+    for (auto row = matrix.createbegin(); row != matrix.createend(); ++row) {
+        for (auto j = rowIndices[row.index()]; j != rowIndices[row.index() + 1]; ++j) {
+            const auto columnIndex = columnIndices[j];
+            row.insert(columnIndex);
+        }
+    }
+
+    for (std::size_t i = 0; i < N; ++i) {
+        for (auto j = rowIndices[i]; j != rowIndices[i + 1]; ++j) {
+            const auto columnIndex = columnIndices[j];
+            // Now it gets a bit tricky, first we need to fetch the block matrix
+            BlockType blockMatrix;
+            constexpr static auto rows = BlockType::rows;
+
+            for (std::size_t k = 0; k < rows; ++k) {
+                for (std::size_t l = 0; l < rows; ++l) {
+                    blockMatrix[k][l] = nonZeros[j * rows * rows + k * rows + l];
+                }
+            }
+            matrix[i][columnIndex] = blockMatrix;
+        }
+    }
+
+    return matrix;
+}
+
+
+} // namespace Opm::gpuistl::detail
+
+#endif // OPM_GPUISTL_DETAIL_GPU_PRECONDITIONER_UTILS_HEADER


### PR DESCRIPTION
This PR contains three different additions:

- A fix to ensure that the GPU communicator stays alive.
- Adds a couple of missing steps for the parallel setup for the new ISTLSolverGPUISTL class, which is only used when `--linear-solver-accelerator=gpu` and we are running MPI parallel.
- Registers the GPU preconditioners into the preconditioner factory for MPI parallel GPU preconditioners.