### PR TITLE
Avoid copying pressure_first_connection from the previous well state

### DIFF
--- a/opm/simulators/wells/PerfData.cpp
+++ b/opm/simulators/wells/PerfData.cpp
@@ -29,11 +29,9 @@ namespace Opm {
 
 template<class Scalar>
 PerfData<Scalar>::PerfData(const std::size_t num_perf,
-                           const Scalar pressure_first_connection_,
                            const bool injector_,
                            const std::size_t num_phases)
     : injector(injector_)
-    , pressure_first_connection(pressure_first_connection_)
     , pressure(num_perf)
     , rates(num_perf)
     , phase_rates(num_perf * num_phases)
@@ -74,7 +72,6 @@ PerfData<Scalar> PerfData<Scalar>::serializationTestObject()
 {
     PerfData result;
     result.injector = true;
-    result.pressure_first_connection = 1.0;
     result.pressure = {2.0, 3.0, 4.0};
     result.rates = {5.0, 6.0};
     result.phase_rates = {7.0};
@@ -126,7 +123,6 @@ bool PerfData<Scalar>::try_assign(const PerfData& other)
         return false;
     }
 
-    this->pressure_first_connection = other.pressure_first_connection;
     this->pressure = other.pressure;
     this->rates = other.rates;
     this->phase_rates = other.phase_rates;
@@ -153,7 +149,6 @@ template<class Scalar>
 bool PerfData<Scalar>::operator==(const PerfData& rhs) const
 {
     return (this->injector == rhs.injector)
-        && (this->pressure_first_connection == rhs.pressure_first_connection)
         && (this->pressure == rhs.pressure)
         && (this->rates == rhs.rates)
         && (this->phase_rates == rhs.phase_rates)

--- a/opm/simulators/wells/PerfData.hpp
+++ b/opm/simulators/wells/PerfData.hpp
@@ -38,7 +38,6 @@ private:
 public:
     PerfData() = default;
     PerfData(std::size_t num_perf,
-             Scalar pressure_first_connection_,
              bool injector_,
              std::size_t num_phases);
 
@@ -57,7 +56,6 @@ public:
     void serializeOp(Serializer& serializer)
     {
         serializer(injector);
-        serializer(pressure_first_connection);
         serializer(pressure);
         serializer(rates);
         serializer(phase_rates);
@@ -92,7 +90,6 @@ public:
     // if you're adding a new member representing a dynamically calculated
     // result, e.g., a flow rate, then please update try_assign() as well.
 
-    Scalar pressure_first_connection{};
     std::vector<Scalar> pressure{};
     std::vector<Scalar> rates{};
     std::vector<Scalar> phase_rates{};

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -36,13 +36,14 @@ SingleWellState(const std::string& name_,
                 const ParallelWellInfo<Scalar>& pinfo,
                 const PhaseUsageInfo<IndexTraits>&  pu_arg,
                 bool is_producer,
-                Scalar pressure_first_connection,
+                Scalar pressure_first_connection_,
                 const std::vector<PerforationData<Scalar>>& perf_input,
                 Scalar temp)
     : name(name_)
     , parallel_info(pinfo)
     , producer(is_producer)
     , pu(pu_arg)
+    , pressure_first_connection(pressure_first_connection_)
     , temperature(temp)
     , well_potentials(pu.numActivePhases())
     , productivity_index(pu.numActivePhases())
@@ -51,7 +52,7 @@ SingleWellState(const std::string& name_,
     , surface_rates(pu.numActivePhases())
     , reservoir_rates(pu.numActivePhases())
     , prev_surface_rates(pu.numActivePhases())
-    , perf_data(perf_input.size(), pressure_first_connection, !is_producer, pu.numActivePhases())
+    , perf_data(perf_input.size(), !is_producer, pu.numActivePhases())
     , trivial_group_target(false)
 {
     for (std::size_t perf = 0; perf < perf_input.size(); perf++) {
@@ -255,7 +256,7 @@ update_producer_targets(const Well& ecl_well, const SummaryState& st)
         if (cmode_is_bhp)
             this->bhp = bhp_limit;
         else
-            this->bhp = this->perf_data.pressure_first_connection;
+            this->bhp = this->pressure_first_connection;
 
         return;
     }
@@ -297,7 +298,7 @@ update_producer_targets(const Well& ecl_well, const SummaryState& st)
     if (cmode_is_bhp)
         this->bhp = bhp_limit;
     else
-        this->bhp = this->perf_data.pressure_first_connection * bhp_safety_factor;
+        this->bhp = this->pressure_first_connection * bhp_safety_factor;
 }
 
 template<typename Scalar, typename IndexTraits>
@@ -317,7 +318,7 @@ update_injector_targets(const Well& ecl_well, const SummaryState& st)
         if (cmode_is_bhp)
             this->bhp = bhp_limit;
         else
-            this->bhp = this->perf_data.pressure_first_connection;
+            this->bhp = this->pressure_first_connection;
 
         return;
     }
@@ -349,7 +350,7 @@ update_injector_targets(const Well& ecl_well, const SummaryState& st)
     if (cmode_is_bhp)
         this->bhp = bhp_limit;
     else
-        this->bhp = this->perf_data.pressure_first_connection * bhp_safety_factor;
+        this->bhp = this->pressure_first_connection * bhp_safety_factor;
 }
 
 template<typename Scalar, typename IndexTraits>
@@ -392,6 +393,7 @@ bool SingleWellState<Scalar, IndexTraits>::operator==(const SingleWellState& rhs
            this->producer == rhs.producer &&
            this->bhp == rhs.bhp &&
            this->thp == rhs.thp &&
+           this->pressure_first_connection == rhs.pressure_first_connection &&
            this->temperature == rhs.temperature &&
            this->phase_mixing_rates == rhs.phase_mixing_rates &&
            this->well_potentials == rhs.well_potentials &&

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -50,7 +50,7 @@ public:
                     const ParallelWellInfo<Scalar>& pinfo,
                     const PhaseUsageInfo<IndexTraits>& pu,
                     bool is_producer,
-                    Scalar presssure_first_connection,
+                    Scalar pressure_first_connection,
                     const std::vector<PerforationData<Scalar>>& perf_input,
                     Scalar temp);
 
@@ -64,6 +64,7 @@ public:
         serializer(producer);
         serializer(bhp);
         serializer(thp);
+        serializer(pressure_first_connection);
         serializer(temperature);
         serializer(energy_rate);
         serializer(efficiency_scaling_factor);
@@ -97,6 +98,7 @@ public:
     PhaseUsageInfo<IndexTraits> pu;
     Scalar bhp{0};
     Scalar thp{0};
+    Scalar pressure_first_connection{0};
 
     // thermal related
     Scalar temperature{0};

--- a/tests/test_wellstate.cpp
+++ b/tests/test_wellstate.cpp
@@ -578,10 +578,10 @@ BOOST_AUTO_TEST_CASE(TESTSegmentState2) {
 
 
 BOOST_AUTO_TEST_CASE(TESTPerfData) {
-    Opm::PerfData pd1(3, 100.0, true, 3);
-    Opm::PerfData pd2(3, 100.0, true, 3);
-    Opm::PerfData pd3(2, 100.0, true, 3);
-    Opm::PerfData pd4(3, 100.0, false, 3);
+    Opm::PerfData<double> pd1(3, true, 3);
+    Opm::PerfData<double> pd2(3, true, 3);
+    Opm::PerfData<double> pd3(2, true, 3);
+    Opm::PerfData<double> pd4(3, false, 3);
 
 
     for (std::size_t i = 0; i < 3; i++) {


### PR DESCRIPTION
Avoid copying _pressure\_first\_connection_ from the previous well state. After all, at this point it has a value from the _cell\_pressure_ which was communicated. Moreover, the copying is a source of a deadlock. `PerfData` is copied from the previous state only when the number of connections does not change. When a well is distributed, the number of connections can change on one rank and remain the same on other, so one rank will end up with the previous pressure and the other with the current pressure of the cell.

This PR moves the _pressure\_first\_connection_ from `PerfData` to `SingleWellState`. The method `WellState::init` sets _pressure\_first\_connection_ from _cell\_pressure_ in the call to `base_init`, and the copying of `PerfData` (inside _try\_assign_) won't touch _pressure\_first\_connection_ anymore.

The PR addresses two issues. First of them is a possibility of a deadlock caused by different _pressure\_first\_connection_ on a distributed well that has a rank that changes the number of connections and a rank that does not. Second is the fact that copying _pressure\_first\_connection_ from the previous state gave it a value different to the _cell\_pressure_. (This is even more dangerous than it seems. _pressure\_first\_connection_ is not used widely, so the code could be dragging along the value from the previous' previous' previous' previous' state.)

It is up to the discussion whether the copying of the `PerfData` is right. It is copied if the number of connections did not change but it can happen that the same number of connections was opened and closed. Not copying the `PerfData` and always choosing the branch of the _if_ (that was used when the number of connections changed) leads to many failed regression tests. However, what to do with `PerfData` is out of scope of this PR, here I want to address the deadlock (avoiding the copying of the wrong value from the previous state into _pressure\_first\_connection_ is a bonus).