### PR TITLE
fixed: updating of restart reference files

### DIFF
--- a/tests/update_test_reference.sh
+++ b/tests/update_test_reference.sh
@@ -233,7 +233,7 @@ updateFullSimulationResults () {
         changed_tests+=" ${test_name}"
     fi
 
-    if [ -d "${configuration}/build-opm-simulators/tests/results/${binary}+${test_name}/restart" ]
+    if [ -d "${BUILD_DIR}/tests/results/${binary}+${test_name}/restart" ]
     then
         updateRestartResults "${binary}" "${dir_name}" "${file_name}" "${test_name}"
     fi


### PR DESCRIPTION
As noted by @GitPaean in #6596, the date update missed the restart reference files. Somehow this path was not updated when restructuring the scripts from relative to absolute paths.