### PR TITLE
Remove a branching that discoordinates split wells

### DIFF
--- a/opm/simulators/wells/WellGroupHelpers.cpp
+++ b/opm/simulators/wells/WellGroupHelpers.cpp
@@ -573,11 +573,6 @@ updateWellRatesFromGroupTargetScale(const Scalar scale,
         if (!well_index.has_value())
             continue;
 
-        if (! wellState.wellIsOwned(well_index.value(), wellName) ) // Only sum once
-        {
-            continue;
-        }
-
         auto& ws = wellState.well(well_index.value());
         if (ws.status == Well::Status::SHUT)
             continue;


### PR DESCRIPTION
WellGroupHelpers have several suspicious methods that skip actions on ranks that do not own a well. Each skip has a comment "Only sum once" but only a few actually sum something. It looks like a copy-paste error and it is wrong at minimum in the method `updateWellRatesFromGroupTargetScale` where surface_rates remain different across ranks.

In a model I looked into the difference in surface_rates led to differences in segment_rates (in method `scaleSegmentRatesWithWellRates`) which then affected primary_variables (in their `.update`), then residual in `getWellConvergence`, and, finally, caused a deadlock.

WellGroupHelpers do not communicate, the communication happens at a higher level. The copy-pasted non-owner skip is for some methods correct (e.g. `sumSolventRates`). I am planning to check all such skips in this file. (There is actually one more file with a skip with comment "Only sum once" in opm-simulators and it is correct.)