### PR TITLE
Refactor auto choke group controlled wells exclusion logic in GroupStateHelper

### DIFF
--- a/opm/simulators/wells/GroupStateHelper.cpp
+++ b/opm/simulators/wells/GroupStateHelper.cpp
@@ -1623,9 +1623,7 @@ GroupStateHelper<Scalar, IndexTraits>::getSatelliteRate_(const Group& group,
 
 template <typename Scalar, typename IndexTraits>
 bool
-GroupStateHelper<Scalar, IndexTraits>::isAutoChokeGroupUnderperforming_(
-    const Group& group,
-    DeferredLogger& deferred_logger) const
+GroupStateHelper<Scalar, IndexTraits>::isAutoChokeGroupUnderperforming_(const Group& group) const
 {
     // Only applies to production auto choke groups
     if (!group.as_choke()) {
@@ -1654,7 +1652,7 @@ GroupStateHelper<Scalar, IndexTraits>::isAutoChokeGroupUnderperforming_(
     GroupStateHelpers::TargetCalculator<Scalar, IndexTraits> tcalc{*this,
                                                                    resv_coeff,
                                                                    control_group};
-    const auto& control_group_target = tcalc.groupTarget(deferred_logger);
+    const auto& control_group_target = tcalc.groupTarget();
     const auto& control_group_guide_rate
         = this->getGuideRate(control_group_name, tcalc.guideTargetMode());
 
@@ -1813,7 +1811,7 @@ GroupStateHelper<Scalar, IndexTraits>::updateGroupControlledWellsRecursive_(
     // If the group is underperforming its target, wells are not counted as group-controlled,
     // effectively excluding this group from guide rate distribution at the parent level.
     const bool exclude_for_auto_choke = is_production_group
-        && this->isAutoChokeGroupUnderperforming_(group, deferred_logger);
+        && this->isAutoChokeGroupUnderperforming_(group);
 
     for (const std::string& child_well : group.wells()) {
         bool included = false;

--- a/opm/simulators/wells/GroupStateHelper.hpp
+++ b/opm/simulators/wells/GroupStateHelper.hpp
@@ -491,8 +491,7 @@ private:
     /// Check if a production auto choke group is underperforming its target rate.
     /// Returns true if the group's current rate is below its allocated target,
     /// which means wells should be excluded from the GCW count.
-    bool isAutoChokeGroupUnderperforming_(const Group& group,
-        DeferredLogger& deferred_logger) const;
+    bool isAutoChokeGroupUnderperforming_(const Group& group) const;
 
 /// check if well/group bottom is a sub well/group of the group top
     bool isInGroupChainTopBot_(const std::string& bottom, const std::string& top) const;


### PR DESCRIPTION
Move the auto choke exclusion logic out of the well loop in `updateGroupControlledWellsRecursive_()` and into a new helper method `isAutoChokeGroupUnderperforming_()`. The calculation determines whether to exclude all wells in an auto choke group from the Group Controlled Wells (GCW) count based on whether the group is meeting its target rate.

The original code recalculated this group-level decision redundantly for each well in the loop, even though the result is the same for all wells. The refactored code computes it once before the loop.

This is a pure refactoring with no functional change.