### PR TITLE
Use python3 from the environment in plot_well_comparison.py

### DIFF
--- a/tests/plot_well_comparison.py
+++ b/tests/plot_well_comparison.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Generates a PDF with plots of all summary curves from a reference
 # case and a 'new' simulation.


### PR DESCRIPTION
So those of use with non-standard python installs can make local failure reports without remembering to update this every time.. 