### PR TITLE
introducing GroupTarget struct for SingleWellState

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1336,7 +1336,8 @@ updateAndCommunicateGroupData(const int reportStepIdx,
             const Scalar efficiencyFactor = well->wellEcl().getEfficiencyFactor() *
                                     ws.efficiency_scaling_factor;
             // Translate injector type from control to Phase.
-            std::optional<Scalar> group_target;
+            using GroupTarget = typename SingleWellState<Scalar, IndexTraits>::GroupTarget;
+            std::optional<GroupTarget> group_target;
             if (well->isProducer()) {
                 group_target = group_state_helper.getWellGroupTargetProducer(
                     well->name(),

--- a/opm/simulators/wells/GroupStateHelper.cpp
+++ b/opm/simulators/wells/GroupStateHelper.cpp
@@ -198,7 +198,8 @@ GroupStateHelper<Scalar, IndexTraits>::checkGroupConstraintsInj(const std::strin
     if (this->schedule_.hasWell(name)
         && this->wellState().well(name).group_target) { // for wells we already have computed the target
         Scalar scale = 1.0;
-        const Scalar group_target_rate_available = *this->wellState().well(name).group_target;
+        const auto& group_target = this->wellState().well(name).group_target;
+        const Scalar group_target_rate_available = group_target->target_value;
         const Scalar current_well_rate_available
             = tcalc.calcModeRateFromRates(rates); // Switch sign since 'rates' are negative for producers.
         if (current_well_rate_available > 1e-12) {
@@ -371,7 +372,8 @@ GroupStateHelper<Scalar, IndexTraits>::checkGroupConstraintsProd(const std::stri
 
         // Switch sign since 'rates' are negative for producers.
         const Scalar current_well_rate_available = -tcalc.calcModeRateFromRates(rates);
-        const Scalar group_target_rate_available = *this->wellState().well(name).group_target;
+        const auto& group_target = this->wellState().well(name).group_target;
+        const Scalar group_target_rate_available = group_target->target_value;
         Scalar scale = 1.0;
         if (current_well_rate_available > 1e-12) {
             scale = group_target_rate_available / current_well_rate_available;
@@ -483,15 +485,15 @@ GroupStateHelper<Scalar, IndexTraits>::getProductionGroupRateVector(const std::s
 }
 
 template <typename Scalar, typename IndexTraits>
-std::optional<Scalar>
+std::optional<typename SingleWellState<Scalar, IndexTraits>::GroupTarget>
 GroupStateHelper<Scalar, IndexTraits>::getWellGroupTargetInjector(const std::string& name,
-                                                                 const std::string& parent,
-                                                                 const Group& group,
-                                                                 const Scalar* rates,
-                                                                 Phase injection_phase,
-                                                                 const Scalar efficiency_factor,
-                                                                 const std::vector<Scalar>& resv_coeff,
-                                                                 DeferredLogger& deferred_logger) const
+                                                                  const std::string& parent,
+                                                                  const Group& group,
+                                                                  const Scalar* rates,
+                                                                  Phase injection_phase,
+                                                                  const Scalar efficiency_factor,
+                                                                  const std::vector<Scalar>& resv_coeff,
+                                                                  DeferredLogger& deferred_logger) const
 {
     // This function computes a wells group target.
     // 'parent' will be the name of 'group'. But if we recurse, 'name' and
@@ -612,19 +614,20 @@ GroupStateHelper<Scalar, IndexTraits>::getWellGroupTargetInjector(const std::str
             target *= local_fraction_lambda(chain[ii + 1], chain[ii + 1]);
         }
     }
-    // Avoid negative target rates comming from too large local reductions.
-    return std::max(Scalar(0.0), target / efficiency_factor);
+    // Avoid negative target rates coming from too large local reductions.
+    const auto target_value = std::max(Scalar(0.0), target / efficiency_factor);
+    return GroupTarget::injectionGroupTarget(group.name(), current_group_control, target_value);
 }
 
 template <typename Scalar, typename IndexTraits>
-std::optional<Scalar>
+std::optional<typename SingleWellState<Scalar, IndexTraits>::GroupTarget>
 GroupStateHelper<Scalar, IndexTraits>::getWellGroupTargetProducer(const std::string& name,
-                                                                 const std::string& parent,
-                                                                 const Group& group,
-                                                                 const Scalar* rates,
-                                                                 const Scalar efficiency_factor,
-                                                                 const std::vector<Scalar>& resv_coeff,
-                                                                 DeferredLogger& deferred_logger) const
+                                                                  const std::string& parent,
+                                                                  const Group& group,
+                                                                  const Scalar* rates,
+                                                                  const Scalar efficiency_factor,
+                                                                  const std::vector<Scalar>& resv_coeff,
+                                                                  DeferredLogger& deferred_logger) const
 {
     // This function computes a wells group target.
     // 'parent' will be the name of 'group'. But if we recurse, 'name' and
@@ -741,7 +744,8 @@ GroupStateHelper<Scalar, IndexTraits>::getWellGroupTargetProducer(const std::str
         }
     }
     // Avoid negative target rates coming from too large local reductions.
-    return std::max(Scalar(0.0), target / efficiency_factor);
+    const auto target_value = std::max(Scalar(0.0), target / efficiency_factor);
+    return GroupTarget::productionGroupTarget(group.name(), current_group_control, target_value);
 }
 
 template <typename Scalar, typename IndexTraits>

--- a/opm/simulators/wells/GroupStateHelper.hpp
+++ b/opm/simulators/wells/GroupStateHelper.hpp
@@ -142,22 +142,24 @@ public:
 
     GuideRate::RateVector getProductionGroupRateVector(const std::string& group_name) const;
 
-    std::optional<Scalar> getWellGroupTargetInjector(const std::string& name,
-                                                     const std::string& parent,
-                                                     const Group& group,
-                                                     const Scalar* rates,
-                                                     const Phase injection_phase,
-                                                     const Scalar efficiency_factor,
-                                                     const std::vector<Scalar>& resv_coeff,
-                                                     DeferredLogger& deferred_logger) const;
+    using GroupTarget = typename SingleWellState<Scalar, IndexTraits>::GroupTarget;
 
-    std::optional<Scalar> getWellGroupTargetProducer(const std::string& name,
-                                                     const std::string& parent,
-                                                     const Group& group,
-                                                     const Scalar* rates,
-                                                     const Scalar efficiency_factor,
-                                                     const std::vector<Scalar>& resv_coeff,
-                                                     DeferredLogger& deferred_logger) const;
+    std::optional<GroupTarget> getWellGroupTargetInjector(const std::string& name,
+                                                          const std::string& parent,
+                                                          const Group& group,
+                                                          const Scalar* rates,
+                                                          const Phase injection_phase,
+                                                          const Scalar efficiency_factor,
+                                                          const std::vector<Scalar>& resv_coeff,
+                                                          DeferredLogger& deferred_logger) const;
+
+    std::optional<GroupTarget> getWellGroupTargetProducer(const std::string& name,
+                                                          const std::string& parent,
+                                                          const Group& group,
+                                                          const Scalar* rates,
+                                                          const Scalar efficiency_factor,
+                                                          const std::vector<Scalar>& resv_coeff,
+                                                          DeferredLogger& deferred_logger) const;
 
     GuideRate::RateVector getWellRateVector(const std::string& name) const;
 

--- a/opm/simulators/wells/SingleWellState.hpp
+++ b/opm/simulators/wells/SingleWellState.hpp
@@ -23,8 +23,9 @@
 #include <functional>
 #include <vector>
 
-#include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
 #include <opm/input/eclipse/Schedule/Events.hpp>
+#include <opm/input/eclipse/Schedule/Group/Group.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
 
 #include <opm/material/fluidsystems/PhaseUsageInfo.hpp>
 
@@ -118,6 +119,32 @@ public:
       vaporized_water = 3
     };
 
+    struct GroupTarget {
+        std::string group_name;
+        Group::ProductionCMode production_cmode {Group::ProductionCMode::NONE};
+        Group::InjectionCMode  injection_cmode  {Group::InjectionCMode::NONE};
+        Scalar target_value;
+
+        static GroupTarget injectionGroupTarget(const std::string& gname,
+                                                Group::InjectionCMode cmode,
+                                                Scalar value) {
+            return {gname, Group::ProductionCMode::NONE, cmode, value};
+        }
+
+        static GroupTarget productionGroupTarget(const std::string& gname,
+                                                 Group::ProductionCMode cmode,
+                                                 Scalar value) {
+            return {gname, cmode, Group::InjectionCMode::NONE, value};
+        }
+
+        bool operator==(const GroupTarget& other) const {
+            return   ( group_name == other.group_name
+                    && target_value == other.target_value
+                    && production_cmode == other.production_cmode
+                    && injection_cmode == other.injection_cmode );
+        }
+    };
+
     std::vector<Scalar> well_potentials;
     std::vector<Scalar> productivity_index;
     std::vector<Scalar> implicit_ipr_a;
@@ -127,7 +154,7 @@ public:
     std::vector<Scalar> prev_surface_rates;
     PerfData<Scalar> perf_data;
     bool trivial_group_target;
-    std::optional<Scalar> group_target;
+    std::optional<GroupTarget> group_target;
     SegmentState<Scalar> segments;
     Events events;
     WellInjectorCMode injection_cmode{WellInjectorCMode::CMODE_UNDEFINED};


### PR DESCRIPTION
PRs https://github.com/OPM/opm-simulators/pull/6596 and https://github.com/OPM/opm-simulators/pull/6545 call for more information through the `SingleWellState::group_target.` 

Introducing a dedicated struct can be one way to make it easier to extend. 

In its current form, we are not using the extension for now.  It will be potentially used by other PRs like #6596 and #6545 , or debugging purposes. 

not sure it is strong argument to get this PR in with its current form. 