### PR TITLE
Don't chop negative derivatives of bhp vs flo

### DIFF
--- a/opm/simulators/wells/VFPProdProperties.cpp
+++ b/opm/simulators/wells/VFPProdProperties.cpp
@@ -196,7 +196,7 @@ bhp(const int       table_id,
     detail::VFPEvaluation bhp_val = VFPHelpers<Scalar>::interpolate(table, flo_i, thp_i, wfr_i,
                                                                     gfr_i, alq_i);
 
-    bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (std::max(Scalar{0.0}, bhp_val.dflo) * flo);
+    bhp = (bhp_val.dwfr * wfr) + (bhp_val.dgfr * gfr) - (bhp_val.dflo * flo);
     bhp.setValue(bhp_val.value);
     return bhp;
 }


### PR DESCRIPTION
The chopping of negative derivatives of dbhp/dflo helps in making the solution converge to the stable one. On the other hand, it can considerably slow down convergence. By removing the chopping, we more often end up in the unstable solution, but this is subsequently repaired in the stability check, so overall I think this is the more robust option (but subject to testing).