### PR TITLE
correcting the GRUPTREE in GLIFT1.DATA

### DIFF
--- a/tests/GLIFT1.DATA
+++ b/tests/GLIFT1.DATA
@@ -217,7 +217,7 @@ TUNING
 
 
 GRUPTREE
- 'PROD'    'FIELD' /
+ 'PLAT-A'    'FIELD' /
 
  'M5S'    'PLAT-A'  /
  'M5N'    'PLAT-A'  /


### PR DESCRIPTION
PROD should be PLAT-A.

Spotted when looking into regression failures. 