### PR TITLE
Change behaviour for non-intersection cases when computing thp from bhp

### DIFF
--- a/opm/simulators/wells/VFPHelpers.cpp
+++ b/opm/simulators/wells/VFPHelpers.cpp
@@ -499,11 +499,14 @@ findTHP(const std::vector<Scalar>& bhp_array,
             const Scalar& y1 = bhp_array[array_ix+1];
             thp = findX(x0, x1, y0, y1, bhp);
         } else {
-            // no intersection, just return largest/smallest value in table
-            if (find_largest) {
-                thp = thp_array[nthp-1];
-            } else {
+            // No intersections from interpolation or extrapolation 
+            // bhp is either smaller than or larger than all values in
+            // bhp_array. If bhp < all values, return smallest thp-value
+            // in table, otherwise return largest.
+            if (bhp < bhp_array[0]) {
                 thp = thp_array[0];
+            } else {
+                thp = thp_array[nthp-1];
             }
         }
     }


### PR DESCRIPTION
In a few cases when computing thp from bhp/rates, it may happen that we find no solution from interpolation/extrapolation (e.g., the bhp(thp) - function is non-monotonic and current bhp is outside its range). In master, current approach in this situation is to return largest thp-value in table. This has been observed to be problematic as it may prevent a well that should be on thp-control from switching to thp-control.

This PR simply suggest change behaviour in this special case to rather return smallest thp-value in table if current bhp is less than all bhp(thp)-values, and largerst otherwise. I think this is a more reasonnable approach.  