### PR TITLE
Chase API for Well Specification Report

### DIFF
--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -849,11 +849,15 @@ private:
         const auto changedWells = this->schedule_
             .changed_wells(timer.reportStepNum(), this->initialStep());
 
-        if (changedWells.empty()) {
+        const auto changedWellLists = this->schedule_
+            .changedWellLists(timer.reportStepNum(), this->initialStep());
+
+        if (changedWells.empty() && !changedWellLists) {
             return;
         }
 
         this->outputModule_->outputWellspecReport(changedWells,
+                                                  changedWellLists,
                                                   timer.reportStepNum(),
                                                   timer.simulationTimeElapsed(),
                                                   timer.currentDateTime());

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -295,6 +295,7 @@ calc_inplace(std::map<std::string, double>& miscSummaryData,
 template<class FluidSystem>
 void GenericOutputBlackoilModule<FluidSystem>::
 outputWellspecReport(const std::vector<std::string>& changedWells,
+                     const bool                      changedWellLists,
                      const std::size_t               reportStepNum,
                      const double                    elapsed,
                      boost::posix_time::ptime        currentDate) const
@@ -302,7 +303,10 @@ outputWellspecReport(const std::vector<std::string>& changedWells,
     this->logOutput_.timeStamp("WELSPECS", elapsed,
                                static_cast<int>(reportStepNum),
                                currentDate);
-    this->logOutput_.wellSpecification(changedWells, reportStepNum);
+
+    this->logOutput_.wellSpecification(changedWells,
+                                       changedWellLists,
+                                       reportStepNum);
 }
 
 template<class FluidSystem>

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -121,7 +121,28 @@ public:
                          std::map<std::string, std::vector<double>>& regionData,
                          const Parallel::Communication& comm);
 
+    /// Emit well specification report
+    ///
+    /// Includes well level, connection level, and segment level information
+    /// for structurally changed wells.  Also includes contents of well
+    /// lists for structurally changed well lists.
+    ///
+    /// \param[in] changedWells Wells whose structures differ from those of
+    /// the previous well specification report.
+    ///
+    /// \param[in] changedWellLists Whether or not any of the run's current
+    /// well lists changed structurally since the previous well
+    /// specification report.
+    ///
+    /// \param[in] reportStepNum One-based report step index.
+    ///
+    /// \param[in] elapsed Simulated time, in seconds, since start of
+    /// simulation run.
+    ///
+    /// \param[in] currentDate Time point at which this well specification
+    /// report is emitted.
     void outputWellspecReport(const std::vector<std::string>& changedWells,
+                              const bool changedWellLists,
                               const std::size_t reportStepNum,
                               const double elapsed,
                               boost::posix_time::ptime currentDate) const;

--- a/opm/simulators/flow/LogOutputHelper.cpp
+++ b/opm/simulators/flow/LogOutputHelper.cpp
@@ -686,6 +686,7 @@ production(const std::size_t reportStepNum,
 template<class Scalar>
 void LogOutputHelper<Scalar>::
 wellSpecification(const std::vector<std::string>& changedWells,
+                  const bool                      changedWellLists,
                   const std::size_t               reportStepNum) const
 {
     std::ostringstream ss;
@@ -696,8 +697,11 @@ wellSpecification(const std::vector<std::string>& changedWells,
         { return grid.getCellDepth(globalCellIndex); }
     };
 
-    PrtFile::Reports::wellSpecification(changedWells, reportStepNum,
-                                        this->schedule_, blockDepth, ss);
+    PrtFile::Reports::wellSpecification(changedWells,
+                                        changedWellLists,
+                                        reportStepNum,
+                                        this->schedule_,
+                                        blockDepth, ss);
 
     OpmLog::note(ss.str());
 }

--- a/opm/simulators/flow/LogOutputHelper.hpp
+++ b/opm/simulators/flow/LogOutputHelper.hpp
@@ -87,8 +87,12 @@ public:
     //! \param[in] changedWells List of wells whose structure changed at
     //! this time.
     //!
+    //! \param[in] changedWells Whether or not any of the run's well list
+    //! changed structurally at this time.
+    //!
     //! \param[in] reportStepNum Report step index (1-based).
     void wellSpecification(const std::vector<std::string>& changedWells,
+                           const bool                      changedWellLists,
                            const std::size_t               reportStepNum) const;
 
     void timeStamp(const std::string& lbl,


### PR DESCRIPTION
In particular, we now need to pass a flag that says whether or not any of the run's well lists have changed since the previous report step.  If so, the well specification report will emit a sheet detailing the contents of all of the run's current well lists.