### PR TITLE
gpu_smart_pointer: extend GPU smart-pointer utilities

### DIFF
--- a/opm/simulators/linalg/gpuistl/MiniVector.hpp
+++ b/opm/simulators/linalg/gpuistl/MiniVector.hpp
@@ -78,7 +78,6 @@ public:
         fill(value);
     }
 
-    #if HAVE_DUNE_COMMON
     /**
      * @brief Conversion constructor from Dune::FieldVector.
      * @param fv Source FieldVector (must have dimension `Dimension`).
@@ -89,7 +88,6 @@ public:
             data_[i] = fv[i];
         }
     }
-    #endif
 
     /**
      * @brief Initializer‑list constructor.

--- a/opm/simulators/linalg/gpuistl/MiniVector.hpp
+++ b/opm/simulators/linalg/gpuistl/MiniVector.hpp
@@ -78,6 +78,7 @@ public:
         fill(value);
     }
 
+    #if HAVE_DUNE_COMMON
     /**
      * @brief Conversion constructor from Dune::FieldVector.
      * @param fv Source FieldVector (must have dimension `Dimension`).
@@ -88,6 +89,7 @@ public:
             data_[i] = fv[i];
         }
     }
+    #endif
 
     /**
      * @brief Initializer‑list constructor.

--- a/opm/simulators/linalg/gpuistl/gpu_smart_pointer.hpp
+++ b/opm/simulators/linalg/gpuistl/gpu_smart_pointer.hpp
@@ -116,6 +116,96 @@ make_gpu_unique_ptr(const T& value)
 }
 
 /**
+ * @brief Deleter that releases a GPU array allocation made with \c cudaMalloc.
+ *
+ * Used by \c make_gpu_unique_ptr_array. Having a named deleter type (rather than a lambda)
+ * makes the resulting \c std::unique_ptr type stable across translation units, which is
+ * important when storing it as a class member.
+ */
+template <class T>
+struct GpuArrayDeleter {
+    void operator()(T* ptr) const noexcept
+    {
+        OPM_GPU_WARN_IF_ERROR(cudaFree(ptr));
+    }
+};
+
+/**
+ * @brief Deleter for objects living in unified (managed) GPU memory.
+ *
+ * Calls the destructor of the contained object before releasing the allocation with
+ * \c cudaFree. Used by \c make_gpu_managed_unique_ptr.
+ */
+template <class T>
+struct GpuManagedDeleter {
+    void operator()(T* ptr) const noexcept
+    {
+        if (ptr != nullptr) {
+            ptr->~T();
+            OPM_GPU_WARN_IF_ERROR(cudaFree(ptr));
+        }
+    }
+};
+
+/**
+ * @brief Creates a unique pointer managing a GPU-allocated array of \p numElements elements.
+ *
+ * This function allocates memory on the GPU for \p numElements elements of type \c T using
+ * \c cudaMalloc. It returns a \c std::unique_ptr that automatically releases the GPU memory
+ * with \c cudaFree when destroyed.
+ *
+ * The returned smart pointer uses the \c T[] specialization, so element access via
+ * \c operator[] is well defined; however, dereferencing the returned pointer on the host is
+ * not safe because the underlying memory lives on the device.
+ *
+ * @tparam T The element type to allocate on the GPU.
+ * @param numElements The number of elements of type \c T to allocate.
+ * @return A \c std::unique_ptr to the GPU-allocated array.
+ */
+template <typename T>
+std::unique_ptr<T[], GpuArrayDeleter<T>>
+make_gpu_unique_ptr_array(std::size_t numElements)
+{
+    T* ptr = nullptr;
+    OPM_GPU_SAFE_CALL(cudaMalloc(&ptr, numElements * sizeof(T)));
+    return std::unique_ptr<T[], GpuArrayDeleter<T>>(ptr);
+}
+
+/**
+ * @brief Creates a unique pointer managing GPU unified (managed) memory for a single object.
+ *
+ * Allocates one \c T worth of unified memory with \c cudaMallocManaged, then constructs a
+ * \c T in-place using the supplied arguments via placement-new. The returned
+ * \c std::unique_ptr destroys the contained object and releases the unified memory with
+ * \c cudaFree when it goes out of scope.
+ *
+ * Unified memory is accessible from both host and device, so the returned pointer can be
+ * dereferenced directly on either side. This is useful when an object must be visible to
+ * GPU kernels but also needs to be touched from host code (e.g. when a device-side member
+ * holds a pointer into the same unified-memory region).
+ *
+ * @tparam T The type of the object to construct in unified memory.
+ * @tparam Args Argument types forwarded to \c T's constructor.
+ * @param args Arguments forwarded to \c T's constructor.
+ * @return A \c std::unique_ptr owning the unified-memory allocation.
+ */
+template <typename T, class... Args>
+std::unique_ptr<T, GpuManagedDeleter<T>>
+make_gpu_managed_unique_ptr(Args&&... args)
+{
+    void* raw = nullptr;
+    OPM_GPU_SAFE_CALL(cudaMallocManaged(&raw, sizeof(T)));
+    T* ptr = nullptr;
+    try {
+        ptr = new (raw) T(std::forward<Args>(args)...);
+    } catch (...) {
+        OPM_GPU_WARN_IF_ERROR(cudaFree(raw));
+        throw;
+    }
+    return std::unique_ptr<T, GpuManagedDeleter<T>>(ptr);
+}
+
+/**
  * @brief Copies a value from GPU-allocated memory to the host.
  *
  * @param value A pointer to the value on the GPU.
@@ -336,7 +426,9 @@ class ValueAsPointer {
 public:
     using element_type = T;
 
-    ValueAsPointer(const T& t) : value(t) {}
+    OPM_HOST_DEVICE ValueAsPointer() = default;
+
+    OPM_HOST_DEVICE explicit ValueAsPointer(const T& t) : value(t) {}
 
     OPM_HOST_DEVICE T* operator->() {
         return &value;

--- a/tests/gpuistl/test_gpu_smart_pointers.cu
+++ b/tests/gpuistl/test_gpu_smart_pointers.cu
@@ -145,3 +145,44 @@ BOOST_AUTO_TEST_CASE(TestCopyToGPU) {
     BOOST_CHECK_EQUAL(valueFromDeviceArray[2], 3.0);
     BOOST_CHECK_EQUAL(valueFromDeviceArray[3], 4.0);
 }
+
+BOOST_AUTO_TEST_CASE(TestUniquePointerArray)
+{
+    constexpr std::size_t numElements = 5;
+    auto arrayPtr = Opm::gpuistl::make_gpu_unique_ptr_array<double>(numElements);
+
+    const std::array<double, numElements> hostInput {1.5, 2.5, 3.5, 4.5, 5.5};
+    OPM_GPU_SAFE_CALL(cudaMemcpy(arrayPtr.get(),
+                                 hostInput.data(),
+                                 numElements * sizeof(double),
+                                 cudaMemcpyHostToDevice));
+
+    std::array<double, numElements> hostOutput {};
+    OPM_GPU_SAFE_CALL(cudaMemcpy(hostOutput.data(),
+                                 arrayPtr.get(),
+                                 numElements * sizeof(double),
+                                 cudaMemcpyDeviceToHost));
+
+    for (std::size_t i = 0; i < numElements; ++i) {
+        BOOST_CHECK_EQUAL(hostOutput[i], hostInput[i]);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(TestManagedUniquePointer)
+{
+    // Default-constructed payload.
+    auto managedPtr = Opm::gpuistl::make_gpu_managed_unique_ptr<SomeStruct>();
+    BOOST_CHECK_EQUAL(managedPtr->isCalled, false);
+
+    // Mutate from the device through a regular kernel; the unified-memory
+    // pointer is dereferenceable on the device, just like cudaMallocManaged.
+    callFunction<<<1, 1>>>(Opm::gpuistl::make_view(managedPtr));
+    OPM_GPU_SAFE_CALL(cudaDeviceSynchronize());
+
+    // Read back directly from host (the whole point of unified memory).
+    BOOST_CHECK_EQUAL(managedPtr->isCalled, true);
+
+    // Forwarded constructor arguments.
+    auto managedDouble = Opm::gpuistl::make_gpu_managed_unique_ptr<double>(7.25);
+    BOOST_CHECK_EQUAL(*managedDouble, 7.25);
+}


### PR DESCRIPTION
Adds host-side allocator helpers, host/device-decorated raw-pointer accessors and small additions to MiniVector that the rest of the GPU intensive-quantities work depends on.  Updates test_gpu_smart_pointers.cu to cover the new behaviour.