### PR TITLE
add missing includes

### DIFF
--- a/opm/simulators/wells/WellGroupHelper.cpp
+++ b/opm/simulators/wells/WellGroupHelper.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <config.h>
+#include <opm/simulators/wells/WellGroupHelper.hpp>
 
 #include <opm/common/TimingMacros.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
@@ -27,8 +28,12 @@
 #include <opm/simulators/utils/DeferredLoggingErrorHelpers.hpp>
 #include <opm/simulators/wells/FractionCalculator.hpp>
 #include <opm/simulators/wells/TargetCalculator.hpp>
-#include <opm/simulators/wells/WellGroupHelper.hpp>
 
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <stack>
+#include <set>
 
 namespace Opm
 {

--- a/opm/simulators/wells/WellGroupHelper.hpp
+++ b/opm/simulators/wells/WellGroupHelper.hpp
@@ -20,6 +20,7 @@
 #define OPM_WELLGROUPHELPER_HEADER_INCLUDED
 
 #include <opm/common/TimingMacros.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/Schedule/Group/GPMaint.hpp>
 #include <opm/input/eclipse/Schedule/Group/GSatProd.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRate.hpp>
@@ -34,7 +35,11 @@
 
 #include <opm/simulators/utils/ParallelCommunication.hpp>
 
+#include <algorithm>
 #include <map>
+#include <memory>
+#include <optional>
+#include <stdexcept>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Post-builder broke after merge of #6535

This adds all the missing includes I could identify, and puts the TU's own header first in the include list as it always should be.