### PR TITLE
Enable PYINPUT Processing Through Common Python Interpreter

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -349,6 +349,7 @@ namespace {
                       const bool                           slaveMode)
     {
         OPM_TIMEBLOCK(readDeck);
+
         if (((schedule == nullptr) || (summaryConfig == nullptr)) &&
             (parseContext == nullptr))
         {
@@ -357,9 +358,11 @@ namespace {
                       "or summaryConfig are not initialized");
         }
 
-        auto parser = Opm::Parser{};
-        const auto deck = readDeckFile(deckFilename, checkDeck, parser,
-                                       *parseContext, treatCriticalAsNonCritical, errorGuard);
+        auto parser = Opm::Parser { python };
+        const auto deck = readDeckFile(deckFilename, checkDeck,
+                                       parser, *parseContext,
+                                       treatCriticalAsNonCritical,
+                                       errorGuard);
 
         if (eclipseState == nullptr) {
             OPM_TIMEBLOCK(createEclState);


### PR DESCRIPTION
This PR switches to using the caller's Python interpreter for the file parsing operation.  We need this in order to properly handle the `PYINPUT` keyword since if we do not use the existing interpreter, then the internal support for `PYINPUT` will fail to initialise a second interpreter object and will end up generating a false negative of the form
```
Problem with keyword PYINPUT
In file CASE.DATA line 1234.
Python interpreter not enabled.
```
even in build configurations that include an embedded interpreter.