### PR TITLE
Chase Summary::Eval() API Change

### DIFF
--- a/opm/simulators/flow/EclGenericWriter.hpp
+++ b/opm/simulators/flow/EclGenericWriter.hpp
@@ -36,6 +36,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -144,7 +145,7 @@ protected:
                      const std::map<std::string, double>&                 miscSummaryData,
                      const std::map<std::string, std::vector<double>>&    regionData,
                      const Inplace&                                       inplace,
-                     const std::optional<Inplace>&                        initialInPlace,
+                     const Inplace*                                       initialInPlace,
                      const InterRegFlowMap&                               interRegFlows,
                      SummaryState&                                        summaryState,
                      UDQState&                                            udqState);

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -377,13 +377,16 @@ public:
             fip.output(FIPConfig::OutputField::RESV))
         {
             OPM_TIMEBLOCK(outputFipLogAndFipresvLog);
-            boost::posix_time::ptime start_time =
-                boost::posix_time::from_time_t(simulator_.vanguard().schedule().getStartTime());
+
+            const auto start_time = boost::posix_time::
+                from_time_t(simulator_.vanguard().schedule().getStartTime());
 
             if (this->collectOnIORank_.isIORank()) {
-                inplace_ = outputModule_->initialInplace().value();
-                outputModule_->outputFipAndResvLog(inplace_, 0, 0.0, start_time,
-                                                  false, simulator_.gridView().comm());
+                this->inplace_ = *this->outputModule_->initialInplace();
+
+                this->outputModule_->
+                    outputFipAndResvLog(this->inplace_, 0, 0.0, start_time,
+                                        false, simulator_.gridView().comm());
             }
         }
 
@@ -705,8 +708,8 @@ public:
         this->outputModule_->calc_initial_inplace(this->simulator_.gridView().comm());
 
         if (this->collectOnIORank_.isIORank()) {
-            if (this->outputModule_->initialInplace().has_value()) {
-                this->inplace_ = this->outputModule_->initialInplace().value();
+            if (const auto* iip = this->outputModule_->initialInplace(); iip != nullptr) {
+                this->inplace_ = *iip;
             }
         }
     }

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -247,9 +247,11 @@ public:
         return extraBlockData_;
     }
 
-    const std::optional<Inplace>& initialInplace() const
+    const Inplace* initialInplace() const
     {
-        return this->initialInplace_;
+        return this->initialInplace_.has_value()
+            ? &*this->initialInplace_
+            : nullptr;
     }
 
     bool localDataValid() const{

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -351,7 +351,7 @@ public:
 
             this->logOutput_.timeStamp("BALANCE", elapsed, reportStepNum, currentDate);
 
-            const auto& initial_inplace = this->initialInplace().value();
+            const auto& initial_inplace = *this->initialInplace();
             this->logOutput_.fip(inplace, initial_inplace, "");
 
             if (fipc.output(FIPConfig::OutputField::FIPNUM)) {
@@ -393,7 +393,7 @@ public:
 
             this->logOutput_.csv_header(csv_stream);
 
-            const auto& initial_inplace = this->initialInplace().value();
+            const auto& initial_inplace = *this->initialInplace();
 
             this->logOutput_.fip_csv(csv_stream, initial_inplace, "FIPNUM");
 


### PR DESCRIPTION
In particular, switch to passing a collection of pointers through the `Summary::DynamicSimulatorState` object (OPM/opm-common#4882) instead of passing references to individual state objects.  This is in preparation of adding more state objects, in particular for summary quantities at the region level without having to pay a large API cost for each of those.

To this end also switch the output module's `initialInPlace()` function to returning a pointer&ndash;with `nullptr` being "no such value"&ndash;instead of a reference to an `optional<>`.