### PR TITLE
Set linear solver accelerator to CPU for NLDD local linear solvers

### DIFF
--- a/opm/simulators/linalg/FlowLinearSolverParameters.cpp
+++ b/opm/simulators/linalg/FlowLinearSolverParameters.cpp
@@ -68,11 +68,18 @@ void FlowLinearSolverParameters::init(bool cprRequestedInDataFile)
     }
 
     accelerator_mode_ = Parameters::Get<Parameters::AcceleratorMode>();
+    cpr_weights_thread_parallel_ = Parameters::Get<Parameters::CprWeightsThreadParallel>();
     gpu_device_id_ = Parameters::Get<Parameters::GpuDeviceId>();
     opencl_platform_id_ = Parameters::Get<Parameters::OpenclPlatformId>();
     opencl_ilu_parallel_ = Parameters::Get<Parameters::OpenclIluParallel>();
-    linear_solver_accelerator_ = Parameters::linearSolverAcceleratorTypeFromCLI();
-    cpr_weights_thread_parallel_ = Parameters::Get<Parameters::CprWeightsThreadParallel>();
+
+    // NLDD local solvers must use CPU accelerator because extractMatrix and other
+    // operations in the NLDD implementation are not GPU-compatible yet.
+    if (is_nldd_local_solver_) {
+        linear_solver_accelerator_ = Parameters::LinearSolverAcceleratorType::CPU;
+    } else {
+        linear_solver_accelerator_ = Parameters::linearSolverAcceleratorTypeFromCLI();
+    }
 
     if (linear_solver_accelerator_ == Parameters::LinearSolverAcceleratorType::GPU) {
         if (!Parameters::IsSet<Parameters::LinearSolver>()) {


### PR DESCRIPTION
Small fix to make sure it doesn't crash if the user requests `--nonlinear-solver=nldd` and `--linear-solver-accelerator=gpu`.

I can make NLDD fully support `--linear-solver-accelerator=gpu` where the input matrices and vectors are GPU types, but I don't think I should prioritise this before the release. This would involve making a GPU compatible implementation of `opm/simulators/linalg/extractMatrix.hpp`.

In its current state it is still possible to test NLDD local linear solvers on the GPU through the `solverAdapter` by for example passing in the "gpubicgstab" solver and "gpudilu" preconditioner in the input json.