### PR TITLE
updating the EQUIL keyword item names in PartiallySupportedFlowKeywords

### DIFF
--- a/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/PartiallySupportedFlowKeywords.cpp
@@ -362,9 +362,9 @@ partiallySupported()
          {
             "EQUIL",
             {
-               {9,{true, [](int x) { return x >= -20 && x <= 20; }, "EQUIL(EQLOPT3): only values between -20 and 20 are allowed (default is -5)"}}, // OIP_INIT
-               {10,{false, allow_values<int> {}, "EQUIL(EQLOPT4): compositional option not used, should be defaulted"}}, // EQLOPT4
-               {11,{false, allow_values<int> {}, "EQUIL(EQLOPT5): compositional option not used, should be defaulted"}}, // EQLOPT5
+               {9,{true, [](int x) { return x >= -20 && x <= 20; }, "EQUIL(OIP_INIT): only values between -20 and 20 are allowed (default is -5)"}}, // OIP_INIT
+               {10,{false, allow_values<int> {}, "EQUIL(COMP_INIT_TYPE): compositional option not used, should be defaulted"}}, // COMP_INIT_TYPE
+               {11,{false, allow_values<int> {}, "EQUIL(COMP_NOT_SET_SAT_PRESSURE): compositional option not used, should be defaulted"}}, // COMP_NOT_SET_SAT_PRESSURE
             },
          },
          {


### PR DESCRIPTION
following the item name change from https://github.com/OPM/opm-common/pull/5113 .

Furthermore, I suspect there is some bugs related this part. 

With the keyword definition like 
```
EQUIL
-- Item #: 1 2    3    4 5    6 7 8 9
    8400 4800 8450 0 8300 0 1 0 0 /
```

The master branch complains
<img width="701" height="77" alt="image" src="https://github.com/user-attachments/assets/b14e813f-7970-4cef-b3fd-86a048f18e6a" />

But the item 10 is defaulted, while it has a default value of `1`. 