### PR TITLE
removing undefined function pressureDropAutoICD() from MultisegmentWellEval.

### DIFF
--- a/opm/simulators/wells/MultisegmentWellEval.hpp
+++ b/opm/simulators/wells/MultisegmentWellEval.hpp
@@ -131,9 +131,6 @@ protected:
     void assembleAccelerationPressureLoss(const int seg,
                                           WellState<Scalar, IndexTraits>& well_state);
 
-    EvalWell pressureDropAutoICD(const int seg,
-                                 const UnitSystem& unit_system) const;
-
     // convert a Eval from reservoir to contain the derivative related to wells
     EvalWell extendEval(const Eval& in) const;
 


### PR DESCRIPTION
It might be leftover after the function implemented/moved to `MultisegmentWellSegments`. 