### PR TITLE
Using epsilon for oil function consistency check

### DIFF
--- a/opm/simulators/utils/satfunc/OilPhaseConsistencyChecks.cpp
+++ b/opm/simulators/utils/satfunc/OilPhaseConsistencyChecks.cpp
@@ -25,6 +25,8 @@
 
 #include <opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp>
 
+#include <limits>
+
 // ---------------------------------------------------------------------------
 
 template <typename Scalar>
@@ -40,7 +42,7 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    const auto low = this->sogcr_ < Scalar{0};
+    const auto low = this->sogcr_ < Scalar{-std::numeric_limits<double>::epsilon()};
     const auto high = ! (this->sogcr_ < Scalar{1});
 
     if (low || high) {


### PR DESCRIPTION
In master, running [SPE10-MOD02-01.DATA](https://github.com/OPM/opm-tests/blob/master/spe10/SPE10-MOD02-01.DATA) results in:

> ```
> Error: Saturation Function End-point Consistency Failures
> Consistency Problem:
>   Non-negative critical oil saturation in G/O system
>   0 <= SOGCR < 1
>   Total Violations: 1
> 
> List of Violations
> +--------+---------------+
> | SATNUM | SOGCR         |
> +--------+---------------+
> | 1      | -5.551115e-17 |
> +--------+---------------+
> ```

This PR makes the model run. However, I am not sure if this is the proper way to fix this.