### PR TITLE
Remove unnecessary mutable qualifier for the solution object.

### DIFF
--- a/opm/models/discretization/common/fvbasediscretization.hh
+++ b/opm/models/discretization/common/fvbasediscretization.hh
@@ -2017,7 +2017,7 @@ protected:
     // while these are logically bools, concurrent writes to vector<bool> are not thread safe.
     mutable std::vector<std::vector<unsigned char>> intensiveQuantityCacheUpToDate_;
 
-    mutable std::array<std::unique_ptr<DiscreteFunction>, historySize> solution_;
+    std::array<std::unique_ptr<DiscreteFunction>, historySize> solution_;
 
     std::list<std::unique_ptr<BaseOutputModule<TypeTag>>> outputModules_;
 


### PR DESCRIPTION
I do not know why it was made mutable in the first place. It should not be, as it is not a cache but an essential part of the state of the class.