### PR TITLE
Fix race condition in Python tests by disabling async ECL output

### DIFF
--- a/python/test/pytest_common.py
+++ b/python/test/pytest_common.py
@@ -10,3 +10,54 @@ def pushd(path):
     yield
     os.chdir(cwd)
 
+ENABLE_ASYNC_ECL_OUTPUT_FLAG = '--enable-async-ecl-output=false'
+
+def create_black_oil_simulator(*args, **kwargs):
+    """Create BlackOilSimulator with test-safe default arguments.
+
+    Automatically disables async ECL output to prevent race conditions
+    with pushd context manager in tests.
+    """
+    from opm.simulators import BlackOilSimulator
+
+    flag_to_add = ENABLE_ASYNC_ECL_OUTPUT_FLAG
+    # Handle different constructor patterns
+    if 'args' in kwargs:
+        # Add our flag to existing args
+        if flag_to_add not in kwargs['args']:
+            kwargs['args'].append(flag_to_add)
+    elif len(args) >= 4:
+        # Constructor with deck, state, schedule, summary_config
+        # Add args parameter
+        if len(args) == 4:
+            args = args + ([flag_to_add],)
+        elif len(args) == 5:
+            # Args already provided, add our flag
+            args_list = list(args[4]) if args[4] else []
+            if flag_to_add not in args_list:
+                args_list.append(flag_to_add)
+            args = args[:4] + (args_list,)
+    else:
+        # Constructor with filename - add args parameter
+        kwargs['args'] = kwargs.get('args', [])
+        if flag_to_add not in kwargs['args']:
+            kwargs['args'].append(flag_to_add)
+
+    return BlackOilSimulator(*args, **kwargs)
+
+def create_gas_water_simulator(*args, **kwargs):
+    """Create GasWaterSimulator with test-safe default arguments.
+
+    Automatically disables async ECL output to prevent race conditions
+    with pushd context manager in tests.
+    """
+    from opm.simulators import GasWaterSimulator
+
+    flag_to_add = ENABLE_ASYNC_ECL_OUTPUT_FLAG
+    # Add our flag to args
+    kwargs['args'] = kwargs.get('args', [])
+    if flag_to_add not in kwargs['args']:
+        kwargs['args'].append(flag_to_add)
+
+    return GasWaterSimulator(*args, **kwargs)
+

--- a/python/test/test_basic.py
+++ b/python/test/test_basic.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 from pathlib import Path
-from opm.simulators import BlackOilSimulator, GasWaterSimulator
-from .pytest_common import pushd
+from .pytest_common import pushd, create_black_oil_simulator, create_gas_water_simulator
 
 class TestBasic(unittest.TestCase):
     @classmethod
@@ -21,7 +20,7 @@ class TestBasic(unittest.TestCase):
     # IMPORTANT: This test must be run first since it calls MPI_Init()
     def test_01_blackoil(self):
         with pushd(self.data_dir_bo):
-            sim = BlackOilSimulator(args=['--linear-solver=ilu0', '--enable-async-ecl-output=false'], filename="SPE1CASE1.DATA")
+            sim = create_black_oil_simulator(args=['--linear-solver=ilu0'], filename="SPE1CASE1.DATA")
             sim.setup_mpi(init=True, finalize=False)
             sim.step_init()
             sim.step()
@@ -48,7 +47,7 @@ class TestBasic(unittest.TestCase):
     # IMPORTANT: This test must be run last since it calls MPI_Finalize()
     def test_99_gaswater(self):
         with pushd(self.data_dir_gw):
-            sim = GasWaterSimulator(args=['--linear-solver=ilu0', '--enable-async-ecl-output=false'], filename="SPE1CASE2_GASWATER.DATA")
+            sim = create_gas_water_simulator(args=['--linear-solver=ilu0'], filename="SPE1CASE2_GASWATER.DATA")
             sim.setup_mpi(init=False, finalize=True)
             sim.step_init()
             sim.step()

--- a/python/test/test_fluidstate_variables.py
+++ b/python/test/test_fluidstate_variables.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 from pathlib import Path
-from opm.simulators import BlackOilSimulator, GasWaterSimulator
-from .pytest_common import pushd
+from .pytest_common import pushd, create_black_oil_simulator, create_gas_water_simulator
 
 class TestBasic(unittest.TestCase):
     @classmethod
@@ -21,7 +20,7 @@ class TestBasic(unittest.TestCase):
     # IMPORTANT:This test must be run first since it calls MPI_Init()
     def test_01_blackoil(self):
         with pushd(self.data_dir_bo):
-            sim = BlackOilSimulator(args=['--enable-async-ecl-output=false'], filename="SPE1CASE1.DATA")
+            sim = create_black_oil_simulator(filename="SPE1CASE1.DATA")
             sim.setup_mpi(True, False)
             sim.step_init()
             sim.step()
@@ -53,7 +52,7 @@ class TestBasic(unittest.TestCase):
     # IMPORTANT: This test must be run last since it calls MPI_Finalize()
     def test_99_gaswater(self):
         with pushd(self.data_dir_gw):
-            sim = GasWaterSimulator(args=['--enable-async-ecl-output=false'], filename="SPE1CASE2_GASWATER.DATA")
+            sim = create_gas_water_simulator(filename="SPE1CASE2_GASWATER.DATA")
             sim.setup_mpi(False, True)
             sim.step_init()
             sim.step()

--- a/python/test/test_mpi.py
+++ b/python/test/test_mpi.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 from pathlib import Path
-from opm.simulators import BlackOilSimulator
-from .pytest_common import pushd
+from .pytest_common import pushd, create_black_oil_simulator
 
 class TestBasic(unittest.TestCase):
     @classmethod
@@ -18,14 +17,14 @@ class TestBasic(unittest.TestCase):
     #  are run in a given order.
     def test_01_mpi_init(self):
         with pushd(self.data_dir):
-            sim = BlackOilSimulator(args=['--enable-async-ecl-output=false'], filename="SPE1CASE1.DATA")
+            sim = create_black_oil_simulator(filename="SPE1CASE1.DATA")
             sim.setup_mpi(init=True, finalize=False)
             sim.step_init()  # This will create the OPM::Main() object which will call MPI_Init()
             assert True
 
     def test_02_mpi_no_init(self):
         with pushd(self.data_dir):
-            sim = BlackOilSimulator(args=['--enable-async-ecl-output=false'], filename="SPE1CASE1.DATA")
+            sim = create_black_oil_simulator(filename="SPE1CASE1.DATA")
             sim.setup_mpi(init=False, finalize=True)
             sim.step_init()  # This will create the OPM::Main() object which will not call MPI_Init()
             # That this test runs shows that the simulator does not call

--- a/python/test/test_primary_variables.py
+++ b/python/test/test_primary_variables.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 from pathlib import Path
-from opm.simulators import BlackOilSimulator, GasWaterSimulator
-from .pytest_common import pushd
+from .pytest_common import pushd, create_black_oil_simulator, create_gas_water_simulator
 
 class TestBasic(unittest.TestCase):
     @classmethod
@@ -24,7 +23,7 @@ class TestBasic(unittest.TestCase):
     # IMPORTANT:This test must be run first since it calls MPI_Init()
     def test_01_blackoil(self):
         with pushd(self.data_dir_bo):
-            sim = BlackOilSimulator(args=['--enable-async-ecl-output=false'], filename="SPE1CASE1.DATA")
+            sim = create_black_oil_simulator(filename="SPE1CASE1.DATA")
             sim.setup_mpi(True, False)
             sim.step_init()
             sim.step()
@@ -54,7 +53,7 @@ class TestBasic(unittest.TestCase):
     # IMPORTANT: This test must be run last since it calls MPI_Finalize()
     def test_99_gaswater(self):
         with pushd(self.data_dir_gw):
-            sim = GasWaterSimulator(args=['--enable-async-ecl-output=false'], filename="SPE1CASE2_GASWATER.DATA")
+            sim = create_gas_water_simulator(filename="SPE1CASE2_GASWATER.DATA")
             sim.setup_mpi(False, True)
             sim.step_init()
             sim.step()

--- a/python/test/test_schedule.py
+++ b/python/test/test_schedule.py
@@ -3,7 +3,7 @@ import unittest
 import datetime as dt
 from pathlib import Path
 import re
-from opm.simulators import BlackOilSimulator
+from .pytest_common import create_black_oil_simulator
 from opm.io.parser import Parser
 from opm.io.ecl_state import EclipseState
 from opm.io.schedule import Schedule
@@ -29,8 +29,8 @@ class TestBasic(unittest.TestCase):
             self.assertTrue('INJ'  in self.schedule)
             self.assertEqual(dt.datetime(2015, 1, 1),   self.schedule.start)
             self.assertEqual(dt.datetime(2016, 1, 1), self.schedule.end)
-            self.sim = BlackOilSimulator(
-                self.deck, state, self.schedule, summary_config, args=['--enable-async-ecl-output=false'])
+            self.sim = create_black_oil_simulator(
+                self.deck, state, self.schedule, summary_config)
             tsteps = self.schedule.timesteps
             self.assertEqual(dt.datetime(2015, 1, 1), tsteps[0])
             last_step = len(tsteps) - 1

--- a/python/test/test_throw.py
+++ b/python/test/test_throw.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 from pathlib import Path
-from opm.simulators import BlackOilSimulator
-from .pytest_common import pushd
+from .pytest_common import pushd, create_black_oil_simulator
 
 class TestBasic(unittest.TestCase):
     @classmethod
@@ -12,7 +11,7 @@ class TestBasic(unittest.TestCase):
 
     def test_all(self):
         with pushd(self.data_dir):
-            sim = BlackOilSimulator(args=['--enable-async-ecl-output=false'], filename="SPE1CASE1.DATA")
+            sim = create_black_oil_simulator(filename="SPE1CASE1.DATA")
             # NOTE: The following call should throw an exception since the simulation
             #   has not been initialized
             with self.assertRaises(RuntimeError):


### PR DESCRIPTION
Thanks to @akva2 for reporting this issue: Sometimes running Python unit tests left misplaced output files (like `SPE1CASE2_GASWATER.UNRST`) and error message like:
```
Error: [/tmp/opm/opm-common/opm/io/eclipse/EclFile.cpp:243] Could not open file: './SPE1CASE2_GASWATER.UNRST'
ERROR: Uncaught std::exception when running tasklet: [/tmp/opm/opm-common/opm/io/eclipse/EclFile.cpp:243] Could not open file: './
SPE1CASE2_GASWATER.UNRST'.
```

The problem is that:
- Tests use `pushd()` to change directory before running simulations
- Simulator dispatches async tasklets to write ECL output files
- pushd context exits before the async writes complete
- Tasklets write files in wrong directory (`build/python/` instead of `build/python/test_data/<case>/`)
- Causes confusing error messages and misplaced output files


This PR adds `--enable-async-ecl-output=false` to all Python simulator tests to prevent race condition between async file writing tasklets and pushd context manager.

