### PR TITLE
Make output of ESMRY files default

### DIFF
--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -77,7 +77,7 @@ struct EclOutputDoublePrecision { static constexpr bool value = false; };
 struct EnableWriteAllSolutions { static constexpr bool value = false; };
 
 // Write ESMRY file for fast loading of summary data
-struct EnableEsmry { static constexpr bool value = false; };
+struct EnableEsmry { static constexpr bool value = true; };
 
 } // namespace Opm::Parameters
 


### PR DESCRIPTION
ESMRY output from OPM Flow has been tested in Equinor for a long period of time and the experience is very good. Hence, we would like to make this default behaviour for the simulator