### PR TITLE
Ensure correct summary output for iteration counts.

### DIFF
--- a/opm/simulators/flow/BlackoilModel.hpp
+++ b/opm/simulators/flow/BlackoilModel.hpp
@@ -155,11 +155,6 @@ public:
                                                    const SimulatorTimerInterface& timer,
                                                    NonlinearSolverType& nonlinear_solver);
 
-    /// Called once after each time step.
-    /// In this class, this function does nothing.
-    /// \param[in] timer                  simulation timer
-    SimulatorReportSingle afterStep(const SimulatorTimerInterface&);
-
     /// Assemble the residual and Jacobian of the nonlinear system.
     SimulatorReportSingle assembleReservoir(const SimulatorTimerInterface& /* timer */,
                                             const int iterationIdx);

--- a/opm/simulators/flow/BlackoilModel_impl.hpp
+++ b/opm/simulators/flow/BlackoilModel_impl.hpp
@@ -341,19 +341,6 @@ nonlinearIterationNewton(const int iteration,
 template <class TypeTag>
 SimulatorReportSingle
 BlackoilModel<TypeTag>::
-afterStep(const SimulatorTimerInterface&)
-{
-    SimulatorReportSingle report;
-    Dune::Timer perfTimer;
-    perfTimer.start();
-    simulator_.problem().endTimeStep();
-    report.pre_post_time += perfTimer.stop();
-    return report;
-}
-
-template <class TypeTag>
-SimulatorReportSingle
-BlackoilModel<TypeTag>::
 assembleReservoir(const SimulatorTimerInterface& /* timer */,
                   const int iterationIdx)
 {

--- a/opm/simulators/flow/NonlinearSolver.hpp
+++ b/opm/simulators/flow/NonlinearSolver.hpp
@@ -185,8 +185,6 @@ struct NonlinearSolverParameters
                 OPM_THROW_NOLOG(TimeSteppingBreakdown, msg);
             }
 
-            // Do model-specific post-step actions.
-            report += model_->afterStep(timer);
             report.converged = true;
             return report;
         }

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -501,12 +501,14 @@ public:
                 events.hasEvent(ScheduleEvents::WELL_STATUS_CHANGE);
             auto stepReport = adaptiveTimeStepping_->step(timer, *solver_, event, tuningUpdater);
             report_ += stepReport;
-            //Pass simulation report to eclwriter for summary output
-            simulator_.problem().setSimulationReport(report_);
         } else {
             // solve for complete report step
             auto stepReport = solver_->step(timer, nullptr);
             report_ += stepReport;
+            // Pass simulation report to eclwriter for summary output
+            simulator_.problem().setSubStepReport(stepReport);
+            simulator_.problem().setSimulationReport(report_);
+            simulator_.problem().endTimeStep();
             if (terminalOutput_) {
                 std::ostringstream ss;
                 stepReport.reportStep(ss);


### PR DESCRIPTION
Summary NEWTON array (and similar) is off by one, and wrong after a timestep cut.