### PR TITLE
Prefer Std::Numbers::PI

### DIFF
--- a/opm/models/blackoil/blackoilfoammodules.hh
+++ b/opm/models/blackoil/blackoilfoammodules.hh
@@ -43,6 +43,7 @@
 
 #include <cassert>
 #include <istream>
+#include <numbers>
 #include <ostream>
 #include <stdexcept>
 #include <string>
@@ -443,7 +444,7 @@ public:
             const Evaluation F1 = pow(C_surf / fm_surf, ep_surf);
             const Evaluation F2 = pow((fm_oil - S_o) / (fm_oil - fl_oil), ep_oil);
             const Evaluation F3 = pow(fm_cap / Ca, ep_cap);
-            const Evaluation F7 = 0.5 + atan(ep_dry * (S_w - fm_dry)) / M_PI;
+            const Evaluation F7 = 0.5 + atan(ep_dry * (S_w - fm_dry)) / std::numbers::pi_v<Scalar>;
 
             mobilityReductionFactor = 1. / (1. + fm_mob * F1 * F2 * F3 * F7);
         } else {

--- a/opm/simulators/flow/equil/InitStateEquil_impl.hpp
+++ b/opm/simulators/flow/equil/InitStateEquil_impl.hpp
@@ -51,9 +51,10 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <limits>
-#include <cmath>
+#include <numbers>
 #include <stdexcept>
 
 namespace Opm {
@@ -233,13 +234,13 @@ void computeBlockDip(const CellCornerData<Scalar>& cellCorners,
         if (std::abs(nx) > 1e-10 || std::abs(ny) > 1e-10) {
             dipAzimuth = std::atan2(ny, nx);
             // Convert to 0-2π range
-            dipAzimuth = std::fmod(dipAzimuth + 2*M_PI, 2*M_PI);
+            dipAzimuth = std::fmod(dipAzimuth + 2*std::numbers::pi_v<Scalar>, 2*std::numbers::pi_v<Scalar>);
         } else {
             dipAzimuth = 0.0; // Vertical cell
         }
 
         // Clamp dip angle to reasonable values
-        const Scalar maxDip = M_PI/2 - 1e-6;
+        const Scalar maxDip = std::numbers::pi_v<Scalar>/2 - static_cast<Scalar>(1e-6);
         dipAngle = std::min(dipAngle, maxDip);
     } else {
         // Degenerate cell - assume horizontal

--- a/opm/simulators/wells/StandardWell_impl.hpp
+++ b/opm/simulators/wells/StandardWell_impl.hpp
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <functional>
+#include <numbers>
 
 #include <fmt/format.h>
 
@@ -1943,7 +1944,7 @@ namespace Opm
             computePerfRate(int_quant, mob, bhp, Tw, perf, allow_cf, cq_s,
                             perf_rates, deferred_logger);
             // TODO: make area a member
-            const Scalar area = 2 * M_PI * this->perf_rep_radius_[perf] * this->perf_length_[perf];
+            const Scalar area = 2 * std::numbers::pi_v<Scalar> * this->perf_rep_radius_[perf] * this->perf_length_[perf];
             const auto& material_law_manager = simulator.problem().materialLawManager();
             const auto& scaled_drainage_info =
                         material_law_manager->oilWaterScaledEpsInfoDrainage(cell_idx);
@@ -2141,7 +2142,7 @@ namespace Opm
         const auto& int_quants = simulator.model().intensiveQuantities(cell_idx, /*timeIdx=*/ 0);
         const auto& fs = int_quants.fluidState();
         const EvalWell b_w = this->extendEval(fs.invB(FluidSystem::waterPhaseIdx));
-        const Scalar area = M_PI * this->bore_diameters_[perf] * this->perf_length_[perf];
+        const Scalar area = std::numbers::pi_v<Scalar> * this->bore_diameters_[perf] * this->perf_length_[perf];
         const int wat_vel_index = Bhp + 1 + perf;
         const unsigned water_comp_idx = FluidSystem::canonicalToActiveCompIdx(FluidSystem::waterCompIdx);
 
@@ -2167,7 +2168,7 @@ namespace Opm
         const auto& fs = int_quants.fluidState();
         const EvalWell b_w = this->extendEval(fs.invB(FluidSystem::waterPhaseIdx));
         const EvalWell water_flux_r = water_flux_s / b_w;
-        const Scalar area = M_PI * this->bore_diameters_[perf] * this->perf_length_[perf];
+        const Scalar area = std::numbers::pi_v<Scalar> * this->bore_diameters_[perf] * this->perf_length_[perf];
         const EvalWell water_velocity = water_flux_r / area;
         const int wat_vel_index = Bhp + 1 + perf;
 

--- a/opm/simulators/wells/WellInterface_impl.hpp
+++ b/opm/simulators/wells/WellInterface_impl.hpp
@@ -45,6 +45,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <numbers>
 #include <utility>
 
 #include <fmt/format.h>
@@ -1908,7 +1909,7 @@ namespace Opm
         // If more than one solution, pick the one corresponding to lowest absolute rate (smallest skin).
         const auto& connection = this->well_ecl_.getConnections()[ws.perf_data.ecl_index[perf]];
         const Scalar Kh = connection.Kh();
-        const Scalar scaling = 3.141592653589 * Kh * connection.wpimult();
+        const Scalar scaling = std::numbers::pi * Kh * connection.wpimult();
         const unsigned gas_comp_idx = FluidSystem::canonicalToActiveCompIdx(FluidSystem::gasCompIdx);
 
         const Scalar connection_pressure = ws.perf_data.pressure[perf];


### PR DESCRIPTION
We have C++20 now so we can use the portable alternative to spelling out the value or the Posix-only `M_PI` macro.