### PR TITLE
Not creating identity matrix as reverse of singular well matrix for StandardWell. 

### DIFF
--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -159,16 +159,8 @@ void StandardWellEquations<Scalar, IndexTraits, numEq>::apply(BVector& r) const
 template<typename Scalar, typename IndexTraits, int numEq>
 void StandardWellEquations<Scalar, IndexTraits, numEq>::invert()
 {
-    try {
-        invDuneD_ = duneD_; // Not strictly need if not cpr with well contributions is used
-        detail::invertMatrix(invDuneD_[0][0]);
-    } catch (NumericalProblem&) {
-        // for singular matrices, use identity as the inverse
-        invDuneD_[0][0] = 0.0;
-        for (std::size_t i = 0; i < invDuneD_[0][0].rows(); ++i) {
-            invDuneD_[0][0][i][i] = 1.0;
-        }
-    }
+    invDuneD_ = duneD_; // Not strictly need if not cpr with well contributions is used
+    detail::invertMatrix(invDuneD_[0][0]);
 }
 
 template<typename Scalar, typename IndexTraits, int numEq>


### PR DESCRIPTION
referring to the discussion in https://github.com/OPM/opm-simulators/pull/6608 . 

When a singular matrix assembled for StandardWell, we should not create an identity matrix as a inverse to continue.

With https://github.com/OPM/opm-simulators/pull/6608 merged, the singular matrix from StandardWell assembling during well testing from all the regression tests looks like gone, this PR does not introduce any regression failures. 

This also makes the processing of the singular well matrix consistent between StandardWell and MultisegmentWell. 