### PR TITLE
Add energy module type and use it.

### DIFF
--- a/flow/flow_brine_energy.cpp
+++ b/flow/flow_brine_energy.cpp
@@ -19,6 +19,7 @@
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
 
 namespace Opm {
 namespace Properties {
@@ -34,11 +35,6 @@ struct EnableBrine<TypeTag, TTag::FlowBrineEnergyProblem> {
 };
 
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::FlowBrineEnergyProblem> {
-    static constexpr bool value = true;
-};
-
-template<class TypeTag>
 struct Linearizer<TypeTag, TTag::FlowBrineEnergyProblem> {
     using type = TpfaLinearizer<TypeTag>;
 };
@@ -47,6 +43,9 @@ template<class TypeTag>
 struct LocalResidual<TypeTag, TTag::FlowBrineEnergyProblem> {
     using type = BlackOilLocalResidualTPFA<TypeTag>;
 };
+template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowBrineEnergyProblem>
+{ static constexpr EnergyModules value = EnergyModules::FullyImplicitThermal; };
 }
 
 int flowBrineEnergyMain(int argc, char** argv)

--- a/flow/flow_energy.cpp
+++ b/flow/flow_energy.cpp
@@ -22,9 +22,9 @@
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
-
 namespace Opm {
 namespace Properties {
 namespace TTag {
@@ -34,9 +34,10 @@ struct FlowEnergyProblem {
 }
 
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::FlowEnergyProblem> {
-    static constexpr bool value = true;
-};
+struct EnergyModuleType<TypeTag, TTag::FlowEnergyProblem>
+{ static constexpr EnergyModules value = EnergyModules::FullyImplicitThermal; };
+
+
 template<class TypeTag>
 struct Linearizer<TypeTag, TTag::FlowEnergyProblem> { using type = TpfaLinearizer<TypeTag>; };
 template<class TypeTag>

--- a/flow/flow_gasoil.cpp
+++ b/flow/flow_gasoil.cpp
@@ -27,6 +27,7 @@
 
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
+#include <opm/material/thermal/EnergyModuleType.hpp>
 
 namespace Opm {
 namespace Properties {
@@ -45,6 +46,10 @@ struct LocalResidual<TypeTag, TTag::FlowGasOilProblem> { using type = BlackOilLo
 template<class TypeTag>
 struct EnableDiffusion<TypeTag, TTag::FlowGasOilProblem> { static constexpr bool value = false; };
 
+template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowGasOilProblem>
+{ static constexpr EnergyModules value = EnergyModules::ConstantTemperature; };
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlowGasOilProblem>
@@ -55,12 +60,13 @@ private:
     // messages unfortunately are *really* confusing and not really helpful.
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
-
+    static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
 public:
   using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                        getPropValue<TypeTag, Properties::EnableExtbo>(),
                                        getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                       getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                       numEnergyVars,
                                        getPropValue<TypeTag, Properties::EnableFoam>(),
                                        getPropValue<TypeTag, Properties::EnableBrine>(),
                                        /*PVOffset=*/0,

--- a/flow/flow_gasoildiffuse.cpp
+++ b/flow/flow_gasoildiffuse.cpp
@@ -26,6 +26,7 @@
 #include <opm/simulators/flow/Main.hpp>
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
+#include <opm/material/thermal/EnergyModuleType.hpp>
 
 namespace Opm {
 namespace Properties {
@@ -47,6 +48,10 @@ struct EnableDiffusion<TypeTag, TTag::FlowGasOilDiffuseProblem> { static constex
 template<class TypeTag>
 struct EnableDispersion<TypeTag, TTag::FlowGasOilDiffuseProblem> { static constexpr bool value = true; };
 
+template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowGasOilDiffuseProblem>
+{ static constexpr EnergyModules value = EnergyModules::ConstantTemperature; };
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlowGasOilDiffuseProblem>
@@ -57,12 +62,13 @@ private:
     // messages unfortunately are *really* confusing and not really helpful.
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
-
+    static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
 public:
   using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                        getPropValue<TypeTag, Properties::EnableExtbo>(),
                                        getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                       getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                       numEnergyVars,
                                        getPropValue<TypeTag, Properties::EnableFoam>(),
                                        getPropValue<TypeTag, Properties::EnableBrine>(),
                                        /*PVOffset=*/0,

--- a/flow/flow_gaswater.cpp
+++ b/flow/flow_gaswater.cpp
@@ -43,6 +43,10 @@ struct LocalResidual<TypeTag, TTag::FlowGasWaterProblem> { using type = BlackOil
 template<class TypeTag>
 struct EnableDiffusion<TypeTag, TTag::FlowGasWaterProblem> { static constexpr bool value = false; };
 
+template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowGasWaterProblem>
+{ static constexpr EnergyModules value = EnergyModules::ConstantTemperature; };
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlowGasWaterProblem>
@@ -58,7 +62,7 @@ public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),
                                          getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
                                          getPropValue<TypeTag, Properties::EnableFoam>(),
                                          getPropValue<TypeTag, Properties::EnableBrine>(),
                                          /*PVOffset=*/0,

--- a/flow/flow_gaswater_brine.cpp
+++ b/flow/flow_gaswater_brine.cpp
@@ -26,6 +26,7 @@
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
 
 namespace Opm {
 namespace Properties {
@@ -60,6 +61,10 @@ struct LocalResidual<TypeTag, TTag::FlowGasWaterBrineProblem> {
     using type = BlackOilLocalResidualTPFA<TypeTag>;
 };
 
+template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowGasWaterBrineProblem>
+{ static constexpr EnergyModules value = EnergyModules::ConstantTemperature; };
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlowGasWaterBrineProblem>
@@ -70,12 +75,13 @@ private:
     // messages unfortunately are *really* confusing and not really helpful.
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
-
+    static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),
                                          getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         numEnergyVars,
                                          getPropValue<TypeTag, Properties::EnableFoam>(),
                                          getPropValue<TypeTag, Properties::EnableBrine>(),
                                          /*PVOffset=*/0,

--- a/flow/flow_gaswater_dissolution.cpp
+++ b/flow/flow_gaswater_dissolution.cpp
@@ -30,6 +30,7 @@
 
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
+#include <opm/material/thermal/EnergyModuleType.hpp>
 
 namespace Opm {
 namespace Properties {
@@ -54,6 +55,10 @@ struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterDissolutionProblem> {
 };
 
 template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowGasWaterDissolutionProblem>
+{ static constexpr EnergyModules value = EnergyModules::ConstantTemperature; };
+
+template<class TypeTag>
 struct EnableVapwat<TypeTag, TTag::FlowGasWaterDissolutionProblem> {
     static constexpr bool value = true;
 };
@@ -68,12 +73,13 @@ private:
     // messages unfortunately are *really* confusing and not really helpful.
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
-
+    static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),
                                          getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         numEnergyVars,
                                          getPropValue<TypeTag, Properties::EnableFoam>(),
                                          getPropValue<TypeTag, Properties::EnableBrine>(),
                                          /*PVOffset=*/0,

--- a/flow/flow_gaswater_dissolution_diffuse.cpp
+++ b/flow/flow_gaswater_dissolution_diffuse.cpp
@@ -30,6 +30,7 @@
 
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
+#include <opm/material/thermal/EnergyModuleType.hpp>
 
 namespace Opm {
 namespace Properties {
@@ -61,6 +62,10 @@ struct EnableVapwat<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem> {
     static constexpr bool value = true;
 };
 
+template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem>
+{ static constexpr EnergyModules value = EnergyModules::ConstantTemperature; };
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlowGasWaterDissolutionDiffuseProblem>
@@ -71,12 +76,13 @@ private:
     // messages unfortunately are *really* confusing and not really helpful.
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
-
+    static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),
                                          getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         numEnergyVars,
                                          getPropValue<TypeTag, Properties::EnableFoam>(),
                                          getPropValue<TypeTag, Properties::EnableBrine>(),
                                          /*PVOffset=*/0,

--- a/flow/flow_gaswater_energy.cpp
+++ b/flow/flow_gaswater_energy.cpp
@@ -30,6 +30,7 @@
 
 #include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
 #include <opm/models/discretization/common/tpfalinearizer.hh>
+#include <opm/material/thermal/EnergyModuleType.hpp>
 
 namespace Opm {
 namespace Properties {
@@ -52,9 +53,8 @@ template<class TypeTag>
 struct EnableDispersion<TypeTag, TTag::FlowGasWaterEnergyProblem> { static constexpr bool value = true; };
 
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::FlowGasWaterEnergyProblem> {
-    static constexpr bool value = true;
-};
+struct EnergyModuleType<TypeTag, TTag::FlowGasWaterEnergyProblem>
+{ static constexpr EnergyModules value = EnergyModules::FullyImplicitThermal; };
 
 template<class TypeTag>
 struct EnableDisgasInWater<TypeTag, TTag::FlowGasWaterEnergyProblem> {
@@ -76,12 +76,13 @@ private:
     // messages unfortunately are *really* confusing and not really helpful.
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
-
+    static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),
                                          getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         numEnergyVars,
                                          getPropValue<TypeTag, Properties::EnableFoam>(),
                                          getPropValue<TypeTag, Properties::EnableBrine>(),
                                          /*PVOffset=*/0,

--- a/flow/flow_gaswater_saltprec_vapwat.cpp
+++ b/flow/flow_gaswater_saltprec_vapwat.cpp
@@ -26,6 +26,7 @@
 #include <opm/grid/CpGrid.hpp>
 #include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
 #include <opm/simulators/flow/Main.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
 
 namespace Opm {
 namespace Properties {
@@ -63,6 +64,9 @@ template<class TypeTag>
 struct LocalResidual<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem> {
     using type = BlackOilLocalResidualTPFA<TypeTag>;
 };
+template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowGasWaterSaltprecVapwatProblem>
+{ static constexpr EnergyModules value = EnergyModules::ConstantTemperature; };
 
 //! The indices required by the model
 template<class TypeTag>
@@ -74,12 +78,13 @@ private:
     // messages unfortunately are *really* confusing and not really helpful.
     using BaseTypeTag = TTag::FlowProblem;
     using FluidSystem = GetPropType<BaseTypeTag, Properties::FluidSystem>;
-
+    static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
+    static constexpr int numEnergyVars = energyModuleType == EnergyModules::FullyImplicitThermal;
 public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),
                                          getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         numEnergyVars,
                                          getPropValue<TypeTag, Properties::EnableFoam>(),
                                          getPropValue<TypeTag, Properties::EnableBrine>(),
                                          /*PVOffset=*/0,

--- a/flow/flow_gaswater_solvent.cpp
+++ b/flow/flow_gaswater_solvent.cpp
@@ -41,6 +41,10 @@ struct EnableSolvent<TypeTag, TTag::FlowGasWaterSolventProblem> {
     static constexpr bool value = true;
 };
 
+template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowGasWaterSolventProblem>
+{ static constexpr EnergyModules value = EnergyModules::ConstantTemperature; };
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlowGasWaterSolventProblem>
@@ -56,7 +60,7 @@ public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),
                                          getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
                                          getPropValue<TypeTag, Properties::EnableFoam>(),
                                          getPropValue<TypeTag, Properties::EnableBrine>(),
                                          /*PVOffset=*/0,

--- a/flow/flow_micp.cpp
+++ b/flow/flow_micp.cpp
@@ -63,7 +63,7 @@ public:
     using type = BlackOilOnePhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),
                                          getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
                                          getPropValue<TypeTag, Properties::EnableFoam>(),
                                          getPropValue<TypeTag, Properties::EnableBrine>(),
                                          /*PVOffset=*/0,

--- a/flow/flow_oilwater.cpp
+++ b/flow/flow_oilwater.cpp
@@ -61,7 +61,7 @@ public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),
                                          getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
                                          getPropValue<TypeTag, Properties::EnableFoam>(),
                                          getPropValue<TypeTag, Properties::EnableBrine>(),
                                          /*PVOffset=*/0,

--- a/flow/flow_oilwater_brine.cpp
+++ b/flow/flow_oilwater_brine.cpp
@@ -65,7 +65,7 @@ public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),
                                          getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
                                          getPropValue<TypeTag, Properties::EnableFoam>(),
                                          getPropValue<TypeTag, Properties::EnableBrine>(),
                                          /*PVOffset=*/0,

--- a/flow/flow_oilwater_polymer.cpp
+++ b/flow/flow_oilwater_polymer.cpp
@@ -51,7 +51,7 @@ public:
     using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),
                                          getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
                                          getPropValue<TypeTag, Properties::EnableFoam>(),
                                          getPropValue<TypeTag, Properties::EnableBrine>(),
                                          /*PVOffset=*/0,

--- a/flow/flow_onephase.cpp
+++ b/flow/flow_onephase.cpp
@@ -58,7 +58,7 @@ public:
     using type = BlackOilOnePhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                          getPropValue<TypeTag, Properties::EnableExtbo>(),
                                          getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                         getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                         getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
                                          getPropValue<TypeTag, Properties::EnableFoam>(),
                                          getPropValue<TypeTag, Properties::EnableBrine>(),
                                          /*PVOffset=*/0,

--- a/flow/flow_onephase_energy.cpp
+++ b/flow/flow_onephase_energy.cpp
@@ -35,9 +35,9 @@ struct FlowWaterOnlyEnergyProblem {
 };
 }
 template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::FlowWaterOnlyEnergyProblem> {
-    static constexpr bool value = true;
-};
+struct EnergyModuleType<TypeTag, TTag::FlowWaterOnlyEnergyProblem>
+{ static constexpr EnergyModules value = EnergyModules::FullyImplicitThermal; };
+
 //! The indices required by the model
 template<class TypeTag>
 struct Indices<TypeTag, TTag::FlowWaterOnlyEnergyProblem>
@@ -53,7 +53,7 @@ public:
     using type = Opm::BlackOilOnePhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                               getPropValue<TypeTag, Properties::EnableExtbo>(),
                                               getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                              getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                              getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
                                               getPropValue<TypeTag, Properties::EnableFoam>(),
                                               getPropValue<TypeTag, Properties::EnableBrine>(),
                                               /*PVOffset=*/0,

--- a/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
+++ b/flowexperimental/BlackOilIntensiveQuantitiesGlobalIndex.hpp
@@ -78,7 +78,7 @@ class BlackOilIntensiveQuantitiesGlobalIndex
     , public BlackOilPolymerIntensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnablePolymer>()>
     , public BlackOilFoamIntensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableFoam>()>
     , public BlackOilBrineIntensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableBrine>()>
-    , public BlackOilEnergyIntensiveQuantitiesGlobalIndex<TypeTag, getPropValue<TypeTag, Properties::EnableEnergy>()>
+    , public BlackOilEnergyIntensiveQuantitiesGlobalIndex<TypeTag, getPropValue<TypeTag, Properties::EnergyModuleType>()>
     , public BlackOilBioeffectsIntensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableBioeffects>()>
     , public BlackOilConvectiveMixingIntensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableConvectiveMixing>()>
 {
@@ -103,8 +103,9 @@ class BlackOilIntensiveQuantitiesGlobalIndex
     enum { enableBrine = getPropValue<TypeTag, Properties::EnableBrine>() };
     enum { enableVapwat = getPropValue<TypeTag, Properties::EnableVapwat>() };
     enum { enableSaltPrecipitation = getPropValue<TypeTag, Properties::EnableSaltPrecipitation>() };
-    enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
-    enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
+    enum { enableTemperature = (energyModuleType == EnergyModules::ConstantTemperature) };
+    enum { enableEnergy = (energyModuleType == EnergyModules::FullyImplicitThermal) };
     enum { enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>() };
     enum { enableConvectiveMixing = getPropValue<TypeTag, Properties::EnableConvectiveMixing>() };
     enum { enableBioeffects = getPropValue<TypeTag, Properties::EnableBioeffects>() };
@@ -527,7 +528,7 @@ private:
     friend BlackOilSolventIntensiveQuantities<TypeTag, enableSolvent>;
     friend BlackOilExtboIntensiveQuantities<TypeTag, enableExtbo>;
     friend BlackOilPolymerIntensiveQuantities<TypeTag, enablePolymer>;
-    friend BlackOilEnergyIntensiveQuantitiesGlobalIndex<TypeTag, enableEnergy>;
+    friend BlackOilEnergyIntensiveQuantitiesGlobalIndex<TypeTag, energyModuleType>;
     friend BlackOilFoamIntensiveQuantities<TypeTag, enableFoam>;
     friend BlackOilBrineIntensiveQuantities<TypeTag, enableBrine>;
     friend BlackOilBioeffectsIntensiveQuantities<TypeTag, enableBioeffects>;

--- a/flowexperimental/comp/flowexp_comp.hpp
+++ b/flowexperimental/comp/flowexp_comp.hpp
@@ -208,11 +208,6 @@ struct EnableApiTracking<TypeTag, TTag::FlowExpCompProblem<NumComp, EnableWater>
 };
 
 template<class TypeTag, int NumComp, bool EnableWater>
-struct EnableTemperature<TypeTag, TTag::FlowExpCompProblem<NumComp, EnableWater>> {
-    static constexpr bool value = false;
-};
-
-template<class TypeTag, int NumComp, bool EnableWater>
 struct EnableSaltPrecipitation<TypeTag, TTag::FlowExpCompProblem<NumComp, EnableWater>> {
     static constexpr bool value = false;
 };
@@ -242,10 +237,6 @@ struct EnableVapwat<TypeTag, TTag::FlowExpCompProblem<NumComp, EnableWater>> {
 
 template<class TypeTag, int NumComp, bool EnableWater>
 struct EnableSolvent<TypeTag, TTag::FlowExpCompProblem<NumComp, EnableWater>> {
-    static constexpr bool value = false;
-};
-template<class TypeTag, int NumComp, bool EnableWater>
-struct EnableEnergy<TypeTag, TTag::FlowExpCompProblem<NumComp, EnableWater>> {
     static constexpr bool value = false;
 };
 template<class TypeTag, int NumComp, bool EnableWater>

--- a/opm/models/blackoil/blackoilboundaryratevector.hh
+++ b/opm/models/blackoil/blackoilboundaryratevector.hh
@@ -59,7 +59,7 @@ class BlackOilBoundaryRateVector : public GetPropType<TypeTag, Properties::RateV
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
     enum { enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>() };
     enum { enablePolymer = getPropValue<TypeTag, Properties::EnablePolymer>() };
-    enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    enum { enableEnergy = (getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal) };
     enum { contiEnergyEqIdx = Indices::contiEnergyEqIdx };
     enum { enableFoam = getPropValue<TypeTag, Properties::EnableFoam>() };
     enum { enableMICP = Indices::enableMICP };
@@ -67,7 +67,8 @@ class BlackOilBoundaryRateVector : public GetPropType<TypeTag, Properties::RateV
     static constexpr bool blackoilConserveSurfaceVolume =
         getPropValue<TypeTag, Properties::BlackoilConserveSurfaceVolume>();
 
-    using EnergyModule = BlackOilEnergyModule<TypeTag, enableEnergy>;
+    static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
+    using EnergyModule = BlackOilEnergyModule<TypeTag, energyModuleType>;
 
 public:
     /*!

--- a/opm/models/blackoil/blackoilconvectivemixingmodule.hh
+++ b/opm/models/blackoil/blackoilconvectivemixingmodule.hh
@@ -37,6 +37,7 @@
 #include <opm/material/common/Valgrind.hpp>
 
 #include <opm/models/common/multiphasebaseproperties.hh>
+#include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/discretization/common/fvbaseproperties.hh>
 
 #if HAVE_ECL_INPUT
@@ -137,7 +138,7 @@ class BlackOilConvectiveMixingModule<TypeTag, /*enableConvectiveMixing=*/true>
     enum { dimWorld = GridView::dimensionworld };
     enum { waterPhaseIdx = FluidSystem::waterPhaseIdx };
     enum { oilPhaseIdx = FluidSystem::oilPhaseIdx };
-    static constexpr bool enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>();
+    static constexpr bool enableEnergy = (getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal);
     static constexpr unsigned contiEnergyEqIdx = Indices::contiEnergyEqIdx;
 
 public:

--- a/opm/models/blackoil/blackoilextensivequantities.hh
+++ b/opm/models/blackoil/blackoilextensivequantities.hh
@@ -53,7 +53,7 @@ class BlackOilExtensiveQuantities
     : public MultiPhaseBaseExtensiveQuantities<TypeTag>
     , public BlackOilSolventExtensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableSolvent>()>
     , public BlackOilPolymerExtensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnablePolymer>()>
-    , public BlackOilEnergyExtensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableEnergy>()>
+    , public BlackOilEnergyExtensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnergyModuleType>()>
     , public BlackOilDiffusionExtensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableDiffusion>()>
     , public BlackOilBioeffectsExtensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableBioeffects>()>
 {

--- a/opm/models/blackoil/blackoilintensivequantities.hh
+++ b/opm/models/blackoil/blackoilintensivequantities.hh
@@ -79,7 +79,7 @@ class BlackOilIntensiveQuantities
     , public BlackOilPolymerIntensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnablePolymer>()>
     , public BlackOilFoamIntensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableFoam>()>
     , public BlackOilBrineIntensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableBrine>()>
-    , public BlackOilEnergyIntensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableEnergy>()>
+    , public BlackOilEnergyIntensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnergyModuleType>()>
     , public BlackOilBioeffectsIntensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableBioeffects>()>
     , public BlackOilConvectiveMixingIntensiveQuantities<TypeTag, getPropValue<TypeTag, Properties::EnableConvectiveMixing>()>
 {
@@ -103,8 +103,9 @@ class BlackOilIntensiveQuantities
     enum { enableVapwat = getPropValue<TypeTag, Properties::EnableVapwat>() };
     enum { enableDisgasInWater = getPropValue<TypeTag, Properties::EnableDisgasInWater>() };
     enum { enableSaltPrecipitation = getPropValue<TypeTag, Properties::EnableSaltPrecipitation>() };
-    enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
-    enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
+    enum { enableTemperature = (energyModuleType == EnergyModules::ConstantTemperature) };
+    enum { enableEnergy = (energyModuleType == EnergyModules::FullyImplicitThermal) };
     enum { enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>() };
     enum { enableDispersion = getPropValue<TypeTag, Properties::EnableDispersion>() };
     enum { enableConvectiveMixing = getPropValue<TypeTag, Properties::EnableConvectiveMixing>() };
@@ -821,7 +822,7 @@ private:
     friend BlackOilSolventIntensiveQuantities<TypeTag, enableSolvent>;
     friend BlackOilExtboIntensiveQuantities<TypeTag, enableExtbo>;
     friend BlackOilPolymerIntensiveQuantities<TypeTag, enablePolymer>;
-    friend BlackOilEnergyIntensiveQuantities<TypeTag, enableEnergy>;
+    friend BlackOilEnergyIntensiveQuantities<TypeTag, energyModuleType>;
     friend BlackOilFoamIntensiveQuantities<TypeTag, enableFoam>;
     friend BlackOilBrineIntensiveQuantities<TypeTag, enableBrine>;
     friend BlackOilBioeffectsIntensiveQuantities<TypeTag, enableBioeffects>;

--- a/opm/models/blackoil/blackoillocalresidual.hh
+++ b/opm/models/blackoil/blackoillocalresidual.hh
@@ -83,7 +83,7 @@ class BlackOilLocalResidual : public GetPropType<TypeTag, Properties::DiscLocalR
     static constexpr bool compositionSwitchEnabled = (compositionSwitchIdx >= 0);
 
     static constexpr bool blackoilConserveSurfaceVolume = getPropValue<TypeTag, Properties::BlackoilConserveSurfaceVolume>();
-    static constexpr bool enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>();
+    static constexpr bool enableEnergy = (getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal);
     static constexpr bool enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>();
     static constexpr bool enableConvectiveMixing = getPropValue<TypeTag, Properties::EnableConvectiveMixing>();
 

--- a/opm/models/blackoil/blackoillocalresidualtpfa.hh
+++ b/opm/models/blackoil/blackoillocalresidualtpfa.hh
@@ -99,7 +99,7 @@ class BlackOilLocalResidualTPFA : public GetPropType<TypeTag, Properties::DiscLo
     static constexpr bool enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>();
     static constexpr bool enableExtbo = getPropValue<TypeTag, Properties::EnableExtbo>();
     static constexpr bool enablePolymer = getPropValue<TypeTag, Properties::EnablePolymer>();
-    static constexpr bool enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>();
+    static constexpr bool enableEnergy = (getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal);
     static constexpr bool enableFoam = getPropValue<TypeTag, Properties::EnableFoam>();
     static constexpr bool enableBrine = getPropValue<TypeTag, Properties::EnableBrine>();
     static constexpr bool enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>();

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -38,6 +38,7 @@
 #include <opm/models/blackoil/blackoildarcyfluxmodule.hh>
 #include <opm/models/blackoil/blackoildiffusionmodule.hh>
 #include <opm/models/blackoil/blackoildispersionmodule.hh>
+#include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/blackoil/blackoilextbomodules.hh>
 #include <opm/models/blackoil/blackoilextensivequantities.hh>
 #include <opm/models/blackoil/blackoilfoammodules.hh>
@@ -143,7 +144,7 @@ struct Indices<TypeTag, TTag::BlackOilModel>
     using type = BlackOilVariableAndEquationIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                                     getPropValue<TypeTag, Properties::EnableExtbo>(),
                                                     getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                                    getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                                    getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
                                                     getPropValue<TypeTag, Properties::EnableFoam>(),
                                                     getPropValue<TypeTag, Properties::EnableBrine>(),
                                                     /*PVOffset=*/0,
@@ -201,14 +202,9 @@ template<class TypeTag>
 struct EnableBioeffects<TypeTag, TTag::BlackOilModel>
 { static constexpr bool value = false; };
 
-//! By default, the blackoil model is isothermal and does not conserve energy
 template<class TypeTag>
-struct EnableTemperature<TypeTag, TTag::BlackOilModel>
-{ static constexpr bool value = false; };
-
-template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::BlackOilModel>
-{ static constexpr bool value = false; };
+struct EnergyModuleType<TypeTag, TTag::BlackOilModel>
+{ static constexpr EnergyModules value = EnergyModules::NoTemperature; };
 
 //! disable diffusion by default
 template<class TypeTag>

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -107,8 +107,9 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag>
     enum { enableBrine = getPropValue<TypeTag, Properties::EnableBrine>() };
     enum { enableSaltPrecipitation = getPropValue<TypeTag, Properties::EnableSaltPrecipitation>() };
     enum { enableVapwat = getPropValue<TypeTag, Properties::EnableVapwat>() };
-    enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
-    enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
+    static constexpr EnergyModules energyModuleType = getPropValue<TypeTag, Properties::EnergyModuleType>();
+    enum { enableEnergy = (energyModuleType == EnergyModules::FullyImplicitThermal) };
+    enum { enableTemperature = (energyModuleType == EnergyModules::ConstantTemperature) };
     enum { enableBioeffects = getPropValue<TypeTag, Properties::EnableBioeffects>() };
     enum { enableMICP = Indices::enableMICP };
     enum { gasCompIdx = FluidSystem::gasCompIdx };
@@ -119,7 +120,7 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag>
     using ComponentVector = Dune::FieldVector<Scalar, numComponents>;
     using SolventModule = BlackOilSolventModule<TypeTag, enableSolvent>;
     using ExtboModule = BlackOilExtboModule<TypeTag, enableExtbo>;
-    using EnergyModule = BlackOilEnergyModule<TypeTag, enableEnergy>;
+    using EnergyModule = BlackOilEnergyModule<TypeTag, energyModuleType>;
     using BrineModule = BlackOilBrineModule<TypeTag, enableBrine>;
     using BioeffectsModule = BlackOilBioeffectsModule<TypeTag>;
 

--- a/opm/models/blackoil/blackoilproperties.hh
+++ b/opm/models/blackoil/blackoilproperties.hh
@@ -82,11 +82,6 @@ struct EnableDisgasInWater { using type = UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct EnableBioeffects { using type = UndefinedProperty; };
 
-//! Allow the spatial and temporal domains to exhibit non-constant temperature
-//! in the black-oil model
-template<class TypeTag, class MyTypeTag>
-struct EnableTemperature { using type = UndefinedProperty; };
-
 template<class TypeTag, class MyTypeTag>
 struct EnableMech { using type = UndefinedProperty; };
 
@@ -103,6 +98,11 @@ struct BlackOilEnergyScalingFactor { using type = UndefinedProperty; };
 //! Similarly to the energy equation, a scaling is applied to the urea equation in MICP
 template<class TypeTag, class MyTypeTag>
 struct BlackOilUreaScalingFactor { using type = UndefinedProperty; };
+
+//! Specifies who temperature is modeled by the simulator
+template<class TypeTag, class MyTypeTag>
+struct EnergyModuleType { using type = UndefinedProperty; };
+
 
 } // namespace Opm::Properties
 

--- a/opm/models/blackoil/blackoilratevector.hh
+++ b/opm/models/blackoil/blackoilratevector.hh
@@ -73,7 +73,7 @@ class BlackOilRateVector
     enum { numEq = getPropValue<TypeTag, Properties::NumEq>() };
     enum { numComponents = getPropValue<TypeTag, Properties::NumComponents>() };
     enum { conti0EqIdx = Indices::conti0EqIdx };
-    enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    enum { enableEnergy = (getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal) };
     enum { enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>() };
     enum { enablePolymer = getPropValue<TypeTag, Properties::EnablePolymer>() };
     enum { enablePolymerMolarWeight = getPropValue<TypeTag, Properties::EnablePolymerMW>() };

--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -117,7 +117,7 @@ class TpfaLinearizer
 
     static constexpr bool linearizeNonLocalElements =
         getPropValue<TypeTag, Properties::LinearizeNonLocalElements>();
-    static constexpr bool enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>();
+    static constexpr bool enableEnergy = (getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal);
     static constexpr bool enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>();
     static constexpr bool enableDispersion = getPropValue<TypeTag, Properties::EnableDispersion>();
     static const bool enableBioeffects = getPropValue<TypeTag, Properties::EnableBioeffects>();

--- a/opm/simulators/aquifers/AquiferAnalytical.hpp
+++ b/opm/simulators/aquifers/AquiferAnalytical.hpp
@@ -33,6 +33,7 @@
 #include <opm/material/densead/Math.hpp>
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 
+#include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/blackoil/blackoilproperties.hh>
 #include <opm/models/utils/basicproperties.hh>
 
@@ -64,8 +65,9 @@ public:
     using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
     using ElementMapper = GetPropType<TypeTag, Properties::ElementMapper>;
 
-    enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
-    enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    enum { enableEnergy = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal };
+    enum { enableTemperature = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::ConstantTemperature };
+
     enum { enableBrine = getPropValue<TypeTag, Properties::EnableBrine>() };
     enum { enableVapwat = getPropValue<TypeTag, Properties::EnableVapwat>() };
     enum { has_disgas_in_water = getPropValue<TypeTag, Properties::EnableDisgasInWater>() };

--- a/opm/simulators/flow/AluGridVanguard.hpp
+++ b/opm/simulators/flow/AluGridVanguard.hpp
@@ -186,8 +186,8 @@ public:
                                                                  this->cartesianIndexMapper(),
                                                                  this->grid(),
                                                                  this->cellCentroids(),
-                                                                 getPropValue<TypeTag,
-                                                                 Properties::EnableEnergy>(),
+                                                                 getPropValue<TypeTag, Properties::EnergyModuleType>()
+                                                                   == EnergyModules::FullyImplicitThermal,
                                                                  getPropValue<TypeTag,
                                                                  Properties::EnableDiffusion>(),
                                                                  getPropValue<TypeTag,

--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -323,7 +323,7 @@ protected:
     static constexpr bool has_extbo_ = getPropValue<TypeTag, Properties::EnableExtbo>();
     static constexpr bool has_polymer_ = getPropValue<TypeTag, Properties::EnablePolymer>();
     static constexpr bool has_polymermw_ = getPropValue<TypeTag, Properties::EnablePolymerMW>();
-    static constexpr bool has_energy_ = getPropValue<TypeTag, Properties::EnableEnergy>();
+    static constexpr bool has_energy_ = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal;
     static constexpr bool has_foam_ = getPropValue<TypeTag, Properties::EnableFoam>();
     static constexpr bool has_brine_ = getPropValue<TypeTag, Properties::EnableBrine>();
     static constexpr bool has_bioeffects_ = getPropValue<TypeTag, Properties::EnableBioeffects>();

--- a/opm/simulators/flow/BlackoilModelProperties.hpp
+++ b/opm/simulators/flow/BlackoilModelProperties.hpp
@@ -66,14 +66,6 @@ struct EnableSolvent<TypeTag, TTag::FlowProblem>
 { static constexpr bool value = false; };
 
 template<class TypeTag>
-struct EnableTemperature<TypeTag, TTag::FlowProblem>
-{ static constexpr bool value = true; };
-
-template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::FlowProblem>
-{ static constexpr bool value = false; };
-
-template<class TypeTag>
 struct EnableFoam<TypeTag, TTag::FlowProblem>
 { static constexpr bool value = false; };
 

--- a/opm/simulators/flow/CpGridVanguard.hpp
+++ b/opm/simulators/flow/CpGridVanguard.hpp
@@ -30,8 +30,8 @@
 #include <opm/common/TimingMacros.hpp>
 
 #include <opm/models/common/multiphasebaseproperties.hh>
+#include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/blackoil/blackoilproperties.hh>
-
 #include <opm/simulators/flow/FemCpGridCompat.hpp>
 #include <opm/simulators/flow/FlowBaseVanguard.hpp>
 #include <opm/simulators/flow/GenericCpGridVanguard.hpp>
@@ -139,11 +139,11 @@ public:
 
         // check for correct module setup
         if (config.isThermal()) {
-            if (getPropValue<TypeTag, Properties::EnableEnergy>() == false) {
+            if (getPropValue<TypeTag, Properties::EnergyModuleType>() != EnergyModules::FullyImplicitThermal) {
                 throw std::runtime_error("Input specifies energy while simulator has disabled it, try xxx_energy");
             }
         } else {
-            if (getPropValue<TypeTag, Properties::EnableEnergy>() == true) {
+            if (getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal) {
                 throw std::runtime_error("Input specifies no energy while simulator has energy, try run without _energy");
             }
         }
@@ -331,7 +331,7 @@ protected:
                                                     this->cartesianIndexMapper(),
                                                     this->grid(),
                                                     this->cellCentroids(),
-                                                    getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                                    getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
                                                     getPropValue<TypeTag, Properties::EnableDiffusion>(),
                                                     getPropValue<TypeTag, Properties::EnableDispersion>()));
         globalTrans_->update(false, TransmissibilityType::TransUpdateQuantities::Trans);

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -40,6 +40,7 @@
 #include <opm/output/eclipse/Inplace.hpp>
 #include <opm/output/eclipse/RestartValue.hpp>
 
+#include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/blackoil/blackoilproperties.hh> // Properties::EnableMech, EnableTemperature, EnableSolvent
 #include <opm/models/common/multiphasebaseproperties.hh> // Properties::FluidSystem
 
@@ -127,9 +128,9 @@ class EclWriter : public EclGenericWriter<GetPropType<TypeTag, Properties::Grid>
 
     typedef Dune::MultipleCodimMultipleGeomTypeMapper< GridView > VertexMapper;
 
-    enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    enum { enableEnergy = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal };
     enum { enableMech = getPropValue<TypeTag, Properties::EnableMech>() };
-    enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
+    enum { enableTemperature = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::ConstantTemperature };
     enum { enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>() };
 
 public:

--- a/opm/simulators/flow/EquilInitializer.hpp
+++ b/opm/simulators/flow/EquilInitializer.hpp
@@ -33,6 +33,7 @@
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 
+#include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/blackoil/blackoilproperties.hh>
 #include <opm/models/discretization/common/fvbaseproperties.hh>
 #include <opm/models/utils/propertysystem.hh>
@@ -74,8 +75,8 @@ class EquilInitializer
     enum { waterCompIdx = FluidSystem::waterCompIdx };
 
     enum { dimWorld = GridView::dimensionworld };
-    enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
-    enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    enum { enableEnergy = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal };
+    enum { enableTemperature = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::ConstantTemperature };
     enum { enableDissolution = Indices::compositionSwitchIdx >= 0 };
     enum { enableBrine = getPropValue<TypeTag, Properties::EnableBrine>() };
     enum { enableVapwat = getPropValue<TypeTag, Properties::EnableVapwat>() };
@@ -158,7 +159,7 @@ public:
             }
 
             // set the temperature.
-            if (enableTemperature || enableEnergy)
+            if constexpr (enableTemperature || enableEnergy)
                 fluidState.setTemperature(initialState.temperature()[elemIdx]);
 
             // set the phase pressures, invB factor and density

--- a/opm/simulators/flow/FlowBaseProblemProperties.hpp
+++ b/opm/simulators/flow/FlowBaseProblemProperties.hpp
@@ -200,11 +200,6 @@ template<class TypeTag>
 struct EnableApiTracking<TypeTag, TTag::FlowBaseProblem>
 { static constexpr bool value = false; };
 
-// store temperature (but do not conserve energy, as long as EnableEnergy is false)
-template<class TypeTag>
-struct EnableTemperature<TypeTag, TTag::FlowBaseProblem>
-{ static constexpr bool value = true; };
-
 template<class TypeTag>
 struct EnableMech<TypeTag, TTag::FlowBaseProblem>
 { static constexpr bool value = false; };
@@ -217,10 +212,6 @@ struct EnablePolymer<TypeTag, TTag::FlowBaseProblem>
 
 template<class TypeTag>
 struct EnableSolvent<TypeTag, TTag::FlowBaseProblem>
-{ static constexpr bool value = false; };
-
-template<class TypeTag>
-struct EnableEnergy<TypeTag, TTag::FlowBaseProblem>
 { static constexpr bool value = false; };
 
 template<class TypeTag>

--- a/opm/simulators/flow/FlowProblem.hpp
+++ b/opm/simulators/flow/FlowProblem.hpp
@@ -121,7 +121,8 @@ protected:
     enum { enableConvectiveMixing = getPropValue<TypeTag, Properties::EnableConvectiveMixing>() };
     enum { enableDiffusion = getPropValue<TypeTag, Properties::EnableDiffusion>() };
     enum { enableDispersion = getPropValue<TypeTag, Properties::EnableDispersion>() };
-    enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    enum { enableEnergy = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal };
+    enum { enableTemperature = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::ConstantTemperature };
     enum { enableExperiments = getPropValue<TypeTag, Properties::EnableExperiments>() };
     enum { enableExtbo = getPropValue<TypeTag, Properties::EnableExtbo>() };
     enum { enableFoam = getPropValue<TypeTag, Properties::EnableFoam>() };
@@ -130,7 +131,6 @@ protected:
     enum { enablePolymerMolarWeight = getPropValue<TypeTag, Properties::EnablePolymerMW>() };
     enum { enableSaltPrecipitation = getPropValue<TypeTag, Properties::EnableSaltPrecipitation>() };
     enum { enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>() };
-    enum { enableTemperature = getPropValue<TypeTag, Properties::EnableTemperature>() };
     enum { enableThermalFluxBoundaries = getPropValue<TypeTag, Properties::EnableThermalFluxBoundaries>() };
 
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx };

--- a/opm/simulators/flow/FlowProblemCompProperties.hpp
+++ b/opm/simulators/flow/FlowProblemCompProperties.hpp
@@ -30,10 +30,10 @@
 
 
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
-
 #include <opm/models/utils/propertysystem.hh>
 
 #include <opm/simulators/flow/FlowBaseProblemProperties.hpp>
+#include <opm/material/thermal/EnergyModuleType.hpp>
 
 #include <tuple>
 
@@ -60,6 +60,10 @@ template<class TypeTag>
 struct TracerModel<TypeTag, TTag::FlowBaseProblemComp> {
     using type = ::Opm::TracerModel<TypeTag>;
 };
+
+template<class TypeTag>
+struct EnergyModuleType<TypeTag, TTag::FlowBaseProblemComp>
+{ static constexpr EnergyModules value = EnergyModules::NoTemperature; };
 
 // Set the material law for fluid fluxes
 template<class TypeTag>

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -756,7 +756,7 @@ doAllocBuffers(const unsigned bufferSize,
        Entry{&fluidPressure_,             "PRESSURE", true},
        // If TEMP is set in RPTRST we output temperature even if THERMAL
        // is not activated
-       Entry{&temperature_,                   "TEMP", enableEnergy_ || rstKeywords["TEMP"] > 0},
+       Entry{&temperature_,                   "TEMP", enableEnergy_ || (enableTemperature_ && rstKeywords["TEMP"] > 0)},
        Entry{&rs_,                              "RS", FluidSystem::enableDissolvedGas()},
        Entry{&rsw_,                            "RSW", FluidSystem::enableDissolvedGasInWater()},
        Entry{&rv_,                              "RV", FluidSystem::enableVaporizedOil()},

--- a/opm/simulators/flow/NewTranFluxModule.hpp
+++ b/opm/simulators/flow/NewTranFluxModule.hpp
@@ -121,7 +121,7 @@ class NewTranExtensiveQuantities
     enum { numPhases = FluidSystem::numPhases };
     enum { enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>() };
     enum { enableExtbo = getPropValue<TypeTag, Properties::EnableExtbo>() };
-    enum { enableEnergy = getPropValue<TypeTag, Properties::EnableEnergy>() };
+    enum { enableEnergy = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal };
 
     static constexpr bool enableConvectiveMixing = getPropValue<TypeTag, Properties::EnableConvectiveMixing>();
 

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -40,6 +40,7 @@
 
 #include <opm/material/common/Valgrind.hpp>
 
+#include <opm/models/blackoil/blackoilenergymodules.hh>
 #include <opm/models/blackoil/blackoilproperties.hh>
 #include <opm/models/common/multiphasebaseproperties.hh>
 #include <opm/models/utils/parametersystem.hpp>
@@ -102,8 +103,8 @@ public:
                    [this](const int idx)
                    { return simulator_.problem().eclWriter().collectOnIORank().localIdxToGlobalIdx(idx); },
                    simulator.vanguard().grid().comm(),
-                   getPropValue<TypeTag, Properties::EnableEnergy>(),
-                   getPropValue<TypeTag, Properties::EnableTemperature>(),
+                   getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
+                   getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::ConstantTemperature,
                    getPropValue<TypeTag, Properties::EnableMech>(),
                    getPropValue<TypeTag, Properties::EnableSolvent>(),
                    getPropValue<TypeTag, Properties::EnablePolymer>(),

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -124,7 +124,7 @@ template<class Scalar> class WellContributions;
             static const int solventSaturationIdx = Indices::solventSaturationIdx;
             static constexpr bool has_solvent_ = getPropValue<TypeTag, Properties::EnableSolvent>();
             static constexpr bool has_polymer_ = getPropValue<TypeTag, Properties::EnablePolymer>();
-            static constexpr bool has_energy_ = getPropValue<TypeTag, Properties::EnableEnergy>();
+            static constexpr bool has_energy_ = (getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal);
             static constexpr bool has_micp_ = Indices::enableMICP;
 
             // TODO: where we should put these types, WellInterface or Well Model?

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -111,8 +111,9 @@ public:
     static constexpr bool has_solvent = getPropValue<TypeTag, Properties::EnableSolvent>();
     static constexpr bool has_zFraction = getPropValue<TypeTag, Properties::EnableExtbo>();
     static constexpr bool has_polymer = getPropValue<TypeTag, Properties::EnablePolymer>();
-    static constexpr bool has_energy = getPropValue<TypeTag, Properties::EnableEnergy>();
-    static const bool has_temperature = getPropValue<TypeTag, Properties::EnableTemperature>();
+    static constexpr bool has_energy = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal;
+    static const bool has_temperature = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::ConstantTemperature
+    ;
     // flag for polymer molecular weight related
     static constexpr bool has_polymermw = getPropValue<TypeTag, Properties::EnablePolymerMW>();
     static constexpr bool has_foam = getPropValue<TypeTag, Properties::EnableFoam>();

--- a/python/simulators/PyGasWaterSimulator.cpp
+++ b/python/simulators/PyGasWaterSimulator.cpp
@@ -45,7 +45,7 @@ namespace Opm {
                 using type = BlackOilTwoPhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                                      getPropValue<TypeTag, Properties::EnableExtbo>(),
                                                      getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                                     getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                                     getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
                                                      getPropValue<TypeTag, Properties::EnableFoam>(),
                                                      getPropValue<TypeTag, Properties::EnableBrine>(),
                                                      /*PVOffset=*/0,

--- a/python/simulators/PyOnePhaseSimulator.cpp
+++ b/python/simulators/PyOnePhaseSimulator.cpp
@@ -44,7 +44,7 @@ namespace Opm::Properties {
         using type = BlackOilOnePhaseIndices<getPropValue<TypeTag, Properties::EnableSolvent>(),
                                              getPropValue<TypeTag, Properties::EnableExtbo>(),
                                              getPropValue<TypeTag, Properties::EnablePolymer>(),
-                                             getPropValue<TypeTag, Properties::EnableEnergy>(),
+                                             getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal,
                                              getPropValue<TypeTag, Properties::EnableFoam>(),
                                              getPropValue<TypeTag, Properties::EnableBrine>(),
                                              /*PVOffset=*/0,


### PR DESCRIPTION
Add a more flexible energy module setup. Current 3 types. NoTemperature (default), ConstTemperature(for CO2/H2STORE relevant simulators and FullyImplicitThermal for the "energy" simulators. The goal is to make it easier to incorporate the sequential implicit approach in #5854.  Note that we currently don't support the NoTemperature version, so this should give some memory reduction for the standard blackoil cases. 