### PR TITLE
changed: use unique_ptr for wells

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -187,7 +187,7 @@ template<class Scalar> class WellContributions;
                                          unsigned timeIdx) const;
 
 
-            using WellInterfacePtr = std::shared_ptr<WellInterface<TypeTag> >;
+            using WellInterfacePtr = std::unique_ptr<WellInterface<TypeTag>>;
 
             using BlackoilWellModelGeneric<Scalar, IndexTraits>::initFromRestartFile;
             void initFromRestartFile(const RestartValue& restartValues)
@@ -292,7 +292,7 @@ template<class Scalar> class WellContributions;
                                     const int reportStepIdx,
                                     const int iterationIdx);
 
-            WellInterfacePtr getWell(const std::string& well_name) const;
+            const WellInterface<TypeTag>& getWell(const std::string& well_name) const;
 
             using PressureMatrix = Dune::BCRSMatrix<Opm::MatrixBlock<Scalar, 1, 1>>;
 

--- a/opm/simulators/wells/BlackoilWellModelGasLift.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGasLift.hpp
@@ -106,7 +106,7 @@ public:
     using GLiftSyncGroups = typename GasLiftSingleWellGeneric<Scalar, IndexTraits>::GLiftSyncGroups;
     using GLiftWellStateMap =  typename Base::GLiftWellStateMap;
     using Simulator = GetPropType<TypeTag, Properties::Simulator>;
-    using WellInterfacePtr = std::shared_ptr<WellInterface<TypeTag>>;
+    using WellInterfacePtr = std::unique_ptr<WellInterface<TypeTag>>;
     using WellStateType = WellState<Scalar, IndexTraits>;
 
     explicit BlackoilWellModelGasLift(bool terminal_output)

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1557,7 +1557,7 @@ namespace Opm {
 
         for(unsigned int i = 0; i < well_container_.size(); i++){
             auto& well = well_container_[i];
-            std::shared_ptr<StandardWell<TypeTag> > derived = std::dynamic_pointer_cast<StandardWell<TypeTag> >(well);
+            auto derived = dynamic_cast<StandardWell<TypeTag>*>(well.get());
             if (derived) {
                 wellContribs.addNumBlocks(derived->linSys().getNumBlocks());
             }
@@ -1569,11 +1569,11 @@ namespace Opm {
         for(unsigned int i = 0; i < well_container_.size(); i++){
             auto& well = well_container_[i];
             // maybe WellInterface could implement addWellContribution()
-            auto derived_std = std::dynamic_pointer_cast<StandardWell<TypeTag>>(well);
+            auto derived_std = dynamic_cast<StandardWell<TypeTag>*>(well.get());
             if (derived_std) {
                 derived_std->linSys().extract(derived_std->numStaticWellEq, wellContribs);
             } else {
-                auto derived_ms = std::dynamic_pointer_cast<MultisegmentWell<TypeTag> >(well);
+                auto derived_ms = dynamic_cast<MultisegmentWell<TypeTag>*>(well.get());
                 if (derived_ms) {
                     derived_ms->linSys().extract(wellContribs);
                 } else {
@@ -2326,7 +2326,7 @@ namespace Opm {
     }
 
     template<typename TypeTag>
-    typename BlackoilWellModel<TypeTag>::WellInterfacePtr
+    const WellInterface<TypeTag>&
     BlackoilWellModel<TypeTag>::
     getWell(const std::string& well_name) const
     {
@@ -2339,7 +2339,7 @@ namespace Opm {
 
         assert(well != well_container_.end());
 
-        return *well;
+        return **well;
     }
 
     template <typename TypeTag>

--- a/tests/test_glift1.cpp
+++ b/tests/test_glift1.cpp
@@ -159,8 +159,8 @@ BOOST_AUTO_TEST_CASE(G1)
     well_model.calculateExplicitQuantities(deferred_logger);
     well_model.prepareTimeStep(deferred_logger);
     well_model.updateWellControls(deferred_logger);
-    Opm::WellInterface<TypeTag> *well_ptr = well_model.getWell("B-1H").get();
-    StdWell *std_well = dynamic_cast<StdWell *>(well_ptr);
+    const Opm::WellInterface<TypeTag>* well_ptr = &well_model.getWell("B-1H");
+    const StdWell *std_well = dynamic_cast<const StdWell *>(well_ptr);
 
     const auto& schedule = simulator->vanguard().schedule();
     auto wells_ecl = schedule.getWells(report_step_idx);


### PR DESCRIPTION
No sharing, no reason to tickle them refcounts.