### PR TITLE
Allow SLAVES without GRUPMAST for history mode reservoir coupling

### DIFF
--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -201,18 +201,14 @@ public:
             auto rescoup = this->schedule()[report_step].rescoup();
             auto slave_count = rescoup.slaveCount();
             auto master_group_count = rescoup.masterGroupCount();
-            // - GRUPMAST and SLAVES keywords need to be specified at the same report step
-            // - They can only occur once in the schedule
-            if (slave_count > 0 && master_group_count > 0) {
+            // Master mode is enabled when SLAVES keyword is present.
+            // - Prediction mode: SLAVES + GRUPMAST (master allocates rates)
+            // - History mode: SLAVES only (master synchronizes time-stepping)
+            if (slave_count > 0) {
                 return true;
             }
-            else if (slave_count > 0 && master_group_count == 0) {
-                throw ReservoirCouplingError(
-                    "Inconsistent reservoir coupling master schedule: "
-                    "Slave count is greater than 0 but master group count is 0"
-                );
-            }
-            else if (slave_count == 0 && master_group_count > 0) {
+            else if (master_group_count > 0) {
+                // GRUPMAST without SLAVES is invalid
                 throw ReservoirCouplingError(
                     "Inconsistent reservoir coupling master schedule: "
                     "Master group count is greater than 0 but slave count is 0"

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMaster.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMaster.cpp
@@ -214,8 +214,10 @@ maybeSpawnSlaveProcesses(int report_step)
     }
     const auto& rescoup = this->schedule_[report_step].rescoup();
     auto slave_count = rescoup.slaveCount();
-    auto master_group_count = rescoup.masterGroupCount();
-    if (slave_count > 0 && master_group_count > 0) {
+    // Spawn slaves when SLAVES keyword is present.
+    // - Prediction mode: SLAVES + GRUPMAST (master allocates rates)
+    // - History mode: SLAVES only (master synchronizes time-stepping)
+    if (slave_count > 0) {
         ReservoirCouplingSpawnSlaves<Scalar> spawn_slaves{*this, rescoup};
         spawn_slaves.spawn();
     }

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -262,9 +262,9 @@ namespace {
     {
         const auto& final_state = schedule.back();
         const auto& rescoup = final_state.rescoup();
-        if (rescoup.slaveCount() > 0 && rescoup.masterGroupCount() == 0) {
-            inconsistentScheduleError("SLAVES keyword without GRUPMAST keyword");
-        }
+        // Note: SLAVES without GRUPMAST is valid for history mode reservoir coupling.
+        // In history mode, the master only synchronizes time-stepping and does not
+        // perform rate allocation, so GRUPMAST is not required.
         if (rescoup.slaveCount() == 0 && rescoup.masterGroupCount() > 0) {
             inconsistentScheduleError("GRUPMAST keyword without SLAVES keyword");
         }


### PR DESCRIPTION
Allow SLAVES keyword without GRUPMAST for history mode reservoir coupling

In history mode reservoir coupling, the master model only synchronizes time-stepping across slaves and does not perform rate allocation. Wells in slave models are controlled directly by WCONHIST/WCONINJH with imposed historical rates, so GRUPMAST (which links master groups to slave groups for rate allocation) is not required.