### PR TITLE
[LGR] TRAN* for refined level grids

### DIFF
--- a/opm/simulators/flow/EclGenericWriter.hpp
+++ b/opm/simulators/flow/EclGenericWriter.hpp
@@ -165,7 +165,7 @@ protected:
     SimulatorReportSingle sub_step_report_;
     SimulatorReport simulation_report_;
     mutable std::vector<NNCdata> outputNnc_;
-    mutable std::unique_ptr<data::Solution> outputTrans_;
+    mutable std::unique_ptr<std::vector<data::Solution>> outputTrans_;
 
 private:
     void computeTrans_(const std::unordered_map<int,int>& cartesianToActive, const std::function<unsigned int(unsigned int)>& map) const;


### PR DESCRIPTION
This PR collects information for transmisibility values between cells belonging to the same level grid. Since grid refinement is currently supported only for corner-point grids, the implementation is limited to that case.

Additional work in opm-common is required—for example, modifying or overloading EclipseIO::writeInitial(...) to accept a std::vector<data::Solution> rather than a single data::Solution as its first argument.

A few lambda expressions have been "converted" into private member functions to reduce code duplication.

PR depends on OPM/opm-grid#969