### PR TITLE
fixed: move getNumThreads into TU

### DIFF
--- a/opm/simulators/flow/Main.cpp
+++ b/opm/simulators/flow/Main.cpp
@@ -44,6 +44,10 @@
 #include <amgx_c.h>
 #endif
 
+#if HAVE_OPENMP
+#include <omp.h>
+#endif
+
 #include <iostream>
 // NOTE: There is no C++ header replacement for these C posix headers (as of C++17)
 #include <fcntl.h>  // for open()
@@ -380,5 +384,14 @@ void Main::setupDamaris(const std::string& outputDir )
     }
 }
 #endif
+
+int Main::getNumThreads()
+{
+#ifdef _OPENMP
+    return omp_get_max_threads();
+#else
+    return 1;
+#endif
+}
 
 } // namespace Opm

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -520,14 +520,7 @@ private:
                   std::string_view moduleVersion,
                   std::string_view compileTimestamp);
 
-    static int getNumThreads()
-    {
-#ifdef _OPENMP
-        return omp_get_max_threads();
-#else
-        return 1;
-#endif
-    }
+    static int getNumThreads();
 
 #if HAVE_DAMARIS
     void setupDamaris(const std::string& outputDir);


### PR DESCRIPTION
openmp is only linked for the library right now, which meant this function ended up with the wrong implementation in the separate simulator binaries. artifact of the in-flux refactoring..

and this method belongs in the TU in any case.