### PR TITLE
Added git-clang-format as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,11 @@
 # - trailing-whitespace: Removes trailing whitespace from lines
 #   (preserves Markdown hard line breaks with --markdown-linebreak-ext=md)
 # - end-of-file-fixer: Ensures files end with exactly one newline
+# - git-clang-format-fix: Applies clang-format to staged C/C++/CUDA files (only the diff)
 #
+# Note:
+# - The git-clang-format-fix hook will re-stage any changes it makes. After it runs, you will need to review the changes and re-run your commit.
+# - The git-clang-format-fix can be disabled by setting SKIP=git-clang-format-fix=1 in your environment, eg. `SKIP=git-clang-format-fix=1 git commit -m "Your commit message"`
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -40,3 +44,30 @@ repos:
       - id: end-of-file-fixer
         types_or: [c, c++, python, shell, yaml, cmake, markdown, text]
         exclude: '^(build/|\.git/)'
+  - repo: local
+    hooks:
+      - id: git-clang-format-fix
+        name: git-clang-format (diff-only, auto-fix)
+        entry: |
+          bash -c '
+            # First check if anything needs formatting
+            if git clang-format --staged --diff --quiet; then
+              # No changes needed
+              exit 0
+            fi
+
+            echo "[git-clang-format] Applying formatting to staged changes..."
+            git clang-format --staged
+            # Re-add anything the formatter touched
+            git add -A
+
+            echo
+            echo "[git-clang-format] Changes have been applied."
+            echo "Please review and re-run your commit."
+            echo
+            # Force user to re-run commit so they see the changes
+            exit 1
+          '
+        language: system
+        types_or: [c++, c, cuda]
+        pass_filenames: false


### PR DESCRIPTION
I am opening this PR also to create a discussion. Before you go on reading, please note that this can be selectively disabled by exporting the `SKIP` environment variable to contain `git-clang-format-fix=1`, so eg.

```bash
SKIP=git-clang-format-fix=1 git commit -m 'Did stuff I do not want formatted'
```

As far as I can tell, there is no ready-made pre-commit hook for this, so a bash script is the solution for now.

Do note that this applies git-clang-format, so it will only clang-format the diff. 

Example workflow where I have added extra spacing that should not be there:

```bash
$ git commit -m 'Made meaning more spatious'
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
git-clang-format (diff-only, auto-fix)...................................Failed
- hook id: git-clang-format-fix
- exit code: 1

diff --git a/opm/models/blackoil/blackoilprimaryvariables.hh b/opm/models/blackoil/blackoilprimaryvariables.hh
index 8aa1524d8..8030ceaf7 100644
--- a/opm/models/blackoil/blackoilprimaryvariables.hh
+++ b/opm/models/blackoil/blackoilprimaryvariables.hh
@@ -181,8 +181,8 @@ public:
         result.primaryVarsMeaningGas_ = GasMeaning::Rv;
         result.primaryVarsMeaningPressure_ = PressureMeaning::Pg;
         result.primaryVarsMeaningWater_ = WaterMeaning::Rsw;
-        result.primaryVarsMeaningSolvent_          = SolventMeaning::Ss;
-        for (std::size_t i = 0; i < result.size(); ++i)              {
+        result.primaryVarsMeaningSolvent_ = SolventMeaning::Ss;
+        for (std::size_t i = 0; i < result.size(); ++i) {
             result[i] = i + 1;
         }
 
[git-clang-format] Applying formatting to staged changes...
changed files:
    opm/models/blackoil/blackoilprimaryvariables.hh

[git-clang-format] Changes have been applied.
Please review and re-run your commit.


opm-simulators on  precommit [$!?] via  v3.31.6 
$ git commit -m 'Made meaning more spatious''
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
git-clang-format (diff-only, auto-fix)...............(no files to check)Skipped
[precommit a4c90e0b7] added new precommit
 1 file changed, 2 insertions(+), 2 deletions(-)
 ```
 
 Note that I have for the proof-of-concept kept the shell-script in the YAML-file. It is probably worthwhile to move this to a separate file, or even a separate repo if we want this for opm-common and grid as well, but before that I think it is wise to discuss wether this is something we want. 