### PR TITLE
Added include of cstdint

### DIFF
--- a/opm/simulators/wells/WellHelpers.hpp
+++ b/opm/simulators/wells/WellHelpers.hpp
@@ -26,6 +26,8 @@
 #include <dune/istl/bcrsmatrix.hh>
 #include <dune/common/dynmatrix.hh>
 
+#include <cstdint>
+
 namespace Opm {
 
 template<class Scalar> class ParallelWellInfo;


### PR DESCRIPTION
The enum is based on `std::unint16_t`, which is not available without including `cstdint`.