### PR TITLE
not setting FLD to be NONE for group

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -2011,7 +2011,8 @@ updateNONEProductionGroups(const GasLiftOpt& glo, DeferredLogger& deferred_logge
             continue;
         }
         const auto& gname = gnames[i];
-        if (group_state.production_control(gname) != Group::ProductionCMode::NONE) {
+        if (group_state.production_control(gname) != Group::ProductionCMode::NONE &&
+            group_state.production_control(gname) != Group::ProductionCMode::FLD) {
             // If the production group is specified for gas lift optimization,
             // the current gas lift optimization implementation relies on the control
             // mode is not NONE or FLD. As a result, we can not set it to NONE here.


### PR DESCRIPTION
since SingleWellState::GroupTarget does not get group target from a group under FLD control.

If a group under FLD control, the wells under it blow might get the group target from the higher level, the higher level group will be recorded in the SingleWellState::GroupTarget. 

It does not mean the group under FLD control should be set as NONE control. 