### PR TITLE
Move getAutoChokeGroupProductionTargetRate() to GroupStateHelper

### DIFF
--- a/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModelNetwork_impl.hpp
@@ -38,7 +38,6 @@
 #include <opm/simulators/wells/BlackoilWellModel.hpp>
 #include <opm/simulators/wells/TargetCalculator.hpp>
 #include <opm/simulators/wells/WellBhpThpCalculator.hpp>
-#include <opm/simulators/wells/WellGroupControls.hpp>
 
 #include <fmt/format.h>
 
@@ -192,10 +191,9 @@ computeWellGroupThp(const double dt, DeferredLogger& local_deferredLogger)
                 // derived via group guide rates
                 const Scalar efficiencyFactor = 1.0;
                 const Group& parentGroup = well_model_.schedule().getGroup(group.parent(), reportStepIdx);
-                auto target = WellGroupControls<Scalar, IndexTraits>::
+                auto target = well_model_.groupStateHelper().
                     getAutoChokeGroupProductionTargetRate(group,
                                                           parentGroup,
-                                                          well_model_.groupStateHelper(),
                                                           resv_coeff,
                                                           efficiencyFactor);
                 target_tmp = target.first;

--- a/opm/simulators/wells/GroupStateHelper.hpp
+++ b/opm/simulators/wells/GroupStateHelper.hpp
@@ -243,26 +243,18 @@ public:
     /// @return The corresponding GuideRateModel::Target for the injection phase
     GuideRateModel::Target getInjectionGuideTargetMode(Phase injection_phase) const;
 
-    //! \brief Find the local reduction level in a group chain.
-    //!
-    //! The local reduction level is the deepest level in the chain (starting from level 1)
-    //! where a group has both a guide rate and group-controlled wells (GCW > 0).
-    //! This level determines where reductions are applied and add-back occurs.
-    //!
-    //! \param chain Group chain from control group (top) to bottom group
-    //! \param is_production_group True for production, false for injection
-    //! \param injection_phase Phase for injection groups (ignored for production)
-    //! \return The local reduction level (0 if no intermediate group qualifies)
-    std::size_t getLocalReductionLevel(const std::vector<std::string>& chain,
-        bool is_production_group,
-        Phase injection_phase) const;
-
     Scalar getProductionGroupTarget(const Group& group) const;
 
     /// @brief Get the guide rate target mode for a production group
     /// @param group The production group
     /// @return The GuideRateModel::Target based on the group's production control mode
     GuideRateModel::Target getProductionGuideTargetMode(const Group& group) const;
+
+    std::pair<Scalar, Group::ProductionCMode>
+    getAutoChokeGroupProductionTargetRate(const Group& bottom_group,
+                                          const Group& group,
+                                          const std::vector<Scalar>& resv_coeff,
+                                          Scalar efficiencyFactor) const;
 
     GuideRate::RateVector getProductionGroupRateVector(const std::string& group_name) const;
 
@@ -537,6 +529,19 @@ private:
 
     GuideRate::RateVector getGuideRateVector_(const std::vector<Scalar>& rates) const;
 
+    //! \brief Find the local reduction level in a group chain.
+    //!
+    //! The local reduction level is the deepest level in the chain (starting from level 1)
+    //! where a group has both a guide rate and group-controlled wells (GCW > 0).
+    //! This level determines where reductions are applied and add-back occurs.
+    //!
+    //! \param chain Group chain from control group (top) to bottom group
+    //! \param is_production_group True for production, false for injection
+    //! \param injection_phase Phase for injection groups (ignored for production)
+    //! \return The local reduction level (0 if no intermediate group qualifies)
+    std::size_t getLocalReductionLevel_(const std::vector<std::string>& chain,
+        bool is_production_group,
+        Phase injection_phase) const;
 
 #ifdef RESERVOIR_COUPLING_ENABLED
     Scalar getReservoirCouplingMasterGroupRate_(const Group& group,

--- a/opm/simulators/wells/WellGroupControls.hpp
+++ b/opm/simulators/wells/WellGroupControls.hpp
@@ -86,12 +86,6 @@ public:
                                         const RateConvFunc& rateConverter,
                                         Scalar efficiencyFactor) const;
 
-    static std::pair<Scalar, Group::ProductionCMode> getAutoChokeGroupProductionTargetRate(const Group& bottom_group,
-                                                        const Group& group,
-                                                        const GroupStateHelperType& groupStateHelper,
-                                                        const std::vector<Scalar>& resv_coeff,
-                                                        Scalar efficiencyFactor);
-
 private:
     const WellInterfaceGeneric<Scalar, IndexTraits>& well_; //!< Reference to well interface
 };

--- a/tests/test_group_higher_constraints.cpp
+++ b/tests/test_group_higher_constraints.cpp
@@ -62,7 +62,6 @@
 #include <opm/simulators/wells/GroupState.hpp>
 #include <opm/simulators/wells/FractionCalculator.hpp>
 #include <opm/simulators/wells/TargetCalculator.hpp>
-#include <opm/simulators/wells/WellGroupControls.hpp>
 
 #include <boost/test/unit_test.hpp>
 
@@ -1057,16 +1056,14 @@ BOOST_AUTO_TEST_CASE(TestAutoChokeGroupProductionTargetRate)
 
     // Call getAutoChokeGroupProductionTargetRate()
     // This is how it's called in BlackoilWellModelNetwork:
-    //   getAutoChokeGroupProductionTargetRate(bottom_group=MANI, group=MANI, gsh, resv_coeff, 1.0)
+    //   gsh.getAutoChokeGroupProductionTargetRate(bottom_group=MANI, group=MANI, resv_coeff, 1.0)
     // The function recurses upward from MANI (FLD) → PLAT (FLD) → FIELD (ORAT=controlling).
     // During recursion: efficiencyFactor accumulates E_MANI * E_PLAT = 0.8 * 0.9 = 0.72.
     auto resv_coeff = resvCoeff();
 
-    using WGC = Opm::WellGroupControls<double, IndexTraits>;
-    auto [target_rate_si, control_mode] = WGC::getAutoChokeGroupProductionTargetRate(
+    auto [target_rate_si, control_mode] = gsh.getAutoChokeGroupProductionTargetRate(
         maniGroup(),      // bottom_group
         maniGroup(),      // group (starts recursion here, recurses up to controlling group)
-        gsh,
         resv_coeff,
         /*efficiencyFactor=*/1.0
     );
@@ -1218,11 +1215,9 @@ BOOST_AUTO_TEST_CASE(TestAutoChokeGroupTargetRateWithUnderperformance)
 
     // Call getAutoChokeGroupProductionTargetRate
     auto resv_coeff = resvCoeff();
-    using WGC = Opm::WellGroupControls<double, IndexTraits>;
-    auto [target_rate_si, control_mode] = WGC::getAutoChokeGroupProductionTargetRate(
+    auto [target_rate_si, control_mode] = gsh.getAutoChokeGroupProductionTargetRate(
         maniGroup(),      // bottom_group
         maniGroup(),      // group (starts recursion here)
-        gsh,
         resv_coeff,
         /*efficiencyFactor=*/1.0
     );


### PR DESCRIPTION
Builds on #6835 which should be merged first.

- **Move `getAutoChokeGroupProductionTargetRate()`** from `WellGroupControls` (static method) to `GroupStateHelper` (member method). The method has no well dependency and manually reimplements chain iteration already available as `applyReductionsAndFractions_()`.

- **Delegate to `applyReductionsAndFractions_()`** with `do_addback=false` and the actual `getLocalReductionLevel_()` value, replacing the manual reduction loop.

- **Make `getLocalReductionLevel_()` private again**, reverting the visibility change from #6835, since its only external caller was the now-removed static method in `WellGroupControls`.
