### PR TITLE
Reorganize GroupStateHelper private methods by caller group

### DIFF
--- a/opm/simulators/wells/GroupStateHelper.cpp
+++ b/opm/simulators/wells/GroupStateHelper.cpp
@@ -371,7 +371,7 @@ checkGroupProductionConstraints(const Group& group) const
             continue;
         }
 
-        Scalar current_rate = this->sumProductionRate_(group, cmode);
+        Scalar current_rate = this->sumProductionRateForControlMode_(group, cmode);
         Scalar target = this->getProductionConstraintTarget_(group, cmode, controls);
 
         // LRAT skip heuristic: if liquid and oil targets are equal
@@ -472,6 +472,14 @@ getProductionGroupTarget(const Group& group) const
     {
         auto [master_target, master_cmode] =
             this->reservoirCouplingSlave().masterProductionTarget(group.name());
+        // Slave group's cmode should already be updated to the master cmode,
+        // see updateSlaveGroupCmodesFromMaster()
+        if (cmode != master_cmode) {
+            OPM_DEFLOG_THROW(std::runtime_error,
+                "Group " + group.name()
+                + " cmode mismatch between slave and master",
+                this->deferredLogger());
+        }
         auto filter = this->getProductionFilterFlag_(group.name(), master_cmode);
         using FilterFlag = ReservoirCoupling::GrupSlav::FilterFlag;
         if (filter == FilterFlag::MAST) {
@@ -1836,7 +1844,7 @@ getProductionGroupTargetForMode_(const Group& group,
 template<typename Scalar, typename IndexTraits>
 Scalar
 GroupStateHelper<Scalar, IndexTraits>::
-sumProductionRate_(const Group& group,
+sumProductionRateForControlMode_(const Group& group,
                     Group::ProductionCMode cmode) const
 {
     const auto& pu = this->phaseUsage();
@@ -1980,11 +1988,9 @@ activePhaseIdxToRescoupPhase_(int phase_pos) const
         phase_pos == pu.canonicalToActivePhaseIdx(IndexTraits::waterPhaseIdx)) {
         return ReservoirCoupling::Phase::Water;
     }
-    // TODO: We would like to use OPM_DEFLOG_THROW() here, but it is requires the deferred logger to be passed
-    //   as an argument to all the sumWellPhaseRates() calls, which is a major refactoring effort.
-    //   Alternatively, we could store a reference to the deferred logger in the GroupStateHelper class,
-    //   which would also require a major refactoring effort.
-    throw std::logic_error("Invalid phase_pos in activePhaseIdxToRescoupPhase");
+    OPM_DEFLOG_THROW(std::logic_error,
+                     "Invalid phase_pos in activePhaseIdxToRescoupPhase",
+                     this->deferredLogger());
     return ReservoirCoupling::Phase::Oil; // just to avoid warning
 }
 

--- a/opm/simulators/wells/GroupStateHelper.hpp
+++ b/opm/simulators/wells/GroupStateHelper.hpp
@@ -640,7 +640,7 @@ private:
 
     std::optional<GSatProd::GSatProdGroupProp::Rate> selectRateComponent_(const int phase_pos) const;
 
-    Scalar sumProductionRate_(const Group& group, Group::ProductionCMode cmode) const;
+    Scalar sumProductionRateForControlMode_(const Group& group, Group::ProductionCMode cmode) const;
 
     int updateGroupControlledWellsRecursive_(const std::string& group_name,
                                              const bool is_production_group,


### PR DESCRIPTION
Builds on #6853, which should be merged first.

Improve readability and help maintenance of the `GroupStateHelper` class by reorganizing the private methods into groups and adding short comments about callers above each method.

#### Reorganize private methods into logical sections (commit 1)

- **Group 24 private methods into six sections** based on which public methods call them: constraint checking helpers, injection & production target helpers, guide rate & hierarchy navigation, reservoir coupling helpers, satellite group rate helpers, and recursive update helpers
- **Add section banner comments** listing the public callers for each group, and short per-method comments describing purpose and caller
- **Move `getInjectionGroupTargetForMode_()`** from the public methods area into the private section (Group B) where it belongs
- **Consolidate five scattered `#ifdef RESERVOIR_COUPLING_ENABLED`** guards for the reservoir coupling group into a single block
- This is a **pure code-move** with no logic changes

#### Minor cleanups noticed during reorganization (commit 2)

- **Rename `sumProductionRate_()`** to `sumProductionRateForControlMode_()` to better describe that it sums rates for a specific control mode
- **Add defensive cmode mismatch check** in `getProductionGroupTarget()` for reservoir coupling slave groups — the slave's cmode should already match the master's after `updateSlaveGroupCmodesFromMaster()`
- **Replace bare `std::logic_error`** throw with `OPM_DEFLOG_THROW` in `activePhaseIdxToRescoupPhase_()` — the old TODO noted `deferredLogger()` was unavailable, but the method now lives in `GroupStateHelper` which provides it
