### PR TITLE
adding a context to StandardWellPrimaryVariables::checkFinite

### DIFF
--- a/opm/simulators/wells/StandardWellPrimaryVariables.cpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.cpp
@@ -750,13 +750,16 @@ relaxationFactorFractionsProducer(const BVectorWell& dwells,
 
 template<class FluidSystem, class Indices>
 void StandardWellPrimaryVariables<FluidSystem,Indices>::
-checkFinite(DeferredLogger& deferred_logger) const
+checkFinite(DeferredLogger& deferred_logger, std::string_view context) const
 {
     for (const Scalar v : value_) {
-        if (!isfinite(v))
+        if (!isfinite(v)) {
+            const std::string msg =
+                    fmt::format("Non-finite primary variable for well {} after {}", well_.name(), context);
             OPM_DEFLOG_PROBLEM(NumericalProblem,
-                               "Infinite primary variable after update from wellState, well: " + well_.name(),
+                               msg,
                                deferred_logger);
+        }
     }
 }
 

--- a/opm/simulators/wells/StandardWellPrimaryVariables.hpp
+++ b/opm/simulators/wells/StandardWellPrimaryVariables.hpp
@@ -27,6 +27,7 @@
 
 #include <opm/simulators/wells/StandardWellEquations.hpp>
 
+#include <string_view>
 #include <vector>
 
 namespace Opm
@@ -118,7 +119,7 @@ public:
     void updateNewtonPolyMW(const BVectorWell& dwells);
 
     //! \brief Check that all values are finite.
-    void checkFinite(DeferredLogger& deferred_logger) const;
+    void checkFinite(DeferredLogger& deferred_logger, std::string_view context) const;
 
     //! \brief Copy values to well state.
     void copyToWellState(WellState<Scalar, IndexTraits>& well_state,

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -782,7 +782,7 @@ namespace Opm
             this->primary_variables_.updateNewtonPolyMW(dwells);
         }
 
-        this->primary_variables_.checkFinite(deferred_logger);
+        this->primary_variables_.checkFinite(deferred_logger, "Newton update");
     }
 
 
@@ -1871,7 +1871,7 @@ namespace Opm
             this->primary_variables_.updatePolyMW(well_state);
         }
 
-        this->primary_variables_.checkFinite(deferred_logger);
+        this->primary_variables_.checkFinite(deferred_logger, "updating from well state");
     }
 
 


### PR DESCRIPTION
so we can give some more information about where the non-finite primary variable is generated.

it was spotted during working with https://github.com/OPM/opm-simulators/issues/6621 .

we have two occasions where we check the non-finite primary variables, while the message is not clear when the non-finite primary variable is generated after the newton update. 