### PR TITLE
quell compiler warning

### DIFF
--- a/opm/models/discretization/vcfv/vcfvstencil.hh
+++ b/opm/models/discretization/vcfv/vcfvstencil.hh
@@ -42,6 +42,7 @@
 #endif // HAVE_DUNE_LOCALFUNCTIONS
 
 #include <array>
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <stdexcept>
@@ -853,6 +854,9 @@ public:
         const Geometry& geometry = e.geometry();
         geometryType_ = geometry.type();
         const auto& referenceElement = Dune::ReferenceElements<CoordScalar,dim>::general(geometryType_);
+        // should be the same, but let's let the compiler know to quell (false) diagnostics
+        assert(numVertices == static_cast<unsigned>(referenceElement.size(dim)));
+        numVertices = std::min(numVertices, static_cast<unsigned>(referenceElement.size(dim)));
         for (unsigned vertexIdx = 0; vertexIdx < numVertices; ++vertexIdx) {
             subContVol[vertexIdx].local = referenceElement.position(static_cast<int>(vertexIdx), dim);
             subContVol[vertexIdx].global = geometry.corner(static_cast<int>(vertexIdx));


### PR DESCRIPTION
Not sure what gcc is on about, but beat it into shape

```
In member function 'constexpr std::array<_Tp, _Nm>::value_type& std::array<_Tp, _Nm>::operator[](size_type) [with _Tp = Opm::VcfvStencil<double, Dune::GridView<Dune::ALU3dLeafGridViewTraits<const Dune::ALUGrid<2, 2, Dune::cube, Dune::nonconforming>, Dune::All_Partition> > >::SubControlVolume; long unsigned int _Nm = 4]',
    inlined from 'void Opm::VcfvStencil<Scalar, GridView>::updateTopology(const Element&) [with Scalar = double; GridView = Dune::GridView<Dune::ALU3dLeafGridViewTraits<const Dune::ALUGrid<2, 2, Dune::cube, Dune::nonconforming>, Dune::All_Partition> >]' at /build/opm/models/discretization/vcfv/vcfvstencil.hh:857:23,
    inlined from 'void Opm::VcfvStencil<Scalar, GridView>::updatePrimaryTopology(const Element&) [with Scalar = double; GridView = Dune::GridView<Dune::ALU3dLeafGridViewTraits<const Dune::ALUGrid<2, 2, Dune::cube, Dune::nonconforming>, Dune::All_Partition> >]' at /build/opm/models/discretization/vcfv/vcfvstencil.hh:867:23,
    inlined from 'void Opm::FvBaseElementContext<TypeTag>::updatePrimaryStencil(const Element&) [with TypeTag = Opm::Properties::TTag::FingerProblemVcfv]' at /build/opm/models/discretization/common/fvbaseelementcontext.hh:157:39,
    inlined from '_ZNK3Opm20FvBaseDiscretizationINS_10Properties4TTag17FingerProblemVcfvEE38invalidateAndUpdateIntensiveQuantitiesEj._omp_fn.0' at /build/opm/models/discretization/common/fvbasediscretization.hh:738:45:
/usr/include/c++/14/array:209:24: warning: array subscript 4 is above array bounds of 'std::__array_traits<Opm::VcfvStencil<double, Dune::GridView<Dune::ALU3dLeafGridViewTraits<const Dune::ALUGrid<2, 2, Dune::cube, Dune::nonconforming>, Dune::All_Partition> > >::SubControlVolume, 4>::_Type' {aka 'Opm::VcfvStencil<double, Dune::GridView<Dune::ALU3dLeafGridViewTraits<const Dune::ALUGrid<2, 2, Dune::cube, Dune::nonconforming>, Dune::All_Partition> > >::SubControlVolume [4]'} [-Warray-bounds=]
  209 |         return _M_elems[__n];
```