### PR TITLE
Improve unit test parser error handling

### DIFF
--- a/opm/simulators/flow/FlowGenericVanguard.cpp
+++ b/opm/simulators/flow/FlowGenericVanguard.cpp
@@ -207,7 +207,8 @@ void FlowGenericVanguard::defineSimulationModel(SimulationModelParams&& params)
     summaryState_ = std::move(params.summaryState_);
 }
 
-void FlowGenericVanguard::readDeck(const std::string& filename)
+void FlowGenericVanguard::readDeck(const std::string& filename,
+                                   bool throwOnError)
 {
     Dune::Timer setupTimer;
     setupTimer.start();
@@ -220,7 +221,8 @@ void FlowGenericVanguard::readDeck(const std::string& filename)
                   modelParams_.actionState_,
                   modelParams_.wtestState_,
                   modelParams_.eclSummaryConfig_,
-                  nullptr, "normal", "normal", "100", false, false, false, {}, /*slaveMode=*/false);
+                  nullptr, "normal", "normal", "100", false, false, false, {},
+                  /*slaveMode=*/false, throwOnError);
     modelParams_.setupTime_ = setupTimer.stop();
 }
 

--- a/opm/simulators/flow/FlowGenericVanguard.hpp
+++ b/opm/simulators/flow/FlowGenericVanguard.hpp
@@ -155,7 +155,8 @@ public:
      * \brief Read a deck.
      * \param filename file to read
      */
-    static void readDeck(const std::string& filename);
+    static void readDeck(const std::string& filename,
+                         bool throwOnError = false);
 
     /*!
      * \brief Set the simulation configuration objects.

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -699,7 +699,8 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
                    const bool                      checkDeck,
                    const bool                      keepKeywords,
                    const std::optional<int>&       outputInterval,
-                   const bool                      slaveMode)
+                   const bool                      slaveMode,
+                   const bool                      throwOnError)
 {
     auto errorGuard = std::make_unique<ErrorGuard>();
     int parseSuccess = 1; // > 0 is success
@@ -785,6 +786,13 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
     if (! parseSuccess) {
         if (comm.rank() == 0) {
             OpmLog::error(fmt::format("Unrecoverable errors while loading input:\n{}", failureMessage));
+        }
+
+        // Note: failureMessage is only populated on rank 0.
+        // This is fine since throwOnError is only used in single-process
+        // unit tests. Under MPI the existing std::exit() path applies.
+        if (throwOnError) {
+            throw std::runtime_error(failureMessage);
         }
 
 #if HAVE_MPI

--- a/opm/simulators/utils/readDeck.hpp
+++ b/opm/simulators/utils/readDeck.hpp
@@ -100,7 +100,8 @@ void readDeck(Parallel::Communication         comm,
               bool                            checkDeck,
               bool                            keepKeywords,
               const std::optional<int>&       outputInterval,
-              bool                            slaveMode);
+              bool                            slaveMode,
+              bool                            throwOnError = false);
 
 void verifyValidCellGeometry(Parallel::Communication comm,
                              const EclipseState&     eclipseState);

--- a/tests/SimulatorFixture.hpp
+++ b/tests/SimulatorFixture.hpp
@@ -34,6 +34,10 @@
 #include <opm/models/utils/parametersystem.hpp>
 #include <opm/models/utils/start.hh>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+#include <opm/common/OpmLog/LogUtil.hpp>
+
 #include <opm/simulators/flow/FlowGenericVanguard.hpp>
 #include <opm/simulators/flow/BlackoilModelParameters.hpp>
 #include <opm/simulators/timestepping/EclTimeSteppingParams.hpp>
@@ -52,6 +56,7 @@
 #include <boost/test/tools/floating_point_comparison.hpp>
 #endif
 
+#include <iostream>
 #include <memory>
 #include <string>
 
@@ -74,6 +79,12 @@ struct SimulatorFixture
         Dune::MPIHelper::instance(argc, argv);
 #endif
         FlowGenericVanguard::setCommunication(std::make_unique<Parallel::Communication>());
+
+        // Register OpmLog backend so parser errors are visible in test output
+        if (!OpmLog::hasBackend("STDERR_LOGGER")) {
+            auto streamLog = std::make_shared<StreamLog>(std::cerr, Log::DefaultMessageTypes);
+            OpmLog::addBackend("STDERR_LOGGER", streamLog);
+        }
     }
 };
 
@@ -116,7 +127,7 @@ initSimulator(const char* filename,
                               /*handleHelp=*/true,
                               /*myRank=*/0);
 
-    FlowGenericVanguard::readDeck(filename);
+    FlowGenericVanguard::readDeck(filename, /*throwOnError=*/true);
     return std::make_unique<Simulator>();
 }
 

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -36,6 +36,10 @@
 
 #include <opm/models/blackoil/blackoilprimaryvariables.hh>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+#include <opm/common/OpmLog/LogUtil.hpp>
+
 #include <opm/simulators/flow/FemCpGridCompat.hpp>
 #include <opm/simulators/flow/FlowGenericVanguard.hpp>
 #include <opm/simulators/flow/FlowProblemBlackoil.hpp>
@@ -58,6 +62,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <iostream>
 
 namespace Opm::Properties {
     namespace TTag {
@@ -538,6 +543,12 @@ struct AquiferFixture {
         Parameters::Register<Parameters::EnableTerminalOutput>("Do *NOT* use!");
         setupParameters_<TT>(2, argv, /*registerParams=*/true, false, true, 0);
         Opm::FlowGenericVanguard::setCommunication(std::make_unique<Opm::Parallel::Communication>());
+
+        // Register OpmLog backend so parser errors are visible in test output
+        if (!Opm::OpmLog::hasBackend("STDERR_LOGGER")) {
+            auto streamLog = std::make_shared<Opm::StreamLog>(std::cerr, Opm::Log::DefaultMessageTypes);
+            Opm::OpmLog::addBackend("STDERR_LOGGER", streamLog);
+        }
     }
 };
 
@@ -549,7 +560,7 @@ BOOST_GLOBAL_FIXTURE(AquiferFixture);
 BOOST_AUTO_TEST_CASE(TYPE) \
 { \
     using TT = Opm::Properties::TTag::TestRestartTypeTag; \
-    Opm::FlowGenericVanguard::readDeck("GLIFT1.DATA"); \
+    Opm::FlowGenericVanguard::readDeck("GLIFT1.DATA", /*throwOnError=*/true); \
     using Simulator = Opm::GetPropType<TT, Opm::Properties::Simulator>; \
     Simulator sim; \
     auto data_out = Opm::TYPE<TT>::serializationTestObject(sim); \
@@ -570,7 +581,7 @@ TEST_FOR_AQUIFER(AquiferFetkovich)
 BOOST_AUTO_TEST_CASE(AquiferNumerical)
 {
     using TT = Opm::Properties::TTag::TestRestartTypeTag;
-    Opm::FlowGenericVanguard::readDeck("GLIFT1.DATA");
+    Opm::FlowGenericVanguard::readDeck("GLIFT1.DATA", /*throwOnError=*/true);
     using Simulator = Opm::GetPropType<TT, Opm::Properties::Simulator>;
     Simulator sim;
     auto data_out = Opm::AquiferNumerical<TT>::serializationTestObject(sim);
@@ -588,7 +599,7 @@ BOOST_AUTO_TEST_CASE(AquiferNumerical)
 BOOST_AUTO_TEST_CASE(AquiferConstantFlux)
 {
     using TT = Opm::Properties::TTag::TestRestartTypeTag;
-    Opm::FlowGenericVanguard::readDeck("GLIFT1.DATA");
+    Opm::FlowGenericVanguard::readDeck("GLIFT1.DATA", /*throwOnError=*/true);
     using Simulator = Opm::GetPropType<TT, Opm::Properties::Simulator>;
     Simulator sim;
     auto data_out = Opm::AquiferConstantFlux<TT>::serializationTestObject(sim);

--- a/tests/test_equil.cpp
+++ b/tests/test_equil.cpp
@@ -46,6 +46,10 @@
 #include <opm/models/utils/start.hh>
 
 #include <opm/simulators/flow/BlackoilModelParameters.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+#include <opm/common/OpmLog/LogUtil.hpp>
+
 #include <opm/simulators/flow/FlowGenericVanguard.hpp>
 #include <opm/simulators/flow/FlowProblemBlackoil.hpp>
 #include <opm/simulators/flow/FlowProblemBlackoilProperties.hpp>
@@ -129,7 +133,7 @@ initSimulator(const char *filename)
                                    /*handleHelp*/true,
                                    /*myRank*/0);
 
-    Opm::FlowGenericVanguard::readDeck(filename);
+    Opm::FlowGenericVanguard::readDeck(filename, /*throwOnError=*/true);
 
     return std::make_unique<Simulator>();
 }
@@ -246,6 +250,12 @@ struct EquilFixture {
 #endif
         using namespace Opm;
         FlowGenericVanguard::setCommunication(std::make_unique<Opm::Parallel::Communication>());
+
+        // Register OpmLog backend so parser errors are visible in test output
+        if (!OpmLog::hasBackend("STDERR_LOGGER")) {
+            auto streamLog = std::make_shared<StreamLog>(std::cerr, Log::DefaultMessageTypes);
+            OpmLog::addBackend("STDERR_LOGGER", streamLog);
+        }
         Opm::ThreadManager::registerParameters();
         // Since this parameter is registered in opm/models/nonlinear/newtonmethodparams.cpp but not accessed here
         Parameters::Register<Parameters::NewtonMaxIterations>("The maximum number of Newton iterations per time step");


### PR DESCRIPTION
#### Problem

When `readDeck()` encounters parse errors in unit tests, it calls `std::exit(1)` which bypasses `Boost.Test` entirely. This produces a silent failure (exit code 1, no error message) because:
1. `OpmLog` has no registered backend in test fixtures, so error messages are discarded
2. `std::exit()` skips Boost.Test's exception handling, so no test failure is reported

#### Solution

- Add **`throwOnError`** parameter to `readDeck()` and `FlowGenericVanguard::readDeck()` (defaults to `false` for backward compatibility)
- When enabled, throws `std::runtime_error` with the failure message instead of calling `std::exit(1)`
- Register an `OpmLog` stderr backend in test fixture constructors so parser diagnostics are printed
- Enable both in `SimulatorFixture`, `test_equil`, and `test_RestartSerialization`

#### Before / after

| | Before | After |
|---|---|---|
| **Error message** | Silently discarded | Printed to stderr |
| **Test result** | Silent exit code 1 | Boost.Test reports `std::runtime_error` with message |
| **Production behavior** | Unchanged | Unchanged (`throwOnError` defaults to `false`) |
