### PR TITLE
[bugfix] Mark output writing due to EXIT in ACTIONX as last writing.

### DIFF
--- a/opm/simulators/flow/EclGenericWriter.hpp
+++ b/opm/simulators/flow/EclGenericWriter.hpp
@@ -121,6 +121,7 @@ protected:
     void doWriteOutput(const int                          reportStepNum,
                        const std::optional<int>           timeStepNum,
                        const bool                         isSubStep,
+                       const bool                         forcedSimulationFinished,
                        data::Solution&&                   localCellData,
                        data::Wells&&                      localWellData,
                        data::GroupAndNetworkValues&&      localGroupAndNetworkData,

--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -150,6 +150,8 @@ struct EclWriteTasklet : public Opm::TaskletInterface
     double secondsElapsed_;
     std::vector<Opm::RestartValue> restartValue_;
     bool writeDoublePrecision_;
+    /// \brief True if there was an EXIT keyword in ACTIONX causing a simulation end
+    bool forcedSimulationFinished_;
 
     explicit EclWriteTasklet(const Opm::Action::State& actionState,
                              const Opm::WellTestState& wtestState,
@@ -161,7 +163,8 @@ struct EclWriteTasklet : public Opm::TaskletInterface
                              bool isSubStep,
                              double secondsElapsed,
                              std::vector<Opm::RestartValue> restartValue,
-                             bool writeDoublePrecision)
+                             bool writeDoublePrecision,
+                             bool forcedSimulationFinished)
         : actionState_(actionState)
         , wtestState_(wtestState)
         , summaryState_(summaryState)
@@ -173,6 +176,7 @@ struct EclWriteTasklet : public Opm::TaskletInterface
         , secondsElapsed_(secondsElapsed)
         , restartValue_(std::move(restartValue))
         , writeDoublePrecision_(writeDoublePrecision)
+        , forcedSimulationFinished_(forcedSimulationFinished)
     {}
 
     // callback to eclIO serial writeTimeStep method
@@ -188,7 +192,8 @@ struct EclWriteTasklet : public Opm::TaskletInterface
                                        this->secondsElapsed_,
                                        std::move(this->restartValue_.back()),
                                        this->writeDoublePrecision_,
-                                       this->timeStepNum_);
+                                       this->timeStepNum_,
+                                       forcedSimulationFinished_);
         }
         else{
             this->eclIO_.writeTimeStep(this->actionState_,
@@ -200,7 +205,8 @@ struct EclWriteTasklet : public Opm::TaskletInterface
                                        this->secondsElapsed_,
                                        std::move(this->restartValue_),
                                        this->writeDoublePrecision_,
-                                       this->timeStepNum_);
+                                       this->timeStepNum_,
+                                       forcedSimulationFinished_);
         }
     }
 };
@@ -894,6 +900,7 @@ void EclGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>::
 doWriteOutput(const int                          reportStepNum,
               const std::optional<int>           timeStepNum,
               const bool                         isSubStep,
+              const bool                         isForcedFinalOutput,
               data::Solution&&                   localCellData,
               data::Wells&&                      localWellData,
               data::GroupAndNetworkValues&&      localGroupAndNetworkData,
@@ -991,7 +998,8 @@ doWriteOutput(const int                          reportStepNum,
         actionState,
         isParallel ? this->collectOnIORank_.globalWellTestState() : std::move(localWTestState),
         summaryState, udqState, *this->eclIO_,
-        reportStepNum, timeStepNum, isSubStep, curTime, std::move(restartValues), doublePrecision);
+        reportStepNum, timeStepNum, isSubStep, curTime, std::move(restartValues), doublePrecision,
+        isForcedFinalOutput);
 
     // finally, start a new output writing job
     this->taskletRunner_->dispatch(std::move(eclWriteTasklet));

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -449,7 +449,7 @@ public:
         OpmLog::note("");   // Blank line after all reports.
     }
 
-    void writeOutput(data::Solution&& localCellData, bool isSubStep)
+    void writeOutput(data::Solution&& localCellData, const bool isSubStep, const bool isForcedFinalOutput)
     {
         OPM_TIMEBLOCK(writeOutput);
 
@@ -517,6 +517,7 @@ public:
                 timeStepIdx = simulator_.timeStepIndex();
             }
             this->doWriteOutput(reportStepNum, timeStepIdx, isSubStep,
+                                isForcedFinalOutput,
                                 std::move(localCellData),
                                 std::move(localWellData),
                                 std::move(localGroupAndNetworkData),

--- a/opm/simulators/flow/FlowProblemBlackoil.hpp
+++ b/opm/simulators/flow/FlowProblemBlackoil.hpp
@@ -583,7 +583,9 @@ public:
 #endif
 
         if (this->enableEclOutput_ && (this->eclWriter_ != nullptr)) {
-            this->eclWriter_->writeOutput(std::move(localCellData), isSubStep);
+            this->eclWriter_->writeOutput(std::move(localCellData), isSubStep,
+                                          this->simulator().vanguard().schedule()
+                                         .exitStatus().has_value());
         }
     }
 

--- a/opm/simulators/flow/FlowProblemComp.hpp
+++ b/opm/simulators/flow/FlowProblemComp.hpp
@@ -292,7 +292,9 @@ public:
         if (!isSubStep || Parameters::Get<Parameters::EnableWriteAllSolutions>()) {
             auto localCellData = data::Solution {};
 
-            this->eclWriter_->writeOutput(std::move(localCellData), isSubStep);
+            this->eclWriter_->writeOutput(std::move(localCellData), isSubStep,
+                                          this->simulator().vanguard().schedule()
+                                         .exitStatus().has_value());
         }
     }
 


### PR DESCRIPTION
We do some special things in the last write out (e.g. writing RSM file). Previously that was only done if we reached the last report step. With an EXIT in an exectuted ACTIONX the simulation end is reached earlier and we missed some output.

With this change we perform the same write out, if there was an ACTIONX/EXIT, as for a regular write out at the last report step.

Needs OPM/opm-common#5038