### PR TITLE
fixed: boost propertytree 1.66 cannot be built as c++-20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,26 @@ macro(opm-simulators_sources_hook)
   if(HAVE_AVX2_EXTENSION)
     set_property(SOURCE ${AVX2_SOURCE_FILES} PROPERTY COMPILE_OPTIONS ${AVX2_FLAGS})
   endif()
+
+  # Boost 1.66 used on RHEL8 cannot be built as c++-20
+  if(Boost_VERSION VERSION_LESS 1.67)
+    set_source_files_properties(
+      opm/simulators/linalg/PropertyTree.cpp
+      opm/simulators/utils/SetupPartitioningParams.cpp
+      PROPERTIES
+      COMPILE_OPTIONS
+        -std=c++17
+    )
+    if(amgcl_FOUND AND USE_GPU_BRIDGE)
+      set_source_files_properties(
+        opm/simulators/linalg/gpubridge/amgclSolverBackend.cpp
+        opm/simulators/linalg/gpubridge/GpuBridge.cpp
+        PROPERTIES
+        COMPILE_OPTIONS
+          -std=c++17
+      )
+    endif()
+  endif()
 endmacro()
 
 macro(opm-simulators_config_hook)

--- a/opm/simulators/linalg/PropertyTree.cpp
+++ b/opm/simulators/linalg/PropertyTree.cpp
@@ -117,7 +117,13 @@ PropertyTree::get_child_items_as_vector(const std::string& child) const
     }
 
     items.emplace();
-    std::ranges::transform(*subTree, std::back_inserter(*items),
+    // compatibility with older platforms where code is built as c++-17
+#if __cplusplus>= 202002L
+    std::ranges::transform(*subTree,
+#else
+    std::transform(subTree->begin(), subTree->end(),
+#endif
+                           std::back_inserter(*items),
                            [](const auto& childItem)
                            { return childItem.second.template get_value<T>(); });
 

--- a/opm/simulators/linalg/gpubridge/amgclSolverBackend.cpp
+++ b/opm/simulators/linalg/gpubridge/amgclSolverBackend.cpp
@@ -311,8 +311,13 @@ solve_system(Scalar* b, GpuResult& res)
 
                 print(solve);
 
+                // compatibility with older platforms where code is built as c++-17
                 // reset x vector
+#if __cplusplus >= 202002L
                 std::ranges::fill(x, 0.0);
+#else
+                std::fill(x.begin(), x.end(), 0.0);
+#endif
 
                 std::vector<Scalar> b_(b, b + N);
 
@@ -336,8 +341,13 @@ solve_system(Scalar* b, GpuResult& res)
                 // print solver structure (once)
                 print(solve);
 
+                // compatibility with older platforms where code is built as c++-17
                 // reset x vector
+#if __cplusplus >= 202002L
                 std::ranges::fill(x, 0.0);
+#else
+                std::fill(x.begin(), x.end(), 0.0);
+#endif
 
                 // create blocked vectors
                 auto b_ptr = reinterpret_cast<dvec_type*>(b);
@@ -402,7 +412,12 @@ void amgclSolverBackend<Scalar,block_size>::get_result(Scalar* x_)
 {
     Timer t;
 
+    // compatibility with older platforms where code is built as c++-17
+#if __cplusplus >= 202002L
     std::ranges::copy(x, x_);
+#else
+    std::copy(x.begin(), x.end(), x_);
+#endif
 
     if (verbosity >= 3) {
         std::ostringstream out;


### PR DESCRIPTION
workaround engines engaged

wish I had a time machine so I could go back 5 years and high five myself for encapsulating ptree :wink: 