### PR TITLE
Take into account parent grid names

### DIFF
--- a/opm/simulators/flow/GenericCpGridVanguard.cpp
+++ b/opm/simulators/flow/GenericCpGridVanguard.cpp
@@ -580,14 +580,16 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::addLgrsUpdateLeafView
                                                                                  const int lgrsSize,
                                                                                  Dune::CpGrid& grid)
 {
-    std::vector<std::array<int,3>> cells_per_dim_vec;
-    std::vector<std::array<int,3>> startIJK_vec;
-    std::vector<std::array<int,3>> endIJK_vec;
-    std::vector<std::string> lgrName_vec;
+    std::vector<std::array<int,3>> cells_per_dim_vec{};
+    std::vector<std::array<int,3>> startIJK_vec{};
+    std::vector<std::array<int,3>> endIJK_vec{};
+    std::vector<std::string> lgrName_vec{};
+    std::vector<std::string> parentName_vec{};
     cells_per_dim_vec.reserve(lgrsSize);
     startIJK_vec.reserve(lgrsSize);
     endIJK_vec.reserve(lgrsSize);
     lgrName_vec.reserve(lgrsSize);
+    parentName_vec.reserve(lgrsSize);
     for (int lgr = 0; lgr < lgrsSize; ++lgr)
     {
         const auto lgrCarfin = lgrCollection.getLgr(lgr);
@@ -596,8 +598,9 @@ void GenericCpGridVanguard<ElementMapper,GridView,Scalar>::addLgrsUpdateLeafView
         startIJK_vec.push_back({lgrCarfin.I1(), lgrCarfin.J1(), lgrCarfin.K1()});
         endIJK_vec.push_back({lgrCarfin.I2()+1, lgrCarfin.J2()+1, lgrCarfin.K2()+1});
         lgrName_vec.emplace_back(lgrCarfin.NAME());
+        parentName_vec.emplace_back(lgrCarfin.PARENT_NAME());
     }
-    grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgrName_vec);
+    grid.addLgrsUpdateLeafView(cells_per_dim_vec, startIJK_vec, endIJK_vec, lgrName_vec, parentName_vec);
 };
 
 template<class ElementMapper, class GridView, class Scalar>


### PR DESCRIPTION
This PR takes into account the parent grid name, to support nested refinement. 
It allows running the simulation with nested CARFIN blocks and the flags:
--parsing-strictness=low
--enable-ecl-output=true
Note that some work in opm-common is needed to have all properties.

<img width="1877" height="1378" alt="carfin_nested" src="https://github.com/user-attachments/assets/fbb439e1-91c3-4503-a91d-047956a2117d" />

 