### PR TITLE
Bugfix (micp+disperc) to uninitialized velocity

### DIFF
--- a/opm/models/blackoil/blackoildispersionmodule.hh
+++ b/opm/models/blackoil/blackoildispersionmodule.hh
@@ -523,16 +523,6 @@ public:
             if (!FluidSystem::phaseIsActive(phaseIdx)) {
                 continue;
             }
-            // no dispersion in water for blackoil models unless water can contain dissolved gas
-            if (!FluidSystem::enableDissolvedGasInWater() && FluidSystem::waterPhaseIdx == phaseIdx) {
-                continue;
-            }
-            // adding dispersion in the gas phase leads to
-            // convergence issues and unphysical results.
-            // we disable dispersion in the gas phase for now
-            if (FluidSystem::gasPhaseIdx == phaseIdx) {
-                continue;
-            }
             // use the arithmetic average for the effective
             // velocity coefficients at the face's integration point.
             normVelocityAvg[phaseIdx] =

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -839,7 +839,8 @@ add_test_compareECLFiles(CASENAME micp
                          SIMULATOR flow
                          ABS_TOL ${abs_tol}
                          REL_TOL ${rel_tol}
-                         DIR micp)
+                         DIR micp
+                         TEST_ARGS --enable-opm-rst-file=true)
 
 add_test_compareECLFiles(CASENAME 0_base_model6
                          FILENAME 0_BASE_MODEL6


### PR DESCRIPTION
Thanks @akva2 for pointing the discrepancy for release and debug while running the [MICP.DATA](https://github.com/daavid00/opm-tests/blob/master/micp/MICP.DATA), which results in this bugfix.
While on it, addressing a warning of `EQLDIMS` missing, adding the flag `--enable-opm-rst-file=true` to the regression test, and updating the schedule also in the [MICP.DATA](https://github.com/daavid00/opm-tests/blob/master/micp/MICP.DATA) to prevent the time step cuts (an alternative would be to use the `--time-step-after-event-in-days=0.001`flag, but currently changing the injected concentrations does not count as an event).