### PR TITLE
Enable compatibility with newer CMake and Boost

### DIFF
--- a/opm-simulators-prereqs.cmake
+++ b/opm-simulators-prereqs.cmake
@@ -32,13 +32,18 @@ set (opm-simulators_CONFIG_VAR
   OPM_COMPILE_COMPONENTS_TEMPLATE_LIST
   )
 
+# CMake 3.30.0 requires to find Boost in CONFIG mode
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30.0)
+	set(_Boost_CONFIG_MODE CONFIG)
+endif()
+
 # dependencies
 set (opm-simulators_DEPS
   # Compile with C99 support if available
   "C99"
   # Various runtime library enhancements
   "Boost 1.44.0
-    COMPONENTS date_time system unit_test_framework REQUIRED"
+    COMPONENTS date_time unit_test_framework REQUIRED ${_Boost_CONFIG_MODE}"
   # DUNE prerequisites
   "dune-common REQUIRED"
   "dune-istl REQUIRED"


### PR DESCRIPTION
* Avoid warning when finding Boost libraries with CMake 3.30.0 or newer.
* Newer versions of Boost config (>=1.88) do not properly handle the system component.  But since it's not used, this patch removes it.

This is essentially the equivalent of https://github.com/OPM/opm-common/pull/4807