### PR TITLE
Add FieldTraits specialization for MatrixBlock

### DIFF
--- a/opm/simulators/linalg/matrixblock.hh
+++ b/opm/simulators/linalg/matrixblock.hh
@@ -316,6 +316,11 @@ struct IsNumber<Opm::MatrixBlock<T, n, m>>
     : public IsNumber<Dune::FieldMatrix<T,n,m>>
 {};
 
+template<typename T, int n, int m>
+struct FieldTraits<Opm::MatrixBlock<T, n, m>>
+    : public FieldTraits<Dune::FieldMatrix<T,n,m>>
+{};
+
 } // end namespace Dune
 
 


### PR DESCRIPTION
This allows MatrixBlock to be used in generic contexts where Dune requires FieldTraits. This will be required for future DUNE releases. See https://gitlab.dune-project.org/core/dune-istl/-/commit/aaaec6db345df32363f4528cf776e30de206fc90.