### PR TITLE
Feature: cprw solver: add overlap connections of distributed wells to the pressure matrix

### DIFF
--- a/opm/simulators/flow/FlowBaseVanguard.hpp
+++ b/opm/simulators/flow/FlowBaseVanguard.hpp
@@ -199,7 +199,35 @@ public:
     {
         auto index_pair = cartesianToCompressed_.find(cartesianCellIdx);
         if (index_pair == cartesianToCompressed_.end() ||
+            is_interior_[index_pair->second] != 1)
+        {
+            return -1;
+        }
+        else
+        {
+            return index_pair->second;
+        }
+    }
+
+    int compressedIndexForInteriorOrOverlap(int cartesianCellIdx) const
+    {
+        auto index_pair = cartesianToCompressed_.find(cartesianCellIdx);
+        if (index_pair == cartesianToCompressed_.end() ||
             !is_interior_[index_pair->second])
+        {
+            return -1;
+        }
+        else
+        {
+            return index_pair->second;
+        }
+    }
+
+    int compressedIndexForOverlap(int cartesianCellIdx) const
+    {
+        auto index_pair = cartesianToCompressed_.find(cartesianCellIdx);
+        if (index_pair == cartesianToCompressed_.end() ||
+            is_interior_[index_pair->second] != 2)
         {
             return -1;
         }
@@ -344,13 +372,10 @@ protected:
             const auto elemIdx = elemMapper.index(element);
             unsigned cartesianCellIdx = cartesianIndex(elemIdx);
             cartesianToCompressed_[cartesianCellIdx] = elemIdx;
-            if (element.partitionType() == Dune::InteriorEntity)
-            {
-                is_interior_[elemIdx] = 1;
-            }
-            else
-            {
-                is_interior_[elemIdx] = 0;
+            switch (element.partitionType()) {
+                case Dune::InteriorEntity: is_interior_[elemIdx] = 1; break;
+                case Dune::OverlapEntity:  is_interior_[elemIdx] = 2; break;
+                default: is_interior_[elemIdx] = 0;
             }
         }
     }

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -344,6 +344,16 @@ template<class Scalar> class WellContributions;
                 return simulator_.vanguard().compressedIndexForInterior(cartesian_cell_idx);
             }
 
+            int compressedIndexForInteriorOrOverlap(int cartesian_cell_idx) const override
+            {
+                return simulator_.vanguard().compressedIndexForInteriorOrOverlap(cartesian_cell_idx);
+            }
+
+            int compressedIndexForOverlap(int cartesian_cell_idx) const override
+            {
+                return simulator_.vanguard().compressedIndexForOverlap(cartesian_cell_idx);
+            }
+
             int compressedIndexForInteriorLGR(const std::string& lgr_tag, const Connection& conn) const override
             {
                 return simulator_.vanguard().compressedIndexForInteriorLGR(lgr_tag, conn);

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1249,7 +1249,7 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                 if (this->groupState().has_injection_control(gr_name, phase)) {
                     if (this->groupState().injection_control(gr_name, phase) == Group::InjectionCMode::VREP ||
                         this->groupState().injection_control(gr_name, phase) == Group::InjectionCMode::REIN) {
-		        OPM_TIMEBLOCK(extraIterationsAfterNupcol);
+                        OPM_TIMEBLOCK(extraIterationsAfterNupcol);
                         const bool is_vrep = this->groupState().injection_control(gr_name, phase) == Group::InjectionCMode::VREP;
                         const Group& group = schedule().getGroup(gr_name, reportStepIdx);
                         const int np = this->wellState().numPhases();
@@ -1695,6 +1695,54 @@ getCellsForConnections(const Well& well) const
 }
 
 template<typename Scalar, typename IndexTraits>
+std::vector<int> BlackoilWellModelGeneric<Scalar, IndexTraits>::
+getCellsForConnectionsWithOverlap(const Well& well) const
+{
+    std::vector<int> wellCells;
+    // All possible connections of the well
+    const auto& connectionSet = well.getConnections();
+    wellCells.reserve(connectionSet.size());
+
+    for (const auto& connection : connectionSet)
+    {
+        // TODO: there is no method for LGR and overlap
+        int compressed_idx = well.is_lgr_well()
+            ? compressedIndexForInteriorLGR(well.get_lgr_well_tag().value(), connection)
+            : this->compressedIndexForInteriorOrOverlap(connection.global_index());
+
+        if (compressed_idx >= 0) { // Ignore connections in inactive/remote cells.
+            wellCells.push_back(compressed_idx);
+        }
+    }
+
+    return wellCells;
+}
+
+template<typename Scalar, typename IndexTraits>
+std::vector<int> BlackoilWellModelGeneric<Scalar, IndexTraits>::
+getCellsForConnectionsOnOverlap(const Well& well) const
+{
+    std::vector<int> wellCells;
+    // All possible connections of the well
+    const auto& connectionSet = well.getConnections();
+    wellCells.reserve(connectionSet.size());
+
+    for (const auto& connection : connectionSet)
+    {
+        // TODO: there is no method for LGR and overlap
+        int compressed_idx = well.is_lgr_well()
+            ? compressedIndexForInteriorLGR(well.get_lgr_well_tag().value(), connection)
+            : this->compressedIndexForOverlap(connection.global_index());
+
+        if (compressed_idx >= 0) { // Ignore connections in inactive/remote cells.
+            wellCells.push_back(compressed_idx);
+        }
+    }
+
+    return wellCells;
+}
+
+template<typename Scalar, typename IndexTraits>
 std::vector<std::string> BlackoilWellModelGeneric<Scalar, IndexTraits>::
 getWellsForTesting(const int timeStepIdx,
                    const double simulationTime)
@@ -1794,12 +1842,12 @@ getMaxWellConnections() const
     // initialize the additional cell connections introduced by wells.
     for (const auto& well : schedule_wells) {
         auto& compressed_well_perforations = wellConnections.emplace_back
-            (this->getCellsForConnections(this->schedule().back().wells(well)));
+            (this->getCellsForConnectionsWithOverlap(this->schedule().back().wells(well)));
 
         const auto possibleFutureConnectionSetIt = possibleFutureConnections.find(well);
         if (possibleFutureConnectionSetIt != possibleFutureConnections.end()) {
             for (const auto& global_index : possibleFutureConnectionSetIt->second) {
-                const int compressed_idx = compressedIndexForInterior(global_index);
+                const int compressed_idx = compressedIndexForInteriorOrOverlap(global_index);
                 if (compressed_idx >= 0) { // Ignore connections in inactive/remote cells.
                     compressed_well_perforations.push_back(compressed_idx);
                 }

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -235,6 +235,8 @@ public:
     const WellGroupEvents& reportStepStartEvents() const { return report_step_start_events_; }
 
     std::vector<int> getCellsForConnections(const Well& well) const;
+    std::vector<int> getCellsForConnectionsWithOverlap(const Well& well) const;
+    std::vector<int> getCellsForConnectionsOnOverlap(const Well& well) const;
 
     bool reportStepStarts() const { return report_step_starts_; }
 
@@ -267,6 +269,9 @@ public:
     }
 
     bool operator==(const BlackoilWellModelGeneric& rhs) const;
+
+    const auto& parallelWellInfo() const
+    { return parallel_well_info_; }
 
     const ParallelWellInfo<Scalar>&
     parallelWellInfo(const std::size_t idx) const
@@ -490,6 +495,8 @@ protected:
 
     /// \brief get compressed index for interior cells (-1, otherwise
     virtual int compressedIndexForInterior(int cartesian_cell_idx) const = 0;
+    virtual int compressedIndexForInteriorOrOverlap(int cartesian_cell_idx) const = 0;
+    virtual int compressedIndexForOverlap(int cartesian_cell_idx) const = 0;
 
     std::vector<std::vector<int>> getMaxWellConnections() const;
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -1539,6 +1539,15 @@ namespace Opm {
                                            pressureVarIndex,
                                            use_well_weights,
                                            this->wellState());
+
+            auto getOverlap = [this](const WellInterfaceGeneric<Scalar, IndexTraits>& well_) -> std::vector<int> {
+                return this->getCellsForConnectionsOnOverlap(this->schedule().back().wells(well_.name()));
+            };
+            auto getInterior = [this](const WellInterfaceGeneric<Scalar, IndexTraits>& well_) -> std::vector<int> {
+                return this->getCellsForConnections(this->schedule().back().wells(well_.name()));
+            };
+            well->initOverlapConnections(getOverlap, getInterior, this->simulator_.vanguard().globalCell());
+            well->addWellOverlapConnectionsToPressureEquations(jacobian, weights.size());
         }
     }
 

--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -149,6 +149,8 @@ namespace Opm {
                                       const bool use_well_weights,
                                       const WellStateType& well_state) const override;
 
+        void addWellOverlapConnectionsToPressureEquations(PressureMatrix& mat,
+                                                          const int cell_number) const override;
         std::vector<Scalar>
         computeCurrentWellRates(const Simulator& simulator,
                                 DeferredLogger& deferred_logger) const override;

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -913,6 +913,13 @@ namespace Opm
                                                well_state);
     }
 
+    template<typename TypeTag>
+    void
+    MultisegmentWell<TypeTag>::
+    addWellOverlapConnectionsToPressureEquations([[maybe_unused]] PressureMatrix& mat,
+                                                 [[maybe_unused]] const int cell_number) const
+    {}
+
 
     template<typename TypeTag>
     template<class Value>

--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -188,6 +188,9 @@ namespace Opm
                                       const bool use_well_weights,
                                       const WellStateType& well_state) const override;
 
+        void addWellOverlapConnectionsToPressureEquations(PressureMatrix& mat,
+                                                          const int cell_number) const override;
+
         // iterate well equations with the specified control until converged
         bool iterateWellEqWithControl(const Simulator& simulator,
                                       const double dt,

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -418,9 +418,9 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
 template<typename Scalar, typename IndexTraits, int numEq>
 template<class PressureMatrix>
 void StandardWellEquations<Scalar, IndexTraits, numEq>::
-addOverlapConnectionsToPressureMatrix(PressureMatrix& jacobian,
-                                      const int number_cells,
-                                      const WellInterfaceGeneric<Scalar, IndexTraits>& well) const
+addOverlapConnectionsToPressureMatrix([[maybe_unused]] PressureMatrix& jacobian,
+                                      [[maybe_unused]] const int number_cells,
+                                      [[maybe_unused]] const WellInterfaceGeneric<Scalar, IndexTraits>& well) const
 {
 #if HAVE_MPI
     const auto& comm = well.parallelWellInfo().communication();

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -20,6 +20,7 @@
 */
 
 #include <config.h>
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/Exceptions.hpp>
 #include <opm/common/TimingMacros.hpp>
 #include <opm/simulators/wells/StandardWellEquations.hpp>
@@ -427,6 +428,16 @@ addOverlapConnectionsToPressureMatrix([[maybe_unused]] PressureMatrix& jacobian,
     if (comm.size() == 1)
         return;
 
+    MPI_Datatype mpiTypeScalar;
+    if constexpr (std::is_same<Scalar, double>::value)
+        mpiTypeScalar = MPI_DOUBLE;
+    else if constexpr (std::is_same<Scalar, float>::value)
+        mpiTypeScalar = MPI_FLOAT;
+    else if constexpr (std::is_same<Scalar, long double>::value)
+        mpiTypeScalar = MPI_LONG_DOUBLE;
+    else
+        OPM_THROW(std::logic_error, "Type of Scalar is incompatible with MPI types for floats of different lengths.");
+
     // ownedOverlapConnections and missingOverlapConnections determine the communication pattern
     // for passing the overlap values (send and receive respectively).
     const auto& ownedOverlapConnections = well.getOwnedOverlap();
@@ -444,10 +455,9 @@ addOverlapConnectionsToPressureMatrix([[maybe_unused]] PressureMatrix& jacobian,
         for (const auto& col : ownedOverlapConnections[rankI]) {
             sendJacobianValues[i].push_back(jacobian[welldof_ind][col]);
         }
-        static_assert(std::is_same<Scalar, double>::value);
         int tag = 23 + comm.size() * comm.rank() + rankI; // random tag
         // this might communicate vectors of size 0
-        MPI_Isend(sendJacobianValues[i].data(), jacSize, MPI_DOUBLE, rankI, tag, comm, &request[i]);
+        MPI_Isend(sendJacobianValues[i].data(), jacSize, mpiTypeScalar, rankI, tag, comm, &request[i]);
     }
 
     // synchronously receive overlap connection values
@@ -456,9 +466,8 @@ addOverlapConnectionsToPressureMatrix([[maybe_unused]] PressureMatrix& jacobian,
         int rankI = i + static_cast<int>(i >= comm.rank());
         int jacSize = missingOverlapConnections[rankI].size();
         recvJacobianValues[i].resize(jacSize);
-        static_assert(std::is_same<Scalar, double>::value);
         int tag = 23 + comm.size() * rankI + comm.rank(); // matching random tag
-        MPI_Recv(recvJacobianValues[i].data(), jacSize, MPI_DOUBLE, rankI, tag, comm, MPI_STATUS_IGNORE);
+        MPI_Recv(recvJacobianValues[i].data(), jacSize, mpiTypeScalar, rankI, tag, comm, MPI_STATUS_IGNORE);
     }
 
     MPI_Waitall(request.size(), request.data(), MPI_STATUS_IGNORE);

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -429,11 +429,11 @@ addOverlapConnectionsToPressureMatrix([[maybe_unused]] PressureMatrix& jacobian,
         return;
 
     MPI_Datatype mpiTypeScalar;
-    if constexpr (std::is_same<Scalar, double>::value)
+    if constexpr (std::is_same_v<Scalar, double>)
         mpiTypeScalar = MPI_DOUBLE;
-    else if constexpr (std::is_same<Scalar, float>::value)
+    else if constexpr (std::is_same_v<Scalar, float>)
         mpiTypeScalar = MPI_FLOAT;
-    else if constexpr (std::is_same<Scalar, long double>::value)
+    else if constexpr (std::is_same_v<Scalar, long double>)
         mpiTypeScalar = MPI_LONG_DOUBLE;
     else
         OPM_THROW(std::logic_error, "Type of Scalar is incompatible with MPI types for floats of different lengths.");
@@ -445,25 +445,36 @@ addOverlapConnectionsToPressureMatrix([[maybe_unused]] PressureMatrix& jacobian,
     const int commSM1 = comm.size() - 1;
     const int welldof_ind = number_cells + well.indexOfWell();
 
-    // asynchronously send overlap connection values
-    std::vector<MPI_Request> request(commSM1);
-    std::vector<std::vector<Scalar>> sendJacobianValues(commSM1);
+    // check which ranks need to communicate
+    std::vector<int> sendToRanks, receiveFromRanks;
+    sendToRanks.reserve(commSM1);
+    receiveFromRanks.reserve(commSM1);
     for (int i = 0; i < commSM1; ++i) {
         int rankI = i + static_cast<int>(i >= comm.rank());
+        if (ownedOverlapConnections[rankI].size() > 0)
+            sendToRanks.push_back(rankI);
+        if (missingOverlapConnections[rankI].size() > 0)
+            receiveFromRanks.push_back(rankI);
+    }
+
+    // asynchronously send overlap connection values
+    std::vector<MPI_Request> request(sendToRanks.size());
+    std::vector<std::vector<Scalar>> sendJacobianValues(sendToRanks.size());
+    for (std::size_t i = 0; i < sendToRanks.size(); ++i) {
+        int rankI = sendToRanks[i];
         int jacSize = ownedOverlapConnections[rankI].size();
         sendJacobianValues[i].reserve(jacSize);
         for (const auto& col : ownedOverlapConnections[rankI]) {
             sendJacobianValues[i].push_back(jacobian[welldof_ind][col]);
         }
         int tag = 23 + comm.size() * comm.rank() + rankI; // random tag
-        // this might communicate vectors of size 0
         MPI_Isend(sendJacobianValues[i].data(), jacSize, mpiTypeScalar, rankI, tag, comm, &request[i]);
     }
 
     // synchronously receive overlap connection values
-    std::vector<std::vector<Scalar>> recvJacobianValues(commSM1);
-    for (int i = 0; i < commSM1; ++i) {
-        int rankI = i + static_cast<int>(i >= comm.rank());
+    std::vector<std::vector<Scalar>> recvJacobianValues(receiveFromRanks.size());
+    for (std::size_t i = 0; i < receiveFromRanks.size(); ++i) {
+        int rankI = receiveFromRanks[i];
         int jacSize = missingOverlapConnections[rankI].size();
         recvJacobianValues[i].resize(jacSize);
         int tag = 23 + comm.size() * rankI + comm.rank(); // matching random tag
@@ -473,8 +484,8 @@ addOverlapConnectionsToPressureMatrix([[maybe_unused]] PressureMatrix& jacobian,
     MPI_Waitall(request.size(), request.data(), MPI_STATUS_IGNORE);
 
     // fill overlap connections of the well in the jacobian
-    for (int i = 0; i < commSM1; ++i) {
-        int rankI = i + static_cast<int>(i >= comm.rank());
+    for (std::size_t i = 0; i < receiveFromRanks.size(); ++i) {
+        int rankI = receiveFromRanks[i];
         for (std::size_t j = 0; j < recvJacobianValues[i].size(); ++j) {
             assert(jacobian[welldof_ind][missingOverlapConnections[rankI][j]] == 0);
             jacobian[welldof_ind][missingOverlapConnections[rankI][j]] = recvJacobianValues[i][j];

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -33,6 +33,7 @@
 #include <opm/simulators/linalg/istlsparsematrixadapter.hh>
 #include <opm/simulators/linalg/matrixblock.hh>
 #include <opm/simulators/linalg/SmallDenseMatrixUtils.hpp>
+#include <opm/simulators/wells/ParallelWellInfo.hpp>
 #include <opm/simulators/wells/WellInterfaceGeneric.hpp>
 
 #include <algorithm>
@@ -326,10 +327,17 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
             nperf += 1;
         }
     }
+
+    // average the cell_weights across the ranks
+    const auto& comm = well.parallelWellInfo().communication();
+    if (comm.size()>1) {
+        nperf = comm.sum(nperf);
+        cell_weights = comm.sum(cell_weights);
+    }
     if (nperf != 0)
         cell_weights /= nperf;
     else {
-        // duneC_.size==0, which can happen e.g. if a well has no active perforations on this rank.
+        // duneC_.size==0, which can happen if a well has no active perforations on any rank.
         // Add positive weight to diagonal to regularize Jacobian (other row entries are 0).
         // Row's variable has no observable effect, since there are no perforations.
         cell_weights = 1.;
@@ -408,6 +416,65 @@ extractCPRPressureMatrix(PressureMatrix& jacobian,
 }
 
 template<typename Scalar, typename IndexTraits, int numEq>
+template<class PressureMatrix>
+void StandardWellEquations<Scalar, IndexTraits, numEq>::
+addOverlapConnectionsToPressureMatrix(PressureMatrix& jacobian,
+                                      const int number_cells,
+                                      const WellInterfaceGeneric<Scalar, IndexTraits>& well) const
+{
+#if HAVE_MPI
+    const auto& comm = well.parallelWellInfo().communication();
+    if (comm.size() == 1)
+        return;
+
+    // ownedOverlapConnections and missingOverlapConnections determine the communication pattern
+    // for passing the overlap values (send and receive respectively).
+    const auto& ownedOverlapConnections = well.getOwnedOverlap();
+    const auto& missingOverlapConnections = well.getMissingOverlap();
+    const int commSM1 = comm.size() - 1;
+    const int welldof_ind = number_cells + well.indexOfWell();
+
+    // asynchronously send overlap connection values
+    std::vector<MPI_Request> request(commSM1);
+    std::vector<std::vector<Scalar>> sendJacobianValues(commSM1);
+    for (int i = 0; i < commSM1; ++i) {
+        int rankI = i + static_cast<int>(i >= comm.rank());
+        int jacSize = ownedOverlapConnections[rankI].size();
+        sendJacobianValues[i].reserve(jacSize);
+        for (const auto& col : ownedOverlapConnections[rankI]) {
+            sendJacobianValues[i].push_back(jacobian[welldof_ind][col]);
+        }
+        static_assert(std::is_same<Scalar, double>::value);
+        int tag = 23 + comm.size() * comm.rank() + rankI; // random tag
+        // this might communicate vectors of size 0
+        MPI_Isend(sendJacobianValues[i].data(), jacSize, MPI_DOUBLE, rankI, tag, comm, &request[i]);
+    }
+
+    // synchronously receive overlap connection values
+    std::vector<std::vector<Scalar>> recvJacobianValues(commSM1);
+    for (int i = 0; i < commSM1; ++i) {
+        int rankI = i + static_cast<int>(i >= comm.rank());
+        int jacSize = missingOverlapConnections[rankI].size();
+        recvJacobianValues[i].resize(jacSize);
+        static_assert(std::is_same<Scalar, double>::value);
+        int tag = 23 + comm.size() * rankI + comm.rank(); // matching random tag
+        MPI_Recv(recvJacobianValues[i].data(), jacSize, MPI_DOUBLE, rankI, tag, comm, MPI_STATUS_IGNORE);
+    }
+
+    MPI_Waitall(request.size(), request.data(), MPI_STATUS_IGNORE);
+
+    // fill overlap connections of the well in the jacobian
+    for (int i = 0; i < commSM1; ++i) {
+        int rankI = i + static_cast<int>(i >= comm.rank());
+        for (std::size_t j = 0; j < recvJacobianValues[i].size(); ++j) {
+            assert(jacobian[welldof_ind][missingOverlapConnections[rankI][j]] == 0);
+            jacobian[welldof_ind][missingOverlapConnections[rankI][j]] = recvJacobianValues[i][j];
+        }
+    }
+#endif // HAVE_MPI
+}
+
+template<typename Scalar, typename IndexTraits, int numEq>
 void StandardWellEquations<Scalar, IndexTraits, numEq>::
 sumDistributed(Parallel::Communication comm)
 {
@@ -426,7 +493,11 @@ sumDistributed(Parallel::Communication comm)
                                  const bool,                                          \
                                  const WellInterfaceGeneric<T,BlackOilDefaultFluidSystemIndices>&,                      \
                                  const int,                                           \
-                                 const WellState<T,BlackOilDefaultFluidSystemIndices>&) const;
+                                 const WellState<T,BlackOilDefaultFluidSystemIndices>&) const;                          \
+    template void StandardWellEquations<T,BlackOilDefaultFluidSystemIndices,N>::                                        \
+        addOverlapConnectionsToPressureMatrix(Dune::BCRSMatrix<MatrixBlock<T,1,1>>&,  \
+                                 const int,                                           \
+                                 const WellInterfaceGeneric<T,BlackOilDefaultFluidSystemIndices>&) const;
 
 #define INSTANTIATE_TYPE(T) \
     INSTANTIATE(T,1)        \

--- a/opm/simulators/wells/StandardWellEquations.hpp
+++ b/opm/simulators/wells/StandardWellEquations.hpp
@@ -117,6 +117,13 @@ public:
                                   const int bhp_var_index,
                                   const WellState<Scalar, IndexTraits>& well_state) const;
 
+    //! \brief Add overlap connections of wells to CPR pressure matrix.
+    template<class PressureMatrix>
+    void addOverlapConnectionsToPressureMatrix(PressureMatrix& jacobian,
+                                               const int number_cells,
+                                               const WellInterfaceGeneric<Scalar, IndexTraits>& well) const;
+
+
     //! \brief Get the number of blocks of the C and B matrices.
     unsigned int getNumBlocks() const;
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -1998,7 +1998,13 @@ namespace Opm
                                                well_state);
     }
 
-
+    template<typename TypeTag>
+    void
+    StandardWell<TypeTag>::addWellOverlapConnectionsToPressureEquations(PressureMatrix& jacobian,
+                                                                        const int cell_number) const
+    {
+        this->linSys_.addOverlapConnectionsToPressureMatrix(jacobian, cell_number, *this);
+    }
 
     template<typename TypeTag>
     typename StandardWell<TypeTag>::EvalWell

--- a/opm/simulators/wells/WellInterface.hpp
+++ b/opm/simulators/wells/WellInterface.hpp
@@ -281,6 +281,9 @@ public:
                                           const bool use_well_weights,
                                           const WellStateType& well_state) const = 0;
 
+    virtual void addWellOverlapConnectionsToPressureEquations(PressureMatrix& mat,
+                                                              const int cell_number) const = 0;
+
     void addCellRates(std::map<int, RateVector>& cellRates_) const;
 
     Scalar volumetricSurfaceRateForConnection(int cellIdx, int phaseIdx) const;

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -719,6 +719,70 @@ void WellInterfaceGeneric<Scalar, IndexTraits>::addPerforations(const std::vecto
 }
 
 template<typename Scalar, typename IndexTraits>
+void WellInterfaceGeneric<Scalar, IndexTraits>::
+initOverlapConnections (const std::function<std::vector<int>(const WellInterfaceGeneric&)>& getOverlapConnections,
+                        const std::function<std::vector<int>(const WellInterfaceGeneric&)>& getInteriorConnections,
+                        const std::vector<int>& globalCells)
+{
+    const auto& comm = this->parallelWellInfo().communication();
+    if (overlapConnectionsWereSet || comm.size() == 1)
+        return;
+
+    // initialize ownedOverlapConnections: 2D vector[rank][Ids] that records to whom to send entries
+    // and missingOverlapConnections: 2D vector[rank][Ids] that records from whom to receive entries
+
+    std::vector<std::vector<int>> overlapConnections(comm.size()); // IDs of overlap for each rank
+    std::vector<std::vector<int>> connOwners(comm.size()); // ranks owning the connections from overlapConnections
+
+    auto translateToGlobal = [&globalCells](const std::vector<int>& localIDs) {
+        std::vector<int> globalIDs;
+        globalIDs.reserve(localIDs.size());
+        std::for_each(localIDs.begin(), localIDs.end(), [&](int lID) { globalIDs.push_back(globalCells[lID]); });
+        return globalIDs;
+    };
+
+    // build overlapConnections: get local IDs of overlap, translate them to global IDs, and communicate
+    std::vector<int> localOverlapConnections = getOverlapConnections(*this);
+    overlapConnections[comm.rank()] = translateToGlobal(localOverlapConnections);
+    std::vector<int> nrConnections(comm.size(), 0);
+    nrConnections[comm.rank()] = overlapConnections[comm.rank()].size();
+    comm.sum(nrConnections.data(), nrConnections.size());
+    assert(nrConnections[comm.rank()] == overlapConnections[comm.rank()].size());
+    for (int i = 0; i < comm.size(); ++i) {
+        overlapConnections[i].resize(nrConnections[i], 0);
+        connOwners[i].resize(nrConnections[i], -1);
+        comm.sum(overlapConnections[i].data(), overlapConnections[i].size());
+    }
+
+    // build connOwners, and record owned cells that lie in other ranks' overlap
+    ownedOverlapConnections.resize(comm.size());
+    std::vector<int> localInteriorConnections = getInteriorConnections(*this); // local IDs of owned cells
+    std::unordered_map<int, int> interiorGlobalToLocal;
+    interiorGlobalToLocal.reserve(localInteriorConnections.size());
+    std::for_each(localInteriorConnections.begin(), localInteriorConnections.end(), [&](int lID) { interiorGlobalToLocal.emplace(globalCells[lID], lID); });
+    for (int i = 0; i < comm.size(); ++i) {
+        for (std::size_t j = 0; j < overlapConnections[i].size(); ++j) {
+            const auto pIC = interiorGlobalToLocal.find(overlapConnections[i][j]);
+            if (pIC != interiorGlobalToLocal.end()) {
+                // connection *pIC will be sent rank i, we store local ID
+                ownedOverlapConnections[i].push_back(pIC->second);
+                assert(connOwners[i][j] == -1);
+                connOwners[i][j] = comm.rank();
+            }
+        }
+    }
+    for (auto& rankOverlap : connOwners)
+        comm.max(rankOverlap.data(), rankOverlap.size());
+
+    // record from which rank to receive the overlap data
+    missingOverlapConnections.resize(comm.size());
+    for (std::size_t i = 0; i < localOverlapConnections.size(); ++i) {
+        missingOverlapConnections[connOwners[comm.rank()][i]].push_back(localOverlapConnections[i]);
+    }
+    overlapConnectionsWereSet = true;
+}
+
+template<typename Scalar, typename IndexTraits>
 Scalar
 WellInterfaceGeneric<Scalar, IndexTraits>::wmicrobes_() const
 {

--- a/opm/simulators/wells/WellInterfaceGeneric.cpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.cpp
@@ -747,7 +747,7 @@ initOverlapConnections (const std::function<std::vector<int>(const WellInterface
     std::vector<int> nrConnections(comm.size(), 0);
     nrConnections[comm.rank()] = overlapConnections[comm.rank()].size();
     comm.sum(nrConnections.data(), nrConnections.size());
-    assert(nrConnections[comm.rank()] == overlapConnections[comm.rank()].size());
+    assert(nrConnections[comm.rank()] == (int)overlapConnections[comm.rank()].size());
     for (int i = 0; i < comm.size(); ++i) {
         overlapConnections[i].resize(nrConnections[i], 0);
         connOwners[i].resize(nrConnections[i], -1);

--- a/opm/simulators/wells/WellInterfaceGeneric.hpp
+++ b/opm/simulators/wells/WellInterfaceGeneric.hpp
@@ -32,6 +32,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <functional>
 
 namespace Opm
 {
@@ -83,6 +84,11 @@ public:
 
     /// Well cells.
     const std::vector<int>& cells() const { return well_cells_; }
+
+    /// Local IDs of other ranks' overlap cells that are interior on this rank
+    const std::vector<std::vector<int>>& getOwnedOverlap() const {return ownedOverlapConnections;}
+    /// Local IDs of other ranks' interior cells that are overlap on this rank
+    const std::vector<std::vector<int>>& getMissingOverlap() const {return missingOverlapConnections;}
 
     /// Index of well in the wells struct and wellState
     int indexOfWell() const;
@@ -211,6 +217,14 @@ public:
 
     void addPerforations(const std::vector<RuntimePerforation>& perfs);
 
+    /// \brief initialize ownedOverlapConnections, missingOverlapConnections
+    /// \param[in] getOverlapConnections a function returning local IDs of the well's connections on the overlap
+    /// \param[in] getInteriorConnections a function returning local IDs of the well's connections inside the subdomain
+    /// \param[in] globalCells a vector of global IDs; indexed by local ID
+    void initOverlapConnections (const std::function<std::vector<int>(const WellInterfaceGeneric&)>& getOverlapConnections,
+                                 const std::function<std::vector<int>(const WellInterfaceGeneric&)>& getInteriorConnections,
+                                 const std::vector<int>& globalCells);
+
 protected:
     bool getAllowCrossFlow() const;
 
@@ -337,6 +351,11 @@ protected:
 
     // cell index for each well perforation
     std::vector<int> well_cells_;
+
+    // structures for communicating the distributed well's connections on the overlap
+    // vec[rank][ID] holds the target rank for pair-wise communication and local IDs of cells
+    std::vector<std::vector<int>> ownedOverlapConnections, missingOverlapConnections;
+    bool overlapConnectionsWereSet = false;
 
     // well index for each perforation
     std::vector<Scalar> well_index_;

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -370,6 +370,16 @@ public:
         return 0;
     }
 
+    int compressedIndexForInteriorOrOverlap(int) const override
+    {
+        return 0;
+    }
+
+    int compressedIndexForOverlap(int) const override
+    {
+        return 0;
+    }
+
 private:
     BlackoilWellModelNetworkGeneric<double, IndexTraits> network_;
     ParallelWellInfo<double> dummy;


### PR DESCRIPTION
The pressure system of the cprw solver does treats a distributed well as a collection of smaller wells - each rank has a smaller well. Just using a correct IDs for the well equations allowed us to get the equations to the correct row of the matrix on the coarsest level but the performance got worse. We hope that adding the overlap connections will improve the performance.

To treat a distributed well as one entity in the pressure system, we:

1. Match IDs of well equations in the coarse system
2. Extend the pattern of the matrix to accommodate the overlap
3. Communicate the overlap entries from other ranks (this the the most difficult part)
4. Change the diagonal term - consider weights of all cells, not just the local perforations