### PR TITLE
detail::multMatrix: replace out param with return value

### DIFF
--- a/opm/simulators/linalg/SmallDenseMatrixUtils.hpp
+++ b/opm/simulators/linalg/SmallDenseMatrixUtils.hpp
@@ -111,9 +111,10 @@ namespace detail
 
     //! calculates ret = A * B
     template< class K>
-    static inline void multMatrix(const Dune::DynamicMatrix<K>& A,
-                                  const Dune::DynamicMatrix<K>& B,
-                                  Dune::DynamicMatrix<K>& ret )
+    static inline
+    Dune::DynamicMatrix<K>
+    multMatrix(const Dune::DynamicMatrix<K>& A,
+               const Dune::DynamicMatrix<K>& B)
     {
         using size_type = typename Dune::DynamicMatrix<K> :: size_type;
 
@@ -124,7 +125,7 @@ namespace detail
 
         const size_type p = B.cols();
 
-        ret.resize(m, p);
+        Dune::DynamicMatrix<K> ret(m, p);
 
         for( size_type i = 0; i < m; ++i )
         {
@@ -135,6 +136,8 @@ namespace detail
                     ret[ i ][ j ] += A[ i ][ k ] * B[ k ][ j ];
             }
         }
+
+        return ret;
     }
 
 } // namespace detail

--- a/opm/simulators/wells/StandardWellEquations.cpp
+++ b/opm/simulators/wells/StandardWellEquations.cpp
@@ -253,7 +253,6 @@ extract(SparseMatrixAdapter& jacobian) const
     // B and C have 1 row, nc colums and nonzero
     // at (0,j) only if this well has a perforation at cell j.
     typename SparseMatrixAdapter::MatrixBlock tmpMat;
-    Dune::DynamicMatrix<Scalar> tmp;
     for (auto colC = duneC_[0].begin(),
               endC = duneC_[0].end(); colC != endC; ++colC)
     {
@@ -265,7 +264,7 @@ extract(SparseMatrixAdapter& jacobian) const
         {
             // map the well perforated cell index to global cell index
             const auto col_index = this->cells_[colB.index()];
-            detail::multMatrix(invDuneD_[0][0], (*colB), tmp);
+            const auto tmp = detail::multMatrix(invDuneD_[0][0], (*colB));
             detail::negativeMultMatrixTransposed((*colC), tmp, tmpMat);
             jacobian.addToBlock(row_index, col_index, tmpMat);
         }


### PR DESCRIPTION
use return of matrix instead of out-param.

the resize() method does not take existing size into account so this causes no extra allocations

as a side effect this removes a confusing compiler warning from the resize call,
```
In file included from /usr/include/x86_64-linux-gnu/c++/14/bits/c++allocator.h:33,
                 from /usr/include/c++/14/bits/allocator.h:46,
                 from /usr/include/c++/14/string:43,
                 from /usr/include/c++/14/stdexcept:39,
                 from /build/default/install/include/opm/common/Exceptions.hpp:26,
                 from /build/opm/simulators/wells/StandardWellEquations.cpp:23:
In member function 'void std::__new_allocator<_Tp>::deallocate(_Tp*, size_type) [with _Tp = double]',
    inlined from 'constexpr void std::allocator< <template-parameter-1-1> >::deallocate(_Tp*, std::size_t) [with _Tp = double]' at /usr/include/c++/14/bits/allocator.h:208:35,
    inlined from 'static constexpr void std::allocator_traits<std::allocator<_CharT> >::deallocate(allocator_type&, pointer, size_type) [with _Tp = double]' at /usr/include/c++/14/bits/alloc_traits.h:513:23,
    inlined from 'constexpr void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(pointer, std::size_t) [with _Tp = double; _Alloc = std::allocator<double>]' at /usr/include/c++/14/bits/stl_vector.h:389:19,
    inlined from 'constexpr std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = double; _Alloc = std::allocator<double>]' at /usr/include/c++/14/bits/stl_vector.h:368:15,
    inlined from 'constexpr std::vector<_Tp, _Alloc>::~vector() [with _Tp = double; _Alloc = std::allocator<double>]' at /usr/include/c++/14/bits/stl_vector.h:738:7,
    inlined from 'constexpr Dune::DynamicVector<double, std::allocator<double> >::~DynamicVector()' at /usr/include/dune/common/dynvector.hh:58:9,
    inlined from 'void Dune::DynamicMatrix< <template-parameter-1-1> >::resize(size_type, size_type, value_type) [with K = double]' at /usr/include/dune/common/dynmatrix.hh:109:23,
    inlined from 'void Opm::detail::multMatrix(const Dune::DynamicMatrix<K>&, const Dune::DynamicMatrix<K>&, Dune::DynamicMatrix<K>&) [with K = double]' at /build/opm/simulators/linalg/SmallDenseMatrixUtils.hpp:127:19,
    inlined from 'void Opm::StandardWellEquations<Scalar, IndexTraits, numEq>::extract(SparseMatrixAdapter&) const [with SparseMatrixAdapter = Opm::Linear::IstlSparseMatrixAdapter<Opm::MatrixBlock<double, 1, 1> >; Scalar = double; IndexTraits = Opm::BlackOilDefaultFluidSystemIndices; int numEq = 1]' at /build/opm/simulators/wells/StandardWellEquations.cpp:268:31:
/usr/include/c++/14/bits/new_allocator.h:172:33: warning: 'void operator delete(void*, std::size_t)' called on pointer '<unknown>' with nonzero offset [8, 9223372036854775800] [-Wfree-nonheap-object]
  172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
```