### PR TITLE
Fix wrong args passed to maybeUpdateTuning_

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -561,7 +561,7 @@ runStepOriginal_()
     const auto elapsed = this->simulator_timer_.simulationTimeElapsed();
     const auto original_time_step = this->simulator_timer_.currentStepLength();
     const auto report_step = this->simulator_timer_.reportStepNum();
-    maybeUpdateTuning_(elapsed, original_time_step, report_step);
+    maybeUpdateTuning_(elapsed, suggestedNextTimestep_(), /*substep=*/0);
     maybeModifySuggestedTimeStepAtBeginningOfReportStep_(original_time_step);
 
     AdaptiveSimulatorTimer substep_timer{
@@ -664,7 +664,7 @@ runStepReservoirCouplingMaster_()
         ));
         reservoirCouplingMaster_().sendNextTimeStepToSlaves(current_step_length);
         if (start_of_report_step) {
-            maybeUpdateTuning_(current_time, current_step_length, /*substep=*/0);
+            maybeUpdateTuning_(current_time, suggestedNextTimestep_(), /*substep=*/0);
             maybeModifySuggestedTimeStepAtBeginningOfReportStep_(current_step_length);
         }
         AdaptiveSimulatorTimer substep_timer{
@@ -724,7 +724,7 @@ runStepReservoirCouplingSlave_()
         reservoirCouplingSlave_().sendNextReportDateToMasterProcess();
         const auto timestep = reservoirCouplingSlave_().receiveNextTimeStepFromMaster();
         if (start_of_report_step) {
-            maybeUpdateTuning_(current_time, original_time_step, /*substep=*/0);
+            maybeUpdateTuning_(current_time, suggestedNextTimestep_(), /*substep=*/0);
             maybeModifySuggestedTimeStepAtBeginningOfReportStep_(timestep);
         }
         AdaptiveSimulatorTimer substep_timer{


### PR DESCRIPTION
The `tuning_updater` callback (defined in `SimulatorFullyImplicitBlackoil::runStep`) expects `(elapsed, dt, sub_step_number)` where `dt` is the length of the upcoming substep and `sub_step_number` is `0` at the start of a report step. Three call sites in `AdaptiveTimeStepping_impl.hpp` were passing outer `SimulatorTimer` values instead: the report-step length (Sites A, C), the sync-step length (Site B), and the report-step index (Site A). Replace them with `suggestedNextTimestep_()` and `/*substep=*/0`, matching the pattern already used at the initial `tuningUpdater` invocation in `SimulatorFullyImplicitBlackoil::runStep` and inside `maybeUpdateTuningAndTimeStep_`.

#### Sites fixed

- **Site A**: `runStepOriginal_` (line 564): was passing the report-step length as `dt` and the report-step index as `sub_step_number`.
- **Site B**: `runStepReservoirCouplingMaster_` (line 667): was passing the sync-step length as `dt` (`sub_step_number` was already correct).
- **Site C**: `runStepReservoirCouplingSlave_` (line 727): was passing the report-step length as `dt` (`sub_step_number` was already correct).

#### Impact

Impact is gated by `WCYCLE` being active in the deck. The TUNING branch of the callback is unaffected because `TUNING_CHANGE` and `TUNINGDP_CHANGE` are already cleared by the initial call at `SimulatorFullyImplicitBlackoil.hpp:533`. The WCYCLE branch re-runs on each call and uses `dt` as the look-ahead horizon for event-driven chopping in `WCYCLE::nextTimeStep`. A too-wide horizon (report- or sync-step length instead of substep length) causes `nextTimeStep` to over-chop and invoke `updateNEXTSTEP(wcycle_time_step)` when no chop was warranted. The result could be seeding the next substep with a many-days value that the solver then would struggle with (extra Newton iterations, restart log lines, or silent clamping by `TSMAXZ`). The wrong `sub_step_number` in Site A additionally bypasses the `REQUEST_OPEN_WELL` guard for every report step after the first.

#### Regression origin

Introduced in `b94868633` (Dec 2024) when the callback signature grew three parameters as part of reconciling the impl file with the WCYCLE-support PR (#5792). The pre-refactor calls were `maybeUpdateTuning_()` with no arguments; when the signature grew, the wrong timer getters were plugged in.

