### PR TITLE
Only use bhp well temperature for RESV calculations for THERMAL not TEMP

### DIFF
--- a/opm/simulators/wells/MultisegmentWell_impl.hpp
+++ b/opm/simulators/wells/MultisegmentWell_impl.hpp
@@ -746,8 +746,11 @@ namespace Opm
             auto& ws = well_state.well(this->index_of_well_);
             this->segments_.copyPhaseDensities(ws.segments);
         }
-
-        Base::calculateReservoirRates(simulator.vanguard().eclState().runspec().co2Storage(), well_state.well(this->index_of_well_));
+        // For injectors in a co2 storage case or a thermal case
+        // we convert to reservoir rates using the well bhp and temperature
+        const bool isThermal = simulator.vanguard().eclState().getSimulationConfig().isThermal();
+        const bool co2store = simulator.vanguard().eclState().runspec().co2Storage();
+        Base::calculateReservoirRates( (isThermal || co2store), well_state.well(this->index_of_well_));
     }
 
 

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -768,7 +768,12 @@ namespace Opm
 
         const auto& summary_state = simulator.vanguard().summaryState();
         updateWellStateFromPrimaryVariables(well_state, summary_state, deferred_logger);
-        Base::calculateReservoirRates(simulator.vanguard().eclState().runspec().co2Storage(), well_state.well(this->index_of_well_));
+
+        // For injectors in a co2 storage case or a thermal case
+        // we convert to reservoir rates using the well bhp and temperature
+        const bool isThermal = simulator.vanguard().eclState().getSimulationConfig().isThermal();
+        const bool co2store = simulator.vanguard().eclState().runspec().co2Storage();
+        Base::calculateReservoirRates( (isThermal || co2store), well_state.well(this->index_of_well_));
     }
 
 

--- a/opm/simulators/wells/WellInterfaceFluidSystem.cpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.cpp
@@ -65,12 +65,12 @@ WellInterfaceFluidSystem(const Well& well,
 template<typename FluidSystem>
 void
 WellInterfaceFluidSystem<FluidSystem>::
-calculateReservoirRates(const bool co2store, SingleWellState<Scalar, IndexTraits>& ws) const
+calculateReservoirRates(const bool use_well_bhp_temperature, SingleWellState<Scalar, IndexTraits>& ws) const
 {
     const int np = this->number_of_phases_;
     const auto& pu = this->phaseUsage();
     // Calculate reservoir rates from average pressure and temperature
-    if ( !(co2store || pu.hasEnergy()) || this->wellEcl().isProducer()) {
+    if ( !(use_well_bhp_temperature) || this->wellEcl().isProducer()) {
         const int fipreg = 0; // not considering the region for now
         this->rateConverter_
             .calcReservoirVoidageRates(fipreg,

--- a/opm/simulators/wells/WellInterfaceFluidSystem.hpp
+++ b/opm/simulators/wells/WellInterfaceFluidSystem.hpp
@@ -83,7 +83,7 @@ protected:
                              const std::vector<PerforationData<Scalar>>& perf_data);
 
     // updating the voidage rates in well_state when requested
-    void calculateReservoirRates(const bool co2store, SingleWellState<Scalar, IndexTraits>& ws) const;
+    void calculateReservoirRates(const bool use_well_bhp_temperature, SingleWellState<Scalar, IndexTraits>& ws) const;
 
     bool checkIndividualConstraints(SingleWellState<Scalar, IndexTraits>& ws,
                                     const SummaryState& summaryState,


### PR DESCRIPTION
This is to ensure that the TEMP is completely independent of the blackoil equations. 