### PR TITLE
Ensure filtrate mass balance in case of cross-flow

### DIFF
--- a/opm/simulators/wells/WellFilterCake.cpp
+++ b/opm/simulators/wells/WellFilterCake.cpp
@@ -150,7 +150,7 @@ updateSkinFactorsAndMultipliers(const WellInterfaceGeneric<Scalar, IndexTraits>&
         qw_sum += crate;
     }
     if (qwpos_sum > qw_sum && qwpos_sum > 1.0e-12) {
-        xfact = qw_sum / qwpos_sum;
+        xfact = std::max(Scalar{0.}, qw_sum) / qwpos_sum;
     }
 
 


### PR DESCRIPTION
In current master the injected filtrate volume exceeds the actually injected volume because cross-flowing water implicitly gets the same filtrate concentration as injected water. This PR restores mass balance of injected filtrate by assuming zero filtrate concentration in cross-flow, as well as complete mixing of injected and cross-flowing water. 