### PR TITLE
Support Updating INIT File Only Test Cases

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -506,12 +506,13 @@ add_test_compareECLFiles(CASENAME norne
 # Init tests
 opm_set_test_driver(${PROJECT_SOURCE_DIR}/tests/run-init-regressionTest.sh "")
 
-add_test_compareECLFiles(CASENAME norne
+add_test_compareECLFiles(CASENAME norne_init
                          FILENAME NORNE_ATW2013
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
                          PREFIX compareECLInitFiles
+                         DIR norne
                          DIR_PREFIX /init)
 
 # This is not a proper regression test; the test will load a norne case prepared

--- a/tests/update_reference_data.sh
+++ b/tests/update_reference_data.sh
@@ -276,17 +276,23 @@ updateDamarisResults () {
     changed_tests+=" ${test_name}"
 }
 
-# Update .INIT and .EGRID files for Norne model as applicable.
+# Generate reference solution updates for cases that don't run a full
+# simulation (e.g., those that use the 'NOSIM' keyword).
 #
-# This is a special case.
-updateNorneInitFiles () {
+# Updates the .EGRID and .INIT files only.
+updateInitFileResults () {
+    local binary=${testProperty["binary"]}
+    local dir_name=${testProperty["dir_name"]}
+    local file_name=${testProperty["file_name"]}
+    local test_name=${testProperty["test_name"]}
+
     if copyToReferenceDir \
-        "${BUILD_DIR}/tests/results/init/flow+norne" \
-        "${OPM_TESTS_ROOT}/norne/opm-simulation-reference/flow" \
-        NORNE_ATW2013 \
-        EGRID INIT
+           "${BUILD_DIR}/tests/results/init/${binary}+${test_name}" \
+           "${OPM_TESTS_ROOT}/${dir_name}/opm-simulation-reference/${binary}" \
+           "${file_name}" \
+           EGRID INIT
     then
-        changed_tests+=" norne_init"
+        changed_tests+=" ${test_name}"
     fi
 }
 
@@ -322,14 +328,14 @@ do
             *compareECLFiles* )
                 updateFullSimulationResults ;;
 
+            *compareECLInitFiles* )
+                updateInitFileResults ;;
+
             *compareDamarisFiles* )
                 updateDamarisResults ;;
         esac
     done < "${logfile}"
 done
-
-# Special case handling of certain particular tests.
-updateNorneInitFiles
 
 if [ -z "${changed_tests}" ]
 then


### PR DESCRIPTION
Certain example models don't have meaningful dynamic results, but we'd still like to be able to automatically update the static result files like EGRID and INIT. This PR adds such support under the assumption that those test cases have names that match the pattern
```sh
*compareECLInitFiles*
```