### PR TITLE
Call extractRestartValueLevelGrids

### DIFF
--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -25,6 +25,7 @@
 
 #include <dune/grid/common/mcmgmapper.hh>
 
+#include <opm/grid/cpgrid/LgrOutputHelpers.hpp>
 #include <opm/grid/GridHelpers.hpp>
 #include <opm/grid/utility/cartesianToCompressed.hpp>
 
@@ -147,7 +148,7 @@ struct EclWriteTasklet : public Opm::TaskletInterface
     std::optional<int> timeStepNum_;
     bool isSubStep_;
     double secondsElapsed_;
-    Opm::RestartValue restartValue_;
+    std::vector<Opm::RestartValue> restartValue_;
     bool writeDoublePrecision_;
 
     explicit EclWriteTasklet(const Opm::Action::State& actionState,
@@ -159,7 +160,7 @@ struct EclWriteTasklet : public Opm::TaskletInterface
                              std::optional<int> timeStepNum,
                              bool isSubStep,
                              double secondsElapsed,
-                             Opm::RestartValue restartValue,
+                             std::vector<Opm::RestartValue> restartValue,
                              bool writeDoublePrecision)
         : actionState_(actionState)
         , wtestState_(wtestState)
@@ -177,17 +178,30 @@ struct EclWriteTasklet : public Opm::TaskletInterface
     // callback to eclIO serial writeTimeStep method
     void run() override
     {
-        this->eclIO_.writeTimeStep(this->actionState_,
-                                   this->wtestState_,
-                                   this->summaryState_,
-                                   this->udqState_,
-                                   this->reportStepNum_,
-                                   this->isSubStep_,
-                                   this->secondsElapsed_,
-                                   std::move(this->restartValue_),
-                                   this->writeDoublePrecision_,
-                                   this->timeStepNum_
-);
+        if (this->restartValue_.size() == 1) {
+            this->eclIO_.writeTimeStep(this->actionState_,
+                                       this->wtestState_,
+                                       this->summaryState_,
+                                       this->udqState_,
+                                       this->reportStepNum_,
+                                       this->isSubStep_,
+                                       this->secondsElapsed_,
+                                       std::move(this->restartValue_.back()),
+                                       this->writeDoublePrecision_,
+                                       this->timeStepNum_);
+        }
+        else{
+            this->eclIO_.writeTimeStep(this->actionState_,
+                                       this->wtestState_,
+                                       this->summaryState_,
+                                       this->udqState_,
+                                       this->reportStepNum_,
+                                       this->isSubStep_,
+                                       this->secondsElapsed_,
+                                       std::move(this->restartValue_),
+                                       this->writeDoublePrecision_,
+                                       this->timeStepNum_);
+        }
     }
 };
 
@@ -600,6 +614,21 @@ doWriteOutput(const int                          reportStepNum,
             restartValue.addExtra(flores.name, UnitSystem::measure::rate, flores.values);
         }
     }
+
+    std::vector<Opm::RestartValue> restartValues{};
+    // only serial, only CpGrid (for now)
+    if ( !isParallel && !needsReordering && (this->eclState_.getLgrs().size()>0) && (this->grid_.maxLevel()>0) ) {
+        // Level cells that appear on the leaf grid view get the data::Solution values from there.
+        // Other cells (i.e., parent cells that vanished due to refinement) get rubbish values for now.
+        // Only data::Solution is restricted to the level grids. Well, GroupAndNetwork, Aquifer are
+        // not modified in this method.
+        Opm::Lgr::extractRestartValueLevelGrids<Grid>(this->grid_, restartValue, restartValues);
+    }
+    else {
+        restartValues.reserve(1); // minimum size
+        restartValues.push_back(std::move(restartValue)); // no LGRs-> only one restart value
+    }
+
     // make sure that the previous I/O request has been completed
     // and the number of incomplete tasklets does not increase between
     // time steps
@@ -615,7 +644,7 @@ doWriteOutput(const int                          reportStepNum,
         actionState,
         isParallel ? this->collectOnIORank_.globalWellTestState() : std::move(localWTestState),
         summaryState, udqState, *this->eclIO_,
-        reportStepNum, timeStepNum, isSubStep, curTime, std::move(restartValue), doublePrecision);
+        reportStepNum, timeStepNum, isSubStep, curTime, std::move(restartValues), doublePrecision);
 
     // finally, start a new output writing job
     this->taskletRunner_->dispatch(std::move(eclWriteTasklet));


### PR DESCRIPTION
Downstream of OPM/opm-grid#945

This PR calls a method to extract restart values from the leaf grid to the level grids. For now, for the cells that vanished during refinement, i.e., parent cells, "rubbish" values are assigned. This will be improved and corrected in future PRs. 
