### PR TITLE
m_efficiency_scaling_factors default to be 1. instead of 0.

### DIFF
--- a/opm/simulators/wells/GlobalWellInfo.cpp
+++ b/opm/simulators/wells/GlobalWellInfo.cpp
@@ -39,7 +39,7 @@ GlobalWellInfo(const Schedule& sched,
     this->m_in_injecting_group.resize(num_wells);
     this->m_in_producing_group.resize(num_wells);
     this->m_is_open.resize(num_wells);
-    this->m_efficiency_scaling_factors.resize(num_wells);
+    this->m_efficiency_scaling_factors.resize(num_wells, static_cast<Scalar>(1.0));
     for (const auto& wname : sched.wellNames(report_step)) {
         const auto& well = sched.getWell(wname, report_step);
         auto global_well_index = well.seqIndex();


### PR DESCRIPTION
as an efficiency factor, it is more reasonable to default it be 1. otherwise, it can be 0 when WCYCLE is not around.