### PR TITLE
Instrument reservoir coupling MPI exchanges for Tracy

### DIFF
--- a/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingSlave.cpp
@@ -24,6 +24,7 @@
 #include <opm/simulators/flow/rescoup/ReservoirCouplingSlaveReportStep.hpp>
 #include <opm/simulators/flow/rescoup/ReservoirCouplingSlave.hpp>
 
+#include <opm/common/TimingMacros.hpp>
 #include <opm/input/eclipse/Schedule/ResCoup/ReservoirCouplingInfo.hpp>
 #include <opm/input/eclipse/Schedule/ResCoup/MasterGroup.hpp>
 #include <opm/input/eclipse/Schedule/ResCoup/Slaves.hpp>
@@ -222,6 +223,7 @@ template <class Scalar>
 double
 ReservoirCouplingSlave<Scalar>::
 receiveNextTimeStepFromMaster() {
+    OPM_TIMEFUNCTION();
     double timestep;
     if (this->comm_.rank() == 0) {
         // NOTE: See comment about error handling at the top of this file.
@@ -318,6 +320,7 @@ void
 ReservoirCouplingSlave<Scalar>::
 sendNextReportDateToMasterProcess() const
 {
+    OPM_TIMEFUNCTION();
     if (this->comm_.rank() == 0) {
         double elapsed_time = this->timer_.simulationTimeElapsed();
         double current_step_length = this->timer_.currentStepLength();

--- a/opm/simulators/flow/rescoup/ReservoirCouplingTimeStepper.cpp
+++ b/opm/simulators/flow/rescoup/ReservoirCouplingTimeStepper.cpp
@@ -27,6 +27,7 @@
 #include <opm/input/eclipse/Schedule/ResCoup/MasterGroup.hpp>
 #include <opm/input/eclipse/Schedule/ResCoup/Slaves.hpp>
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/common/TimingMacros.hpp>
 #include <opm/simulators/utils/ParallelCommunication.hpp>
 
 #include <dune/common/parallel/mpitraits.hh>
@@ -104,6 +105,7 @@ void
 ReservoirCouplingTimeStepper<Scalar>::
 receiveNextReportDateFromSlaves()
 {
+    OPM_TIMEFUNCTION();
     auto num_slaves = this->numSlaves();
     if (this->comm().rank() == 0) {
         this->logger().debug("Receiving next report dates from slave processes");
@@ -145,6 +147,7 @@ void
 ReservoirCouplingTimeStepper<Scalar>::
 sendNextTimeStepToSlaves(double timestep)
 {
+    OPM_TIMEFUNCTION();
     if (this->comm().rank() == 0) {
         for (unsigned int slave_idx = 0; slave_idx < this->numSlaves(); slave_idx++) {
             if (!this->slaveIsActivated(slave_idx)) {

--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -602,6 +602,7 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     receiveSlaveGroupData()
     {
+        OPM_TIMEFUNCTION();
         assert(this->isReservoirCouplingMaster());
         RescoupReceiveSlaveGroupData<Scalar, IndexTraits> slave_group_data_receiver{
             this->groupStateHelper(),
@@ -614,6 +615,7 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     sendSlaveGroupDataToMaster()
     {
+        OPM_TIMEFUNCTION();
         assert(this->isReservoirCouplingSlave());
         RescoupSendSlaveGroupData<Scalar, IndexTraits> slave_group_data_sender{this->groupStateHelper()};
         slave_group_data_sender.sendSlaveGroupDataToMaster();
@@ -624,6 +626,7 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     sendMasterGroupConstraintsToSlaves()
     {
+        OPM_TIMEFUNCTION();
         // This function is called by the master process to send the group constraints to the slaves.
         RescoupConstraintsCalculator<Scalar, IndexTraits> constraints_calculator{
             this->guide_rate_handler_,
@@ -637,6 +640,7 @@ namespace Opm {
     BlackoilWellModel<TypeTag>::
     receiveGroupConstraintsFromMaster()
     {
+        OPM_TIMEFUNCTION();
         RescoupReceiveGroupConstraints<Scalar, IndexTraits> constraint_receiver{
             this->guide_rate_handler_,
             this->groupStateHelper()


### PR DESCRIPTION
Adds `OPM_TIMEFUNCTION()` to the eight MPI exchange entry points between the master and slave processes in reservoir coupling, so the per-call cost of each exchange is visible in Tracy traces. The macros are no-ops unless built with `USE_TRACY_PROFILER=ON`, so this adds **no overhead in normal builds**.

#### Functions instrumented

Four master/slave pairs:

- `BlackoilWellModel::sendMasterGroupConstraintsToSlaves` / `receiveGroupConstraintsFromMaster`
- `BlackoilWellModel::sendSlaveGroupDataToMaster` / `receiveSlaveGroupData`
- `ReservoirCouplingSlave::sendNextReportDateToMasterProcess` / `ReservoirCouplingTimeStepper::receiveNextReportDateFromSlaves`
- `ReservoirCouplingTimeStepper::sendNextTimeStepToSlaves` / `ReservoirCouplingSlave::receiveNextTimeStepFromMaster`

#### Motivation

Precursor for upcoming work to change the reservoir coupling sync cadence from **per-slave-report-step** to **per-master-actual-step**. The new cadence increases the number of MPI exchange events per simulation, so the ability to measure per-exchange cost is needed to verify that the overhead stays acceptable.

