### PR TITLE
Use WELL_STATUS_CHANGE instead of REQUEST_SHUT/OPEN WELL

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -863,8 +863,10 @@ namespace Opm {
                 const auto well_status = this->schedule()
                     .getWell(well_name, report_step).getStatus();
 
-                const bool shut_event = this->wellState().well(w).events.hasEvent(ScheduleEvents::REQUEST_SHUT_WELL);
-                const bool open_event = this->wellState().well(w).events.hasEvent(ScheduleEvents::REQUEST_OPEN_WELL);
+                const bool shut_event = this->wellState().well(w).events.hasEvent(ScheduleEvents::WELL_STATUS_CHANGE)
+                                    && well_status == Well::Status::SHUT;
+                const bool open_event = this->wellState().well(w).events.hasEvent(ScheduleEvents::WELL_STATUS_CHANGE)
+                                    && well_status == Well::Status::OPEN;
                 const auto& ws = this->wellState().well(well_name);
 
                 if (shut_event && ws.status != Well::Status::SHUT) {


### PR DESCRIPTION
The Norne regression (See https://github.com/OPM/opm-simulators/pull/6050) was caused by a well where all connection was closed at the same time as the well was opened with a zero rate. (Probably not the best thing to do, but it helped identify an issue in the code). 

Using WELL_STATUS_CHANGE + checking the state is a more robust solution. We could probably also remove the REQUEST_SHUT_WELL event, as it would no longer be used. 
