### PR TITLE
Fix CMake linking for rocalution, rocblas and rocsparse.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,8 +551,10 @@ macro(opm-simulators_targets_hook)
     target_link_libraries(opmsimulators PUBLIC roc::hipblas roc::hipsparse)
   endif()
 
-  if(USE_GPU_BRIDGE AND hip_FOUND)
-    target_link_libraries(opmsimulators PUBLIC roc::rocalution)
+  if(USE_GPU_BRIDGE)
+    if(ROCALUTION_FOUND)
+      target_link_libraries(opmsimulators PUBLIC roc::rocalution)
+    endif()
   endif()
 
   if(CUDA_FOUND)


### PR DESCRIPTION
We cannot rely on finding them via hip. A found HIP might even be pulled in by dependencies.

For me the rocalution target was not there but hip was somehow found.