### PR TITLE
[bugfix,cmake] Make sure avx2 defines are set for compilation if supported.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,7 @@ macro(opm-simulators_sources_hook)
 
   if(HAVE_AVX2_EXTENSION)
     set_property(SOURCE ${AVX2_SOURCE_FILES} PROPERTY COMPILE_OPTIONS ${AVX2_FLAGS})
+    target_compile_definitions(opmsimulators PUBLIC HAVE_AVX2_EXTENSION=1)
   endif()
 
   # Boost 1.66 used on RHEL8 cannot be built as c++-20


### PR DESCRIPTION
Previously this was done via config.h, but due to the recent build system refactoring these defines became MIA and some  code is never activated even if it would be supported by the hardware.

We now set the necessary compile definitois as properties for the relevant source files to fix this.