### PR TITLE
fix installation path when building from a symlink with HIP

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -37,7 +37,8 @@ macro (ADD_CUDA_OR_HIP_FILE LIST DIR FILE)
     # and include the correct path which is in the build/binary dir
     string(REPLACE ".cu" ".hip" HIP_SOURCE_FILE ${FILE})
     set (hip_file_path "${PROJECT_BINARY_DIR}/${DIR}/gpuistl_hip/${HIP_SOURCE_FILE}")
-    file(RELATIVE_PATH relpath ${PROJECT_SOURCE_DIR} ${hip_file_path})
+    get_filename_component(REAL_PROJECT_SOURCE_DIR ${PROJECT_SOURCE_DIR} REALPATH)
+    file(RELATIVE_PATH relpath ${REAL_PROJECT_SOURCE_DIR} ${hip_file_path})
 
     # add a custom command that will hipify
     add_custom_command(


### PR DESCRIPTION
the installation paths for the generated files have always been broken. this is not really a fix but at least restores the previous behavior