### PR TITLE
Add option for drift compensation for TEMP

### DIFF
--- a/opm/simulators/flow/FlowGenericProblem.hpp
+++ b/opm/simulators/flow/FlowGenericProblem.hpp
@@ -351,6 +351,7 @@ protected:
     int numPressurePointsEquil_;
 
     bool enableDriftCompensation_;
+    bool enableDriftCompensationTemp_{false};
     bool explicitRockCompaction_;
 
     // To lookup origin cell indices

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -410,7 +410,7 @@ public:
         // compute and set eq weights based on initial b values
         this->computeAndSetEqWeights_();
 
-        if (this->enableDriftCompensation_) {
+        if (this->enableDriftCompensation_ || this->enableDriftCompensationTemp_) {
             this->drift_.resize(this->model().numGridDof());
             this->drift_ = 0.0;
         }

--- a/opm/simulators/flow/FlowProblemParameters.cpp
+++ b/opm/simulators/flow/FlowProblemParameters.cpp
@@ -53,6 +53,9 @@ void registerFlowProblemParameters()
     Parameters::Register<Parameters::EnableDriftCompensation>
         ("Enable partial compensation of systematic mass losses via "
          "the source term of the next time step");
+    Parameters::Register<Parameters::EnableDriftCompensationTemp>
+        ("Enable compensation of systematic mass losses "
+         "in the energy equation (only TEMP option)");
     Parameters::Register<Parameters::OutputMode>
         ("Specify which messages are going to be printed. "
          "Valid values are: none, log, all (default)");

--- a/opm/simulators/flow/FlowProblemParameters.hpp
+++ b/opm/simulators/flow/FlowProblemParameters.hpp
@@ -36,6 +36,10 @@ namespace Opm::Parameters {
 // the source term of the next time step
 struct EnableDriftCompensation { static constexpr bool value = false; };
 
+// Enable compensation of systematic mass losses in
+// the sequential energy equation
+struct EnableDriftCompensationTemp { static constexpr bool value = true; };
+
 // implicit or explicit pressure in rock compaction
 struct ExplicitRockCompaction { static constexpr bool value = false; };
 


### PR DESCRIPTION
Compensate for mass loss in the energy equation to avoid unphysical temperatures. Activated by default --enable-droft-compensation-temp (Default = true)