### PR TITLE
Reservoir coupling: Apply master group targets on slave Schedule

### DIFF
--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
@@ -369,6 +369,15 @@ setLastSubstepOfSyncTimestep(bool value)
     this->report_step_data_->setLastSubstepOfSyncTimestep(value);
 }
 
+template <class Scalar>
+void
+ReservoirCouplingSlave<Scalar>::
+updateSlaveGroupTargetsInSchedule(Schedule& schedule, const int report_step_idx)
+{
+    assert(this->report_step_data_);
+    this->report_step_data_->updateSlaveGroupTargetsInSchedule(schedule, report_step_idx);
+}
+
 // ------------------
 // Private methods
 // ------------------

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
@@ -372,10 +372,10 @@ setLastSubstepOfSyncTimestep(bool value)
 template <class Scalar>
 void
 ReservoirCouplingSlave<Scalar>::
-updateSlaveGroupTargetsInSchedule(Schedule& schedule, const int report_step_idx)
+markSlaveGroupsInSchedule(Schedule& schedule, const int report_step_idx)
 {
     assert(this->report_step_data_);
-    this->report_step_data_->updateSlaveGroupTargetsInSchedule(schedule, report_step_idx);
+    this->report_step_data_->markSlaveGroupsInSchedule(schedule, report_step_idx);
 }
 
 // ------------------

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
@@ -118,10 +118,9 @@ public:
     /// @param value true if this is the last substep of a "sync" timestep, false if not
     void setLastSubstepOfSyncTimestep(bool value);
 
-    /// @brief Update the Schedule's Group production properties for slave groups.
-    /// @details Delegates to ReservoirCouplingSlaveReportStep.  See its
-    ///   updateSlaveGroupTargetsInSchedule() for details.
-    void updateSlaveGroupTargetsInSchedule(Schedule& schedule, const int report_step_idx);
+    /// @brief Mark slave groups in the Schedule as production/injection groups.
+    /// @details Delegates to ReservoirCouplingSlaveReportStep.
+    void markSlaveGroupsInSchedule(Schedule& schedule, int report_step_idx);
 
     const std::string& slaveGroupIdxToGroupName(std::size_t group_idx) const {
         return this->slave_group_order_.at(group_idx);

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp
@@ -117,6 +117,12 @@ public:
     /// @details See isLastSubstepOfSyncTimestep() for details.
     /// @param value true if this is the last substep of a "sync" timestep, false if not
     void setLastSubstepOfSyncTimestep(bool value);
+
+    /// @brief Update the Schedule's Group production properties for slave groups.
+    /// @details Delegates to ReservoirCouplingSlaveReportStep.  See its
+    ///   updateSlaveGroupTargetsInSchedule() for details.
+    void updateSlaveGroupTargetsInSchedule(Schedule& schedule, const int report_step_idx);
+
     const std::string& slaveGroupIdxToGroupName(std::size_t group_idx) const {
         return this->slave_group_order_.at(group_idx);
     }

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.cpp
@@ -262,28 +262,17 @@ setMasterProductionTarget(const std::string& gname, const Scalar target, const G
 template <class Scalar>
 void
 ReservoirCouplingSlaveReportStep<Scalar>::
-updateSlaveGroupTargetsInSchedule(Schedule& schedule, const int report_step_idx)
+markSlaveGroupsInSchedule(Schedule& schedule, const int report_step_idx)
 {
-    // After receiving production constraints from the master, update the
-    // Schedule's Group production properties so the group is recognized as
-    // a production group.  Slave groups may not have GCONPROD in the slave
-    // deck, the master provides the target at runtime.  Without this, the
-    // existing constraint enforcement mechanisms (checkGroupHigherConstraints,
-    // getWellGroupTargetProducer, etc.) skip the group since
-    // isProductionGroup() returns false.
     for (std::size_t i = 0; i < this->slave_.numSlaveGroups(); ++i) {
         const auto& gname = this->slave_.slaveGroupIdxToGroupName(i);
         if (this->hasMasterProductionTarget(gname)) {
-            auto [master_target, master_cmode] = this->masterProductionTarget(gname);
-            schedule.updateSlaveGroupProductionTarget(
-                report_step_idx, gname, master_cmode, master_target);
+            schedule.markSlaveProductionGroup(report_step_idx, gname);
         }
-        // Injection targets — check each phase
         for (const auto phase : {Phase::WATER, Phase::OIL, Phase::GAS}) {
             if (this->hasMasterInjectionTarget(gname, phase)) {
-                auto [master_target, master_cmode] = this->masterInjectionTarget(gname, phase);
-                schedule.updateSlaveGroupInjectionTarget(
-                    report_step_idx, gname, phase, master_cmode, master_target);
+                schedule.markSlaveInjectionGroup(report_step_idx, gname);
+                break;  // only need to mark once per group
             }
         }
     }

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.cpp
@@ -259,6 +259,36 @@ setMasterProductionTarget(const std::string& gname, const Scalar target, const G
     this->master_production_targets_[gname] = {target, cmode};
 }
 
+template <class Scalar>
+void
+ReservoirCouplingSlaveReportStep<Scalar>::
+updateSlaveGroupTargetsInSchedule(Schedule& schedule, const int report_step_idx)
+{
+    // After receiving production constraints from the master, update the
+    // Schedule's Group production properties so the group is recognized as
+    // a production group.  Slave groups may not have GCONPROD in the slave
+    // deck, the master provides the target at runtime.  Without this, the
+    // existing constraint enforcement mechanisms (checkGroupHigherConstraints,
+    // getWellGroupTargetProducer, etc.) skip the group since
+    // isProductionGroup() returns false.
+    for (std::size_t i = 0; i < this->slave_.numSlaveGroups(); ++i) {
+        const auto& gname = this->slave_.slaveGroupIdxToGroupName(i);
+        if (this->hasMasterProductionTarget(gname)) {
+            auto [master_target, master_cmode] = this->masterProductionTarget(gname);
+            schedule.updateSlaveGroupProductionTarget(
+                report_step_idx, gname, master_cmode, master_target);
+        }
+        // Injection targets — check each phase
+        for (const auto phase : {Phase::WATER, Phase::OIL, Phase::GAS}) {
+            if (this->hasMasterInjectionTarget(gname, phase)) {
+                auto [master_target, master_cmode] = this->masterInjectionTarget(gname, phase);
+                schedule.updateSlaveGroupInjectionTarget(
+                    report_step_idx, gname, phase, master_cmode, master_target);
+            }
+        }
+    }
+}
+
 // ------------------
 // Private methods
 // ------------------

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp
@@ -176,6 +176,16 @@ public:
     /// @param value true if this is the last substep of a "sync" timestep, false if not
     void setLastSubstepOfSyncTimestep(bool value) { is_last_substep_of_sync_timestep_ = value; }
 
+    /// @brief Update the Schedule's Group production properties for slave groups
+    ///   that have received master production targets.
+    /// @details Creates a synthetic GCONPROD entry so that the existing constraint
+    ///   enforcement mechanisms (checkGroupHigherConstraints,
+    ///   getWellGroupTargetProducer, etc.) recognize the group as a production
+    ///   group and apply the master's target.
+    /// @param schedule Non-const reference to the Schedule
+    /// @param report_step_idx 0-based report step index
+    void updateSlaveGroupTargetsInSchedule(Schedule& schedule, int report_step_idx);
+
     /// @brief Get the name of this slave process
     /// @return Reference to the name string for this slave
     const std::string& slaveName() const { return this->slave_.getSlaveName(); }

--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp
@@ -176,15 +176,13 @@ public:
     /// @param value true if this is the last substep of a "sync" timestep, false if not
     void setLastSubstepOfSyncTimestep(bool value) { is_last_substep_of_sync_timestep_ = value; }
 
-    /// @brief Update the Schedule's Group production properties for slave groups
-    ///   that have received master production targets.
-    /// @details Creates a synthetic GCONPROD entry so that the existing constraint
-    ///   enforcement mechanisms (checkGroupHigherConstraints,
-    ///   getWellGroupTargetProducer, etc.) recognize the group as a production
-    ///   group and apply the master's target.
+    /// @brief Mark slave groups in the Schedule as production/injection groups.
+    /// @details For slave groups that have received master production/injection
+    ///   targets, mark them so isProductionGroup()/isInjectionGroup() return true.
+    ///   This ensures the existing constraint enforcement mechanisms recognize them.
     /// @param schedule Non-const reference to the Schedule
     /// @param report_step_idx 0-based report step index
-    void updateSlaveGroupTargetsInSchedule(Schedule& schedule, int report_step_idx);
+    void markSlaveGroupsInSchedule(Schedule& schedule, int report_step_idx);
 
     /// @brief Get the name of this slave process
     /// @return Reference to the name string for this slave

--- a/opm/simulators/wells/BlackoilWellModelConstraints.cpp
+++ b/opm/simulators/wells/BlackoilWellModelConstraints.cpp
@@ -181,6 +181,10 @@ std::pair<Group::ProductionCMode, Scalar>
 BlackoilWellModelConstraints<Scalar, IndexTraits>::
 checkGroupProductionConstraints(const Group& group) const
 {
+    // NOTE: For reservoir coupling slave groups with no GCONPROD in the slave deck,
+    // checkGroupProductionConstraints() below returns NONE because has_control() is
+    // false for all modes.  So actionOnBrokenConstraints() will never be called,
+    // this is correct since the group only has one mode imposed by the master.
     return groupStateHelper().checkGroupProductionConstraints(group);
 }
 

--- a/opm/simulators/wells/BlackoilWellModelGeneric.cpp
+++ b/opm/simulators/wells/BlackoilWellModelGeneric.cpp
@@ -739,6 +739,13 @@ checkGroupHigherConstraints(const Group& group,
         // Check higher up only if under individual (not FLD) control.
         if (currentControl != Group::ProductionCMode::FLD && group.productionGroupControlAvailable()) {
             const Group& parentGroup = schedule().getGroup(group.parent(), reportStepIdx);
+            // NOTE: For reservoir coupling slave groups with no GCONPROD in the slave deck,
+            // checkGroupConstraintsProd() below checks if this group's rate violates
+            // the parent group's constraint. But groups superior to slave groups should in
+            // general not have any constraints on them to avoid interference with the master group
+            // constraints, so checkGroupConstraintsProd() returns is_changed=false which is correct
+            // since the group only has a single constraint imposed by the master and should not be
+            // subject to actionOnBrokenConstraints() below.
             const auto [is_changed, scaling_factor] = this->groupStateHelper().checkGroupConstraintsProd(
                 group.name(),
                 group.parent(),
@@ -1356,7 +1363,7 @@ updateAndCommunicateGroupData(const int reportStepIdx,
                     ws.production_cmode = Well::ProducerCMode::BHP;
                 }
                 if (group_target.has_value()) {
-                    // check whether group giving target is operating at its original cmode, and if not, compute the target 
+                    // check whether group giving target is operating at its original cmode, and if not, compute the target
                     // corresponding to original cmode for potential later use in case current cmode is/becomes infeasible
                     const Group& target_group = this->schedule().getGroup(group_target->group_name, reportStepIdx);
                     const auto cmode_orig = target_group.productionControls(summaryState_).cmode;

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -478,7 +478,7 @@ namespace Opm {
                 this->sendSlaveGroupDataToMaster();
                 this->receiveGroupConstraintsFromMaster();
                 this->groupStateHelper().updateSlaveGroupCmodesFromMaster();
-                this->reservoirCouplingSlave().updateSlaveGroupTargetsInSchedule(
+                this->reservoirCouplingSlave().markSlaveGroupsInSchedule(
                     this->schedule_, reportStepIdx);
                 slave_needs_well_solution = true;
             }

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -478,6 +478,8 @@ namespace Opm {
                 this->sendSlaveGroupDataToMaster();
                 this->receiveGroupConstraintsFromMaster();
                 this->groupStateHelper().updateSlaveGroupCmodesFromMaster();
+                this->reservoirCouplingSlave().updateSlaveGroupTargetsInSchedule(
+                    this->schedule_, reportStepIdx);
                 slave_needs_well_solution = true;
             }
         }

--- a/opm/simulators/wells/GroupConstraintCalculator.cpp
+++ b/opm/simulators/wells/GroupConstraintCalculator.cpp
@@ -588,6 +588,9 @@ calculateGroupConstraint()
     // This is the full target rate that should be assigned to the bottom group, to be seen as the unscaled
     // target rate for the top group.
     const Scalar full_target = target / this->chain_efficiency_factor_;
+    // NOTE: Injection targets for VREP, RESV, and REIN modes are always sent as RATE
+    //   control mode to the slave, see
+    //   RescoupConstraintsCalculator.cpp::calculateSlaveGroupConstraints_()
     if (bottom_group_current_rate_available > TARGET_RATE_TOLERANCE) {  // > 1e-12
         const auto toplevel_control_mode = this->getToplevelControlMode_();
         if ((bottom_group_current_rate_available > full_target)) {

--- a/opm/simulators/wells/GroupStateHelper.cpp
+++ b/opm/simulators/wells/GroupStateHelper.cpp
@@ -389,6 +389,13 @@ checkGroupProductionConstraints(const Group& group) const
     const auto controls = group.productionControls(this->summary_state_);
     const auto currentControl = this->groupState().production_control(group.name());
 
+    // NOTE: For reservoir coupling slave groups with no GCONPROD in the slave deck,
+    // has_control() returns false for all modes.
+    // This means the loop below does nothing for such groups, which is correct:
+    // this function checks for control mode switching (e.g. ORAT→WRAT),
+    // and RC slave groups have only one mode imposed by the master.
+    // The actual target enforcement happens in getProductionGroupTarget()
+    // getProductionGroupTarget() via hasMasterProductionTarget().
     for (const auto cmode : {
         Group::ProductionCMode::ORAT,
         Group::ProductionCMode::WRAT,
@@ -777,7 +784,7 @@ GroupStateHelper<Scalar, IndexTraits>::getWellGroupTargetInjector(const std::str
     // Avoid negative target rates coming from too large local reductions.
     // guiderate_fraction is not used for injectors, so set to 0.0
     return GroupTarget{group.name(), std::max(Scalar(0.0), target / efficiency_factor),
-                       Group::ProductionCMode::NONE, current_group_control, 0.0}; 
+                       Group::ProductionCMode::NONE, current_group_control, 0.0};
 }
 
 template <typename Scalar, typename IndexTraits>
@@ -800,7 +807,7 @@ GroupStateHelper<Scalar, IndexTraits>::getWellGroupTargetProducer(const std::str
     OPM_TIMEFUNCTION();
     const Group::ProductionCMode& current_group_cmode = this->groupState().production_control(group.name());
     // If fallback_cmode is provided and different from current_group_cmode, we will translate the target from
-    // original mode to fallback mode using group fractions at previous step. Otherwise, fallback_cmode is 
+    // original mode to fallback mode using group fractions at previous step. Otherwise, fallback_cmode is
     // the same as current_group_cmode and no translation will be done.
     const Group::ProductionCMode target_group_cmode = fallback_cmode.has_value() ? fallback_cmode.value() : current_group_cmode;
 
@@ -857,7 +864,12 @@ GroupStateHelper<Scalar, IndexTraits>::getWellGroupTargetProducer(const std::str
         return fcalc.localFraction(child, always_included);
     };
 
-    Scalar orig_target = this->getProductionGroupTarget(group); // current cmode
+    // NOTE: For reservoir coupling slave groups which does not have GCONPROD in the slave deck,
+    // getProductionGroupTarget() returns the master-imposed target directly from
+    // hasMasterProductionTarget() (received via MPI), not from
+    // group.productionControls() which reads GCONPROD properties (which will be empty
+    // for such groups). This is correct since the group only has one mode imposed by the master.
+    Scalar orig_target = this->getProductionGroupTarget(group); // current cmode target
     if (target_group_cmode != current_group_cmode) {
         // translate orig_target to target_cmode using "previous" group rate fractions
         const auto& prev_rates = this->groupState().prev_production_rates(group.name());
@@ -890,15 +902,15 @@ GroupStateHelper<Scalar, IndexTraits>::getWellGroupTargetProducer(const std::str
                                                              local_reduction_lambda,
                                                              local_fraction_lambda,
                                                              do_addback);
-    // Finally, we provide the well-to-group guide-rate ratio for subsequent diagnostics of 
-    // target feasibility. Note that we cannot use the target directly for this, since a ~zero 
-    // target may very well just be the result of non-converged group tree. 
+    // Finally, we provide the well-to-group guide-rate ratio for subsequent diagnostics of
+    // target feasibility. Note that we cannot use the target directly for this, since a ~zero
+    // target may very well just be the result of non-converged group tree.
     Scalar guide_rate_fraction = 1.0;
     const Scalar well_guide_rate = fcalc.guideRate(name, name, /*always_use_potentials=*/false);
     const Scalar group_guide_rate = fcalc.guideRate(group.name(), name, /*always_use_potentials=*/false);
     if (group_guide_rate > 0.0) {
         guide_rate_fraction = (well_guide_rate / group_guide_rate);
-    }  
+    }
     // Avoid negative target rates coming from too large local reductions.
     return GroupTarget{group.name(), std::max(Scalar(0.0), target / efficiency_factor),
                        target_group_cmode, Group::InjectionCMode::NONE, guide_rate_fraction};


### PR DESCRIPTION
Builds on #6979. Depends on companion https://github.com/OPM/opm-common/pull/5109

- **Add `updateSlaveGroupTargetsInSchedule()`** to `ReservoirCouplingSlaveReportStep` and `ReservoirCouplingSlave`: after receiving constraints from the master, updates the slave's Schedule with synthetic GCONPROD/GCONINJE entries for both production and injection targets
- **Call from `BlackoilWellModel::beginTimeStep()`** on the first substep of each sync timestep, after receiving master constraints and updating control modes

### Background

In reservoir coupling, slave groups may not have `GCONPROD` or `GCONINJE` in the slave deck, rather the master provides targets at runtime. The existing constraint enforcement code has `isProductionGroup()` / `isInjectionGroup()` gates at multiple locations that skip groups without deck-level group controls:

- `checkGroupHigherConstraints` (`BlackoilWellModelGeneric.cpp`)
- `getWellGroupTargetProducer` / `getWellGroupTargetInjector` (`GroupStateHelper.cpp`)
- `updateGroupIndividualControl` (`BlackoilWellModelConstraints.cpp`)

Without synthetic group properties, slave wells run at their individual WCONPROD/WCONINJE limits unconstrained by the master's group target.

### Companion PR

- **opm-common**: https://github.com/OPM/opm-common/pull/5109 :adds `Schedule::updateSlaveGroupProductionTarget()` and `Schedule::updateSlaveGroupInjectionTarget()`

