### PR TITLE
Reservoir coupling: Fix master hang when slave fails to parse deck

### DIFF
--- a/opm/simulators/flow/Main.cpp
+++ b/opm/simulators/flow/Main.cpp
@@ -279,6 +279,29 @@ void Main::handleTestSplitCommunicatorCmdLine_()
     }
 }
 
+void Main::notifyMasterSlaveInitFailed_()
+{
+#if HAVE_MPI
+    if (Parameters::Get<Parameters::Slave>()) {
+        MPI_Comm parent_comm = MPI_COMM_NULL;
+        MPI_Comm_get_parent(&parent_comm);
+        if (parent_comm != MPI_COMM_NULL) {
+            int rank;
+            MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+            if (rank == 0) {
+                int slave_status = 1;  // FAILED
+                MPI_Send(
+                    &slave_status, 1, MPI_INT, /*dest=*/0,
+                    static_cast<int>(ReservoirCoupling::MessageTag::SlaveStatus),
+                    parent_comm
+                );
+            }
+            MPI_Comm_disconnect(&parent_comm);
+        }
+    }
+#endif
+}
+
 void Main::readDeck(const std::string& deckFilename,
                     const std::string& outputDir,
                     const std::string& outputMode,

--- a/opm/simulators/flow/Main.cpp
+++ b/opm/simulators/flow/Main.cpp
@@ -285,6 +285,13 @@ void Main::notifyMasterSlaveInitFailed_()
     if (Parameters::Get<Parameters::Slave>()) {
         MPI_Comm parent_comm = MPI_COMM_NULL;
         MPI_Comm_get_parent(&parent_comm);
+        // MPI_Comm_get_parent() returns MPI_COMM_NULL when this process was not
+        // spawned by a master. --slave is a private flag the master sets when
+        // spawning, so this normally cannot happen. If it does (e.g. a deck run
+        // standalone with --slave), there is simply no master to notify. We do
+        // NOT MPI_Abort() here: this is the cooperative-shutdown path (the parse
+        // error is already reported and we return EXIT_FAILURE), and with no
+        // spawned master there is no peer that could hang.
         if (parent_comm != MPI_COMM_NULL) {
             int rank;
             MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -297,6 +304,11 @@ void Main::notifyMasterSlaveInitFailed_()
                 );
             }
             MPI_Comm_disconnect(&parent_comm);
+        }
+        else if (outputCout_) {
+            std::cerr << "Warning: --slave was set but this process has no parent "
+                         "communicator; running standalone, no master to notify."
+                      << std::endl;
         }
     }
 #endif

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -42,6 +42,7 @@
 
 #if HAVE_MPI
 #include <opm/simulators/utils/ParallelEclipseState.hpp>
+#include <opm/simulators/flow/rescoup/ReservoirCoupling.hpp>
 #endif
 
 #if HAVE_CUDA
@@ -341,6 +342,12 @@ protected:
                 std::cerr << "Failed to create valid EclipseState object." << std::endl;
                 std::cerr << e.what() << std::endl;
             }
+#if HAVE_MPI
+            // If we are a spawned slave, notify the master that initialization
+            // failed so it does not hang waiting for our initial data exchange.
+            // Only rank 0 sends the status (master receives from source=0).
+            notifyMasterSlaveInitFailed_();
+#endif
             exitCode = EXIT_FAILURE;
             return false;
         }
@@ -388,6 +395,10 @@ private:
     // Note: initializing the parameter system before MPI could make this
     // use the parameter system instead.
     void handleTestSplitCommunicatorCmdLine_();
+
+    // If this process is a reservoir coupling slave, notify the master that
+    // initialization failed so it does not hang waiting for the initial data exchange.
+    void notifyMasterSlaveInitFailed_();
 
     /// Dispatch to actual simulation functions based on input deck's setup.
     ///

--- a/opm/simulators/flow/rescoup/ReservoirCoupling.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCoupling.cpp
@@ -129,43 +129,47 @@ void setErrhandler(MPI_Comm comm, bool is_master)
 // ---------------------------
 
 void Logger::debug(const std::string &msg) const {
-    if (haveDeferredLogger()) {
-        // DeferredLogger: All ranks log - messages will be gathered later
-        this->deferred_logger_->debug(msg);
-    } else {
-        // OpmLog fallback: Only rank 0 logs (see comment in info() below)
-        if (comm_.rank() == 0) {
-            OpmLog::debug(msg);
-        }
-    }
+    forward_(msg,
+        [](DeferredLogger &dl, const std::string &m) { dl.debug(m); },
+        [](const std::string &m) { OpmLog::debug(m); });
+}
+
+void Logger::error(const std::string &msg) const {
+    forward_(msg,
+        [](DeferredLogger &dl, const std::string &m) { dl.error(m); },
+        [](const std::string &m) { OpmLog::error(m); });
 }
 
 void Logger::info(const std::string &msg) const {
+    forward_(msg,
+        [](DeferredLogger &dl, const std::string &m) { dl.info(m); },
+        [](const std::string &m) { OpmLog::info(m); });
+}
+
+void Logger::warning(const std::string &msg) const {
+    forward_(msg,
+        [](DeferredLogger &dl, const std::string &m) { dl.warning(m); },
+        [](const std::string &m) { OpmLog::warning(m); });
+}
+
+// Private methods of Logger
+// -------------------------
+
+// Forward a log message to either DeferredLogger (all ranks) or OpmLog (rank 0 only).
+// DeferredLogger being null is the expected normal state - it's only temporarily set
+// during beginTimeStep() via ScopedLoggerGuard. Messages logged here are identical on
+// all ranks, so rank-0-only OpmLog fallback preserves all information.
+template<typename DeferredFn, typename OpmLogFn>
+void Logger::forward_(const std::string &msg, DeferredFn deferred_fn, OpmLogFn opmlog_fn) const {
     if (haveDeferredLogger()) {
-        // DeferredLogger: All ranks log - messages will be gathered later
-        this->deferred_logger_->info(msg);
+        deferred_fn(*this->deferred_logger_, msg);
     } else {
-        // OpmLog fallback: Only rank 0 logs to avoid logging fallout files.
-        // NOTE: DeferredLogger being null is the expected normal state - it's only
-        // temporarily set during beginTimeStep() via ScopedLoggerGuard. Messages logged
-        // here are identical on all ranks, so rank-0-only logging preserves all information.
         if (comm_.rank() == 0) {
-            OpmLog::info(msg);
+            opmlog_fn(msg);
         }
     }
 }
 
-void Logger::warning(const std::string &msg) const {
-    if (haveDeferredLogger()) {
-        // DeferredLogger: All ranks log - messages will be gathered later
-        this->deferred_logger_->warning(msg);
-    } else {
-        // OpmLog fallback: Only rank 0 logs (see comment in info() above)
-        if (comm_.rank() == 0) {
-            OpmLog::warning(msg);
-        }
-    }
-}
 
 // Seconds class alphabetically
 // ----------------------------

--- a/opm/simulators/flow/rescoup/ReservoirCoupling.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCoupling.hpp
@@ -141,6 +141,7 @@ enum class MessageTag : int {
     MasterGroupNames,
     MasterGroupNamesSize,
     MasterGroupNodePressures,
+    MasterInitStatus,
     MasterStartOfReportStep,
     NumMasterGroupNodePressures,
     NumSlaveGroupConstraints,

--- a/opm/simulators/flow/rescoup/ReservoirCoupling.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCoupling.hpp
@@ -48,12 +48,16 @@ public:
     void debug(const std::string &msg) const;
     DeferredLogger& deferredLogger() { return *deferred_logger_; }
     DeferredLogger& deferredLogger() const { return *deferred_logger_; }
+    void error(const std::string &msg) const;
     bool haveDeferredLogger() const { return deferred_logger_ != nullptr; }
     void info(const std::string &msg) const;
     void warning(const std::string &msg) const;
     void setDeferredLogger(DeferredLogger *deferred_logger) { deferred_logger_ = deferred_logger; }
 
 private:
+    template<typename DeferredFn, typename OpmLogFn>
+    void forward_(const std::string &msg, DeferredFn deferred_fn, OpmLogFn opmlog_fn) const;
+
     const Parallel::Communication& comm_;
     DeferredLogger *deferred_logger_ = nullptr;
 };
@@ -152,6 +156,7 @@ enum class MessageTag : int {
     SlaveProductionData,
     SlaveSimulationStartDate,
     SlaveStartOfReportStep,
+    SlaveStatus,
 };
 
 /// @brief Phase indices for reservoir coupling, we currently only support black-oil phases

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
@@ -368,6 +368,8 @@ void
 ReservoirCouplingSlave<Scalar>::
 sendAndReceiveInitialData() {
     // Communication order must match master's spawn() method.
+    // First, send status OK to let master know we initialized successfully.
+    this->sendStatusToMasterProcess_(/*ok=*/true);
     // We receive master group names before sending activation date so that
     // we can detect history matching mode (no master groups) and use start_date as activation.
     this->sendSimulationStartDateToMasterProcess_();
@@ -691,6 +693,24 @@ sendSimulationStartDateToMasterProcess_() const
         );
         this->logger_.debug("Sent start date to master");
    }
+}
+
+template <class Scalar>
+void
+ReservoirCouplingSlave<Scalar>::
+sendStatusToMasterProcess_(bool ok) {
+    if (this->comm_.rank() == 0) {
+        int status = ok ? 0 : 1;
+        MPI_Send(
+            &status,
+            /*count=*/1,
+            /*datatype=*/MPI_INT,
+            /*dest_rank=*/0,
+            /*tag=*/static_cast<int>(MessageTag::SlaveStatus),
+            this->slave_master_comm_
+        );
+        this->logger_.debug(fmt::format("Sent status {} to master", ok ? "OK" : "FAILED"));
+    }
 }
 
 // Explicit template instantiations

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
@@ -370,6 +370,11 @@ sendAndReceiveInitialData() {
     // Communication order must match master's spawn() method.
     // First, send status OK to let master know we initialized successfully.
     this->sendStatusToMasterProcess_(/*ok=*/true);
+    // Then wait for the master's go-ahead. If another slave failed to
+    // initialize, the master replies "abort" here so that we disconnect our
+    // communicator collectively (the master cannot disconnect it on its own
+    // while we are still mid-handshake). On "proceed" we continue normally.
+    this->receiveInitStatusFromMasterProcess_();
     // We receive master group names before sending activation date so that
     // we can detect history matching mode (no master groups) and use start_date as activation.
     this->sendSimulationStartDateToMasterProcess_();
@@ -710,6 +715,37 @@ sendStatusToMasterProcess_(bool ok) {
             this->slave_master_comm_
         );
         this->logger_.debug(fmt::format("Sent status {} to master", ok ? "OK" : "FAILED"));
+    }
+}
+
+template <class Scalar>
+void
+ReservoirCouplingSlave<Scalar>::
+receiveInitStatusFromMasterProcess_() {
+    // Receive the master's go-ahead after we reported our OK status: 0 = proceed,
+    // non-zero = abort (another slave failed). On rank 0 we receive from the
+    // master and broadcast to all slave ranks so that the collective
+    // MPI_Comm_disconnect below is matched on every rank.
+    int proceed = 1;  // default to abort if nothing is received
+    if (this->comm_.rank() == 0) {
+        MPI_Recv(
+            &proceed,
+            /*count=*/1,
+            /*datatype=*/MPI_INT,
+            /*source_rank=*/0,
+            /*tag=*/static_cast<int>(MessageTag::MasterInitStatus),
+            this->slave_master_comm_,
+            MPI_STATUS_IGNORE
+        );
+    }
+    this->comm_.broadcast(&proceed, /*count=*/1, /*emitter_rank=*/0);
+    if (proceed != 0) {
+        this->logger_.info(
+            "Master signaled initialization abort (another slave failed to initialize)");
+        MPI_Comm_disconnect(&this->slave_master_comm_);
+        this->slave_master_comm_ = MPI_COMM_NULL;
+        RCOUP_LOG_THROW(std::runtime_error,
+            "Reservoir coupling initialization aborted by master");
     }
 }
 

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
@@ -198,6 +198,7 @@ private:
     void sendActivationDateToMasterProcess_();
     void sendActivationHandshakeToMasterProcess_() const;
     void sendSimulationStartDateToMasterProcess_() const;
+    void sendStatusToMasterProcess_(bool ok);
 
     const Parallel::Communication &comm_;
     const Schedule& schedule_;

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
@@ -192,6 +192,13 @@ private:
     std::pair<double, bool> getGrupSlavActivationDateAndCheckHistoryMatchingMode_() const;
     bool historyMatchingMode_() const { return this->history_matching_mode_; }
     std::size_t numMasterGroups_() const { return this->slave_to_master_group_map_.size(); }
+    //! \brief Receive the master's go-ahead after reporting our OK status.
+    //!
+    //! Blocks until the master replies "proceed" (continue the handshake) or
+    //! "abort" (another slave failed to initialize). On abort, all slave ranks
+    //! disconnect the master communicator collectively and throw, so the master
+    //! can tear down cleanly instead of deadlocking on the disconnect.
+    void receiveInitStatusFromMasterProcess_();
     void receiveMasterGroupNamesFromMasterProcess_();
     void receiveSlaveNameFromMasterProcess_();
     void saveMasterGroupNamesAsMapAndEstablishOrder_(const std::vector<char>& group_names);

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSpawnSlaves.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSpawnSlaves.cpp
@@ -69,6 +69,7 @@ spawn()
     // Communication order is important - slaves need master group names
     // before they can determine their activation date (for history mode detection).
     this->spawnSlaveProcesses_();
+    this->receiveSlaveStatus_();
     this->receiveSimulationStartDateFromSlaves_();
     this->sendSlaveNamesToSlaves_();
     // These methods handle empty masterGroups gracefully (history mode)
@@ -262,6 +263,49 @@ receiveActivationDateFromSlaves_()
     const double* data = this->master_.getSlaveActivationDates();
     this->comm_.broadcast(const_cast<double *>(data), /*count=*/num_slaves, /*emitter_rank=*/0);
     this->logger_.debug("Broadcasted slave activation dates to all ranks");
+}
+
+template <class Scalar>
+void
+ReservoirCouplingSpawnSlaves<Scalar>::
+receiveSlaveStatus_()
+{
+    auto num_slaves = this->master_.numSlavesStarted();
+    if (this->comm_.rank() == 0) {
+        for (unsigned int i = 0; i < num_slaves; i++) {
+            int status = 0;
+            MPI_Recv(
+                &status,
+                /*count=*/1,
+                /*datatype=*/MPI_INT,
+                /*source_rank=*/0,
+                /*tag=*/static_cast<int>(MessageTag::SlaveStatus),
+                this->master_.getSlaveComm(i),
+                MPI_STATUS_IGNORE
+            );
+            if (status != 0) {
+                this->logger_.error(fmt::format(
+                    "Slave '{}' failed to initialize (parse error or other failure). "
+                    "The master cannot continue without all slaves.",
+                    this->master_.getSlaveName(i)
+                ));
+                // Disconnect from all slave communicators to avoid hanging
+                for (unsigned int j = 0; j < num_slaves; j++) {
+                    auto comm = this->master_.getSlaveComm(j);
+                    if (comm != MPI_COMM_NULL) {
+                        MPI_Comm_disconnect(&comm);
+                    }
+                }
+                RCOUP_LOG_THROW(std::runtime_error,
+                    "Reservoir coupling slave '" + this->master_.getSlaveName(i) +
+                    "' failed to initialize"
+                );
+            }
+            this->logger_.debug(fmt::format(
+                "Received OK status from slave '{}'", this->master_.getSlaveName(i)
+            ));
+        }
+    }
 }
 
 template <class Scalar>

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSpawnSlaves.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSpawnSlaves.cpp
@@ -272,10 +272,17 @@ receiveSlaveStatus_()
 {
     auto num_slaves = this->master_.numSlavesStarted();
     if (this->comm_.rank() == 0) {
+        // Step 1: receive the init status from every slave that finished spawning.
+        // We must receive from all slaves before disconnecting any communicator:
+        // a slave that reported OK proceeds with the rest of the handshake and is
+        // not sitting at MPI_Comm_disconnect, so disconnecting its (collective)
+        // communicator out from under it would deadlock. See step 2.
+        std::vector<int> statuses(num_slaves, 0);
+        bool any_failed = false;
+        unsigned int first_failed = 0;
         for (unsigned int i = 0; i < num_slaves; i++) {
-            int status = 0;
             MPI_Recv(
-                &status,
+                &statuses[i],
                 /*count=*/1,
                 /*datatype=*/MPI_INT,
                 /*source_rank=*/0,
@@ -283,27 +290,60 @@ receiveSlaveStatus_()
                 this->master_.getSlaveComm(i),
                 MPI_STATUS_IGNORE
             );
-            if (status != 0) {
+            if (statuses[i] != 0) {
                 this->logger_.error(fmt::format(
-                    "Slave '{}' failed to initialize (parse error or other failure). "
-                    "The master cannot continue without all slaves.",
+                    "Received FAILED status from slave '{}': it failed to initialize "
+                    "(parse error or other failure). The master cannot continue "
+                    "without all slaves.",
                     this->master_.getSlaveName(i)
                 ));
-                // Disconnect from all slave communicators to avoid hanging
-                for (unsigned int j = 0; j < num_slaves; j++) {
-                    auto comm = this->master_.getSlaveComm(j);
-                    if (comm != MPI_COMM_NULL) {
-                        MPI_Comm_disconnect(&comm);
-                    }
+                if (!any_failed) {
+                    any_failed = true;
+                    first_failed = i;
                 }
-                RCOUP_LOG_THROW(std::runtime_error,
-                    "Reservoir coupling slave '" + this->master_.getSlaveName(i) +
-                    "' failed to initialize"
+            }
+            else {
+                this->logger_.debug(fmt::format(
+                    "Received OK status from slave '{}'", this->master_.getSlaveName(i)
+                ));
+            }
+        }
+        // Step 2: tell every slave that reported OK whether to proceed (0) or
+        // abort (1). A slave that reported FAILED has already disconnected its
+        // parent communicator (see Main::notifyMasterSlaveInitFailed_()) and is
+        // not waiting for a reply, so we do not send it one. An OK slave blocks
+        // on this reply right after sending its status, so on abort it will reach
+        // MPI_Comm_disconnect and the disconnect below is collectively matched.
+        int reply = any_failed ? 1 : 0;
+        for (unsigned int i = 0; i < num_slaves; i++) {
+            if (statuses[i] == 0) {
+                MPI_Send(
+                    &reply,
+                    /*count=*/1,
+                    /*datatype=*/MPI_INT,
+                    /*dest_rank=*/0,
+                    /*tag=*/static_cast<int>(MessageTag::MasterInitStatus),
+                    this->master_.getSlaveComm(i)
                 );
             }
-            this->logger_.debug(fmt::format(
-                "Received OK status from slave '{}'", this->master_.getSlaveName(i)
-            ));
+        }
+        if (any_failed) {
+            // Disconnect from all slave communicators. Failed slaves are already in MPI_Comm_disconnect;
+            // OK slaves received the abort reply and disconnect in response.
+            for (unsigned int i = 0; i < num_slaves; i++) {
+                // MPI_Comm is a copyable handle, so disconnecting a copy releases the underlying communicator.
+                auto comm = this->master_.getSlaveComm(i);
+                if (comm != MPI_COMM_NULL) {
+                    MPI_Comm_disconnect(&comm);
+                    this->logger_.debug(fmt::format(
+                        "Disconnected from slave '{}'", this->master_.getSlaveName(i)
+                    ));
+                }
+            }
+            RCOUP_LOG_THROW(std::runtime_error,
+                "Reservoir coupling slave '" + this->master_.getSlaveName(first_failed) +
+                "' failed to initialize"
+            );
         }
     }
 }

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSpawnSlaves.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSpawnSlaves.hpp
@@ -59,6 +59,14 @@ private:
         std::string &log_filename) const;
     void receiveActivationDateFromSlaves_();
     void receiveSimulationStartDateFromSlaves_();
+    /// @brief Receive initialization status from each slave process.
+    /// @details After spawning, each slave sends a status code (0 = OK, non-zero = failed).
+    ///   If any slave reports failure, disconnects all slave communicators and throws
+    ///   std::runtime_error to prevent the master from hanging on subsequent MPI calls.
+    /// @note Currently only covers failures during readDeck() (parse errors). Exceptions
+    ///   between readDeck() and SimulatorFullyImplicitBlackoil::init() (where the slave
+    ///   sends its OK status) are not yet caught.
+    void receiveSlaveStatus_();
     void sendMasterGroupNamesToSlaves_();
     void sendSlaveNamesToSlaves_();
     void spawnSlaveProcesses_();

--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -767,6 +767,12 @@ void Opm::readDeck(Opm::Parallel::Communication    comm,
         const bool lowActionParsingStrictness = (actionParsingStrictness == "low");
         try {
             auto parseContext = setupParseContext(exitOnAllErrors);
+            if (slaveMode) {
+                // In slave mode, fatal parse errors must throw instead of calling
+                // std::exit() so the slave can notify the master before exiting.
+                // Without this, the master hangs on MPI_Recv waiting for the slave.
+                parseContext->update(ParseContext::PARSE_MISSING_INCLUDE, InputErrorAction::THROW_EXCEPTION);
+            }
             if (treatCriticalAsNonCritical) { // Continue with invalid names if parsing strictness is set to low
                 parseContext->update(ParseContext::SCHEDULE_INVALID_NAME, InputErrorAction::WARN);
             }

--- a/rescoupTests.cmake
+++ b/rescoupTests.cmake
@@ -76,3 +76,27 @@ add_test(NAME rc_slave_parsing_err
   CONFIGURATIONS Integration
 )
 set_tests_properties(rc_slave_parsing_err PROPERTIES TIMEOUT 30)
+
+# Multi-slave parse error test: one slave fails to parse while another is
+# healthy. Verifies the master aborts the healthy slave cleanly (exit 1) instead
+# of deadlocking on a collective MPI_Comm_disconnect.
+add_custom_target(test_rc_slave_parsing_err_2slaves
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/rescoup/slave_parse_error_2slaves
+    ${CMAKE_CURRENT_BINARY_DIR}/tests/rescoup/slave_parse_error_2slaves
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/include
+    ${CMAKE_CURRENT_BINARY_DIR}/tests/include
+  COMMENT "Copying slave_parse_error_2slaves test data to build tree"
+  DEPENDS ${_rescoup_simulator}
+)
+add_test(NAME rc_slave_parsing_err_2slaves
+  COMMAND
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/rescoup/slave_parse_error_2slaves/run_ctest.sh
+    $<TARGET_FILE:${_rescoup_simulator}>
+    ${_rescoup_mpiexec}
+  WORKING_DIRECTORY
+    ${CMAKE_CURRENT_BINARY_DIR}/tests/rescoup/slave_parse_error_2slaves
+  CONFIGURATIONS Integration
+)
+set_tests_properties(rc_slave_parsing_err_2slaves PROPERTIES TIMEOUT 40)

--- a/tests/rescoup/slave_parse_error/run_ctest.sh
+++ b/tests/rescoup/slave_parse_error/run_ctest.sh
@@ -17,16 +17,11 @@
 # along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 
 # CTest wrapper for the reservoir coupling slave parse error test.
-# Exits 0 on expected (currently unfixed) behavior, 1 on unexpected behavior.
 #
-# The slave deck has a deliberate parse error. The master should never
-# complete successfully (exit 0). Expected outcomes depending on MPI:
-#   - exit 1:   MPI runtime detected slave exit (OpenMPI 4.1.6)
-#   - exit 9:   MPI runtime killed master when slave exited (custom MPICH v4.3.2)
-#   - exit 124: master hung on MPI_Recv until timeout (OpenMPI 5.0.8, system MPICH v4.2.1)
-#
-# Any non-zero exit code is treated as PASS. Only exit 0 (master completed
-# despite slave parse error) is treated as FAIL.
+# The slave deck has a deliberate parse error. The slave notifies the master
+# of the failure via MPI, and the master exits with code 1 on all MPI
+# implementations. Exit 0 (master completed despite slave parse error)
+# is treated as FAIL.
 #
 # Known issue — OpenMPI 5.x BTL TCP IPv6 bug (observed with Ubuntu package):
 #   On systems where a network interface has both IPv4 and IPv6 addresses
@@ -71,8 +66,7 @@ echo "MPI launcher: $MPI_LAUNCHER"
 echo "Working dir:  $(pwd)"
 echo ""
 
-# Run with a timeout as a safety net. Some MPI implementations detect the
-# slave exit immediately (exit 1 or 9), others hang until the timeout (exit 124).
+# Run with a timeout as a safety net in case of regression (master hanging).
 timeout 10 \
     "$MPI_LAUNCHER" -np 1 "$FLOW_BINARY" \
     RC_MASTER.DATA \
@@ -82,10 +76,13 @@ timeout 10 \
 
 EXIT_CODE=$?
 
-if [ $EXIT_CODE -eq 0 ]; then
+if [ $EXIT_CODE -eq 1 ]; then
+    echo "PASS: Master detected slave failure (exit code 1)"
+    exit 0
+elif [ $EXIT_CODE -eq 0 ]; then
     echo "FAIL: Master completed successfully — unexpected for slave parse error"
     exit 1
 else
-    echo "PASS: Master did not complete (exit code $EXIT_CODE)"
-    exit 0
+    echo "FAIL: Unexpected exit code $EXIT_CODE (expected 1)"
+    exit 1
 fi

--- a/tests/rescoup/slave_parse_error_2slaves/RC_MASTER.DATA
+++ b/tests/rescoup/slave_parse_error_2slaves/RC_MASTER.DATA
@@ -1,0 +1,163 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2026 Equinor
+
+-- Reservoir coupling master deck for testing slave parse error behavior with
+-- MULTIPLE slaves. The master has a single 1x1x1 grid cell, no wells, and
+-- spawns two slaves:
+--   RES-1 (slave1): DATA file contains a deliberate parse error -> fails
+--   RES-2 (slave2): a valid deck -> initializes and reports OK
+--
+-- This exercises the mixed failed+healthy abort path: the master must detect
+-- RES-1's failure and cleanly abort the healthy RES-2 (which is mid-handshake)
+-- without deadlocking on a collective MPI_Comm_disconnect. The master should
+-- exit cleanly with code 1 on all MPI implementations.
+--
+-- Usage: mpirun -np 1 flow RC_MASTER.DATA --parsing-strictness=low
+-- (--parsing-strictness=low is needed because RC keywords are not yet
+-- activated in opm-common, pending PR #5643)
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+DIMENS
+ 1 1 1 /
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 1 'OCT' 2018 /
+
+EQLDIMS
+ 1 1*  25 /
+
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 5          10            10        10   /
+
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  1          1      50          60         72         60 /
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+NEWTRAN
+
+GRIDFILE
+ 0  1 /
+
+GRIDUNIT
+METRES  /
+
+INIT
+
+SPECGRID
+ 1 1 1 1 F /
+
+COORD
+  2000.0000  2000.0000  2000.0000   2000.0000  2000.0000  2002.5000
+  2100.0000  2000.0000  2000.0000   2100.0000  2000.0000  2002.5000
+  2000.0000  2100.0000  2000.0000   2000.0000  2100.0000  2002.5000
+  2100.0000  2100.0000  2000.0000   2100.0000  2100.0000  2002.5000
+/
+
+ZCORN
+  2000.0000  2000.0000  2000.0000  2000.0000  2002.5000  2002.5000
+  2002.5000  2002.5000 /
+
+PORO
+ 0.25 /
+
+PERMX
+ 2100 /
+
+COPY
+ PERMX PERMY /
+ PERMX PERMZ /
+/
+
+MULTIPLY
+ 'PERMZ' 0.1 /
+/
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ '../../include/PVT-WET-GAS.INC' /
+
+INCLUDE
+ '../../include/scal_mod2.inc' /
+
+FILLEPS
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+RPTRST
+ BASIC=2 /
+
+EQUIL
+-- Datum    P     woc     Pc   goc      Pc  Rsvd  Rvvd  N
+2300.00   300.0  2300.0   0.0  1800.00  0.0   1     1   0 /
+
+PBVD
+ 2000.0 100.0
+ 2300.0 100.0 /
+
+PDVD
+ 2000.0 100.0
+ 2300.0 100.0 /
+/
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+TUNING
+ 1.0  5.0 /
+ /
+ /
+
+GRUPTREE
+ 'MOD2'   'FIELD' /
+ 'E1_M'   'MOD2' /
+/
+
+SLAVES
+  'RES-1'  'RC_SLAVE'  '*'  'slave1'  1 /
+  'RES-2'  'RC_SLAVE'  '*'  'slave2'  1 /
+/
+
+DATES
+ 1 NOV 2018 /
+/
+
+END

--- a/tests/rescoup/slave_parse_error_2slaves/run_ctest.sh
+++ b/tests/rescoup/slave_parse_error_2slaves/run_ctest.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright 2026 Equinor
+#
+# This file is part of the Open Porous Media project (OPM).
+#
+# OPM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OPM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+# CTest wrapper for the multi-slave reservoir coupling parse error test.
+#
+# The master spawns two slaves: RES-1 (slave1) has a deliberate parse error and
+# fails; RES-2 (slave2) is valid and reports OK, then waits for the master's
+# go-ahead. The master must detect RES-1's failure and cleanly abort the healthy
+# RES-2 (which is mid-handshake) without deadlocking on a collective
+# MPI_Comm_disconnect, then exit with code 1.
+#
+# Expected outcome (with the master-hang fix): exit code 1 on all MPI
+# implementations.
+#   - exit 1:   master detected the slave failure and aborted cleanly  -> PASS
+#   - exit 0:   master completed despite a slave parse error           -> FAIL
+#   - exit 124: master hung (e.g. the old multi-slave disconnect bug)  -> FAIL
+#   - other:    unexpected                                             -> FAIL
+#
+# Usage: run_ctest.sh <flow_binary> <mpi_launcher>
+
+set -u
+
+FLOW_BINARY="${1:?Usage: $0 <flow_binary> <mpi_launcher>}"
+MPI_LAUNCHER="${2:?Usage: $0 <flow_binary> <mpi_launcher>}"
+
+echo "Flow binary:  $FLOW_BINARY"
+echo "MPI launcher: $MPI_LAUNCHER"
+echo "Working dir:  $(pwd)"
+echo ""
+
+# Run with a timeout as a safety net. With the fix the master exits quickly with
+# code 1; a timeout (124) would indicate the master hung (regression).
+timeout 20 \
+    "$MPI_LAUNCHER" -np 1 "$FLOW_BINARY" \
+    RC_MASTER.DATA \
+    --parsing-strictness=low \
+    --output-dir=. \
+    2>&1
+
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 1 ]; then
+    echo "PASS: Master detected slave failure and aborted cleanly (exit code 1)"
+    exit 0
+elif [ $EXIT_CODE -eq 0 ]; then
+    echo "FAIL: Master completed successfully — slave parse error was ignored"
+    exit 1
+elif [ $EXIT_CODE -eq 124 ]; then
+    echo "FAIL: Master hung until timeout (possible multi-slave disconnect deadlock)"
+    exit 1
+else
+    echo "FAIL: Master exited with unexpected code $EXIT_CODE"
+    exit 1
+fi

--- a/tests/rescoup/slave_parse_error_2slaves/slave1/RC_SLAVE.DATA
+++ b/tests/rescoup/slave_parse_error_2slaves/slave1/RC_SLAVE.DATA
@@ -1,0 +1,44 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2026 Equinor
+
+-- Deliberately broken slave deck (RES-1) for the multi-slave reservoir coupling
+-- parse error test. The INCLUDE in the GRID section references a non-existent
+-- file, which triggers a parse error regardless of --parsing-strictness setting.
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+DIMENS
+ 2 2 2 /
+
+OIL
+WATER
+
+METRIC
+
+START
+ 1 'JAN' 2019 /
+
+EQLDIMS
+ 1 /
+
+TABDIMS
+ 1 1 /
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+-- Intentional error: this file does not exist
+INCLUDE
+ 'nonexistent_grid_file.inc' /
+
+END

--- a/tests/rescoup/slave_parse_error_2slaves/slave2/RC_SLAVE.DATA
+++ b/tests/rescoup/slave_parse_error_2slaves/slave2/RC_SLAVE.DATA
@@ -1,0 +1,144 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2026 Equinor
+
+-- Valid slave deck (RES-2) for the multi-slave reservoir coupling parse error
+-- test. This slave initializes successfully and reports OK status, then waits
+-- for the master's go-ahead. When the other slave (RES-1) fails to parse, the
+-- master signals abort here and this slave disconnects cleanly. A minimal
+-- 1x1x1 single-cell deck (history matching mode, no master groups).
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+DIMENS
+ 1 1 1 /
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 1 'OCT' 2018 /
+
+EQLDIMS
+ 1 1*  25 /
+
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 5          10            10        10   /
+
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  1          1      50          60         72         60 /
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+NEWTRAN
+
+GRIDFILE
+ 0  1 /
+
+GRIDUNIT
+METRES  /
+
+INIT
+
+SPECGRID
+ 1 1 1 1 F /
+
+COORD
+  2000.0000  2000.0000  2000.0000   2000.0000  2000.0000  2002.5000
+  2100.0000  2000.0000  2000.0000   2100.0000  2000.0000  2002.5000
+  2000.0000  2100.0000  2000.0000   2000.0000  2100.0000  2002.5000
+  2100.0000  2100.0000  2000.0000   2100.0000  2100.0000  2002.5000
+/
+
+ZCORN
+  2000.0000  2000.0000  2000.0000  2000.0000  2002.5000  2002.5000
+  2002.5000  2002.5000 /
+
+PORO
+ 0.25 /
+
+PERMX
+ 2100 /
+
+COPY
+ PERMX PERMY /
+ PERMX PERMZ /
+/
+
+MULTIPLY
+ 'PERMZ' 0.1 /
+/
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ '../../../include/PVT-WET-GAS.INC' /
+
+INCLUDE
+ '../../../include/scal_mod2.inc' /
+
+FILLEPS
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+RPTRST
+ BASIC=2 /
+
+EQUIL
+-- Datum    P     woc     Pc   goc      Pc  Rsvd  Rvvd  N
+2300.00   300.0  2300.0   0.0  1800.00  0.0   1     1   0 /
+
+PBVD
+ 2000.0 100.0
+ 2300.0 100.0 /
+
+PDVD
+ 2000.0 100.0
+ 2300.0 100.0 /
+/
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+TUNING
+ 1.0  5.0 /
+ /
+ /
+
+DATES
+ 1 NOV 2018 /
+/
+
+END


### PR DESCRIPTION
Builds on #6951  and #6935.

When a reservoir coupling slave process fails to parse its DATA file (e.g., missing INCLUDE), the master hangs indefinitely on `MPI_Recv()` waiting for initial data that never arrives. This commit fixes the hang by adding a status handshake protocol after `MPI_Comm_spawn()`.

#### Status handshake protocol

- **Add `SlaveStatus` message tag**: after spawn, each slave sends an OK (0) or FAILED (non-zero) status to the master before any data exchange
- **Slave side** (`ReservoirCouplingSlave`): `sendStatusToMasterProcess_()` sends the status; called at the start of `sendAndReceiveInitialData()`
- **Master side** (`ReservoirCouplingSpawnSlaves`): `receiveSlaveStatus_()` checks each slave's status. On failure, disconnects all slave communicators and throws `std::runtime_error` to prevent hanging on subsequent MPI calls

#### Slave parse failure notification

- **`readDeck.cpp`**: in slave mode, override `PARSE_MISSING_INCLUDE` to throw instead of calling `std::exit()`, enabling cooperative MPI shutdown
- **`Main::notifyMasterSlaveInitFailed_()`**: new private helper called from the `readDeck()` catch handle. Sends FAILED status to the master so it doesn't hang waiting for the slave's initial data exchange

#### Test updates

- **Tighten `run_ctest.sh`** to expect exit code 1 specifically (cooperative shutdown), rather than accepting any non-zero exit code
