### PR TITLE
Reservoir coupling: add a slave DATA file parsing error test case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,6 +463,7 @@ macro(opm-simulators_tests_hook)
 
   if(MPI_FOUND)
     include(${CMAKE_CURRENT_SOURCE_DIR}/parallelUnitTests.cmake)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/rescoupTests.cmake)
   endif()
 
   if(OPM_ENABLE_PYTHON)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -718,6 +718,9 @@ list (APPEND TEST_DATA_FILES
   tests/include/PVT-WET-GAS.INC
   tests/include/scal_mod2.inc
   tests/include/summary_rc.inc
+  tests/rescoup/slave_parse_error/RC_MASTER.DATA
+  tests/rescoup/slave_parse_error/run_test.sh
+  tests/rescoup/slave_parse_error/slave/RC_SLAVE.DATA
   tests/test10.partition
   tests/parametersystem.ini
   tests/data/co2injection.dgf

--- a/rescoupTests.cmake
+++ b/rescoupTests.cmake
@@ -1,0 +1,51 @@
+# Reservoir coupling integration tests.
+# Included from CMakeLists.txt inside if(MPI_FOUND).
+
+# MPIEXEC_EXECUTABLE may point to a different MPI implementation than
+# the one the binaries were compiled against. This happens when CMake's
+# FindMPI locates MPIEXEC_EXECUTABLE via PATH independently of
+# MPI_C_COMPILER (e.g., system OpenMPI found first when compiled against
+# a custom MPICH).
+#
+# Resolution order:
+#   1. If MPIEXEC_EXECUTABLE is in the same directory as MPI_C_COMPILER,
+#      it was either explicitly set by the user (-DMPIEXEC_EXECUTABLE=...)
+#      or correctly auto-detected — use it directly.
+#   2. Otherwise, search for a matching launcher in MPI_C_COMPILER's bin
+#      directory (workaround for PATH-based detection picking wrong impl).
+#   3. Fall back to MPIEXEC_EXECUTABLE if nothing else is found.
+get_filename_component(_rescoup_mpi_bin_dir "${MPI_C_COMPILER}" DIRECTORY)
+get_filename_component(_rescoup_mpiexec_dir "${MPIEXEC_EXECUTABLE}" DIRECTORY)
+if("${_rescoup_mpiexec_dir}" STREQUAL "${_rescoup_mpi_bin_dir}")
+  set(_rescoup_mpiexec "${MPIEXEC_EXECUTABLE}")
+else()
+  find_program(_rescoup_mpiexec
+    NAMES mpiexec.hydra mpiexec mpirun
+    HINTS "${_rescoup_mpi_bin_dir}"
+    NO_DEFAULT_PATH
+  )
+  if(NOT _rescoup_mpiexec)
+    set(_rescoup_mpiexec "${MPIEXEC_EXECUTABLE}")
+  endif()
+endif()
+
+# Slave parse error test.
+add_custom_target(test_rc_slave_parsing_err
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/rescoup/slave_parse_error
+    ${CMAKE_CURRENT_BINARY_DIR}/tests/rescoup/slave_parse_error
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/include
+    ${CMAKE_CURRENT_BINARY_DIR}/tests/include
+  COMMENT "Copying slave_parse_error test data to build tree"
+  DEPENDS flow_blackoil
+)
+add_test(NAME rc_slave_parsing_err
+  COMMAND
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/rescoup/slave_parse_error/run_ctest.sh
+    $<TARGET_FILE:flow_blackoil>
+    ${_rescoup_mpiexec}
+  WORKING_DIRECTORY
+    ${CMAKE_CURRENT_BINARY_DIR}/tests/rescoup/slave_parse_error
+)
+set_tests_properties(rc_slave_parsing_err PROPERTIES TIMEOUT 30)

--- a/rescoupTests.cmake
+++ b/rescoupTests.cmake
@@ -38,14 +38,15 @@ add_custom_target(test_rc_slave_parsing_err
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/include
     ${CMAKE_CURRENT_BINARY_DIR}/tests/include
   COMMENT "Copying slave_parse_error test data to build tree"
-  DEPENDS flow_blackoil
+  DEPENDS flow
 )
 add_test(NAME rc_slave_parsing_err
   COMMAND
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/rescoup/slave_parse_error/run_ctest.sh
-    $<TARGET_FILE:flow_blackoil>
+    $<TARGET_FILE:flow>
     ${_rescoup_mpiexec}
   WORKING_DIRECTORY
     ${CMAKE_CURRENT_BINARY_DIR}/tests/rescoup/slave_parse_error
+  CONFIGURATIONS Integration
 )
 set_tests_properties(rc_slave_parsing_err PROPERTIES TIMEOUT 30)

--- a/rescoupTests.cmake
+++ b/rescoupTests.cmake
@@ -1,3 +1,20 @@
+# Copyright 2026 Equinor
+#
+# This file is part of the Open Porous Media project (OPM).
+#
+# OPM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OPM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
 # Reservoir coupling integration tests.
 # Included from CMakeLists.txt inside if(MPI_FOUND).
 

--- a/rescoupTests.cmake
+++ b/rescoupTests.cmake
@@ -29,6 +29,15 @@ else()
   endif()
 endif()
 
+# Select the simulator binary. When USE_DEV_SIMULATOR_IN_TESTS is set, use the
+# faster-to-build development simulator (flow_blackoil) instead of the full flow
+# target. This matches the pattern used by the other test cmake files.
+if(USE_DEV_SIMULATOR_IN_TESTS)
+  set(_rescoup_simulator flow_blackoil)
+else()
+  set(_rescoup_simulator flow)
+endif()
+
 # Slave parse error test.
 add_custom_target(test_rc_slave_parsing_err
   COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -38,12 +47,12 @@ add_custom_target(test_rc_slave_parsing_err
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/include
     ${CMAKE_CURRENT_BINARY_DIR}/tests/include
   COMMENT "Copying slave_parse_error test data to build tree"
-  DEPENDS flow
+  DEPENDS ${_rescoup_simulator}
 )
 add_test(NAME rc_slave_parsing_err
   COMMAND
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/rescoup/slave_parse_error/run_ctest.sh
-    $<TARGET_FILE:flow>
+    $<TARGET_FILE:${_rescoup_simulator}>
     ${_rescoup_mpiexec}
   WORKING_DIRECTORY
     ${CMAKE_CURRENT_BINARY_DIR}/tests/rescoup/slave_parse_error

--- a/tests/rescoup/slave_parse_error/RC_MASTER.DATA
+++ b/tests/rescoup/slave_parse_error/RC_MASTER.DATA
@@ -1,0 +1,160 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2026 Equinor
+
+-- Minimal reservoir coupling master deck for testing slave parse error behavior.
+-- The master has a single 1x1x1 grid cell, no wells, and spawns one slave
+-- process whose DATA file contains a deliberate parse error.
+--
+-- Expected behavior depends on MPI implementation:
+--   Custom MPICH (v4.3.2): hydra kills master immediately (exit code 9)
+--   System MPICH  (v4.2.1): master hangs on MPI_Recv until timeout (exit code 124)
+--   OpenMPI       (v5.0.8): master hangs on MPI_Recv until timeout (exit code 124)
+--
+-- Usage: mpirun -np 1 flow RC_MASTER.DATA --parsing-strictness=low
+-- (--parsing-strictness=low is needed because RC keywords are not yet
+-- activated in opm-common, pending PR #5643)
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+DIMENS
+ 1 1 1 /
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 1 'OCT' 2018 /
+
+EQLDIMS
+ 1 1*  25 /
+
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 5          10            10        10   /
+
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  1          1      50          60         72         60 /
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+NEWTRAN
+
+GRIDFILE
+ 0  1 /
+
+GRIDUNIT
+METRES  /
+
+INIT
+
+SPECGRID
+ 1 1 1 1 F /
+
+COORD
+  2000.0000  2000.0000  2000.0000   2000.0000  2000.0000  2002.5000
+  2100.0000  2000.0000  2000.0000   2100.0000  2000.0000  2002.5000
+  2000.0000  2100.0000  2000.0000   2000.0000  2100.0000  2002.5000
+  2100.0000  2100.0000  2000.0000   2100.0000  2100.0000  2002.5000
+/
+
+ZCORN
+  2000.0000  2000.0000  2000.0000  2000.0000  2002.5000  2002.5000
+  2002.5000  2002.5000 /
+
+PORO
+ 0.25 /
+
+PERMX
+ 2100 /
+
+COPY
+ PERMX PERMY /
+ PERMX PERMZ /
+/
+
+MULTIPLY
+ 'PERMZ' 0.1 /
+/
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ '../../include/PVT-WET-GAS.INC' /
+
+INCLUDE
+ '../../include/scal_mod2.inc' /
+
+FILLEPS
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+RPTRST
+ BASIC=2 /
+
+EQUIL
+-- Datum    P     woc     Pc   goc      Pc  Rsvd  Rvvd  N
+2300.00   300.0  2300.0   0.0  1800.00  0.0   1     1   0 /
+
+PBVD
+ 2000.0 100.0
+ 2300.0 100.0 /
+
+PDVD
+ 2000.0 100.0
+ 2300.0 100.0 /
+/
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+TUNING
+ 1.0  5.0 /
+ /
+ /
+
+GRUPTREE
+ 'MOD2'   'FIELD' /
+ 'E1_M'   'MOD2' /
+/
+
+SLAVES
+  'RES-1'  'RC_SLAVE'  '*'  'slave'  1 /
+/
+
+DATES
+ 1 NOV 2018 /
+/
+
+END

--- a/tests/rescoup/slave_parse_error/RC_MASTER.DATA
+++ b/tests/rescoup/slave_parse_error/RC_MASTER.DATA
@@ -10,7 +10,8 @@
 -- process whose DATA file contains a deliberate parse error.
 --
 -- Expected behavior depends on MPI implementation:
---   Custom MPICH (v4.3.2): hydra kills master immediately (exit code 9)
+--   OpenMPI       (v4.1.6): detects slave exit, terminates master (exit code 1)
+--   Custom MPICH  (v4.3.2): hydra kills master immediately (exit code 9)
 --   System MPICH  (v4.2.1): master hangs on MPI_Recv until timeout (exit code 124)
 --   OpenMPI       (v5.0.8): master hangs on MPI_Recv until timeout (exit code 124)
 --

--- a/tests/rescoup/slave_parse_error/run_ctest.sh
+++ b/tests/rescoup/slave_parse_error/run_ctest.sh
@@ -4,8 +4,12 @@
 #
 # The slave deck has a deliberate parse error. The master should never
 # complete successfully (exit 0). Expected outcomes depending on MPI:
-#   - exit 9:   MPI runtime killed master when slave exited (custom MPICH)
-#   - exit 124: master hung on MPI_Recv until timeout (OpenMPI, system MPICH)
+#   - exit 1:   MPI runtime detected slave exit (OpenMPI 4.1.6)
+#   - exit 9:   MPI runtime killed master when slave exited (custom MPICH v4.3.2)
+#   - exit 124: master hung on MPI_Recv until timeout (OpenMPI 5.0.8, system MPICH v4.2.1)
+#
+# Any non-zero exit code is treated as PASS. Only exit 0 (master completed
+# despite slave parse error) is treated as FAIL.
 #
 # Usage: run_ctest.sh <flow_binary> <mpi_launcher>
 
@@ -19,8 +23,8 @@ echo "MPI launcher: $MPI_LAUNCHER"
 echo "Working dir:  $(pwd)"
 echo ""
 
-# Always run with a timeout. Custom MPICH (v4.3.2) exits immediately with code 9;
-# OpenMPI (v5.0.8) and system MPICH (v4.2.1) hang until the timeout fires (exit 124).
+# Run with a timeout as a safety net. Some MPI implementations detect the
+# slave exit immediately (exit 1 or 9), others hang until the timeout (exit 124).
 timeout 10 \
     "$MPI_LAUNCHER" -np 1 "$FLOW_BINARY" \
     RC_MASTER.DATA \
@@ -33,13 +37,7 @@ EXIT_CODE=$?
 if [ $EXIT_CODE -eq 0 ]; then
     echo "FAIL: Master completed successfully — unexpected for slave parse error"
     exit 1
-elif [ $EXIT_CODE -eq 9 ]; then
-    echo "PASS: MPI runtime killed master on slave exit (exit code 9)"
-    exit 0
-elif [ $EXIT_CODE -eq 124 ]; then
-    echo "PASS: Master hung on MPI_Recv as expected (timed out after 10s)"
-    exit 0
 else
-    echo "FAIL: Unexpected exit code $EXIT_CODE"
-    exit 1
+    echo "PASS: Master did not complete (exit code $EXIT_CODE)"
+    exit 0
 fi

--- a/tests/rescoup/slave_parse_error/run_ctest.sh
+++ b/tests/rescoup/slave_parse_error/run_ctest.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# CTest wrapper for the reservoir coupling slave parse error test.
+# Exits 0 on expected (currently unfixed) behavior, 1 on unexpected behavior.
+#
+# The slave deck has a deliberate parse error. The master should never
+# complete successfully (exit 0). Expected outcomes depending on MPI:
+#   - exit 9:   MPI runtime killed master when slave exited (custom MPICH)
+#   - exit 124: master hung on MPI_Recv until timeout (OpenMPI, system MPICH)
+#
+# Usage: run_ctest.sh <flow_binary> <mpi_launcher>
+
+set -u
+
+FLOW_BINARY="${1:?Usage: $0 <flow_binary> <mpi_launcher>}"
+MPI_LAUNCHER="${2:?Usage: $0 <flow_binary> <mpi_launcher>}"
+
+echo "Flow binary:  $FLOW_BINARY"
+echo "MPI launcher: $MPI_LAUNCHER"
+echo "Working dir:  $(pwd)"
+echo ""
+
+# Always run with a timeout. Custom MPICH (v4.3.2) exits immediately with code 9;
+# OpenMPI (v5.0.8) and system MPICH (v4.2.1) hang until the timeout fires (exit 124).
+timeout 10 \
+    "$MPI_LAUNCHER" -np 1 "$FLOW_BINARY" \
+    RC_MASTER.DATA \
+    --parsing-strictness=low \
+    --output-dir=. \
+    2>&1
+
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "FAIL: Master completed successfully — unexpected for slave parse error"
+    exit 1
+elif [ $EXIT_CODE -eq 9 ]; then
+    echo "PASS: MPI runtime killed master on slave exit (exit code 9)"
+    exit 0
+elif [ $EXIT_CODE -eq 124 ]; then
+    echo "PASS: Master hung on MPI_Recv as expected (timed out after 10s)"
+    exit 0
+else
+    echo "FAIL: Unexpected exit code $EXIT_CODE"
+    exit 1
+fi

--- a/tests/rescoup/slave_parse_error/run_ctest.sh
+++ b/tests/rescoup/slave_parse_error/run_ctest.sh
@@ -11,21 +11,26 @@
 # Any non-zero exit code is treated as PASS. Only exit 0 (master completed
 # despite slave parse error) is treated as FAIL.
 #
-# Known issue — OpenMPI 5.x BTL TCP IPv6 bug:
+# Known issue — OpenMPI 5.x BTL TCP IPv6 bug (observed with Ubuntu package):
 #   On systems where a network interface has both IPv4 and IPv6 addresses
 #   (common with WiFi), OpenMPI 5.x BTL TCP registers only the IPv6
-#   address for the interface, regardless of any if_include/if_exclude
-#   settings. When MPI_Comm_spawn is used, the spawned child connects
-#   back to the parent using IPv4, but the parent only knows the child's
-#   IPv6 address — so it rejects the connection ("dropped inbound
-#   connection" or "UNREACHABLE").
+#   address for the interface when built with --enable-ipv6. When
+#   MPI_Comm_spawn is used, the spawned child may connect back to the
+#   parent using an IPv4 source address that the parent doesn't recognize,
+#   causing the connection to be rejected ("dropped inbound connection"
+#   or "UNREACHABLE").
 #
-#   This bug is NOT present in OpenMPI 4.1.6.
+#   This bug is NOT present in OpenMPI 4.1.6. It has been observed with
+#   the Ubuntu 25.10 system package (5.0.8-8ubuntu1) but could not be
+#   reproduced with custom source builds of the same version, suggesting
+#   additional runtime factors (e.g., --with-verbs, --with-libfabric)
+#   affect connection routing.
 #
 #   Root cause: opal/mca/btl/tcp/btl_tcp_component.c mca_btl_tcp_create()
 #   iterates opal_if_list and takes the FIRST address for each interface,
-#   which is IPv6 when both families are present. The code has a comment
-#   acknowledging this limitation.
+#   which is IPv6 when both families are present. The source code has a
+#   comment acknowledging this limitation:
+#   https://github.com/open-mpi/ompi/blob/v5.0.8/opal/mca/btl/tcp/btl_tcp_component.c#L501-L515
 #
 #   Workaround: disable IPv6 in BTL TCP address selection:
 #     export OMPI_MCA_btl_tcp_disable_family=6

--- a/tests/rescoup/slave_parse_error/run_ctest.sh
+++ b/tests/rescoup/slave_parse_error/run_ctest.sh
@@ -11,6 +11,28 @@
 # Any non-zero exit code is treated as PASS. Only exit 0 (master completed
 # despite slave parse error) is treated as FAIL.
 #
+# Known issue — OpenMPI 5.x BTL TCP IPv6 bug:
+#   On systems where a network interface has both IPv4 and IPv6 addresses
+#   (common with WiFi), OpenMPI 5.x BTL TCP registers only the IPv6
+#   address for the interface, regardless of any if_include/if_exclude
+#   settings. When MPI_Comm_spawn is used, the spawned child connects
+#   back to the parent using IPv4, but the parent only knows the child's
+#   IPv6 address — so it rejects the connection ("dropped inbound
+#   connection" or "UNREACHABLE").
+#
+#   This bug is NOT present in OpenMPI 4.1.6.
+#
+#   Root cause: opal/mca/btl/tcp/btl_tcp_component.c mca_btl_tcp_create()
+#   iterates opal_if_list and takes the FIRST address for each interface,
+#   which is IPv6 when both families are present. The code has a comment
+#   acknowledging this limitation.
+#
+#   Workaround: disable IPv6 in BTL TCP address selection:
+#     export OMPI_MCA_btl_tcp_disable_family=6
+#   or persistently in ~/.openmpi/mca-params.conf:
+#     btl_tcp_disable_family = 6
+#   Note: the parameter uses literal 4/6, NOT AF_INET (2) / AF_INET6 (10).
+#
 # Usage: run_ctest.sh <flow_binary> <mpi_launcher>
 
 set -u

--- a/tests/rescoup/slave_parse_error/run_ctest.sh
+++ b/tests/rescoup/slave_parse_error/run_ctest.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+# Copyright 2026 Equinor
+#
+# This file is part of the Open Porous Media project (OPM).
+#
+# OPM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OPM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
 # CTest wrapper for the reservoir coupling slave parse error test.
 # Exits 0 on expected (currently unfixed) behavior, 1 on unexpected behavior.
 #

--- a/tests/rescoup/slave_parse_error/run_ctest.sh
+++ b/tests/rescoup/slave_parse_error/run_ctest.sh
@@ -37,11 +37,15 @@
 #   causing the connection to be rejected ("dropped inbound connection"
 #   or "UNREACHABLE").
 #
-#   This bug is NOT present in OpenMPI 4.1.6. It has been observed with
-#   the Ubuntu 25.10 system package (5.0.8-8ubuntu1) but could not be
-#   reproduced with custom source builds of the same version, suggesting
-#   additional runtime factors (e.g., --with-verbs, --with-libfabric)
-#   affect connection routing.
+#   This bug is NOT present in OpenMPI 4.1.6. It was observed only with the
+#   Ubuntu 25.10 system package (5.0.8-8ubuntu1); custom source builds of the
+#   same version did not reproduce it, suggesting it depends on the specific
+#   OpenMPI build and runtime transport providers (e.g., --with-verbs,
+#   --with-libfabric). It could NOT be reproduced on the Ubuntu 26.04 system
+#   package (5.0.10-1): even with IPv6 registered first for the dual-stack
+#   interface (btl_tcp_disable_family unset), the spawned slave connects back
+#   successfully. The master-hang behavior this test detects is independent of
+#   this TCP bug — it stems from the slave exiting before the initial handshake.
 #
 #   Root cause: opal/mca/btl/tcp/btl_tcp_component.c mca_btl_tcp_create()
 #   iterates opal_if_list and takes the FIRST address for each interface,

--- a/tests/rescoup/slave_parse_error/run_test.sh
+++ b/tests/rescoup/slave_parse_error/run_test.sh
@@ -10,7 +10,8 @@
 # whose DATA file has a deliberate parse error (missing INCLUDE file).
 #
 # Expected behavior depends on the MPI implementation:
-#   Custom MPICH (v4.3.2): hydra kills master immediately (exit code 9)
+#   OpenMPI       (v4.1.6): detects slave exit, terminates master (exit code 1)
+#   Custom MPICH  (v4.3.2): hydra kills master immediately (exit code 9)
 #   System MPICH  (v4.2.1): master hangs until timeout (exit code 124)
 #   OpenMPI       (v5.0.8): master hangs until timeout (exit code 124)
 #

--- a/tests/rescoup/slave_parse_error/run_test.sh
+++ b/tests/rescoup/slave_parse_error/run_test.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Manual test runner: Reservoir coupling slave deck parse error
+#
+# For automated testing use run_ctest.sh (registered as CTest target
+# rc_slave_parsing_err). This script is kept for manual inspection: it
+# prints human-readable output including the slave log file, making it
+# easier to diagnose behavior interactively.
+#
+# This test runs a reservoir coupling master that spawns a slave process
+# whose DATA file has a deliberate parse error (missing INCLUDE file).
+#
+# Expected behavior depends on the MPI implementation:
+#   Custom MPICH (v4.3.2): hydra kills master immediately (exit code 9)
+#   System MPICH  (v4.2.1): master hangs until timeout (exit code 124)
+#   OpenMPI       (v5.0.8): master hangs until timeout (exit code 124)
+#
+# Future goal: the slave communicates its parse failure to the master,
+# allowing cooperative shutdown without a hang (exit code 1 on all impls).
+#
+# Usage:
+#   run_test.sh <flow_binary_path> [mpi_launcher] [timeout_seconds]
+#
+# Examples:
+#   ./run_test.sh /path/to/build/bin/flow
+#   ./run_test.sh /path/to/build/bin/flow mpiexec
+#   ./run_test.sh /path/to/build/bin/flow mpirun 60
+
+set -u
+
+FLOW_BINARY="${1:?Usage: $0 <flow_binary_path> [mpi_launcher] [timeout_seconds]}"
+MPI_LAUNCHER="${2:-mpirun}"
+TIMEOUT_SECONDS="${3:-30}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Resolve to absolute path before cd'ing to the test data directory
+FLOW_BINARY="$(realpath "$FLOW_BINARY" 2>/dev/null || readlink -f "$FLOW_BINARY")"
+
+if [ ! -x "$FLOW_BINARY" ]; then
+    echo "ERROR: Flow binary not found or not executable: $FLOW_BINARY"
+    exit 2
+fi
+
+if ! command -v "$MPI_LAUNCHER" >/dev/null 2>&1; then
+    echo "ERROR: MPI launcher not found: $MPI_LAUNCHER"
+    exit 2
+fi
+
+# Run from the master data file directory so relative paths in the deck work
+cd "$SCRIPT_DIR" || exit 2
+
+# Clean up any previous output files
+rm -f RC_MASTER.INFOSTEP RC_MASTER.UNSMRY RC_MASTER.SMSPEC
+rm -f RES-1*.log
+rm -f *.PRT *.DBG
+
+echo "=== Reservoir Coupling: Slave Parse Error Test ==="
+echo "Flow binary:   $FLOW_BINARY"
+echo "MPI launcher:  $MPI_LAUNCHER"
+echo "Timeout:       ${TIMEOUT_SECONDS}s"
+echo "Working dir:   $(pwd)"
+echo ""
+echo "--- Running test ---"
+
+timeout "$TIMEOUT_SECONDS" \
+    "$MPI_LAUNCHER" -np 1 "$FLOW_BINARY" \
+    RC_MASTER.DATA \
+    --parsing-strictness=low \
+    --output-dir=. \
+    2>&1
+
+EXIT_CODE=$?
+
+echo ""
+echo "=== Results ==="
+if [ $EXIT_CODE -eq 124 ]; then
+    echo "RESULT: TIMEOUT (exit code 124)"
+    echo "  Master hung waiting for slave — this is the expected current behavior."
+    echo "  The slave failed to parse its deck and exited without sending"
+    echo "  initial data to the master."
+elif [ $EXIT_CODE -eq 0 ]; then
+    echo "RESULT: SUCCESS (exit code 0) — unexpected, master should not succeed"
+elif [ $EXIT_CODE -eq 137 ]; then
+    echo "RESULT: KILLED (exit code 137, SIGKILL)"
+    echo "  Process was killed, possibly by timeout or MPI runtime."
+elif [ $EXIT_CODE -eq 1 ]; then
+    echo "RESULT: ERROR (exit code 1)"
+    echo "  Master exited with error — may indicate slave failure was detected."
+else
+    echo "RESULT: Exit code $EXIT_CODE"
+fi
+
+# Check slave log file if it exists
+echo ""
+echo "=== Slave Log Files ==="
+FOUND_LOG=0
+for logfile in RES-1*.log; do
+    if [ -f "$logfile" ]; then
+        FOUND_LOG=1
+        echo "--- $logfile ---"
+        cat "$logfile"
+        echo ""
+    fi
+done
+if [ $FOUND_LOG -eq 0 ]; then
+    echo "(no slave log files found — slave may have exited before output redirect)"
+fi
+
+exit $EXIT_CODE

--- a/tests/rescoup/slave_parse_error/run_test.sh
+++ b/tests/rescoup/slave_parse_error/run_test.sh
@@ -9,14 +9,8 @@
 # This test runs a reservoir coupling master that spawns a slave process
 # whose DATA file has a deliberate parse error (missing INCLUDE file).
 #
-# Expected behavior depends on the MPI implementation:
-#   OpenMPI       (v4.1.6): detects slave exit, terminates master (exit code 1)
-#   Custom MPICH  (v4.3.2): hydra kills master immediately (exit code 9)
-#   System MPICH  (v4.2.1): master hangs until timeout (exit code 124)
-#   OpenMPI       (v5.0.8): master hangs until timeout (exit code 124)
-#
-# Future goal: the slave communicates its parse failure to the master,
-# allowing cooperative shutdown without a hang (exit code 1 on all impls).
+# For expected behavior per MPI implementation and known OpenMPI 5.x issues,
+# see the comments in run_ctest.sh.
 #
 # Usage:
 #   run_test.sh <flow_binary_path> [mpi_launcher] [timeout_seconds]

--- a/tests/rescoup/slave_parse_error/run_test.sh
+++ b/tests/rescoup/slave_parse_error/run_test.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+# Copyright 2026 Equinor
+#
+# This file is part of the Open Porous Media project (OPM).
+#
+# OPM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OPM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
 # Manual test runner: Reservoir coupling slave deck parse error
 #
 # For automated testing use run_ctest.sh (registered as CTest target

--- a/tests/rescoup/slave_parse_error/slave/RC_SLAVE.DATA
+++ b/tests/rescoup/slave_parse_error/slave/RC_SLAVE.DATA
@@ -1,0 +1,44 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2026 Equinor
+
+-- Deliberately broken slave deck for reservoir coupling parse error testing.
+-- The INCLUDE in the GRID section references a non-existent file, which
+-- triggers a parse error regardless of --parsing-strictness setting.
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+DIMENS
+ 2 2 2 /
+
+OIL
+WATER
+
+METRIC
+
+START
+ 1 'JAN' 2019 /
+
+EQLDIMS
+ 1 /
+
+TABDIMS
+ 1 1 /
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+-- Intentional error: this file does not exist
+INCLUDE
+ 'nonexistent_grid_file.inc' /
+
+END


### PR DESCRIPTION
## Summary

- Adds a minimal test case (`rc_slave_parsing_err`) that reproduces and detects the hang that occurs when a reservoir coupling slave fails to parse its DATA file
- The master spawns a slave whose deck contains a deliberate parse error (missing `INCLUDE` file); the slave exits immediately but the master blocks indefinitely on `MPI_Recv` waiting for the slave's initial data exchange
- Registers the test as a proper CTest so it runs in CI and can be executed with `ninja test_rc_slave_parsing_err && ctest -R rc_slave_parsing_err`

## Background

When `MPI_Comm_spawn` is used to launch a slave process and that slave exits before completing its initial handshake, the master blocks forever on `MPI_Recv`. The test documents this as the current known behavior and provides a reproducible regression baseline.

Observed behavior varies by MPI implementation:

| MPI | Master outcome | Exit code |
|-----|---------------|-----------|
| Custom MPICH v4.3.2 | Killed by hydra immediately | 9 |
| System MPICH v4.2.1 | Hangs until timeout | 124 |
| OpenMPI v5.0.8 | Hangs until timeout | 124 |

The test passes for both outcomes (exit 9 and exit 124), and fails only if the master exits cleanly (exit 0), which would mean the slave parse error was silently ignored.

## Future work

A follow-up PR will fix the hang by having the slave send a **"parse failed"** signal as its first MPI message after being spawned, before reaching `sendAndReceiveInitialData()`. The master will check for this signal and call `sendTerminateAndDisconnect()` before exiting with a clear error. This fix will be applied for both OpenMPI and MPICH so that all implementations produce a clean exit with a meaningful error message. Once the fix lands, this test will be updated to expect exit code 1 on all implementations.

## New files

- `tests/rescoup/slave_parse_error/RC_MASTER.DATA` — minimal 1×1×1 master deck with a single slave reference
- `tests/rescoup/slave_parse_error/slave/RC_SLAVE.DATA` — slave deck with deliberate parse error
- `tests/rescoup/slave_parse_error/run_test.sh` — manual runner with human-readable output and slave log display
- `tests/rescoup/slave_parse_error/run_ctest.sh` — automated wrapper (exits 0/1) used by CTest
- `rescoupTests.cmake` — CTest registration; includes logic to select the correct MPI launcher when `MPIEXEC_EXECUTABLE` and `MPI_C_COMPILER` come from different MPI installations

