### PR TITLE
copying efficiency_scaling_factor from previous well state

### DIFF
--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -89,6 +89,7 @@ void SingleWellState<Scalar, IndexTraits>::init_timestep(const SingleWellState& 
     this->bhp = other.bhp;
     this->thp = other.thp;
     this->temperature = other.temperature;
+    this->efficiency_scaling_factor = other.efficiency_scaling_factor;
 }
 
 template<typename Scalar, typename IndexTraits>


### PR DESCRIPTION
It is something shows up when working with https://github.com/OPM/opm-simulators/pull/6608 . 

@akva2 , you are familiar with `WCYCLE`, please have a look and comment. 