### PR TITLE
Reservoir coupling: Populate satellite data for summary output

### DIFF
--- a/opm/simulators/flow/EclGenericWriter.hpp
+++ b/opm/simulators/flow/EclGenericWriter.hpp
@@ -30,6 +30,8 @@
 
 #include <opm/models/parallel/tasklets.hpp>
 
+#include <opm/output/data/Groups.hpp>
+
 #include <opm/simulators/flow/CollectDataOnIORank.hpp>
 #include <opm/simulators/flow/Transmissibility.hpp>
 #include <opm/simulators/timestepping/SimulatorReport.hpp>
@@ -149,7 +151,8 @@ protected:
                      const Inplace*                                       initialInPlace,
                      const InterRegFlowMap&                               interRegFlows,
                      SummaryState&                                        summaryState,
-                     UDQState&                                            udqState);
+                     UDQState&                                            udqState,
+                     const data::ReservoirCouplingGroupRates*             rcGroupRates = nullptr);
 
     CollectDataOnIORankType collectOnIORank_;
     const Grid& grid_;
@@ -180,7 +183,7 @@ protected:
     mutable std::vector<std::vector<NNCdata>> outputNncGlobalLocal_; // here GLOBAL refers to level 0 grid, local to any LGR (refined grid)
 
     // Amalgamated NNCs: nncs between different LGRs. For example, nested refinement or neighboring LGRs.
-    // The cells belong to different refined level grids. 
+    // The cells belong to different refined level grids.
     // nnc.cell1 (NNA1 in *.EGRID) Level/Local Cartesian index of cell1 (in its level grid: level1)
     // nnc.cell2 (NNA2 in *.EGRID) Level/Local Cartesian index of cell2 (in its level grid: level2, with level2 > level1).
     // Equivalent to TRANLL in *.INIT
@@ -209,16 +212,16 @@ private:
     bool isCartesianNeighbour_(const std::array<int,3>& levelCartDims,
                                const std::size_t levelCartIdx1,
                                const std::size_t levelCartIdx2) const;
-    
+
     bool isDirectNeighbours_(const std::unordered_map<int,int>& levelCartesianToActive,
                              const std::array<int,3>& levelCartDims,
                              const std::size_t levelCartIdx1,
                              const std::size_t levelCartIdx2) const;
-    
+
     auto activeCell_(const std::unordered_map<int,int>& levelCartToLevelCompressed,
                      const std::size_t levelCartIdx) const;
-    
-    
+
+
 
     /// Returns true if the given Cartesian cell index belongs to a numerical aquifer.
     /// If no numerical aquifer exists, always returns false.
@@ -285,7 +288,7 @@ private:
     /// Allocates NNCdata  vectors for
     /// - TRANNNC for level grids,
     /// - TRANGL for NNCs between level zero grid and an LGR (refined level grid)
-    /// - TRANLL for NNCs between two different refined level grids. 
+    /// - TRANLL for NNCs between two different refined level grids.
     /// Only for CpGrid. Other grid types do not support refinement yet.
     void allocateAllNncs_(int maxLevel) const;
 };

--- a/opm/simulators/flow/EclGenericWriter_impl.hpp
+++ b/opm/simulators/flow/EclGenericWriter_impl.hpp
@@ -536,7 +536,7 @@ computeTrans_(const std::vector<std::unordered_map<int,int>>&  levelCartToLevelC
 
             // For level-zero grid, level Cartesian indices coincide with the grid Cartesian indices.
             if (isNumAquCell_(originCartIdxIn) || isNumAquCell_(originCartIdxOut)) {
-                // Check there are no refined aquifer cells. 
+                // Check there are no refined aquifer cells.
                 assert(level == 0);
                 // Connections involving numerical aquifers are always NNCs
                 // for the purpose of file output.  This holds even for
@@ -597,7 +597,7 @@ EclGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>::
 isDirectNeighbours_(const std::unordered_map<int,int>& levelCartesianToActive,
                     const std::array<int,3>& levelCartDims,
                     const std::size_t levelCartIdx1,
-                    const std::size_t levelCartIdx2) const 
+                    const std::size_t levelCartIdx2) const
 {
     return isCartesianNeighbour_(levelCartDims, levelCartIdx1, levelCartIdx2)
         || directVerticalNeighbors(levelCartDims, levelCartesianToActive, levelCartIdx1, levelCartIdx2);
@@ -607,7 +607,7 @@ template<class Grid, class EquilGrid, class GridView, class ElementMapper, class
 auto
 EclGenericWriter<Grid,EquilGrid,GridView,ElementMapper,Scalar>::
 activeCell_(const std::unordered_map<int,int>& levelCartToLevelCompressed,
-            const std::size_t levelCartIdx) const 
+            const std::size_t levelCartIdx) const
 {
     auto pos = levelCartToLevelCompressed.find(levelCartIdx);
     return (pos == levelCartToLevelCompressed.end()) ? -1 : pos->second;
@@ -634,7 +634,7 @@ allocateAllNncs_(int maxLevel) const
         //          outputAmalgamatedNnc_[0][0] -> NNCs between level 1 and level 2
         //          outputAmalgamatedNnc_[0][1] -> NNCs between level 1 and level 3
         //          outputAmalgamatedNnc_[1][2] -> NNCs between level 2 and level 3
-        this->outputAmalgamatedNnc_.resize(maxLevel-1); 
+        this->outputAmalgamatedNnc_.resize(maxLevel-1);
         for (int i = 0; i < maxLevel-1; ++i) {
             this->outputAmalgamatedNnc_[i].resize(maxLevel-1-i);
         }
@@ -660,7 +660,7 @@ exportNncStructure_(const std::vector<std::unordered_map<int,int>>& levelCartToL
 
     // Cartesian index mapper for the serial I/O grid
     const auto& equilCartMapper = *equilCartMapper_;
-    
+
     const auto& level0CartDims = equilCartMapper.cartesianDimensions();
 
     int maxLevel = this->equilGrid_->maxLevel();
@@ -702,7 +702,7 @@ exportNncStructure_(const std::vector<std::unordered_map<int,int>>& levelCartToL
 
                 const auto& [smallerLevel, smallerLevelCartIdx] = smallerPair;
                 const auto& [largerLevel, largerLevelCartIdx] = largerPair;
-                
+
                 auto t = this->globalTrans().transmissibility(c1, c2);
 
                 // ECLIPSE ignores NNCs with zero transmissibility
@@ -765,13 +765,13 @@ exportNncStructure_(const std::vector<std::unordered_map<int,int>>& levelCartToL
                     // We need to check whether an NNC for this face was also
                     // specified via the NNC keyword in the deck.
                     auto t = this->globalTrans().transmissibility(c1, c2);
-                    
+
                     if (level == 0) {
                         auto candidate = std::lower_bound(nncData.begin(), nncData.end(),
                                                           NNCdata { originCartIdxIn, originCartIdxOut, 0.0 });
                         const auto transMlt = transMult.getRegionMultiplierNNC(originCartIdxIn, originCartIdxOut);
                         bool foundNncEditr = false;
-                    
+
                         while ((candidate != nncData.end()) &&
                                (candidate->cell1 == originCartIdxIn) &&
                                (candidate->cell2 == originCartIdxOut))
@@ -802,7 +802,7 @@ exportNncStructure_(const std::vector<std::unordered_map<int,int>>& levelCartToL
                             continue;
                         }
                     }
-                    
+
                     // ECLIPSE ignores NNCs with zero transmissibility
                     // (different threshold than for NNC with corresponding
                     // EDITNNC above).  In addition we do set small
@@ -1012,7 +1012,8 @@ evalSummary(const int                                            reportStepNum,
             const Inplace*                                       initialInPlace,
             const InterRegFlowMap&                               interRegFlows,
             SummaryState&                                        summaryState,
-            UDQState&                                            udqState)
+            UDQState&                                            udqState,
+            const data::ReservoirCouplingGroupRates*             rcGroupRates)
 {
     if (collectOnIORank_.isIORank()) {
         const auto& summary = eclIO_->summary();
@@ -1044,6 +1045,7 @@ evalSummary(const int                                            reportStepNum,
             /* block_values            = */ &blockData,
             /* aquifer_values          = */ &aquiferData,
             /* interreg_flows          = */ &interreg_flows,
+            /* rc_group_rates          = */ rcGroupRates,
             /* inplace                 = */ {
                 /* current = */ &inplace,
                 /* initial = */ initialInPlace

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -325,12 +325,9 @@ public:
             miscSummaryData["MSUMNEWT"] = this->simulation_report_.success.total_newton_iterations;
         }
 
-        // For reservoir coupling master: populate satellite production/injection
-        // data from slave groups so that summary.eval() picks up the rates through
-        // the existing GSatProd / satellite_rate machinery in opm-common's Summary.cpp.
-        // This must be done before evalSummary() so the rates are available when
-        // summary vectors are evaluated.
-        this->updateReservoirCouplingSatelliteData_();
+        // For reservoir coupling master: collect slave production/injection
+        // rates to pass through to Summary::eval() via DynamicSimulatorState.
+        const auto rcGroupRates = this->collectReservoirCouplingGroupRates_();
 
         {
             OPM_TIMEBLOCK(evalSummary);
@@ -356,7 +353,8 @@ public:
                               this->outputModule_->initialInplace(),
                               interRegFlows,
                               this->summaryState(),
-                              this->udqState());
+                              this->udqState(),
+                              rcGroupRates ? &(*rcGroupRates) : nullptr);
         }
     }
 
@@ -764,10 +762,9 @@ private:
     const Schedule& schedule() const
     { return simulator_.vanguard().schedule(); }
 
-    /// Populate satellite production/injection data from reservoir coupling
-    /// slave groups into the Schedule's GSatProd / GroupSatelliteInjection
-    /// structures.  Delegates to ReservoirCouplingMaster::updateScheduleSatelliteData().
-    void updateReservoirCouplingSatelliteData_()
+    /// Collect reservoir coupling master group rates for Summary::eval().
+    /// Returns nullopt for non-RC simulations or non-master processes.
+    std::optional<data::ReservoirCouplingGroupRates> collectReservoirCouplingGroupRates_()
     {
 #ifdef RESERVOIR_COUPLING_ENABLED
         // Guard: only BlackoilWellModel has reservoir coupling support.
@@ -779,12 +776,13 @@ private:
         if constexpr (requires(WellModelType& wm) { wm.isReservoirCouplingMaster(); }) {
             auto& wellModel = simulator_.problem().wellModel();
             if (!wellModel.isReservoirCouplingMaster()) {
-                return;
+                return std::nullopt;
             }
-            wellModel.reservoirCouplingMaster().updateScheduleSatelliteData(
-                simulator_.vanguard().schedule(), simulator_.episodeIndex());
+            return wellModel.reservoirCouplingMaster()
+                .collectGroupRatesForSummary();
         }
 #endif
+        return std::nullopt;
     }
 
     void prepareLocalCellData(const bool isSubStep,

--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -53,6 +53,11 @@
 #include <opm/simulators/utils/ParallelRestart.hpp>
 #include <opm/simulators/utils/ParallelSerialization.hpp>
 
+#include <opm/simulators/flow/rescoup/ReservoirCouplingEnabled.hpp>
+#ifdef RESERVOIR_COUPLING_ENABLED
+#include <opm/simulators/flow/rescoup/ReservoirCouplingMaster.hpp>
+#endif
+
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <limits>
@@ -128,7 +133,7 @@ class EclWriter : public EclGenericWriter<GetPropType<TypeTag, Properties::Grid>
 
     typedef Dune::MultipleCodimMultipleGeomTypeMapper< GridView > VertexMapper;
 
-    enum { enableEnergy = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal || 
+    enum { enableEnergy = getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::FullyImplicitThermal ||
            getPropValue<TypeTag, Properties::EnergyModuleType>() == EnergyModules::SequentialImplicitThermal };
     enum { enableMech = getPropValue<TypeTag, Properties::EnableMech>() };
     enum { enableSolvent = getPropValue<TypeTag, Properties::EnableSolvent>() };
@@ -319,6 +324,13 @@ public:
         if (this->simulation_report_.success.total_newton_iterations != 0) {
             miscSummaryData["MSUMNEWT"] = this->simulation_report_.success.total_newton_iterations;
         }
+
+        // For reservoir coupling master: populate satellite production/injection
+        // data from slave groups so that summary.eval() picks up the rates through
+        // the existing GSatProd / satellite_rate machinery in opm-common's Summary.cpp.
+        // This must be done before evalSummary() so the rates are available when
+        // summary vectors are evaluated.
+        this->updateReservoirCouplingSatelliteData_();
 
         {
             OPM_TIMEBLOCK(evalSummary);
@@ -751,6 +763,29 @@ private:
 
     const Schedule& schedule() const
     { return simulator_.vanguard().schedule(); }
+
+    /// Populate satellite production/injection data from reservoir coupling
+    /// slave groups into the Schedule's GSatProd / GroupSatelliteInjection
+    /// structures.  Delegates to ReservoirCouplingMaster::updateScheduleSatelliteData().
+    void updateReservoirCouplingSatelliteData_()
+    {
+#ifdef RESERVOIR_COUPLING_ENABLED
+        // Guard: only BlackoilWellModel has reservoir coupling support.
+        // CompWellModel (compositional) does not, so we use if constexpr
+        // to avoid compilation errors when EclWriter is instantiated with
+        // a compositional TypeTag.
+        using WellModelType = std::remove_cvref_t<
+            decltype(simulator_.problem().wellModel())>;
+        if constexpr (requires(WellModelType& wm) { wm.isReservoirCouplingMaster(); }) {
+            auto& wellModel = simulator_.problem().wellModel();
+            if (!wellModel.isReservoirCouplingMaster()) {
+                return;
+            }
+            wellModel.reservoirCouplingMaster().updateScheduleSatelliteData(
+                simulator_.vanguard().schedule(), simulator_.episodeIndex());
+        }
+#endif
+    }
 
     void prepareLocalCellData(const bool isSubStep,
                               const int  reportStepNum)

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMaster.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMaster.cpp
@@ -497,6 +497,15 @@ updateMasterGroupNameOrderMap(
     this->master_group_name_order_[slave_name] = master_group_name_map;
 }
 
+template <class Scalar>
+void
+ReservoirCouplingMaster<Scalar>::
+updateScheduleSatelliteData(Schedule& schedule, const int report_step_idx)
+{
+    assert(this->report_step_data_);
+    this->report_step_data_->updateScheduleSatelliteData(schedule, report_step_idx);
+}
+
 // ------------------
 // Private methods
 // ------------------

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMaster.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMaster.cpp
@@ -498,12 +498,12 @@ updateMasterGroupNameOrderMap(
 }
 
 template <class Scalar>
-void
+data::ReservoirCouplingGroupRates
 ReservoirCouplingMaster<Scalar>::
-updateScheduleSatelliteData(Schedule& schedule, const int report_step_idx)
+collectGroupRatesForSummary() const
 {
     assert(this->report_step_data_);
-    this->report_step_data_->updateScheduleSatelliteData(schedule, report_step_idx);
+    return this->report_step_data_->collectGroupRatesForSummary();
 }
 
 // ------------------

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMaster.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMaster.hpp
@@ -155,12 +155,10 @@ public:
     }
     void setFirstSubstepOfSyncTimestep(bool value);
 
-    /// @brief Update the Schedule's satellite production/injection data from
-    ///   slave group rates.
-    /// @details Called from EclWriter::evalSummaryState() at the end of each
-    ///   sync step. Delegates to ReservoirCouplingMasterReportStep.  See its
-    ///   updateScheduleSatelliteData() for details.
-    void updateScheduleSatelliteData(Schedule& schedule, int report_step_idx);
+    /// @brief Collect production/injection rates for all master groups.
+    /// @details Returns a ReservoirCouplingGroupRates struct that can be
+    ///   passed through DynamicSimulatorState to Summary::eval().
+    data::ReservoirCouplingGroupRates collectGroupRatesForSummary() const;
     // These are currently only used for unit testing
     void setSlaveActivationDate(int index, double date) { this->slave_activation_dates_[index] = date; }
     void setSlaveNextReportTimeOffset(int index, double offset);

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMaster.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMaster.hpp
@@ -154,6 +154,13 @@ public:
          this->logger_.setDeferredLogger(deferred_logger);
     }
     void setFirstSubstepOfSyncTimestep(bool value);
+
+    /// @brief Update the Schedule's satellite production/injection data from
+    ///   slave group rates.
+    /// @details Called from EclWriter::evalSummaryState() at the end of each
+    ///   sync step. Delegates to ReservoirCouplingMasterReportStep.  See its
+    ///   updateScheduleSatelliteData() for details.
+    void updateScheduleSatelliteData(Schedule& schedule, int report_step_idx);
     // These are currently only used for unit testing
     void setSlaveActivationDate(int index, double date) { this->slave_activation_dates_[index] = date; }
     void setSlaveNextReportTimeOffset(int index, double offset);

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.cpp
@@ -320,6 +320,53 @@ setReportStepIdx(int report_step_idx)
     this->report_step_idx_ = report_step_idx;
 }
 
+template <class Scalar>
+void
+ReservoirCouplingMasterReportStep<Scalar>::
+updateScheduleSatelliteData(Schedule& schedule, const int report_step_idx)
+{
+    using RcPhase = ReservoirCoupling::Phase;
+    using RateKind = ReservoirCoupling::RateKind;
+
+    const auto numSlaves = this->numSlaves();
+    for (unsigned int i = 0; i < numSlaves; ++i) {
+        const auto& masterGroupNames = this->getMasterGroupNamesForSlave(i);
+        for (const auto& groupName : masterGroupNames) {
+            // GSatProd expects positive production rates.  The rates from
+            // getMasterGroupRate_(ProductionSurface) originate from the slave's
+            // GuideRate::RateVector which stores positive values for production
+            // (guide rate convention, not the well-state sign convention).
+            const double oilRate = this->getMasterGroupRate_(
+                groupName, RcPhase::Oil, RateKind::ProductionSurface);
+            const double gasRate = this->getMasterGroupRate_(
+                groupName, RcPhase::Gas, RateKind::ProductionSurface);
+            const double waterRate = this->getMasterGroupRate_(
+                groupName, RcPhase::Water, RateKind::ProductionSurface);
+            const double resvRate =
+                this->getMasterGroupRate_(groupName, RcPhase::Oil, RateKind::ProductionReservoir)
+                + this->getMasterGroupRate_(groupName, RcPhase::Gas, RateKind::ProductionReservoir)
+                + this->getMasterGroupRate_(groupName, RcPhase::Water, RateKind::ProductionReservoir);
+
+            schedule.updateSatelliteProduction(
+                report_step_idx, groupName, oilRate, gasRate, waterRate, resvRate);
+
+            // Injection rates: positive values match what GSatInje expects.
+            for (const auto phase : {RcPhase::Oil, RcPhase::Gas, RcPhase::Water}) {
+                const double surfRate = this->getMasterGroupRate_(
+                    groupName, phase, RateKind::InjectionSurface);
+                const double resRate = this->getMasterGroupRate_(
+                    groupName, phase, RateKind::InjectionReservoir);
+
+                if (surfRate != 0.0 || resRate != 0.0) {
+                    const auto opmPhase = convertToOpmPhase(phase);
+                    schedule.updateSatelliteInjection(
+                        report_step_idx, groupName, opmPhase, surfRate, resRate);
+                }
+            }
+        }
+    }
+}
+
 
 // ------------------
 // Private methods

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.cpp
@@ -321,50 +321,44 @@ setReportStepIdx(int report_step_idx)
 }
 
 template <class Scalar>
-void
+data::ReservoirCouplingGroupRates
 ReservoirCouplingMasterReportStep<Scalar>::
-updateScheduleSatelliteData(Schedule& schedule, const int report_step_idx)
+collectGroupRatesForSummary() const
 {
     using RcPhase = ReservoirCoupling::Phase;
     using RateKind = ReservoirCoupling::RateKind;
+
+    data::ReservoirCouplingGroupRates result;
 
     const auto numSlaves = this->numSlaves();
     for (unsigned int i = 0; i < numSlaves; ++i) {
         const auto& masterGroupNames = this->getMasterGroupNamesForSlave(i);
         for (const auto& groupName : masterGroupNames) {
-            // GSatProd expects positive production rates.  The rates from
-            // getMasterGroupRate_(ProductionSurface) originate from the slave's
-            // GuideRate::RateVector which stores positive values for production
-            // (guide rate convention, not the well-state sign convention).
-            const double oilRate = this->getMasterGroupRate_(
-                groupName, RcPhase::Oil, RateKind::ProductionSurface);
-            const double gasRate = this->getMasterGroupRate_(
-                groupName, RcPhase::Gas, RateKind::ProductionSurface);
-            const double waterRate = this->getMasterGroupRate_(
-                groupName, RcPhase::Water, RateKind::ProductionSurface);
-            const double resvRate =
+            // Production rates (positive values, SI units)
+            data::ReservoirCouplingGroupRates::ProductionRates prod;
+            prod.oil = this->getMasterGroupRate_(groupName, RcPhase::Oil, RateKind::ProductionSurface);
+            prod.gas = this->getMasterGroupRate_(groupName, RcPhase::Gas, RateKind::ProductionSurface);
+            prod.water = this->getMasterGroupRate_(groupName, RcPhase::Water, RateKind::ProductionSurface);
+            prod.resv =
                 this->getMasterGroupRate_(groupName, RcPhase::Oil, RateKind::ProductionReservoir)
                 + this->getMasterGroupRate_(groupName, RcPhase::Gas, RateKind::ProductionReservoir)
                 + this->getMasterGroupRate_(groupName, RcPhase::Water, RateKind::ProductionReservoir);
+            result.production[groupName] = prod;
 
-            schedule.updateSatelliteProduction(
-                report_step_idx, groupName, oilRate, gasRate, waterRate, resvRate);
-
-            // Injection rates: positive values match what GSatInje expects.
+            // Injection rates (positive values, SI units)
             for (const auto phase : {RcPhase::Oil, RcPhase::Gas, RcPhase::Water}) {
                 const double surfRate = this->getMasterGroupRate_(
                     groupName, phase, RateKind::InjectionSurface);
                 const double resRate = this->getMasterGroupRate_(
                     groupName, phase, RateKind::InjectionReservoir);
-
                 if (surfRate != 0.0 || resRate != 0.0) {
                     const auto opmPhase = convertToOpmPhase(phase);
-                    schedule.updateSatelliteInjection(
-                        report_step_idx, groupName, opmPhase, surfRate, resRate);
+                    result.injection[groupName][opmPhase] = {surfRate, resRate};
                 }
             }
         }
     }
+    return result;
 }
 
 

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.hpp
@@ -22,6 +22,7 @@
 
 #include <opm/simulators/flow/rescoup/ReservoirCoupling.hpp>
 #include <opm/simulators/flow/rescoup/ReservoirCouplingMpiTraits.hpp>
+#include <opm/output/data/Groups.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/simulators/utils/ParallelCommunication.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
@@ -221,16 +222,9 @@ public:
     /// being processed.
     void setReportStepIdx(int report_step_idx);
 
-    /// @brief Update the Schedule's satellite production/injection data from
-    ///   slave group rates received via MPI.
-    /// @details Populates the Schedule's GSatProd and GroupSatelliteInjection
-    ///   for each master group so that opm-common's Summary.cpp satellite_rate
-    ///   machinery computes all rate-based summary vectors correctly for all
-    ///   master groups.
-    /// @param schedule Non-const reference to the Schedule (needed for
-    ///   updateSatelliteProduction/Injection)
-    /// @param report_step_idx 0-based report step index
-    void updateScheduleSatelliteData(Schedule& schedule, int report_step_idx);
+    /// @brief Collect production/injection rates for all master groups.
+    /// @return ReservoirCouplingGroupRates struct with per-group rates.
+    data::ReservoirCouplingGroupRates collectGroupRatesForSummary() const;
 
     /// @brief Check if a specific slave process has been activated
     /// @param index Index of the slave process

--- a/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingMasterReportStep.hpp
@@ -221,6 +221,17 @@ public:
     /// being processed.
     void setReportStepIdx(int report_step_idx);
 
+    /// @brief Update the Schedule's satellite production/injection data from
+    ///   slave group rates received via MPI.
+    /// @details Populates the Schedule's GSatProd and GroupSatelliteInjection
+    ///   for each master group so that opm-common's Summary.cpp satellite_rate
+    ///   machinery computes all rate-based summary vectors correctly for all
+    ///   master groups.
+    /// @param schedule Non-const reference to the Schedule (needed for
+    ///   updateSatelliteProduction/Injection)
+    /// @param report_step_idx 0-based report step index
+    void updateScheduleSatelliteData(Schedule& schedule, int report_step_idx);
+
     /// @brief Check if a specific slave process has been activated
     /// @param index Index of the slave process
     /// @return true if the slave is activated, false otherwise


### PR DESCRIPTION
 **Add `collectGroupRatesForSummary()`** to `ReservoirCouplingMasterReportStep` and `ReservoirCouplingMaster`, collecting slave production/injection rates into a `ReservoirCouplingGroupRates` struct
- **Pass RC rates through `DynamicSimulatorState`** to `Summary::eval()` via an optional `rcGroupRates` parameter on `evalSummary()`
- **Call from `EclWriter::evalSummaryState()`** before summary evaluation so that all rate-based summary vectors (FOPR, GOPR, FGOR, FWCT, etc.) are computed correctly for the master process

## Background

In reservoir coupling, the master model has no wells, all production and injection happens in the slave models. Previously, all rate-based summary vectors (FOPR, GOPR, etc.) were zero in the master's summary output because opm-common's `Summary.cpp` computes them by summing well rates, and the master has no wells.

The [companion opm-common PR](https://github.com/OPM/opm-common/pull/5101) adds a `ReservoirCouplingGroupRates` struct to `DynamicSimulatorState` and extends the `satellite_rate` function in `Summary.cpp` to check for RC group rates alongside the existing GSatProd/GSATINJE sources. The `accum_groups` tree-walking logic accumulates the rates through the group hierarchy for both group-level (GOPR) and field-level (FOPR) vectors.

This PR populates the `ReservoirCouplingGroupRates` struct from the slave data received via MPI and passes it through the `evalSummary()` call chain.
