### PR TITLE
Generalize initial value retrieval of reduction operators

### DIFF
--- a/opm/simulators/linalg/ParallelIstlInformation.cpp
+++ b/opm/simulators/linalg/ParallelIstlInformation.cpp
@@ -130,8 +130,9 @@ computeLocalReduction(const std::tuple<Containers...>& containers,
         // in this regard in the future.
         //auto newVal = container.begin();
         auto mask   = ownerMask.begin();
-        auto& value = std::get<I>(values);
-        value = reduceOperator.getInitialValue();
+        using ValueType = std::tuple_element_t<I, std::tuple<ReturnValues...> >;
+        ValueType& value = std::get<I>(values);
+        value = reduceOperator.template getInitialValue<ValueType>();
 
         for (auto endVal = ownerMask.end(); mask != endVal; /*++newVal,*/ ++mask )
         {

--- a/opm/simulators/linalg/ParallelIstlInformation.hpp
+++ b/opm/simulators/linalg/ParallelIstlInformation.hpp
@@ -254,17 +254,7 @@ private:
         template<class T>
         T getInitialValue()
         {
-            //g++-4.4 does not support std::numeric_limits<T>::lowest();
-            // we rely on IEE 754 for floating point values and use min()
-            // for integral types.
-            if( std::is_integral<T>::value )
-            {
-                return std::numeric_limits<T>::min();
-            }
-            else
-            {
-                return -std::numeric_limits<T>::max();
-            }
+            return std::numeric_limits<T>::lowest();
         }
         /// \brief Get the underlying binary operator.
         ///


### PR DESCRIPTION
The initial value retrieval in the reduction operator is generalized to allow the return from a template argument. The reason behind this is that binary operators return type in the standard are deprecated (C++17) and removed (C++20) (e.g., [`std::plus`](https://en.cppreference.com/w/cpp/utility/functional/plus.html)), meaning that the return type cannot be inferred by purely looking at them.

Note: The idea is to make the next OPM release compatible with the next release of DUNE (see https://lists.dune-project.org/pipermail/dune-devel/2025-October/003173.html), which will require C++20.