### PR TITLE
Improve reservoir coupling log readability

### DIFF
--- a/opm/simulators/flow/rescoup/ReservoirCoupling.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCoupling.cpp
@@ -114,6 +114,18 @@ void setErrhandler(MPI_Comm comm, bool is_master)
 // Logger class alphabetically
 // ---------------------------
 
+void Logger::debug(const std::string &msg) const {
+    if (haveDeferredLogger()) {
+        // DeferredLogger: All ranks log - messages will be gathered later
+        this->deferred_logger_->debug(msg);
+    } else {
+        // OpmLog fallback: Only rank 0 logs (see comment in info() below)
+        if (comm_.rank() == 0) {
+            OpmLog::debug(msg);
+        }
+    }
+}
+
 void Logger::info(const std::string &msg) const {
     if (haveDeferredLogger()) {
         // DeferredLogger: All ranks log - messages will be gathered later

--- a/opm/simulators/flow/rescoup/ReservoirCoupling.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCoupling.hpp
@@ -23,8 +23,11 @@
 #include <opm/simulators/utils/ParallelCommunication.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRate.hpp>
+#include <opm/input/eclipse/Units/Units.hpp>
 
 #include <dune/common/parallel/mpitraits.hh>
+
+#include <fmt/format.h>
 
 #include <mpi.h>
 #include <cmath>
@@ -42,6 +45,7 @@ public:
     explicit Logger(const Parallel::Communication& comm) : comm_(comm) {}
 
     void clearDeferredLogger() { deferred_logger_ = nullptr; }
+    void debug(const std::string &msg) const;
     DeferredLogger& deferredLogger() { return *deferred_logger_; }
     DeferredLogger& deferredLogger() const { return *deferred_logger_; }
     bool haveDeferredLogger() const { return deferred_logger_ != nullptr; }
@@ -238,6 +242,14 @@ void customErrorHandlerSlave_(MPI_Comm* comm, int* err, ...);
 void customErrorHandlerMaster_(MPI_Comm* comm, int* err, ...);
 void setErrhandler(MPI_Comm comm, bool is_master);
 std::pair<std::vector<char>, std::size_t> serializeStrings(const std::vector<std::string>& data);
+
+/// \brief Format seconds as a human-readable string showing both seconds and days.
+/// \param seconds The time value in seconds.
+/// \return A string like "864000s (10.00 days)".
+inline std::string formatDays(double seconds) {
+    double days = seconds / unit::day;
+    return fmt::format("{:.0f}s ({:.2f} days)", seconds, days);
+}
 
 /// \brief Utility class for comparing double values representing epoch dates or elapsed time.
 ///

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMaster.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMaster.cpp
@@ -162,7 +162,7 @@ initStartOfReportStep(int report_step_idx)
 {
     assert(this->report_step_data_);
     this->report_step_data_->setReportStepIdx(report_step_idx);
-    this->logger_.info("Initializing start of report step");
+    this->logger_.debug("Initializing start of report step");
 }
 
 template <class Scalar>
@@ -291,6 +291,20 @@ ReservoirCouplingMaster<Scalar>::
 numSlavesStarted() const
 {
     return this->slave_names_.size();
+}
+
+template <class Scalar>
+std::size_t
+ReservoirCouplingMaster<Scalar>::
+numActivatedSlaves() const
+{
+    std::size_t count = 0;
+    for (std::size_t i = 0; i < this->slave_activation_status_.size(); ++i) {
+        if (this->slave_activation_status_[i] != 0) {
+            ++count;
+        }
+    }
+    return count;
 }
 
 template <class Scalar>

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMaster.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMaster.hpp
@@ -114,6 +114,7 @@ public:
     std::size_t numSlaveGroups(unsigned int index);
     std::size_t numSlaves() const { return this->numSlavesStarted(); }
     std::size_t numSlavesStarted() const;
+    std::size_t numActivatedSlaves() const;
     void rebuildSlaveIdxToMasterGroupsVector();
     void receiveNextReportDateFromSlaves();
     void receiveProductionDataFromSlaves();

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.cpp
@@ -117,12 +117,12 @@ ReservoirCouplingMasterReportStep<Scalar>::
 receiveInjectionDataFromSlaves()
 {
     auto num_slaves = this->numSlaves();
-    this->logger().info("Receiving injection data from slave processes");
+    this->logger().debug("Receiving injection data from slave processes");
     for (unsigned int i = 0; i < num_slaves; i++) {
         auto num_slave_groups = this->numSlaveGroups(i);
         if (num_slave_groups == 0) {
             // History mode: no slave groups defined, skip data exchange
-            this->logger().info(fmt::format(
+            this->logger().debug(fmt::format(
                 "Slave {} has no slave groups (history mode), skipping injection data exchange",
                 this->slaveName(i)
             ));
@@ -142,19 +142,16 @@ receiveInjectionDataFromSlaves()
                     this->getSlaveComm(i),
                     MPI_STATUS_IGNORE
                 );
-                this->logger().info(
-                    fmt::format(
-                        "Received injection data for {} groups from slave process with name: {}. "
-                        "Number of slave groups: {}", num_slave_groups, this->slaveName(i), num_slave_groups
-                    )
-                );
+                this->logger().debug(fmt::format(
+                    "Received injection data for {} groups from {}",
+                    num_slave_groups, this->slaveName(i)
+                ));
             }
             else {
-                this->logger().info(fmt::format(
-                    "Slave {} has not activated yet, skipping receiving injection data from slave",
-                        this->slaveName(i)
-                    )
-                );
+                this->logger().debug(fmt::format(
+                    "Slave {} has not activated yet, skipping injection data",
+                    this->slaveName(i)
+                ));
                 injection_data.assign(num_slave_groups, SlaveGroupInjectionData{}); // Set to zero injection data
             }
         }
@@ -173,12 +170,12 @@ ReservoirCouplingMasterReportStep<Scalar>::
 receiveProductionDataFromSlaves()
 {
     auto num_slaves = this->numSlaves();
-    this->logger().info("Receiving production data from slave processes");
+    this->logger().debug("Receiving production data from slave processes");
     for (unsigned int i = 0; i < num_slaves; i++) {
         auto num_slave_groups = this->numSlaveGroups(i);
         if (num_slave_groups == 0) {
             // History mode: no slave groups defined, skip data exchange
-            this->logger().info(fmt::format(
+            this->logger().debug(fmt::format(
                 "Slave {} has no slave groups (history mode), skipping production data exchange",
                 this->slaveName(i)
             ));
@@ -198,19 +195,16 @@ receiveProductionDataFromSlaves()
                     this->getSlaveComm(i),
                     MPI_STATUS_IGNORE
                 );
-                this->logger().info(
-                    fmt::format(
-                        "Received production data for {} groups from slave process with name: {}. "
-                        "Number of slave groups: {}", num_slave_groups, this->slaveName(i), num_slave_groups
-                    )
-                );
+                this->logger().debug(fmt::format(
+                    "Received production data for {} groups from {}",
+                    num_slave_groups, this->slaveName(i)
+                ));
             }
             else {
-                this->logger().info(fmt::format(
-                    "Slave {} has not activated yet, skipping receiving production data from slave",
-                        this->slaveName(i)
-                    )
-                );
+                this->logger().debug(fmt::format(
+                    "Slave {} has not activated yet, skipping production data",
+                    this->slaveName(i)
+                ));
                 production_data.assign(num_slave_groups, SlaveGroupProductionData{}); // Set to zero production data
             }
         }
@@ -243,8 +237,8 @@ sendInjectionTargetsToSlave(std::size_t slave_idx,
             /*tag=*/static_cast<int>(MessageTag::InjectionGroupTargets),
             this->getSlaveComm(slave_idx)
         );
-        this->logger().info(fmt::format(
-            "Sent {} injection targets to slave process with name: {}",
+        this->logger().debug(fmt::format(
+            "Sent {} injection targets to {}",
             num_injection_targets, this->slaveName(slave_idx)
         ));
     }
@@ -274,8 +268,8 @@ sendNumGroupTargetsToSlave(std::size_t slave_idx,
             /*tag=*/static_cast<int>(MessageTag::NumSlaveGroupTargets),
             this->getSlaveComm(slave_idx)
         );
-        this->logger().info(fmt::format(
-            "Sent number of injection targets {} and production targets {} to slave process with name: {}",
+        this->logger().debug(fmt::format(
+            "Sent target counts (inj={}, prod={}) to {}",
             num_injection_targets, num_production_targets, this->slaveName(slave_idx)
         ));
     }
@@ -301,8 +295,8 @@ sendProductionTargetsToSlave(std::size_t slave_idx,
             /*tag=*/static_cast<int>(MessageTag::ProductionGroupTargets),
             this->getSlaveComm(slave_idx)
         );
-        this->logger().info(fmt::format(
-            "Sent {} production targets to slave process with name: {}",
+        this->logger().debug(fmt::format(
+            "Sent {} production targets to {}",
             num_production_targets, this->slaveName(slave_idx)
         ));
     }

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
@@ -155,12 +155,13 @@ receiveNextTimeStepFromMaster() {
             this->slave_master_comm_,
             MPI_STATUS_IGNORE
         );
-        this->logger_.info(
-            fmt::format("Slave rank 0 received next timestep {} from master.", timestep)
-        );
+        this->logger_.debug(fmt::format(
+            "Received next timestep {} from master",
+            ReservoirCoupling::formatDays(timestep)
+        ));
     }
     this->comm_.broadcast(&timestep, /*count=*/1, /*emitter_rank=*/0);
-    this->logger_.info("Broadcasted slave next time step to all ranks");
+    this->logger_.debug("Broadcasted slave next time step to all ranks");
     return timestep;
 }
 
@@ -262,7 +263,10 @@ sendNextReportDateToMasterProcess() const
             /*tag=*/static_cast<int>(MessageTag::SlaveNextReportDate),
             this->slave_master_comm_
         );
-        this->logger_.info("Sent next report date to master process from rank 0");
+        this->logger_.debug(fmt::format(
+            "Sent next report date {} to master (offset from slave start)",
+            ReservoirCoupling::formatDays(next_report_time_offset)
+        ));
    }
 }
 
@@ -367,8 +371,8 @@ receiveMasterGroupNamesFromMasterProcess_() {
             this->slave_master_comm_,
             MPI_STATUS_IGNORE
         );
-        this->logger_.info(fmt::format(
-            "Received master group names size from master process rank 0: {}", size));
+        this->logger_.debug(fmt::format(
+            "Received master group names size from master: {}", size));
         // size can be 0 for history matching mode (no GRUPMAST on master)
         if (size > 0) {
             group_names.resize(size);
@@ -381,7 +385,7 @@ receiveMasterGroupNamesFromMasterProcess_() {
                 this->slave_master_comm_,
                 MPI_STATUS_IGNORE
             );
-            this->logger_.info("Received master group names from master process rank 0");
+            this->logger_.debug("Received master group names from master");
         }
     }
     this->comm_.broadcast(&size, /*count=*/1, /*emitter_rank=*/0);
@@ -414,7 +418,7 @@ receiveSlaveNameFromMasterProcess_() {
             this->slave_master_comm_,
             MPI_STATUS_IGNORE
         );
-        this->logger_.info("Received slave name size from master process rank 0");
+        this->logger_.debug("Received slave name size from master");
         slave_name.resize(size+1); // +1 for the null terminator
         MPI_Recv(
             slave_name.data(),
@@ -426,7 +430,7 @@ receiveSlaveNameFromMasterProcess_() {
             MPI_STATUS_IGNORE
         );
         slave_name[size] = '\0';  // Add null terminator
-        this->logger_.info("Received slave name from master process rank 0");
+        this->logger_.debug("Received slave name from master");
     }
     this->comm_.broadcast(&size, /*count=*/1, /*emitter_rank=*/0);
     if (this->comm_.rank() != 0) {
@@ -479,7 +483,7 @@ sendActivationDateToMasterProcess_()
             /*tag=*/static_cast<int>(MessageTag::SlaveActivationDate),
             this->slave_master_comm_
         );
-        this->logger_.info("Sent simulation activation date to master process from rank 0");
+        this->logger_.debug("Sent activation date to master");
    }
 }
 
@@ -500,7 +504,7 @@ sendActivationHandshakeToMasterProcess_() const
             /*tag=*/static_cast<int>(MessageTag::SlaveActivationHandshake),
             this->slave_master_comm_
         );
-        this->logger_.info("Sent simulation activation handshake to master process from rank 0");
+        this->logger_.debug("Sent activation handshake to master");
     }
     this->comm_.barrier();
 }
@@ -522,7 +526,7 @@ sendSimulationStartDateToMasterProcess_() const
             /*tag=*/static_cast<int>(MessageTag::SlaveSimulationStartDate),
             this->slave_master_comm_
         );
-        this->logger_.info("Sent simulation start date to master process from rank 0");
+        this->logger_.debug("Sent start date to master");
    }
 }
 

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSpawnSlaves.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSpawnSlaves.cpp
@@ -252,12 +252,11 @@ receiveActivationDateFromSlaves_()
                                               "the master process' activation date");
             }
             this->master_.addSlaveActivationDate(slave_activation_date);
-            this->logger_.info(
-                fmt::format(
-                    "Received activation date from slave process with name: {}. "
-                    "Activation date: {}", this->master_.getSlaveName(i), slave_activation_date
-                )
-            );
+            this->logger_.debug(fmt::format(
+                "Received activation date from {}: {}",
+                this->master_.getSlaveName(i),
+                ReservoirCoupling::formatDays(slave_activation_date)
+            ));
         }
     }
     if (this->comm_.rank() != 0) {
@@ -266,7 +265,7 @@ receiveActivationDateFromSlaves_()
     }
     const double* data = this->master_.getSlaveActivationDates();
     this->comm_.broadcast(const_cast<double *>(data), /*count=*/num_slaves, /*emitter_rank=*/0);
-    this->logger_.info("Broadcasted slave activation dates to all ranks");
+    this->logger_.debug("Broadcasted slave activation dates to all ranks");
 }
 
 template <class Scalar>
@@ -289,12 +288,11 @@ receiveSimulationStartDateFromSlaves_()
                 MPI_STATUS_IGNORE
             );
             this->master_.addSlaveStartDate(slave_start_date);
-            this->logger_.info(
-                fmt::format(
-                    "Received start date from slave process with name: {}. "
-                    "Start date: {}", this->master_.getSlaveName(i), slave_start_date
-                )
-            );
+            this->logger_.debug(fmt::format(
+                "Received start date from {}: {}",
+                this->master_.getSlaveName(i),
+                ReservoirCoupling::formatDays(slave_start_date)
+            ));
         }
     }
     if (this->comm_.rank() != 0) {
@@ -303,7 +301,7 @@ receiveSimulationStartDateFromSlaves_()
     }
     const double* data = this->master_.getSlaveStartDates();
     this->comm_.broadcast(const_cast<double *>(data), /*count=*/num_slaves, /*emitter_rank=*/0);
-    this->logger_.info("Broadcasted slave start dates to all ranks");
+    this->logger_.debug("Broadcasted slave start dates to all ranks");
 }
 
 template <class Scalar>
@@ -339,8 +337,8 @@ sendMasterGroupNamesToSlaves_()
                     this->master_.getSlaveComm(slave_idx)
                 );
             }
-            this->logger_.info(fmt::format(
-                "Sent master group names to slave process rank 0 with name: {} (size: {})",
+            this->logger_.debug(fmt::format(
+                "Sent master group names to {} (size: {})",
                 slave_name, size)
             );
         }
@@ -375,9 +373,7 @@ sendSlaveNamesToSlaves_()
                 /*tag=*/static_cast<int>(MessageTag::SlaveName),
                 this->master_.getSlaveComm(i)
             );
-            this->logger_.info(fmt::format(
-                "Sent slave name to slave process rank 0 with name: {}", slave_name)
-            );
+            this->logger_.debug(fmt::format("Sent slave name to {}", slave_name));
         }
     }
 }

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -656,6 +656,12 @@ runStepReservoirCouplingMaster_()
         }
         current_step_length = reservoirCouplingMaster_().maybeChopSubStep(
                                           current_step_length, current_time);
+        auto num_active = reservoirCouplingMaster_().numActivatedSlaves();
+        OpmLog::info(fmt::format(
+            "\nChoosing next sync time between master and {} active slave {}: {:.2f} days",
+            num_active, (num_active == 1 ? "process" : "processes"),
+            current_step_length / unit::day
+        ));
         reservoirCouplingMaster_().sendNextTimeStepToSlaves(current_step_length);
         if (start_of_report_step) {
             maybeUpdateTuning_(current_time, current_step_length, /*substep=*/0);


### PR DESCRIPTION
Builds on #6775, which should be merged first.
 
Cleaned up reservoir coupling logging to improve readability.
 - Added `Logger::debug()` method for debug-level logging
 - Added `formatDays()` helper for human-readable time display
 - Change verbose MPI communication messages from `info` to `debug` level so they only appear in `.DBG` file, not `.PRT` file or `stdout`
 - Add info-level message showing sync step coordination:   "Choosing next sync time between master and N active slave process(es): X days"
