### PR TITLE
Add padding to consistency checks to accommodate rounding errors

### DIFF
--- a/opm/simulators/utils/satfunc/GasPhaseConsistencyChecks.cpp
+++ b/opm/simulators/utils/satfunc/GasPhaseConsistencyChecks.cpp
@@ -40,8 +40,8 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    const auto low = this->sgl_ < Scalar{0};
-    const auto high = ! (this->sgl_ < Scalar{1});
+    const auto low = this->sgl_ < Scalar{0} - this->epsilon_;
+    const auto high = ! (this->sgl_ < Scalar{1} + this->epsilon_);
 
     if (low || high) {
         this->setViolated();
@@ -66,8 +66,8 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    const auto low = ! (this->sgu_ > Scalar{0});
-    const auto high = this->sgu_ > Scalar{1};
+    const auto low = ! (this->sgu_ > Scalar{0} - this->epsilon_);
+    const auto high = this->sgu_ > Scalar{1} + this->epsilon_;
 
     if (low || high) {
         this->setViolated();
@@ -95,8 +95,8 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    const auto low = this->sgcr_ < this->sgl_;
-    const auto high = ! (this->sgcr_ < this->sgu_);
+    const auto low = this->sgcr_ < this->sgl_ - this->epsilon_;
+    const auto high = ! (this->sgcr_ < this->sgu_ + this->epsilon_);
 
     if (low || high) {
         this->setViolated();

--- a/opm/simulators/utils/satfunc/OilPhaseConsistencyChecks.cpp
+++ b/opm/simulators/utils/satfunc/OilPhaseConsistencyChecks.cpp
@@ -40,8 +40,8 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    const auto low = this->sogcr_ < Scalar{0};
-    const auto high = ! (this->sogcr_ < Scalar{1});
+    const auto low = this->sogcr_ < Scalar{0} - this->epsilon_;
+    const auto high = !(this->sogcr_ < Scalar{1} + this->epsilon_);
 
     if (low || high) {
         this->setViolated();
@@ -67,7 +67,7 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    if (this->swl_ + this->sgu_ > Scalar{1}) {
+    if (this->swl_ + this->sgu_ > Scalar{1} + this->epsilon_) {
         this->setViolated();
     }
 }
@@ -92,7 +92,7 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    if (! (this->sogcr_ < Scalar{1} - this->swl_ - this->sgl_)) {
+    if (! (this->sogcr_ < Scalar{1} - this->swl_ - this->sgl_ + this->epsilon_)) {
         this->setViolated();
     }
 }
@@ -117,7 +117,7 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    if (! (this->sogcr_ < Scalar{1} - this->swl_ - this->sgcr_)) {
+    if (! (this->sogcr_ < Scalar{1} - this->swl_ - this->sgcr_ + this->epsilon_)) {
         this->setViolated();
     }
 }
@@ -137,8 +137,8 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    const auto low = this->sowcr_ < Scalar{0};
-    const auto high = ! (this->sowcr_ < Scalar{1});
+    const auto low = this->sowcr_ < Scalar{0} - this->epsilon_;
+    const auto high = ! (this->sowcr_ < Scalar{1} + this->epsilon_);
 
     if (low || high) {
         this->setViolated();
@@ -164,7 +164,7 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    if (this->sgl_ + this->swu_ > Scalar{1}) {
+    if (this->sgl_ + this->swu_ > Scalar{1} + this->epsilon_) {
         this->setViolated();
     }
 }
@@ -189,7 +189,7 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    if (! (this->sowcr_ < Scalar{1} - this->swl_ - this->sgl_)) {
+    if (! (this->sowcr_ < Scalar{1} - this->swl_ - this->sgl_ + this->epsilon_)) {
         this->setViolated();
     }
 }
@@ -214,7 +214,7 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    if (! (this->sowcr_ < Scalar{1} - this->swcr_ - this->sgl_)) {
+    if (! (this->sowcr_ < Scalar{1} - this->swcr_ - this->sgl_ + this->epsilon_)) {
         this->setViolated();
     }
 }

--- a/opm/simulators/utils/satfunc/PhaseCheckBase.hpp
+++ b/opm/simulators/utils/satfunc/PhaseCheckBase.hpp
@@ -64,6 +64,9 @@ namespace Opm::Satfunc::PhaseChecks {
         /// Intended to be called by derived types only.
         void setCritical();
 
+        /// Put epsilon margins in checks to accept rounding errors
+        static constexpr Scalar epsilon_{1e-5};
+
     private:
         /// Collection of violation flags.
         ///

--- a/opm/simulators/utils/satfunc/ThreePointHorizontalConsistencyChecks.cpp
+++ b/opm/simulators/utils/satfunc/ThreePointHorizontalConsistencyChecks.cpp
@@ -51,8 +51,8 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
 
     const auto sr = Scalar{1} - (this->sogcr_ + this->swl_);
 
-    const auto low = ! (this->sgcr_ < sr);
-    const auto high = sr > this->sgu_;
+    const auto low = ! (this->sgcr_ < sr + this->epsilon_);
+    const auto high = sr > this->sgu_ + this->epsilon_;
 
     if (low || high) {
         this->setViolated();
@@ -86,8 +86,8 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
 
     const auto sr = Scalar{1} - (this->sowcr_ + this->sgl_);
 
-    const auto low = ! (this->swcr_ < sr);
-    const auto high = sr > this->swu_;
+    const auto low = ! (this->swcr_ < sr + this->epsilon_);
+    const auto high = sr > this->swu_ + this->epsilon_;
 
     if (low || high) {
         this->setViolated();

--- a/opm/simulators/utils/satfunc/WaterPhaseConsistencyChecks.cpp
+++ b/opm/simulators/utils/satfunc/WaterPhaseConsistencyChecks.cpp
@@ -42,8 +42,8 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    const auto low = this->swl_ < Scalar{0};
-    const auto high = ! (this->swl_ < Scalar{1});
+    const auto low = this->swl_ < Scalar{0} - this->epsilon_;
+    const auto high = ! (this->swl_ < Scalar{1} + this->epsilon_);
 
     if (low || high) {
         this->setViolated();
@@ -68,8 +68,8 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    const auto low = ! (this->swu_ > Scalar{0});
-    const auto high = this->swu_ > Scalar{1};
+    const auto low = ! (this->swu_ > Scalar{0} - this->epsilon_);
+    const auto high = this->swu_ > Scalar{1} + this->epsilon_;
 
     if (low || high) {
         this->setViolated();
@@ -99,8 +99,8 @@ testImpl(const EclEpsScalingPointsInfo<Scalar>& endPoints)
         return;
     }
 
-    const auto low = this->swcr_ < this->swl_;
-    const auto high = ! (this->swcr_ < this->swu_);
+    const auto low = this->swcr_ < this->swl_ - this->epsilon_;
+    const auto high = ! (this->swcr_ < this->swu_ + this->epsilon_);
 
     if (low || high) {
         this->setViolated();


### PR DESCRIPTION
The consistency checks are strict and a rounding error can make them fail. This causes problems in some models. This PR softens the checks by a constant to accommodate the rounding errors.

There are two points to be discussed:
1. How big should the tolerance be? 
2. Would setting it through a command line argument (or json file) be desirable? (If yes, manual:irrelevant tag must be changed.)