### PR TITLE
throw if a well under GRUP control while does not have calculated group target

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -1351,6 +1351,12 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                     efficiencyFactor,
                     resv_coeff
                 );
+                if (!group_target.has_value() && ws.production_cmode == Well::ProducerCMode::GRUP) {
+                    const std::string msg = fmt::format("Well {} is under GRUP control but no valid group target "
+                        "could be determined. Switching the well to under BHP control.", well->name());
+                    group_state_helper.deferredLogger().debug(msg);
+                    this->wellState().well(well->indexOfWell()).production_cmode = Well::ProducerCMode::BHP;
+                }
             } else {
                 const auto& well_controls = well->wellEcl().injectionControls(summaryState_);
                 auto injectorType = well_controls.injector_type;


### PR DESCRIPTION
This is a follow up PR after https://github.com/OPM/opm-simulators/pull/6596 . It is inspired by the reviewing comment https://github.com/OPM/opm-simulators/pull/6596#discussion_r2726646040 . 

In this PR, we consider if a well is OPEN and under GRUP control, while the group target is not set, it is a bug and we throw. 

At the same time, if a well under GRUP control, while the simulator could not determine the group target for it, we switch it to be under BHP control. It is in line with the current fallback when assembling the well control equation, we assemble a BHP equation when a GRUP controlled well does not have a group target. But this PR will make it clear through the control mode. 
