### PR TITLE
Check there are no refined aquifer cells in output

### DIFF
--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -794,8 +794,7 @@ exportNncStructure_(const std::vector<std::unordered_map<int,int>>& levelCartToL
                 const auto& levelCartDims = computeLevelCartDims(level);
 
                 // Check there are no refined aquifer connections
-                if (isNumAquConn_(originCartIdxIn, originCartIdxOut)) 
-                    assert(level == 0);
+                assert(!isNumAquConn_(originCartIdxIn, originCartIdxOut) || level == 0);
 
                 if (isNumAquConn_(originCartIdxIn, originCartIdxOut) ||
                     ! isDirectNeighbours_(levelCartToLevelCompressed[level],


### PR DESCRIPTION
For now, refinement of aquifer cells and connections is not supported. This PR checks that the aquifer cells and connections belong to level zero grid, in the output NNCs. 