### PR TITLE
using WellInterfaceGeneric::pvtRegionIdx() for pvt_region for MultisegmentWellSegments

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -70,7 +70,7 @@ namespace Opm {
         using typename MSWEval::BVectorWell;
         using MSWEval::SPres;
         using typename Base::PressureMatrix;
-        using FSInfo = std::tuple<Scalar,typename std::decay<decltype(std::declval<decltype(std::declval<const Simulator&>().model().intensiveQuantities(0, 0).fluidState())>().saltConcentration())>::type,int>;
+        using FSInfo = std::tuple<Scalar,typename std::decay<decltype(std::declval<decltype(std::declval<const Simulator&>().model().intensiveQuantities(0, 0).fluidState())>().saltConcentration())>::type>;
 
         MultisegmentWell(const Well& well,
                          const ParallelWellInfo<Scalar>& pw_info,

--- a/opm/simulators/wells/MultisegmentWellSegments.cpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.cpp
@@ -140,9 +140,9 @@ void MultisegmentWellSegments<FluidSystem,Indices>::
 computeFluidProperties(const EvalWell& temperature,
                        const EvalWell& saltConcentration,
                        const PrimaryVariables& primary_variables,
-                       int pvt_region_index,
                        DeferredLogger& deferred_logger)
 {
+    const int pvt_region_index = well_.pvtRegionIdx();
     std::vector<Scalar> surf_dens(well_.numConservationQuantities());
     // Surface density.
     for (unsigned phaseIdx = 0; phaseIdx < FluidSystem::numPhases; ++phaseIdx) {
@@ -349,7 +349,6 @@ MultisegmentWellSegments<FluidSystem,Indices>::
 getSurfaceVolume(const EvalWell& temperature,
                  const EvalWell& saltConcentration,
                  const PrimaryVariables& primary_variables,
-                 const int pvt_region_index,
                  const int seg_idx) const
 {
     const EvalWell seg_pressure = primary_variables.getSegmentPressure(seg_idx);
@@ -359,6 +358,7 @@ getSurfaceVolume(const EvalWell& temperature,
         mix_s[comp_idx] = primary_variables.surfaceVolumeFraction(seg_idx, comp_idx);
     }
 
+    const int pvt_region_index = well_.pvtRegionIdx();
     std::vector<EvalWell> b(well_.numConservationQuantities(), 0.);
     if (FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx)) {
         const unsigned waterCompIdx = FluidSystem::canonicalToActiveCompIdx(FluidSystem::waterCompIdx);

--- a/opm/simulators/wells/MultisegmentWellSegments.hpp
+++ b/opm/simulators/wells/MultisegmentWellSegments.hpp
@@ -56,7 +56,6 @@ public:
     void computeFluidProperties(const EvalWell& temperature,
                                 const EvalWell& saltConcentration,
                                 const PrimaryVariables& primary_variables,
-                                int pvt_region_index,
                                 DeferredLogger& deferred_logger);
 
     //! \brief Update upwinding segments.
@@ -72,7 +71,6 @@ public:
     EvalWell getSurfaceVolume(const EvalWell& temperature,
                               const EvalWell& saltConcentration,
                               const PrimaryVariables& primary_variables,
-                              const int pvt_region_index,
                               const int seg_idx) const;
 
     EvalWell getFrictionPressureLoss(const int seg,

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1140,7 +1140,6 @@ namespace Opm
         this->segments_.computeFluidProperties(temperature,
                                                saltConcentration,
                                                this->primary_variables_,
-                                               std::get<2>(info), //pvt_region_index
                                                deferred_logger);
     }
 
@@ -2047,7 +2046,6 @@ namespace Opm
         return this->segments_.getSurfaceVolume(temperature,
                                                 saltConcentration,
                                                 this->primary_variables_,
-                                                std::get<2>(info), //pvt_region_index
                                                 seg_idx);
     }
 
@@ -2287,13 +2285,13 @@ namespace Opm
     }
 
     template <typename TypeTag>
-    typename MultisegmentWell<TypeTag>::FSInfo MultisegmentWell<TypeTag>::
+    typename MultisegmentWell<TypeTag>::FSInfo
+    MultisegmentWell<TypeTag>::
     getFirstPerforationFluidStateInfo(const Simulator& simulator) const
     {
         Scalar fsTemperature = 0.0;
         using SaltConcType = typename std::decay<decltype(std::declval<decltype(simulator.model().intensiveQuantities(0, 0).fluidState())>().saltConcentration())>::type;
         SaltConcType fsSaltConcentration{};
-        int pvt_region_index = 0;
 
         // If this process does not contain active perforations, this->well_cells_ is empty.
         if (this->well_cells_.size() > 0) {
@@ -2305,10 +2303,9 @@ namespace Opm
 
             fsTemperature = fs.temperature(FluidSystem::oilPhaseIdx).value();
             fsSaltConcentration = fs.saltConcentration();
-            pvt_region_index = fs.pvtRegionIndex();
         }
 
-        auto info = std::make_tuple(fsTemperature, fsSaltConcentration, pvt_region_index);
+        auto info = std::make_tuple(fsTemperature, fsSaltConcentration);
 
         // The following broadcast call is neccessary to ensure that processes that do *not* contain
         // the first perforation get the correct temperature, saltConcentration and pvt_region_index

--- a/opm/simulators/wells/ParallelWellInfo.cpp
+++ b/opm/simulators/wells/ParallelWellInfo.cpp
@@ -815,10 +815,10 @@ template<class Scalar> using dIter = typename std::vector<Scalar>::iterator;
 template<class Scalar> using cdIter = typename std::vector<Scalar>::const_iterator;
 
 #define INSTANTIATE_BROADCAST_FIRST_PERF_DENSEAD_EVALUATION(T, DIM)                 \
-    template std::tuple<T, Opm::DenseAd::Evaluation<T, DIM, 0u>,int>                \
+    template std::tuple<T, Opm::DenseAd::Evaluation<T, DIM, 0u>>                \
         Opm::ParallelWellInfo<T>::broadcastFirstPerforationValue                    \
-        <std::tuple<T, Opm::DenseAd::Evaluation<T, DIM, 0u>,int>>                   \
-        (std::tuple<T, Opm::DenseAd::Evaluation<T, DIM, 0u>,int> const&)            \
+        <std::tuple<T, Opm::DenseAd::Evaluation<T, DIM, 0u>>>                   \
+        (std::tuple<T, Opm::DenseAd::Evaluation<T, DIM, 0u>> const&)            \
         const;
 
 #define INSTANTIATE_TYPE(T)                                                         \


### PR DESCRIPTION
I do not see it is necessary to get new one each time when using it. 