### PR TITLE
Fix MPI intercommunicator disconnect at reservoir coupling simulation end

### DIFF
--- a/opm/simulators/flow/rescoup/ReservoirCouplingMaster.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMaster.hpp
@@ -150,6 +150,25 @@ public:
     void updateMasterGroupNameOrderMap(
         const std::string& slave_name, const std::map<std::string, std::size_t>& master_group_map);
 
+    /// @brief Send "don't terminate" signal (value=0) to all active slaves.
+    ///
+    /// This method is called at the start of each iteration in the master's substep loop,
+    /// before receiving the next report date from slaves. The slave waits for this signal
+    /// at the start of each iteration - if it receives 0, it continues; if it receives 1
+    /// (from sendTerminateAndDisconnect()), it terminates.
+    void sendDontTerminateSignalToSlaves();
+
+    /// @brief Send terminate signal to all active slaves and disconnect intercommunicators.
+    ///
+    /// This method must be called at the end of the simulation to cleanly shut down
+    /// the MPI intercommunicators created by MPI_Comm_spawn(). It performs two steps:
+    /// 1. Sends a terminate signal to all active slaves (only from rank 0)
+    /// 2. Disconnects the intercommunicators (collective operation)
+    ///
+    /// Both master and slaves must call their respective disconnect methods for
+    /// MPI_Comm_disconnect() to complete - it is a collective operation.
+    void sendTerminateAndDisconnect();
+
 private:
     double getMasterActivationDate_() const;
 

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -648,6 +648,7 @@ runStepReservoirCouplingMaster_()
     // The master needs to know which slaves have activated before it can start the substep loop
     reservoirCouplingMaster_().maybeReceiveActivationHandshakeFromSlaves(current_time);
     while (true) {
+        reservoirCouplingMaster_().sendDontTerminateSignalToSlaves(); // Tell the slaves to keep running.
         reservoirCouplingMaster_().receiveNextReportDateFromSlaves();
         bool start_of_report_step = (iteration == 0);
         if (start_of_report_step) {
@@ -706,6 +707,10 @@ runStepReservoirCouplingSlave_()
     }
     while (true) {
         bool start_of_report_step = (iteration == 0);
+        if (reservoirCouplingSlave_().maybeReceiveTerminateSignalFromMaster()) {
+            // Call MPI_Comm_disconnect() to terminate the MPI communicator, etc..
+            break;
+        }
         reservoirCouplingSlave_().sendNextReportDateToMasterProcess();
         const auto timestep = reservoirCouplingSlave_().receiveNextTimeStepFromMaster();
         if (start_of_report_step) {


### PR DESCRIPTION
Builds on #6771 which should be merged first.

Fixes MPI intercommunicator disconnection at the end of master/slave simulation process. The master process previously crashed during `MPI_Finalize()` with `ompi_dpm_dyn_finalize: error -12` because slaves terminated before master could disconnect the intercommunicators created by `MPI_Comm_spawn()`.
    
The fix implements a synchronous terminate/continue protocol:
- Master sends terminate signal (0=continue, 1=terminate) at each iteration
- Slave does blocking receive at start of each iteration
- When master finishes, it sends terminate=1 and both sides call `MPI_Comm_disconnect()` before `MPI_Finalize()`
