### PR TITLE
not copying well state from if the well was SHUT before applying action

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -844,6 +844,9 @@ updateEclWellsConstraints(const int              timeStepIdx,
                          (const auto wellIdx, const auto& well)
     {
         auto& ws = this->wellState().well(wellIdx);
+        // whether the well was SHUT before applying the action
+        ws.was_shut_before_action_applied = (ws.status == WellStatus::SHUT);
+
         ws.updateStatus(well.getStatus());
         ws.update_type_and_targets(well, st);
     });

--- a/opm/simulators/wells/SingleWellState.cpp
+++ b/opm/simulators/wells/SingleWellState.cpp
@@ -412,7 +412,8 @@ bool SingleWellState<Scalar, IndexTraits>::operator==(const SingleWellState& rhs
            this->production_cmode == rhs.production_cmode &&
            this->alq_state == rhs.alq_state &&
            this->primaryvar == rhs.primaryvar &&
-           this->group_target == rhs.group_target;
+           this->group_target == rhs.group_target &&
+           this->was_shut_before_action_applied == rhs.was_shut_before_action_applied;
 }
 
 template class SingleWellState<double, BlackOilDefaultFluidSystemIndices>;

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -86,6 +86,7 @@ public:
         serializer(primaryvar);
         serializer(alq_state);
         serializer(group_target);
+        serializer(was_shut_before_action_applied);
     }
 
     bool operator==(const SingleWellState&) const;
@@ -133,6 +134,10 @@ public:
     WellProducerCMode production_cmode{WellProducerCMode::CMODE_UNDEFINED};
     std::vector<Scalar> primaryvar;
     ALQState<Scalar> alq_state;
+    // This is used to indicate whether the well was shut before applying an action
+    // if it was SHUT, even the action set the well to OPEN, the data in the well state
+    // is not well-defined. We do not use it to overwrite the current well state.
+    bool was_shut_before_action_applied {false};
 
     /// Special purpose method to support dynamically rescaling a well's
     /// CTFs through WELPI.

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -392,7 +392,7 @@ init(const std::vector<Scalar>& cellPressures,
             auto& new_well = this->well(w);
             new_well.init_timestep(prev_well);
 
-            if (prev_well.status == Well::Status::SHUT) {
+            if (prev_well.status == Well::Status::SHUT || prev_well.was_shut_before_action_applied) {
                 // Well was shut in previous state, do not use its values.
                 continue;
             }
@@ -903,7 +903,8 @@ initWellStateMSWell(const std::vector<Well>& wells_ecl,
             if (prev_well_state->has(wname)) {
                 auto& ws = this->well(w);
                 const auto& prev_ws = prev_well_state->well(wname);
-                if (prev_ws.status == Well::Status::SHUT) {
+                if (prev_ws.status == Well::Status::SHUT || prev_ws.was_shut_before_action_applied) {
+                    // Well was shut in previous state, do not use its values.
                     continue;
                 }
 


### PR DESCRIPTION
It the well was SHUT before applying action (action might set the well state status to be OPEN), the well state does not contain much well defined data. We rather not use it. It appears to remove a lot of singularity warning in some field case. 