### PR TITLE
drop checks for boost >= 1.48

### DIFF
--- a/opm/simulators/linalg/setupPropertyTree.cpp
+++ b/opm/simulators/linalg/setupPropertyTree.cpp
@@ -27,7 +27,6 @@
 #include <opm/simulators/linalg/FlowLinearSolverParameters.hpp>
 
 #include <filesystem>
-#include <boost/version.hpp>
 
 namespace Opm
 {
@@ -187,7 +186,6 @@ setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters 
 
     // Get configuration from file.
     if (conf.size() > 5 && conf.substr(conf.size() - 5, 5) == ".json") { // the ends_with() method is not available until C++20
-#if BOOST_VERSION / 100 % 1000 > 48
         if ( !std::filesystem::exists(conf) ) {
             OPM_THROW(std::invalid_argument, "JSON file " + conf + " does not exist.");
         }
@@ -197,11 +195,6 @@ setupPropertyTree(FlowLinearSolverParameters p, // Note: copying the parameters 
         catch (...) {
             OPM_THROW(std::invalid_argument, "Failed reading linear solver configuration from JSON file " + conf);
         }
-#else
-        OPM_THROW(std::invalid_argument,
-                  "--linear-solver-configuration=file.json not supported with "
-                  "boost version. Needs version > 1.48.");
-#endif
     }
 
     // We use lower case as the internal canonical representation of solver names.

--- a/opm/simulators/utils/SetupPartitioningParams.cpp
+++ b/opm/simulators/utils/SetupPartitioningParams.cpp
@@ -24,11 +24,7 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 
-#include <boost/version.hpp>
-
-#if BOOST_VERSION / 100 % 1000 > 48
 #include <boost/property_tree/json_parser.hpp>
-#endif
 
 #include <filesystem>
 #include <map>
@@ -40,8 +36,6 @@
 #include <fmt/format.h>
 
 namespace {
-
-#if BOOST_VERSION / 100 % 1000 > 48
 
     std::map<std::string, std::string>
     jsonConfiguration(const std::string&    conf,
@@ -71,21 +65,6 @@ namespace {
 
         return result;
     }
-
-#else // ! Boost.PTree has JSON support.
-
-    [[noreturn]] std::map<std::string, std::string>
-    jsonConfiguration(const std::string& conf,
-                      std::string_view   paramName)
-    {
-        OPM_THROW(std::invalid_argument,
-                  fmt::format("{}=file.json ({}) is not supported in "
-                              "current Boost version (1.{}). "
-                              "Need Boost version 1.49 or later.",
-                              paramName, conf, (BOOST_VERSION / 100) % 1000));
-    }
-
-#endif // Boost.PTree has JSON support.
 
     bool isJsonConfiguration(const std::string& conf)
     {


### PR DESCRIPTION
it most certainly is or it won't be compiling as c++-20 in any case.