### PR TITLE
More robust handling of wells that do not converge

### DIFF
--- a/opm/simulators/wells/GroupStateHelper.cpp
+++ b/opm/simulators/wells/GroupStateHelper.cpp
@@ -1049,7 +1049,10 @@ GroupStateHelper<Scalar, IndexTraits>::sumWellPhaseRates(bool res_rates,
             continue;
 
         const auto& ws = this->wellState().well(well_index.value());
-        if (ws.status == Opm::Well::Status::SHUT)
+        // In addition to exclude the shut wells we also exclude stopped wells (with rate 0)
+        // as they sometimes introduce noise into the group controls if they
+        // struggle to converge
+        if (ws.status != Opm::Well::Status::OPEN)
             continue;
 
         const Scalar factor = well_ecl.getEfficiencyFactor(network)

--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -1692,6 +1692,7 @@ namespace Opm
         // if we fail to solve eqs, we reset status/operability before leaving
         const auto well_status_orig = this->wellStatus_;
         const auto operability_orig = this->operability_status_;
+        const auto well_state_orig = well_state;
         auto well_status_cur = well_status_orig;
         // don't allow opening wells that has a stopped well status
         const bool allow_open = well_state.well(this->index_of_well_).status == WellStatus::OPEN;
@@ -1814,6 +1815,7 @@ namespace Opm
         } else {
             this->wellStatus_ = well_status_orig;
             this->operability_status_ = operability_orig;
+            well_state = well_state_orig;
             const std::string message = fmt::format("   Well {} did not converge in {} inner iterations ("
                 "{} switches, {} status changes).", this->name(), it, switch_count, status_switch_count);
             deferred_logger.debug(message);

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -2477,6 +2477,7 @@ namespace Opm
         // if we fail to solve eqs, we reset status/operability before leaving
         const auto well_status_orig = this->wellStatus_;
         const auto operability_orig = this->operability_status_;
+        const auto well_state_orig = well_state;
         auto well_status_cur = well_status_orig;
         int status_switch_count = 0;
         // don't allow opening wells that has a stopped well status
@@ -2566,6 +2567,7 @@ namespace Opm
         } else {
             this->wellStatus_ = well_status_orig;
             this->operability_status_ = operability_orig;
+            well_state = well_state_orig;
             const std::string message = fmt::format("   Well {} did not converge in {} inner iterations ("
                                                     "{} switches, {} status changes).", this->name(), it, switch_count, status_switch_count);
             deferred_logger.debug(message);


### PR DESCRIPTION
This PR addresses issues exposed by the Norne prediction cases. 

MASTER 
```
NORNE_ATW2013_1A_STDW: 239.26           548
NORNE_ATW2013_1B_STDW: 425.09           1449
NORNE_ATW2013_2A_STDW: 365.94           1077
NORNE_ATW2013_2B_STDW: 475.39           2025
NORNE_ATW2013_3A_STDW: 313.66           673
NORNE_ATW2013_3B_STDW: 314.99           633
NORNE_ATW2013_3C_STDW: 325.09           683
NORNE_ATW2013_4A_STDW: 302.47           696
NORNE_ATW2013_4B_STDW: 14169.03         110135
NORNE_ATW2013_4C_STDW: 30888.29         275205
```

NUPCOL 3 (PR: https://github.com/OPM/opm-common/pull/4373)
```
NORNE_ATW2013_1A_STDW: 188.28           547
NORNE_ATW2013_1B_STDW: 440.38           2785
NORNE_ATW2013_2A_STDW: 257.35           860
NORNE_ATW2013_2B_STDW: 310.31           1410
NORNE_ATW2013_3A_STDW: 245.80           674
NORNE_ATW2013_3B_STDW: 244.23           631
NORNE_ATW2013_3C_STDW: 255.82           690
NORNE_ATW2013_4A_STDW: 225.33           662
NORNE_ATW2013_4B_STDW: 23873.63         197779
NORNE_ATW2013_4C_STDW: 45417.75         432628
```

THIS PR (+ NUPCOL 3)
```
NORNE_ATW2013_1A_STDW: 152.73           540
NORNE_ATW2013_1B_STDW: 384.43           2724
NORNE_ATW2013_2A_STDW: 204.37           784
NORNE_ATW2013_2B_STDW: 226.77           913
NORNE_ATW2013_3A_STDW: 247.05           907
NORNE_ATW2013_3B_STDW: 211.62           691
NORNE_ATW2013_3C_STDW: 205.20           669
NORNE_ATW2013_4A_STDW: 184.09           651
NORNE_ATW2013_4B_STDW: 477.78           3059
NORNE_ATW2013_4C_STDW: 314.91           1484
```

And for MSW

Master
```
NORNE_ATW2013_1A_MSW: 167.42            1406
NORNE_ATW2013_1B_MSW: 255.10            2397
NORNE_ATW2013_2A_MSW: 106.97            893
NORNE_ATW2013_2B_MSW: 95.29             781
NORNE_ATW2013_3A_MSW not finished yet
NORNE_ATW2013_3B_MSW: 89.82             711
NORNE_ATW2013_3C_MSW: 87.88             678
NORNE_ATW2013_4A_MSW: 87.81             655
NORNE_ATW2013_4B_MSW: 14161.01          148507
NORNE_ATW2013_4C_MSW: 1777.97           18740
```

NUPCOL 3 (PR: https://github.com/OPM/opm-common/pull/4373)
```
NORNE_ATW2013_1A_MSW: 159.29            1271
NORNE_ATW2013_1B_MSW: 249.09            2136
NORNE_ATW2013_2A_MSW: 106.79            839
NORNE_ATW2013_2B_MSW: 114.53            935
NORNE_ATW2013_3A_MSW not finished yet
NORNE_ATW2013_3B_MSW: 98.74             743
NORNE_ATW2013_3C_MSW: 92.04             672
NORNE_ATW2013_4A_MSW: 92.18             656
NORNE_ATW2013_4B_MSW: 14340.33          150985
NORNE_ATW2013_4C_MSW: 1520.43           14935
```

THIS PR (+ NUPCOL 3)
```
NORNE_ATW2013_1A_MSW: 157.73            1386
NORNE_ATW2013_1B_MSW: 201.57            1898
NORNE_ATW2013_2A_MSW: 101.14            913
NORNE_ATW2013_2B_MSW: 94.58             828
NORNE_ATW2013_3A_MSW: 96.48             781
NORNE_ATW2013_3B_MSW: 91.34             723
NORNE_ATW2013_3C_MSW: 92.68             714
NORNE_ATW2013_4A_MSW: 82.97             640
NORNE_ATW2013_4B_MSW: 427.76            4435
NORNE_ATW2013_4C_MSW: 393.54            3857
```