### PR TITLE
Add reset to gpu matrices

### DIFF
--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrix.cpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrix.cpp
@@ -203,11 +203,11 @@ GpuSparseMatrix<T>::updateNonzeroValues(const GpuSparseMatrixGeneric<T>& matrix)
 
 template <class T>
 void
-GpuSparseMatrix<T>::resetMatrix()
+GpuSparseMatrix<T>::setToZero()
 {
     // For blockSize == 1, use GpuSparseMatrixGeneric
     if (m_genericMatrixForBlockSize1) {
-        m_genericMatrixForBlockSize1->resetMatrix();
+        m_genericMatrixForBlockSize1->setToZero();
         return;
     }
 

--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrix.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrix.hpp
@@ -342,9 +342,9 @@ public:
      void updateNonzeroValues(const GpuSparseMatrixGeneric<T>& matrix);
 
     /**
-     * @brief resetMatrix resets the matrix to zero values.
+     * @brief setToZero resets the matrix to zero values.
      */
-     void resetMatrix();
+     void setToZero();
 
     /**
      * @brief Dispatches a function based on the block size of the matrix.

--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrixGeneric.cpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrixGeneric.cpp
@@ -255,7 +255,7 @@ GpuSparseMatrixGeneric<T>::updateNonzeroValues(const GpuSparseMatrixGeneric<T>& 
 
 template <class T>
 void
-GpuSparseMatrixGeneric<T>::resetMatrix()
+GpuSparseMatrixGeneric<T>::setToZero()
 {
     cudaMemset(m_nonZeroElements.data(), 0, nonzeroes() * blockSize() * blockSize() * sizeof(T));
 }

--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrixGeneric.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrixGeneric.hpp
@@ -265,9 +265,9 @@ public:
     void updateNonzeroValues(const GpuSparseMatrixGeneric<T>& matrix);
 
     /**
-     * @brief resetMatrix resets the matrix to zero values.
+     * @brief setToZero resets the matrix to zero values.
      */
-    void resetMatrix();
+    void setToZero();
 
     /**
      * @brief Dispatches a function based on the block size of the matrix.

--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrixWrapper.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrixWrapper.hpp
@@ -392,11 +392,11 @@ public:
     }
 
     /**
-     * @brief resetMatrix resets the matrix to zero values.
+     * @brief setToZero resets the matrix to zero values.
      */
-    void resetMatrix()
+    void setToZero()
     {
-        m_matrix->resetMatrix();
+        m_matrix->setToZero();
     }
 
     /**


### PR DESCRIPTION
Add reset functionality for GPU matrices that is useful for assembly (this PR handles one of the changes needed in https://github.com/OPM/opm-simulators/pull/6612)