### PR TITLE
make FLOW_INSTANTIATE_FLOAT a private compile definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,7 +345,10 @@ macro(opm-simulators_config_hook)
   include_directories(${EXTRA_INCLUDES})
 
   if(BUILD_FLOW_FLOAT_VARIANTS)
-    set(FLOW_INSTANTIATE_FLOAT 1)
+    target_compile_definitions(opmsimulators
+      PRIVATE
+        FLOW_INSTANTIATE_FLOAT=1
+    )
   endif()
 
   # The parameter system can leverage std::from_chars() for

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -199,7 +199,6 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/utils/ComponentName.cpp
   opm/simulators/utils/DeferredLogger.cpp
   opm/simulators/utils/FullySupportedFlowKeywords.cpp
-  opm/simulators/utils/InstantiationIndicesMacros.hpp
   opm/simulators/utils/ParallelFileMerger.cpp
   opm/simulators/utils/ParallelRestart.cpp
   opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -279,7 +278,11 @@ list (APPEND MAIN_SOURCE_FILES
   opm/simulators/wells/WellState.cpp
   opm/simulators/wells/WellTest.cpp
   opm/simulators/wells/WGState.cpp
-  )
+)
+
+list(APPEND PRIVATE_HEADER_FILES
+  opm/simulators/utils/InstantiationIndicesMacros.hpp
+)
 
 if (HAVE_AVX2_EXTENSION)
   set (AVX2_SOURCE_FILES
@@ -1230,7 +1233,6 @@ if (USE_GPU_BRIDGE)
     opm/simulators/linalg/gpubridge/opencl/openclBISAI.hpp
     opm/simulators/linalg/gpubridge/Reorder.hpp
     opm/simulators/linalg/gpubridge/opencl/opencl.hpp
-    opm/simulators/linalg/gpubridge/opencl/openclKernels.hpp
     opm/simulators/linalg/gpubridge/opencl/OpenclMatrix.hpp
     opm/simulators/linalg/gpubridge/opencl/openclPreconditioner.hpp
     opm/simulators/linalg/gpubridge/opencl/openclSolverBackend.hpp
@@ -1247,6 +1249,9 @@ if (USE_GPU_BRIDGE)
     opm/simulators/linalg/gpubridge/rocm/rocsparseMatrix.hpp
     opm/simulators/linalg/gpubridge/WellContributions.hpp
     opm/simulators/linalg/ISTLSolverGpuBridge.hpp
+  )
+  list(APPEND PRIVATE_HEADER_FILES
+    opm/simulators/linalg/gpubridge/opencl/openclKernels.hpp
   )
 endif()
 

--- a/opm-simulators-prereqs.cmake
+++ b/opm-simulators-prereqs.cmake
@@ -20,7 +20,6 @@ set (opm-simulators_CONFIG_VAR
   HAVE_DUNE_ALUGRID
   HAVE_DUNE_FEM
   USE_HIP
-  FLOW_INSTANTIATE_FLOAT
 )
 
 include(CheckAVX2)


### PR DESCRIPTION
only used in cpp files and two header files. neither of these header files are part of any public interface, so mark them private.

while this means downstreams cannot detect if the library was built with float support, they will certainly notice the linking errors. should this become a problem, we can easily move it to public