### PR TITLE
Fix MPI deadlock in sendSlaveGroupDataToMaster()

### DIFF
--- a/opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.cpp
+++ b/opm/simulators/wells/rescoup/RescoupSendSlaveGroupData.cpp
@@ -118,11 +118,8 @@ void
 RescoupSendSlaveGroupData<Scalar, IndexTraits>::
 sendSlaveGroupDataToMaster()
 {
-    auto& rescoup_slave = this->reservoir_coupling_slave_;
-    if (rescoup_slave.getComm().rank() == 0) {
-        this->sendSlaveGroupProductionDataToMaster_();
-        this->sendSlaveGroupInjectionDataToMaster_();
-    }
+    this->sendSlaveGroupProductionDataToMaster_();
+    this->sendSlaveGroupInjectionDataToMaster_();
 }
 
 


### PR DESCRIPTION
Builds on #6915.

The rank-0 guard around `sendSlaveGroupProductionDataToMaster_()` and `sendSlaveGroupInjectionDataToMaster_()` prevented non-zero ranks from participating in the `comm().sum()` collectives inside the data collection functions.
