### PR TITLE
Bugfix: enable diagonal solve in amgcpr:pre

### DIFF
--- a/opm/simulators/linalg/amgcpr.hh
+++ b/opm/simulators/linalg/amgcpr.hh
@@ -637,11 +637,17 @@ namespace Dune
         Block diagonal;
         for(ColIter col=row->begin(); col!=row->end(); ++col) {
           if(row.index()==col.index()) {
-            diagonal = *col;
-            hasDiagonal = false;
+            if (*col != zero) {
+              diagonal = *col;
+              hasDiagonal = true;
+            } else {
+                break;
+            }
           }else{
-            if(*col!=zero)
+            if (*col != zero) {
               isDirichlet = false;
+              break;
+            }
           }
         }
         if(isDirichlet && hasDiagonal)


### PR DESCRIPTION
The bugfix targets a for-cycle that checks if the column has nonzero diagonal and zero off-diagonal entries. If the diagonal is not zero, variable `hasDiagonal` was mistakenly kept to `false` which made the whole for-cycle useless because the `diagonal.solve` would never be reached. Besides correcting the bug, I made it possible to exit the loop early.