### PR TITLE
python packaging: update to use python_simulator_modules target

### DIFF
--- a/python/docker/run-docker-build.sh
+++ b/python/docker/run-docker-build.sh
@@ -149,7 +149,7 @@ parse_arguments() {
     VERSION_GRID="master"
     VERSION_SIMULATORS="master"
     TARGET_COMMON="opmcommon_python"
-    TARGET_SIMULATORS="simulators"
+    TARGET_SIMULATORS="python_simulator_modules"
     VERSION_TAG=""
     NO_BUILDX=false
 


### PR DESCRIPTION
Use the target that builds all python modules to avoid having to update this if any new modules are added in the future.