### PR TITLE
Reservoir coupling: Fix well model slave group data exchange for history mode

### DIFF
--- a/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.cpp
@@ -120,7 +120,14 @@ receiveInjectionDataFromSlaves()
     this->logger().info("Receiving injection data from slave processes");
     for (unsigned int i = 0; i < num_slaves; i++) {
         auto num_slave_groups = this->numSlaveGroups(i);
-        assert( num_slave_groups > 0 );
+        if (num_slave_groups == 0) {
+            // History mode: no slave groups defined, skip data exchange
+            this->logger().info(fmt::format(
+                "Slave {} has no slave groups (history mode), skipping injection data exchange",
+                this->slaveName(i)
+            ));
+            continue;
+        }
         std::vector<SlaveGroupInjectionData> injection_data(num_slave_groups);
         if (this->comm().rank() == 0) {
             if (this->slaveIsActivated(i)) {
@@ -169,7 +176,14 @@ receiveProductionDataFromSlaves()
     this->logger().info("Receiving production data from slave processes");
     for (unsigned int i = 0; i < num_slaves; i++) {
         auto num_slave_groups = this->numSlaveGroups(i);
-        assert( num_slave_groups > 0 );
+        if (num_slave_groups == 0) {
+            // History mode: no slave groups defined, skip data exchange
+            this->logger().info(fmt::format(
+                "Slave {} has no slave groups (history mode), skipping production data exchange",
+                this->slaveName(i)
+            ));
+            continue;
+        }
         std::vector<SlaveGroupProductionData> production_data(num_slave_groups);
         if (this->comm().rank() == 0) {
             if (this->slaveIsActivated(i)) {

--- a/opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.cpp
+++ b/opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.cpp
@@ -299,6 +299,10 @@ sendSlaveGroupProductionDataToMaster_() const
 {
     auto& rescoup_slave = this->reservoir_coupling_slave_;
     auto num_slave_groups = rescoup_slave.numSlaveGroups();
+    if (num_slave_groups == 0) {
+        // History mode: no slave groups defined, nothing to send
+        return;
+    }
     std::vector<SlaveGroupProductionData> production_data;
     for (std::size_t group_idx = 0; group_idx < num_slave_groups; ++group_idx) {
         // NOTE: We have to send production data even if the slave group is not a production group,
@@ -315,6 +319,10 @@ sendSlaveGroupInjectionDataToMaster_() const
 {
     auto& rescoup_slave = this->reservoir_coupling_slave_;
     auto num_slave_groups = rescoup_slave.numSlaveGroups();
+    if (num_slave_groups == 0) {
+        // History mode: no slave groups defined, nothing to send
+        return;
+    }
     std::vector<SlaveGroupInjectionData> injection_data;
     for (std::size_t group_idx = 0; group_idx < num_slave_groups; ++group_idx) {
         // NOTE: We would like to only send injection data only if the master group is an injector,


### PR DESCRIPTION
Builds on #6759, which should be merged first.

Fix well model slave group data exchange for history matching mode reservoir coupling.
    
In history matching mode reservoir coupling, no `GRUPSLAV` keyword is defined because rate allocation is not needed (wells use WCONHIST with imposed rates). This caused assertion failures when the well model attempted to exchange slave group data with `numSlaveGroups == 0`.
    
Changes:
- Skip receiving slave group production/injection data when `numSlaveGroups == 0`
 - Skip sending slave group data when `numSlaveGroups == 0`
