### PR TITLE
Basic .clang-tidy and recommendation to use it

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,73 @@
+# .clang-tidy-suggested
+# Goal: minimum + a few extra checks for stricter safety and modernisation.
+# Adds: cppcoreguidelines-special-member-functions,
+#        bugprone-narrowing-conversions,
+#        cppcoreguidelines-narrowing-conversions,
+#        modernize-use-nullptr,
+#        bugprone-exception-escape,
+#        cppcoreguidelines-avoid-c-arrays + modernize-avoid-c-arrays,
+#        readability-function-cognitive-complexity,
+#        readability-implicit-bool-conversion
+
+Checks: >
+  -*,
+  bugprone-exception-escape,
+  bugprone-use-after-move,
+  bugprone-undefined-memory-manipulation,
+  bugprone-integer-division,
+  bugprone-macro-parentheses,
+  bugprone-misplaced-widening-cast,
+  bugprone-narrowing-conversions,
+  bugprone-sizeof-expression,
+  bugprone-string-constructor,
+  bugprone-suspicious-memset-usage,
+  bugprone-suspicious-semicolon,
+  bugprone-suspicious-string-compare,
+  bugprone-too-small-loop-variable,
+  bugprone-unused-raii,
+  bugprone-unused-return-value,
+  cppcoreguidelines-avoid-c-arrays,
+  cppcoreguidelines-narrowing-conversions,
+  cppcoreguidelines-no-malloc,
+  cppcoreguidelines-pro-type-cstyle-cast,
+  cppcoreguidelines-pro-type-vararg,
+  cppcoreguidelines-slicing,
+  cppcoreguidelines-special-member-functions,
+  google-explicit-constructor,
+  hicpp-exception-baseclass,
+  hicpp-multiway-paths-covered,
+  modernize-avoid-c-arrays,
+  modernize-deprecated-headers,
+  modernize-use-nullptr,
+  modernize-use-override,
+  modernize-use-equals-default,
+  modernize-use-equals-delete,
+  performance-for-range-copy,
+  performance-implicit-conversion-in-loop,
+  performance-unnecessary-value-param,
+  performance-move-const-arg,
+  readability-function-cognitive-complexity,
+  readability-implicit-bool-conversion,
+  readability-make-member-function-const,
+  readability-misleading-indentation,
+  readability-non-const-parameter
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '^(opm|tests)/.*\.(hpp|hh|h)$'
+FormatStyle: file
+
+CheckOptions:
+  - key:   modernize-use-override.IgnoreDestructors
+    value: true
+  - key:   modernize-use-override.AllowOverrideAndFinal
+    value: true
+  - key:   performance-unnecessary-value-param.AllowedTypes
+    value: 'std::shared_ptr;std::unique_ptr;std::function'
+  - key:   performance-for-range-copy.WarnOnAllAutoCopies
+    value: false
+  - key:   google-explicit-constructor.WarnOnDefaultedOrDeleted
+    value: false
+  - key:   cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value: true
+  - key:   readability-function-cognitive-complexity.Threshold
+    value: '25'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-# .clang-tidy-suggested
+# .clang-tidy
 # Goal: minimum + a few extra checks for stricter safety and modernisation.
 # Adds: cppcoreguidelines-special-member-functions,
 #        bugprone-narrowing-conversions,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thank you for your interest in contributing to the Open Porous Media (OPM) Simul
 - [Development Process](#development-process)
 - [Code Style and Formatting](#code-style-and-formatting)
 - [Automated Formatting Tools](#automated-formatting-tools)
+- [Static Analysis with clang-tidy](#static-analysis-with-clang-tidy)
 - [Testing](#testing)
 - [Submitting Changes](#submitting-changes)
 - [Reporting Issues](#reporting-issues)
@@ -181,6 +182,46 @@ again. This ensures you see exactly what was changed before it's committed.
    # Update hook versions
    pre-commit autoupdate
    ```
+
+## Static Analysis with clang-tidy
+
+We recommend running `clang-tidy` on code you contribute. A `.clang-tidy` configuration file is provided in the repository root with a curated set of checks covering bug-prone patterns, C++ Core Guidelines, modernization, and performance.
+
+### Setup
+
+`clang-tidy` requires a compilation database. Generate one by passing `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to CMake:
+
+```bash
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+```
+
+This produces a `compile_commands.json` file in the build directory.
+
+### Running clang-tidy
+
+Run on a single file (from the build directory or pointing to `compile_commands.json`):
+
+```bash
+clang-tidy -p build/ opm/simulators/your_file.cpp
+```
+
+Or use `run-clang-tidy` to analyse multiple files in parallel:
+
+```bash
+run-clang-tidy -p build/ 'opm/simulators/.*\.cpp'
+```
+
+The `.clang-tidy` file in the root is picked up automatically; no extra flags are needed to load it.
+
+### Fixing Issues
+
+Many findings can be fixed automatically with the `--fix` flag:
+
+```bash
+clang-tidy -p build/ --fix opm/simulators/your_file.cpp
+```
+
+Review the applied fixes with `git diff` before committing.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,7 +199,7 @@ This produces a `compile_commands.json` file in the build directory.
 
 ### Running clang-tidy
 
-Run on a single file (from the build directory or pointing to `compile_commands.json`):
+Run the following commands from the **repository root** (where the `.clang-tidy` file lives):
 
 ```bash
 clang-tidy -p build/ opm/simulators/your_file.cpp


### PR DESCRIPTION
This attempts to set some baseline practices for code quality.

Note that this is *completely voluntary to use and meant as a help at the moment*. 

To see what kind of code this clang-tidy configuration would trigger on, [check example file](https://github.com/kjetilly/clangtidyexamples/blob/main/suggested/example.cpp)