### PR TITLE
WIP use IPR in gaslift optimization

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -397,6 +397,11 @@ namespace Opm {
                 well->updatePerforatedCell(is_cell_perforated_);
             }
 
+            // update max perf pressure in each well
+            for (auto& well: well_container_) {
+                well->updateMaxPerfPressure(simulator_);
+            }
+
             // calculate the efficiency factors for each well
             this->calculateEfficiencyFactors(reportStepIdx);
 
@@ -1150,6 +1155,11 @@ namespace Opm {
             if (!this->wellsActive() && !network.active()) {
                 return;
             }
+        }
+
+        // update max perf pressure in each well
+        for (auto& well: well_container_) {
+            well->updateMaxPerfPressure(simulator_);
         }
 
         if (iterationIdx == 0 && this->wellsActive()) {

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -327,7 +327,7 @@ namespace Opm {
                                 const SummaryState& summary_state,
                                 DeferredLogger& deferred_logger) const;
 
-        Scalar maxPerfPress(const Simulator& simulator) const;
+        Scalar maxPerfPress(const Simulator& simulator) const override;
 
         // check whether the well is operable under BHP limit with current reservoir condition
         void checkOperabilityUnderBHPLimit(const WellStateType& well_state,

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -246,6 +246,8 @@ namespace Opm
                                      std::vector<Scalar>& well_flux,
                                      DeferredLogger& deferred_logger) const override;
 
+        Scalar maxPerfPress(const Simulator& simulator) const override;
+
         // NOTE: These cannot be protected since they are used by GasLiftRuntime
         using Base::vfp_properties_;
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2277,33 +2277,30 @@ namespace Opm
     {
         OPM_TIMEFUNCTION();
         // Make the frates() function.
-        auto frates = [this, &simulator, &deferred_logger](const Scalar bhp) {
-            // Not solving the well equations here, which means we are
+        auto frates = [this, &wgHelper, &simulator, &deferred_logger](const Scalar bhp) {
+            // Not solving the well equations here instead use ipr, 
+            // which means we are
             // calculating at the current Fg/Fw values of the
             // well. This does not matter unless the well is
             // crossflowing, and then it is likely still a good
             // approximation.
+            const auto& well_state = wgHelper.wellState();
+            const auto & ws = well_state.well(this->index_of_well_);
             std::vector<Scalar> rates(3);
-            computeWellRatesWithBhp(simulator, bhp, rates, deferred_logger);
+            Scalar sum_rates = 0;
+            for (int comp_idx = 0; comp_idx < 3; comp_idx++) {
+                rates[comp_idx] = ws.implicit_ipr_b[comp_idx] * bhp - ws.implicit_ipr_a[comp_idx];
+                sum_rates += rates[comp_idx];
+            }
+            if (std::fabs(sum_rates) < 1e-6) {
+                computeWellRatesWithBhp(simulator, bhp, rates, deferred_logger);
+            }
             this->adaptRatesForVFP(rates);
             return rates;
         };
-
-        Scalar max_pressure = 0.0;
-        for (int perf = 0; perf < this->number_of_local_perforations_; ++perf) {
-            const int cell_idx = this->well_cells_[perf];
-            const auto& int_quants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
-            const auto& fs = int_quants.fluidState();
-            Scalar pressure_cell = this->getPerfCellPressure(fs).value();
-            max_pressure = std::max(max_pressure, pressure_cell);
-        }
-        const auto& comm = this->parallel_well_info_.communication();
-        if (comm.size() > 1) {
-            max_pressure = comm.max(max_pressure);
-        }
         auto bhpAtLimit = WellBhpThpCalculator(*this).computeBhpAtThpLimitProd(frates,
                                                                                summary_state,
-                                                                               max_pressure,
+                                                                               this->max_pressure_,
                                                                                this->getRefDensity(),
                                                                                alq_value,
                                                                                this->getTHPConstraint(summary_state),
@@ -2331,7 +2328,7 @@ namespace Opm
 
         bhpAtLimit = WellBhpThpCalculator(*this).computeBhpAtThpLimitProd(fratesIter,
                                                                           summary_state,
-                                                                          max_pressure,
+                                                                          maxPerfPress(simulator),
                                                                           this->getRefDensity(),
                                                                           alq_value,
                                                                           this->getTHPConstraint(summary_state),
@@ -2731,6 +2728,26 @@ namespace Opm
 
         return result * this->well_efficiency_factor_;
     }
+
+    template <typename TypeTag>
+    typename StandardWell<TypeTag>::Scalar
+    StandardWell<TypeTag>::
+    maxPerfPress(const Simulator& simulator) const {
+        Scalar max_pressure = 0.0;
+        for (int perf = 0; perf < this->number_of_local_perforations_; ++perf) {
+            const int cell_idx = this->well_cells_[perf];
+            const auto& int_quants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
+            const auto& fs = int_quants.fluidState();
+            Scalar pressure_cell = this->getPerfCellPressure(fs).value();
+            max_pressure = std::max(max_pressure, pressure_cell);
+        }
+        const auto& comm = this->parallel_well_info_.communication();
+        if (comm.size() > 1) {
+            max_pressure = comm.max(max_pressure);
+        }
+        return max_pressure;
+    }
+
 } // namespace Opm
 
 #endif

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -368,6 +368,9 @@ public:
                                             DeferredLogger& deferred_logger,
                                             const bool fixed_control = false,
                                             const bool fixed_status = false) = 0;
+    virtual Scalar maxPerfPress(const Simulator& simulator) const = 0;
+    void updateMaxPerfPressure(const Simulator& simulator);
+
 protected:
     // simulation parameters
     std::vector<RateVector> connectionRates_;
@@ -375,6 +378,7 @@ protected:
     bool changed_to_stopped_this_step_ = false;
     bool thp_update_iterations = false;
     int number_of_well_reopenings_{0};
+    Scalar max_pressure_;
 
     Scalar wpolymer() const;
     Scalar wfoam() const;

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -2275,6 +2275,14 @@ namespace Opm
 
     }
 
+    template<typename TypeTag>
+    void
+    WellInterface<TypeTag>::
+    updateMaxPerfPressure(const Simulator& simulator) {
+        max_pressure_ = maxPerfPress(simulator);
+    }
+
+
 } // namespace Opm
 
 #endif


### PR DESCRIPTION
Use IPR when computing BHP from THP limit. 

Also, avoid re-computing max_perf_pressure. 

Needs more testing. 