### PR TITLE
Fix dangling reference in InjectionTargetCalculator

### DIFF
--- a/opm/simulators/wells/TargetCalculator.hpp
+++ b/opm/simulators/wells/TargetCalculator.hpp
@@ -98,7 +98,7 @@ private:
     const GroupStateHelperType& groupStateHelper_;
     const std::vector<Scalar>& resv_coeff_;
     const Group& group_;
-    const Phase& injection_phase_;
+    const Phase injection_phase_;
     Group::InjectionCMode cmode_;
     int pos_;
     GuideRateModel::Target target_;


### PR DESCRIPTION
Store `injection_phase` by value instead of by reference to prevent dangling reference when the calculator is returned from a function.

The previous code stored a const reference to the `Phase` parameter, which works when the calculator is constructed and used within the same scope (e.g., in `GroupStateHelper::checkGroupConstraintsInj()`). However, when the calculator is returned from a e.g a function the temporary `Phase` value passed to the constructor is destroyed, leaving a dangling reference that can cause undefined behavior.