### PR TITLE
bump minimum cmake version to 3.23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 # Mandatory call to project
 
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.23)
 
 project(opm-simulators C CXX)
 


### PR DESCRIPTION
common buildsystem now uses file sets

Downstream of https://github.com/OPM/opm-common/pull/4922