### PR TITLE
use target unit_test_framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,14 +453,14 @@ opm_add_test(test_tuning_trgmbe
               SOURCES
                 tests/test_tuning_TRGMBE.cpp
               LIBRARIES
-                ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+                Boost::unit_test_framework
               ONLY_COMPILE)
 
 opm_add_test(test_tuning_tsinit_nextstep
               SOURCES
                 tests/test_tuning_TSINIT_NEXTSTEP.cpp
               LIBRARIES
-                ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} opmcommon
+                Boost::unit_test_framework opmcommon
               ONLY_COMPILE)
 
 # this test is identical to the simulation of the lens problem that

--- a/opm-simulators-prereqs.cmake
+++ b/opm-simulators-prereqs.cmake
@@ -42,7 +42,7 @@ check_for_avx2()
 set (opm-simulators_DEPS
   # Various runtime library enhancements
   "Boost 1.44.0
-    COMPONENTS date_time unit_test_framework REQUIRED ${_Boost_CONFIG_MODE}"
+    COMPONENTS date_time REQUIRED ${_Boost_CONFIG_MODE}"
   # DUNE prerequisites
   "dune-common REQUIRED"
   "dune-istl REQUIRED"


### PR DESCRIPTION
main module only needs Boost::date_time

Downstream of https://github.com/OPM/opm-common/pull/4966