### PR TITLE
Output and assigning well rates for opm-geochemistry module

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -137,6 +137,7 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/flow/FlowProblemParameters.cpp
   opm/simulators/flow/FlowsContainer.cpp
   opm/simulators/flow/FlowUtils.cpp
+  opm/simulators/flow/GeochemistryContainer.cpp
   opm/simulators/flow/GenericCpGridVanguard.cpp
   opm/simulators/flow/GenericOutputBlackoilModule.cpp
   opm/simulators/flow/GenericTemperatureModel.cpp
@@ -953,6 +954,7 @@ list (APPEND PUBLIC_HEADER_FILES
   opm/simulators/flow/FlowUtils.hpp
   opm/simulators/flow/FlowsData.hpp
   opm/simulators/flow/FlowThresholdPressure.hpp
+  opm/simulators/flow/GeochemistryContainer.hpp
   opm/simulators/flow/GenericCpGridVanguard.hpp
   opm/simulators/flow/GenericOutputBlackoilModule.hpp
   opm/simulators/flow/GenericTemperatureModel.hpp

--- a/opm/models/blackoil/blackoilproperties.hh
+++ b/opm/models/blackoil/blackoilproperties.hh
@@ -85,6 +85,10 @@ struct EnableBioeffects { using type = UndefinedProperty; };
 template<class TypeTag, class MyTypeTag>
 struct EnableMech { using type = UndefinedProperty; };
 
+//! Enable blackoil simulation with geochemical species
+template<class TypeTag, class MyTypeTag>
+struct EnableGeochemistry { using type = UndefinedProperty; };
+
 //! The relative weight of the residual of the energy equation compared to the mass
 //! residuals
 //!

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -132,6 +132,7 @@ class EclWriter : public EclGenericWriter<GetPropType<TypeTag, Properties::Grid>
            getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::SequentialImplicitThermal };
     enum { enableMech = getPropValue<TypeTag, Properties::EnableMech>() };
     enum { enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>() };
+    enum { enableGeochemistry = getPropValue<TypeTag, Properties::EnableGeochemistry>() };
 
 public:
 

--- a/opm/simulators/flow/FlowBaseProblemProperties.hpp
+++ b/opm/simulators/flow/FlowBaseProblemProperties.hpp
@@ -211,6 +211,10 @@ template<class TypeTag>
 struct EnableMech<TypeTag, TTag::FlowBaseProblem>
 { static constexpr bool value = false; };
 
+template<class TypeTag>
+struct EnableGeochemistry<TypeTag, TTag::FlowBaseProblem>
+{ static constexpr bool value = false; };
+
 // disable all extensions supported by black oil model. this should not really be
 // necessary but it makes things a bit more explicit
 template<class TypeTag>

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -139,6 +139,7 @@ private:
     enum { enableDissolvedGas = Indices::compositionSwitchIdx >= 0 };
     enum { enableVapwat = getPropValue<TypeTag, Properties::EnableVapwat>() };
     enum { enableDisgasInWater = getPropValue<TypeTag, Properties::EnableDisgasInWater>() };
+    enum { enableGeochemistry = getPropValue<TypeTag, Properties::EnableGeochemistry>() };
 
     using SolventModule = BlackOilSolventModule<TypeTag>;
     using PolymerModule = BlackOilPolymerModule<TypeTag>;
@@ -229,6 +230,14 @@ public:
         // create the ECL writer
         eclWriter_ = std::make_unique<EclWriterType>(simulator);
         enableEclOutput_ = Parameters::Get<Parameters::EnableEclOutput>();
+
+        // Safeguard against geochemistry since it exsist in a separate module with a separate problem class
+        if constexpr (!enableGeochemistry) {
+            if (vanguard.eclState().runspec().geochem().enabled()) {
+                throw std::runtime_error("GEOCHEM keyword in the deck but geochemistry module "
+                                         "disabled at compile time!");
+            }
+        }
 
 #if HAVE_DAMARIS
         // create Damaris writer

--- a/opm/simulators/flow/GenericOutputBlackoilModule.cpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.cpp
@@ -136,7 +136,8 @@ GenericOutputBlackoilModule(const EclipseState& eclState,
                             bool enableBrine,
                             bool enableSaltPrecipitation,
                             bool enableExtbo,
-                            bool enableBioeffects)
+                            bool enableBioeffects,
+                            bool enableGeochemistry)
     : eclState_(eclState)
     , schedule_(schedule)
     , summaryState_(summaryState)
@@ -155,6 +156,7 @@ GenericOutputBlackoilModule(const EclipseState& eclState,
     , enableSaltPrecipitation_(enableSaltPrecipitation)
     , enableExtbo_(enableExtbo)
     , enableBioeffects_(enableBioeffects)
+    , enableGeochemistry_(enableGeochemistry)
     , flowsC_(schedule, summaryConfig, isInterior)
     , rftC_(eclState_, schedule_,
             [this](const std::string& wname) { return this->isOwnedByCurrentRank(wname); },
@@ -471,6 +473,9 @@ assignToSolution(data::Solution& sol)
 
     // Tracers
     this->tracerC_.outputRestart(sol, eclState_.tracer());
+
+    // Geochemistry
+    this->geochemC_.outputRestart(sol, eclState_.species(), eclState_.mineral());
 }
 
 template<class FluidSystem>
@@ -916,6 +921,11 @@ doAllocBuffers(const unsigned bufferSize,
 
     if ((eclState_.runspec().co2Storage() || eclState_.runspec().h2Storage()) && !rsw_.empty()) {
         this->CO2H2C_.allocate(bufferSize, eclState_.runspec().co2Storage());
+    }
+
+    // geochemical species output
+    if (enableGeochemistry_) {
+        this->geochemC_.allocate(bufferSize, eclState_.species(), eclState_.mineral());
     }
 
     // tracers

--- a/opm/simulators/flow/GenericOutputBlackoilModule.hpp
+++ b/opm/simulators/flow/GenericOutputBlackoilModule.hpp
@@ -43,6 +43,7 @@
 #include <opm/simulators/flow/RegionPhasePVAverage.hpp>
 #include <opm/simulators/flow/RFTContainer.hpp>
 #include <opm/simulators/flow/RSTConv.hpp>
+#include <opm/simulators/flow/GeochemistryContainer.hpp>
 #include <opm/simulators/flow/TracerContainer.hpp>
 
 #include <opm/simulators/utils/ParallelCommunication.hpp>
@@ -314,7 +315,8 @@ protected:
                                 bool enableBrine,
                                 bool enableSaltPrecipitation,
                                 bool enableExtbo,
-                                bool enableBioeffects);
+                                bool enableBioeffects,
+                                bool enableGeochemistry);
 
     void doAllocBuffers(unsigned bufferSize,
                         unsigned reportStepNum,
@@ -382,7 +384,8 @@ protected:
     bool enableSaltPrecipitation_{false};
     bool enableExtbo_{false};
     bool enableBioeffects_{false};
-
+    bool enableGeochemistry_{false};
+    
     bool forceDisableFipOutput_{false};
     bool forceDisableFipresvOutput_{false};
     bool computeFip_{false};
@@ -451,6 +454,8 @@ protected:
     std::array<ScalarBuffer, numPhases> density_;
     std::array<ScalarBuffer, numPhases> viscosity_;
     std::array<ScalarBuffer, numPhases> relativePermeability_;
+
+    GeochemistryContainer<Scalar> geochemC_;
 
     TracerContainer<FluidSystem> tracerC_;
 

--- a/opm/simulators/flow/GeochemistryContainer.cpp
+++ b/opm/simulators/flow/GeochemistryContainer.cpp
@@ -1,0 +1,172 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+
+#include <opm/input/eclipse/EclipseState/Geochemistry/SpeciesConfig.hpp>
+#include <opm/input/eclipse/EclipseState/Geochemistry/MineralConfig.hpp>
+
+#include <opm/material/fluidsystems/BlackOilDefaultFluidSystemIndices.hpp>
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
+#include <opm/material/fluidsystems/GenericOilGasWaterFluidSystem.hpp>
+
+#include <opm/simulators/flow/GeochemistryContainer.hpp>
+
+#include <opm/output/data/Solution.hpp>
+
+#include <algorithm>
+#include <utility>
+
+namespace Opm {
+
+template<class Scalar>
+void GeochemistryContainer<Scalar>::
+allocate(const unsigned bufferSize,
+         const SpeciesConfig& species,
+         const MineralConfig& minerals)
+{
+    if (!species.empty()) {
+        speciesConcentrations_.resize(species.size());
+        for (std::size_t idx = 0; idx < species.size(); ++idx) {
+            speciesConcentrations_[idx].resize(bufferSize);
+        }
+    }
+    if (!minerals.empty()) {
+        mineralConcentrations_.resize(minerals.size());
+        for (std::size_t idx = 0; idx < minerals.size(); ++idx) {
+            mineralConcentrations_[idx].resize(bufferSize);
+        }
+    }
+    pH_.resize(bufferSize, 0.0);
+    allocated_ = true;
+}
+
+template<class Scalar>
+void GeochemistryContainer<Scalar>::
+assignSpeciesConcentrations(const unsigned globalDofIdx,
+                            const AssignFunction& concentration)
+{
+    std::ranges::for_each(
+        speciesConcentrations_,
+        [globalDofIdx, idx = 0, &concentration](auto& single_species) mutable
+        {
+            if (!single_species.empty()) {
+                single_species[globalDofIdx] = concentration(idx);
+            }
+            ++idx;
+        }
+    );
+}
+
+template<class Scalar>
+void GeochemistryContainer<Scalar>::
+assignMineralConcentrations(const unsigned globalDofIdx,
+                            const AssignFunction& concentration)
+{
+    std::ranges::for_each(
+        mineralConcentrations_,
+        [globalDofIdx, idx = 0, &concentration](auto& single_mineral) mutable
+        {
+            if (!single_mineral.empty()) {
+                single_mineral[globalDofIdx] = concentration(idx);
+            }
+            ++idx;
+        }
+    );
+}
+
+template<class Scalar>
+void GeochemistryContainer<Scalar>::
+assignPH(const unsigned globalDofIdx, const Scalar ph)
+{
+    pH_[globalDofIdx] = ph;
+}
+
+template<class Scalar>
+void GeochemistryContainer<Scalar>::
+outputRestart(data::Solution& sol,
+              const SpeciesConfig& species,
+              const MineralConfig& minerals)
+{
+    if (!allocated_) {
+        return;
+    }
+
+    // Output species concentrations
+    std::ranges::for_each(
+        species,
+        [idx = 0, &sol, this](const auto& single_species) mutable
+        {
+            sol.insert(single_species.name,
+                       UnitSystem::measure::identity,
+                       std::move(speciesConcentrations_[idx]),
+                       data::TargetType::RESTART_OPM_EXTENDED
+                    );
+            ++idx;
+        }
+    );
+    // Output mineral concentrations
+    std::ranges::for_each(
+        minerals,
+        [idx = 0, &sol, this](const auto& single_mineral) mutable
+        {
+            sol.insert(single_mineral.name,
+                       UnitSystem::measure::identity,
+                       std::move(mineralConcentrations_[idx]),
+                       data::TargetType::RESTART_OPM_EXTENDED
+                    );
+            ++idx;
+        }
+    );
+
+    // Output other geochemistry vectors
+    using DataEntry =
+        std::tuple<std::string, UnitSystem::measure, std::vector<Scalar>&>;
+    auto solutionVectors = std::array {
+        DataEntry{"PH",  UnitSystem::measure::identity, pH_}
+    };
+    std::ranges::for_each(
+        solutionVectors,
+        [&sol](auto& entry)
+        {
+            if (!std::get<2>(entry).empty()) {
+                sol.insert(
+                    std::get<std::string>(entry),
+                    std::get<UnitSystem::measure>(entry),
+                    std::move(std::get<2>(entry)),
+                    data::TargetType::RESTART_OPM_EXTENDED
+                );
+            }
+        }
+    );
+
+    allocated_ = false;
+}
+
+template class GeochemistryContainer<double>;
+
+#if FLOW_INSTANTIATE_FLOAT
+template class GeochemistryContainer<float>;
+#endif
+
+}  // namespace Opm
+

--- a/opm/simulators/flow/GeochemistryContainer.hpp
+++ b/opm/simulators/flow/GeochemistryContainer.hpp
@@ -1,0 +1,68 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#ifndef GEOCHEMISTRY_CONTAINER_HPP
+#define GEOCHEMISTRY_CONTAINER_HPP
+
+#include <functional>
+#include <vector>
+
+namespace Opm {
+
+namespace data { class Solution; }
+class SpeciesConfig;
+class MineralConfig;
+
+template<class Scalar>
+class GeochemistryContainer
+{
+    using ScalarBuffer = std::vector<Scalar>;
+
+public:
+    void allocate(const unsigned bufferSize,
+                  const SpeciesConfig& species,
+                  const MineralConfig& minerals);
+
+    using AssignFunction = std::function<Scalar(const unsigned)>;
+
+    void assignSpeciesConcentrations(const unsigned globalDofIdx,
+                                     const AssignFunction& concentration);
+    void assignMineralConcentrations(const unsigned globalDofIdx,
+                                     const AssignFunction& concentration);
+    void assignPH(const unsigned globalDofIdx, const Scalar ph);
+
+    void outputRestart(data::Solution& sol,
+                       const SpeciesConfig& species,
+                       const MineralConfig& minerals);
+
+    bool allocated() const
+    { return allocated_; }
+
+private:
+    std::vector<ScalarBuffer> speciesConcentrations_{};
+    std::vector<ScalarBuffer> mineralConcentrations_{};
+    ScalarBuffer pH_;
+    bool allocated_{false};
+};  // class GeochemistryContainer
+
+} // namespace Opm
+
+#endif

--- a/opm/simulators/flow/OutputBlackoilModule.hpp
+++ b/opm/simulators/flow/OutputBlackoilModule.hpp
@@ -154,7 +154,8 @@ public:
                    getPropValue<TypeTag, Properties::EnableBrine>(),
                    getPropValue<TypeTag, Properties::EnableSaltPrecipitation>(),
                    getPropValue<TypeTag, Properties::EnableExtbo>(),
-                   getPropValue<TypeTag, Properties::EnableBioeffects>())
+                   getPropValue<TypeTag, Properties::EnableBioeffects>(),
+                   getPropValue<TypeTag, Properties::EnableGeochemistry>())
         , simulator_(simulator)
         , collectOnIORank_(collectOnIORank)
     {
@@ -647,6 +648,14 @@ private:
     template <typename Problem>
     struct HasGeoMech<
         Problem, std::void_t<decltype(std::declval<Problem>().geoMechModel())>
+    > : public std::true_type {};
+
+    template <typename, class = void>
+    struct HasGeochemistry : public std::false_type {};
+
+    template <typename Problem>
+    struct HasGeochemistry<
+        Problem, std::void_t<decltype(std::declval<Problem>().geochemistryModel())>
     > : public std::true_type {};
 
     bool isDefunctParallelWell(const std::string& wname) const override
@@ -1821,6 +1830,32 @@ private:
         // Setup active extractors
         this->extractors_ = Extractor::removeInactive(extractors);
 
+        // Geochemistry
+        if constexpr (getPropValue<TypeTag, Properties::EnableGeochemistry>()) {
+            if (this->geochemC_.allocated()) {
+                this->extractors_.push_back(
+                    Entry{
+                        [&gC = this->geochemC_,
+                         &gM = this->simulator_.problem().geochemistryModel()](const Context& ectx)
+                        {
+                            gC.assignSpeciesConcentrations(
+                                ectx.globalDofIdx,
+                                [gIdx = ectx.globalDofIdx, &gM](const unsigned speciesIdx)
+                                    { return gM.speciesConcentration(speciesIdx, gIdx); }
+                            );
+                            gC.assignMineralConcentrations(
+                                ectx.globalDofIdx,
+                                [gIdx = ectx.globalDofIdx, &gM](const unsigned mineralIdx)
+                                    { return gM.mineralConcentration(mineralIdx, gIdx); }
+                            );
+                            gC.assignPH(ectx.globalDofIdx, gM.PH(ectx.globalDofIdx));
+                        }
+                    }
+                );
+            }
+        }
+
+        // Geomechanics
         if constexpr (getPropValue<TypeTag, Properties::EnableMech>()) {
             if (this->mech_.allocated()) {
                 this->extractors_.push_back(

--- a/opm/simulators/flow/OutputCompositionalModule.hpp
+++ b/opm/simulators/flow/OutputCompositionalModule.hpp
@@ -114,7 +114,8 @@ public:
                    getPropValue<TypeTag, Properties::EnableBrine>(),
                    getPropValue<TypeTag, Properties::EnableSaltPrecipitation>(),
                    getPropValue<TypeTag, Properties::EnableExtbo>(),
-                   getPropValue<TypeTag, Properties::EnableBioeffects>())
+                   getPropValue<TypeTag, Properties::EnableBioeffects>(),
+                   getPropValue<TypeTag, Properties::EnableGeochemistry>())
         , simulator_(simulator)
     {
         for (auto& region_pair : this->regions_) {

--- a/opm/simulators/wells/BlackoilWellModel.hpp
+++ b/opm/simulators/wells/BlackoilWellModel.hpp
@@ -123,6 +123,7 @@ template<class Scalar> class WellContributions;
             static constexpr EnergyModules energyModuleType_ = getPropValue<TypeTag, Properties::EnergyModuleType>();
             static constexpr bool has_energy_ = (energyModuleType_ == EnergyModules::FullyImplicitThermal);
             static constexpr bool has_micp_ = Indices::enableMICP;
+            static constexpr bool has_geochem_ = getPropValue<TypeTag, Properties::EnableGeochemistry>();
 
             // TODO: where we should put these types, WellInterface or Well Model?
             // or there is some other strategy, like TypeTag
@@ -216,6 +217,10 @@ template<class Scalar> class WellContributions;
                     .assignWellGuideRates(wsrpt, this->reportStepIndex());
 
                 this->assignWellTracerRates(wsrpt);
+
+                if constexpr (has_geochem_) {
+                    this->assignWellSpeciesRates(wsrpt);
+                }
 
                 if (const auto& rspec = eclState().runspec();
                     rspec.co2Storage() || rspec.h2Storage())
@@ -626,6 +631,7 @@ template<class Scalar> class WellContributions;
             std::map<int, RateVector> cellRates_;
 
             void assignWellTracerRates(data::Wells& wsrpt) const;
+            void assignWellSpeciesRates(data::Wells& wsrpt) const;
         };
 
 } // namespace Opm

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -2233,6 +2233,18 @@ namespace Opm {
         this->assignMswTracerRates(wsrpt, trMod.getMswTracerRates(), reportStepIdx);
     }
 
+    template <typename TypeTag>
+    void BlackoilWellModel<TypeTag>::
+    assignWellSpeciesRates(data::Wells& wsrpt) const
+    {
+        const auto reportStepIdx = static_cast<unsigned int>(this->reportStepIndex());
+        const auto& geochemMod = this->simulator_.problem().geochemistryModel();
+
+        BlackoilWellModelGeneric<Scalar, IndexTraits>::assignWellTracerRates(wsrpt, geochemMod.getWellSpeciesRates(), reportStepIdx);
+
+        this->assignMswTracerRates(wsrpt, geochemMod.getMswSpeciesRates(), reportStepIdx);
+    }
+
 } // namespace Opm
 
 #endif // OPM_BLACKOILWELLMODEL_IMPL_HEADER_INCLUDED


### PR DESCRIPTION
This PR introduces output and well rate assignment for the new OPM geochemistry module, [opm-geochemistry](https://github.com/OPM/opm-geochemistry). Additionally, a new geochemistry property is introduced for activating the geochemistry module.

Depends on https://github.com/OPM/opm-common/pull/5036