### PR TITLE
remove C99 package

### DIFF
--- a/opm-simulators-prereqs.cmake
+++ b/opm-simulators-prereqs.cmake
@@ -43,8 +43,6 @@ check_for_avx2()
 
 # dependencies
 set (opm-simulators_DEPS
-  # Compile with C99 support if available
-  "C99"
   # Various runtime library enhancements
   "Boost 1.44.0
     COMPONENTS date_time unit_test_framework REQUIRED ${_Boost_CONFIG_MODE}"


### PR DESCRIPTION
Since the common build system now requests C11, this is in effect a bump to C11.

Downstream of https://github.com/OPM/opm-common/pull/4914