### PR TITLE
Backport PR6998: Fix wrong args passed to maybeUpdateTuning_

### DIFF
--- a/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
+++ b/opm/simulators/timestepping/AdaptiveTimeStepping_impl.hpp
@@ -561,7 +561,7 @@ runStepOriginal_()
     const auto elapsed = this->simulator_timer_.simulationTimeElapsed();
     const auto original_time_step = this->simulator_timer_.currentStepLength();
     const auto report_step = this->simulator_timer_.reportStepNum();
-    maybeUpdateTuning_(elapsed, original_time_step, report_step);
+    maybeUpdateTuning_(elapsed, suggestedNextTimestep_(), /*substep=*/0);
     maybeModifySuggestedTimeStepAtBeginningOfReportStep_(original_time_step);
 
     AdaptiveSimulatorTimer substep_timer{
@@ -664,7 +664,7 @@ runStepReservoirCouplingMaster_()
         ));
         reservoirCouplingMaster_().sendNextTimeStepToSlaves(current_step_length);
         if (start_of_report_step) {
-            maybeUpdateTuning_(current_time, current_step_length, /*substep=*/0);
+            maybeUpdateTuning_(current_time, suggestedNextTimestep_(), /*substep=*/0);
             maybeModifySuggestedTimeStepAtBeginningOfReportStep_(current_step_length);
         }
         AdaptiveSimulatorTimer substep_timer{
@@ -724,7 +724,7 @@ runStepReservoirCouplingSlave_()
         reservoirCouplingSlave_().sendNextReportDateToMasterProcess();
         const auto timestep = reservoirCouplingSlave_().receiveNextTimeStepFromMaster();
         if (start_of_report_step) {
-            maybeUpdateTuning_(current_time, original_time_step, /*substep=*/0);
+            maybeUpdateTuning_(current_time, suggestedNextTimestep_(), /*substep=*/0);
             maybeModifySuggestedTimeStepAtBeginningOfReportStep_(timestep);
         }
         AdaptiveSimulatorTimer substep_timer{


### PR DESCRIPTION
The tuning_updater callback expects (elapsed, dt, sub_step_number) where dt is the length of the upcoming substep and sub_step_number is 0 at the start of a report step.  All three call sites in runStepOriginal_ and the reservoir coupling variants were passing outer SimulatorTimer values instead: The report-step length (Sites A, C), the sync-step length (Site B), and the report-step index (Site A).

Use suggestedNextTimestep_() and /*substep=*/0 at all three sites, matching the pattern already in use at the initial tuningUpdater invocation in SimulatorFullyImplicitBlackoil::runStep and inside maybeUpdateTuningAndTimeStep_.

Impact is gated by WCYCLE being active in the deck.  The TUNING branch of the callback is unaffected (TUNING_CHANGE and TUNINGDP_CHANGE are already cleared by the initial call in SimulatorFullyImplicitBlackoil::runStep).  The WCYCLE branch re-runs with a too-wide look-ahead horizon, causing WCYCLE::nextTimeStep to over-chop and invoke
updateNEXTSTEP(wcycle_time_step) when no chop was warranted.  The wrong sub_step_number in runStepOriginal_ also bypasses the REQUEST_OPEN_WELL guard for every report step after the first.

Regression introduced in b94868633 when the callback signature grew three parameters as part of reconciling the impl file with the WCYCLE-support PR (#5792).