### PR TITLE
use ilu in serialize restart test

### DIFF
--- a/parallelRestartTests.cmake
+++ b/parallelRestartTests.cmake
@@ -73,6 +73,6 @@ if(HDF5_FOUND)
                                                  ABS_TOL 2e-2
                                                  REL_TOL 1e-5
                                                  RESTART_STEP 94
-                                                 TEST_ARGS --tolerance-mb=1e-7
+                                                 TEST_ARGS --tolerance-mb=1e-7 --linear-solver=ilu0
                                                  MPI_PROCS 4)
 endif()


### PR DESCRIPTION
the reuse of operators in cprw lead to differences since we end up with different preconditioners in the two runs

while it currently passes on jenkins, the differences were enough to make the test fail in the docker builder, complicating matters. this is a better approach than changing tolerance I think.