### PR TITLE
Backport PR6984: Tag Potentially Unused Parameter as Maybe_Unused

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -1164,7 +1164,7 @@ template<class TypeTag>
 template<class Solver>
 void
 AdaptiveTimeStepping<TypeTag>::SubStepIteration<Solver>::
-maybeUpdateLastSubstepOfSyncTimestep_(double dt)
+maybeUpdateLastSubstepOfSyncTimestep_([[maybe_unused]] const double dt)
 {
 #ifdef RESERVOIR_COUPLING_ENABLED
     // For reservoir coupling slaves: predict if this substep will complete


### PR DESCRIPTION
The time step size parameter is referenced only when reservoir coupling is enabled, which is not the case for sequential builds.