### PR TITLE
Improve error message for missing simulator binary in regression tests

### DIFF
--- a/tests/run-regressionTest.sh
+++ b/tests/run-regressionTest.sh
@@ -53,6 +53,7 @@ if [ ! -x "${BINPATH}/${EXE_NAME}" ]; then
     echo "To build this binary, run one of:"
     echo "  ninja ${EXE_NAME}"
     echo "  make ${EXE_NAME}"
+    echo "  cmake --build . --target ${EXE_NAME}"
     echo ""
     echo "Or build all targets with: ninja / make"
     exit 1


### PR DESCRIPTION
Add a check in `run-regressionTest.sh` that provides a clear error message with build instructions when the simulator binary is not found. This often happens if I only build `flow_blackoil` and then try to run a regression test (which needs `flow` to run).
