### PR TITLE
Remove deferred_logger from updateAndCommunicate()

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -277,8 +277,7 @@ template<class Scalar> class WellContributions;
             updateWellControls(DeferredLogger& deferred_logger);
 
             void updateAndCommunicate(const int reportStepIdx,
-                                      const int iterationIdx,
-                                      DeferredLogger& deferred_logger);
+                                      const int iterationIdx);
 
             bool updateGroupControls(const Group& group,
                                     DeferredLogger& deferred_logger,

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1217,8 +1217,7 @@ void BlackoilWellModelGeneric<Scalar, IndexTraits>::
 updateAndCommunicateGroupData(const int reportStepIdx,
                               const int iterationIdx,
                               const Scalar tol_nupcol,
-                              const bool update_wellgrouptarget,
-                              DeferredLogger& deferred_logger)
+                              const bool update_wellgrouptarget)
 {
     OPM_TIMEFUNCTION();
     const Group& fieldGroup = schedule().getGroup("FIELD", reportStepIdx);
@@ -1293,7 +1292,7 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                                 const std::string msg = fmt::format("Group prodution relative change {} larger than tolerance {} "
                                                         "at iteration {}. Update {} for Group {} even if iteration is larger than {} given by NUPCOL." ,
                                                         rel_change, tol_nupcol, iterationIdx, control_str, gr_name, nupcol);
-                                deferred_logger.debug(msg);
+                                group_state_helper.deferredLogger().debug(msg);
                             }
                         }
                     }

--- a/opm/simulators/wells/BlackoilWellModelGeneric.hpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.hpp
@@ -308,8 +308,7 @@ public:
                                        const Scalar tol_nupcol,
                                        // we only want to update the wellgroup target
                                        // after the groups have found their controls
-                                       const bool update_wellgrouptarget,
-                                       DeferredLogger& deferred_logger);
+                                       const bool update_wellgrouptarget);
 
     const EclipseState& eclState() const
     { return eclState_; }

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -149,8 +149,7 @@ update(const bool mandatory_network_balance,
             well_model_.updateAndCommunicateGroupData(episodeIdx,
                                                       iterationIdx,
                                                       well_model_.param().nupcol_group_rate_tolerance_,
-                                                      /*update_wellgrouptarget*/ true,
-                                                      deferred_logger);
+                                                      /*update_wellgrouptarget*/ true);
         }
         more_network_update = more_network_sub_update || well_group_thp_updated;
     }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -389,8 +389,7 @@ namespace Opm {
             // to make sure we get the correct mapping.
             this->updateAndCommunicateGroupData(reportStepIdx,
                                     simulator_.model().newtonMethod().numIterations(),
-                                    param_.nupcol_group_rate_tolerance_, /*update_wellgrouptarget*/ false,
-                                    local_deferredLogger);
+                                    param_.nupcol_group_rate_tolerance_, /*update_wellgrouptarget*/ false);
 
             // Wells are active if they are active wells on at least one process.
             const Grid& grid = simulator_.vanguard().grid();
@@ -490,8 +489,7 @@ namespace Opm {
         this->updateAndCommunicateGroupData(reportStepIdx,
                                     simulator_.model().newtonMethod().numIterations(),
                                     param_.nupcol_group_rate_tolerance_,
-                                    /*update_wellgrouptarget*/ true,
-                                    local_deferredLogger);
+                                    /*update_wellgrouptarget*/ true);
         try {
             // Compute initial well solution for new wells and injectors that change injection type i.e. WAG.
             for (auto& well : well_container_) {
@@ -1280,7 +1278,7 @@ namespace Opm {
         const int iterationIdx = simulator_.model().newtonMethod().numIterations();
         const int reportStepIdx = simulator_.episodeIndex();
         this->updateAndCommunicateGroupData(reportStepIdx, iterationIdx,
-            param_.nupcol_group_rate_tolerance_, /*update_wellgrouptarget*/ true, local_deferredLogger);
+            param_.nupcol_group_rate_tolerance_, /*update_wellgrouptarget*/ true);
         // We need to call updateWellControls before we update the network as
         // network updates are only done on thp controlled wells.
         // Note that well controls are allowed to change during updateNetwork
@@ -1672,7 +1670,7 @@ namespace Opm {
 
             changed_well_to_group = comm.sum(static_cast<int>(changed_well_to_group));
             if (changed_well_to_group) {
-                updateAndCommunicate(episodeIdx, iterationIdx, deferred_logger);
+                updateAndCommunicate(episodeIdx, iterationIdx);
                 changed_well_group = true;
             }
 
@@ -1697,7 +1695,7 @@ namespace Opm {
 
             changed_well_individual = comm.sum(static_cast<int>(changed_well_individual));
             if (changed_well_individual) {
-                updateAndCommunicate(episodeIdx, iterationIdx, deferred_logger);
+                updateAndCommunicate(episodeIdx, iterationIdx);
                 changed_well_group = true;
             }
             iter++;
@@ -1714,14 +1712,12 @@ namespace Opm {
     void
     BlackoilWellModel<TypeTag>::
     updateAndCommunicate(const int reportStepIdx,
-                         const int iterationIdx,
-                         DeferredLogger& deferred_logger)
+                         const int iterationIdx)
     {
         this->updateAndCommunicateGroupData(reportStepIdx,
                                             iterationIdx,
                                             param_.nupcol_group_rate_tolerance_,
-                                            /*update_wellgrouptarget*/ true,
-                                            deferred_logger);
+                                            /*update_wellgrouptarget*/ true);
 
         // updateWellStateWithTarget might throw for multisegment wells hence we
         // have a parallel try catch here to thrown on all processes.
@@ -1743,8 +1739,7 @@ namespace Opm {
         this->updateAndCommunicateGroupData(reportStepIdx,
                                             iterationIdx,
                                             param_.nupcol_group_rate_tolerance_,
-                                            /*update_wellgrouptarget*/ true,
-                                            deferred_logger);
+                                            /*update_wellgrouptarget*/ true);
     }
 
     template<typename TypeTag>
@@ -1764,7 +1759,7 @@ namespace Opm {
         const bool changed_hc = this->checkGroupHigherConstraints(group, deferred_logger, reportStepIdx, max_number_of_group_switches, update_group_switching_log);
         if (changed_hc) {
             changed = true;
-            updateAndCommunicate(reportStepIdx, iterationIdx, deferred_logger);
+            updateAndCommunicate(reportStepIdx, iterationIdx);
         }
 
         bool changed_individual =
@@ -1782,7 +1777,7 @@ namespace Opm {
 
         if (changed_individual) {
             changed = true;
-            updateAndCommunicate(reportStepIdx, iterationIdx, deferred_logger);
+            updateAndCommunicate(reportStepIdx, iterationIdx);
         }
         // call recursively down the group hierarchy
         for (const std::string& groupName : group.groups()) {


### PR DESCRIPTION
Remove deferred_logger parameter from `updateAndCommunicate()` and `updateAndCommunicateGroupData()`. `GroupStateHelper` now has a deferred logger so no need to pass the logger to these methods.