### PR TITLE
Janitoring: removing unused definitions in models/common/*.hh

### DIFF
--- a/opm/models/blackoil/blackoilextensivequantities.hh
+++ b/opm/models/blackoil/blackoilextensivequantities.hh
@@ -98,9 +98,6 @@ public:
 protected:
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
-
-    const Implementation& asImp_() const
-    { return *static_cast<const Implementation*>(this); }
 };
 
 } // namespace Opm

--- a/opm/models/blackoil/blackoilmodel.hh
+++ b/opm/models/blackoil/blackoilmodel.hh
@@ -690,9 +690,6 @@ private:
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
 
-    const Implementation& asImp_() const
-    { return *static_cast<const Implementation*>(this); }
-
     template <class Context>
     void updatePvtRegionIndex_(PrimaryVariables& priVars,
                                const Context& context,

--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -954,9 +954,6 @@ private:
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
 
-    const Implementation& asImp_() const
-    { return *static_cast<const Implementation*>(this); }
-
     Scalar solventSaturation_() const
     {
         if constexpr (enableSolvent) {

--- a/opm/models/common/darcyfluxmodule.hh
+++ b/opm/models/common/darcyfluxmodule.hh
@@ -132,7 +132,6 @@ class DarcyExtensiveQuantities
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
 
     using Toolbox = MathToolbox<Evaluation>;
-    using ParameterCache = typename FluidSystem::template ParameterCache<Evaluation>;
     using EvalDimVector = Dune::FieldVector<Evaluation, dimWorld>;
     using DimVector = Dune::FieldVector<Scalar, dimWorld>;
     using DimMatrix = Dune::FieldMatrix<Scalar, dimWorld, dimWorld>;
@@ -551,9 +550,6 @@ protected:
 private:
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
-
-    const Implementation& asImp_() const
-    { return *static_cast<const Implementation*>(this); }
 
 protected:
     // intrinsic permeability tensor and its square root

--- a/opm/models/common/diffusionmodule.hh
+++ b/opm/models/common/diffusionmodule.hh
@@ -56,8 +56,6 @@ class DiffusionModule;
 template <class TypeTag>
 class DiffusionModule<TypeTag, /*enableDiffusion=*/false>
 {
-    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
-    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
     using RateVector = GetPropType<TypeTag, Properties::RateVector>;
 
 public:
@@ -297,7 +295,6 @@ class DiffusionExtensiveQuantities;
 template <class TypeTag>
 class DiffusionExtensiveQuantities<TypeTag, /*enableDiffusion=*/false>
 {
-    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
     using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
 

--- a/opm/models/common/energymodule.hh
+++ b/opm/models/common/energymodule.hh
@@ -61,7 +61,6 @@ class EnergyModule<TypeTag, /*enableEnergy=*/false>
 {
     using Scalar = GetPropType<TypeTag, Properties::Scalar>;
     using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
-    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
     using RateVector = GetPropType<TypeTag, Properties::RateVector>;
     using PrimaryVariables = GetPropType<TypeTag, Properties::PrimaryVariables>;
     using ExtensiveQuantities = GetPropType<TypeTag, Properties::ExtensiveQuantities>;
@@ -69,8 +68,6 @@ class EnergyModule<TypeTag, /*enableEnergy=*/false>
     using Model = GetPropType<TypeTag, Properties::Model>;
 
     enum { numEq = getPropValue<TypeTag, Properties::NumEq>() };
-
-    using EvalEqVector = Dune::FieldVector<Evaluation, numEq>;
 
 public:
     /*!
@@ -229,7 +226,6 @@ class EnergyModule<TypeTag, /*enableEnergy=*/true>
     using Scalar = GetPropType<TypeTag, Properties::Scalar>;
     using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
     using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
-    using EqVector = GetPropType<TypeTag, Properties::EqVector>;
     using RateVector = GetPropType<TypeTag, Properties::RateVector>;
     using PrimaryVariables = GetPropType<TypeTag, Properties::PrimaryVariables>;
     using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
@@ -242,7 +238,6 @@ class EnergyModule<TypeTag, /*enableEnergy=*/true>
     enum { energyEqIdx = Indices::energyEqIdx };
     enum { temperatureIdx = Indices::temperatureIdx };
 
-    using EvalEqVector = Dune::FieldVector<Evaluation, numEq>;
     using Toolbox = Opm::MathToolbox<Evaluation>;
 
 public:
@@ -613,7 +608,6 @@ class EnergyIntensiveQuantities<TypeTag, /*enableEnergy=*/true>
     using Indices = GetPropType<TypeTag, Properties::Indices>;
 
     enum { numPhases = FluidSystem::numPhases };
-    enum { energyEqIdx = Indices::energyEqIdx };
     enum { temperatureIdx = Indices::temperatureIdx };
 
     using Toolbox = Opm::MathToolbox<Evaluation>;

--- a/opm/models/common/forchheimerfluxmodule.hh
+++ b/opm/models/common/forchheimerfluxmodule.hh
@@ -132,7 +132,6 @@ public:
 template <class TypeTag>
 class ForchheimerIntensiveQuantities
 {
-    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
     using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
 
@@ -219,8 +218,6 @@ class ForchheimerExtensiveQuantities
     : public DarcyExtensiveQuantities<TypeTag>
 {
     using DarcyExtQuants = DarcyExtensiveQuantities<TypeTag>;
-    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
-    using MaterialLaw = GetPropType<TypeTag, Properties::MaterialLaw>;
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
     using Scalar = GetPropType<TypeTag, Properties::Scalar>;
     using Evaluation = GetPropType<TypeTag, Properties::Evaluation>;
@@ -570,9 +567,6 @@ protected:
     }
 
 private:
-    Implementation& asImp_()
-    { return *static_cast<Implementation *>(this); }
-
     const Implementation& asImp_() const
     { return *static_cast<const Implementation *>(this); }
 

--- a/opm/models/common/multiphasebaseextensivequantities.hh
+++ b/opm/models/common/multiphasebaseextensivequantities.hh
@@ -54,7 +54,6 @@ class MultiPhaseBaseExtensiveQuantities
     using ParentType = GetPropType<TypeTag, Properties::DiscExtensiveQuantities>;
     using Scalar = GetPropType<TypeTag, Properties::Scalar>;
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
-    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
 
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
 
@@ -110,7 +109,6 @@ public:
      *              the extensive quantities should be calculated.
      * \param timeIdx The index used by the time discretization.
      * \param fluidState The FluidState on the domain boundary.
-     * \param paramCache The FluidSystem's parameter cache.
      */
     template <class Context, class FluidState>
     void updateBoundary(const Context& context,

--- a/opm/models/common/multiphasebasemodel.hh
+++ b/opm/models/common/multiphasebasemodel.hh
@@ -167,12 +167,8 @@ template <class TypeTag>
 class MultiPhaseBaseModel : public GetPropType<TypeTag, Properties::Discretization>
 {
     using ParentType = GetPropType<TypeTag, Properties::Discretization>;
-    using Implementation = GetPropType<TypeTag, Properties::Model>;
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
     using ThreadManager = GetPropType<TypeTag, Properties::ThreadManager>;
-    using Scalar = GetPropType<TypeTag, Properties::Scalar>;
-    using Indices = GetPropType<TypeTag, Properties::Indices>;
-    using FluidSystem = GetPropType<TypeTag, Properties::FluidSystem>;
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
     using EqVector = GetPropType<TypeTag, Properties::EqVector>;
     using GridView = GetPropType<TypeTag, Properties::GridView>;
@@ -181,7 +177,6 @@ class MultiPhaseBaseModel : public GetPropType<TypeTag, Properties::Discretizati
     using Element = typename GridView::template Codim<0>::Entity;
 
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
-    enum { numComponents = FluidSystem::numComponents };
 
 public:
     explicit MultiPhaseBaseModel(Simulator& simulator)
@@ -275,10 +270,6 @@ public:
         this->addOutputModule(std::make_unique<VtkMultiPhaseModule<TypeTag>>(this->simulator_));
         this->addOutputModule(std::make_unique<VtkTemperatureModule<TypeTag>>(this->simulator_));
     }
-
-private:
-    const Implementation& asImp_() const
-    { return *static_cast<const Implementation*>(this); }
 };
 
 } // namespace Opm

--- a/opm/models/common/multiphasebaseproblem.hh
+++ b/opm/models/common/multiphasebaseproblem.hh
@@ -79,6 +79,7 @@ class MultiPhaseBaseProblem
 
     enum { dimWorld = GridView::dimensionworld };
     enum { numPhases = getPropValue<TypeTag, Properties::NumPhases>() };
+
     using DimVector = Dune::FieldVector<Scalar, dimWorld>;
     using DimMatrix = Dune::FieldMatrix<Scalar, dimWorld, dimWorld>;
 //! \endcond
@@ -393,10 +394,6 @@ protected:
 
 private:
     //! Returns the implementation of the problem (i.e. static polymorphism)
-    Implementation& asImp_()
-    { return *static_cast<Implementation *>(this); }
-
-    //! \copydoc asImp_()
     const Implementation& asImp_() const
     { return *static_cast<const Implementation *>(this); }
 

--- a/opm/models/common/quantitycallbacks.hh
+++ b/opm/models/common/quantitycallbacks.hh
@@ -139,7 +139,6 @@ class BoundaryPressureCallback
     using IQRawFluidState = decltype(std::declval<IntensiveQuantities>().fluidState());
     using IQFluidState = std::remove_const_t<std::remove_reference_t<IQRawFluidState>>;
     using IQScalar = typename IQFluidState::Scalar;
-    using Toolbox = MathToolbox<IQScalar>;
 
 public:
     using ResultType = IQScalar;
@@ -342,11 +341,8 @@ class VelocityCallback
 {
     using ElementContext = GetPropType<TypeTag, Properties::ElementContext>;
     using IntensiveQuantities = GetPropType<TypeTag, Properties::IntensiveQuantities>;
-    using GridView = GetPropType<TypeTag, Properties::GridView>;
 
     using ResultRawType = decltype(IntensiveQuantities().velocityCenter());
-
-    enum { dim = GridView::dimensionworld };
 
 public:
     using ResultType = std::remove_const_t<std::remove_reference_t<ResultRawType>>;

--- a/opm/models/common/transfluxmodule.hh
+++ b/opm/models/common/transfluxmodule.hh
@@ -117,7 +117,6 @@ class TransExtensiveQuantities
     enum { numPhases = FluidSystem::numPhases };
 
     typedef MathToolbox<Evaluation> Toolbox;
-    typedef Dune::FieldVector<Scalar, dimWorld> DimVector;
     typedef Dune::FieldVector<Evaluation, dimWorld> EvalDimVector;
     typedef Dune::FieldMatrix<Scalar, dimWorld, dimWorld> DimMatrix;
 
@@ -504,9 +503,6 @@ private:
 
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
-
-    const Implementation& asImp_() const
-    { return *static_cast<const Implementation*>(this); }
 
     // the volumetric flux of all phases [m^3/s]
     std::array<Evaluation, numPhases> volumeFlux_;


### PR DESCRIPTION
Removing unused definitions in models/common/*.hh (and three missing in https://github.com/OPM/opm-simulators/pull/6512)