### PR TITLE
Make getGuideRate's result identical on all ranks

### DIFF
--- a/opm/simulators/wells/WellGroupHelper.cpp
+++ b/opm/simulators/wells/WellGroupHelper.cpp
@@ -593,6 +593,7 @@ WellGroupHelper<Scalar, IndexTraits>::getGuideRate(const std::string& name,
     if (this->guide_rate_.has(name)) {
         return this->guide_rate_.get(name, target, this->getProductionGroupRateVector(name));
     }
+
     Scalar total_guide_rate = 0.0;
     const Group& group = this->schedule_.getGroup(name, this->report_step_);
 


### PR DESCRIPTION
In this file (formerly WellGroupHelper**s**.cpp), several methods have a copy-pasted code and one part with _Only sum once_ has turned to be wrong #6544. I checked the other occurrences and came to conclusion that this is wrong too.

Unfortunately, I was not able to reach this part of the code at all, all tests I tried returned from this method earlier via _return this->guide\_rate\_.get_. However, the result returned this way is the same on all ranks. Therefore, the _if_ that makes the result different between ranks must be wrong.

Additional information:
There are more hints that this method should return the same result on all ranks. It is used extensively in FractionCalculator::localFraction and neither case communicates.
There is one more place from where this method was called and it was the only place, where I was unsure if the result should be different between ranks. It was in BlackoilWellModelGeneric::updateAndCommunicateGroupData, specifically the call _updateGroupControlledWells_. However, the recent rework #6535 made it clearer that the updates to the _group_ are different than the following block (with temporary nupcol well state) that is followed by communications.