### PR TITLE
Move addition of simulators to target hook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -830,6 +830,11 @@ macro(opm-simulators_install_hook)
     FILES_MATCHING PATTERN
       "*.1"
   )
+  if (BUILD_FLOW)
+    install(TARGETS flow DESTINATION bin)
+    include(OpmBashCompletion)
+    opm_add_bash_completion(flow)
+  endif()
 endmacro()
 
 # Ensure OPM_COMPILE_COMPONENTS is a list of at least one element
@@ -894,10 +899,3 @@ include ("${project}-prereqs")
 
 # all setup common to the OPM library modules is done here
 include (OpmLibMain)
-
-include(OpmBashCompletion)
-
-if (BUILD_FLOW)
-  install(TARGETS flow DESTINATION bin)
-  opm_add_bash_completion(flow)
-endif()


### PR DESCRIPTION
This moves addition of the simulators to the targets hook and the remaining installation code to the installation hook. The BUILD_FLOW_VARIANTS option has been broken. This fixes it, but to ensure nobody is surprised I have also flipped to default to ON.

There is some potential for further refinement of options, I have maintained current behavior for now but;
- BUILD_FLOW_VARIANTS controls whether or not they are built by *default*, targets are always added
- BUILD_FLOW controls whether or not flow is built by default, but it also disables installation
- BUILD_FLOW_FLOAT_VARIANTS controls whether or not float support is enabled, but still respects BUILD_FLOW_VARIANTS, ie, a target is added but it may be disabled by default
- BUILD_FLOW_ALU_GRID, BUILD_FLOW_POLY_GRID controls whether or not a target is actually added, not just the default

my suggestion would be that BUILD_FLOW, BUILD_FLOW_ALU_GRID, BUILD_FLOW_POLY_GRID, BUILD_FLOW_FLOAT_VARIANTS is renamed to ENABLE_XXX, with BUILD_FLOW_VARIANTS left as the only BUILD_XXX option which controls whether targets are built by default (plus adding another, equivalent ENABLE_SOMETHING option for the ewoms simulators, and setting this one to false).