### PR TITLE
Avoid potential throw upon restart

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -275,6 +275,9 @@ namespace {
                                 const int stepIdx,
                                 const bool isInj)
     {
+        // Avoid throw when checking step 0 on restart
+        if (!schedule.hasGroup(parentname, stepIdx)) return false;
+
         const auto& parent = schedule.getGroup(parentname, stepIdx);
         if (isInj) {
             if (parent.isInjectionGroup()) {


### PR DESCRIPTION
(when looking for non-existing group at step 0)