### PR TITLE
Biofilm and Calcite set to volume fraction instead of concentration

### DIFF
--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -311,7 +311,7 @@ public:
         else if constexpr (enableBioeffects) {
             if (BioeffectsModule::hasPcfactTables() && referencePorosity_ > 0) {
                 unsigned satnumRegionIdx = problem.satnumRegionIndex(globalSpaceIdx);
-                const Evaluation Sb = priVars.makeEvaluation(Indices::biofilmConcentrationIdx, timeIdx);
+                const Evaluation Sb = priVars.makeEvaluation(Indices::biofilmVolumeFractionIdx, timeIdx);
                 const Evaluation porosityFactor  = min(1.0 - Sb/referencePorosity_, 1.0); //phi/phi_0
                 const auto& pcfactTable = BioeffectsModule::pcfactTable(satnumRegionIdx);
                 const Evaluation pcFactor = pcfactTable.eval(porosityFactor, /*extrapolation=*/true);
@@ -580,11 +580,11 @@ public:
 
         // deal with bioeffects (minimum porosity of 1e-8 to prevent numerical issues)
         if constexpr (enableBioeffects) {
-            const Evaluation biofilm_ = priVars.makeEvaluation(Indices::biofilmConcentrationIdx,
+            const Evaluation biofilm_ = priVars.makeEvaluation(Indices::biofilmVolumeFractionIdx,
                                                                timeIdx, linearizationType);
             Evaluation calcite_ = 0.0;
             if constexpr (enableMICP) {
-                calcite_ = priVars.makeEvaluation(Indices::calciteConcentrationIdx, timeIdx, linearizationType); 
+                calcite_ = priVars.makeEvaluation(Indices::calciteVolumeFractionIdx, timeIdx, linearizationType); 
             }
             porosity_ -= min(biofilm_ + calcite_, referencePorosity_ - 1e-8);
         }

--- a/opm/models/blackoil/blackoilnewtonmethod.hpp
+++ b/opm/models/blackoil/blackoilnewtonmethod.hpp
@@ -211,7 +211,7 @@ protected:
         static constexpr bool enableEnergy = Indices::temperatureIdx >= 0;
         static constexpr bool enableFoam = Indices::foamConcentrationIdx >= 0;
         static constexpr bool enableBrine = Indices::saltConcentrationIdx >= 0;
-        static constexpr bool enableBioeffects = Indices::biofilmConcentrationIdx >= 0;
+        static constexpr bool enableBioeffects = Indices::biofilmVolumeFractionIdx >= 0;
         static constexpr bool enableMICP = Indices::enableMICP;
 
         currentValue.checkDefined();
@@ -397,7 +397,7 @@ protected:
                 if (pvIdx == Indices::microbialConcentrationIdx) {
                     nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                 }
-                if (pvIdx == Indices::biofilmConcentrationIdx) {
+                if (pvIdx == Indices::biofilmVolumeFractionIdx) {
                     nextValue[pvIdx] = std::clamp(nextValue[pvIdx],
                                                   Scalar{0.0},
                                                   this->problem().referencePorosity(globalDofIdx, 0) - 1e-8);
@@ -409,7 +409,7 @@ protected:
                     if (pvIdx == Indices::ureaConcentrationIdx) {
                         nextValue[pvIdx] = std::max(nextValue[pvIdx], Scalar{0.0});
                     }
-                    if (pvIdx == Indices::calciteConcentrationIdx) {
+                    if (pvIdx == Indices::calciteVolumeFractionIdx) {
                         nextValue[pvIdx] = std::clamp(nextValue[pvIdx], Scalar{0.0},
                                                                         this->problem().referencePorosity(globalDofIdx, 0) - 1e-8);
                     }

--- a/opm/models/blackoil/blackoilonephaseindices.hh
+++ b/opm/models/blackoil/blackoilonephaseindices.hh
@@ -163,12 +163,12 @@ struct BlackOilOnePhaseIndices
         numMICPs > 2 ? oxygenConcentrationIdx + 1 : -1000;
 
     //! Index of the primary variable for the fourth MICP component
-    static constexpr int biofilmConcentrationIdx =
+    static constexpr int biofilmVolumeFractionIdx =
         numMICPs > 3 ? ureaConcentrationIdx + 1 : -1000;
 
     //! Index of the primary variable for the fifth MICP component
-    static constexpr int calciteConcentrationIdx =
-        numMICPs > 4 ? biofilmConcentrationIdx + 1 : -1000;
+    static constexpr int calciteVolumeFractionIdx =
+        numMICPs > 4 ? biofilmVolumeFractionIdx + 1 : -1000;
 
     //! Index of the primary variable for the foam
     static constexpr int foamConcentrationIdx =

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -601,7 +601,7 @@ public:
         else if constexpr (enableBioeffects) {
             if (BioeffectsModule::hasPcfactTables() && problem.referencePorosity(globalDofIdx, 0) > 0) {
                 unsigned satnumRegionIdx = problem.satnumRegionIndex(globalDofIdx);
-                Scalar Sb = biofilmConcentration_() / 
+                Scalar Sb = biofilmVolumeFraction_() / 
                             problem.referencePorosity(globalDofIdx, 0);
                 Scalar porosityFactor  = std::min(1.0 - Sb, 1.0); //phi/phi_0
                 const auto& pcfactTable = BioeffectsModule::pcfactTable(satnumRegionIdx);
@@ -987,10 +987,10 @@ private:
         }
     }
 
-    Scalar biofilmConcentration_() const
+    Scalar biofilmVolumeFraction_() const
     {
         if constexpr (enableBioeffects)
-            return (*this)[Indices::biofilmConcentrationIdx];
+            return (*this)[Indices::biofilmVolumeFractionIdx];
         else
             return 0.0;
     }

--- a/opm/models/blackoil/blackoiltwophaseindices.hh
+++ b/opm/models/blackoil/blackoiltwophaseindices.hh
@@ -155,13 +155,13 @@ struct BlackOilTwoPhaseIndices
         enableBiofilm ? PVOffset + numPhases + numSolvents : -1000;
 
     //! Index of the primary variable for the biofilm component
-    static constexpr int biofilmConcentrationIdx =
+    static constexpr int biofilmVolumeFractionIdx =
         enableBiofilm ? PVOffset + numPhases + numSolvents + 1 : -1000;
 
     //! MICP only available for one phase indices
     static constexpr int oxygenConcentrationIdx = -1000;
     static constexpr int ureaConcentrationIdx = -1000;
-    static constexpr int calciteConcentrationIdx = -1000;
+    static constexpr int calciteVolumeFractionIdx = -1000;
 
     //! Index of the primary variable for the foam
     static constexpr int foamConcentrationIdx =

--- a/opm/models/blackoil/blackoilvariableandequationindices.hh
+++ b/opm/models/blackoil/blackoilvariableandequationindices.hh
@@ -142,8 +142,8 @@ struct BlackOilVariableAndEquationIndices
     static constexpr int microbialConcentrationIdx = -1000;
     static constexpr int oxygenConcentrationIdx = -1000;
     static constexpr int ureaConcentrationIdx = -1000;
-    static constexpr int biofilmConcentrationIdx = -1000;
-    static constexpr int calciteConcentrationIdx = -1000;
+    static constexpr int biofilmVolumeFractionIdx = -1000;
+    static constexpr int calciteVolumeFractionIdx = -1000;
 
     //! Index of the primary variable for the foam
     static constexpr int foamConcentrationIdx =

--- a/opm/models/io/vtkblackoilbioeffectsmodule.hpp
+++ b/opm/models/io/vtkblackoilbioeffectsmodule.hpp
@@ -103,8 +103,8 @@ public:
             if (params_.microbialConcentrationOutput_) {
                 this->resizeScalarBuffer_(microbialConcentration_, BufferType::Dof);
             }
-            if (params_.biofilmConcentrationOutput_) {
-                this->resizeScalarBuffer_(biofilmConcentration_, BufferType::Dof);
+            if (params_.biofilmVolumeFractionOutput_) {
+                this->resizeScalarBuffer_(biofilmVolumeFraction_, BufferType::Dof);
             }
             if constexpr (enableMICP) {
                 if (params_.oxygenConcentrationOutput_) {
@@ -113,8 +113,8 @@ public:
                 if (params_.ureaConcentrationOutput_) {
                     this->resizeScalarBuffer_(ureaConcentration_, BufferType::Dof);
                 }
-                if (params_.calciteConcentrationOutput_) {
-                    this->resizeScalarBuffer_(calciteConcentration_, BufferType::Dof);
+                if (params_.calciteVolumeFractionOutput_) {
+                    this->resizeScalarBuffer_(calciteVolumeFraction_, BufferType::Dof);
                 }
             }
         }
@@ -139,9 +139,9 @@ public:
                     microbialConcentration_[globalDofIdx] =
                         scalarValue(intQuants.microbialConcentration());
                 }
-                if (params_.biofilmConcentrationOutput_) {
-                    biofilmConcentration_[globalDofIdx] =
-                        scalarValue(intQuants.biofilmConcentration());
+                if (params_.biofilmVolumeFractionOutput_) {
+                    biofilmVolumeFraction_[globalDofIdx] =
+                        scalarValue(intQuants.biofilmVolumeFraction());
                 }
                 if constexpr (enableMICP) {
                     if (params_.oxygenConcentrationOutput_) {
@@ -152,9 +152,9 @@ public:
                         ureaConcentration_[globalDofIdx] =
                             scalarValue(intQuants.ureaConcentration());
                     }
-                    if (params_.calciteConcentrationOutput_) {
-                        calciteConcentration_[globalDofIdx] =
-                            scalarValue(intQuants.calciteConcentration());
+                    if (params_.calciteVolumeFractionOutput_) {
+                        calciteVolumeFraction_[globalDofIdx] =
+                            scalarValue(intQuants.calciteVolumeFraction());
                     }
                 }
             }
@@ -175,9 +175,9 @@ public:
                 this->commitScalarBuffer_(baseWriter, "microbial concentration",
                                           microbialConcentration_, BufferType::Dof);
             }
-            if (params_.biofilmConcentrationOutput_) {
-                this->commitScalarBuffer_(baseWriter, "biofilm fraction",
-                                          biofilmConcentration_, BufferType::Dof);
+            if (params_.biofilmVolumeFractionOutput_) {
+                this->commitScalarBuffer_(baseWriter, "biofilm voulme fraction",
+                                          biofilmVolumeFraction_, BufferType::Dof);
             }
             if constexpr (enableMICP) {
                 if (params_.oxygenConcentrationOutput_) {
@@ -188,9 +188,9 @@ public:
                     this->commitScalarBuffer_(baseWriter, "urea concentration",
                                               ureaConcentration_, BufferType::Dof);
                 }
-                if (params_.calciteConcentrationOutput_) {
-                    this->commitScalarBuffer_(baseWriter, "calcite fraction",
-                                              calciteConcentration_, BufferType::Dof);
+                if (params_.calciteVolumeFractionOutput_) {
+                    this->commitScalarBuffer_(baseWriter, "calcite volume fraction",
+                                              calciteVolumeFraction_, BufferType::Dof);
                 }
             }
         }
@@ -201,8 +201,8 @@ private:
     ScalarBuffer microbialConcentration_{};
     ScalarBuffer oxygenConcentration_{};
     ScalarBuffer ureaConcentration_{};
-    ScalarBuffer biofilmConcentration_{};
-    ScalarBuffer calciteConcentration_{};
+    ScalarBuffer biofilmVolumeFraction_{};
+    ScalarBuffer calciteVolumeFraction_{};
 };
 
 } // namespace Opm

--- a/opm/models/io/vtkblackoilbioeffectsparams.cpp
+++ b/opm/models/io/vtkblackoilbioeffectsparams.cpp
@@ -33,7 +33,7 @@ void VtkBlackOilBioeffectsParams::registerParameters(const bool isMICP)
     Parameters::Register<Parameters::VtkWriteMicrobialConcentration>
         ("Include the concentration of the microbial component in the water phase "
          "in the VTK output files");
-    Parameters::Register<Parameters::VtkWriteBiofilmConcentration>
+    Parameters::Register<Parameters::VtkWriteBiofilmVolumeFraction>
         ("Include the biofilm volume fraction in the VTK output files");
     if (isMICP) {
         Parameters::Register<Parameters::VtkWriteOxygenConcentration>
@@ -42,7 +42,7 @@ void VtkBlackOilBioeffectsParams::registerParameters(const bool isMICP)
         Parameters::Register<Parameters::VtkWriteUreaConcentration>
             ("Include the concentration of the urea component in the water phase "
             "in the VTK output files");
-        Parameters::Register<Parameters::VtkWriteCalciteConcentration>
+        Parameters::Register<Parameters::VtkWriteCalciteVolumeFraction>
             ("Include the calcite volume fraction in the VTK output files");
     }
 }
@@ -50,11 +50,11 @@ void VtkBlackOilBioeffectsParams::registerParameters(const bool isMICP)
 void VtkBlackOilBioeffectsParams::read(const bool isMICP)
 {
     microbialConcentrationOutput_ = Parameters::Get<Parameters::VtkWriteMicrobialConcentration>();
-    biofilmConcentrationOutput_ = Parameters::Get<Parameters::VtkWriteBiofilmConcentration>();
+    biofilmVolumeFractionOutput_ = Parameters::Get<Parameters::VtkWriteBiofilmVolumeFraction>();
     if (isMICP) {
         oxygenConcentrationOutput_ = Parameters::Get<Parameters::VtkWriteOxygenConcentration>();
         ureaConcentrationOutput_ = Parameters::Get<Parameters::VtkWriteUreaConcentration>();
-        calciteConcentrationOutput_ = Parameters::Get<Parameters::VtkWriteCalciteConcentration>();
+        calciteVolumeFractionOutput_ = Parameters::Get<Parameters::VtkWriteCalciteVolumeFraction>();
     }
 }
 

--- a/opm/models/io/vtkblackoilbioeffectsparams.hpp
+++ b/opm/models/io/vtkblackoilbioeffectsparams.hpp
@@ -33,8 +33,8 @@ namespace Opm::Parameters {
 struct VtkWriteMicrobialConcentration { static constexpr bool value = true; };
 struct VtkWriteOxygenConcentration { static constexpr bool value = true; };
 struct VtkWriteUreaConcentration { static constexpr bool value = true; };
-struct VtkWriteBiofilmConcentration { static constexpr bool value = true; };
-struct VtkWriteCalciteConcentration { static constexpr bool value = true; };
+struct VtkWriteBiofilmVolumeFraction { static constexpr bool value = true; };
+struct VtkWriteCalciteVolumeFraction { static constexpr bool value = true; };
 
 } // namespace Opm::Parameters
 
@@ -54,8 +54,8 @@ struct VtkBlackOilBioeffectsParams
     bool microbialConcentrationOutput_;
     bool oxygenConcentrationOutput_;
     bool ureaConcentrationOutput_;
-    bool biofilmConcentrationOutput_;
-    bool calciteConcentrationOutput_;
+    bool biofilmVolumeFractionOutput_;
+    bool calciteVolumeFractionOutput_;
 };
 
 } // namespace Opm

--- a/opm/simulators/flow/BioeffectsContainer.cpp
+++ b/opm/simulators/flow/BioeffectsContainer.cpp
@@ -55,21 +55,21 @@ void BioeffectsContainer<Scalar>::
 assign(const unsigned globalDofIdx,
        const Scalar oxygenConcentration,
        const Scalar ureaConcentration,
-       const Scalar calciteConcentration)
+       const Scalar calciteVolumeFraction)
 {
     cOxygen_[globalDofIdx] = oxygenConcentration;
     cUrea_[globalDofIdx] = ureaConcentration;
-    cCalcite_[globalDofIdx] = calciteConcentration;
+    cCalcite_[globalDofIdx] = calciteVolumeFraction;
 }
 
 template<class Scalar>
 void BioeffectsContainer<Scalar>::
 assign(const unsigned globalDofIdx,
        const Scalar microbialConcentration,
-       const Scalar biofilmConcentration)
+       const Scalar biofilmVolumeFraction)
 {
     cMicrobes_[globalDofIdx] = microbialConcentration;
-    cBiofilm_[globalDofIdx] = biofilmConcentration;
+    cBiofilm_[globalDofIdx] = biofilmVolumeFraction;
 }
 
 template<class Scalar>

--- a/opm/simulators/flow/BioeffectsContainer.hpp
+++ b/opm/simulators/flow/BioeffectsContainer.hpp
@@ -44,11 +44,11 @@ public:
     void assign(const unsigned globalDofIdx,
                 const Scalar oxygenConcentration,
                 const Scalar ureaConcentration,
-                const Scalar calciteConcentration);
+                const Scalar calciteVolumeFraction);
 
     void assign(const unsigned globalDofIdx,
                 const Scalar microbialConcentration,
-                const Scalar biofilmConcentration);
+                const Scalar biofilmVolumeFraction);
 
     BioeffectsSolutionContainer<Scalar> getSolution() const;
 

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -98,8 +98,8 @@ public:
     static constexpr int microbialConcentrationIdx = Indices::microbialConcentrationIdx;
     static constexpr int oxygenConcentrationIdx = Indices::oxygenConcentrationIdx;
     static constexpr int ureaConcentrationIdx = Indices::ureaConcentrationIdx;
-    static constexpr int biofilmConcentrationIdx = Indices::biofilmConcentrationIdx;
-    static constexpr int calciteConcentrationIdx = Indices::calciteConcentrationIdx;
+    static constexpr int biofilmVolumeFractionIdx = Indices::biofilmVolumeFractionIdx;
+    static constexpr int calciteVolumeFractionIdx = Indices::calciteVolumeFractionIdx;
 
     using VectorBlockType = Dune::FieldVector<Scalar, numEq>;
     using MatrixBlockType = typename SparseMatrixAdapter::MatrixBlock;

--- a/opm/simulators/flow/FlowGenericProblem.hpp
+++ b/opm/simulators/flow/FlowGenericProblem.hpp
@@ -192,14 +192,14 @@ public:
     Scalar ureaConcentration(unsigned elemIdx) const;
 
     /*!
-     * \brief Returns the initial biofilm concentration for a given a cell index
+     * \brief Returns the initial biofilm volume fraction for a given a cell index
      */
-    Scalar biofilmConcentration(unsigned elemIdx) const;
+    Scalar biofilmVolumeFraction(unsigned elemIdx) const;
 
     /*!
-     * \brief Returns the initial calcite concentration for a given a cell index
+     * \brief Returns the initial calcite volume fraction for a given a cell index
      */
-    Scalar calciteConcentration(unsigned elemIdx) const;
+    Scalar calciteVolumeFraction(unsigned elemIdx) const;
 
     /*!
      * \brief Returns the index the relevant PVT region given a cell index

--- a/opm/simulators/flow/FlowGenericProblem_impl.hpp
+++ b/opm/simulators/flow/FlowGenericProblem_impl.hpp
@@ -528,9 +528,9 @@ readBlackoilExtentionsInitialConditions_(std::size_t numDof,
             bioeffects_.microbialConcentration.resize(numDof, 0.0);
         }
         if (eclState_.fieldProps().has_double("SBIOF")) {
-            bioeffects_.biofilmConcentration = getArray(eclState_.fieldProps().get_double("SBIOF"));
+            bioeffects_.biofilmVolumeFraction = getArray(eclState_.fieldProps().get_double("SBIOF"));
         } else {
-            bioeffects_.biofilmConcentration.resize(numDof, 0.0);
+            bioeffects_.biofilmVolumeFraction.resize(numDof, 0.0);
         }
         if (enableMICP) {
             if (eclState_.fieldProps().has_double("SOXYG")) {
@@ -544,9 +544,9 @@ readBlackoilExtentionsInitialConditions_(std::size_t numDof,
                 bioeffects_.ureaConcentration.resize(numDof, 0.0);
             }
             if (eclState_.fieldProps().has_double("SCALC")) {
-                bioeffects_.calciteConcentration = getArray(eclState_.fieldProps().get_double("SCALC"));
+                bioeffects_.calciteVolumeFraction = getArray(eclState_.fieldProps().get_double("SCALC"));
             } else {
-                bioeffects_.calciteConcentration.resize(numDof, 0.0);
+                bioeffects_.calciteVolumeFraction.resize(numDof, 0.0);
             }
         }
     }
@@ -672,25 +672,25 @@ ureaConcentration(unsigned elemIdx) const
 template<class GridView, class FluidSystem>
 typename FlowGenericProblem<GridView,FluidSystem>::Scalar
 FlowGenericProblem<GridView,FluidSystem>::
-biofilmConcentration(unsigned elemIdx) const
+biofilmVolumeFraction(unsigned elemIdx) const
 {
-    if (bioeffects_.biofilmConcentration.empty()) {
+    if (bioeffects_.biofilmVolumeFraction.empty()) {
         return 0;
     }
 
-    return bioeffects_.biofilmConcentration[elemIdx];
+    return bioeffects_.biofilmVolumeFraction[elemIdx];
 }
 
 template<class GridView, class FluidSystem>
 typename FlowGenericProblem<GridView,FluidSystem>::Scalar
 FlowGenericProblem<GridView,FluidSystem>::
-calciteConcentration(unsigned elemIdx) const
+calciteVolumeFraction(unsigned elemIdx) const
 {
-    if (bioeffects_.calciteConcentration.empty()) {
+    if (bioeffects_.calciteVolumeFraction.empty()) {
         return 0;
     }
 
-    return bioeffects_.calciteConcentration[elemIdx];
+    return bioeffects_.calciteVolumeFraction[elemIdx];
 }
 
 template<class GridView, class FluidSystem>

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -931,11 +931,11 @@ public:
 
         if constexpr (enableBioeffects) {
             values[Indices::microbialConcentrationIdx] = this->bioeffects_.microbialConcentration[globalDofIdx];
-            values[Indices::biofilmConcentrationIdx]= this->bioeffects_.biofilmConcentration[globalDofIdx];
+            values[Indices::biofilmVolumeFractionIdx]= this->bioeffects_.biofilmVolumeFraction[globalDofIdx];
             if constexpr (enableMICP) {
                 values[Indices::oxygenConcentrationIdx]= this->bioeffects_.oxygenConcentration[globalDofIdx];
                 values[Indices::ureaConcentrationIdx]= this->bioeffects_.ureaConcentration[globalDofIdx];
-                values[Indices::calciteConcentrationIdx]= this->bioeffects_.calciteConcentration[globalDofIdx];
+                values[Indices::calciteVolumeFractionIdx]= this->bioeffects_.calciteVolumeFraction[globalDofIdx];
             }
         }
 

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -1590,12 +1590,12 @@ private:
                   {
                       bioeffectsC.assign(ectx.globalDofIdx,
                                          ectx.intQuants.microbialConcentration().value(),
-                                         ectx.intQuants.biofilmConcentration().value());
+                                         ectx.intQuants.biofilmVolumeFraction().value());
                       if (Indices::enableMICP) {
                           bioeffectsC.assign(ectx.globalDofIdx,
                                              ectx.intQuants.oxygenConcentration().value(),
                                              ectx.intQuants.ureaConcentration().value(),
-                                             ectx.intQuants.calciteConcentration().value());
+                                             ectx.intQuants.calciteVolumeFraction().value());
                       }
                   }, this->bioeffectsC_.allocated()
             },

--- a/opm/simulators/flow/SolutionContainers.cpp
+++ b/opm/simulators/flow/SolutionContainers.cpp
@@ -65,8 +65,8 @@ void BioeffectsSolutionContainer<Scalar>::resize(const unsigned numElems)
     microbialConcentration.resize(numElems, 0.0);
     oxygenConcentration.resize(numElems, 0.0);
     ureaConcentration.resize(numElems, 0.0);
-    biofilmConcentration.resize(numElems, 0.0);
-    calciteConcentration.resize(numElems, 0.0);
+    biofilmVolumeFraction.resize(numElems, 0.0);
+    calciteVolumeFraction.resize(numElems, 0.0);
 }
 
 template<class Scalar>
@@ -76,8 +76,8 @@ operator==(const BioeffectsSolutionContainer<Scalar>& rhs) const
     return this->microbialConcentration == rhs.microbialConcentration &&
            this->oxygenConcentration == rhs.oxygenConcentration &&
            this->ureaConcentration == rhs.ureaConcentration &&
-           this->biofilmConcentration == rhs.biofilmConcentration &&
-           this->calciteConcentration == rhs.calciteConcentration;
+           this->biofilmVolumeFraction == rhs.biofilmVolumeFraction &&
+           this->calciteVolumeFraction == rhs.calciteVolumeFraction;
 }
 
 #define INSTANTIATE_TYPE(T) \

--- a/opm/simulators/flow/SolutionContainers.hpp
+++ b/opm/simulators/flow/SolutionContainers.hpp
@@ -58,8 +58,8 @@ struct BioeffectsSolutionContainer {
     std::vector<Scalar> microbialConcentration;
     std::vector<Scalar> oxygenConcentration;
     std::vector<Scalar> ureaConcentration;
-    std::vector<Scalar> biofilmConcentration;
-    std::vector<Scalar> calciteConcentration;
+    std::vector<Scalar> biofilmVolumeFraction;
+    std::vector<Scalar> calciteVolumeFraction;
 
     static BioeffectsSolutionContainer serializationTestObject();
 
@@ -72,8 +72,8 @@ struct BioeffectsSolutionContainer {
         serializer(microbialConcentration);
         serializer(oxygenConcentration);
         serializer(ureaConcentration);
-        serializer(biofilmConcentration);
-        serializer(calciteConcentration);
+        serializer(biofilmVolumeFraction);
+        serializer(calciteVolumeFraction);
     }
 
     bool operator==(const BioeffectsSolutionContainer& rhs) const;

--- a/opm/simulators/utils/ComponentName.cpp
+++ b/opm/simulators/utils/ComponentName.cpp
@@ -81,13 +81,13 @@ ComponentName<FluidSystem,Indices>::ComponentName()
         names_[Indices::microbialConcentrationIdx] = "Microbes";
         names_[Indices::oxygenConcentrationIdx] = "Oxygen";
         names_[Indices::ureaConcentrationIdx] = "Urea";
-        names_[Indices::biofilmConcentrationIdx] = "Biofilm";
-        names_[Indices::calciteConcentrationIdx] = "Calcite";
+        names_[Indices::biofilmVolumeFractionIdx] = "Biofilm";
+        names_[Indices::calciteVolumeFractionIdx] = "Calcite";
     }
 
     if constexpr (Indices::enableBiofilm) {
         names_[Indices::microbialConcentrationIdx] = "Microbes";
-        names_[Indices::biofilmConcentrationIdx] = "Biofilm";
+        names_[Indices::biofilmVolumeFractionIdx] = "Biofilm";
     }
 }
 


### PR DESCRIPTION
The variables `biofilm` and `calcite` are actually volume fractions, setting the correct names in this PR. Related to https://github.com/OPM/opm-common/pull/4750