### PR TITLE
Rename hybrid Newton flag

### DIFF
--- a/opm/simulators/flow/FlowProblemParameters.cpp
+++ b/opm/simulators/flow/FlowProblemParameters.cpp
@@ -69,10 +69,10 @@ void registerFlowProblemParameters()
     Parameters::Register<Parameters::NumSatfuncConsistencySamplePoints>
         ("Maximum number of reported failures for each individual saturation function consistency check");
 
-    Parameters::Register<Parameters::HyNeConfigFile>
-        ("Use config files for Hybrid Newton");
+    Parameters::Register<Parameters::HybridNewtonConfigFile>
+        ("JSON Config file path for Hybrid Newton");
 
-    Parameters::Register<Parameters::UseHyNe>
+    Parameters::Register<Parameters::UseHybridNewton>
         ("Wheter or not to use Hybrid Newton");
 
     // By default, stop it after the universe will probably have stopped

--- a/opm/simulators/flow/FlowProblemParameters.hpp
+++ b/opm/simulators/flow/FlowProblemParameters.hpp
@@ -57,9 +57,9 @@ struct OutputMode { static constexpr auto value = "all"; };
 struct RestartWritingInterval { static constexpr int value = 0xffffff; }; // disable
 
 // Path to the config file containing all Hybrid Newton parameters
-struct HyNeConfigFile { static constexpr auto value = "hybridNewtonConfig.json"; };
+struct HybridNewtonConfigFile { static constexpr auto value = "hybridNewtonConfig.json"; };
 // Wheter or not to use Hybrid Newton nonlinear preconditioning
-struct UseHyNe { static constexpr bool value = false; };
+struct UseHybridNewton { static constexpr bool value = false; };
 
 } // namespace Opm::Parameters
 

--- a/opm/simulators/flow/HybridNewton.hpp
+++ b/opm/simulators/flow/HybridNewton.hpp
@@ -84,7 +84,7 @@ public:
     *
     * This function acts as the entry point for Hybrid Newton corrections.
     * It first checks whether the Hybrid Newton mechanism is enabled
-    * (via `Parameters::UseHyNe`). If enabled, it validates the fluid system
+    * (via `Parameters::UseHybridNewton`). If enabled, it validates the fluid system
     * and loads model configurations from the parameter-specified
     * configuration file (if not already loaded).
     *
@@ -99,13 +99,13 @@ public:
     void tryApplyHybridNewton()
     {
         // Check if flag activated
-        if (!Parameters::Get<Parameters::UseHyNe>())
+        if (!Parameters::Get<Parameters::UseHybridNewton>())
             return;
 
         validateFluidSystem();
 
         if (!configsLoaded_) {
-            std::string config_file = Parameters::Get<Parameters::HyNeConfigFile>();
+            std::string config_file = Parameters::Get<Parameters::HybridNewtonConfigFile>();
             PropertyTree pt(config_file);
             for (const auto& model_key : pt.get_child_keys()) {
                 HybridNewtonConfig config(pt.get_child(model_key));

--- a/python/integration_tests/ml/hybrid_newton/README.md
+++ b/python/integration_tests/ml/hybrid_newton/README.md
@@ -55,7 +55,7 @@ For each test case:
 3. `flow` is run with:
 
    ```bash
-   --use-hy-ne=true --hy-ne-config-file=config.json
+   --use-hybrid-newton=true --hybrid-newton-config-file=config.json
    ```
 4. Hybrid Newton iteration counts are extracted and compared to baseline.
 

--- a/python/integration_tests/ml/hybrid_newton/test_hybrid_newton.py
+++ b/python/integration_tests/ml/hybrid_newton/test_hybrid_newton.py
@@ -127,8 +127,8 @@ class TestHybridNewton(unittest.TestCase):
         cmd = [
             os.environ.get("FLOW_BINARY", default="flow"),
             str(self.data_dir / self.deck_file),
-            f"--hy-ne-config-file={json_path}",
-            "--use-hy-ne=true",
+            f"--hybrid-newton-config-file={json_path}",
+            "--use-hybrid-newton=true",
             "--output-extra-convergence-info=steps,iterations",
             "--newton-min-iterations=0",
             "--output-dir=.",


### PR DESCRIPTION
Rename hybrid Newton flag more explicitly. 

Based on issue #6574 