### PR TITLE
Reservoir coupling: Enforce per-rate-type master production limits on slave

### DIFF
--- a/opm/simulators/flow/rescoup/ReservoirCoupling.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCoupling.hpp
@@ -182,7 +182,6 @@ struct InjectionRates {
     [[nodiscard]] Scalar  operator[](Phase p) const noexcept { return rate[static_cast<std::size_t>(p)]; }
 };
 
-
 // Used to communicate potentials for oil, gas, and water rates between slave and master processes
 template <class Scalar>
 struct Potentials {
@@ -256,6 +255,17 @@ struct ProductionGroupConstraints {
     Scalar gas_limit;
     Scalar liquid_limit;
     Scalar resv_limit;
+};
+
+/// @brief Per-rate-type production limits received from master hierarchy.
+/// A value of -1 means no limit defined in the hierarchy for that rate type.
+template <class Scalar>
+struct MasterProductionLimits {
+    Scalar oil_limit{-1};
+    Scalar water_limit{-1};
+    Scalar gas_limit{-1};
+    Scalar liquid_limit{-1};
+    Scalar resv_limit{-1};
 };
 
 // Helper functions

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
@@ -74,6 +74,15 @@ hasMasterInjectionTarget(const std::string& gname, const Phase phase) const
 template <class Scalar>
 bool
 ReservoirCouplingSlave<Scalar>::
+hasMasterProductionLimits(const std::string& gname) const
+{
+    assert(this->report_step_data_);
+    return this->report_step_data_->hasMasterProductionLimits(gname);
+}
+
+template <class Scalar>
+bool
+ReservoirCouplingSlave<Scalar>::
 hasMasterProductionTarget(const std::string& gname) const
 {
     assert(this->report_step_data_);
@@ -112,6 +121,15 @@ masterInjectionTarget(const std::string& gname, const Phase phase) const
 {
     assert(this->report_step_data_);
     return this->report_step_data_->masterInjectionTarget(gname, phase);
+}
+
+template <class Scalar>
+const typename ReservoirCouplingSlave<Scalar>::MasterProductionLimits&
+ReservoirCouplingSlave<Scalar>::
+masterProductionLimits(const std::string& gname) const
+{
+    assert(this->report_step_data_);
+    return this->report_step_data_->masterProductionLimits(gname);
 }
 
 template <class Scalar>

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
@@ -44,6 +44,7 @@ public:
     using SlaveGroupInjectionData = ReservoirCoupling::SlaveGroupInjectionData<Scalar>;
     using SlaveGroupProductionData = ReservoirCoupling::SlaveGroupProductionData<Scalar>;
     using InjectionGroupTarget = ReservoirCoupling::InjectionGroupTarget<Scalar>;
+    using MasterProductionLimits = typename ReservoirCoupling::MasterProductionLimits<Scalar>;
     using ProductionGroupConstraints = ReservoirCoupling::ProductionGroupConstraints<Scalar>;
 
     ReservoirCouplingSlave(
@@ -60,6 +61,10 @@ public:
     /// @details Delegates to ReservoirCouplingSlaveReportStep
     bool hasMasterInjectionTarget(const std::string& gname, const Phase phase) const;
 
+    /// @brief Check if master-imposed per-rate-type production limits exist for a group
+    /// @details Delegates to ReservoirCouplingSlaveReportStep
+    bool hasMasterProductionLimits(const std::string& gname) const;
+
     /// @brief Check if a master-imposed production target exists for a group
     /// @details Delegates to ReservoirCouplingSlaveReportStep
     bool hasMasterProductionTarget(const std::string& gname) const;
@@ -72,6 +77,10 @@ public:
     /// @details Delegates to ReservoirCouplingSlaveReportStep
     std::pair<Scalar, Group::InjectionCMode> masterInjectionTarget(
         const std::string& gname, const Phase phase) const;
+
+    /// @brief Get the master-imposed per-rate-type production limits for a group
+    /// @details Delegates to ReservoirCouplingSlaveReportStep
+    const MasterProductionLimits& masterProductionLimits(const std::string& gname) const;
 
     /// @brief Get the master-imposed production target and control mode for a group
     /// @details Delegates to ReservoirCouplingSlaveReportStep

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.cpp
@@ -60,6 +60,14 @@ hasMasterInjectionTarget(const std::string& gname, const Phase phase) const
 template <class Scalar>
 bool
 ReservoirCouplingSlaveReportStep<Scalar>::
+hasMasterProductionLimits(const std::string& gname) const
+{
+    return this->master_production_limits_.count(gname) > 0;
+}
+
+template <class Scalar>
+bool
+ReservoirCouplingSlaveReportStep<Scalar>::
 hasMasterProductionTarget(const std::string& gname) const
 {
     return this->master_production_targets_.count(gname) > 0;
@@ -71,6 +79,14 @@ ReservoirCouplingSlaveReportStep<Scalar>::
 masterInjectionTarget(const std::string& gname, const Phase phase) const
 {
     return this->master_injection_targets_.at({phase, gname});
+}
+
+template <class Scalar>
+const typename ReservoirCouplingSlaveReportStep<Scalar>::MasterProductionLimits&
+ReservoirCouplingSlaveReportStep<Scalar>::
+masterProductionLimits(const std::string& gname) const
+{
+    return this->master_production_limits_.at(gname);
 }
 
 template <class Scalar>
@@ -175,13 +191,21 @@ receiveProductionGroupConstraintsFromMaster(std::size_t num_targets)
     this->comm().broadcast(
         production_constraints.data(), num_targets, /*emitter_rank=*/0
     );
-    // Clear old targets before storing new ones from master
+    // Clear old targets and limits before storing new ones from master
     this->master_production_targets_.clear();
+    this->master_production_limits_.clear();
     for (const auto& target : production_constraints) {
         const auto& group_name = this->slave_.slaveGroupIdxToGroupName(target.group_name_idx);
         this->setMasterProductionTarget(
             group_name, target.target, target.cmode
         );
+        MasterProductionLimits limits;
+        limits.oil_limit = target.oil_limit;
+        limits.water_limit = target.water_limit;
+        limits.gas_limit = target.gas_limit;
+        limits.liquid_limit = target.liquid_limit;
+        limits.resv_limit = target.resv_limit;
+        this->setMasterProductionLimits(group_name, limits);
         this->logger().debug(fmt::format(
             "Stored master production target for group '{}': target={}, cmode={}",
             group_name, target.target, static_cast<int>(target.cmode)
@@ -217,6 +241,14 @@ setMasterInjectionTarget(
 )
 {
     this->master_injection_targets_[{phase, gname}] = {target, cmode};
+}
+
+template <class Scalar>
+void
+ReservoirCouplingSlaveReportStep<Scalar>::
+setMasterProductionLimits(const std::string& gname, const MasterProductionLimits& limits)
+{
+    this->master_production_limits_[gname] = limits;
 }
 
 template <class Scalar>

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp
@@ -57,8 +57,9 @@ public:
     using InjectionGroupTarget = ReservoirCoupling::InjectionGroupTarget<Scalar>;
     using ProductionGroupConstraints = ReservoirCoupling::ProductionGroupConstraints<Scalar>;
     using MessageTag = ReservoirCoupling::MessageTag;
-    using SlaveGroupProductionData = ReservoirCoupling::SlaveGroupProductionData<Scalar>;
+    using MasterProductionLimits = ReservoirCoupling::MasterProductionLimits<Scalar>;
     using SlaveGroupInjectionData = ReservoirCoupling::SlaveGroupInjectionData<Scalar>;
+    using SlaveGroupProductionData = ReservoirCoupling::SlaveGroupProductionData<Scalar>;
 
     /// @brief Construct a report step manager for the slave process
     /// @param slave Reference to the parent ReservoirCouplingSlave object
@@ -79,6 +80,11 @@ public:
     /// @param phase Injection phase (e.g., Phase::WATER, Phase::GAS)
     /// @return true if the master sent an injection target for this group/phase pair
     bool hasMasterInjectionTarget(const std::string& gname, const Phase phase) const;
+
+    /// @brief Check if master-imposed per-rate-type production limits exist for a group
+    /// @param gname Slave group name
+    /// @return true if the master sent per-rate-type limits for this group
+    bool hasMasterProductionLimits(const std::string& gname) const;
 
     /// @brief Check if a master-imposed production target exists for a group
     /// @param gname Slave group name
@@ -103,6 +109,12 @@ public:
     /// @throws std::out_of_range if no target exists for the given group/phase pair
     std::pair<Scalar, Group::InjectionCMode> masterInjectionTarget(
         const std::string& gname, const Phase phase) const;
+
+    /// @brief Get the master-imposed per-rate-type production limits for a group
+    /// @param gname Slave group name
+    /// @return Reference to the limits struct (-1 = no limit for that rate type)
+    /// @throws std::out_of_range if no limits exist for the given group
+    const MasterProductionLimits& masterProductionLimits(const std::string& gname) const;
 
     /// @brief Get the master-imposed production target and control mode for a group
     /// @param gname Slave group name
@@ -162,6 +174,11 @@ public:
     void setMasterInjectionTarget(
         const std::string& gname, const Phase phase, const Scalar target, const Group::InjectionCMode cmode);
 
+    /// @brief Store master-imposed per-rate-type production limits for a group
+    /// @param gname Slave group name
+    /// @param limits Per-rate-type limits (-1 = no limit for that rate type)
+    void setMasterProductionLimits(const std::string& gname, const MasterProductionLimits& limits);
+
     /// @brief Store a master-imposed production target for a group
     /// @param gname Slave group name
     /// @param target Target production rate
@@ -207,6 +224,9 @@ private:
     std::map<std::string, std::pair<Scalar, Group::ProductionCMode>> master_production_targets_;
     // Key: (injection phase, slave group name). Value: (target rate, injection control mode).
     std::map<std::pair<Phase, std::string>, std::pair<Scalar, Group::InjectionCMode>> master_injection_targets_;
+    // Per-rate-type production limits from master hierarchy. Key: slave group name.
+    // A limit of -1 means no limit defined in the hierarchy for that rate type.
+    std::map<std::string, MasterProductionLimits> master_production_limits_;
 };
 } // namespace Opm
 #endif // OPM_RESERVOIR_COUPLING_SLAVE_REPORT_STEP_HPP

--- a/opm/simulators/wells/GroupStateHelper.cpp
+++ b/opm/simulators/wells/GroupStateHelper.cpp
@@ -1671,6 +1671,30 @@ GroupStateHelper<Scalar, IndexTraits>::applyReductionsAndFractions_(const std::v
     return target;
 }
 
+template<typename Scalar, typename IndexTraits>
+std::pair<Group::ProductionCMode, Scalar>
+GroupStateHelper<Scalar, IndexTraits>::
+checkProductionRateConstraint_(const Group& group,
+                                Group::ProductionCMode cmode,
+                                Group::ProductionCMode currentControl,
+                                Scalar target,
+                                Scalar current_rate) const
+{
+    if (!group.has_control(cmode)) {
+        return {Group::ProductionCMode::NONE, Scalar(1.0)};
+    }
+    if (currentControl == cmode) {
+        return {Group::ProductionCMode::NONE, Scalar(1.0)};
+    }
+    if (target < current_rate) {
+        Scalar scale = 1.0;
+        if (current_rate > 1e-12)
+            scale = target / current_rate;
+        return {cmode, scale};
+    }
+    return {Group::ProductionCMode::NONE, Scalar(1.0)};
+}
+
 template <typename Scalar, typename IndexTraits>
 Scalar
 GroupStateHelper<Scalar, IndexTraits>::computeAddbackEfficiency_(const std::vector<std::string>& chain,
@@ -1824,18 +1848,29 @@ getProductionConstraintTarget_(const Group& group,
                                 Group::ProductionCMode cmode,
                                 const Group::ProductionControls& controls) const
 {
+    Scalar target = 0.0;
     switch (cmode) {
-    case Group::ProductionCMode::ORAT: return controls.oil_target;
-    case Group::ProductionCMode::WRAT: return controls.water_target;
-    case Group::ProductionCMode::GRAT: return controls.gas_target;
-    case Group::ProductionCMode::LRAT: return controls.liquid_target;
+    case Group::ProductionCMode::ORAT: target = controls.oil_target; break;
+    case Group::ProductionCMode::WRAT: target = controls.water_target; break;
+    case Group::ProductionCMode::GRAT: target = controls.gas_target; break;
+    case Group::ProductionCMode::LRAT: target = controls.liquid_target; break;
     case Group::ProductionCMode::RESV: {
         if (group.has_gpmaint_control(Group::ProductionCMode::RESV))
-            return this->groupState().gpmaint_target(group.name());
-        return controls.resv_target;
+            target = this->groupState().gpmaint_target(group.name());
+        else
+            target = controls.resv_target;
+        break;
     }
     default: return 0.0;
     }
+#ifdef RESERVOIR_COUPLING_ENABLED
+    if (this->isReservoirCouplingSlave()
+        && this->isReservoirCouplingSlaveGroup(group))
+    {
+        target = this->getEffectiveProductionLimit_(group.name(), cmode, target);
+    }
+#endif
+    return target;
 }
 
 template<typename Scalar, typename IndexTraits>
@@ -1880,31 +1915,44 @@ getProductionGroupTargetForMode_(const Group& group,
     }
 }
 
-template<typename Scalar, typename IndexTraits>
-std::pair<Group::ProductionCMode, Scalar>
+#ifdef RESERVOIR_COUPLING_ENABLED
+template <typename Scalar, typename IndexTraits>
+Scalar
 GroupStateHelper<Scalar, IndexTraits>::
-checkProductionRateConstraint_(const Group& group,
-                                Group::ProductionCMode cmode,
-                                Group::ProductionCMode currentControl,
-                                Scalar target,
-                                Scalar current_rate) const
+getEffectiveProductionLimit_(
+    const std::string& gname,
+    Group::ProductionCMode rate_type,
+    Scalar slave_local_target) const
 {
-    if (!group.has_control(cmode)) {
-        return {Group::ProductionCMode::NONE, Scalar(1.0)};
+    auto& slave = this->reservoirCouplingSlave();
+    if (!slave.hasMasterProductionLimits(gname)) {
+        return slave_local_target;
     }
-    if (currentControl == cmode) {
-        return {Group::ProductionCMode::NONE, Scalar(1.0)};
+    const auto& limits = slave.masterProductionLimits(gname);
+    Scalar master_limit = -1;
+    switch (rate_type) {
+    case Group::ProductionCMode::ORAT: master_limit = limits.oil_limit; break;
+    case Group::ProductionCMode::WRAT: master_limit = limits.water_limit; break;
+    case Group::ProductionCMode::GRAT: master_limit = limits.gas_limit; break;
+    case Group::ProductionCMode::LRAT: master_limit = limits.liquid_limit; break;
+    case Group::ProductionCMode::RESV: master_limit = limits.resv_limit; break;
+    default: return slave_local_target;
     }
-    if (target < current_rate) {
-        Scalar scale = 1.0;
-        if (current_rate > 1e-12)
-            scale = target / current_rate;
-        return {cmode, scale};
+    if (master_limit < 0) {
+        return slave_local_target;  // no master limit for this rate type
     }
-    return {Group::ProductionCMode::NONE, Scalar(1.0)};
+    auto filter = this->getProductionFilterFlag_(gname, rate_type);
+    using FilterFlag = ReservoirCoupling::GrupSlav::FilterFlag;
+    if (filter == FilterFlag::MAST) {
+        return master_limit;
+    }
+    if (filter == FilterFlag::BOTH) {
+        return std::min(master_limit, slave_local_target);
+    }
+    // FilterFlag::SLAV
+    return slave_local_target;
 }
 
-#ifdef RESERVOIR_COUPLING_ENABLED
 template <typename Scalar, typename IndexTraits>
 Scalar
 GroupStateHelper<Scalar, IndexTraits>::
@@ -1920,7 +1968,7 @@ getReservoirCouplingMasterGroupRate_(const Group& group,
         return 0.0;
     }
 }
-#endif
+#endif // RESERVOIR_COUPLING_ENABLED
 
 template <typename Scalar, typename IndexTraits>
 Scalar

--- a/opm/simulators/wells/GroupStateHelper.hpp
+++ b/opm/simulators/wells/GroupStateHelper.hpp
@@ -555,6 +555,25 @@ private:
 
     std::string controlGroup_(const Group& group) const;
 
+    #ifdef RESERVOIR_COUPLING_ENABLED
+    /// @brief Get the effective production limit for a group and rate type,
+    /// combining master limit, slave-local target, and GRUPSLAV filter flag.
+    ///
+    /// If the master sent a per-rate-type limit for this group and rate type,
+    /// the filter flag determines which value to use:
+    /// - MAST: return master limit
+    /// - BOTH: return min(master limit, slave_local_target)
+    /// - SLAV: return slave_local_target
+    ///
+    /// @param gname Slave group name
+    /// @param rate_type The production rate type to check
+    /// @param slave_local_target The slave's own target from GCONPROD
+    /// @return The effective limit to apply
+    Scalar getEffectiveProductionLimit_(const std::string& gname,
+                                        Group::ProductionCMode rate_type,
+                                        Scalar slave_local_target) const;
+#endif  // RESERVOIR_COUPLING_ENABLED
+
     GuideRate::RateVector getGuideRateVector_(const std::vector<Scalar>& rates) const;
 
     Scalar getInjectionGroupTargetForMode_(const Group& group,


### PR DESCRIPTION
Builds on #6852 which should be merged first.

- **Store per-rate-type production limits** (`MasterProductionLimits` struct with oil, water, gas, liquid, resv fields) in `ReservoirCouplingSlaveReportStep`, received alongside the active target from the master. A sentinel value of -1 means no limit for that rate type.
- **Add delegation** through `ReservoirCouplingSlave` (`hasMasterProductionLimits()`, `masterProductionLimits()`)
- **Add `getEffectiveProductionLimit()`** to `GroupStateHelper` which combines the master limit, the slave's local GCONPROD target, and the GRUPSLAV filter flag (MAST/SLAV/BOTH) to select the effective constraint
- **Apply the override in `getProductionConstraintTarget_()`** so all five rate types (ORAT, WRAT, GRAT, LRAT, RESV) are handled in one place
