### PR TITLE
Some janitoring in python classes

### DIFF
--- a/opm/simulators/flow/TTagFlowProblemGasWater.hpp
+++ b/opm/simulators/flow/TTagFlowProblemGasWater.hpp
@@ -23,10 +23,8 @@
 #include <tuple>
 
 namespace Opm::Properties::TTag {
-
     struct FlowProblem;
 
-    
     /// Specialized type tag for gas-water simulations.
     ///
     /// All properties are otherwise the same as for the regular

--- a/opm/simulators/flow/python/PyBaseSimulator.hpp
+++ b/opm/simulators/flow/python/PyBaseSimulator.hpp
@@ -44,65 +44,78 @@ template<class TypeTag>
 class PyBaseSimulator
 {
 private:
-    using Simulator = Opm::GetPropType<TypeTag, Opm::Properties::Simulator>;
+    using Simulator = GetPropType<TypeTag, Properties::Simulator>;
 
 public:
     PyBaseSimulator(const std::string& deckFilename,
                     const std::vector<std::string>& args);
-    PyBaseSimulator(std::shared_ptr<Opm::Deck> deck,
-                    std::shared_ptr<Opm::EclipseState> state,
-                    std::shared_ptr<Opm::Schedule> schedule,
-                    std::shared_ptr<Opm::SummaryConfig> summary_config,
+
+    PyBaseSimulator(std::shared_ptr<Deck> deck,
+                    std::shared_ptr<EclipseState> state,
+                    std::shared_ptr<Schedule> schedule,
+                    std::shared_ptr<SummaryConfig> summary_config,
                     const std::vector<std::string>& args);
 
     void advance(int report_step);
+
     bool checkSimulationFinished();
+
     int currentStep();
-    py::array_t<double> getFluidStateVariable(const std::string &name) const;
+
+    py::array_t<double>
+    getFluidStateVariable(const std::string& name) const;
+
     py::array_t<double> getCellVolumes();
+
     double getDT();
+
     py::array_t<double> getPorosity();
-    py::array_t<double> getPrimaryVariable(const std::string &variable) const;
-    py::array_t<int> getPrimaryVarMeaning(const std::string &variable) const;
-    std::map<std::string, int> getPrimaryVarMeaningMap(const std::string &variable) const;
+
+    py::array_t<double> getPrimaryVariable(const std::string& variable) const;
+    py::array_t<int> getPrimaryVarMeaning(const std::string& variable) const;
+
+    std::map<std::string, int>
+    getPrimaryVarMeaningMap(const std::string& variable) const;
+
     int run();
-    void setPorosity(
-         py::array_t<double, py::array::c_style | py::array::forcecast> array);
-    void setPrimaryVariable(
-        const std::string &idx_name,
-        py::array_t<double,
-        py::array::c_style | py::array::forcecast> array);
+
+    using PyCArray = py::array_t<double, py::array::c_style | py::array::forcecast>;
+
+    void setPorosity(PyCArray array);
+
+    void setPrimaryVariable(const std::string& idx_name,
+                            PyCArray array);
+
     void setupMpi(bool init_mpi, bool finalize_mpi);
     int step();
     int stepCleanup();
     int stepInit();
 
 protected:
-    Opm::FlowMain<TypeTag>& getFlowMain() const;
+    FlowMain<TypeTag>& getFlowMain() const;
     PyFluidState<TypeTag>& getFluidState() const;
     PyMaterialState<TypeTag>& getMaterialState() const;
 
-    const std::string deck_filename_;
-    bool has_run_init_ = false;
-    bool has_run_cleanup_ = false;
-    bool mpi_init_ = true;
-    bool mpi_finalize_ = true;
-    //bool debug_ = false;
+    const std::string deck_filename_{};
+    bool has_run_init_{false};
+    bool has_run_cleanup_{false};
+    bool mpi_init_{true};
+    bool mpi_finalize_{true};
 
     // NOTE: the main_ pointer *must* be declared before the flow_main_ pointer
     // to ensure that it is destroyed before the main object since the main object
     // destructor will call MPI_Finalize() and flow_main_ object destructor will call
     // MPI_Comm_free().
-    std::unique_ptr<Opm::PyMain<TypeTag>> main_;
-    std::unique_ptr<Opm::FlowMain<TypeTag>> flow_main_;
-    Simulator* simulator_;
-    std::unique_ptr<PyFluidState<TypeTag>> fluid_state_;
-    std::unique_ptr<PyMaterialState<TypeTag>> material_state_;
-    std::shared_ptr<Opm::Deck> deck_;
-    std::shared_ptr<Opm::EclipseState> eclipse_state_;
-    std::shared_ptr<Opm::Schedule> schedule_;
-    std::shared_ptr<Opm::SummaryConfig> summary_config_;
-    std::vector<std::string> args_;
+    std::unique_ptr<PyMain<TypeTag>> main_{};
+    std::unique_ptr<FlowMain<TypeTag>> flow_main_{};
+    Simulator* simulator_{nullptr};
+    std::unique_ptr<PyFluidState<TypeTag>> fluid_state_{};
+    std::unique_ptr<PyMaterialState<TypeTag>> material_state_{};
+    std::shared_ptr<Deck> deck_{};
+    std::shared_ptr<EclipseState> eclipse_state_{};
+    std::shared_ptr<Schedule> schedule_{};
+    std::shared_ptr<SummaryConfig> summary_config_{};
+    std::vector<std::string> args_{};
 };  // class PyBaseSimulator
 
 }  // namespace Opm::Pybind

--- a/opm/simulators/flow/python/PyBlackOilSimulator.hpp
+++ b/opm/simulators/flow/python/PyBlackOilSimulator.hpp
@@ -46,8 +46,8 @@ public:
                         const std::vector<std::string>& args)
         : BaseType(deck, state, schedule, summary_config, args)
     {}
-
 };
 
 } // namespace Opm::Pybind
+
 #endif // OPM_PY_BLACKOIL_SIMULATOR_HEADER_INCLUDED

--- a/opm/simulators/flow/python/PyFluidState.hpp
+++ b/opm/simulators/flow/python/PyFluidState.hpp
@@ -20,52 +20,73 @@
 #ifndef OPM_PY_FLUID_STATE_HEADER_INCLUDED
 #define OPM_PY_FLUID_STATE_HEADER_INCLUDED
 
+#include <opm/models/common/multiphasebaseproperties.hh>
+#include <opm/models/discretization/common/fvbaseproperties.hh>
+#include <opm/models/utils/basicproperties.hh>
 #include <opm/models/utils/propertysystem.hh>
 
-#include <exception>
-#include <iostream>
+#include <cstddef>
 #include <map>
-#include <memory>
 #include <string>
 #include <vector>
 
-namespace Opm::Pybind
-{
-    template <class TypeTag>
-    class PyFluidState {
-        using Simulator = GetPropType<TypeTag, Opm::Properties::Simulator>;
-        using Problem = GetPropType<TypeTag, Opm::Properties::Problem>;
-        using Model = GetPropType<TypeTag, Opm::Properties::Model>;
-        using ElementContext = GetPropType<TypeTag, Opm::Properties::ElementContext>;
-        using FluidSystem = GetPropType<TypeTag, Opm::Properties::FluidSystem>;
-        using Indices = GetPropType<TypeTag, Opm::Properties::Indices>;
-        using GridView = GetPropType<TypeTag, Opm::Properties::GridView>;
-        using PrimaryVariables = GetPropType<TypeTag, Properties::PrimaryVariables>;
+namespace Opm::Pybind {
 
-        enum class VariableType {
-            // Primary variables: Sw, Sg, po, pg, Rs, Rv
-            Sw, Sg, So, pw, pg, po, Rs, Rv, rho_w, rho_g, rho_o, T
-        };
-    public:
-        PyFluidState(Simulator* simulator);
-        std::vector<double> getFluidStateVariable(const std::string &name) const;
-        std::vector<int> getPrimaryVarMeaning(const std::string &variable) const;
-        std::map<std::string, int> getPrimaryVarMeaningMap(const std::string &variable) const;
-        std::vector<double> getPrimaryVariable(const std::string &idx_name) const;
-        void setPrimaryVariable(const std::string &idx_name, const double *data, std::size_t size);
+template <class TypeTag>
+class PyFluidState {
+    using Simulator = GetPropType<TypeTag, Properties::Simulator>;
+    using Problem = GetPropType<TypeTag, Properties::Problem>;
+    using Model = GetPropType<TypeTag, Properties::Model>;
+    using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
+    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
+    using Indices = GetPropType<TypeTag, Properties::Indices>;
+    using GridView = GetPropType<TypeTag, Properties::GridView>;
+    using PrimaryVariables = GetPropType<TypeTag, Properties::PrimaryVariables>;
 
-    private:
-        std::size_t getPrimaryVarIndex_(const std::string &idx_name) const;
-        int getVariableMeaning_(PrimaryVariables &primary_vars, const std::string &variable) const;
-        VariableType getVariableType_(const std::string &name) const;
-        template <class FluidState> double getVariableValue_(
-            FluidState &fs, VariableType var_type, const std::string &name) const;
-        void variableNotFoundError_(const std::string &name) const;
-
-        Simulator* simulator_;
+    enum class VariableType {
+        // Primary variables: Sw, Sg, po, pg, Rs, Rv
+        Sw, Sg, So, pw, pg, po, Rs, Rv, rho_w, rho_g, rho_o, T
     };
-}
+
+public:
+    PyFluidState(Simulator* simulator);
+
+    std::vector<double>
+    getFluidStateVariable(const std::string& name) const;
+
+    std::vector<int>
+    getPrimaryVarMeaning(const std::string& variable) const;
+
+    std::map<std::string, int>
+    getPrimaryVarMeaningMap(const std::string& variable) const;
+
+    std::vector<double>
+    getPrimaryVariable(const std::string &idx_name) const;
+
+    void setPrimaryVariable(const std::string& idx_name,
+                            const double* data,
+                            std::size_t size);
+
+private:
+    std::size_t getPrimaryVarIndex_(const std::string& idx_name) const;
+
+    int getVariableMeaning_(PrimaryVariables& primary_vars,
+                            const std::string& variable) const;
+
+    VariableType getVariableType_(const std::string& name) const;
+
+    template <class FluidState>
+    double getVariableValue_(FluidState& fs,
+                             VariableType var_type,
+                             const std::string& name) const;
+
+    void variableNotFoundError_(const std::string& name) const;
+
+    Simulator* simulator_{nullptr};
+};
+
+} // namespace Opm::Pybind
+
 #include "PyFluidState_impl.hpp"
 
 #endif // OPM_PY_FLUID_STATE_HEADER_INCLUDED
-

--- a/opm/simulators/flow/python/PyGasWaterSimulator.hpp
+++ b/opm/simulators/flow/python/PyGasWaterSimulator.hpp
@@ -26,11 +26,11 @@
 
 namespace Opm::Pybind {
 
-class PyGasWaterSimulator : public PyBaseSimulator<Opm::Properties::TTag::FlowGasWaterProblem>
+class PyGasWaterSimulator : public PyBaseSimulator<Properties::TTag::FlowGasWaterProblem>
 {
 private:
-    using BaseType = PyBaseSimulator<Opm::Properties::TTag::FlowGasWaterProblem>;
-    using TypeTag = Opm::Properties::TTag::FlowGasWaterProblem;
+    using BaseType = PyBaseSimulator<Properties::TTag::FlowGasWaterProblem>;
+    using TypeTag = Properties::TTag::FlowGasWaterProblem;
 
 public:
     PyGasWaterSimulator(const std::string& deck_filename,
@@ -38,14 +38,13 @@ public:
         : BaseType(deck_filename, args)
     {}
 
-    PyGasWaterSimulator(std::shared_ptr<Opm::Deck> deck,
-                        std::shared_ptr<Opm::EclipseState> state,
-                        std::shared_ptr<Opm::Schedule> schedule,
-                        std::shared_ptr<Opm::SummaryConfig> summary_config,
+    PyGasWaterSimulator(std::shared_ptr<Deck> deck,
+                        std::shared_ptr<EclipseState> state,
+                        std::shared_ptr<Schedule> schedule,
+                        std::shared_ptr<SummaryConfig> summary_config,
                         const std::vector<std::string>& args)
         : BaseType(deck, state, schedule, summary_config, args)
     {}
-
 };
 
 } // namespace Opm::Pybind

--- a/opm/simulators/flow/python/PyMaterialState.hpp
+++ b/opm/simulators/flow/python/PyMaterialState.hpp
@@ -26,7 +26,6 @@
 #include <opm/models/utils/propertysystem.hh>
 
 #include <cstddef>
-#include <memory>
 
 namespace Opm::Pybind
 {
@@ -42,11 +41,13 @@ namespace Opm::Pybind
 
     public:
         PyMaterialState(Simulator* simulator)
-            : simulator_(simulator) { }
+            : simulator_(simulator)
+        {}
 
         std::vector<double> getCellVolumes();
         std::vector<double> getPorosity();
-        void setPorosity(const double *poro, std::size_t size);
+        void setPorosity(const double* poro, std::size_t size);
+
     private:
         Simulator* simulator_;
     };

--- a/opm/simulators/flow/python/PyMaterialState_impl.hpp
+++ b/opm/simulators/flow/python/PyMaterialState_impl.hpp
@@ -16,6 +16,14 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+#ifndef OPM_PY_MATERIAL_STATE_IMPL_HEADER_INCLUDED
+#define OPM_PY_MATERIAL_STATE_IMPL_HEADER_INCLUDED
+
+// Improve IDE experience
+#ifndef OPM_PY_MATERIAL_STATE_HEADER_INCLUDED
+#include <config.h>
+#include <opm/simulators/flow/python/PyMaterialState.hpp>
+#endif
 
 #include <fmt/format.h>
 
@@ -26,8 +34,8 @@ std::vector<double>
 PyMaterialState<TypeTag>::
 getCellVolumes()
 {
-    Model &model = this->simulator_->model();
-    auto size = model.numGridDof();
+    Model& model = this->simulator_->model();
+    const auto size = model.numGridDof();
     std::vector<double> array(size);
     for (unsigned dof_idx = 0; dof_idx < size; ++dof_idx) {
         array[dof_idx] = model.dofTotalVolume(dof_idx);
@@ -40,9 +48,9 @@ std::vector<double>
 PyMaterialState<TypeTag>::
 getPorosity()
 {
-    Problem &problem = this->simulator_->problem();
-    Model &model = this->simulator_->model();
-    auto size = model.numGridDof();
+    Problem& problem = this->simulator_->problem();
+    Model& model = this->simulator_->model();
+    const auto size = model.numGridDof();
     std::vector<double> array(size);
     for (unsigned dof_idx = 0; dof_idx < size; ++dof_idx) {
         array[dof_idx] = problem.referencePorosity(dof_idx, /*timeIdx*/0);
@@ -57,15 +65,19 @@ setPorosity(const double* poro, std::size_t size)
 {
     Problem& problem = this->simulator_->problem();
     Model& model = this->simulator_->model();
-    auto model_size = model.numGridDof();
+    const auto model_size = model.numGridDof();
     if (model_size != size) {
         const std::string msg = fmt::format(
             "Cannot set porosity. Expected array of size: {}, got array of size: ",
-            model_size, size);
+            model_size, size
+        );
         throw std::runtime_error(msg);
     }
     for (unsigned dof_idx = 0; dof_idx < size; ++dof_idx) {
         problem.setPorosity(poro[dof_idx], dof_idx);
     }
 }
-} //namespace Opm::Pybind
+
+} // namespace Opm::Pybind
+
+#endif // OPM_PY_MATERIAL_STATE_IMPL_HEADER_INCLUDED


### PR DESCRIPTION
- add some breathing space in headers
- remove Opm:: for symbols in Opm namespace
- use type-aligned &/*
- add "IDE helper structure"
- add some const
- add a type alias to reduce long statements
- reformat some clang-format atrocities
- return directly in a switch clause