### PR TITLE
Skip refined cells when computing trans and nncs for output

### DIFF
--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -344,6 +344,9 @@ computeTrans_(const std::unordered_map<int,int>& cartesianToActive,
             if (!is.neighbor())
                 continue; // intersection is on the domain boundary
 
+            if ( (is.inside().level()>0) || (is.outside().level()>0))
+                continue; // for CpGrid with LGRs, we only care about level zero cells, for now.
+
             // Not 'const' because remapped if 'map' is non-null.
             unsigned c1 = globalElemMapper.index(is.inside());
             unsigned c2 = globalElemMapper.index(is.outside());
@@ -489,6 +492,9 @@ exportNncStructure_(const std::unordered_map<int,int>& cartesianToActive,
         for (const auto& is : intersections(globalGridView, elem)) {
             if (!is.neighbor())
                 continue; // intersection is on the domain boundary
+
+            if ( (is.inside().level()>0) || (is.outside().level()>0))
+                continue; // for CpGrid with LGRs, we only care about level zero cells, for now.
 
             // Not 'const' because remapped if 'map' is non-null.
             unsigned c1 = globalElemMapper.index(is.inside());


### PR DESCRIPTION
This PR updates the INIT output generation for CpGrid with LGRs by skipping intersections between cells that do not belong to the level-zero grid when computing transmissibilities and non-neighboring connections (NNCs).

This prevents creation of superfluous level-zero NNCs and represents the first step toward full INIT output support for corner-point grids with LGRs.
 