### PR TITLE
flow_blackoil_alugrid: workaround inifinite loop with dune-alugrid 2.11

### DIFF
--- a/opm/simulators/flow/AluGridVanguard.hpp
+++ b/opm/simulators/flow/AluGridVanguard.hpp
@@ -175,9 +175,15 @@ public:
         grid().loadBalance(*dataHandle);
 
         // communicate non-interior cells values
-        grid().communicate(*dataHandle,
-                           Dune::InteriorBorder_All_Interface,
-                           Dune::ForwardCommunication );
+        // TODO: This causes an infinite loop within fixedSize()
+        // on dune-alugrid 2.11. Since this application has never really
+        // worked in parallel, simply workaround by not calling
+        // in a sequential run for now.
+        if (grid().comm().size() > 1) {
+            grid().communicate(*dataHandle,
+                               Dune::InteriorBorder_All_Interface,
+                               Dune::ForwardCommunication );
+        }
 
        if (grid().size(0))
        {


### PR DESCRIPTION
Calling the communication function causes an infinite loop within fixedSize() call in the ctor of GatherScatterBaseImpl in dune/alugrid/3d/datahandle.hh. As in, it keeps calling itself until we exhaust the stack. Since this application has never worked in parallel, simply avoiding this call when run with a single process should be harmless.

@ElyesAhmed