### PR TITLE
Also detect Oscillations if only for single component

### DIFF
--- a/opm/simulators/flow/NonlinearSolver.hpp
+++ b/opm/simulators/flow/NonlinearSolver.hpp
@@ -240,7 +240,7 @@ struct NonlinearSolverParameters
                                 const int it, bool& oscillate, bool& stagnate) const
         {
             detail::detectOscillations(residualHistory, it, model_->numPhases(),
-                                       this->relaxRelTol(), 2, oscillate, stagnate);
+                                       this->relaxRelTol(), 1, oscillate, stagnate);
         }
 
 


### PR DESCRIPTION
I have a case where the water equation oscillates. I don't see why we shouldn't damp if the oscillation is only for one component/equation. This PR helps. 
This also aligns with the approach taken for NLDD. 