### PR TITLE
Update cell rates for NLDD after domain assembly

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -365,6 +365,12 @@ template<class Scalar> class WellContributions;
             // xw to update Well State
             void recoverWellSolutionAndUpdateWellStateDomain(const BVector& x,
                                                              const int domainIdx);
+            // Update cellRates_ with contributions from all wells
+            void updateCellRates();
+
+            // Update cellRates_ with contributions from wells in a specific domain
+            void updateCellRatesForDomain(int domainIndex,
+                                          const std::map<std::string, int>& well_domain_map);
 
             const Grid& grid() const
             { return simulator_.vanguard().grid(); }

--- a/opm/simulators/wells/BlackoilWellModelNldd_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNldd_impl.hpp
@@ -49,6 +49,9 @@ assemble(const int /*iterationIdx*/,
     DeferredLogger local_deferredLogger;
     this->updateWellControls(local_deferredLogger, domain);
     this->assembleWellEq(dt, domain, local_deferredLogger);
+
+    // Update cellRates_ with current contributions from wells in this domain for reservoir linearization
+    wellModel_.updateCellRatesForDomain(domain.index, this->well_domain());
 }
 
 template<typename TypeTag>


### PR DESCRIPTION
https://github.com/OPM/opm-simulators/pull/6583 introduced a performance optimisation that caches well contributions in cellRates_, but NLDD's domain assembly didn't populate this cache. This caused the domain reservoir linearization to use stale well data, leading to convergence failures.

This PR adds updateCellRatesForDomain() method that NLDD now calls after domain assembly to ensure the reservoir sees current well contributions, for only the wells in this domain. This restores the NLDD performance.

Tests on Norne before this fix:

```bash
Number of MPI processes:        12
Threads per MPI process:         1
Setup time:                      2.97 s
  Deck input:                    1.99 s
Number of timesteps:           788
Simulation time:               808.67 s
  Assembly time:               132.66 s (Wasted: 77.6 s; 58.5%)
    Well assembly:              12.04 s (Wasted: 6.7 s; 55.9%)
  Linear solve time:           234.46 s (Wasted: 151.9 s; 64.8%)
    Linear setup:              105.37 s (Wasted: 64.2 s; 60.9%)
  Local solve time:            324.89 s (Wasted: 249.7 s; 76.9%)
  Props/update time:            48.05 s (Wasted: 29.0 s; 60.3%)
  Pre/post step:                47.65 s (Wasted: 2.9 s; 6.1%)
  Output write time:             5.69 s
Overall Linearizations:      10910      (Wasted:  6471; 59.3%)
Overall Newton Iterations:    5497      (Wasted:  3350; 60.9%)
Overall Linear Iterations:   14414      (Wasted: 10106; 70.1%)
```

After this fix:

```bash
Number of MPI processes:        12
Threads per MPI process:         1
Setup time:                      2.85 s
  Deck input:                    1.74 s
Number of timesteps:           333
Simulation time:               117.33 s
  Assembly time:                21.59 s (Wasted: 0.0 s; 0.0%)
    Well assembly:               2.11 s (Wasted: 0.0 s; 0.0%)
  Linear solve time:            36.67 s (Wasted: 0.0 s; 0.0%)
    Linear setup:               15.30 s (Wasted: 0.0 s; 0.0%)
  Local solve time:             17.05 s (Wasted: 0.0 s; 0.0%)
  Props/update time:             7.57 s (Wasted: 0.0 s; 0.0%)
  Pre/post step:                25.67 s (Wasted: 0.0 s; 0.0%)
  Output write time:             4.68 s
Overall Linearizations:       1584      (Wasted:     0; 0.0%)
Overall Newton Iterations:     759      (Wasted:     0; 0.0%)
Overall Linear Iterations:    2221      (Wasted:     0; 0.0%)
```

This severe performance degradation went undetected for a while since we don't have any regression tests for NLDD. We should really prioritise to add some regression tests for NLDD as well.