### PR TITLE
Use new lineariser for simulators with EnableBrine

### DIFF
--- a/flow/flow_brine.cpp
+++ b/flow/flow_brine.cpp
@@ -19,6 +19,9 @@
 #include <flow/flow_brine.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
@@ -30,9 +33,20 @@ struct FlowBrineProblem {
     using InheritsFrom = std::tuple<FlowProblem>;
 };
 }
+
 template<class TypeTag>
 struct EnableBrine<TypeTag, TTag::FlowBrineProblem> {
     static constexpr bool value = true;
+};
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowBrineProblem> { 
+    using type = TpfaLinearizer<TypeTag>;
+};
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowBrineProblem> {
+    using type = BlackOilLocalResidualTPFA<TypeTag>;
 };
 }}
 

--- a/flow/flow_brine_energy.cpp
+++ b/flow/flow_brine_energy.cpp
@@ -15,6 +15,9 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "config.h"
+
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
 #include <opm/simulators/flow/Main.hpp>
 
 namespace Opm {
@@ -24,13 +27,25 @@ struct FlowBrineEnergyProblem {
     using InheritsFrom = std::tuple<FlowProblem>;
 };
 }
+
 template<class TypeTag>
 struct EnableBrine<TypeTag, TTag::FlowBrineEnergyProblem> {
     static constexpr bool value = true;
 };
+
 template<class TypeTag>
 struct EnableEnergy<TypeTag, TTag::FlowBrineEnergyProblem> {
     static constexpr bool value = true;
+};
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowBrineEnergyProblem> { 
+    using type = TpfaLinearizer<TypeTag>;
+};
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowBrineEnergyProblem> {
+    using type = BlackOilLocalResidualTPFA<TypeTag>;
 };
 }
 

--- a/flow/flow_brine_precsalt_vapwat.cpp
+++ b/flow/flow_brine_precsalt_vapwat.cpp
@@ -19,6 +19,9 @@
 #include <flow/flow_brine_precsalt_vapwat.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
@@ -43,6 +46,16 @@ struct EnableSaltPrecipitation<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem> {
 template<class TypeTag>
 struct EnableVapwat<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem> {
     static constexpr bool value = true;
+};
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem> { 
+    using type = TpfaLinearizer<TypeTag>;
+};
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowBrinePrecsaltVapwatProblem> {
+    using type = BlackOilLocalResidualTPFA<TypeTag>;
 };
 }}
 

--- a/flow/flow_brine_saltprecipitation.cpp
+++ b/flow/flow_brine_saltprecipitation.cpp
@@ -19,6 +19,9 @@
 #include <flow/flow_brine_saltprecipitation.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
@@ -30,6 +33,7 @@ struct FlowBrineSaltPrecipitationProblem {
     using InheritsFrom = std::tuple<FlowProblem>;
 };
 }
+
 template<class TypeTag>
 struct EnableBrine<TypeTag, TTag::FlowBrineSaltPrecipitationProblem> {
     static constexpr bool value = true;
@@ -38,6 +42,16 @@ struct EnableBrine<TypeTag, TTag::FlowBrineSaltPrecipitationProblem> {
 template<class TypeTag>
 struct EnableSaltPrecipitation<TypeTag, TTag::FlowBrineSaltPrecipitationProblem> {
     static constexpr bool value = true;
+};
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowBrineSaltPrecipitationProblem> { 
+    using type = TpfaLinearizer<TypeTag>;
+};
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowBrineSaltPrecipitationProblem> {
+    using type = BlackOilLocalResidualTPFA<TypeTag>;
 };
 }}
 

--- a/flow/flow_gaswater_brine.cpp
+++ b/flow/flow_gaswater_brine.cpp
@@ -19,7 +19,9 @@
 #include <flow/flow_gaswater_brine.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
@@ -32,18 +34,32 @@ struct FlowGasWaterBrineProblem {
     using InheritsFrom = std::tuple<FlowProblem>;
 };
 }
+
 template<class TypeTag>
 struct EnableBrine<TypeTag, TTag::FlowGasWaterBrineProblem> {
     static constexpr bool value = true;
 };
+
 template<class TypeTag>
 struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterBrineProblem> {
     static constexpr bool value = true;
 };
+
 template<class TypeTag>
 struct EnableVapwat<TypeTag, TTag::FlowGasWaterBrineProblem> {
     static constexpr bool value = true;
 };
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowGasWaterBrineProblem> { 
+    using type = TpfaLinearizer<TypeTag>;
+};
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowGasWaterBrineProblem> {
+    using type = BlackOilLocalResidualTPFA<TypeTag>;
+};
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlowGasWaterBrineProblem>

--- a/flow/flow_gaswater_saltprec_energy.cpp
+++ b/flow/flow_gaswater_saltprec_energy.cpp
@@ -19,7 +19,9 @@
 #include <flow/flow_gaswater_saltprec_energy.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
@@ -55,6 +57,16 @@ struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem> {
 template<class TypeTag>
 struct EnableEnergy<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem> {
     static constexpr bool value = true;
+};
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem> { 
+    using type = TpfaLinearizer<TypeTag>;
+};
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowGasWaterSaltprecEnergyProblem> {
+    using type = BlackOilLocalResidualTPFA<TypeTag>;
 };
 
 //! The indices required by the model

--- a/flow/flow_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_gaswater_saltprec_vapwat.cpp
@@ -19,7 +19,9 @@
 #include <flow/flow_gaswater_saltprec_vapwat.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
@@ -50,6 +52,16 @@ struct EnableVapwat<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem> {
 template<class TypeTag>
 struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem> {
     static constexpr bool value = true;
+};
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem> { 
+    using type = TpfaLinearizer<TypeTag>;
+};
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem> {
+    using type = BlackOilLocalResidualTPFA<TypeTag>;
 };
 
 //! The indices required by the model

--- a/flow/flow_oilwater_brine.cpp
+++ b/flow/flow_oilwater_brine.cpp
@@ -19,7 +19,9 @@
 #include <flow/flow_oilwater_brine.hpp>
 
 #include <opm/material/common/ResetLocale.hpp>
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/blackoil/blackoiltwophaseindices.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
 
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
@@ -32,10 +34,22 @@ struct FlowOilWaterBrineProblem {
     using InheritsFrom = std::tuple<FlowProblem>;
 };
 }
+
 template<class TypeTag>
 struct EnableBrine<TypeTag, TTag::FlowOilWaterBrineProblem> {
     static constexpr bool value = true;
 };
+
+template<class TypeTag>
+struct Linearizer<TypeTag, TTag::FlowOilWaterBrineProblem> { 
+    using type = TpfaLinearizer<TypeTag>;
+};
+
+template<class TypeTag>
+struct LocalResidual<TypeTag, TTag::FlowOilWaterBrineProblem> {
+    using type = BlackOilLocalResidualTPFA<TypeTag>;
+};
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlowOilWaterBrineProblem>

--- a/opm/models/blackoil/blackoillocalresidual.hh
+++ b/opm/models/blackoil/blackoillocalresidual.hh
@@ -250,7 +250,7 @@ public:
         DiffusionModule::addDiffusiveFlux(flux, elemCtx, scvfIdx, timeIdx);
 
         // deal with convective mixing (if enabled)
-        ConvectiveMixingModule::addConvectiveMixingFlux(flux,elemCtx, scvfIdx, timeIdx);
+        ConvectiveMixingModule::addConvectiveMixingFlux(flux, elemCtx, scvfIdx, timeIdx);
     }
 
     /*!

--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -418,17 +418,25 @@ public:
                     BioeffectsModule::template addBioeffectsFluxes_<Evaluation, Evaluation, IntensiveQuantities>
                         (flux, phaseIdx, darcyFlux, up);
                 }
+                if constexpr (enableBrine) {
+                    BrineModule::template
+                        addBrineFluxes_<Evaluation, FluidState>(flux, phaseIdx, darcyFlux, up.fluidState());
+                }
             } else {
                 const auto& invB = getInvB_<FluidSystem, FluidState, Scalar>(up.fluidState(), phaseIdx, pvtRegionIdx);
                 const auto& surfaceVolumeFlux = invB * darcyFlux;
                 evalPhaseFluxes_<Scalar>(flux, phaseIdx, pvtRegionIdx, surfaceVolumeFlux, up.fluidState());
                 if constexpr (enableEnergy) {
                     EnergyModule::template
-                        addPhaseEnthalpyFluxes_<Scalar>(flux,phaseIdx,darcyFlux, up.fluidState());
+                        addPhaseEnthalpyFluxes_<Scalar>(flux, phaseIdx, darcyFlux, up.fluidState());
                 }
                 if constexpr (enableBioeffects) {
                     BioeffectsModule::template addBioeffectsFluxes_<Scalar, Evaluation, IntensiveQuantities>
                         (flux, phaseIdx, darcyFlux, up);
+                }
+                if constexpr (enableBrine) {
+                    BrineModule::template
+                        addBrineFluxes_<Scalar, FluidState>(flux, phaseIdx, darcyFlux, up.fluidState());
                 }
             }
         }
@@ -490,11 +498,6 @@ public:
         static_assert(!enableFoam,
                       "Relevant computeFlux() method must be implemented for this module before enabling.");
         // FoamModule::computeFlux(flux, elemCtx, scvfIdx, timeIdx);
-
-        // deal with salt (if present)
-        static_assert(!enableBrine,
-                      "Relevant computeFlux() method must be implemented for this module before enabling.");
-        // BrineModule::computeFlux(flux, elemCtx, scvfIdx, timeIdx);
 
         // deal with diffusion (if present). opm-models expects per area flux (added in the tmpdiffusivity).
         if constexpr (enableDiffusion) {


### PR DESCRIPTION
Making the TPFA lineariser default for simulators with `EnableBrine=true` (and fixing some format in a few files while working on this as well).