### PR TITLE
Change .clang-format ColumnLimit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@
         BinPackParameters: false,
         BreakBeforeBraces: Linux,
         BreakConstructorInitializers: BeforeComma,
-        ColumnLimit: 120,
+        ColumnLimit: 100,
         Cpp11BracedListStyle: true,
         FixNamespaceComments: true,
         InsertNewlineAtEOF: true,


### PR DESCRIPTION
Change `.clang-format` ColumnLimit from 120 to 100 characters. See #6592 for more information.