### PR TITLE
python tests: add output-dir parameters

### DIFF
--- a/python/test/test_basic.py
+++ b/python/test/test_basic.py
@@ -21,7 +21,7 @@ class TestBasic(unittest.TestCase):
     # IMPORTANT: This test must be run first since it calls MPI_Init()
     def test_01_blackoil(self):
         with pushd(self.data_dir_bo):
-            sim = create_black_oil_simulator(args=['--linear-solver=ilu0'], filename="SPE1CASE1.DATA")
+            sim = create_black_oil_simulator(args=['--linear-solver=ilu0', '--output-dir=01_basic'], filename="SPE1CASE1.DATA")
             sim.setup_mpi(init=True, finalize=False)
             sim.step_init()
             sim.step()
@@ -47,7 +47,7 @@ class TestBasic(unittest.TestCase):
 
     def test_02_onephase(self):
         with pushd(self.data_dir_op):
-            sim = create_onephase_simulator(args=['--linear-solver=ilu0'], filename="SPE1CASE1_WATER.DATA")
+            sim = create_onephase_simulator(args=['--linear-solver=ilu0', '--output-dir=02_basic'], filename="SPE1CASE1_WATER.DATA")
             sim.setup_mpi(init=False, finalize=False)
             sim.step_init()
             sim.step()
@@ -68,7 +68,7 @@ class TestBasic(unittest.TestCase):
     # IMPORTANT: This test must be run last since it calls MPI_Finalize()
     def test_99_gaswater(self):
         with pushd(self.data_dir_gw):
-            sim = create_gas_water_simulator(args=['--linear-solver=ilu0'], filename="SPE1CASE2_GASWATER.DATA")
+            sim = create_gas_water_simulator(args=['--linear-solver=ilu0', '--output-dir=99_basic'], filename="SPE1CASE2_GASWATER.DATA")
             sim.setup_mpi(init=False, finalize=True)
             sim.step_init()
             sim.step()

--- a/python/test/test_fluidstate_variables.py
+++ b/python/test/test_fluidstate_variables.py
@@ -21,7 +21,7 @@ class TestBasic(unittest.TestCase):
     # IMPORTANT:This test must be run first since it calls MPI_Init()
     def test_01_blackoil(self):
         with pushd(self.data_dir_bo):
-            sim = create_black_oil_simulator(filename="SPE1CASE1.DATA")
+            sim = create_black_oil_simulator(args=['--output-dir=01_fluidstate'], filename="SPE1CASE1.DATA")
             sim.setup_mpi(True, False)
             sim.step_init()
             sim.step()
@@ -52,7 +52,7 @@ class TestBasic(unittest.TestCase):
 
     def test_02_onephase(self):
         with pushd(self.data_dir_op):
-            sim = create_onephase_simulator("SPE1CASE1_WATER.DATA")
+            sim = create_onephase_simulator(args=["--output-dir=02_fluidstate"], filename="SPE1CASE1_WATER.DATA")
             sim.setup_mpi(False, False)
             sim.step_init()
             sim.step()
@@ -66,7 +66,7 @@ class TestBasic(unittest.TestCase):
     # IMPORTANT: This test must be run last since it calls MPI_Finalize()
     def test_99_gaswater(self):
         with pushd(self.data_dir_gw):
-            sim = create_gas_water_simulator(filename="SPE1CASE2_GASWATER.DATA")
+            sim = create_gas_water_simulator(args=["--output-dir=99_fluidstate"], filename="SPE1CASE2_GASWATER.DATA")
             sim.setup_mpi(False, True)
             sim.step_init()
             sim.step()

--- a/python/test/test_primary_variables.py
+++ b/python/test/test_primary_variables.py
@@ -24,7 +24,7 @@ class TestBasic(unittest.TestCase):
     # IMPORTANT:This test must be run first since it calls MPI_Init()
     def test_01_blackoil(self):
         with pushd(self.data_dir_bo):
-            sim = create_black_oil_simulator(filename="SPE1CASE1.DATA")
+            sim = create_black_oil_simulator(args=["--output-dir=01_primary"], filename="SPE1CASE1.DATA")
             sim.setup_mpi(True, False)
             sim.step_init()
             sim.step()
@@ -53,7 +53,7 @@ class TestBasic(unittest.TestCase):
 
     def test_02_onephase(self):
         with pushd(self.data_dir_op):
-            sim = create_onephase_simulator("SPE1CASE1_WATER.DATA")
+            sim = create_onephase_simulator(args=["--output-dir=02_primary"], filename="SPE1CASE1_WATER.DATA")
             sim.setup_mpi(False, False)
             sim.step_init()
             sim.step()
@@ -78,7 +78,7 @@ class TestBasic(unittest.TestCase):
     # IMPORTANT: This test must be run last since it calls MPI_Finalize()
     def test_99_gaswater(self):
         with pushd(self.data_dir_gw):
-            sim = create_gas_water_simulator(filename="SPE1CASE2_GASWATER.DATA")
+            sim = create_gas_water_simulator(args=["--output-dir=99_primary"], filename="SPE1CASE2_GASWATER.DATA")
             sim.setup_mpi(False, True)
             sim.step_init()
             sim.step()


### PR DESCRIPTION
avoid races on the UNRST file when tests run in parallel.

multiple python tests can run in parallel, and these use the same input files, leading to the same output files. this again lead to spurious test failures, e.g. https://ci.opm-project.org/job/opm-common-PR-builder/9254/