### PR TITLE
supporting well energy summary output

### DIFF
--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -65,6 +65,7 @@ public:
         serializer(bhp);
         serializer(thp);
         serializer(temperature);
+        serializer(energy_rate);
         serializer(efficiency_scaling_factor);
         serializer(phase_mixing_rates);
         serializer(well_potentials);
@@ -96,7 +97,11 @@ public:
     PhaseUsageInfo<IndexTraits> pu;
     Scalar bhp{0};
     Scalar thp{0};
+
+    // thermal related
     Scalar temperature{0};
+    Scalar energy_rate{0.};
+
     Scalar efficiency_scaling_factor{1.0};
 
     // filtration injection concentration

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -378,6 +378,9 @@ namespace Opm
 
         auto& ws = well_state.well(this->index_of_well_);
         ws.phase_mixing_rates.fill(0.0);
+        if constexpr (has_energy) {
+            ws.energy_rate = 0.0;
+        }
 
 
         const int np = this->number_of_phases_;
@@ -542,6 +545,7 @@ namespace Opm
         if constexpr (has_energy) {
             connectionRates[perf][Indices::contiEnergyEqIdx] =
                 connectionRateEnergy(cq_s, intQuants, deferred_logger);
+            ws.energy_rate += getValue(connectionRates[perf][Indices::contiEnergyEqIdx]);
         }
 
         if constexpr (has_polymer) {

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -591,6 +591,10 @@ report(const int* globalCellIdxMap,
             well.rates.set(rt::brine, ws.sum_brine_rates());
         }
 
+        if (pu.hasEnergy()) {
+            well.rates.set(rt::energy,  ws.energy_rate);
+        }
+
         if (pu.hasBiofilm() || pu.hasMICP()) {
             well.rates.set(rt::microbial, ws.sum_microbial_rates());
             if (pu.hasMICP()) {


### PR DESCRIPTION
With this, we can output the following summary keywords, 

WTPRHEA, WTPTHEA, WTIRHEA and WTITHEA .

Like the ones added in https://github.com/OPM/opm-tests/pull/1344 . 

At the same time, the values are extremely big, not sure what to expect though. (first time to see energy rate output)

<img width="735" height="455" alt="image" src="https://github.com/user-attachments/assets/c6117b3d-6696-4cbc-963a-ccab9d3f12de" />

Creating the PR here for discussion. 

@totto82 @bska @hnil @vkip  