### PR TITLE
using active phase position when updating componentMixture

### DIFF
--- a/opm/simulators/wells/StandardWellConnections.cpp
+++ b/opm/simulators/wells/StandardWellConnections.cpp
@@ -155,6 +155,39 @@ namespace {
         }
     }
 
+    template <typename Ix>
+    std::optional<Ix>
+    preferredPhaseIndex(const bool isInjector,
+                        const Opm::Well& well,
+                        const Ix opos,
+                        const Ix gpos,
+                        const Ix wpos)
+    {
+        if (isInjector) {
+            switch (well.injectorType()) {
+                case Opm::InjectorType::WATER:
+                    return {wpos};
+                case Opm::InjectorType::OIL:
+                    return {opos};
+                case Opm::InjectorType::GAS:
+                    return {gpos};
+                default:
+                    return {};
+            }
+        } else {
+            switch (well.getPreferredPhase()) {
+                case Opm::Phase::WATER:
+                    return {wpos};
+                case Opm::Phase::OIL:
+                    return {opos};
+                case Opm::Phase::GAS:
+                    return {gpos};
+                default:
+                    return {};
+            }
+        }
+    }
+
 } // Anonymous namespace
 
 namespace Opm
@@ -248,11 +281,15 @@ computeDensities(const std::vector<Scalar>& perfComponentRates,
     auto componentMixture = std::vector<Scalar>(num_quantities, Scalar{0});
     auto phaseMixture     = std::vector<Scalar>(num_quantities, Scalar{0});
 
+    const auto preferredPhaseIdx =
+            preferredPhaseIndex(this->well_.isInjector(),
+                                this->well_.wellEcl(),
+                                oilpos, gaspos, waterpos);
+
     for (int perf = 0; perf < nperf; ++perf) {
-        this->initialiseConnectionMixture(num_quantities, perf,
-                                          waterpos,
-                                          oilpos,
-                                          gaspos,
+        this->initialiseConnectionMixture(num_quantities,
+                                          perf,
+                                          preferredPhaseIdx,
                                           q_out_perf,
                                           phaseMixture,
                                           componentMixture);
@@ -342,12 +379,11 @@ calculatePerforationOutflow(const std::vector<Scalar>& perfComponentRates) const
 }
 
 template<typename FluidSystem, typename Indices>
+template <typename Ix>
 void StandardWellConnections<FluidSystem, Indices>::
 initialiseConnectionMixture(const int                  num_quantities,
                             const int                  perf,
-                            const typename std::vector<Scalar>::size_type waterpos,
-                            const typename std::vector<Scalar>::size_type oilpos,
-                            const typename std::vector<Scalar>::size_type gaspos,
+                            const std::optional<Ix>    preferredPhaseIdx,
                             const std::vector<Scalar>& q_out_perf,
                             const std::vector<Scalar>& phaseMixture,
                             std::vector<Scalar>&       componentMixture) const
@@ -371,57 +407,12 @@ initialiseConnectionMixture(const int                  num_quantities,
         std::fill(componentMixture.begin(), componentMixture.end(), Scalar{0});
 
         // No flow => use fractions defined at well level for componentMixture.
-        if (this->well_.isInjector()) {
-            switch (this->well_.wellEcl().injectorType()) {
-            case InjectorType::WATER:
-                componentMixture[waterpos] = Scalar{1};
-                break;
-
-            case InjectorType::GAS:
-                componentMixture[gaspos] = Scalar{1};
-                break;
-
-            case InjectorType::OIL:
-                componentMixture[oilpos] = Scalar{1};
-                break;
-
-            case InjectorType::MULTI:
-                // Not supported.
-                // deferred_logger.warning("MULTI_PHASE_INJECTOR_NOT_SUPPORTED",
-                //                         "Multi phase injectors are not supported, requested for well " + name());
-                break;
-            }
-        }
-        else {
-            assert(this->well_.isProducer());
-
-            if (perf == 0) {
-                // For the first perforation without flow we use the
-                // preferred phase to decide the componentMixture initialization.
-
-                switch (this->well_.wellEcl().getPreferredPhase()) {
-                case Phase::OIL:
-                    componentMixture[oilpos] = Scalar{1};
-                    break;
-
-                case Phase::GAS:
-                    componentMixture[gaspos] = Scalar{1};
-                    break;
-
-                case Phase::WATER:
-                    componentMixture[waterpos] = Scalar{1};
-                    break;
-
-                default:
-                    // No others supported.
-                    break;
-                }
-            }
-            else {
-                // For the rest of the perforations without flow we use the
-                // componentMixture from the perforation above.
-                componentMixture = phaseMixture;
-            }
+        if ( (this->well_.isInjector() || (perf == 0)) &&  preferredPhaseIdx.has_value()) {
+            componentMixture[*preferredPhaseIdx] = Scalar{1};
+        } else if (!this->well_.isInjector() && (perf != 0)) {
+            // For the rest of the perforations without flow we use the
+            // componentMixture from the perforation above.
+            componentMixture = phaseMixture;
         }
     }
 }

--- a/opm/simulators/wells/StandardWellConnections.hpp
+++ b/opm/simulators/wells/StandardWellConnections.hpp
@@ -152,11 +152,10 @@ private:
     std::vector<Scalar>
     calculatePerforationOutflow(const std::vector<Scalar>& perfComponentRates) const;
 
+    template <typename Ix>
     void initialiseConnectionMixture(const int                  num_comp,
                                      const int                  perf,
-                                     const typename std::vector<Scalar>::size_type waterpos,
-                                     const typename std::vector<Scalar>::size_type oilpos,
-                                     const typename std::vector<Scalar>::size_type gaspos,
+                                     const std::optional<Ix>    preferredPhaseIdx,
                                      const std::vector<Scalar>& q_out_perf,
                                      const std::vector<Scalar>& currentMixture,
                                      std::vector<Scalar>&       previousMixture) const;


### PR DESCRIPTION
it closes https://github.com/OPM/opm-simulators/issues/6621 . 

referring to the discussion in https://github.com/OPM/opm-simulators/issues/6621 . 

For a gas water case, if the preferred phase is gas, then it will be write out-of-bound and the Scalar{1} will be lost. 

Then some NaN will be generated when updating the perf_densities_ and  perf_pressure_diffs_, which will ruin the initial assembling. 