### PR TITLE
bump to dune 2.11 in python wheels

### DIFF
--- a/python/docker/scripts/build-dune.sh
+++ b/python/docker/scripts/build-dune.sh
@@ -22,7 +22,7 @@ export CMAKE_GENERATOR=Ninja
 pushd /tmp/opm
 
 # Build dune-common
-git clone --depth 1 --branch releases/opm/2024.04 https://gitlab.dune-project.org/core/dune-common.git
+git clone --depth 1 --branch v2.11.0 https://gitlab.dune-project.org/core/dune-common.git
 pushd dune-common
 mkdir build
 cd build
@@ -32,7 +32,7 @@ cmake --build . --target install
 popd
 
 # Build dune-geometry
-git clone --depth 1 --branch v2.9.1 https://gitlab.dune-project.org/core/dune-geometry.git
+git clone --depth 1 --branch v2.11.0 https://gitlab.dune-project.org/core/dune-geometry.git
 pushd dune-geometry
 mkdir build
 cd build
@@ -42,7 +42,7 @@ cmake --build . --target install
 popd
 
 # Build dune-istl
-git clone --depth 1 --branch v2.9.0 https://gitlab.dune-project.org/core/dune-istl.git
+git clone --depth 1 --branch v2.11.0 https://gitlab.dune-project.org/core/dune-istl.git
 pushd dune-istl
 mkdir build
 cd build
@@ -53,7 +53,7 @@ popd
 
 # Build dune-uggrid
 # NOTE: The core dune-uggrid repository requires user authentication to clone, so we use the staging repository.
-git clone --depth 1 --branch v2.9.1 https://gitlab.dune-project.org/staging/dune-uggrid.git
+git clone --depth 1 --branch v2.11.0 https://gitlab.dune-project.org/staging/dune-uggrid.git
 pushd dune-uggrid
 mkdir build
 cd build
@@ -63,7 +63,7 @@ cmake --build . --target install
 popd
 
 # Build dune-grid
-git clone --depth 1 --branch v2.9.1 https://gitlab.dune-project.org/core/dune-grid.git
+git clone --depth 1 --branch v2.11.0 https://gitlab.dune-project.org/core/dune-grid.git
 pushd dune-grid
 mkdir build
 cd build
@@ -73,7 +73,7 @@ cmake --build . --target install
 popd
 
 # Build dune-localfunctions
-git clone --depth 1 --branch v2.9.1 https://gitlab.dune-project.org/core/dune-localfunctions.git
+git clone --depth 1 --branch v2.11.0 https://gitlab.dune-project.org/core/dune-localfunctions.git
 pushd dune-localfunctions
 mkdir build
 cd build


### PR DESCRIPTION
We will be moving to dune 2.11, I'm starting with the wheels. Opening PR early to do local testing (scripts requires a PR).