### PR TITLE
recovering to use std::optional for SingleWellState::group_target

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1386,7 +1386,7 @@ updateAndCommunicateGroupData(const int reportStepIdx,
             const Scalar efficiencyFactor = well->wellEcl().getEfficiencyFactor() *
                                     ws.efficiency_scaling_factor;
             // Translate injector type from control to Phase.
-            Scalar group_target = std::numeric_limits<Scalar>::max();
+            std::optional<Scalar> group_target;
             if (well->isProducer()) {
                 group_target = wg_helper.getWellGroupTargetProducer(
                     well->name(),

--- a/opm/simulators/wells/WellGroupHelper.hpp
+++ b/opm/simulators/wells/WellGroupHelper.hpp
@@ -144,22 +144,22 @@ public:
 
     GuideRate::RateVector getProductionGroupRateVector(const std::string& group_name) const;
 
-    Scalar getWellGroupTargetInjector(const std::string& name,
-                                      const std::string& parent,
-                                      const Group& group,
-                                      const Scalar* rates,
-                                      const Phase injection_phase,
-                                      const Scalar efficiency_factor,
-                                      const std::vector<Scalar>& resv_coeff,
-                                      DeferredLogger& deferred_logger) const;
+    std::optional<Scalar> getWellGroupTargetInjector(const std::string& name,
+                                                     const std::string& parent,
+                                                     const Group& group,
+                                                     const Scalar* rates,
+                                                     const Phase injection_phase,
+                                                     const Scalar efficiency_factor,
+                                                     const std::vector<Scalar>& resv_coeff,
+                                                     DeferredLogger& deferred_logger) const;
 
-    Scalar getWellGroupTargetProducer(const std::string& name,
-                                      const std::string& parent,
-                                      const Group& group,
-                                      const Scalar* rates,
-                                      const Scalar efficiency_factor,
-                                      const std::vector<Scalar>& resv_coeff,
-                                      DeferredLogger& deferred_logger) const;
+    std::optional<Scalar> getWellGroupTargetProducer(const std::string& name,
+                                                     const std::string& parent,
+                                                     const Group& group,
+                                                     const Scalar* rates,
+                                                     const Scalar efficiency_factor,
+                                                     const std::vector<Scalar>& resv_coeff,
+                                                     DeferredLogger& deferred_logger) const;
 
     GuideRate::RateVector getWellRateVector(const std::string& name) const;
 


### PR DESCRIPTION
When working with https://github.com/OPM/opm-simulators/pull/6559 , it was found out that `std::numeric_limits<Scalar>::max()` was used to describe the scenarios that group target is not found/defined. 

At the same out, the `this->wellState().well(name).group_target` is used as a if condition to show whether the group target is defined.  It is not correct usage. 

This PR recover the design of std::optional by use std::nullopt to show that the group target is not defined. 