### PR TITLE
Only call WellTestState::close_well() for local wells.

### DIFF
--- a/opm/simulators/wells/GroupEconomicLimitsChecker.cpp
+++ b/opm/simulators/wells/GroupEconomicLimitsChecker.cpp
@@ -381,9 +381,12 @@ closeWellsRecursive(const Group& group, int level)
             const std::string msg = fmt::format("\n{} Closing well {}", indent, well_name);
             this->message_ += msg;
 
-            this->well_test_state_.close_well(
-                well_name, WellTestConfig::Reason::GROUP, this->simulation_time_);
-            this->well_model_.updateClosedWellsThisStep(well_name);
+            // Only update the well_test_state_ on ranks that have the well in question.
+            if (well_model_.hasLocalWell(well_name)) {
+                this->well_test_state_.close_well(
+                    well_name, WellTestConfig::Reason::GROUP, this->simulation_time_);
+                this->well_model_.updateClosedWellsThisStep(well_name);
+            }
         }
     }
 


### PR DESCRIPTION
Resolves an issue in the parallel case where after a group is closed for economic reasons, some ranks may later try to perform well testing on wells that do not exist on the rank. Note that the output is kept, so that all wells closed will be in the log messages (not only those on rank 0).