### PR TITLE
Clean up compiler warnings

### DIFF
--- a/opm/models/utils/quadraturegeometries.hh
+++ b/opm/models/utils/quadraturegeometries.hh
@@ -139,8 +139,6 @@ public:
      */
     Scalar cornerWeight(const LocalPosition& localPos, unsigned cornerIdx) const
     {
-        GlobalPosition globalPos(0.0);
-
         // this code is based on the Q1 finite element code from
         // dune-localfunctions
         Scalar weight = 1.0;

--- a/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping.hpp
@@ -199,7 +199,7 @@ public:
                          const SimulatorReport& full_report,
                          const bool terminalOutput = true);
 
-    bool operator==(const AdaptiveTimeStepping<TypeTag>& rhs);
+    bool operator==(const AdaptiveTimeStepping<TypeTag>& rhs) const;
 
     static void registerParameters();
     void setSuggestedNextStep(const double x);

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -135,7 +135,7 @@ AdaptiveTimeStepping(double max_next_tstep,
 template<class TypeTag>
 bool
 AdaptiveTimeStepping<TypeTag>::
-operator==(const AdaptiveTimeStepping<TypeTag>& rhs)
+operator==(const AdaptiveTimeStepping<TypeTag>& rhs) const
 {
     if (this->time_step_control_type_ != rhs.time_step_control_type_ ||
         (this->time_step_control_ && !rhs.time_step_control_) ||

--- a/tests/test_rftcontainer.cpp
+++ b/tests/test_rftcontainer.cpp
@@ -981,10 +981,10 @@ BOOST_AUTO_TEST_CASE(Single_Split_Well)
     };
 
     // Well owned by rank 2, but intersected on all ranks.
-    const auto owner = 2;
+    constexpr int owner = 2;
     auto rftc = RFTContainer {
         cse.es, cse.sched,
-        [r = comm.rank(), owner](const std::string&) { return r == owner; },
+        [r = comm.rank()](const std::string&) { return r == owner; },
         [](const std::string&) { return true; }
     };
 
@@ -1431,11 +1431,11 @@ BOOST_AUTO_TEST_CASE(Single_Split_Well)
 
     // Well owned by rank 2, but intersected on ranks 0, 1, and 3.  Does
     // typically not happen in a real simulator run...
-    const auto owner = 2;
+    constexpr int owner = 2;
     auto rftc = RFTContainer {
         cse.es, cse.sched,
-        [r = comm.rank(), owner](const std::string&) { return r == owner; },
-        [r = comm.rank(), owner](const std::string&) { return r != owner; }
+        [r = comm.rank()](const std::string&) { return r == owner; },
+        [r = comm.rank()](const std::string&) { return r != owner; }
     };
 
     rftc.allocate(0);


### PR DESCRIPTION
* Remove unused parameters
* Declare equality operator of AdaptiveTimeStepping to be const
* Remove warning on lambda captures.