### PR TITLE
Add missing communication after sumWellPhaseRates

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1372,11 +1372,13 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                         Scalar rel_change = denominator > small_rate ? std::abs( (gr_rate_nupcol - gr_rate) / denominator) : 0.0;
                         if ( rel_change > tol_nupcol) {
                             this->updateNupcolWGState();
-                            const std::string control_str = is_vrep? "VREP" : "REIN";
-                            const std::string msg = fmt::format("Group prodution relative change {} larger than tolerance {} "
-                                                    "at iteration {}. Update {} for Group {} even if iteration is larger than {} given by NUPCOL." ,
-                                                    rel_change, tol_nupcol, iterationIdx, control_str, gr_name, nupcol);
-                            deferred_logger.debug(msg);
+                            if (comm_.rank() == 0) {
+                                const std::string control_str = is_vrep? "VREP" : "REIN";
+                                const std::string msg = fmt::format("Group prodution relative change {} larger than tolerance {} "
+                                                        "at iteration {}. Update {} for Group {} even if iteration is larger than {} given by NUPCOL." ,
+                                                        rel_change, tol_nupcol, iterationIdx, control_str, gr_name, nupcol);
+                                deferred_logger.debug(msg);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The method sumWellPhaseRates accumulates only contributions from well owners. The result has to be summed over ranks to get the correct result on all ranks. Otherwise ranks will have different results.

In this case, processes that do not own any well will get 0 and always get _false_ in the following _if_. Process ranks that own a well can get _true_ and call `this->updateNupcolWGState()` which can introduce differences across processes.