### PR TITLE
Reservoir coupling: Fix REIN/VREP injection cmode sent from master group to slave group

### DIFF
--- a/opm/simulators/wells/GroupConstraintCalculator.cpp
+++ b/opm/simulators/wells/GroupConstraintCalculator.cpp
@@ -607,8 +607,15 @@ calculateGroupConstraint()
             return ConstraintInfo{full_target, toplevel_control_mode};
         }
     }
-    // Return the bottom group's constraint as is.
-    return this->getGroupConstraintNoGuideRate_(this->bottom_group_);
+    // Return the more restrictive of the top-level distributed target and the
+    // bottom group's own target. This prevents the slave group from overshooting the
+    // top-level budget
+    auto bottom_constraint = this->getGroupConstraintNoGuideRate_(this->bottom_group_);
+    if (bottom_constraint.has_value() && full_target < bottom_constraint->constraint) {
+        const auto toplevel_control_mode = this->getToplevelControlMode_();
+        return ConstraintInfo{full_target, toplevel_control_mode};
+    }
+    return bottom_constraint;
 }
 
 // -------------------------------------------------------
@@ -748,6 +755,12 @@ TopToBottomCalculator::
 getTopLevelTargetOrLimit_()
 {
     if (this->isInjectionConstraint()) {
+        // NOTE: For VREP mode and (and also for multi-phase injection with RESV mode),
+        //   getInjectionGroupTarget() converts from reservoir to surface rate using the master's resv_coeff.
+        //   If the top level group has subordinate groups connected to slave reservoirs, and
+        //   possibly also combined with subordinate well groups in the master reservoir
+        //   with different PVT properties, the conversion will be inaccurate.
+        // TODO: Implement a more accurate approach.
         return this->groupStateHelper().getInjectionGroupTarget(
             this->top_group_, this->injectionPhase_(), this->resvCoeffsInj());
     }

--- a/opm/simulators/wells/rescoup/RescoupConstraintsCalculator.cpp
+++ b/opm/simulators/wells/rescoup/RescoupConstraintsCalculator.cpp
@@ -176,9 +176,15 @@ calculateSlaveGroupConstraints_(std::size_t slave_idx, GroupConstraintCalculator
             for (ReservoirCoupling::Phase phase : phases) {
                 auto target_info = calculator.groupInjectionTarget(group, phase);
                 if (target_info.has_value()) {
+                    // Always send injection targets as RATE. The numeric value is
+                    // already a surface rate for all modes (RATE, REIN, RESV, VREP),
+                    // and the slave cannot evaluate derived modes (REIN, VREP, RESV)
+                    // because it lacks the master's schedule data (reinj_group,
+                    // voidage_group, GCONSUMP, resv_coeff, etc.).
                     injection_targets.push_back(
                         InjectionGroupTarget{
-                            group_idx, target_info->constraint, target_info->cmode, phase
+                            group_idx, target_info->constraint,
+                            Group::InjectionCMode::RATE, phase
                         }
                     );
                 }


### PR DESCRIPTION
Builds on #6916.

- **Derived injection cmodes** (REIN, VREP, RESV) propagated from the master's constraint calculator caused a `map::at` crash in `updateWsolvent()` on the slave, which lacks the master's schedule data (`reinj_group`, `voidage_group`, `GCONSUMP`, etc.)

- **Always convert** injection cmodes to `RATE` in `calculateSlaveGroupConstraints_()` before sending to slave, since the numeric target is already a surface rate for all modes

- **Return the minimum** of the top-level distributed target and the bottom group's own target in `calculateGroupConstraint()`, preventing slaves from ramping up beyond the master's budget during independent substeps

