### PR TITLE
remove unsupport diagnostic

### DIFF
--- a/tests/gpuistl/test_primary_variables_gpu.cu
+++ b/tests/gpuistl/test_primary_variables_gpu.cu
@@ -27,17 +27,9 @@
 #define HAVE_DUNE_FEM 0
 
 // Suppress enum conversion warnings from Boost.Test on ROCm platform
-#ifdef __HIP_PLATFORM_AMD__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
-#endif
 #define BOOST_TEST_MODULE TestPrimaryVariablesGPU
 
 #include <boost/test/unit_test.hpp>
-
-#ifdef __HIP_PLATFORM_AMD__
-#pragma clang diagnostic pop
-#endif
 
 #include <boost/test/unit_test.hpp>
 


### PR DESCRIPTION
at least with rocm 7.1, hipcc does not support this diagnostic. and thus it obviously isn't necessary (any longer)

```
/build/hipify/build-opm-simulators/tests/gpuistl_hip/test_primary_variables_gpu.hip:33:34: warning: unknown warning group '-Wenum-constexpr-conversion', ignored [-Wunknown-warning-option]
   33 | #pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
```