### PR TITLE
Fix preconditioner update wrapper and usage.

### DIFF
--- a/opm/simulators/linalg/PreconditionerWithUpdate.hpp
+++ b/opm/simulators/linalg/PreconditionerWithUpdate.hpp
@@ -22,6 +22,8 @@
 
 #include <dune/istl/preconditioner.hh>
 #include <memory>
+#include <tuple>
+#include <utility>
 
 namespace Dune
 {
@@ -109,7 +111,7 @@ template <class OriginalPreconditioner, class... Args>
 struct PreconditionerMaker : public GeneralPreconditionerMaker<OriginalPreconditioner> {
     using GenericPreconditioner = Preconditioner<typename OriginalPreconditioner::domain_type, typename OriginalPreconditioner::range_type>;
 
-    explicit PreconditionerMaker(Args&&... args)
+    explicit PreconditionerMaker(Args... args)
         : args_(args...)
     {
     }
@@ -136,7 +138,7 @@ class RebuildOnUpdatePreconditioner : public PreconditionerWithUpdate<typename O
 public:
     template<class... Args>
     explicit RebuildOnUpdatePreconditioner(Args... args)
-        : preconditioner_maker_(std::make_unique<PreconditionerMaker<OriginalPreconditioner, Args...>>(std::forward<Args>(args)...))
+        : preconditioner_maker_(std::make_unique<PreconditionerMaker<OriginalPreconditioner, Args...>>(args...))
     {
         update();
     }
@@ -192,8 +194,7 @@ template <class OriginalPreconditioner, class... Args>
 auto
 getRebuildOnUpdateWrapper(Args... args)
 {
-    return std::make_shared<RebuildOnUpdatePreconditioner<OriginalPreconditioner>>(
-        std::forward<Args>(args)...);
+    return std::make_shared<RebuildOnUpdatePreconditioner<OriginalPreconditioner>>(args...);
 }
 
 } // namespace Dune

--- a/opm/simulators/linalg/StandardPreconditioners_mpi.hpp
+++ b/opm/simulators/linalg/StandardPreconditioners_mpi.hpp
@@ -29,6 +29,9 @@
 #endif
 #endif
 
+#include <functional>
+#include <memory>
+#include <type_traits>
 
 namespace Opm {
 
@@ -154,7 +157,7 @@ struct StandardPreconditioners
             const double w = prm.get<double>("relaxation", 1.0);
             const bool resort = prm.get<bool>("resort", false);
             return wrapBlockPreconditioner<RebuildOnUpdatePreconditioner<Dune::SeqILU<M, V, V>>>(
-                comm, op.getmat(), n, w, resort);
+                comm, std::cref(op.getmat()), n, w, resort);
         });
         F::addCreator("dilu", [](const O& op, const P& prm, const std::function<V()>&, std::size_t, const C& comm) {
             DUNE_UNUSED_PARAMETER(prm);

--- a/opm/simulators/linalg/StandardPreconditioners_serial.hpp
+++ b/opm/simulators/linalg/StandardPreconditioners_serial.hpp
@@ -29,6 +29,10 @@
 #endif
 #endif
 
+#include <functional>
+#include <memory>
+#include <type_traits>
+
 namespace Opm {
 
 template <class X, class Y>
@@ -66,7 +70,7 @@ struct StandardPreconditioners<Operator, Dune::Amg::SequentialInformation, typen
             const double w = prm.get<double>("relaxation", 1.0);
             const int n = prm.get<int>("ilulevel", 0);
             const bool resort = prm.get<bool>("resort", false);
-            return getRebuildOnUpdateWrapper<Dune::SeqILU<M, V, V>>(op.getmat(), n, w, resort);
+            return getRebuildOnUpdateWrapper<Dune::SeqILU<M, V, V>>(std::cref(op.getmat()), n, w, resort);
         });
         F::addCreator("paroverilu0", [](const O& op, const P& prm, const std::function<V()>&, std::size_t) {
             const double w = prm.get<double>("relaxation", 1.0);


### PR DESCRIPTION
Used for the Dune::SeqILU preconditioner. Using std::reference_wrapper by calling std::cref at the call site ensures that the matrix is stored with reference semantics, instead of copying the matrix from the initial call.

Also remove some unnecessary (and misleading) use of `&&` and `std::forward`.

For the manual: fix the "duneilu" preconditioner choice available through the JSON interface for the linear solver.