### PR TITLE
Add missing template default argument in forward declaration.

### DIFF
--- a/opm/simulators/linalg/gpuistl/detail/gpu_type_detection.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/gpu_type_detection.hpp
@@ -28,7 +28,7 @@ namespace Opm::gpuistl
 // Forward declarations
 template <typename T>
 class GpuVector;
-template <typename T, bool ForceLegacy>
+template <typename T, bool ForceLegacy = false>
 class GpuSparseMatrixWrapper;
 template <typename T>
 class GpuSparseMatrixGeneric;


### PR DESCRIPTION
Might be a bit fragile to repeat the default, but likely better than removing it. Missing arg causes compile error on clang.