### PR TITLE
comment out code that causes out-of-bounds indexing warnings

### DIFF
--- a/opm/models/pvs/pvsintensivequantities.hh
+++ b/opm/models/pvs/pvsintensivequantities.hh
@@ -198,9 +198,11 @@ public:
             }
 
             for (; auxIdx < numAuxConstraints; ++auxIdx, ++switchIdx) {
-                const unsigned compIdx = numPhases - numNonPresentPhases + auxIdx;
-                auxConstraints[auxIdx].set(lowestPresentPhaseIdx, compIdx,
-                                           priVars.makeEvaluation(switch0Idx + switchIdx, timeIdx));
+                assert(0 && "Should not be here!");
+                // This code is commented out because it causes oob indexing warnings
+                // const unsigned compIdx = numPhases - numNonPresentPhases + auxIdx;
+                // auxConstraints[auxIdx].set(lowestPresentPhaseIdx, compIdx,
+                //                            priVars.makeEvaluation(switch0Idx + switchIdx, timeIdx));
             }
 
             // both phases are present, i.e. phase compositions are a result of the the


### PR DESCRIPTION
this code is never used.

granted, this is mostly a cop-out, but I am struggling to understand what this block is trying to do, and it clearly has an off by one error in the indexing that causes lots of warnings like

```
In file included from /usr/include/c++/14/functional:65,
                 from /usr/include/dune/common/parallel/mpicommunication.hh:19,
                 from /usr/include/dune/common/parallel/mpihelper.hh:18,
                 from /build/opm/models/utils/start.hh:30,
                 from /build/examples/diffusion_pvs.cpp:30:
In member function 'constexpr const std::array<_Tp, _Nm>::value_type& std::array<_Tp, _Nm>::operator[](size_type) const [with _Tp = double; long unsigned int _Nm = 2]',
    inlined from 'constexpr const Dune::FieldVector<K, n>::value_type& Dune::FieldVector<K, n>::operator[](size_type) const [with K = double; int SIZE = 2]' at /usr/include/dune/common/fvector.hh:243:19,
    inlined from 'Opm::FvBasePrimaryVariables<TypeTag, VectorType>::Evaluation Opm::FvBasePrimaryVariables<TypeTag, VectorType>::makeEvaluation(unsigned int, unsigned int, Opm::LinearizationType) const [with TypeTag = Opm::Properties::TTag::DiffusionProblem; VectorType = Dune::FieldVector]' at /build/opm/models/discretization/common/fvbaseprimaryvariables.hh:120:27,
    inlined from 'void Opm::PvsIntensiveQuantities<TypeTag>::update(const ElementContext&, unsigned int, unsigned int) [with TypeTag = Opm::Properties::TTag::DiffusionProblem]' at /build/opm/models/pvs/pvsintensivequantities.hh:202:43:
/usr/include/c++/14/array:219:24: warning: array subscript 2 is above array bounds of 'std::__array_traits<double, 2>::_Type' {aka 'const double [2]'} [-Warray-bounds=]
  219 |         return _M_elems[__n];
      |                ~~~~~~~~^
/usr/include/c++/14/array: In member function 'void Opm::PvsIntensiveQuantities<TypeTag>::update(const ElementContext&, unsigned int, unsigned int) [with TypeTag = Opm::Properties::TTag::DiffusionProblem]':
/usr/include/c++/14/array:115:55: note: while referencing 'std::array<double, 2>::_M_elems'
  115 |       typename __array_traits<_Tp, _Nm>::_Type        _M_elems;
```
as the assert is never hit in any of the tests for this, I suggest this workaround unless somebody with a better understanding than me wants to fix it.