### PR TITLE
Add no-hysteresis variant of Flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -641,6 +641,16 @@ opm_add_test(flow_blackoil_polyhedralgrid
   flow/flow_blackoil_polyhedralgrid.cpp
   $<TARGET_OBJECTS:moduleVersion>)
 
+opm_add_test(flow_blackoil_nohyst
+  ONLY_COMPILE
+  ALWAYS_ENABLE
+  DEFAULT_ENABLE_IF ${FLOW_POLY_ONLY_DEFAULT_ENABLE_IF}
+  DEPENDS opmsimulators
+  LIBRARIES opmsimulators
+  SOURCES
+  flow/flow_blackoil_nohyst.cpp
+  $<TARGET_OBJECTS:moduleVersion>)
+
 opm_add_test(flow_distribute_z
   ONLY_COMPILE
   ALWAYS_ENABLE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,7 +577,8 @@ set(FLOW_MODELS blackoil brine energy extbo foam gasoil gaswater
                 gasoil_energy brine_saltprecipitation
                 gaswater_saltprec_vapwat gaswater_saltprec_energy brine_precsalt_vapwat
                 blackoil_legacyassembly gasoildiffuse gaswater_dissolution
-                gaswater_dissolution_diffuse gaswater_energy gaswater_solvent biofilm)
+                gaswater_dissolution_diffuse gaswater_energy gaswater_solvent biofilm
+                blackoil_nohyst)
 set(FLOW_VARIANT_MODELS brine_energy onephase onephase_energy)
 
 set(FLOW_TGTS)
@@ -639,16 +640,6 @@ opm_add_test(flow_blackoil_polyhedralgrid
   LIBRARIES opmsimulators
   SOURCES
   flow/flow_blackoil_polyhedralgrid.cpp
-  $<TARGET_OBJECTS:moduleVersion>)
-
-opm_add_test(flow_blackoil_nohyst
-  ONLY_COMPILE
-  ALWAYS_ENABLE
-  DEFAULT_ENABLE_IF ${FLOW_POLY_ONLY_DEFAULT_ENABLE_IF}
-  DEPENDS opmsimulators
-  LIBRARIES opmsimulators
-  SOURCES
-  flow/flow_blackoil_nohyst.cpp
   $<TARGET_OBJECTS:moduleVersion>)
 
 opm_add_test(flow_distribute_z

--- a/examples/problems/co2ptflashproblem.hh
+++ b/examples/problems/co2ptflashproblem.hh
@@ -131,7 +131,9 @@ private:
     using Traits = Opm::ThreePhaseMaterialTraits<Scalar,
                                                /*wettingPhaseIdx=*/FluidSystem::waterPhaseIdx,
                                                /*nonWettingPhaseIdx=*/FluidSystem::oilPhaseIdx,
-                                               /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx>;
+                                               /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx,
+                                               /* hysteresis */ false,
+                                               /* endpointscaling */ false>;
 
     // define the material law which is parameterized by effective saturation
     using EffMaterialLaw = Opm::NullMaterial<Traits>;

--- a/examples/problems/cuvetteproblem.hh
+++ b/examples/problems/cuvetteproblem.hh
@@ -88,7 +88,9 @@ private:
         Scalar,
         /*wettingPhaseIdx=*/FluidSystem::waterPhaseIdx,
         /*nonWettingPhaseIdx=*/FluidSystem::naplPhaseIdx,
-        /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx>;
+        /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx,
+        /* hysteresis */ false,
+        /* endpointscaling */ false>;
 
 public:
     using type = Opm::ThreePhaseParkerVanGenuchten<Traits>;

--- a/examples/problems/infiltrationproblem.hh
+++ b/examples/problems/infiltrationproblem.hh
@@ -86,7 +86,9 @@ private:
         Scalar,
         /*wettingPhaseIdx=*/FluidSystem::waterPhaseIdx,
         /*nonWettingPhaseIdx=*/FluidSystem::naplPhaseIdx,
-        /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx>;
+        /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx,
+        /* hysteresis */ false,
+        /* endpointscaling */ false>;
 
 public:
     using type = Opm::ThreePhaseParkerVanGenuchten<Traits>;

--- a/examples/problems/reservoirproblem.hh
+++ b/examples/problems/reservoirproblem.hh
@@ -93,7 +93,9 @@ private:
         ThreePhaseMaterialTraits<Scalar,
                                  /*wettingPhaseIdx=*/FluidSystem::waterPhaseIdx,
                                  /*nonWettingPhaseIdx=*/FluidSystem::oilPhaseIdx,
-                                 /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx>;
+                                 /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx,
+                                 /* hysteresis */ false,
+                                 /* endpointscaling */ false>;
 
 public:
     using type = Opm::LinearMaterial<Traits>;

--- a/flow/flow_blackoil_nohyst.cpp
+++ b/flow/flow_blackoil_nohyst.cpp
@@ -1,4 +1,6 @@
 /*
+  Copyright 2025 Equinor ASA.
+
   This file is part of the Open Porous Media project (OPM).
 
   OPM is free software: you can redistribute it and/or modify
@@ -30,38 +32,61 @@
 namespace Opm {
 namespace Properties {
     namespace TTag {
-        struct FlowProblemNoHystNoEps {
+        struct FlowProblemNohyst {
             using InheritsFrom = std::tuple<FlowProblem>;
         };
     }
     template<class TypeTag>
-    struct Linearizer<TypeTag, TTag::FlowProblemNoHystNoEps> { using type = TpfaLinearizer<TypeTag>; };
+    struct Linearizer<TypeTag, TTag::FlowProblemNohyst> { using type = TpfaLinearizer<TypeTag>; };
 
     template<class TypeTag>
-    struct LocalResidual<TypeTag, TTag::FlowProblemNoHystNoEps> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+    struct LocalResidual<TypeTag, TTag::FlowProblemNohyst> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
 
     template<class TypeTag>
-    struct EnableDiffusion<TypeTag, TTag::FlowProblemNoHystNoEps> { static constexpr bool value = false; };
+    struct EnableDiffusion<TypeTag, TTag::FlowProblemNohyst> { static constexpr bool value = false; };
 
     template<class TypeTag>
-    struct EnableHysteresis<TypeTag, TTag::FlowProblemNoHystNoEps> { static constexpr bool value = false; };
+    struct EnableHysteresis<TypeTag, TTag::FlowProblemNohyst> { static constexpr bool value = false; };
 
     template<class TypeTag>
-    struct EnableEndpointScaling<TypeTag, TTag::FlowProblemNoHystNoEps> { static constexpr bool value = true; };
+    struct EnableEndpointScaling<TypeTag, TTag::FlowProblemNohyst> { static constexpr bool value = true; };
 
     template<class TypeTag>
-    struct AvoidElementContext<TypeTag, TTag::FlowProblemNoHystNoEps> { static constexpr bool value = true; };
+    struct AvoidElementContext<TypeTag, TTag::FlowProblemNohyst> { static constexpr bool value = true; };
 
 }
-} // namespace Opm
 
-
-int main(int argc, char** argv)
+std::unique_ptr<FlowMain<Properties::TTag::FlowProblemNohyst>>
+flowBlackoilTpfaNohystMainInit(int argc, char** argv, bool outputCout, bool outputFiles)
 {
-    using TypeTag = Opm::Properties::TTag::FlowProblemNoHystNoEps;
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    resetLocale();
+
+    return std::make_unique<FlowMain<Properties::TTag::FlowProblemNohyst>>(
+        argc, argv, outputCout, outputFiles);
+}
+
+// ----------------- Main program -----------------
+int flowBlackoilTpfaNohystMain(int argc, char** argv, bool outputCout, bool outputFiles)
+{
+    // we always want to use the default locale, and thus spare us the trouble
+    // with incorrect locale settings.
+    resetLocale();
+
+    FlowMain<Properties::TTag::FlowProblemNohyst>
+        mainfunc {argc, argv, outputCout, outputFiles};
+    return mainfunc.execute();
+}
+
+int flowBlackoilTpfaNohystMainStandalone(int argc, char** argv)
+{
+    using TypeTag = Opm::Properties::TTag::FlowProblemNohyst;
     auto mainObject = std::make_unique<Opm::Main>(argc, argv);
     auto ret = mainObject->runStatic<TypeTag>();
     // Destruct mainObject as the destructor calls MPI_Finalize!
     mainObject.reset();
     return ret;
 }
+
+} // namespace Opm

--- a/flow/flow_blackoil_nohyst.cpp
+++ b/flow/flow_blackoil_nohyst.cpp
@@ -1,0 +1,67 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "config.h"
+
+#include <flow/flow_blackoil.hpp>
+
+#include <opm/material/common/ResetLocale.hpp>
+#include <opm/grid/CpGrid.hpp>
+#include <opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp>
+#include <opm/simulators/flow/Main.hpp>
+
+#include <opm/models/blackoil/blackoillocalresidualtpfa.hh>
+#include <opm/models/discretization/common/tpfalinearizer.hh>
+
+
+namespace Opm {
+namespace Properties {
+    namespace TTag {
+        struct FlowProblemNoHystNoEps {
+            using InheritsFrom = std::tuple<FlowProblem>;
+        };
+    }
+    template<class TypeTag>
+    struct Linearizer<TypeTag, TTag::FlowProblemNoHystNoEps> { using type = TpfaLinearizer<TypeTag>; };
+
+    template<class TypeTag>
+    struct LocalResidual<TypeTag, TTag::FlowProblemNoHystNoEps> { using type = BlackOilLocalResidualTPFA<TypeTag>; };
+
+    template<class TypeTag>
+    struct EnableDiffusion<TypeTag, TTag::FlowProblemNoHystNoEps> { static constexpr bool value = false; };
+
+    template<class TypeTag>
+    struct EnableHysteresis<TypeTag, TTag::FlowProblemNoHystNoEps> { static constexpr bool value = false; };
+
+    template<class TypeTag>
+    struct EnableEndpointScaling<TypeTag, TTag::FlowProblemNoHystNoEps> { static constexpr bool value = true; };
+
+    template<class TypeTag>
+    struct AvoidElementContext<TypeTag, TTag::FlowProblemNoHystNoEps> { static constexpr bool value = true; };
+
+}
+} // namespace Opm
+
+
+int main(int argc, char** argv)
+{
+    using TypeTag = Opm::Properties::TTag::FlowProblemNoHystNoEps;
+    auto mainObject = std::make_unique<Opm::Main>(argc, argv);
+    auto ret = mainObject->runStatic<TypeTag>();
+    // Destruct mainObject as the destructor calls MPI_Finalize!
+    mainObject.reset();
+    return ret;
+}

--- a/flow/flow_blackoil_nohyst.hpp
+++ b/flow/flow_blackoil_nohyst.hpp
@@ -1,0 +1,44 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef FLOW_BLACKOIL_NOHYST_HPP
+#define FLOW_BLACKOIL_NOHYST_HPP
+
+#include <opm/simulators/flow/TTagFlowProblemTPFA.hpp>
+
+#include <memory>
+
+namespace Opm {
+
+namespace Properties { namespace TTag { struct FlowProblemNohyst; } }
+
+//! \brief Main function used in flow binary.
+int flowBlackoilTpfaNohystMain(int argc, char** argv, bool outputCout, bool outputFiles);
+
+template<class TypeTag> class FlowMain;
+
+//! \brief Initialization function used in flow binary and python simulator.
+std::unique_ptr<FlowMain<Properties::TTag::FlowProblemNohyst>>
+flowBlackoilTpfaNohystMainInit(int argc, char** argv, bool outputCout, bool outputFiles);
+
+//! \brief Main function used in flow_brine binary.
+int flowBlackoilTpfaNohystMainStandalone(int argc, char** argv);
+
+}
+
+#endif // FLOW_BLACKOIL_NOHYST_HPP

--- a/flow/flow_blackoil_nohyst_main.cpp
+++ b/flow/flow_blackoil_nohyst_main.cpp
@@ -1,0 +1,27 @@
+/*
+  Copyright 2025 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include <flow/flow_blackoil_nohyst.hpp>
+
+int main(int argc, char** argv)
+{
+    return Opm::flowBlackoilTpfaNohystMainStandalone(argc, argv);
+}

--- a/opm/simulators/flow/FlowBaseProblemProperties.hpp
+++ b/opm/simulators/flow/FlowBaseProblemProperties.hpp
@@ -77,6 +77,12 @@ struct EnableApiTracking { using type = UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct EnableDebuggingChecks { using type = Properties::UndefinedProperty; };
 
+template<class TypeTag, class MyTypeTag>
+struct EnableHysteresis { using type = Properties::UndefinedProperty; };
+
+template<class TypeTag, class MyTypeTag>
+struct EnableEndpointScaling { using type = Properties::UndefinedProperty; };
+
 // Avoid using ElementContext-based code if possible.
 template<class TypeTag, class MyTypeTag>
 struct AvoidElementContext { using type = Properties::UndefinedProperty; };
@@ -243,6 +249,14 @@ struct EnableExperiments<TypeTag, TTag::FlowBaseProblem>
 // By default, we enable the debugging checks if we're compiled in debug mode
 template<class TypeTag>
 struct EnableDebuggingChecks<TypeTag, TTag::FlowBaseProblem>
+{ static constexpr bool value = true; };
+
+template<class TypeTag>
+struct EnableHysteresis<TypeTag, TTag::FlowBaseProblem>
+{ static constexpr bool value = true; };
+
+template<class TypeTag>
+struct EnableEndpointScaling<TypeTag, TTag::FlowBaseProblem>
 { static constexpr bool value = true; };
 
 // Most modules are implemented only in terms of element contexts,

--- a/opm/simulators/flow/FlowProblemBlackoilProperties.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoilProperties.hpp
@@ -82,7 +82,9 @@ private:
     using Traits = ThreePhaseMaterialTraits<Scalar,
                                             /*wettingPhaseIdx=*/FluidSystem::waterPhaseIdx,
                                             /*nonWettingPhaseIdx=*/FluidSystem::oilPhaseIdx,
-                                            /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx>;
+                                            /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx,
+                                            getPropValue<TypeTag, Properties::EnableHysteresis>(),
+                                            getPropValue<TypeTag, Properties::EnableEndpointScaling>()>;
 
 public:
     using EclMaterialLawManager = ::Opm::EclMaterialLaw::Manager<Traits>;

--- a/opm/simulators/flow/FlowProblemCompProperties.hpp
+++ b/opm/simulators/flow/FlowProblemCompProperties.hpp
@@ -72,7 +72,9 @@ private:
     using Traits = ThreePhaseMaterialTraits<Scalar,
                                             /*wettingPhaseIdx=*/FluidSystem::waterPhaseIdx,
                                             /*nonWettingPhaseIdx=*/FluidSystem::oilPhaseIdx,
-                                            /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx>;
+                                            /*gasPhaseIdx=*/FluidSystem::gasPhaseIdx,
+                                            /* hysteresis */ true,
+                                            /* endpointscaling */ true>;
 
 public:
     using EclMaterialLawManager = ::Opm::EclMaterialLaw::Manager<Traits>;

--- a/opm/simulators/flow/MainDispatchDynamic.cpp
+++ b/opm/simulators/flow/MainDispatchDynamic.cpp
@@ -27,6 +27,7 @@
 #include <flow/flow_biofilm.hpp>
 #include <flow/flow_blackoil.hpp>
 #include <flow/flow_blackoil_legacyassembly.hpp>
+#include <flow/flow_blackoil_nohyst.hpp>
 #include <flow/flow_brine.hpp>
 #include <flow/flow_brine_precsalt_vapwat.hpp>
 #include <flow/flow_brine_saltprecipitation.hpp>
@@ -423,6 +424,10 @@ int Opm::Main::runBlackOil()
         // support the diffusion module yet.
         return flowBlackoilMain(argc_, argv_, outputCout_, outputFiles_);
     }
-
-    return flowBlackoilTpfaMain(argc_, argv_, outputCout_, outputFiles_);
+    if (this->eclipseState_->runspec().hysterPar().active()) {
+        return flowBlackoilTpfaMain(argc_, argv_, outputCout_, outputFiles_);
+    } else {
+        // Use variant without hysteresis support to save memory.
+        return flowBlackoilTpfaNohystMain(argc_, argv_, outputCout_, outputFiles_);
+    }
 }

--- a/opm/simulators/flow/equil/EquilibrationHelpers.cpp
+++ b/opm/simulators/flow/equil/EquilibrationHelpers.cpp
@@ -28,7 +28,7 @@ namespace Opm {
 namespace EQUIL {
 
 template<class Scalar>
-using MatLaw = EclMaterialLaw::Manager<ThreePhaseMaterialTraits<Scalar,0,1,2>>;
+using MatLaw = EclMaterialLaw::Manager<ThreePhaseMaterialTraits<Scalar,0,1,2,true,true>>;
 template<class Scalar> using FS = BlackOilFluidSystem<Scalar>;
 
 #define INSTANTIATE_TYPE(T) \

--- a/opm/simulators/flow/equil/EquilibrationHelpers.cpp
+++ b/opm/simulators/flow/equil/EquilibrationHelpers.cpp
@@ -27,13 +27,10 @@
 namespace Opm {
 namespace EQUIL {
 
-template<class Scalar>
-using MatLaw = EclMaterialLaw::Manager<ThreePhaseMaterialTraits<Scalar,0,1,2,true,true>>;
 template<class Scalar> using FS = BlackOilFluidSystem<Scalar>;
 
-#define INSTANTIATE_TYPE(T) \
+#define INSTANTIATE_TYPE1(T, MatLaw) \
     template struct PcEq<FS<T>,MatLaw<T>>; \
-    template class EquilReg<T>; \
     template T satFromPc<FS<T>,MatLaw<T>>(const MatLaw<T>&, \
                                           const int,const int, \
                                           const T,const bool); \
@@ -43,7 +40,10 @@ template<class Scalar> using FS = BlackOilFluidSystem<Scalar>;
     template T satFromDepth<FS<T>,MatLaw<T>>(const MatLaw<T>&, \
                                              const T,const T, \
                                              const int,const int,const bool); \
-    template bool isConstPc<FS<T>,MatLaw<T>>(const MatLaw<T>&,const int,const int); \
+    template bool isConstPc<FS<T>,MatLaw<T>>(const MatLaw<T>&,const int,const int);
+
+#define INSTANTIATE_TYPE2(T) \
+    template class EquilReg<T>; \
     template class Miscibility::PBVD<FS<T>>; \
     template class Miscibility::PDVD<FS<T>>; \
     template class Miscibility::RsVD<FS<T>>; \
@@ -53,10 +53,20 @@ template<class Scalar> using FS = BlackOilFluidSystem<Scalar>;
     template class Miscibility::RvVD<FS<T>>; \
     template class Miscibility::RvwVD<FS<T>>;
 
-INSTANTIATE_TYPE(double)
+#define INSTANTIATE_TYPE(T, ML1, ML2) \
+INSTANTIATE_TYPE1(T, ML1) \
+INSTANTIATE_TYPE1(T, ML2) \
+INSTANTIATE_TYPE2(T)
+
+template<class Scalar>
+using MatLaw1 = EclMaterialLaw::Manager<ThreePhaseMaterialTraits<Scalar,0,1,2,true,true>>;
+template<class Scalar>
+using MatLaw2 = EclMaterialLaw::Manager<ThreePhaseMaterialTraits<Scalar,0,1,2,false,true>>;
+
+INSTANTIATE_TYPE(double, MatLaw1, MatLaw2)
 
 #if FLOW_INSTANTIATE_FLOAT
-INSTANTIATE_TYPE(float)
+INSTANTIATE_TYPE(float, MatLaw1, MatLaw2)
 #endif
 
 } // namespace Equil

--- a/opm/simulators/flow/equil/InitStateEquil.cpp
+++ b/opm/simulators/flow/equil/InitStateEquil.cpp
@@ -35,7 +35,7 @@
 namespace Opm {
 
 template<class Scalar>
-using MatLaw = EclMaterialLaw::Manager<ThreePhaseMaterialTraits<Scalar,0,1,2>>;
+using MatLaw = EclMaterialLaw::Manager<ThreePhaseMaterialTraits<Scalar,0,1,2,true,true>>;
 
 namespace EQUIL {
 namespace DeckDependent {

--- a/opm/simulators/flow/equil/InitStateEquil.cpp
+++ b/opm/simulators/flow/equil/InitStateEquil.cpp
@@ -35,17 +35,21 @@
 namespace Opm {
 
 template<class Scalar>
-using MatLaw = EclMaterialLaw::Manager<ThreePhaseMaterialTraits<Scalar,0,1,2,true,true>>;
+using MatLaw1 = EclMaterialLaw::Manager<ThreePhaseMaterialTraits<Scalar,0,1,2,true,true>>;
+template<class Scalar>
+using MatLaw2 = EclMaterialLaw::Manager<ThreePhaseMaterialTraits<Scalar,0,1,2,false,true>>;
 
 namespace EQUIL {
 namespace DeckDependent {
 
-#define INSTANTIATE_COMP(T, GridView, Mapper)                                      \
+#define INSTANTIATE_COMP1(T, GridView, Mapper)                                     \
     template class InitialStateComputer<BlackOilFluidSystem<T>,                    \
                                         Dune::CpGrid,                              \
                                         GridView,                                  \
                                         Mapper,                                    \
-                                        Dune::CartesianIndexMapper<Dune::CpGrid>>; \
+                                        Dune::CartesianIndexMapper<Dune::CpGrid>>;
+
+#define INSTANTIATE_COMP2(T, MatLaw, GridView, Mapper)                             \
     template InitialStateComputer<BlackOilFluidSystem<T>,                          \
                                   Dune::CpGrid,                                    \
                                   GridView,                                        \
@@ -60,12 +64,17 @@ namespace DeckDependent {
                                   const int,                                       \
                                   const bool);
 
+#define INSTANTIATE_COMP(T, ML1, ML2, GridView, Mapper)                            \
+INSTANTIATE_COMP1(T, GridView, Mapper)                                             \
+INSTANTIATE_COMP2(T, ML1, GridView, Mapper)                                        \
+INSTANTIATE_COMP2(T, ML2, GridView, Mapper)
+
 using GridView = Dune::GridView<Dune::DefaultLeafGridViewTraits<Dune::CpGrid>>;
 using Mapper = Dune::MultipleCodimMultipleGeomTypeMapper<GridView>;
 
-INSTANTIATE_COMP(double, GridView, Mapper)
+INSTANTIATE_COMP(double, MatLaw1, MatLaw2, GridView, Mapper)
 #if FLOW_INSTANTIATE_FLOAT
-INSTANTIATE_COMP(float, GridView, Mapper)
+INSTANTIATE_COMP(float, MatLaw1, MatLaw2, GridView, Mapper)
 #endif
 
 #if HAVE_DUNE_FEM
@@ -74,10 +83,10 @@ using GridViewFem = Dune::Fem::AdaptiveLeafGridPart<Dune::CpGrid,
                                                     false>;
 using MapperFem = Dune::MultipleCodimMultipleGeomTypeMapper<GridViewFem>;
 
-INSTANTIATE_COMP(double, GridViewFem, MapperFem)
+INSTANTIATE_COMP(double, MatLaw1, MatLaw2, GridViewFem, MapperFem)
 
 #if FLOW_INSTANTIATE_FLOAT
-INSTANTIATE_COMP(float, GridViewFem, MapperFem)
+INSTANTIATE_COMP(float, MatLaw1, MatLaw2, GridViewFem, MapperFem)
 #endif
 
 #endif // HAVE_DUNE_FEM
@@ -85,20 +94,22 @@ INSTANTIATE_COMP(float, GridViewFem, MapperFem)
 } // namespace DeckDependent
 
 namespace Details {
-#define INSTANTIATE_TYPE(T)                                                 \
+#define INSTANTIATE_TYPE(T, MatLaw1, MatLaw2)                               \
     template class PressureTable<BlackOilFluidSystem<T>,EquilReg<T>>;       \
     template void verticalExtent(const std::vector<int>&,                   \
                                  const std::vector<std::pair<T,T>>&,        \
                                  const Parallel::Communication&,            \
                                  std::array<T,2>&);                         \
-    template class PhaseSaturations<MatLaw<T>,BlackOilFluidSystem<T>,       \
+    template class PhaseSaturations<MatLaw1<T>,BlackOilFluidSystem<T>,      \
+                                    EquilReg<T>,std::size_t>;               \
+    template class PhaseSaturations<MatLaw2<T>,BlackOilFluidSystem<T>,      \
                                     EquilReg<T>,std::size_t>;               \
     template std::pair<T,T> cellZMinMax<T>(const Dune::cpgrid::Entity<0>&);
 
-INSTANTIATE_TYPE(double)
+INSTANTIATE_TYPE(double, MatLaw1, MatLaw2)
 
 #if FLOW_INSTANTIATE_FLOAT
-INSTANTIATE_TYPE(float)
+INSTANTIATE_TYPE(float, MatLaw1, MatLaw2)
 #endif
 }
 


### PR DESCRIPTION
Downstream of https://github.com/OPM/opm-common/pull/4766.

Adds flow_blackoil_nohyst, standalone simulator for testing. Not yet integrated in main flow executable with dynamic dispatch.