### PR TITLE
mark format string as runtime

### DIFF
--- a/opm/models/discretization/common/tpfalinearizer.hh
+++ b/opm/models/discretization/common/tpfalinearizer.hh
@@ -429,10 +429,10 @@ public:
         // increment indices and generate tag
         exportCount_ = exportIndex_ == idx ? ++exportCount_ : 0;
         exportIndex_ = idx;
-        tag = fmt::format("_{:03d}_{:02d}", exportIndex_, exportCount_);
+        tag = fmt::format(fmt::runtime("_{:03d}_{:02d}"), exportIndex_, exportCount_);
 
-        fmt::print("index = {:d}\n", exportIndex_);
-        fmt::print("count = {:d}\n", exportCount_);
+        fmt::print(fmt::runtime("index = {:d}\n"), exportIndex_);
+        fmt::print(fmt::runtime("count = {:d}\n"), exportCount_);
 
         Opm::exportSystem(jacobian_->istlMatrix(), residual_, export_sparsity, tag.c_str(), path);
     }

--- a/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
+++ b/opm/simulators/aquifers/BlackoilAquiferModel_impl.hpp
@@ -297,8 +297,8 @@ createAnalyticAquiferPointer(const AquiferData& aqData,
         this->simulator_.vanguard().eclState().aquifer().connections();
 
     if (! connections.hasAquiferConnections(aquiferID)) {
-        const auto msg = fmt::format("No valid connections for {} aquifer {}.  "
-                                     "Aquifer {} will be ignored.",
+        const auto msg = fmt::format(fmt::runtime("No valid connections for {} aquifer {}.  "
+                                     "Aquifer {} will be ignored."),
                                      aqType, aquiferID, aquiferID);
         OpmLog::warning(msg);
 

--- a/opm/simulators/flow/BlackoilModelNldd.hpp
+++ b/opm/simulators/flow/BlackoilModelNldd.hpp
@@ -400,7 +400,7 @@ public:
 
         const bool is_iorank = this->rank_ == 0;
         if (is_iorank) {
-            OpmLog::debug(fmt::format("Local solves finished. Converged for {}/{} domains. {} domains were skipped. {} domains did no work. {} total local Newton iterations.\n",
+            OpmLog::debug(fmt::format(fmt::runtime("Local solves finished. Converged for {}/{} domains. {} domains were skipped. {} domains did no work. {} total local Newton iterations.\n"),
                                       num_converged, num_domains, num_skipped, num_converged_already, num_local_newtons));
         }
         auto total_local_solve_time = localSolveTimer.stop();
@@ -630,7 +630,7 @@ private:
                                            Scalar{0.2}, 1, oscillate, stagnate);
                 if (oscillate) {
                     damping_factor *= 0.85;
-                    logger.debug(fmt::format("| Damping factor is now {}", damping_factor));
+                    logger.debug(fmt::format(fmt::runtime("| Damping factor is now {}"), damping_factor));
                 }
             }
         } while (!convreport.converged() && iter <= max_iter);

--- a/opm/simulators/flow/BlackoilModel_impl.hpp
+++ b/opm/simulators/flow/BlackoilModel_impl.hpp
@@ -473,7 +473,7 @@ solveJacobianSystem(BVector& x)
             times[solver] = perfTimer.stop();
             perfTimer.reset();
             if (terminal_output_) {
-                OpmLog::debug(fmt::format("Solver time {}: {}", solver, times[solver]));
+                OpmLog::debug(fmt::format(fmt::runtime("Solver time {}: {}"), solver, times[solver]));
             }
         }
 

--- a/opm/simulators/flow/DamarisWriter.hpp
+++ b/opm/simulators/flow/DamarisWriter.hpp
@@ -225,7 +225,7 @@ public:
               if (wanted_vars_set_.count(name) || wanted_vars_set_.empty())
               {
                   const data::CellData&  dataCol = damVar.second ;
-                  OpmLog::debug(fmt::format("Name of Damaris Variable       : ( rank:{})  name: {}  ",  rank_, name));
+                  OpmLog::debug(fmt::format(fmt::runtime("Name of Damaris Variable       : ( rank:{})  name: {}  "),  rank_, name));
 
                   // Call damaris_set_position() for all available variables
                   // There is an assumption that all variables are the same size, with the same offset.
@@ -238,7 +238,7 @@ public:
                     if (dataCol.data<double>().size() >= static_cast<std::vector<double>::size_type>(this->numElements_)) {
                         dam_err_ = DamarisOutput::write(name.c_str(), dataCol.data<double>().data()) ;
                     } else {
-                        OpmLog::info(fmt::format("( rank:{}) The variable \"{}\" was found to be of a different size {} (not {}).",  rank_, name, dataCol.data<double>().size(), this->numElements_ ));
+                        OpmLog::info(fmt::format(fmt::runtime("( rank:{}) The variable \"{}\" was found to be of a different size {} (not {})."),  rank_, name, dataCol.data<double>().size(), this->numElements_ ));
                     }
                   }
                   catch (std::bad_variant_access const& ex) {
@@ -246,7 +246,7 @@ public:
                     if (dataCol.data<int>().size() >= static_cast<std::vector<int>::size_type>(this->numElements_)) {
                         dam_err_ = DamarisOutput::write(name.c_str(), dataCol.data<int>().data()) ;
                     } else {
-                        OpmLog::info(fmt::format("( rank:{}) The variable \"{}\" was found to be of a different size {} (not {}).",  rank_, name, dataCol.data<int>().size(), this->numElements_ ));
+                        OpmLog::info(fmt::format(fmt::runtime("( rank:{}) The variable \"{}\" was found to be of a different size {} (not {})."),  rank_, name, dataCol.data<int>().size(), this->numElements_ ));
                     }
                   }
                   ++cell_data_written ;
@@ -255,9 +255,9 @@ public:
             DamarisOutput::handleError(dam_err_, cc, "setPosition() and write() for available variables");
 
             if (!cell_data_written) {
-                  OpmLog::info(fmt::format("( rank:{}) No simulation data written to the Damaris server - check --damaris-limit-variables command line option (if used) has valid variable name(s) and that the Damaris XML file contains variable names that are available in your simulation.",  rank_));
+                  OpmLog::info(fmt::format(fmt::runtime("( rank:{}) No simulation data written to the Damaris server - check --damaris-limit-variables command line option (if used) has valid variable name(s) and that the Damaris XML file contains variable names that are available in your simulation."),  rank_));
             } else {
-                  OpmLog::debug(fmt::format("( rank:{}) {} Damaris Variables written to the Damaris servers",  rank_, cell_data_written));
+                  OpmLog::debug(fmt::format(fmt::runtime("( rank:{}) {} Damaris Variables written to the Damaris servers"),  rank_, cell_data_written));
             }
 
            /*
@@ -353,7 +353,7 @@ private:
         try {
             const bool hasPolyCells = geomData.polyhedralCellPresent() ;
             if ( hasPolyCells ) {
-                OpmLog::error(fmt::format("ERORR: rank {} The DUNE geometry grid has polyhedral elements - These elements are currently not supported.", rank_ ));
+                OpmLog::error(fmt::format(fmt::runtime("ERORR: rank {} The DUNE geometry grid has polyhedral elements - These elements are currently not supported."), rank_ ));
             }
 
             // This is the template XML model for x,y,z coordinates defined in initDamarisXmlFile.cpp which is used to

--- a/opm/simulators/flow/NlddReporting.hpp
+++ b/opm/simulators/flow/NlddReporting.hpp
@@ -194,7 +194,7 @@ void writePartitions(
     }
 
     const auto nDigit = 1 + static_cast<int>(std::floor(std::log10(comm.size())));
-    auto partition_fname = odir / fmt::format("{1:0>{0}}", nDigit, rank);
+    auto partition_fname = odir / fmt::format(fmt::runtime("{1:0>{0}}"), nDigit, rank);
     std::ofstream pfile { partition_fname };
 
     auto cell_index = 0;

--- a/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
+++ b/opm/simulators/flow/SimulatorFullyImplicitBlackoil.hpp
@@ -305,8 +305,8 @@ public:
         modelParam_.newton_max_iter_ = tuning.NEWTMX;
         modelParam_.newton_min_iter_ = tuning.NEWTMN;
         if (terminalOutput_) {
-            const auto msg = fmt::format("Tuning values: "
-                                         "MB: {:.2e}, CNV: {:.2e}, NEWTMN: {}, NEWTMX: {}",
+            const auto msg = fmt::format(fmt::runtime("Tuning values: "
+                                         "MB: {:.2e}, CNV: {:.2e}, NEWTMN: {}, NEWTMX: {}"),
                                          tuning.TRGMBE, tuning.TRGCNV, tuning.NEWTMN, tuning.NEWTMX);
             OpmLog::debug(msg);
             if (tuning.TRGTTE_has_value) {

--- a/opm/simulators/flow/SubDomain.hpp
+++ b/opm/simulators/flow/SubDomain.hpp
@@ -51,7 +51,7 @@ namespace Opm
         } else if (measure == "averagepressure") {
             return DomainOrderingMeasure::AveragePressure;
         } else {
-            throw std::runtime_error(fmt::format("Invalid domain ordering '{}' specified", measure));
+            throw std::runtime_error(fmt::format(fmt::runtime("Invalid domain ordering '{}' specified"), measure));
         }
     }
 

--- a/opm/simulators/flow/TemperatureModel.hpp
+++ b/opm/simulators/flow/TemperatureModel.hpp
@@ -229,8 +229,10 @@ protected:
             solveAndUpdate();
         }
         if (!is_converged) {
-            const auto msg = fmt::format("Temperature model (TEMP): Newton did not converge after {} iterations. \n"
-                                         "The Simulator will continue to the next step with an unconverged solution.",max_iter);
+            const auto msg =
+                fmt::format(fmt::runtime("Temperature model (TEMP): Newton did not converge after {} iterations. \n"
+                                         "The Simulator will continue to the next step with an unconverged solution."),
+                            max_iter);
             OpmLog::debug(msg);
         }
     }
@@ -293,13 +295,14 @@ protected:
         const bool tolerance_cnv_energy = relax? Parameters::Get<Parameters::ToleranceCnvEnergyRelaxed<Scalar>>():
                                             tolerance_cnv_energy_strict;
 
-        const auto msg = fmt::format("Temperature model (TEMP): Newton iter {}: "
-                                     "CNV(E): {:.1e}, EB: {:.1e}",
+        const auto msg = fmt::format(fmt::runtime("Temperature model (TEMP): Newton iter {}: "
+                                     "CNV(E): {:.1e}, EB: {:.1e}"),
                                      iter, maxNorm, sumNorm);
         OpmLog::debug(msg);
         if (maxNorm < tolerance_cnv_energy && sumNorm < tolerance_energy_balance) {
-            const auto msg2 = fmt::format("Temperature model (TEMP): Newton converged after {} iterations"
-                                         , iter);
+            const auto msg2 =
+                fmt::format(fmt::runtime("Temperature model (TEMP): Newton converged after {} iterations"),
+                                         iter);
             OpmLog::debug(msg2);
             return true;
         }

--- a/opm/simulators/flow/rescoup/ReservoirCoupling.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCoupling.hpp
@@ -264,7 +264,7 @@ std::pair<std::vector<char>, std::size_t> serializeStrings(const std::vector<std
 /// \return A string like "864000s (10.00 days)".
 inline std::string formatDays(double seconds) {
     double days = seconds / unit::day;
-    return fmt::format("{:.0f}s ({:.2f} days)", seconds, days);
+    return fmt::format(fmt::runtime("{:.0f}s ({:.2f} days)"), seconds, days);
 }
 
 /// \brief Utility class for comparing double values representing epoch dates or elapsed time.

--- a/opm/simulators/linalg/ISTLSolverRuntimeOptionProxy.hpp
+++ b/opm/simulators/linalg/ISTLSolverRuntimeOptionProxy.hpp
@@ -164,7 +164,7 @@ private:
         else {
             // If we reach here, it means the backend is not supported. This could be because we have added a third backend
             // that we need to handle. A user error would be handled in the linearSolverAcceleratorTypeFromString function called above.
-            OPM_THROW(std::invalid_argument, fmt::format("Unknown backend: {}", Parameters::toString(backend)));
+            OPM_THROW(std::invalid_argument, fmt::format(fmt::runtime("Unknown backend: {}"), Parameters::toString(backend)));
         }
     }
 };

--- a/opm/simulators/linalg/gpuistl/GpuAwareMPISender.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuAwareMPISender.hpp
@@ -114,7 +114,7 @@ public:
 
             if (status.MPI_ERROR != MPI_SUCCESS) {
                 OPM_THROW(std::runtime_error,
-                          fmt::format("MPI_Error occurred while rank {} received a message from rank {}",
+                          fmt::format(fmt::runtime("MPI_Error occurred while rank {} received a message from rank {}"),
                                       rank,
                                       processMap[finished]));
             }
@@ -123,7 +123,7 @@ public:
         for (size_t i = 0; i < m_messageInformation.size(); i++) {
             if (MPI_SUCCESS != MPI_Wait(&sendRequests[i], &recvStatus)) {
                 OPM_THROW(std::runtime_error,
-                          fmt::format("MPI_Error occurred while rank {} sent a message from rank {}",
+                          fmt::format(fmt::runtime("MPI_Error occurred while rank {} sent a message from rank {}"),
                                       rank,
                                       processMap[finished]));
             }

--- a/opm/simulators/linalg/gpuistl/GpuBuffer.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuBuffer.hpp
@@ -212,7 +212,8 @@ public:
     {
         if (numberOfElements > size()) {
             OPM_THROW(std::runtime_error,
-                    fmt::format("Requesting to copy too many elements. buffer has {} elements, while {} was requested.",
+                    fmt::format(fmt::runtime("Requesting to copy too many elements. "
+                                             "buffer has {} elements, while {} was requested."),
                                 size(),
                                 numberOfElements));
         }
@@ -359,7 +360,8 @@ private:
     {
         if (size != m_numberOfElements) {
             OPM_THROW(std::invalid_argument,
-                    fmt::format("Given buffer has {}, while we have {}.", size, m_numberOfElements));
+                    fmt::format(fmt::runtime("Given buffer has {}, while we have {}."),
+                                size, m_numberOfElements));
         }
     }
 

--- a/opm/simulators/linalg/gpuistl/GpuOwnerOverlapCopy.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuOwnerOverlapCopy.hpp
@@ -122,13 +122,13 @@ makeGpuOwnerOverlapCopy(const OwnerOverlapCopyCommunicationType& cpuOwnerOverlap
 
             if (!mpiSupportsCudaAwareAtCompileTime || !mpiSupportsCudaAwareAtRunTime) {
                 OPM_THROW(std::runtime_error,
-                          fmt::format("The GPU-aware MPI support is not available. "
+                          fmt::format(fmt::runtime("The GPU-aware MPI support is not available. "
                                       "CUDA aware support at compile time: {}, "
                                       "CUDA aware support at runtime: {}. "
                                       "Please check your MPI installation and the OPM configuration "
                                       "or run with --gpu-aware-mpi=false. If you are sure that your MPI "
                                       "implementation supports GPU aware MPI, you can disable this check "
-                                      "by setting --verify-gpu-aware-mpi=false.",
+                                      "by setting --verify-gpu-aware-mpi=false."),
                                       mpiSupportsCudaAwareAtCompileTime ? "yes" : "no",
                                       mpiSupportsCudaAwareAtRunTime ? "yes" : "no"));
             }

--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrix.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrix.hpp
@@ -404,7 +404,7 @@ private:
         if constexpr (blockSizeCompileTime > 1) {
             return dispatchOnBlocksizeImpl<blockSizeCompileTime - 1>(function);
         } else {
-            OPM_THROW(std::runtime_error, fmt::format("Unsupported block size: {}", m_blockSize));
+            OPM_THROW(std::runtime_error, fmt::format(fmt::runtime("Unsupported block size: {}"), m_blockSize));
         }
     }
 };

--- a/opm/simulators/linalg/gpuistl/GpuSparseMatrixGeneric.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuSparseMatrixGeneric.hpp
@@ -347,7 +347,7 @@ private:
         if constexpr (blockSizeCompileTime > 1) {
             return dispatchOnBlocksizeImpl<blockSizeCompileTime - 1>(function);
         } else {
-            OPM_THROW(std::runtime_error, fmt::format("Unsupported block size: {}", m_blockSize));
+            OPM_THROW(std::runtime_error, fmt::format(fmt::runtime("Unsupported block size: {}"), m_blockSize));
         }
     }
 };

--- a/opm/simulators/linalg/gpuistl/GpuVector.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuVector.hpp
@@ -233,8 +233,8 @@ public:
         // TODO: [perf] vector.dim() can be replaced by bvector.N() * BlockDimension
         if (detail::to_size_t(m_numberOfElements) != bvector.dim()) {
             OPM_THROW(std::runtime_error,
-                      fmt::format("Given incompatible vector size. GpuVector has size {},\n however, the BlockVector "
-                                  "has has N() = {}, and dim() = {}.",
+                      fmt::format(fmt::runtime("Given incompatible vector size. GpuVector has size {},\n"
+                                               "however, the BlockVector has has N() = {}, and dim() = {}."),
                                   m_numberOfElements,
                                   bvector.N(),
                                   bvector.dim()));

--- a/opm/simulators/linalg/gpuistl/GpuView.hpp
+++ b/opm/simulators/linalg/gpuistl/GpuView.hpp
@@ -371,7 +371,7 @@ private:
 #else
         if (size != m_numberOfElements) {
             OPM_THROW(std::invalid_argument,
-                    fmt::format("Given view has {}, while this View has {}.", size, m_numberOfElements));
+                    fmt::format(fmt::runtime("Given view has {}, while this View has {}."), size, m_numberOfElements));
         }
 #endif
     }
@@ -398,7 +398,7 @@ private:
 #else
         if (idx >= m_numberOfElements) {
             OPM_THROW(std::invalid_argument,
-                    fmt::format("The index provided was not in the range [0, buffersize-1]"));
+                    fmt::format(fmt::runtime("The index provided was not in the range [0, buffersize-1]")));
         }
 #endif
     }

--- a/opm/simulators/linalg/gpuistl/detail/cublas_safe_call.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/cublas_safe_call.hpp
@@ -56,7 +56,7 @@ namespace
         CHECK_CUBLAS_ERROR_TYPE(code, CUBLAS_STATUS_NOT_SUPPORTED);
         CHECK_CUBLAS_ERROR_TYPE(code, CUBLAS_STATUS_LICENSE_ERROR);
 
-        return fmt::format("UNKNOWN CUBLAS ERROR {}.", code);
+        return fmt::format(fmt::runtime("UNKNOWN CUBLAS ERROR {}."), code);
     }
 
 #undef CHECK_CUBLAS_ERROR_TYPE
@@ -85,10 +85,10 @@ getCublasErrorMessage(cublasStatus_t error,
                       const std::string_view& functionName,
                       size_t lineNumber)
 {
-    return fmt::format("cuBLAS expression did not execute correctly. Expression was: \n\n"
+    return fmt::format(fmt::runtime("cuBLAS expression did not execute correctly. Expression was: \n\n"
                        "    {}\n\n"
                        "in function {}, in {}, at line {}.\n"
-                       "CuBLAS error code was: {}\n",
+                       "CuBLAS error code was: {}\n"),
                        expression,
                        functionName,
                        filename,

--- a/opm/simulators/linalg/gpuistl/detail/cusparse_safe_call.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/cusparse_safe_call.hpp
@@ -51,7 +51,7 @@ getCusparseErrorCodeToString(int code)
     CHECK_CUSPARSE_ERROR_TYPE(code, CUSPARSE_STATUS_ZERO_PIVOT);
     CHECK_CUSPARSE_ERROR_TYPE(code, CUSPARSE_STATUS_NOT_SUPPORTED);
     CHECK_CUSPARSE_ERROR_TYPE(code, CUSPARSE_STATUS_INSUFFICIENT_RESOURCES);
-    return fmt::format("UNKNOWN CUSPARSE ERROR {}.", code);
+    return fmt::format(fmt::runtime("UNKNOWN CUSPARSE ERROR {}."), code);
 }
 
 #undef CHECK_CUSPARSE_ERROR_TYPE
@@ -77,9 +77,9 @@ getCusparseErrorMessage(cusparseStatus_t error,
                         const std::string_view& functionName,
                         size_t lineNumber)
 {
-    return fmt::format("cuSparse expression did not execute correctly. Expression was: \n\n"
+    return fmt::format(fmt::runtime("cuSparse expression did not execute correctly. Expression was: \n\n"
                        "    {}\n\nin function {}, in {}, at line {}\n"
-                       "CuSparse error code was: {}\n",
+                       "CuSparse error code was: {}\n"),
                        expression,
                        functionName,
                        filename,

--- a/opm/simulators/linalg/gpuistl/detail/gpu_safe_call.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/gpu_safe_call.hpp
@@ -48,10 +48,10 @@ getCudaErrorMessage(cudaError_t error,
                     const std::string_view& functionName,
                     size_t lineNumber)
 {
-    return fmt::format("GPU expression did not execute correctly. Expression was: \n"
+    return fmt::format(fmt::runtime("GPU expression did not execute correctly. Expression was: \n"
                        "    {}\n"
                        "GPU error was {}\n"
-                       "in function {}, in {}, at line {}\n",
+                       "in function {}, in {}, at line {}\n"),
                        expression,
                        cudaGetErrorString(error),
                        functionName,

--- a/opm/simulators/linalg/gpuistl/detail/gpusparse_matrix_utilities.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/gpusparse_matrix_utilities.hpp
@@ -216,7 +216,8 @@ validateVectorMatrixSizes(size_t vectorSize, size_t matrixBlockSize, size_t matr
     const size_t expectedSize = matrixBlockSize * matrixColumns;
     if (vectorSize != expectedSize) {
         OPM_THROW(std::invalid_argument,
-                  fmt::format("Size mismatch. Input vector has {} elements, while matrix expects {} elements.",
+                  fmt::format(fmt::runtime("Size mismatch. Input vector has {} elements, "
+                                          "while matrix expects {} elements."),
                               vectorSize,
                               expectedSize));
     }

--- a/opm/simulators/linalg/gpuistl/detail/kernel_enums.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/kernel_enums.hpp
@@ -41,11 +41,11 @@ namespace Opm::gpuistl {
     inline MatrixStorageMPScheme makeMatrixStorageMPScheme(int scheme) {
         if (!detail::isValidMatrixStorageMPScheme(scheme)) {
             OPM_THROW(std::invalid_argument,
-                      fmt::format("Invalid matrix storage mixed precision scheme chosen: {}.\n"
+                      fmt::format(fmt::runtime("Invalid matrix storage mixed precision scheme chosen: {}.\n"
                                   "Valid Schemes:\n"
                                   "\t0: DOUBLE_DIAG_DOUBLE_OFFDIAG\n"
                                   "\t1: FLOAT_DIAG_FLOAT_OFFDIAG\n"
-                                  "\t2: DOUBLE_DIAG_FLOAT_OFFDIAG",
+                                  "\t2: DOUBLE_DIAG_FLOAT_OFFDIAG"),
                                   scheme));
         }
         return static_cast<MatrixStorageMPScheme>(scheme);

--- a/opm/simulators/linalg/gpuistl/detail/safe_conversion.hpp
+++ b/opm/simulators/linalg/gpuistl/detail/safe_conversion.hpp
@@ -65,7 +65,7 @@ to_int(std::size_t s)
 
     if (s > std::size_t(std::numeric_limits<int>::max())) {
         OPM_THROW(std::invalid_argument,
-                  fmt::format("Trying to convert {} to int, but it is out of range. Maximum possible int: {}. ",
+                  fmt::format(fmt::runtime("Trying to convert {} to int, but it is out of range. Maximum possible int: {}. "),
                               s,
                               std::numeric_limits<int>::max()));
     }
@@ -100,7 +100,7 @@ to_size_t(int i)
     assert(i >= int(0));
 #else
     if (i < int(0)) {
-        OPM_THROW(std::invalid_argument, fmt::format("Trying to convert the negative number {} to size_t.", i));
+        OPM_THROW(std::invalid_argument, fmt::format(fmt::runtime("Trying to convert the negative number {} to size_t."), i));
     }
 #endif
 

--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -916,7 +916,7 @@ checkTimeStepMaxRestartLimit_(const int restarts) const
     // many times, we have failed and throw an exception.
     if (restarts >= solverRestartMax_()) {
         const auto msg = fmt::format(
-            "Solver failed to converge after cutting timestep {} times.", restarts
+            fmt::runtime("Solver failed to converge after cutting timestep {} times."), restarts
         );
         if (solverVerbose_()) {
             OpmLog::error(msg);
@@ -936,7 +936,7 @@ checkTimeStepMinLimit_(const double new_time_step) const
     // If we have restarted (i.e. cut the timestep) too
     // much, we have failed and throw an exception.
     if (new_time_step < minTimeStep_()) {
-        auto msg = fmt::format("Solver failed to converge after cutting timestep to ");
+        std::string msg = "Solver failed to converge after cutting timestep to ";
         if (Parameters::Get<Parameters::EnableTuning>()) {
             const UnitSystem& unit_system = solver_().model().simulator().vanguard().eclState().getDeckUnitSystem();
             msg += fmt::format(
@@ -967,7 +967,7 @@ chopTimeStep_(const double new_time_step)
 {
     setTimeStep_(new_time_step);
     if (solverVerbose_()) {
-        const auto msg = fmt::format("{}\nTimestep chopped to {} days\n",
+        const auto msg = fmt::format(fmt::runtime("{}\nTimestep chopped to {} days\n"),
                     this->cause_of_failure_,
                     unit::convert::to(this->substep_timer_.currentStepLength(), unit::day));
         OpmLog::problem(msg);
@@ -1026,8 +1026,8 @@ chopTimeStepOrCloseFailingWells_(const double new_time_step)
             wells_shut = true;
             if (solverVerbose_()) {
                 const std::string msg =
-                        fmt::format("\nProblematic well(s) were shut: {}"
-                                    "(retrying timestep)\n",
+                        fmt::format(fmt::runtime("\nProblematic well(s) were shut: {}"
+                                    "(retrying timestep)\n"),
                                     fmt::join(shut_wells, " "));
                 OpmLog::problem(msg);
             }

--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -79,9 +79,7 @@ doPreStepRebalance(DeferredLogger& deferred_logger)
                                 well_model_.simulator().vanguard().grid().comm());
 
     if (!converged) {
-        const std::string msg =
-            fmt::format("Initial (pre-step) network balance did not converge.");
-        deferred_logger.warning(msg);
+        deferred_logger.warning("Initial (pre-step) network balance did not converge.");
     }
 }
 

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -676,7 +676,9 @@ namespace Opm {
                                   ecl_well_map,
                                   this->well_open_times_);
             } catch (const std::exception& e) {
-                const std::string msg = fmt::format("Exception during testing of well: {}. The well will not open.\n Exception message: {}", wellEcl.name(), e.what());
+                const std::string msg =
+                  fmt::format(fmt::runtime("Exception during testing of well: {}. The well will not open.\n"
+                                           "Exception message: {}"), wellEcl.name(), e.what());
                 deferred_logger.warning("WELL_TESTING_FAILED", msg);
             }
         }
@@ -1003,7 +1005,7 @@ namespace Opm {
                         : well_ecl.injectionControls(this->summaryState_).anyZeroRateConstraint();
                     if (any_zero_rate_constraint) {
                         // Treat as shut, do not add to container.
-                        local_deferredLogger.debug(fmt::format("  Well {} gets shut due to having zero rate constraint and disallowing crossflow ", well_ecl.name()) );
+                        local_deferredLogger.debug(fmt::format(fmt::runtime("  Well {} gets shut due to having zero rate constraint and disallowing crossflow "), well_ecl.name()));
                         this->wellState().shutWell(w);
                         this->well_close_times_.erase(well_name);
                         this->well_open_times_.erase(well_name);
@@ -1140,7 +1142,7 @@ namespace Opm {
         // It should be able to find in wells_ecl.
         if (it == this->wells_ecl_.end()) {
             OPM_DEFLOG_THROW(std::logic_error,
-                             fmt::format("Could not find well {} in wells_ecl ", well_name),
+                             fmt::format(fmt::runtime("Could not find well {} in wells_ecl"), well_name),
                              deferred_logger);
         }
 
@@ -1163,7 +1165,7 @@ namespace Opm {
         if constexpr (BlackoilWellModelGasLift<TypeTag>::glift_debug) {
             if (gaslift_.terminalOutput()) {
                 const std::string msg =
-                    fmt::format("assemble() : iteration {}" , iterationIdx);
+                    fmt::format(fmt::runtime("assemble() : iteration {}"), iterationIdx);
                 gaslift_.gliftDebug(msg, local_deferredLogger);
             }
         }


### PR DESCRIPTION
When building as c++-20, these format strings generate compiler errors when built with nvcc.

A lot of these look perfectly compile time verifiable to me, so it's more than likely that this is the result of a buggy nvcc dragging a buggy libfmt through our mud of templates, inline functions and macros.

Since the current state (ie c++-17) is no compile time format string verification at all and that we are likely going to move as much as possible of these to std::format, my opinion is that this should not be a show stopper for enabling c++-20. One has to start at one end..