### PR TITLE
Add modification tracking to GroupState for selective communication

### DIFF
--- a/opm/simulators/wells/GroupState.cpp
+++ b/opm/simulators/wells/GroupState.cpp
@@ -97,6 +97,7 @@ void GroupState<Scalar>::update_production_rates(const std::string& gname,
         throw std::logic_error("Wrong number of phases");
 
     this->m_production_rates[gname] = rates;
+    this->mark_modified(Modification::PRODUCTION_RATES);
 }
 
 template<class Scalar>
@@ -107,6 +108,7 @@ void GroupState<Scalar>::update_network_leaf_node_production_rates(const std::st
         throw std::logic_error("Wrong number of phases");
 
     this->m_network_leaf_node_production_rates[gname] = rates;
+    this->mark_modified(Modification::NETWORK_RATES);
 }
 
 template<class Scalar>
@@ -177,6 +179,7 @@ update_production_reduction_rates(const std::string& gname,
         throw std::logic_error("Wrong number of phases");
 
     this->prod_red_rates[gname] = rates;
+    this->mark_modified(Modification::PROD_REDUCTION_RATES);
 }
 
 template<class Scalar>
@@ -209,6 +212,7 @@ update_injection_reduction_rates(const std::string& gname,
         throw std::logic_error("Wrong number of phases");
 
     this->inj_red_rates[gname] = rates;
+    this->mark_modified(Modification::INJ_REDUCTION_RATES);
 }
 
 template<class Scalar>
@@ -240,6 +244,7 @@ update_injection_surface_rates(const std::string& gname,
         throw std::logic_error("Wrong number of phases");
 
     this->inj_surface_rates[gname] = rates;
+    this->mark_modified(Modification::INJ_SURFACE_RATES);
 }
 
 template<class Scalar>
@@ -273,6 +278,7 @@ update_injection_reservoir_rates(const std::string& gname,
         throw std::logic_error("Wrong number of phases");
 
     this->inj_resv_rates[gname] = rates;
+    this->mark_modified(Modification::INJ_RESV_RATES);
 }
 
 template<class Scalar>
@@ -297,6 +303,7 @@ update_injection_rein_rates(const std::string& gname,
         throw std::logic_error("Wrong number of phases");
 
     this->inj_rein_rates[gname] = rates;
+    this->mark_modified(Modification::INJ_REIN_RATES);
 }
 
 template<class Scalar>
@@ -318,6 +325,7 @@ void GroupState<Scalar>::
 update_injection_vrep_rate(const std::string& gname, Scalar rate)
 {
     this->inj_vrep_rate[gname] = rate;
+    this->mark_modified(Modification::INJ_VREP_RATE);
 }
 
 template<class Scalar>

--- a/opm/simulators/wells/GroupState.hpp
+++ b/opm/simulators/wells/GroupState.hpp
@@ -40,6 +40,21 @@ namespace Opm {
 template<class Scalar>
 class GroupState {
 public:
+    /// Flags indicating which rate vectors have been modified since last communication.
+    /// Used by communicate_rates() to selectively communicate only modified data.
+    enum class Modification : uint32_t {
+        NONE                    = 0,
+        PRODUCTION_RATES        = 1 << 0,  // m_production_rates
+        NETWORK_RATES           = 1 << 1,  // m_network_leaf_node_production_rates
+        PROD_REDUCTION_RATES    = 1 << 2,  // prod_red_rates
+        INJ_REDUCTION_RATES     = 1 << 3,  // inj_red_rates
+        INJ_RESV_RATES          = 1 << 4,  // inj_resv_rates
+        INJ_REIN_RATES          = 1 << 5,  // inj_rein_rates
+        INJ_SURFACE_RATES       = 1 << 6,  // inj_surface_rates
+        INJ_VREP_RATE           = 1 << 7,  // inj_vrep_rate
+        ALL                     = 0xFF
+    };
+
     GroupState() = default;
     explicit GroupState(std::size_t num_phases);
 
@@ -134,11 +149,16 @@ public:
 
     GPMaint::State& gpmaint(const std::string& gname);
 
+    /// Check if a modification flag is set (for testing/debugging)
+    bool is_modified(Modification mod) const {
+        return (modifications_ & static_cast<uint32_t>(mod)) != 0;
+    }
+
     template<class Comm>
     void communicate_rates(const Comm& comm)
     {
         // Note that injection_group_vrep_rates is handled separate from
-        // the forAllGroupData() function, since it contains single doubles,
+        // the forModifiedData() function, since it contains single doubles,
         // not vectors.
 
         // Create a function that calls some function
@@ -150,24 +170,37 @@ public:
             }
         };
 
-
-        auto forAllGroupData = [&](auto& func) {
-            iterateContainer(m_production_rates, func);
-            iterateContainer(m_network_leaf_node_production_rates, func);
-            iterateContainer(prod_red_rates, func);
-            iterateContainer(inj_red_rates, func);
-            iterateContainer(inj_resv_rates, func);
-            iterateContainer(inj_rein_rates, func);
-            iterateContainer(inj_surface_rates, func);
+        // Only include modified vectors in communication
+        auto forModifiedData = [&](auto& func) {
+            if (is_modified(Modification::PRODUCTION_RATES))
+                iterateContainer(m_production_rates, func);
+            if (is_modified(Modification::NETWORK_RATES))
+                iterateContainer(m_network_leaf_node_production_rates, func);
+            if (is_modified(Modification::PROD_REDUCTION_RATES))
+                iterateContainer(prod_red_rates, func);
+            if (is_modified(Modification::INJ_REDUCTION_RATES))
+                iterateContainer(inj_red_rates, func);
+            if (is_modified(Modification::INJ_RESV_RATES))
+                iterateContainer(inj_resv_rates, func);
+            if (is_modified(Modification::INJ_REIN_RATES))
+                iterateContainer(inj_rein_rates, func);
+            if (is_modified(Modification::INJ_SURFACE_RATES))
+                iterateContainer(inj_surface_rates, func);
         };
 
-        // Compute the size of the data.
+        // Compute the size of the modified data.
         std::size_t sz = 0;
         auto computeSize = [&sz](const auto& v) {
             sz += v.size();
         };
-        forAllGroupData(computeSize);
-        sz += this->inj_vrep_rate.size();
+        forModifiedData(computeSize);
+        if (is_modified(Modification::INJ_VREP_RATE))
+            sz += this->inj_vrep_rate.size();
+
+        // Early exit if nothing to communicate
+        if (sz == 0) {
+            return;
+        }
 
         // Make a vector and collect all data into it.
         std::vector<Scalar> data(sz);
@@ -181,9 +214,12 @@ public:
                 x = -1;
             }
         };
-        forAllGroupData(doCollect);
-        for (const auto& x : this->inj_vrep_rate) {
-            data[pos++] = x.second;
+        forModifiedData(doCollect);
+        if (is_modified(Modification::INJ_VREP_RATE)) {
+            for (auto& x : this->inj_vrep_rate) {
+                data[pos++] = x.second;
+                x.second = -1;
+            }
         }
         if (pos != sz)
             throw std::logic_error("Internal size mismatch when collecting groupData");
@@ -197,12 +233,17 @@ public:
             std::copy_n(data.begin() + pos, v.size(), v.begin());
             pos += v.size();
         };
-        forAllGroupData(doDistribute);
-        for (auto& x : this->inj_vrep_rate) {
-            x.second = data[pos++];
+        forModifiedData(doDistribute);
+        if (is_modified(Modification::INJ_VREP_RATE)) {
+            for (auto& x : this->inj_vrep_rate) {
+                x.second = data[pos++];
+            }
         }
         if (pos != sz)
             throw std::logic_error("Internal size mismatch when distributing groupData");
+
+        // Clear modification flags after successful communication
+        clear_modifications();
     }
 
     template<class Serializer>
@@ -251,6 +292,19 @@ private:
     WellContainer<GPMaint::State> gpmaint_state;
     std::map<std::string, std::pair<Scalar, Scalar>> m_gconsump_rates; // Pair with {consumption_rate, import_rate} for each group
     static constexpr std::pair<Scalar, Scalar> zero_pair = {0.0, 0.0};
+
+    /// Bitmask tracking which rate vectors have been modified since last communication
+    uint32_t modifications_ = 0;
+
+    /// Mark a vector type as modified (called by update_*() methods)
+    void mark_modified(Modification mod) {
+        modifications_ |= static_cast<uint32_t>(mod);
+    }
+
+    /// Clear all modification flags (called after successful communication)
+    void clear_modifications() {
+        modifications_ = 0;
+    }
 };
 
 }


### PR DESCRIPTION
Add a bitmask-based modification tracking mechanism to `GroupState` that allows `communicate_rates()` to selectively communicate only vectors that have been modified since the last communication. This prevents double- counting when `communicate_rates()` is called multiple times and reduces redundant MPI communication.

Changes:
- Add `Modification` enum with flags for each rate vector type
- Add `mark_modified()` calls to all 8 update methods
- Update `communicate_rates()` to only include modified vectors
- Clear modification flags after successful communication
- Add early exit when no data needs communication

I plan to use this in #6733.
