### PR TITLE
Fix serial build for reservoir coupling

### DIFF
--- a/opm/simulators/wells/GroupStateHelper.cpp
+++ b/opm/simulators/wells/GroupStateHelper.cpp
@@ -985,6 +985,7 @@ GroupStateHelper<Scalar, IndexTraits>::sumWellPhaseRates(bool res_rates,
         if (this->isSatelliteGroup_(group)) {
             return this->getSatelliteRate_(group, phase_pos, res_rates, is_injector);
         }
+#ifdef RESERVOIR_COUPLING_ENABLED
         if (this->isReservoirCouplingMasterGroup(group)) {
             using RateKind = ReservoirCoupling::RateKind;
             RateKind kind;
@@ -1000,6 +1001,7 @@ GroupStateHelper<Scalar, IndexTraits>::sumWellPhaseRates(bool res_rates,
             }
             return this->getReservoirCouplingMasterGroupRate_(group, phase_pos, kind);
         }
+#endif
     }
     Scalar rate = 0.0;
     for (const std::string& group_name : group.groups()) {
@@ -1618,14 +1620,14 @@ GroupStateHelper<Scalar, IndexTraits>::getLocalReductionLevel_(const std::vector
     return local_reduction_level;
 }
 
+#ifdef RESERVOIR_COUPLING_ENABLED
 template <typename Scalar, typename IndexTraits>
 Scalar
 GroupStateHelper<Scalar, IndexTraits>::
-getReservoirCouplingMasterGroupRate_([[maybe_unused]] const Group& group,
-                                     [[maybe_unused]] const int phase_pos,
-                                     [[maybe_unused]] ReservoirCoupling::RateKind kind) const
+getReservoirCouplingMasterGroupRate_(const Group& group,
+                                     const int phase_pos,
+                                     ReservoirCoupling::RateKind kind) const
 {
-#ifdef RESERVOIR_COUPLING_ENABLED
     if (this->isReservoirCouplingMaster()) {
         ReservoirCoupling::Phase rescoup_phase = this->activePhaseIdxToRescoupPhase_(phase_pos);
         return this->reservoirCouplingMaster().getMasterGroupRate(group.name(), rescoup_phase, kind);
@@ -1633,10 +1635,8 @@ getReservoirCouplingMasterGroupRate_([[maybe_unused]] const Group& group,
     else {
         return 0.0;
     }
-#else
-    return 0.0;
-#endif
 }
+#endif
 
 template <typename Scalar, typename IndexTraits>
 Scalar

--- a/opm/simulators/wells/GroupStateHelper.hpp
+++ b/opm/simulators/wells/GroupStateHelper.hpp
@@ -539,9 +539,11 @@ private:
                                         bool is_production_group,
                                         Phase injection_phase) const;
 
+#ifdef RESERVOIR_COUPLING_ENABLED
     Scalar getReservoirCouplingMasterGroupRate_(const Group& group,
                                                 const int phase_pos,
                                                 ReservoirCoupling::RateKind kind) const;
+#endif
 
     Scalar getSatelliteRate_(const Group& group,
         const int phase_pos,

--- a/opm/simulators/wells/rescoup/RescoupProxy.hpp
+++ b/opm/simulators/wells/rescoup/RescoupProxy.hpp
@@ -171,6 +171,10 @@ private:
     bool isMasterGroup(const std::string& /*group_name*/) const noexcept {
         return false;
     }
+
+    bool isSlaveGroup(const std::string& /*group_name*/) const noexcept {
+        return false;
+    }
 #endif // !RESERVOIR_COUPLING_ENABLED
 };
 


### PR DESCRIPTION
Guard `RateKind` usage with `#ifdef RESERVOIR_COUPLING_ENABLED` in `GroupStateHelper` declaration, call site, and implementation. In serial builds, `ReservoirCoupling.hpp` is not included so `RateKind` is not declared.

Add missing `isSlaveGroup()` stub to the non-MPI `RescoupProxy`.