### PR TITLE
exit early if there are no wells

### DIFF
--- a/opm/simulators/wells/GuideRateHandler.cpp
+++ b/opm/simulators/wells/GuideRateHandler.cpp
@@ -38,6 +38,7 @@
 #include <array>
 #include <cstddef>
 #include <optional>
+#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -601,6 +602,9 @@ updateGuideRatesForWells_()
     constexpr auto npot = w_ix + 1;
 
     const auto& wnames = this->schedule()[this->report_step_idx_].well_order();
+    if (std::ranges::empty(wnames)) {
+        return;
+    }
 
     auto all_well_pot = std::vector<double>(npot * wnames.size());
     auto well_pot = all_well_pot.begin();


### PR DESCRIPTION
quells a compiler warning

For some reason this only shows up in the serial build,
```
In file included from /usr/include/c++/14/string:51,
                 from /usr/include/c++/14/stdexcept:39,
                 from /build/opm/simulators/wells/rescoup/RescoupProxy.hpp:29,
                 from /build/opm/simulators/wells/GuideRateHandler.hpp:23,
                 from /build/opm/simulators/wells/GuideRateHandler.cpp:22:
In function 'constexpr typename __gnu_cxx::__enable_if<std::__is_scalar<_Tp>::__value, void>::__type std::__fill_a1(_ForwardIterator, _ForwardIterator, const _Tp&) [with _ForwardIterator = double*; _Tp = double]',
    inlined from 'constexpr void std::__fill_a(_FIte, _FIte, const _Tp&) [with _FIte = double*; _Tp = double]' at /usr/include/c++/14/bits/stl_algobase.h:998:21,
    inlined from 'constexpr _OutputIterator std::__fill_n_a(_OutputIterator, _Size, const _Tp&, random_access_iterator_tag) [with _OutputIterator = double*; _Size = long unsigned int; _Tp = double]' at /usr/include/c++/14/bits/stl_algobase.h:1151:20,
    inlined from 'constexpr _OI std::fill_n(_OI, _Size, const _Tp&) [with _OI = double*; _Size = long unsigned int; _Tp = double]' at /usr/include/c++/14/bits/stl_algobase.h:1180:29,
    inlined from 'static constexpr _ForwardIterator std::__uninitialized_default_n_1<true>::__uninit_default_n(_ForwardIterator, _Size) [with _ForwardIterator = double*; _Size = long unsigned int]' at /usr/include/c++/14/bits/stl_uninitialized.h:668:29,
    inlined from 'static constexpr _ForwardIterator std::__uninitialized_default_n_1<true>::__uninit_default_n(_ForwardIterator, _Size) [with _ForwardIterator = double*; _Size = long unsigned int]' at /usr/include/c++/14/bits/stl_uninitialized.h:660:9,
    inlined from 'constexpr _ForwardIterator std::__uninitialized_default_n(_ForwardIterator, _Size) [with _ForwardIterator = double*; _Size = long unsigned int]' at /usr/include/c++/14/bits/stl_uninitialized.h:712:20,
    inlined from 'constexpr _ForwardIterator std::__uninitialized_default_n_a(_ForwardIterator, _Size, allocator<_Tp>&) [with _ForwardIterator = double*; _Size = long unsigned int; _Tp = double]' at /usr/include/c++/14/bits/stl_uninitialized.h:779:44,
    inlined from 'constexpr void std::vector<_Tp, _Alloc>::_M_default_initialize(size_type) [with _Tp = double; _Alloc = std::allocator<double>]' at /usr/include/c++/14/bits/stl_vector.h:1720:36,
    inlined from 'constexpr std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = double; _Alloc = std::allocator<double>]' at /usr/include/c++/14/bits/stl_vector.h:558:30,
    inlined from 'void Opm::GuideRateHandler<Scalar, IndexTraits>::UpdateGuideRates::updateGuideRatesForWells_() [with Scalar = double; IndexTraits = Opm::BlackOilDefaultFluidSystemIndices]' at /build/opm/simulators/wells/GuideRateHandler.cpp:605:10:
/usr/include/c++/14/bits/stl_algobase.h:952:18: warning: 'void* __builtin_memset(void*, int, long unsigned int)' offset [0, 15] is out of the bounds [0, 0] [-Warray-bounds=]
  952 |         *__first = __tmp;
      |         ~~~~~~~~~^~~~~~~
```