### PR TITLE
read embedded status from target

### DIFF
--- a/compareECLFiles.cmake
+++ b/compareECLFiles.cmake
@@ -499,6 +499,7 @@ add_test_runSimulator(CASENAME tuning_tsinit_nextstep
                       TEST_ARGS --enable-tuning=true
                       POST_COMMAND $<TARGET_FILE:test_tuning_tsinit_nextstep>)
 
+get_property(opm-common_EMBEDDED_PYTHON TARGET opmcommon PROPERTY EMBEDDED_PYTHON)
 if (opm-common_EMBEDDED_PYTHON)
   include (${CMAKE_CURRENT_SOURCE_DIR}/pyactionActionXComparisons.cmake)
 endif ()

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -631,7 +631,8 @@ add_test_compareECLFiles(CASENAME ppcwmax
                          REL_TOL ${rel_tol}
                          DIR ppcwmax)
 
-if (opm-common_EMBEDDED_PYTHON)
+get_property(opm-common_EMBEDDED_PYTHON TARGET opmcommon PROPERTY EMBEDDED_PYTHON)
+if(opm-common_EMBEDDED_PYTHON)
   add_test_compareECLFiles(CASENAME udq_pyaction
                            FILENAME PYACTION_WCONPROD
                            SIMULATOR flow


### PR DESCRIPTION
To be processed after https://github.com/OPM/opm-common/pull/5033

While it's not strictly necessary since the prereqs file do set this variable, I prefer to be explicit here as well and not rely on the current scoping of vars (which will change).