### PR TITLE
investigate potentially problematic updating of well status from action handler 

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -854,7 +854,7 @@ updateEclWellsConstraints(const int              timeStepIdx,
                          (const auto wellIdx, const auto& well)
     {
         auto& ws = this->wellState().well(wellIdx);
-        ws.updateStatus(well.getStatus());
+        //ws.updateStatus(well.getStatus());
         ws.update_type_and_targets(well, st);
     });
 }


### PR DESCRIPTION
As discussed in https://github.com/OPM/opm-simulators/pull/6587, shut wells opened through actions will wrongly get a `prevState` status OPEN when entering the initialization phase in the next time-step. This leads to initialization problems (circumvented by https://github.com/OPM/opm-simulators/pull/6587).

Discussed with @bska whether it also could have other implications. Reason for the problem is the `ws.updateStatus()` in  `BlackoilWellModelGeneric<>::updateEclWellsConstraints()`. It's probably there for a reason, so just running through the tests to see if anything is triggered by commenting it out.